### PR TITLE
feat: load default and custom icrc tokens with duplicate

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -5,7 +5,7 @@
 	import type { IcToken } from '$icp/types/ic';
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
-	import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
+	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { CKERC20_TO_ERC20_MAX_TRANSACTION_FEE } from '$icp/constants/cketh.constants';
 	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
@@ -34,7 +34,7 @@
 		: undefined;
 
 	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = $enabledIcrcTokens
+	$: tokenCkEth = $icrcTokens
 		.filter(isTokenCkEthLedger)
 		.find(
 			(tokenCkEth) => isTokenIcrcTestnet(tokenCkEth ?? {}) === isTokenIcrcTestnet($token ?? {})

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -13,7 +13,7 @@
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import SkeletonCardWithoutAmount from '$lib/components/ui/SkeletonCardWithoutAmount.svelte';
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
-	import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
+	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
@@ -33,7 +33,7 @@
 			ledgerCanisterId,
 			indexCanisterId,
 			identity: $authStore.identity,
-			icrcTokens: $enabledIcrcTokens
+			icrcTokens: $icrcTokens
 		});
 
 		if (result === 'error' || isNullish(data)) {

--- a/src/frontend/src/icp/derived/ethereum-fee.derived.ts
+++ b/src/frontend/src/icp/derived/ethereum-fee.derived.ts
@@ -1,4 +1,4 @@
-import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
+import { icrcTokens } from '$icp/derived/icrc.derived';
 import type { IcToken, OptionIcCkToken } from '$icp/types/ic';
 import { token } from '$lib/stores/token.store';
 import { nonNullish } from '@dfinity/utils';
@@ -8,7 +8,7 @@ import { derived, type Readable } from 'svelte/store';
  * Ethereum fees for converting ckErc20 in ckEth are paid in ckEth.
  */
 export const ethereumFeeTokenCkEth: Readable<IcToken | undefined> = derived(
-	[token, enabledIcrcTokens],
+	[token, icrcTokens],
 	([$token, $icrcTokens]) => {
 		const feeLedgerCanisterId = ($token as OptionIcCkToken)?.feeLedgerCanisterId;
 		return nonNullish(feeLedgerCanisterId)

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -81,16 +81,19 @@ const icrcCustomTokensToggleable: Readable<IcrcCustomToken[]> = derived(
 		)
 );
 
-const icrcCustomTokensEnabled: Readable<IcrcCustomToken[]> = derived(
+const enabledIcrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
 	[icrcCustomTokens],
 	([$icrcCustomTokens]) => $icrcCustomTokens.filter(({ enabled }) => enabled)
 );
 
+/**
+ * The list of all Icrc tokens.
+ */
 export const icrcTokens: Readable<IcToken[]> = derived(
-	[icrcDefaultTokens, icrcCustomTokensEnabled],
-	([$icrcDefaultTokens, $icrcCustomTokensEnabled]) => [
-		...$icrcDefaultTokens,
-		...$icrcCustomTokensEnabled
+	[icrcDefaultTokensToggleable, icrcCustomTokensToggleable],
+	([$icrcDefaultTokensToggleable, $icrcCustomTokensToggleable]) => [
+		...$icrcDefaultTokensToggleable,
+		...$icrcCustomTokensToggleable
 	]
 );
 

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -97,6 +97,11 @@ export const icrcTokens: Readable<IcToken[]> = derived(
 	]
 );
 
+export const sortedIcrcTokens: Readable<IcToken[]> = derived(
+	[icrcTokens],
+	([$icrcTokens]) => $icrcTokens.sort(sortIcTokens)
+);
+
 /**
  * The list of Icrc tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
  */
@@ -106,9 +111,4 @@ export const enabledIcrcTokens: Readable<IcToken[]> = derived(
 		...$enabledIcrcDefaultTokens,
 		...$enabledIcrcCustomTokens
 	]
-);
-
-export const sortedEnabledIcrcTokens: Readable<IcToken[]> = derived(
-	[enabledIcrcTokens],
-	([$enabledIcrcTokens]) => $enabledIcrcTokens.sort(sortIcTokens)
 );

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -97,9 +97,8 @@ export const icrcTokens: Readable<IcToken[]> = derived(
 	]
 );
 
-export const sortedIcrcTokens: Readable<IcToken[]> = derived(
-	[icrcTokens],
-	([$icrcTokens]) => $icrcTokens.sort(sortIcTokens)
+export const sortedIcrcTokens: Readable<IcToken[]> = derived([icrcTokens], ([$icrcTokens]) =>
+	$icrcTokens.sort(sortIcTokens)
 );
 
 /**

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -7,6 +7,9 @@ import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { testnets } from '$lib/derived/testnets.derived';
 import { derived, type Readable } from 'svelte/store';
 
+/**
+ * The list of Icrc default tokens - i.e. the statically configured Icrc tokens of Oisy + their metadata, unique ids etc. fetched at runtime.
+ */
 export const icrcDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcDefaultTokensStore, testnets],
 	([$icrcTokensStore, $testnets]) =>
@@ -15,6 +18,10 @@ export const icrcDefaultTokens: Readable<IcToken[]> = derived(
 		)
 );
 
+/**
+ * The list of Icrc tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
+ * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "custom token" in the backend.
+ */
 export const icrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
 	[icrcCustomTokensStore],
 	([$icrcCustomTokensStore]) => $icrcCustomTokensStore?.map(({ data: token }) => token) ?? []

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -6,7 +6,7 @@ import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { testnets } from '$lib/derived/testnets.derived';
-import { isNullish } from '@dfinity/utils';
+import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -38,13 +38,14 @@ const icrcDefaultTokensToggleable: Readable<IcTokenToggleable[]> = derived(
 					userLedgerCanisterId === ledgerCanisterId && userIndexCanisterId === indexCanisterId
 			);
 
-			return {
-				ledgerCanisterId,
-				indexCanisterId,
-				...rest,
-				enabled: isNullish(userToken) || userToken.enabled,
-				version: userToken?.version
-			};
+			return mapDefaultTokenToToggleable({
+				defaultToken: {
+					ledgerCanisterId,
+					indexCanisterId,
+					...rest
+				},
+				userToken
+			});
 		})
 );
 

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -97,14 +97,18 @@ export const icrcTokens: Readable<IcToken[]> = derived(
 	]
 );
 
+/**
+ * The list of Icrc tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
+ */
 export const enabledIcrcTokens: Readable<IcToken[]> = derived(
-	[icrcDefaultTokens, enabledIcrcCustomTokens],
-	([$icrcDefaultTokens, $icrcCustomTokensEnabled]) => [
-		...$icrcDefaultTokens,
-		...$icrcCustomTokensEnabled
+	[enabledIcrcDefaultTokens, enabledIcrcCustomTokens],
+	([$enabledIcrcDefaultTokens, $enabledIcrcCustomTokens]) => [
+		...$enabledIcrcDefaultTokens,
+		...$enabledIcrcCustomTokens
 	]
 );
 
-export const sortedIcrcTokens: Readable<IcToken[]> = derived([icrcTokens], ([$icrcTokens]) =>
-	$icrcTokens.sort(sortIcTokens)
+export const sortedIcrcTokens: Readable<IcToken[]> = derived(
+	[enabledIcrcTokens],
+	([$enabledIcrcTokens]) => $enabledIcrcTokens.sort(sortIcTokens)
 );

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -21,6 +21,17 @@ export const icrcDefaultTokens: Readable<IcToken[]> = derived(
 );
 
 /**
+ * A flatten list of the default Icrc Ledger and Index canister Ids.
+ */
+const icrcDefaultTokensCanisterIds: Readable<string[]> = derived(
+	[icrcDefaultTokens],
+	([$icrcDefaultTokens]) =>
+		$icrcDefaultTokens.map(
+			({ ledgerCanisterId, indexCanisterId }) => `${ledgerCanisterId}:${indexCanisterId}`
+		)
+);
+
+/**
  * The list of Icrc tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
  * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "custom token" in the backend.
  */
@@ -47,6 +58,27 @@ const icrcDefaultTokensToggleable: Readable<IcTokenToggleable[]> = derived(
 				userToken
 			});
 		})
+);
+
+/**
+ * The list of default tokens that are enabled - i.e. the list of default Icrc tokens minus those disabled by the user.
+ */
+const enabledIcrcDefaultTokens: Readable<IcToken[]> = derived(
+	[icrcDefaultTokensToggleable],
+	([$icrcDefaultTokensToggleable]) => $icrcDefaultTokensToggleable.filter(({ enabled }) => enabled)
+);
+
+/**
+ * The list of Icrc tokens enabled by the user - i.e. saved in the backend canister as enabled - minus those that duplicate default tokens.
+ * We do so because the default statically configured are those to be used for various feature. This is notably useful for ERC20 <> ckERC20 conversion given that tokens on both sides (ETH an IC) should know about each others ("Twin Token" links).
+ */
+const icrcCustomTokensToggleable: Readable<IcrcCustomToken[]> = derived(
+	[icrcCustomTokens, icrcDefaultTokensCanisterIds],
+	([$icrcCustomTokens, $icrcDefaultTokensCanisterIds]) =>
+		$icrcCustomTokens.filter(
+			({ ledgerCanisterId, indexCanisterId }) =>
+				!$icrcDefaultTokensCanisterIds.includes(`${ledgerCanisterId}:${indexCanisterId}`)
+		)
 );
 
 const icrcCustomTokensEnabled: Readable<IcrcCustomToken[]> = derived(

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -89,14 +89,8 @@ const loadIcrcCustomTokens = async (params: {
 }): Promise<IcrcCustomTokenWithoutId[]> => {
 	const tokens = await listCustomTokens(params);
 
-	const icrcDefaultLedgerIds = ICRC_TOKENS.map(({ ledgerCanisterId }) => ledgerCanisterId);
-
-	// We filter the custom tokens that are enabled and Icrc, but also not part of the default tokens of Oisy.
-	// For example, and for some reason, a user might manually add the ckBTC ledger and index canister again to their list of tokens.
-	// Not an issue per se, but given that the list of tokens is sorted, one token might move, which equals a visual glitch.
-	const icrcTokens = tokens.filter(
-		({ token }) => 'Icrc' in token && !icrcDefaultLedgerIds.includes(token.Icrc.ledger_id.toText())
-	);
+	// We filter the custom tokens that are Icrc (the backend "Custom Token" potentially supports other types).
+	const icrcTokens = tokens.filter(({ token }) => 'Icrc' in token);
 
 	return await loadCustomIcrcTokensData({
 		tokens: icrcTokens,

--- a/src/frontend/src/icp/types/ic-token-toggleable.ts
+++ b/src/frontend/src/icp/types/ic-token-toggleable.ts
@@ -1,0 +1,4 @@
+import type { IcToken } from '$icp/types/ic';
+import type { TokenToggleable } from '$lib/types/token-toggleable';
+
+export type IcTokenToggleable = TokenToggleable<IcToken>;

--- a/src/frontend/src/icp/types/icrc-custom-token.ts
+++ b/src/frontend/src/icp/types/icrc-custom-token.ts
@@ -1,18 +1,14 @@
-import type { CustomToken } from '$declarations/backend/backend.did';
 import type { IcToken, IcTokenWithoutId } from '$icp/types/ic';
 import type { IcrcEnvToken, IcrcEnvTokenMetadata } from '$icp/types/icrc-env-token';
+import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 
 export type IcrcCustomTokenExtra = Pick<IcrcEnvTokenMetadata, 'alternativeName'> &
 	Partial<Pick<IcrcEnvToken, 'indexCanisterVersion'>>;
 
 export type IcTokenWithoutIdExtended = IcTokenWithoutId & IcrcCustomTokenExtra;
 
-export type IcCustomTokenState = Omit<CustomToken, 'token' | 'version'> & {
-	version?: bigint;
-};
+export type IcrcCustomTokenWithoutId = UserTokenState & IcTokenWithoutIdExtended;
 
-export type IcrcCustomTokenWithoutId = IcCustomTokenState & IcTokenWithoutIdExtended;
-
-export type IcrcCustomToken = IcCustomTokenState & IcToken & IcrcCustomTokenExtra;
+export type IcrcCustomToken = TokenToggleable<IcToken> & IcrcCustomTokenExtra;
 
 export type OptionIcrcCustomToken = IcrcCustomToken | undefined | null;

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -1,13 +1,13 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-import { sortedEnabledIcrcTokens } from '$icp/derived/icrc.derived';
+import { sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
 export const tokens: Readable<Token[]> = derived(
-	[erc20Tokens, sortedEnabledIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
+	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
 	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
 		...$enabledEthereumTokens,


### PR DESCRIPTION
# Motivation

Product want to allow user to disable or enable default Icrc tokens. Default tokens are provided in the frontend and user, upon disabled or enabling custom tokens, save a copy of the information with the related state in the backend. So, when Oisy load tokens it loads default and custom tokens and the latest might contains duplication of the first. Likewise, a default might have been disabled.

That's why, similarly to Erc20, the icrc derived tokens should merge those information.
