### PR TITLE
feat: use receive button in eth receive

### DIFF
--- a/src/frontend/src/eth/components/receive/Receive.svelte
+++ b/src/frontend/src/eth/components/receive/Receive.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-	import IconReceive from '$lib/components/icons/IconReceive.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { addressNotCertified } from '$lib/derived/address.derived';
 	import ReceiveModal from '$eth/components/receive/ReceiveModal.svelte';
 	import { metamaskNotInitialized } from '$eth/derived/metamask.derived';
-	import { isBusy } from '$lib/derived/busy.derived';
 	import { waitWalletReady } from '$lib/services/actions.services';
 	import { modalReceive } from '$lib/derived/modal.derived';
-	import { i18n } from '$lib/stores/i18n.store';
+	import ReceiveButton from '$lib/components/receive/ReceiveButton.svelte';
 
 	const isDisabled = (): boolean => $addressNotCertified || $metamaskNotInitialized;
 
@@ -24,15 +22,7 @@
 	};
 </script>
 
-<button
-	class="flex-1 hero"
-	disabled={$isBusy}
-	class:opacity-50={$isBusy}
-	on:click={async () => await openReceive()}
->
-	<IconReceive size="28" />
-	<span>{$i18n.receive.text.receive}</span></button
->
+<ReceiveButton on:click={async () => await openReceive()} />
 
 {#if $modalReceive}
 	<ReceiveModal />


### PR DESCRIPTION
# Motivation

We have extracted a common `ReceiveButton` in #1415 so we can use it as well for ETH.

# Changes

- Use component. This will help us reduce code with the upcoming required styling (future PRs).
