### PR TITLE
chore: pin ws at least v7.5.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,26 +1652,6 @@
 				"ws": "7.4.6"
 			}
 		},
-		"node_modules/@ethersproject/providers/node_modules/ws": {
-			"version": "7.4.6",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@ethersproject/random": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
 		"vite": "^5.2.12",
 		"vitest": "^1.6.0"
 	},
-	"type": "module"
+	"type": "module",
+	"overrides": {
+		"ws": "^7.5.10"
+	}
 }


### PR DESCRIPTION
# Motivation

Resolve `npm audit` while still using Etherjs v5 (which we aim to bump once we got automatic tests).
