### PR TITLE
feat: trim sns alternative name (ICX contains an empty space)

### DIFF
--- a/scripts/build.tokens.sns.mjs
+++ b/scripts/build.tokens.sns.mjs
@@ -160,7 +160,7 @@ export const findSnses = async () => {
 				rootCanisterId: root_canister_id,
 				metadata: {
 					...mapOptionalToken(icrc1_metadata),
-					alternativeName,
+					alternativeName: alternativeName.trim(),
 					url
 				}
 			})


### PR DESCRIPTION
# Motivation

Not sure if it's an issue or a typo (I tend to the latest) but noticed that `ICX `  governance name contains an empty.

# Changes

- trim alternative name in our Sns script
