### PR TITLE
refactor: rename eth modal event

### DIFF
--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -3,7 +3,7 @@ import { derived, type Readable } from 'svelte/store';
 
 export const modalReceive: Readable<boolean> = derived(
 	modalStore,
-	($modalStore) => $modalStore?.type === 'receive'
+	($modalStore) => $modalStore?.type === 'eth-receive'
 );
 export const modalIcpReceive: Readable<boolean> = derived(
 	modalStore,

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -3,7 +3,7 @@ import { writable } from 'svelte/store';
 
 export interface Modal<T> {
 	type:
-		| 'receive'
+		| 'eth-receive'
 		| 'icp-receive'
 		| 'icrc-receive'
 		| 'ckbtc-receive'
@@ -60,7 +60,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 	const { subscribe, set } = writable<ModalData<T>>(undefined);
 
 	return {
-		openReceive: <D extends T>(data: D) => set({ type: 'receive', data }),
+		openReceive: <D extends T>(data: D) => set({ type: 'eth-receive', data }),
 		openIcpReceive: <D extends T>(data: D) => set({ type: 'icp-receive', data }),
 		openIcrcReceive: <D extends T>(data: D) => set({ type: 'icrc-receive', data }),
 		openCkBTCReceive: <D extends T>(data: D) => set({ type: 'ckbtc-receive', data }),


### PR DESCRIPTION
# Motivation

A bit more descriptive event that way we can add a more generic event for chain fusion.
