### PR TITLE
fix: Nodejs uses utf8 not utf-8

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -94,7 +94,7 @@ const injectLinkPreloader = (indexHtml) => {
  * 3. we use our custom script loader to load the main.js script
  */
 const extractStartScript = (htmlFile) => {
-	const indexHtml = readFileSync(htmlFile, 'utf-8');
+	const indexHtml = readFileSync(htmlFile, 'utf8');
 
 	const svelteKitStartScript = /(<script>)([\s\S]*?)(<\/script>)/gm;
 
@@ -114,7 +114,7 @@ const extractStartScript = (htmlFile) => {
 		.replaceAll('document.currentScript.parentElement', "document.querySelector('body')")
 		.replaceAll(/__sveltekit_(.*)\s=/g, 'window.$&');
 
-	writeFileSync(join(folderPath, 'main.js'), moduleScript, 'utf-8');
+	writeFileSync(join(folderPath, 'main.js'), moduleScript, 'utf8');
 
 	// 3. Replace original SvelteKit script tag content with empty
 	return indexHtml.replace(svelteKitStartScript, '$1$3');

--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -13,7 +13,7 @@ const replaceEnv = ({ html, pattern, value }) => {
 };
 
 const parseMetadata = (targetFile) => {
-	let content = readFileSync(targetFile, 'utf-8');
+	let content = readFileSync(targetFile, 'utf8');
 
 	const METADATA_KEYS = [
 		'VITE_OISY_NAME',
@@ -39,7 +39,7 @@ const parseMetadata = (targetFile) => {
 };
 
 const parseUrl = (filePath) => {
-	let content = readFileSync(filePath, 'utf-8');
+	let content = readFileSync(filePath, 'utf8');
 
 	content = replaceEnv({
 		html: content,
@@ -68,7 +68,7 @@ const removeMetaRobots = (targetFile) => {
 		return;
 	}
 
-	let content = readFileSync(targetFile, 'utf-8');
+	let content = readFileSync(targetFile, 'utf8');
 
 	const update = content.replace(/<meta\s+name="robots"\s+content="noindex"\s*\/>/, '');
 

--- a/scripts/did.delete.types.mjs
+++ b/scripts/did.delete.types.mjs
@@ -2,7 +2,7 @@ import { readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const { canisters } = JSON.parse(
-	(await readFile(join(process.cwd(), 'dfx.json'))).toString('utf-8')
+	(await readFile(join(process.cwd(), 'dfx.json'))).toString('utf8')
 );
 
 const deleteFolder = async (canister) => {

--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -41,7 +41,7 @@ const cleanFactory = async ({ dest = `./src/declarations` }) => {
 					return;
 				}
 
-				const content = await readFile(factoryPath, 'utf-8');
+				const content = await readFile(factoryPath, 'utf8');
 				const cleanFactory = content.replace(
 					/export const idlFactory = \({ IDL }\) => {/g,
 					`// @ts-ignore
@@ -53,7 +53,7 @@ export const idlFactory = ({ IDL }) => {`
 export const init = ({ IDL }) => {`
 				);
 
-				await writeFile(factoryPath, cleanInit, 'utf-8');
+				await writeFile(factoryPath, cleanInit, 'utf8');
 
 				resolve();
 			})

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -15,7 +15,7 @@ const readIds = ({
 			local?: string;
 		};
 
-		const config: Record<string, Details> = JSON.parse(readFileSync(filePath, 'utf-8'));
+		const config: Record<string, Details> = JSON.parse(readFileSync(filePath, 'utf8'));
 
 		return Object.entries(config).reduce((acc, current: [string, Details]) => {
 			const [canisterName, canisterDetails] = current;
@@ -83,7 +83,7 @@ const readRemoteCanisterIds = ({ prefix }: { prefix?: string }): Record<string, 
 			canisters: Record<string, Details>;
 		};
 
-		const { canisters }: DfxJson = JSON.parse(readFileSync(dfxJsonFile, 'utf-8'));
+		const { canisters }: DfxJson = JSON.parse(readFileSync(dfxJsonFile, 'utf8'));
 
 		return Object.entries(canisters).reduce((acc, current: [string, Details]) => {
 			const [canisterName, canisterDetails] = current;


### PR DESCRIPTION
# Motivation
Nodejs refers to UTF-8 as `utf8` rather than `utf-8`.  The list of nodejs encodings is [here](https://github.com/nodejs/node/blob/main/lib/buffer.js#L615).

De-facto this has no effect as `utf-8` is supported as an alternative: https://github.com/nodejs/node/blob/main/lib/buffer.js#L717 

Meh, probably not worth changing.

# Changes
- For `readFile` and `writeFile` use `utf8` rather than `utf-8`.

# Tests
Existing tests should suffice.