### PR TITLE
refactor: moved the components test folder inside the lib test folder

### DIFF
--- a/src/frontend/src/tests/lib/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendInputAmount.spec.ts
@@ -2,7 +2,7 @@ import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { expect } from 'vitest';
-import en from '../../mocks/i18n.mock';
+import en from '../../../mocks/i18n.mock';
 
 describe('SendInputAmount', () => {
 	const amount = 10.25;


### PR DESCRIPTION
# Motivation

This simple refactoring is just to keep the tests well organized and in the correct places.

# Changes

Moved the path `src/frontend/src/tests/components` to `src/frontend/src/tests/lib/components`
