### PR TITLE
feat(frontend): access to hide ck tokens

### DIFF
--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -1,4 +1,3 @@
-import { icTokenErc20UserToken } from '$eth/utils/erc20.utils';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import { token } from '$lib/stores/token.store';
 import type { OptionTokenId, OptionTokenStandard, Token, TokenCategory } from '$lib/types/token';
@@ -35,10 +34,7 @@ export const tokenCategory: Readable<TokenCategory | undefined> = derived(
 	([$token]) => $token?.category
 );
 
-// TODO: $tokenCategory is used here for backwards compatibility with ICRC.
-// Once ICRC default tokens can also be enabled or disabled, this should be reviewed.
 export const tokenToggleable: Readable<boolean> = derived(
-	[token, tokenCategory],
-	([$token, $tokenCategory]) =>
-		nonNullish($token) && (icTokenErc20UserToken($token) || $tokenCategory === 'custom')
+	[token],
+	([$token]) => nonNullish($token) && 'enabled' in $token
 );


### PR DESCRIPTION
# Motivation

A TODO to derive the toggleable tokens was not yet resolved and as a result, accessing "Hiden token" for ck tokens on the transactions view was not yet displayed.

# Changes

- if token contains "enabled" then it's a toggleable token

# Screenshots

<img width="1536" alt="Capture d’écran 2024-07-15 à 08 41 51" src="https://github.com/user-attachments/assets/2f6e7665-a0b6-447b-b30c-171c3022ca6d">
