### PR TITLE
feat: created list of network tokens with prop to be showed or not

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -3,10 +3,10 @@
 	import { exchangeInitialized, exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { usdValue } from '$lib/utils/exchange.utils';
-	import { networkTokens } from '$lib/derived/network-tokens.derived';
+	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 
 	let totalUsd: number;
-	$: totalUsd = $networkTokens.reduce(
+	$: totalUsd = $enabledNetworkTokens.reduce(
 		(acc, token) =>
 			acc +
 			usdValue({

--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -7,7 +7,6 @@
 	import Listener from '$lib/components/core/Listener.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
-	import { networkTokens } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import Header from '$lib/components/ui/Header.svelte';
 	import TokensMenu from '$lib/components/tokens/TokensMenu.svelte';
@@ -18,12 +17,13 @@
 	import AddTokenModal from '$eth/components/tokens/AddTokenModal.svelte';
 	import IcManageTokensModal from '$icp/components/tokens/IcManageTokensModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 
 	let displayZeroBalance: boolean;
 	$: displayZeroBalance = $hideZeroBalancesStore?.enabled !== true;
 
 	let tokens: Token[];
-	$: tokens = $networkTokens.filter(
+	$: tokens = $enabledNetworkTokens.filter(
 		({ id: tokenId }) =>
 			($balancesStore?.[tokenId]?.data ?? BigNumber.from(0n)).gt(0n) || displayZeroBalance
 	);

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,7 +1,7 @@
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import { selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
-import type { Token } from '$lib/types/token';
+import type { Token, TokenInList } from '$lib/types/token';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -20,4 +20,14 @@ export const networkTokens: Readable<Token[]> = derived(
 				$selectedNetwork?.id === networkId
 			);
 		})
+);
+
+export const manageableNetworkTokens: Readable<TokenInList[]> = derived(
+	[networkTokens],
+	([$networkTokens]) => $networkTokens.map((token) => ({ enabled: true, ...token }))
+);
+
+export const enabledNetworkTokens: Readable<TokenInList[]> = derived(
+	[manageableNetworkTokens],
+	([$manageableNetworkTokens]) => $manageableNetworkTokens.filter(({ enabled }) => enabled)
 );

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -21,3 +21,5 @@ export interface TokenMetadata {
 }
 
 export type RequiredToken = Required<Token>;
+
+export type TokenInList = Token & { enabled: boolean };


### PR DESCRIPTION
# Motivation

As first step to make all the tokens manageable from a show/hide modal, we add prop `enabled` to `networkTokens` derived.

# Changes

- Create new derived `manageableNetworkTokens` to add prop enabled to `networkTokens`.
- Create new derived `enabledNetworkTokens` to be used as official list of tokens.
- Adapt the components that were using `networkTokens` to use `enabledNetworkTokens`.

