### PR TITLE
feat: AddTokenReview component has its related functions inside to be more re-useful

### DIFF
--- a/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
@@ -2,18 +2,8 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import AddTokenReview from '$eth/components/tokens/AddTokenReview.svelte';
 	import AddTokenForm from '$eth/components/tokens/AddTokenForm.svelte';
-	import type { Erc20Metadata } from '$eth/types/erc20';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
-	import { toastsError } from '$lib/stores/toasts.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { isNullish } from '@dfinity/utils';
-	import { authStore } from '$lib/stores/auth.store';
-	import { nullishSignOut } from '$lib/services/auth.services';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
-	import { addUserToken } from '$lib/api/backend.api';
-	import { selectedChainId, selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { erc20TokensStore } from '$eth/stores/erc20.store';
-	import { mapErc20Token } from '$eth/utils/erc20.utils';
 	import { modalStore } from '$lib/stores/modal.store';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 
@@ -34,74 +24,12 @@
 		}
 	];
 
-	let saveProgressStep: string = ProgressStepsAddToken.INITIALIZATION;
+	let saveProgressStep: ProgressStepsAddToken = ProgressStepsAddToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
 
 	let contractAddress = '';
-	let metadata: Erc20Metadata | undefined;
-
-	const save = async () => {
-		if (isNullishOrEmpty(contractAddress)) {
-			toastsError({
-				msg: { text: $i18n.tokens.error.invalid_contract_address }
-			});
-			return;
-		}
-
-		if (isNullish(metadata)) {
-			toastsError({
-				msg: { text: $i18n.tokens.error.no_metadata }
-			});
-			return;
-		}
-
-		if (isNullish($authStore.identity)) {
-			await nullishSignOut();
-			return;
-		}
-
-		modal.next();
-
-		try {
-			saveProgressStep = ProgressStepsAddToken.SAVE;
-
-			await addUserToken({
-				identity: $authStore.identity,
-				token: {
-					chain_id: $selectedChainId,
-					contract_address: contractAddress,
-					symbol: [],
-					decimals: [],
-					version: []
-				}
-			});
-
-			saveProgressStep = ProgressStepsAddToken.UPDATE_UI;
-
-			erc20TokensStore.add(
-				mapErc20Token({
-					address: contractAddress,
-					exchange: 'ethereum',
-					category: 'custom',
-					network: $selectedEthereumNetwork,
-					...metadata
-				})
-			);
-
-			saveProgressStep = ProgressStepsAddToken.DONE;
-
-			setTimeout(() => close(), 750);
-		} catch (err: unknown) {
-			toastsError({
-				msg: { text: $i18n.tokens.error.unexpected },
-				err
-			});
-
-			modal.back();
-		}
-	};
 
 	const close = () => {
 		modalStore.close();
@@ -120,7 +48,13 @@
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
 	{#if currentStep?.name === 'Review'}
-		<AddTokenReview on:icBack={modal.back} on:icSave={save} {contractAddress} bind:metadata />
+		<AddTokenReview
+			on:icBack={modal.back}
+			on:icClose={close}
+			{contractAddress}
+			bind:modal
+			bind:saveProgressStep
+		/>
 	{:else if currentStep?.name === 'Saving'}
 		<InProgressWizard progressStep={saveProgressStep} steps={addTokenSteps($i18n)} />
 	{:else}

--- a/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
@@ -12,9 +12,19 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { authStore } from '$lib/stores/auth.store';
+	import { nullishSignOut } from '$lib/services/auth.services';
+	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+	import { addUserToken } from '$lib/api/backend.api';
+	import { selectedChainId, selectedEthereumNetwork } from '$eth/derived/network.derived';
+	import { mapErc20Token } from '$eth/utils/erc20.utils';
+	import type { WizardModal } from '@dfinity/gix-components';
 
+	export let modal: WizardModal;
+	export let saveProgressStep: ProgressStepsAddToken;
 	export let contractAddress = '';
-	export let metadata: Erc20Metadata | undefined;
+
+	let metadata: Erc20Metadata | undefined;
 
 	onMount(async () => {
 		if (
@@ -71,6 +81,67 @@
 	$: invalid = isNullishOrEmpty(contractAddress) || isNullish(metadata);
 
 	const dispatch = createEventDispatcher();
+
+	const save = async () => {
+		if (isNullishOrEmpty(contractAddress)) {
+			toastsError({
+				msg: { text: $i18n.tokens.error.invalid_contract_address }
+			});
+			return;
+		}
+
+		if (isNullish(metadata)) {
+			toastsError({
+				msg: { text: $i18n.tokens.error.no_metadata }
+			});
+			return;
+		}
+
+		if (isNullish($authStore.identity)) {
+			await nullishSignOut();
+			return;
+		}
+
+		modal.next();
+
+		try {
+			saveProgressStep = ProgressStepsAddToken.SAVE;
+
+			await addUserToken({
+				identity: $authStore.identity,
+				token: {
+					chain_id: $selectedChainId,
+					contract_address: contractAddress,
+					symbol: [],
+					decimals: [],
+					version: []
+				}
+			});
+
+			saveProgressStep = ProgressStepsAddToken.UPDATE_UI;
+
+			erc20TokensStore.add(
+				mapErc20Token({
+					address: contractAddress,
+					exchange: 'ethereum',
+					category: 'custom',
+					network: $selectedEthereumNetwork,
+					...metadata
+				})
+			);
+
+			saveProgressStep = ProgressStepsAddToken.DONE;
+
+			setTimeout(() => dispatch('icClose'), 750);
+		} catch (err: unknown) {
+			toastsError({
+				msg: { text: $i18n.tokens.error.unexpected },
+				err
+			});
+
+			modal.back();
+		}
+	};
 </script>
 
 <div class="stretch">
@@ -117,7 +188,7 @@
 		class="primary block flex-1"
 		disabled={invalid}
 		class:opacity-10={invalid}
-		on:click={() => dispatch('icSave')}
+		on:click={save}
 	>
 		{$i18n.tokens.import.text.add_the_token}
 	</button>


### PR DESCRIPTION
# Motivation

To make the component `AddTokenReview` more usable in other modals too (not strictly the ETH modal), we move the related functions inside the component.

# Changes

- Moved `save` function from `AddTokenModal` to `AddTokenReview`.
- Created bindable variables modal and saveProgressStep in AddTokenReview.
- Instead of `save` executing the `close` function, it dispatches `icClose` event that is now listened by `AddTokenModal`.
- Removed unused imports and variables in `AddTokenModal`.

# Tests

Behavior unchanged for Ethereum network in local replica.
