### PR TITLE
refactor: steps to progress-steps

### DIFF
--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -3,7 +3,7 @@
 	import { getContext } from 'svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendTokenWizard from '$eth/components/send/SendTokenWizard.svelte';
-	import { SendStep } from '$lib/enums/steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { sendWizardSteps } from '$eth/config/send.config';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import type { Network } from '$lib/types/network';
@@ -21,7 +21,7 @@
 	export let targetNetwork: Network | undefined = undefined;
 
 	let amount: number | undefined = undefined;
-	let sendProgressStep: string = SendStep.INITIALIZATION;
+	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	/**
 	 * Send context store
@@ -62,7 +62,7 @@
 			amount = undefined;
 			targetNetwork = undefined;
 
-			sendProgressStep = SendStep.INITIALIZATION;
+			sendProgressStep = ProgressStepsSend.INITIALIZATION;
 
 			currentStep = undefined;
 		});

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -6,7 +6,7 @@
 	import SendForm from './SendForm.svelte';
 	import SendReview from './SendReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
-	import { SendStep } from '$lib/enums/steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { address } from '$lib/derived/address.derived';
 	import {
 		FEE_CONTEXT_KEY,
@@ -156,7 +156,7 @@
 			await executeSend({
 				from: $address,
 				to: mapAddressStartsWith0x(destination),
-				progress: (step: SendStep) => (sendProgressStep = step),
+				progress: (step: ProgressStepsSend) => (sendProgressStep = step),
 				token: $sendToken,
 				amount: parseToken({
 					value: `${amount}`,

--- a/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
@@ -9,7 +9,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { authStore } from '$lib/stores/auth.store';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { AddTokenStep } from '$lib/enums/steps';
+	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { addUserToken } from '$lib/api/backend.api';
 	import { selectedChainId, selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { erc20TokensStore } from '$eth/stores/erc20.store';
@@ -34,7 +34,7 @@
 		}
 	];
 
-	let saveProgressStep: string = AddTokenStep.INITIALIZATION;
+	let saveProgressStep: string = ProgressStepsAddToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
@@ -65,7 +65,7 @@
 		modal.next();
 
 		try {
-			saveProgressStep = AddTokenStep.SAVE;
+			saveProgressStep = ProgressStepsAddToken.SAVE;
 
 			await addUserToken({
 				identity: $authStore.identity,
@@ -78,7 +78,7 @@
 				}
 			});
 
-			saveProgressStep = AddTokenStep.UPDATE_UI;
+			saveProgressStep = ProgressStepsAddToken.UPDATE_UI;
 
 			erc20TokensStore.add(
 				mapErc20Token({
@@ -90,7 +90,7 @@
 				})
 			);
 
-			saveProgressStep = AddTokenStep.DONE;
+			saveProgressStep = ProgressStepsAddToken.DONE;
 
 			setTimeout(() => close(), 750);
 		} catch (err: unknown) {
@@ -106,7 +106,7 @@
 	const close = () => {
 		modalStore.close();
 
-		saveProgressStep = AddTokenStep.INITIALIZATION;
+		saveProgressStep = ProgressStepsAddToken.INITIALIZATION;
 	};
 </script>
 

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -17,7 +17,7 @@
 	import { address } from '$lib/derived/address.derived';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import WalletConnectSendReview from './WalletConnectSendReview.svelte';
-	import { SendStep } from '$lib/enums/steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
 	import {
@@ -132,7 +132,7 @@
 	 * Send and approve
 	 */
 
-	let sendProgressStep: string = SendStep.INITIALIZATION;
+	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	let amount: BigNumber;
 	$: amount = BigNumber.from(firstTransaction?.value ?? '0');
@@ -146,7 +146,7 @@
 			fee: $feeStore,
 			modalNext: modal.next,
 			token: $sendToken,
-			progress: (step: SendStep) => (sendProgressStep = step),
+			progress: (step: ProgressStepsSend) => (sendProgressStep = step),
 			identity: $authStore.identity,
 			minterInfo: $ckEthMinterInfoStore?.[$ethereumTokenId],
 			sourceNetwork,

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
@@ -3,7 +3,7 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 	import type { WalletConnectListener } from '$eth/types/wallet-connect';
-	import { SignStep } from '$lib/enums/steps';
+	import { ProgressStepsSign } from '$lib/enums/progress-steps';
 	import WalletConnectSignReview from './WalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$eth/constants/steps.constants';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
@@ -38,7 +38,7 @@
 	 * WalletConnect
 	 */
 
-	let signProgressStep: string = SignStep.INITIALIZATION;
+	let signProgressStep: string = ProgressStepsSign.INITIALIZATION;
 
 	/**
 	 * Reject a message
@@ -55,7 +55,7 @@
 			request,
 			listener,
 			modalNext: modal.next,
-			progress: (step: SignStep) => (signProgressStep = step)
+			progress: (step: ProgressStepsSign) => (signProgressStep = step)
 		});
 
 		setTimeout(() => close(), success ? 750 : 0);

--- a/src/frontend/src/eth/constants/steps.constants.ts
+++ b/src/frontend/src/eth/constants/steps.constants.ts
@@ -1,4 +1,4 @@
-import { SendStep } from '$lib/enums/steps';
+import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import type { ProgressStep } from '@dfinity/gix-components';
 
 export const sendSteps = ({
@@ -9,31 +9,31 @@ export const sendSteps = ({
 	sendWithApproval: boolean;
 }): [ProgressStep, ...ProgressStep[]] => [
 	{
-		step: SendStep.INITIALIZATION,
+		step: ProgressStepsSend.INITIALIZATION,
 		text: i18n.send.text.initializing_transaction,
 		state: 'in_progress'
 	} as ProgressStep,
 	...(sendWithApproval
 		? [
 				{
-					step: SendStep.SIGN_APPROVE,
+					step: ProgressStepsSend.SIGN_APPROVE,
 					text: i18n.send.text.signing_approval,
 					state: 'next'
 				} as ProgressStep,
 				{
-					step: SendStep.APPROVE,
+					step: ProgressStepsSend.APPROVE,
 					text: i18n.send.text.approving,
 					state: 'next'
 				} as ProgressStep
 			]
 		: []),
 	{
-		step: SendStep.SIGN_TRANSFER,
+		step: ProgressStepsSend.SIGN_TRANSFER,
 		text: i18n.send.text.signing_transaction,
 		state: 'next'
 	} as ProgressStep,
 	{
-		step: SendStep.TRANSFER,
+		step: ProgressStepsSend.TRANSFER,
 		text: i18n.send.text.sending,
 		state: 'next'
 	} as ProgressStep
@@ -51,7 +51,7 @@ export const walletConnectSendSteps = ({
 		...rest
 	}),
 	{
-		step: SendStep.APPROVE_WALLET_CONNECT,
+		step: ProgressStepsSend.APPROVE_WALLET_CONNECT,
 		text: i18n.send.text.approving_wallet_connect,
 		state: 'next'
 	}
@@ -59,17 +59,17 @@ export const walletConnectSendSteps = ({
 
 export const walletConnectSignSteps = (i18n: I18n): [ProgressStep, ...ProgressStep[]] => [
 	{
-		step: SendStep.INITIALIZATION,
+		step: ProgressStepsSend.INITIALIZATION,
 		text: i18n.send.text.initializing,
 		state: 'in_progress'
 	} as ProgressStep,
 	{
-		step: SendStep.SIGN_TRANSFER,
+		step: ProgressStepsSend.SIGN_TRANSFER,
 		text: i18n.send.text.signing_message,
 		state: 'next'
 	} as ProgressStep,
 	{
-		step: SendStep.TRANSFER,
+		step: ProgressStepsSend.TRANSFER,
 		text: i18n.send.text.approving,
 		state: 'next'
 	} as ProgressStep

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -21,7 +21,7 @@ import {
 } from '$icp-eth/utils/cketh.utils';
 import { signTransaction } from '$lib/api/backend.api';
 import { DEFAULT_NETWORK } from '$lib/constants/networks.constants';
-import { SendStep } from '$lib/enums/steps';
+import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { ETH_ADDRESS } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
@@ -245,7 +245,7 @@ const prepare = async ({
 };
 
 export const send = async ({
-	lastProgressStep = SendStep.DONE,
+	lastProgressStep = ProgressStepsSend.DONE,
 	progress,
 	sourceNetwork,
 	token,
@@ -257,7 +257,7 @@ export const send = async ({
 		maxFeePerGas: BigNumber;
 		maxPriorityFeePerGas: BigNumber;
 	}): Promise<{ hash: string }> => {
-	progress(SendStep.INITIALIZATION);
+	progress(ProgressStepsSend.INITIALIZATION);
 
 	const { id: networkId } = sourceNetwork;
 
@@ -399,11 +399,11 @@ const sendTransaction = async ({
 							: infuraErc20Providers(networkId).populateTransaction
 				}));
 
-	progress(SendStep.SIGN_TRANSFER);
+	progress(ProgressStepsSend.SIGN_TRANSFER);
 
 	const rawTransaction = await signTransaction({ identity, transaction });
 
-	progress(SendStep.TRANSFER);
+	progress(ProgressStepsSend.TRANSFER);
 
 	return await sendTransaction(rawTransaction);
 };
@@ -456,11 +456,11 @@ const approve = async ({
 		spender: erc20HelperContractAddress
 	});
 
-	progress(SendStep.SIGN_APPROVE);
+	progress(ProgressStepsSend.SIGN_APPROVE);
 
 	const rawTransaction = await signTransaction({ identity, transaction: approve });
 
-	progress(SendStep.APPROVE);
+	progress(ProgressStepsSend.APPROVE);
 
 	const { sendTransaction } = infuraProviders(networkId);
 

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -12,7 +12,7 @@ import {
 	TRACK_COUNT_WC_ETH_SEND_ERROR,
 	TRACK_COUNT_WC_ETH_SEND_SUCCESS
 } from '$lib/constants/analytics.contants';
-import { SendStep, SignStep } from '$lib/enums/steps';
+import { ProgressStepsSend, ProgressStepsSign } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
 import { authStore } from '$lib/stores/auth.store';
 import { busy } from '$lib/stores/busy.store';
@@ -46,7 +46,7 @@ export type WalletConnectSendParams = WalletConnectExecuteParams & {
 export type WalletConnectSignMessageParams = WalletConnectExecuteParams & {
 	listener: WalletConnectListener | null | undefined;
 	modalNext: () => void;
-	progress: (step: SignStep) => void;
+	progress: (step: ProgressStepsSign) => void;
 };
 
 export const reject = (
@@ -80,7 +80,7 @@ export const send = ({
 	token,
 	progress,
 	amount,
-	lastProgressStep = SendStep.DONE,
+	lastProgressStep = ProgressStepsSend.DONE,
 	identity,
 	minterInfo,
 	sourceNetwork,
@@ -178,7 +178,7 @@ export const send = ({
 					from: address,
 					to,
 					progress,
-					lastProgressStep: SendStep.APPROVE,
+					lastProgressStep: ProgressStepsSend.APPROVE,
 					token,
 					amount,
 					maxFeePerGas,
@@ -241,7 +241,7 @@ export const signMessage = ({
 			modalNext();
 
 			try {
-				progress(SignStep.SIGN);
+				progress(ProgressStepsSign.SIGN);
 
 				const sign = (params: string[]): Promise<string> => {
 					const { identity } = get(authStore);
@@ -260,11 +260,11 @@ export const signMessage = ({
 
 				const signedMessage = await sign(params);
 
-				progress(SignStep.APPROVE);
+				progress(ProgressStepsSign.APPROVE);
 
 				await listener.approveRequest({ topic, id, message: signedMessage });
 
-				progress(SignStep.DONE);
+				progress(ProgressStepsSign.DONE);
 
 				return { success: true };
 			} catch (err: unknown) {

--- a/src/frontend/src/eth/types/send.ts
+++ b/src/frontend/src/eth/types/send.ts
@@ -1,13 +1,13 @@
 import type { EthereumNetwork } from '$eth/types/network';
 import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
-import { SendStep } from '$lib/enums/steps';
+import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Network } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 
 export type SendParams = {
-	progress: (step: SendStep) => void;
-	lastProgressStep?: SendStep;
+	progress: (step: ProgressStepsSend) => void;
+	lastProgressStep?: ProgressStepsSend;
 	token: Token;
 	sourceNetwork: EthereumNetwork;
 	targetNetwork?: Network | undefined;

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { SendStep } from '$lib/enums/steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import type { Network } from '$lib/types/network';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
@@ -36,7 +36,7 @@
 	let targetNetwork: Network | undefined = ICP_NETWORK;
 
 	let amount: number | undefined = undefined;
-	let sendProgressStep: string = SendStep.INITIALIZATION;
+	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	/**
 	 * Wizard modal
@@ -54,7 +54,7 @@
 			amount = undefined;
 			targetNetwork = undefined;
 
-			sendProgressStep = SendStep.INITIALIZATION;
+			sendProgressStep = ProgressStepsSend.INITIALIZATION;
 
 			currentStep = undefined;
 		});

--- a/src/frontend/src/icp/components/receive/IcReceiveBitcoin.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveBitcoin.svelte
@@ -5,7 +5,7 @@
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import { updateBalance } from '$icp/services/ckbtc.services';
 	import { authStore } from '$lib/stores/auth.store';
-	import { UpdateBalanceCkBtcStep } from '$lib/enums/steps';
+	import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
 	import { Modal } from '@dfinity/gix-components';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { modalReceiveBitcoin } from '$lib/derived/modal.derived';
@@ -19,7 +19,7 @@
 	let receiveProgressStep: string | undefined = undefined;
 
 	const receive = async () => {
-		receiveProgressStep = UpdateBalanceCkBtcStep.INITIALIZATION;
+		receiveProgressStep = ProgressStepsUpdateBalanceCkBtc.INITIALIZATION;
 
 		modalStore.openReceiveBitcoin();
 
@@ -27,10 +27,10 @@
 			await updateBalance({
 				token: $token as IcToken,
 				identity: $authStore.identity,
-				progress: (step: UpdateBalanceCkBtcStep) => (receiveProgressStep = step)
+				progress: (step: ProgressStepsUpdateBalanceCkBtc) => (receiveProgressStep = step)
 			});
 
-			receiveProgressStep = UpdateBalanceCkBtcStep.DONE;
+			receiveProgressStep = ProgressStepsUpdateBalanceCkBtc.DONE;
 
 			setTimeout(() => modalStore.close(), 750);
 		} catch (err: unknown) {

--- a/src/frontend/src/icp/components/receive/IcReceiveBitcoinProgress.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveBitcoinProgress.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-	import { UpdateBalanceCkBtcStep } from '$lib/enums/steps';
+	import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import type { ProgressStep } from '@dfinity/gix-components';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	export let receiveProgressStep: string = UpdateBalanceCkBtcStep.INITIALIZATION;
+	export let receiveProgressStep: string = ProgressStepsUpdateBalanceCkBtc.INITIALIZATION;
 
 	let steps: [ProgressStep, ...ProgressStep[]];
 	$: steps = [
 		{
-			step: UpdateBalanceCkBtcStep.INITIALIZATION,
+			step: ProgressStepsUpdateBalanceCkBtc.INITIALIZATION,
 			text: $i18n.receive.bitcoin.text.initializing,
 			state: 'in_progress'
 		} as ProgressStep,
 		{
-			step: UpdateBalanceCkBtcStep.RETRIEVE,
+			step: ProgressStepsUpdateBalanceCkBtc.RETRIEVE,
 			text: $i18n.receive.bitcoin.text.checking_incoming,
 			state: 'next'
 		} as ProgressStep,
 		{
-			step: UpdateBalanceCkBtcStep.RELOAD,
+			step: ProgressStepsUpdateBalanceCkBtc.RELOAD,
 			text: $i18n.receive.bitcoin.text.refreshing_wallet,
 			state: 'next'
 		} as ProgressStep

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { SendStep } from '$lib/enums/steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import type { Network } from '$lib/types/network';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
@@ -39,7 +39,7 @@
 	let targetNetwork: Network | undefined = ICP_NETWORK;
 
 	let amount: number | undefined = undefined;
-	let sendProgressStep: string = SendStep.INITIALIZATION;
+	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	/**
 	 * Wizard modal
@@ -70,7 +70,7 @@
 			amount = undefined;
 			targetNetwork = undefined;
 
-			sendProgressStep = SendStep.INITIALIZATION;
+			sendProgressStep = ProgressStepsSend.INITIALIZATION;
 
 			currentStep = undefined;
 		});

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep } from '@dfinity/gix-components';
 	import type { WizardSteps } from '@dfinity/gix-components';
-	import { SendIcStep } from '$lib/enums/steps';
+	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 	import IcSendForm from './IcSendForm.svelte';
 	import IcSendReview from './IcSendReview.svelte';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
@@ -56,7 +56,7 @@
 	 * Send
 	 */
 
-	let sendProgressStep: string = SendIcStep.INITIALIZATION;
+	let sendProgressStep: string = ProgressStepsSendIc.INITIALIZATION;
 
 	const send = async () => {
 		if (isNullishOrEmpty(destination)) {
@@ -83,7 +83,7 @@
 					unitName: $tokenDecimals
 				}),
 				identity: $authStore.identity,
-				progress: (step: SendIcStep) => (sendProgressStep = step)
+				progress: (step: ProgressStepsSendIc) => (sendProgressStep = step)
 			};
 
 			await sendIc({
@@ -103,7 +103,7 @@
 				}
 			});
 
-			sendProgressStep = SendIcStep.DONE;
+			sendProgressStep = ProgressStepsSendIc.DONE;
 
 			setTimeout(() => close(), 750);
 		} catch (err: unknown) {
@@ -158,7 +158,7 @@
 			amount = undefined;
 			networkId = undefined;
 
-			sendProgressStep = SendIcStep.INITIALIZATION;
+			sendProgressStep = ProgressStepsSendIc.INITIALIZATION;
 
 			currentStep = undefined;
 		});

--- a/src/frontend/src/icp/components/send/IcSendProgress.svelte
+++ b/src/frontend/src/icp/components/send/IcSendProgress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { SendIcStep } from '$lib/enums/steps';
+	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import type { ProgressStep } from '@dfinity/gix-components';
 	import type { NetworkId } from '$lib/types/network';
@@ -7,20 +7,20 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { tokenCkErc20Ledger } from '$icp/derived/ic-token.derived';
 
-	export let sendProgressStep: string = SendIcStep.INITIALIZATION;
+	export let sendProgressStep: string = ProgressStepsSendIc.INITIALIZATION;
 	export let networkId: NetworkId | undefined = undefined;
 
 	let steps: [ProgressStep, ...ProgressStep[]];
 	$: steps = [
 		{
-			step: SendIcStep.INITIALIZATION,
+			step: ProgressStepsSendIc.INITIALIZATION,
 			text: $i18n.send.text.initializing_transaction,
 			state: 'in_progress'
 		} as ProgressStep,
 		...($tokenCkErc20Ledger
 			? [
 					{
-						step: SendIcStep.APPROVE_FEES,
+						step: ProgressStepsSendIc.APPROVE_FEES,
 						text: $i18n.send.text.approving_fees,
 						state: 'next'
 					} as ProgressStep
@@ -29,7 +29,7 @@
 		...(isNetworkIdBTC(networkId) || isNetworkIdETH(networkId)
 			? [
 					{
-						step: SendIcStep.APPROVE_TRANSFER,
+						step: ProgressStepsSendIc.APPROVE_TRANSFER,
 						text: $tokenCkErc20Ledger
 							? $i18n.send.text.approving_transfer
 							: $i18n.send.text.approving,
@@ -38,12 +38,12 @@
 				]
 			: []),
 		{
-			step: SendIcStep.SEND,
+			step: ProgressStepsSendIc.SEND,
 			text: $i18n.send.text.sending,
 			state: 'next'
 		} as ProgressStep,
 		{
-			step: SendIcStep.RELOAD,
+			step: ProgressStepsSendIc.RELOAD,
 			text: $i18n.send.text.refreshing_ui,
 			state: 'next'
 		} as ProgressStep

--- a/src/frontend/src/icp/components/tokens/IcManageTokensModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcManageTokensModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AddTokenStep } from '$lib/enums/steps';
+	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import IcManageTokens from '$icp/components/tokens/IcManageTokens.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -34,7 +34,7 @@
 		}
 	];
 
-	let saveProgressStep: string = AddTokenStep.INITIALIZATION;
+	let saveProgressStep: string = ProgressStepsAddToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
@@ -74,10 +74,10 @@
 			await saveCustomTokens({
 				identity: $authStore.identity,
 				tokens,
-				progress: (step: AddTokenStep) => (saveProgressStep = step)
+				progress: (step: ProgressStepsAddToken) => (saveProgressStep = step)
 			});
 
-			saveProgressStep = AddTokenStep.DONE;
+			saveProgressStep = ProgressStepsAddToken.DONE;
 
 			setTimeout(() => close(), 750);
 		} catch (err: unknown) {
@@ -93,7 +93,7 @@
 	const close = () => {
 		modalStore.close();
 
-		saveProgressStep = AddTokenStep.INITIALIZATION;
+		saveProgressStep = ProgressStepsAddToken.INITIALIZATION;
 	};
 
 	let ledgerCanisterId = '';

--- a/src/frontend/src/icp/services/ck.services.ts
+++ b/src/frontend/src/icp/services/ck.services.ts
@@ -11,7 +11,7 @@ import type { IcCanisters, IcCkMetadata, IcCkToken } from '$icp/types/ic';
 import type { IcTransferParams } from '$icp/types/ic-send';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import { LOCAL, NANO_SECONDS_IN_MINUTE, STAGING } from '$lib/constants/app.constants';
-import { SendIcStep } from '$lib/enums/steps';
+import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { IcrcBlockIndex } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
@@ -39,7 +39,7 @@ export const convertCkBTCToBtc = async ({
 		to
 	});
 
-	progress(SendIcStep.SEND);
+	progress(ProgressStepsSendIc.SEND);
 
 	await retrieveBtc({
 		identity,
@@ -83,7 +83,7 @@ export const convertCkErc20ToErc20 = async ({
 		canisters: { ledgerCanisterId: ckEthledgerCanisterId, minterCanisterId },
 		identity,
 		progress,
-		progressStep: SendIcStep.APPROVE_FEES,
+		progressStep: ProgressStepsSendIc.APPROVE_FEES,
 		amount: CKERC20_TO_ERC20_MAX_TRANSACTION_FEE,
 		to
 	});
@@ -102,7 +102,7 @@ export const convertCkErc20ToErc20 = async ({
 
 	// 3. Withdraw Erc20
 
-	progress(SendIcStep.SEND);
+	progress(ProgressStepsSendIc.SEND);
 
 	await withdrawErc20({
 		identity,
@@ -134,7 +134,7 @@ export const convertCkETHToEth = async ({
 		to
 	});
 
-	progress(SendIcStep.SEND);
+	progress(ProgressStepsSendIc.SEND);
 
 	await withdrawEth({
 		identity,
@@ -147,10 +147,10 @@ export const convertCkETHToEth = async ({
 const approveTransfer = async ({
 	canisters: { ledgerCanisterId, minterCanisterId },
 	progress,
-	progressStep = SendIcStep.APPROVE_TRANSFER,
+	progressStep = ProgressStepsSendIc.APPROVE_TRANSFER,
 	amount,
 	identity
-}: Omit<IcTransferParams, 'amount'> & { amount: bigint; progressStep?: SendIcStep } & {
+}: Omit<IcTransferParams, 'amount'> & { amount: bigint; progressStep?: ProgressStepsSendIc } & {
 	canisters: Pick<IcCanisters, 'ledgerCanisterId'> & IcCkMetadata;
 }): Promise<IcrcBlockIndex> => {
 	progress(progressStep);

--- a/src/frontend/src/icp/services/ckbtc.services.ts
+++ b/src/frontend/src/icp/services/ckbtc.services.ts
@@ -10,7 +10,7 @@ import type { CkBtcUpdateBalanceParams } from '$icp/types/ckbtc';
 import type { IcCkMetadata, IcCkToken, IcToken } from '$icp/types/ic';
 import { waitAndTriggerWallet } from '$icp/utils/ic-wallet.utils';
 import { queryAndUpdate, type QueryAndUpdateRequestParams } from '$lib/actors/query.ic';
-import { UpdateBalanceCkBtcStep } from '$lib/enums/steps';
+import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
 import { waitWalletReady } from '$lib/services/actions.services';
 import { busy } from '$lib/stores/busy.store';
 import type { CertifiedSetterStoreStore } from '$lib/stores/certified-setter.store';
@@ -36,7 +36,7 @@ export const updateBalance = async ({
 }): Promise<void> => {
 	assertNonNullish(minterCanisterId, get(i18n).init.error.minter_btc);
 
-	progress(UpdateBalanceCkBtcStep.RETRIEVE);
+	progress(ProgressStepsUpdateBalanceCkBtc.RETRIEVE);
 
 	try {
 		const ok = await updateBalanceApi({
@@ -64,7 +64,7 @@ export const updateBalance = async ({
 		populatePendingUtxos({ tokenId, pendingUtxos });
 	}
 
-	progress(UpdateBalanceCkBtcStep.RELOAD);
+	progress(ProgressStepsUpdateBalanceCkBtc.RELOAD);
 
 	await waitAndTriggerWallet();
 };

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -2,7 +2,7 @@ import { loadUserTokens } from '$icp/services/icrc.services';
 import { icrcTokensStore } from '$icp/stores/icrc.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setManyCustomTokens } from '$lib/api/backend.api';
-import { AddTokenStep } from '$lib/enums/steps';
+import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { toNullable } from '@dfinity/utils';
@@ -12,11 +12,11 @@ export const saveCustomTokens = async ({
 	identity,
 	tokens
 }: {
-	progress: (step: AddTokenStep) => void;
+	progress: (step: ProgressStepsAddToken) => void;
 	identity: Identity;
 	tokens: Pick<IcrcCustomToken, 'enabled' | 'version' | 'ledgerCanisterId' | 'indexCanisterId'>[];
 }) => {
-	progress(AddTokenStep.SAVE);
+	progress(ProgressStepsAddToken.SAVE);
 
 	await setManyCustomTokens({
 		identity,
@@ -32,7 +32,7 @@ export const saveCustomTokens = async ({
 		}))
 	});
 
-	progress(AddTokenStep.UPDATE_UI);
+	progress(ProgressStepsAddToken.UPDATE_UI);
 
 	// Hide tokens that have been disabled
 	const disabledTokens = tokens.filter(({ enabled }) => !enabled);

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -19,7 +19,7 @@ import {
 import { waitAndTriggerWallet } from '$icp/utils/ic-wallet.utils';
 import { invalidIcpAddress } from '$icp/utils/icp-account.utils';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
-import { SendIcStep } from '$lib/enums/steps';
+import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
 import type { BlockHeight } from '@dfinity/ledger-icp';
@@ -38,7 +38,7 @@ export const sendIc = async ({
 		...rest
 	});
 
-	progress(SendIcStep.RELOAD);
+	progress(ProgressStepsSendIc.RELOAD);
 
 	await waitAndTriggerWallet();
 };
@@ -104,7 +104,7 @@ const sendIcrc = async ({
 		throw new Error(get(i18n).send.error.invalid_destination);
 	}
 
-	progress(SendIcStep.SEND);
+	progress(ProgressStepsSendIc.SEND);
 
 	return transferIcrc({
 		identity,
@@ -128,7 +128,7 @@ const sendIcp = async ({
 		throw new Error(get(i18n).send.error.invalid_destination);
 	}
 
-	progress(SendIcStep.SEND);
+	progress(ProgressStepsSendIc.SEND);
 
 	return validIcrcAddress
 		? icrc1TransferIcp({

--- a/src/frontend/src/icp/types/ckbtc.ts
+++ b/src/frontend/src/icp/types/ckbtc.ts
@@ -1,9 +1,9 @@
-import { UpdateBalanceCkBtcStep } from '$lib/enums/steps';
+import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
 import type { OptionIdentity } from '$lib/types/identity';
 
 export interface CkBtcUpdateBalanceParams {
 	identity: OptionIdentity;
-	progress: (step: UpdateBalanceCkBtcStep) => void;
+	progress: (step: ProgressStepsUpdateBalanceCkBtc) => void;
 }
 
 export type UtxoTxidText = string;

--- a/src/frontend/src/icp/types/ic-send.ts
+++ b/src/frontend/src/icp/types/ic-send.ts
@@ -1,10 +1,10 @@
-import { SendIcStep } from '$lib/enums/steps';
+import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TransferParams } from '$lib/types/send';
 
 export type IcTransferParams = Pick<TransferParams, 'amount' | 'to'> & {
 	identity: OptionIdentity;
-	progress: (step: SendIcStep) => void;
+	progress: (step: ProgressStepsSendIc) => void;
 };
 
 export class IcAmountAssertionError extends Error {}

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -12,29 +12,29 @@
 	import { browser } from '$app/environment';
 	import { isNullish } from '@dfinity/utils';
 	import { loading } from '$lib/stores/loader.store';
-	import { LoaderStep } from '$lib/enums/steps';
+	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
 	import { loadIcrcTokens } from '$icp/services/icrc.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authStore } from '$lib/stores/auth.store';
 
-	let progressStep: string = LoaderStep.ETH_ADDRESS;
+	let progressStep: string = ProgressStepsLoader.ETH_ADDRESS;
 
 	let steps: [ProgressStep, ...ProgressStep[]];
 	$: steps = [
 		{
-			step: LoaderStep.INITIALIZATION,
+			step: ProgressStepsLoader.INITIALIZATION,
 			text: $i18n.init.text.securing_session,
 			state: 'completed'
 		} as ProgressStep,
 		{
-			step: LoaderStep.ETH_ADDRESS,
+			step: ProgressStepsLoader.ETH_ADDRESS,
 			text: $i18n.init.text.retrieving_eth_key,
 			state: 'in_progress'
 		} as ProgressStep
 	];
 
 	$: (() => {
-		if (progressStep !== LoaderStep.DONE) {
+		if (progressStep !== ProgressStepsLoader.DONE) {
 			return;
 		}
 
@@ -52,7 +52,7 @@
 	const confirm = isNullish(oisy_introduction);
 
 	let disabledConfirm = true;
-	$: disabledConfirm = progressStep !== LoaderStep.DONE;
+	$: disabledConfirm = progressStep !== ProgressStepsLoader.DONE;
 
 	const loadData = async () => {
 		// Load Erc20 contracts and ICRC metadata before loading balances and transactions
@@ -65,7 +65,7 @@
 	};
 
 	const progressAndLoad = async () => {
-		progressStep = LoaderStep.DONE;
+		progressStep = ProgressStepsLoader.DONE;
 
 		// Once the address initialized, we load the data without displaying a progress step.
 		// Instead, we use effect, placeholders and skeleton until those data are loaded.

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -10,7 +10,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { authStore } from '$lib/stores/auth.store';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { HideTokenStep } from '$lib/enums/steps';
+	import { ProgressStepsHideToken } from '$lib/enums/progress-steps';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import HideTokenReview from '$lib/components/tokens/HideTokenReview.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -46,13 +46,13 @@
 		modal.next();
 
 		try {
-			hideProgressStep = HideTokenStep.HIDE;
+			hideProgressStep = ProgressStepsHideToken.HIDE;
 
 			await hideToken({
 				identity: $authStore.identity
 			});
 
-			hideProgressStep = HideTokenStep.UPDATE_UI;
+			hideProgressStep = ProgressStepsHideToken.UPDATE_UI;
 
 			// We must navigate first otherwise we might land on the default token Ethereum selected while being on network ICP.
 			await back({ networkId: backToNetworkId, pop: true });
@@ -61,7 +61,7 @@
 				identity: $authStore.identity
 			});
 
-			hideProgressStep = HideTokenStep.DONE;
+			hideProgressStep = ProgressStepsHideToken.DONE;
 
 			setTimeout(close, 750);
 		} catch (err: unknown) {
@@ -87,23 +87,23 @@
 
 	const HIDE_TOKEN_STEPS: [ProgressStep, ...ProgressStep[]] = [
 		{
-			step: HideTokenStep.INITIALIZATION,
+			step: ProgressStepsHideToken.INITIALIZATION,
 			text: $i18n.tokens.text.initializing,
 			state: 'in_progress'
 		} as ProgressStep,
 		{
-			step: HideTokenStep.HIDE,
+			step: ProgressStepsHideToken.HIDE,
 			text: $i18n.tokens.hide.hiding,
 			state: 'next'
 		} as ProgressStep,
 		{
-			step: HideTokenStep.UPDATE_UI,
+			step: ProgressStepsHideToken.UPDATE_UI,
 			text: $i18n.tokens.text.updating_ui,
 			state: 'next'
 		} as ProgressStep
 	];
 
-	let hideProgressStep: string = HideTokenStep.INITIALIZATION;
+	let hideProgressStep: string = ProgressStepsHideToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
@@ -111,7 +111,7 @@
 	const close = () => {
 		modalStore.close();
 
-		hideProgressStep = HideTokenStep.INITIALIZATION;
+		hideProgressStep = ProgressStepsHideToken.INITIALIZATION;
 	};
 </script>
 

--- a/src/frontend/src/lib/components/ui/InProgressWizard.svelte
+++ b/src/frontend/src/lib/components/ui/InProgressWizard.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import type { ProgressStep } from '@dfinity/gix-components';
 	import InProgress from '$lib/components/ui/InProgress.svelte';
-	import { SendStep } from '$lib/enums/steps';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { onDestroy, onMount } from 'svelte';
 	import { confirmToCloseBrowser } from '$lib/utils/before-unload.utils';
 	import Warning from '$lib/components/ui/Warning.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { nonNullish } from '@dfinity/utils';
 
-	export let progressStep: string = SendStep.INITIALIZATION;
+	export let progressStep: string = ProgressStepsSend.INITIALIZATION;
 	export let steps: [ProgressStep, ...ProgressStep[]];
 
 	onMount(() => confirmToCloseBrowser(true));

--- a/src/frontend/src/lib/constants/steps.constants.ts
+++ b/src/frontend/src/lib/constants/steps.constants.ts
@@ -1,19 +1,19 @@
-import { AddTokenStep } from '$lib/enums/steps';
+import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import type { ProgressStep } from '@dfinity/gix-components';
 
 export const addTokenSteps = (i18n: I18n): [ProgressStep, ...ProgressStep[]] => [
 	{
-		step: AddTokenStep.INITIALIZATION,
+		step: ProgressStepsAddToken.INITIALIZATION,
 		text: i18n.tokens.text.initializing,
 		state: 'in_progress'
 	} as ProgressStep,
 	{
-		step: AddTokenStep.SAVE,
+		step: ProgressStepsAddToken.SAVE,
 		text: i18n.tokens.import.text.saving,
 		state: 'next'
 	} as ProgressStep,
 	{
-		step: AddTokenStep.UPDATE_UI,
+		step: ProgressStepsAddToken.UPDATE_UI,
 		text: i18n.tokens.text.updating_ui,
 		state: 'next'
 	} as ProgressStep

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -1,4 +1,7 @@
-export enum SendStep {
+// A collection of enums used in Oisy's various wizards when the effective actions are being executed.
+// For example, in an Ethereum transfer, when the message is first signed and then effectively sent.
+
+export enum ProgressStepsSend {
 	INITIALIZATION = 'initialization',
 	SIGN_APPROVE = 'sign_approve',
 	APPROVE = 'approve',
@@ -8,34 +11,34 @@ export enum SendStep {
 	DONE = 'done'
 }
 
-export enum SignStep {
+export enum ProgressStepsSign {
 	INITIALIZATION = 'initialization',
 	SIGN = 'sign',
 	APPROVE = 'approve',
 	DONE = 'done'
 }
 
-export enum LoaderStep {
+export enum ProgressStepsLoader {
 	INITIALIZATION = 'initialization',
 	ETH_ADDRESS = 'eth_address',
 	DONE = 'done'
 }
 
-export enum AddTokenStep {
+export enum ProgressStepsAddToken {
 	INITIALIZATION = 'initialization',
 	SAVE = 'save',
 	UPDATE_UI = 'update_ui',
 	DONE = 'done'
 }
 
-export enum HideTokenStep {
+export enum ProgressStepsHideToken {
 	INITIALIZATION = 'initialization',
 	HIDE = 'hide',
 	UPDATE_UI = 'update_ui',
 	DONE = 'done'
 }
 
-export enum SendIcStep {
+export enum ProgressStepsSendIc {
 	INITIALIZATION = 'initialization',
 	APPROVE_FEES = 'approve_fees',
 	APPROVE_TRANSFER = 'approve_transfer',
@@ -44,7 +47,7 @@ export enum SendIcStep {
 	DONE = 'done'
 }
 
-export enum UpdateBalanceCkBtcStep {
+export enum ProgressStepsUpdateBalanceCkBtc {
 	INITIALIZATION = 'initialization',
 	RETRIEVE = 'retrieve',
 	RELOAD = 'reload',


### PR DESCRIPTION
# Motivation

Relates to #1350. There are two types of "steps" in Oisy. The "steps" of the wizard modal (this screen, then this screen, then this screen) and the "steps" of the progress component when actions are effectively executed (signing a transaction before transferring it).

Renaming the enums which are currently used for the latests hopefuly makes their usage a bit more clear.