### PR TITLE
fix: using tokenStandard in calculation for max amount

### DIFF
--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -19,7 +19,7 @@
 	$: insufficientFunds = nonNullish(insufficientFundsError);
 
 	const { feeStore: storeFeeData, minGasFee, maxGasFee } = getContext<FeeContext>(FEE_CONTEXT_KEY);
-	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken } =
+	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken, sendTokenStandard } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	$: customValidate = (userAmount: BigNumber) => {
@@ -57,7 +57,7 @@
 			balance: $sendBalance?.toBigInt(),
 			fee: $maxGasFee?.toBigInt(),
 			tokenDecimals: $sendTokenDecimals,
-			tokenId: $sendTokenId
+			tokenStandard: $sendTokenStandard
 		});
 	};
 </script>

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -1,5 +1,4 @@
-import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
-import type { TokenId } from '$lib/types/token';
+import type { TokenStandard } from '$lib/types/token';
 
 /**
  * Calculates the maximum amount for a transaction.
@@ -8,22 +7,21 @@ import type { TokenId } from '$lib/types/token';
  * @param {bigint | undefined} params.balance The balance of the account.
  * @param {bigint | undefined} params.fee The fee of the transaction.
  * @param {number} params.tokenDecimals The decimals of the token.
- * @param {TokenId} params.tokenId The token of the transaction.
+ * @param {string} params.tokenStandard The standard of the token.
  * @returns {number} The maximum amount for the transaction.
  */
 export const getMaxTransactionAmount = ({
 	balance = 0n,
 	fee = 0n,
 	tokenDecimals,
-	tokenId
+	tokenStandard
 }: {
 	balance?: bigint;
 	fee?: bigint;
 	tokenDecimals: number;
-	tokenId: TokenId;
+	tokenStandard: TokenStandard;
 }): number => {
-	if (isSupportedEthTokenId(tokenId)) {
-		return Math.max(Number(balance - fee), 0) / 10 ** tokenDecimals;
-	}
-	return Math.max(Number(balance), 0) / 10 ** tokenDecimals;
+	return (
+		Math.max(Number(balance - (tokenStandard !== 'erc20' ? fee : 0n)), 0) / 10 ** tokenDecimals
+	);
 };

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,70 +1,75 @@
+import type { TokenStandard } from '$lib/types/token';
 import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 
 const tokenDecimals = 8;
-const tokenId = Symbol('mock');
+const tokenStandards: TokenStandard[] = ['ethereum', 'icp', 'icrc', 'bitcoin'];
 
 const balance = 1000000000n;
 const fee = 10000000n;
 
-vi.mock('$eth/utils/eth.utils', () => ({
-	isSupportedEthTokenId: vi.fn((id: symbol) => id === tokenId)
-}));
-
 describe('getMaxTransactionAmount', () => {
-	it('should return the correct maximum amount for a transaction', () => {
-		const result = getMaxTransactionAmount({
-			balance,
-			fee,
-			tokenDecimals: tokenDecimals,
-			tokenId: tokenId
+	it('should return the correct maximum amount for a transaction for each token standard', () => {
+		tokenStandards.forEach((tokenStandard) => {
+			const result = getMaxTransactionAmount({
+				balance,
+				fee,
+				tokenDecimals,
+				tokenStandard
+			});
+			expect(result).toBe(Number(balance - fee) / 10 ** tokenDecimals);
 		});
-		expect(result).toBe(Number(balance - fee) / 10 ** tokenDecimals);
 	});
 
 	it('should return 0 if balance is less than fee', () => {
-		const result = getMaxTransactionAmount({
-			balance: fee,
-			fee: balance,
-			tokenDecimals: tokenDecimals,
-			tokenId: tokenId
+		tokenStandards.forEach((tokenStandard) => {
+			const result = getMaxTransactionAmount({
+				balance: fee,
+				fee: balance,
+				tokenDecimals,
+				tokenStandard
+			});
+			expect(result).toBe(0);
 		});
-		expect(result).toBe(0);
 	});
 
 	it('should return 0 if balance and fee are undefined', () => {
-		const result = getMaxTransactionAmount({
-			balance: undefined,
-			fee: undefined,
-			tokenDecimals: tokenDecimals,
-			tokenId: tokenId
+		tokenStandards.forEach((tokenStandard) => {
+			const result = getMaxTransactionAmount({
+				balance: undefined,
+				fee: undefined,
+				tokenDecimals,
+				tokenStandard
+			});
+			expect(result).toBe(0);
 		});
-		expect(result).toBe(0);
 	});
 
 	it('should handle balance or fee being undefined', () => {
-		let result = getMaxTransactionAmount({
-			balance: undefined,
-			fee,
-			tokenDecimals: tokenDecimals,
-			tokenId: tokenId
-		});
-		expect(result).toBe(0);
+		tokenStandards.forEach((tokenStandard) => {
+			let result = getMaxTransactionAmount({
+				balance: undefined,
+				fee,
+				tokenDecimals,
+				tokenStandard
+			});
+			expect(result).toBe(0);
 
-		result = getMaxTransactionAmount({
-			balance,
-			fee: undefined,
-			tokenDecimals: tokenDecimals,
-			tokenId: tokenId
+			result = getMaxTransactionAmount({
+				balance,
+				fee: undefined,
+				tokenDecimals,
+				tokenStandard
+			});
+			expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 		});
-		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 	});
 
-	it('should return the untouched amount if the token is not ETH supported', () => {
+	it('should return the untouched amount if the token is ERC20', () => {
 		const result = getMaxTransactionAmount({
 			balance,
 			fee,
 			tokenDecimals: tokenDecimals,
-			tokenId: Symbol('otherMock')
+			tokenStandard: 'erc20'
 		});
 		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 	});


### PR DESCRIPTION
# Motivation

Changing the check getMaxTransactionAmount to consider the tokenStandard instead of using defined functions. 

# Changes

Function getMaxTransactionAmount will now take tokenStandard as input parameter.

# Test

Changed test `token.utils.spec.ts` to consider all possible non-ERC20 values.

