### PR TITLE
chore(frontend): improve response types for Coingecko requests

### DIFF
--- a/src/frontend/src/lib/rest/goincecko.rest.ts
+++ b/src/frontend/src/lib/rest/goincecko.rest.ts
@@ -1,7 +1,10 @@
 import type {
+	CoingeckoResponse,
 	CoingeckoSimpleParams,
+	CoingeckoSimplePrice,
 	CoingeckoSimplePriceParams,
 	CoingeckoSimplePriceResponse,
+	CoingeckoSimpleTokenPrice,
 	CoingeckoSimpleTokenPriceParams,
 	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
@@ -21,7 +24,7 @@ export const simplePrice = async ({
 	ids,
 	...rest
 }: CoingeckoSimplePriceParams): Promise<CoingeckoSimplePriceResponse | null> =>
-	fetchCoingecko<CoingeckoSimplePriceResponse>({
+	fetchCoingecko<CoingeckoSimplePrice>({
 		endpointPath: 'simple/price',
 		queryParams: joinParams([
 			`ids=${Array.isArray(ids) ? ids.join(',') : ids}`,
@@ -41,7 +44,7 @@ export const simpleTokenPrice = async ({
 	contract_addresses,
 	...rest
 }: CoingeckoSimpleTokenPriceParams): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
-	fetchCoingecko<CoingeckoSimpleTokenPriceResponse>({
+	fetchCoingecko<CoingeckoSimpleTokenPrice>({
 		endpointPath: `simple/token_price/${id}`,
 		queryParams: joinParams([
 			`contract_addresses=${
@@ -51,13 +54,13 @@ export const simpleTokenPrice = async ({
 		])
 	});
 
-const fetchCoingecko = async <T>({
+const fetchCoingecko = async <T extends CoingeckoSimplePrice | CoingeckoSimpleTokenPrice>({
 	endpointPath,
 	queryParams
 }: {
 	endpointPath: string;
 	queryParams: string;
-}): Promise<T | null> => {
+}): Promise<CoingeckoResponse<T> | null> => {
 	const response = await fetch(`${API_URL}/${endpointPath}?${queryParams}`, {
 		headers: {
 			...(nonNullish(API_KEY) && { ['x-cg-pro-api-key']: API_KEY })

--- a/src/frontend/src/lib/rest/goincecko.rest.ts
+++ b/src/frontend/src/lib/rest/goincecko.rest.ts
@@ -2,7 +2,8 @@ import type {
 	CoingeckoSimpleParams,
 	CoingeckoSimplePriceParams,
 	CoingeckoSimplePriceResponse,
-	CoingeckoSimpleTokenPriceParams
+	CoingeckoSimpleTokenPriceParams,
+	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
 import { nonNullish } from '@dfinity/utils';
 
@@ -16,11 +17,11 @@ const API_KEY = import.meta.env.VITE_COINGECKO_API_KEY;
  * - https://www.coingecko.com/api/documentation
  *
  */
-export const simplePrice = async <T extends CoingeckoSimplePriceParams>({
+export const simplePrice = async ({
 	ids,
 	...rest
-}: CoingeckoSimplePriceParams): Promise<CoingeckoSimplePriceResponse<T> | null> =>
-	fetchCoingecko<CoingeckoSimplePriceResponse<T>>({
+}: CoingeckoSimplePriceParams): Promise<CoingeckoSimplePriceResponse | null> =>
+	fetchCoingecko<CoingeckoSimplePriceResponse>({
 		endpointPath: 'simple/price',
 		queryParams: joinParams([
 			`ids=${Array.isArray(ids) ? ids.join(',') : ids}`,
@@ -35,12 +36,12 @@ export const simplePrice = async <T extends CoingeckoSimplePriceParams>({
  * - https://www.coingecko.com/api/documentation
  *
  */
-export const simpleTokenPrice = async <T extends CoingeckoSimpleTokenPriceParams>({
+export const simpleTokenPrice = async ({
 	id,
 	contract_addresses,
 	...rest
-}: CoingeckoSimpleTokenPriceParams): Promise<CoingeckoSimplePriceResponse<T> | null> =>
-	fetchCoingecko<CoingeckoSimplePriceResponse<T>>({
+}: CoingeckoSimpleTokenPriceParams): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
+	fetchCoingecko<CoingeckoSimpleTokenPriceResponse>({
 		endpointPath: `simple/token_price/${id}`,
 		queryParams: joinParams([
 			`contract_addresses=${

--- a/src/frontend/src/lib/rest/goincecko.rest.ts
+++ b/src/frontend/src/lib/rest/goincecko.rest.ts
@@ -16,11 +16,11 @@ const API_KEY = import.meta.env.VITE_COINGECKO_API_KEY;
  * - https://www.coingecko.com/api/documentation
  *
  */
-export const simplePrice = async ({
+export const simplePrice = async <T extends CoingeckoSimplePriceParams>({
 	ids,
 	...rest
-}: CoingeckoSimplePriceParams): Promise<CoingeckoSimplePriceResponse | null> =>
-	fetchCoingecko({
+}: CoingeckoSimplePriceParams): Promise<CoingeckoSimplePriceResponse<T> | null> =>
+	fetchCoingecko<CoingeckoSimplePriceResponse<T>>({
 		endpointPath: 'simple/price',
 		queryParams: joinParams([
 			`ids=${Array.isArray(ids) ? ids.join(',') : ids}`,
@@ -35,12 +35,12 @@ export const simplePrice = async ({
  * - https://www.coingecko.com/api/documentation
  *
  */
-export const simpleTokenPrice = async ({
+export const simpleTokenPrice = async <T extends CoingeckoSimpleTokenPriceParams>({
 	id,
 	contract_addresses,
 	...rest
-}: CoingeckoSimpleTokenPriceParams): Promise<CoingeckoSimplePriceResponse | null> =>
-	fetchCoingecko({
+}: CoingeckoSimpleTokenPriceParams): Promise<CoingeckoSimplePriceResponse<T> | null> =>
+	fetchCoingecko<CoingeckoSimplePriceResponse<T>>({
 		endpointPath: `simple/token_price/${id}`,
 		queryParams: joinParams([
 			`contract_addresses=${
@@ -50,13 +50,13 @@ export const simpleTokenPrice = async ({
 		])
 	});
 
-const fetchCoingecko = async ({
+const fetchCoingecko = async <T>({
 	endpointPath,
 	queryParams
 }: {
 	endpointPath: string;
 	queryParams: string;
-}): Promise<CoingeckoSimplePriceResponse | null> => {
+}): Promise<T | null> => {
 	const response = await fetch(`${API_URL}/${endpointPath}?${queryParams}`, {
 		headers: {
 			...(nonNullish(API_KEY) && { ['x-cg-pro-api-key']: API_KEY })

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -2,37 +2,33 @@ import type { Erc20ContractAddress } from '$eth/types/erc20';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/goincecko.rest';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import type {
-	CoingeckoSimplePriceParams,
 	CoingeckoSimplePriceResponse,
-	CoingeckoSimpleTokenPriceParams
+	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
 import type { PostMessageDataResponseExchange } from '$lib/types/post-message';
 import { nonNullish } from '@dfinity/utils';
 
-export const exchangeRateETHToUsd =
-	async (): Promise<CoingeckoSimplePriceResponse<CoingeckoSimplePriceParams> | null> =>
-		simplePrice({
-			ids: 'ethereum',
-			vs_currencies: 'usd'
-		});
+export const exchangeRateETHToUsd = async (): Promise<CoingeckoSimplePriceResponse | null> =>
+	simplePrice({
+		ids: 'ethereum',
+		vs_currencies: 'usd'
+	});
 
-export const exchangeRateBTCToUsd =
-	async (): Promise<CoingeckoSimplePriceResponse<CoingeckoSimplePriceParams> | null> =>
-		simplePrice({
-			ids: 'bitcoin',
-			vs_currencies: 'usd'
-		});
+export const exchangeRateBTCToUsd = async (): Promise<CoingeckoSimplePriceResponse | null> =>
+	simplePrice({
+		ids: 'bitcoin',
+		vs_currencies: 'usd'
+	});
 
-export const exchangeRateICPToUsd =
-	async (): Promise<CoingeckoSimplePriceResponse<CoingeckoSimplePriceParams> | null> =>
-		simplePrice({
-			ids: 'internet-computer',
-			vs_currencies: 'usd'
-		});
+export const exchangeRateICPToUsd = async (): Promise<CoingeckoSimplePriceResponse | null> =>
+	simplePrice({
+		ids: 'internet-computer',
+		vs_currencies: 'usd'
+	});
 
 export const exchangeRateERC20ToUsd = async (
 	contractAddresses: Erc20ContractAddress[]
-): Promise<CoingeckoSimplePriceResponse<CoingeckoSimpleTokenPriceParams> | null> =>
+): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
 	simpleTokenPrice({
 		id: 'ethereum',
 		vs_currencies: 'usd',

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -1,35 +1,43 @@
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/goincecko.rest';
 import { exchangeStore } from '$lib/stores/exchange.store';
-import type { CoingeckoSimplePriceResponse } from '$lib/types/coingecko';
+import type {
+	CoingeckoSimplePriceParams,
+	CoingeckoSimplePriceResponse,
+	CoingeckoSimpleTokenPriceParams
+} from '$lib/types/coingecko';
 import type { PostMessageDataResponseExchange } from '$lib/types/post-message';
 import { nonNullish } from '@dfinity/utils';
 
-export const exchangeRateETHToUsd = async (): Promise<CoingeckoSimplePriceResponse | null> =>
-	simplePrice({
-		ids: 'ethereum',
-		vs_currencies: 'usd'
-	});
+export const exchangeRateETHToUsd =
+	async (): Promise<CoingeckoSimplePriceResponse<CoingeckoSimplePriceParams> | null> =>
+		simplePrice({
+			ids: 'ethereum',
+			vs_currencies: 'usd'
+		});
 
-export const exchangeRateBTCToUsd = async (): Promise<CoingeckoSimplePriceResponse | null> =>
-	simplePrice({
-		ids: 'bitcoin',
-		vs_currencies: 'usd'
-	});
+export const exchangeRateBTCToUsd =
+	async (): Promise<CoingeckoSimplePriceResponse<CoingeckoSimplePriceParams> | null> =>
+		simplePrice({
+			ids: 'bitcoin',
+			vs_currencies: 'usd'
+		});
 
-export const exchangeRateICPToUsd = async (): Promise<CoingeckoSimplePriceResponse | null> =>
-	simplePrice({
-		ids: 'internet-computer',
-		vs_currencies: 'usd'
-	});
+export const exchangeRateICPToUsd =
+	async (): Promise<CoingeckoSimplePriceResponse<CoingeckoSimplePriceParams> | null> =>
+		simplePrice({
+			ids: 'internet-computer',
+			vs_currencies: 'usd'
+		});
 
 export const exchangeRateERC20ToUsd = async (
 	contractAddresses: Erc20ContractAddress[]
-): Promise<CoingeckoSimplePriceResponse | null> =>
+): Promise<CoingeckoSimplePriceResponse<CoingeckoSimpleTokenPriceParams> | null> =>
 	simpleTokenPrice({
 		id: 'ethereum',
 		vs_currencies: 'usd',
-		contract_addresses: contractAddresses.map(({ address }) => address.toLowerCase())
+		contract_addresses: contractAddresses.map(({ address }) => address.toLowerCase()),
+		include_market_cap: true
 	});
 
 export const syncExchange = (data: PostMessageDataResponseExchange | undefined) =>

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -52,13 +52,11 @@ export interface CoingeckoSimplePrice {
 	last_updated_at?: number;
 }
 
-export type CoingeckoSimplePriceResponse = Record<CoingeckoCoinsId | string, CoingeckoSimplePrice>;
+export type CoingeckoSimpleTokenPrice = Omit<CoingeckoSimplePrice, 'usd_market_cap'> &
+	Required<Pick<CoingeckoSimplePrice, 'usd_market_cap'>>;
 
-export interface CoingeckoSimpleTokenPrice extends CoingeckoSimplePrice {
-	usd_market_cap: number;
-}
+export type CoingeckoResponse<T> = Record<CoingeckoCoinsId | string, T>;
 
-export type CoingeckoSimpleTokenPriceResponse = Record<
-	CoingeckoCoinsId | string,
-	CoingeckoSimpleTokenPrice
->;
+export type CoingeckoSimplePriceResponse = CoingeckoResponse<CoingeckoSimplePrice>;
+
+export type CoingeckoSimpleTokenPriceResponse = CoingeckoResponse<CoingeckoSimpleTokenPrice>;

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -42,39 +42,23 @@ export interface CoingeckoSimpleTokenPriceParams extends CoingeckoSimpleParams {
 	id: CoingeckoPlatformId;
 	// The contract address of tokens, comma separated
 	contract_addresses: string | string[];
-	//
-	include_market_cap: true;
 }
 
-interface CoingeckoSimplePriceBase {
+export interface CoingeckoSimplePrice {
 	usd: number;
+	usd_market_cap?: number;
+	usd_24h_vol?: number;
+	usd_24h_change?: number;
+	last_updated_at?: number;
 }
 
-interface CoingeckoSimplePriceEmpty {}
+export type CoingeckoSimplePriceResponse = Record<CoingeckoCoinsId | string, CoingeckoSimplePrice>;
 
-export type CoingeckoSimplePrice<T extends CoingeckoSimpleParams> = CoingeckoSimplePriceBase &
-	(T['include_market_cap'] extends true
-		? {
-				usd_market_cap: number;
-			}
-		: CoingeckoSimplePriceEmpty) &
-	(T['include_24hr_vol'] extends true
-		? {
-				usd_24h_vol: number;
-			}
-		: CoingeckoSimplePriceEmpty) &
-	(T['include_24hr_change'] extends true
-		? {
-				usd_24h_change: number;
-			}
-		: CoingeckoSimplePriceEmpty) &
-	(T['include_last_updated_at'] extends true
-		? {
-				last_updated_at: number;
-			}
-		: CoingeckoSimplePriceEmpty);
+export interface CoingeckoSimpleTokenPrice extends CoingeckoSimplePrice {
+	usd_market_cap: number;
+}
 
-export type CoingeckoSimplePriceResponse<T extends CoingeckoSimpleParams> = Record<
+export type CoingeckoSimpleTokenPriceResponse = Record<
 	CoingeckoCoinsId | string,
-	CoingeckoSimplePrice<T>
+	CoingeckoSimpleTokenPrice
 >;

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -42,14 +42,39 @@ export interface CoingeckoSimpleTokenPriceParams extends CoingeckoSimpleParams {
 	id: CoingeckoPlatformId;
 	// The contract address of tokens, comma separated
 	contract_addresses: string | string[];
+	//
+	include_market_cap: true;
 }
 
-export interface CoingeckoSimplePrice {
+interface CoingeckoSimplePriceBase {
 	usd: number;
-	usd_market_cap?: number;
-	usd_24h_vol?: number;
-	usd_24h_change?: number;
-	last_updated_at?: number;
 }
 
-export type CoingeckoSimplePriceResponse = Record<CoingeckoCoinsId | string, CoingeckoSimplePrice>;
+interface CoingeckoSimplePriceEmpty {}
+
+export type CoingeckoSimplePrice<T extends CoingeckoSimpleParams> = CoingeckoSimplePriceBase &
+	(T['include_market_cap'] extends true
+		? {
+				usd_market_cap: number;
+			}
+		: CoingeckoSimplePriceEmpty) &
+	(T['include_24hr_vol'] extends true
+		? {
+				usd_24h_vol: number;
+			}
+		: CoingeckoSimplePriceEmpty) &
+	(T['include_24hr_change'] extends true
+		? {
+				usd_24h_change: number;
+			}
+		: CoingeckoSimplePriceEmpty) &
+	(T['include_last_updated_at'] extends true
+		? {
+				last_updated_at: number;
+			}
+		: CoingeckoSimplePriceEmpty);
+
+export type CoingeckoSimplePriceResponse<T extends CoingeckoSimpleParams> = Record<
+	CoingeckoCoinsId | string,
+	CoingeckoSimplePrice<T>
+>;


### PR DESCRIPTION
# Motivation

After PR #1737 , the response type of function `exchangeRateERC20ToUsd` returns the prop `usd_market_cap` as `number` (and not possibly `undefined`). To be type-safe, we create a new type specific to this function.

# Changes

- Create type `CoingeckoSimpleTokenPriceResponse` that remove optionality of `usd_market_cap`.
- Use the type for function `exchangeRateERC20ToUsd`.
- Adapt function that fetches prices to have variable type on response.
