### PR TITLE
fix(frontend): usdc and other ck erc20 tokens dollar display

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -93,6 +93,11 @@ export const erc20Tokens: Readable<Erc20TokenToggleable[]> = derived(
 	]
 );
 
+export const erc20TokensAddresses: Readable<Erc20ContractAddress[]> = derived(
+	[erc20Tokens],
+	([$erc20Tokens]) => $erc20Tokens.map(({ address }: Erc20Token) => ({ address }))
+);
+
 /**
  * The list of ERC20 tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
  */
@@ -112,9 +117,4 @@ export const erc20UserTokensInitialized: Readable<boolean> = derived(
 export const erc20UserTokensNotInitialized: Readable<boolean> = derived(
 	[erc20UserTokensInitialized],
 	([$erc20TokensInitialized]) => !$erc20TokensInitialized
-);
-
-export const erc20TokensAddresses: Readable<Erc20ContractAddress[]> = derived(
-	[enabledErc20Tokens],
-	([$erc20Tokens]) => $erc20Tokens.map(({ address }: Erc20Token) => ({ address }))
 );


### PR DESCRIPTION
# Motivation

USDC in dollars were not displayed, that's because the exchange rate was only loaded for the enabled ERC20 tokens. Given that none are enabled per default, no exchange rate was loaded. So, for simplicity reason, let's load the rate for all ERC20 tokens regardless if disabled or enabled.
