### PR TITLE
refactor: rename utils icTokenContainsEnabled

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -15,7 +15,7 @@
 	import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { ICP_TOKEN } from '$env/tokens.env';
-	import { icTokenContainsEnabled, sortIcTokens } from '$icp/utils/icrc.utils';
+	import { icTokenIcrcCustomToken, sortIcTokens } from '$icp/utils/icrc.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Token } from '$lib/types/token';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
@@ -90,7 +90,7 @@
 				(token) =>
 					token.name.toLowerCase().includes(filterTokens.toLowerCase()) ||
 					token.symbol.toLowerCase().includes(filterTokens.toLowerCase()) ||
-					(icTokenContainsEnabled(token) &&
+					(icTokenIcrcCustomToken(token) &&
 						(token.alternativeName ?? '').toLowerCase().includes(filterTokens.toLowerCase()))
 			);
 
@@ -100,7 +100,7 @@
 
 		return {
 			...token,
-			...(icTokenContainsEnabled(token)
+			...(icTokenIcrcCustomToken(token)
 				? {
 						enabled: (modifiedToken as IcrcCustomToken)?.enabled ?? token.enabled
 					}
@@ -186,7 +186,7 @@
 				</span>
 
 				<svelte:fragment slot="action">
-					{#if icTokenContainsEnabled(token)}
+					{#if icTokenIcrcCustomToken(token)}
 						<IcManageTokenToggle {token} on:icToken={onToggle} />
 					{:else}
 						<ManageTokenToggle {token} on:icShowOrHideToken={onToggle} />

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -132,5 +132,5 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 	];
 };
 
-export const icTokenContainsEnabled = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
+export const icTokenIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
 	(token.standard === 'icp' || token.standard === 'icrc') && 'enabled' in token;


### PR DESCRIPTION
# Motivation

Rename `icTokenContainsEnabled` to `icTokenIcrcCustomToken` because we will also have a similar utils for Erc20 and "User Token".
