### PR TITLE
chore: remove param chainId from saveErc20Contract because is redundant

### DIFF
--- a/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenModal.svelte
@@ -6,7 +6,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authStore } from '$lib/stores/auth.store';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
-	import { selectedChainId, selectedEthereumNetwork } from '$eth/derived/network.derived';
+	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { addTokenSteps } from '$lib/constants/steps.constants';
@@ -41,7 +41,6 @@
 		await saveErc20Contract({
 			contractAddress,
 			metadata,
-			chainId: $selectedChainId,
 			network: $selectedEthereumNetwork,
 			updateSaveProgressStep,
 			modalNext: modal.next,

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -7,7 +7,7 @@ import { ERC20_CONTRACTS, ERC20_TWIN_TOKENS } from '$env/tokens.erc20.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { erc20TokensStore } from '$eth/stores/erc20.store';
 import type { Erc20Contract, Erc20Metadata, Erc20Token } from '$eth/types/erc20';
-import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
+import type { EthereumNetwork } from '$eth/types/network';
 import { mapErc20Token } from '$eth/utils/erc20.utils';
 import { addUserToken, listUserTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
@@ -91,7 +91,6 @@ export const loadErc20Contracts = async (): Promise<{ success: boolean }> => {
 export const saveErc20Contract = async ({
 	contractAddress,
 	metadata,
-	chainId,
 	network,
 	updateSaveProgressStep,
 	modalNext,
@@ -101,7 +100,6 @@ export const saveErc20Contract = async ({
 }: {
 	contractAddress: string;
 	metadata: Erc20Metadata | undefined;
-	chainId: EthereumChainId;
 	network: EthereumNetwork;
 	updateSaveProgressStep: (step: ProgressStepsAddToken) => void;
 	modalNext: () => void;
@@ -138,7 +136,7 @@ export const saveErc20Contract = async ({
 		await addUserToken({
 			identity,
 			token: {
-				chain_id: chainId,
+				chain_id: network.chainId,
 				contract_address: contractAddress,
 				symbol: [],
 				decimals: [],

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -61,7 +61,6 @@
 		await saveErc20Contract({
 			contractAddress: erc20ContractAddress,
 			metadata: erc20Metadata,
-			chainId: (network as EthereumNetwork).chainId,
 			network: network as EthereumNetwork,
 			updateSaveProgressStep: progress,
 			modalNext: modal.next,


### PR DESCRIPTION
# Motivation

In service `saveErc20Contract`, variable `chainId` can be extracted from param `network` since is of type `EthereumNetwork`.

# Changes

- Removed param `chainId` from `saveErc20Contract`.
- Adapted usage of function `saveErc20Contract`.
