### PR TITLE
feat(env): Add Proof Of Humanity issuer to environment

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -16,13 +16,24 @@
 		},
 		"internet_identity": {
 			"type": "custom",
-			"candid": "https://github.com/dfinity/internet-identity/releases/download/release-2023-11-17/internet_identity.did",
-			"wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2023-11-17/internet_identity_dev.wasm.gz",
+			"candid": "https://github.com/dfinity/internet-identity/releases/download/release-2024-04-05/internet_identity.did",
+			"wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2024-04-05/internet_identity_dev.wasm.gz",
 			"shrink": false,
 			"remote": {
 				"candid": "internet_identity.did",
 				"id": {
 					"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+				}
+			}
+		},
+		"poh_issuer": {
+			"type": "custom",
+			"candid": "https://github.com/dfinity/verifiable-credentials-sdk/releases/download/release-2024-07-01/dummy_issuer.did",
+			"wasm": "https://github.com/dfinity/verifiable-credentials-sdk/releases/download/release-2024-07-01/dummy_issuer.wasm.gz",
+			"shrink": false,
+			"remote": {
+				"id": {
+					"staging": "qbw6f-caaaa-aaaah-qdcwa-cai"
 				}
 			}
 		},

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,5 +16,6 @@ mkdir -p ./target/ic
 ./scripts/deploy.ckerc20.sh
 
 dfx deploy internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
+dfx deploy poh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
 
 

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -9,6 +9,14 @@ export const INTERNET_IDENTITY_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_INTERNET_IDENTITY_CANISTER_ID
 	: undefined;
 
+export const POH_ISSUER_CANISTER_ID = LOCAL
+	? import.meta.env.VITE_LOCAL_POH_ISSUER_CANISTER_ID
+	: STAGING
+	? import.meta.env.VITE_STAGING_POH_ISSUER_CANISTER_ID
+	: PROD
+	? import.meta.env.VITE_IC_POH_ISSUER_CANISTER_ID
+	: undefined;
+
 export const BACKEND_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_BACKEND_CANISTER_ID
 	: STAGING

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -12,10 +12,10 @@ export const INTERNET_IDENTITY_CANISTER_ID = LOCAL
 export const POH_ISSUER_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_POH_ISSUER_CANISTER_ID
 	: STAGING
-	? import.meta.env.VITE_STAGING_POH_ISSUER_CANISTER_ID
-	: PROD
-	? import.meta.env.VITE_IC_POH_ISSUER_CANISTER_ID
-	: undefined;
+		? import.meta.env.VITE_STAGING_POH_ISSUER_CANISTER_ID
+		: PROD
+			? import.meta.env.VITE_IC_POH_ISSUER_CANISTER_ID
+			: undefined;
 
 export const BACKEND_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_BACKEND_CANISTER_ID


### PR DESCRIPTION
# Motivation

We would like to present the Proof Of Humanity credentials in Oisy.

In this PR, I introduce the issuer into the enviornment for Oisy. I added the entry to dfx.json pointing to a dummy issuer that will return any requested credential. As canister id, I used the canister id that Modclub gave us and we can use to test it in mainnet.

# Changes

* Update Internet Identity version to support VCs.
* New entry in dfx.json `poh_issuer`.
* Deploy the `poh_issuer` in `deploy.sh`.
* Add issuer canister id to constants.ts to confirm that it's added by the scripts.

# Tests

I even tested that we can present a credential using the JS library and passing all the necessary details.
