### PR TITLE
fix: wallet connect send network

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -40,7 +40,6 @@
 	import { ckErc20HelperContractAddress } from '$icp-eth/derived/cketh.derived';
 	import { isErc20TransactionApprove } from '$eth/utils/transactions.utils';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
 
 	export let request: Web3WalletTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;
@@ -84,7 +83,7 @@
 		destination ===
 		toCkEthHelperContractAddress($ckEthMinterInfoStore?.[$sendTokenId], sourceNetwork.id)
 			? ICP_NETWORK
-			: $tokenWithFallback.network;
+			: $sendToken.network;
 
 	let sendWithApproval: boolean;
 	$: sendWithApproval = shouldSendWithApproval({


### PR DESCRIPTION
# Motivation

Did a first test with WalletConnect and already spotted a first issue with our refactoring of the network and token. The incorrect destination was displayed (UI display error "only").

# Changes

- Use token network as fallback to fix the display issue.

# Screenshots

Issue: 
<img width="1536" alt="Capture d’écran 2024-06-18 à 17 26 45" src="https://github.com/dfinity/oisy-wallet/assets/16886711/75a93b43-d89e-498c-a0c5-294f20dab21d">

Fix:
<img width="1536" alt="Capture d’écran 2024-06-18 à 17 27 29" src="https://github.com/dfinity/oisy-wallet/assets/16886711/627db993-5139-4a60-bba4-ba6747108e63">

