### PR TITLE
lint: include scripts in the ESLint configs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,6 +26,12 @@ module.exports = {
 			parserOptions: {
 				parser: '@typescript-eslint/parser'
 			}
+		},
+		{
+			files: ['scripts/**/*.mjs'],
+			rules: {
+				'no-console': 'off',
+			}
 		}
 	],
 	rules: {

--- a/scripts/build.copy-workers.mjs
+++ b/scripts/build.copy-workers.mjs
@@ -6,7 +6,7 @@ await cp(
 	'./build/workers',
 	{
 		recursive: true,
-		filter: (source, destination) => extname(source) !== '.map'
+		filter: (source) => extname(source) !== '.map'
 	},
 	(err) => {
 		if (err === null) {

--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -31,7 +31,7 @@ const parseMetadata = (targetFile) => {
 	// Special use case. We need to build the dapp with a real URL within app.html other build fails.
 	content = replaceEnv({
 		html: content,
-		pattern: `https:\/\/oisy\.com`,
+		pattern: `https://oisy.com`,
 		value: process.env.VITE_OISY_URL
 	});
 
@@ -43,7 +43,7 @@ const parseUrl = (filePath) => {
 
 	content = replaceEnv({
 		html: content,
-		pattern: `https:\/\/oisy\.com`,
+		pattern: `https://oisy.com`,
 		value: process.env.VITE_OISY_URL
 	});
 

--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -31,9 +31,9 @@ const deleteIndexes = async ({ dest = `./src/declarations` }) => {
  *
  */
 const cleanFactory = async ({ dest = `./src/declarations` }) => {
-	const promises = readdirSync(dest).map(
-		(dir) =>
-			new Promise(async (resolve) => {
+	const promises = readdirSync(dest).map((dir) => {
+		return new Promise((resolve) => {
+			const cleanFile = async () => {
 				const factoryPath = join(dest, dir, `${dir}.did.js`);
 
 				if (!existsSync(factoryPath)) {
@@ -56,16 +56,19 @@ export const init = ({ IDL }) => {`
 				await writeFile(factoryPath, cleanInit, 'utf8');
 
 				resolve();
-			})
-	);
+			};
+
+			cleanFile();
+		});
+	});
 
 	await Promise.all(promises);
 };
 
 const renameFactory = async ({ dest = `./src/declarations` }) => {
-	const promises = readdirSync(dest).map(
-		(dir) =>
-			new Promise(async (resolve) => {
+	const promises = readdirSync(dest).map((dir) => {
+		return new Promise((resolve) => {
+			const renameFile = async () => {
 				const factoryPath = join(dest, dir, `${dir}.did.js`);
 				const formattedPath = join(dest, dir, `${dir}.factory.did.js`);
 
@@ -77,8 +80,11 @@ const renameFactory = async ({ dest = `./src/declarations` }) => {
 				await rename(factoryPath, formattedPath);
 
 				resolve();
-			})
-	);
+			};
+
+			renameFile();
+		});
+	});
 
 	await Promise.all(promises);
 };
@@ -86,9 +92,9 @@ const renameFactory = async ({ dest = `./src/declarations` }) => {
 const copyCertifiedFactory = async ({ dest = `./src/declarations` }) => {
 	const promises = readdirSync(dest)
 		.filter((dir) => !['frontend'].includes(dir))
-		.map(
-			(dir) =>
-				new Promise(async (resolve) => {
+		.map((dir) => {
+			return new Promise((resolve) => {
+				const copyFile = async () => {
 					const uncertifiedFactoryPath = join(dest, dir, `${dir}.factory.did.js`);
 
 					if (!existsSync(uncertifiedFactoryPath)) {
@@ -103,8 +109,11 @@ const copyCertifiedFactory = async ({ dest = `./src/declarations` }) => {
 					await writeFile(certifiedFactoryPath, content.toString().replace(/\['query']/g, ''));
 
 					resolve();
-				})
-		);
+				};
+
+				copyFile();
+			});
+		});
 
 	await Promise.all(promises);
 };

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -16,7 +16,8 @@
 		"./postcss.config.js",
 		"./playwright.config.ts",
 		"./e2e/**/*.js",
-		"./e2e/**/*.ts"
+		"./e2e/**/*.ts",
+		"./scripts/*.mjs"
 	],
 	"exclude": [
 		"./node_modules/**",


### PR DESCRIPTION
# Motivation

We want to include scripts in the ESLint to check code style. However, we exclude them from the **no-console** rule, since it is useful to have console feedbacks in their case.

# Test

It raised the following problems:

```shell
/Users/antonio.ventilii/projects/oisy-wallet/scripts/build.copy-workers.mjs
  9:20  warning  'destination' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/Users/antonio.ventilii/projects/oisy-wallet/scripts/build.metadata.mjs
  34:19  error  Unnecessary escape character: \/  no-useless-escape
  34:21  error  Unnecessary escape character: \/  no-useless-escape
  34:27  error  Unnecessary escape character: \.  no-useless-escape
  46:19  error  Unnecessary escape character: \/  no-useless-escape
  46:21  error  Unnecessary escape character: \/  no-useless-escape
  46:27  error  Unnecessary escape character: \.  no-useless-escape

/Users/antonio.ventilii/projects/oisy-wallet/scripts/did.update.types.mjs
  10:16  error  Promise executor functions should not be async  no-async-promise-executor
  36:16  error  Promise executor functions should not be async  no-async-promise-executor
  68:16  error  Promise executor functions should not be async  no-async-promise-executor
  91:17  error  Promise executor functions should not be async  no-async-promise-executor

✖ 11 problems (10 errors, 1 warning)
```

I will use this PR to solve those too.
