### PR TITLE
feat: chain fusion/create networks

### DIFF
--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -97,16 +97,17 @@ export const BITCOIN_NETWORKS: Network[] = [BTC_MAINNET_NETWORK, BTC_TESTNET_NET
 
 export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);
 
-export const CHAIN_FUSION_MAINNET_NETWORK_SYMBOL = 'Chain Fusion (all mainnets)';
+export const CHAIN_FUSION_MAINNET_NETWORK_SYMBOL = 'ChainFusion';
 
 export const CHAIN_FUSION_MAINNET_NETWORK_ID = Symbol(CHAIN_FUSION_MAINNET_NETWORK_SYMBOL);
 
 export const CHAIN_FUSION_MAINNET_NETWORK: Network = {
 	id: CHAIN_FUSION_MAINNET_NETWORK_ID,
 	env: 'mainnet',
-	name: 'Chain Fusion (all mainnets)'
+	name: 'Chain Fusion'
 };
 
+// TODO: remove this when we have finished implementing the single-page view with Chain Fusion
 export const CHAIN_FUSION_ENABLED =
 	JSON.parse(import.meta.env.VITE_CHAIN_FUSION_ENABLED ?? false) === true;
 

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -116,3 +116,12 @@ export const CHAIN_FUSION_TESTNET_NETWORK: Network = {
 	env: 'testnet',
 	name: 'Chain Fusion (all testnets)'
 };
+
+export const CHAIN_FUSION_ENABLED =
+	JSON.parse(import.meta.env.VITE_CHAIN_FUSION_ENABLED ?? false) === true;
+
+export const CHAIN_FUSION_NETWORKS: Network[] = CHAIN_FUSION_ENABLED
+	? [CHAIN_FUSION_MAINNET_NETWORK, CHAIN_FUSION_TESTNET_NETWORK]
+	: [];
+
+export const CHAIN_FUSION_NETWORKS_IDS: symbol[] = CHAIN_FUSION_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -96,3 +96,23 @@ export const BTC_TESTNET_NETWORK: Network = {
 export const BITCOIN_NETWORKS: Network[] = [BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK];
 
 export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);
+
+export const CHAIN_FUSION_MAINNET_NETWORK_SYMBOL = 'Chain Fusion (all mainnets)';
+
+export const CHAIN_FUSION_MAINNET_NETWORK_ID = Symbol(CHAIN_FUSION_MAINNET_NETWORK_SYMBOL);
+
+export const CHAIN_FUSION_MAINNET_NETWORK: Network = {
+	id: CHAIN_FUSION_MAINNET_NETWORK_ID,
+	env: 'mainnet',
+	name: 'Chain Fusion (all mainnets)'
+};
+
+export const CHAIN_FUSION_TESTNET_NETWORK_SYMBOL = 'Chain Fusion (all testnets)';
+
+export const CHAIN_FUSION_TESTNET_NETWORK_ID = Symbol(CHAIN_FUSION_TESTNET_NETWORK_SYMBOL);
+
+export const CHAIN_FUSION_TESTNET_NETWORK: Network = {
+	id: CHAIN_FUSION_TESTNET_NETWORK_ID,
+	env: 'testnet',
+	name: 'Chain Fusion (all testnets)'
+};

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -107,21 +107,11 @@ export const CHAIN_FUSION_MAINNET_NETWORK: Network = {
 	name: 'Chain Fusion (all mainnets)'
 };
 
-export const CHAIN_FUSION_TESTNET_NETWORK_SYMBOL = 'Chain Fusion (all testnets)';
-
-export const CHAIN_FUSION_TESTNET_NETWORK_ID = Symbol(CHAIN_FUSION_TESTNET_NETWORK_SYMBOL);
-
-export const CHAIN_FUSION_TESTNET_NETWORK: Network = {
-	id: CHAIN_FUSION_TESTNET_NETWORK_ID,
-	env: 'testnet',
-	name: 'Chain Fusion (all testnets)'
-};
-
 export const CHAIN_FUSION_ENABLED =
 	JSON.parse(import.meta.env.VITE_CHAIN_FUSION_ENABLED ?? false) === true;
 
 export const CHAIN_FUSION_NETWORKS: Network[] = CHAIN_FUSION_ENABLED
-	? [CHAIN_FUSION_MAINNET_NETWORK, CHAIN_FUSION_TESTNET_NETWORK]
+	? [CHAIN_FUSION_MAINNET_NETWORK]
 	: [];
 
 export const CHAIN_FUSION_NETWORKS_IDS: symbol[] = CHAIN_FUSION_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -108,10 +108,10 @@ export const CHAIN_FUSION_MAINNET_NETWORK: Network = {
 };
 
 // TODO: remove this when we have finished implementing the single-page view with Chain Fusion
-export const CHAIN_FUSION_ENABLED =
-	JSON.parse(import.meta.env.VITE_CHAIN_FUSION_ENABLED ?? false) === true;
+export const NETWORK_CHAIN_FUSION_ENABLED =
+	JSON.parse(import.meta.env.VITE_NETWORK_CHAIN_FUSION_ENABLED ?? false) === true;
 
-export const CHAIN_FUSION_NETWORKS: Network[] = CHAIN_FUSION_ENABLED
+export const CHAIN_FUSION_NETWORKS: Network[] = NETWORK_CHAIN_FUSION_ENABLED
 	? [CHAIN_FUSION_MAINNET_NETWORK]
 	: [];
 

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -1,4 +1,3 @@
-import { CHAIN_FUSION_NETWORKS_IDS } from '$env/networks.env';
 import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 import { DEFAULT_NETWORK, DEFAULT_NETWORK_ID } from '$lib/constants/networks.constants';
 import { address } from '$lib/derived/address.derived';
@@ -8,7 +7,11 @@ import { tokens } from '$lib/derived/tokens.derived';
 import type { OptionAddress } from '$lib/types/address';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
-import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
+import {
+	isNetworkIdChainFusion,
+	isNetworkIdEthereum,
+	isNetworkIdICP
+} from '$lib/utils/network.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -27,12 +30,12 @@ export const selectedNetwork: Readable<Network> = derived(
 
 export const networkTokens: Readable<Token[]> = derived(
 	[tokens, selectedNetwork],
-	([$tokens, $selectedNetwork]) => {
-		if (CHAIN_FUSION_NETWORKS_IDS.includes($selectedNetwork.id)) {
-			return $tokens.filter(({ network: { env } }) => env === $selectedNetwork.env);
-		}
-		return $tokens.filter(({ network: { id } }) => id === $selectedNetwork.id);
-	}
+	([$tokens, $selectedNetwork]) =>
+		$tokens.filter(
+			({ network: { id, env } }) =>
+				(isNetworkIdChainFusion($selectedNetwork.id) && env === $selectedNetwork.env) ||
+				id === $selectedNetwork.id
+		)
 );
 
 export const networkICP: Readable<boolean> = derived([networkId], ([$networkId]) =>

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -26,8 +26,13 @@ export const selectedNetwork: Readable<Network> = derived(
 );
 
 export const networkTokens: Readable<Token[]> = derived(
-	[tokens, networkId],
-	([$tokens, $networkId]) => $tokens.filter(({ network: { id } }) => id === $networkId)
+	[tokens, selectedNetwork],
+	([$tokens, $selectedNetwork]) => {
+		if (CHAIN_FUSION_NETWORKS_IDS.includes($selectedNetwork.id)) {
+			return $tokens.filter(({ network: { env } }) => env === $selectedNetwork.env);
+		}
+		return $tokens.filter(({ network: { id } }) => id === $selectedNetwork.id);
+	}
 );
 
 export const networkICP: Readable<boolean> = derived([networkId], ([$networkId]) =>

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -1,3 +1,4 @@
+import { CHAIN_FUSION_NETWORKS_IDS } from '$env/networks.env';
 import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 import { DEFAULT_NETWORK, DEFAULT_NETWORK_ID } from '$lib/constants/networks.constants';
 import { address } from '$lib/derived/address.derived';
@@ -19,6 +20,11 @@ export const networkId: Readable<NetworkId> = derived(
 			: DEFAULT_NETWORK_ID
 );
 
+export const selectedNetwork: Readable<Network> = derived(
+	[networks, networkId],
+	([$networks, $networkId]) => $networks.find(({ id }) => id === $networkId) ?? DEFAULT_NETWORK
+);
+
 export const networkTokens: Readable<Token[]> = derived(
 	[tokens, networkId],
 	([$tokens, $networkId]) => $tokens.filter(({ network: { id } }) => id === $networkId)
@@ -36,9 +42,4 @@ export const networkAddress: Readable<OptionAddress | string> = derived(
 	[address, icrcAccountIdentifierText, networkICP],
 	([$address, $icrcAccountIdentifierStore, $networkICP]) =>
 		$networkICP ? $icrcAccountIdentifierStore : $address
-);
-
-export const selectedNetwork: Readable<Network> = derived(
-	[networks, networkId],
-	([$networks, $networkId]) => $networks.find(({ id }) => id === $networkId) ?? DEFAULT_NETWORK
 );

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -1,11 +1,15 @@
-import { ICP_NETWORK } from '$env/networks.env';
+import { CHAIN_FUSION_NETWORKS, ICP_NETWORK } from '$env/networks.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
 
 export const networks: Readable<Network[]> = derived(
 	[enabledEthereumNetworks],
-	([$enabledEthereumNetworks]) => [...$enabledEthereumNetworks, ICP_NETWORK]
+	([$enabledEthereumNetworks]) => [
+		...CHAIN_FUSION_NETWORKS,
+		...$enabledEthereumNetworks,
+		ICP_NETWORK
+	]
 );
 
 interface NetworksEnvs {

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,5 +1,6 @@
 import {
 	BITCOIN_NETWORKS_IDS,
+	CHAIN_FUSION_NETWORKS_IDS,
 	ICP_NETWORK_ID,
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
 } from '$env/networks.env';
@@ -15,3 +16,6 @@ export const isNetworkIdEthereum = (id: NetworkId | undefined): boolean =>
 
 export const isNetworkIdBitcoin = (id: NetworkId | undefined): boolean =>
 	nonNullish(id) && BITCOIN_NETWORKS_IDS.includes(id);
+
+export const isNetworkIdChainFusion = (id: NetworkId | undefined): boolean =>
+	nonNullish(id) && CHAIN_FUSION_NETWORKS_IDS.includes(id);


### PR DESCRIPTION
# Motivation

For the single-page view, we create the network **Chain Fusion** that allows the user to select all the available _mainnet_ networks at once. We refactor the derived store `networkTokens` to filter for the `network.env` prop of the tokens (instead of the `network.id`) when the selected network is Chain Fusion.

# Changes

- Created Chain Fusion mainnet network.
- Moved derived store `selectedNetwork` higher to be re-used.
- Included filter by environment in derived store `networkTokens`.
- Included Chain Fusion Networks among the selectable networks.

# Tests

Manual test in local replica.


### NOTE: there is temporary environment variable `VITE_CHAIN_FUSION_ENABLED` to enable this feature on the local replica. It will be removed once all Chain-Fusion-related features are approved.
