### PR TITLE
refactor: moving BTC Network-related functions to replicate the same functions of ETH

### DIFF
--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -88,3 +88,7 @@ export const BTC_TESTNET_NETWORK: Network = {
 	env: 'testnet',
 	name: 'Bitcoin'
 };
+
+export const BITCOIN_NETWORKS: Network[] = [BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK];
+
+export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -1,8 +1,4 @@
-import {
-	BTC_MAINNET_NETWORK_ID,
-	BTC_TESTNET_NETWORK_ID,
-	ETHEREUM_NETWORK_ID
-} from '$env/networks.env';
+import { BTC_MAINNET_NETWORK_ID, ETHEREUM_NETWORK_ID } from '$env/networks.env';
 import {
 	CKBTC_LEDGER_CANISTER_IDS,
 	CKERC20_LEDGER_CANISTER_IDS,
@@ -15,7 +11,7 @@ import type { NetworkId } from '$lib/types/network';
 import type { TokenStandard } from '$lib/types/token';
 import { isEthAddress } from '$lib/utils/account.utils';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
-import { isNetworkIdEthereum } from '$lib/utils/network.utils';
+import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 import { BtcNetwork, parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
@@ -45,7 +41,7 @@ export const isTokenCkErc20Ledger = ({ ledgerCanisterId }: Partial<IcToken>): bo
 	nonNullish(ledgerCanisterId) && CKERC20_LEDGER_CANISTER_IDS.includes(ledgerCanisterId);
 
 export const isNetworkIdBTC = (networkId: NetworkId | undefined): boolean =>
-	nonNullish(networkId) && [BTC_MAINNET_NETWORK_ID, BTC_TESTNET_NETWORK_ID].includes(networkId);
+	nonNullish(networkId) && isNetworkIdBitcoin(networkId);
 
 export const isNetworkIdETHMainnet = (networkId: NetworkId | undefined): boolean =>
 	ETHEREUM_NETWORK_ID === networkId;

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,4 +1,8 @@
-import { ICP_NETWORK_ID, SUPPORTED_ETHEREUM_NETWORKS_IDS } from '$env/networks.env';
+import {
+	BITCOIN_NETWORKS_IDS,
+	ICP_NETWORK_ID,
+	SUPPORTED_ETHEREUM_NETWORKS_IDS
+} from '$env/networks.env';
 import type { Network, NetworkId } from '$lib/types/network';
 import { nonNullish } from '@dfinity/utils';
 
@@ -8,3 +12,6 @@ export const isNetworkIdICP = (id: NetworkId): boolean => ICP_NETWORK_ID === id;
 
 export const isNetworkIdEthereum = (id: NetworkId | undefined): boolean =>
 	nonNullish(id) && SUPPORTED_ETHEREUM_NETWORKS_IDS.includes(id);
+
+export const isNetworkIdBitcoin = (id: NetworkId | undefined): boolean =>
+	nonNullish(id) && BITCOIN_NETWORKS_IDS.includes(id);


### PR DESCRIPTION
# Motivation

To prepare for BTC integration, we moved some base functions about BTC network to the same file where are the similar ones for ETH, to centralize them.

# Changes

- Create env variables for the list of Bitcoin networks.
- Create  bool functions to check current Network ID.
