### PR TITLE
test: created env variables useful for running tests with token stores

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,9 @@
 import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import type { UserConfig } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
-import { readCanisterIds } from './vite.utils';
-
-const file = fileURLToPath(new URL('package.json', import.meta.url));
-const json = readFileSync(file, 'utf8');
-const { version } = JSON.parse(json);
+import { defineViteReplacements, readCanisterIds } from './vite.utils';
 
 // npm run dev = local
 // npm run build = local
@@ -116,8 +110,7 @@ export default defineConfig((): UserConfig => {
 				...readCanisterIds({}),
 				DFX_NETWORK: network
 			},
-			VITE_APP_VERSION: JSON.stringify(version),
-			VITE_DFX_NETWORK: JSON.stringify(network)
+			...defineViteReplacements()
 		}
 	};
 });

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const readIds = ({
 	filePath,
@@ -119,3 +120,25 @@ export const readCanisterIds = (params: { prefix?: string }): Record<string, str
 	...readOisyCanisterIds(params),
 	...readRemoteCanisterIds(params)
 });
+
+export const defineViteReplacements = (): {
+	VITE_APP_VERSION: string;
+	VITE_DFX_NETWORK: string;
+} => {
+	const file = fileURLToPath(new URL('package.json', import.meta.url));
+	const json = readFileSync(file, 'utf8');
+	const { version } = JSON.parse(json);
+
+	// npm run dev = local
+	// npm run build = local
+	// npm run test = local
+	// dfx deploy = local
+	// dfx deploy --network ic = ic
+	// dfx deploy --network staging = staging
+	const network = process.env.DFX_NETWORK ?? 'local';
+
+	return {
+		VITE_APP_VERSION: JSON.stringify(version),
+		VITE_DFX_NETWORK: JSON.stringify(network)
+	};
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { resolve } from 'path';
-import type { UserConfig } from 'vite';
+import { type UserConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
-
-const file = fileURLToPath(new URL('package.json', import.meta.url));
-const json = readFileSync(file, 'utf8');
-const { version } = JSON.parse(json);
-
-const network = process.env.DFX_NETWORK ?? 'local';
+import { defineViteReplacements } from './vite.utils';
 
 export default defineConfig(
 	(): UserConfig => ({
@@ -48,8 +41,7 @@ export default defineConfig(
 			]
 		},
 		define: {
-			VITE_APP_VERSION: JSON.stringify(version),
-			VITE_DFX_NETWORK: JSON.stringify(network)
+			...defineViteReplacements()
 		},
 		test: {
 			environment: 'jsdom',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { resolve } from 'path';
 import type { UserConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
+
+const file = fileURLToPath(new URL('package.json', import.meta.url));
+const json = readFileSync(file, 'utf8');
+const { version } = JSON.parse(json);
+
+const network = process.env.DFX_NETWORK ?? 'local';
 
 export default defineConfig(
 	(): UserConfig => ({
@@ -38,6 +46,10 @@ export default defineConfig(
 					replacement: resolve(__dirname, 'src/frontend/src/env')
 				}
 			]
+		},
+		define: {
+			VITE_APP_VERSION: JSON.stringify(version),
+			VITE_DFX_NETWORK: JSON.stringify(network)
 		},
 		test: {
 			environment: 'jsdom',


### PR DESCRIPTION
# Motivation

There is a ENV variable error, when trying to run some test using the token stores, for example when:

```typescript
import { ICP_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
import { tokens } from '$lib/derived/tokens.derived';

```

<img width="1151" alt="Screenshot 2024-05-23 at 12 58 56" src="https://github.com/dfinity/oisy-wallet/assets/169057656/80931400-ade6-467f-8af3-a95853ae30bd">



# Changes

In `vitest.config.ts`, we will use the same `VITE_APP_VERSION` and `VITE_DFX_NETWORK` as defined in `vite.config.ts` (for example that we take it from package.json for the version).

