### PR TITLE
feat: disable btc status timer as well

### DIFF
--- a/src/frontend/src/icp/constants/ckbtc.constants.ts
+++ b/src/frontend/src/icp/constants/ckbtc.constants.ts
@@ -1,4 +1,3 @@
-import { SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
 import { BtcNetwork } from '@dfinity/ckbtc';
 
 export const BTC_NETWORK: BtcNetwork =
@@ -11,6 +10,6 @@ export const BTC_NETWORK_ID = Symbol(BTC_NETWORK_SYMBOL);
 export const BTC_DECIMALS = 8;
 
 // Worker refresh rate
-export const BTC_STATUSES_TIMER_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 1000; // 1 minute in milliseconds
+export const BTC_STATUSES_TIMER_INTERVAL_MILLIS = 'disabled';
 export const CKBTC_UPDATE_BALANCE_TIMER_INTERVAL_MILLIS = 'disabled';
 export const CKBTC_MINTER_INFO_TIMER = 'disabled';


### PR DESCRIPTION
That way everything ckBTC has to be manually triggered and it's consistent for a first version.