### PR TITLE
fix: call to fee evaluation on max race condition

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -140,7 +140,7 @@
 	$: $ckEthMinterInfoStore, debounceUpdateFeeData();
 
 	/**
-	 * Expose call to evaluate the that way consumers can re-evaluate those imperatively for example when amount or destination are manually updated by the user.
+	 * Expose a call to evaluate, so that consumers can re-evaluate imperatively, for example, when the amount or destination is manually updated by the user.
 	 */
 	export const triggerUpdateFee = () => debounceUpdateFeeData();
 </script>

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -5,7 +5,7 @@
 	import { toastsError, toastsHide } from '$lib/stores/toasts.store';
 	import { debounce } from '@dfinity/utils';
 	import { initMinedTransactionsListener } from '$eth/services/eth-listener.services';
-	import { getContext, onDestroy } from 'svelte';
+	import { getContext, onDestroy, onMount } from 'svelte';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import {
@@ -121,13 +121,14 @@
 			return;
 		}
 
-		await updateFeeData();
+		debounceUpdateFeeData();
 		listener = initMinedTransactionsListener({
 			callback: async () => debounceUpdateFeeData(),
 			networkId: sourceNetwork.id
 		});
 	};
 
+	onMount(() => debounceUpdateFeeData());
 	onDestroy(() => listener?.disconnect());
 
 	/**
@@ -136,7 +137,12 @@
 
 	$: obverseFeeData(observe);
 
-	$: amount, destination, $ckEthMinterInfoStore, debounceUpdateFeeData();
+	$: $ckEthMinterInfoStore, debounceUpdateFeeData();
+
+	/**
+	 * Expose call to evaluate the that way consumers can re-evaluate those imperatively for example when amount or destination are manually updated by the user.
+	 */
+	export const triggerUpdateFee = () => debounceUpdateFeeData();
 </script>
 
 <slot />

--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -20,7 +20,7 @@
 
 	$: insufficientFunds = nonNullish(insufficientFundsError);
 
-	const { feeStore: storeFeeData } = getContext<FeeContext>(FEE_CONTEXT_KEY);
+	const { feeStore: storeFeeData, evaluateFee } = getContext<FeeContext>(FEE_CONTEXT_KEY);
 	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 
@@ -63,6 +63,8 @@
 			tokenId: $sendTokenId
 		});
 	};
+
+	const onInput = () => evaluateFee?.();
 </script>
 
 <SendInputAmount
@@ -71,4 +73,5 @@
 	{customValidate}
 	{calculateMax}
 	bind:error={insufficientFundsError}
+	on:nnsInput={onInput}
 />

--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -18,7 +18,12 @@
 
 	$: insufficientFunds = nonNullish(insufficientFundsError);
 
-	const { feeStore: storeFeeData, minGasFee, maxGasFee, evaluateFee } = getContext<FeeContext>(FEE_CONTEXT_KEY);
+	const {
+		feeStore: storeFeeData,
+		minGasFee,
+		maxGasFee,
+		evaluateFee
+	} = getContext<FeeContext>(FEE_CONTEXT_KEY);
 	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 

--- a/src/frontend/src/eth/components/send/SendDestination.svelte
+++ b/src/frontend/src/eth/components/send/SendDestination.svelte
@@ -3,6 +3,8 @@
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isEthAddress } from '$lib/utils/account.utils';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { getContext } from 'svelte';
+	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 
 	export let destination = '';
 	export let invalidDestination = false;
@@ -15,6 +17,9 @@
 
 		return !isEthAddress(destination);
 	};
+
+	const { evaluateFee } = getContext<FeeContext>(FEE_CONTEXT_KEY);
+	const onInput = () => evaluateFee?.();
 </script>
 
 <SendInputDestination
@@ -22,4 +27,5 @@
 	bind:invalidDestination
 	{isInvalidDestination}
 	inputPlaceholder={$i18n.send.placeholder.enter_eth_address}
+	on:nnsInput={onInput}
 />

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -81,15 +81,15 @@
 	let feeSymbolStore = writable<string | undefined>(undefined);
 	$: feeSymbolStore.set(nativeEthereumToken.symbol);
 
-    let feeContext: FeeContext | undefined;
-    const evaluateFee = () => feeContext?.triggerUpdateFee();
+	let feeContext: FeeContext | undefined;
+	const evaluateFee = () => feeContext?.triggerUpdateFee();
 
 	setContext<FeeContextType>(
 		FEE_CONTEXT_KEY,
 		initFeeContext({
 			feeStore,
 			feeSymbolStore,
-            evaluateFee
+			evaluateFee
 		})
 	);
 

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -80,9 +80,13 @@
 	let feeSymbolStore = writable<string | undefined>(undefined);
 	$: feeSymbolStore.set(nativeEthereumToken.symbol);
 
+	let feeContext: FeeContext | undefined;
+	const evaluateFee = () => feeContext?.triggerUpdateFee();
+
 	setContext<FeeContextType>(FEE_CONTEXT_KEY, {
 		feeStore,
-		feeSymbolStore
+		feeSymbolStore,
+		evaluateFee
 	});
 
 	/**
@@ -193,6 +197,7 @@
 </script>
 
 <FeeContext
+	bind:this={feeContext}
 	{amount}
 	{destination}
 	observe={currentStep?.name !== 'Sending'}

--- a/src/frontend/src/eth/stores/fee.store.ts
+++ b/src/frontend/src/eth/stores/fee.store.ts
@@ -23,6 +23,7 @@ export const initFeeStore = (): FeeStore => {
 export interface FeeContext {
 	feeStore: FeeStore;
 	feeSymbolStore: Writable<string | undefined>;
+	evaluateFee?: () => void;
 }
 
 export const FEE_CONTEXT_KEY = Symbol('fee');

--- a/src/frontend/src/eth/stores/fee.store.ts
+++ b/src/frontend/src/eth/stores/fee.store.ts
@@ -27,7 +27,7 @@ export interface FeeContext {
 	feeSymbolStore: Writable<string | undefined>;
 	maxGasFee: Readable<BigNumber | undefined>;
 	minGasFee: Readable<BigNumber | undefined>;
-    evaluateFee?: () => void;
+	evaluateFee?: () => void;
 }
 
 export const initFeeContext = ({

--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -48,6 +48,7 @@
 	{placeholder}
 	spellcheck={false}
 	testId="amount-input"
+	on:nnsInput
 >
 	<svelte:fragment slot="inner-end">
 		{#if nonNullish(calculateMax)}

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -26,6 +26,7 @@
 	bind:value={destination}
 	placeholder={inputPlaceholder}
 	spellcheck={false}
+	on:nnsInput
 />
 
 {#if invalidDestination}


### PR DESCRIPTION
# Motivation

The "Max" feature is available when fees are set. In its current implementation, clicking "Max" modifies the "amount," which triggers a reevaluation of the fee. This can potentially result in a different fee being calculated.

In other words, the amount is calculated based on a fee that may change after the calculation, making the amount incorrect.

# Changes

- Add a function to reevaluate the fee in FeeContext.
- Expose an imperative feature in the fee component to trigger the fee calculation.
- Bind the reevaluate function with the effective calculation.
- Update the fee on mount and only when the user inputs (amount and destination) are manually updated by the user.
- Debounce fee calculation to ensure it is called as few times as possible.
