### PR TITLE
chore: changed 'address' to 'destination' in i18n error text

### DIFF
--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -101,7 +101,7 @@ const sendIcrc = async ({
 
 	// UI validates addresses and disable form if not compliant. Therefore, this issue should unlikely happen.
 	if (!validIcrcAddress) {
-		throw new Error(get(i18n).send.error.invalid_address);
+		throw new Error(get(i18n).send.error.invalid_destination);
 	}
 
 	progress(SendIcStep.SEND);
@@ -125,7 +125,7 @@ const sendIcp = async ({
 
 	// UI validates addresses and disable form if not compliant. Therefore, this issue should unlikely happen.
 	if (!validIcrcAddress && !validIcpAddress) {
-		throw new Error(get(i18n).send.error.invalid_address);
+		throw new Error(get(i18n).send.error.invalid_destination);
 	}
 
 	progress(SendIcStep.SEND);

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -242,7 +242,7 @@
 			"erc20_data_undefined": "Erc20 transaction Data cannot be undefined or null.",
 			"data_undefined": "Transaction Data cannot be undefined or null.",
 			"no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
-			"invalid_address": "The address is invalid. Please try again with a valid address identifier."
+			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination."
 		}
 	},
 	"convert": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -216,7 +216,7 @@ interface I18nSend {
 		erc20_data_undefined: string;
 		data_undefined: string;
 		no_identity_calculate_fee: string;
-		invalid_address: string;
+		invalid_destination: string;
 	};
 }
 


### PR DESCRIPTION
# Motivation

Referring to review of PR #1339 , we changed the word **_address_** to **_destination_** to be more generic for the scope of Oisy.
