### PR TITLE
feat(frontend): clear WalletConnect related localstorage entries before initialization

### DIFF
--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -23,6 +23,17 @@ export const initWalletConnect = async ({
 	uri: string;
 	address: ETH_ADDRESS;
 }): Promise<WalletConnectListener> => {
+	const clearLocalStorage = () => {
+		const keys = Object.keys(localStorage).filter((key) => key.startsWith('wc@'));
+		keys.forEach((key) => localStorage.removeItem(key));
+	};
+
+	// During testing, we frequently encountered session approval failures with Uniswap due to the following reason:
+	// Unexpected error while communicating with WalletConnect. / No matching key. pairing: 12345c....
+	// The issue appears to be linked to incorrect cached information used by the WalletConnect library.
+	// To address this, we clear the local storage of any WalletConnect keys to ensure the proper instantiation of a new Wec3Wallet object.
+	clearLocalStorage();
+
 	const web3wallet = await Web3Wallet.init({
 		core: new Core({
 			projectId: PROJECT_ID


### PR DESCRIPTION
During testing, we frequently encountered session approval failures with Uniswap due to the following reason:

> Unexpected error while communicating with WalletConnect. / No matching key. pairing: 12345c....

The issue appears to be linked to incorrect cached information used by the WalletConnect library.
To address this, we clear the local storage of any WalletConnect keys to ensure the proper instantiation of a new Wec3Wallet object.