### PR TITLE
chore: fix script lint

### DIFF
--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -5,21 +5,17 @@ import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const deleteIndexes = async ({ dest = `./src/declarations` }) => {
-	const promises = readdirSync(dest).map(
-		(dir) =>
-			new Promise(async (resolve) => {
-				const indexPath = join(dest, dir, 'index.js');
+	const rmIndex = async (dir) => {
+		const indexPath = join(dest, dir, 'index.js');
 
-				if (!existsSync(indexPath)) {
-					resolve();
-					return;
-				}
+		if (!existsSync(indexPath)) {
+			return;
+		}
 
-				await rm(indexPath, { force: true });
+		await rm(indexPath, { force: true });
+	};
 
-				resolve();
-			})
-	);
+	const promises = readdirSync(dest).map(rmIndex);
 
 	await Promise.all(promises);
 };


### PR DESCRIPTION
# Motivation

> npm run lint
>
> /Users/daviddalbusco/projects/dfinity/oisy-wallet/scripts/did.update.types.mjs
>  10:16  error  Promise executor functions should not be async  no-async-promise-executor
>
>✖ 1 problem (1 error, 0 warnings)

