### PR TITLE
fix: changed back function to use the previous route if defined

### DIFF
--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -16,6 +16,7 @@
 
 <button
 	class="flex gap-0.5 text-white font-bold pointer-events-auto ml-2"
-	on:click={async () => back({ pop: nonNullish(fromRoute), networkId: $networkId })}
+	on:click={async () =>
+		back({ pop: nonNullish(fromRoute), networkId: $networkId, fromUrl: fromRoute?.url })}
 	><IconBack /> {$i18n.navigation.text.back_to_wallet}</button
 >

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -35,8 +35,16 @@ const tokenUrl = ({
 export const networkParam = (networkId: NetworkId): string =>
 	`network=${networkId.description ?? ''}`;
 
-export const back = async ({ pop, networkId }: { pop: boolean; networkId: NetworkId }) => {
-	const rootUrl = `/?${networkParam(networkId)}`;
+export const back = async ({
+	pop,
+	networkId,
+	fromUrl
+}: {
+	pop: boolean;
+	networkId: NetworkId;
+	fromUrl?: URL;
+}) => {
+	const rootUrl = fromUrl?.toString() ?? `/?${networkParam(networkId)}`;
 
 	if (!pop) {
 		await goto(rootUrl);


### PR DESCRIPTION
# Motivation

The "Back to Wallet" button in each `transaction` page was using the networkId defined by default in the current URL.
For example, if we are in `(app)/transactions/?token=ICP&network=ICP`, it would have returned to `(app)/?network=ICP`.

However that is an incorrect behavior when we deal with Chain Fusion, since the URL network parameter does not match Chain Fusion.
For example:
1) We are in `(app)/?network=ChainFusion`
2) We click on the ICP token that redirects to `(app)/transactions/?token=ICP&network=ICP`
3) We click on "Back to Wallet"
4) We are redirected to `(app)/?network=ICP`, **that is not what we would expect**.

# Changes

- Change function `back` in `nav.utils.ts` to have an optional parameter `fromUrl` that, if it is defined, takes priority over `networkId`.
- Change `Back` component to use the URL of navigational variable `fromRoute`.

# Tests

Manual test in local replica.

### Before:


https://github.com/dfinity/oisy-wallet/assets/169057656/2f4953ff-f187-4cc6-8b3a-28eac9ba718e



### After:


https://github.com/dfinity/oisy-wallet/assets/169057656/7da33a0c-f933-4ba8-bd97-8fdac9a7ddf7


