### PR TITLE
feat: display max three toasts on screen

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -101,5 +101,5 @@
 {/await}
 
 <Banner />
-<Toasts />
+<Toasts maxVisible={3} />
 <Busy />


### PR DESCRIPTION
# Motivation

There could be lots of errors which lead the screen to be flooded with toasts. We can probably solve this gracefully by filtering the memory and state, but as a pragmatic first step, we can limit the number of toasts displayed on screen.
