### PR TITLE
style(frontend): overscroll-behavior contain for inner modal

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -202,7 +202,7 @@
 		>
 	</button>
 {:else}
-	<div class="container md:max-h-[26rem] pr-2 pt-1 overflow-y-auto">
+	<div class="container md:max-h-[26rem] pr-2 pt-1 overflow-y-auto overscroll-contain">
 		{#each tokens as token (`${token.network.id.description}-${token.id.description}`)}
 			<Card>
 				{token.name}

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -135,6 +135,8 @@ div.modal {
 
 		div.content {
 			border-radius: var(--padding-0_75x);
+
+			overscroll-behavior: contain;
 		}
 	}
 


### PR DESCRIPTION
# Motivation

Use [overscroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) for inner modal scroll to avoid scrolling body when inner scroll length is reached.
