### PR TITLE
refactor: rename icrcTokens to enabledIcrcTokens

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -5,7 +5,7 @@
 	import type { IcToken } from '$icp/types/ic';
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
-	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { CKERC20_TO_ERC20_MAX_TRANSACTION_FEE } from '$icp/constants/cketh.constants';
 	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
@@ -33,7 +33,7 @@
 		: undefined;
 
 	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = $icrcTokens.find(isTokenCkEthLedger);
+	$: tokenCkEth = $enabledIcrcTokens.find(isTokenCkEthLedger);
 
 	let maxTransactionFeePlusEthLedgerApprove: bigint | undefined = undefined;
 	$: maxTransactionFeePlusEthLedgerApprove = nonNullish(maxTransactionFeeEth)

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -13,7 +13,7 @@
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import SkeletonCardWithoutAmount from '$lib/components/ui/SkeletonCardWithoutAmount.svelte';
 	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
-	import { icrcTokens } from '$icp/derived/icrc.derived';
+	import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
@@ -33,7 +33,7 @@
 			ledgerCanisterId,
 			indexCanisterId,
 			identity: $authStore.identity,
-			icrcTokens: $icrcTokens
+			icrcTokens: $enabledIcrcTokens
 		});
 
 		if (result === 'error' || isNullish(data)) {

--- a/src/frontend/src/icp/derived/ethereum-fee.derived.ts
+++ b/src/frontend/src/icp/derived/ethereum-fee.derived.ts
@@ -1,4 +1,4 @@
-import { icrcTokens } from '$icp/derived/icrc.derived';
+import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcToken, OptionIcCkToken } from '$icp/types/ic';
 import { token } from '$lib/stores/token.store';
 import { nonNullish } from '@dfinity/utils';
@@ -8,7 +8,7 @@ import { derived, type Readable } from 'svelte/store';
  * Ethereum fees for converting ckErc20 in ckEth are paid in ckEth.
  */
 export const ethereumFeeTokenCkEth: Readable<IcToken | undefined> = derived(
-	[token, icrcTokens],
+	[token, enabledIcrcTokens],
 	([$token, $icrcTokens]) => {
 		const feeLedgerCanisterId = ($token as OptionIcCkToken)?.feeLedgerCanisterId;
 		return nonNullish(feeLedgerCanisterId)

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -25,7 +25,7 @@ const icrcCustomTokensEnabled: Readable<IcrcCustomToken[]> = derived(
 	([$icrcCustomTokens]) => $icrcCustomTokens.filter(({ enabled }) => enabled)
 );
 
-export const icrcTokens: Readable<IcToken[]> = derived(
+export const enabledIcrcTokens: Readable<IcToken[]> = derived(
 	[icrcDefaultTokens, icrcCustomTokensEnabled],
 	([$icrcDefaultTokens, $icrcCustomTokensEnabled]) => [
 		...$icrcDefaultTokens,
@@ -33,6 +33,6 @@ export const icrcTokens: Readable<IcToken[]> = derived(
 	]
 );
 
-export const sortedIcrcTokens: Readable<IcToken[]> = derived([icrcTokens], ([$icrcTokens]) =>
+export const sortedIcrcTokens: Readable<IcToken[]> = derived([enabledIcrcTokens], ([$icrcTokens]) =>
 	$icrcTokens.sort(sortIcTokens)
 );

--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -1,7 +1,7 @@
 import { ETHEREUM_TOKEN_ID, ICP_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens.env';
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import type { Erc20Token } from '$eth/types/erc20';
-import { icrcTokens } from '$icp/derived/icrc.derived';
+import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcCkToken } from '$icp/types/ic';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import type { ExchangesData } from '$lib/types/exchange';
@@ -13,7 +13,7 @@ export const exchangeInitialized: Readable<boolean> = derived([exchangeStore], (
 );
 
 export const exchanges: Readable<ExchangesData> = derived(
-	[exchangeStore, enabledErc20Tokens, icrcTokens],
+	[exchangeStore, enabledErc20Tokens, enabledIcrcTokens],
 	([$exchangeStore, $erc20Tokens, $icrcTokens]) => {
 		const ethPrice = $exchangeStore?.ethereum;
 		const btcPrice = $exchangeStore?.bitcoin;

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -1,6 +1,6 @@
 import { ETHEREUM_TOKEN, ICP_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
-import { icrcTokens } from '$icp/derived/icrc.derived';
+import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import { routeToken } from '$lib/derived/nav.derived';
 import type { OptionToken } from '$lib/types/token';
 import { isNullish } from '@dfinity/utils';
@@ -10,7 +10,7 @@ import { derived, type Readable } from 'svelte/store';
  * A token derived from the route URL - i.e. if the URL contains a query parameters "token", then this store tries to derive the object from it.
  */
 export const pageToken: Readable<OptionToken> = derived(
-	[routeToken, enabledErc20Tokens, icrcTokens],
+	[routeToken, enabledErc20Tokens, enabledIcrcTokens],
 	([$routeToken, $erc20Tokens, $icrcTokens]) => {
 		if (isNullish($routeToken)) {
 			return undefined;


### PR DESCRIPTION
# Motivation

In #1610 we have a split between all and enabled Icrc tokens. So similarly to erc20, it makes sense to rename `icrcTokens` into `enabledIcrcTokens`.
