### PR TITLE
build(ci): fix E2E Docker failed to write PEM to file

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -9,6 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     netcat \
     ca-certificates \
     build-essential \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install NodeJS


### PR DESCRIPTION
# Motivation

Try to fix Docker E2E build dfx error:

> #22 70.26 Error: Failed to save pem: Failed to write PEM to file: Failed to encrypt PEM file: /home/apprunner/.config/dfx/identity/___temp___minter/identity.pem.encrypted

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
