### PR TITLE
feat: trigger validation imperatively

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendInputAmount.svelte
@@ -50,6 +50,8 @@
 	const debounceValidate = debounce(validate, 300);
 
 	$: amount, tokenDecimals, debounceValidate();
+
+	export const triggerValidate = debounceValidate;
 </script>
 
 <label for="amount" class="font-bold px-4.5">{$i18n.core.text.amount}</label>

--- a/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
@@ -5,6 +5,15 @@ import { expect } from 'vitest';
 import en from '../../mocks/i18n.mock';
 
 describe('SendInputAmount', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+	});
+
 	const amount = 10.25;
 
 	const props = {
@@ -63,6 +72,29 @@ describe('SendInputAmount', () => {
 		await waitFor(() => {
 			const input: HTMLInputElement | null = container.querySelector(inputSelector);
 			expect(input?.value).toBe(props.calculateMax().toString());
+		});
+	});
+
+	it('should imperatively trigger validation', async () => {
+		const customValidate = vi.fn();
+
+		const { component } = render(SendInputAmount, {
+			props: {
+				...props,
+				customValidate
+			}
+		});
+
+		await waitFor(() => {
+			expect(customValidate).toHaveBeenCalledTimes(1);
+		});
+
+		vi.advanceTimersByTime(300);
+
+		component.$$.ctx[component.$$.props['triggerValidate']]();
+
+		await waitFor(() => {
+			expect(customValidate).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/components/send/SendInputAmount.spec.ts
@@ -5,15 +5,6 @@ import { expect } from 'vitest';
 import en from '../../mocks/i18n.mock';
 
 describe('SendInputAmount', () => {
-	beforeEach(() => {
-		vi.useFakeTimers();
-	});
-
-	afterEach(() => {
-		vi.runOnlyPendingTimers();
-		vi.useRealTimers();
-	});
-
 	const amount = 10.25;
 
 	const props = {
@@ -88,8 +79,6 @@ describe('SendInputAmount', () => {
 		await waitFor(() => {
 			expect(customValidate).toHaveBeenCalledTimes(1);
 		});
-
-		vi.advanceTimersByTime(300);
 
 		component.$$.ctx[component.$$.props['triggerValidate']]();
 


### PR DESCRIPTION
# Motivation

In #1333 we need to update the validation of the amount if the Ethereum estimated fees are updated. This is really specific to ckErc20 and IC, so I added an imperative call to debounce the validation within the amount field.

# Changes

- Expose a component function to trigger the validation