### PR TITLE
fix: downgrade Rust 1.78 to 1.75

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.75.0"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

The team has identified an issue in Rust v1.78 with CI jobs that started failing after the upgrade.

The root cause of the issue appears to be linked to the wasm-bindgen issue documented here: https://github.com/rustwasm/wasm-bindgen/issues/3801. Although this issue is fixed, it has not been patched in Rust 1.78 (more information can be found on Slack in #dev channel).

I believe that Oisy might not be impacted since the backend canister was updated a few weeks ago without any reported errors. Nevertheless, it is probably safer to downgrade the Rust version.

I am using v1.75 in Juno, which is why I suggest downgrading to this particular version.

# Changes

- downgrade rust toolchain from 1.78 to 1.75
