### PR TITLE
feat(frontend): ICP token name is Internet Computer

### DIFF
--- a/src/frontend/src/env/tokens.env.ts
+++ b/src/frontend/src/env/tokens.env.ts
@@ -68,7 +68,7 @@ export const ICP_TOKEN: Required<IcToken> = {
 	category: 'default',
 	exchangeCoinId: 'internet-computer',
 	position: 0,
-	name: 'ICP',
+	name: 'Internet Computer',
 	symbol: ICP_SYMBOL,
 	decimals: 8,
 	icon: icpLight,


### PR DESCRIPTION
# Motivation

In Figma "Internet Computer" is used for the name of the ICP token. So I double checked the metadata of the ICP ledger canister and indeed, it's "Internet Computer".
