### PR TITLE
feat: derive twinToken for ckEth Receive modal

### DIFF
--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
 	import { modalCkETHReceive } from '$lib/derived/modal.derived';
-	import { setContext } from 'svelte';
+	import { getContext, setContext } from 'svelte';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import IcReceiveCkEthereumModal from '$icp/components/receive/IcReceiveCkEthereumModal.svelte';
 	import ReceiveButton from '$lib/components/receive/ReceiveButton.svelte';
-	import { ckEthereumTwinToken } from '$icp-eth/derived/cketh.derived';
+	import {
+		RECEIVE_TOKEN_CONTEXT_KEY,
+		type ReceiveTokenContext
+	} from '$icp/stores/receive-token.store';
+	import type { Token } from '$lib/types/token';
+	import type { IcCkToken } from '$icp/types/ic';
+	import { ETHEREUM_TOKEN } from '$env/tokens.env';
+
+	const { token } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
+
+	let twinToken: Token;
+	$: twinToken = ($token as IcCkToken)?.twinToken ?? ETHEREUM_TOKEN;
 
 	/**
 	 * Send modal context store
@@ -13,14 +24,14 @@
 
 	const { sendToken, ...rest } = initSendContext({
 		sendPurpose: 'convert-eth-to-cketh',
-		token: $ckEthereumTwinToken
+		token: twinToken
 	});
 	setContext<SendContext>(SEND_CONTEXT_KEY, {
 		sendToken,
 		...rest
 	});
 
-	$: sendToken.set($ckEthereumTwinToken);
+	$: sendToken.set(twinToken);
 </script>
 
 <ReceiveButton on:click={modalStore.openCkETHReceive} />


### PR DESCRIPTION
# Motivation

Now that we use a token as property for the "Receive" modal, we should also derive the twin token from it and not used the global derived `$ckEthereumTwinToken`.
