### PR TITLE
chore(backend): Add user_profile tests to backend tests

### DIFF
--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -3,6 +3,6 @@ mod custom_token;
 mod sign;
 mod token;
 mod upgrade;
+mod user_profile;
 mod user_token;
 mod utils;
-mod user_profile;

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -5,3 +5,4 @@ mod token;
 mod upgrade;
 mod user_token;
 mod utils;
+mod user_profile;

--- a/src/backend/tests/it/user_profile.rs
+++ b/src/backend/tests/it/user_profile.rs
@@ -1,4 +1,4 @@
-use crate::utils::pocketic::{query_call, setup, update_call};
+use crate::utils::{mock::CALLER, pocketic::{query_call, setup, update_call}};
 use candid::Principal;
 use shared::types::user_profile::{AddUserCredentialRequest, GetUsersRequest, GetUsersResponse, UserProfile};
 
@@ -11,10 +11,9 @@ fn test_add_user_credential() {
     let request = AddUserCredentialRequest {
         credential_jwt: "test".to_string(),
     };
-    let before_set = update_call::<()>(&pic_setup, caller, "add_user_credential", (request));
+    let before_set = update_call::<()>(&pic_setup, caller, "add_user_credential", request);
 
     assert!(before_set.is_ok());
-    assert_eq!(before_set.unwrap().len(), 0);
 }
 
 #[test]
@@ -26,7 +25,6 @@ fn test_get_or_create_user_profile() {
     let before_set = update_call::<UserProfile>(&pic_setup, caller, "get_or_create_user_profile", ());
 
     assert!(before_set.is_ok());
-    assert_eq!(before_set.unwrap().len(), 0);
 }
 
 #[test]
@@ -37,11 +35,10 @@ fn test_get_users() {
 
     let request = GetUsersRequest {
         updated_after_timestamp: None,
-        limit_response: None,
+        matches_max_length: None,
     };
 
-    let before_set = update_call::<GetUsersResponse>(&pic_setup, caller, "get_users", (request));
+    let before_set = query_call::<GetUsersResponse>(&pic_setup, caller, "get_users", request);
 
     assert!(before_set.is_ok());
-    assert_eq!(before_set.unwrap().len(), 0);
 }

--- a/src/backend/tests/it/user_profile.rs
+++ b/src/backend/tests/it/user_profile.rs
@@ -1,6 +1,11 @@
-use crate::utils::{mock::CALLER, pocketic::{query_call, setup, update_call}};
+use crate::utils::{
+    mock::CALLER,
+    pocketic::{query_call, setup, update_call},
+};
 use candid::Principal;
-use shared::types::user_profile::{AddUserCredentialRequest, GetUsersRequest, GetUsersResponse, UserProfile};
+use shared::types::user_profile::{
+    AddUserCredentialRequest, GetUsersRequest, GetUsersResponse, UserProfile,
+};
 
 #[test]
 fn test_add_user_credential() {
@@ -22,7 +27,8 @@ fn test_get_or_create_user_profile() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let before_set = update_call::<UserProfile>(&pic_setup, caller, "get_or_create_user_profile", ());
+    let before_set =
+        update_call::<UserProfile>(&pic_setup, caller, "get_or_create_user_profile", ());
 
     assert!(before_set.is_ok());
 }


### PR DESCRIPTION
# Motivation

Some Rust tests were introduced in #1743 but they were not being executed in the CI pipeline nor with the script `test.backend.sh`.

# Changes

* Add user_profile to main.rs in tests.
* Fix tests.

# Tests

Only test changes.
