### PR TITLE
fix: init analytics on sub-pages direct access

### DIFF
--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -16,7 +16,10 @@ export const initAnalytics = async () => {
 
 	await initOrbiter({
 		satelliteId: SATELLITE_ID,
-		orbiterId: ORBITER_ID
+		orbiterId: ORBITER_ID,
+		worker: {
+			path: '/workers/analytics.worker.js'
+		}
 	});
 };
 


### PR DESCRIPTION
When pages are accessed directly - e.g. oisy.com/transactions... - it seems that the canister cannot resolve the route if the url contains a `./` instead of `/` as the default path to load the worker.