### PR TITLE
chore: lint nullish

### DIFF
--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -63,7 +63,7 @@
 		: (): number =>
 				getMaxTransactionAmount({
 					balance: $sendBalance?.toBigInt(),
-					fee: $maxGasFee.toBigInt(),
+					fee: $maxGasFee?.toBigInt(),
 					tokenDecimals: $sendTokenDecimals,
 					tokenStandard: $sendTokenStandard
 				});


### PR DESCRIPTION
# Motivation

Webstorm has issue intepreting an `isNullish` and displays a positive negative error regarding a lint issue. So here's just a pragmatic PR.

# Changes

- use a nullish coalish to make editor linter happy

# Screenshot

<img width="1470" alt="Capture d’écran 2024-05-21 à 16 50 11" src="https://github.com/dfinity/oisy-wallet/assets/16886711/99abe780-4576-4add-b2b4-cd68d498d4d5">
