### PR TITLE
chore: changed name of sepolia USDC to be same of mainnet USDC

### DIFF
--- a/src/frontend/src/env/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens.usdc.env.ts
@@ -31,7 +31,7 @@ export const SEPOLIA_USDC_TOKEN: RequiredErc20Token = {
 	network: SEPOLIA_NETWORK,
 	standard: 'erc20',
 	category: 'default',
-	name: 'USDC',
+	name: 'USD Coin',
 	symbol: 'USDC',
 	decimals: USDC_DECIMALS,
 	icon: usdc,


### PR DESCRIPTION
# Motivation

During working on a separate PR, I noticed that the name of Sepolia USDC is different from USDC mainnet.