### PR TITLE
fix(frontend): chain fusion tokens subset display

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -9,34 +9,49 @@ import { tokens } from '$lib/derived/tokens.derived';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { Token } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
+import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
  * All tokens matching the selected network or chain fusion, regardless if they are enabled by the user or not.
  */
-export const networkTokens: Readable<Token[]> = derived(
+const networkTokens: Readable<Token[]> = derived(
 	[tokens, selectedNetwork, pseudoNetworkChainFusion],
 	filterTokensForSelectedNetwork
 );
 
-export const enabledNetworkTokens: Readable<Token[]> = derived(
-	[networkTokens],
-	([$networkTokens]) =>
-		$networkTokens.filter((token) => ('enabled' in token ? token.enabled : true))
+const enabledNetworkTokens: Readable<Token[]> = derived([networkTokens], ([$networkTokens]) =>
+	$networkTokens.filter((token) => ('enabled' in token ? token.enabled : true))
 );
 
+/**
+ * For various networks (e.g., ICP, Ethereum), we display tokens that are enabled.
+ * This includes:
+ * - Default tokens that have not been disabled by users
+ * - Custom tokens that have been added and enabled by users
+ *
+ * For the pseudo network Chain Fusion we display:
+ * - ICP tokens
+ * - Ethereum tokens
+ * - A subset of cK tokens
+ * - Tokens that have been enabled by the user
+ *
+ * To determine if a token is enabled in the Chain Fusion network, in addition to checking the "enabled" flag,
+ * we also verify if the "version" field is set. The "version" field indicates that the token has been persisted
+ * in the backend canister and per extension set by the user.
+ */
 export const filteredNetworkTokens: Readable<Token[]> = derived(
-	[enabledNetworkTokens, notPseudoNetworkChainFusion],
-	([$enabledNetworkTokens, $notPseudoNetworkChainFusion]) =>
+	[enabledNetworkTokens, networkTokens, notPseudoNetworkChainFusion],
+	([$enabledNetworkTokens, $networkTokens, $notPseudoNetworkChainFusion]) =>
 		$notPseudoNetworkChainFusion
 			? $enabledNetworkTokens
-			: $enabledNetworkTokens.filter(
+			: $networkTokens.filter(
 					(token) =>
 						[ICP_TOKEN_ID, ETHEREUM_TOKEN_ID].includes(token.id) ||
 						('ledgerCanisterId' in token &&
 							ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS.includes(
 								(token as { ledgerCanisterId: CanisterIdText }).ledgerCanisterId
 							)) ||
-						('enabled' in token && token.enabled)
+						('enabled' in token && token.enabled && 'version' in token && nonNullish(token.version))
 				)
 );


### PR DESCRIPTION
# Motivation

On "Chain Fusion" we want to display a custom list of tokens with some various rules. After last enhancement to make the Icrc toggleable, those rules were fully functional anymore. This PR fixes the display and add a comment about those rules.