### PR TITLE
feat(frontend): token menu actions order

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -46,13 +46,13 @@
 
 <Popover bind:visible anchor={button} invisibleBackdrop direction="rtl">
 	<div class="flex flex-col gap-3">
-		<slot />
-
 		{#if $tokenToggleable}
 			<ButtonMenu ariaLabel={hideTokenLabel} on:click={hideToken}>
 				{hideTokenLabel}
 			</ButtonMenu>
 		{/if}
+
+		<slot />
 
 		<ButtonMenu ariaLabel={$i18n.tokens.details.title} on:click={openToken}>
 			{$i18n.tokens.details.title}


### PR DESCRIPTION
# Motivation

Because not all tokens have the action "Hide token" in the token menu, it's worth updating the order of the displayed for consistency reason.

That way, "View on Explorer" and "Token details" are always displayed next to each other.

# Screenshots

<img width="1536" alt="Capture d’écran 2024-07-15 à 08 07 21" src="https://github.com/user-attachments/assets/f3533a65-bb7b-4158-84fc-212430c98167">
<img width="1536" alt="Capture d’écran 2024-07-15 à 08 07 41" src="https://github.com/user-attachments/assets/d9bae530-0c4f-4d7b-bf8e-61f200574688">

