### PR TITLE
refactor(frontend): Rename POH to POUH

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -26,7 +26,7 @@
 				}
 			}
 		},
-		"poh_issuer": {
+		"pouh_issuer": {
 			"type": "custom",
 			"candid": "https://github.com/dfinity/verifiable-credentials-sdk/releases/download/release-2024-07-01/dummy_issuer.did",
 			"wasm": "https://github.com/dfinity/verifiable-credentials-sdk/releases/download/release-2024-07-01/dummy_issuer.wasm.gz",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,6 +16,6 @@ mkdir -p ./target/ic
 ./scripts/deploy.ckerc20.sh
 
 dfx deploy internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
-dfx deploy poh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
+dfx deploy pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
 
 

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -17,7 +17,7 @@ export const INTERNET_IDENTITY_ORIGIN = LOCAL
 	? `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
 	: 'https://identity.ic0.app';
 
-export const POH_ISSUER_CANISTER_ID = LOCAL
+export const POUH_ISSUER_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_POH_ISSUER_CANISTER_ID
 	: STAGING
 		? import.meta.env.VITE_STAGING_POH_ISSUER_CANISTER_ID
@@ -25,10 +25,10 @@ export const POH_ISSUER_CANISTER_ID = LOCAL
 			? import.meta.env.VITE_IC_POH_ISSUER_CANISTER_ID
 			: undefined;
 
-export const POH_ISSUER_ORIGIN = nonNullish(POH_ISSUER_CANISTER_ID)
+export const POUH_ISSUER_ORIGIN = nonNullish(POUH_ISSUER_CANISTER_ID)
 	? LOCAL
-		? `http://${POH_ISSUER_CANISTER_ID}.localhost:4943`
-		: `https://${POH_ISSUER_CANISTER_ID}.${MAINNET_DOMAIN}`
+		? `http://${POUH_ISSUER_CANISTER_ID}.localhost:4943`
+		: `https://${POUH_ISSUER_CANISTER_ID}.${MAINNET_DOMAIN}`
 	: undefined;
 
 export const BACKEND_CANISTER_ID = LOCAL

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -18,11 +18,11 @@ export const INTERNET_IDENTITY_ORIGIN = LOCAL
 	: 'https://identity.ic0.app';
 
 export const POUH_ISSUER_CANISTER_ID = LOCAL
-	? import.meta.env.VITE_LOCAL_POH_ISSUER_CANISTER_ID
+	? import.meta.env.VITE_LOCAL_POUH_ISSUER_CANISTER_ID
 	: STAGING
-		? import.meta.env.VITE_STAGING_POH_ISSUER_CANISTER_ID
+		? import.meta.env.VITE_STAGING_POUH_ISSUER_CANISTER_ID
 		: PROD
-			? import.meta.env.VITE_IC_POH_ISSUER_CANISTER_ID
+			? import.meta.env.VITE_IC_POUH_ISSUER_CANISTER_ID
 			: undefined;
 
 export const POUH_ISSUER_ORIGIN = nonNullish(POUH_ISSUER_CANISTER_ID)

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -49,9 +49,9 @@
 		},
 		"error": {
 			"no_internet_identity": "No internet identity.",
-			"error_requesting_poh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
-			"missing_poh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
-			"no_poh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?"
+			"error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
+			"missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
+			"no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?"
 		}
 	},
 	"wallet": {

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -15,7 +15,7 @@ import {
 import { get } from 'svelte/store';
 
 // This credential type is defined by the issuer Decide AI
-const POH_CREDENTIAL_TYPE = 'ProofOfUniqueness';
+const POUH_CREDENTIAL_TYPE = 'ProofOfUniqueness';
 
 const handleSuccess = async (
 	response: VerifiablePresentationResponse
@@ -24,13 +24,13 @@ const handleSuccess = async (
 	if ('Ok' in response) {
 		// TODO: GIX-2646 Add credential to backend and load user profile
 		const fakeTemporaryCredentialSummary = {
-			credential_type: POH_CREDENTIAL_TYPE,
+			credential_type: POUH_CREDENTIAL_TYPE,
 			verified_date_timestamp: BigInt(Date.now()),
 			expire_date_timestamp: BigInt(Date.now() + 1000 * 60 * 60 * 24 * 365)
 		};
 		const fakeUserProfile: UserProfile = {
 			credentials: {
-				[POH_CREDENTIAL_TYPE]: fakeTemporaryCredentialSummary
+				[POUH_CREDENTIAL_TYPE]: fakeTemporaryCredentialSummary
 			},
 			created_timestamp: BigInt(Date.now()),
 			updated_timestamp: BigInt(Date.now())
@@ -39,7 +39,7 @@ const handleSuccess = async (
 		return { success: true };
 	}
 	toastsError({
-		msg: { text: authI18n.error.no_poh_credential }
+		msg: { text: authI18n.error.no_pouh_credential }
 	});
 	return { success: false };
 };
@@ -56,7 +56,7 @@ export const requestPouhCredential = async ({
 			: undefined;
 		if (isNullish(POUH_ISSUER_ORIGIN) || isNullish(issuerCanisterId)) {
 			toastsError({
-				msg: { text: authI18n.error.missing_poh_issuer_origin }
+				msg: { text: authI18n.error.missing_pouh_issuer_origin }
 			});
 			resolve({ success: false });
 			return;
@@ -69,14 +69,14 @@ export const requestPouhCredential = async ({
 			identityProvider: new URL(INTERNET_IDENTITY_ORIGIN),
 			credentialData: {
 				credentialSpec: {
-					credentialType: POH_CREDENTIAL_TYPE,
+					credentialType: POUH_CREDENTIAL_TYPE,
 					arguments: {}
 				},
 				credentialSubject
 			},
 			onError() {
 				toastsError({
-					msg: { text: authI18n.error.error_requesting_poh_credential }
+					msg: { text: authI18n.error.error_requesting_pouh_credential }
 				});
 				reject();
 			},

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -1,7 +1,7 @@
 import {
 	INTERNET_IDENTITY_ORIGIN,
-	POH_ISSUER_CANISTER_ID,
-	POH_ISSUER_ORIGIN
+	POUH_ISSUER_CANISTER_ID,
+	POUH_ISSUER_ORIGIN
 } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { userProfileStore, type UserProfile } from '$lib/stores/settings.store';
@@ -44,17 +44,17 @@ const handleSuccess = async (
 	return { success: false };
 };
 
-export const requestPohCredential = async ({
+export const requestPouhCredential = async ({
 	credentialSubject
 }: {
 	credentialSubject: Principal;
 }): Promise<{ success: boolean }> => {
 	const { auth: authI18n } = get(i18n);
 	return new Promise((resolve, reject) => {
-		const issuerCanisterId = nonNullish(POH_ISSUER_CANISTER_ID)
-			? Principal.fromText(POH_ISSUER_CANISTER_ID)
+		const issuerCanisterId = nonNullish(POUH_ISSUER_CANISTER_ID)
+			? Principal.fromText(POUH_ISSUER_CANISTER_ID)
 			: undefined;
-		if (isNullish(POH_ISSUER_ORIGIN) || isNullish(issuerCanisterId)) {
+		if (isNullish(POUH_ISSUER_ORIGIN) || isNullish(issuerCanisterId)) {
 			toastsError({
 				msg: { text: authI18n.error.missing_poh_issuer_origin }
 			});
@@ -63,7 +63,7 @@ export const requestPohCredential = async ({
 		}
 		requestVerifiablePresentation({
 			issuerData: {
-				origin: POH_ISSUER_ORIGIN,
+				origin: POUH_ISSUER_ORIGIN,
 				canisterId: issuerCanisterId
 			},
 			identityProvider: new URL(INTERNET_IDENTITY_ORIGIN),

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -44,9 +44,9 @@ interface I18nAuth {
 	alt: { sign_in: string };
 	error: {
 		no_internet_identity: string;
-		error_requesting_poh_credential: string;
-		missing_poh_issuer_origin: string;
-		no_poh_credential: string;
+		error_requesting_pouh_credential: string;
+		missing_pouh_issuer_origin: string;
+		no_pouh_credential: string;
 	};
 }
 


### PR DESCRIPTION
# Motivation

We agreed that the name of the credential is Proof Of Unique Humanity, not Proof Of Humanity.

In this PR, I rename all the variables, files etc from POH to POUH.

# Changes

* Rename canister poh_issuer in dfx json to pouh_issuer
* Rename env vars that use dfx.json canister name
* Rename a file with the service.
* Rename constants.
* Rename i18n keys.

# Tests

I tested by redeploying the canister and checking that the env vars are still there as expected.
