### PR TITLE
fix(frontend): match erc20 user token with chain id

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -5,6 +5,7 @@ import type { ContractAddressText } from '$eth/types/address';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
+import type { EthereumNetwork } from '$eth/types/network';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { derived, type Readable } from 'svelte/store';
@@ -41,14 +42,17 @@ const erc20UserTokens: Readable<Erc20UserToken[]> = derived(
 const erc20DefaultTokensToggleable: Readable<Erc20TokenToggleable[]> = derived(
 	[erc20DefaultTokens, erc20UserTokens],
 	([$erc20DefaultTokens, $erc20UserTokens]) =>
-		$erc20DefaultTokens.map(({ address, ...rest }) => {
+		$erc20DefaultTokens.map(({ address, network, ...rest }) => {
 			const userToken = $erc20UserTokens.find(
-				({ address: contractAddress }) => contractAddress === address
+				({ address: contractAddress, network: contractNetwork }) =>
+					contractAddress === address &&
+					(network as EthereumNetwork).chainId === (contractNetwork as EthereumNetwork).chainId
 			);
 
 			return mapDefaultTokenToToggleable({
 				defaultToken: {
 					address,
+					network,
 					...rest
 				},
 				userToken


### PR DESCRIPTION
# Motivation

While testing the staging version, I encountered an issue. I was unable to enable the Uniswap token because the `version` provided by the frontend was not the one expected by the backend. After debugging, I discovered that the frontend was providing the version of the Sepolia user token instead of using the Mainnet version. The root cause was that both contract addresses on both networks use the same address. Since the chain ID was not considered when matching default tokens and user tokens, the state memory ended up with an incorrect version number mismatch.
