### PR TITLE
feat: added code to trigger the QR Code Scan step on ICP

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendDestination.svelte
+++ b/src/frontend/src/icp/components/send/IcSendDestination.svelte
@@ -6,10 +6,13 @@
 	import { debounce } from '@dfinity/utils';
 	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { createEventDispatcher } from 'svelte';
 
 	export let destination = '';
 	export let networkId: NetworkId | undefined = undefined;
 	export let invalidDestination = false;
+
+	const dispatch = createEventDispatcher();
 
 	let isInvalidDestination: () => boolean;
 
@@ -38,4 +41,6 @@
 	bind:invalidDestination
 	{isInvalidDestination}
 	{inputPlaceholder}
+	on:icQRCodeScan
+	onQRButtonClick={() => dispatch('icQRCodeScan')}
 />

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -33,7 +33,7 @@
 
 <form on:submit={() => dispatch('icNext')} method="POST">
 	<div class="stretch">
-		<IcSendDestination bind:destination bind:invalidDestination {networkId} />
+		<IcSendDestination bind:destination bind:invalidDestination {networkId} on:icQRCodeScan />
 
 		<IcSendAmount bind:amount bind:amountError {networkId} />
 

--- a/src/frontend/src/icp/config/ic-send.config.ts
+++ b/src/frontend/src/icp/config/ic-send.config.ts
@@ -15,3 +15,11 @@ export const icSendWizardSteps = (i18n: I18n): WizardSteps => [
 		title: i18n.send.text.sending
 	}
 ];
+
+export const icSendWizardStepsWithQrCodeScan = (i18n: I18n): WizardSteps => [
+	...icSendWizardSteps(i18n),
+	{
+		name: WizardStepsSend.QR_CODE_SCAN,
+		title: i18n.send.text.scan_qr
+	}
+];


### PR DESCRIPTION
# Motivation

To trigger the QR Code scan step, we created specific events `icQRCodeScan` and `icQRCodeBack`.

# Changes

- Create event `icQRCodeScan` that is dispatched by the QR Code Button.
- Create event `icQRCodeBack` that is dispatched by the Cancel button in the QR Code Scan step.
- Assign them to navigate to the appropriate Wizard Step, using new function `goToWizardStep`. 

# Test
Manual testing done on local environment.


