### PR TITLE
fix(backend): candid annotation

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -1,4 +1,4 @@
-use candid::{candid_method, CandidType, Deserialize, Nat, Principal};
+use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk_macros::{export_candid, init, post_upgrade, pre_upgrade, update};
 use k256::PublicKey;
 use std::cell::RefCell;
@@ -84,7 +84,6 @@ fn pubkey_bytes_to_address(pubkey_bytes: &[u8]) -> String {
 }
 
 #[update]
-#[candid_method(update)]
 async fn caller_eth_address() -> String {
     use ic_cdk::api::management_canister::ecdsa::{
         ecdsa_public_key, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument,
@@ -117,7 +116,6 @@ pub struct SignRequest {
 }
 
 #[update]
-#[candid_method(update)]
 fn sign_transaction() -> String {
     todo!()
 }


### PR DESCRIPTION
Candid annotations should be removed when last version of the cdk and `export_candid` is used.

Otherwise when generating types we get:

> error: duplicate method name caller_eth_address
>  --> src/backend/src/lib.rs:88:10
>   |
> 88 | async fn caller_eth_address() -> String {
>   |          ^^^^^^^^^^^^^^^^^^
>
> error: duplicate method name sign_transaction
>   --> src/backend/src/lib.rs:121:4
>    |
> 121 | fn sign_transaction() -> String {
>    |    ^^^^^^^^^^^^^^^^
