### PR TITLE
feat(frontend): remove unused disabled option

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -1,21 +1,13 @@
 <script lang="ts">
 	import Img from '$lib/components/ui/Img.svelte';
 
-	export let disabled = false;
 	export let button: HTMLButtonElement | undefined = undefined;
 	export let ariaLabel: string;
 	export let imgSrc: string;
 	export let imgAlt: string;
 </script>
 
-<button
-	class="token icon desktop-wide"
-	bind:this={button}
-	on:click
-	aria-label={ariaLabel}
-	{disabled}
-	class:opacity-50={disabled}
->
+<button class="token icon desktop-wide" bind:this={button} on:click aria-label={ariaLabel}>
 	<span class="block w-[22px] h-[22px]">
 		<Img src={imgSrc} alt={imgAlt} width="100%" height="100%" rounded />
 	</span>


### PR DESCRIPTION
# Motivation

Ultimately the `disabled` option of the new cmp `ButtonHero` won't be used.

# Changes

- Remove unused prop.
