### PR TITLE
feat(frontend): unique erc20 symbol string improved

### DIFF
--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -26,13 +26,15 @@ export const mapErc20UserToken = ({
 	id,
 	symbol,
 	name,
+	network,
 	...rest
 }: MapErc20TokenParams & UserTokenState): Erc20UserToken => ({
-	id: id ?? Symbol(`user-token#${symbol}`),
+	id: id ?? Symbol(`user-token#${symbol}#${network.chainId}`),
 	standard: 'erc20',
 	name,
 	symbol,
 	icon: mapErc20Icon(symbol),
+	network,
 	...rest
 });
 


### PR DESCRIPTION
# Motivation

For readability make the string of the erc20 user token symbol more unique by including the chain id given that a same contract address can be potentially be used on various chain.
