### PR TITLE
refactor: changed function decodeQrCode to use interal decodeQrCodeUrn

### DIFF
--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -1,15 +1,13 @@
-import { ICP_TOKEN } from '$env/tokens.env';
+import { ICP_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
 import type { EthereumNetwork } from '$eth/types/network';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
 import { decodeQrCode, decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
-import { decodePayment } from '@dfinity/ledger-icrc';
 import { assertNonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import type { MockedFunction } from 'vitest';
 import { generateUrn } from '../../mocks/qr-generator.mock';
 
-describe('decodeUrn', () => {
+describe('decodeQrCodeUrn', () => {
 	const tokenList = get(tokens);
 	const destination = 'some-destination';
 	const amount = 1.23;
@@ -40,7 +38,7 @@ describe('decodeUrn', () => {
 				amount: amount
 			};
 			if (standard === 'ethereum' || standard === 'erc20') {
-				expectedResult.networkId = (token.network as EthereumNetwork).chainId.toString();
+				expectedResult.ethereumChainId = (token.network as EthereumNetwork).chainId.toString();
 			}
 			if (standard === 'erc20' && 'address' in token) {
 				expectedResult.functionName = 'transfer';
@@ -52,21 +50,10 @@ describe('decodeUrn', () => {
 	});
 });
 
-const token = ICP_TOKEN;
-const address = 'some-address';
-const amount = 1.23;
-const code = 'some-qr-code';
-
-vi.mock('@dfinity/ledger-icrc', () => ({
-	decodePayment: vi.fn()
-}));
-
 describe('decodeQrCode', () => {
-	const mockDecodePayment = decodePayment as MockedFunction<typeof decodePayment>;
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
+	const tokenList = get(tokens);
+	const destination = 'some-address';
+	const amount = 1.23;
 
 	it('should return { result } when result is not success', () => {
 		const response = decodeQrCode({ status: 'cancelled' });
@@ -78,43 +65,28 @@ describe('decodeQrCode', () => {
 		expect(response).toEqual({ status: 'cancelled' });
 	});
 
-	it('should return { status: "success", identifier: code } when payment is nullish', () => {
-		mockDecodePayment.mockReturnValue(undefined);
-
-		const response = decodeQrCode({ status: 'success', code });
-		expect(response).toEqual({ status: 'success', destination: code });
-
-		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	it('should return { status: "success", destination: code } when payment is nullish', () => {
+		const urn = 'some-urn-that-does-not-exist';
+		const response = decodeQrCode({ status: 'success', code: urn });
+		expect(response).toEqual({ status: 'success', destination: urn });
 	});
 
 	it('should return { status: "token_incompatible" } when tokens do not match', () => {
-		const payment = {
-			token: `not-${token.symbol}`,
-			identifier: address,
-			amount: amount
-		};
-		mockDecodePayment.mockReturnValue(payment);
-
-		const response = decodeQrCode({ status: 'success', code: code, expectedToken: token });
+		const urn = generateUrn(ICP_TOKEN, destination, { amount });
+		const response = decodeQrCode({ status: 'success', code: urn, expectedToken: SEPOLIA_TOKEN });
 		expect(response).toEqual({ status: 'token_incompatible' });
-		expect(mockDecodePayment).toHaveBeenCalledWith(code);
 	});
 
-	it('should return { status: "success", identifier, token, amount } when everything matches', () => {
-		const payment = {
-			token: token.symbol,
-			identifier: address,
-			amount: amount
-		};
-		mockDecodePayment.mockReturnValue(payment);
-
-		const response = decodeQrCode({ status: 'success', code: code, expectedToken: token });
-		expect(response).toEqual({
-			status: 'success',
-			destination: address,
-			token: token.symbol,
-			amount: amount
+	tokenList.forEach((token) => {
+		it(`should return the correct response for the token ${token.name} when everything matches`, () => {
+			const urn = generateUrn(token, destination, { amount });
+			const response = decodeQrCode({ status: 'success', code: urn, expectedToken: token });
+			expect(response).toEqual({
+				status: 'success',
+				destination: destination,
+				token: token.symbol,
+				amount: amount
+			});
 		});
-		expect(mockDecodePayment).toHaveBeenCalledWith(code);
 	});
 });


### PR DESCRIPTION
# Motivation

Instead of using the `decodePayment` function from package `@dfinity/ledger-icrc`, we will use the function `decodeQrCodeUrn` that treats a broader spectrum of tokens and transactions.

# Changes

- Changed the decoding function in `decodeQrCode`.
- Created an internal method to match specific Ethereum tokens based on the decoded QR code..

# Tests

Modified the original test of `decodeQrCode` to adapt to the new code.
