### PR TITLE
refactor: re-ordered store tokens to show Ethereum native tokens before ICRC tokens

### DIFF
--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -9,8 +9,8 @@ export const tokens: Readable<Token[]> = derived(
 	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens],
 	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens]) => [
 		ICP_TOKEN,
-		...$icrcTokens,
 		...$enabledEthereumTokens,
+		...$icrcTokens,
 		...$erc20Tokens
 	]
 );


### PR DESCRIPTION
# Motivation

Since we will have a single-view with the list of all tokens of all networks, as part of the requirements, the Ethereum native tokens will be put before the list of ICRC tokens, but after ICP.

# Changes

Changed order of store `tokens`.

