### PR TITLE
feat: script to retrieve the current list of ckErc20

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,4 @@ yarn.lock
 .dfx
 
 src/frontend/src/env/tokens.sns.json
+src/frontend/src/env/tokens.ckerc20.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@dfinity/auth-client": "^1.3.0",
 				"@dfinity/candid": "^1.3.0",
 				"@dfinity/ckbtc": "^2.3.3",
-				"@dfinity/cketh": "^3.0.1-next-2024-05-21.1",
+				"@dfinity/cketh": "^3.0.1-next-2024-05-21.2",
 				"@dfinity/gix-components": "^4.2.0-next-2024-05-06.2",
 				"@dfinity/ic-management": "^4.0.0",
 				"@dfinity/ledger-icp": "^2.2.4",
@@ -660,9 +660,9 @@
 			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
 		},
 		"node_modules/@dfinity/cketh": {
-			"version": "3.0.1-next-2024-05-21.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/cketh/-/cketh-3.0.1-next-2024-05-21.1.tgz",
-			"integrity": "sha512-Hgxzy80FcR1D2LUmi/mB0xl0B/jdWF8M6Kl7ES/2LuTIRRvcBiRV+v9uiamu3zwMVlG9ESYiOHaKcz6QCpPb2A==",
+			"version": "3.0.1-next-2024-05-21.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/cketh/-/cketh-3.0.1-next-2024-05-21.2.tgz",
+			"integrity": "sha512-WeZK8KJzb/08k/TNKB/eDMCqDg0jPYfcVfSJnyn/9BjUDQG7q9PeBshflYygyEd7bngV6E9uS4D+MhxbT1Omew==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@dfinity/agent": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@dfinity/auth-client": "^1.3.0",
 				"@dfinity/candid": "^1.3.0",
 				"@dfinity/ckbtc": "^2.3.3",
-				"@dfinity/cketh": "^3.0.1",
+				"@dfinity/cketh": "^3.0.1-next-2024-05-21.1",
 				"@dfinity/gix-components": "^4.2.0-next-2024-05-06.2",
 				"@dfinity/ic-management": "^4.0.0",
 				"@dfinity/ledger-icp": "^2.2.4",
@@ -660,14 +660,15 @@
 			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
 		},
 		"node_modules/@dfinity/cketh": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/cketh/-/cketh-3.0.1.tgz",
-			"integrity": "sha512-fk7uAxZQSn1ZTCKsFRlJbrcD1ax6iqxlwgJ5WH/6rk5lsUvM8RRajQ78FIfc6QTjDB6CCNc24Qpm/rjjtHbrSA==",
+			"version": "3.0.1-next-2024-05-21.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/cketh/-/cketh-3.0.1-next-2024-05-21.1.tgz",
+			"integrity": "sha512-Hgxzy80FcR1D2LUmi/mB0xl0B/jdWF8M6Kl7ES/2LuTIRRvcBiRV+v9uiamu3zwMVlG9ESYiOHaKcz6QCpPb2A==",
+			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "^1.3.0",
-				"@dfinity/candid": "^1.3.0",
-				"@dfinity/principal": "^1.3.0",
-				"@dfinity/utils": "^2.3.0"
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/principal": "*",
+				"@dfinity/utils": "*"
 			}
 		},
 		"node_modules/@dfinity/gix-components": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@dfinity/auth-client": "^1.3.0",
 		"@dfinity/candid": "^1.3.0",
 		"@dfinity/ckbtc": "^2.3.3",
-		"@dfinity/cketh": "^3.0.1-next-2024-05-21.1",
+		"@dfinity/cketh": "^3.0.1-next-2024-05-21.2",
 		"@dfinity/gix-components": "^4.2.0-next-2024-05-06.2",
 		"@dfinity/ic-management": "^4.0.0",
 		"@dfinity/ledger-icp": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@dfinity/auth-client": "^1.3.0",
 		"@dfinity/candid": "^1.3.0",
 		"@dfinity/ckbtc": "^2.3.3",
-		"@dfinity/cketh": "^3.0.1",
+		"@dfinity/cketh": "^3.0.1-next-2024-05-21.1",
 		"@dfinity/gix-components": "^4.2.0-next-2024-05-06.2",
 		"@dfinity/ic-management": "^4.0.0",
 		"@dfinity/ledger-icp": "^2.2.4",

--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import { AnonymousIdentity } from '@dfinity/agent';
+import { CkETHOrchestratorCanister } from '@dfinity/cketh';
+import { Principal } from '@dfinity/principal';
+import { createAgent, fromNullable, isNullish } from '@dfinity/utils';
+
+const orchestratorInfo = async ({ orchestratorId: canisterId }) => {
+	const agent = await createAgent({
+		identity: new AnonymousIdentity(),
+		host: 'https://icp-api.io'
+	});
+
+	const { getOrchestratorInfo } = CkETHOrchestratorCanister.create({
+		agent,
+		canisterId
+	});
+
+	return getOrchestratorInfo({ certified: true });
+};
+
+const buildOrchestratorInfo = async (orchestratorId) => {
+	const { managed_canisters } = await orchestratorInfo({ orchestratorId });
+
+	const mapManagedCanisters = ({ ledger, index, ckerc20_token_symbol }) => {
+		const ledgerCanister = fromNullable(ledger);
+		const indexCanister = fromNullable(index);
+
+		if (isNullish(ledgerCanister) || isNullish(indexCanister)) {
+			return undefined;
+		}
+
+		const { canister_id: ledgerCanisterId } =
+			'Created' in ledgerCanister ? ledgerCanister.Created : ledgerCanister.Installed;
+		const { canister_id: indexCanisterId } =
+			'Created' in indexCanister ? indexCanister.Created : indexCanister.Installed;
+
+		return {
+			ledgerCanisterId: ledgerCanisterId.toText(),
+			indexCanisterId: indexCanisterId.toText(),
+			ckerc20_token_symbol
+		};
+	};
+
+	return managed_canisters.map(mapManagedCanisters);
+};
+
+const ORCHESTRATOR_STAGING_ID = Principal.fromText('2s5qh-7aaaa-aaaar-qadya-cai');
+const ORCHESTRATOR_PRODUCTION_ID = Principal.fromText('vxkom-oyaaa-aaaar-qafda-cai');
+
+const findCkErc20 = async () => {
+	const [staging, production] = await Promise.all(
+		[ORCHESTRATOR_STAGING_ID, ORCHESTRATOR_PRODUCTION_ID].map(buildOrchestratorInfo)
+	);
+
+	console.log(staging, production);
+};
+
+try {
+	await findCkErc20();
+} catch (err) {
+	console.error(err);
+}

--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -28,8 +28,9 @@ const buildOrchestratorInfo = async (orchestratorId) => {
 		const ledgerCanister = fromNullable(ledger);
 		const indexCanister = fromNullable(index);
 
+		// Skip tokens without Ledger or Index (by definition, this can happen).
 		if (isNullish(ledgerCanister) || isNullish(indexCanister)) {
-			return undefined;
+			return acc;
 		}
 
 		const { canister_id: ledgerCanisterId } =

--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -3,7 +3,9 @@
 import { AnonymousIdentity } from '@dfinity/agent';
 import { CkETHOrchestratorCanister } from '@dfinity/cketh';
 import { Principal } from '@dfinity/principal';
-import { createAgent, fromNullable, isNullish } from '@dfinity/utils';
+import { createAgent, fromNullable, isNullish, jsonReplacer } from '@dfinity/utils';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 const orchestratorInfo = async ({ orchestratorId: canisterId }) => {
 	const agent = await createAgent({
@@ -22,7 +24,7 @@ const orchestratorInfo = async ({ orchestratorId: canisterId }) => {
 const buildOrchestratorInfo = async (orchestratorId) => {
 	const { managed_canisters } = await orchestratorInfo({ orchestratorId });
 
-	const mapManagedCanisters = ({ ledger, index, ckerc20_token_symbol }) => {
+	const mapManagedCanisters = (acc, { ledger, index, ckerc20_token_symbol }) => {
 		const ledgerCanister = fromNullable(ledger);
 		const indexCanister = fromNullable(index);
 
@@ -36,24 +38,52 @@ const buildOrchestratorInfo = async (orchestratorId) => {
 			'Created' in indexCanister ? indexCanister.Created : indexCanister.Installed;
 
 		return {
-			ledgerCanisterId: ledgerCanisterId.toText(),
-			indexCanisterId: indexCanisterId.toText(),
-			ckerc20_token_symbol
+			...acc,
+			[ckerc20_token_symbol]: [
+				...(acc[ckerc20_token_symbol] ?? []),
+				{
+					ledgerCanisterId: ledgerCanisterId.toText(),
+					indexCanisterId: indexCanisterId.toText()
+				}
+			]
 		};
 	};
 
-	return managed_canisters.map(mapManagedCanisters);
+	const tokens = managed_canisters.reduce(mapManagedCanisters, {});
+
+	const assertUniqueTokenSymbol = Object.values(tokens).find((value) => value.length > 1);
+
+	if (assertUniqueTokenSymbol !== undefined) {
+		throw new Error(
+			`More than one pair of ledger and index canisters were used for the token symbol ${assertUniqueTokenSymbol}.`
+		);
+	}
+
+	return Object.entries(tokens).reduce(
+		(acc, [key, value]) => ({
+			...acc,
+			[key]: value[0]
+		}),
+		{}
+	);
 };
 
 const ORCHESTRATOR_STAGING_ID = Principal.fromText('2s5qh-7aaaa-aaaar-qadya-cai');
 const ORCHESTRATOR_PRODUCTION_ID = Principal.fromText('vxkom-oyaaa-aaaar-qafda-cai');
+
+const DATA_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'env');
 
 const findCkErc20 = async () => {
 	const [staging, production] = await Promise.all(
 		[ORCHESTRATOR_STAGING_ID, ORCHESTRATOR_PRODUCTION_ID].map(buildOrchestratorInfo)
 	);
 
-	console.log(staging, production);
+	const tokens = {
+		production,
+		staging
+	};
+
+	writeFileSync(join(DATA_FOLDER, 'tokens.ckerc20.json'), JSON.stringify(tokens, jsonReplacer));
 };
 
 try {

--- a/src/frontend/src/env/tokens.ckerc20.json
+++ b/src/frontend/src/env/tokens.ckerc20.json
@@ -1,0 +1,1 @@
+{"production":{},"staging":{"ckSepoliaUSDC":{"ledgerCanisterId":"yfumr-cyaaa-aaaar-qaela-cai","indexCanisterId":"ycvkf-paaaa-aaaar-qaelq-cai"}}}


### PR DESCRIPTION
# Motivation

Similar to SNSes, we aim to set up a weekly job that collects the ckERC20 tokens that exist on mainnet for staging and production.

This PR provides a script that queries the ckETH orchestrator to retrieve the list of tokens with their corresponding IC ledger and index canisters.

# Changes

- Update `@dfinity/cketh@next`, which contains an update to introduce the ckETH orchestrator canister (see ic-js PR [632](https://github.com/dfinity/ic-js/pull/632)).
- Create a new script that queries the orchestrator and generates a JSON file.

# Notes

The script contains a check that asserts that token symbols are provided only once per environment. This allows us to prefix the information per token as we are still going to integrate that information manually within our codebase.
