### PR TITLE
fix(ci): typo artifact name

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Load Docker image
         run: |
-          gzip -d oisy-e2e-image.gz
+          gzip -d oisy-e2e-image.tar.gz
           docker load -i oisy-e2e-image.tar
 
       - name: Run E2E Docker container


### PR DESCRIPTION
# Motivation

The downloaded artifact file name was missing the correct extension `oisy-e2e-image.tar.gz`.
