### PR TITLE
refactor: include optional property to override Network env in token

### DIFF
--- a/src/frontend/src/env/networks.ircrc.env.ts
+++ b/src/frontend/src/env/networks.ircrc.env.ts
@@ -280,3 +280,13 @@ export const ICRC_TOKENS: IcCkInterface[] = [
 	...(nonNullish(CKUSDC_STAGING_DATA) ? [CKUSDC_STAGING_DATA] : []),
 	...(nonNullish(CKUSDC_IC_DATA) ? [CKUSDC_IC_DATA] : [])
 ];
+
+/**
+ * All ICRC testnet ledger canister IDs
+ */
+
+export const ICRC_TESTNET_LEDGER_CANISTER_IDS: CanisterIdText[] = [
+	...CKBTC_LEDGER_CANISTER_TESTNET_IDS,
+	...CKETH_LEDGER_CANISTER_TESTNET_IDS,
+	...CKUSDC_LEDGER_CANISTER_TESTNET_IDS
+];

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -1,4 +1,5 @@
 import { ICP_NETWORK } from '$env/networks.env';
+import { ICRC_TESTNET_LEDGER_CANISTER_IDS } from '$env/networks.ircrc.env';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcFee, IcInterface, IcToken } from '$icp/types/ic';
 import type { IcTokenWithoutIdExtended } from '$icp/types/icrc-custom-token';
@@ -48,6 +49,7 @@ export const mapIcrcToken = ({
 			indexCanisterVersion: icrcCustomTokens[ledgerCanisterId].indexCanisterVersion
 		}),
 		ledgerCanisterId,
+		...(isIcrcTestLedgerCanister(ledgerCanisterId) && { overrideEnv: 'testnet' }),
 		...metadataToken,
 		...rest
 	};
@@ -131,3 +133,6 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 		...(nonNullish(icon) ? [icon] : [])
 	];
 };
+
+export const isIcrcTestLedgerCanister = (ledgerCanisterId: CanisterIdText) =>
+	ICRC_TESTNET_LEDGER_CANISTER_IDS.includes(ledgerCanisterId);

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,4 +1,4 @@
-import type { Network } from '$lib/types/network';
+import type { Network, NetworkEnvironment } from '$lib/types/network';
 
 export type TokenId = symbol;
 
@@ -11,6 +11,7 @@ export type Token = {
 	network: Network;
 	standard: TokenStandard;
 	category: TokenCategory;
+	overrideNetworkEnv?: NetworkEnvironment;
 } & TokenMetadata;
 
 export interface TokenMetadata {


### PR DESCRIPTION
# To be decided if we pursue this one or PR #

# Motivation

There are ICRC tokens that are considered test tokens, even if they lay in the mainnet network. I created the optional property `overrideNetworkEnv` to distinguish them.

# Changes

- Create utils to distinguish Test Ledger Canisters.
- Use the util above to define `overrideNetworkEnv` in ICRC tokens.
