### PR TITLE
feat(frontend): pin specific tokens on top

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,6 +1,6 @@
 import type { Erc20Token } from '$eth/types/erc20';
 import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
-import { tokens } from '$lib/derived/tokens.derived';
+import { sortedTokens } from '$lib/derived/tokens.derived';
 import type { Token } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { derived, type Readable } from 'svelte/store';
@@ -9,7 +9,7 @@ import { derived, type Readable } from 'svelte/store';
  * All tokens matching the selected network or chain fusion, regardless if they are enabled by the user or not.
  */
 const networkTokens: Readable<Token[]> = derived(
-	[tokens, selectedNetwork, pseudoNetworkChainFusion],
+	[sortedTokens, selectedNetwork, pseudoNetworkChainFusion],
 	filterTokensForSelectedNetwork
 );
 

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -3,10 +3,11 @@ import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { Token } from '$lib/types/token';
+import { pinTokensAtTop } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
-export const tokens: Readable<Token[]> = derived(
+const tokens: Readable<Token[]> = derived(
 	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
 	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
@@ -15,4 +16,8 @@ export const tokens: Readable<Token[]> = derived(
 		...$erc20Tokens,
 		...$icrcTokens
 	]
+);
+
+export const sortedTokens: Readable<Token[]> = derived([tokens], ([$tokens]) =>
+	pinTokensAtTop($tokens)
 );

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -1,0 +1,43 @@
+import { ICP_NETWORK_ID } from '$env/networks.env';
+import { USDC_TOKEN } from '$env/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import type { Token } from '$lib/types/token';
+import { isNullish, nonNullish } from '@dfinity/utils';
+
+const PINNED_TOKENS_ORDER: (Token & { twinTokenSymbol?: string })[] = [
+	ICP_TOKEN,
+	{ ...BTC_MAINNET_TOKEN, twinTokenSymbol: 'ckBTC' },
+	{ ...ETHEREUM_TOKEN, twinTokenSymbol: 'ckETH' },
+	USDC_TOKEN
+];
+
+export const pinTokensAtTop = (tokens: Token[]): Token[] => {
+	const pinnedTokens = PINNED_TOKENS_ORDER.map(
+		({ id: pinnedId, network: { id: pinnedNetworkId }, twinTokenSymbol }) => {
+			const token = tokens.find(
+				({ id, network: { id: networkId } }) => id === pinnedId && networkId === pinnedNetworkId
+			);
+
+			if (isNullish(twinTokenSymbol)) {
+				return nonNullish(token) ? [token] : [];
+			}
+
+			const twinToken = tokens.find(
+				({ id: twinTokenId, network: { id: twinTokenNetworkId } }) =>
+					twinTokenId === Symbol(twinTokenSymbol) && twinTokenNetworkId === ICP_NETWORK_ID
+			);
+
+			return [token, twinToken].filter(nonNullish);
+		}
+	).flat();
+
+	const otherTokens = tokens.filter(
+		(token) =>
+			!pinnedTokens.some(
+				({ id, network: { id: networkId } }) => id === token.id && networkId === token.network.id
+			)
+	);
+
+	return [...pinnedTokens, ...otherTokens];
+};

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -1,5 +1,5 @@
 import type { EthereumNetwork } from '$eth/types/network';
-import { tokens } from '$lib/derived/tokens.derived';
+import { sortedTokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -7,7 +7,7 @@ import { get } from 'svelte/store';
 import { generateUrn } from '../../mocks/qr-generator.mock';
 
 describe('decodeUrn', () => {
-	const tokenList = get(tokens);
+	const tokenList = get(sortedTokens);
 	const destination = 'some-destination';
 	const amount = 1.23;
 


### PR DESCRIPTION
# Motivation

According to a recent requirement, the list of tokens that shall be pinned on top in every token list is (in order):

1. ICP
2. BTC
3. ckBTC
4. ETH
5. ckETH
6. USDC
7. ckUSDC

# Changes

- Create list of pinned tokens.
- Create function to pin those on top.
- Create new derived for the sorted tokens (it will be used for further sorting).

