### PR TITLE
feat(frontend): load less erc20 exchanges

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -1,7 +1,7 @@
 import { enabledEthereumNetworksIds } from '$eth/derived/networks.derived';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
-import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
@@ -93,11 +93,6 @@ export const erc20Tokens: Readable<Erc20TokenToggleable[]> = derived(
 	]
 );
 
-export const erc20TokensAddresses: Readable<Erc20ContractAddress[]> = derived(
-	[erc20Tokens],
-	([$erc20Tokens]) => $erc20Tokens.map(({ address }: Erc20Token) => ({ address }))
-);
-
 /**
  * The list of ERC20 tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
  */
@@ -107,6 +102,11 @@ export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
 		...$enabledErc20DefaultTokens,
 		...$enabledErc20UserTokens
 	]
+);
+
+export const enabledErc20TokensAddresses: Readable<string[]> = derived(
+	[enabledErc20Tokens],
+	([$enabledErc20Tokens]) => $enabledErc20Tokens.map(({ address }: Erc20Token) => address)
 );
 
 export const erc20UserTokensInitialized: Readable<boolean> = derived(

--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -1,6 +1,7 @@
 import { enabledEthereumNetworksIds } from '$eth/derived/networks.derived';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
+import type { ContractAddressText } from '$eth/types/address';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
@@ -104,7 +105,7 @@ export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
 	]
 );
 
-export const enabledErc20TokensAddresses: Readable<string[]> = derived(
+export const enabledErc20TokensAddresses: Readable<ContractAddressText[]> = derived(
 	[enabledErc20Tokens],
 	([$enabledErc20Tokens]) => $enabledErc20Tokens.map(({ address }: Erc20Token) => address)
 );

--- a/src/frontend/src/eth/types/address.ts
+++ b/src/frontend/src/eth/types/address.ts
@@ -1,3 +1,5 @@
 import type { BaseContract } from 'ethers';
 
 export type ContractAddress = Pick<BaseContract, 'address'>;
+
+export type ContractAddressText = typeof BaseContract.prototype.address;

--- a/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
+++ b/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
@@ -1,0 +1,22 @@
+import { enabledErc20TokensAddresses } from '$eth/derived/erc20.derived';
+import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
+import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
+import type { IcCkToken, IcToken } from '$icp/types/ic';
+import { nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const enabledIcrcTwinTokensAddresses: Readable<string[]> = derived(
+	[enabledIcrcTokens],
+	([$enabledIcrcTokens]) =>
+		$enabledIcrcTokens
+			.filter((token: IcToken) => nonNullish((token as IcCkToken).twinToken) && 'address' in token)
+			.map((token) => ((token as IcCkToken).twinToken as Erc20Token).address)
+);
+
+export const enabledMergedErc20TokensAddresses: Readable<Erc20ContractAddress[]> = derived(
+	[enabledIcrcTwinTokensAddresses, enabledErc20TokensAddresses],
+	([$enabledIcrcTwinTokensAddresses, $enabledErc20TokensAddresses]) =>
+		[...new Set([...$enabledErc20TokensAddresses, ...$enabledIcrcTwinTokensAddresses])].map(
+			(address) => ({ address })
+		)
+);

--- a/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
+++ b/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
@@ -1,11 +1,12 @@
 import { enabledErc20TokensAddresses } from '$eth/derived/erc20.derived';
+import type { ContractAddressText } from '$eth/types/address';
 import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcCkToken, IcToken } from '$icp/types/ic';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const enabledIcrcTwinTokensAddresses: Readable<string[]> = derived(
+export const enabledIcrcTwinTokensAddresses: Readable<ContractAddressText[]> = derived(
 	[enabledIcrcTokens],
 	([$enabledIcrcTokens]) =>
 		$enabledIcrcTokens

--- a/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
@@ -2,7 +2,8 @@
 	import { onDestroy, onMount } from 'svelte';
 	import type { ExchangeWorker } from '$lib/services/worker.exchange.services';
 	import { initExchangeWorker } from '$lib/services/worker.exchange.services';
-	import { erc20TokensAddresses } from '$eth/derived/erc20.derived';
+	import { enabledErc20TokensAddresses } from '$eth/derived/erc20.derived';
+	import { enabledMergedErc20TokensAddresses } from '$icp-eth/derived/icrc-erc20.derived';
 
 	let worker: ExchangeWorker | undefined;
 
@@ -21,10 +22,10 @@
 
 	const syncTimer = () => {
 		worker?.stopExchangeTimer();
-		worker?.startExchangeTimer({ erc20Addresses: $erc20TokensAddresses });
+		worker?.startExchangeTimer({ erc20Addresses: $enabledMergedErc20TokensAddresses });
 	};
 
-	$: worker, $erc20TokensAddresses, syncTimer();
+	$: worker, $enabledMergedErc20TokensAddresses, syncTimer();
 </script>
 
 <slot />

--- a/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
@@ -2,7 +2,6 @@
 	import { onDestroy, onMount } from 'svelte';
 	import type { ExchangeWorker } from '$lib/services/worker.exchange.services';
 	import { initExchangeWorker } from '$lib/services/worker.exchange.services';
-	import { enabledErc20TokensAddresses } from '$eth/derived/erc20.derived';
 	import { enabledMergedErc20TokensAddresses } from '$icp-eth/derived/icrc-erc20.derived';
 
 	let worker: ExchangeWorker | undefined;


### PR DESCRIPTION
# Motivation

There was a quick fix to load all ERC20 exchange rates (issue #1666), but that isn't very efficient as it loads all rates, even for those ERC20 tokens that are disabled. This PR collects the ERC20 tokens of the twin tokens to limit the number of exchanges to load, assuming that merging the addresses of the derived stores requires fewer resources than querying the CoinGecko API unnecessarily.