### PR TITLE
refactor: rename loadUserTokens to loadCustomTokens

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -11,7 +11,7 @@
 	import { ICP_NETWORK_ID } from '$env/networks.env';
 	import { onMount } from 'svelte';
 	import type { OptionIcrcCustomToken } from '$icp/types/icrc-custom-token';
-	import { loadUserTokens } from '$icp/services/icrc.services';
+	import { loadCustomTokens } from '$icp/services/icrc.services';
 	import { token } from '$lib/stores/token.store';
 
 	let selectedToken: OptionIcrcCustomToken;
@@ -65,7 +65,7 @@
 		});
 	};
 
-	const updateUi = (params: { identity: Identity }): Promise<void> => loadUserTokens(params);
+	const updateUi = (params: { identity: Identity }): Promise<void> => loadCustomTokens(params);
 </script>
 
 <HideTokenModal backToNetworkId={ICP_NETWORK_ID} {assertHide} {hideToken} {updateUi} />

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -1,4 +1,4 @@
-import { loadUserTokens } from '$icp/services/icrc.services';
+import { loadCustomTokens } from '$icp/services/icrc.services';
 import { icrcTokensStore } from '$icp/stores/icrc.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setManyCustomTokens } from '$lib/api/backend.api';
@@ -44,7 +44,7 @@ export const saveCustomTokens = async ({
 	disabledTokens.forEach(({ ledgerCanisterId }) => icrcTokensStore.reset(ledgerCanisterId));
 
 	// Reload all custom tokens for simplicity reason.
-	await loadUserTokens({ identity });
+	await loadCustomTokens({ identity });
 };
 
 export const saveIcrcCustomToken = async ({

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -22,14 +22,14 @@ import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 export const loadIcrcTokens = async ({ identity }: { identity: OptionIdentity }): Promise<void> => {
-	await Promise.all([loadDefaultIcrcTokens(), loadUserTokens({ identity })]);
+	await Promise.all([loadDefaultIcrcTokens(), loadCustomTokens({ identity })]);
 };
 
 const loadDefaultIcrcTokens = async () => {
 	await Promise.all(ICRC_TOKENS.map(loadDefaultIcrc));
 };
 
-export const loadUserTokens = ({ identity }: { identity: OptionIdentity }): Promise<void> =>
+export const loadCustomTokens = ({ identity }: { identity: OptionIdentity }): Promise<void> =>
 	queryAndUpdate<IcrcCustomTokenWithoutId[]>({
 		request: (params) => loadIcrcCustomTokens(params),
 		onLoad: loadIcrcCustomData,


### PR DESCRIPTION
# Motivation

`loadUserTokens` effectively load `CustomToken` and we are about to add a function to load `UserToken` (erc20) so makes sense to rename current function to something closer to the type it loads.