### PR TITLE
fix: ETH transaction listener

### DIFF
--- a/src/frontend/src/eth/services/eth-listener.services.ts
+++ b/src/frontend/src/eth/services/eth-listener.services.ts
@@ -25,7 +25,8 @@ export const initTransactionsListener = ({
 		return initEthPendingTransactionsListenerProvider({
 			toAddress: address,
 			listener: async (hash: string) => await processEthTransaction({ hash, token }),
-			networkId: token.network.id
+			networkId: token.network.id,
+			hashesOnly: true
 		});
 	}
 


### PR DESCRIPTION
# Motivation

I noticed an issue in production yesterday, the Ethereum WebSocket listener wasn't working anymore and way throwing an error in the console log. I was able to reproduce it locally and narrow the issue to the fact that we expect receiving only the hash of the transaction while we were actually receiving the all pending transaction (an object).

# Changes

- Set the WebSocket option to only provides hash.

# Screenshot

<img width="1536" alt="Capture d’écran 2024-06-05 à 06 33 38" src="https://github.com/dfinity/oisy-wallet/assets/16886711/f13c8508-0a42-44a0-b30a-62d6314a6e8d">

