### PR TITLE
chore: use i18n for alt string of logos

### DIFF
--- a/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
@@ -34,7 +34,10 @@
 	>
 	<span class="flex gap-1">
 		{sourceNetwork.name}
-		<Logo src={sourceNetwork.icon ?? eth} alt={`${sourceNetwork.name} logo`} />
+		<Logo
+			src={sourceNetwork.icon ?? eth}
+			alt={replacePlaceholders($i18n.core.alt.logo, { $name: sourceNetwork.name })}
+		/>
 	</span>
 </Value>
 

--- a/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
+++ b/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
@@ -10,6 +10,7 @@
 	import bitcoin from '$icp/assets/bitcoin.svg';
 	import eth from '$icp-eth/assets/eth.svg';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let networkId: NetworkId | undefined = undefined;
 
@@ -38,7 +39,9 @@
 				{$ckEthereumTwinToken.network.name}
 				<Logo
 					src={$ckEthereumTwinToken.network.icon ?? eth}
-					alt={`${$ckEthereumTwinToken.network.name} logo`}
+					alt={replacePlaceholders($i18n.core.alt.logo, {
+						$name: $ckEthereumTwinToken.network.name
+					})}
 				/>
 			{/if}
 		</span>

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -15,6 +15,7 @@
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let ledgerCanisterId = '';
 	export let indexCanisterId = '';
@@ -56,7 +57,7 @@
 					<Logo
 						src={token.token.icon}
 						slot="icon"
-						alt={`${token.token.name} logo`}
+						alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.token.name })}
 						size="medium"
 						color="white"
 					/>

--- a/src/frontend/src/icp/components/tokens/IcManageTokens.svelte
+++ b/src/frontend/src/icp/components/tokens/IcManageTokens.svelte
@@ -18,6 +18,7 @@
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { ICP_TOKEN } from '$env/tokens.env';
 	import { sortIcTokens } from '$icp/utils/icrc.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	const dispatch = createEventDispatcher();
 
@@ -142,7 +143,13 @@
 			<Card>
 				{token.name}
 
-				<Logo src={token.icon} slot="icon" alt={`${token.name} logo`} size="medium" color="white" />
+				<Logo
+					src={token.icon}
+					slot="icon"
+					alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
+					size="medium"
+					color="white"
+				/>
 
 				<span class="break-all" slot="description">
 					{token.symbol}

--- a/src/frontend/src/icp/components/tokens/IcTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcTokenModal.svelte
@@ -10,6 +10,7 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	let twinToken: TokenType | undefined;
 	$: twinToken = ($token as IcCkToken).twinToken;
@@ -28,7 +29,11 @@
 					<svelte:fragment slot="label">{$i18n.tokens.details.twin_token}</svelte:fragment>
 					<span class="flex gap-1 items-center">
 						<output>{twinToken.name}</output>
-						<Logo src={twinToken.icon} alt={`${twinToken.name} logo`} color="white" />
+						<Logo
+							src={twinToken.icon}
+							alt={replacePlaceholders($i18n.core.alt.logo, { $name: twinToken.name })}
+							color="white"
+						/>
 					</span>
 				</Value>
 			{/if}

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -14,6 +14,8 @@
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
 	import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	export let usdTotal = false;
 	export let summary = false;
@@ -41,7 +43,12 @@
 					<div>
 						{#if displayTokenSymbol}
 							<div in:fade>
-								<Logo src={$token.icon} size="big" alt={`${$token.name} logo`} color="off-white" />
+								<Logo
+									src={$token.icon}
+									size="big"
+									alt={replacePlaceholders($i18n.core.alt.logo, { $name: $token.name })}
+									color="off-white"
+								/>
 							</div>
 						{:else}
 							<SkeletonLogo size="big" />

--- a/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
@@ -13,7 +13,12 @@
 
 <div class="stretch">
 	<div class="icon flex flex-col items-center gap-3">
-		<Logo src={$token.icon} size="big" alt={`${$token.name} logo`} color="off-white" />
+		<Logo
+			src={$token.icon}
+			size="big"
+			alt={replacePlaceholders($i18n.core.alt.logo, { $name: $token.name })}
+			color="off-white"
+		/>
 
 		<p class="font-bold text-center">{$token.name}</p>
 	</div>

--- a/src/frontend/src/lib/components/tokens/Token.svelte
+++ b/src/frontend/src/lib/components/tokens/Token.svelte
@@ -3,6 +3,7 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import type { Token } from '$lib/types/token';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let token: Token;
 </script>
@@ -11,7 +12,11 @@
 	<svelte:fragment slot="label">{$i18n.tokens.details.network}</svelte:fragment>
 	<span class="flex gap-1 items-center">
 		<output>{token.network.name}</output>
-		<Logo src={token.network.icon} alt={`${token.network.name} logo`} color="white" />
+		<Logo
+			src={token.network.icon}
+			alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.network.name })}
+			color="white"
+		/>
 	</span>
 </Value>
 
@@ -19,7 +24,11 @@
 	<svelte:fragment slot="label">{$i18n.tokens.details.token}</svelte:fragment>
 	<span class="flex gap-1 items-center">
 		<output>{token.name}</output>
-		<Logo src={token.icon} alt={`${token.name} logo`} color="white" />
+		<Logo
+			src={token.icon}
+			alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
+			color="white"
+		/>
 	</span>
 </Value>
 

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import type { Token } from '$lib/types/token';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	export let token: Token;
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
@@ -14,10 +16,19 @@
 </script>
 
 <div class="relative">
-	<Logo src={icon} alt={`${name} logo`} size="medium" {color} />
+	<Logo
+		src={icon}
+		alt={replacePlaceholders($i18n.core.alt.logo, { $name: name })}
+		size="medium"
+		{color}
+	/>
 	{#if showNetworkIcon}
 		<div class="absolute bottom-0 right-0">
-			<Logo src={networkIcon} alt={`${networkName} logo`} {color} />
+			<Logo
+				src={networkIcon}
+				alt={replacePlaceholders($i18n.core.alt.logo, { $name: networkName })}
+				{color}
+			/>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
# Motivation

It is better to use `i18n` when giving the `alt` string to `Logo` components.

# Changes

Changed all uses of snippet ``alt=`{...} logo` `` to use `i18n.core.alt.logo`.