### PR TITLE
feat: contract address and ledger/index canister ids are potentially undefined

### DIFF
--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -98,7 +98,7 @@ export const saveErc20Contract = async ({
 	onError,
 	identity
 }: {
-	contractAddress: string;
+	contractAddress: string | undefined;
 	metadata: Erc20Metadata | undefined;
 	network: EthereumNetwork;
 	updateSaveProgressStep: (step: ProgressStepsAddToken) => void;

--- a/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
@@ -12,9 +12,10 @@
 	import AddTokenByNetworkToolbar from '$icp-eth/components/tokens/AddTokenByNetworkToolbar.svelte';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { selectedNetwork } from '$lib/derived/network.derived';
+	import type { AddTokenData } from '$icp-eth/types/add-token';
 
 	export let network: Network | undefined;
-	export let tokenData: Record<string, string>;
+	export let tokenData: Partial<AddTokenData>;
 
 	let networkName: string | undefined = network?.name;
 	$: networkName,
@@ -32,7 +33,7 @@
 		if (isNetworkIdICP(network?.id)) {
 			tokenData = { ledgerCanisterId, indexCanisterId };
 		} else if (isNetworkIdEthereum(network?.id)) {
-			tokenData = { erc20ContractAddress };
+			tokenData = { contractAddress: erc20ContractAddress };
 		} else {
 			tokenData = {};
 		}

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -18,6 +18,10 @@
 	import { saveErc20Contract } from '$eth/services/erc20.services';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
+	import type { AddTokenData } from '$icp-eth/types/add-token';
+	import { isNullish } from '@dfinity/utils';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import { get } from 'svelte/store';
 
 	const steps: WizardSteps = [
 		{
@@ -48,6 +52,20 @@
 	};
 
 	const addToken = async () => {
+		if (isNullish(ledgerCanisterId)) {
+			toastsError({
+				msg: { text: get(i18n).tokens.import.error.missing_ledger_id }
+			});
+			return;
+		}
+
+		if (isNullish(indexCanisterId)) {
+			toastsError({
+				msg: { text: get(i18n).tokens.import.error.missing_index_id }
+			});
+			return;
+		}
+
 		await save([
 			{
 				enabled: true,
@@ -91,16 +109,17 @@
 		saveProgressStep = ProgressStepsAddToken.INITIALIZATION;
 	};
 
-	let ledgerCanisterId = '';
-	let indexCanisterId = '';
+	let ledgerCanisterId: string | undefined;
+	let indexCanisterId: string | undefined;
 
-	let erc20ContractAddress = '';
+	let erc20ContractAddress: string | undefined;
 	let erc20Metadata: Erc20Metadata | undefined;
 
 	let network: Network | undefined = $selectedNetwork;
-	let tokenData: Record<string, string> = {};
+	let tokenData: Partial<AddTokenData> = {};
 
-	$: tokenData, ({ ledgerCanisterId, indexCanisterId, erc20ContractAddress } = tokenData);
+	$: tokenData,
+		({ ledgerCanisterId, indexCanisterId, contractAddress: erc20ContractAddress } = tokenData);
 </script>
 
 <WizardModal

--- a/src/frontend/src/icp-eth/types/add-token.ts
+++ b/src/frontend/src/icp-eth/types/add-token.ts
@@ -1,0 +1,12 @@
+import type { Either } from '$lib/utils/ts.utils';
+
+export interface Erc20AddTokenData {
+	contractAddress: string;
+}
+
+export interface IcAddTokenData {
+	ledgerCanisterId: string;
+	indexCanisterId: string;
+}
+
+export type AddTokenData = Either<Erc20AddTokenData, IcAddTokenData>;

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -17,8 +17,8 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let ledgerCanisterId = '';
-	export let indexCanisterId = '';
+	export let ledgerCanisterId: string | undefined;
+	export let indexCanisterId: string | undefined;
 
 	let invalid = true;
 	$: invalid = isNullish(token);

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -309,7 +309,9 @@
 				"no_metadata": "No metadata for the token are provided. This is unexpected.",
 				"unexpected_index": "Something went wrong while validating the Index canister.",
 				"unexpected_index_ledger": "Something went wrong while loading the Ledger ID related to the Index canister.",
-				"invalid_ledger_id": "The Ledger ID is not related the Index canister."
+				"invalid_ledger_id": "The Ledger ID is not related the Index canister.",
+				"missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
+				"missing_index_id": "The Index ID is missing. Did you provide a value?"
 			}
 		},
 		"manage": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -284,6 +284,8 @@ interface I18nTokens {
 			unexpected_index: string;
 			unexpected_index_ledger: string;
 			invalid_ledger_id: string;
+			missing_ledger_id: string;
+			missing_index_id: string;
 		};
 	};
 	manage: {

--- a/src/frontend/src/lib/utils/input.utils.ts
+++ b/src/frontend/src/lib/utils/input.utils.ts
@@ -1,6 +1,6 @@
 import { isNullish } from '@dfinity/utils';
 
-export const isNullishOrEmpty = (value: string | undefined | null): boolean =>
+export const isNullishOrEmpty = (value: string | undefined | null): value is undefined | null =>
 	isNullish(value) || value === '';
 
 export const invalidAmount = (amount: number | undefined): boolean =>

--- a/src/frontend/src/lib/utils/ts.utils.ts
+++ b/src/frontend/src/lib/utils/ts.utils.ts
@@ -1,0 +1,8 @@
+// Source: https://stackoverflow.com/a/66605669/5404186
+export type Only<T, U> = {
+	[P in keyof T]: T[P];
+} & {
+	[P in keyof U]?: never;
+};
+
+export type Either<T, U> = Only<T, U> | Only<U, T>;


### PR DESCRIPTION
# Motivation

In `AddTokenByNetwork` we are setting only the relevant values when they are set. Those values are then destructed in the manage modal to assign contract address and edger/index canister ids.

Currently we assumed those values were always string defined but, becaure of this assignation those information were potentially undefined.

This PR improves types and adds few guards that throws an error if the information are undefined which can mostly happens in case of race condition.
