### PR TITLE
refactor: modified ETH Amount Input component to use SendInputAmount generic component

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -11,7 +11,9 @@
 
 	const { feeStore: feeData, feeSymbolStore }: FeeContext = getContext<FeeContext>(FEE_CONTEXT_KEY);
 
-	let fee: BigNumber | undefined | null = undefined;
+	// TODO: This is a shortcut to provide the fee to the input amount component to calculate the
+	// max amount. This should be refactored, maybe to use a store.
+	export let fee: BigNumber | undefined | null = undefined;
 
 	let timer: NodeJS.Timeout | undefined;
 

--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -1,91 +1,74 @@
 <script lang="ts">
-	import { Input } from '@dfinity/gix-components';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import { getContext } from 'svelte';
-	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { maxGasFee, minGasFee } from '$eth/utils/fee.utils';
-	import { invalidAmount } from '$lib/utils/input.utils';
-	import { parseToken } from '$lib/utils/parse.utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import { slide } from 'svelte/transition';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { Token } from '$lib/types/token';
+	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
+	import { InsufficientFundsError } from '$lib/types/send';
+	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 
 	export let amount: number | undefined = undefined;
+	export let fee: BigNumber | undefined | null = undefined;
 	export let insufficientFunds: boolean;
-	export let nativeEthereumToken: Token;
 
-	let insufficientFundsError: string | undefined;
+	let insufficientFundsError: InsufficientFundsError | undefined = undefined;
 
 	$: insufficientFunds = nonNullish(insufficientFundsError);
 
 	const { feeStore: storeFeeData } = getContext<FeeContext>(FEE_CONTEXT_KEY);
-	const { sendTokenDecimals, sendBalance, sendTokenId } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const validate = () => {
-		if (invalidAmount(amount)) {
-			insufficientFundsError = undefined;
-			return;
-		}
-
+	$: customValidate = (userAmount: BigNumber) => {
 		if (isNullish($storeFeeData)) {
-			insufficientFundsError = undefined;
 			return;
 		}
-
-		const userAmount = parseToken({
-			value: `${amount}`,
-			unitName: $sendTokenDecimals
-		});
 
 		// If ETH, the balance should cover the user entered amount plus the min gas fee
 		if (isSupportedEthTokenId($sendTokenId)) {
 			const total = userAmount.add(minGasFee($storeFeeData));
 
 			if (total.gt($sendBalance ?? BigNumber.from(0n))) {
-				insufficientFundsError = $i18n.send.assertion.insufficient_funds_for_gas;
-				return;
+				return new InsufficientFundsError($i18n.send.assertion.insufficient_funds_for_gas);
 			}
 
-			insufficientFundsError = undefined;
 			return;
 		}
 
 		// If ERC20, the balance of the token - e.g. 20 DAI - should cover the amount entered by the user
 		if (userAmount.gt($sendBalance ?? BigNumber.from(0n))) {
-			insufficientFundsError = $i18n.send.assertion.insufficient_funds_for_amount;
-			return;
+			return new InsufficientFundsError($i18n.send.assertion.insufficient_funds_for_amount);
 		}
+
 		// Finally, if ERC20, the ETH balance should be less or greater than the max gas fee
 		const maxFee = maxGasFee($storeFeeData);
-		const ethBalance = $balancesStore?.[nativeEthereumToken.id]?.data ?? BigNumber.from(0n);
-
+		const ethBalance = $balancesStore?.[$sendToken.id]?.data ?? BigNumber.from(0n);
 		if (nonNullish(maxFee) && ethBalance.lt(maxFee)) {
-			insufficientFundsError = $i18n.send.assertion.insufficient_ethereum_funds_to_cover_the_fees;
-			return;
+			return new InsufficientFundsError(
+				$i18n.send.assertion.insufficient_ethereum_funds_to_cover_the_fees
+			);
 		}
-
-		insufficientFundsError = undefined;
 	};
 
-	const debounceValidate = debounce(validate);
-
-	$: amount, $storeFeeData, debounceValidate();
+	$: calculateMax = (): number => {
+		return getMaxTransactionAmount({
+			balance: $sendBalance?.toBigInt(),
+			fee: fee?.toBigInt(),
+			tokenDecimals: $sendTokenDecimals,
+			tokenId: $sendTokenId
+		});
+	};
 </script>
 
-<label for="amount" class="font-bold px-4.5">{$i18n.core.text.amount}:</label>
-<Input
-	name="amount"
-	inputType="currency"
-	required
-	bind:value={amount}
-	decimals={$sendTokenDecimals}
-	placeholder={$i18n.core.text.amount}
+<SendInputAmount
+	bind:amount
+	tokenDecimals={$sendTokenDecimals}
+	{customValidate}
+	{calculateMax}
+	bind:error={insufficientFundsError}
 />
-
-{#if insufficientFunds}
-	<p transition:slide={{ duration: 250 }} class="text-cyclamen pb-3">{insufficientFundsError}</p>
-{/if}

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -12,16 +12,17 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
-	import type { Token } from '$lib/types/token';
 	import type { EthereumNetwork } from '$eth/types/network';
+	import type { BigNumber } from '@ethersproject/bignumber';
 
 	export let destination = '';
 	export let network: Network | undefined = undefined;
 	export let destinationEditable = true;
 	export let amount: number | undefined = undefined;
-	export let nativeEthereumToken: Token;
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	export let sourceNetwork: EthereumNetwork;
+
+	let fee: BigNumber | undefined | null = undefined;
 
 	let insufficientFunds: boolean;
 	let invalidDestination: boolean;
@@ -43,11 +44,11 @@
 			<SendNetworkICP {destination} {sourceNetwork} bind:network />
 		{/if}
 
-		<SendAmount {nativeEthereumToken} bind:amount bind:insufficientFunds />
+		<SendAmount bind:amount {fee} bind:insufficientFunds />
 
 		<SendSource token={$sendToken} balance={$sendBalance} source={$address ?? ''} />
 
-		<FeeDisplay />
+		<FeeDisplay bind:fee />
 	</div>
 
 	<ButtonGroup>

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -222,7 +222,6 @@
 			bind:destination
 			bind:amount
 			bind:network={targetNetwork}
-			{nativeEthereumToken}
 			{destinationEditable}
 			{sourceNetwork}
 		>

--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -13,8 +13,7 @@
 	export let placeholder: string = $i18n.core.text.amount;
 	export let customValidate: (userAmount: BigNumber) => Error | undefined = () => undefined;
 	export let calculateMax: (() => number | undefined) | undefined = undefined;
-
-	let error: Error | undefined;
+	export let error: Error | undefined;
 
 	let onMax = () => {
 		amount = calculateMax?.();

--- a/src/frontend/src/lib/types/send.ts
+++ b/src/frontend/src/lib/types/send.ts
@@ -8,3 +8,5 @@ export interface TransferParams {
 	maxFeePerGas: bigint;
 	data?: string;
 }
+
+export class InsufficientFundsError extends Error {}

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -1,0 +1,29 @@
+import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
+import type { TokenId } from '$lib/types/token';
+
+/**
+ * Calculates the maximum amount for a transaction.
+ *
+ * @param {Object} params
+ * @param {bigint | undefined} params.balance The balance of the account.
+ * @param {bigint | undefined} params.fee The fee of the transaction.
+ * @param {number} params.tokenDecimals The decimals of the token.
+ * @param {TokenId} params.tokenId The token of the transaction.
+ * @returns {number} The maximum amount for the transaction.
+ */
+export const getMaxTransactionAmount = ({
+	balance = 0n,
+	fee = 0n,
+	tokenDecimals,
+	tokenId
+}: {
+	balance?: bigint;
+	fee?: bigint;
+	tokenDecimals: number;
+	tokenId: TokenId;
+}): number => {
+	if (isSupportedEthTokenId(tokenId)) {
+		return Math.max(Number(balance - fee), 0) / 10 ** tokenDecimals;
+	}
+	return Math.max(Number(balance), 0) / 10 ** tokenDecimals;
+};

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,0 +1,71 @@
+import { getMaxTransactionAmount } from '$lib/utils/token.utils';
+
+const tokenDecimals = 8;
+const tokenId = Symbol('mock');
+
+const balance = 1000000000n;
+const fee = 10000000n;
+
+vi.mock('$eth/utils/eth.utils', () => ({
+	isSupportedEthTokenId: vi.fn((id: symbol) => id === tokenId)
+}));
+
+describe('getMaxTransactionAmount', () => {
+	it('should return the correct maximum amount for a transaction', () => {
+		const result = getMaxTransactionAmount({
+			balance,
+			fee,
+			tokenDecimals: tokenDecimals,
+			tokenId: tokenId
+		});
+		expect(result).toBe(Number(balance - fee) / 10 ** tokenDecimals);
+	});
+
+	it('should return 0 if balance is less than fee', () => {
+		const result = getMaxTransactionAmount({
+			balance: fee,
+			fee: balance,
+			tokenDecimals: tokenDecimals,
+			tokenId: tokenId
+		});
+		expect(result).toBe(0);
+	});
+
+	it('should return 0 if balance and fee are undefined', () => {
+		const result = getMaxTransactionAmount({
+			balance: undefined,
+			fee: undefined,
+			tokenDecimals: tokenDecimals,
+			tokenId: tokenId
+		});
+		expect(result).toBe(0);
+	});
+
+	it('should handle balance or fee being undefined', () => {
+		let result = getMaxTransactionAmount({
+			balance: undefined,
+			fee,
+			tokenDecimals: tokenDecimals,
+			tokenId: tokenId
+		});
+		expect(result).toBe(0);
+
+		result = getMaxTransactionAmount({
+			balance,
+			fee: undefined,
+			tokenDecimals: tokenDecimals,
+			tokenId: tokenId
+		});
+		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
+	});
+
+	it('should return the untouched amount if the token is not ETH supported', () => {
+		const result = getMaxTransactionAmount({
+			balance,
+			fee,
+			tokenDecimals: tokenDecimals,
+			tokenId: Symbol('otherMock')
+		});
+		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
+	});
+});


### PR DESCRIPTION
# Motivation

Components `SendAmount` should use the generic component `SendInputAmount` that provides the Max button optionality.

# Changes

- Refactored component and its parents and peers to use the bound `fee` variable.
- Modified the validation function to return an `Error` object or `undefined`.
- Created a `calculateMax` function for each component, using function `getMaxTransactionAmount` from `token.utils.ts` file.
- Created test for `functiongetMaxTransactionAmount`.

# Tests

Manual test in the local development web-interface to confirm the correct behavior. Unittest for `functiongetMaxTransactionAmount`.
