### PR TITLE
feat: we turn on the listener to event icShowOrHideToken for ManageTokenToggle

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -191,7 +191,7 @@
 					{#if icTokenContainsEnabled(token)}
 						<IcManageTokenToggle {token} on:icToken={onToggle} />
 					{:else}
-						<ManageTokenToggle {token} />
+						<ManageTokenToggle {token} on:icShowOrHideToken={onToggle} />
 					{/if}
 				</svelte:fragment>
 			</Card>


### PR DESCRIPTION
# Motivation

Since we disabled all non-ICRC token toggle with PR #1509 , we are safe to turn on the event listener for `ManageTokenToggle`
