### PR TITLE
feat(backend): speedup signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ethers-core",
+ "futures",
  "getrandom",
  "hex",
  "ic-cdk",
@@ -66,7 +67,6 @@ dependencies = [
  "ic-cdk-timers",
  "k256",
  "serde",
- "sha3",
 ]
 
 [[package]]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.9.3"
 ethers-core = "2"
+futures = "0.3"
 ic-cdk = "0.10.0"
 ic-cdk-macros = "0.7.1"
 ic-cdk-timers = "0.4"
 serde = "1"
-sha3 = "0.10"
 k256 = "0.13"
 hex = "0.4"
 getrandom = { version = "0.2", features = ["custom"] }


### PR DESCRIPTION
Fetch user pubkeys concurrently to reduce the e2e latency. Also avoid computing the hash twice when computing the parity bit.