### PR TITLE
feat: include list of BTC networks in derived 'networks'

### DIFF
--- a/src/frontend/src/btc/derived/networks.derived.ts
+++ b/src/frontend/src/btc/derived/networks.derived.ts
@@ -1,0 +1,14 @@
+import { BTC_MAINNET_ENABLED, NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
+import { BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
+import { testnets } from '$lib/derived/testnets.derived';
+import type { Network } from '$lib/types/network';
+import { derived, type Readable } from 'svelte/store';
+
+export const enabledBitcoinNetworks: Readable<Network[]> = derived([testnets], ([$testnets]) =>
+	NETWORK_BITCOIN_ENABLED
+		? [
+				...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
+				...($testnets ? [BTC_TESTNET_NETWORK] : [])
+			]
+		: []
+);

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -2,11 +2,13 @@ import { CHAIN_FUSION_NETWORKS, ICP_NETWORK } from '$env/networks.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
+import { enabledBitcoinNetworks } from '../../btc/derived/networks.derived';
 
 export const networks: Readable<Network[]> = derived(
-	[enabledEthereumNetworks],
-	([$enabledEthereumNetworks]) => [
+	[enabledBitcoinNetworks, enabledEthereumNetworks],
+	([$enabledBitcoinNetworks, $enabledEthereumNetworks]) => [
 		...CHAIN_FUSION_NETWORKS,
+		...$enabledBitcoinNetworks,
 		...$enabledEthereumNetworks,
 		ICP_NETWORK
 	]


### PR DESCRIPTION
# Motivation

Preparing for the BTC onboarding, we created a list of Bitcoin networks to add to the `networks` derived store.

# Changes

- Create store of native BTC networks: mainnet and testnet.
- Include Bitcoin networks derived in the main `network` store.