### PR TITLE
style: remove list of custom tokens bottom margin

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcManageTokens.svelte
+++ b/src/frontend/src/icp/components/tokens/IcManageTokens.svelte
@@ -137,7 +137,7 @@
 		>
 	</button>
 {:else}
-	<div class="container stretch md:max-h-96 pr-2 mb-1 pt-1 overflow-y-auto">
+	<div class="container md:max-h-96 pr-2 pt-1 overflow-y-auto">
 		{#each tokens as token (token.symbol)}
 			<Card>
 				{token.name}


### PR DESCRIPTION
# Motivation

Remove list of custom tokens bottom margin as requested by Artem.

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-05-15 à 10 17 54" src="https://github.com/dfinity/oisy-wallet/assets/16886711/247a300f-b5c6-4b96-a8e7-41db9afc7049">
<img width="1536" alt="Capture d’écran 2024-05-15 à 10 18 07" src="https://github.com/dfinity/oisy-wallet/assets/16886711/3e274f04-8ef5-48b3-b785-f452a26b8697">

After:

<img width="1536" alt="Capture d’écran 2024-05-15 à 10 18 27" src="https://github.com/dfinity/oisy-wallet/assets/16886711/36600d54-50e7-479d-b4d2-b630f0a2dfb7">
<img width="1536" alt="Capture d’écran 2024-05-15 à 10 18 37" src="https://github.com/dfinity/oisy-wallet/assets/16886711/1548287b-b91a-437a-a1c7-26866c0c310a">

