### PR TITLE
build: run backend tests on ubuntu 20.04

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -6,10 +6,13 @@ on:
       - 'src/backend/**'
       - 'src/shared/**'
 
+env:
+  RUNNER_OS: ubuntu-20.04
+
 jobs:
 
   docker-build-base:
-    runs-on: ubuntu-latest
+    runs-on: ${{ env.RUNNER_OS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,7 +21,7 @@ jobs:
         uses: ./.github/actions/docker-build-base
 
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ env.RUNNER_OS }}
     needs: docker-build-base
     strategy:
       matrix:
@@ -37,7 +40,7 @@ jobs:
           target: ${{ matrix.target }}
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ env.RUNNER_OS }}
     needs: [ 'docker-build' ]
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +65,7 @@ jobs:
 
   may-merge:
     needs: [ 'tests' ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ env.RUNNER_OS }}
     steps:
       - name: Cleared for merging
         run: echo OK


### PR DESCRIPTION
Microsoft has issue so downgrade ubuntu at least for now.

Our pipeline issue: https://github.com/dfinity/oisy-wallet/actions/runs/8816195026/job/24199782484?pr=1150

Thread: https://github.com/orgs/community/discussions/120966