### PR TITLE
feat: added code to trigger the QR Code Scan step on ETH

### DIFF
--- a/src/frontend/src/eth/components/send/SendDestination.svelte
+++ b/src/frontend/src/eth/components/send/SendDestination.svelte
@@ -30,6 +30,6 @@
 	{isInvalidDestination}
 	inputPlaceholder={$i18n.send.placeholder.enter_eth_address}
 	on:nnsInput={onInput}
-	on:qrCodeScan
-	onQRButtonClick={() => dispatch('qrCodeScan')}
+	on:icQRCodeScan
+	onQRButtonClick={() => dispatch('icQRCodeScan')}
 />

--- a/src/frontend/src/eth/components/send/SendDestination.svelte
+++ b/src/frontend/src/eth/components/send/SendDestination.svelte
@@ -3,11 +3,13 @@
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isEthAddress } from '$lib/utils/account.utils';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { getContext } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 
 	export let destination = '';
 	export let invalidDestination = false;
+
+	const dispatch = createEventDispatcher();
 
 	let isInvalidDestination: () => boolean;
 	$: isInvalidDestination = (): boolean => {
@@ -28,4 +30,6 @@
 	{isInvalidDestination}
 	inputPlaceholder={$i18n.send.placeholder.enter_eth_address}
 	on:nnsInput={onInput}
+	on:qrCodeScan
+	onQRButtonClick={() => dispatch('qrCodeScan')}
 />

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -38,7 +38,7 @@
 <form on:submit={() => dispatch('icNext')} method="POST">
 	<div class="stretch">
 		{#if destinationEditable}
-			<SendDestination bind:destination bind:invalidDestination />
+			<SendDestination bind:destination bind:invalidDestination on:qrCodeScan />
 
 			<SendNetworkICP {destination} {sourceNetwork} bind:network />
 		{/if}

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -38,7 +38,7 @@
 <form on:submit={() => dispatch('icNext')} method="POST">
 	<div class="stretch">
 		{#if destinationEditable}
-			<SendDestination bind:destination bind:invalidDestination on:qrCodeScan />
+			<SendDestination bind:destination bind:invalidDestination on:icQRCodeScan />
 
 			<SendNetworkICP {destination} {sourceNetwork} bind:network />
 		{/if}

--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -94,7 +94,7 @@
 		on:icBack={modal.back}
 		on:icNext={modal.next}
 		on:icClose={close}
-		on:qrCodeScan={() => goToWizardStep(WizardStepsSend.QR_CODE_SCAN)}
-		on:qrCodeBack={() => goToWizardStep(WizardStepsSend.SEND)}
+		on:icQRCodeScan={() => goToWizardStep(WizardStepsSend.QR_CODE_SCAN)}
+		on:icQRCodeBack={() => goToWizardStep(WizardStepsSend.SEND)}
 	/>
 </WizardModal>

--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -70,7 +70,7 @@
 
 	const goToWizardStep = (stepName: WizardStepsSend) => {
 		const stepNumber = steps.findIndex(({ name }) => name === stepName);
-		modal.set(stepNumber);
+		modal.set(Math.max(stepNumber, 0));
 	};
 </script>
 

--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -67,6 +67,11 @@
 
 			currentStep = undefined;
 		});
+
+	const goToWizardStep = (stepName: WizardStepsSend) => {
+		const stepNumber = steps.findIndex(({ name }) => name === stepName);
+		modal.set(stepNumber);
+	};
 </script>
 
 <WizardModal
@@ -89,5 +94,7 @@
 		on:icBack={modal.back}
 		on:icNext={modal.next}
 		on:icClose={close}
+		on:qrCodeScan={() => goToWizardStep(WizardStepsSend.QR_CODE_SCAN)}
+		on:qrCodeBack={() => goToWizardStep(WizardStepsSend.SEND)}
 	/>
 </WizardModal>

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -251,7 +251,7 @@
 		<SendForm
 			on:icNext
 			on:icClose={close}
-			on:qrCodeScan
+			on:icQRCodeScan
 			bind:destination
 			bind:amount
 			bind:network={targetNetwork}
@@ -277,7 +277,7 @@
 			bind:destination
 			bind:amount
 			decodeQrCode={onDecodeQrCode}
-			on:qrCodeBack
+			on:icQRCodeBack
 		/>
 	{:else}
 		<slot />

--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -251,6 +251,7 @@
 		<SendForm
 			on:icNext
 			on:icClose={close}
+			on:qrCodeScan
 			bind:destination
 			bind:amount
 			bind:network={targetNetwork}
@@ -276,6 +277,7 @@
 			bind:destination
 			bind:amount
 			decodeQrCode={onDecodeQrCode}
+			on:qrCodeBack
 		/>
 	{:else}
 		<slot />

--- a/src/frontend/src/lib/components/send/QRCodeScan.svelte
+++ b/src/frontend/src/lib/components/send/QRCodeScan.svelte
@@ -68,7 +68,7 @@
 	};
 
 	const back = () => {
-		dispatch('qrCodeBack');
+		dispatch('icQRCodeBack');
 	};
 </script>
 

--- a/src/frontend/src/lib/components/send/QRCodeScan.svelte
+++ b/src/frontend/src/lib/components/send/QRCodeScan.svelte
@@ -68,7 +68,7 @@
 	};
 
 	const back = () => {
-		dispatch('icBack');
+		dispatch('qrCodeBack');
 	};
 </script>
 


### PR DESCRIPTION
# Motivation

To trigger the QR Code scan step, we created specific events `qrCodeScan` and `qrCodeBack`.

# Changes

- Create event `qrCodeScan` that is dispatched by the QR Code Button.
- Create event `qrCodeBack` that is dispatched by the Cancel button in the QR Code Scan step.
- Assign them to navigate to the appropriate Wizard Step, using new function `goToWizardStep`. 

# Test
Manual testing done on local environment.

<img width="520" alt="Screenshot 2024-06-04 at 10 30 42" src="https://github.com/dfinity/oisy-wallet/assets/169057656/7c2af299-3363-4bf5-9401-3bef4f917bea">
<img width="540" alt="Screenshot 2024-06-04 at 10 32 12" src="https://github.com/dfinity/oisy-wallet/assets/169057656/486be402-5e60-423e-bdd6-0637b2ca7056">
<img width="508" alt="Screenshot 2024-06-04 at 10 32 29" src="https://github.com/dfinity/oisy-wallet/assets/169057656/65ba7ac4-3bf6-4bae-bb81-24cec757e4df">


