### PR TITLE
chore: removed unused param  from util back

### DIFF
--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -3,7 +3,6 @@
 	import { back } from '$lib/utils/nav.utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate } from '$app/navigation';
-	import { nonNullish } from '@dfinity/utils';
 	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -16,7 +15,6 @@
 
 <button
 	class="flex gap-0.5 text-white font-bold pointer-events-auto ml-2"
-	on:click={async () =>
-		back({ pop: nonNullish(fromRoute), networkId: $networkId, fromUrl: fromRoute?.url })}
+	on:click={async () => back({ networkId: $networkId, fromUrl: fromRoute?.url })}
 	><IconBack /> {$i18n.navigation.text.back_to_wallet}</button
 >

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -18,7 +18,7 @@
 		await switchNetwork(network.id);
 
 		if (isRouteTransactions($page)) {
-			await back({ pop: true, networkId: $networkId });
+			await back({ networkId: $networkId });
 		}
 
 		// A small delay to give the user a visual feedback that the network is checked

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -55,7 +55,7 @@
 			hideProgressStep = ProgressStepsHideToken.UPDATE_UI;
 
 			// We must navigate first otherwise we might land on the default token Ethereum selected while being on network ICP.
-			await back({ networkId: backToNetworkId, pop: true });
+			await back({ networkId: backToNetworkId });
 
 			await updateUi({
 				identity: $authStore.identity

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -35,23 +35,10 @@ const tokenUrl = ({
 export const networkParam = (networkId: NetworkId): string =>
 	`network=${networkId.description ?? ''}`;
 
-export const back = async ({
-	pop,
-	networkId,
-	fromUrl
-}: {
-	pop: boolean;
-	networkId: NetworkId;
-	fromUrl?: URL;
-}) => {
+export const back = async (params: { networkId: NetworkId; fromUrl?: URL }) => {
+	const { networkId, fromUrl } = params;
 	const rootUrl = fromUrl?.toString() ?? `/?${networkParam(networkId)}`;
-
-	if (!pop) {
-		await goto(rootUrl);
-		return;
-	}
-
-	await goto(rootUrl, { replaceState: true });
+	await goto(rootUrl, { replaceState: 'fromUrl' in params ? nonNullish(fromUrl) : true });
 };
 
 export type RouteParams = {


### PR DESCRIPTION
# Motivation

We noticed in PR #1425, that function `back` had the param `pop` that was actually alway `true`, except when passed the param `fromUrl`. To simplify, we removed such parameter and adapted the function logic.

# Changes

- Changed params and logic of function `back`.
- Adapted usage of such function.

# Tests

Behavior remains unchanged in manual tests in local replica.
