### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @dfinity/gix
+# The codebase is owned by the Governance & Identity Experience team at DFINITY
+# For questions, reach out to: <gix@dfinity.org>


### PR DESCRIPTION
This makes sure the whole team isn't pinged on every PR, and makes it more in line with the NNS dapp's CODEOWNERS.