### PR TITLE
feat: derive a shorthand for pseud network chain fusion

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { IconClose, Input } from '@dfinity/gix-components';
 	import { createEventDispatcher, onMount } from 'svelte';
-	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import { debounce, nonNullish } from '@dfinity/utils';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import Card from '$lib/components/ui/Card.svelte';
@@ -20,7 +20,11 @@
 	import type { Token } from '$lib/types/token';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
-	import { networkICP, selectedNetwork } from '$lib/derived/network.derived';
+	import {
+		networkICP,
+		pseudoNetworkChainFusion,
+		selectedNetwork
+	} from '$lib/derived/network.derived';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 
 	const dispatch = createEventDispatcher();
@@ -62,7 +66,7 @@
 					(icrcToken) => token.id === icrcToken.id && token.network.id === icrcToken.network.id
 				) ?? { ...token, show: true }
 		),
-		...(isNullish($selectedNetwork) || $networkICP
+		...($pseudoNetworkChainFusion || $networkICP
 			? allIcrcTokens.filter(
 					(icrcToken) =>
 						!$networkTokens.some(

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,20 +1,19 @@
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
-import { selectedNetwork } from '$lib/derived/network.derived';
+import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { Token } from '$lib/types/token';
-import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const networkTokens: Readable<Token[]> = derived(
-	[tokens, selectedNetwork],
-	([$tokens, $selectedNetwork]) =>
+	[tokens, selectedNetwork, pseudoNetworkChainFusion],
+	([$tokens, $selectedNetwork, $pseudoNetworkChainFusion]) =>
 		$tokens.filter((token) => {
 			const {
 				network: { id: networkId }
 			} = token;
 
 			return (
-				(isNullish($selectedNetwork) &&
+				($pseudoNetworkChainFusion &&
 					!isTokenIcrcTestnet(token) &&
 					token.network.env !== 'testnet') ||
 				$selectedNetwork?.id === networkId

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -5,7 +5,7 @@ import { networks } from '$lib/derived/networks.derived';
 import type { OptionAddress } from '$lib/types/address';
 import type { Network, NetworkId } from '$lib/types/network';
 import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const networkId: Readable<NetworkId | undefined> = derived(
@@ -27,6 +27,11 @@ export const networkICP: Readable<boolean> = derived([networkId], ([$networkId])
 
 export const networkEthereum: Readable<boolean> = derived([networkId], ([$networkId]) =>
 	isNetworkIdEthereum($networkId)
+);
+
+export const pseudoNetworkChainFusion: Readable<boolean> = derived(
+	[selectedNetwork],
+	([$selectedNetwork]) => isNullish($selectedNetwork)
 );
 
 export const networkAddress: Readable<OptionAddress | string> = derived(


### PR DESCRIPTION
# Motivation

It's handy to have a shorthand for chain fusion, that way we don't have to check for nullability in code without exactly knowing why when we read the code.
