### PR TITLE
chore: remove deprecated add-token modal from modal store

### DIFF
--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -65,10 +65,6 @@ export const modalIcTransaction: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'ic-transaction'
 );
-export const modalAddToken: Readable<boolean> = derived(
-	modalStore,
-	($modalStore) => $modalStore?.type === 'add-token'
-);
 export const modalManageTokens: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'manage-tokens'

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -19,7 +19,6 @@ export interface Modal<T> {
 		| 'wallet-connect-send'
 		| 'transaction'
 		| 'ic-transaction'
-		| 'add-token'
 		| 'manage-tokens'
 		| 'hide-token'
 		| 'ic-hide-token'
@@ -48,7 +47,6 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openWalletConnectSend: <D extends T>(data: D) => void;
 	openTransaction: <D extends T>(data: D) => void;
 	openIcTransaction: <D extends T>(data: D) => void;
-	openAddToken: () => void;
 	openManageTokens: () => void;
 	openHideToken: () => void;
 	openIcHideToken: () => void;
@@ -78,7 +76,6 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openWalletConnectSend: <D extends T>(data: D) => set({ type: 'wallet-connect-send', data }),
 		openTransaction: <D extends T>(data: D) => set({ type: 'transaction', data }),
 		openIcTransaction: <D extends T>(data: D) => set({ type: 'ic-transaction', data }),
-		openAddToken: () => set({ type: 'add-token' }),
 		openManageTokens: () => set({ type: 'manage-tokens' }),
 		openHideToken: () => set({ type: 'hide-token' }),
 		openIcHideToken: () => set({ type: 'ic-hide-token' }),


### PR DESCRIPTION
# Motivation

With PRs #1523 and #1524 , there is no need anymore for modal `add-token`.

# Changes

Removed `add-token` related functions.
