### PR TITLE
chore(dfx): mkdir in docker image

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -40,6 +40,9 @@ RUN DFXVM_INIT_YES=true DFX_VERSION=$DFX_VERSION sh -ci "$(curl -fsSL https://in
 # Set permission to .config folder so that dfx can write whatever files are needed
 RUN mkdir -p /home/apprunner/.config/dfx && chmod -R 700 /home/apprunner/.config
 
+# Likewise, /home/apprunner/.config/dfx/identity/___temp___minter/
+RUN mkdir -p /home/apprunner/.config/dfx/identity/
+
 # Add dfx to path
 ENV PATH="/home/apprunner/.local/share/dfx/bin:$PATH"
 


### PR DESCRIPTION
# Motivation

Try to solve another dfx issue when building the Docker image:

> #22 72.95 Error: Failed to save pem: Failed to write PEM to file: Failed to encrypt PEM file: /home/apprunner/.config/dfx/identity/___temp___minter/identity.pem.encrypted
> #22 72.95 Using identity: "minter".
> #22 72.95 Error: Identity must exist: Identity minter does not exist at '/home/apprunner/.config/dfx/identity/minter/identity.json'.

