### PR TITLE
feat(backend): optional index canister id

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -34,7 +34,7 @@ type HttpResponse = record {
   headers : vec record { text; text };
   status_code : nat16;
 };
-type IcrcToken = record { ledger_id : principal; index_id : principal };
+type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   ecdsa_key_name : text;
   allowed_callers : vec principal;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -34,7 +34,7 @@ type HttpResponse = record {
   headers : vec record { text; text };
   status_code : nat16;
 };
-type IcrcToken = record { ledger_id : principal; index_id : principal };
+type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   ecdsa_key_name : text;
   allowed_callers : vec principal;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -40,7 +40,7 @@ export interface HttpResponse {
 }
 export interface IcrcToken {
 	ledger_id: Principal;
-	index_id: Principal;
+	index_id: [] | [Principal];
 }
 export interface InitArg {
 	ecdsa_key_name: string;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -48,7 +48,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const IcrcToken = IDL.Record({
 		ledger_id: IDL.Principal,
-		index_id: IDL.Principal
+		index_id: IDL.Opt(IDL.Principal)
 	});
 	const Token = IDL.Variant({ Icrc: IcrcToken });
 	const CustomToken = IDL.Record({

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -48,7 +48,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const IcrcToken = IDL.Record({
 		ledger_id: IDL.Principal,
-		index_id: IDL.Principal
+		index_id: IDL.Opt(IDL.Principal)
 	});
 	const Token = IDL.Variant({ Icrc: IcrcToken });
 	const CustomToken = IDL.Record({

--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -58,7 +58,7 @@
 				token: {
 					Icrc: {
 						ledger_id: Principal.fromText(ledgerCanisterId),
-						index_id: Principal.fromText(indexCanisterId)
+						index_id: toNullable(Principal.fromText(indexCanisterId))
 					}
 				}
 			}

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -26,7 +26,7 @@ export const saveCustomTokens = async ({
 			token: {
 				Icrc: {
 					ledger_id: Principal.fromText(ledgerCanisterId),
-					index_id: Principal.fromText(indexCanisterId)
+					index_id: toNullable(Principal.fromText(indexCanisterId))
 				}
 			}
 		}))

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -127,18 +127,27 @@ const loadCustomIcrcTokensData = async ({
 			}
 		} = token;
 
-		const ledgerCanisterId = ledger_id.toText();
+		const indexCanisterId = fromNullable(index_id);
+
+		// Index canister ID currently mandatory in Oisy's frontend
+		if (isNullish(indexCanisterId)) {
+			return undefined;
+		}
+
+		const ledgerCanisterIdText = ledger_id.toText();
 
 		// For performance reasons, if we can build the token metadata using the known custom tokens from the environments, we do so and save a call to the ledger to fetch the metadata.
 		const meta = buildIcrcCustomTokenMetadataPseudoResponse({
 			icrcCustomTokens: indexedIcrcCustomTokens,
-			ledgerCanisterId
+			ledgerCanisterId: ledgerCanisterIdText
 		});
 
 		const data: IcrcLoadData = {
-			metadata: nonNullish(meta) ? meta : await metadata({ ledgerCanisterId, identity, certified }),
-			ledgerCanisterId: ledger_id.toText(),
-			indexCanisterId: index_id.toText(),
+			metadata: nonNullish(meta)
+				? meta
+				: await metadata({ ledgerCanisterId: ledgerCanisterIdText, identity, certified }),
+			ledgerCanisterId: ledgerCanisterIdText,
+			indexCanisterId: indexCanisterId.toText(),
 			position: ICRC_TOKENS.length + 1 + index,
 			category: 'custom',
 			icrcCustomTokens: indexedIcrcCustomTokens

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -72,7 +72,7 @@ pub mod custom_token {
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
     pub struct IcrcToken {
         pub ledger_id: LedgerId,
-        pub index_id: IndexId,
+        pub index_id: Option<IndexId>,
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
# Motivation

We've noticed that many custom ICRC tokens on the IC currently have no indexer or are not using the so-called "Index" canister for such a purpose. While an Index canister is currently mandatory in the Oisy frontend, we cannot rule out that at some point in the future we might decide to make this information optional. This would provide fewer features for those tokens that do not have an index or to handle features differently.

Given that our latest changes are not yet in production, I think it's the right moment to change how we handle the Index canister information in the backend—i.e., to make it optional instead of mandatory. This approach will make us less prone to potential migration if we ever decide to take such action as described above.

# Changes

- Make `index_id` in `IcrcToken` optional
- Adapt test to run those which modify the states with and without value
- Generate did types and adapt frontend accordingly