### PR TITLE
refactor: rename Token and UserToken

### DIFF
--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -3,20 +3,20 @@ use crate::utils::mock::CALLER;
 use crate::utils::pocketic::{query_call, setup, update_call};
 use candid::Principal;
 use lazy_static::lazy_static;
-use shared::types::custom_token::{CustomToken, IcrcToken, UserToken, CustomTokenId};
+use shared::types::custom_token::{CustomToken, CustomTokenId, IcrcToken, Token};
 
 lazy_static! {
     static ref ICRC_TOKEN: IcrcToken = IcrcToken {
         ledger_id: Principal::from_text("ddsp7-7iaaa-aaaaq-aacqq-cai".to_string()).unwrap(),
         index_id: Principal::from_text("dnqcx-eyaaa-aaaaq-aacrq-cai".to_string()).unwrap(),
     };
-    static ref USER_TOKEN: UserToken = UserToken {
-        token: CustomToken::Icrc(ICRC_TOKEN.clone()),
+    static ref USER_TOKEN: CustomToken = CustomToken {
+        token: Token::Icrc(ICRC_TOKEN.clone()),
         enabled: true
     };
     static ref USER_TOKEN_ID: CustomTokenId = CustomTokenId::Icrc(ICRC_TOKEN.ledger_id.clone());
-    static ref ANOTHER_USER_TOKEN: UserToken = UserToken {
-        token: CustomToken::Icrc(IcrcToken {
+    static ref ANOTHER_USER_TOKEN: CustomToken = CustomToken {
+        token: Token::Icrc(IcrcToken {
             ledger_id: Principal::from_text("uf2wh-taaaa-aaaaq-aabna-cai".to_string()).unwrap(),
             index_id: Principal::from_text("ux4b6-7qaaa-aaaaq-aaboa-cai".to_string()).unwrap(),
         }),
@@ -55,15 +55,15 @@ fn test_update_user_token() {
 
     assert!(result.is_ok());
 
-    let results = query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
+    let results = query_call::<Vec<CustomToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![USER_TOKEN.clone()];
+    let expected_tokens: Vec<CustomToken> = vec![USER_TOKEN.clone()];
 
     assert!(results.is_ok());
 
     assert_custom_tokens_eq(results.unwrap(), expected_tokens);
 
-    let update_token: UserToken = UserToken {
+    let update_token: CustomToken = CustomToken {
         enabled: false,
         token: USER_TOKEN.token.clone(),
     };
@@ -78,9 +78,9 @@ fn test_update_user_token() {
     assert!(update_result.is_ok());
 
     let updated_results =
-        query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
+        query_call::<Vec<CustomToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
 
-    let expected_updated_tokens: Vec<UserToken> = vec![update_token.clone()];
+    let expected_updated_tokens: Vec<CustomToken> = vec![update_token.clone()];
 
     assert!(updated_results.is_ok());
 
@@ -93,7 +93,7 @@ fn test_add_many_user_custom_tokens() {
 
     let caller = Principal::from_text(CALLER.to_string()).unwrap();
 
-    let tokens: Vec<UserToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
+    let tokens: Vec<CustomToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
 
     let result = update_call::<()>(&pic_setup, caller, "set_many_user_custom_tokens", tokens);
 
@@ -106,7 +106,7 @@ fn test_update_many_user_tokens() {
 
     let caller = Principal::from_text(CALLER.to_string()).unwrap();
 
-    let tokens: Vec<UserToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
+    let tokens: Vec<CustomToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
 
     let result = update_call::<()>(
         &pic_setup,
@@ -117,23 +117,23 @@ fn test_update_many_user_tokens() {
 
     assert!(result.is_ok());
 
-    let results = query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
+    let results = query_call::<Vec<CustomToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
 
     assert!(results.is_ok());
 
     assert_custom_tokens_eq(results.unwrap(), tokens.clone());
 
-    let update_token: UserToken = UserToken {
+    let update_token: CustomToken = CustomToken {
         enabled: false,
         token: USER_TOKEN.token.clone(),
     };
 
-    let update_another_token: UserToken = UserToken {
+    let update_another_token: CustomToken = CustomToken {
         enabled: false,
         token: ANOTHER_USER_TOKEN.token.clone(),
     };
 
-    let update_tokens: Vec<UserToken> = vec![update_token.clone(), update_another_token.clone()];
+    let update_tokens: Vec<CustomToken> = vec![update_token.clone(), update_another_token.clone()];
 
     let update_result = update_call::<()>(
         &pic_setup,
@@ -145,7 +145,7 @@ fn test_update_many_user_tokens() {
     assert!(update_result.is_ok());
 
     let updated_results =
-        query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
+        query_call::<Vec<CustomToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
 
     assert!(updated_results.is_ok());
 
@@ -197,9 +197,9 @@ fn test_list_user_custom_tokens() {
         ANOTHER_USER_TOKEN.clone(),
     );
 
-    let results = query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
+    let results = query_call::<Vec<CustomToken>>(&pic_setup, caller, "list_user_custom_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
+    let expected_tokens: Vec<CustomToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
 
     assert!(results.is_ok());
 
@@ -278,7 +278,7 @@ fn test_user_cannot_list_another_user_tokens() {
             .unwrap();
 
     let results =
-        query_call::<Vec<UserToken>>(&pic_setup, another_caller, "list_user_custom_tokens", ());
+        query_call::<Vec<CustomToken>>(&pic_setup, another_caller, "list_user_custom_tokens", ());
 
     assert!(results.is_ok());
 

--- a/src/backend/tests/it/token.rs
+++ b/src/backend/tests/it/token.rs
@@ -5,16 +5,16 @@ use crate::utils::mock::{
 use crate::utils::pocketic::{query_call, setup, update_call};
 use candid::Principal;
 use lazy_static::lazy_static;
-use shared::types::token::{Token, TokenId};
+use shared::types::token::{UserToken, UserTokenId};
 
 lazy_static! {
-    static ref MOCK_TOKEN: Token = Token {
+    static ref MOCK_TOKEN: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
         contract_address: WEENUS_CONTRACT_ADDRESS.to_string(),
         decimals: Some(WEENUS_DECIMALS),
         symbol: Some(WEENUS_SYMBOL.to_string()),
     };
-    static ref MOCK_TOKEN_ID: TokenId = TokenId {
+    static ref MOCK_TOKEN_ID: UserTokenId = UserTokenId {
         chain_id: MOCK_TOKEN.chain_id.clone(),
         contract_address: MOCK_TOKEN.contract_address.clone(),
     };
@@ -41,7 +41,7 @@ fn test_update_user_token() {
 
     assert!(result.is_ok());
 
-    let update_token: Token = Token {
+    let update_token: UserToken = UserToken {
         symbol: Some("Updated".to_string()),
         ..MOCK_TOKEN.clone()
     };
@@ -51,9 +51,9 @@ fn test_update_user_token() {
 
     assert!(update_result.is_ok());
 
-    let results = query_call::<Vec<Token>>(&pic_setup, caller, "list_user_tokens", ());
+    let results = query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<Token> = vec![update_token.clone()];
+    let expected_tokens: Vec<UserToken> = vec![update_token.clone()];
 
     assert!(results.is_ok());
 
@@ -88,7 +88,7 @@ fn test_list_user_tokens() {
 
     let _ = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
-    let another_token: Token = Token {
+    let another_token: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
         contract_address: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984".to_string(),
         decimals: Some(18),
@@ -97,9 +97,9 @@ fn test_list_user_tokens() {
 
     let _ = update_call::<()>(&pic_setup, caller, "add_user_token", another_token.clone());
 
-    let results = query_call::<Vec<Token>>(&pic_setup, caller, "list_user_tokens", ());
+    let results = query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<Token> = vec![MOCK_TOKEN.clone(), another_token.clone()];
+    let expected_tokens: Vec<UserToken> = vec![MOCK_TOKEN.clone(), another_token.clone()];
 
     assert!(results.is_ok());
 
@@ -112,7 +112,7 @@ fn test_add_user_token_symbol_max_length() {
 
     let caller = Principal::from_text(CALLER.to_string()).unwrap();
 
-    let token: Token = Token {
+    let token: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
         contract_address: WEENUS_CONTRACT_ADDRESS.to_string(),
         decimals: Some(WEENUS_DECIMALS),
@@ -193,7 +193,7 @@ fn test_user_cannot_list_another_user_tokens() {
         Principal::from_text("yaa3n-twfur-6xz6e-3z7ep-xln56-222kz-w2b2m-y5wqz-vu6kk-s3fdg-lqe")
             .unwrap();
 
-    let results = query_call::<Vec<Token>>(&pic_setup, another_caller, "list_user_tokens", ());
+    let results = query_call::<Vec<UserToken>>(&pic_setup, another_caller, "list_user_tokens", ());
 
     assert!(results.is_ok());
 

--- a/src/backend/tests/it/upgrade.rs
+++ b/src/backend/tests/it/upgrade.rs
@@ -60,3 +60,38 @@ fn test_upgrade_allowed_caller_eth_address_of() {
     assert!(post_upgrade_result.is_ok());
     assert_eq!(post_upgrade_result.unwrap(), CALLER_ETH_ADDRESS.to_string());
 }
+
+#[test]
+fn test_upgrade_add_user_token() {
+    // Deploy a released canister
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
+
+    pic_setup.0.tick();
+
+    // Upgrade canister with new wasm
+    upgrade(&pic_setup).unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
+
+    // Add a user token
+    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+
+    let token: UserToken = UserToken {
+        chain_id: 11155111,
+        contract_address: WEENUS_CONTRACT_ADDRESS.to_string(),
+        decimals: Some(WEENUS_DECIMALS),
+        symbol: Some(WEENUS_SYMBOL.to_string()),
+    };
+
+    let result = update_call::<()>(&pic_setup, caller, "add_user_token", token.clone());
+
+    // Add user token still works after upgrade?
+    assert!(result.is_ok());
+
+    // Get the list of token and check that it still contains the one we added before upgrade
+    let results = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
+
+    let expected_tokens: Vec<UserToken> = vec![token.clone()];
+
+    assert!(results.is_ok());
+
+    assert_tokens_eq(results.unwrap(), expected_tokens);
+}

--- a/src/backend/tests/it/upgrade.rs
+++ b/src/backend/tests/it/upgrade.rs
@@ -4,7 +4,7 @@ use crate::utils::mock::{
 };
 use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade};
 use candid::Principal;
-use shared::types::token::Token;
+use shared::types::token::UserToken;
 
 const BACKEND_V0_0_13_WASM_PATH: &str = "../../backend-v0.0.13.wasm.gz";
 
@@ -16,7 +16,7 @@ fn test_upgrade_user_token() {
     // Add a user token
     let caller = Principal::from_text(CALLER.to_string()).unwrap();
 
-    let token: Token = Token {
+    let token: UserToken = UserToken {
         chain_id: 11155111,
         contract_address: WEENUS_CONTRACT_ADDRESS.to_string(),
         decimals: Some(WEENUS_DECIMALS),
@@ -31,9 +31,9 @@ fn test_upgrade_user_token() {
     upgrade(&pic_setup).unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade
-    let results = update_call::<Vec<Token>>(&pic_setup, caller, "list_user_tokens", ());
+    let results = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<Token> = vec![token.clone()];
+    let expected_tokens: Vec<UserToken> = vec![token.clone()];
 
     assert!(results.is_ok());
 

--- a/src/backend/tests/it/utils/assertion.rs
+++ b/src/backend/tests/it/utils/assertion.rs
@@ -1,7 +1,7 @@
-use shared::types::custom_token::UserToken;
-use shared::types::token::Token;
+use shared::types::custom_token::CustomToken;
+use shared::types::token::UserToken;
 
-pub fn assert_tokens_eq(results_tokens: Vec<Token>, expected_tokens: Vec<Token>) {
+pub fn assert_tokens_eq(results_tokens: Vec<UserToken>, expected_tokens: Vec<UserToken>) {
     assert_eq!(results_tokens.len(), expected_tokens.len());
 
     for (token, expected) in results_tokens.iter().zip(expected_tokens.iter()) {
@@ -12,7 +12,10 @@ pub fn assert_tokens_eq(results_tokens: Vec<Token>, expected_tokens: Vec<Token>)
     }
 }
 
-pub fn assert_custom_tokens_eq(results_tokens: Vec<UserToken>, expected_tokens: Vec<UserToken>) {
+pub fn assert_custom_tokens_eq(
+    results_tokens: Vec<CustomToken>,
+    expected_tokens: Vec<CustomToken>,
+) {
     assert_eq!(results_tokens.len(), expected_tokens.len());
 
     for (token, expected) in results_tokens.iter().zip(expected_tokens.iter()) {

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -1,9 +1,9 @@
-use crate::types::custom_token::{CustomToken, CustomTokenId};
+use crate::types::custom_token::{CustomTokenId, Token};
 
-impl From<&CustomToken> for CustomTokenId {
-    fn from(token: &CustomToken) -> Self {
+impl From<&Token> for CustomTokenId {
+    fn from(token: &Token) -> Self {
         match token {
-            CustomToken::Icrc(token) => CustomTokenId::Icrc(token.ledger_id),
+            Token::Icrc(token) => CustomTokenId::Icrc(token.ledger_id),
         }
     }
 }

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -35,7 +35,7 @@ pub mod token {
     pub type ChainId = u64;
 
     #[derive(CandidType, Deserialize, Clone)]
-    pub struct Token {
+    pub struct UserToken {
         pub contract_address: String,
         pub chain_id: ChainId,
         pub symbol: Option<String>,
@@ -43,7 +43,7 @@ pub mod token {
     }
 
     #[derive(CandidType, Deserialize, Clone)]
-    pub struct TokenId {
+    pub struct UserTokenId {
         pub contract_address: String,
         pub chain_id: ChainId,
     }
@@ -65,13 +65,13 @@ pub mod custom_token {
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq)]
-    pub enum CustomToken {
+    pub enum Token {
         Icrc(IcrcToken),
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq)]
-    pub struct UserToken {
-        pub token: CustomToken,
+    pub struct CustomToken {
+        pub token: Token,
         pub enabled: bool,
     }
 


### PR DESCRIPTION
## Motivation

In PR [#1100](https://github.com/dfinity/oisy-wallet/pull/1100#discussion_r1565499000) we discussed the fact that using `UserToken` and `CustomToken` was confusing. This was the result of the fact that the original custom token for user for ERC20 which exists on mainnet are called `Token` and the related functions are called `add_user_token`.

To clean-up and make this more comprehensive, this PR rename the various structs.

- `Token` -> `UserToken` (ERC20, already in prod and relates to `add_user_token` which won't change)
- `UserToken` -> `CustomToken` (new custom token type we have recently added)
- `CustomToken` -> `Token` (the token enum that contains either ICRC token or future other tokens)

## Notes

After this PR, I'll provide a PR that renames the new functions that are not yet live on mainnet (`set_user_custom_token` -> `set_custom_token`).

This PR does not update the did file on purpose to narrow the number of changes in the PR. I'll provide a separate PR here as well for tracability reason.

