### PR TITLE
fix: early click on max UI race condition

### DIFF
--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -55,14 +55,16 @@
 		}
 	};
 
-	$: calculateMax = (): number => {
-		return getMaxTransactionAmount({
-			balance: $sendBalance?.toBigInt(),
-			fee: fee?.toBigInt(),
-			tokenDecimals: $sendTokenDecimals,
-			tokenId: $sendTokenId
-		});
-	};
+	let calculateMax: (() => number | undefined) | undefined;
+	$: calculateMax = isNullish(fee)
+		? undefined
+		: (): number =>
+				getMaxTransactionAmount({
+					balance: $sendBalance?.toBigInt(),
+					fee: fee?.toBigInt(),
+					tokenDecimals: $sendTokenDecimals,
+					tokenId: $sendTokenId
+				});
 </script>
 
 <SendInputAmount

--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -65,7 +65,7 @@
 					balance: $sendBalance?.toBigInt(),
 					fee: $maxGasFee.toBigInt(),
 					tokenDecimals: $sendTokenDecimals,
-                    tokenStandard: $sendTokenStandard
+					tokenStandard: $sendTokenStandard
 				});
 
 	const onInput = () => evaluateFee?.();

--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -58,15 +58,15 @@
 	};
 
 	let calculateMax: (() => number | undefined) | undefined;
-    $: calculateMax = isNullish($maxGasFee)
-        ? undefined
-        : (): number =>
-            getMaxTransactionAmount({
-                balance: $sendBalance?.toBigInt(),
-                fee: $maxGasFee.toBigInt(),
-                tokenDecimals: $sendTokenDecimals,
-                tokenId: $sendTokenId
-            });
+	$: calculateMax = isNullish($maxGasFee)
+		? undefined
+		: (): number =>
+				getMaxTransactionAmount({
+					balance: $sendBalance?.toBigInt(),
+					fee: $maxGasFee.toBigInt(),
+					tokenDecimals: $sendTokenDecimals,
+					tokenId: $sendTokenId
+				});
 
 	const onInput = () => evaluateFee?.();
 </script>

--- a/src/frontend/src/lib/components/common/MaxButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxButton.svelte
@@ -10,6 +10,7 @@
 	on:click|preventDefault
 	class="text-blue hover:text-dark-blue active:text-dark-blue font-medium"
 	{disabled}
+	class:opacity-50={disabled}
 >
 	{$i18n.core.text.max}
 </button>

--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Input } from '@dfinity/gix-components';
-	import { debounce, nonNullish } from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { slide } from 'svelte/transition';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -49,11 +49,7 @@
 	spellcheck={false}
 	testId="amount-input"
 >
-	<svelte:fragment slot="inner-end">
-		{#if nonNullish(calculateMax)}
-			<MaxButton on:click={onMax} />
-		{/if}
-	</svelte:fragment>
+	<MaxButton slot="inner-end" on:click={onMax} disabled={isNullish(calculateMax)} />
 </Input>
 
 {#if nonNullish(error)}

--- a/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
@@ -23,14 +23,14 @@ describe('SendInputAmount', () => {
 		expect(input?.value).toBe(props.amount.toString());
 	});
 
-	it('should not render a max button if calculateMax is not provided', () => {
+	it('should render a max button disabled if calculateMax is not provided', () => {
 		const { calculateMax: _, ...newProps } = props;
 		const { container } = render(SendInputAmount, { props: newProps });
 
 		const button: HTMLButtonElement | null = container.querySelector(
 			'button[data-tid="max-button"]'
 		);
-		expect(button).toBeNull();
+		expect(button).toBeDisabled();
 	});
 
 	it('should render a max button if calculateMax is provided', () => {


### PR DESCRIPTION
# Motivation

Fees are not instantly calculated, but the "Max" button is instantly available. This can lead to a UI race condition where the user clicks on the "Max" button early, which calculates the maximum amount without considering the fees. Milliseconds later, an error will inform the user that the balance is insufficient to cover the amount because the fees are ultimately estimated.

# Changes

- `MaxButton` always displayed in send amount input but disabled if no function is provided
- Provide `calculateMax` only if fees are loaded
