### PR TITLE
fix: ckSepoliaUSDC display

### DIFF
--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -1,6 +1,7 @@
 import {
 	CKBTC_LEDGER_CANISTER_TESTNET_IDS,
-	CKETH_LEDGER_CANISTER_TESTNET_IDS
+	CKETH_LEDGER_CANISTER_TESTNET_IDS,
+	CKUSDC_LEDGER_CANISTER_TESTNET_IDS
 } from '$env/networks.ircrc.env';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcTokensStore } from '$icp/stores/icrc.store';
@@ -16,9 +17,11 @@ export const icrcDefaultTokens: Readable<IcToken[]> = derived(
 		($icrcTokensStore?.map(({ data: token }) => token) ?? []).filter(
 			({ ledgerCanisterId }) =>
 				$testnets ||
-				![...CKBTC_LEDGER_CANISTER_TESTNET_IDS, ...CKETH_LEDGER_CANISTER_TESTNET_IDS].includes(
-					ledgerCanisterId
-				)
+				![
+					...CKBTC_LEDGER_CANISTER_TESTNET_IDS,
+					...CKETH_LEDGER_CANISTER_TESTNET_IDS,
+					...CKUSDC_LEDGER_CANISTER_TESTNET_IDS
+				].includes(ledgerCanisterId)
 		)
 );
 


### PR DESCRIPTION
# Motivation

The ckSepoliaUSDC is currently displayed even if user does not select the "testnet" flag. This is incorrect.

This bug exists in production.

# Changes

- list ckSepoliaUSDC only if derived testnet store is selected
