### PR TITLE
feat: init input values in add token by network

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
@@ -23,9 +23,9 @@
 			? $networks.find(({ name }) => name === networkName)
 			: undefined);
 
-	let ledgerCanisterId: string;
-	let indexCanisterId: string;
-	let erc20ContractAddress: string;
+	let ledgerCanisterId = tokenData?.ledgerCanisterId ?? '';
+	let indexCanisterId = tokenData?.indexCanisterId ?? '';
+	let erc20ContractAddress = tokenData?.contractAddress ?? '';
 
 	// Since we persist the values of relevant variables when switching networks, this ensures that
 	// only the data related to the selected network is passed.


### PR DESCRIPTION
# Motivation

If we do not init the values on mount, then the user might loose their entry if they go next with the wizard but, the validation detects and error and send back the user to previous step.
