### PR TITLE
fix: now the overflow menu closes after opening a new modal

### DIFF
--- a/src/frontend/src/eth/components/tokens/ManageTokensMenuButton.svelte
+++ b/src/frontend/src/eth/components/tokens/ManageTokensMenuButton.svelte
@@ -2,10 +2,18 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	const onClick = () => {
+		modalStore.openAddToken();
+		dispatch('icCloseMenu');
+	};
 </script>
 
 <div class="content">
-	<ButtonMenu ariaLabel={$i18n.tokens.import.text.title} on:click={modalStore.openAddToken}>
+	<ButtonMenu ariaLabel={$i18n.tokens.import.text.title} on:click={onClick}>
 		{`+ ${$i18n.tokens.import.text.title}`}
 	</ButtonMenu>
 </div>

--- a/src/frontend/src/icp/components/tokens/IcManageTokensMenuButton.svelte
+++ b/src/frontend/src/icp/components/tokens/IcManageTokensMenuButton.svelte
@@ -2,10 +2,18 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	const onClick = () => {
+		modalStore.openManageTokens();
+		dispatch('icCloseMenu');
+	};
 </script>
 
 <div class="content">
-	<ButtonMenu ariaLabel={$i18n.tokens.manage.text.title} on:click={modalStore.openManageTokens}>
+	<ButtonMenu ariaLabel={$i18n.tokens.manage.text.title} on:click={onClick}>
 		{$i18n.tokens.manage.text.title}
 	</ButtonMenu>
 </div>

--- a/src/frontend/src/lib/components/tokens/TokensMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensMenu.svelte
@@ -34,9 +34,9 @@
 			</div>
 
 			{#if $networkICP}
-				<IcManageTokensMenuButton />
+				<IcManageTokensMenuButton on:icCloseMenu={() => (visible = false)} />
 			{:else if $networkEthereum}
-				<ManageTokensMenuButton />
+				<ManageTokensMenuButton on:icCloseMenu={() => (visible = false)} />
 			{/if}
 		{/if}
 	</div>


### PR DESCRIPTION
# Motivation

Somewhere along the past weeks, I removed incorrectly the behavior that would close the Overflow Menu once clicked on it to open a modal.


### Before

![Screen Recording 2024-06-19 at 13 54 39](https://github.com/dfinity/oisy-wallet/assets/169057656/b0d8e225-3ff5-4665-b144-76e3e9e962dd)

### After

![Screen Recording 2024-06-19 at 13 54 58](https://github.com/dfinity/oisy-wallet/assets/169057656/d6c6c9b4-9607-4818-9782-55977dc6c8ab)


