### PR TITLE
refactor(backend): assert token symbol length

### DIFF
--- a/src/backend/src/assertions.rs
+++ b/src/backend/src/assertions.rs
@@ -1,0 +1,14 @@
+use crate::MAX_SYMBOL_LENGTH;
+use shared::types::token::UserToken;
+
+pub fn assert_token_symbol_length(token: &UserToken) -> Result<(), String> {
+    if let Some(symbol) = token.symbol.as_ref() {
+        if symbol.len() > MAX_SYMBOL_LENGTH {
+            return Err(format!(
+                "Token symbol should not exceed {MAX_SYMBOL_LENGTH} bytes",
+            ));
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Motivation

In #1550 we will require the assertion of the token symbol length in two functions. That's why I'm extracting here the function to a utility.

# Changes

- Move assertion `assert_token_symbol_length` to a new module `assertions`.
- Inverse order where the assertion is made - i.e. first assert and then, if everything is ok, parse the eth address.

# Tests

The assertion was already covered by an existing test `test_add_user_token_symbol_max_length`.
