### PR TITLE
chore(release): update version as released patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "0.0.19",
+	"version": "0.0.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "0.0.19",
+			"version": "0.0.21",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/agent": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "0.0.19",
+	"version": "0.0.21",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {


### PR DESCRIPTION
# Motivation

We released patches to unleash ckOCT, ckPEPE and ckLINK, therefore we bumped the version in branches.
This apply the last number to the `main`.
