### PR TITLE
fix(frontend): icrc custom tokens should also be filtered according testnets

### DIFF
--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -36,8 +36,11 @@ const icrcDefaultTokensCanisterIds: Readable<string[]> = derived(
  * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "custom token" in the backend.
  */
 const icrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
-	[icrcCustomTokensStore],
-	([$icrcCustomTokensStore]) => $icrcCustomTokensStore?.map(({ data: token }) => token) ?? []
+	[icrcCustomTokensStore, testnets],
+	([$icrcCustomTokensStore, $testnets]) =>
+		($icrcCustomTokensStore?.map(({ data: token }) => token) ?? []).filter(
+			(token) => $testnets || !isTokenIcrcTestnet(token)
+		)
 );
 
 const icrcDefaultTokensToggleable: Readable<IcTokenToggleable[]> = derived(


### PR DESCRIPTION
# Motivation

If a user enabled a test token on ic, then the test token should not be displayed if the testnet flag is not turned on - i.e. not only the default icrc tokens should be depending of the testnet flag but custom tokens as well.
