### PR TITLE
build: fix for prettier-plugin-organize-imports which deletes imports in WebStorm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"eslint-config-prettier": "^9.0.0",
 				"eslint-plugin-svelte": "^2.34.0",
 				"prettier": "^3.0.3",
-				"prettier-plugin-organize-imports": "^3.2.3",
+				"prettier-plugin-organize-imports": "^3.2.4",
 				"prettier-plugin-svelte": "^3.0.3",
 				"sass": "^1.69.5",
 				"svelte": "^4.2.2",
@@ -5197,9 +5197,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-organize-imports": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.3.tgz",
-			"integrity": "sha512-KFvk8C/zGyvUaE3RvxN2MhCLwzV6OBbFSkwZ2OamCrs9ZY4i5L77jQ/w4UmUr+lqX8qbaqVq6bZZkApn+IgJSg==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz",
+			"integrity": "sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==",
 			"dev": true,
 			"peerDependencies": {
 				"@volar/vue-language-plugin-pug": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-svelte": "^2.34.0",
 		"prettier": "^3.0.3",
-		"prettier-plugin-organize-imports": "^3.2.3",
+		"prettier-plugin-organize-imports": "^3.2.4",
 		"prettier-plugin-svelte": "^3.0.3",
 		"sass": "^1.69.5",
 		"svelte": "^4.2.2",


### PR DESCRIPTION
Related to https://youtrack.jetbrains.com/issue/WEB-50178#focus=Comments-27-8352541.0-0