### PR TITLE
chore(ci): canister ids config for e2e

### DIFF
--- a/canister_e2e_ids.json
+++ b/canister_e2e_ids.json
@@ -1,0 +1,41 @@
+{
+	"backend": {
+		"local": "tdxud-2yaaa-aaaad-aadiq-cai"
+	},
+	"ckbtc_index": {
+		"local": "mm444-5iaaa-aaaar-qaabq-cai"
+	},
+	"ckbtc_kyt": {
+		"local": "pvm5g-xaaaa-aaaar-qaaia-cai"
+	},
+	"ckbtc_ledger": {
+		"local": "mc6ru-gyaaa-aaaar-qaaaq-cai"
+	},
+	"ckbtc_minter": {
+		"local": "ml52i-qqaaa-aaaar-qaaba-cai"
+	},
+	"cketh_index": {
+		"local": "sh5u2-cqaaa-aaaar-qacna-cai"
+	},
+	"cketh_ledger": {
+		"local": "apia6-jaaaa-aaaar-qabma-cai"
+	},
+	"cketh_minter": {
+		"local": "jzenf-aiaaa-aaaar-qaa7q-cai"
+	},
+	"ckusdc_index": {
+		"local": "ycvkf-paaaa-aaaar-qaelq-cai"
+	},
+	"ckusdc_ledger": {
+		"local": "yfumr-cyaaa-aaaar-qaela-cai"
+	},
+	"icp_index": {
+		"local": "qhbym-qaaaa-aaaaa-aaafq-cai"
+	},
+	"icp_ledger": {
+		"local": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+	},
+	"internet_identity": {
+		"local": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+	}
+}

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -48,8 +48,12 @@ const readIds = ({
  * @param prefix
  */
 const readLocalCanisterIds = ({ prefix }: { prefix?: string }): Record<string, string> => {
-	const canisterIdsJsonFile = join(process.cwd(), '.dfx', 'local', 'canister_ids.json');
-	return readIds({ filePath: canisterIdsJsonFile, prefix });
+	const dfxCanisterIdsJsonFile = join(process.cwd(), '.dfx', 'local', 'canister_ids.json');
+	const e2eCanisterIdsJsonFile = join(process.cwd(), 'canister_e2e_ids.json');
+	return readIds({
+		filePath: existsSync(dfxCanisterIdsJsonFile) ? dfxCanisterIdsJsonFile : e2eCanisterIdsJsonFile,
+		prefix
+	});
 };
 
 /**


### PR DESCRIPTION
# Motivation

There are probably other way but, this is just the most pragmatic solution to load those canister IDs the frontend app requires when the E2E tests are running in the CI.
