### PR TITLE
feat: the exchange balance should represent the displayed tokens

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -3,10 +3,10 @@
 	import { exchangeInitialized, exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { usdValue } from '$lib/utils/exchange.utils';
-	import { networkTokens } from '$lib/derived/network-tokens.derived';
+	import { filteredNetworkTokens } from '$lib/derived/network-tokens.derived';
 
 	let totalUsd: number;
-	$: totalUsd = $networkTokens.reduce(
+	$: totalUsd = $filteredNetworkTokens.reduce(
 		(acc, token) =>
 			acc +
 			usdValue({


### PR DESCRIPTION
# Motivation

The balance in dollars displayed in the hero pane should amend only the tokens that are enabled and displayed in the selected network or chain fusion.
