### PR TITLE
build: resolve sveltekit v2 alias

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,6 +23,9 @@ const config = {
 			lib: filesPath('src/lib'),
 			routes: filesPath('src/routes'),
 			appTemplate: filesPath('src/app.html')
+		},
+		alias: {
+			$declarations: './src/declarations'
 		}
 	},
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,6 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"paths": {
-			"$lib": ["./src/frontend/src/lib"],
-			"$lib/*": ["./src/frontend/src/lib/*"],
-			"$declarations": ["./src/declarations"],
-			"$declarations/*": ["./src/declarations/*"]
-		},
 		"types": ["node"]
 	}
 }


### PR DESCRIPTION
> > svelte-kit sync && svelte-check --tsconfig ./tsconfig.json
>
> You have specified a baseUrl and/or paths in your tsconfig.json which interferes with SvelteKit's auto-generated tsconfig.json. Remove it to avoid problems with intellisense. For path aliases, use `kit.alias` instead: https://kit.svelte.dev/docs/configuration#alias
