### PR TITLE
chore: remove todo

### DIFF
--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -7,7 +7,6 @@ import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { testnets } from '$lib/derived/testnets.derived';
 import { derived, type Readable } from 'svelte/store';
 
-// TODO: rename me enabledIcrcTokens
 export const icrcDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcTokensStore, testnets],
 	([$icrcTokensStore, $testnets]) =>


### PR DESCRIPTION
# Motivation

Current name `icrcDefaultTokens` works fine so we can just remove the todo.
