### PR TITLE
style(frontend): a focus-visible

### DIFF
--- a/src/frontend/src/lib/styles/global/theme.scss
+++ b/src/frontend/src/lib/styles/global/theme.scss
@@ -61,15 +61,10 @@ a {
 a:active,
 a:hover {
 	color: var(--color-blue);
-	outline-width: 0;
 }
 a:hover,
 a:focus {
 	text-decoration: underline;
-}
-a:focus,
-a:focus-visible {
-	outline: none;
 }
 b,
 strong {


### PR DESCRIPTION
# Motivation

Maybe we should style focus-visible but, until we do so, at least we should be consistent and display a focus when link are selected.

# Changes

- Remove no focus visible for links

# Tests

No focus on link (currently)

<img width="1536" alt="Capture d’écran 2024-07-09 à 07 06 48" src="https://github.com/dfinity/oisy-wallet/assets/16886711/20a44aa8-c33c-4812-9b08-9c0388a70b21">

Focus on button (currently)

<img width="1536" alt="Capture d’écran 2024-07-09 à 07 06 39" src="https://github.com/dfinity/oisy-wallet/assets/16886711/380c6cd8-daad-465d-ac8f-1d98a4918dc4">

Focus on link (after PR)

<img width="1536" alt="Capture d’écran 2024-07-09 à 07 06 35" src="https://github.com/dfinity/oisy-wallet/assets/16886711/bce79c88-fd8a-4bb5-8785-4ee8390e92bf">

