### PR TITLE
test: align values on backend similar memo test

### DIFF
--- a/src/frontend/src/tests/icp/utils/cketh-memo.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/cketh-memo.utils.spec.ts
@@ -1,15 +1,20 @@
-import { decodeBurnMemo, decodeMintMemo, MINT_MEMO_CONVERT } from '$icp/utils/cketh-memo.utils';
-import { Cbor } from '@dfinity/agent';
-import { hexStringToUint8Array, uint8ArrayToHexString } from '@dfinity/utils';
+import {
+	BURN_MEMO_CONVERT,
+	decodeBurnMemo,
+	decodeMintMemo,
+	MINT_MEMO_CONVERT,
+	MINT_MEMO_REIMBURSE
+} from '$icp/utils/cketh-memo.utils';
+import { uint8ArrayToHexString } from '@dfinity/utils';
 import { expect } from 'vitest';
 
 describe('cketh-memo.utils', () => {
 	describe('decode mint memo', () => {
 		it('should decode memo to converted', () => {
 			const memo = new Uint8Array([
-				130, 0, 131, 84, 5, 153, 246, 109, 133, 205, 248, 66, 113, 14, 80, 204, 194, 44, 28, 124,
-				106, 86, 54, 236, 88, 32, 69, 157, 42, 73, 138, 11, 70, 125, 99, 163, 169, 127, 237, 23,
-				211, 193, 50, 219, 122, 202, 238, 198, 1, 12, 69, 131, 69, 152, 173, 198, 9, 5, 24, 84
+				130, 0, 131, 84, 221, 40, 81, 205, 212, 10, 230, 83, 104, 49, 85, 141, 212, 109, 182, 47,
+				172, 122, 132, 77, 88, 32, 112, 95, 130, 104, 97, 200, 2, 180, 7, 132, 62, 153, 175, 152,
+				108, 253, 232, 116, 155, 102, 158, 94, 10, 90, 21, 15, 67, 80, 188, 170, 155, 195, 24, 39
 			]);
 
 			const [type, values] = decodeMintMemo(memo);
@@ -19,33 +24,49 @@ describe('cketh-memo.utils', () => {
 			const [from_address, tx_hash, log_index] = values;
 
 			expect(uint8ArrayToHexString(from_address as Uint8Array)).toEqual(
-				'0599f66d85cdf842710e50ccc22c1c7c6a5636ec'
+				'dd2851cdd40ae6536831558dd46db62fac7a844d'
 			);
 			expect(uint8ArrayToHexString(tx_hash)).toEqual(
-				'459d2a498a0b467d63a3a97fed17d3c132db7acaeec6010c45834598adc60905'
+				'705f826861c802b407843e99af986cfde8749b669e5e0a5a150f4350bcaa9bc3'
 			);
-			expect(log_index).toEqual(84);
+			expect(log_index).toEqual(39);
 		});
 
 		it('should decode memo to reimbursement', () => {
-			const withdrawalId = 1331;
-			const tx_hash = hexStringToUint8Array(
-				'459d2a498a0b467d63a3a97fed17d3c132db7acaeec6010c45834598adc60905'
-			);
-			const decodedMemo = [1, [withdrawalId, tx_hash]];
-			const memo = new Uint8Array(Cbor.encode(decodedMemo));
+			const memo = new Uint8Array([
+				130, 1, 130, 25, 4, 210, 88, 32, 112, 95, 130, 104, 97, 200, 2, 180, 7, 132, 62, 153, 175,
+				152, 108, 253, 232, 116, 155, 102, 158, 94, 10, 90, 21, 15, 67, 80, 188, 170, 155, 195
+			]);
 
-			expect(decodeMintMemo(memo)).toEqual(decodedMemo);
+			const [type, values] = decodeMintMemo(memo);
+
+			expect(type).toEqual(MINT_MEMO_REIMBURSE);
+
+			const [withdrawalId, from_address] = values;
+
+			expect(withdrawalId).toEqual(1234);
+			expect(uint8ArrayToHexString(from_address as Uint8Array)).toEqual(
+				'705f826861c802b407843e99af986cfde8749b669e5e0a5a150f4350bcaa9bc3'
+			);
 		});
 	});
 
 	describe('decode burn memo', () => {
-		it('should decode memo as withdrawal', () => {
-			const toAddress = hexStringToUint8Array('0599f66d85cdf842710e50ccc22c1c7c6a5636ec');
-			const decodedMemo = [0, [toAddress]];
-			const memo = new Uint8Array(Cbor.encode(decodedMemo));
+		it('should decode memo to withdrawal', () => {
+			const memo = new Uint8Array([
+				130, 0, 129, 84, 221, 40, 81, 205, 212, 10, 230, 83, 104, 49, 85, 141, 212, 109, 182, 47,
+				172, 122, 132, 77
+			]);
 
-			expect(decodeBurnMemo(memo)).toEqual(decodedMemo);
+			const [type, values] = decodeBurnMemo(memo);
+
+			expect(type).toEqual(BURN_MEMO_CONVERT);
+
+			const [to_address] = values;
+
+			expect(uint8ArrayToHexString(to_address as Uint8Array)).toEqual(
+				'dd2851cdd40ae6536831558dd46db62fac7a844d'
+			);
 		});
 	});
 });


### PR DESCRIPTION
Use similar memo and expected value as the `encode` purpose tests implemented in ckETH backend: https://docs.google.com/document/d/1rmOWTL7_MrkiUHVUlX1UP7_cqB97VSNFEcedHiF5cIc/edit