### PR TITLE
feat: delete remove custom token

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -12,7 +12,6 @@ type CanisterStatusResultV2 = record {
 };
 type CanisterStatusType = variant { stopped; stopping; running };
 type CustomToken = record { token : Token; enabled : bool };
-type CustomTokenId = variant { Icrc : principal };
 type DefiniteCanisterSettingsArgs = record {
   controller : principal;
   freezing_threshold : nat;
@@ -63,7 +62,6 @@ service : (Arg) -> {
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
   personal_sign : (text) -> (text);
-  remove_custom_token : (CustomTokenId) -> ();
   remove_user_token : (UserTokenId) -> ();
   set_custom_token : (CustomToken) -> ();
   set_many_custom_tokens : (vec CustomToken) -> ();

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -430,15 +430,6 @@ fn set_many_custom_tokens(tokens: Vec<CustomToken>) {
     });
 }
 
-#[update(guard = "caller_is_not_anonymous")]
-fn remove_custom_token(token_id: CustomTokenId) {
-    let stored_principal = StoredPrincipal(ic_cdk::caller());
-
-    let find = |t: &CustomToken| -> bool { CustomTokenId::from(&t.token) == token_id };
-
-    mutate_state(|s| remove_from_user_token(stored_principal, &mut s.custom_token, &find));
-}
-
 #[query(guard = "caller_is_not_anonymous")]
 fn list_custom_tokens() -> Vec<CustomToken> {
     let stored_principal = StoredPrincipal(ic_cdk::caller());

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -153,31 +153,6 @@ fn test_update_many_user_tokens() {
 }
 
 #[test]
-fn test_remove_custom_token() {
-    let pic_setup = setup();
-
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
-
-    let add_result = update_call::<()>(
-        &pic_setup,
-        caller,
-        "remove_custom_token",
-        USER_TOKEN_ID.clone(),
-    );
-
-    assert!(add_result.is_ok());
-
-    let remove_result = update_call::<()>(
-        &pic_setup,
-        caller,
-        "remove_custom_token",
-        USER_TOKEN_ID.clone(),
-    );
-
-    assert!(remove_result.is_ok());
-}
-
-#[test]
 fn test_list_custom_tokens() {
     let pic_setup = setup();
 
@@ -215,24 +190,6 @@ fn test_anonymous_cannot_add_user_token() {
         Principal::anonymous(),
         "set_custom_token",
         USER_TOKEN.clone(),
-    );
-
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err(),
-        "Anonymous caller not authorized.".to_string()
-    );
-}
-
-#[test]
-fn test_anonymous_cannot_remove_user_token() {
-    let pic_setup = setup();
-
-    let result = update_call::<()>(
-        &pic_setup,
-        Principal::anonymous(),
-        "remove_custom_token",
-        USER_TOKEN_ID.clone(),
     );
 
     assert!(result.is_err());

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -12,7 +12,6 @@ type CanisterStatusResultV2 = record {
 };
 type CanisterStatusType = variant { stopped; stopping; running };
 type CustomToken = record { token : Token; enabled : bool };
-type CustomTokenId = variant { Icrc : principal };
 type DefiniteCanisterSettingsArgs = record {
   controller : principal;
   freezing_threshold : nat;
@@ -63,7 +62,6 @@ service : (Arg) -> {
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
   personal_sign : (text) -> (text);
-  remove_custom_token : (CustomTokenId) -> ();
   remove_user_token : (UserTokenId) -> ();
   set_custom_token : (CustomToken) -> ();
   set_many_custom_tokens : (vec CustomToken) -> ();

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -19,7 +19,6 @@ export interface CustomToken {
 	token: Token;
 	enabled: boolean;
 }
-export type CustomTokenId = { Icrc: Principal };
 export interface DefiniteCanisterSettingsArgs {
 	controller: Principal;
 	freezing_threshold: bigint;
@@ -76,7 +75,6 @@ export interface _SERVICE {
 	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
 	list_user_tokens: ActorMethod<[], Array<UserToken>>;
 	personal_sign: ActorMethod<[string], string>;
-	remove_custom_token: ActorMethod<[CustomTokenId], undefined>;
 	remove_user_token: ActorMethod<[UserTokenId], undefined>;
 	set_custom_token: ActorMethod<[CustomToken], undefined>;
 	set_many_custom_tokens: ActorMethod<[Array<CustomToken>], undefined>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -51,7 +51,6 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Token = IDL.Variant({ Icrc: IcrcToken });
 	const CustomToken = IDL.Record({ token: Token, enabled: IDL.Bool });
-	const CustomTokenId = IDL.Variant({ Icrc: IDL.Principal });
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -75,7 +74,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)]),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)]),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
-		remove_custom_token: IDL.Func([CustomTokenId], [], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -51,7 +51,6 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Token = IDL.Variant({ Icrc: IcrcToken });
 	const CustomToken = IDL.Record({ token: Token, enabled: IDL.Bool });
-	const CustomTokenId = IDL.Variant({ Icrc: IDL.Principal });
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -75,7 +74,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], ['query']),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)], ['query']),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
-		remove_custom_token: IDL.Func([CustomTokenId], [], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),


### PR DESCRIPTION
## Motivation

We are not using `remove_custom_token` function. Given that the changes are not yet live nor deployed anywhere, it's a good time to remove it instead of building tech depth.