### PR TITLE
ci(backend): create script shortcut to format backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"test": "vitest",
 		"cargo:test": "./scripts/test.backend.sh",
 		"clippy": "./scripts/lint.rust.sh",
+		"format:backend": "./scripts/format.sh",
 		"lint": "prettier --check './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}' && eslint .",
 		"format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}'",
 		"generate": "scripts/did.sh && dfx generate && node scripts/did.update.types.mjs && node scripts/did.delete.types.mjs && npm run format",


### PR DESCRIPTION
# Motivation

It would be useful to have a shortcut command to format the backend.