### PR TITLE
fix: estimateGas for Usdc

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -52,7 +52,9 @@
 		try {
 			const params: GetFeeData = {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				address: mapAddressStartsWith0x(destination !== '' ? destination : $address!)
+				to: mapAddressStartsWith0x(destination !== '' ? destination : $address!),
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				from: mapAddressStartsWith0x($address!)
 			};
 
 			const { getFeeData } = infuraProviders($sendToken.network.id);
@@ -73,10 +75,9 @@
 
 			const erc20GasFeeParams = {
 				contract: $sendToken as Erc20Token,
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				address: mapAddressStartsWith0x(destination !== '' ? destination : $address!),
 				amount: parseToken({ value: `${amount ?? '1'}` }),
-				sourceNetwork
+				sourceNetwork,
+				...params
 			};
 
 			// TODO: use amount + 10% to estimate fee dynamically to have some buffer

--- a/src/frontend/src/eth/providers/infura-cketh.providers.ts
+++ b/src/frontend/src/eth/providers/infura-cketh.providers.ts
@@ -29,14 +29,16 @@ export class InfuraCkETHProvider implements Erc20Provider {
 
 	getFeeData = ({
 		contract: { address: contractAddress },
-		address
+		from,
+		to
 	}: {
 		contract: Erc20ContractAddress;
-		address: ETH_ADDRESS;
+		from: ETH_ADDRESS;
+		to: ETH_ADDRESS;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const ckEthContract = new ethers.Contract(contractAddress, CKETH_ABI, this.provider);
-		return ckEthContract.estimateGas.deposit(address);
+		return ckEthContract.estimateGas.deposit(to, { from });
 	};
 
 	populateTransaction = ({

--- a/src/frontend/src/eth/providers/infura-erc20-icp.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20-icp.providers.ts
@@ -26,15 +26,17 @@ export class InfuraErc20IcpProvider implements Erc20Provider {
 
 	getFeeData = ({
 		contract: { address: contractAddress },
-		address,
+		from,
+		to,
 		amount
 	}: {
 		contract: Erc20ContractAddress;
-		address: ETH_ADDRESS;
+		to: ETH_ADDRESS;
+		from: ETH_ADDRESS;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ICP_ABI, this.provider);
-		return erc20Contract.estimateGas.burnToAccountId(amount, address);
+		return erc20Contract.estimateGas.burnToAccountId(amount, to, { from });
 	};
 
 	/**

--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -53,15 +53,17 @@ export class InfuraErc20Provider implements Erc20Provider {
 
 	getFeeData = ({
 		contract: { address: contractAddress },
-		address,
+		to,
+		from,
 		amount
 	}: {
 		contract: Erc20ContractAddress;
-		address: ETH_ADDRESS;
+		from: ETH_ADDRESS;
+		to: ETH_ADDRESS;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);
-		return erc20Contract.estimateGas.approve(address, amount);
+		return erc20Contract.estimateGas.approve(to, amount, { from });
 	};
 
 	// Transaction send: https://ethereum.stackexchange.com/a/131944

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -14,18 +14,17 @@ import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export interface GetFeeData {
-	address: ETH_ADDRESS;
+	from: ETH_ADDRESS;
+	to: ETH_ADDRESS;
 }
 
 export const getEthFeeData = async ({
-	address,
+	to,
 	helperContractAddress
 }: GetFeeData & {
 	helperContractAddress: OptionAddress;
 }): Promise<BigNumber> => {
-	if (
-		isDestinationContractAddress({ destination: address, contractAddress: helperContractAddress })
-	) {
+	if (isDestinationContractAddress({ destination: to, contractAddress: helperContractAddress })) {
 		return BigNumber.from(CKETH_FEE);
 	}
 
@@ -60,7 +59,7 @@ export const getErc20FeeData = async ({
 
 export const getCkErc20FeeData = async ({
 	erc20HelperContractAddress,
-	address,
+	to,
 	...rest
 }: GetFeeData & {
 	contract: Erc20ContractAddress;
@@ -69,13 +68,13 @@ export const getCkErc20FeeData = async ({
 	erc20HelperContractAddress: OptionAddress;
 }): Promise<BigNumber> => {
 	const estimateGasForApprove = await getErc20FeeData({
-		address,
+		to,
 		targetNetwork: undefined,
 		...rest
 	});
 
 	const targetCkErc20Helper = isDestinationContractAddress({
-		destination: address,
+		destination: to,
 		contractAddress: erc20HelperContractAddress
 	});
 

--- a/src/frontend/src/eth/types/contracts-providers.ts
+++ b/src/frontend/src/eth/types/contracts-providers.ts
@@ -23,7 +23,8 @@ export interface Erc20Provider {
 
 	getFeeData(params: {
 		contract: Erc20ContractAddress;
-		address: ETH_ADDRESS;
+		from: ETH_ADDRESS;
+		to: ETH_ADDRESS;
 		amount: BigNumber;
 	}): Promise<BigNumber>;
 }


### PR DESCRIPTION
# Motivation

Estimating the gas for USDC transactions has consistently failed, whereas it has always worked for other ERC-20 contracts. According to Ben and [Stackoverflow](https://stackoverflow.com/a/78481144/5404186) the root cause of the issue is the missing from address, which appears to be unprovidable using ethers.js. However, today I discovered that the library has a somewhat hidden option called [overrides](https://docs.ethers.org/v5/api/contract/contract/#Contract--readonly) which allows developers to override parameters when calling an ABI. By using it, we can provide the from address for contracts like USDC, which do not default to the zero address.

# Changes

- extends interface `GetFeeData` with the `from` address
- rename `GetFeeData` param `address` to `to` in order to distingish it
- implement `overrides` - i.e. `{from}` - in the prodivers to estimate the gas fee

# Stacktrace

This PR fixes following issue:

> Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="execution reverted: ERC20: approve from the zero address", method="estimateGas", transaction={"to":"0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238","data":"0x095ea7b30000000000000000000000005fab5f7b279ba540bd54e7a0c46953a61ad5c82b0000000000000000000000000000000000000000000000000de0b6b3a7640000","accessList":null}, error={"reason":"processing response error","code":"SERVER_ERROR","body":"{\"jsonrpc\":\"2.0\",\"id\":59,\"error\":{\"code\":3,\"data\":\"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002445524332303a20617070726f76652066726f6d20746865207a65726f206164647265737300000000000000000000000000000000000000000000000000000000\",\"message\":\"execution reverted: ERC20: approve from the zero address\"}}","error":{"code":3,"data":"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002445524332303a20617070726f76652066726f6d20746865207a65726f206164647265737300000000000000000000000000000000000000000000000000000000"},"requestBody":"{\"method\":\"eth_estimateGas\",\"params\":[{\"to\":\"0x1c7d4b196cb0c7b01d743fbc6116a902379c7238\",\"data\":\"0x095ea7b30000000000000000000000005fab5f7b279ba540bd54e7a0c46953a61ad5c82b0000000000000000000000000000000000000000000000000de0b6b3a7640000\"}],\"id\":59,\"jsonrpc\":\"2.0\"}","requestMethod":"POST","url":"https://sepolia.infura.io/v3/bb094b985d4444e08d1358697d22dbd5"}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.7.2)
    at Cr.makeError (vendor.C9sLF6Pr.js:56:12759)
    at Cr.throwError (vendor.C9sLF6Pr.js:56:12877)
    at p4 (vendor.C9sLF6Pr.js:75:99983)
    at HD.<anonymous> (vendor.C9sLF6Pr.js:75:109439)
    at Generator.throw (<anonymous>)
    at u (vendor.C9sLF6Pr.js:75:99156)
    
    
<img width="1536" alt="Capture d’écran 2024-05-15 à 10 03 22" src="https://github.com/dfinity/oisy-wallet/assets/16886711/dd37e845-547a-42cf-be9f-f02f54913a99">
