### PR TITLE
style(frontend): adjust the main title to show 'to Oisy' on separate line

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div class="mt-6 xl:mt-12 mb-0.5 pt-2">
-	<h1 class="text-off-white text-5xl max-w-[16rem]">
+	<h1 class="text-off-white text-5xl max-w-[15rem]">
 		{$i18n.auth.text.connect_to_oisy}
 	</h1>
 


### PR DESCRIPTION
# Motivation
 
We would like to have the "to Oisy" part of the main title on a separate line.

# Before

<img width="1271" alt="Screenshot 2024-07-09 at 19 11 34" src="https://github.com/dfinity/oisy-wallet/assets/169057656/34c5c53c-209e-4e6c-8689-f351a808a8a3">
<img width="446" alt="Screenshot 2024-07-09 at 19 11 47" src="https://github.com/dfinity/oisy-wallet/assets/169057656/fd855852-51db-49bd-8e9c-7b817df33f19">
<img width="409" alt="Screenshot 2024-07-09 at 19 11 56" src="https://github.com/dfinity/oisy-wallet/assets/169057656/c6cbb153-038e-46d8-8d84-6c7d28a75d0c">

# After

<img width="1273" alt="Screenshot 2024-07-09 at 19 12 12" src="https://github.com/dfinity/oisy-wallet/assets/169057656/724c415c-adb0-4682-a31f-a444beb64d33">
<img width="453" alt="Screenshot 2024-07-09 at 19 12 22" src="https://github.com/dfinity/oisy-wallet/assets/169057656/3cc8da02-9023-4af0-8065-2006ba8550b6">
<img width="392" alt="Screenshot 2024-07-09 at 19 12 30" src="https://github.com/dfinity/oisy-wallet/assets/169057656/72ff38c7-329a-4345-97c2-9fa7517060f1">

