### PR TITLE
feat: created component ManageTokenToggle to be used for generic token

### DIFF
--- a/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { Toggle } from '@dfinity/gix-components';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { createEventDispatcher } from 'svelte';
+	import type { DisplayToken } from '$lib/types/token';
+
+	export let token: DisplayToken;
+
+	let disabled = false;
+	$: disabled = token.category === 'default';
+
+	let checked: boolean;
+	$: checked = token.show ?? false;
+
+	const dispatch = createEventDispatcher();
+
+	const toggle = () => {
+		if (disabled) {
+			return;
+		}
+
+		checked = !checked;
+
+		dispatch('icShowOrHideToken', {
+			...token,
+			show: checked
+		});
+	};
+
+	const onClick = () => {};
+</script>
+
+<!-- svelte-ignore a11y-interactive-supports-focus -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div role="button" on:click={onClick}>
+	<Toggle
+		ariaLabel={checked ? $i18n.tokens.text.hide_token : $i18n.tokens.text.show_token}
+		{disabled}
+		bind:checked
+		on:nnsToggle={toggle}
+	/>
+</div>

--- a/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
@@ -2,7 +2,7 @@
 	import { Toggle } from '@dfinity/gix-components';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { createEventDispatcher } from 'svelte';
-	import type { DisplayToken } from '$lib/types/token';
+	import type { DisplayToken } from '$lib/types/manage-token';
 
 	export let token: DisplayToken;
 

--- a/src/frontend/src/lib/types/manage-token.ts
+++ b/src/frontend/src/lib/types/manage-token.ts
@@ -1,0 +1,3 @@
+import type { Token } from '$lib/types/token';
+
+export type DisplayToken = Token & { show?: boolean };

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -25,3 +25,5 @@ export type RequiredToken = Required<Token>;
 export type OptionToken = Token | undefined | null;
 export type OptionTokenId = TokenId | undefined | null;
 export type OptionTokenStandard = TokenStandard | undefined | null;
+
+export type DisplayToken = Token & { show?: boolean };

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -25,5 +25,3 @@ export type RequiredToken = Required<Token>;
 export type OptionToken = Token | undefined | null;
 export type OptionTokenId = TokenId | undefined | null;
 export type OptionTokenStandard = TokenStandard | undefined | null;
-
-export type DisplayToken = Token & { show?: boolean };


### PR DESCRIPTION
# Motivation

We will need to have a generic toggle button to use for object Token. However we create the custom type DisplayToken, to facilitate the usage:

`export type DisplayToken = Token & { show?: boolean };`

# Changes

- Created type `DisplayToken`.
- Create `ManageTokenToggle` that is a copy of `IcManageTokenToggle` but without the specific ICRC features.
