### PR TITLE
style(frontend): disable body scroll when menu or dialog (modal) are open

### DIFF
--- a/src/frontend/src/lib/styles/global/body.scss
+++ b/src/frontend/src/lib/styles/global/body.scss
@@ -9,4 +9,9 @@ body {
 
 	overflow-y: auto;
 	overflow-x: hidden;
+
+	&:has([role='menu']),
+	&:has([role='dialog']) {
+		overflow: hidden;
+	}
 }


### PR DESCRIPTION
# Motivation

On desktop it does not bother too much that user can scroll the body while a modal is open but, on mobile, particularly iOS, it feels a bit glitchy for some reason even though the modal are full screen on mobile. To prevent the glitch we can disable the overflow when a modal (dialog) or popover (menu) is open and I just figured out that we can solve this with CSS only using `has` which is now well supported.
