### PR TITLE
feat: ckErc20 estimated fee symbol ckEth instead of Eth

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -46,6 +46,11 @@
 			? maxTransactionFeePlusEthLedgerApprove + CKERC20_TO_ERC20_MAX_TRANSACTION_FEE
 			: maxTransactionFeePlusEthLedgerApprove;
 
+	let feeSymbol: string;
+	$: feeSymbol = ckEr20
+		? tokenCkEth?.symbol ?? $ckEthereumNativeToken.symbol
+		: $ckEthereumNativeToken.symbol;
+
 	const loadFee = async () => {
 		clearTimer();
 
@@ -82,7 +87,7 @@
 							value: BigNumber.from(maxTransactionFee),
 							displayDecimals: EIGHT_DECIMALS
 						})}
-						{$ckEthereumNativeToken.symbol}
+						{feeSymbol}
 					</span>
 				{/if}
 			</div>

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -17,16 +17,16 @@
 	import type { IcToken } from '$icp/types/ic';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 
-    let ckEr20 = false;
-    $: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
+	let ckEr20 = false;
+	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
 
-    let tokenCkEth: IcToken | undefined;
-    $: tokenCkEth = $icrcTokens.find(isTokenCkEthLedger);
+	let tokenCkEth: IcToken | undefined;
+	$: tokenCkEth = $icrcTokens.find(isTokenCkEthLedger);
 
-    let feeSymbol: string;
-    $: feeSymbol = ckEr20
-        ? tokenCkEth?.symbol ?? $ckEthereumNativeToken.symbol
-        : $ckEthereumNativeToken.symbol;
+	let feeSymbol: string;
+	$: feeSymbol = ckEr20
+		? tokenCkEth?.symbol ?? $ckEthereumNativeToken.symbol
+		: $ckEthereumNativeToken.symbol;
 
 	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 


### PR DESCRIPTION
# Motivation

The estimated fee for a converstion ckErc20 -> Erc20 should be display with the ckEth symbol instead of ETH.

