### PR TITLE
feat(frontend): review display of enabled tokens

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -3,10 +3,10 @@
 	import { exchangeInitialized, exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { usdValue } from '$lib/utils/exchange.utils';
-	import { filteredNetworkTokens } from '$lib/derived/network-tokens.derived';
+	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 
 	let totalUsd: number;
-	$: totalUsd = $filteredNetworkTokens.reduce(
+	$: totalUsd = $enabledNetworkTokens.reduce(
 		(acc, token) =>
 			acc +
 			usdValue({

--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -7,7 +7,7 @@
 	import Listener from '$lib/components/core/Listener.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
-	import { filteredNetworkTokens } from '$lib/derived/network-tokens.derived';
+	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import Header from '$lib/components/ui/Header.svelte';
 	import TokensMenu from '$lib/components/tokens/TokensMenu.svelte';
@@ -24,7 +24,7 @@
 	$: displayZeroBalance = $hideZeroBalancesStore?.enabled !== true;
 
 	let tokens: Token[];
-	$: tokens = $filteredNetworkTokens.filter(
+	$: tokens = $enabledNetworkTokens.filter(
 		({ id: tokenId }) =>
 			($balancesStore?.[tokenId]?.data ?? BigNumber.from(0n)).gt(0n) || displayZeroBalance
 	);

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,15 +1,7 @@
-import { ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS } from '$env/networks.icrc.env';
-import { ETHEREUM_TOKEN_ID, ICP_TOKEN_ID } from '$env/tokens.env';
-import {
-	notPseudoNetworkChainFusion,
-	pseudoNetworkChainFusion,
-	selectedNetwork
-} from '$lib/derived/network.derived';
+import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
-import type { CanisterIdText } from '$lib/types/canister';
 import type { Token } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -20,38 +12,8 @@ const networkTokens: Readable<Token[]> = derived(
 	filterTokensForSelectedNetwork
 );
 
-const enabledNetworkTokens: Readable<Token[]> = derived([networkTokens], ([$networkTokens]) =>
-	$networkTokens.filter((token) => ('enabled' in token ? token.enabled : true))
-);
-
-/**
- * For various networks (e.g., ICP, Ethereum), we display tokens that are enabled.
- * This includes:
- * - Default tokens that have not been disabled by users
- * - Custom tokens that have been added and enabled by users
- *
- * For the pseudo network Chain Fusion we display:
- * - ICP tokens
- * - Ethereum tokens
- * - A subset of cK tokens
- * - Tokens that have been enabled by the user
- *
- * To determine if a token is enabled in the Chain Fusion network, in addition to checking the "enabled" flag,
- * we also verify if the "version" field is set. The "version" field indicates that the token has been persisted
- * in the backend canister and per extension set by the user.
- */
-export const filteredNetworkTokens: Readable<Token[]> = derived(
-	[enabledNetworkTokens, networkTokens, notPseudoNetworkChainFusion],
-	([$enabledNetworkTokens, $networkTokens, $notPseudoNetworkChainFusion]) =>
-		$notPseudoNetworkChainFusion
-			? $enabledNetworkTokens
-			: $networkTokens.filter(
-					(token) =>
-						[ICP_TOKEN_ID, ETHEREUM_TOKEN_ID].includes(token.id) ||
-						('ledgerCanisterId' in token &&
-							ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS.includes(
-								(token as { ledgerCanisterId: CanisterIdText }).ledgerCanisterId
-							)) ||
-						('enabled' in token && token.enabled && 'version' in token && nonNullish(token.version))
-				)
+export const enabledNetworkTokens: Readable<Token[]> = derived(
+	[networkTokens],
+	([$networkTokens]) =>
+		$networkTokens.filter((token) => ('enabled' in token ? token.enabled : true))
 );

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -1,6 +1,7 @@
+import { ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS } from '$env/networks.icrc.env';
+import type { CanisterIdText } from '$lib/types/canister';
 import type { Token, TokenStandard } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
-import { isNullish } from '@dfinity/utils';
 
 /**
  * Calculates the maximum amount for a transaction.
@@ -28,6 +29,18 @@ export const getMaxTransactionAmount = ({
 	);
 };
 
+/**
+ * /**
+ *  * We always display following tokens on the "Tokens" view:
+ *  * - ICP token
+ *  * - Ethereum token
+ *  * - A subset of cK tokens
+ *
+ * In addition to those, we display also:
+ * - The tokens that have been enabled by the user
+ *
+ * That is why the `enabled` flag is either enabled for a subset of ledgerCanisterIds or if user has set an enabled custom token in the backend.
+ */
 export const mapDefaultTokenToToggleable = <T extends Token>({
 	defaultToken,
 	userToken
@@ -36,6 +49,11 @@ export const mapDefaultTokenToToggleable = <T extends Token>({
 	userToken: TokenToggleable<T> | undefined;
 }): TokenToggleable<T> => ({
 	...defaultToken,
-	enabled: isNullish(userToken) || userToken.enabled,
+	enabled:
+		('ledgerCanisterId' in defaultToken &&
+			ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS.includes(
+				(defaultToken as { ledgerCanisterId: CanisterIdText }).ledgerCanisterId
+			)) ||
+		userToken?.enabled === true,
 	version: userToken?.version
 });


### PR DESCRIPTION
# Motivation

I'm quoting myself:

> I detected an issue with the UX. As discussed, we want to display a subset of the tokens by default on "Chain Fusion" but display all default tokens on their respective networks.
>
>For example, PEPE is not displayed by default on Chain Fusion but is displayed by default on the Ethereum network.
>
> This approach leads to an inconsistency in the "Manage Tokens" modal. Currently, the same token is displayed as "Enabled" by default in this modal. Therefore, when a user opens this modal on "Chain Fusion," they see a list of "Enabled" tokens that are actually not displayed.
>
> We could potentially display those tokens as "Disabled" in the modal when "Chain Fusion" is selected. However, this might be confusing because these tokens would still be shown as "Enabled" when the user selects a specific network.

# Changes

- Review when default tokens are enabled and when those are listed.
