### PR TITLE
refactor(frontend): move ckERC20 JSON parsing to separate file for reusability

### DIFF
--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -5,13 +5,9 @@ import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens-erc20/tokens.pepe.en
 import { SHIB_TOKEN } from '$env/tokens-erc20/tokens.shib.env';
 import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
-import ckErc20Tokens from '$env/tokens.ckerc20.json';
+import { ckErc20Production, ckErc20Staging } from '$env/tokens.ckerc20.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
-import {
-	envTokensCkErc20,
-	type EnvTokenSymbol,
-	type EnvTokens
-} from '$icp/types/env-token-ckerc20';
+import { type EnvTokenSymbol, type EnvTokens } from '$icp/types/env-token-ckerc20';
 import type { IcCkInterface } from '$icp/types/ic';
 import { LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
 import type { CanisterIdText } from '$lib/types/canister';
@@ -186,12 +182,6 @@ export const CKETH_LEDGER_CANISTER_IDS: [CanisterIdText, ...CanisterIdText[]] = 
 /**
  * ckERC20
  */
-
-const ckErc20 = envTokensCkErc20.safeParse(ckErc20Tokens);
-
-const { production: ckErc20Production, staging: ckErc20Staging } = ckErc20.success
-	? ckErc20.data
-	: { production: {}, staging: {} };
 
 export const LOCAL_CKUSDC_LEDGER_CANISTER_ID = import.meta.env
 	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as CanisterIdText | null | undefined;

--- a/src/frontend/src/env/tokens.ckerc20.env.ts
+++ b/src/frontend/src/env/tokens.ckerc20.env.ts
@@ -1,0 +1,8 @@
+import ckErc20Tokens from '$env/tokens.ckerc20.json';
+import { envTokensCkErc20 } from '$icp/types/env-token-ckerc20';
+
+const ckErc20 = envTokensCkErc20.safeParse(ckErc20Tokens);
+
+export const { production: ckErc20Production, staging: ckErc20Staging } = ckErc20.success
+	? ckErc20.data
+	: { production: {}, staging: {} };


### PR DESCRIPTION
# Motivation

To be able to re-use the list of ckERC20 tokens that are in the JSON, we move the parsing to a separate file.
