### PR TITLE
style: text capitalize first-letter only

### DIFF
--- a/src/frontend/src/eth/components/transactions/TransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/TransactionStatus.svelte
@@ -76,7 +76,7 @@
 
 <label for="to" class="font-bold px-4.5">Status:</label>
 
-<p id="to" class="font-normal mb-4 px-4.5 break-all" style="text-transform: capitalize;">
+<p id="to" class="font-normal mb-4 px-4.5 break-all first-letter:capitalize">
 	{#if nonNullish(status)}
 		<span in:fade>{$i18n.transaction.status[status]}</span>
 	{:else}

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -49,7 +49,7 @@
 
 <button on:click={() => modalStore.openIcTransaction(transaction)} class="block w-full border-0">
 	<Card>
-		<span class="capitalize"
+		<span class="first-letter:capitalize"
 			><IcTransactionLabel label={transactionTypeLabel} fallback={transactionType} /></span
 		>
 

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -72,7 +72,7 @@
 		<Value ref="type" element="div">
 			<svelte:fragment slot="label">{$i18n.transaction.text.type}</svelte:fragment>
 
-			<p class="capitalize">{type}</p>
+			<p class="first-letter:capitalize">{type}</p>
 		</Value>
 
 		{#if nonNullish(from) || nonNullish(fromLabel)}
@@ -80,7 +80,7 @@
 				<svelte:fragment slot="label">{$i18n.transaction.text.from}</svelte:fragment>
 
 				{#if nonNullish(fromLabel)}
-					<p class="capitalize mb-0.5"><IcTransactionLabel label={fromLabel} /></p>
+					<p class="first-letter:capitalize mb-0.5"><IcTransactionLabel label={fromLabel} /></p>
 				{/if}
 
 				{#if nonNullish(from)}
@@ -108,7 +108,7 @@
 				<svelte:fragment slot="label">{$i18n.transaction.text.to}</svelte:fragment>
 
 				{#if nonNullish(toLabel)}
-					<p class="capitalize mb-0.5"><IcTransactionLabel label={toLabel} /></p>
+					<p class="first-letter:capitalize mb-0.5"><IcTransactionLabel label={toLabel} /></p>
 				{/if}
 
 				{#if nonNullish(to)}

--- a/src/frontend/src/lib/components/tokens/Token.svelte
+++ b/src/frontend/src/lib/components/tokens/Token.svelte
@@ -37,7 +37,7 @@
 {#if ['icrc', 'erc20'].includes(token.standard)}
 	<Value ref="symbol">
 		<svelte:fragment slot="label">{$i18n.tokens.details.standard}</svelte:fragment>
-		<output class="capitalize">{token.standard}</output>
+		<output class="first-letter:capitalize">{token.standard}</output>
 	</Value>
 {/if}
 


### PR DESCRIPTION
# Motivation

Capitalizing only the first letter of sentence to prevent unexpected capitalization such as following (CkUSDC instead of ckUSDC):

![image](https://github.com/dfinity/oisy-wallet/assets/16886711/e6893123-571f-4ada-bdf1-f67d4ad1ac73)

