### PR TITLE
feat: button menu actionable on the full width

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <button
-	class={`flex gap-2 items-center no-underline hover:text-blue active:text-blue`}
+	class="flex gap-2 items-center no-underline hover:text-blue active:text-blue w-full"
 	aria-label={ariaLabel}
 	on:click
 >


### PR DESCRIPTION
# Motivation

For UX reason, it's better to make the menu button clickable on the all width of the popover.