### PR TITLE
feat: rename icrcTokensStore to default

### DIFF
--- a/src/frontend/src/icp-eth/components/core/CkEthLoader.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthLoader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { loadCkEthMinterInfo } from '$icp-eth/services/cketh.services';
 	import { erc20ToCkErc20Enabled, ethToCkETHEnabled } from '$icp-eth/derived/cketh.derived';
-	import { icrcTokensStore } from '$icp/stores/icrc.store';
+	import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 	import {
 		IC_CKETH_MINTER_CANISTER_ID,
 		LOCAL_CKETH_MINTER_CANISTER_ID,
@@ -51,7 +51,7 @@
 
 	$: $ethToCkETHEnabled,
 		$erc20ToCkErc20Enabled,
-		$icrcTokensStore,
+		$icrcDefaultTokensStore,
 		nativeTokenId,
 		(async () => await load())();
 </script>

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -1,5 +1,5 @@
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
-import { icrcTokensStore } from '$icp/stores/icrc.store';
+import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { IcToken } from '$icp/types/ic';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
@@ -8,7 +8,7 @@ import { testnets } from '$lib/derived/testnets.derived';
 import { derived, type Readable } from 'svelte/store';
 
 export const icrcDefaultTokens: Readable<IcToken[]> = derived(
-	[icrcTokensStore, testnets],
+	[icrcDefaultTokensStore, testnets],
 	([$icrcTokensStore, $testnets]) =>
 		($icrcTokensStore?.map(({ data: token }) => token) ?? []).filter(
 			(token) => $testnets || !isTokenIcrcTestnet(token)

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -41,6 +41,7 @@ export const saveCustomTokens = async ({
 
 	// Hide tokens that have been disabled
 	const disabledTokens = tokens.filter(({ enabled }) => !enabled);
+	// TODO: this is renamed in this PR but, it's actually a bug. That should be icrcCustomTokensStore
 	disabledTokens.forEach(({ ledgerCanisterId }) => icrcDefaultTokensStore.reset(ledgerCanisterId));
 
 	// Reload all custom tokens for simplicity reason.

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -1,5 +1,5 @@
 import { loadCustomTokens } from '$icp/services/icrc.services';
-import { icrcTokensStore } from '$icp/stores/icrc.store';
+import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setManyCustomTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
@@ -41,7 +41,7 @@ export const saveCustomTokens = async ({
 
 	// Hide tokens that have been disabled
 	const disabledTokens = tokens.filter(({ enabled }) => !enabled);
-	disabledTokens.forEach(({ ledgerCanisterId }) => icrcTokensStore.reset(ledgerCanisterId));
+	disabledTokens.forEach(({ ledgerCanisterId }) => icrcDefaultTokensStore.reset(ledgerCanisterId));
 
 	// Reload all custom tokens for simplicity reason.
 	await loadCustomTokens({ identity });

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -3,7 +3,7 @@ import { ICRC_TOKENS } from '$env/networks.icrc.env';
 import { metadata } from '$icp/api/icrc-ledger.api';
 import { buildIndexedIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
-import { icrcTokensStore } from '$icp/stores/icrc.store';
+import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { IcInterface } from '$icp/types/ic';
 import type { IcrcCustomTokenWithoutId } from '$icp/types/icrc-custom-token';
 import {
@@ -49,7 +49,7 @@ const loadDefaultIcrc = (data: IcInterface): Promise<void> =>
 		request: (params) => requestIcrcMetadata({ ...params, ...data, category: 'default' }),
 		onLoad: loadIcrcData,
 		onCertifiedError: ({ error: err }) => {
-			icrcTokensStore.reset(data.ledgerCanisterId);
+			icrcDefaultTokensStore.reset(data.ledgerCanisterId);
 
 			toastsError({
 				msg: { text: get(i18n).init.error.icrc_canisters },
@@ -80,7 +80,7 @@ const loadIcrcData = ({
 }) => {
 	const data = mapIcrcToken(token);
 	// In the unlikely event of a token not being mapped, we choose to skip it instead of throwing an error. This prevents the token from being displayed and, consequently, from being noticed as missing by the user.
-	nonNullish(data) && icrcTokensStore.set({ data, certified });
+	nonNullish(data) && icrcDefaultTokensStore.set({ data, certified });
 };
 
 const loadIcrcCustomTokens = async (params: {

--- a/src/frontend/src/icp/stores/icrc-default-tokens.store.ts
+++ b/src/frontend/src/icp/stores/icrc-default-tokens.store.ts
@@ -1,4 +1,4 @@
 import { initCertifiedIcrcTokensStore } from '$icp/stores/certified-icrc.store';
 import type { IcToken, IcTokenWithoutId } from '$icp/types/ic';
 
-export const icrcTokensStore = initCertifiedIcrcTokensStore<IcTokenWithoutId, IcToken>();
+export const icrcDefaultTokensStore = initCertifiedIcrcTokensStore<IcTokenWithoutId, IcToken>();


### PR DESCRIPTION
# Motivation

Similarly to Erc20, product want Icrc default tokens provided by Oisy to be toggleable by the users. So, as a first step, to implement the feature we rename `icrcTokensStore` to `icrcDefaultTokensStore` given that it contains the default tokens.
