### PR TITLE
feat: display network in logo for tokens in manage modal

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -5,7 +5,6 @@
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import Card from '$lib/components/ui/Card.svelte';
-	import Logo from '$lib/components/ui/Logo.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import IcManageTokenToggle from '$icp/components/tokens/IcManageTokenToggle.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -22,6 +22,7 @@
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
 	import { networkICP, selectedNetwork } from '$lib/derived/network.derived';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -175,13 +176,7 @@
 			<Card>
 				{token.name}
 
-				<Logo
-					src={token.icon}
-					slot="icon"
-					alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
-					size="medium"
-					color="white"
-				/>
+				<TokenLogo slot="icon" color="white" {token} />
 
 				<span class="break-all" slot="description">
 					{token.symbol}


### PR DESCRIPTION
# Motivation

According Figma with should also display the network next to the tokens in the manage modal which makes sense given that "chain fusion" pseudo view is also supported there.
