### PR TITLE
fix: function isIcrcCustomToken shall include icp standard

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -16,7 +16,7 @@
 	import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { ICP_TOKEN } from '$env/tokens.env';
-	import { isCustomTokenIC, sortIcTokens } from '$icp/utils/icrc.utils';
+	import { icTokenContainsEnabled, sortIcTokens } from '$icp/utils/icrc.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Token } from '$lib/types/token';
 
@@ -74,7 +74,7 @@
 
 		return {
 			...token,
-			...(isCustomTokenIC(token)
+			...(icTokenContainsEnabled(token)
 				? {
 						enabled: (modifiedToken as IcrcCustomToken)?.enabled ?? token.enabled
 					}
@@ -158,7 +158,7 @@
 				</span>
 
 				<svelte:fragment slot="action">
-					{#if isCustomTokenIC(token)}
+					{#if icTokenContainsEnabled(token)}
 						<IcManageTokenToggle {token} on:icToken={onToggle} />
 					{/if}
 				</svelte:fragment>

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -16,7 +16,7 @@
 	import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { ICP_TOKEN } from '$env/tokens.env';
-	import { isIcrcCustomToken, sortIcTokens } from '$icp/utils/icrc.utils';
+	import { isCustomTokenIC, sortIcTokens } from '$icp/utils/icrc.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Token } from '$lib/types/token';
 
@@ -74,7 +74,7 @@
 
 		return {
 			...token,
-			...(isIcrcCustomToken(token)
+			...(isCustomTokenIC(token)
 				? {
 						enabled: (modifiedToken as IcrcCustomToken)?.enabled ?? token.enabled
 					}
@@ -158,7 +158,7 @@
 				</span>
 
 				<svelte:fragment slot="action">
-					{#if isIcrcCustomToken(token)}
+					{#if isCustomTokenIC(token)}
 						<IcManageTokenToggle {token} on:icToken={onToggle} />
 					{/if}
 				</svelte:fragment>

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -132,5 +132,5 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 	];
 };
 
-export const isIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
+export const isCustomTokenIC = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
 	(token.standard === 'icp' || token.standard === 'icrc') && 'enabled' in token;

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -132,5 +132,5 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 	];
 };
 
-export const isCustomTokenIC = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
+export const icTokenContainsEnabled = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
 	(token.standard === 'icp' || token.standard === 'icrc') && 'enabled' in token;

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -133,4 +133,4 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 };
 
 export const isIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
-	token.standard === 'icrc' && 'enabled' in token;
+	(token.standard === 'icp' || token.standard === 'icrc') && 'enabled' in token;


### PR DESCRIPTION
# Motivation

There was an issue with ICP due to PR #1492 : it was not considered as an ICRC custom token type.

### Before

<img width="462" alt="Screenshot 2024-06-19 at 12 33 48" src="https://github.com/dfinity/oisy-wallet/assets/169057656/9cc054c0-3451-4ba5-a736-f496faae09f2">

### After

<img width="479" alt="Screenshot 2024-06-19 at 12 35 18" src="https://github.com/dfinity/oisy-wallet/assets/169057656/eb100e64-ac02-47d3-b1bb-a6244ccce649">
