### PR TITLE
fix: corrected ERC20 amount property, according to EIP-681

### DIFF
--- a/src/frontend/src/eth/utils/qr-code.utils.ts
+++ b/src/frontend/src/eth/utils/qr-code.utils.ts
@@ -4,6 +4,7 @@ import { type QrResponse, type QrStatus } from '$lib/types/qr-code';
 import type { Token } from '$lib/types/token';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { hexStringToUint8Array, isNullish, nonNullish } from '@dfinity/utils';
+import { formatEther } from 'ethers/lib/utils';
 
 export const decodeQrCode = ({
 	status,
@@ -32,7 +33,7 @@ export const decodeQrCode = ({
 		return { status: 'success', destination: code };
 	}
 
-	const { prefix, destination, amount, address, ethereumChainId, functionName } = payment;
+	const { prefix, destination, value, uint256, address, ethereumChainId, functionName } = payment;
 
 	const normalizeChainId = (chainId: string): string => {
 		if (chainId.startsWith('0x')) {
@@ -96,6 +97,13 @@ export const decodeQrCode = ({
 	) {
 		return { status: 'token_incompatible' };
 	}
+
+	const amount =
+		functionName === 'transfer'
+			? uint256
+			: nonNullish(value)
+				? +formatEther(value.toString())
+				: undefined;
 
 	return { status: 'success', destination, token: token.symbol, amount };
 };

--- a/src/frontend/src/eth/utils/qr-code.utils.ts
+++ b/src/frontend/src/eth/utils/qr-code.utils.ts
@@ -2,9 +2,10 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import { type QrResponse, type QrStatus } from '$lib/types/qr-code';
 import type { Token } from '$lib/types/token';
+import { formatToken } from '$lib/utils/format.utils';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { hexStringToUint8Array, isNullish, nonNullish } from '@dfinity/utils';
-import { formatEther } from 'ethers/lib/utils';
+import { BigNumber } from '@ethersproject/bignumber';
 
 export const decodeQrCode = ({
 	status,
@@ -102,7 +103,7 @@ export const decodeQrCode = ({
 		functionName === 'transfer'
 			? uint256
 			: nonNullish(value)
-				? +formatEther(value.toString())
+				? +formatToken({ value: BigNumber.from(value.toString()), unitName: token.decimals })
 				: undefined;
 
 	return { status: 'success', destination, token: token.symbol, amount };

--- a/src/frontend/src/lib/types/qr-code.ts
+++ b/src/frontend/src/lib/types/qr-code.ts
@@ -9,7 +9,7 @@ export type QrResponse = {
 	amount?: number;
 };
 
-export const URN_NUMERIC_PARAMS = ['amount', 'value'] as const;
+export const URN_NUMERIC_PARAMS = ['amount', 'value', 'uint256'] as const;
 
 export const URN_STRING_PARAMS = ['address'] as const;
 

--- a/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
@@ -70,7 +70,7 @@ describe('decodeQrCode', () => {
 		const payment = {
 			prefix: 'ethereum',
 			destination: destination,
-			amount: amount,
+			value: amount * 10 ** token.decimals,
 			ethereumChainId: (token.network as EthereumNetwork).chainId.toString()
 		};
 		mockDecodeQrCodeUrn.mockReturnValue(payment);


### PR DESCRIPTION
# Motivation

There was a mistake when choosing what property consider when the QR code refers to ERC-20 tokens. According to [EIP-681](https://eips.ethereum.org/EIPS/eip-681):

> Requesting payments in [ERC-20](https://eips.ethereum.org/EIPS/eip-20) tokens involves a request to call the `transfer` function of the token contract with an `address` and a `uint256` typed parameter, containing the _beneficiary address_ and the _amount in atomic units_, respectively. For example, requesting a Unicorn to address `0x8e23ee67d1332ad560396262c48ffbb01f93d052` looks as follows: `ethereum:0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7/transfer?address=0x8e23ee67d1332ad560396262c48ffbb01f93d052&uint256=1`

# Changes

The function `decodeQrCode` was adapted to get the prop uint256 in case the QR code refers to an ERC20 token, defined by the existence of the prop `functionName`.

# Tests

Changed test of decodeQrCode to consider the correct prop.
