### PR TITLE
chore: removed unused token.mocks file that became useless with PR #1344

### DIFF
--- a/src/frontend/src/tests/mocks/tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/tokens.mock.ts
@@ -1,9 +1,0 @@
-import type { Token } from '@dfinity/utils';
-
-export const ICP_SYMBOL = 'ICP';
-
-export const ICP_TOKEN: Token = {
-	name: 'ICP',
-	symbol: ICP_SYMBOL,
-	decimals: 8
-};


### PR DESCRIPTION
# Motivation

With PR #1344 , we removed the necessity to create mock tokens, and we started using the concrete list from the token store that is depending on the test environment.

# To-Do

At some point, for the complete test on all the possible tokens that could be available, we will need to create a thorough list of tokens, independently of the environment it is running the test.
For example, if it is running locally, it will test only the Sepolia ETH according to the snippets below:

```typescript
// tokens.derived.ts
export const enabledEthereumTokens: Readable<RequiredToken[]> = derived(
  [testnets],
  ([$testnets]) => [
    ...(ETH_MAINNET_ENABLED ? [ETHEREUM_TOKEN] : []),
    ...($testnets ? [SEPOLIA_TOKEN] : [])
  ]
);


// networks.eth.env.ts
export const ETH_MAINNET_ENABLED =
  JSON.parse(import.meta.env.VITE_ETHEREUM_MAINNET ?? false) === true;
```