### PR TITLE
fix(frontend): sns tokens not listed in manage tokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { IconClose, Input } from '@dfinity/gix-components';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -13,7 +13,7 @@
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import { ICP_TOKEN } from '$env/tokens.env';
-	import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
+	import { icTokenIcrcCustomToken, sortIcTokens } from '$icp/utils/icrc.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import type { Token } from '$lib/types/token';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
@@ -28,13 +28,33 @@
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
-	import { networkTokens } from '$lib/derived/network-tokens.derived';
+	import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
+	import type { LedgerCanisterIdText } from '$icp/types/canister';
+	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 
 	const dispatch = createEventDispatcher();
 
+	// The list of ICRC tokens (SNSes) is defined as environment variables.
+	// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
+	let icrcEnvTokens: IcrcCustomToken[] = [];
+	onMount(() => {
+		const tokens = buildIcrcCustomTokens();
+		icrcEnvTokens =
+			tokens?.map((token) => ({ ...token, id: Symbol(token.symbol), enabled: false })) ?? [];
+	});
+
+	// All the Icrc ledger ids including the default tokens and the user custom tokens regardless if enabled or disabled.
+	let knownLedgerCanisterIds: LedgerCanisterIdText[] = [];
+	$: knownLedgerCanisterIds = $icrcTokens.map(({ ledgerCanisterId }) => ledgerCanisterId);
+
 	// The entire list of tokens to display to the user.
 	let allIcrcTokens: IcrcCustomToken[] = [];
-	$: allIcrcTokens = $icrcTokens;
+	$: allIcrcTokens = [
+		...$icrcTokens,
+		...icrcEnvTokens.filter(
+			({ ledgerCanisterId }) => !knownLedgerCanisterIds.includes(ledgerCanisterId)
+		)
+	].sort(sortIcTokens);
 
 	let allErc20Tokens: EthereumUserToken[] = [];
 	$: allErc20Tokens = $erc20Tokens;
@@ -47,17 +67,19 @@
 
 	// TODO: Bitcoin tokens ($enabledBitcoinTokens) are not included yet.
 	let allTokens: Token[] = [];
-	$: allTokens = [
-		{
-			...ICP_TOKEN,
-			enabled: true
-		},
-		...$enabledEthereumTokens.map((token) => ({ ...token, enabled: true })),
-		...(manageEthereumTokens ? allErc20Tokens : []),
-		...(manageIcTokens ? allIcrcTokens : [])
-	].filter(({ id: tokenId }) =>
-		$networkTokens.some(({ id: networkTokenId }) => tokenId === networkTokenId)
-	);
+	$: allTokens = filterTokensForSelectedNetwork([
+		[
+			{
+				...ICP_TOKEN,
+				enabled: true
+			},
+			...$enabledEthereumTokens.map((token) => ({ ...token, enabled: true })),
+			...(manageEthereumTokens ? allErc20Tokens : []),
+			...(manageIcTokens ? allIcrcTokens : [])
+		],
+		$selectedNetwork,
+		$pseudoNetworkChainFusion
+	]);
 
 	let filterTokens = '';
 	const updateFilter = () => (filterTokens = filter);

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -47,7 +47,8 @@
 	let knownLedgerCanisterIds: LedgerCanisterIdText[] = [];
 	$: knownLedgerCanisterIds = $icrcTokens.map(({ ledgerCanisterId }) => ledgerCanisterId);
 
-	// The entire list of tokens to display to the user.
+	// The entire list of ICRC tokens to display to the user:
+	// This includes the default tokens (disabled or enabled), the custom tokens (disabled or enabled), and the environment tokens that have never been used.
 	let allIcrcTokens: IcrcCustomToken[] = [];
 	$: allIcrcTokens = [
 		...$icrcTokens,
@@ -56,6 +57,7 @@
 		)
 	].sort(sortIcTokens);
 
+	// The entire list of Erc20 tokens to display to the user.
 	let allErc20Tokens: EthereumUserToken[] = [];
 	$: allErc20Tokens = $erc20Tokens;
 

--- a/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
@@ -23,7 +23,7 @@ export const buildIndexedIcrcCustomTokens = (): Record<
 		{}
 	);
 
-const buildIcrcCustomTokens = (): IcTokenWithoutIdExtended[] => {
+export const buildIcrcCustomTokens = (): IcTokenWithoutIdExtended[] => {
 	try {
 		const tokens = icrcEnvTokens
 			.parse(

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,6 +1,5 @@
 import { ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS } from '$env/networks.icrc.env';
 import { ETHEREUM_TOKEN_ID, ICP_TOKEN_ID } from '$env/tokens.env';
-import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import {
 	notPseudoNetworkChainFusion,
 	pseudoNetworkChainFusion,
@@ -9,6 +8,7 @@ import {
 import { tokens } from '$lib/derived/tokens.derived';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { Token } from '$lib/types/token';
+import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -16,19 +16,7 @@ import { derived, type Readable } from 'svelte/store';
  */
 export const networkTokens: Readable<Token[]> = derived(
 	[tokens, selectedNetwork, pseudoNetworkChainFusion],
-	([$tokens, $selectedNetwork, $pseudoNetworkChainFusion]) =>
-		$tokens.filter((token) => {
-			const {
-				network: { id: networkId }
-			} = token;
-
-			return (
-				($pseudoNetworkChainFusion &&
-					!isTokenIcrcTestnet(token) &&
-					token.network.env !== 'testnet') ||
-				$selectedNetwork?.id === networkId
-			);
-		})
+	filterTokensForSelectedNetwork
 );
 
 export const enabledNetworkTokens: Readable<Token[]> = derived(

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -3,7 +3,9 @@ import {
 	ICP_NETWORK_ID,
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
 } from '$env/networks.env';
+import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import type { Network, NetworkId } from '$lib/types/network';
+import type { Token } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
 
 export const isNetworkICP = ({ id }: Network): boolean => isNetworkIdICP(id);
@@ -16,3 +18,22 @@ export const isNetworkIdEthereum = (id: NetworkId | undefined): boolean =>
 
 export const isNetworkIdBitcoin = (id: NetworkId | undefined): boolean =>
 	nonNullish(id) && BITCOIN_NETWORKS_IDS.includes(id);
+
+/**
+ * Filter the tokens that either lives on the selected network or, if no network is provided, pseud Chain Fusion, then those that are not testnets.
+ */
+export const filterTokensForSelectedNetwork = ([
+	$tokens,
+	$selectedNetwork,
+	$pseudoNetworkChainFusion
+]: [Token[], Network | undefined, boolean]) =>
+	$tokens.filter((token) => {
+		const {
+			network: { id: networkId, env }
+		} = token;
+
+		return (
+			($pseudoNetworkChainFusion && !isTokenIcrcTestnet(token) && env !== 'testnet') ||
+			$selectedNetwork?.id === networkId
+		);
+	});


### PR DESCRIPTION
# Motivation

I deployed a first version on staging and we noticed that the Sns tokens were not listed, if never enabled or disabled, in the "Manage Tokens" modal.