### PR TITLE
feat: spread custom token order

### DIFF
--- a/src/frontend/src/icp/stores/certified-icrc.store.ts
+++ b/src/frontend/src/icp/stores/certified-icrc.store.ts
@@ -28,13 +28,13 @@ export const initCertifiedIcrcTokensStore = <
 				{
 					certified,
 					data: {
+						...data,
 						// We are using Symbols as key IDs for the ETH and ICP tokens, which is ideal for our use case due to their uniqueness. This ensures that even if two coins fetched dynamically have the same symbol or name, they will be used correctly.
 						// However, this approach presents a challenge with ICRC tokens, which need to be loaded twice - once with a query and once with an update. When they are loaded the second time, the existing Symbol should be reused to ensure they are identified as the same token.
 						id:
 							(state ?? []).find(
 								({ data: { ledgerCanisterId } }) => ledgerCanisterId === data.ledgerCanisterId
 							)?.data.id ?? Symbol(data.symbol),
-						...data
 					} as T
 				}
 			]),

--- a/src/frontend/src/icp/stores/certified-icrc.store.ts
+++ b/src/frontend/src/icp/stores/certified-icrc.store.ts
@@ -34,7 +34,7 @@ export const initCertifiedIcrcTokensStore = <
 						id:
 							(state ?? []).find(
 								({ data: { ledgerCanisterId } }) => ledgerCanisterId === data.ledgerCanisterId
-							)?.data.id ?? Symbol(data.symbol),
+							)?.data.id ?? Symbol(data.symbol)
 					} as T
 				}
 			]),


### PR DESCRIPTION
# Motivation

Even if it does not make a big difference in this particular use case, spreading the data of the custom token first given that we try to retrieve the id is better.
