### PR TITLE
chore: changed DEFAULT_NETWORK to use Chain Fusion networks

### DIFF
--- a/src/frontend/src/lib/constants/networks.constants.ts
+++ b/src/frontend/src/lib/constants/networks.constants.ts
@@ -1,4 +1,5 @@
-import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks.env';
+import { CHAIN_FUSION_NETWORKS, SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks.env';
 
-export const [DEFAULT_NETWORK, _rest] = SUPPORTED_ETHEREUM_NETWORKS;
+// TODO: remove SUPPORTED_ETHEREUM_NETWORKS fallback when we have finished implementing the single-page view with Chain Fusion
+export const [DEFAULT_NETWORK] = [...CHAIN_FUSION_NETWORKS, ...SUPPORTED_ETHEREUM_NETWORKS];
 export const { id: DEFAULT_NETWORK_ID } = DEFAULT_NETWORK;


### PR DESCRIPTION
# Motivation

The new Default Network will be Chain Fusion. However, until we decide to release it properly, we still use Ethereum Networks as fallback.

# Changes

Changed `DEFAULT_NETWORK` constant to get the first available Chain Fusion network, or fall back to the first available Ethereum Network.

# To-Do

- [ ] Remove the Ethereum network fallback as `DEFAULT_NETWORK`
