### PR TITLE
fix: disable add token "next" action was inverted

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
@@ -47,7 +47,7 @@
 	$: invalidIc = isNullishOrEmpty(ledgerCanisterId) || isNullishOrEmpty(indexCanisterId);
 
 	let invalid = true;
-	$: invalid = isNetworkIdEthereum(network?.id) ? invalidIc : invalidErc20;
+	$: invalid = isNetworkIdEthereum(network?.id) ? invalidErc20 : invalidIc;
 
 	let disabledNetworkSelector = false;
 	$: disabledNetworkSelector = nonNullish($selectedNetwork);


### PR DESCRIPTION
# Motivation

I inverted the check to disable the "Next" action in add modal.
