### PR TITLE
feat: clean up tokenCkEth by deriving it globally

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -15,15 +15,16 @@
 	import { isTokenCkErc20Ledger } from '$icp/utils/ic-send.utils';
 	import { token } from '$lib/derived/token.derived';
 	import type { IcToken } from '$icp/types/ic';
+	import { ethereumFeeTokenCkEth } from '$icp/derived/ethereum-fee.derived';
 
 	let ckEr20 = false;
 	$: ckEr20 = isTokenCkErc20Ledger($token as IcToken);
 
-	const { store, tokenCkEthStore } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
+	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 
 	let feeSymbol: string;
 	$: feeSymbol = ckEr20
-		? $tokenCkEthStore?.symbol ?? $ckEthereumNativeToken.symbol
+		? $ethereumFeeTokenCkEth?.symbol ?? $ckEthereumNativeToken.symbol
 		: $ckEthereumNativeToken.symbol;
 
 	let maxTransactionFee: bigint | undefined | null = undefined;

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -6,12 +6,12 @@
 	import IcSendReview from './IcSendReview.svelte';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { toastsError } from '$lib/stores/toasts.store';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { isNullish } from '@dfinity/utils';
 	import { sendIc } from '$icp/services/ic-send.services';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { token, tokenDecimals } from '$lib/derived/token.derived';
 	import { authStore } from '$lib/stores/auth.store';
-	import type { IcCkToken, IcToken } from '$icp/types/ic';
+	import type { IcToken } from '$icp/types/ic';
 	import type { NetworkId } from '$lib/types/network';
 	import IcSendProgress from '$icp/components/send/IcSendProgress.svelte';
 	import type { IcTransferParams } from '$icp/types/ic-send';
@@ -43,9 +43,6 @@
 		initEthereumFeeStore,
 		type EthereumFeeContext as EthereumFeeContextType
 	} from '$icp/stores/ethereum-fee.store';
-	import { writable } from 'svelte/store';
-	import type { LedgerCanisterIdText } from '$icp/types/canister';
-	import { icrcTokens } from '$icp/derived/icrc.derived';
 
 	/**
 	 * Props
@@ -178,20 +175,8 @@
 	 * Ethereum fee context store
 	 */
 
-	let feeLedgerCanisterId: LedgerCanisterIdText | undefined;
-	$: feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
-
-	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = nonNullish(feeLedgerCanisterId)
-		? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
-		: undefined;
-
-	let tokenCkEthStore = writable<IcToken | undefined>(undefined);
-	$: tokenCkEthStore.set(tokenCkEth);
-
 	setContext<EthereumFeeContextType>(ETHEREUM_FEE_CONTEXT_KEY, {
-		store: initEthereumFeeStore(),
-		tokenCkEthStore
+		store: initEthereumFeeStore()
 	});
 </script>
 

--- a/src/frontend/src/icp/derived/ethereum-fee.derived.ts
+++ b/src/frontend/src/icp/derived/ethereum-fee.derived.ts
@@ -1,0 +1,18 @@
+import { icrcTokens } from '$icp/derived/icrc.derived';
+import type { IcCkToken, IcToken } from '$icp/types/ic';
+import { token } from '$lib/derived/token.derived';
+import { nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+/**
+ * Ethereum fee for converting ckErc20 in ckEth are paid in ckEth.
+ */
+export const ethereumFeeTokenCkEth: Readable<IcToken | undefined> = derived(
+	[token, icrcTokens],
+	([$token, $icrcTokens]) => {
+		const feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
+		return nonNullish(feeLedgerCanisterId)
+			? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
+			: undefined;
+	}
+);

--- a/src/frontend/src/icp/derived/ethereum-fee.derived.ts
+++ b/src/frontend/src/icp/derived/ethereum-fee.derived.ts
@@ -5,7 +5,7 @@ import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
- * Ethereum fee for converting ckErc20 in ckEth are paid in ckEth.
+ * Ethereum fees for converting ckErc20 in ckEth are paid in ckEth.
  */
 export const ethereumFeeTokenCkEth: Readable<IcToken | undefined> = derived(
 	[token, icrcTokens],

--- a/src/frontend/src/icp/stores/ethereum-fee.store.ts
+++ b/src/frontend/src/icp/stores/ethereum-fee.store.ts
@@ -1,5 +1,4 @@
-import type { IcToken } from '$icp/types/ic';
-import type { Readable, Writable } from 'svelte/store';
+import type { Readable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
 export type EthereumFeeStoreData =
@@ -27,7 +26,6 @@ export const initEthereumFeeStore = (): EthereumFeeStore => {
 
 export interface EthereumFeeContext {
 	store: EthereumFeeStore;
-	tokenCkEthStore: Writable<IcToken | undefined>;
 }
 
 export const ETHEREUM_FEE_CONTEXT_KEY = Symbol('ethereum-fee');


### PR DESCRIPTION
# Motivation

The token ckEth used to display and validate the fee for converting ckErc20 can actually be derived globally, therefore it's cleaner to implement it that way rather than in a context.

# Changes

- Implement globally derived store instead of holding the value in a writable context.
