### PR TITLE
feat(frontend): filter manage tokens twin tokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -31,7 +31,7 @@
 	import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-	import type { IcCkToken, IcToken } from '$icp/types/ic';
+	import type { IcCkToken } from '$icp/types/ic';
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -31,6 +31,7 @@
 	import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
+	import type { IcCkToken, IcToken } from '$icp/types/ic';
 
 	const dispatch = createEventDispatcher();
 
@@ -90,16 +91,19 @@
 	let filter = '';
 	$: filter, debounceUpdateFilter();
 
+	const matchingToken = (token: Token): boolean =>
+		token.name.toLowerCase().includes(filterTokens.toLowerCase()) ||
+		token.symbol.toLowerCase().includes(filterTokens.toLowerCase()) ||
+		(icTokenIcrcCustomToken(token) &&
+			(token.alternativeName ?? '').toLowerCase().includes(filterTokens.toLowerCase()));
+
 	let filteredTokens: Token[] = [];
 	$: filteredTokens = isNullishOrEmpty(filterTokens)
 		? allTokens
-		: allTokens.filter(
-				(token) =>
-					token.name.toLowerCase().includes(filterTokens.toLowerCase()) ||
-					token.symbol.toLowerCase().includes(filterTokens.toLowerCase()) ||
-					(icTokenIcrcCustomToken(token) &&
-						(token.alternativeName ?? '').toLowerCase().includes(filterTokens.toLowerCase()))
-			);
+		: allTokens.filter((token) => {
+				const twinToken = (token as IcCkToken).twinToken;
+				return matchingToken(token) || (nonNullish(twinToken) && matchingToken(twinToken));
+			});
 
 	let tokens: Token[] = [];
 	$: tokens = filteredTokens.map((token) => {


### PR DESCRIPTION
# Motivation

Ck tokens are set with names equals to their symbols. As a result, a user looking for a particular tokens in the manage tokens modals might not found a twin tokens. For example, a user looking for "Chainlink" will not find ckLINK. To overcome this issue, this PR extend the filter with comparing twin tokens as well.

# Screenshots

<img width="1536" alt="Capture d’écran 2024-07-03 à 09 01 24" src="https://github.com/dfinity/oisy-wallet/assets/16886711/c4db0727-5077-4a20-a8ca-fb02355af2e3">

<img width="1536" alt="Capture d’écran 2024-07-03 à 09 01 20" src="https://github.com/dfinity/oisy-wallet/assets/16886711/add26c66-75ca-46de-af34-9229fc3a3168">
