### PR TITLE
refactor: rename erc20 tokens store

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -1,13 +1,13 @@
 import { enabledEthereumNetworksIds } from '$eth/derived/networks.derived';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
-import { erc20TokensStore } from '$eth/stores/erc20.store';
 import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const erc20DefaultTokens: Readable<Erc20Token[]> = derived(
-	[erc20TokensStore, enabledEthereumNetworksIds],
+	[erc20DefaultTokensStore, enabledEthereumNetworksIds],
 	([$erc20TokensStore, $enabledEthereumNetworksIds]) =>
 		($erc20TokensStore ?? []).filter(({ network: { id: networkId } }) =>
 			$enabledEthereumNetworksIds.includes(networkId)

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -5,8 +5,8 @@ import {
 } from '$env/networks.env';
 import { ERC20_CONTRACTS, ERC20_TWIN_TOKENS } from '$env/tokens.erc20.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
-import { erc20TokensStore } from '$eth/stores/erc20.store';
 import type { Erc20Contract, Erc20Metadata, Erc20Token } from '$eth/types/erc20';
 import type { Erc20UserToken, Erc20UserTokenState } from '$eth/types/erc20-user-token';
 import type { EthereumNetwork } from '$eth/types/network';
@@ -45,9 +45,9 @@ const loadDefaultErc20Tokens = async (): Promise<{ success: boolean }> => {
 			);
 
 		const contracts = await Promise.all(loadKnownContracts());
-		erc20TokensStore.set([...ERC20_TWIN_TOKENS, ...contracts.map(mapErc20Token)]);
+		erc20DefaultTokensStore.set([...ERC20_TWIN_TOKENS, ...contracts.map(mapErc20Token)]);
 	} catch (err: unknown) {
-		erc20TokensStore.reset();
+		erc20DefaultTokensStore.reset();
 
 		const {
 			init: {

--- a/src/frontend/src/eth/stores/erc20-default-tokens.store.ts
+++ b/src/frontend/src/eth/stores/erc20-default-tokens.store.ts
@@ -2,22 +2,22 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { TokenId } from '$lib/types/token';
 import { writable, type Readable } from 'svelte/store';
 
-export type Ecr20TokensData = Erc20Token[] | undefined;
+export type Ecr20DefaultTokensData = Erc20Token[] | undefined;
 
-export interface Ecr20TokensStore extends Readable<Ecr20TokensData> {
-	set: (tokens: Ecr20TokensData) => void;
+export interface Ecr20DefaultTokensStore extends Readable<Ecr20DefaultTokensData> {
+	set: (tokens: Ecr20DefaultTokensData) => void;
 	add: (token: Erc20Token) => void;
 	remove: (tokenId: TokenId) => void;
 	reset: () => void;
 }
 
-const initEcr20TokensStore = (): Ecr20TokensStore => {
-	const INITIAL: Ecr20TokensData = undefined;
+const initEcr20DefaultTokensStore = (): Ecr20DefaultTokensStore => {
+	const INITIAL: Ecr20DefaultTokensData = undefined;
 
-	const { subscribe, set, update } = writable<Ecr20TokensData>(INITIAL);
+	const { subscribe, set, update } = writable<Ecr20DefaultTokensData>(INITIAL);
 
 	return {
-		set: (tokens: Ecr20TokensData) => set(tokens),
+		set: (tokens: Ecr20DefaultTokensData) => set(tokens),
 		add: (token: Erc20Token) =>
 			update((state) => [
 				...(state ?? []).filter(
@@ -32,4 +32,4 @@ const initEcr20TokensStore = (): Ecr20TokensStore => {
 	};
 };
 
-export const erc20TokensStore = initEcr20TokensStore();
+export const erc20DefaultTokensStore = initEcr20DefaultTokensStore();


### PR DESCRIPTION
# Motivation

We now use the erc20.store for default tokens only so it makes sense to use a more verbose name for readability.
