### PR TITLE
lint: include rules no-continue and no-unnecessary-type-assertion

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -41,7 +41,9 @@ module.exports = {
 		'no-console': ['error', { allow: ['error', 'warn'] }],
 		'no-else-return': ['warn', { allowElseIf: false }],
 		'local-rules/no-svelte-store-in-api': 'error',
-		"@typescript-eslint/prefer-nullish-coalescing": "error"
+		'@typescript-eslint/prefer-nullish-coalescing': 'error',
+		'no-continue': 'warn',
+		'@typescript-eslint/no-unnecessary-type-assertion': 'error',
 	},
 	globals: {
 		NodeJS: true

--- a/src/frontend/src/icp/schedulers/wallet.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/wallet.scheduler.ts
@@ -137,7 +137,7 @@ export class WalletScheduler<
 					(acc: Record<string, CertifiedData<IndexedTransaction<T>>>, { id, transaction }) => ({
 						...acc,
 						[`${id}`]: {
-							data: transaction as IndexedTransaction<T>,
+							data: transaction,
 							certified
 						}
 					}),

--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -33,7 +33,7 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 			const text =
 				'An error occurred while attempting to retrieve the USD exchange rates.' as const;
 
-			const msg = (value as PostMessageDataResponseExchangeError | undefined)?.err;
+			const msg = value?.err;
 
 			if (isNullish(msg)) {
 				toastsError({
@@ -68,7 +68,7 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 
 			toastsError({
 				msg: { text },
-				err: (value as PostMessageDataResponseExchangeError | undefined)?.err
+				err: value?.err
 			});
 		};
 

--- a/src/frontend/src/lib/utils/error.utils.ts
+++ b/src/frontend/src/lib/utils/error.utils.ts
@@ -1,8 +1,8 @@
 export const errorDetailToString = (err: unknown): string | undefined =>
 	typeof err === 'string'
-		? (err as string)
+		? err
 		: err instanceof Error
-			? (err as Error).message
-			: 'message' in (err as unknown as { message: string })
-				? (err as unknown as { message: string }).message
+			? err.message
+			: 'message' in (err as { message: string })
+				? (err as { message: string }).message
 				: undefined;


### PR DESCRIPTION
# Motivation

We introduce two new rules:

1. `no-continue` as warn ([source](https://eslint.org/docs/latest/rules/no-continue))
2. `@typescript-eslint/no-unnecessary-type-assertion` as error ([source](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/))

# Tests

It raised the following problems:

```shell
/Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/icp/schedulers/wallet.scheduler.ts
  140:14  error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion

/Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/services/worker.exchange.services.ts
  36:17  error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion
  71:11  error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion

/Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/utils/error.utils.ts
  3:6   error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion
  5:7   error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion
  6:20  error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion
  7:8   error  This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion

✖ 7 problems (7 errors, 0 warnings)
  7 errors and 0 warnings potentially fixable with the `--fix` option.
```
  
 So, I will use this PR to solve them too, running with `--fix`
