### PR TITLE
Revert "feat: allow crawlers (#430)"

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -55,6 +55,8 @@
 		<meta content="#33156A" name="theme-color" />
 		%sveltekit.head%
 
+		<meta name="robots" content="noindex" />
+
 		<style>
 			body {
 				background: #fcfaf6;

--- a/src/frontend/static/robots.txt
+++ b/src/frontend/static/robots.txt
@@ -1,4 +1,4 @@
+# robotstxt.org/
+
 User-agent: *
-Allow: /
-Sitemap: https://oisy.com/sitemap.xml
-Host: https://oisy.com
+Disallow: /


### PR DESCRIPTION
This reverts commit #430

No crawler is the default but a post build opens it, I forgot that for 1min