### PR TITLE
build: bump wallet connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@sveltejs/adapter-static": "^3.0.1",
 				"@sveltejs/kit": "^2.0.4",
 				"@sveltejs/vite-plugin-svelte": "^3.0.1",
-				"@walletconnect/web3wallet": "^1.9.1",
+				"@walletconnect/web3wallet": "^1.9.5",
 				"alchemy-sdk": "^3.1.0",
 				"buffer": "^6.0.3",
 				"ethers": "^5.7.0",
@@ -2737,23 +2737,23 @@
 			}
 		},
 		"node_modules/@walletconnect/core": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.1.tgz",
-			"integrity": "sha512-WAoXfmj+Zy5q48TnrKUjmHXJCBahzKwbul+noepRZf7JDtUAZ9IOWpUjg+UPRbfK5EiWZ0TF42S6SXidf7EHoQ==",
+			"version": "2.10.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.6.tgz",
+			"integrity": "sha512-Z4vh4ZdfcoQjgPEOxeuF9HUZCVLtV3MgRbS/awLIj/omDrFnOwlBhxi5Syr4Y8muVGC0ocRetQYHae0/gX5crQ==",
 			"dependencies": {
 				"@walletconnect/heartbeat": "1.2.1",
 				"@walletconnect/jsonrpc-provider": "1.0.13",
 				"@walletconnect/jsonrpc-types": "1.0.3",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
-				"@walletconnect/jsonrpc-ws-connection": "1.0.13",
-				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/jsonrpc-ws-connection": "1.0.14",
+				"@walletconnect/keyvaluestorage": "^1.1.1",
 				"@walletconnect/logger": "^2.0.1",
 				"@walletconnect/relay-api": "^1.0.9",
 				"@walletconnect/relay-auth": "^1.0.4",
 				"@walletconnect/safe-json": "^1.0.2",
 				"@walletconnect/time": "^1.0.2",
-				"@walletconnect/types": "2.10.1",
-				"@walletconnect/utils": "2.10.1",
+				"@walletconnect/types": "2.10.6",
+				"@walletconnect/utils": "2.10.6",
 				"events": "^3.3.0",
 				"lodash.isequal": "4.5.0",
 				"uint8arrays": "^3.1.0"
@@ -2846,21 +2846,15 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@walletconnect/jsonrpc-ws-connection": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
-			"integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+			"integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
 			"dependencies": {
 				"@walletconnect/jsonrpc-utils": "^1.0.6",
 				"@walletconnect/safe-json": "^1.0.2",
 				"events": "^3.3.0",
-				"tslib": "1.14.1",
 				"ws": "^7.5.1"
 			}
-		},
-		"node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@walletconnect/keyvaluestorage": {
 			"version": "1.1.1",
@@ -2940,18 +2934,18 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@walletconnect/sign-client": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.10.1.tgz",
-			"integrity": "sha512-iG3eJGi1yXeG3xGeVSSMf8wDFyx239B0prLQfy1uYDtYFb2ynnH/09oqAZyKn96W5nfQzUgM2Mz157PVdloH3Q==",
+			"version": "2.10.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.10.6.tgz",
+			"integrity": "sha512-EvUWjaZBQu2yKnH5/5F2qzbuiIuUN9ZgrNKgvXkw5z1Dq5RJCks0S9/MFlKH/ZSGqXnLl7uAzBXtoX4sMgbCMA==",
 			"dependencies": {
-				"@walletconnect/core": "2.10.1",
+				"@walletconnect/core": "2.10.6",
 				"@walletconnect/events": "^1.0.1",
 				"@walletconnect/heartbeat": "1.2.1",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/logger": "^2.0.1",
 				"@walletconnect/time": "^1.0.2",
-				"@walletconnect/types": "2.10.1",
-				"@walletconnect/utils": "2.10.1",
+				"@walletconnect/types": "2.10.6",
+				"@walletconnect/utils": "2.10.6",
 				"events": "^3.3.0"
 			}
 		},
@@ -2969,22 +2963,22 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@walletconnect/types": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.1.tgz",
-			"integrity": "sha512-7pccAhajQdiH2kYywjE1XI64IqRI+4ioyGy0wvz8d0UFQ/DSG3MLKR8jHf5aTOafQQ/HRLz6xvlzN4a7gIVkUQ==",
+			"version": "2.10.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.6.tgz",
+			"integrity": "sha512-WgHfiTG1yakmxheaBRiXhUdEmgxwrvsAdOIWaMf/spvrzVKYh6sHI3oyEEky5qj5jjiMiyQBeB57QamzCotbcQ==",
 			"dependencies": {
 				"@walletconnect/events": "^1.0.1",
 				"@walletconnect/heartbeat": "1.2.1",
 				"@walletconnect/jsonrpc-types": "1.0.3",
-				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/keyvaluestorage": "^1.1.1",
 				"@walletconnect/logger": "^2.0.1",
 				"events": "^3.3.0"
 			}
 		},
 		"node_modules/@walletconnect/utils": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.1.tgz",
-			"integrity": "sha512-DM0dKgm9O58l7VqJEyV2OVv16XRePhDAReI23let6WdW1dSpw/Y/A89Lp99ZJOjLm2FxyblMRF3YRaZtHwBffw==",
+			"version": "2.10.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.6.tgz",
+			"integrity": "sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==",
 			"dependencies": {
 				"@stablelib/chacha20poly1305": "1.0.1",
 				"@stablelib/hkdf": "1.0.1",
@@ -2994,7 +2988,7 @@
 				"@walletconnect/relay-api": "^1.0.9",
 				"@walletconnect/safe-json": "^1.0.2",
 				"@walletconnect/time": "^1.0.2",
-				"@walletconnect/types": "2.10.1",
+				"@walletconnect/types": "2.10.6",
 				"@walletconnect/window-getters": "^1.0.1",
 				"@walletconnect/window-metadata": "^1.0.1",
 				"detect-browser": "5.3.0",
@@ -3003,18 +2997,18 @@
 			}
 		},
 		"node_modules/@walletconnect/web3wallet": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@walletconnect/web3wallet/-/web3wallet-1.9.1.tgz",
-			"integrity": "sha512-amijU+dK8zhDTxbJqxQvBlysFEroHUbE9HyMGKp6HSba5k5fXI0F+mvxeidDkOXur+ZsCj86rPQqSuPrTkPySg==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@walletconnect/web3wallet/-/web3wallet-1.9.5.tgz",
+			"integrity": "sha512-98ymdQ1QuNaC0krsyalzSBpMX6iYmBG2pvUMeStqnI4bas30dt4LaVqGXcklmnxZd2nFJsHLIFqN9jHAg39hhw==",
 			"dependencies": {
 				"@walletconnect/auth-client": "2.1.2",
-				"@walletconnect/core": "2.10.1",
+				"@walletconnect/core": "2.10.6",
 				"@walletconnect/jsonrpc-provider": "1.0.13",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/logger": "2.0.1",
-				"@walletconnect/sign-client": "2.10.1",
-				"@walletconnect/types": "2.10.1",
-				"@walletconnect/utils": "2.10.1"
+				"@walletconnect/sign-client": "2.10.6",
+				"@walletconnect/types": "2.10.6",
+				"@walletconnect/utils": "2.10.6"
 			}
 		},
 		"node_modules/@walletconnect/window-getters": {
@@ -7431,11 +7425,11 @@
 			}
 		},
 		"node_modules/untun": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/untun/-/untun-0.1.2.tgz",
-			"integrity": "sha512-wLAMWvxfqyTiBODA1lg3IXHQtjggYLeTK7RnSfqtOXixWJ3bAa2kK/HHmOOg19upteqO3muLvN6O/icbyQY33Q==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
+			"integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
 			"dependencies": {
-				"citty": "^0.1.3",
+				"citty": "^0.1.5",
 				"consola": "^3.2.3",
 				"pathe": "^1.1.1"
 			},

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@sveltejs/adapter-static": "^3.0.1",
 		"@sveltejs/kit": "^2.0.4",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
-		"@walletconnect/web3wallet": "^1.9.1",
+		"@walletconnect/web3wallet": "^1.9.5",
 		"alchemy-sdk": "^3.1.0",
 		"buffer": "^6.0.3",
 		"ethers": "^5.7.0",


### PR DESCRIPTION
Yesterday we have removed the node polyfillier for local development, therefore we can bump Wallet Connect as  #478 gets resolved.