### PR TITLE
chore: run tokens cron twice a week

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -3,6 +3,7 @@ name: Update Tokens
 on:
   schedule:
     - cron: '30 3 * * MON'
+    - cron: '30 3 * * THU'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Motivation

We can run the job to detects sns and tokens a bit more often.
