### PR TITLE
feat: adapted component ManageTokensModal to be able to treat both IC and Ethereum tokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -7,10 +7,17 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { addTokenSteps } from '$lib/constants/steps.constants';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
-	import IcAddTokenForm from '$icp/components/tokens/IcAddTokenForm.svelte';
 	import { authStore } from '$lib/stores/auth.store';
 	import { saveIcrcCustomToken } from '$icp/services/ic-custom-tokens.services';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
+	import type { Erc20Metadata } from '$eth/types/erc20';
+	import AddTokenByNetwork from '$icp-eth/components/tokens/AddTokenByNetwork.svelte';
+	import type { Network } from '$lib/types/network';
+	import AddTokenReview from '$eth/components/tokens/AddTokenReview.svelte';
+	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
+	import { saveErc20Contract } from '$eth/services/erc20.services';
+	import { selectedChainId, selectedEthereumNetwork } from '$eth/derived/network.derived';
+	import { selectedNetwork } from '$lib/derived/network.derived';
 
 	const steps: WizardSteps = [
 		{
@@ -50,6 +57,20 @@
 		]);
 	};
 
+	const saveErc20Token = async () => {
+		await saveErc20Contract({
+			contractAddress: erc20ContractAddress,
+			metadata: erc20Metadata,
+			chainId: $selectedChainId,
+			network: $selectedEthereumNetwork,
+			updateSaveProgressStep: progress,
+			modalNext: modal.next,
+			onSuccess: close,
+			onError: modal.back,
+			identity: $authStore.identity
+		});
+	};
+
 	const progress = (step: ProgressStepsAddToken) => (saveProgressStep = step);
 
 	const save = async (
@@ -73,6 +94,14 @@
 
 	let ledgerCanisterId = '';
 	let indexCanisterId = '';
+
+	let erc20ContractAddress = '';
+	let erc20Metadata: Erc20Metadata | undefined;
+
+	let network: Network | undefined = $selectedNetwork;
+	let tokenData: Record<string, string> = {};
+
+	$: tokenData, ({ ledgerCanisterId, indexCanisterId, erc20ContractAddress } = tokenData);
 </script>
 
 <WizardModal
@@ -85,21 +114,25 @@
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
 	{#if currentStep?.name === 'Review'}
-		<IcAddTokenReview
-			on:icBack={modal.back}
-			on:icSave={addToken}
-			{ledgerCanisterId}
-			{indexCanisterId}
-		/>
+		{#if isNetworkIdICP(network?.id)}
+			<IcAddTokenReview
+				on:icBack={modal.back}
+				on:icSave={addToken}
+				{ledgerCanisterId}
+				{indexCanisterId}
+			/>
+		{:else if isNetworkIdEthereum(network?.id)}
+			<AddTokenReview
+				on:icBack={modal.back}
+				on:icSave={saveErc20Token}
+				contractAddress={erc20ContractAddress}
+				bind:metadata={erc20Metadata}
+			/>
+		{/if}
 	{:else if currentStep?.name === 'Saving'}
 		<InProgressWizard progressStep={saveProgressStep} steps={addTokenSteps($i18n)} />
 	{:else if currentStep?.name === 'Import'}
-		<IcAddTokenForm
-			on:icBack={modal.back}
-			on:icNext={modal.next}
-			bind:ledgerCanisterId
-			bind:indexCanisterId
-		/>
+		<AddTokenByNetwork on:icBack={modal.back} on:icNext={modal.next} bind:network bind:tokenData />
 	{:else}
 		<ManageTokens on:icClose={close} on:icAddToken={modal.next} on:icSave={saveTokens} />
 	{/if}

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -16,8 +16,8 @@
 	import AddTokenReview from '$eth/components/tokens/AddTokenReview.svelte';
 	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 	import { saveErc20Contract } from '$eth/services/erc20.services';
-	import { selectedChainId, selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
+	import type { EthereumNetwork } from '$eth/types/network';
 
 	const steps: WizardSteps = [
 		{
@@ -61,8 +61,8 @@
 		await saveErc20Contract({
 			contractAddress: erc20ContractAddress,
 			metadata: erc20Metadata,
-			chainId: $selectedChainId,
-			network: $selectedEthereumNetwork,
+			chainId: (network as EthereumNetwork).chainId,
+			network: network as EthereumNetwork,
 			updateSaveProgressStep: progress,
 			modalNext: modal.next,
 			onSuccess: close,


### PR DESCRIPTION
# Motivation

We now proceed to merge the flow of adding Erc20 tokens into the general modal `ManageTokensModal`.

# Changes

- Substituted component `IcAddTokenForm` with component `AddTokenByNetwork` to have the network choice (default to current network, if defined).
- Included use of ERC20 component `AddTokenReview`.
- Create additional variables necessary for the merged flow.

# Tests

On local replica, adding tokens wroked as expected.
