### PR TITLE
chore: remove unused backend functions

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -1,9 +1,4 @@
-import type {
-	CustomToken,
-	SignRequest,
-	UserToken,
-	UserTokenId
-} from '$declarations/backend/backend.did';
+import type { CustomToken, SignRequest, UserToken } from '$declarations/backend/backend.did';
 import { getBackendActor } from '$lib/actors/actors.ic';
 import type { ECDSA_PUBLIC_KEY } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -46,34 +41,6 @@ export const signPrehash = async ({
 }): Promise<string> => {
 	const { sign_prehash } = await getBackendActor({ identity });
 	return sign_prehash(hash);
-};
-
-/**
- * @deprecated
- */
-export const addUserToken = async ({
-	token,
-	identity
-}: {
-	token: UserToken;
-	identity: Identity;
-}): Promise<void> => {
-	const { add_user_token } = await getBackendActor({ identity });
-	return add_user_token(token);
-};
-
-/**
- * @deprecated
- */
-export const removeUserToken = async ({
-	tokenId,
-	identity
-}: {
-	tokenId: UserTokenId;
-	identity: Identity;
-}): Promise<void> => {
-	const { remove_user_token } = await getBackendActor({ identity });
-	return remove_user_token(tokenId);
 };
 
 export const listUserTokens = async ({


### PR DESCRIPTION
# Motivation

Unlike #1598, we can remove unused code in the frontend dapp - i.e. remove implementation of `backend.api` that aren't used anymore.