### PR TITLE
Feature/chain fusion/include network tokens in manage modal

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -159,7 +159,7 @@
 	</button>
 {:else}
 	<div class="container md:max-h-96 pr-2 pt-1 overflow-y-auto">
-		{#each tokens as token (token.symbol)}
+		{#each tokens as token (`${token.network.id.description}-${token.id.description}`)}
 			<Card>
 				{token.name}
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -160,7 +160,7 @@
 	</button>
 {:else}
 	<div class="container md:max-h-96 pr-2 pt-1 overflow-y-auto">
-		{#each tokens as token (`${token.network.id.description}-${token.id.description}`)}
+		{#each tokens as token (token.symbol)}
 			<Card>
 				{token.name}
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -20,6 +20,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Token } from '$lib/types/token';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
+	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -178,6 +179,8 @@
 				<svelte:fragment slot="action">
 					{#if icTokenContainsEnabled(token)}
 						<IcManageTokenToggle {token} on:icToken={onToggle} />
+					{:else}
+						<ManageTokenToggle {token} />
 					{/if}
 				</svelte:fragment>
 			</Card>

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -77,12 +77,13 @@
 
 	let filteredTokens: Token[] = [];
 	$: filteredTokens = isNullishOrEmpty(filterTokens)
-		? allIcrcTokens
-		: allIcrcTokens.filter(
-				({ name, symbol, alternativeName }) =>
-					name.toLowerCase().includes(filterTokens.toLowerCase()) ||
-					symbol.toLowerCase().includes(filterTokens.toLowerCase()) ||
-					(alternativeName ?? '').toLowerCase().includes(filterTokens.toLowerCase())
+		? allTokens
+		: allTokens.filter(
+				(token) =>
+					token.name.toLowerCase().includes(filterTokens.toLowerCase()) ||
+					token.symbol.toLowerCase().includes(filterTokens.toLowerCase()) ||
+					(icTokenContainsEnabled(token) &&
+						(token.alternativeName ?? '').toLowerCase().includes(filterTokens.toLowerCase()))
 			);
 
 	let tokens: Token[] = [];

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -21,6 +21,7 @@
 	import type { Token } from '$lib/types/token';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
+	import { selectedNetwork } from '$lib/derived/network.derived';
 
 	const dispatch = createEventDispatcher();
 
@@ -145,6 +146,16 @@
 		</svelte:fragment>
 	</Input>
 </div>
+
+{#if nonNullish($selectedNetwork)}
+	<div class="mb-4">
+		<p class="text-misty-rose">
+			{replacePlaceholders($i18n.tokens.manage.text.manage_for_network, {
+				$network: $selectedNetwork.name
+			})}
+		</p>
+	</div>
+{/if}
 
 {#if noTokensMatch}
 	<button

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -19,6 +19,7 @@
 	import { icTokenContainsEnabled, sortIcTokens } from '$icp/utils/icrc.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Token } from '$lib/types/token';
+	import { networkTokens } from '$lib/derived/network-tokens.derived';
 
 	const dispatch = createEventDispatcher();
 
@@ -50,6 +51,22 @@
 			({ ledgerCanisterId }) => !knownLedgerCanisterIds.includes(ledgerCanisterId)
 		)
 	].sort(sortIcTokens);
+
+	let allTokens: Token[] = [];
+	$: allTokens = [
+		...$networkTokens.map(
+			(token) =>
+				allIcrcTokens.find(
+					(icrcToken) => token.id === icrcToken.id && token.network.id === icrcToken.network.id
+				) ?? { ...token, show: true }
+		),
+		...allIcrcTokens.filter(
+			(icrcToken) =>
+				!$networkTokens.some(
+					(token) => icrcToken.id === token.id && icrcToken.network.id === token.network.id
+				)
+		)
+	];
 
 	let filterTokens = '';
 	const updateFilter = () => (filterTokens = filter);

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -316,7 +316,8 @@
 			"text": {
 				"title": "Add and hide tokens",
 				"do_not_see_import": "Don’t see your token? Import",
-				"clear_filter": "Clear filter"
+				"clear_filter": "Clear filter",
+				"manage_for_network": "Managing tokens for $network"
 			},
 			"info": {
 				"outdated_index_canister": "$token Index canister is outdated and incompatible with Oisy Wallet. Contact the project team to propose an upgrade."

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -287,7 +287,12 @@ interface I18nTokens {
 		};
 	};
 	manage: {
-		text: { title: string; do_not_see_import: string; clear_filter: string };
+		text: {
+			title: string;
+			do_not_see_import: string;
+			clear_filter: string;
+			manage_for_network: string;
+		};
 		info: { outdated_index_canister: string };
 		error: { unexpected_build: string; empty: string };
 	};


### PR DESCRIPTION
# Motivation

We include the list of all non IC tokens in component `ManageTokens`, respecting the visual order that the user sees in the single-view page (basically the ICRC tokens are last).
Furthermore we provide the ManageTokenToggle to the new tokens (for now disabled).

# Changes

- Created `allTokens` as merged list of `networkTokens` and `allIcrcTokens`. Note that we remove the duplicates, but IC tokens take priority. 
- Change index of loop EACH for `tokens`: it was giving duplicates indices, since the symbol may be repeated for different tokens on different networks (ICP native vs ICP Ethereum network).
- Use `ManageTokenToggle` for non-IC tokens.

# To-Do

- [ ] Remove ckLocal IC tokens from the list in case of Chain Fusion

# Tests

See below a local replica simulation:

![Screen Recording 2024-06-19 at 13 16 20](https://github.com/dfinity/oisy-wallet/assets/169057656/3e3be974-4d39-4788-96da-b52963169fc4)



