### PR TITLE
style(frontend): external link full width

### DIFF
--- a/src/frontend/src/eth/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/eth/components/tokens/TokenMenu.svelte
@@ -24,6 +24,7 @@
 	{#if nonNullish(explorerUrl) && $erc20UserTokensInitialized}
 		<div in:fade>
 			<ExternalLink
+				fullWith
 				href={explorerUrl}
 				ariaLabel={$i18n.tokens.alt.open_etherscan}
 				iconVisible={false}

--- a/src/frontend/src/eth/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/eth/components/tokens/TokenMenu.svelte
@@ -24,7 +24,7 @@
 	{#if nonNullish(explorerUrl) && $erc20UserTokensInitialized}
 		<div in:fade>
 			<ExternalLink
-				fullWith
+				fullWidth
 				href={explorerUrl}
 				ariaLabel={$i18n.tokens.alt.open_etherscan}
 				iconVisible={false}

--- a/src/frontend/src/icp/components/tokens/IcTokenMenu.svelte
+++ b/src/frontend/src/icp/components/tokens/IcTokenMenu.svelte
@@ -18,6 +18,7 @@
 	{#if nonNullish(transactionsExplorerUrl)}
 		<div in:fade>
 			<ExternalLink
+				fullWith
 				href={transactionsExplorerUrl}
 				ariaLabel={$i18n.tokens.alt.open_dashboard}
 				iconVisible={false}

--- a/src/frontend/src/icp/components/tokens/IcTokenMenu.svelte
+++ b/src/frontend/src/icp/components/tokens/IcTokenMenu.svelte
@@ -18,7 +18,7 @@
 	{#if nonNullish(transactionsExplorerUrl)}
 		<div in:fade>
 			<ExternalLink
-				fullWith
+				fullWidth
 				href={transactionsExplorerUrl}
 				ariaLabel={$i18n.tokens.alt.open_dashboard}
 				iconVisible={false}

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -7,7 +7,7 @@
 	export let iconVisible = true;
 	export let inline = false;
 	export let color: 'blue' | 'inherit' = 'inherit';
-	export let fullWith = false;
+	export let fullWidth = false;
 </script>
 
 <a
@@ -22,7 +22,7 @@
 	class:active:text-dark-blue={color === 'blue'}
 	class:hover:text-blue={color === 'inherit'}
 	class:active:text-blue={color === 'inherit'}
-	class:w-full={fullWith}
+	class:w-full={fullWidth}
 >
 	{#if iconVisible}
 		<IconExternalLink size={iconSize} />

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -7,6 +7,7 @@
 	export let iconVisible = true;
 	export let inline = false;
 	export let color: 'blue' | 'inherit' = 'inherit';
+	export let fullWith = false;
 </script>
 
 <a
@@ -21,6 +22,7 @@
 	class:active:text-dark-blue={color === 'blue'}
 	class:hover:text-blue={color === 'inherit'}
 	class:active:text-blue={color === 'inherit'}
+	class:w-full={fullWith}
 >
 	{#if iconVisible}
 		<IconExternalLink size={iconSize} />


### PR DESCRIPTION
# Motivation

"View on explorer" does not match the full with in the context menu which is a bit inconsistent given that other actions (buttons) of the same menu do.

# Screenshots

<img width="1536" alt="Capture d’écran 2024-07-15 à 08 16 56" src="https://github.com/user-attachments/assets/ce3abc90-33d1-4e5d-a0a7-12d524cc4419">

