### PR TITLE
chore: playwright adjustements for dev

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,14 +4,16 @@ const DEV = (process.env.NODE_ENV ?? 'production') === 'development';
 
 export default defineConfig({
 	webServer: {
-		command: 'npm run build && npm run preview',
-		port: 4173
+		command: DEV ? 'npm run dev' : 'npm run build && npm run preview',
+		reuseExistingServer: true,
+		port: DEV ? 5173 : 4173
 	},
 	testDir: 'e2e',
 	testMatch: ['**/*.e2e.ts', '**/*.spec.ts'],
 	use: {
 		testIdAttribute: 'data-tid',
-		trace: 'on'
+		trace: 'on',
+		...(DEV && { headless: false })
 	},
 	projects: [
 		{


### PR DESCRIPTION
# Motivation

To develop Playwright test locally, it's interesting to resuse the same dev server as `npm run dev` and also to run the tests not in an headless mode.

# Changes

- Update `playwright.config` to use dev server and no headless in development.
