### PR TITLE
Fix/remove icrc test token from chain fusion

### DIFF
--- a/src/frontend/src/env/networks.ircrc.env.ts
+++ b/src/frontend/src/env/networks.ircrc.env.ts
@@ -280,3 +280,13 @@ export const ICRC_TOKENS: IcCkInterface[] = [
 	...(nonNullish(CKUSDC_STAGING_DATA) ? [CKUSDC_STAGING_DATA] : []),
 	...(nonNullish(CKUSDC_IC_DATA) ? [CKUSDC_IC_DATA] : [])
 ];
+
+/**
+ * All ICRC testnet ledger canister IDs
+ */
+
+export const ICRC_TESTNET_LEDGER_CANISTER_IDS: CanisterIdText[] = [
+	...CKBTC_LEDGER_CANISTER_TESTNET_IDS,
+	...CKETH_LEDGER_CANISTER_TESTNET_IDS,
+	...CKUSDC_LEDGER_CANISTER_TESTNET_IDS
+];

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -1,13 +1,8 @@
-import {
-	CKBTC_LEDGER_CANISTER_TESTNET_IDS,
-	CKETH_LEDGER_CANISTER_TESTNET_IDS,
-	CKUSDC_LEDGER_CANISTER_TESTNET_IDS
-} from '$env/networks.ircrc.env';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcTokensStore } from '$icp/stores/icrc.store';
 import type { IcToken } from '$icp/types/ic';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import { sortIcTokens } from '$icp/utils/icrc.utils';
+import { isIcrcTestLedgerCanister, sortIcTokens } from '$icp/utils/icrc.utils';
 import { testnets } from '$lib/derived/testnets.derived';
 import { derived, type Readable } from 'svelte/store';
 
@@ -15,13 +10,7 @@ export const icrcDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcTokensStore, testnets],
 	([$icrcTokensStore, $testnets]) =>
 		($icrcTokensStore?.map(({ data: token }) => token) ?? []).filter(
-			({ ledgerCanisterId }) =>
-				$testnets ||
-				![
-					...CKBTC_LEDGER_CANISTER_TESTNET_IDS,
-					...CKETH_LEDGER_CANISTER_TESTNET_IDS,
-					...CKUSDC_LEDGER_CANISTER_TESTNET_IDS
-				].includes(ledgerCanisterId)
+			({ ledgerCanisterId }) => $testnets || !isIcrcTestLedgerCanister(ledgerCanisterId)
 		)
 );
 

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -1,4 +1,5 @@
 import { ICP_NETWORK } from '$env/networks.env';
+import { ICRC_TESTNET_LEDGER_CANISTER_IDS } from '$env/networks.ircrc.env';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcFee, IcInterface, IcToken } from '$icp/types/ic';
 import type { IcTokenWithoutIdExtended } from '$icp/types/icrc-custom-token';
@@ -131,3 +132,6 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 		...(nonNullish(icon) ? [icon] : [])
 	];
 };
+
+export const isIcrcTestLedgerCanister = (ledgerCanisterId: LedgerCanisterIdText) =>
+	ICRC_TESTNET_LEDGER_CANISTER_IDS.includes(ledgerCanisterId);

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -135,3 +135,6 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 
 export const isIcrcTestLedgerCanister = (ledgerCanisterId: LedgerCanisterIdText) =>
 	ICRC_TESTNET_LEDGER_CANISTER_IDS.includes(ledgerCanisterId);
+
+export const determineIcrcLedgerCanisterEnvironment = (ledgerCanisterId: LedgerCanisterIdText) =>
+	isIcrcTestLedgerCanister(ledgerCanisterId) ? 'testnet' : 'mainnet';

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -1,4 +1,6 @@
 import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import { determineIcrcLedgerCanisterEnvironment } from '$icp/utils/icrc.utils';
 import { DEFAULT_NETWORK, DEFAULT_NETWORK_ID } from '$lib/constants/networks.constants';
 import { address } from '$lib/derived/address.derived';
 import { routeNetwork } from '$lib/derived/nav.derived';
@@ -32,9 +34,18 @@ export const networkTokens: Readable<Token[]> = derived(
 	[tokens, selectedNetwork],
 	([$tokens, $selectedNetwork]) =>
 		$tokens.filter(
-			({ network: { id, env } }) =>
-				(isNetworkIdChainFusion($selectedNetwork.id) && env === $selectedNetwork.env) ||
-				id === $selectedNetwork.id
+			({
+				network: { id, env },
+				ledgerCanisterId
+			}: {
+				network: Network;
+				ledgerCanisterId?: LedgerCanisterIdText;
+			}) =>
+				isNetworkIdChainFusion($selectedNetwork.id)
+					? nonNullish(ledgerCanisterId)
+						? determineIcrcLedgerCanisterEnvironment(ledgerCanisterId) === $selectedNetwork.env
+						: env === $selectedNetwork.env
+					: id === $selectedNetwork.id
 		)
 );
 


### PR DESCRIPTION
# Motivation

The Chain Fusion network was mistakenly showing the ICRC test tokens together with all the _mainnet_ tokens.
We filter those tokes based on they Ledger Canister ID.

# Changes

- Create utils to distinguish Test Ledger Canisters.
- Include filter in store `networkTokens` to filter the ICRC tokens by environment, based on the property `ledgerCanisterId`.

# Tests

### Before:

<img width="630" alt="Screenshot 2024-06-12 at 17 26 40" src="https://github.com/dfinity/oisy-wallet/assets/169057656/0f6f1a86-188c-4c72-885a-0ac211b0caf0">

### After:

<img width="629" alt="Screenshot 2024-06-12 at 17 26 55" src="https://github.com/dfinity/oisy-wallet/assets/169057656/8fe7595b-275a-4729-b9f1-a12f63b841a6">
