### PR TITLE
style(frontend): use tailwind class instead of inline style

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -20,8 +20,7 @@
 
 <span class="text-off-white block">
 	<output
-		class={`break-all font-bold ${totalUsd === 0 ? 'opacity-50' : 'opacity-100'} inline-block mt-8`}
-		style="font-size: calc(2 * var(--font-size-h1)); line-height: 0.95;"
+		class={`break-all text-6xl font-bold ${totalUsd === 0 ? 'opacity-50' : 'opacity-100'} inline-block mt-8`}
 	>
 		{#if $exchangeInitialized}
 			{formatUSD(totalUsd, { notation: 'compact' })}

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -11,9 +11,9 @@
 		class={`break-all ${($balance?.toBigInt() ?? 0n) === 0n ? 'opacity-50' : 'opacity-100'} flex flex-col sm:block`}
 	>
 		{#if nonNullish($balance) && !$balanceZero}
-			<span class="amount font-bold"><Amount amount={$balance} /></span>
+			<span class="text-6xl font-bold"><Amount amount={$balance} /></span>
 		{:else}
-			<span class="amount font-bold" class:animate-pulse={isNullish($balance)}>0.00</span>
+			<span class="text-6xl font-bold" class:animate-pulse={isNullish($balance)}>0.00</span>
 		{/if}
 
 		{#if $erc20UserTokensInitialized}
@@ -21,10 +21,3 @@
 		{/if}
 	</output>
 </span>
-
-<style lang="scss">
-	.amount {
-		font-size: calc(2 * var(--font-size-h1));
-		line-height: 0.95;
-	}
-</style>


### PR DESCRIPTION
# Motivation

Close enough, we can replace some custom inline style with tailwind class.

# Changes

- Use `text-6xl` for balance and exchange rate in hero.
