### PR TITLE
feat: rename ckbtc check incoming BTC

### DIFF
--- a/src/frontend/src/icp/components/receive/IcReceiveBitcoin.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveBitcoin.svelte
@@ -88,14 +88,14 @@
 			<span in:blur>Checking BTC status...</span>
 		</div>{:else}
 		<button in:blur class="text text-blue border-0" on:click={async () => await receive()}
-			><IconSync /> Check for incoming BTC</button
+			><IconSync /> Refresh</button
 		>
 	{/if}
 {/if}
 
 {#if $modalReceiveBitcoin}
 	<Modal on:nnsClose={modalStore.close} disablePointerEvents={true}>
-		<svelte:fragment slot="title">Check BTC status</svelte:fragment>
+		<svelte:fragment slot="title">Refresh BTC status</svelte:fragment>
 
 		<div>
 			<IcReceiveBitcoinProgress bind:receiveProgressStep />

--- a/src/frontend/src/icp/components/receive/IcReceiveBitcoin.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveBitcoin.svelte
@@ -85,7 +85,7 @@
 	{#if ckBtcUpdateBalanceSyncState === 'in_progress'}<div
 			class="text-misty-rose flex gap-2.5 animate-pulse"
 		>
-			<span in:blur>Checking for incoming BTC...</span>
+			<span in:blur>Checking BTC status...</span>
 		</div>{:else}
 		<button in:blur class="text text-blue border-0" on:click={async () => await receive()}
 			><IconSync /> Check for incoming BTC</button
@@ -95,7 +95,7 @@
 
 {#if $modalReceiveBitcoin}
 	<Modal on:nnsClose={modalStore.close} disablePointerEvents={true}>
-		<svelte:fragment slot="title">Check for incoming BTC</svelte:fragment>
+		<svelte:fragment slot="title">Check BTC status</svelte:fragment>
 
 		<div>
 			<IcReceiveBitcoinProgress bind:receiveProgressStep />

--- a/src/frontend/src/icp/components/receive/IcReceiveBitcoinProgress.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveBitcoinProgress.svelte
@@ -19,7 +19,7 @@
 		} as ProgressStep,
 		{
 			step: UpdateBalanceCkBtcStep.RELOAD,
-			text: 'Refreshing UI...',
+			text: 'Refreshing wallet...',
 			state: 'next'
 		} as ProgressStep
 	];


### PR DESCRIPTION
Manually firing "Check for incoming BTC" also triggers the wallet which refreshes the BTC statuses, therefore it actually checks for "incoming and outgoing BTC" that's why I suggest to rename the call to action.