### PR TITLE
build: upgrade stable structures to embed fix for memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a314297eb9edb4bbcc2e04d2e634e38d5900b68eadae661e927946d1aba3f9f7"
+checksum = "07e2282054c8ddf0cb2a7abf5c174c373917b4345c9a096ae4aa7f7185cdcdc7"
 dependencies = [
  "ic_principal",
 ]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -12,7 +12,7 @@ ic-cdk-macros.workspace = true
 candid.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
-ic-stable-structures = "0.6.3"
+ic-stable-structures = "0.6.4"
 ethers-core = "= 2.0.11"
 futures = "0.3"
 k256 = "0.13"


### PR DESCRIPTION
Update the `ic-stable-structures` crate to inherit the fix a memory leak in the `BTreeMap`.

See release notes: https://github.com/dfinity/stable-structures/releases/tag/v0.6.4