### PR TITLE
fix: token list in ManageTokens shows ICRC tokens when required

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { IconClose, Input } from '@dfinity/gix-components';
 	import { createEventDispatcher, onMount } from 'svelte';
-	import { debounce, nonNullish } from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import Card from '$lib/components/ui/Card.svelte';
@@ -21,7 +21,7 @@
 	import type { Token } from '$lib/types/token';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
-	import { selectedNetwork } from '$lib/derived/network.derived';
+	import { networkICP, selectedNetwork } from '$lib/derived/network.derived';
 
 	const dispatch = createEventDispatcher();
 
@@ -62,12 +62,14 @@
 					(icrcToken) => token.id === icrcToken.id && token.network.id === icrcToken.network.id
 				) ?? { ...token, show: true }
 		),
-		...allIcrcTokens.filter(
-			(icrcToken) =>
-				!$networkTokens.some(
-					(token) => icrcToken.id === token.id && icrcToken.network.id === token.network.id
+		...(isNullish($selectedNetwork) || $networkICP
+			? allIcrcTokens.filter(
+					(icrcToken) =>
+						!$networkTokens.some(
+							(token) => icrcToken.id === token.id && icrcToken.network.id === token.network.id
+						)
 				)
-		)
+			: [])
 	];
 
 	let filterTokens = '';


### PR DESCRIPTION
# Motivation

I noticed an incongruence: we discussed with Artem that if a network is selected, then the tokens that can be managed are only the one related to it.
However the list was always including ICRC tokens too.
We fix it with this PR.

# Changes

Changed list of allTokens in component ManageTokens to include ICRC tokens only for IC network and Chain Fusion (undefined network).

# Tests

Test on local replica show correct behavior for each selected network.
