### PR TITLE
feat: unique receive modals

### DIFF
--- a/src/frontend/src/eth/components/receive/Receive.svelte
+++ b/src/frontend/src/eth/components/receive/Receive.svelte
@@ -9,6 +9,8 @@
 	import { modalReceive } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
+	const modalId = Symbol();
+
 	const isDisabled = (): boolean => $addressNotCertified || $metamaskNotInitialized;
 
 	const openReceive = async () => {
@@ -20,7 +22,7 @@
 			}
 		}
 
-		modalStore.openReceive();
+		modalStore.openReceive(modalId);
 	};
 </script>
 
@@ -34,6 +36,6 @@
 	<span>{$i18n.receive.text.receive}</span></button
 >
 
-{#if $modalReceive}
+{#if $modalReceive && $modalStore?.data === modalId}
 	<ReceiveModal />
 {/if}

--- a/src/frontend/src/icp/components/receive/IcReceiveCkBTC.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkBTC.svelte
@@ -19,6 +19,8 @@
 
 	const { token, tokenId, twinToken } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
+	const modalId = Symbol();
+
 	let minterInfoLoaded = false;
 
 	const openReceive = async () => {
@@ -34,7 +36,7 @@
 			identity: $authStore.identity
 		});
 
-		modalStore.openCkBTCReceive();
+		modalStore.openCkBTCReceive(modalId);
 		return;
 	};
 </script>
@@ -47,6 +49,6 @@
 	<IcCkListener initFn={initCkBTCMinterInfoWorker} token={$token} twinToken={$twinToken} />
 {/if}
 
-{#if $modalCkBTCReceive}
+{#if $modalCkBTCReceive && $modalStore?.data === modalId}
 	<IcReceiveModal infoCmp={IcReceiveInfoCkBTC} />
 {/if}

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -7,6 +7,8 @@
 	import ReceiveButton from '$lib/components/receive/ReceiveButton.svelte';
 	import { ckEthereumTwinToken } from '$icp-eth/derived/cketh.derived';
 
+	const modalId = Symbol();
+
 	/**
 	 * Send modal context store
 	 */
@@ -23,8 +25,8 @@
 	$: sendToken.set($ckEthereumTwinToken);
 </script>
 
-<ReceiveButton on:click={modalStore.openCkETHReceive} />
+<ReceiveButton on:click={() => modalStore.openCkETHReceive(modalId)} />
 
-{#if $modalCkETHReceive}
+{#if $modalCkETHReceive && $modalStore?.data === modalId}
 	<IcReceiveCkEthereumModal />
 {/if}

--- a/src/frontend/src/icp/components/receive/IcReceiveICP.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveICP.svelte
@@ -12,20 +12,22 @@
 		type ReceiveTokenContext
 	} from '$icp/stores/receive-token.store';
 
+	const modalId = Symbol();
+
 	const { tokenStandard } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
 	const openReceive = () => {
 		if ($tokenStandard === 'icp' || isRouteTokens($page)) {
-			modalStore.openIcpReceive();
+			modalStore.openIcpReceive(modalId);
 			return;
 		}
 
-		modalStore.openReceive();
+		modalStore.openReceive(modalId);
 	};
 </script>
 
 <ReceiveButton on:click={openReceive} />
 
-{#if $modalIcpReceive}
+{#if $modalIcpReceive && $modalStore?.data === modalId}
 	<IcReceiveModal infoCmp={IcReceiveInfoICP} />
 {/if}

--- a/src/frontend/src/icp/components/receive/IcReceiveIcrc.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveIcrc.svelte
@@ -4,10 +4,12 @@
 	import IcReceiveInfoIcrc from '$icp/components/receive/IcReceiveInfoIcrc.svelte';
 	import ReceiveButton from '$lib/components/receive/ReceiveButton.svelte';
 	import { modalIcrcReceive } from '$lib/derived/modal.derived';
+
+	const modalId = Symbol();
 </script>
 
-<ReceiveButton on:click={modalStore.openIcrcReceive} />
+<ReceiveButton on:click={() => modalStore.openIcrcReceive(modalId)} />
 
-{#if $modalIcrcReceive}
+{#if $modalIcrcReceive && $modalStore?.data === modalId}
 	<IcReceiveModal infoCmp={IcReceiveInfoIcrc} />
 {/if}

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -32,11 +32,11 @@ export interface Modal<T> {
 export type ModalData<T> = Modal<T> | undefined | null;
 
 export interface ModalStore<T> extends Readable<ModalData<T>> {
-	openReceive: () => void;
-	openIcpReceive: () => void;
-	openIcrcReceive: () => void;
-	openCkBTCReceive: () => void;
-	openCkETHReceive: () => void;
+	openReceive: <D extends T>(data: D) => void;
+	openIcpReceive: <D extends T>(data: D) => void;
+	openIcrcReceive: <D extends T>(data: D) => void;
+	openCkBTCReceive: <D extends T>(data: D) => void;
+	openCkETHReceive: <D extends T>(data: D) => void;
 	openSend: () => void;
 	openConvertCkBTCToBTC: () => void;
 	openConvertToTwinTokenCkEth: () => void;
@@ -62,11 +62,11 @@ const initModalStore = <T>(): ModalStore<T> => {
 	const { subscribe, set } = writable<ModalData<T>>(undefined);
 
 	return {
-		openReceive: () => set({ type: 'receive' }),
-		openIcpReceive: () => set({ type: 'icp-receive' }),
-		openIcrcReceive: () => set({ type: 'icrc-receive' }),
-		openCkBTCReceive: () => set({ type: 'ckbtc-receive' }),
-		openCkETHReceive: () => set({ type: 'cketh-receive' }),
+		openReceive: <D extends T>(data: D) => set({ type: 'receive', data }),
+		openIcpReceive: <D extends T>(data: D) => set({ type: 'icp-receive', data }),
+		openIcrcReceive: <D extends T>(data: D) => set({ type: 'icrc-receive', data }),
+		openCkBTCReceive: <D extends T>(data: D) => set({ type: 'ckbtc-receive', data }),
+		openCkETHReceive: <D extends T>(data: D) => set({ type: 'cketh-receive', data }),
 		openSend: () => set({ type: 'send' }),
 		openConvertCkBTCToBTC: () => set({ type: 'convert-ckbtc-btc' }),
 		openConvertToTwinTokenCkEth: () => set({ type: 'convert-to-twin-token-cketh' }),


### PR DESCRIPTION
# Motivation

By adding multiple calls to action to open modals, we will end up with multiple listeners and potentially multiple modals opened at once if we don't prevent it. One way to address this would have been to move all modals to the root, but that’s quite a change, and I like that the modals are scoped next to their calls to action. It's also useful to be able to use context. That's why this PR introduces a local ID, which can be used to ensure that the modal that needs to open is the one triggered next to the button.

# Changes

- Use `symbol` to identify receive modal.
