### PR TITLE
feat(backend): set user token

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 POCKET_IC_SERVER_VERSION=3.0.1
-OISY_UPGRADE_VERSION=v0.0.13
+OISY_UPGRADE_VERSION_v0_0_13=v0.0.13
+OISY_UPGRADE_VERSION_v0_0_19=v0.0.19
 
 # If a backend wasm file exists at the root, it will be used for the tests.
 
@@ -17,10 +18,16 @@ fi
 
 # We use a previous version of the release to ensure upgradability
 
-OISY_UPGRADE_PATH="./backend-${OISY_UPGRADE_VERSION}.wasm.gz"
+OISY_UPGRADE_PATH_v0_0_13="./backend-${OISY_UPGRADE_VERSION_v0_0_13}.wasm.gz"
 
-if [ ! -f $OISY_UPGRADE_PATH ]; then
-    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION}/backend.wasm.gz -o $OISY_UPGRADE_PATH
+if [ ! -f $OISY_UPGRADE_PATH_v0_0_13 ]; then
+    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION_v0_0_13}/backend.wasm.gz -o $OISY_UPGRADE_PATH_v0_0_13
+fi
+
+OISY_UPGRADE_PATH_v0_0_19="./backend-${OISY_UPGRADE_VERSION_v0_0_19}.wasm.gz"
+
+if [ ! -f $OISY_UPGRADE_PATH_v0_0_19 ]; then
+    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION_v0_0_19}/backend.wasm.gz -o $OISY_UPGRADE_PATH_v0_0_19
 fi
 
 # Download PocketIC server

--- a/src/backend/src/assertions.rs
+++ b/src/backend/src/assertions.rs
@@ -1,0 +1,14 @@
+use crate::MAX_SYMBOL_LENGTH;
+use shared::types::token::UserToken;
+
+pub fn assert_token_symbol_length(token: &UserToken) -> Result<(), String> {
+    if let Some(symbol) = token.symbol.as_ref() {
+        if symbol.len() > MAX_SYMBOL_LENGTH {
+            return Err(format!(
+                "Token symbol should not exceed {MAX_SYMBOL_LENGTH} bytes",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::assertions::assert_token_symbol_length;
 use crate::guards::{caller_is_allowed, caller_is_not_anonymous};
 use crate::token::{add_to_user_token, remove_from_user_token};
 use candid::{CandidType, Deserialize, Nat, Principal};
@@ -28,6 +29,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::str::FromStr;
 
+mod assertions;
 mod guards;
 mod token;
 
@@ -365,18 +367,19 @@ async fn sign_prehash(prehash: String) -> String {
 }
 
 /// Adds a new token to the user.
+#[deprecated(since = "0.0.4", note = "Use set_user_token")]
 #[update(guard = "caller_is_not_anonymous")]
 fn add_user_token(token: UserToken) {
-    let addr = parse_eth_address(&token.contract_address);
+    set_user_token(token);
+}
 
-    if let Some(symbol) = token.symbol.as_ref() {
-        if symbol.len() > MAX_SYMBOL_LENGTH {
-            ic_cdk::trap(&format!(
-                "Token symbol should not exceed {MAX_SYMBOL_LENGTH} bytes",
-            ));
-        }
-    }
+#[update(guard = "caller_is_not_anonymous")]
+fn set_user_token(token: UserToken) {
+    assert_token_symbol_length(&token).unwrap_or_else(|e| ic_cdk::trap(&e));
+
     let stored_principal = StoredPrincipal(ic_cdk::caller());
+
+    let addr = parse_eth_address(&token.contract_address);
 
     let find = |t: &UserToken| {
         t.chain_id == token.chain_id && parse_eth_address(&t.contract_address) == addr
@@ -385,6 +388,29 @@ fn add_user_token(token: UserToken) {
     mutate_state(|s| add_to_user_token(stored_principal, &mut s.user_token, &token, &find));
 }
 
+#[update(guard = "caller_is_not_anonymous")]
+fn set_many_user_tokens(tokens: Vec<UserToken>) {
+    let stored_principal = StoredPrincipal(ic_cdk::caller());
+
+    mutate_state(|s| {
+        for token in tokens {
+            assert_token_symbol_length(&token).unwrap_or_else(|e| ic_cdk::trap(&e));
+
+            let addr = parse_eth_address(&token.contract_address);
+
+            let find = |t: &UserToken| {
+                t.chain_id == token.chain_id && parse_eth_address(&t.contract_address) == addr
+            };
+
+            add_to_user_token(stored_principal, &mut s.user_token, &token, &find)
+        }
+    });
+}
+
+#[deprecated(
+    since = "0.0.4",
+    note = "Tokens are deleted anymore. Use set_user_token to disable token."
+)]
 #[update(guard = "caller_is_not_anonymous")]
 fn remove_user_token(token_id: UserTokenId) {
     let addr = parse_eth_address(&token_id.contract_address);

--- a/src/backend/tests/it/token.rs
+++ b/src/backend/tests/it/token.rs
@@ -15,6 +15,7 @@ lazy_static! {
         decimals: Some(WEENUS_DECIMALS),
         symbol: Some(WEENUS_SYMBOL.to_string()),
         version: None,
+        enabled: Some(true),
     };
     static ref MOCK_TOKEN_ID: UserTokenId = UserTokenId {
         chain_id: MOCK_TOKEN.chain_id.clone(),
@@ -103,6 +104,7 @@ fn test_list_user_tokens() {
         decimals: Some(18),
         symbol: Some("Uniswap".to_string()),
         version: None,
+        enabled: Some(false),
     };
 
     let _ = update_call::<()>(&pic_setup, caller, "add_user_token", another_token.clone());
@@ -183,6 +185,7 @@ fn test_add_user_token_symbol_max_length() {
         decimals: Some(WEENUS_DECIMALS),
         symbol: Some("01234567890123456789_".to_string()),
         version: None,
+        enabled: Some(true),
     };
 
     let result = update_call::<()>(&pic_setup, caller, "add_user_token", token);

--- a/src/backend/tests/it/upgrade/constants.rs
+++ b/src/backend/tests/it/upgrade/constants.rs
@@ -1,0 +1,2 @@
+pub const BACKEND_V0_0_13_WASM_PATH: &str = "../../backend-v0.0.13.wasm.gz";
+pub const BACKEND_V0_0_19_WASM_PATH: &str = "../../backend-v0.0.19.wasm.gz";

--- a/src/backend/tests/it/upgrade/impls.rs
+++ b/src/backend/tests/it/upgrade/impls.rs
@@ -1,0 +1,20 @@
+use crate::upgrade::types::UserTokenV0_0_19;
+use shared::types::{TokenVersion, Version};
+
+impl TokenVersion for UserTokenV0_0_19 {
+    fn get_version(&self) -> Option<Version> {
+        self.version
+    }
+
+    fn clone_with_incremented_version(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned
+    }
+
+    fn clone_with_initial_version(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.version = Some(1);
+        cloned
+    }
+}

--- a/src/backend/tests/it/upgrade/mod.rs
+++ b/src/backend/tests/it/upgrade/mod.rs
@@ -1,0 +1,5 @@
+mod constants;
+mod impls;
+mod token_enabled;
+mod token_version;
+mod types;

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -1,0 +1,108 @@
+use crate::upgrade::constants::BACKEND_V0_0_19_WASM_PATH;
+use crate::upgrade::types::UserTokenV0_0_19;
+use crate::utils::assertion::assert_tokens_data_eq;
+use crate::utils::mock::{CALLER, WEENUS_CONTRACT_ADDRESS, WEENUS_DECIMALS, WEENUS_SYMBOL};
+use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade_latest};
+use candid::Principal;
+use lazy_static::lazy_static;
+use shared::types::token::UserToken;
+use shared::types::TokenVersion;
+
+lazy_static! {
+    static ref PRE_UPGRADE_TOKEN: UserTokenV0_0_19 = UserTokenV0_0_19 {
+        chain_id: 11155111,
+        contract_address: WEENUS_CONTRACT_ADDRESS.to_string(),
+        decimals: Some(WEENUS_DECIMALS),
+        symbol: Some(WEENUS_SYMBOL.to_string()),
+        version: Some(1),
+    };
+    static ref POST_UPGRADE_TOKEN: UserToken = UserToken {
+        chain_id: PRE_UPGRADE_TOKEN.chain_id,
+        contract_address: PRE_UPGRADE_TOKEN.contract_address.clone(),
+        decimals: PRE_UPGRADE_TOKEN.decimals,
+        symbol: PRE_UPGRADE_TOKEN.symbol.clone(),
+        version: PRE_UPGRADE_TOKEN.version.clone(),
+        enabled: None
+    };
+}
+
+#[test]
+fn test_upgrade_user_token() {
+    // Deploy a released canister
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH);
+
+    // Add a user token
+    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+
+    let result = update_call::<()>(
+        &pic_setup,
+        caller,
+        "add_user_token",
+        PRE_UPGRADE_TOKEN.clone(),
+    );
+
+    assert!(result.is_ok());
+
+    // Upgrade canister with new wasm
+    upgrade_latest(&pic_setup)
+        .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
+
+    // Get the list of token and check that it still contains the one we added before upgrade
+    let results = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
+
+    let expected_tokens: Vec<UserToken> = vec![POST_UPGRADE_TOKEN.clone()];
+
+    assert!(results.is_ok());
+
+    let results_tokens = results.unwrap();
+
+    assert_tokens_data_eq(&results_tokens, &expected_tokens);
+}
+
+#[test]
+fn test_update_user_token_after_upgrade() {
+    // Deploy a released canister
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH);
+
+    // Add a user token
+    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+
+    let result = update_call::<()>(
+        &pic_setup,
+        caller,
+        "add_user_token",
+        PRE_UPGRADE_TOKEN.clone(),
+    );
+
+    assert!(result.is_ok());
+
+    // Upgrade canister with new wasm
+    upgrade_latest(&pic_setup)
+        .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
+
+    // Get the list of token and check that it still contains the one we added before upgrade
+    let results = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
+
+    assert!(results.is_ok());
+
+    let update_token: UserToken = UserToken {
+        symbol: Some("Updated".to_string()),
+        enabled: Some(false),
+        ..results.unwrap().swap_remove(0)
+    };
+
+    let update_result =
+        update_call::<()>(&pic_setup, caller, "add_user_token", update_token.clone());
+
+    assert!(update_result.is_ok());
+
+    let updated_results = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
+
+    let expected_tokens: Vec<UserToken> = vec![update_token.clone_with_incremented_version()];
+
+    assert!(updated_results.is_ok());
+
+    let results_tokens = updated_results.unwrap();
+
+    assert_tokens_data_eq(&results_tokens, &expected_tokens);
+}

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -1,50 +1,14 @@
+use crate::upgrade::constants::{BACKEND_V0_0_13_WASM_PATH, BACKEND_V0_0_19_WASM_PATH};
+use crate::upgrade::types::{AddUserTokenAfterUpgradeOptions, UserTokenV0_0_13, UserTokenV0_0_19};
 use crate::utils::assertion::assert_tokens_data_eq;
 use crate::utils::mock::{
     CALLER, CALLER_ETH_ADDRESS, WEENUS_CONTRACT_ADDRESS, WEENUS_DECIMALS, WEENUS_SYMBOL,
 };
 use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade, upgrade_latest};
-use candid::{CandidType, Deserialize, Principal};
+use candid::Principal;
 use lazy_static::lazy_static;
-use shared::types::token::{ChainId, UserToken};
-use shared::types::{TokenVersion, Version};
-
-const BACKEND_V0_0_13_WASM_PATH: &str = "../../backend-v0.0.13.wasm.gz";
-const BACKEND_V0_0_19_WASM_PATH: &str = "../../backend-v0.0.19.wasm.gz";
-
-#[derive(CandidType, Deserialize, Clone)]
-pub struct UserTokenV0_0_13 {
-    pub contract_address: String,
-    pub chain_id: ChainId,
-    pub symbol: Option<String>,
-    pub decimals: Option<u8>,
-}
-
-#[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
-pub struct UserTokenV0_0_19 {
-    pub contract_address: String,
-    pub chain_id: ChainId,
-    pub symbol: Option<String>,
-    pub decimals: Option<u8>,
-    pub version: Option<Version>,
-}
-
-impl TokenVersion for UserTokenV0_0_19 {
-    fn get_version(&self) -> Option<Version> {
-        self.version
-    }
-
-    fn clone_with_incremented_version(&self) -> Self {
-        let mut cloned = self.clone();
-        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
-        cloned
-    }
-
-    fn clone_with_initial_version(&self) -> Self {
-        let mut cloned = self.clone();
-        cloned.version = Some(1);
-        cloned
-    }
-}
+use shared::types::token::UserToken;
+use shared::types::TokenVersion;
 
 lazy_static! {
     static ref PRE_UPGRADE_TOKEN: UserTokenV0_0_13 = UserTokenV0_0_13 {
@@ -127,13 +91,6 @@ fn test_add_user_token_after_upgrade_should_ignore_premature_increments() {
     test_add_user_token_after_upgrade_with_options(AddUserTokenAfterUpgradeOptions {
         premature_increments: 3,
     });
-}
-
-/// Options for unusual add_user_token behaviour.
-#[derive(Default)]
-struct AddUserTokenAfterUpgradeOptions {
-    /// The version number should be None but we can set it to Some(n) for a few small values to check that.
-    premature_increments: u8,
 }
 
 fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgradeOptions) {

--- a/src/backend/tests/it/upgrade/types.rs
+++ b/src/backend/tests/it/upgrade/types.rs
@@ -1,0 +1,27 @@
+use candid::{CandidType, Deserialize};
+use shared::types::token::ChainId;
+use shared::types::Version;
+
+#[derive(CandidType, Deserialize, Clone)]
+pub struct UserTokenV0_0_13 {
+    pub contract_address: String,
+    pub chain_id: ChainId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+}
+
+#[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
+pub struct UserTokenV0_0_19 {
+    pub contract_address: String,
+    pub chain_id: ChainId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+    pub version: Option<Version>,
+}
+
+/// Options for unusual add_user_token behaviour.
+#[derive(Default)]
+pub struct AddUserTokenAfterUpgradeOptions {
+    /// The version number should be None but we can set it to Some(n) for a few small values to check that.
+    pub premature_increments: u8,
+}

--- a/src/backend/tests/it/utils/assertion.rs
+++ b/src/backend/tests/it/utils/assertion.rs
@@ -1,7 +1,9 @@
 use shared::types::custom_token::CustomToken;
-use shared::types::token::UserToken;
 
-pub fn assert_tokens_data_eq(results_tokens: &[UserToken], expected_tokens: &[UserToken]) {
+pub fn assert_tokens_data_eq<T: PartialEq + std::fmt::Debug>(
+    results_tokens: &[T],
+    expected_tokens: &[T],
+) {
     assert_eq!(
         results_tokens.len(),
         expected_tokens.len(),

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -43,10 +43,17 @@ pub fn setup_with_custom_wasm(wasm_path: &str) -> (PocketIc, Principal) {
     (pic, canister_id)
 }
 
-pub fn upgrade((pic, canister_id): &(PocketIc, Principal)) -> Result<(), String> {
+pub fn upgrade_latest(pocket_ic: &(PocketIc, Principal)) -> Result<(), String> {
     let backend_wasm_path =
         env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string());
 
+    upgrade(pocket_ic, &backend_wasm_path)
+}
+
+pub fn upgrade(
+    (pic, canister_id): &(PocketIc, Principal),
+    backend_wasm_path: &String,
+) -> Result<(), String> {
     let wasm_bytes = read(backend_wasm_path.clone()).expect(&format!(
         "Could not find the backend wasm: {}",
         backend_wasm_path

--- a/src/shared/src/lib.rs
+++ b/src/shared/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod http;
 mod impls;
 pub mod metrics;
+mod serializers;
 pub mod std_canister_status;
 pub mod types;

--- a/src/shared/src/serializers.rs
+++ b/src/shared/src/serializers.rs
@@ -1,0 +1,13 @@
+/// Provides a default deserialization value for boolean fields, defaulting to `true`.
+///
+/// This function is a workaround for handling default values when deserializing with Serde,
+/// particularly useful in scenarios where boolean fields need to default to `true` instead
+/// of the usual `false` when not explicitly provided in the input.
+///
+/// # Returns
+/// Returns `Some(true)`, indicating the default value to use.
+pub fn deserialize_default_as_true() -> Option<bool> {
+    // https://github.com/serde-rs/serde/issues/1030#issuecomment-522278006
+
+    Some(true)
+}

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -43,6 +43,7 @@ pub trait TokenVersion: Debug {
 
 /// Erc20 specific user defined tokens
 pub mod token {
+    use crate::serializers::deserialize_default_as_true;
     use crate::types::Version;
     use candid::{CandidType, Deserialize};
 
@@ -55,6 +56,8 @@ pub mod token {
         pub symbol: Option<String>,
         pub decimals: Option<u8>,
         pub version: Option<Version>,
+        #[serde(default = "deserialize_default_as_true")]
+        pub enabled: Option<bool>,
     }
 
     #[derive(CandidType, Deserialize, Clone)]

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -46,10 +46,11 @@ pub mod token {
     use crate::serializers::deserialize_default_as_true;
     use crate::types::Version;
     use candid::{CandidType, Deserialize};
+    use serde::Serialize;
 
     pub type ChainId = u64;
 
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+    #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
     pub struct UserToken {
         pub contract_address: String,
         pub chain_id: ChainId,


### PR DESCRIPTION
# Motivation

Given that we are required to extend the dApp to allow users to enable and disable ERC20 tokens as well, we decided to take a simplistic approach - i.e., extending the current entities with a similar mechanism as the one we implemented for `CustomToken` by adding an "enabled" flag to `UserToken`. We discussed using the "custom token" types, but extending the stable tree map we already have allows us to avoid a migration at this time that does not necessarily add value for end users. This new approach also means that user tokens (ERC20) won't be added and deleted anymore in the state, which is why this PR deprecates the related function and adds a setter, again similar to the custom token approach.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
