### PR TITLE
feat: AddTokenForm can be used as non-first step in a modal now

### DIFF
--- a/src/frontend/src/eth/components/tokens/AddTokenForm.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenForm.svelte
@@ -6,6 +6,8 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 
 	export let contractAddress = '';
+
+	// TODO: remove this variable as soon as we deprecate AddTokenModal that is specific to Ethereum network
 	export let isFirstWizardStep: boolean = false;
 
 	let invalid = true;

--- a/src/frontend/src/eth/components/tokens/AddTokenForm.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenForm.svelte
@@ -6,6 +6,7 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 
 	export let contractAddress = '';
+	export let isFirstWizardStep: boolean = false;
 
 	let invalid = true;
 	$: invalid = isNullishOrEmpty(contractAddress);
@@ -26,8 +27,11 @@
 
 	<div class="pt-2">
 		<ButtonGroup>
-			<button type="button" class="secondary block flex-1" on:click={() => dispatch('icClose')}
-				>{$i18n.core.text.cancel}</button
+			<button
+				type="button"
+				class="secondary block flex-1"
+				on:click={() => dispatch(isFirstWizardStep ? 'icClose' : 'icBack')}
+				>{isFirstWizardStep ? $i18n.core.text.cancel : $i18n.core.text.back}</button
 			>
 			<button
 				class="primary block flex-1"

--- a/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
@@ -124,6 +124,11 @@
 	{:else if currentStep?.name === 'Saving'}
 		<InProgressWizard progressStep={saveProgressStep} steps={addTokenSteps($i18n)} />
 	{:else}
-		<AddTokenForm on:icNext={modal.next} on:icClose={close} bind:contractAddress />
+		<AddTokenForm
+			on:icNext={modal.next}
+			on:icClose={close}
+			bind:contractAddress
+			isFirstWizardStep={true}
+		/>
 	{/if}
 </WizardModal>


### PR DESCRIPTION
# Motivation

Since we would like to use `AddTokenForm` as non-first step of a Wizard modal (for example for the single ManageTokens), it changes to have an optional variable to define if it is the first step of the modal or not.
I think that the default should be that it is not the first step, that is why the variable defaults to `false`.

# Changes

- Add variable `isFirstWizardStep` that defaults to `false`.
- Change AddTokenModal to use the variable as `true`.

