### PR TITLE
test(ci): chrome only

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Prepare
         uses: ./.github/actions/prepare
-      - name: Install browsers and system dependencies
-        run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npm run e2e:snapshots
       - name: Commit Playwright updated snapshots

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,28 +17,8 @@ export default defineConfig({
 	},
 	projects: [
 		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] }
-		},
-		...(!DEV
-			? [
-					{
-						name: 'firefox',
-						use: { ...devices['Desktop Firefox'] }
-					},
-					{
-						name: 'webkit',
-						use: { ...devices['Desktop Safari'] }
-					},
-					{
-						name: 'iphone',
-						use: { ...devices['iPhone 14'] }
-					},
-					{
-						name: 'android',
-						use: { ...devices['Galaxy S9+'] }
-					}
-				]
-			: [])
+			name: 'Google Chrome',
+			use: { ...devices['Desktop Chrome'], channel: 'chrome' }
+		}
 	]
 });


### PR DESCRIPTION
# Motivation

Let's stick to Chrome for now. When we have everything in place we can use more browsers but, this makes easier to run the Ci without the need to install all browsers.