### PR TITLE
fix: clearTimeout instead of clearInterval

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -39,7 +39,7 @@
 			return;
 		}
 
-		clearInterval(timer);
+		clearTimeout(timer);
 	});
 </script>
 

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectReview.svelte
@@ -37,7 +37,7 @@
 			return;
 		}
 
-		clearInterval(timer);
+		clearTimeout(timer);
 		timer = undefined;
 	});
 </script>


### PR DESCRIPTION
# Motivation

While reviewing #1294 I noticed existing issue where `clearInterval` are used on destroy to clean potential on going timeout.

# Changes

- replace `clearInterval` with `clearTimeout`.
