### PR TITLE
feat: add tokenCkEth to Ethereum fee store

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -14,27 +14,17 @@
 	} from '$icp/stores/ethereum-fee.store';
 	import { isTokenCkErc20Ledger } from '$icp/utils/ic-send.utils';
 	import { token } from '$lib/derived/token.derived';
-	import type { IcCkToken, IcToken } from '$icp/types/ic';
-	import { icrcTokens } from '$icp/derived/icrc.derived';
-	import type { LedgerCanisterIdText } from '$icp/types/canister';
+	import type { IcToken } from '$icp/types/ic';
 
 	let ckEr20 = false;
 	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
 
-	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
-	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
-
-	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
-		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
-		: undefined;
+	const { store, tokenCkEthStore } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 
 	let feeSymbol: string;
 	$: feeSymbol = ckEr20
-		? tokenCkEth?.symbol ?? $ckEthereumNativeToken.symbol
+		? $tokenCkEthStore?.symbol ?? $ckEthereumNativeToken.symbol
 		: $ckEthereumNativeToken.symbol;
-
-	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 
 	let maxTransactionFee: bigint | undefined | null = undefined;
 	$: maxTransactionFee = $store?.maxTransactionFee;

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -6,12 +6,12 @@
 	import IcSendReview from './IcSendReview.svelte';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { toastsError } from '$lib/stores/toasts.store';
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { sendIc } from '$icp/services/ic-send.services';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { token, tokenDecimals } from '$lib/derived/token.derived';
 	import { authStore } from '$lib/stores/auth.store';
-	import type { IcToken } from '$icp/types/ic';
+	import type { IcCkToken, IcToken } from '$icp/types/ic';
 	import type { NetworkId } from '$lib/types/network';
 	import IcSendProgress from '$icp/components/send/IcSendProgress.svelte';
 	import type { IcTransferParams } from '$icp/types/ic-send';
@@ -43,6 +43,9 @@
 		initEthereumFeeStore,
 		type EthereumFeeContext as EthereumFeeContextType
 	} from '$icp/stores/ethereum-fee.store';
+	import { writable } from 'svelte/store';
+	import type { LedgerCanisterIdText } from '$icp/types/canister';
+	import { icrcTokens } from '$icp/derived/icrc.derived';
 
 	/**
 	 * Props
@@ -164,15 +167,31 @@
 		});
 
 	/**
-	 * Init bitcoin and Ethereum fee context stores
+	 * Bitcoin fee context store
 	 */
 
 	setContext<BitcoinFeeContextType>(BITCOIN_FEE_CONTEXT_KEY, {
 		store: initBitcoinFeeStore()
 	});
 
+	/**
+	 * Ethereum fee context store
+	 */
+
+	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
+	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
+
+	let tokenCkEth: IcToken | undefined;
+	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
+		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
+		: undefined;
+
+	let tokenCkEthStore = writable<IcToken | undefined>(undefined);
+	$: tokenCkEthStore.set(tokenCkEth);
+
 	setContext<EthereumFeeContextType>(ETHEREUM_FEE_CONTEXT_KEY, {
-		store: initEthereumFeeStore()
+		store: initEthereumFeeStore(),
+		tokenCkEthStore
 	});
 </script>
 

--- a/src/frontend/src/icp/stores/ethereum-fee.store.ts
+++ b/src/frontend/src/icp/stores/ethereum-fee.store.ts
@@ -1,4 +1,5 @@
-import type { Readable } from 'svelte/store';
+import type { IcToken } from '$icp/types/ic';
+import type { Readable, Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
 export type EthereumFeeStoreData =
@@ -26,6 +27,7 @@ export const initEthereumFeeStore = (): EthereumFeeStore => {
 
 export interface EthereumFeeContext {
 	store: EthereumFeeStore;
+	tokenCkEthStore: Writable<IcToken | undefined>;
 }
 
 export const ETHEREUM_FEE_CONTEXT_KEY = Symbol('ethereum-fee');


### PR DESCRIPTION
# Motivation

In #1333 we will need the `tokenCkEth` in more components so, instead of duplicating the code, given that it's related to the fees, we can add it to the ethereum fee context. That way we reduce the number of times we have to iterate on the icrc tokens.

