### PR TITLE
feat: up to height decimals on transactions list

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -8,6 +8,7 @@
 	import { FEE_CONTEXT_KEY } from '$eth/stores/fee.store';
 	import { ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 	import { maxGasFee } from '$eth/utils/fee.utils';
+	import { HEIGHT_DECIMALS } from '$lib/constants/app.constants';
 
 	const { store: feeData }: FeeContext = getContext<FeeContext>(FEE_CONTEXT_KEY);
 
@@ -51,7 +52,7 @@
 		<div in:fade>
 			{formatToken({
 				value: fee,
-				displayDecimals: 8
+				displayDecimals: HEIGHT_DECIMALS
 			})}
 			{ETHEREUM_TOKEN.symbol}
 		</div>

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -13,6 +13,7 @@
 	import { ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { onDestroy } from 'svelte';
+	import { HEIGHT_DECIMALS } from '$lib/constants/app.constants';
 
 	export let networkId: NetworkId | undefined = undefined;
 
@@ -59,7 +60,7 @@
 					<span in:fade>
 						{formatToken({
 							value: BigNumber.from(maxTransactionFee),
-							displayDecimals: 8
+							displayDecimals: HEIGHT_DECIMALS
 						})}
 						{ETHEREUM_TOKEN.symbol}
 					</span>

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -12,6 +12,7 @@
 	import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic';
 	import IconMint from '$lib/components/icons/IconMint.svelte';
 	import IconBurn from '$lib/components/icons/IconBurn.svelte';
+	import { HEIGHT_DECIMALS } from '$lib/constants/app.constants';
 
 	export let transaction: IcTransactionUi;
 
@@ -55,7 +56,9 @@
 			{nonNullish(amount)
 				? formatToken({
 						value: BigNumber.from(amount),
-						unitName: $token.decimals
+						unitName: $token.decimals,
+						displayDecimals: HEIGHT_DECIMALS,
+						trailingZeros: false
 					})
 				: ''}</svelte:fragment
 		>

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -27,3 +27,7 @@ export const DAYS_IN_NON_LEAP_YEAR = 365;
 
 export const NANO_SECONDS_IN_MILLISECOND = 1_000_000n;
 export const NANO_SECONDS_IN_MINUTE = NANO_SECONDS_IN_MILLISECOND * 1_000n * 60n;
+
+// For some use case we want to display some amount to a maximal number of decimals which is not related to the number of decimals of the selected token.
+// Just a value that looks good visually.
+export const HEIGHT_DECIMALS = 8;

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -7,17 +7,25 @@ import { Utils } from 'alchemy-sdk';
 export const formatToken = ({
 	value,
 	unitName = ETHEREUM_DEFAULT_DECIMALS,
-	displayDecimals = 4
+	displayDecimals = 4,
+	trailingZeros = true
 }: {
 	value: BigNumber;
 	unitName?: string | BigNumberish;
 	displayDecimals?: number;
+	trailingZeros?: boolean;
 }): string => {
 	const res = Utils.formatUnits(value, unitName);
-	return (+res).toLocaleString('en-US', {
+	const formatted = (+res).toLocaleString('en-US', {
 		useGrouping: false,
 		maximumFractionDigits: displayDecimals
 	});
+
+	if (trailingZeros) {
+		return formatted;
+	}
+
+	return formatted.replace(/\.0+$/, '');
 };
 
 /**


### PR DESCRIPTION
UX/UI choice rather than precision choice here. The full value with the number of decimals of the token is available in the modal.