### PR TITLE
style(frontend): fix button menu aligment

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -3,9 +3,9 @@
 </script>
 
 <button
-	class="flex gap-2 items-center no-underline hover:text-blue active:text-blue w-full"
+	class="no-underline hover:text-blue active:text-blue w-full text-left"
 	aria-label={ariaLabel}
 	on:click
 >
-	<slot></slot>
+	<slot />
 </button>


### PR DESCRIPTION
# Motivation

The alignment in the `ButtonMenu` is centered which is incovenient when the provided slot text is long.

# Screenshot

<img width="1536" alt="Capture d’écran 2024-07-15 à 08 43 18" src="https://github.com/user-attachments/assets/58bdbfd8-00cb-4ef7-bdd0-dd332ec624b6">

