### PR TITLE
style: fix header size after tailwind

### DIFF
--- a/src/frontend/src/lib/components/layout/HeaderHero.svelte
+++ b/src/frontend/src/lib/components/layout/HeaderHero.svelte
@@ -12,7 +12,7 @@
 
 <header
 	class="flex justify-between md:px-4 relative z-1 pointer-events-none"
-	style="min-height: 76px"
+	style="min-height: 78px"
 >
 	{#if back}
 		<Back />


### PR DESCRIPTION
The header shifted of 2px on navigation after the introduction of Tailwind.