### PR TITLE
style(frontend): "Connect with" padding

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -53,7 +53,7 @@ button {
 
 	&.ic {
 		width: fit-content;
-		padding: var(--padding) var(--padding-8x) var(--padding) var(--padding-2x);
+		padding: var(--padding-1_5x) var(--padding-8x) var(--padding-1_5x) var(--padding-2x);
 		margin: 0 0 var(--padding-2x);
 
 		span {


### PR DESCRIPTION
# Motivation

I feel like the "Connect with" button is a bit compressed. Adding just a bit of padding make it a bit more pleasant.

# Screenshots

<img width="1536" alt="Capture d’écran 2024-07-15 à 08 10 01" src="https://github.com/user-attachments/assets/aa410cff-e8f9-4553-b3f5-e11a26877e0e">
<img width="1536" alt="Capture d’écran 2024-07-15 à 08 10 22" src="https://github.com/user-attachments/assets/853b5962-a80f-447f-a11a-654403fa883d">

