### PR TITLE
refactor: rename setAll for store

### DIFF
--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -135,5 +135,5 @@ const loadErc20UserTokenData = ({
 	certified: boolean;
 	response: Erc20UserToken[];
 }) => {
-	erc20UserTokensStore.set(tokens.map((token) => ({ data: token, certified })));
+	erc20UserTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
 };

--- a/src/frontend/src/eth/stores/erc20-user-tokens.store.ts
+++ b/src/frontend/src/eth/stores/erc20-user-tokens.store.ts
@@ -6,7 +6,7 @@ import { writable, type Readable } from 'svelte/store';
 export type CertifiedErc20UserTokensData = CertifiedData<Erc20UserToken>[] | undefined | null;
 
 export interface CertifiedErc20UserTokensStore extends Readable<CertifiedErc20UserTokensData> {
-	set: (tokens: CertifiedData<Erc20UserToken>[]) => void;
+	setAll: (tokens: CertifiedData<Erc20UserToken>[]) => void;
 	reset: (tokenId: TokenId) => void;
 	resetAll: () => void;
 }
@@ -15,7 +15,7 @@ export const initCertifiedErc20UserTokensStore = (): CertifiedErc20UserTokensSto
 	const { subscribe, update, set } = writable<CertifiedErc20UserTokensData>(undefined);
 
 	return {
-		set: (tokens: CertifiedData<Erc20UserToken>[]) =>
+		setAll: (tokens: CertifiedData<Erc20UserToken>[]) =>
 			update((state) => [
 				...(state ?? []).filter(
 					({ data: { address } }) =>


### PR DESCRIPTION
# Motivation

For consistency reason rename to `setAll` the setter in the erc20 user tokens store.
