### PR TITLE
chore: use action prepare for update snapshots ci

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm ci
+      - name: Prepare
+        uses: ./.github/actions/prepare
       - name: Install browsers and system dependencies
         run: npx playwright install --with-deps
       - name: Run Playwright tests


### PR DESCRIPTION
# Motivation

That way is uses NodeJS v20 as well and fixes per extension: https://github.com/dfinity/oisy-wallet/actions/runs/9643372633/job/26593223611
