### PR TITLE
feat(frontend): include Shiba Inu in the ICRC token list

### DIFF
--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -2,6 +2,7 @@ import { CKBTC_EXPLORER_URL, CKETH_EXPLORER_URL } from '$env/explorers.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens-erc20/tokens.oct.env';
 import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens-erc20/tokens.pepe.env';
+import { SHIB_TOKEN } from '$env/tokens-erc20/tokens.shib.env';
 import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 import ckErc20Tokens from '$env/tokens.ckerc20.json';
@@ -318,6 +319,14 @@ const CKOCT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_D
 		}
 	: undefined;
 
+const CKSHIB_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckSHIB)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckSHIB,
+			position: 5,
+			twinToken: SHIB_TOKEN
+		}
+	: undefined;
+
 export const CKERC20_LEDGER_CANISTER_TESTNET_IDS: CanisterIdText[] = [
 	...(nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) ? [LOCAL_CKUSDC_LEDGER_CANISTER_ID] : []),
 	...(nonNullish(CKUSDC_STAGING_DATA?.ledgerCanisterId)
@@ -335,7 +344,8 @@ export const CKERC20_LEDGER_CANISTER_IC_IDS: CanisterIdText[] = [
 	...(nonNullish(CKUSDC_IC_DATA?.ledgerCanisterId) ? [CKUSDC_IC_DATA.ledgerCanisterId] : []),
 	...(nonNullish(CKLINK_IC_DATA?.ledgerCanisterId) ? [CKLINK_IC_DATA.ledgerCanisterId] : []),
 	...(nonNullish(CKPEPE_IC_DATA?.ledgerCanisterId) ? [CKPEPE_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKOCT_IC_DATA?.ledgerCanisterId) ? [CKOCT_IC_DATA.ledgerCanisterId] : [])
+	...(nonNullish(CKOCT_IC_DATA?.ledgerCanisterId) ? [CKOCT_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKSHIB_IC_DATA?.ledgerCanisterId) ? [CKSHIB_IC_DATA.ledgerCanisterId] : [])
 ];
 
 export const CKERC20_LEDGER_CANISTER_IDS: CanisterIdText[] = [
@@ -361,7 +371,8 @@ export const ICRC_TOKENS: IcCkInterface[] = [
 	...(nonNullish(CKLINK_IC_DATA) ? [CKLINK_IC_DATA] : []),
 	...(nonNullish(CKPEPE_IC_DATA) ? [CKPEPE_IC_DATA] : []),
 	...(nonNullish(CKPEPE_STAGING_DATA) ? [CKPEPE_STAGING_DATA] : []),
-	...(nonNullish(CKOCT_IC_DATA) ? [CKOCT_IC_DATA] : [])
+	...(nonNullish(CKOCT_IC_DATA) ? [CKOCT_IC_DATA] : []),
+	...(nonNullish(CKSHIB_IC_DATA) ? [CKSHIB_IC_DATA] : [])
 ];
 
 export const ICRC_LEDGER_CANISTER_TESTNET_IDS = [


### PR DESCRIPTION
# Motivation

After updating the JSON file with the new ckERC20 tokens, and after having created the Shiba Inu env variables for the ERC20 token, we can include ckSHIB in the ICRC token list.
