### PR TITLE
style(frontend): network dropdown in manage tokens will display 'Select network' only once

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/AddTokenByNetwork.svelte
@@ -64,7 +64,7 @@
 
 		<div id="network" class="mt-1 pt-0.5 network">
 			<Dropdown name="network" bind:selectedValue={networkName}>
-				<option disabled selected value={undefined} class="hidden"
+				<option disabled selected value={undefined} class:hidden={nonNullish(networkName)}
 					><span class="description">{$i18n.tokens.manage.placeholder.select_network}</span></option
 				>
 				{#each availableNetworks as network}


### PR DESCRIPTION
# Motivation

The Network selection dropdown when adding a new token will show the "Select Network" option as disabled, but only the first time, when the network is still not selected.

# Changes

### Before

<img width="492" alt="Screenshot 2024-07-08 at 10 58 12" src="https://github.com/dfinity/oisy-wallet/assets/169057656/55736d35-58c5-4f79-81c9-1cf7816dc833">

### After

<img width="484" alt="Screenshot 2024-07-08 at 10 57 34" src="https://github.com/dfinity/oisy-wallet/assets/169057656/11f66750-8a67-4b61-ba63-c445a013a8b5">


<img width="494" alt="Screenshot 2024-07-08 at 10 57 50" src="https://github.com/dfinity/oisy-wallet/assets/169057656/c3b99ef3-cf0e-458c-889e-3680a33b7d15">


