### PR TITLE
feat: copy edit bitcoin 6 confirmations

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -372,7 +372,7 @@
 		"bitcoin": {
 			"title": "Receive from Bitcoin Network (BTC)",
 			"description": "ckBTC is a multi-chain bitcoin twin on the Internet Computer created by canister smart contract that directly hold native bitcoin.",
-			"note": "Note that incoming Bitcoin transactions require 12 confirmations. Check status on a block explorer.",
+			"note": "Note that incoming Bitcoin transactions require 6 confirmations. Check status on a block explorer.",
 			"receive": "Receive from BTC network"
 		},
 		"ethereum": {


### PR DESCRIPTION
# Motivation

In proposal https://dashboard.internetcomputer.org/proposal/130096 the number of confirmations for incoming Bitcoin was modified from 12 to 6.

# Changes

- Edit copy in i18n

