### PR TITLE
Feature/chain fusion/testnet single page token list

### DIFF
--- a/src/frontend/src/lib/derived/chain-fusion.derived.ts
+++ b/src/frontend/src/lib/derived/chain-fusion.derived.ts
@@ -1,0 +1,7 @@
+import { chainFusionStore } from '$lib/stores/chain-fusion.store';
+import { derived, type Readable } from 'svelte/store';
+
+export const chainFusionOnlyTestnets: Readable<boolean> = derived(
+	[chainFusionStore],
+	([$chainFusionStore]) => $chainFusionStore?.onlyTestnets ?? false
+);

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,3 +1,4 @@
+import { chainFusionOnlyTestnets } from '$lib/derived/chain-fusion.derived';
 import { selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { Token } from '$lib/types/token';
@@ -6,15 +7,16 @@ import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const networkTokens: Readable<Token[]> = derived(
-	[tokens, selectedNetwork],
-	([$tokens, $selectedNetwork]) =>
+	[tokens, selectedNetwork, chainFusionOnlyTestnets],
+	([$tokens, $selectedNetwork, $chainFusionOnlyTestnets]) =>
 		$tokens.filter((token) => {
 			const {
 				network: { id: networkId }
 			} = token;
 
 			return (
-				(isNullish($selectedNetwork) && !isTokenTestnet(token)) ||
+				(isNullish($selectedNetwork) &&
+					($chainFusionOnlyTestnets ? isTokenTestnet(token) : !isTokenTestnet(token))) ||
 				$selectedNetwork?.id === networkId
 			);
 		})

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,7 +1,7 @@
-import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import { selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { Token } from '$lib/types/token';
+import { isTokenTestnet } from '$lib/utils/token.utils';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -14,9 +14,7 @@ export const networkTokens: Readable<Token[]> = derived(
 			} = token;
 
 			return (
-				(isNullish($selectedNetwork) &&
-					!isTokenIcrcTestnet(token) &&
-					token.network.env !== 'testnet') ||
+				(isNullish($selectedNetwork) && !isTokenTestnet(token)) ||
 				$selectedNetwork?.id === networkId
 			);
 		})

--- a/src/frontend/src/lib/stores/chain-fusion.store.ts
+++ b/src/frontend/src/lib/stores/chain-fusion.store.ts
@@ -1,0 +1,9 @@
+import { initStorageStore } from '$lib/stores/storage.store';
+
+interface ChainFusionData {
+	onlyTestnets: boolean;
+}
+
+export const chainFusionStore = initStorageStore<ChainFusionData>({
+	key: 'chain-fusion'
+});

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -1,4 +1,5 @@
-import type { TokenStandard } from '$lib/types/token';
+import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+import type { Token, TokenStandard } from '$lib/types/token';
 
 /**
  * Calculates the maximum amount for a transaction.
@@ -25,3 +26,6 @@ export const getMaxTransactionAmount = ({
 		Math.max(Number(balance - (tokenStandard !== 'erc20' ? fee : 0n)), 0) / 10 ** tokenDecimals
 	);
 };
+
+export const isTokenTestnet = (token: Token): boolean =>
+	isTokenIcrcTestnet(token) || token.network.env === 'testnet';


### PR DESCRIPTION
# Motivation

To show only the test tokens for the Chain Fusion testnet selection, we first create a store for the Chain Fusion settings, and we use it to simplify the logic of derived `networkTokens`.
The next step will be to adapt NetworksSwitcher to set the store if Chain Fusion is selected or not.

# Changes

- Create utils to point out test tokens.
- Create store and derived for Chain Fusion with prop `onlyTestnets`.
- Adapt derived `networkTokens` to use both the above.

