### PR TITLE
feat(frontend): request market cap to Coingecko in the same request of price

### DIFF
--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -29,7 +29,8 @@ export const exchangeRateERC20ToUsd = async (
 	simpleTokenPrice({
 		id: 'ethereum',
 		vs_currencies: 'usd',
-		contract_addresses: contractAddresses.map(({ address }) => address.toLowerCase())
+		contract_addresses: contractAddresses.map(({ address }) => address.toLowerCase()),
+		include_market_cap: true
 	});
 
 export const syncExchange = (data: PostMessageDataResponseExchange | undefined) =>


### PR DESCRIPTION
# Motivation

As request for sorting, we will need the market cap of the ERC20 tokens. So we request it to Coingecko.

NOTE: for sorting we don't really need the market cap for ICP, BTC and ETH because the logic of sorting them (or their ck* tokens) is different.
