### PR TITLE
feat: redo eip155 for eth on local

### DIFF
--- a/src/frontend/src/env/eip155-chains.env.ts
+++ b/src/frontend/src/env/eip155-chains.env.ts
@@ -4,15 +4,12 @@ import {
 	SEPOLIA_NETWORK,
 	SEPOLIA_NETWORK_CHAIN_ID
 } from '$env/networks.env';
-import { ETH_MAINNET_ENABLED } from '$env/networks.eth.env';
 
 export const EIP155_CHAINS: Record<string, { chainId: number; name: string }> = {
-	...(ETH_MAINNET_ENABLED && {
-		[`eip155:${ETHEREUM_NETWORK_CHAIN_ID}`]: {
-			chainId: Number(ETHEREUM_NETWORK_CHAIN_ID),
-			name: ETHEREUM_NETWORK.name
-		}
-	}),
+	[`eip155:${ETHEREUM_NETWORK_CHAIN_ID}`]: {
+		chainId: Number(ETHEREUM_NETWORK_CHAIN_ID),
+		name: ETHEREUM_NETWORK.name
+	},
 	[`eip155:${SEPOLIA_NETWORK_CHAIN_ID}`]: {
 		chainId: Number(SEPOLIA_NETWORK_CHAIN_ID),
 		name: SEPOLIA_NETWORK.name


### PR DESCRIPTION
Given that I often develop locally using Uniswap (prod) which always requires Eth, if Eth is not present in the list of Eip155 I cannot connect. So let's redo having it always in the list.