### PR TITLE
build: remove raw exception for favicons

### DIFF
--- a/src/frontend/static/.ic-assets.json
+++ b/src/frontend/static/.ic-assets.json
@@ -12,9 +12,5 @@
 			"Referrer-Policy": "same-origin",
 			"X-XSS-Protection": "1; mode=block"
 		}
-	},
-	{
-		"match": "**/favicons/**/*",
-		"allow_raw_access": true
 	}
 ]


### PR DESCRIPTION
Not required anymore following the removal of the SW