### PR TITLE
feat: display ckErc20 fees in ckEth

### DIFF
--- a/src/frontend/src/env/networks.ircrc.env.ts
+++ b/src/frontend/src/env/networks.ircrc.env.ts
@@ -211,7 +211,10 @@ const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
 				minterCanisterId: LOCAL_CKETH_MINTER_CANISTER_ID,
 				exchangeCoinId: 'ethereum',
 				position: 3,
-				twinToken: SEPOLIA_USDC_TOKEN
+				twinToken: SEPOLIA_USDC_TOKEN,
+				...(nonNullish(LOCAL_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: LOCAL_CKETH_LEDGER_CANISTER_ID
+				})
 			}
 		: undefined;
 
@@ -226,7 +229,10 @@ const CKUSDC_STAGING_DATA: IcCkInterface | undefined =
 				minterCanisterId: STAGING_CKETH_MINTER_CANISTER_ID,
 				exchangeCoinId: 'ethereum',
 				position: 2,
-				twinToken: SEPOLIA_USDC_TOKEN
+				twinToken: SEPOLIA_USDC_TOKEN,
+				...(nonNullish(STAGING_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: STAGING_CKETH_LEDGER_CANISTER_ID
+				})
 			}
 		: undefined;
 
@@ -242,7 +248,10 @@ const CKUSDC_IC_DATA: IcCkInterface | undefined =
 				exchangeCoinId: 'ethereum',
 				position: 1,
 				twinToken: USDC_TOKEN,
-				explorerUrl: `${CKETH_EXPLORER_URL}/${IC_CKUSDC_LEDGER_CANISTER_ID}`
+				explorerUrl: `${CKETH_EXPLORER_URL}/${IC_CKUSDC_LEDGER_CANISTER_ID}`,
+				...(nonNullish(IC_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID
+				})
 			}
 		: undefined;
 

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -12,7 +12,7 @@ import {
 	type MapCkEthereumPendingTransactionParams
 } from '$icp-eth/utils/cketh-transactions.utils';
 import { icPendingTransactionsStore } from '$icp/stores/ic-pending-transactions.store';
-import type { IcCkTwinToken, IcToken, IcTransactionUi } from '$icp/types/ic';
+import type { IcCkLinkedAssets, IcToken, IcTransactionUi } from '$icp/types/ic';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -35,7 +35,7 @@ export const loadCkEthereumPendingTransactions = async ({
 	token: IcToken;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	const { id: twinTokenId } = twinToken;
 
 	if (isSupportedEthTokenId(twinTokenId)) {
@@ -61,7 +61,7 @@ const loadCkETHPendingTransactions = async ({
 	token: IcToken;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
 		CKETH_HELPER_CONTRACT_SIGNATURE,
 		null,
@@ -86,7 +86,7 @@ const loadCkErc20PendingTransactions = async ({
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
 	token: IcToken;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
 		CKERC20_HELPER_CONTRACT_SIGNATURE,
 		null,
@@ -118,7 +118,7 @@ const loadPendingTransactions = async ({
 	logsTopics: (to: ETH_ADDRESS) => (string | null)[];
 	token: IcToken;
 	mapPendingTransaction: (params: MapCkEthereumPendingTransactionParams) => IcTransactionUi;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	if (isNullish(identity)) {
 		await nullishSignOut();
 		return;
@@ -199,7 +199,7 @@ export const loadPendingCkEthereumTransaction = async ({
 	hash: string;
 	token: IcToken;
 	networkId: NetworkId;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	try {
 		const { getTransaction } = alchemyProviders(networkId);
 		const transaction = await getTransaction(hash);

--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -1,5 +1,5 @@
 import type { EthereumNetwork } from '$eth/types/network';
-import type { IcCkTwinToken, IcToken, IcTransactionUi } from '$icp/types/ic';
+import type { IcCkLinkedAssets, IcToken, IcTransactionUi } from '$icp/types/ic';
 import { i18n } from '$lib/stores/i18n.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -11,7 +11,7 @@ import { get } from 'svelte/store';
 export type MapCkEthereumPendingTransactionParams = {
 	transaction: Transaction;
 	token: IcToken;
-} & IcCkTwinToken;
+} & IcCkLinkedAssets;
 
 export const mapCkEthPendingTransaction = ({
 	transaction: { value, ...transaction },
@@ -42,7 +42,7 @@ const mapPendingTransaction = ({
 	transaction: Omit<Transaction, 'value' | 'data'>;
 	token: IcToken;
 	value: BigNumber;
-} & IcCkTwinToken): IcTransactionUi => {
+} & IcCkLinkedAssets): IcTransactionUi => {
 	const explorerUrl = (twinToken.network as EthereumNetwork).explorerUrl;
 
 	const { symbol: twinTokenSymbol } = twinToken;

--- a/src/frontend/src/icp/components/fee/CkErc20TokenFee.svelte
+++ b/src/frontend/src/icp/components/fee/CkErc20TokenFee.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { formatToken } from '$lib/utils/format.utils.js';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import { token, tokenDecimals } from '$lib/derived/token.derived';
+	import type { IcCkToken, IcToken } from '$icp/types/ic';
+	import { nonNullish } from '@dfinity/utils';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import type { LedgerCanisterIdText } from '$icp/types/canister';
+	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
+	import type { NetworkId } from '$lib/types/network';
+	import type { Token } from '$lib/types/token';
+
+	export let networkId: NetworkId | undefined = undefined;
+
+	// IC network fees to convert ckErc20 to Erc20 have to be paid in ckEth.
+	// IC network fees to transfer ckErc20 to ckErc20 have to be paid in ckErc20.
+	let ethNetwork = false;
+	$: ethNetwork = isNetworkIdEthereum(networkId);
+
+	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
+	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
+
+	let tokenCkEth: IcToken | undefined;
+	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
+		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
+		: undefined;
+
+	let feeToken: Token;
+	$: feeToken = ethNetwork ? tokenCkEth ?? $token : $token;
+
+	let decimals: number;
+	let symbol: string;
+
+	$: ({ decimals, symbol } = feeToken);
+
+	let fee: bigint | undefined;
+	$: fee = (feeToken as IcToken).fee;
+</script>
+
+<Value ref="fee">
+	<svelte:fragment slot="label">{$i18n.fee.text.fee}</svelte:fragment>
+
+	{#if nonNullish(fee)}
+		{formatToken({
+			value: BigNumber.from(fee),
+			unitName: decimals,
+			displayDecimals: $tokenDecimals
+		})}
+		{symbol}
+	{/if}
+</Value>

--- a/src/frontend/src/icp/components/fee/IcTokenFee.svelte
+++ b/src/frontend/src/icp/components/fee/IcTokenFee.svelte
@@ -3,31 +3,17 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { token, tokenDecimals } from '$lib/derived/token.derived';
-	import type { IcCkToken, IcToken } from '$icp/types/ic';
+	import type { IcToken } from '$icp/types/ic';
 	import { nonNullish } from '@dfinity/utils';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { icrcTokens } from '$icp/derived/icrc.derived';
-	import type { LedgerCanisterIdText } from '$icp/types/canister';
-
-	// IC network fees for ckErc20 tokens have to be paid in ckEth.
-	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
-	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
-
-	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
-		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
-		: undefined;
-
-	let feeToken: IcToken;
-	$: feeToken = tokenCkEth ?? ($token as IcToken);
 
 	let decimals: number;
 	let symbol: string;
 
-	$: ({ decimals, symbol } = feeToken);
+	$: ({ decimals, symbol } = $token);
 
 	let fee: bigint | undefined;
-	$: fee = feeToken.fee;
+	$: fee = ($token as IcToken).fee;
 </script>
 
 <Value ref="fee">

--- a/src/frontend/src/icp/components/fee/IcTokenFee.svelte
+++ b/src/frontend/src/icp/components/fee/IcTokenFee.svelte
@@ -6,14 +6,26 @@
 	import type { IcToken } from '$icp/types/ic';
 	import { nonNullish } from '@dfinity/utils';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
+	import { icrcTokens } from '$icp/derived/icrc.derived';
+
+	// IC network fees for ckErc20 tokens have to be paid in ckEth.
+	let ckEr20 = false;
+	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
+
+	let tokenCkEth: IcToken | undefined;
+	$: tokenCkEth = ckEr20 ? $icrcTokens.find(isTokenCkEthLedger) : undefined;
+
+	let feeToken: IcToken;
+	$: feeToken = tokenCkEth ?? ($token as IcToken);
 
 	let decimals: number;
 	let symbol: string;
 
-	$: ({ decimals, symbol } = $token);
+	$: ({ decimals, symbol } = feeToken);
 
 	let fee: bigint | undefined;
-	$: fee = ($token as IcToken).fee;
+	$: fee = feeToken.fee;
 </script>
 
 <Value ref="fee">

--- a/src/frontend/src/icp/components/fee/IcTokenFee.svelte
+++ b/src/frontend/src/icp/components/fee/IcTokenFee.svelte
@@ -3,18 +3,20 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { token, tokenDecimals } from '$lib/derived/token.derived';
-	import type { IcToken } from '$icp/types/ic';
+	import type { IcCkToken, IcToken } from '$icp/types/ic';
 	import { nonNullish } from '@dfinity/utils';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import type { LedgerCanisterIdText } from '$icp/types/canister';
 
 	// IC network fees for ckErc20 tokens have to be paid in ckEth.
-	let ckEr20 = false;
-	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
+	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
+	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
 
 	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = ckEr20 ? $icrcTokens.find(isTokenCkEthLedger) : undefined;
+	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
+		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
+		: undefined;
 
 	let feeToken: IcToken;
 	$: feeToken = tokenCkEth ?? ($token as IcToken);

--- a/src/frontend/src/icp/components/send/IcFeeDisplay.svelte
+++ b/src/frontend/src/icp/components/send/IcFeeDisplay.svelte
@@ -4,11 +4,22 @@
 	import type { NetworkId } from '$lib/types/network';
 	import BitcoinEstimatedFee from '$icp/components/fee/BitcoinEstimatedFee.svelte';
 	import EthereumEstimatedFee from '$icp/components/fee/EthereumEstimatedFee.svelte';
+	import CkErc20TokenFee from '$icp/components/fee/CkErc20TokenFee.svelte';
+	import { isTokenCkErc20Ledger } from '$icp/utils/ic-send.utils';
+	import { token } from '$lib/derived/token.derived';
+	import type { IcToken } from '$icp/types/ic';
 
 	export let networkId: NetworkId | undefined = undefined;
+
+	let ckEr20 = false;
+	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
 </script>
 
-<IcTokenFee />
+{#if ckEr20}
+	<CkErc20TokenFee {networkId} />
+{:else}
+	<IcTokenFee />
+{/if}
 
 <BitcoinEstimatedFee />
 <BitcoinKYTFee {networkId} />

--- a/src/frontend/src/icp/types/ck-listener.ts
+++ b/src/frontend/src/icp/types/ck-listener.ts
@@ -1,9 +1,9 @@
-import type { IcCkTwinToken } from '$icp/types/ic';
+import type { IcCkLinkedAssets } from '$icp/types/ic';
 import type { PostMessageDataRequestIcCk } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 
 export type IcCkWorkerParams = PostMessageDataRequestIcCk & { token: Token } & Partial<
-		Partial<IcCkTwinToken>
+		Partial<IcCkLinkedAssets>
 	>;
 
 export interface IcCkWorkerInitResult {

--- a/src/frontend/src/icp/types/ic.ts
+++ b/src/frontend/src/icp/types/ic.ts
@@ -68,10 +68,11 @@ export type IcCkInterface = IcInterface & IcCkMetadata;
 
 export type IcCkMetadata = {
 	minterCanisterId: MinterCanisterIdText;
-} & Partial<IcCkTwinToken>;
+} & Partial<IcCkLinkedAssets>;
 
-export type IcCkTwinToken = {
+export type IcCkLinkedAssets = {
 	twinToken: Token;
+	feeLedgerCanisterId?: LedgerCanisterIdText;
 };
 
 export type IcAppMetadata = {


### PR DESCRIPTION
# Motivation

Turns out, the fees to convert ckErc20 to Erc20 have to be paid in ckEth.

# Changes

- rename type `IcCkTwinToken` to add more information such as the ledger canister id to use for the ck fee within the same type
- configure USDC ck token to specifiy such canister ID
- duplicate / copy component to display the IC to a new type dedicated to ckErc20
- display either ckErc20 or ckEth fees for ckErc20

# Screenshots

Is:

<img width="1536" alt="Capture d’écran 2024-05-22 à 13 50 39" src="https://github.com/dfinity/oisy-wallet/assets/16886711/7a093426-7b95-490f-b4f5-375e576848d0">
<img width="1536" alt="Capture d’écran 2024-05-22 à 13 50 42" src="https://github.com/dfinity/oisy-wallet/assets/16886711/9340607b-7b17-4f8a-b0f2-81b74e3c246a">

Fix:

<img width="1536" alt="Capture d’écran 2024-05-22 à 13 50 09" src="https://github.com/dfinity/oisy-wallet/assets/16886711/53699e8c-a487-431c-a732-98e9df27bd2f">
<img width="1536" alt="Capture d’écran 2024-05-22 à 13 50 06" src="https://github.com/dfinity/oisy-wallet/assets/16886711/76b1fca0-08f5-4841-b73a-83513c2b7904">
