### PR TITLE
fix: hero background and chain fusion gradient

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -15,6 +15,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { token } from '$lib/stores/token.store';
+	import { selectedNetwork } from '$lib/derived/network.derived';
 
 	export let usdTotal = false;
 	export let summary = false;
@@ -22,7 +23,7 @@
 	export let send = false;
 
 	let background: string;
-	$: background = ($token?.network.id.description ?? 'eth').toLowerCase();
+	$: background = ($selectedNetwork?.id.description ?? 'chainfusion').toLowerCase();
 
 	let displayTokenSymbol = false;
 	$: displayTokenSymbol = summary && $erc20TokensInitialized;
@@ -92,6 +93,15 @@
 		&.sepoliaeth {
 			background: linear-gradient(0deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.5) 100%),
 				linear-gradient(62deg, #321469 62.5%, #937993 100%);
+		}
+
+		&.chainfusion {
+			background: radial-gradient(
+				90.18% 135.69% at 50% 135.69%,
+				#3653cb 0%,
+				#5331a6 40.06%,
+				#191e86 100%
+			);
 		}
 	}
 


### PR DESCRIPTION
# Motivation

Due to the network changes we did, the background of the hero pane wasn't dynamic anymore. This PR fixes this issue and also set a grandient color for chain fusion defined by Artem.

# Screenshot

<img width="1536" alt="Capture d’écran 2024-06-18 à 14 21 03" src="https://github.com/dfinity/oisy-wallet/assets/16886711/42691a5a-5fd9-4cb8-9571-1428d982fb75">
