### PR TITLE
style(frontend): better fit SHIBA logo size

### DIFF
--- a/src/frontend/src/lib/components/ui/Img.svelte
+++ b/src/frontend/src/lib/components/ui/Img.svelte
@@ -6,6 +6,7 @@
 	export let width: string | undefined = undefined;
 	export let height: string | undefined = undefined;
 	export let rounded = false;
+	export let fitHeight = false;
 </script>
 
 <img
@@ -19,4 +20,5 @@
 	on:load
 	on:error
 	class:rounded-full={rounded}
+	style={fitHeight ? `max-width: inherit; height: ${height};` : undefined}
 />

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -42,7 +42,7 @@
 		<Img
 			{src}
 			{alt}
-			width={sizePx}
+			fitHeight
 			height={sizePx}
 			on:load={() => (loaded = true)}
 			on:error={onError}


### PR DESCRIPTION
# Motivation

The new SHIBA token logo looks really smallish. Not perfect but, this PR try to make it fit better in the UI without chaing it's SVG and without specifying a particular rule - i.e. applying a general CSS style for logo image.

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-07-09 à 09 50 37" src="https://github.com/dfinity/oisy-wallet/assets/16886711/3d900aaf-f322-4439-9125-1658451fe38b">
<img width="1536" alt="Capture d’écran 2024-07-09 à 09 50 45" src="https://github.com/dfinity/oisy-wallet/assets/16886711/57a00fb5-23a1-40aa-a465-47e68015abb1">

After:

<img width="1536" alt="Capture d’écran 2024-07-09 à 09 50 17" src="https://github.com/dfinity/oisy-wallet/assets/16886711/9a5fd8bd-3aca-4778-8511-db49c7d7d7fd">
<img width="1536" alt="Capture d’écran 2024-07-09 à 09 50 30" src="https://github.com/dfinity/oisy-wallet/assets/16886711/cfd01c6f-caa4-427e-9cce-b7c82d6586f5">

