### PR TITLE
feat: reevaluate max when fees are changing

### DIFF
--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import { getContext } from 'svelte';
-	import {debounce, isNullish, nonNullish} from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import { balancesStore } from '$lib/stores/balances.store';
@@ -68,22 +68,21 @@
 
 	const onInput = () => evaluateFee?.();
 
-    /**
-     * Reevaluate max amount if user has used the "Max" button and the fees are changing.
-     */
-    let amountSetToMax = false;
-    let sendInputAmount: SendInputAmount | undefined;
+	/**
+	 * Reevaluate max amount if user has used the "Max" button and the fees are changing.
+	 */
+	let amountSetToMax = false;
+	let sendInputAmount: SendInputAmount | undefined;
 
-    $: $storeFeeData,
-        (() => {
-            if (!amountSetToMax) {
-                return;
-            }
+	$: $maxGasFee,
+		(() => {
+			if (!amountSetToMax) {
+				return;
+			}
 
-            // TODO: we need the PR that provides the derivation of the fee in the context here
-            // Debounce to sync the UI given that the fees' display is animated with a short fade effect.
-            debounce(() => sendInputAmount?.triggerCalculateMax(), 1000)();
-        })();
+			// Debounce to sync the UI given that the fees' display is animated with a short fade effect.
+			debounce(() => sendInputAmount?.triggerCalculateMax(), 500)();
+		})();
 </script>
 
 <SendInputAmount

--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -14,10 +14,16 @@
 	export let customValidate: (userAmount: BigNumber) => Error | undefined = () => undefined;
 	export let calculateMax: (() => number | undefined) | undefined = undefined;
 	export let error: Error | undefined;
+	export let amountSetToMax = false;
+
+	export const triggerCalculateMax = () => (amount = calculateMax?.());
 
 	let onMax = () => {
+		amountSetToMax = true;
 		amount = calculateMax?.();
 	};
+
+	const onInput = () => (amountSetToMax = false);
 
 	const validate = () => {
 		if (invalidAmount(amount)) {
@@ -48,6 +54,7 @@
 	{placeholder}
 	spellcheck={false}
 	testId="amount-input"
+	on:nnsInput={onInput}
 >
 	<svelte:fragment slot="inner-end">
 		{#if nonNullish(calculateMax)}

--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -17,12 +17,12 @@
 	export let error: Error | undefined = undefined;
 	export let amountSetToMax = false;
 
-	export const triggerCalculateMax = () => (amount = calculateMax?.());
-
 	let onMax = () => {
 		amountSetToMax = true;
 		amount = calculateMax?.();
 	};
+
+	export const triggerCalculateMax = onMax;
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -7,7 +7,7 @@
 	import type { BigNumber } from '@ethersproject/bignumber';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import MaxButton from '$lib/components/common/MaxButton.svelte';
-	import {createEventDispatcher} from "svelte";
+	import { createEventDispatcher } from 'svelte';
 
 	export let amount: number | undefined = undefined;
 	export let tokenDecimals: number | undefined = undefined;
@@ -15,9 +15,9 @@
 	export let customValidate: (userAmount: BigNumber) => Error | undefined = () => undefined;
 	export let calculateMax: (() => number | undefined) | undefined = undefined;
 	export let error: Error | undefined = undefined;
-    export let amountSetToMax = false;
+	export let amountSetToMax = false;
 
-    export const triggerCalculateMax = () => (amount = calculateMax?.());
+	export const triggerCalculateMax = () => (amount = calculateMax?.());
 
 	let onMax = () => {
 		amountSetToMax = true;
@@ -27,11 +27,11 @@
 	const dispatch = createEventDispatcher();
 
 	const onInput = () => {
-        amountSetToMax = false;
+		amountSetToMax = false;
 
 		// Bubble nnsInput as consumers might require the event as well (which is the case in Oisy).
-		dispatch("nnsInput");
-    };
+		dispatch('nnsInput');
+	};
 
 	const validate = () => {
 		if (invalidAmount(amount)) {
@@ -62,7 +62,7 @@
 	{placeholder}
 	spellcheck={false}
 	testId="amount-input"
-    on:nnsInput={onInput}
+	on:nnsInput={onInput}
 >
 	<svelte:fragment slot="inner-end">
 		{#if nonNullish(calculateMax)}

--- a/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
@@ -1,6 +1,6 @@
 import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 import { assertNonNullish } from '@dfinity/utils';
-import {fireEvent, render, waitFor} from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { expect } from 'vitest';
 import en from '../../mocks/i18n.mock';
 
@@ -63,7 +63,7 @@ describe('SendInputAmount', () => {
 		await waitFor(() => {
 			const input: HTMLInputElement | null = container.querySelector(inputSelector);
 			expect(input?.value).toBe(props.calculateMax().toString());
-		})
+		});
 	});
 
 	it('should raise an error when the amount is not valid', async () => {


### PR DESCRIPTION
# Motivation

Similar to Metamask, if "Max" is used to evaluate the amount to send and the user does not modify the amount, then if the fees change, the amount should be reevaluated.

# Changes

- add a state `amountSetToMax` to `SendInputAmount` to keep track of usage of "Max" button
- expose a function to trigger the evaluation of the amount within the component
- reevalute the amount on fees change

