### PR TITLE
fix (ci): Add files that trigger the backend test

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -3,8 +3,17 @@ name: Backend Tests
 on:
   pull_request:
     paths:
-      - 'src/backend/**'
+      - # Scripts, GitHub actions that contain 'backend' in their path.
+        '**/*backend*'
+      - # The backend source code
+        'src/backend/**'
       - 'src/shared/**'
+      - # Rust files such as Cargo.lock, Cargo.toml and rust-toolchain.toml
+        '**/Cargo*'
+      - '**/*rust*'
+      - # The dockerfile used in this CI run, and the scripts it COPY's.
+        'Dockerfile'
+      - 'docker/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Motivation
Some changes that affect the rust builds do not trigger the backend (rust code) CI job.  For example, [updating the Rust version did not cause any rust build to be run in CI](https://github.com/dfinity/oisy-wallet/pull/1513/checks).

# Changes
- Include rust and docker files in the list of files that, when changed, cause the backend ci job to be exercised.

# Tests
See CI: The backend build [was triggered](https://github.com/dfinity/oisy-wallet/pull/1559/checks) by changing the backend test.