### PR TITLE
docs: v0.0.1 for airdrop and backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "airdrop"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -63,7 +63,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backend"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "candid",
  "ethers-core",

--- a/src/airdrop/Cargo.toml
+++ b/src/airdrop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "airdrop"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
I will tag the repo with a starting version `v0.0.1` therefore I use the same starting points for both canisters.