### PR TITLE
refactor: created enums for the wizard steps related to send flow

### DIFF
--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -3,7 +3,7 @@
 	import { getContext } from 'svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendTokenWizard from '$eth/components/send/SendTokenWizard.svelte';
-	import { ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSendStepName, ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { sendWizardSteps } from '$eth/config/send.config';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import type { Network } from '$lib/types/network';
@@ -73,7 +73,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === 'Sending'}
+	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -3,7 +3,7 @@
 	import { getContext } from 'svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendTokenWizard from '$eth/components/send/SendTokenWizard.svelte';
-	import { ProgressStepsSendStepName, ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { sendWizardSteps } from '$eth/config/send.config';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import type { Network } from '$lib/types/network';
@@ -12,6 +12,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Erc20Token } from '$eth/types/erc20';
 	import { ethereumToken } from '$eth/derived/token.derived';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 
 	/**
 	 * Props
@@ -73,7 +74,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
+	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -6,7 +6,7 @@
 	import SendForm from './SendForm.svelte';
 	import SendReview from './SendReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
-	import { ProgressStepsSendStepName, ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { address } from '$lib/derived/address.derived';
 	import {
 		FEE_CONTEXT_KEY,
@@ -36,6 +36,7 @@
 	import { shouldSendWithApproval } from '$eth/utils/send.utils';
 	import { toCkErc20HelperContractAddress } from '$icp-eth/utils/cketh.utils';
 	import type { Token } from '$lib/types/token';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 
 	export let currentStep: WizardStep | undefined;
 	export let formCancelAction: 'back' | 'close' = 'close';
@@ -204,12 +205,12 @@
 	bind:this={feeContext}
 	{amount}
 	{destination}
-	observe={currentStep?.name !== ProgressStepsSendStepName.SENDING}
+	observe={currentStep?.name !== WizardStepsSend.SENDING}
 	{sourceNetwork}
 	{targetNetwork}
 	{nativeEthereumToken}
 >
-	{#if currentStep?.name === ProgressStepsSendStepName.REVIEW}
+	{#if currentStep?.name === WizardStepsSend.REVIEW}
 		<SendReview
 			on:icBack
 			on:icSend={send}
@@ -219,12 +220,12 @@
 			{targetNetwork}
 			{destinationEditable}
 		/>
-	{:else if currentStep?.name === ProgressStepsSendStepName.SENDING}
+	{:else if currentStep?.name === WizardStepsSend.SENDING}
 		<InProgressWizard
 			progressStep={sendProgressStep}
 			steps={sendSteps({ i18n: $i18n, sendWithApproval })}
 		/>
-	{:else if currentStep?.name === ProgressStepsSendStepName.SEND}
+	{:else if currentStep?.name === WizardStepsSend.SEND}
 		<SendForm
 			on:icNext
 			on:icClose={close}

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -6,7 +6,7 @@
 	import SendForm from './SendForm.svelte';
 	import SendReview from './SendReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
-	import { ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSendStepName, ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { address } from '$lib/derived/address.derived';
 	import {
 		FEE_CONTEXT_KEY,
@@ -204,12 +204,12 @@
 	bind:this={feeContext}
 	{amount}
 	{destination}
-	observe={currentStep?.name !== 'Sending'}
+	observe={currentStep?.name !== ProgressStepsSendStepName.SENDING}
 	{sourceNetwork}
 	{targetNetwork}
 	{nativeEthereumToken}
 >
-	{#if currentStep?.name === 'Review'}
+	{#if currentStep?.name === ProgressStepsSendStepName.REVIEW}
 		<SendReview
 			on:icBack
 			on:icSend={send}
@@ -219,12 +219,12 @@
 			{targetNetwork}
 			{destinationEditable}
 		/>
-	{:else if currentStep?.name === 'Sending'}
+	{:else if currentStep?.name === ProgressStepsSendStepName.SENDING}
 		<InProgressWizard
 			progressStep={sendProgressStep}
 			steps={sendSteps({ i18n: $i18n, sendWithApproval })}
 		/>
-	{:else if currentStep?.name === 'Send'}
+	{:else if currentStep?.name === ProgressStepsSendStepName.SEND}
 		<SendForm
 			on:icNext
 			on:icClose={close}

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -17,7 +17,7 @@
 	import { address } from '$lib/derived/address.derived';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import WalletConnectSendReview from './WalletConnectSendReview.svelte';
-	import { ProgressStepsSend, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
 	import {
@@ -40,6 +40,7 @@
 	import { shouldSendWithApproval } from '$eth/utils/send.utils';
 	import { ckErc20HelperContractAddress } from '$icp-eth/derived/cketh.derived';
 	import { isErc20TransactionApprove } from '$eth/utils/transactions.utils';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 
 	export let request: Web3WalletTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;
@@ -98,11 +99,11 @@
 
 	const steps: WizardSteps = [
 		{
-			name: ProgressStepsSendStepName.REVIEW,
+			name: WizardStepsSend.REVIEW,
 			title: $i18n.send.text.review
 		},
 		{
-			name: ProgressStepsSendStepName.SENDING,
+			name: WizardStepsSend.SENDING,
 			title: $i18n.send.text.sending
 		}
 	];
@@ -169,12 +170,12 @@
 	<FeeContext
 		amount={amount.toString()}
 		{destination}
-		observe={currentStep?.name !== ProgressStepsSendStepName.SENDING}
+		observe={currentStep?.name !== WizardStepsSend.SENDING}
 		{sourceNetwork}
 		nativeEthereumToken={$ethereumToken}
 	>
 		<CkEthLoader nativeTokenId={$sendTokenId}>
-			{#if currentStep?.name === ProgressStepsSendStepName.SENDING}
+			{#if currentStep?.name === WizardStepsSend.SENDING}
 				<SendProgress
 					progressStep={sendProgressStep}
 					steps={walletConnectSendSteps({ i18n: $i18n, sendWithApproval })}

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -17,7 +17,7 @@
 	import { address } from '$lib/derived/address.derived';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import WalletConnectSendReview from './WalletConnectSendReview.svelte';
-	import { ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
 	import {
@@ -98,11 +98,11 @@
 
 	const steps: WizardSteps = [
 		{
-			name: 'Review',
+			name: ProgressStepsSendStepName.REVIEW,
 			title: $i18n.send.text.review
 		},
 		{
-			name: 'Sending',
+			name: ProgressStepsSendStepName.SENDING,
 			title: $i18n.send.text.sending
 		}
 	];
@@ -169,12 +169,12 @@
 	<FeeContext
 		amount={amount.toString()}
 		{destination}
-		observe={currentStep?.name !== 'Sending'}
+		observe={currentStep?.name !== ProgressStepsSendStepName.SENDING}
 		{sourceNetwork}
 		nativeEthereumToken={$ethereumToken}
 	>
 		<CkEthLoader nativeTokenId={$sendTokenId}>
-			{#if currentStep?.name === 'Sending'}
+			{#if currentStep?.name === ProgressStepsSendStepName.SENDING}
 				<SendProgress
 					progressStep={sendProgressStep}
 					steps={walletConnectSendSteps({ i18n: $i18n, sendWithApproval })}

--- a/src/frontend/src/eth/config/send.config.ts
+++ b/src/frontend/src/eth/config/send.config.ts
@@ -1,17 +1,17 @@
-import { ProgressStepsSendStepName } from '$lib/enums/progress-steps';
+import { WizardStepsSend } from '$lib/enums/wizard-steps';
 import type { WizardSteps } from '@dfinity/gix-components';
 
 export const sendWizardSteps = (i18n: I18n): WizardSteps => [
 	{
-		name: ProgressStepsSendStepName.SEND,
+		name: WizardStepsSend.SEND,
 		title: i18n.send.text.send
 	},
 	{
-		name: ProgressStepsSendStepName.REVIEW,
+		name: WizardStepsSend.REVIEW,
 		title: i18n.send.text.review
 	},
 	{
-		name: ProgressStepsSendStepName.SENDING,
+		name: WizardStepsSend.SENDING,
 		title: i18n.send.text.sending
 	}
 ];

--- a/src/frontend/src/eth/config/send.config.ts
+++ b/src/frontend/src/eth/config/send.config.ts
@@ -1,16 +1,17 @@
+import { ProgressStepsSendStepName } from '$lib/enums/progress-steps';
 import type { WizardSteps } from '@dfinity/gix-components';
 
 export const sendWizardSteps = (i18n: I18n): WizardSteps => [
 	{
-		name: 'Send',
+		name: ProgressStepsSendStepName.SEND,
 		title: i18n.send.text.send
 	},
 	{
-		name: 'Review',
+		name: ProgressStepsSendStepName.REVIEW,
 		title: i18n.send.text.review
 	},
 	{
-		name: 'Sending',
+		name: ProgressStepsSendStepName.SENDING,
 		title: i18n.send.text.sending
 	}
 ];

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { ProgressStepsSend, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import type { Network } from '$lib/types/network';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
@@ -19,6 +19,7 @@
 		toCkEthHelperContractAddress
 	} from '$icp-eth/utils/cketh.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 
 	/**
 	 * Props
@@ -65,7 +66,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
+	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import type { Network } from '$lib/types/network';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
@@ -65,7 +65,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === 'Sending'}
+	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import type { Network } from '$lib/types/network';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
@@ -81,7 +81,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === 'Sending'}
+	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { ProgressStepsSend, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import type { Network } from '$lib/types/network';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
@@ -22,6 +22,7 @@
 		toCkEthHelperContractAddress
 	} from '$icp-eth/utils/cketh.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 
 	/**
 	 * Props
@@ -81,7 +82,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
+	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep } from '@dfinity/gix-components';
 	import type { WizardSteps } from '@dfinity/gix-components';
-	import { ProgressStepsSendIc, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
+	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 	import IcSendForm from './IcSendForm.svelte';
 	import IcSendReview from './IcSendReview.svelte';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
@@ -43,6 +43,7 @@
 		initEthereumFeeStore,
 		type EthereumFeeContext as EthereumFeeContextType
 	} from '$icp/stores/ethereum-fee.store';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 
 	/**
 	 * Props
@@ -130,7 +131,7 @@
 	let steps: WizardSteps;
 	$: steps = [
 		{
-			name: ProgressStepsSendStepName.SEND,
+			name: WizardStepsSend.SEND,
 			title: isNetworkIdBTC(networkId)
 				? $i18n.convert.text.convert_to_btc
 				: isNetworkIdEthereum(networkId)
@@ -140,11 +141,11 @@
 					: $i18n.send.text.send
 		},
 		{
-			name: ProgressStepsSendStepName.REVIEW,
+			name: WizardStepsSend.REVIEW,
 			title: $i18n.send.text.review
 		},
 		{
-			name: ProgressStepsSendStepName.SENDING,
+			name: WizardStepsSend.SENDING,
 			title: $i18n.send.text.sending
 		}
 	];
@@ -185,15 +186,15 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
+	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
 	<EthereumFeeContext {networkId}>
 		<BitcoinFeeContext {amount} {networkId}>
-			{#if currentStep?.name === ProgressStepsSendStepName.REVIEW}
+			{#if currentStep?.name === WizardStepsSend.REVIEW}
 				<IcSendReview on:icBack={modal.back} on:icSend={send} {destination} {amount} {networkId} />
-			{:else if currentStep?.name === ProgressStepsSendStepName.SENDING}
+			{:else if currentStep?.name === WizardStepsSend.SENDING}
 				<IcSendProgress bind:sendProgressStep {networkId} />
 			{:else}
 				<IcSendForm

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep } from '@dfinity/gix-components';
 	import type { WizardSteps } from '@dfinity/gix-components';
-	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
+	import { ProgressStepsSendIc, ProgressStepsSendStepName } from '$lib/enums/progress-steps';
 	import IcSendForm from './IcSendForm.svelte';
 	import IcSendReview from './IcSendReview.svelte';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
@@ -130,7 +130,7 @@
 	let steps: WizardSteps;
 	$: steps = [
 		{
-			name: 'Send',
+			name: ProgressStepsSendStepName.SEND,
 			title: isNetworkIdBTC(networkId)
 				? $i18n.convert.text.convert_to_btc
 				: isNetworkIdEthereum(networkId)
@@ -140,11 +140,11 @@
 					: $i18n.send.text.send
 		},
 		{
-			name: 'Review',
+			name: ProgressStepsSendStepName.REVIEW,
 			title: $i18n.send.text.review
 		},
 		{
-			name: 'Sending',
+			name: ProgressStepsSendStepName.SENDING,
 			title: $i18n.send.text.sending
 		}
 	];
@@ -185,15 +185,15 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === 'Sending'}
+	disablePointerEvents={currentStep?.name === ProgressStepsSendStepName.SENDING}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
 	<EthereumFeeContext {networkId}>
 		<BitcoinFeeContext {amount} {networkId}>
-			{#if currentStep?.name === 'Review'}
+			{#if currentStep?.name === ProgressStepsSendStepName.REVIEW}
 				<IcSendReview on:icBack={modal.back} on:icSend={send} {destination} {amount} {networkId} />
-			{:else if currentStep?.name === 'Sending'}
+			{:else if currentStep?.name === ProgressStepsSendStepName.SENDING}
 				<IcSendProgress bind:sendProgressStep {networkId} />
 			{:else}
 				<IcSendForm

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -53,3 +53,9 @@ export enum ProgressStepsUpdateBalanceCkBtc {
 	RELOAD = 'reload',
 	DONE = 'done'
 }
+
+export enum ProgressStepsSendStepName {
+	SEND = 'Send',
+	REVIEW = 'Review',
+	SENDING = 'Sending'
+}

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -53,9 +53,3 @@ export enum ProgressStepsUpdateBalanceCkBtc {
 	RELOAD = 'reload',
 	DONE = 'done'
 }
-
-export enum ProgressStepsSendStepName {
-	SEND = 'Send',
-	REVIEW = 'Review',
-	SENDING = 'Sending'
-}

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -1,0 +1,5 @@
+export enum WizardStepsSend {
+	SEND = 'Send',
+	REVIEW = 'Review',
+	SENDING = 'Sending'
+}


### PR DESCRIPTION
# Motivation

The Wizard steps for the send flow were hard-coded strings in the code. We want them to be enums as to be better controlled and compared.
There is no clear advantage in creating different sets of enums for ETH and for IC, since the Wizard steps are in the end customized for each case at modal-level, but are based on the same basic flow.

# Changes

- Adding enums referring to the Wizard steps of the send flow.
- Adapt the send scripts to use such enums.

# To-Do

All the hard-coded Wizard steps should be transformed as enum. We will work on it in another PR.
