### PR TITLE
style: do not capitalize from and to

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -84,7 +84,7 @@
 				{/if}
 
 				{#if nonNullish(from)}
-					<p class="capitalize">
+					<p>
 						<output>{from}</output><Copy
 							value={from}
 							text={$i18n.transaction.text.from_copied}
@@ -112,7 +112,7 @@
 				{/if}
 
 				{#if nonNullish(to)}
-					<p class="capitalize">
+					<p>
 						<output>{to}</output><Copy
 							value={to}
 							text={$i18n.transaction.text.to_copied}


### PR DESCRIPTION
# Motivation

From and to information of an IC transaction can be principals or account identifiers; therefore, the field that displays the information in the transaction modal should not be capitalized.

# Changes

- remove `capitalize` in related fields

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-05-21 à 06 49 17" src="https://github.com/dfinity/oisy-wallet/assets/16886711/a9780173-ebb2-4f4f-95cd-3e8a560b1389">
<img width="1536" alt="Capture d’écran 2024-05-21 à 06 49 14" src="https://github.com/dfinity/oisy-wallet/assets/16886711/df35af2a-5707-490a-baee-90b10ad2f1c8">
<img width="1536" alt="Capture d’écran 2024-05-21 à 06 49 04" src="https://github.com/dfinity/oisy-wallet/assets/16886711/af5e7be4-2c16-4a1b-ac31-bc003ca61991">


After:

<img width="1536" alt="Capture d’écran 2024-05-21 à 06 47 48" src="https://github.com/dfinity/oisy-wallet/assets/16886711/287df1bd-1d92-4f70-a56b-d144a7a1d782">
<img width="1536" alt="Capture d’écran 2024-05-21 à 06 47 36" src="https://github.com/dfinity/oisy-wallet/assets/16886711/aea94c0d-13cb-4127-9a87-d30189d863d9">
<img width="1536" alt="Capture d’écran 2024-05-21 à 06 47 18" src="https://github.com/dfinity/oisy-wallet/assets/16886711/9ae9ead6-a8aa-44c3-ad4b-bc4b4cc9e85e">

