### PR TITLE
style(frontend): alpha msg on mobile

### DIFF
--- a/src/frontend/src/lib/components/core/Alpha.svelte
+++ b/src/frontend/src/lib/components/core/Alpha.svelte
@@ -8,20 +8,14 @@
 	href={OISY_ALPHA_WARNING_URL}
 	rel="external noopener noreferrer"
 	target="_blank"
-	class="no-underline inline-flex items-center gap-2 text-center px-6 py-2 font-bold text-xs md:text-base"
+	class="inline-flex items-center gap-2 no-underline px-6 py-2 font-bold text-xs md:text-base mx-auto max-w-72 md:max-w-[100%]"
 >
-	<IconWarning inline />
-	<span class="pl-1">{$i18n.hero.text.use_with_caution}</span>
+	<span class="align-middle inline-block"><IconWarning inline /></span>
+	<span>{$i18n.hero.text.use_with_caution}</span>
 </a>
 
 <style lang="scss">
 	a {
 		color: var(--alpha-color, var(--color-misty-rose));
-		max-width: 300px;
-		margin: 0 auto;
-
-		@include media.min-width(medium) {
-			max-width: 100%;
-		}
 	}
 </style>

--- a/src/frontend/src/lib/components/core/Alpha.svelte
+++ b/src/frontend/src/lib/components/core/Alpha.svelte
@@ -10,7 +10,7 @@
 	target="_blank"
 	class="inline-flex items-center gap-2 no-underline px-6 py-2 font-bold text-xs md:text-base mx-auto max-w-72 md:max-w-[100%]"
 >
-	<span class="align-middle inline-block"><IconWarning inline /></span>
+	<IconWarning inline />
 	<span>{$i18n.hero.text.use_with_caution}</span>
 </a>
 


### PR DESCRIPTION
# Motivation

Now that everything is aligned to left I felt like the "Alpha" message could be aligned left on mobile as well.

# Screenshots

Before:

<img width="612" alt="Capture d’écran 2024-07-09 à 06 46 49" src="https://github.com/dfinity/oisy-wallet/assets/16886711/0d8ba478-0bda-4bbc-b311-10c9bb60dee6">


After:

<img width="637" alt="Capture d’écran 2024-07-09 à 06 46 07" src="https://github.com/dfinity/oisy-wallet/assets/16886711/b5e88d5e-7b2d-4838-9cf3-412dc3d34408">

