### PR TITLE
fix: ERC20 fee validation (revert usage of nativeEthereumToken)

### DIFF
--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -26,7 +26,7 @@
 		maxGasFee,
 		evaluateFee
 	} = getContext<FeeContext>(FEE_CONTEXT_KEY);
-	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken, sendTokenStandard } =
+	const { sendTokenDecimals, sendBalance, sendTokenId, sendTokenStandard } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	$: customValidate = (userAmount: BigNumber): Error | undefined => {

--- a/src/frontend/src/eth/components/send/SendAmount.svelte
+++ b/src/frontend/src/eth/components/send/SendAmount.svelte
@@ -10,9 +10,11 @@
 	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 	import { InsufficientFundsError } from '$lib/types/send';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
+	import type { Token } from '$lib/types/token';
 
 	export let amount: number | undefined = undefined;
 	export let insufficientFunds: boolean;
+	export let nativeEthereumToken: Token;
 
 	let insufficientFundsError: InsufficientFundsError | undefined = undefined;
 
@@ -49,7 +51,7 @@
 		}
 
 		// Finally, if ERC20, the ETH balance should be less or greater than the max gas fee
-		const ethBalance = $balancesStore?.[$sendToken.id]?.data ?? BigNumber.from(0n);
+		const ethBalance = $balancesStore?.[nativeEthereumToken.id]?.data ?? BigNumber.from(0n);
 		if (nonNullish($maxGasFee) && ethBalance.lt($maxGasFee)) {
 			return new InsufficientFundsError(
 				$i18n.send.assertion.insufficient_ethereum_funds_to_cover_the_fees

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -13,11 +13,13 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import type { EthereumNetwork } from '$eth/types/network';
+	import type { Token } from '$lib/types/token';
 
 	export let destination = '';
 	export let network: Network | undefined = undefined;
 	export let destinationEditable = true;
 	export let amount: number | undefined = undefined;
+	export let nativeEthereumToken: Token;
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	export let sourceNetwork: EthereumNetwork;
 
@@ -41,7 +43,7 @@
 			<SendNetworkICP {destination} {sourceNetwork} bind:network />
 		{/if}
 
-		<SendAmount bind:amount bind:insufficientFunds />
+		<SendAmount {nativeEthereumToken} bind:amount bind:insufficientFunds />
 
 		<SendSource token={$sendToken} balance={$sendBalance} source={$address ?? ''} />
 

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -231,6 +231,7 @@
 			bind:destination
 			bind:amount
 			bind:network={targetNetwork}
+			{nativeEthereumToken}
 			{destinationEditable}
 			{sourceNetwork}
 		>


### PR DESCRIPTION
# Motivation

The usage of `nativeEthereumToken` to get the balance of the ETH/SepoliaETH token was incorrectly replaced in #1294 which leads any USDC transform form to become invalide as the balance of the ERC20 token is used instead.

# Changes

- revert usage of `nativeEthereumToken` to access ETH/SepoliaETH balance
