### PR TITLE
fix: change index key of loop EACH in ManageTokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -141,7 +141,7 @@
 	</button>
 {:else}
 	<div class="container md:max-h-96 pr-2 pt-1 overflow-y-auto">
-		{#each tokens as token (token.symbol)}
+		{#each tokens as token (`${token.network.id.description}-${token.id.description}`)}
 			<Card>
 				{token.name}
 


### PR DESCRIPTION
# Motivation

Since there could be tokens with same symbol once we merge into a single list all of them (for example native ICP and Ethereum ICP), we change the key used in the EACH loop to avoid duplicates error.

# Changes

Changed key of loop to `${token.network.id.description}-${token.id.description}`.
