### PR TITLE
feat(frontend): debounce exchange queries

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
@@ -3,6 +3,7 @@
 	import type { ExchangeWorker } from '$lib/services/worker.exchange.services';
 	import { initExchangeWorker } from '$lib/services/worker.exchange.services';
 	import { enabledMergedErc20TokensAddresses } from '$icp-eth/derived/icrc-erc20.derived';
+	import { debounce } from '@dfinity/utils';
 
 	let worker: ExchangeWorker | undefined;
 
@@ -24,7 +25,9 @@
 		worker?.startExchangeTimer({ erc20Addresses: $enabledMergedErc20TokensAddresses });
 	};
 
-	$: worker, $enabledMergedErc20TokensAddresses, syncTimer();
+	const debounceSyncTimer = debounce(syncTimer);
+
+	$: worker, $enabledMergedErc20TokensAddresses, debounceSyncTimer();
 </script>
 
 <slot />


### PR DESCRIPTION
# Motivation

It will slow down the very first queries by a bit but, I noticed that we make too many queries as the derivation of the stores become too complex and reevaluated more often.
