### PR TITLE
build: upgrade dfx v0.20.0 and pin version

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,4 +1,5 @@
 {
+	"dfx": "0.20.0",
 	"canisters": {
 		"backend": {
 			"candid": "src/backend/backend.did",


### PR DESCRIPTION
# Changes

- Upgrade staging and production asset canister to dfx v0.20.0.
- Pin version that way we use the same version everywhere.