### PR TITLE
refactor: changed send.tokens script to accept the principal as input

### DIFF
--- a/scripts/send.tokens.sh
+++ b/scripts/send.tokens.sh
@@ -3,7 +3,12 @@
 # Utility Script: Send Tokens to a Local User
 # Particularly handy after installing the canisters for the first time or being forced by dfx to clean the local state.
 
-PRINCIPAL=x4w27-so7wg-cudsa-yy7fh-wcpy5-njul4-q54tv-euzzi-tdnzz-ill46-zqe
+if [ -z "$1" ]; then
+  read -r -p "Enter the PRINCIPAL: " PRINCIPAL
+else
+  PRINCIPAL=$1
+fi
+
 DFX_NETWORK=local
 
 dfx canister call ckbtc_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"$PRINCIPAL\";}; amount=1000000000; fee=null; memo=null; created_at_time=null;})"


### PR DESCRIPTION
# Motivation

The `PRINCIPAL` variable of the script `send.tokens.sh` was hard-coded. To facilitate local development testing, it now accepts the principal as input.

# Changes

Changed the script to either accept it as variable during command or to have it as user input:

```sh
# Run the script with a command-line argument
$ ./script.sh renlj-oxj5e-cma2d-yzt2e-tb5s5-wm7wi-xaytr-kxa43-2ehrp-xzkik-zae
(variant { Ok = 12 : nat })
(variant { Ok = 120 : nat })
(variant { Ok = 11 : nat })

# Run the script without a command-line argument
$ ./script.sh
Enter the PRINCIPAL: renlj-oxj5e-cma2d-yzt2e-tb5s5-wm7wi-xaytr-kxa43-2ehrp-xzkik-zae
(variant { Ok = 12 : nat })
(variant { Ok = 120 : nat })
(variant { Ok = 11 : nat })
```

# Tests

Successful manual testing for both input types on local development deployment.
