### PR TITLE
fix: classified MaxButton as non-submit button type to prevent being triggered on keydown

### DIFF
--- a/src/frontend/src/lib/components/common/MaxButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxButton.svelte
@@ -6,6 +6,7 @@
 
 <button
 	data-tid="max-button"
+	type="button"
 	on:click|preventDefault
 	class="text-blue hover:text-dark-blue active:text-dark-blue font-medium"
 	{disabled}


### PR DESCRIPTION
# Motivation

Whenever the Send form was triggered with a `keydown` event (consequentially triggering the `submit` event), the MaxButton was triggered too, overwriting the current amount in the Input component.

# Changes

Change the type of button of MaxButton component to be non-submit.

# Tests

Manual testing in local development deployment.
