### PR TITLE
feat: remove Chain Fusion network

### DIFF
--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -96,23 +96,3 @@ export const BTC_TESTNET_NETWORK: Network = {
 export const BITCOIN_NETWORKS: Network[] = [BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK];
 
 export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);
-
-export const CHAIN_FUSION_MAINNET_NETWORK_SYMBOL = 'ChainFusion';
-
-export const CHAIN_FUSION_MAINNET_NETWORK_ID = Symbol(CHAIN_FUSION_MAINNET_NETWORK_SYMBOL);
-
-export const CHAIN_FUSION_MAINNET_NETWORK: Network = {
-	id: CHAIN_FUSION_MAINNET_NETWORK_ID,
-	env: 'mainnet',
-	name: 'Chain Fusion'
-};
-
-// TODO: remove this when we have finished implementing the single-page view with Chain Fusion
-export const NETWORK_CHAIN_FUSION_ENABLED =
-	JSON.parse(import.meta.env.VITE_NETWORK_CHAIN_FUSION_ENABLED ?? false) === true;
-
-export const CHAIN_FUSION_NETWORKS: Network[] = NETWORK_CHAIN_FUSION_ENABLED
-	? [CHAIN_FUSION_MAINNET_NETWORK]
-	: [];
-
-export const CHAIN_FUSION_NETWORKS_IDS: symbol[] = CHAIN_FUSION_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
@@ -8,10 +8,10 @@
 	import { erc20TokensStore } from '$eth/stores/erc20.store';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
-	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
+	import { token } from '$lib/derived/token.derived';
 
 	export let contractAddress = '';
 	export let metadata: Erc20Metadata | undefined;
@@ -31,7 +31,7 @@
 		}
 
 		try {
-			const { metadata: metadataApi } = infuraErc20Providers($networkId);
+			const { metadata: metadataApi } = infuraErc20Providers($token.network.id);
 			metadata = await metadataApi({ address: contractAddress });
 
 			if (isNullish(metadata?.symbol) || isNullish(metadata?.name)) {

--- a/src/frontend/src/eth/components/transactions/TransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/TransactionStatus.svelte
@@ -6,8 +6,8 @@
 	import type { WebSocketListener } from '$eth/types/listener';
 	import { initMinedTransactionsListener } from '$eth/services/eth-listener.services';
 	import { infuraProviders } from '$eth/providers/infura.providers';
-	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { token } from '$lib/derived/token.derived';
 
 	export let blockNumber: number;
 
@@ -17,7 +17,7 @@
 
 	const loadCurrentBlockNumber = async () => {
 		try {
-			const { getBlockNumber } = infuraProviders($networkId);
+			const { getBlockNumber } = infuraProviders($token.network.id);
 			currentBlockNumber = await getBlockNumber();
 		} catch (err: unknown) {
 			disconnect();
@@ -42,7 +42,7 @@
 
 		listener = initMinedTransactionsListener({
 			callback: async () => debounceLoadCurrentBlockNumber(),
-			networkId: $networkId
+			networkId: $token.network.id
 		});
 	});
 

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -31,7 +31,6 @@
 	import type { Network } from '$lib/types/network';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import { ICP_NETWORK } from '$env/networks.env';
-	import { selectedNetwork } from '$lib/derived/network.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { writable } from 'svelte/store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -41,6 +40,7 @@
 	import { ckErc20HelperContractAddress } from '$icp-eth/derived/cketh.derived';
 	import { isErc20TransactionApprove } from '$eth/utils/transactions.utils';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import { token } from '$lib/derived/token.derived';
 
 	export let request: Web3WalletTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;
@@ -84,7 +84,7 @@
 		destination ===
 		toCkEthHelperContractAddress($ckEthMinterInfoStore?.[$sendTokenId], sourceNetwork.id)
 			? ICP_NETWORK
-			: $selectedNetwork;
+			: $token.network;
 
 	let sendWithApproval: boolean;
 	$: sendWithApproval = shouldSendWithApproval({

--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
 	import { address } from '$lib/derived/address.derived';
-	import { networkEthereum, networkId } from '$lib/derived/network.derived';
+	import { networkEthereum } from '$lib/derived/network.derived';
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { debounce } from '@dfinity/utils';
 	import { ERC20_TWIN_TOKENS } from '$env/tokens.erc20.env';
 	import { ckEthereumNativeToken, erc20ToCkErc20Enabled } from '$icp-eth/derived/cketh.derived';
+	import { token } from '$lib/derived/token.derived';
 
 	const load = async () => {
 		await Promise.allSettled([
@@ -17,7 +18,7 @@
 							loadErc20Balances({
 								address: $address,
 								erc20Tokens: $erc20Tokens,
-								networkId: $networkId
+								networkId: $token.network.id
 							})
 						]
 					: []
@@ -40,7 +41,7 @@
 
 	const debounceLoad = debounce(load);
 
-	$: $address, $erc20Tokens, $networkId, $erc20ToCkErc20Enabled, debounceLoad();
+	$: $address, $erc20Tokens, $token, $erc20ToCkErc20Enabled, debounceLoad();
 </script>
 
 <slot />

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -11,7 +11,6 @@
 	import Erc20Icp from '$lib/components/core/Erc20Icp.svelte';
 	import ExchangeBalance from '$lib/components/exchange/ExchangeBalance.svelte';
 	import { isErc20Icp } from '$eth/utils/token.utils';
-	import { selectedNetwork } from '$lib/derived/network.derived';
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
 	import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -23,7 +22,7 @@
 	export let send = false;
 
 	let background: string;
-	$: background = ($selectedNetwork.id.description ?? 'eth').toLowerCase();
+	$: background = ($token.network.id.description ?? 'eth').toLowerCase();
 
 	let displayTokenSymbol = false;
 	$: displayTokenSymbol = summary && $erc20TokensInitialized;

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -1,29 +1,8 @@
 <script lang="ts">
-	import Logo from '$lib/components/ui/Logo.svelte';
-	import { IconCheck } from '@dfinity/gix-components';
-	import { createEventDispatcher } from 'svelte';
-	import { fade } from 'svelte/transition';
 	import type { Network, NetworkId } from '$lib/types/network';
-	import { networkId } from '$lib/derived/network.derived';
-	import { back, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
-	import { page } from '$app/stores';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { i18n } from '$lib/stores/i18n.store';
+	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
 
 	export let network: Network;
-
-	const dispatch = createEventDispatcher();
-
-	const onClick = async () => {
-		await switchNetwork(network.id);
-
-		if (isRouteTransactions($page)) {
-			await back({ networkId: $networkId });
-		}
-
-		// A small delay to give the user a visual feedback that the network is checked
-		setTimeout(() => dispatch('icSelected'), 500);
-	};
 
 	let id: NetworkId;
 	let name: string;
@@ -31,18 +10,4 @@
 	$: ({ id, name, icon } = network);
 </script>
 
-<button class="w-full flex justify-between items-center" on:click={onClick}>
-	<div class="flex gap-2 items-center">
-		<Logo
-			src={icon}
-			alt={replacePlaceholders($i18n.core.alt.logo, {
-				$name: name
-			})}
-		/>
-		<span>{name}</span>
-	</div>
-
-	{#if id === $networkId}
-		<span in:fade><IconCheck size="20px" /></span>
-	{/if}
-</button>
+<NetworkButton {id} {name} {icon} on:icSelected />

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import { IconCheck } from '@dfinity/gix-components';
+	import { createEventDispatcher } from 'svelte';
+	import { fade } from 'svelte/transition';
+	import type { NetworkId } from '$lib/types/network';
+	import { networkId } from '$lib/derived/network.derived';
+	import { back, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
+	import { page } from '$app/stores';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	export let id: NetworkId | undefined;
+	export let name: string;
+	export let icon: string | undefined;
+
+	const dispatch = createEventDispatcher();
+
+	const onClick = async () => {
+		await switchNetwork(id);
+
+		if (isRouteTransactions($page)) {
+			await back({ networkId: $networkId });
+		}
+
+		// A small delay to give the user a visual feedback that the network is checked
+		setTimeout(() => dispatch('icSelected'), 500);
+	};
+</script>
+
+<button class="w-full flex justify-between items-center" on:click={onClick}>
+	<div class="flex gap-2 items-center">
+		<Logo
+			src={icon}
+			alt={replacePlaceholders($i18n.core.alt.logo, {
+				$name: name
+			})}
+		/>
+		<span>{name}</span>
+	</div>
+
+	{#if id === $networkId}
+		<span in:fade><IconCheck size="20px" /></span>
+	{/if}
+</button>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -13,6 +13,7 @@
 	import { quintOut } from 'svelte/easing';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { i18n } from '$lib/stores/i18n.store';
+	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -30,7 +31,7 @@
 	aria-label={$i18n.networks.title}
 >
 	<div class="w-full h-full md:w-[28px] md:h-[28px]">
-		{#if nonNullish($selectedNetwork.icon)}
+		{#if nonNullish($selectedNetwork?.icon)}
 			<Img
 				src={$selectedNetwork.icon}
 				alt={replacePlaceholders($i18n.core.alt.logo, {
@@ -42,11 +43,22 @@
 			/>
 		{/if}
 	</div>
-	<span class="text-black font-bold">{$selectedNetwork.name} <IconChevronDown /></span>
+	<span class="text-black font-bold"
+		>{$selectedNetwork?.name ?? $i18n.networks.chain_fusion} <IconChevronDown /></span
+	>
 </button>
 
 <Popover bind:visible anchor={button} direction="rtl">
 	<ul class="flex flex-col gap-4 list-none">
+		<li>
+			<NetworkButton
+				id={undefined}
+				name={$i18n.networks.chain_fusion}
+				icon={undefined}
+				on:icSelected={close}
+			/>
+		</li>
+
 		{#each $networksMainnets as network}
 			<li>
 				<Network {network} on:icSelected={close} />

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -14,7 +14,9 @@ export const networkTokens: Readable<Token[]> = derived(
 			} = token;
 
 			return (
-				(isNullish($selectedNetwork) && !isTokenIcrcTestnet(token)) ||
+				(isNullish($selectedNetwork) &&
+					!isTokenIcrcTestnet(token) &&
+					token.network.env !== 'testnet') ||
 				$selectedNetwork?.id === networkId
 			);
 		})

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -2,7 +2,7 @@ import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import { selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { Token } from '$lib/types/token';
-import { isNetworkIdChainFusion } from '$lib/utils/network.utils';
+import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const networkTokens: Readable<Token[]> = derived(
@@ -10,15 +10,12 @@ export const networkTokens: Readable<Token[]> = derived(
 	([$tokens, $selectedNetwork]) =>
 		$tokens.filter((token) => {
 			const {
-				network: { id, env }
+				network: { id: networkId }
 			} = token;
 
-			// TODO: extract Chain Fusion logic to a utility maybe?
 			return (
-				(isNetworkIdChainFusion($selectedNetwork.id) &&
-					env === $selectedNetwork.env &&
-					!isTokenIcrcTestnet(token)) ||
-				id === $selectedNetwork.id
+				(isNullish($selectedNetwork) && !isTokenIcrcTestnet(token)) ||
+				$selectedNetwork?.id === networkId
 			);
 		})
 );

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -1,5 +1,4 @@
 import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
-import { DEFAULT_ETHEREUM_NETWORK, DEFAULT_NETWORK_ID } from '$lib/constants/networks.constants';
 import { address } from '$lib/derived/address.derived';
 import { routeNetwork } from '$lib/derived/nav.derived';
 import { networks } from '$lib/derived/networks.derived';
@@ -9,18 +8,17 @@ import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const networkId: Readable<NetworkId> = derived(
+export const networkId: Readable<NetworkId | undefined> = derived(
 	[networks, routeNetwork],
 	([$networks, $routeNetwork]) =>
 		nonNullish($routeNetwork)
-			? $networks.find(({ id }) => id.description === $routeNetwork)?.id ?? DEFAULT_NETWORK_ID
-			: DEFAULT_NETWORK_ID
+			? $networks.find(({ id }) => id.description === $routeNetwork)?.id
+			: undefined
 );
 
-export const selectedNetwork: Readable<Network> = derived(
+export const selectedNetwork: Readable<Network | undefined> = derived(
 	[networks, networkId],
-	([$networks, $networkId]) =>
-		$networks.find(({ id }) => id === $networkId) ?? DEFAULT_ETHEREUM_NETWORK
+	([$networks, $networkId]) => $networks.find(({ id }) => id === $networkId)
 );
 
 export const networkICP: Readable<boolean> = derived([networkId], ([$networkId]) =>

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -1,4 +1,4 @@
-import { CHAIN_FUSION_NETWORKS, ICP_NETWORK } from '$env/networks.env';
+import { ICP_NETWORK } from '$env/networks.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
@@ -7,7 +7,6 @@ import { enabledBitcoinNetworks } from '../../btc/derived/networks.derived';
 export const networks: Readable<Network[]> = derived(
 	[enabledBitcoinNetworks, enabledEthereumNetworks],
 	([$enabledBitcoinNetworks, $enabledEthereumNetworks]) => [
-		...CHAIN_FUSION_NETWORKS,
 		...$enabledBitcoinNetworks,
 		...$enabledEthereumNetworks,
 		ICP_NETWORK

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -127,7 +127,8 @@
 	"networks": {
 		"title": "Current network. Access to selection.",
 		"show_testnets": "Show test networks",
-		"more": "More networks coming soon..."
+		"more": "More networks coming soon...",
+		"chain_fusion": "Chain Fusion"
 	},
 	"receive": {
 		"text": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -113,6 +113,7 @@ interface I18nNetworks {
 	title: string;
 	show_testnets: string;
 	more: string;
+	chain_fusion: string;
 }
 
 interface I18nReceive {

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -2,7 +2,6 @@ import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import type { NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
-import { isNetworkIdChainFusion } from '$lib/utils/network.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { LoadEvent, Page } from '@sveltejs/kit';
 
@@ -33,12 +32,13 @@ const tokenUrl = ({
 		name.replace(/\p{Emoji}/gu, (m, _idx) => `\\u${m.codePointAt(0)?.toString(16)}`)
 	)}${nonNullish(networkId.description) ? `&${networkParam(networkId)}` : ''}`;
 
-export const networkParam = (networkId: NetworkId): string =>
-	isNetworkIdChainFusion(networkId) ? '' : `network=${networkId.description ?? ''}`;
+export const networkParam = (networkId: NetworkId | undefined): string =>
+	isNullish(networkId) ? '' : `network=${networkId.description ?? ''}`;
 
-export const back = async (params: { networkId: NetworkId; fromUrl?: URL }) => {
+export const back = async (params: { networkId: NetworkId | undefined; fromUrl?: URL }) => {
 	const { networkId, fromUrl } = params;
-	const rootUrl = fromUrl?.toString() ?? `/?${networkParam(networkId)}`;
+	const rootUrl =
+		fromUrl?.toString() ?? `/${nonNullish(networkId) ? `?${networkParam(networkId)}` : ''}`;
 	await goto(rootUrl, { replaceState: 'fromUrl' in params ? nonNullish(fromUrl) : true });
 };
 
@@ -86,11 +86,7 @@ export const loadRouteParams = ($event: LoadEvent): RouteParams => {
 export const switchNetwork = async (networkId: NetworkId | undefined | null) => {
 	const url = new URL(window.location.href);
 
-	if (
-		isNullish(networkId) ||
-		isNullish(networkId.description) ||
-		isNetworkIdChainFusion(networkId)
-	) {
+	if (isNullish(networkId) || isNullish(networkId.description)) {
 		url.searchParams.delete('network');
 	} else {
 		url.searchParams.set('network', networkId.description);

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,6 +1,5 @@
 import {
 	BITCOIN_NETWORKS_IDS,
-	CHAIN_FUSION_NETWORKS_IDS,
 	ICP_NETWORK_ID,
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
 } from '$env/networks.env';
@@ -9,13 +8,11 @@ import { nonNullish } from '@dfinity/utils';
 
 export const isNetworkICP = ({ id }: Network): boolean => isNetworkIdICP(id);
 
-export const isNetworkIdICP = (id: NetworkId): boolean => ICP_NETWORK_ID === id;
+export const isNetworkIdICP = (id: NetworkId | undefined): boolean =>
+	nonNullish(id) && ICP_NETWORK_ID === id;
 
 export const isNetworkIdEthereum = (id: NetworkId | undefined): boolean =>
 	nonNullish(id) && SUPPORTED_ETHEREUM_NETWORKS_IDS.includes(id);
 
 export const isNetworkIdBitcoin = (id: NetworkId | undefined): boolean =>
 	nonNullish(id) && BITCOIN_NETWORKS_IDS.includes(id);
-
-export const isNetworkIdChainFusion = (id: NetworkId | undefined): boolean =>
-	nonNullish(id) && CHAIN_FUSION_NETWORKS_IDS.includes(id);


### PR DESCRIPTION
# Motivation

The term "Chain Fusion" is not a network but a marketing term. Introducing it into the code base as a networks.env environment is prone to errors.

Firstly, each token is linked to a network, which could lead to a situation where a token is associated with a marketing term instead of an actual network. Secondly, networks are used to load various data (e.g., minter information) or create providers for effective interaction with their corresponding networks (e.g., Etherscan provider). Therefore, treating "Chain Fusion" as a network is potentially problematic and should be avoided.

Instead, we should consider "Chain Fusion" as a filter. When no specific network is selected, all networks should be displayed.

# Notes

The PR introduces a few changes, but there was no clear path for "CHAIN_FUSION" to be iteratively undone.

# Changes

- Remove `CHAIN_FUSION` environment variables and utils.
- Make derived states `networkId` and `selectedNetwork`  nullable.
- Replace selected usages of those states with their effective token (`$token.network`) usage.
- Review `NetworkSwitcher` and action to introduce a static "Chain Fusion" call to action.
- Handles `selectedNetwork` possibelly undefined in navigation.
- Update `networkTokens` derived states to list all tokens (except icrc) when selected network is undefined.

