### PR TITLE
chore: vitest include src path for tests only

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,7 +48,8 @@ export default defineConfig(
 			globals: true,
 			watch: false,
 			silent: true,
-			setupFiles: ['./vitest.setup.ts']
+			setupFiles: ['./vitest.setup.ts'],
+			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)']
 		}
 	})
 );


### PR DESCRIPTION
# Motivation

Vitest are failing currently because it includes the E2E test.

# Changes

- Include only tests under `src` for vitest.
