### PR TITLE
style: include Chain Fusion logo

### DIFF
--- a/src/frontend/src/lib/assets/chain_fusion.svg
+++ b/src/frontend/src/lib/assets/chain_fusion.svg
@@ -1,0 +1,46 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_1376_8668)">
+        <mask id="mask0_1376_8668" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="120" height="120">
+            <circle cx="60" cy="60" r="60" fill="#D9D9D9"/>
+        </mask>
+        <g mask="url(#mask0_1376_8668)">
+            <g filter="url(#filter0_f_1376_8668)">
+                <path d="M134.941 34C134.941 58.8528 115.031 79 90.4706 79C65.9102 79 46 58.8528 46 34C46 9.14719 65.9102 -11 90.4706 -11C115.031 -11 134.941 9.14719 134.941 34Z" fill="#F15B25"/>
+            </g>
+            <g filter="url(#filter1_f_1376_8668)">
+                <path d="M80.931 29C80.931 53.8528 61.247 74 36.9655 74C12.684 74 -7 53.8528 -7 29C-7 4.14719 12.684 -16 36.9655 -16C61.247 -16 80.931 4.14719 80.931 29Z" fill="#29ABE2"/>
+            </g>
+            <g filter="url(#filter2_f_1376_8668)">
+                <path d="M129 86C129 110.853 108.853 131 84 131C59.1472 131 39 110.853 39 86C39 61.1472 59.1472 41 84 41C108.853 41 129 61.1472 129 86Z" fill="#FBB03C"/>
+            </g>
+            <g filter="url(#filter3_f_1376_8668)">
+                <path d="M74.8462 91C74.8462 115.853 54.9573 136 30.4231 136C5.88889 136 -14 115.853 -14 91C-14 66.1472 5.88889 46 30.4231 46C54.9573 46 74.8462 66.1472 74.8462 91Z" fill="#ED1F7A"/>
+            </g>
+        </g>
+    </g>
+    <defs>
+        <filter id="filter0_f_1376_8668" x="30" y="-27" width="120.941" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+            <feGaussianBlur stdDeviation="8" result="effect1_foregroundBlur_1376_8668"/>
+        </filter>
+        <filter id="filter1_f_1376_8668" x="-23" y="-32" width="119.931" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+            <feGaussianBlur stdDeviation="8" result="effect1_foregroundBlur_1376_8668"/>
+        </filter>
+        <filter id="filter2_f_1376_8668" x="23" y="25" width="122" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+            <feGaussianBlur stdDeviation="8" result="effect1_foregroundBlur_1376_8668"/>
+        </filter>
+        <filter id="filter3_f_1376_8668" x="-30" y="30" width="120.846" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+            <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+            <feGaussianBlur stdDeviation="8" result="effect1_foregroundBlur_1376_8668"/>
+        </filter>
+        <clipPath id="clip0_1376_8668">
+            <rect width="120" height="120" fill="white"/>
+        </clipPath>
+    </defs>
+</svg>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -5,7 +5,6 @@
 	import IconMorePlain from '$lib/components/icons/IconMorePlain.svelte';
 	import Network from '$lib/components/networks/Network.svelte';
 	import { selectedNetwork } from '$lib/derived/network.derived';
-	import { nonNullish } from '@dfinity/utils';
 	import { networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
 	import NetworksTestnetsToggle from '$lib/components/networks/NetworksTestnetsToggle.svelte';
 	import { testnetsStore } from '$lib/stores/settings.store';
@@ -14,6 +13,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
+	import chainFusion from '$lib/assets/chain_fusion.svg';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -31,17 +31,15 @@
 	aria-label={$i18n.networks.title}
 >
 	<div class="w-full h-full md:w-[28px] md:h-[28px]">
-		{#if nonNullish($selectedNetwork?.icon)}
-			<Img
-				src={$selectedNetwork.icon}
-				alt={replacePlaceholders($i18n.core.alt.logo, {
-					$name: $selectedNetwork.name
-				})}
-				width="100%"
-				height="100%"
-				rounded
-			/>
-		{/if}
+		<Img
+			src={$selectedNetwork?.icon ?? chainFusion}
+			alt={replacePlaceholders($i18n.core.alt.logo, {
+				$name: $selectedNetwork?.name ?? $i18n.networks.chain_fusion
+			})}
+			width="100%"
+			height="100%"
+			rounded
+		/>
 	</div>
 	<span class="text-black font-bold"
 		>{$selectedNetwork?.name ?? $i18n.networks.chain_fusion} <IconChevronDown /></span
@@ -54,7 +52,7 @@
 			<NetworkButton
 				id={undefined}
 				name={$i18n.networks.chain_fusion}
-				icon={undefined}
+				icon={chainFusion}
 				on:icSelected={close}
 			/>
 		</li>


### PR DESCRIPTION
# Motivation

We introduce the Chain Fusion logo in its first version.

# Changes

- Add Chain Fusion logo as SVG.
- Include the logo in the `NetworksSwitcher` component.

