### PR TITLE
feat: add QRButton component in Destination Input

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -2,14 +2,16 @@
 	import { Input } from '@dfinity/gix-components';
 	import type { NetworkId } from '$lib/types/network';
 	import { slide } from 'svelte/transition';
-	import { debounce } from '@dfinity/utils';
+	import { debounce, nonNullish } from '@dfinity/utils';
 	import { i18n } from '$lib/stores/i18n.store';
+	import QRButton from '$lib/components/common/QRButton.svelte';
 
 	export let destination = '';
 	export let networkId: NetworkId | undefined = undefined;
 	export let invalidDestination = false;
 	export let inputPlaceholder: string;
 	export let isInvalidDestination: (() => boolean) | undefined;
+	export let onQRButtonClick: (() => void) | undefined = undefined;
 
 	const validate = () => (invalidDestination = isInvalidDestination?.() ?? false);
 
@@ -27,7 +29,13 @@
 	placeholder={inputPlaceholder}
 	spellcheck={false}
 	on:nnsInput
-/>
+>
+	<svelte:fragment slot="inner-end">
+		{#if nonNullish(onQRButtonClick)}
+			<QRButton on:click={onQRButtonClick} />
+		{/if}
+	</svelte:fragment>
+</Input>
 
 {#if invalidDestination}
 	<p transition:slide={{ duration: 250 }} class="text-cyclamen pb-3">


### PR DESCRIPTION
# Motivation

We include the `QRButton` component into the common `SendInputDestination`, to be used in the main Send Modals.

# Changes

- Included `QRButton` in the `inner-end` of the destination input.
- Added a prop function that is triggered by the button.