### PR TITLE
feat: ethereum fee context for ckEth

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -1,75 +1,25 @@
 <script lang="ts">
 	import { slide, fade } from 'svelte/transition';
-	import { token, tokenId } from '$lib/derived/token.derived';
 	import { nonNullish } from '@dfinity/utils';
-	import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
-	import type { IcToken } from '$icp/types/ic';
-	import type { NetworkId } from '$lib/types/network';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
-	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import { onDestroy } from 'svelte';
+	import { getContext } from 'svelte';
 	import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
-	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { CKERC20_TO_ERC20_MAX_TRANSACTION_FEE } from '$icp/constants/cketh.constants';
-	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import {
+		ETHEREUM_FEE_CONTEXT_KEY,
+		type EthereumFeeContext
+	} from '$icp/stores/ethereum-fee.store';
 
-	export let networkId: NetworkId | undefined = undefined;
+	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 
-	let ckETH = false;
-	$: ckETH = isTokenCkEthLedger($token as IcToken);
-
-	let ckEr20 = false;
-	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
-
-	let ethNetwork = false;
-	$: ethNetwork = isNetworkIdEthereum(networkId);
-
-	let maxTransactionFeeEth: bigint | undefined = undefined;
-	$: maxTransactionFeeEth = $eip1559TransactionPriceStore?.[$tokenId]?.data.max_transaction_fee;
-
-	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = $icrcTokens.find(isTokenCkEthLedger);
-
-	let maxTransactionFeePlusEthLedgerApprove: bigint | undefined = undefined;
-	$: maxTransactionFeePlusEthLedgerApprove = nonNullish(maxTransactionFeeEth)
-		? maxTransactionFeeEth + CKERC20_TO_ERC20_MAX_TRANSACTION_FEE + (tokenCkEth?.fee ?? 0n)
-		: undefined;
-
-	let maxTransactionFee: bigint | undefined = undefined;
-	$: maxTransactionFee =
-		nonNullish(maxTransactionFeePlusEthLedgerApprove) && ckEr20
-			? maxTransactionFeePlusEthLedgerApprove + CKERC20_TO_ERC20_MAX_TRANSACTION_FEE
-			: maxTransactionFeePlusEthLedgerApprove;
-
-	const loadFee = async () => {
-		clearTimer();
-
-		if ((!ckETH && !ckEr20) || !ethNetwork) {
-			return;
-		}
-
-		const load = async () => await loadEip1559TransactionPrice($token as IcToken);
-
-		await load();
-
-		timer = setInterval(load, 30000);
-	};
-
-	$: networkId, (async () => await loadFee())();
-
-	let timer: NodeJS.Timeout | undefined;
-
-	const clearTimer = () => clearInterval(timer);
-
-	onDestroy(clearTimer);
+	let maxTransactionFee: bigint | undefined | null = undefined;
+	$: maxTransactionFee = $store?.maxTransactionFee;
 </script>
 
-{#if (ckETH || ckEr20) && ethNetwork}
+{#if nonNullish($store)}
 	<div transition:slide={{ duration: 250 }}>
 		<Value ref="kyt-fee">
 			<svelte:fragment slot="label">{$i18n.fee.text.estimated_eth}</svelte:fragment>

--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import type { NetworkId } from '$lib/types/network';
+	import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
+	import { token, tokenId } from '$lib/derived/token.derived';
+	import type { IcToken } from '$icp/types/ic';
+	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
+	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
+	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import { nonNullish } from '@dfinity/utils';
+	import { CKERC20_TO_ERC20_MAX_TRANSACTION_FEE } from '$icp/constants/cketh.constants';
+	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
+	import { getContext, onDestroy } from 'svelte';
+	import {
+		ETHEREUM_FEE_CONTEXT_KEY,
+		type EthereumFeeContext
+	} from '$icp/stores/ethereum-fee.store';
+
+	export let networkId: NetworkId | undefined = undefined;
+
+	let ckETH = false;
+	$: ckETH = isTokenCkEthLedger($token as IcToken);
+
+	let ckEr20 = false;
+	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
+
+	let ethNetwork = false;
+	$: ethNetwork = isNetworkIdEthereum(networkId);
+
+	let maxTransactionFeeEth: bigint | undefined = undefined;
+	$: maxTransactionFeeEth = $eip1559TransactionPriceStore?.[$tokenId]?.data.max_transaction_fee;
+
+	let tokenCkEth: IcToken | undefined;
+	$: tokenCkEth = $icrcTokens.find(isTokenCkEthLedger);
+
+	let maxTransactionFeePlusEthLedgerApprove: bigint | undefined = undefined;
+	$: maxTransactionFeePlusEthLedgerApprove = nonNullish(maxTransactionFeeEth)
+		? maxTransactionFeeEth + CKERC20_TO_ERC20_MAX_TRANSACTION_FEE + (tokenCkEth?.fee ?? 0n)
+		: undefined;
+
+	let maxTransactionFee: bigint | undefined = undefined;
+	$: maxTransactionFee =
+		nonNullish(maxTransactionFeePlusEthLedgerApprove) && ckEr20
+			? maxTransactionFeePlusEthLedgerApprove + CKERC20_TO_ERC20_MAX_TRANSACTION_FEE
+			: maxTransactionFeePlusEthLedgerApprove;
+
+	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
+	$: store.setFee({ maxTransactionFee });
+
+	const updateContext = () => {
+		if ((!ckETH && !ckEr20) || !ethNetwork) {
+			store.setFee(null);
+			return;
+		}
+
+		store.setFee({ maxTransactionFee });
+	};
+
+	$: maxTransactionFee, updateContext();
+
+	const loadFee = async () => {
+		clearTimer();
+
+		if ((!ckETH && !ckEr20) || !ethNetwork) {
+			updateContext();
+			return;
+		}
+
+		const load = async () => await loadEip1559TransactionPrice($token as IcToken);
+
+		await load();
+
+		timer = setInterval(load, 30000);
+	};
+
+	$: networkId, (async () => await loadFee())();
+
+	let timer: NodeJS.Timeout | undefined;
+
+	const clearTimer = () => clearInterval(timer);
+
+	onDestroy(clearTimer);
+</script>
+
+<slot />

--- a/src/frontend/src/icp/components/send/IcFeeDisplay.svelte
+++ b/src/frontend/src/icp/components/send/IcFeeDisplay.svelte
@@ -12,4 +12,4 @@
 
 <BitcoinEstimatedFee />
 <BitcoinKYTFee {networkId} />
-<EthereumEstimatedFee {networkId} />
+<EthereumEstimatedFee />

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -37,6 +37,7 @@
 	} from '$lib/constants/analytics.contants';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { ckEthereumTwinToken } from '$icp-eth/derived/cketh.derived';
+	import EthereumFeeContext from '$icp/components/fee/EthereumFeeContext.svelte';
 
 	/**
 	 * Props
@@ -177,19 +178,21 @@
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
-	<BitcoinFeeContext {amount} {networkId}>
-		{#if currentStep?.name === 'Review'}
-			<IcSendReview on:icBack={modal.back} on:icSend={send} {destination} {amount} {networkId} />
-		{:else if currentStep?.name === 'Sending'}
-			<IcSendProgress bind:sendProgressStep {networkId} />
-		{:else}
-			<IcSendForm
-				on:icNext={modal.next}
-				on:icClose={close}
-				bind:destination
-				bind:amount
-				bind:networkId
-			/>
-		{/if}
-	</BitcoinFeeContext>
+	<EthereumFeeContext {networkId}>
+		<BitcoinFeeContext {amount} {networkId}>
+			{#if currentStep?.name === 'Review'}
+				<IcSendReview on:icBack={modal.back} on:icSend={send} {destination} {amount} {networkId} />
+			{:else if currentStep?.name === 'Sending'}
+				<IcSendProgress bind:sendProgressStep {networkId} />
+			{:else}
+				<IcSendForm
+					on:icNext={modal.next}
+					on:icClose={close}
+					bind:destination
+					bind:amount
+					bind:networkId
+				/>
+			{/if}
+		</BitcoinFeeContext>
+	</EthereumFeeContext>
 </WizardModal>

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -38,6 +38,11 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { ckEthereumTwinToken } from '$icp-eth/derived/cketh.derived';
 	import EthereumFeeContext from '$icp/components/fee/EthereumFeeContext.svelte';
+	import {
+		ETHEREUM_FEE_CONTEXT_KEY,
+		initEthereumFeeStore,
+		type EthereumFeeContext as EthereumFeeContextType
+	} from '$icp/stores/ethereum-fee.store';
 
 	/**
 	 * Props
@@ -159,13 +164,15 @@
 		});
 
 	/**
-	 * Btc Fee context store
+	 * Init bitcoin and Ethereum fee context stores
 	 */
 
-	let storeFeeData = initBitcoinFeeStore();
-
 	setContext<BitcoinFeeContextType>(BITCOIN_FEE_CONTEXT_KEY, {
-		store: storeFeeData
+		store: initBitcoinFeeStore()
+	});
+
+	setContext<EthereumFeeContextType>(ETHEREUM_FEE_CONTEXT_KEY, {
+		store: initEthereumFeeStore()
 	});
 </script>
 

--- a/src/frontend/src/icp/stores/ethereum-fee.store.ts
+++ b/src/frontend/src/icp/stores/ethereum-fee.store.ts
@@ -1,0 +1,31 @@
+import type { Readable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+export type EthereumFeeStoreData =
+	| {
+			maxTransactionFee?: bigint | undefined;
+	  }
+	| undefined
+	| null;
+
+export interface EthereumFeeStore extends Readable<EthereumFeeStoreData> {
+	setFee: (data: EthereumFeeStoreData) => void;
+}
+
+export const initEthereumFeeStore = (): EthereumFeeStore => {
+	const { subscribe, set } = writable<EthereumFeeStoreData>(undefined);
+
+	return {
+		subscribe,
+
+		setFee(data: EthereumFeeStoreData) {
+			set(data);
+		}
+	};
+};
+
+export interface EthereumFeeContext {
+	store: EthereumFeeStore;
+}
+
+export const ETHEREUM_FEE_CONTEXT_KEY = Symbol('ethereum-fee');


### PR DESCRIPTION
# Motivation

We will need the Ethereum `maxTransactionFee` estimation, currently only used  for display purpose, in the validation of the user amount. Therefore this PR introduces a new fee context for Ethereum and refactor the code logic to calculate those fees from the display component to the context.

# Notes

No logic changes. Load and derivation has been moved.

# Changes

- New context and store (similar to BitcoinContextFee)
- New context component
- Move logic from display to context component
- Used store for display purpose
- Init fee store context in `IcSendModal`
