### PR TITLE
build: use released gix-cmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@dfinity/candid": "^1.3.0",
 				"@dfinity/ckbtc": "^2.3.3",
 				"@dfinity/cketh": "^3.0.1-next-2024-05-21.2",
-				"@dfinity/gix-components": "^4.2.0-next-2024-05-06.2",
+				"@dfinity/gix-components": "^4.3.0",
 				"@dfinity/ic-management": "^4.0.0",
 				"@dfinity/ledger-icp": "^2.2.4",
 				"@dfinity/ledger-icrc": "^2.3.1",
@@ -672,9 +672,10 @@
 			}
 		},
 		"node_modules/@dfinity/gix-components": {
-			"version": "4.2.0-next-2024-05-06.2",
-			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-06.2.tgz",
-			"integrity": "sha512-/75YXTBRP5bAeFhbiRiOascBnCY6fmPn4VehIEftMx+MslNH1EYLpse6woTc+FJXonlcFsn5PtnUOsoC4obmWQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.3.0.tgz",
+			"integrity": "sha512-g224o3dzwUOtJD6htCYI1wPLCkJwzvwB9nZUwuarZQI5Kyr0GaJ1w2NMhoJwbhW2dPMpD/rWbJEko7o4iX2znQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"dompurify": "^3.0.8",
 				"html5-qrcode": "^2.3.8",
@@ -5093,9 +5094,10 @@
 			"dev": true
 		},
 		"node_modules/dompurify": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.2.tgz",
-			"integrity": "sha512-hLGGBI1tw5N8qTELr3blKjAML/LY4ANxksbS612UiJyDfyf/2D092Pvm+S7pmeTGJRqvlJkFzBoHBQKgQlOQVg=="
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
+			"integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA==",
+			"license": "(MPL-2.0 OR Apache-2.0)"
 		},
 		"node_modules/dotenv": {
 			"version": "16.4.5",
@@ -6421,7 +6423,8 @@
 		"node_modules/html5-qrcode": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
-			"integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="
+			"integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -8339,7 +8342,8 @@
 		"node_modules/qr-creator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
-			"integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ=="
+			"integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+			"license": "MIT"
 		},
 		"node_modules/query-string": {
 			"version": "7.1.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@dfinity/candid": "^1.3.0",
 		"@dfinity/ckbtc": "^2.3.3",
 		"@dfinity/cketh": "^3.0.1-next-2024-05-21.2",
-		"@dfinity/gix-components": "^4.2.0-next-2024-05-06.2",
+		"@dfinity/gix-components": "^4.3.0",
 		"@dfinity/ic-management": "^4.0.0",
 		"@dfinity/ledger-icp": "^2.2.4",
 		"@dfinity/ledger-icrc": "^2.3.1",


### PR DESCRIPTION
# Motivation

I released a new version of the gix-cmp so we can use it instead of a next version.