### PR TITLE
Increase font size of 'or use walletconnect uri' in WC form

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectForm.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectForm.svelte
@@ -44,7 +44,7 @@
 	{/if}
 </div>
 
-<p class="text-center p-2 text-xs">or use walletconnect uri</p>
+<p class="text-center p-2 text-base">or use walletconnect uri</p>
 
 <Input
 	name="uri"


### PR DESCRIPTION
Before:
<img width="534" alt="image" src="https://github.com/dfinity/ic-eth-wallet/assets/135699452/371b61bc-a2e8-406d-ac28-fd37fd528804">

After:
<img width="491" alt="image" src="https://github.com/dfinity/ic-eth-wallet/assets/135699452/c0f131b4-a68c-4f8a-adc0-0c774db8495d">
