### PR TITLE
chore: remove unused to_string()

### DIFF
--- a/src/backend/tests/it/address.rs
+++ b/src/backend/tests/it/address.rs
@@ -6,7 +6,7 @@ use candid::Principal;
 fn test_caller_eth_address() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let address = update_call::<String>(&pic_setup, caller, "caller_eth_address", ())
         .expect("Failed to call eth address.");
@@ -18,7 +18,7 @@ fn test_caller_eth_address() {
 fn test_eth_address_of() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let address = update_call::<String>(&pic_setup, caller, "eth_address_of", caller)
         .expect("Failed to call eth address of.");
@@ -44,7 +44,7 @@ fn test_anonymous_cannot_call_eth_address() {
 fn test_non_allowed_caller_cannot_call_eth_address_of() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let address =
         update_call::<String>(&pic_setup, Principal::anonymous(), "eth_address_of", caller);
@@ -57,7 +57,7 @@ fn test_non_allowed_caller_cannot_call_eth_address_of() {
 fn test_cannot_call_eth_address_of_for_anonymous() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let address =
         update_call::<String>(&pic_setup, caller, "eth_address_of", Principal::anonymous());

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -50,7 +50,7 @@ fn test_add_custom_token_without_index() {
 fn test_add_custom_token(user_token: &CustomToken) {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_custom_token", user_token.clone());
 
@@ -70,7 +70,7 @@ fn test_update_custom_token_without_index() {
 fn test_update_custom_token(user_token: &CustomToken) {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_custom_token", user_token.clone());
 
@@ -121,7 +121,7 @@ fn test_add_many_custom_tokens_without_index() {
 fn test_add_many_custom_tokens(user_token: &CustomToken) {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let tokens: Vec<CustomToken> = vec![user_token.clone(), ANOTHER_USER_TOKEN.clone()];
 
@@ -143,7 +143,7 @@ fn test_update_many_custom_tokens_without_index() {
 fn test_update_many_custom_tokens(user_token: &CustomToken) {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let tokens: Vec<CustomToken> = vec![user_token.clone(), ANOTHER_USER_TOKEN.clone()];
 
@@ -204,7 +204,7 @@ fn test_update_many_custom_tokens(user_token: &CustomToken) {
 fn test_list_custom_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let _ = update_call::<()>(&pic_setup, caller, "set_custom_token", USER_TOKEN.clone());
 
@@ -242,7 +242,7 @@ fn test_cannot_update_custom_token_without_version_without_index() {
 fn test_cannot_update_custom_token_without_version(user_token: &CustomToken) {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_custom_token", user_token.clone());
 
@@ -276,7 +276,7 @@ fn test_cannot_update_custom_token_with_invalid_version_without_index() {
 fn test_cannot_update_custom_token_with_invalid_version(user_token: &CustomToken) {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_custom_token", user_token.clone());
 
@@ -337,7 +337,7 @@ fn test_anonymous_cannot_list_custom_tokens() {
 fn test_user_cannot_list_another_custom_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let _ = update_call::<()>(&pic_setup, caller, "set_custom_token", USER_TOKEN.clone());
 

--- a/src/backend/tests/it/sign.rs
+++ b/src/backend/tests/it/sign.rs
@@ -18,7 +18,7 @@ fn test_sign_transaction() {
         data: None,
     };
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let transaction = update_call::<String>(&pic_setup, caller, "sign_transaction", sign_request);
 
@@ -32,7 +32,7 @@ fn test_sign_transaction() {
 fn test_personal_sign() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let transaction = update_call::<String>(
         &pic_setup,
@@ -51,7 +51,7 @@ fn test_personal_sign() {
 fn test_cannot_personal_sign_if_message_is_not_hex_string() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<String>(
         &pic_setup,
@@ -79,7 +79,7 @@ fn test_cannot_sign_transaction_with_invalid_to_address() {
         data: None,
     };
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<String>(&pic_setup, caller, "sign_transaction", sign_request);
 

--- a/src/backend/tests/it/token.rs
+++ b/src/backend/tests/it/token.rs
@@ -27,7 +27,7 @@ lazy_static! {
 fn test_add_user_token() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
@@ -38,7 +38,7 @@ fn test_add_user_token() {
 fn test_update_user_token() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
@@ -74,7 +74,7 @@ fn test_update_user_token() {
 fn test_remove_user_token() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let add_result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
@@ -94,7 +94,7 @@ fn test_remove_user_token() {
 fn test_list_user_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let _ = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
@@ -127,7 +127,7 @@ fn test_list_user_tokens() {
 fn test_cannot_update_user_token_without_version() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
@@ -152,7 +152,7 @@ fn test_cannot_update_user_token_without_version() {
 fn test_cannot_update_user_token_with_invalid_version() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 
@@ -177,7 +177,7 @@ fn test_cannot_update_user_token_with_invalid_version() {
 fn test_add_user_token_symbol_max_length() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let token: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
@@ -254,7 +254,7 @@ fn test_anonymous_cannot_list_user_tokens() {
 fn test_user_cannot_list_another_user_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let _ = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
 

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -32,7 +32,7 @@ fn test_upgrade_user_token() {
     let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH);
 
     // Add a user token
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(
         &pic_setup,
@@ -65,7 +65,7 @@ fn test_update_user_token_after_upgrade() {
     let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH);
 
     // Add a user token
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(
         &pic_setup,

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -34,7 +34,7 @@ fn test_upgrade_user_token() {
     let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
 
     // Add a user token
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(
         &pic_setup,
@@ -67,7 +67,7 @@ fn test_upgrade_allowed_caller_eth_address_of() {
     let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
 
     // Caller is allowed to call eth_address_of
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<String>(&pic_setup, caller, "eth_address_of", caller);
     assert!(result.is_ok());
@@ -106,7 +106,7 @@ fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgr
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Add a user token
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let mut token = POST_UPGRADE_TOKEN.clone();
     // The version number should be ignored but we can check that.
@@ -138,7 +138,7 @@ fn test_update_user_token_after_upgrade() {
     let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
 
     // Add a user token
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(
         &pic_setup,

--- a/src/backend/tests/it/user_token.rs
+++ b/src/backend/tests/it/user_token.rs
@@ -35,7 +35,7 @@ lazy_static! {
 fn test_add_user_token() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
@@ -46,7 +46,7 @@ fn test_add_user_token() {
 fn test_add_many_custom_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let tokens: Vec<UserToken> = vec![MOCK_TOKEN.clone(), ANOTHER_TOKEN.clone()];
 
@@ -59,7 +59,7 @@ fn test_add_many_custom_tokens() {
 fn test_update_user_token() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
@@ -95,7 +95,7 @@ fn test_update_user_token() {
 fn test_update_many_user_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let tokens: Vec<UserToken> = vec![MOCK_TOKEN.clone(), ANOTHER_TOKEN.clone()];
 
@@ -156,7 +156,7 @@ fn test_update_many_user_tokens() {
 fn test_disable_user_token() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
@@ -192,7 +192,7 @@ fn test_disable_user_token() {
 fn test_list_user_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let _ = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
@@ -216,7 +216,7 @@ fn test_list_user_tokens() {
 fn test_cannot_update_user_token_without_version() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
@@ -241,7 +241,7 @@ fn test_cannot_update_user_token_without_version() {
 fn test_cannot_update_user_token_with_invalid_version() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
@@ -266,7 +266,7 @@ fn test_cannot_update_user_token_with_invalid_version() {
 fn test_set_user_token_enabled_none() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let token: UserToken = UserToken {
         enabled: None,
@@ -285,7 +285,7 @@ fn test_set_user_token_enabled_none() {
 fn test_set_many_user_tokens_enabled_none() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let token: UserToken = UserToken {
         enabled: None,
@@ -306,7 +306,7 @@ fn test_set_many_user_tokens_enabled_none() {
 fn test_set_user_token_symbol_max_length() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let token: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
@@ -329,7 +329,7 @@ fn test_set_user_token_symbol_max_length() {
 fn test_set_user_many_tokens_symbol_max_length() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let token: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
@@ -390,7 +390,7 @@ fn test_anonymous_cannot_list_user_tokens() {
 fn test_user_cannot_list_another_user_tokens() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER.to_string()).unwrap();
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let _ = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 


### PR DESCRIPTION
# Motivation

We do not need to cast `CALLER.to_string()` in our test. Just `CALLER` is fine.
