### PR TITLE
feat: ckErc20 to Erc20 anonymous analytics track events

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -24,12 +24,18 @@
 	import BitcoinFeeContext from '$icp/components/fee/BitcoinFeeContext.svelte';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
-	import { isNetworkIdETH } from '$icp/utils/ic-send.utils';
+	import {
+		isNetworkIdETH,
+		isTokenCkErc20Ledger,
+		isTokenCkEthLedger
+	} from '$icp/utils/ic-send.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import {
 		TRACK_COUNT_CONVERT_CKBTC_TO_BTC_ERROR,
 		TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS,
+		TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_ERROR,
+		TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_SUCCESS,
 		TRACK_COUNT_CONVERT_CKETH_TO_ETH_ERROR,
 		TRACK_COUNT_CONVERT_CKETH_TO_ETH_SUCCESS,
 		TRACK_COUNT_IC_SEND_ERROR,
@@ -100,9 +106,11 @@
 			await trackEvent({
 				name: isNetworkIdBitcoin(networkId)
 					? TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS
-					: isNetworkIdETH(networkId)
+					: isNetworkIdETH(networkId) && isTokenCkEthLedger($token)
 						? TRACK_COUNT_CONVERT_CKETH_TO_ETH_SUCCESS
-						: TRACK_COUNT_IC_SEND_SUCCESS,
+						: isNetworkIdETH(networkId) && isTokenCkErc20Ledger($token)
+							? TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_SUCCESS
+							: TRACK_COUNT_IC_SEND_SUCCESS,
 				metadata: {
 					token: $token.symbol
 				}
@@ -115,9 +123,11 @@
 			await trackEvent({
 				name: isNetworkIdBitcoin(networkId)
 					? TRACK_COUNT_CONVERT_CKBTC_TO_BTC_ERROR
-					: isNetworkIdETH(networkId)
+					: isNetworkIdETH(networkId) && isTokenCkEthLedger($token)
 						? TRACK_COUNT_CONVERT_CKETH_TO_ETH_ERROR
-						: TRACK_COUNT_IC_SEND_ERROR,
+						: isNetworkIdETH(networkId) && isTokenCkErc20Ledger($token)
+							? TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_ERROR
+							: TRACK_COUNT_IC_SEND_ERROR,
 				metadata: {
 					token: $token.symbol
 				}

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -17,5 +17,7 @@ export const TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS = 'ic_ckbtc_to_btc_success
 export const TRACK_COUNT_CONVERT_CKBTC_TO_BTC_ERROR = 'ic_ckbtc_to_btc_error_count';
 export const TRACK_COUNT_CONVERT_CKETH_TO_ETH_SUCCESS = 'ic_cketh_to_eth_success_count';
 export const TRACK_COUNT_CONVERT_CKETH_TO_ETH_ERROR = 'ic_cketh_to_eth_error_count';
+export const TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_SUCCESS = 'ic_ckerc20_to_erc20_success_count';
+export const TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_ERROR = 'ic_ckerc20_to_erc20_error_count';
 export const TRACK_COUNT_IC_SEND_SUCCESS = 'ic_send_success_count';
 export const TRACK_COUNT_IC_SEND_ERROR = 'ic_send_error_count';


### PR DESCRIPTION
# Motivation

We have an anonymous "track events" analytics metric for the conversion of ckETH to ETH, but not for ERC20. While we can identify the two according to their token symbols collected as anonymous metadata, it would be interesting to distinguish the two, as both conversions require different calls.

# Changes

- Add success and error events for ckErc20 to Erc20
