### PR TITLE
fix(frontend): enabledIcrcTwinTokensAddresses mapping

### DIFF
--- a/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
+++ b/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
@@ -10,7 +10,9 @@ export const enabledIcrcTwinTokensAddresses: Readable<ContractAddressText[]> = d
 	[enabledIcrcTokens],
 	([$enabledIcrcTokens]) =>
 		$enabledIcrcTokens
-			.filter((token: IcToken) => nonNullish((token as IcCkToken).twinToken) && 'address' in token)
+			.filter((token: IcToken) =>
+				nonNullish(((token as Partial<IcCkToken>).twinToken as Erc20Token | undefined)?.address)
+			)
 			.map((token) => ((token as IcCkToken).twinToken as Erc20Token).address)
 );
 


### PR DESCRIPTION
# Motivation

Casting the address was not accurate which had for effect, once again, to display no ckUSDC dollar rate as the exchange was not queried.
