### PR TITLE
feat: input error property undefined default value

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -13,7 +13,7 @@
 	export let placeholder: string = $i18n.core.text.amount;
 	export let customValidate: (userAmount: BigNumber) => Error | undefined = () => undefined;
 	export let calculateMax: (() => number | undefined) | undefined = undefined;
-	export let error: Error | undefined;
+	export let error: Error | undefined = undefined;
 
 	let onMax = () => {
 		amount = calculateMax?.();


### PR DESCRIPTION
# Motivation

The `SendInputAmount.spec.ts` has types error because the property `error` was mandatory. I could have resolve the input in the test but, I actually think it was a better idea to set a default `undefined` value for the property within the component `SendInputAmount`.
