### PR TITLE
feat: derive min and max gas fee

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -6,31 +6,29 @@
 	import { formatToken } from '$lib/utils/format.utils';
 	import type { FeeContext } from '$eth/stores/fee.store';
 	import { FEE_CONTEXT_KEY } from '$eth/stores/fee.store';
-	import { maxGasFee } from '$eth/utils/fee.utils';
 	import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
 
-	const { feeStore: feeData, feeSymbolStore }: FeeContext = getContext<FeeContext>(FEE_CONTEXT_KEY);
+	const { maxGasFee, feeSymbolStore }: FeeContext = getContext<FeeContext>(FEE_CONTEXT_KEY);
 
-	// TODO: This is a shortcut to provide the fee to the input amount component to calculate the
-	// max amount. This should be refactored, maybe to use a store.
-	export let fee: BigNumber | undefined | null = undefined;
+	let fee: BigNumber | undefined | null = undefined;
 
+	// The time is used to animate the UI - i.e. displays a fade animation each time the fee is updated
 	let timer: NodeJS.Timeout | undefined;
 
-	$: $feeData,
+	$: $maxGasFee,
 		(() => {
 			fee = undefined;
 
-			if (isNullish($feeData) || isNullish($feeData?.maxFeePerGas)) {
+			if (isNullish($maxGasFee)) {
 				return;
 			}
 
 			const calculateFee = () => {
-				if (isNullish($feeData) || isNullish($feeData?.maxFeePerGas)) {
+				if (isNullish($maxGasFee)) {
 					return;
 				}
 
-				fee = maxGasFee($feeData);
+				fee = $maxGasFee;
 			};
 
 			timer = setTimeout(calculateFee, 500);

--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -12,7 +12,6 @@
 
 	let fee: BigNumber | undefined | null = undefined;
 
-	// The time is used to animate the UI - i.e. displays a fade animation each time the fee is updated
 	let timer: NodeJS.Timeout | undefined;
 
 	$: $maxGasFee,

--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -14,7 +14,7 @@
 
 	let timer: NodeJS.Timeout | undefined;
 
-    // The time is used to animate the UI - i.e. displays a fade animation each time the fee is updated
+	// The time is used to animate the UI - i.e. displays a fade animation each time the fee is updated
 	$: $maxGasFee,
 		(() => {
 			fee = undefined;

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -13,7 +13,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import type { EthereumNetwork } from '$eth/types/network';
-	import type { BigNumber } from '@ethersproject/bignumber';
 
 	export let destination = '';
 	export let network: Network | undefined = undefined;
@@ -21,8 +20,6 @@
 	export let amount: number | undefined = undefined;
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	export let sourceNetwork: EthereumNetwork;
-
-	let fee: BigNumber | undefined | null = undefined;
 
 	let insufficientFunds: boolean;
 	let invalidDestination: boolean;
@@ -44,11 +41,11 @@
 			<SendNetworkICP {destination} {sourceNetwork} bind:network />
 		{/if}
 
-		<SendAmount bind:amount {fee} bind:insufficientFunds />
+		<SendAmount bind:amount bind:insufficientFunds />
 
 		<SendSource token={$sendToken} balance={$sendBalance} source={$address ?? ''} />
 
-		<FeeDisplay bind:fee />
+		<FeeDisplay />
 	</div>
 
 	<ButtonGroup>

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -11,6 +11,7 @@
 	import {
 		FEE_CONTEXT_KEY,
 		type FeeContext as FeeContextType,
+		initFeeContext,
 		initFeeStore
 	} from '$eth/stores/fee.store';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
@@ -80,10 +81,13 @@
 	let feeSymbolStore = writable<string | undefined>(undefined);
 	$: feeSymbolStore.set(nativeEthereumToken.symbol);
 
-	setContext<FeeContextType>(FEE_CONTEXT_KEY, {
-		feeStore,
-		feeSymbolStore
-	});
+	setContext<FeeContextType>(
+		FEE_CONTEXT_KEY,
+		initFeeContext({
+			feeStore,
+			feeSymbolStore
+		})
+	);
 
 	/**
 	 * Send

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -11,6 +11,7 @@
 	import {
 		FEE_CONTEXT_KEY,
 		type FeeContext as FeeContextType,
+		initFeeContext,
 		initFeeStore
 	} from '$eth/stores/fee.store';
 	import { address } from '$lib/derived/address.derived';
@@ -62,10 +63,13 @@
 	let feeSymbolStore = writable<string | undefined>(undefined);
 	$: feeSymbolStore.set($sendToken.symbol);
 
-	setContext<FeeContextType>(FEE_CONTEXT_KEY, {
-		feeStore,
-		feeSymbolStore
-	});
+	setContext<FeeContextType>(
+		FEE_CONTEXT_KEY,
+		initFeeContext({
+			feeStore,
+			feeSymbolStore
+		})
+	);
 
 	/**
 	 * Network

--- a/src/frontend/src/eth/stores/fee.store.ts
+++ b/src/frontend/src/eth/stores/fee.store.ts
@@ -1,6 +1,8 @@
+import { maxGasFee as maxGasFeeUtils, minGasFee as minGasFeeUtils } from '$eth/utils/fee.utils';
 import type { TransactionFeeData } from '$lib/types/transaction';
-import type { Readable, Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { nonNullish } from '@dfinity/utils';
+import { BigNumber } from '@ethersproject/bignumber';
+import { derived, writable, type Readable, type Writable } from 'svelte/store';
 
 export type FeeStoreData = TransactionFeeData | undefined;
 
@@ -23,6 +25,27 @@ export const initFeeStore = (): FeeStore => {
 export interface FeeContext {
 	feeStore: FeeStore;
 	feeSymbolStore: Writable<string | undefined>;
+	maxGasFee: Readable<BigNumber | undefined>;
+	minGasFee: Readable<BigNumber | undefined>;
 }
+
+export const initFeeContext = ({
+	feeStore,
+	...rest
+}: Omit<FeeContext, 'maxGasFee' | 'minGasFee'>): FeeContext => {
+	const maxGasFee = derived(feeStore, (feeData) =>
+		nonNullish(feeData) ? maxGasFeeUtils(feeData) : undefined
+	);
+	const minGasFee = derived(feeStore, (feeData) =>
+		nonNullish(feeData) ? minGasFeeUtils(feeData) : undefined
+	);
+
+	return {
+		feeStore,
+		maxGasFee,
+		minGasFee,
+		...rest
+	};
+};
 
 export const FEE_CONTEXT_KEY = Symbol('fee');


### PR DESCRIPTION
# Motivation

Instead of imperatively evaluating the maximum and minimum gas fees and passing around a fee property, we can derive these values within the Ethereum fee context.

This PR resolves a TODO created in PR #1294.

# Changes

- derive `minGasFee` and `maxGasFee` in `FeeContext`
- use those values instead of imperative calls
- resolve and remove TODO by removing property `fee`