### PR TITLE
chore(ci): update automated PR title

### DIFF
--- a/.github/workflows/update-tokens.yml
+++ b/.github/workflows/update-tokens.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
           branch: bot-tokens-sns-update
-          title: 'build: Update Sns Tokens'
+          title: 'feat(frontend): Update Sns Tokens'
           body: |
             Modifications have been made to the icons and metadata of the Icrc tokens known to the Sns-Aggregator.
 
@@ -57,6 +57,6 @@ jobs:
         with:
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
           branch: bot-tokens-ckerc20-update
-          title: 'build: Update ckErc20 Tokens'
+          title: 'feat(frontend): Update ckErc20 Tokens'
           body: |
             Modifications have been made to the list of ckErc20 tokens deployed by the Orchestrator.


### PR DESCRIPTION
# Motivation

There is a `pr-checks` now that checks the title of the pr for semantic version with context. The automated PR used to generate `build: ...` which does not comply.

# Changes

- Update title to comply - i.e. add `(frontend).
- Change goal from `build` to `feat`. Feels more approriate.
