### PR TITLE
feat: display exchange currency compact

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -24,7 +24,7 @@
 		style="font-size: calc(2 * var(--font-size-h1)); line-height: 0.95;"
 	>
 		{#if $exchangeInitialized}
-			{formatUSD(totalUsd)}
+			{formatUSD(totalUsd, { notation: 'compact' })}
 		{:else}
 			&ZeroWidthSpace;
 		{/if}

--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -22,7 +22,7 @@
 <output class="break-all">
 	{#if $exchangeInitialized}
 		{#if hasExchangeValue}
-			{formatUSD(usd)}
+			{formatUSD(usd, { notation: 'compact' })}
 		{:else}
 			{formatUSD(0, { minFraction: 0, maxFraction: 0 }).replace('0', '-')}
 		{/if}

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -68,17 +68,19 @@ export const formatUSD = (
 		maxFraction?: number;
 		maximumSignificantDigits?: number;
 		symbol?: boolean;
-	}
+	} & Pick<Intl.NumberFormatOptions, 'notation'>
 ): string => {
 	const {
 		minFraction = 2,
 		maxFraction = 2,
 		maximumSignificantDigits,
-		symbol = true
+		symbol = true,
+		notation
 	} = options ?? {};
 
 	return new Intl.NumberFormat('en-US', {
 		...(symbol && { style: 'currency', currency: 'USD' }),
+		notation,
 		minimumFractionDigits: minFraction,
 		maximumFractionDigits: maxFraction,
 		...(nonNullish(maximumSignificantDigits) && { maximumSignificantDigits })


### PR DESCRIPTION
# Motivation

On one hand we have now less space to display balances, on the other, if you've got lots of money, numbers are hard to read anyway with some much zero in the dollars 😉.

So, let's display the balance in dollars in a compact way.


# Screenshots

<img width="1536" alt="Capture d’écran 2024-06-18 à 14 54 39" src="https://github.com/dfinity/oisy-wallet/assets/16886711/db7a2ed2-c855-4040-bfed-3aff376839bc">
<img width="1536" alt="Capture d’écran 2024-06-18 à 14 53 54" src="https://github.com/dfinity/oisy-wallet/assets/16886711/1fad94f7-8fb9-4f95-b698-ea2e5e18dfac">

