### PR TITLE
chore: split CI checks and frontend tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,8 +2,6 @@ name: Checks
 
 on:
   pull_request:
-    paths:
-      - 'src/frontend/**'
 
 jobs:
 
@@ -29,19 +27,8 @@ jobs:
       - name: Lint
         run: npm run check
 
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Prepare
-        uses: ./.github/actions/prepare
-      - name: Test
-        run: npm run test
-
   may-merge:
-    needs: ['check', 'lint', 'test']
+    needs: ['check', 'lint']
     runs-on: ubuntu-latest
     steps:
       - name: Cleared for merging

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,26 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    paths:
+      - 'src/frontend/**'
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Test
+        run: npm run test
+
+  may-merge:
+    needs: ['test']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleared for merging
+        run: echo OK


### PR DESCRIPTION
# Motivation

PR #1515 is blocked despite being approved because `may-merge` is required, but no steps have been performed for that particular PR.

On the other hand, I also noticed that checks and linters were not run for changes in the root config file (e.g., vite.config.ts) or JS scripts within the scripts folder.

That's why this PR moves the frontend tests to a particular action that runs only for frontend (similar to what we do for backend) and removes the scope frontend for the checks.
