### PR TITLE
fix: resolve USDC dollar exchange value

### DIFF
--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -47,7 +47,9 @@ export const exchanges: Readable<ExchangesData> = derived(
 
 				const { twinToken } = token as Partial<IcCkToken>;
 				const { address } = (twinToken as Partial<Erc20Token>) ?? { address: undefined };
-				const ckEthereumPrice = nonNullish(address) ? $exchangeStore?.[address] : ethPrice;
+				const ckEthereumPrice = nonNullish(address)
+					? $exchangeStore?.[address.toLowerCase()]
+					: ethPrice;
 
 				return {
 					...acc,

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -29,7 +29,7 @@ export const exchangeRateERC20ToUsd = async (
 	simpleTokenPrice({
 		id: 'ethereum',
 		vs_currencies: 'usd',
-		contract_addresses: contractAddresses.map(({ address }) => address)
+		contract_addresses: contractAddresses.map(({ address }) => address.toLowerCase())
 	});
 
 export const syncExchange = (data: PostMessageDataResponseExchange | undefined) =>


### PR DESCRIPTION
# Motivation

ckUSDC dollar exchange is not display on production because coingecko does not use the same character case as the one we pass for the query.

# Changes

- `toLowerCase` address for comparison

# Tests

<img width="586" alt="Capture d’écran 2024-05-22 à 12 06 39" src="https://github.com/dfinity/oisy-wallet/assets/16886711/6d5a1f0e-88a9-4ac5-aae5-30b527035360">
