### PR TITLE
feat: display either ckEth or ckSepoliaEth on convert ckUsdc or ckSepoliaUsdc

### DIFF
--- a/src/frontend/src/env/networks.ircrc.env.ts
+++ b/src/frontend/src/env/networks.ircrc.env.ts
@@ -211,7 +211,10 @@ const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
 				minterCanisterId: LOCAL_CKETH_MINTER_CANISTER_ID,
 				exchangeCoinId: 'ethereum',
 				position: 3,
-				twinToken: SEPOLIA_USDC_TOKEN
+				twinToken: SEPOLIA_USDC_TOKEN,
+				...(nonNullish(LOCAL_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: LOCAL_CKETH_LEDGER_CANISTER_ID
+				})
 			}
 		: undefined;
 
@@ -226,7 +229,10 @@ const CKUSDC_STAGING_DATA: IcCkInterface | undefined =
 				minterCanisterId: STAGING_CKETH_MINTER_CANISTER_ID,
 				exchangeCoinId: 'ethereum',
 				position: 2,
-				twinToken: SEPOLIA_USDC_TOKEN
+				twinToken: SEPOLIA_USDC_TOKEN,
+				...(nonNullish(STAGING_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: STAGING_CKETH_LEDGER_CANISTER_ID
+				})
 			}
 		: undefined;
 
@@ -242,7 +248,10 @@ const CKUSDC_IC_DATA: IcCkInterface | undefined =
 				exchangeCoinId: 'ethereum',
 				position: 1,
 				twinToken: USDC_TOKEN,
-				explorerUrl: `${CKETH_EXPLORER_URL}/${IC_CKUSDC_LEDGER_CANISTER_ID}`
+				explorerUrl: `${CKETH_EXPLORER_URL}/${IC_CKUSDC_LEDGER_CANISTER_ID}`,
+				...(nonNullish(IC_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID
+				})
 			}
 		: undefined;
 

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -12,7 +12,7 @@ import {
 	type MapCkEthereumPendingTransactionParams
 } from '$icp-eth/utils/cketh-transactions.utils';
 import { icPendingTransactionsStore } from '$icp/stores/ic-pending-transactions.store';
-import type { IcCkTwinToken, IcToken, IcTransactionUi } from '$icp/types/ic';
+import type { IcCkLinkedAssets, IcToken, IcTransactionUi } from '$icp/types/ic';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -35,7 +35,7 @@ export const loadCkEthereumPendingTransactions = async ({
 	token: IcToken;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	const { id: twinTokenId } = twinToken;
 
 	if (isSupportedEthTokenId(twinTokenId)) {
@@ -61,7 +61,7 @@ const loadCkETHPendingTransactions = async ({
 	token: IcToken;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
 		CKETH_HELPER_CONTRACT_SIGNATURE,
 		null,
@@ -86,7 +86,7 @@ const loadCkErc20PendingTransactions = async ({
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
 	token: IcToken;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
 		CKERC20_HELPER_CONTRACT_SIGNATURE,
 		null,
@@ -118,7 +118,7 @@ const loadPendingTransactions = async ({
 	logsTopics: (to: ETH_ADDRESS) => (string | null)[];
 	token: IcToken;
 	mapPendingTransaction: (params: MapCkEthereumPendingTransactionParams) => IcTransactionUi;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	if (isNullish(identity)) {
 		await nullishSignOut();
 		return;
@@ -199,7 +199,7 @@ export const loadPendingCkEthereumTransaction = async ({
 	hash: string;
 	token: IcToken;
 	networkId: NetworkId;
-} & IcCkTwinToken) => {
+} & IcCkLinkedAssets) => {
 	try {
 		const { getTransaction } = alchemyProviders(networkId);
 		const transaction = await getTransaction(hash);

--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -1,5 +1,5 @@
 import type { EthereumNetwork } from '$eth/types/network';
-import type { IcCkTwinToken, IcToken, IcTransactionUi } from '$icp/types/ic';
+import type { IcCkLinkedAssets, IcToken, IcTransactionUi } from '$icp/types/ic';
 import { i18n } from '$lib/stores/i18n.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -11,7 +11,7 @@ import { get } from 'svelte/store';
 export type MapCkEthereumPendingTransactionParams = {
 	transaction: Transaction;
 	token: IcToken;
-} & IcCkTwinToken;
+} & IcCkLinkedAssets;
 
 export const mapCkEthPendingTransaction = ({
 	transaction: { value, ...transaction },
@@ -42,7 +42,7 @@ const mapPendingTransaction = ({
 	transaction: Omit<Transaction, 'value' | 'data'>;
 	token: IcToken;
 	value: BigNumber;
-} & IcCkTwinToken): IcTransactionUi => {
+} & IcCkLinkedAssets): IcTransactionUi => {
 	const explorerUrl = (twinToken.network as EthereumNetwork).explorerUrl;
 
 	const { symbol: twinTokenSymbol } = twinToken;

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -12,16 +12,22 @@
 		ETHEREUM_FEE_CONTEXT_KEY,
 		type EthereumFeeContext
 	} from '$icp/stores/ethereum-fee.store';
-	import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
+	import { isTokenCkErc20Ledger } from '$icp/utils/ic-send.utils';
 	import { token } from '$lib/derived/token.derived';
-	import type { IcToken } from '$icp/types/ic';
+	import type { IcCkToken, IcToken } from '$icp/types/ic';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import type { LedgerCanisterIdText } from '$icp/types/canister';
 
 	let ckEr20 = false;
 	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
 
+	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
+	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
+
 	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = $icrcTokens.find(isTokenCkEthLedger);
+	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
+		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
+		: undefined;
 
 	let feeSymbol: string;
 	$: feeSymbol = ckEr20

--- a/src/frontend/src/icp/types/ck-listener.ts
+++ b/src/frontend/src/icp/types/ck-listener.ts
@@ -1,9 +1,9 @@
-import type { IcCkTwinToken } from '$icp/types/ic';
+import type { IcCkLinkedAssets } from '$icp/types/ic';
 import type { PostMessageDataRequestIcCk } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 
 export type IcCkWorkerParams = PostMessageDataRequestIcCk & { token: Token } & Partial<
-		Partial<IcCkTwinToken>
+		Partial<IcCkLinkedAssets>
 	>;
 
 export interface IcCkWorkerInitResult {

--- a/src/frontend/src/icp/types/ic.ts
+++ b/src/frontend/src/icp/types/ic.ts
@@ -68,10 +68,11 @@ export type IcCkInterface = IcInterface & IcCkMetadata;
 
 export type IcCkMetadata = {
 	minterCanisterId: MinterCanisterIdText;
-} & Partial<IcCkTwinToken>;
+} & Partial<IcCkLinkedAssets>;
 
-export type IcCkTwinToken = {
+export type IcCkLinkedAssets = {
 	twinToken: Token;
+	feeLedgerCanisterId?: LedgerCanisterIdText;
 };
 
 export type IcAppMetadata = {


### PR DESCRIPTION
# Motivation

Turns out we still need parts of #1334 because on the "Convert ckUSDC -> USDC" modal we need to display the estimated fee with symbol ckSepoliaETH or ckETH, not the first symbol we find.

# Changes

- add a `feeLedgerCanisterId` to the environment, that way in ckErc20 we can find the ckEth ledger and from there the token
