### PR TITLE
fix(frontend): load erc20 tokens balance on "Tokens" view

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -63,7 +63,7 @@ const erc20DefaultTokensToggleable: Readable<Erc20TokenToggleable[]> = derived(
 /**
  * The list of default tokens that are enabled - i.e. the list of default ERC20 tokens minus those disabled by the user.
  */
-const enabledErc20DefaultTokens: Readable<Erc20Token[]> = derived(
+const enabledErc20DefaultTokens: Readable<Erc20TokenToggleable[]> = derived(
 	[erc20DefaultTokensToggleable],
 	([$erc20DefaultTokensToggleable]) =>
 		$erc20DefaultTokensToggleable.filter(({ enabled }) => enabled)
@@ -84,7 +84,7 @@ const erc20UserTokensToggleable: Readable<Erc20UserToken[]> = derived(
 
 const enabledErc20UserTokens: Readable<Erc20UserToken[]> = derived(
 	[erc20UserTokens],
-	([$erc20UserTokensToggleable]) => $erc20UserTokensToggleable.filter(({ enabled }) => enabled)
+	([$erc20UserTokens]) => $erc20UserTokens.filter(({ enabled }) => enabled)
 );
 
 /**
@@ -101,7 +101,7 @@ export const erc20Tokens: Readable<Erc20TokenToggleable[]> = derived(
 /**
  * The list of ERC20 tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
  */
-export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
+export const enabledErc20Tokens: Readable<Erc20TokenToggleable[]> = derived(
 	[enabledErc20DefaultTokens, enabledErc20UserTokens],
 	([$enabledErc20DefaultTokens, $enabledErc20UserTokens]) => [
 		...$enabledErc20DefaultTokens,

--- a/src/frontend/src/eth/services/balance.services.ts
+++ b/src/frontend/src/eth/services/balance.services.ts
@@ -2,6 +2,7 @@ import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import type { Erc20Token } from '$eth/types/erc20';
+import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { address as addressStore } from '$lib/derived/address.derived';
 import { balancesStore } from '$lib/stores/balances.store';
@@ -125,12 +126,12 @@ export const loadErc20Balances = async ({
 	networkId
 }: {
 	address: OptionAddress;
-	erc20Tokens: Erc20Token[];
+	erc20Tokens: Erc20TokenToggleable[];
 	networkId: NetworkId;
 }): Promise<{ success: boolean }> => {
 	const results = await Promise.all([
 		...erc20Tokens
-			.filter(({ network: { id } }) => id === networkId)
+			.filter(({ network: { id }, enabled }) => id === networkId && enabled)
 			.map((token) => loadErc20Balance({ token, address }))
 	]);
 

--- a/src/frontend/src/eth/services/balance.services.ts
+++ b/src/frontend/src/eth/services/balance.services.ts
@@ -2,7 +2,6 @@ import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import type { Erc20Token } from '$eth/types/erc20';
-import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { address as addressStore } from '$lib/derived/address.derived';
 import { balancesStore } from '$lib/stores/balances.store';
@@ -122,17 +121,13 @@ export const loadBalances = async (): Promise<{ success: boolean }> => {
 
 export const loadErc20Balances = async ({
 	address,
-	erc20Tokens,
-	networkId
+	erc20Tokens
 }: {
 	address: OptionAddress;
-	erc20Tokens: Erc20TokenToggleable[];
-	networkId: NetworkId;
+	erc20Tokens: Erc20Token[];
 }): Promise<{ success: boolean }> => {
 	const results = await Promise.all([
-		...erc20Tokens
-			.filter(({ network: { id }, enabled }) => id === networkId && enabled)
-			.map((token) => loadErc20Balance({ token, address }))
+		...erc20Tokens.map((token) => loadErc20Balance({ token, address }))
 	]);
 
 	return { success: results.every(({ success }) => success === true) };

--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -1,31 +1,23 @@
 <script lang="ts">
 	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
 	import { address } from '$lib/derived/address.derived';
-	import { selectedNetwork } from '$lib/derived/network.derived';
-	import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
-	import { debounce, nonNullish } from '@dfinity/utils';
+	import { debounce } from '@dfinity/utils';
+	import { enabledErc20NetworkTokens } from '$lib/derived/network-tokens.derived';
 
 	const load = async () => {
 		await Promise.allSettled([
 			// We might require Ethereum balance on IC network as well given that one can convert ckETH to ETH.
 			loadBalances(),
-			...[
-				nonNullish($selectedNetwork?.id)
-					? [
-							loadErc20Balances({
-								address: $address,
-								erc20Tokens: $enabledErc20Tokens,
-								networkId: $selectedNetwork.id
-							})
-						]
-					: []
-			]
+			loadErc20Balances({
+				address: $address,
+				erc20Tokens: $enabledErc20NetworkTokens
+			})
 		]);
 	};
 
 	const debounceLoad = debounce(load);
 
-	$: $address, $enabledErc20Tokens, $selectedNetwork, debounceLoad();
+	$: $address, $enabledErc20NetworkTokens, debounceLoad();
 </script>
 
 <slot />

--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -1,37 +1,21 @@
 <script lang="ts">
 	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
 	import { address } from '$lib/derived/address.derived';
-	import { networkEthereum } from '$lib/derived/network.derived';
+	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
-	import { debounce } from '@dfinity/utils';
-	import { ERC20_TWIN_TOKENS } from '$env/tokens.erc20.env';
-	import { ckEthereumNativeToken, erc20ToCkErc20Enabled } from '$icp-eth/derived/cketh.derived';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { debounce, nonNullish } from '@dfinity/utils';
 
 	const load = async () => {
 		await Promise.allSettled([
 			// We might require Ethereum balance on IC network as well given that one can convert ckETH to ETH.
 			loadBalances(),
 			...[
-				$networkEthereum
+				nonNullish($selectedNetwork?.id)
 					? [
 							loadErc20Balances({
 								address: $address,
 								erc20Tokens: $enabledErc20Tokens,
-								networkId: $tokenWithFallback.network.id
-							})
-						]
-					: []
-			],
-			...[
-				$erc20ToCkErc20Enabled
-					? [
-							// We might require Erc20 balance on IC network as well given that one can convert ckErc20 to Erc20.
-							// e.g. USDC <> ckUSDC
-							loadErc20Balances({
-								address: $address,
-								erc20Tokens: ERC20_TWIN_TOKENS,
-								networkId: $ckEthereumNativeToken.network.id
+								networkId: $selectedNetwork.id
 							})
 						]
 					: []
@@ -41,7 +25,7 @@
 
 	const debounceLoad = debounce(load);
 
-	$: $address, $enabledErc20Tokens, $tokenWithFallback, $erc20ToCkErc20Enabled, debounceLoad();
+	$: $address, $enabledErc20Tokens, $selectedNetwork, debounceLoad();
 </script>
 
 <slot />

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,3 +1,4 @@
+import type { Erc20Token } from '$eth/types/erc20';
 import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { Token } from '$lib/types/token';
@@ -16,4 +17,13 @@ export const enabledNetworkTokens: Readable<Token[]> = derived(
 	[networkTokens],
 	([$networkTokens]) =>
 		$networkTokens.filter((token) => ('enabled' in token ? token.enabled : true))
+);
+
+/**
+ * It isn't performant to post filter again the Erc20 tokens that are enabled for the specific selected network or no network selected but, it's code wise convenient to avoid duplication of logic.
+ */
+export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
+	[enabledNetworkTokens],
+	([$enabledNetworkTokens]) =>
+		$enabledNetworkTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
 );


### PR DESCRIPTION
# Motivation

Because of the introduction of "Chain Fusion" the balances for Erc20 tokens were not loaded anymore on the "Tokens" view. The root cause was the fact that we checked for various condition to only load those when required but, nowadays, there are basically always required but, enabled or disabled with a flag.
