### PR TITLE
refactor: build.sns.tokens module name to build.tokens.sns

### DIFF
--- a/.github/workflows/update-sns-tokens.yml
+++ b/.github/workflows/update-sns-tokens.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Update
-        run: npm run build:sns-tokens
+        run: npm run build:tokens-sns
 
       - name: Check for Changes
         run: |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"build:metadata": "node scripts/build.metadata.mjs",
 		"build:copy-workers": "node ./scripts/build.copy-workers.mjs",
 		"build:post-process": "npm run build:metadata && npm run build:csp && npm run build:copy-workers && npm run build:compress",
-		"build:sns-tokens": "node scripts/build.sns.tokens.mjs",
+		"build:tokens-sns": "node scripts/build.tokens.sns.mjs",
 		"dev": "vite dev",
 		"build": "tsc --noEmit && vite build && npm run build:post-process",
 		"preview": "vite preview",

--- a/scripts/build.tokens.sns.mjs
+++ b/scripts/build.tokens.sns.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { AnonymousIdentity } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { IcrcIndexNgCanister, IcrcMetadataResponseEntries } from '@dfinity/ledger-icrc';


### PR DESCRIPTION
# Motivation

We might/will add some more weekly jobs to build list of tokens automatically (for example PR #1314), that's why this PR rename `build.sns.tokens.mjs` and to `build.tokens.sns.mjs`. Just a bit more handy to retrieve those jobs in the project if they are all indexed with the same prefix `build.tokens`.

# Notes

Unrelated to PR, I added the header `#!/usr/bin/env node` to the script that way it can also be run without referencing node. in a terminal.

# Changes

- rename script
- update reference to script
