### PR TITLE
feat: hold mapped IC transaction in store and map in workers

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -2,7 +2,7 @@
 	import { modalStore } from '$lib/stores/modal.store.js';
 	import { Modal } from '@dfinity/gix-components';
 	import Copy from '$lib/components/ui/Copy.svelte';
-	import type { BigNumber } from '@ethersproject/bignumber';
+	import { BigNumber } from '@ethersproject/bignumber';
 	import { nonNullish } from '@dfinity/utils';
 	import { formatNanosecondsToDate, formatToken } from '$lib/utils/format.utils';
 	import { token } from '$lib/derived/token.derived';
@@ -14,7 +14,7 @@
 	let id: bigint;
 	let from: string | undefined;
 	let to: string | undefined;
-	let value: BigNumber | undefined;
+	let value: bigint | undefined;
 	let timestamp: bigint | undefined;
 	let type: IcTransactionType;
 	let toLabel: string | undefined;
@@ -87,7 +87,7 @@
 				<svelte:fragment slot="label">Value</svelte:fragment>
 				<output>
 					{formatToken({
-						value,
+						value: BigNumber.from(value),
 						unitName: $token.decimals,
 						displayDecimals: $token.decimals
 					})}

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -10,7 +10,7 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import IcpTransactionModal from './IcTransactionModal.svelte';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
-	import type { IcToken, IcTransaction as IcTransactionType, IcTransactionUi } from '$icp/types/ic';
+	import type { IcToken, IcTransactionUi } from '$icp/types/ic';
 	import { token, tokenId } from '$lib/derived/token.derived';
 	import { loadNextTransactions } from '$icp/services/ic-transactions.services';
 	import type { CertifiedData } from '$lib/types/store';
@@ -22,7 +22,7 @@
 	import IcTransactionsBtcListener from '$icp/components/transactions/IcTransactionsBtcListener.svelte';
 	import IcTransactionsNoListener from '$icp/components/transactions/IcTransactionsNoListener.svelte';
 
-	let transactions: CertifiedData<IcTransactionType>[];
+	let transactions: CertifiedData<IcTransactionUi>[];
 	$: transactions = $icTransactionsStore?.[$tokenId] ?? [];
 
 	let additionalListener: ComponentType;

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -15,6 +15,7 @@ import { syncWallet } from './ic-listener.services';
 
 export const initIcrcWalletWorker = async ({
 	indexCanisterId,
+	ledgerCanisterId,
 	id: tokenId
 }: IcToken): Promise<WalletWorker> => {
 	const WalletWorker = await import('$icp/workers/icrc-wallet.worker?worker');
@@ -60,7 +61,8 @@ export const initIcrcWalletWorker = async ({
 			worker.postMessage({
 				msg: 'startIcrcWalletTimer',
 				data: {
-					indexCanisterId
+					indexCanisterId,
+					ledgerCanisterId
 				}
 			});
 		},
@@ -73,7 +75,8 @@ export const initIcrcWalletWorker = async ({
 			worker.postMessage({
 				msg: 'triggerIcrcWalletTimer',
 				data: {
-					indexCanisterId
+					indexCanisterId,
+					ledgerCanisterId
 				}
 			});
 		}

--- a/src/frontend/src/icp/stores/ic-transactions.store.ts
+++ b/src/frontend/src/icp/stores/ic-transactions.store.ts
@@ -1,22 +1,30 @@
-import type { IcTransaction } from '$icp/types/ic';
+import type { IcTransactionUi } from '$icp/types/ic';
 import { initCertifiedStore, type CertifiedStore } from '$lib/stores/certified.store';
 import type { CertifiedData } from '$lib/types/store';
 import type { TokenId } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
 
-export type IcTransactionsData<T> = CertifiedData<T>[];
+export type IcCertifiedTransaction = CertifiedData<IcTransactionUi>;
 
-export interface IcTransactionsStore<T> extends CertifiedStore<IcTransactionsData<T>> {
-	prepend: (params: { tokenId: TokenId; transactions: CertifiedData<T>[] }) => void;
-	append: (params: { tokenId: TokenId; transactions: CertifiedData<T>[] }) => void;
+export type IcTransactionsData = IcCertifiedTransaction[];
+
+export interface IcTransactionsStore extends CertifiedStore<IcTransactionsData> {
+	prepend: (params: { tokenId: TokenId; transactions: IcCertifiedTransaction[] }) => void;
+	append: (params: { tokenId: TokenId; transactions: IcCertifiedTransaction[] }) => void;
 	cleanUp: (params: { tokenId: TokenId; transactionIds: string[] }) => void;
 }
 
-const initIcTransactionsStore = <T extends IcTransaction>(): IcTransactionsStore<T> => {
-	const { subscribe, update, reset } = initCertifiedStore<IcTransactionsData<T>>();
+const initIcTransactionsStore = (): IcTransactionsStore => {
+	const { subscribe, update, reset } = initCertifiedStore<IcTransactionsData>();
 
 	return {
-		prepend: ({ tokenId, transactions }: { tokenId: TokenId; transactions: CertifiedData<T>[] }) =>
+		prepend: ({
+			tokenId,
+			transactions
+		}: {
+			tokenId: TokenId;
+			transactions: IcCertifiedTransaction[];
+		}) =>
 			update((state) => ({
 				...(nonNullish(state) && state),
 				[tokenId]: [
@@ -26,7 +34,13 @@ const initIcTransactionsStore = <T extends IcTransaction>(): IcTransactionsStore
 					)
 				]
 			})),
-		append: ({ tokenId, transactions }: { tokenId: TokenId; transactions: CertifiedData<T>[] }) =>
+		append: ({
+			tokenId,
+			transactions
+		}: {
+			tokenId: TokenId;
+			transactions: IcCertifiedTransaction[];
+		}) =>
 			update((state) => ({
 				...(nonNullish(state) && state),
 				[tokenId]: [...((state ?? {})[tokenId] ?? []), ...transactions]

--- a/src/frontend/src/icp/types/ic.ts
+++ b/src/frontend/src/icp/types/ic.ts
@@ -6,7 +6,6 @@ import type {
 	IcrcTransaction as IcrcTransactionCandid,
 	IcrcTransactionWithId
 } from '@dfinity/ledger-icrc';
-import type { BigNumber } from '@ethersproject/bignumber';
 
 export interface IcTransactionAddOnsInfo {
 	transferToSelf?: 'send' | 'receive';
@@ -40,7 +39,7 @@ export interface IcTransactionUi {
 	// e.g. To: BTC Network
 	toLabel?: string;
 	incoming?: boolean;
-	value?: BigNumber;
+	value?: bigint;
 	timestamp?: bigint;
 	status: IcTransactionStatus;
 }

--- a/src/frontend/src/icp/utils/icp-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icp-transactions.utils.ts
@@ -3,7 +3,6 @@ import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Tokens, Transaction, TransactionWithId } from '@dfinity/ledger-icp';
 import { fromNullable, nonNullish } from '@dfinity/utils';
-import { BigNumber } from '@ethersproject/bignumber';
 
 export const mapTransactionIcpToSelf = (
 	tx: TransactionWithId
@@ -79,7 +78,7 @@ export const mapIcpTransaction = ({
 		incoming: boolean | undefined;
 		fee: Tokens;
 		amount: Tokens;
-	}): BigNumber => BigNumber.from(amount.e8s).add(incoming === false ? fee.e8s : 0n);
+	}): bigint => amount.e8s + (incoming === false ? fee.e8s : 0n);
 
 	if ('Approve' in operation) {
 		return {
@@ -94,7 +93,7 @@ export const mapIcpTransaction = ({
 			...tx,
 			type: 'burn',
 			...mapFrom(operation.Burn.from),
-			value: BigNumber.from(operation.Burn.amount.e8s)
+			value: operation.Burn.amount.e8s
 		};
 	}
 
@@ -104,7 +103,7 @@ export const mapIcpTransaction = ({
 			type: 'mint',
 			to: operation.Mint.to,
 			incoming: true,
-			value: BigNumber.from(operation.Mint.amount.e8s)
+			value: operation.Mint.amount.e8s
 		};
 	}
 

--- a/src/frontend/src/icp/utils/icrc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icrc-transactions.utils.ts
@@ -3,7 +3,6 @@ import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
 import type { OptionIdentity } from '$lib/types/identity';
 import { encodeIcrcAccount, type IcrcTransactionWithId } from '@dfinity/ledger-icrc';
 import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
-import { BigNumber } from '@ethersproject/bignumber';
 
 export const mapTransactionIcrcToSelf = (tx: IcrcTransactionWithId): IcrcTransaction[] => {
 	const { transaction, id } = tx;
@@ -108,13 +107,12 @@ export const mapIcrcTransaction = ({
 					: 'receive';
 
 	const value = isApprove
-		? BigNumber.from(0n)
+		? 0n
 		: nonNullish(data?.amount)
-			? BigNumber.from(data.amount).add(
-					isTransfer && source.incoming === false
-						? fromNullable(fromNullable(transfer)?.fee ?? []) ?? 0n
-						: 0n
-				)
+			? data.amount +
+				(isTransfer && source.incoming === false
+					? fromNullable(fromNullable(transfer)?.fee ?? []) ?? 0n
+					: 0n)
 			: undefined;
 
 	return {

--- a/src/frontend/src/icp/worker-utils/wallet.worker-utils.ts
+++ b/src/frontend/src/icp/worker-utils/wallet.worker-utils.ts
@@ -1,5 +1,5 @@
 import { WALLET_TIMER_INTERVAL_MILLIS } from '$icp/constants/ic.constants';
-import type { IcTransactionAddOnsInfo } from '$icp/types/ic';
+import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic';
 import type { GetTransactions } from '$icp/types/ic.post-message';
 import { queryAndUpdate } from '$lib/actors/query.ic';
 import type {
@@ -48,6 +48,11 @@ export class WalletWorkerUtils<
 		private mapToSelfTransaction: (
 			transaction: TWithId
 		) => (Pick<TWithId, 'id'> & { transaction: IndexedTransaction<T> })[],
+		private mapTransaction: (
+			params: {
+				transaction: Pick<TWithId, 'id'> & { transaction: IndexedTransaction<T> };
+			} & Pick<TimerWorkerUtilsJobData<PostMessageDataRequest>, 'identity'>
+		) => IcTransactionUi,
 		private msg: 'syncIcpWallet' | 'syncIcrcWallet'
 	) {}
 
@@ -78,7 +83,7 @@ export class WalletWorkerUtils<
 			request: ({ identity: _, certified }) =>
 				this.getTransactions({ ...data, identity, certified }),
 			onLoad: ({ certified, ...rest }) => {
-				this.syncTransactions({ certified, ...rest });
+				this.syncTransactions({ identity, certified, ...rest });
 				this.cleanTransactions({ certified });
 			},
 			onCertifiedError: ({ error }) => this.postMessageWalletError(error),
@@ -89,11 +94,12 @@ export class WalletWorkerUtils<
 
 	private syncTransactions = ({
 		response: { transactions: fetchedTransactions, balance, ...rest },
-		certified
+		certified,
+		identity
 	}: {
 		response: GetTransactions & { transactions: TWithId[] };
 		certified: boolean;
-	}) => {
+	} & Pick<TimerWorkerUtilsJobData<PostMessageDataRequest>, 'identity'>) => {
 		// Is there any new transactions unknown so far or which has become certified
 		const newTransactions = fetchedTransactions.filter(
 			({ id }) =>
@@ -112,7 +118,7 @@ export class WalletWorkerUtils<
 			// We execute postMessage at least once because developer may have no transaction at all so, we want to display the balance zero
 			if (!this.initialized) {
 				this.postMessageWallet({
-					transactions: newExtendedTransactions,
+					transactions: [],
 					balance,
 					certified,
 					...rest
@@ -141,8 +147,12 @@ export class WalletWorkerUtils<
 			}
 		};
 
+		const newUiTransactions = newExtendedTransactions.map((transaction) =>
+			this.mapTransaction({ transaction, identity })
+		);
+
 		this.postMessageWallet({
-			transactions: newExtendedTransactions,
+			transactions: newUiTransactions,
 			balance,
 			certified,
 			...rest
@@ -198,7 +208,7 @@ export class WalletWorkerUtils<
 		certified,
 		...rest
 	}: GetTransactions & {
-		transactions: (Pick<TWithId, 'id'> & { transaction: IndexedTransaction<T> })[];
+		transactions: IcTransactionUi[];
 	} & {
 		certified: boolean;
 	}) {

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -1,8 +1,16 @@
 import { getTransactions as getTransactionsApi } from '$icp/api/icp-index.api';
-import { mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
-import { type TimerWorkerUtilsJobParams } from '$icp/worker-utils/timer.worker-utils';
+import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic';
+import { mapIcpTransaction, mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
+import {
+	type TimerWorkerUtilsJobData,
+	type TimerWorkerUtilsJobParams
+} from '$icp/worker-utils/timer.worker-utils';
 import { WalletWorkerUtils } from '$icp/worker-utils/wallet.worker-utils';
-import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
+import type {
+	PostMessage,
+	PostMessageDataRequest,
+	PostMessageDataRequestIcrc
+} from '$lib/types/post-message';
 import type {
 	GetAccountIdentifierTransactionsResponse,
 	Transaction,
@@ -22,8 +30,16 @@ const getTransactions = ({
 	});
 };
 
+const mapTransaction = (
+	params: {
+		transaction: Pick<TransactionWithId, 'id'> & {
+			transaction: Transaction & IcTransactionAddOnsInfo;
+		};
+	} & Pick<TimerWorkerUtilsJobData<PostMessageDataRequestIcrc>, 'identity'>
+): IcTransactionUi => mapIcpTransaction(params);
+
 const worker: WalletWorkerUtils<Transaction, TransactionWithId, PostMessageDataRequest> =
-	new WalletWorkerUtils(getTransactions, mapTransactionIcpToSelf, 'syncIcpWallet');
+	new WalletWorkerUtils(getTransactions, mapTransactionIcpToSelf, mapTransaction, 'syncIcpWallet');
 
 onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -6,11 +6,7 @@ import {
 	type TimerWorkerUtilsJobParams
 } from '$icp/worker-utils/timer.worker-utils';
 import { WalletWorkerUtils } from '$icp/worker-utils/wallet.worker-utils';
-import type {
-	PostMessage,
-	PostMessageDataRequest,
-	PostMessageDataRequestIcrc
-} from '$lib/types/post-message';
+import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
 import type {
 	GetAccountIdentifierTransactionsResponse,
 	Transaction,
@@ -30,13 +26,15 @@ const getTransactions = ({
 	});
 };
 
-const mapTransaction = (
-	params: {
-		transaction: Pick<TransactionWithId, 'id'> & {
-			transaction: Transaction & IcTransactionAddOnsInfo;
-		};
-	} & Pick<TimerWorkerUtilsJobData<PostMessageDataRequestIcrc>, 'identity'>
-): IcTransactionUi => mapIcpTransaction(params);
+const mapTransaction = ({
+	transaction,
+	jobData: { identity }
+}: {
+	transaction: Pick<TransactionWithId, 'id'> & {
+		transaction: Transaction & IcTransactionAddOnsInfo;
+	};
+	jobData: TimerWorkerUtilsJobData<PostMessageDataRequest>;
+}): IcTransactionUi => mapIcpTransaction({ transaction, identity });
 
 const worker: WalletWorkerUtils<Transaction, TransactionWithId, PostMessageDataRequest> =
 	new WalletWorkerUtils(getTransactions, mapTransactionIcpToSelf, mapTransaction, 'syncIcpWallet');

--- a/src/frontend/src/icp/workers/icrc-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icrc-wallet.worker.ts
@@ -1,6 +1,10 @@
 import { getTransactions as getTransactionsApi } from '$icp/api/icrc-index.api';
-import { mapTransactionIcrcToSelf } from '$icp/utils/icrc-transactions.utils';
-import { type TimerWorkerUtilsJobParams } from '$icp/worker-utils/timer.worker-utils';
+import type { IcTransactionUi } from '$icp/types/ic';
+import { mapIcrcTransaction, mapTransactionIcrcToSelf } from '$icp/utils/icrc-transactions.utils';
+import {
+	type TimerWorkerUtilsJobData,
+	type TimerWorkerUtilsJobParams
+} from '$icp/worker-utils/timer.worker-utils';
 import { WalletWorkerUtils } from '$icp/worker-utils/wallet.worker-utils';
 import type { PostMessage, PostMessageDataRequestIcrc } from '$lib/types/post-message';
 import {
@@ -27,11 +31,26 @@ const getTransactions = ({
 	});
 };
 
+const mapTransaction = (
+	params: {
+		transaction: Pick<IcrcTransactionWithId, 'id'> & { transaction: IcrcTransaction };
+	} & Pick<TimerWorkerUtilsJobData<PostMessageDataRequestIcrc>, 'identity'>
+): IcTransactionUi => {
+	// TODO ckBTC
+
+	return mapIcrcTransaction(params);
+};
+
 const worker: WalletWorkerUtils<
 	IcrcTransaction,
 	IcrcTransactionWithId,
 	PostMessageDataRequestIcrc
-> = new WalletWorkerUtils(getTransactions, mapTransactionIcrcToSelf, 'syncIcrcWallet');
+> = new WalletWorkerUtils(
+	getTransactions,
+	mapTransactionIcrcToSelf,
+	mapTransaction,
+	'syncIcrcWallet'
+);
 
 onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestIcrc>>) => {
 	const { msg, data } = dataMsg;

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -30,7 +30,7 @@ export interface PostMessageDataRequestExchangeTimer {
 	erc20Addresses: Erc20ContractAddress[];
 }
 
-export type PostMessageDataRequestIcrc = Pick<IcCanisters, 'indexCanisterId'>;
+export type PostMessageDataRequestIcrc = IcCanisters;
 
 export type PostMessageDataRequestBtcStatuses = Partial<Pick<IcCkCanisters, 'minterCanisterId'>>;
 


### PR DESCRIPTION
We need this because we have to fetch and map ckBTC pending Utxo to pseudo transactions for display purpose.
In addition, this improves performance by deferring some addition work to the workers.

So, win win.