### PR TITLE
feat(frontend): tokens list in manage modal will be sorted by market cap and some pinned

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -32,6 +32,10 @@
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 	import type { IcCkToken } from '$icp/types/ic';
+	import { pinTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { tokensToPin } from '$lib/derived/tokens.derived';
+	import type { ExchangesData } from '$lib/types/exchange';
 
 	const dispatch = createEventDispatcher();
 
@@ -84,6 +88,23 @@
 		$pseudoNetworkChainFusion
 	]);
 
+	// To avoid strange behavior when the exchange data changes (for example, the tokens may shift
+	// since some of them are sorted by market cap), we store the exchange data in a variable during
+	// the life of the component.
+	let exchangesStaticData: ExchangesData | undefined;
+	onMount(() => {
+		exchangesStaticData = $exchanges;
+	});
+
+	let allTokensSorted: Token[] = [];
+	$: exchangesStaticData,
+		(allTokensSorted = nonNullish(exchangesStaticData)
+			? pinTokensAtTop({
+					$tokens: sortTokens({ $tokens: allTokens, $exchanges: exchangesStaticData }),
+					$tokensToPin: $tokensToPin
+				})
+			: []);
+
 	let filterTokens = '';
 	const updateFilter = () => (filterTokens = filter);
 	const debounceUpdateFilter = debounce(updateFilter);
@@ -99,8 +120,8 @@
 
 	let filteredTokens: Token[] = [];
 	$: filteredTokens = isNullishOrEmpty(filterTokens)
-		? allTokens
-		: allTokens.filter((token) => {
+		? allTokensSorted
+		: allTokensSorted.filter((token) => {
 				const twinToken = (token as IcCkToken).twinToken;
 				return matchingToken(token) || (nonNullish(twinToken) && matchingToken(twinToken));
 			});

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -20,7 +20,7 @@ const tokens: Readable<Token[]> = derived(
 	]
 );
 
-const tokensToPin: Readable<TokenToPin[]> = derived(
+export const tokensToPin: Readable<TokenToPin[]> = derived(
 	[icrcChainFusionDefaultTokens],
 	([$icrcChainFusionDefaultTokens]) => [
 		ICP_TOKEN,


### PR DESCRIPTION
# Motivation

For the `ManageTokens` list, we sort by marketcap first and then we pin some tokens on top. The logic is the same as per the list of tokens shown in the main page.
Since we want to persist the order of the list during the usage of the modal, we use static data for the exchanges data.

# Changes

- Create static variable for exchanges data, set with `onMount`.
- Create list of sorted tokens.

# Tests

Manual test on local replica showed correct sorting.
