### PR TITLE
refactor(frontend): put BTC tokens before ETH tokens

### DIFF
--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -10,8 +10,8 @@ export const tokens: Readable<Token[]> = derived(
 	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
 	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
-		...$enabledEthereumTokens,
 		...$enabledBitcoinTokens,
+		...$enabledEthereumTokens,
 		...$erc20Tokens,
 		...$icrcTokens
 	]


### PR DESCRIPTION
# Motivation

It was recently decided that, in any case, the generic tokens orders shall have Bitcoin tokens before Ethereum tokens.
