### PR TITLE
style(frontend): mobile layout a bit less wide

### DIFF
--- a/src/frontend/src/lib/styles/global/layout.scss
+++ b/src/frontend/src/lib/styles/global/layout.scss
@@ -3,7 +3,7 @@
 main,
 .main {
 	margin: 0 auto;
-	padding: 0 var(--padding-2x) var(--padding-3x);
+	padding: 0 calc(2.5 * var(--padding)) var(--padding-3x);
 
 	max-width: media.$breakpoint-small;
 }


### PR DESCRIPTION
# Motivation

I compared Figma and existing implementation and it feels that the Figma design is a bit less wide on mobile. I also feel that just a bit of margin on X axis would be appreciated on mobile so this PR add just a bit more of padding within the layout for mobile.
