### PR TITLE
fix: use selected network to import erc20 custom token

### DIFF
--- a/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
@@ -11,15 +11,25 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import type { Network } from '$lib/types/network';
 
 	export let contractAddress: string | undefined;
 	export let metadata: Erc20Metadata | undefined;
+	export let network: Network | undefined;
 
 	onMount(async () => {
 		if (isNullish(contractAddress)) {
 			toastsError({
 				msg: { text: $i18n.tokens.import.error.missing_contract_address }
+			});
+
+			dispatch('icBack');
+			return;
+		}
+
+		if (isNullish(network)) {
+			toastsError({
+				msg: { text: $i18n.tokens.import.error.no_network }
 			});
 
 			dispatch('icBack');
@@ -40,7 +50,7 @@
 		}
 
 		try {
-			const { metadata: metadataApi } = infuraErc20Providers($tokenWithFallback.network.id);
+			const { metadata: metadataApi } = infuraErc20Providers(network.id);
 			metadata = await metadataApi({ address: contractAddress });
 
 			if (isNullish(metadata?.symbol) || isNullish(metadata?.name)) {

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -144,6 +144,7 @@
 				on:icBack={modal.back}
 				on:icSave={saveErc20Token}
 				contractAddress={erc20ContractAddress}
+				{network}
 				bind:metadata={erc20Metadata}
 			/>
 		{/if}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -312,7 +312,8 @@
 				"invalid_ledger_id": "The Ledger ID is not related the Index canister.",
 				"missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
 				"missing_index_id": "The Index ID is missing. Did you provide a value?",
-				"missing_contract_address": "The contract address is missing. Did you provide a value?"
+				"missing_contract_address": "The contract address is missing. Did you provide a value?",
+				"no_network": "No network is selected. This is unexpected."
 			}
 		},
 		"manage": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -287,6 +287,7 @@ interface I18nTokens {
 			missing_ledger_id: string;
 			missing_index_id: string;
 			missing_contract_address: string;
+			no_network: string;
 		};
 	};
 	manage: {


### PR DESCRIPTION
# Motivation

Importing erc20 token currently fails at the validation step because it does not use the selected network.
