### PR TITLE
fix (ci): Env vars are not supported for the runner

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -6,13 +6,10 @@ on:
       - 'src/backend/**'
       - 'src/shared/**'
 
-env:
-  RUNNER_OS: ubuntu-20.04
-
 jobs:
 
   docker-build-base:
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,7 +18,7 @@ jobs:
         uses: ./.github/actions/docker-build-base
 
   docker-build:
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-20.04
     needs: docker-build-base
     strategy:
       matrix:
@@ -40,7 +37,7 @@ jobs:
           target: ${{ matrix.target }}
 
   tests:
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-20.04
     needs: [ 'docker-build' ]
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +62,7 @@ jobs:
 
   may-merge:
     needs: [ 'tests' ]
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-20.04
     steps:
       - name: Cleared for merging
         run: echo OK


### PR DESCRIPTION
# Motivation
The backend test [fails on main](https://github.com/dfinity/oisy-wallet/actions/runs/9658380600) with "invalid workflow file".  In particular Ci doesn't like the use of env in the `runs-on` clause.  The backend tests [have been failing without exception for a couple of months](https://github.com/dfinity/oisy-wallet/actions/workflows/backend-tests.yml).

I see no evidence of env variables being supported for runs-on in the CI docs or functioning examples in GitHub.  `var` can be used but that is different.

While it would be nice to factor out the runner, something simple that works is better than something fancy that doesn't. (yet!)

# Changes
- Specify the backend test runner manually.

# Tests
- See the backend tests succeeding with this change: https://github.com/dfinity/oisy-wallet/actions/runs/9658643523
  - Note: This run was triggered manually.