### PR TITLE
style: changed the background of QRCodeScan to have more opacity

### DIFF
--- a/src/frontend/src/lib/components/send/SendQRCodeScan.svelte
+++ b/src/frontend/src/lib/components/send/SendQRCodeScan.svelte
@@ -72,7 +72,7 @@
 	};
 </script>
 
-<div class="stretch md:min-h-[300px]">
+<div class="stretch md:min-h-[300px] qr-code-wrapper">
 	<QRCodeReader on:nnsCancel={onCancel} on:nnsQRCode={onQRCode} />
 </div>
 
@@ -81,3 +81,10 @@
 		{$i18n.core.text.back}
 	</button>
 </ButtonGroup>
+
+<style lang="scss">
+	.qr-code-wrapper {
+		--primary-rgb: 50, 20, 105;
+		color: rgba(var(--primary-rgb), 0.6);
+	}
+</style>


### PR DESCRIPTION
# Motivation

Changed to opacity of the QR Code Scan background to **60%** (value agreed with @artkorotkikh-dfinity) and using the theme color.

# Changes

### Before

<img width="517" alt="Screenshot 2024-06-04 at 14 38 51" src="https://github.com/dfinity/oisy-wallet/assets/169057656/863421f2-aa5a-4afa-a56c-961b96e11e9b">

### After

<img width="506" alt="Screenshot 2024-06-04 at 15 17 58" src="https://github.com/dfinity/oisy-wallet/assets/169057656/02261dfb-1826-4b9b-95bd-64ccfe78d251">


