### PR TITLE
feat(backend): add a method to sign a prehash

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -13,5 +13,6 @@ type SignRequest = record {
 service : (Arg) -> {
   caller_eth_address : () -> (text);
   personal_sign : (text) -> (text);
+  sign_prehash : (text) -> (text);
   sign_transaction : (SignRequest) -> (text);
 }

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -209,6 +209,19 @@ async fn personal_sign(plaintext: String) -> String {
     format!("0x{}", hex::encode(&signature))
 }
 
+#[update]
+async fn sign_prehash(prehash: String) -> String {
+    let caller = ic_cdk::caller();
+
+    let hash_bytes = decode_hex(&prehash);
+
+    let (pubkey, mut signature) = pubkey_and_signature(&caller, hash_bytes.to_vec()).await;
+
+    let v = y_parity(&hash_bytes, &signature, &pubkey);
+    signature.push(v as u8);
+    format!("0x{}", hex::encode(&signature))
+}
+
 fn y_parity(prehash: &[u8], sig: &[u8], pubkey: &[u8]) -> u64 {
     use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -17,5 +17,6 @@ export interface SignRequest {
 export interface _SERVICE {
 	caller_eth_address: ActorMethod<[], string>;
 	personal_sign: ActorMethod<[string], string>;
+	sign_prehash: ActorMethod<[string], string>;
 	sign_transaction: ActorMethod<[SignRequest], string>;
 }

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -15,6 +15,7 @@ export const idlFactory = ({ IDL }) => {
 	return IDL.Service({
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
+		sign_prehash: IDL.Func([IDL.Text], [IDL.Text], []),
 		sign_transaction: IDL.Func([SignRequest], [IDL.Text], [])
 	});
 };


### PR DESCRIPTION
This change introduces a new method, `sign_prehash`, that allows the caller to sign an arbitrary precomputed hash.