### PR TITLE
refactor: moved function goToWizardStep in common utils

### DIFF
--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -13,7 +13,7 @@
 	import type { Erc20Token } from '$eth/types/erc20';
 	import { ethereumToken } from '$eth/derived/token.derived';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
-	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
+	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
 
 	/**
 	 * Props
@@ -91,13 +91,13 @@
 		on:icNext={modal.next}
 		on:icClose={close}
 		on:icQRCodeScan={() =>
-			goToWizardStep({
+			goToWizardSendStep({
 				modal,
 				steps,
 				stepName: WizardStepsSend.QR_CODE_SCAN
 			})}
 		on:icQRCodeBack={() =>
-			goToWizardStep({
+			goToWizardSendStep({
 				modal,
 				steps,
 				stepName: WizardStepsSend.SEND

--- a/src/frontend/src/eth/components/send/SendTokenModal.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenModal.svelte
@@ -13,6 +13,7 @@
 	import type { Erc20Token } from '$eth/types/erc20';
 	import { ethereumToken } from '$eth/derived/token.derived';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	/**
 	 * Props
@@ -67,11 +68,6 @@
 
 			currentStep = undefined;
 		});
-
-	const goToWizardStep = (stepName: WizardStepsSend) => {
-		const stepNumber = steps.findIndex(({ name }) => name === stepName);
-		modal.set(Math.max(stepNumber, 0));
-	};
 </script>
 
 <WizardModal
@@ -94,7 +90,17 @@
 		on:icBack={modal.back}
 		on:icNext={modal.next}
 		on:icClose={close}
-		on:icQRCodeScan={() => goToWizardStep(WizardStepsSend.QR_CODE_SCAN)}
-		on:icQRCodeBack={() => goToWizardStep(WizardStepsSend.SEND)}
+		on:icQRCodeScan={() =>
+			goToWizardStep({
+				modal,
+				steps,
+				stepName: WizardStepsSend.QR_CODE_SCAN
+			})}
+		on:icQRCodeBack={() =>
+			goToWizardStep({
+				modal,
+				steps,
+				stepName: WizardStepsSend.SEND
+			})}
 	/>
 </WizardModal>

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -47,6 +47,7 @@
 	import { icSendWizardStepsWithQrCodeScan } from '$icp/config/ic-send.config';
 	import { icDecodeQrCode } from '$icp/utils/qr-code.utils';
 	import QRCodeScan from '$lib/components/send/QRCodeScan.svelte';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	/**
 	 * Props
@@ -179,11 +180,6 @@
 	setContext<EthereumFeeContextType>(ETHEREUM_FEE_CONTEXT_KEY, {
 		store: initEthereumFeeStore()
 	});
-
-	const goToWizardStep = (stepName: WizardStepsSend) => {
-		const stepNumber = steps.findIndex(({ name }) => name === stepName);
-		modal.set(Math.max(stepNumber, 0));
-	};
 </script>
 
 <WizardModal
@@ -208,7 +204,12 @@
 					bind:destination
 					bind:amount
 					bind:networkId
-					on:icQRCodeScan={() => goToWizardStep(WizardStepsSend.QR_CODE_SCAN)}
+					on:icQRCodeScan={() =>
+						goToWizardStep({
+							modal,
+							steps,
+							stepName: WizardStepsSend.QR_CODE_SCAN
+						})}
 				/>
 			{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
 				<QRCodeScan
@@ -216,7 +217,12 @@
 					bind:destination
 					bind:amount
 					decodeQrCode={icDecodeQrCode}
-					on:icQRCodeBack={() => goToWizardStep(WizardStepsSend.SEND)}
+					on:icQRCodeBack={() =>
+						goToWizardStep({
+							modal,
+							steps,
+							stepName: WizardStepsSend.SEND
+						})}
 				/>
 			{:else}
 				<slot />

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -47,7 +47,7 @@
 	import { icSendWizardStepsWithQrCodeScan } from '$icp/config/ic-send.config';
 	import { icDecodeQrCode } from '$icp/utils/qr-code.utils';
 	import QRCodeScan from '$lib/components/send/QRCodeScan.svelte';
-	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
+	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
 
 	/**
 	 * Props
@@ -205,7 +205,7 @@
 					bind:amount
 					bind:networkId
 					on:icQRCodeScan={() =>
-						goToWizardStep({
+						goToWizardSendStep({
 							modal,
 							steps,
 							stepName: WizardStepsSend.QR_CODE_SCAN
@@ -218,7 +218,7 @@
 					bind:amount
 					decodeQrCode={icDecodeQrCode}
 					on:icQRCodeBack={() =>
-						goToWizardStep({
+						goToWizardSendStep({
 							modal,
 							steps,
 							stepName: WizardStepsSend.SEND

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -1,7 +1,7 @@
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
 import { WizardModal, type WizardSteps } from '@dfinity/gix-components';
 
-export const goToWizardStep = ({
+export const goToWizardSendStep = ({
 	modal,
 	steps,
 	stepName

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -1,0 +1,15 @@
+import { WizardStepsSend } from '$lib/enums/wizard-steps';
+import { WizardModal, type WizardSteps } from '@dfinity/gix-components';
+
+export const goToWizardStep = ({
+	modal,
+	steps,
+	stepName
+}: {
+	modal: WizardModal;
+	steps: WizardSteps;
+	stepName: WizardStepsSend;
+}) => {
+	const stepNumber = steps.findIndex(({ name }) => name === stepName);
+	modal.set(Math.max(stepNumber, 0));
+};

--- a/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
@@ -1,5 +1,5 @@
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
-import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
+import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
 import { WizardModal, type WizardSteps } from '@dfinity/gix-components';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -22,7 +22,7 @@ describe('goToWizardStep', () => {
 	it('should set the modal to the correct step number for each step', () => {
 		mockSteps.forEach((step, index) => {
 			mockModal.set.mockClear();
-			goToWizardStep({
+			goToWizardSendStep({
 				modal: mockModal as unknown as WizardModal,
 				steps: mockSteps,
 				stepName: step.name as WizardStepsSend
@@ -33,7 +33,7 @@ describe('goToWizardStep', () => {
 	});
 
 	it('should set the modal to 0 if step name is not found', () => {
-		goToWizardStep({
+		goToWizardSendStep({
 			modal: mockModal as unknown as WizardModal,
 			steps: mockSteps,
 			stepName: 'nonExistentStep' as WizardStepsSend

--- a/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
@@ -1,0 +1,44 @@
+import { WizardStepsSend } from '$lib/enums/wizard-steps';
+import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
+import { WizardModal, type WizardSteps } from '@dfinity/gix-components';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockModal = {
+	set: vi.fn()
+};
+
+describe('goToWizardStep', () => {
+	const mockSteps: WizardSteps = [
+		{ name: 'step1', title: 'Step 1' },
+		{ name: 'step2', title: 'Step 2' },
+		{ name: 'step3', title: 'Step 3' },
+		{ name: 'step4', title: 'Step 4' }
+	];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should set the modal to the correct step number for each step', () => {
+		mockSteps.forEach((step, index) => {
+			mockModal.set.mockClear();
+			goToWizardStep({
+				modal: mockModal as unknown as WizardModal,
+				steps: mockSteps,
+				stepName: step.name as WizardStepsSend
+			});
+
+			expect(mockModal.set).toHaveBeenCalledWith(index);
+		});
+	});
+
+	it('should set the modal to 0 if step name is not found', () => {
+		goToWizardStep({
+			modal: mockModal as unknown as WizardModal,
+			steps: mockSteps,
+			stepName: 'nonExistentStep' as WizardStepsSend
+		});
+
+		expect(mockModal.set).toHaveBeenCalledWith(0);
+	});
+});


### PR DESCRIPTION
# Motivation

To centralize the utils, we moved the merged the functions `goToWizardSendStep` into a single common one, to be used throughout the code.

# Changes

- Created common `goToWizardSendStep` in utils folder.
- Removed `goToWizardSendStep` from ETH universe and adapted the code.
- Removed `goToWizardSendStep` from ICP universe and adapted the code.

# Tests

Created small tests for `goToWizardSendStep`.
