### PR TITLE
fix(frontend): display undefined token symbol

### DIFF
--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -16,7 +16,7 @@
 			<span class="text-5xl font-bold" class:animate-pulse={isNullish($balance)}>0.00</span>
 		{/if}
 
-		{#if $erc20UserTokensInitialized}
+		{#if $erc20UserTokensInitialized && nonNullish(tokenSymbol)}
 			<span class="opacity-100">{$tokenSymbol}</span>
 		{/if}
 	</output>


### PR DESCRIPTION
# Motivation

I spotted a leftover of our chore modification that transformed the global `$token` in an optional information. 

# Screenshot

<img width="1536" alt="Capture d’écran 2024-07-15 à 08 47 30" src="https://github.com/user-attachments/assets/39d6c327-934e-4619-842d-19524c1ee0ff">

