### PR TITLE
build: set cargo resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "src/backend",
     "src/shared"
 ]
+resolver = "2"


### PR DESCRIPTION
> warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
