### PR TITLE
feat: included timeout error on component QRCodeScan

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -244,7 +244,8 @@
 			"data_undefined": "Transaction Data cannot be undefined or null.",
 			"no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
 			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
-			"incompatible_token": "The token is incompatible. Please try again with a compatible token."
+			"incompatible_token": "The token is incompatible. Please try again with a compatible token.",
+			"qr_scan_timeout": "No QR code found. Please try again."
 		}
 	},
 	"convert": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -219,6 +219,7 @@ interface I18nSend {
 		no_identity_calculate_fee: string;
 		invalid_destination: string;
 		incompatible_token: string;
+		qr_scan_timeout: string;
 	};
 }
 

--- a/src/frontend/src/lib/types/qr-code.ts
+++ b/src/frontend/src/lib/types/qr-code.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export type QrStatus = 'success' | 'cancelled' | 'token_incompatible';
+export type QrStatus = 'success' | 'cancelled' | 'token_incompatible' | 'timeout';
 
 export type QrResponse = {
 	status: QrStatus;

--- a/src/frontend/src/tests/lib/components/send/QRCodeScan.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/QRCodeScan.spec.ts
@@ -1,0 +1,37 @@
+import { ICP_TOKEN } from '$env/tokens.env';
+import QRCodeScan from '$lib/components/send/QRCodeScan.svelte';
+import { toastsError } from '$lib/stores/toasts.store';
+import { render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import en from '../../../mocks/i18n.mock';
+
+const props = {
+	expectedToken: ICP_TOKEN,
+	destination: 'some-destination',
+	amount: 1,
+	decodeQrCode: vi.fn()
+};
+
+vi.mock('$lib/stores/toasts.store');
+
+describe('QRCodeReaderComponent', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should show timeout error on QR scan timeout', async () => {
+		vi.useFakeTimers();
+
+		render(QRCodeScan, { props });
+
+		vi.advanceTimersByTime(30001);
+
+		await waitFor(() =>
+			expect(toastsError).toHaveBeenCalledWith({
+				msg: { text: en.send.error.qr_scan_timeout }
+			})
+		);
+
+		vi.useRealTimers();
+	});
+});


### PR DESCRIPTION
# Motivation

It is better to have a timeout for the QR code scan, so that after a certain amount of seconds, the component unmounts itself.

# Changes

- Included a `timeout` error status among the status results of a QR code scan.
- Added 30 seconds of timeout in component `QRCodeScan`, after which, it will resolve itself, returning the error as a message.

# Tests

We created a new test for the component to check the correct return triggered by the `timeout` error.
