### PR TITLE
refactor: changed indexing in component IcManageTokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/IcManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/IcManageTokens.svelte
@@ -105,8 +105,10 @@
 	const save = () =>
 		dispatch(
 			'icSave',
-			Object.values(modifiedTokens).flatMap((subObject) =>
-				Object.values(subObject as Record<TokenId, IcrcCustomToken>)
+			Object.getOwnPropertySymbols(modifiedTokens).flatMap((networkId) =>
+				Object.getOwnPropertySymbols(modifiedTokens[networkId]).map(
+					(tokenId) => modifiedTokens[networkId][tokenId]
+				)
 			)
 		);
 </script>


### PR DESCRIPTION
# Motivation

To start generalizing its usage, we change the way that tokens are indexed in IcManageTokens component. Before they were using property `ledgerCanisterId`, that is unique for token of type `IcrcCustomToken`. However, we would prefer to use it for the more generic type that could be `Token` or a close child.

# Changes

Changed indexing of modifiedTokens variable to use token ID and network ID, which combination is considered unique for any token in our list throughout the code.
