### PR TITLE
refactor: change function tokenUrl to use the token network instead of a prop

### DIFF
--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -8,7 +8,7 @@
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
-	import { networkId, networkTokens } from '$lib/derived/network.derived';
+	import { networkTokens } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import Header from '$lib/components/ui/Header.svelte';
 	import TokensMenu from '$lib/components/tokens/TokensMenu.svelte';
@@ -37,7 +37,7 @@
 
 <TokensSkeletons>
 	{#each tokens as token (token.id)}
-		{@const url = transactionsUrl({ token, networkId: $networkId })}
+		{@const url = transactionsUrl({ token })}
 
 		<Listener {token}>
 			<a

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -5,13 +5,8 @@ import type { Token } from '$lib/types/token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { LoadEvent, Page } from '@sveltejs/kit';
 
-export const transactionsUrl = ({
-	token,
-	networkId
-}: {
-	token: Token;
-	networkId: NetworkId;
-}): string => tokenUrl({ path: '/transactions/', token, networkId });
+export const transactionsUrl = ({ token }: { token: Token }): string =>
+	tokenUrl({ path: '/transactions/', token });
 
 export const isRouteTransactions = ({ route: { id } }: Page): boolean =>
 	id === '/(app)/transactions';
@@ -24,17 +19,15 @@ export const isSubRoute = (page: Page): boolean =>
 	isRouteTransactions(page) || isRouteSettings(page);
 
 const tokenUrl = ({
-	token: { name },
-	networkId,
+	token: { name, network },
 	path
 }: {
 	token: Token;
-	networkId: NetworkId;
 	path: '/transactions/' | '/';
 }): string =>
 	`${path}?token=${encodeURIComponent(
 		name.replace(/\p{Emoji}/gu, (m, _idx) => `\\u${m.codePointAt(0)?.toString(16)}`)
-	)}${nonNullish(networkId.description) ? `&${networkParam(networkId)}` : ''}`;
+	)}${nonNullish(network.id.description) ? `&${networkParam(network.id)}` : ''}`;
 
 export const networkParam = (networkId: NetworkId): string =>
 	`network=${networkId.description ?? ''}`;

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -19,7 +19,10 @@ export const isSubRoute = (page: Page): boolean =>
 	isRouteTransactions(page) || isRouteSettings(page);
 
 const tokenUrl = ({
-	token: { name, network },
+	token: {
+		name,
+		network: { id: networkId }
+	},
 	path
 }: {
 	token: Token;
@@ -27,7 +30,7 @@ const tokenUrl = ({
 }): string =>
 	`${path}?token=${encodeURIComponent(
 		name.replace(/\p{Emoji}/gu, (m, _idx) => `\\u${m.codePointAt(0)?.toString(16)}`)
-	)}${nonNullish(network.id.description) ? `&${networkParam(network.id)}` : ''}`;
+	)}${nonNullish(networkId.description) ? `&${networkParam(networkId)}` : ''}`;
 
 export const networkParam = (networkId: NetworkId): string =>
 	`network=${networkId.description ?? ''}`;


### PR DESCRIPTION
# Motivation

When creating the token URL, the network was given as prop. 

```typescript
const tokenUrl = ({
  token: { name },
  networkId,
  path
}: {
  token: Token;
  networkId: NetworkId;
  path: '/transactions/' | '/';
}): string => [...]
```

However, the `Token` object has the `network` property, and it would be better to use directly that prop, to avoid inconsistencies.

# Changes

- Removed `networkId` from function `tokenUrl`.
- Adapted the usage of such function throughout the code:
   - function `transactionsUrl`
   - component `Tokens`

# Tests

Behavior unchanged during manual testing in local development env, on each network.
