### PR TITLE
feat: erc20 list of tokens and manageable

### DIFF
--- a/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
@@ -11,7 +11,7 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
 	import type { Network } from '$lib/types/network';
-	import { erc20UserTokens } from '$eth/derived/erc20.derived';
+	import { erc20Tokens } from '$eth/derived/erc20.derived';
 
 	export let contractAddress: string | undefined;
 	export let metadata: Erc20Metadata | undefined;
@@ -37,7 +37,7 @@
 		}
 
 		if (
-			$erc20UserTokens?.find(
+			$erc20Tokens?.find(
 				({ address }) => address.toLowerCase() === contractAddress?.toLowerCase()
 			) !== undefined
 		) {
@@ -63,7 +63,7 @@
 			}
 
 			if (
-				$erc20UserTokens?.find(
+				$erc20Tokens?.find(
 					({ symbol, name }) =>
 						symbol.toLowerCase() === (metadata?.symbol.toLowerCase() ?? '') ||
 						name.toLowerCase() === (metadata?.name.toLowerCase() ?? '')

--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -43,7 +43,7 @@ const erc20UserTokensDisabledAddresses: Readable<string[]> = derived(
 
 type Erc20TokenToggeable = Erc20Token & { enabled: boolean };
 
-export const erc20DefaultTokensToggeable: Readable<Erc20TokenToggeable[]> = derived(
+export const erc20DefaultTokensToggleable: Readable<Erc20TokenToggeable[]> = derived(
 	[erc20DefaultTokens, erc20UserTokensDisabledAddresses],
 	([$erc20DefaultTokens, $erc20UserTokensDisabledAddresses]) =>
 		$erc20DefaultTokens.reduce(
@@ -63,7 +63,7 @@ export const erc20DefaultTokensToggeable: Readable<Erc20TokenToggeable[]> = deri
  * The list of default tokens that are enabled - i.e. the list of default ERC20 tokens minus those disabled by the user.
  */
 const erc20DefaultTokensEnabled: Readable<Erc20Token[]> = derived(
-	[erc20DefaultTokensToggeable],
+	[erc20DefaultTokensToggleable],
 	([$erc20DefaultTokensToggeable]) => $erc20DefaultTokensToggeable.filter(({ enabled }) => enabled)
 );
 
@@ -84,7 +84,7 @@ const erc20UserTokensEnabled: Readable<Erc20UserToken[]> = derived(
 
 // TODO: rename to erc20Tokens
 export const erc20TokensAll: Readable<Erc20Token[]> = derived(
-	[erc20DefaultTokensToggeable, erc20UserTokensEnabled],
+	[erc20DefaultTokensToggleable, erc20UserTokensEnabled],
 	([$erc20DefaultTokensToggeable, $erc20UserTokensEnabled]) => [
 		...$erc20DefaultTokensToggeable,
 		...$erc20UserTokensEnabled

--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -81,8 +81,10 @@ const enabledErc20UserTokens: Readable<Erc20UserToken[]> = derived(
 		)
 );
 
-// TODO: rename to erc20Tokens
-export const erc20TokensAll: Readable<Erc20Token[]> = derived(
+/**
+ * The list of all ERC20 tokens.
+ */
+export const erc20Tokens: Readable<Erc20Token[]> = derived(
 	[erc20DefaultTokensToggleable, enabledErc20UserTokens],
 	([$erc20DefaultTokensToggeable, $enabledErc20UserTokens]) => [
 		...$erc20DefaultTokensToggeable,

--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -40,6 +40,7 @@ const erc20UserTokensDisabledAddresses: Readable<string[]> = derived(
 		)
 );
 
+// TODO: extract type
 type Erc20TokenToggeable = Erc20Token & { enabled: boolean };
 
 export const erc20DefaultTokensToggleable: Readable<Erc20TokenToggeable[]> = derived(

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -28,11 +28,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import type { Erc20UserToken, EthereumUserToken } from '$eth/types/erc20-user-token';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-	import {
-		erc20DefaultTokensToggleable,
-		erc20Tokens,
-		erc20UserTokensToggleable
-	} from '$eth/derived/erc20.derived';
+	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -28,7 +28,11 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import type { Erc20UserToken, EthereumUserToken } from '$eth/types/erc20-user-token';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-	import { erc20DefaultTokensToggleable, erc20UserTokens } from '$eth/derived/erc20.derived';
+	import {
+		erc20DefaultTokensToggleable,
+		erc20Tokens,
+		erc20UserTokensToggleable
+	} from '$eth/derived/erc20.derived';
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 
@@ -66,8 +70,7 @@
 	let allEthereumTokens: EthereumUserToken[] = [];
 	$: allEthereumTokens = [
 		...$enabledEthereumTokens.map((token) => ({ ...token, enabled: true })),
-		...$erc20DefaultTokensToggleable,
-		...$erc20UserTokens
+		...$erc20Tokens
 	];
 
 	let manageIcTokens = false;

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -28,7 +28,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import type { Erc20UserToken, EthereumUserToken } from '$eth/types/erc20-user-token';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-	import { erc20DefaultTokensToggeable, erc20UserTokens } from '$eth/derived/erc20.derived';
+	import { erc20DefaultTokensToggleable, erc20UserTokens } from '$eth/derived/erc20.derived';
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 
@@ -66,7 +66,7 @@
 	let allEthereumTokens: EthereumUserToken[] = [];
 	$: allEthereumTokens = [
 		...$enabledEthereumTokens.map((token) => ({ ...token, enabled: true })),
-		...$erc20DefaultTokensToggeable,
+		...$erc20DefaultTokensToggleable,
 		...$erc20UserTokens
 	];
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -28,7 +28,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import type { Erc20UserToken, EthereumUserToken } from '$eth/types/erc20-user-token';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-	import { erc20DefaultTokens, erc20UserTokens } from '$eth/derived/erc20.derived';
+	import { erc20DefaultTokensToggeable, erc20UserTokens } from '$eth/derived/erc20.derived';
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
 	import { networkTokens } from '$lib/derived/network-tokens.derived';
 
@@ -66,7 +66,7 @@
 	let allEthereumTokens: EthereumUserToken[] = [];
 	$: allEthereumTokens = [
 		...$enabledEthereumTokens.map((token) => ({ ...token, enabled: true })),
-		...$erc20DefaultTokens.map((token) => ({ ...token, enabled: true })),
+		...$erc20DefaultTokensToggeable,
 		...$erc20UserTokens
 	];
 

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -28,12 +28,18 @@ export const networkTokens: Readable<Token[]> = derived(
 		})
 );
 
+export const enabledNetworkTokens: Readable<Token[]> = derived(
+	[networkTokens],
+	([$networkTokens]) =>
+		$networkTokens.filter((token) => ('enabled' in token ? token.enabled : true))
+);
+
 export const filteredNetworkTokens: Readable<Token[]> = derived(
-	[networkTokens, notPseudoNetworkChainFusion],
-	([$networkTokens, $notPseudoNetworkChainFusion]) =>
+	[enabledNetworkTokens, notPseudoNetworkChainFusion],
+	([$enabledNetworkTokens, $notPseudoNetworkChainFusion]) =>
 		$notPseudoNetworkChainFusion
-			? $networkTokens
-			: $networkTokens.filter(
+			? $enabledNetworkTokens
+			: $enabledNetworkTokens.filter(
 					(token) =>
 						[ICP_TOKEN_ID, ETHEREUM_TOKEN_ID].includes(token.id) ||
 						('ledgerCanisterId' in token &&

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -11,6 +11,9 @@ import type { CanisterIdText } from '$lib/types/canister';
 import type { Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
+/**
+ * All tokens matching the selected network or chain fusion, regardless if they are enabled by the user or not.
+ */
 export const networkTokens: Readable<Token[]> = derived(
 	[tokens, selectedNetwork, pseudoNetworkChainFusion],
 	([$tokens, $selectedNetwork, $pseudoNetworkChainFusion]) =>

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -8,11 +8,11 @@ import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
 export const tokens: Readable<Token[]> = derived(
 	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
-	([$erc20TokensAll, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
+	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
 		...$enabledEthereumTokens,
 		...$enabledBitcoinTokens,
-		...$erc20TokensAll,
+		...$erc20Tokens,
 		...$icrcTokens
 	]
 );

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -1,5 +1,5 @@
 import { ICP_TOKEN } from '$env/tokens.env';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
+import { erc20TokensAll } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { Token } from '$lib/types/token';
@@ -7,12 +7,12 @@ import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
 export const tokens: Readable<Token[]> = derived(
-	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
-	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
+	[erc20TokensAll, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
+	([$erc20TokensAll, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
 		...$enabledEthereumTokens,
 		...$enabledBitcoinTokens,
-		...$erc20Tokens,
+		...$erc20TokensAll,
 		...$icrcTokens
 	]
 );

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -1,5 +1,5 @@
 import { ICP_TOKEN } from '$env/tokens.env';
-import { erc20TokensAll } from '$eth/derived/erc20.derived';
+import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { Token } from '$lib/types/token';
@@ -7,7 +7,7 @@ import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
 export const tokens: Readable<Token[]> = derived(
-	[erc20TokensAll, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
+	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
 	([$erc20TokensAll, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
 		...$enabledEthereumTokens,


### PR DESCRIPTION
# Motivation

Product want default ERC20 tokens to be toggeable so we have to derive more information and user different derived stores according the view to amend the ERC20 tokens custom state and also make those available in the manage tokens modal regardless of their state.

In this PR, `AddTokenReview` is also adjusted to check the potential token to the list of all erc20 tokens.