### PR TITLE
fix: load oisy when user has now erc20 user token

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -6,7 +6,6 @@ import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
-import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -107,7 +106,7 @@ export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
 
 export const erc20UserTokensInitialized: Readable<boolean> = derived(
 	[erc20UserTokensStore],
-	([$erc20UserTokensStore]) => nonNullish($erc20UserTokensStore)
+	([$erc20UserTokensStore]) => $erc20UserTokensStore !== undefined
 );
 
 export const erc20UserTokensNotInitialized: Readable<boolean> = derived(

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -71,7 +71,7 @@ export const loadUserTokens = ({ identity }: { identity: OptionIdentity }): Prom
 		request: (params) => loadErc20UserTokens(params),
 		onLoad: loadErc20UserTokenData,
 		onCertifiedError: ({ error: err }) => {
-			erc20UserTokensStore.clear();
+			erc20UserTokensStore.resetAll();
 
 			toastsError({
 				msg: { text: get(i18n).init.error.erc20_user_tokens },
@@ -135,10 +135,5 @@ const loadErc20UserTokenData = ({
 	certified: boolean;
 	response: Erc20UserToken[];
 }) => {
-	tokens.forEach((token) =>
-		erc20UserTokensStore.set({
-			data: token,
-			certified
-		})
-	);
+	erc20UserTokensStore.set(tokens.map((token) => ({ data: token, certified })));
 };

--- a/src/frontend/src/eth/stores/erc20-user-tokens.store.ts
+++ b/src/frontend/src/eth/stores/erc20-user-tokens.store.ts
@@ -6,19 +6,22 @@ import { writable, type Readable } from 'svelte/store';
 export type CertifiedErc20UserTokensData = CertifiedData<Erc20UserToken>[] | undefined | null;
 
 export interface CertifiedErc20UserTokensStore extends Readable<CertifiedErc20UserTokensData> {
-	set: (token: CertifiedData<Erc20UserToken>) => void;
+	set: (tokens: CertifiedData<Erc20UserToken>[]) => void;
 	reset: (tokenId: TokenId) => void;
-	clear: () => void;
+	resetAll: () => void;
 }
 
 export const initCertifiedErc20UserTokensStore = (): CertifiedErc20UserTokensStore => {
 	const { subscribe, update, set } = writable<CertifiedErc20UserTokensData>(undefined);
 
 	return {
-		set: ({ data, certified }: CertifiedData<Erc20UserToken>) =>
+		set: (tokens: CertifiedData<Erc20UserToken>[]) =>
 			update((state) => [
-				...(state ?? []).filter(({ data: { address } }) => address !== data.address),
-				{
+				...(state ?? []).filter(
+					({ data: { address } }) =>
+						!tokens.map(({ data: { address } }) => address).includes(address)
+				),
+				...tokens.map(({ data, certified }) => ({
 					certified,
 					data: {
 						...data,
@@ -28,11 +31,11 @@ export const initCertifiedErc20UserTokensStore = (): CertifiedErc20UserTokensSto
 							(state ?? []).find(({ data: { address } }) => address === data.address)?.data.id ??
 							data.id
 					}
-				}
+				}))
 			]),
 		reset: (tokenId: TokenId) =>
 			update((state) => [...(state ?? []).filter(({ data: { id } }) => id !== tokenId)]),
-		clear: () => set(null),
+		resetAll: () => set(null),
 		subscribe
 	};
 };


### PR DESCRIPTION
# Motivation

After deploying on Staging we noticed that the skeleton never fade away. The root cause of the issue is user who do not have user tokens. Because no tokens are loaded, the store stays undefined, because undefined, skeletons are displayed for ever.

# Changes

- If not tokens then load an empty array in store.