### PR TITLE
feat: revert cketh signatures

### DIFF
--- a/src/frontend/src/env/networks.cketh.env.ts
+++ b/src/frontend/src/env/networks.cketh.env.ts
@@ -1,12 +1,7 @@
-import { SEPOLIA_NETWORK_ID } from '$env/networks.env';
-import type { NetworkId } from '$lib/types/network';
+// ckETH helper event signature. Immutable. Similar on Mainnet and Sepolia.
+export const CKETH_HELPER_CONTRACT_SIGNATURE =
+	'0x257e057bb61920d8d0ed2cb7b720ac7f9c513cd1110bc9fa543079154f45f435';
 
-// ckETH helper event signature. Immutable.
-export const CKETH_HELPER_CONTRACT_SIGNATURES: Record<NetworkId, string> = {
-	[SEPOLIA_NETWORK_ID]: '0x257e057bb61920d8d0ed2cb7b720ac7f9c513cd1110bc9fa543079154f45f435'
-};
-
-// ckErc20 helper event signature. Same for all Erc20 helpers. Immutable.
-export const CKERC20_HELPER_CONTRACT_SIGNATURES: Record<NetworkId, string> = {
-	[SEPOLIA_NETWORK_ID]: '0x4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b'
-};
+// ckErc20 helper event signature. Same for all Erc20 helpers. Immutable. Similar on Mainnet and Sepolia.
+export const CKERC20_HELPER_CONTRACT_SIGNATURE =
+	'0x4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b';

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -1,6 +1,6 @@
 import {
-	CKERC20_HELPER_CONTRACT_SIGNATURES,
-	CKETH_HELPER_CONTRACT_SIGNATURES
+	CKERC20_HELPER_CONTRACT_SIGNATURE,
+	CKETH_HELPER_CONTRACT_SIGNATURE
 } from '$env/networks.cketh.env';
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
@@ -47,38 +47,6 @@ export const loadCkEthereumPendingTransactions = async ({
 	});
 };
 
-const contractSignature = ({
-	env,
-	twinToken
-}: { env: Record<NetworkId, string> } & IcCkTwinToken): string | undefined => {
-	const {
-		symbol,
-		network: { id: twinTokenNetworkId }
-	} = twinToken;
-
-	const signature = env[twinTokenNetworkId];
-
-	if (isNullish(signature)) {
-		const {
-			transactions: {
-				error: { helper_signature_missing }
-			}
-		} = get(i18n);
-
-		toastsError({
-			msg: {
-				text: replacePlaceholders(helper_signature_missing, {
-					$token: symbol
-				})
-			}
-		});
-
-		return undefined;
-	}
-
-	return signature;
-};
-
 const loadCkETHPendingTransactions = async ({
 	toAddress,
 	twinToken,
@@ -89,16 +57,11 @@ const loadCkETHPendingTransactions = async ({
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
 } & IcCkTwinToken) => {
-	const signature = contractSignature({
-		env: CKETH_HELPER_CONTRACT_SIGNATURES,
-		twinToken
-	});
-
-	if (isNullish(signature)) {
-		return;
-	}
-
-	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [signature, null, to];
+	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
+		CKETH_HELPER_CONTRACT_SIGNATURE,
+		null,
+		to
+	];
 
 	await loadPendingTransactions({
 		toAddress,
@@ -118,16 +81,12 @@ const loadCkErc20PendingTransactions = async ({
 	identity: OptionIdentity;
 	token: IcToken;
 } & IcCkTwinToken) => {
-	const signature = contractSignature({
-		env: CKERC20_HELPER_CONTRACT_SIGNATURES,
-		twinToken
-	});
-
-	if (isNullish(signature)) {
-		return;
-	}
-
-	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [signature, null, null, to];
+	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
+		CKERC20_HELPER_CONTRACT_SIGNATURE,
+		null,
+		null,
+		to
+	];
 
 	await loadPendingTransactions({
 		toAddress,

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -474,8 +474,7 @@
 			"uncertified_transactions_removed": "Several uncertified transactions were identified and subsequently removed from the displayed lists.",
 			"loading_pending_ck_ethereum_transactions": "Something went wrong while fetching the pending $network transactions.",
 			"get_transaction_for_hash": "Failed to get the transaction from the provided (hash: $hash).",
-			"unexpected_transaction_for_hash": "Something went wrong while loading the pending for hash: $hash.",
-			"helper_signature_missing": "Error the signature for the $token helper contract is not configured."
+			"unexpected_transaction_for_hash": "Something went wrong while loading the pending for hash: $hash."
 		}
 	}
 }

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -413,7 +413,6 @@ interface I18nTransactions {
 		loading_pending_ck_ethereum_transactions: string;
 		get_transaction_for_hash: string;
 		unexpected_transaction_for_hash: string;
-		helper_signature_missing: string;
 	};
 }
 


### PR DESCRIPTION
The signatures are similar on homestead and sepolia.
We still keep those hardcoded values as environments values rather than in constants.