### PR TITLE
refactor: rename erc20Tokens derived store

### DIFF
--- a/src/frontend/src/eth/components/send/SendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/SendTokenWizard.svelte
@@ -41,7 +41,7 @@
 	import SendQRCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
 	import { decodeQrCode } from '$eth/utils/qr-code.utils';
 	import type { QrResponse, QrStatus } from '$lib/types/qr-code';
-	import { erc20Tokens } from '$eth/derived/erc20.derived';
+	import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 
 	export let currentStep: WizardStep | undefined;
 	export let formCancelAction: 'back' | 'close' = 'close';
@@ -219,7 +219,7 @@
 			code,
 			expectedToken,
 			ethereumTokens: $enabledEthereumTokens,
-			erc20Tokens: $erc20Tokens
+			erc20Tokens: $erc20DefaultTokens
 		});
 </script>
 

--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -4,7 +4,7 @@ import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const erc20Tokens: Readable<Erc20Token[]> = derived(
+export const erc20DefaultTokens: Readable<Erc20Token[]> = derived(
 	[erc20TokensStore, enabledEthereumNetworksIds],
 	([$erc20TokensStore, $enabledEthereumNetworksIds]) =>
 		($erc20TokensStore ?? []).filter(({ network: { id: networkId } }) =>
@@ -23,6 +23,6 @@ export const erc20TokensNotInitialized: Readable<boolean> = derived(
 );
 
 export const erc20TokensAddresses: Readable<Erc20ContractAddress[]> = derived(
-	[erc20Tokens],
+	[erc20DefaultTokens],
 	([$erc20Tokens]) => $erc20Tokens.map(({ address }: Erc20Token) => ({ address }))
 );

--- a/src/frontend/src/eth/derived/nav.derived.ts
+++ b/src/frontend/src/eth/derived/nav.derived.ts
@@ -1,11 +1,11 @@
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import { routeToken } from '$lib/derived/nav.derived';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const tokenInitialized: Readable<boolean> = derived(
-	[routeToken, erc20Tokens],
+	[routeToken, erc20DefaultTokens],
 	([$routeToken, $erc20Tokens]) =>
 		$routeToken === ETHEREUM_TOKEN.name ||
 		$routeToken === SEPOLIA_TOKEN.name ||

--- a/src/frontend/src/eth/services/transactions.services.ts
+++ b/src/frontend/src/eth/services/transactions.services.ts
@@ -1,4 +1,4 @@
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import { etherscanProviders } from '$eth/providers/etherscan.providers';
 import { etherscanRests } from '$eth/rest/etherscan.rest';
 import { transactionsStore } from '$eth/stores/transactions.store';
@@ -95,7 +95,7 @@ export const loadErc20Transactions = async ({
 		return { success: false };
 	}
 
-	const tokens = get(erc20Tokens);
+	const tokens = get(erc20DefaultTokens);
 	const token = tokens.find(({ id }) => id === tokenId);
 
 	if (isNullish(token)) {

--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -2,7 +2,7 @@
 	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
 	import { address } from '$lib/derived/address.derived';
 	import { networkEthereum } from '$lib/derived/network.derived';
-	import { erc20Tokens } from '$eth/derived/erc20.derived';
+	import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 	import { debounce } from '@dfinity/utils';
 	import { ERC20_TWIN_TOKENS } from '$env/tokens.erc20.env';
 	import { ckEthereumNativeToken, erc20ToCkErc20Enabled } from '$icp-eth/derived/cketh.derived';
@@ -17,7 +17,7 @@
 					? [
 							loadErc20Balances({
 								address: $address,
-								erc20Tokens: $erc20Tokens,
+								erc20Tokens: $erc20DefaultTokens,
 								networkId: $tokenWithFallback.network.id
 							})
 						]
@@ -41,7 +41,7 @@
 
 	const debounceLoad = debounce(load);
 
-	$: $address, $erc20Tokens, $tokenWithFallback, $erc20ToCkErc20Enabled, debounceLoad();
+	$: $address, $erc20DefaultTokens, $tokenWithFallback, $erc20ToCkErc20Enabled, debounceLoad();
 </script>
 
 <slot />

--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -1,5 +1,5 @@
 import { ETHEREUM_TOKEN_ID, ICP_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens.env';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import type { Erc20Token } from '$eth/types/erc20';
 import { icrcTokens } from '$icp/derived/icrc.derived';
 import type { IcCkToken } from '$icp/types/ic';
@@ -13,7 +13,7 @@ export const exchangeInitialized: Readable<boolean> = derived([exchangeStore], (
 );
 
 export const exchanges: Readable<ExchangesData> = derived(
-	[exchangeStore, erc20Tokens, icrcTokens],
+	[exchangeStore, erc20DefaultTokens, icrcTokens],
 	([$exchangeStore, $erc20Tokens, $icrcTokens]) => {
 		const ethPrice = $exchangeStore?.ethereum;
 		const btcPrice = $exchangeStore?.bitcoin;

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -1,5 +1,5 @@
 import { ETHEREUM_TOKEN, ICP_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import { icrcTokens } from '$icp/derived/icrc.derived';
 import { routeToken } from '$lib/derived/nav.derived';
 import type { OptionToken } from '$lib/types/token';
@@ -10,7 +10,7 @@ import { derived, type Readable } from 'svelte/store';
  * A token derived from the route URL - i.e. if the URL contains a query parameters "token", then this store tries to derive the object from it.
  */
 export const pageToken: Readable<OptionToken> = derived(
-	[routeToken, erc20Tokens, icrcTokens],
+	[routeToken, erc20DefaultTokens, icrcTokens],
 	([$routeToken, $erc20Tokens, $icrcTokens]) => {
 		if (isNullish($routeToken)) {
 			return undefined;

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -1,5 +1,5 @@
 import { ICP_TOKEN } from '$env/tokens.env';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { Token } from '$lib/types/token';
@@ -7,7 +7,7 @@ import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
 export const tokens: Readable<Token[]> = derived(
-	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
+	[erc20DefaultTokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
 	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		...$enabledEthereumTokens,
 		ICP_TOKEN,

--- a/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
@@ -1,5 +1,5 @@
 import { SEPOLIA_TOKEN } from '$env/tokens.env';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { EthereumNetwork } from '$eth/types/network';
 import { decodeQrCode } from '$eth/utils/qr-code.utils';
@@ -20,7 +20,7 @@ describe('decodeQrCode', () => {
 	const otherProps = {
 		expectedToken: token,
 		ethereumTokens: get(enabledEthereumTokens),
-		erc20Tokens: get(erc20Tokens)
+		erc20Tokens: get(erc20DefaultTokens)
 	};
 
 	const mockDecodeQrCodeUrn = decodeQrCodeUrn as MockedFunction<typeof decodeQrCodeUrn>;


### PR DESCRIPTION
# Motivation

We want to introduce custom erc20 tokens store, therefore it makes sense to rename `erc20Tokens` to `erc20DefaultTokens`. Similar to `icrcDefaultTokens`.
