### PR TITLE
chore(scripts): deploy locally with specified ids

### DIFF
--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -27,5 +27,5 @@ else
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
      }
-  })"
+  })" --specified-id tdxud-2yaaa-aaaad-aadiq-cai
 fi

--- a/scripts/deploy.ckbtc.sh
+++ b/scripts/deploy.ckbtc.sh
@@ -6,9 +6,9 @@
 DFX_NETWORK=local
 
 echo "Step 1: create canisters..."
-dfx canister create ckbtc_ledger --network "$DFX_NETWORK"
-dfx canister create ckbtc_minter --network "$DFX_NETWORK"
-dfx canister create ckbtc_kyt --network "$DFX_NETWORK"
+dfx canister create ckbtc_ledger --specified-id mc6ru-gyaaa-aaaar-qaaaq-cai --network "$DFX_NETWORK"
+dfx canister create ckbtc_minter --specified-id ml52i-qqaaa-aaaar-qaaba-cai --network "$DFX_NETWORK"
+dfx canister create ckbtc_kyt --specified-id pvm5g-xaaaa-aaaar-qaaia-cai --network "$DFX_NETWORK"
 
 MINTERID="$(dfx canister id ckbtc_minter --network "$DFX_NETWORK")"
 echo "$MINTERID"
@@ -18,7 +18,7 @@ KYTID="$(dfx canister id ckbtc_kyt --network "$DFX_NETWORK")"
 echo "$KYTID"
 
 echo "Step 2: deploy minter canister..."
-dfx deploy ckbtc_minter --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_minter --specified-id ml52i-qqaaa-aaaar-qaaba-cai --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
        btc_network = variant { Regtest };
        ledger_id = principal \"$LEDGERID\";
@@ -34,7 +34,7 @@ dfx deploy ckbtc_minter --network "$DFX_NETWORK" --argument "(variant {
 
 echo "Step 3: deploy ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"
-dfx deploy ckbtc_ledger --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_ledger --specified-id mc6ru-gyaaa-aaaar-qaaaq-cai --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckBTC\";
      token_name = \"Chain key local Bitcoin\";
@@ -55,7 +55,7 @@ dfx deploy ckbtc_ledger --network "$DFX_NETWORK" --argument "(variant {
 })"
 
 echo "Step 4: deploy kyt canister..."
-dfx deploy ckbtc_kyt --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_kyt --specified-id pvm5g-xaaaa-aaaar-qaaia-cai --network "$DFX_NETWORK" --argument "(variant {
   InitArg = record {
     minter_id = principal \"$MINTERID\";
     maintainers = vec {};
@@ -64,7 +64,7 @@ dfx deploy ckbtc_kyt --network "$DFX_NETWORK" --argument "(variant {
 })"
 
 echo "Step 5: deploy index canister..."
-dfx deploy ckbtc_index --network "$DFX_NETWORK" --argument "(opt variant {
+dfx deploy ckbtc_index --specified-id mm444-5iaaa-aaaar-qaabq-cai --network "$DFX_NETWORK" --argument "(opt variant {
   Init = record {
     ledger_id = principal \"$LEDGERID\";
    }

--- a/scripts/deploy.ckerc20.sh
+++ b/scripts/deploy.ckerc20.sh
@@ -7,21 +7,20 @@ echo "$MINTERID"
 
 function deploy_ckerc20 {
     local LEDGER_CANISTER=$1
-    local INDEX_CANISTER=$2
-    local TOKEN_SYMBOL=$3
-    local TOKEN_NAME=$4
-    local DECIMALS=$5
+    local LEDGER_CANISTER_ID=$2
+    local INDEX_CANISTER=$3
+    local INDEX_CANISTER_ID=$4
+    local TOKEN_SYMBOL=$5
+    local TOKEN_NAME=$6
+    local DECIMALS=$7
 
     echo "Step A: create ledger canisters..."
-    dfx canister create "$LEDGER_CANISTER" --network "$DFX_NETWORK"
-
-    local LEDGERID="$(dfx canister id "$LEDGER_CANISTER" --network "$DFX_NETWORK")"
-    echo "$LEDGERID"
+    dfx canister create "$LEDGER_CANISTER" --specified-id "$LEDGER_CANISTER_ID" --network "$DFX_NETWORK"
 
     echo "Step B: deploy ledger canister..."
     PRINCIPAL="$(dfx identity get-principal)"
 
-    dfx deploy "$LEDGER_CANISTER" --network "$DFX_NETWORK" --argument "(variant {
+    dfx deploy "$LEDGER_CANISTER" --specified-id "$LEDGER_CANISTER_ID" --network "$DFX_NETWORK" --argument "(variant {
       Init = record {
          token_symbol = \"$TOKEN_SYMBOL\";
          token_name = \"$TOKEN_NAME\";
@@ -44,9 +43,9 @@ function deploy_ckerc20 {
     })"
 
     echo "Step C: deploy index canister..."
-    dfx deploy "$INDEX_CANISTER" --network "$DFX_NETWORK" --argument "(opt variant {
+    dfx deploy "$INDEX_CANISTER" --specified-id "$INDEX_CANISTER_ID" --network "$DFX_NETWORK" --argument "(opt variant {
       Init = record {
-        ledger_id = principal \"$LEDGERID\";
+        ledger_id = principal \"$LEDGER_CANISTER_ID\";
        }
     })"
 
@@ -54,4 +53,4 @@ function deploy_ckerc20 {
     dfx canister call "$LEDGER_CANISTER" --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"x4w27-so7wg-cudsa-yy7fh-wcpy5-njul4-q54tv-euzzi-tdnzz-ill46-zqe\";}; amount=500_000_000_000_000_000; fee=null; memo=null; created_at_time=null;})"
 }
 
-deploy_ckerc20 ckusdc_ledger ckusdc_index "ckSepoliaUSDC" "Chain key Sepolia USDC" 6
+deploy_ckerc20 ckusdc_ledger "yfumr-cyaaa-aaaar-qaela-cai" ckusdc_index "ycvkf-paaaa-aaaar-qaelq-cai" "ckSepoliaUSDC" "Chain key Sepolia USDC" 6

--- a/scripts/deploy.cketh.sh
+++ b/scripts/deploy.cketh.sh
@@ -3,8 +3,8 @@
 DFX_NETWORK=local
 
 echo "Step 1: create canisters..."
-dfx canister create cketh_ledger --network "$DFX_NETWORK"
-dfx canister create cketh_minter --network "$DFX_NETWORK"
+dfx canister create cketh_ledger --specified-id apia6-jaaaa-aaaar-qabma-cai --network "$DFX_NETWORK"
+dfx canister create cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$DFX_NETWORK"
 
 MINTERID="$(dfx canister id cketh_minter --network "$DFX_NETWORK")"
 echo "$MINTERID"
@@ -16,7 +16,7 @@ echo "Step 2: deploy minter canister..."
 # ckETH minter deployed on using the smart contract address on Sepolia used by testnet.
 # We can alternatively also deploy our own contract.
 
-dfx deploy cketh_minter --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$DFX_NETWORK" --argument "(variant {
   InitArg = record {
        ethereum_network = variant {Sepolia};
        ecdsa_key_name = \"dfx_test_key\";
@@ -31,7 +31,7 @@ dfx deploy cketh_minter --network "$DFX_NETWORK" --argument "(variant {
 
 echo "Step 3: deploy ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"
-dfx deploy cketh_ledger --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy cketh_ledger --specified-id apia6-jaaaa-aaaar-qabma-cai --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckSepoliaETH\";
      token_name = \"Chain key local Sepolia Ethereum\";
@@ -54,7 +54,7 @@ dfx deploy cketh_ledger --network "$DFX_NETWORK" --argument "(variant {
 })"
 
 echo "Step 4: deploy index canister..."
-dfx deploy cketh_index --network "$DFX_NETWORK" --argument "(opt variant {
+dfx deploy cketh_index --specified-id sh5u2-cqaaa-aaaar-qacna-cai --network "$DFX_NETWORK" --argument "(opt variant {
   Init = record {
     ledger_id = principal \"$LEDGERID\";
    }


### PR DESCRIPTION
# Motivation

Few canister were deployed locally with `--specified-id` and few not. For the E2E it's easier if the canisters are deployed with predictable IDs, so let's deploy locally with all canisters known.
