### PR TITLE
fix(frontend): missing new Coingecko Response types in exchange stores

### DIFF
--- a/src/frontend/src/lib/stores/exchange.store.ts
+++ b/src/frontend/src/lib/stores/exchange.store.ts
@@ -1,11 +1,17 @@
-import type { CoingeckoSimplePriceResponse } from '$lib/types/coingecko';
+import type {
+	CoingeckoSimplePriceResponse,
+	CoingeckoSimpleTokenPriceResponse
+} from '$lib/types/coingecko';
 import { nonNullish } from '@dfinity/utils';
 import { writable, type Readable } from 'svelte/store';
 
-export type ExchangeData = CoingeckoSimplePriceResponse | undefined | null;
+export type ExchangeData =
+	| (CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse)
+	| undefined
+	| null;
 
 export interface ExchangeStore extends Readable<ExchangeData> {
-	set: (params: CoingeckoSimplePriceResponse[]) => void;
+	set: (params: (CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse)[]) => void;
 	reset: () => void;
 }
 
@@ -13,7 +19,7 @@ const initExchangeStore = (): ExchangeStore => {
 	const { subscribe, set, update } = writable<ExchangeData>(undefined);
 
 	return {
-		set: (tokensPrice: CoingeckoSimplePriceResponse[]) =>
+		set: (tokensPrice: (CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse)[]) =>
 			update((state) => ({
 				...(nonNullish(state) && state),
 				...tokensPrice.reduce(

--- a/src/frontend/src/lib/stores/exchange.store.ts
+++ b/src/frontend/src/lib/stores/exchange.store.ts
@@ -1,17 +1,11 @@
-import type {
-	CoingeckoSimplePriceResponse,
-	CoingeckoSimpleTokenPriceResponse
-} from '$lib/types/coingecko';
+import type { CoingeckoPriceResponse } from '$lib/types/coingecko';
 import { nonNullish } from '@dfinity/utils';
 import { writable, type Readable } from 'svelte/store';
 
-export type ExchangeData =
-	| (CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse)
-	| undefined
-	| null;
+export type ExchangeData = CoingeckoPriceResponse | undefined | null;
 
 export interface ExchangeStore extends Readable<ExchangeData> {
-	set: (params: (CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse)[]) => void;
+	set: (params: CoingeckoPriceResponse[]) => void;
 	reset: () => void;
 }
 
@@ -19,7 +13,7 @@ const initExchangeStore = (): ExchangeStore => {
 	const { subscribe, set, update } = writable<ExchangeData>(undefined);
 
 	return {
-		set: (tokensPrice: (CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse)[]) =>
+		set: (tokensPrice: CoingeckoPriceResponse[]) =>
 			update((state) => ({
 				...(nonNullish(state) && state),
 				...tokensPrice.reduce(

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -60,3 +60,7 @@ export type CoingeckoResponse<T> = Record<CoingeckoCoinsId | string, T>;
 export type CoingeckoSimplePriceResponse = CoingeckoResponse<CoingeckoSimplePrice>;
 
 export type CoingeckoSimpleTokenPriceResponse = CoingeckoResponse<CoingeckoSimpleTokenPrice>;
+
+export type CoingeckoPriceResponse =
+	| CoingeckoSimplePriceResponse
+	| CoingeckoSimpleTokenPriceResponse;

--- a/src/frontend/src/lib/types/exchange.ts
+++ b/src/frontend/src/lib/types/exchange.ts
@@ -1,6 +1,9 @@
-import type { CoingeckoSimplePrice } from '$lib/types/coingecko';
+import type { CoingeckoSimplePrice, CoingeckoSimpleTokenPrice } from '$lib/types/coingecko';
 import type { TokenId } from '$lib/types/token';
 
 export type Exchange = 'ethereum' | 'erc20' | 'icp';
 
-export type ExchangesData = Record<TokenId, CoingeckoSimplePrice | undefined>;
+export type ExchangesData = Record<
+	TokenId,
+	(CoingeckoSimplePrice | CoingeckoSimpleTokenPrice) | undefined
+>;

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -1,6 +1,9 @@
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { PostMessageWalletData } from '$icp/types/ic.post-message';
-import type { CoingeckoSimplePriceResponse } from '$lib/types/coingecko';
+import type {
+	CoingeckoSimplePriceResponse,
+	CoingeckoSimpleTokenPriceResponse
+} from '$lib/types/coingecko';
 
 import type { BtcAddressData } from '$icp/stores/btc.store';
 import type { JsonText } from '$icp/types/btc.post-message';
@@ -79,7 +82,7 @@ export interface PostMessageDataResponseAuth extends PostMessageDataResponse {
 export interface PostMessageDataResponseExchange extends PostMessageDataResponse {
 	currentEthPrice: CoingeckoSimplePriceResponse;
 	currentBtcPrice: CoingeckoSimplePriceResponse;
-	currentErc20Prices: CoingeckoSimplePriceResponse;
+	currentErc20Prices: CoingeckoSimpleTokenPriceResponse;
 	currentIcpPrice: CoingeckoSimplePriceResponse;
 }
 


### PR DESCRIPTION
# Motivation

I just noticed that in PR #1738 , I forgot to update the types in the stores that use Coingecko rest wrappers.

I am not using the dynamic type `T extends CoingeckoSimplePriceResponse | CoingeckoSimpleTokenPriceResponse` because the stores effectively provide a record of possibly both types, and not selectively only one of them.
