### PR TITLE
feat: back if no network on add token form

### DIFF
--- a/src/frontend/src/eth/components/tokens/AddTokenForm.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenForm.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
 	import { Input } from '@dfinity/gix-components';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { i18n } from '$lib/stores/i18n.store';
-	import AddTokenByNetworkToolbar from '$icp-eth/components/tokens/AddTokenByNetworkToolbar.svelte';
 
 	export let contractAddress = '';
-
-	let invalid = true;
-	$: invalid = isNullishOrEmpty(contractAddress);
 </script>
 
-<div class="stretch pt-2">
+<div class="stretch">
 	<label for="destination" class="font-bold px-4.5">{$i18n.tokens.text.contract_address}:</label>
 	<Input
 		name="contractAddress"
@@ -21,5 +16,3 @@
 		spellcheck={false}
 	/>
 </div>
-
-<AddTokenByNetworkToolbar {invalid} on:icBack />

--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
 	import { Input } from '@dfinity/gix-components';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
-	import AddTokenByNetworkToolbar from '$icp-eth/components/tokens/AddTokenByNetworkToolbar.svelte';
 
 	export let ledgerCanisterId = '';
 	export let indexCanisterId = '';
-
-	let invalid = true;
-	$: invalid = isNullishOrEmpty(ledgerCanisterId) || isNullishOrEmpty(indexCanisterId);
 </script>
 
-<p class="text-misty-rose my-2">{$i18n.tokens.import.text.info}</p>
+<p class="text-misty-rose mb-2">{$i18n.tokens.import.text.info}</p>
 
 <p class="text-blue font-bold mb-4">
 	<ExternalLink
@@ -48,5 +43,3 @@
 		spellcheck={false}
 	/>
 </div>
-
-<AddTokenByNetworkToolbar {invalid} on:icBack />


### PR DESCRIPTION
# Motivation

User needs a way to go back to manage tokens from the add token wizard step when there is no network selected as well.
