### PR TITLE
feat: add 25% to amount to calculate fee

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -28,7 +28,6 @@
 	} from '$icp-eth/utils/cketh.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import type { Token } from '$lib/types/token';
-	import { amountForFeePlusTenPercent } from '$eth/utils/send.utils';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -76,7 +75,7 @@
 
 			const erc20GasFeeParams = {
 				contract: $sendToken as Erc20Token,
-				amount: amountForFeePlusTenPercent(amount),
+				amount: parseToken({ value: `${amount ?? '1'}` }),
 				sourceNetwork,
 				...params
 			};

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -28,6 +28,7 @@
 	} from '$icp-eth/utils/cketh.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import type { Token } from '$lib/types/token';
+	import { BigNumber } from '@ethersproject/bignumber';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -74,11 +75,12 @@
 			}
 
 			// As recommended by the cross-chain team, we add 10% to the amount to calculate the fee, providing some buffer for when the transaction is effectively executed.
-			const amountForFee = parseToken({ value: `${amount ?? '1'}` }).mul(0.1);
+			const baseAmount = parseToken({ value: `${amount ?? '1'}` });
+			const additionalAmount = baseAmount.mul(BigNumber.from('1')).div(BigNumber.from('10'));
 
 			const erc20GasFeeParams = {
 				contract: $sendToken as Erc20Token,
-				amount: amountForFee,
+				amount: baseAmount.add(additionalAmount),
 				sourceNetwork,
 				...params
 			};

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -73,14 +73,15 @@
 				return;
 			}
 
+			// As recommended by the cross-chain team, we add 10% to the amount to calculate the fee, providing some buffer for when the transaction is effectively executed.
+			const amountForFee = parseToken({ value: `${amount ?? '1'}` }).mul(0.1);
+
 			const erc20GasFeeParams = {
 				contract: $sendToken as Erc20Token,
-				amount: parseToken({ value: `${amount ?? '1'}` }),
+				amount: amountForFee,
 				sourceNetwork,
 				...params
 			};
-
-			// TODO: use amount + 10% to estimate fee dynamically to have some buffer
 
 			if (isSupportedErc20TwinTokenId($sendTokenId)) {
 				feeStore.setFee({

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -28,7 +28,7 @@
 	} from '$icp-eth/utils/cketh.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import type { Token } from '$lib/types/token';
-	import { BigNumber } from '@ethersproject/bignumber';
+	import { amountForFeePlusTenPercent } from '$eth/utils/send.utils';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -74,13 +74,9 @@
 				return;
 			}
 
-			// As recommended by the cross-chain team, we add 10% to the amount to calculate the fee, providing some buffer for when the transaction is effectively executed.
-			const baseAmount = parseToken({ value: `${amount ?? '1'}` });
-			const additionalAmount = baseAmount.mul(BigNumber.from('1')).div(BigNumber.from('10'));
-
 			const erc20GasFeeParams = {
 				contract: $sendToken as Erc20Token,
-				amount: baseAmount.add(additionalAmount),
+				amount: amountForFeePlusTenPercent(amount),
 				sourceNetwork,
 				...params
 			};

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -46,7 +46,13 @@ export const getErc20FeeData = async ({
 			nonNullish(targetNetwork) && isNetworkICP(targetNetwork)
 				? infuraErc20IcpProviders(targetNetwork.id)
 				: infuraErc20Providers(targetNetwork?.id ?? sourceNetworkId);
-		return await fn(rest);
+		const fee = await fn(rest);
+
+		// The cross-chain team recommended adding 10% to the fee to provide some buffer for when the transaction is effectively executed.
+		// However, according to our observations, we noticed that ERC20 transactions require even more fees. That is why we actually add 25%.
+		const additionalAmount = BigNumber.from(fee.toBigInt() / 4n);
+
+		return fee.add(additionalAmount);
 	} catch (err: unknown) {
 		// We silence the error on purpose.
 		// The queries above often produce errors on mainnet, even when all parameters are correctly set.

--- a/src/frontend/src/eth/utils/send.utils.ts
+++ b/src/frontend/src/eth/utils/send.utils.ts
@@ -1,9 +1,7 @@
 import { isNotSupportedErc20TwinTokenId } from '$eth/utils/token.utils';
 import type { OptionAddress } from '$lib/types/address';
 import type { TokenId } from '$lib/types/token';
-import { parseToken } from '$lib/utils/parse.utils';
 import { nonNullish } from '@dfinity/utils';
-import { BigNumber } from '@ethersproject/bignumber';
 
 export const isDestinationContractAddress = ({
 	contractAddress,
@@ -42,15 +40,4 @@ export const shouldSendWithApproval = ({
 	}
 
 	return true;
-};
-
-/**
- * As recommended by the cross-chain team, we add 10% to the amount to calculate the fee, providing some buffer for when the transaction is effectively executed.
- * @param amount An amount which can for example be entered by the user in an input field.
- * @returns The provided amount, defaulting to one if not provided, plus 10%
- */
-export const amountForFeePlusTenPercent = (amount: string | number | undefined): BigNumber => {
-	const baseAmount = parseToken({ value: `${amount ?? '1'}` });
-	const additionalAmount = baseAmount.div(BigNumber.from('10'));
-	return baseAmount.add(additionalAmount);
 };

--- a/src/frontend/src/eth/utils/send.utils.ts
+++ b/src/frontend/src/eth/utils/send.utils.ts
@@ -1,7 +1,9 @@
 import { isNotSupportedErc20TwinTokenId } from '$eth/utils/token.utils';
 import type { OptionAddress } from '$lib/types/address';
 import type { TokenId } from '$lib/types/token';
+import { parseToken } from '$lib/utils/parse.utils';
 import { nonNullish } from '@dfinity/utils';
+import { BigNumber } from '@ethersproject/bignumber';
 
 export const isDestinationContractAddress = ({
 	contractAddress,
@@ -40,4 +42,14 @@ export const shouldSendWithApproval = ({
 	}
 
 	return true;
+};
+
+/**
+ * As recommended by the cross-chain team, we add 10% to the amount to calculate the fee, providing some buffer for when the transaction is effectively executed.
+ * @param amount An amount which can for example be entered by the user in an input field.
+ * @returns The provided amount, defaulting to one if not provided, plus 10%
+ */
+export const amountForFeePlusTenPercent = (amount: string | number | undefined): BigNumber => {
+	const baseAmount = parseToken({ value: `${amount ?? '1'}` });
+	return baseAmount.mul(BigNumber.from('1')).div(BigNumber.from('10'));
 };

--- a/src/frontend/src/eth/utils/send.utils.ts
+++ b/src/frontend/src/eth/utils/send.utils.ts
@@ -51,5 +51,6 @@ export const shouldSendWithApproval = ({
  */
 export const amountForFeePlusTenPercent = (amount: string | number | undefined): BigNumber => {
 	const baseAmount = parseToken({ value: `${amount ?? '1'}` });
-	return baseAmount.mul(BigNumber.from('1')).div(BigNumber.from('10'));
+	const additionalAmount = baseAmount.div(BigNumber.from('10'));
+	return baseAmount.add(additionalAmount);
 };


### PR DESCRIPTION
# Motivation

So this morning I was looking to transfer some ERC20 transactions for PR [1294](https://github.com/dfinity/oisy-wallet/pull/1294#discussion_r1602609249) but, none of my transactions were successful. Root cause of the problem was the gas fee being entirely consumed.

A few weeks ago the cross-chain team recommended us to add a 10% to the fee as buffer, so I tried to implement this solution but, even with this amount it falled close enough.

That's why this PR adds 25% to the calculation of the ERC20 fees.

# Changes

- in `getErc20FeeData` adds a 25% to the fee result

# Test

Example of transaction that ended in error without enough gas:

https://sepolia.etherscan.io/tx/0x5b76eedfb25b6a11ad72a2b882ac624eec612c38fc57eb676fdc1e510b4429ba
https://sepolia.etherscan.io/tx/0x2dc1183471247604cf979d46d773ce21343c2db82ec15af7fc374898df9985d3

Example of transaction that succeeded with this PR:

https://sepolia.etherscan.io/tx/0xd0c119d94493c1f6cda5011414733722a7b207f68aa265219067192c820d078e