### PR TITLE
chore: backend clippy allow deprecated

### DIFF
--- a/scripts/lint.rust.sh
+++ b/scripts/lint.rust.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Lint the rust code
-cargo clippy --locked --target wasm32-unknown-unknown --all-features -- -D warnings -W clippy::pedantic -A clippy::module-name-repetitions -A clippy::struct-field-names
+cargo clippy --locked --target wasm32-unknown-unknown --all-features -- -D warnings -W clippy::pedantic -A clippy::module-name-repetitions -A clippy::struct-field-names -A deprecated


### PR DESCRIPTION
# Motivation

As discussed, we want to allow `deprecated` in backend clippy.