### PR TITLE
refactor: removed reference to DEFAULT_NETWORK as fallback in derived selectedEthereumNetwork

### DIFF
--- a/src/frontend/src/eth/derived/network.derived.ts
+++ b/src/frontend/src/eth/derived/network.derived.ts
@@ -1,13 +1,13 @@
+import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { EthereumNetwork } from '$eth/types/network';
-import { DEFAULT_NETWORK } from '$lib/constants/networks.constants';
 import { networkId } from '$lib/derived/network.derived';
 import { derived, type Readable } from 'svelte/store';
 
 export const selectedEthereumNetwork: Readable<EthereumNetwork> = derived(
 	[enabledEthereumNetworks, networkId],
 	([$enabledEthereumNetworks, $networkId]) =>
-		$enabledEthereumNetworks.find(({ id }) => id === $networkId) ?? DEFAULT_NETWORK
+		$enabledEthereumNetworks.find(({ id }) => id === $networkId) ?? SUPPORTED_ETHEREUM_NETWORKS[0]
 );
 
 export const selectedChainId: Readable<bigint> = derived(


### PR DESCRIPTION
# Motivation

The derived `selectedEthereumNetwork` falls back to `DEFAULT_NETWORK`. At the same time `DEFAULT_NETWORK`, right now, is defined in the code as the first available Ethereum network, between _Homestead_ and _Sepolia_:

```typescript
// from lib/constants/networks.constants.ts
export const [DEFAULT_NETWORK, _rest] = SUPPORTED_ETHEREUM_NETWORKS;
```

That means that when `selectedEthereumNetwork` would not find any `networkId` (meaning that the user selected a non-Ethereum network), it would fall back on either Homestead or Sepolia.

However, it seems more consistent with the context of `selectedEthereumNetwork` to use directly the first element of `SUPPORTED_ETHEREUM_NETWORKS` instead of `DEFAULT_NETWORK`.
