### PR TITLE
fix: style overflow toast error

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -47,6 +47,9 @@
 	--animation-time-short: 0.2s;
 	--secondary: var(--color-dark-blue);
 
+	// Toast message max height is calculated based on the font-size.
+	--font-size-standard: 1rem;
+
 	// Segment
 	--segment-selected-background: var(--color-dark);
 


### PR DESCRIPTION
# Motivation

Toast content overflow in case of error does not work as expected. Gix-cmp relies on a CSS variable that is not set in Oisy and therefore no maximal height is set.

# Screenshot

Issue in prod:

![capture_d___e__cran_2024-05-22_a___10 11 03](https://github.com/dfinity/oisy-wallet/assets/16886711/772117c6-92d7-4aa0-b170-8b3e3515e43a)

