### PR TITLE
feat: make "hide token" available for default ERC20 tokens as well

### DIFF
--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -16,8 +16,8 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { back } from '$lib/utils/nav.utils';
 	import type { Identity } from '@dfinity/agent';
-	import { token } from '$lib/stores/token.store';
 	import { networkId } from '$lib/derived/network.derived';
+	import { tokenToggleable } from '$lib/derived/token.derived';
 
 	export let assertHide: () => { valid: boolean };
 	export let hideToken: (params: { identity: Identity }) => Promise<void>;
@@ -30,9 +30,9 @@
 			return;
 		}
 
-		if ($token?.category !== 'custom') {
+		if (!$tokenToggleable) {
 			toastsError({
-				msg: { text: $i18n.tokens.error.not_custom }
+				msg: { text: $i18n.tokens.error.not_toggleable }
 			});
 			return;
 		}

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -5,7 +5,7 @@
 	import { networkICP } from '$lib/derived/network.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { tokenCategory } from '$lib/derived/token.derived';
+	import { tokenToggleable } from '$lib/derived/token.derived';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
 	import { token } from '$lib/stores/token.store';
@@ -48,7 +48,7 @@
 	<div class="flex flex-col gap-3">
 		<slot />
 
-		{#if $tokenCategory === 'custom'}
+		{#if $tokenToggleable}
 			<ButtonMenu ariaLabel={hideTokenLabel} on:click={hideToken}>
 				{hideTokenLabel}
 			</ButtonMenu>

--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -1,6 +1,8 @@
+import { icTokenErc20UserToken } from '$eth/utils/erc20.utils';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import { token } from '$lib/stores/token.store';
 import type { OptionTokenId, OptionTokenStandard, Token, TokenCategory } from '$lib/types/token';
+import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -31,4 +33,12 @@ export const tokenDecimals: Readable<number | undefined> = derived(
 export const tokenCategory: Readable<TokenCategory | undefined> = derived(
 	[token],
 	([$token]) => $token?.category
+);
+
+// TODO: $tokenCategory is used here for backwards compatibility with ICRC.
+// Once ICRC default tokens can also be enabled or disabled, this should be reviewed.
+export const tokenToggleable: Readable<boolean> = derived(
+	[token, tokenCategory],
+	([$token, $tokenCategory]) =>
+		nonNullish($token) && (icTokenErc20UserToken($token) || $tokenCategory === 'custom')
 );

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -366,7 +366,7 @@
 			"unexpected_hiding": "Something went wrong while hiding the token.",
 			"already_available": "Token is already available.",
 			"loading_metadata": "Error while loading the ERC20 contract metadata.",
-			"not_custom": "Only custom token can be hidden.",
+			"not_toggleable": "Token is not toggleable, it can not be hidden.",
 			"incomplete_metadata": "No name or symbol are provided in the metadata.",
 			"duplicate_metadata": "A token with a similar name or symbol already exists.",
 			"unexpected_undefined": "Token is undefined. This is unexpected."

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -321,7 +321,7 @@ interface I18nTokens {
 		unexpected_hiding: string;
 		already_available: string;
 		loading_metadata: string;
-		not_custom: string;
+		not_toggleable: string;
 		incomplete_metadata: string;
 		duplicate_metadata: string;
 		unexpected_undefined: string;


### PR DESCRIPTION
# Motivation

"Hide Token" on the transaction page used to be accessible in the token menu only for "custom" token. Given that user can now disable default ERC20 tokens as well, the feature should also be made available for those.
