### PR TITLE
test: use v0.0.19 wasm for current upgrade test

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 POCKET_IC_SERVER_VERSION=3.0.1
-OISY_UPGRADE_VERSION=v0.0.13
+OISY_UPGRADE_VERSION_v0_0_13=v0.0.13
+OISY_UPGRADE_VERSION_v0_0_19=v0.0.19
 
 # If a backend wasm file exists at the root, it will be used for the tests.
 
@@ -17,10 +18,16 @@ fi
 
 # We use a previous version of the release to ensure upgradability
 
-OISY_UPGRADE_PATH="./backend-${OISY_UPGRADE_VERSION}.wasm.gz"
+OISY_UPGRADE_PATH_v0_0_13="./backend-${OISY_UPGRADE_VERSION_v0_0_13}.wasm.gz"
 
-if [ ! -f $OISY_UPGRADE_PATH ]; then
-    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION}/backend.wasm.gz -o $OISY_UPGRADE_PATH
+if [ ! -f $OISY_UPGRADE_PATH_v0_0_13 ]; then
+    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION_v0_0_13}/backend.wasm.gz -o $OISY_UPGRADE_PATH_v0_0_13
+fi
+
+OISY_UPGRADE_PATH_v0_0_19="./backend-${OISY_UPGRADE_VERSION_v0_0_19}.wasm.gz"
+
+if [ ! -f $OISY_UPGRADE_PATH_v0_0_19 ]; then
+    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION_v0_0_19}/backend.wasm.gz -o $OISY_UPGRADE_PATH_v0_0_19
 fi
 
 # Download PocketIC server

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 POCKET_IC_SERVER_VERSION=3.0.1
-OISY_UPGRADE_VERSION_v0_0_13=v0.0.13
-OISY_UPGRADE_VERSION_v0_0_19=v0.0.19
+OISY_UPGRADE_VERSIONS="v0.0.13,v0.0.19"
 
 # If a backend wasm file exists at the root, it will be used for the tests.
 
@@ -18,17 +17,15 @@ fi
 
 # We use a previous version of the release to ensure upgradability
 
-OISY_UPGRADE_PATH_v0_0_13="./backend-${OISY_UPGRADE_VERSION_v0_0_13}.wasm.gz"
+IFS=',' read -r -a versions <<< "$OISY_UPGRADE_VERSIONS"
 
-if [ ! -f $OISY_UPGRADE_PATH_v0_0_13 ]; then
-    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION_v0_0_13}/backend.wasm.gz -o $OISY_UPGRADE_PATH_v0_0_13
-fi
+for version in "${versions[@]}"; do
+    OISY_UPGRADE_PATH="./backend-${version}.wasm.gz"
 
-OISY_UPGRADE_PATH_v0_0_19="./backend-${OISY_UPGRADE_VERSION_v0_0_19}.wasm.gz"
-
-if [ ! -f $OISY_UPGRADE_PATH_v0_0_19 ]; then
-    curl -sSL https://github.com/dfinity/oisy-wallet/releases/download/${OISY_UPGRADE_VERSION_v0_0_19}/backend.wasm.gz -o $OISY_UPGRADE_PATH_v0_0_19
-fi
+    if [ ! -f "$OISY_UPGRADE_PATH" ]; then
+        curl -sSL "https://github.com/dfinity/oisy-wallet/releases/download/${version}/backend.wasm.gz" -o "$OISY_UPGRADE_PATH"
+    fi
+done
 
 # Download PocketIC server
 

--- a/src/backend/tests/it/upgrade/constants.rs
+++ b/src/backend/tests/it/upgrade/constants.rs
@@ -1,0 +1,2 @@
+pub const BACKEND_V0_0_13_WASM_PATH: &str = "../../backend-v0.0.13.wasm.gz";
+pub const BACKEND_V0_0_19_WASM_PATH: &str = "../../backend-v0.0.19.wasm.gz";

--- a/src/backend/tests/it/upgrade/impls.rs
+++ b/src/backend/tests/it/upgrade/impls.rs
@@ -1,0 +1,20 @@
+use crate::upgrade::types::UserTokenV0_0_19;
+use shared::types::{TokenVersion, Version};
+
+impl TokenVersion for UserTokenV0_0_19 {
+    fn get_version(&self) -> Option<Version> {
+        self.version
+    }
+
+    fn clone_with_incremented_version(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned
+    }
+
+    fn clone_with_initial_version(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.version = Some(1);
+        cloned
+    }
+}

--- a/src/backend/tests/it/upgrade/mod.rs
+++ b/src/backend/tests/it/upgrade/mod.rs
@@ -1,5 +1,4 @@
 mod constants;
 mod impls;
-mod token_enabled;
 mod token_version;
 mod types;

--- a/src/backend/tests/it/upgrade/mod.rs
+++ b/src/backend/tests/it/upgrade/mod.rs
@@ -1,0 +1,5 @@
+mod constants;
+mod impls;
+mod token_enabled;
+mod token_version;
+mod types;

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -4,7 +4,9 @@ use crate::utils::assertion::assert_tokens_data_eq;
 use crate::utils::mock::{
     CALLER, CALLER_ETH_ADDRESS, WEENUS_CONTRACT_ADDRESS, WEENUS_DECIMALS, WEENUS_SYMBOL,
 };
-use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade_with_wasm, upgrade_latest_wasm};
+use crate::utils::pocketic::{
+    setup_with_custom_wasm, update_call, upgrade_latest_wasm, upgrade_with_wasm,
+};
 use candid::Principal;
 use lazy_static::lazy_static;
 use shared::types::token::UserToken;

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -4,7 +4,7 @@ use crate::utils::assertion::assert_tokens_data_eq;
 use crate::utils::mock::{
     CALLER, CALLER_ETH_ADDRESS, WEENUS_CONTRACT_ADDRESS, WEENUS_DECIMALS, WEENUS_SYMBOL,
 };
-use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade, upgrade_latest};
+use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade_with_wasm, upgrade_latest_wasm};
 use candid::Principal;
 use lazy_static::lazy_static;
 use shared::types::token::UserToken;
@@ -44,7 +44,7 @@ fn test_upgrade_user_token() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string())
+    upgrade_with_wasm(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string())
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade
@@ -71,7 +71,7 @@ fn test_upgrade_allowed_caller_eth_address_of() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_latest(&pic_setup)
+    upgrade_latest_wasm(&pic_setup)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Caller is still allowed to call eth_address_of
@@ -100,7 +100,7 @@ fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgr
     pic_setup.0.tick();
 
     // Upgrade canister with new wasm
-    upgrade(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string())
+    upgrade_with_wasm(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string())
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Add a user token
@@ -148,7 +148,7 @@ fn test_update_user_token_after_upgrade() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_latest(&pic_setup)
+    upgrade_latest_wasm(&pic_setup)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade

--- a/src/backend/tests/it/upgrade/types.rs
+++ b/src/backend/tests/it/upgrade/types.rs
@@ -1,0 +1,27 @@
+use candid::{CandidType, Deserialize};
+use shared::types::token::ChainId;
+use shared::types::Version;
+
+#[derive(CandidType, Deserialize, Clone)]
+pub struct UserTokenV0_0_13 {
+    pub contract_address: String,
+    pub chain_id: ChainId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+}
+
+#[derive(CandidType, Deserialize, Clone, PartialEq, Debug)]
+pub struct UserTokenV0_0_19 {
+    pub contract_address: String,
+    pub chain_id: ChainId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+    pub version: Option<Version>,
+}
+
+/// Options for unusual add_user_token behaviour.
+#[derive(Default)]
+pub struct AddUserTokenAfterUpgradeOptions {
+    /// The version number should be None but we can set it to Some(n) for a few small values to check that.
+    pub premature_increments: u8,
+}

--- a/src/backend/tests/it/utils/assertion.rs
+++ b/src/backend/tests/it/utils/assertion.rs
@@ -1,7 +1,9 @@
 use shared::types::custom_token::CustomToken;
-use shared::types::token::UserToken;
 
-pub fn assert_tokens_data_eq(results_tokens: &[UserToken], expected_tokens: &[UserToken]) {
+pub fn assert_tokens_data_eq<T: PartialEq + std::fmt::Debug>(
+    results_tokens: &[T],
+    expected_tokens: &[T],
+) {
     assert_eq!(
         results_tokens.len(),
         expected_tokens.len(),

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -43,14 +43,14 @@ pub fn setup_with_custom_wasm(wasm_path: &str) -> (PocketIc, Principal) {
     (pic, canister_id)
 }
 
-pub fn upgrade_latest(pocket_ic: &(PocketIc, Principal)) -> Result<(), String> {
+pub fn upgrade_latest_wasm(pocket_ic: &(PocketIc, Principal)) -> Result<(), String> {
     let backend_wasm_path =
         env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string());
 
-    upgrade(pocket_ic, &backend_wasm_path)
+    upgrade_with_wasm(pocket_ic, &backend_wasm_path)
 }
 
-pub fn upgrade(
+pub fn upgrade_with_wasm(
     (pic, canister_id): &(PocketIc, Principal),
     backend_wasm_path: &String,
 ) -> Result<(), String> {

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -43,10 +43,17 @@ pub fn setup_with_custom_wasm(wasm_path: &str) -> (PocketIc, Principal) {
     (pic, canister_id)
 }
 
-pub fn upgrade((pic, canister_id): &(PocketIc, Principal)) -> Result<(), String> {
+pub fn upgrade_latest(pocket_ic: &(PocketIc, Principal)) -> Result<(), String> {
     let backend_wasm_path =
         env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string());
 
+    upgrade(pocket_ic, &backend_wasm_path)
+}
+
+pub fn upgrade(
+    (pic, canister_id): &(PocketIc, Principal),
+    backend_wasm_path: &String,
+) -> Result<(), String> {
     let wasm_bytes = read(backend_wasm_path.clone()).expect(&format!(
         "Could not find the backend wasm: {}",
         backend_wasm_path


### PR DESCRIPTION
# Motivation

As we aim to introduce new fields into the stable structure, this PR sets the current upgrade test, which was previously developed to test a particular upgrade, to use the WASM of the last release instead of the generated WASM.

This PR also refactors the test and splits the files into separate modules, making it easier to add more tests.
