### PR TITLE
feat(frontend): ck btc testnet and sepolia explorer links

### DIFF
--- a/src/frontend/src/env/explorers.env.ts
+++ b/src/frontend/src/env/explorers.env.ts
@@ -3,7 +3,9 @@ const EXPLORER_URLS = {
 	SEPOLIA: 'https://sepolia.etherscan.io',
 	ICP: 'https://dashboard.internetcomputer.org',
 	CKETH: 'https://dashboard.internetcomputer.org/ethereum',
+	CKETH_SEPOLIA: 'https://dashboard.internetcomputer.org/sepoliaeth',
 	CKBTC: 'https://dashboard.internetcomputer.org/bitcoin',
+	CKBTC_TESTNET: 'https://dashboard.internetcomputer.org/testbtc',
 	SNS: 'https://dashboard.internetcomputer.org/sns',
 	BTC_MAINNET: 'https://blockstream.info',
 	BTC_TESTNET: 'https://blockstream.info/testnet'
@@ -14,7 +16,9 @@ export const {
 	SEPOLIA: SEPOLIA_EXPLORER_URL,
 	ICP: ICP_EXPLORER_URL,
 	CKETH: CKETH_EXPLORER_URL,
+	CKETH_SEPOLIA: CKETH_SEPOLIA_EXPLORER_URL,
 	CKBTC: CKBTC_EXPLORER_URL,
+	CKBTC_TESTNET: CKBTC_TESTNET_EXPLORER_URL,
 	SNS: SNS_EXPLORER_URL,
 	BTC_MAINNET: BTC_MAINNET_EXPLORER_URL,
 	BTC_TESTNET: BTC_TESTNET_EXPLORER_URL

--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -1,4 +1,9 @@
-import { CKBTC_EXPLORER_URL, CKETH_EXPLORER_URL } from '$env/explorers.env';
+import {
+	CKBTC_EXPLORER_URL,
+	CKBTC_TESTNET_EXPLORER_URL,
+	CKETH_EXPLORER_URL,
+	CKETH_SEPOLIA_EXPLORER_URL
+} from '$env/explorers.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens-erc20/tokens.oct.env';
 import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens-erc20/tokens.pepe.env';
@@ -11,6 +16,7 @@ import { type EnvTokenSymbol, type EnvTokens } from '$icp/types/env-token-ckerc2
 import type { IcCkInterface } from '$icp/types/ic';
 import { LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
 import type { CanisterIdText } from '$lib/types/canister';
+import type { NetworkEnvironment } from '$lib/types/network';
 import { nonNullish } from '@dfinity/utils';
 
 export const IC_CKBTC_LEDGER_CANISTER_ID =
@@ -67,7 +73,8 @@ const CKBTC_STAGING_DATA: IcCkInterface | undefined =
 				minterCanisterId: STAGING_CKBTC_MINTER_CANISTER_ID,
 				exchangeCoinId: 'bitcoin',
 				position: 2,
-				twinToken: BTC_TESTNET_TOKEN
+				twinToken: BTC_TESTNET_TOKEN,
+				explorerUrl: CKBTC_TESTNET_EXPLORER_URL
 			}
 		: undefined;
 
@@ -209,11 +216,13 @@ const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
 const mapCkErc20Data = ({
 	ckErc20Tokens,
 	minterCanisterId,
-	ledgerCanisterId
+	ledgerCanisterId,
+	env
 }: {
 	ckErc20Tokens: EnvTokens;
 	minterCanisterId: string | null | undefined;
 	ledgerCanisterId: string | null | undefined;
+	env: NetworkEnvironment;
 }): Record<EnvTokenSymbol, Omit<IcCkInterface, 'twinToken' | 'position'>> =>
 	Object.entries(ckErc20Tokens).reduce(
 		(acc, [key, value]) => ({
@@ -225,7 +234,7 @@ const mapCkErc20Data = ({
 						...value,
 						minterCanisterId,
 						exchangeCoinId: 'ethereum',
-						explorerUrl: `${CKETH_EXPLORER_URL}/${value.ledgerCanisterId}`,
+						explorerUrl: `${env === 'testnet' ? CKETH_SEPOLIA_EXPLORER_URL : CKETH_EXPLORER_URL}/${value.ledgerCanisterId}`,
 						...(nonNullish(ledgerCanisterId) && {
 							feeLedgerCanisterId: ledgerCanisterId
 						})
@@ -238,13 +247,15 @@ const mapCkErc20Data = ({
 const CKERC20_STAGING_DATA = mapCkErc20Data({
 	ckErc20Tokens: ckErc20Staging,
 	minterCanisterId: STAGING_CKETH_MINTER_CANISTER_ID,
-	ledgerCanisterId: STAGING_CKETH_LEDGER_CANISTER_ID
+	ledgerCanisterId: STAGING_CKETH_LEDGER_CANISTER_ID,
+	env: 'testnet'
 });
 
 const CKERC20_PRODUCTION_DATA = mapCkErc20Data({
 	ckErc20Tokens: ckErc20Production,
 	minterCanisterId: IC_CKETH_MINTER_CANISTER_ID,
-	ledgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID
+	ledgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID,
+	env: 'mainnet'
 });
 
 const CKUSDC_STAGING_DATA: IcCkInterface | undefined = nonNullish(

--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -159,7 +159,8 @@ const CKETH_STAGING_DATA: IcCkInterface | undefined =
 				minterCanisterId: STAGING_CKETH_MINTER_CANISTER_ID,
 				exchangeCoinId: 'ethereum',
 				position: 2,
-				twinToken: SEPOLIA_TOKEN
+				twinToken: SEPOLIA_TOKEN,
+				explorerUrl: CKETH_SEPOLIA_EXPLORER_URL
 			}
 		: undefined;
 

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -16,7 +16,8 @@ import { syncWallet } from './ic-listener.services';
 export const initIcrcWalletWorker = async ({
 	indexCanisterId,
 	ledgerCanisterId,
-	id: tokenId
+	id: tokenId,
+	network: { env }
 }: IcToken): Promise<WalletWorker> => {
 	const WalletWorker = await import('$icp/workers/icrc-wallet.worker?worker');
 	const worker: Worker = new WalletWorker.default();
@@ -62,7 +63,8 @@ export const initIcrcWalletWorker = async ({
 				msg: 'startIcrcWalletTimer',
 				data: {
 					indexCanisterId,
-					ledgerCanisterId
+					ledgerCanisterId,
+					env
 				}
 			});
 		},
@@ -76,7 +78,8 @@ export const initIcrcWalletWorker = async ({
 				msg: 'triggerIcrcWalletTimer',
 				data: {
 					indexCanisterId,
-					ledgerCanisterId
+					ledgerCanisterId,
+					env
 				}
 			});
 		}

--- a/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
@@ -1,7 +1,8 @@
 import {
 	BTC_MAINNET_EXPLORER_URL,
 	BTC_TESTNET_EXPLORER_URL,
-	CKBTC_EXPLORER_URL
+	CKBTC_EXPLORER_URL,
+	CKBTC_TESTNET_EXPLORER_URL
 } from '$env/explorers.env';
 import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/networks.icrc.env';
 import type { BtcStatusesData } from '$icp/stores/btc.store';
@@ -11,21 +12,28 @@ import { utxoTxIdToString } from '$icp/utils/btc.utils';
 import { MINT_MEMO_KYT_FAIL, decodeBurnMemo, decodeMintMemo } from '$icp/utils/ckbtc-memo.utils';
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
 import type { OptionIdentity } from '$lib/types/identity';
+import type { Network } from '$lib/types/network';
 import type { PendingUtxo, RetrieveBtcStatusV2 } from '@dfinity/ckbtc';
 import { fromNullable, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 
 export const mapCkBTCTransaction = ({
 	transaction,
 	identity,
-	ledgerCanisterId
+	ledgerCanisterId,
+	env
 }: {
 	transaction: IcrcTransaction;
 	identity: OptionIdentity;
-} & Pick<IcToken, 'ledgerCanisterId'>): IcTransactionUi => {
+} & Pick<IcToken, 'ledgerCanisterId'> &
+	Partial<Pick<Network, 'env'>>): IcTransactionUi => {
 	const { id, from, to, ...txRest } = mapIcrcTransaction({ transaction, identity });
 
 	const ckBTCExplorerUrl =
-		IC_CKBTC_LEDGER_CANISTER_ID === ledgerCanisterId ? CKBTC_EXPLORER_URL : undefined;
+		IC_CKBTC_LEDGER_CANISTER_ID === ledgerCanisterId && nonNullish(env)
+			? env === 'testnet'
+				? CKBTC_TESTNET_EXPLORER_URL
+				: CKBTC_EXPLORER_URL
+			: undefined;
 
 	const tx: IcTransactionUi = {
 		id,

--- a/src/frontend/src/icp/utils/ic-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ic-transactions.utils.ts
@@ -40,6 +40,7 @@ export const mapIcTransaction = ({
 		return mapCkBTCTransaction({
 			transaction: transaction as IcrcTransaction,
 			ledgerCanisterId: (token as IcCkToken).ledgerCanisterId,
+			env: token.network.env,
 			...rest
 		});
 	}

--- a/src/frontend/src/icp/workers/icrc-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icrc-wallet.worker.ts
@@ -43,9 +43,10 @@ const mapTransaction = ({
 	jobData: SchedulerJobData<PostMessageDataRequestIcrc>;
 }): IcTransactionUi => {
 	const ledgerId = nonNullish(data) ? { ledgerCanisterId: data.ledgerCanisterId } : undefined;
+	const env = { env: data?.env };
 
 	if (nonNullish(ledgerId) && isTokenCkBtcLedger(ledgerId)) {
-		return mapCkBTCTransaction({ transaction, identity, ...ledgerId });
+		return mapCkBTCTransaction({ transaction, identity, ...env, ...ledgerId });
 	}
 
 	if (nonNullish(ledgerId) && (isTokenCkEthLedger(ledgerId) || isTokenCkErc20Ledger(ledgerId))) {

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -8,6 +8,7 @@ import type {
 import type { BtcAddressData } from '$icp/stores/btc.store';
 import type { JsonText } from '$icp/types/btc.post-message';
 import type { IcCanisters, IcCkMetadata } from '$icp/types/ic';
+import type { Network } from '$lib/types/network';
 import type { SyncState } from '$lib/types/sync';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
 
@@ -40,7 +41,7 @@ export interface PostMessageDataRequestExchangeTimer {
 	erc20Addresses: Erc20ContractAddress[];
 }
 
-export type PostMessageDataRequestIcrc = IcCanisters;
+export type PostMessageDataRequestIcrc = IcCanisters & Pick<Network, 'env'>;
 
 export type PostMessageDataRequestIcCk = Partial<Pick<IcCkMetadata, 'minterCanisterId'>>;
 


### PR DESCRIPTION
# Motivation

The dashboard team has added support for ck test tokens.

- Add links for ckTESTBTC https://dashboard.internetcomputer.org/testbtc
- Add links for ckSepoliaETH https://dashboard.internetcomputer.org/sepoliaeth
- Add links for ckErc20 https://dashboard.internetcomputer.org/sepoliaeth/<ledger-id>

# Changes

- Add new explorer urls constants
- Map staging urls in environment variables
- Path `env` testnet or mainnet to web workers
- Extend `mapIcrcTransaction` utility to support those testnet explorer urls

# Tests

Tested manually on staging.
