### PR TITLE
feat: created URN decoder function to treat generic URN cases

### DIFF
--- a/src/frontend/src/lib/types/qr-code.ts
+++ b/src/frontend/src/lib/types/qr-code.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export type QrStatus = 'success' | 'cancelled' | 'token_incompatible';
 
 export type QrResponse = {
@@ -7,27 +9,36 @@ export type QrResponse = {
 	amount?: number;
 };
 
-type DecodedUrnBase = {
-	prefix: string;
-	destination: string;
-	networkId?: string;
-	functionName?: string;
-};
+export const URN_NUMERIC_PARAMS = ['amount', 'value'] as const;
 
-export const urnNumericParams = ['amount', 'value'] as const;
+export const URN_STRING_PARAMS = ['address'] as const;
 
-type NumericParams = {
-	[K in (typeof urnNumericParams)[number]]?: number;
-};
+const DecodedUrnBaseSchema = z.object({
+	prefix: z.string(),
+	destination: z.string(),
+	ethereumChainId: z.string().optional(),
+	functionName: z.string().optional()
+});
 
-export const urnStringParams = ['address'] as const;
+const NumericParamsSchema = URN_NUMERIC_PARAMS.reduce(
+	(acc, param) => {
+		acc[param] = z.number().optional();
+		return acc;
+	},
+	{} as Record<(typeof URN_NUMERIC_PARAMS)[number], z.ZodNumber | z.ZodOptional<z.ZodNumber>>
+);
 
-type StringParams = {
-	[K in (typeof urnStringParams)[number]]?: string;
-};
+const StringParamsSchema = URN_STRING_PARAMS.reduce(
+	(acc, param) => {
+		acc[param] = z.string().optional();
+		return acc;
+	},
+	{} as Record<(typeof URN_STRING_PARAMS)[number], z.ZodString | z.ZodOptional<z.ZodString>>
+);
 
-export type DecodedUrn = DecodedUrnBase &
-	NumericParams &
-	StringParams & {
-		[key: string]: string | number | undefined;
-	};
+export const DecodedUrnSchema = DecodedUrnBaseSchema.extend({
+	...NumericParamsSchema,
+	...StringParamsSchema
+}).catchall(z.union([z.string(), z.number()]).optional());
+
+export type DecodedUrn = z.infer<typeof DecodedUrnSchema>;

--- a/src/frontend/src/lib/types/qr-code.ts
+++ b/src/frontend/src/lib/types/qr-code.ts
@@ -6,3 +6,28 @@ export type QrResponse = {
 	token?: string;
 	amount?: number;
 };
+
+type DecodedUrnBase = {
+	prefix: string;
+	destination: string;
+	networkId?: string;
+	functionName?: string;
+};
+
+export const urnNumericParams = ['amount', 'value'] as const;
+
+type NumericParams = {
+	[K in (typeof urnNumericParams)[number]]?: number;
+};
+
+export const urnStringParams = ['address'] as const;
+
+type StringParams = {
+	[K in (typeof urnStringParams)[number]]?: string;
+};
+
+export type DecodedUrn = DecodedUrnBase &
+	NumericParams &
+	StringParams & {
+		[key: string]: string | number | undefined;
+	};

--- a/src/frontend/src/lib/utils/qr-code.utils.ts
+++ b/src/frontend/src/lib/utils/qr-code.utils.ts
@@ -1,6 +1,48 @@
-import type { QrResponse, QrStatus } from '$lib/types/qr-code';
+import {
+	urnNumericParams,
+	urnStringParams,
+	type DecodedUrn,
+	type QrResponse,
+	type QrStatus
+} from '$lib/types/qr-code';
 import { decodePayment } from '@dfinity/ledger-icrc';
 import { isNullish, nonNullish, type Token } from '@dfinity/utils';
+
+export const decodeUrn = (urn: string): DecodedUrn | undefined => {
+	const regex = /^([a-zA-Z]+):([a-zA-Z0-9\-.]+)(@(\d+))?(\/([a-zA-Z]+))?(\?(.*))?$/;
+
+	const match = urn.match(regex);
+	if (isNullish(match)) {
+		return undefined;
+	}
+
+	const [_, prefix, destination, , networkId, , functionName, , queryString] = match;
+
+	const params: { [key: string]: string | number | undefined } = {};
+
+	if (queryString) {
+		const queryParams = new URLSearchParams(queryString);
+		queryParams.forEach((value, key) => {
+			if ((urnNumericParams as readonly string[]).includes(key)) {
+				params[key] = parseFloat(value);
+			} else if ((urnStringParams as readonly string[]).includes(key)) {
+				params[key] = value;
+			} else if (!isNaN(parseFloat(value))) {
+				params[key] = parseFloat(value);
+			} else {
+				params[key] = value;
+			}
+		});
+	}
+
+	return {
+		prefix,
+		destination,
+		...(networkId && { networkId }),
+		...(functionName && { functionName }),
+		...params
+	};
+};
 
 export const decodeQrCode = ({
 	status,

--- a/src/frontend/src/lib/utils/qr-code.utils.ts
+++ b/src/frontend/src/lib/utils/qr-code.utils.ts
@@ -46,7 +46,9 @@ export const decodeQrCodeUrn = (urn: string): DecodedUrn | undefined => {
 		return { [key]: value };
 	};
 
-	const parseQueryString = (qs: string): { [key: string]: string | number | undefined } => {
+	const parseQueryString = (
+		qs: string
+	): { [key: string]: string | number | undefined } | undefined => {
 		try {
 			return [...new URLSearchParams(qs).entries()].reduce(
 				(acc, entry) => ({
@@ -55,13 +57,17 @@ export const decodeQrCodeUrn = (urn: string): DecodedUrn | undefined => {
 				}),
 				{}
 			);
-		} catch (error) {
-			console.error('Invalid query string:', error);
-			return {};
+		} catch (error: unknown) {
+			console.warn('Invalid query string:', error);
+			return undefined;
 		}
 	};
 
 	const params = nonNullish(queryString) ? parseQueryString(queryString) : {};
+	// Conservatively, it returns nothing if the function is unable to decipher the query parameters
+	if (params === undefined) {
+		return undefined;
+	}
 
 	const decodedUrn = {
 		prefix,
@@ -73,7 +79,7 @@ export const decodeQrCodeUrn = (urn: string): DecodedUrn | undefined => {
 
 	const result = DecodedUrnSchema.safeParse(decodedUrn);
 	if (!result.success) {
-		console.error(result.error);
+		console.warn('QR code cannot be correctly parsed:', result.error);
 		return undefined;
 	}
 	return result.data;

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -1,13 +1,13 @@
+import { ICP_TOKEN } from '$env/tokens.env';
 import type { EthereumNetwork } from '$eth/types/network';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
-import { decodeQrCode, decodeUrn } from '$lib/utils/qr-code.utils';
+import { decodeQrCode, decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { decodePayment } from '@dfinity/ledger-icrc';
 import { assertNonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 import type { MockedFunction } from 'vitest';
 import { generateUrn } from '../../mocks/qr-generator.mock';
-import { ICP_TOKEN } from '../../mocks/tokens.mock';
 
 describe('decodeUrn', () => {
 	const tokenList = get(tokens);
@@ -16,7 +16,7 @@ describe('decodeUrn', () => {
 
 	it('should return undefined for an invalid URN', () => {
 		const urn = 'invalidURN';
-		const result = decodeUrn(urn);
+		const result = decodeQrCodeUrn(urn);
 		expect(result).toBeUndefined();
 	});
 
@@ -25,7 +25,7 @@ describe('decodeUrn', () => {
 			const urn = generateUrn(token, destination, { amount });
 			assertNonNullish(urn);
 
-			const result = decodeUrn(urn);
+			const result = decodeQrCodeUrn(urn);
 
 			const standard = token.standard;
 			const expectedPrefix =

--- a/src/frontend/src/tests/mocks/qr-generator.mock.ts
+++ b/src/frontend/src/tests/mocks/qr-generator.mock.ts
@@ -1,0 +1,48 @@
+import type { EthereumNetwork } from '$eth/types/network';
+import type { Token } from '$lib/types/token';
+import { isNullish, nonNullish } from '@dfinity/utils';
+
+// This function is used to test the function decodeUrn, looping through tokens in the token store.
+// Ideally, we would have an external API or QR generator, so that the tests are consistent with the proper usage outside the app.
+export const generateUrn = (
+	token: Token,
+	destination: string,
+	params: { [key: string]: string | number | undefined } = {}
+): string | undefined => {
+	let urn: string;
+
+	const { name, standard, network } = token;
+	const tokenAddress: string | undefined =
+		'address' in token ? (token.address as string) : undefined;
+
+	if (standard === 'erc20' && isNullish(tokenAddress)) {
+		return undefined;
+	}
+
+	const prefix =
+		standard === 'erc20' ? 'ethereum' : standard === 'icrc' ? name.toLowerCase() : standard;
+
+	urn = `${prefix}:${destination}`;
+
+	if (standard === 'ethereum' || standard === 'erc20') {
+		urn += nonNullish(network) ? `@${(network as EthereumNetwork).chainId.toString()}` : '';
+	}
+
+	if (standard === 'erc20') {
+		urn += `/transfer`;
+		params.address = tokenAddress;
+	}
+
+	const queryString = new URLSearchParams();
+	for (const [key, value] of Object.entries(params)) {
+		if (value !== undefined) {
+			queryString.append(key, value.toString());
+		}
+	}
+
+	if (queryString.toString()) {
+		urn += `?${queryString.toString()}`;
+	}
+
+	return urn;
+};


### PR DESCRIPTION
# Motivation

To improve the range of URNs that can be decoded, first of all, we created a custom `decodeUrn` function that takes into consideration the schema and the possible cases of the currently onboarded tokens:

- [IC & ICRC](https://github.com/dfinity/ICRC/issues/22)
- [ETH and ERC20](https://eips.ethereum.org/EIPS/eip-681)
- [BTC](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)

To be noted that, for the ERC20 tokens, the process is not the same as the ICRC tokens: ERC20 tokens provide their respective contract address as additional URN parameter. That means that even if the prefix is `ethereum`, to find out the correct token, we need to loop among the ERC20 token addresses.

# Changes

- Created new function `decodeUrn` that receives as input a generic URN and returns it deconstructed into its single parts, including any number of parameters.
- Created types for the URN decoder return that can have some compulsory numeric and/or string parameters; otherwise the function will try to parse the parameter value as number or return as a string if failed.
- Created URN generator function in `mocks` folder to be used in the tests.
- Created tests of function `decodeUrn` that loop among all tokens in the token store.

# Tests

To perform tests, we created function `generateUrn` in the `mocks` folder. Then, the tests are done in loop for every token in the token store. 

# To-Do

- Use the `decodeUrn` instead of `decodePayment` from package `@dfinity/ledger-icrc` and adapt the tests.
- As suggestion: instead of using our own URN generator, we should use a third-party provider, to be sure of the current usage and schemas.
