### PR TITLE
feat: extract interface and generic function to save icrc custom tokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -8,7 +8,6 @@
 	import { addTokenSteps } from '$lib/constants/steps.constants';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { authStore } from '$lib/stores/auth.store';
-	import { saveIcrcCustomToken } from '$icp/services/ic-custom-tokens.services';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import type { Erc20Metadata } from '$eth/types/erc20';
 	import AddTokenByNetwork from '$icp-eth/components/tokens/AddTokenByNetwork.svelte';
@@ -23,6 +22,8 @@
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import { get } from 'svelte/store';
 	import type { Erc20UserToken } from '$eth/types/erc20-user-token';
+	import { saveIcrcCustomTokens } from '$icp-eth/services/manage-tokens.services';
+	import type { SaveCustomToken } from '$icp/services/ic-custom-tokens.services';
 
 	const steps: WizardSteps = [
 		{
@@ -62,7 +63,7 @@
 		}
 
 		await Promise.allSettled([
-			...(icrc.length > 0 ? [save(icrc)] : []),
+			...(icrc.length > 0 ? [saveIcrc(icrc)] : []),
 			// TODO: erc20 save
 			...(erc20.length > 0 ? [] : [])
 		]);
@@ -83,7 +84,7 @@
 			return;
 		}
 
-		await save([
+		await saveIcrc([
 			{
 				enabled: true,
 				ledgerCanisterId,
@@ -107,10 +108,8 @@
 
 	const progress = (step: ProgressStepsAddToken) => (saveProgressStep = step);
 
-	const save = async (
-		tokens: Pick<IcrcCustomToken, 'enabled' | 'version' | 'ledgerCanisterId' | 'indexCanisterId'>[]
-	) => {
-		await saveIcrcCustomToken({
+	const saveIcrc = (tokens: SaveCustomToken[]): Promise<void> =>
+		saveIcrcCustomTokens({
 			tokens,
 			progress,
 			modalNext: () => modal.set(3),
@@ -118,7 +117,6 @@
 			onError: () => modal.set(0),
 			identity: $authStore.identity
 		});
-	};
 
 	const close = () => {
 		modalStore.close();

--- a/src/frontend/src/icp-eth/services/manage-tokens.services.ts
+++ b/src/frontend/src/icp-eth/services/manage-tokens.services.ts
@@ -1,0 +1,88 @@
+import { saveCustomTokens, type SaveCustomToken } from '$icp/services/ic-custom-tokens.services';
+import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import { nullishSignOut } from '$lib/services/auth.services';
+import { i18n } from '$lib/stores/i18n.store';
+import { toastsError } from '$lib/stores/toasts.store';
+import type { OptionIdentity } from '$lib/types/identity';
+import type { Identity } from '@dfinity/agent';
+import { isNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+export interface ManageTokensSaveParams {
+	progress: (step: ProgressStepsAddToken) => void;
+	modalNext: () => void;
+	onSuccess: () => void;
+	onError: () => void;
+	identity: OptionIdentity;
+}
+
+export const saveIcrcCustomTokens = async ({
+	tokens,
+	...rest
+}: {
+	tokens: SaveCustomToken[];
+} & ManageTokensSaveParams) => {
+	const save = (params: {
+		progress: (step: ProgressStepsAddToken) => void;
+		identity: Identity;
+		tokens: [SaveCustomToken, ...SaveCustomToken[]];
+	}): Promise<void> => saveCustomTokens(params);
+
+	await saveTokens({
+		...rest,
+		tokens,
+		save
+	});
+};
+
+const saveTokens = async <T>({
+	tokens,
+	save,
+	progress,
+	modalNext,
+	onSuccess,
+	onError,
+	identity
+}: {
+	tokens: T[];
+	save: (params: {
+		progress: (step: ProgressStepsAddToken) => void;
+		identity: Identity;
+		tokens: [T, ...T[]];
+	}) => Promise<void>;
+} & ManageTokensSaveParams) => {
+	const $i18n = get(i18n);
+
+	if (isNullish(identity)) {
+		await nullishSignOut();
+		return;
+	}
+
+	if (tokens.length === 0) {
+		toastsError({
+			msg: { text: $i18n.tokens.manage.error.empty }
+		});
+		return;
+	}
+
+	modalNext();
+
+	try {
+		await save({
+			progress,
+			identity,
+			tokens: tokens as [T, ...T[]]
+		});
+
+		progress(ProgressStepsAddToken.DONE);
+
+		setTimeout(() => onSuccess(), 750);
+	} catch (err: unknown) {
+		toastsError({
+			msg: { text: $i18n.tokens.error.unexpected },
+			err
+		});
+
+		onError();
+	}
+};

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -3,14 +3,14 @@ import { icrcTokensStore } from '$icp/stores/icrc.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setManyCustomTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
-import { nullishSignOut } from '$lib/services/auth.services';
-import { i18n } from '$lib/stores/i18n.store';
-import { toastsError } from '$lib/stores/toasts.store';
-import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
-import { isNullish, toNullable } from '@dfinity/utils';
-import { get } from 'svelte/store';
+import { toNullable } from '@dfinity/utils';
+
+export type SaveCustomToken = Pick<
+	IcrcCustomToken,
+	'enabled' | 'version' | 'ledgerCanisterId' | 'indexCanisterId'
+>;
 
 export const saveCustomTokens = async ({
 	progress,
@@ -19,7 +19,7 @@ export const saveCustomTokens = async ({
 }: {
 	progress: (step: ProgressStepsAddToken) => void;
 	identity: Identity;
-	tokens: Pick<IcrcCustomToken, 'enabled' | 'version' | 'ledgerCanisterId' | 'indexCanisterId'>[];
+	tokens: SaveCustomToken[];
 }) => {
 	progress(ProgressStepsAddToken.SAVE);
 
@@ -45,55 +45,4 @@ export const saveCustomTokens = async ({
 
 	// Reload all custom tokens for simplicity reason.
 	await loadCustomTokens({ identity });
-};
-
-export const saveIcrcCustomToken = async ({
-	tokens,
-	progress,
-	modalNext,
-	onSuccess,
-	onError,
-	identity
-}: {
-	tokens: Pick<IcrcCustomToken, 'enabled' | 'version' | 'ledgerCanisterId' | 'indexCanisterId'>[];
-	progress: (step: ProgressStepsAddToken) => void;
-	modalNext: () => void;
-	onSuccess: () => void;
-	onError: () => void;
-	identity: OptionIdentity;
-}) => {
-	const $i18n = get(i18n);
-
-	if (isNullish(identity)) {
-		await nullishSignOut();
-		return;
-	}
-
-	if (tokens.length === 0) {
-		toastsError({
-			msg: { text: $i18n.tokens.manage.error.empty }
-		});
-		return;
-	}
-
-	modalNext();
-
-	try {
-		await saveCustomTokens({
-			identity,
-			tokens,
-			progress
-		});
-
-		progress(ProgressStepsAddToken.DONE);
-
-		setTimeout(() => onSuccess(), 750);
-	} catch (err: unknown) {
-		toastsError({
-			msg: { text: $i18n.tokens.error.unexpected },
-			err
-		});
-
-		onError();
-	}
 };


### PR DESCRIPTION
# Motivation

We want to save ERC20 user tokens in the "Manage tokens" modal the same way we do for ICRC. That's why this PR extract some interfaces and common code that we can reuse for such purpose.

# Notes

No logical changes here.
