### PR TITLE
feat(backend): deprecate add_user_token

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -60,7 +60,6 @@ type UserToken = record {
 };
 type UserTokenId = record { chain_id : nat64; contract_address : text };
 service : (Arg) -> {
-  add_user_token : (UserToken) -> ();
   caller_eth_address : () -> (text);
   eth_address_of : (principal) -> (text);
   get_canister_status : () -> (CanisterStatusResultV2);

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -381,14 +381,6 @@ async fn sign_prehash(prehash: String) -> String {
     format!("0x{}", hex::encode(&signature))
 }
 
-/// Adds a new token to the user.
-#[deprecated(since = "0.0.4", note = "Use set_user_token")]
-#[update(guard = "caller_is_not_anonymous")]
-#[allow(clippy::needless_pass_by_value)]
-fn add_user_token(token: UserToken) {
-    set_user_token(token);
-}
-
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(clippy::needless_pass_by_value)]
 fn set_user_token(token: UserToken) {

--- a/src/backend/tests/it/token.rs
+++ b/src/backend/tests/it/token.rs
@@ -29,7 +29,7 @@ fn test_add_user_token() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     assert!(result.is_ok());
 }
@@ -40,7 +40,7 @@ fn test_update_user_token() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     assert!(result.is_ok());
 
@@ -55,7 +55,7 @@ fn test_update_user_token() {
     };
 
     let update_result =
-        update_call::<()>(&pic_setup, caller, "add_user_token", update_token.clone());
+        update_call::<()>(&pic_setup, caller, "set_user_token", update_token.clone());
 
     assert!(update_result.is_ok());
 
@@ -76,7 +76,7 @@ fn test_remove_user_token() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let add_result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let add_result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     assert!(add_result.is_ok());
 
@@ -96,7 +96,7 @@ fn test_list_user_tokens() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let _ = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let _ = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     let another_token: UserToken = UserToken {
         chain_id: SEPOLIA_CHAIN_ID,
@@ -107,7 +107,7 @@ fn test_list_user_tokens() {
         enabled: Some(false),
     };
 
-    let _ = update_call::<()>(&pic_setup, caller, "add_user_token", another_token.clone());
+    let _ = update_call::<()>(&pic_setup, caller, "set_user_token", another_token.clone());
 
     let results = query_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
 
@@ -129,7 +129,7 @@ fn test_cannot_update_user_token_without_version() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     assert!(result.is_ok());
 
@@ -140,7 +140,7 @@ fn test_cannot_update_user_token_without_version() {
     };
 
     let update_result =
-        update_call::<()>(&pic_setup, caller, "add_user_token", update_token.clone());
+        update_call::<()>(&pic_setup, caller, "set_user_token", update_token.clone());
 
     assert!(update_result.is_err());
     assert!(update_result
@@ -154,7 +154,7 @@ fn test_cannot_update_user_token_with_invalid_version() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let result = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let result = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     assert!(result.is_ok());
 
@@ -165,7 +165,7 @@ fn test_cannot_update_user_token_with_invalid_version() {
     };
 
     let update_result =
-        update_call::<()>(&pic_setup, caller, "add_user_token", update_token.clone());
+        update_call::<()>(&pic_setup, caller, "set_user_token", update_token.clone());
 
     assert!(update_result.is_err());
     assert!(update_result
@@ -188,7 +188,7 @@ fn test_add_user_token_symbol_max_length() {
         enabled: Some(true),
     };
 
-    let result = update_call::<()>(&pic_setup, caller, "add_user_token", token);
+    let result = update_call::<()>(&pic_setup, caller, "set_user_token", token);
 
     assert!(result.is_err());
     assert!(result
@@ -203,7 +203,7 @@ fn test_anonymous_cannot_add_user_token() {
     let result = update_call::<()>(
         &pic_setup,
         Principal::anonymous(),
-        "add_user_token",
+        "set_user_token",
         MOCK_TOKEN.clone(),
     );
 
@@ -256,7 +256,7 @@ fn test_user_cannot_list_another_user_tokens() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let _ = update_call::<()>(&pic_setup, caller, "add_user_token", MOCK_TOKEN.clone());
+    let _ = update_call::<()>(&pic_setup, caller, "set_user_token", MOCK_TOKEN.clone());
 
     let another_caller =
         Principal::from_text("yaa3n-twfur-6xz6e-3z7ep-xln56-222kz-w2b2m-y5wqz-vu6kk-s3fdg-lqe")

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -70,7 +70,7 @@ fn test_update_user_token_after_upgrade() {
     let result = update_call::<()>(
         &pic_setup,
         caller,
-        "add_user_token",
+        "set_user_token",
         PRE_UPGRADE_TOKEN.clone(),
     );
 
@@ -92,7 +92,7 @@ fn test_update_user_token_after_upgrade() {
     };
 
     let update_result =
-        update_call::<()>(&pic_setup, caller, "add_user_token", update_token.clone());
+        update_call::<()>(&pic_setup, caller, "set_user_token", update_token.clone());
 
     assert!(update_result.is_ok());
 

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -70,7 +70,7 @@ fn test_update_user_token_after_upgrade() {
     let result = update_call::<()>(
         &pic_setup,
         caller,
-        "set_user_token",
+        "add_user_token",
         PRE_UPGRADE_TOKEN.clone(),
     );
 

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -165,7 +165,7 @@ fn test_update_user_token_after_upgrade() {
     };
 
     let update_result =
-        update_call::<()>(&pic_setup, caller, "add_user_token", update_token.clone());
+        update_call::<()>(&pic_setup, caller, "set_user_token", update_token.clone());
 
     assert!(update_result.is_ok());
 

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -60,7 +60,6 @@ type UserToken = record {
 };
 type UserTokenId = record { chain_id : nat64; contract_address : text };
 service : (Arg) -> {
-  add_user_token : (UserToken) -> ();
   caller_eth_address : () -> (text);
   eth_address_of : (principal) -> (text);
   get_canister_status : () -> (CanisterStatusResultV2);

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -70,7 +70,6 @@ export interface UserTokenId {
 	contract_address: string;
 }
 export interface _SERVICE {
-	add_user_token: ActorMethod<[UserToken], undefined>;
 	caller_eth_address: ActorMethod<[], string>;
 	eth_address_of: ActorMethod<[Principal], string>;
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -5,14 +5,6 @@ export const idlFactory = ({ IDL }) => {
 		allowed_callers: IDL.Vec(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
-	const UserToken = IDL.Record({
-		decimals: IDL.Opt(IDL.Nat8),
-		version: IDL.Opt(IDL.Nat64),
-		enabled: IDL.Opt(IDL.Bool),
-		chain_id: IDL.Nat64,
-		contract_address: IDL.Text,
-		symbol: IDL.Opt(IDL.Text)
-	});
 	const CanisterStatusType = IDL.Variant({
 		stopped: IDL.Null,
 		stopping: IDL.Null,
@@ -57,6 +49,14 @@ export const idlFactory = ({ IDL }) => {
 		version: IDL.Opt(IDL.Nat64),
 		enabled: IDL.Bool
 	});
+	const UserToken = IDL.Record({
+		decimals: IDL.Opt(IDL.Nat8),
+		version: IDL.Opt(IDL.Nat64),
+		enabled: IDL.Opt(IDL.Bool),
+		chain_id: IDL.Nat64,
+		contract_address: IDL.Text,
+		symbol: IDL.Opt(IDL.Text)
+	});
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -72,7 +72,6 @@ export const idlFactory = ({ IDL }) => {
 		nonce: IDL.Nat
 	});
 	return IDL.Service({
-		add_user_token: IDL.Func([UserToken], [], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -5,14 +5,6 @@ export const idlFactory = ({ IDL }) => {
 		allowed_callers: IDL.Vec(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
-	const UserToken = IDL.Record({
-		decimals: IDL.Opt(IDL.Nat8),
-		version: IDL.Opt(IDL.Nat64),
-		enabled: IDL.Opt(IDL.Bool),
-		chain_id: IDL.Nat64,
-		contract_address: IDL.Text,
-		symbol: IDL.Opt(IDL.Text)
-	});
 	const CanisterStatusType = IDL.Variant({
 		stopped: IDL.Null,
 		stopping: IDL.Null,
@@ -57,6 +49,14 @@ export const idlFactory = ({ IDL }) => {
 		version: IDL.Opt(IDL.Nat64),
 		enabled: IDL.Bool
 	});
+	const UserToken = IDL.Record({
+		decimals: IDL.Opt(IDL.Nat8),
+		version: IDL.Opt(IDL.Nat64),
+		enabled: IDL.Opt(IDL.Bool),
+		chain_id: IDL.Nat64,
+		contract_address: IDL.Text,
+		symbol: IDL.Opt(IDL.Text)
+	});
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -72,7 +72,6 @@ export const idlFactory = ({ IDL }) => {
 		nonce: IDL.Nat
 	});
 	return IDL.Service({
-		add_user_token: IDL.Func([UserToken], [], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),


### PR DESCRIPTION
# Motivation

`add_user_token` is deprecated and its replacement, `set_many_user_tokens` is implemented both in the backend and frontend. Both canisters will be released and deployed at the same time.

# Changes

- Remove `add_user_token`.
- Update tests to use `set_user_token` when function is available - i.e. newest wasm.
