### PR TITLE
refactor: moved IC Wizard Steps in separate file

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -44,6 +44,7 @@
 		type EthereumFeeContext as EthereumFeeContextType
 	} from '$icp/stores/ethereum-fee.store';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import { icSendWizardSteps } from '$icp/config/ic-send.config';
 
 	/**
 	 * Props
@@ -128,10 +129,14 @@
 		}
 	};
 
+	let firstStep: WizardStep;
+	let otherSteps: WizardStep[];
+	$: [firstStep, ...otherSteps] = icSendWizardSteps($i18n);
+
 	let steps: WizardSteps;
 	$: steps = [
 		{
-			name: WizardStepsSend.SEND,
+			...firstStep,
 			title: isNetworkIdBTC(networkId)
 				? $i18n.convert.text.convert_to_btc
 				: isNetworkIdEthereum(networkId)
@@ -140,14 +145,7 @@
 						})
 					: $i18n.send.text.send
 		},
-		{
-			name: WizardStepsSend.REVIEW,
-			title: $i18n.send.text.review
-		},
-		{
-			name: WizardStepsSend.SENDING,
-			title: $i18n.send.text.sending
-		}
+		...otherSteps
 	];
 
 	let currentStep: WizardStep | undefined;

--- a/src/frontend/src/icp/config/ic-send.config.ts
+++ b/src/frontend/src/icp/config/ic-send.config.ts
@@ -1,0 +1,17 @@
+import { WizardStepsSend } from '$lib/enums/wizard-steps';
+import type { WizardSteps } from '@dfinity/gix-components';
+
+export const icSendWizardSteps = (i18n: I18n): WizardSteps => [
+	{
+		name: WizardStepsSend.SEND,
+		title: i18n.send.text.send
+	},
+	{
+		name: WizardStepsSend.REVIEW,
+		title: i18n.send.text.review
+	},
+	{
+		name: WizardStepsSend.SENDING,
+		title: i18n.send.text.sending
+	}
+];


### PR DESCRIPTION
# Motivation

We moved the Wizard Steps for IC in a separate config files, to be centralized and consistent with the ETH. This will be helpful when we will have to add the QR Code scan step.
Furthermore, it is a first step for when we will want to further refactor and unify the Wizard Steps for all the universes, avoiding repetition of code.

# Changes

- Created an IC Send Wizard Step list.
- Changed component `IcSendModal` to use the list.

