### PR TITLE
fix: find tokenCkEth to calculate ETH fee on IC

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -15,6 +15,7 @@
 		type EthereumFeeContext
 	} from '$icp/stores/ethereum-fee.store';
 	import { token } from '$lib/stores/token.store';
+	import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 
 	export let networkId: NetworkId | undefined = undefined;
 
@@ -33,7 +34,11 @@
 		: undefined;
 
 	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = $enabledIcrcTokens.find(isTokenCkEthLedger);
+	$: tokenCkEth = $enabledIcrcTokens
+		.filter(isTokenCkEthLedger)
+		.find(
+			(tokenCkEth) => isTokenIcrcTestnet(tokenCkEth ?? {}) === isTokenIcrcTestnet($token ?? {})
+		);
 
 	let maxTransactionFeePlusEthLedgerApprove: bigint | undefined = undefined;
 	$: maxTransactionFeePlusEthLedgerApprove = nonNullish(maxTransactionFeeEth)


### PR DESCRIPTION
# Motivation

There could be two ETH ledger canister IDs on IC network - a production and staging. So, we actually need to compare the type to be sure we select the correct token to calculate the ETH fee on IC.
