### PR TITLE
feat (ci): Support manually running CI tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/backend/**'
       - 'src/shared/**'
+  workflow_dispatch:
 
 env:
   RUNNER_OS: ubuntu-20.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,7 @@ name: Checks
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'src/frontend/**'
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
# Motivation
It is useful to be able to trigger CI checks manually.  For example, the backend test is triggered only on changes to certain files, so it is not easy to check that it works on main.  With "workflow dispatch" enabled, the backend tests can be run on main with the click of a button.

# Changes
- Add "workflow_dispatch" as a trigger for those GitHub CI jobs that don't have it yet.

# Tests
- This needs to be merged into main before the "workflow dispatch" functionality can be exercised.