### PR TITLE
refactor: created two different functions for ICP and for ETH to decode the QR code

### DIFF
--- a/src/frontend/src/eth/utils/qr-code.utils.ts
+++ b/src/frontend/src/eth/utils/qr-code.utils.ts
@@ -1,0 +1,35 @@
+import type { QrResponse, QrStatus } from '$lib/types/qr-code';
+import { decodePayment } from '@dfinity/ledger-icrc';
+import { isNullish, nonNullish, type Token } from '@dfinity/utils';
+
+export const decodeQrCode = ({
+	status,
+	code,
+	expectedToken
+}: {
+	status: QrStatus;
+	code?: string | undefined;
+	expectedToken?: Token;
+}): QrResponse => {
+	if (status !== 'success') {
+		return { status };
+	}
+
+	if (isNullish(code)) {
+		return { status: 'cancelled' };
+	}
+
+	const payment = decodePayment(code);
+
+	if (isNullish(payment)) {
+		return { status: 'success', destination: code };
+	}
+
+	const { token, identifier: destination, amount } = payment;
+
+	if (nonNullish(expectedToken) && token.toLowerCase() !== expectedToken.symbol.toLowerCase()) {
+		return { status: 'token_incompatible' };
+	}
+
+	return { status: 'success', destination, token, amount };
+};

--- a/src/frontend/src/icp/utils/qr-code.utils.ts
+++ b/src/frontend/src/icp/utils/qr-code.utils.ts
@@ -1,0 +1,35 @@
+import type { QrResponse, QrStatus } from '$lib/types/qr-code';
+import { decodePayment } from '@dfinity/ledger-icrc';
+import { isNullish, nonNullish, type Token } from '@dfinity/utils';
+
+export const icDecodeQrCode = ({
+	status,
+	code,
+	expectedToken
+}: {
+	status: QrStatus;
+	code?: string | undefined;
+	expectedToken?: Token;
+}): QrResponse => {
+	if (status !== 'success') {
+		return { status };
+	}
+
+	if (isNullish(code)) {
+		return { status: 'cancelled' };
+	}
+
+	const payment = decodePayment(code);
+
+	if (isNullish(payment)) {
+		return { status: 'success', destination: code };
+	}
+
+	const { token, identifier: destination, amount } = payment;
+
+	if (nonNullish(expectedToken) && token.toLowerCase() !== expectedToken.symbol.toLowerCase()) {
+		return { status: 'token_incompatible' };
+	}
+
+	return { status: 'success', destination, token, amount };
+};

--- a/src/frontend/src/lib/components/send/QRCodeScan.svelte
+++ b/src/frontend/src/lib/components/send/QRCodeScan.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { QRCodeReader } from '@dfinity/gix-components';
 	import { toastsError } from '$lib/stores/toasts.store';
-	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 	import { nonNullish } from '@dfinity/utils';
 	import type { Token } from '@dfinity/utils';
 	import type { QrStatus } from '$lib/types/qr-code';
@@ -12,6 +11,11 @@
 	export let expectedToken: Token;
 	export let destination: string | undefined;
 	export let amount: number | undefined;
+	export let decodeQrCode: (args: {
+		status: QrStatus;
+		code?: string;
+		expectedToken: Token;
+	}) => { status: QrStatus; destination?: string; amount?: number };
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/utils/qr-code.utils.ts
+++ b/src/frontend/src/lib/utils/qr-code.utils.ts
@@ -2,12 +2,9 @@ import {
 	DecodedUrnSchema,
 	URN_NUMERIC_PARAMS,
 	URN_STRING_PARAMS,
-	type DecodedUrn,
-	type QrResponse,
-	type QrStatus
+	type DecodedUrn
 } from '$lib/types/qr-code';
-import { decodePayment } from '@dfinity/ledger-icrc';
-import { isNullish, nonNullish, type Token } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 /**
  * Decodes a URN string into a DecodedUrn object, breaking it down into its components.
@@ -83,36 +80,4 @@ export const decodeQrCodeUrn = (urn: string): DecodedUrn | undefined => {
 		return undefined;
 	}
 	return result.data;
-};
-
-export const decodeQrCode = ({
-	status,
-	code,
-	expectedToken
-}: {
-	status: QrStatus;
-	code?: string | undefined;
-	expectedToken?: Token;
-}): QrResponse => {
-	if (status !== 'success') {
-		return { status };
-	}
-
-	if (isNullish(code)) {
-		return { status: 'cancelled' };
-	}
-
-	const payment = decodePayment(code);
-
-	if (isNullish(payment)) {
-		return { status: 'success', destination: code };
-	}
-
-	const { token, identifier: destination, amount } = payment;
-
-	if (nonNullish(expectedToken) && token.toLowerCase() !== expectedToken.symbol.toLowerCase()) {
-		return { status: 'token_incompatible' };
-	}
-
-	return { status: 'success', destination, token, amount };
 };

--- a/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
@@ -1,0 +1,71 @@
+import { ICP_TOKEN } from '$env/tokens.env';
+import { decodeQrCode } from '$eth/utils/qr-code.utils';
+import { decodePayment } from '@dfinity/ledger-icrc';
+import type { MockedFunction } from 'vitest';
+
+const token = ICP_TOKEN;
+const address = 'some-address';
+const amount = 1.23;
+const code = 'some-qr-code';
+
+vi.mock('@dfinity/ledger-icrc', () => ({
+	decodePayment: vi.fn()
+}));
+
+describe('decodeQrCode', () => {
+	const mockDecodePayment = decodePayment as MockedFunction<typeof decodePayment>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should return { result } when result is not success', () => {
+		const response = decodeQrCode({ status: 'cancelled' });
+		expect(response).toEqual({ status: 'cancelled' });
+	});
+
+	it('should return { status: "cancelled" } when code is nullish', () => {
+		const response = decodeQrCode({ status: 'success', code: undefined });
+		expect(response).toEqual({ status: 'cancelled' });
+	});
+
+	it('should return { status: "success", identifier: code } when payment is nullish', () => {
+		mockDecodePayment.mockReturnValue(undefined);
+
+		const response = decodeQrCode({ status: 'success', code });
+		expect(response).toEqual({ status: 'success', destination: code });
+
+		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	});
+
+	it('should return { status: "token_incompatible" } when tokens do not match', () => {
+		const payment = {
+			token: `not-${token.symbol}`,
+			identifier: address,
+			amount: amount
+		};
+		mockDecodePayment.mockReturnValue(payment);
+
+		const response = decodeQrCode({ status: 'success', code: code, expectedToken: token });
+		expect(response).toEqual({ status: 'token_incompatible' });
+		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	});
+
+	it('should return { status: "success", identifier, token, amount } when everything matches', () => {
+		const payment = {
+			token: token.symbol,
+			identifier: address,
+			amount: amount
+		};
+		mockDecodePayment.mockReturnValue(payment);
+
+		const response = decodeQrCode({ status: 'success', code: code, expectedToken: token });
+		expect(response).toEqual({
+			status: 'success',
+			destination: address,
+			token: token.symbol,
+			amount: amount
+		});
+		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	});
+});

--- a/src/frontend/src/tests/icp/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/qr-code.utils.spec.ts
@@ -1,0 +1,71 @@
+import { ICP_TOKEN } from '$env/tokens.env';
+import { icDecodeQrCode } from '$icp/utils/qr-code.utils';
+import { decodePayment } from '@dfinity/ledger-icrc';
+import type { MockedFunction } from 'vitest';
+
+const token = ICP_TOKEN;
+const address = 'some-address';
+const amount = 1.23;
+const code = 'some-qr-code';
+
+vi.mock('@dfinity/ledger-icrc', () => ({
+	decodePayment: vi.fn()
+}));
+
+describe('icDecodeQrCode', () => {
+	const mockDecodePayment = decodePayment as MockedFunction<typeof decodePayment>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should return { result } when result is not success', () => {
+		const response = icDecodeQrCode({ status: 'cancelled' });
+		expect(response).toEqual({ status: 'cancelled' });
+	});
+
+	it('should return { status: "cancelled" } when code is nullish', () => {
+		const response = icDecodeQrCode({ status: 'success', code: undefined });
+		expect(response).toEqual({ status: 'cancelled' });
+	});
+
+	it('should return { status: "success", identifier: code } when payment is nullish', () => {
+		mockDecodePayment.mockReturnValue(undefined);
+
+		const response = icDecodeQrCode({ status: 'success', code });
+		expect(response).toEqual({ status: 'success', destination: code });
+
+		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	});
+
+	it('should return { status: "token_incompatible" } when tokens do not match', () => {
+		const payment = {
+			token: `not-${token.symbol}`,
+			identifier: address,
+			amount: amount
+		};
+		mockDecodePayment.mockReturnValue(payment);
+
+		const response = icDecodeQrCode({ status: 'success', code: code, expectedToken: token });
+		expect(response).toEqual({ status: 'token_incompatible' });
+		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	});
+
+	it('should return { status: "success", identifier, token, amount } when everything matches', () => {
+		const payment = {
+			token: token.symbol,
+			identifier: address,
+			amount: amount
+		};
+		mockDecodePayment.mockReturnValue(payment);
+
+		const response = icDecodeQrCode({ status: 'success', code: code, expectedToken: token });
+		expect(response).toEqual({
+			status: 'success',
+			destination: address,
+			token: token.symbol,
+			amount: amount
+		});
+		expect(mockDecodePayment).toHaveBeenCalledWith(code);
+	});
+});

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -1,12 +1,9 @@
-import { ICP_TOKEN } from '$env/tokens.env';
 import type { EthereumNetwork } from '$eth/types/network';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
-import { decodeQrCode, decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
-import { decodePayment } from '@dfinity/ledger-icrc';
+import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import type { MockedFunction } from 'vitest';
 import { generateUrn } from '../../mocks/qr-generator.mock';
 
 describe('decodeUrn', () => {
@@ -49,72 +46,5 @@ describe('decodeUrn', () => {
 
 			expect(result).toEqual(expectedResult);
 		});
-	});
-});
-
-const token = ICP_TOKEN;
-const address = 'some-address';
-const amount = 1.23;
-const code = 'some-qr-code';
-
-vi.mock('@dfinity/ledger-icrc', () => ({
-	decodePayment: vi.fn()
-}));
-
-describe('decodeQrCode', () => {
-	const mockDecodePayment = decodePayment as MockedFunction<typeof decodePayment>;
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-	});
-
-	it('should return { result } when result is not success', () => {
-		const response = decodeQrCode({ status: 'cancelled' });
-		expect(response).toEqual({ status: 'cancelled' });
-	});
-
-	it('should return { status: "cancelled" } when code is nullish', () => {
-		const response = decodeQrCode({ status: 'success', code: undefined });
-		expect(response).toEqual({ status: 'cancelled' });
-	});
-
-	it('should return { status: "success", identifier: code } when payment is nullish', () => {
-		mockDecodePayment.mockReturnValue(undefined);
-
-		const response = decodeQrCode({ status: 'success', code });
-		expect(response).toEqual({ status: 'success', destination: code });
-
-		expect(mockDecodePayment).toHaveBeenCalledWith(code);
-	});
-
-	it('should return { status: "token_incompatible" } when tokens do not match', () => {
-		const payment = {
-			token: `not-${token.symbol}`,
-			identifier: address,
-			amount: amount
-		};
-		mockDecodePayment.mockReturnValue(payment);
-
-		const response = decodeQrCode({ status: 'success', code: code, expectedToken: token });
-		expect(response).toEqual({ status: 'token_incompatible' });
-		expect(mockDecodePayment).toHaveBeenCalledWith(code);
-	});
-
-	it('should return { status: "success", identifier, token, amount } when everything matches', () => {
-		const payment = {
-			token: token.symbol,
-			identifier: address,
-			amount: amount
-		};
-		mockDecodePayment.mockReturnValue(payment);
-
-		const response = decodeQrCode({ status: 'success', code: code, expectedToken: token });
-		expect(response).toEqual({
-			status: 'success',
-			destination: address,
-			token: token.symbol,
-			amount: amount
-		});
-		expect(mockDecodePayment).toHaveBeenCalledWith(code);
 	});
 });


### PR DESCRIPTION
# Motivation

Since we are going to use different decoders to deconstruct the QR code URN, we are going to create separate functions for each universe.

# Changes

Moved `decodeQrCode` function in two different utils modules.

# Tests

Created a set of tests for each new function.
