### PR TITLE
chore(frontend): Recreate backend types in FE

### DIFF
--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -51,7 +51,11 @@ type InitArg = record {
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_der : opt blob;
 };
-type OisyUser = record { "principal" : principal; pouh_verified : bool };
+type OisyUser = record {
+  "principal" : principal;
+  pouh_verified : bool;
+  updated_timestamp : nat64;
+};
 type SignRequest = record {
   to : text;
   gas : nat;
@@ -67,7 +71,7 @@ type SupportedCredential = record {
   issuer_origin : text;
   issuer_canister_id : text;
   ii_origin : text;
-  credential_type : text;
+  credential_type : CredentialType;
 };
 type Token = variant { Icrc : IcrcToken };
 type UserCredential = record {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -2,6 +2,9 @@ import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 import type { Principal } from '@dfinity/principal';
 
+export interface AddUserCredentialRequest {
+	credential_jwt: string;
+}
 export type Arg = { Upgrade: null } | { Init: InitArg };
 export interface CanisterStatusResultV2 {
 	controller: Principal;
@@ -15,6 +18,7 @@ export interface CanisterStatusResultV2 {
 	module_hash: [] | [Uint8Array | number[]];
 }
 export type CanisterStatusType = { stopped: null } | { stopping: null } | { running: null };
+export type CredentialType = { ProofOfUniqueness: null };
 export interface CustomToken {
 	token: Token;
 	version: [] | [bigint];
@@ -26,6 +30,14 @@ export interface DefiniteCanisterSettingsArgs {
 	controllers: Array<Principal>;
 	memory_allocation: bigint;
 	compute_allocation: bigint;
+}
+export interface GetUsersRequest {
+	updated_after_timestamp: [] | [bigint];
+	matches_max_length: [] | [bigint];
+}
+export interface GetUsersResponse {
+	users: Array<OisyUser>;
+	matches_max_length: bigint;
 }
 export interface HttpRequest {
 	url: string;
@@ -45,6 +57,13 @@ export interface IcrcToken {
 export interface InitArg {
 	ecdsa_key_name: string;
 	allowed_callers: Array<Principal>;
+	supported_credentials: [] | [Array<SupportedCredential>];
+	ic_root_key_der: [] | [Uint8Array | number[]];
+}
+export interface OisyUser {
+	principal: Principal;
+	pouh_verified: boolean;
+	updated_timestamp: bigint;
 }
 export interface SignRequest {
 	to: string;
@@ -56,7 +75,25 @@ export interface SignRequest {
 	chain_id: bigint;
 	nonce: bigint;
 }
+export interface SupportedCredential {
+	ii_canister_id: string;
+	issuer_origin: string;
+	issuer_canister_id: string;
+	ii_origin: string;
+	credential_type: CredentialType;
+}
 export type Token = { Icrc: IcrcToken };
+export interface UserCredential {
+	verified_date_timestamp: [] | [bigint];
+	expire_date_timestamp: [] | [bigint];
+	credential_type: CredentialType;
+}
+export interface UserProfile {
+	credentials: Array<UserCredential>;
+	version: [] | [bigint];
+	created_timestamp: bigint;
+	updated_timestamp: bigint;
+}
 export interface UserToken {
 	decimals: [] | [number];
 	version: [] | [bigint];
@@ -70,9 +107,12 @@ export interface UserTokenId {
 	contract_address: string;
 }
 export interface _SERVICE {
+	add_user_credential: ActorMethod<[AddUserCredentialRequest], undefined>;
 	caller_eth_address: ActorMethod<[], string>;
 	eth_address_of: ActorMethod<[Principal], string>;
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
+	get_or_create_user_profile: ActorMethod<[], UserProfile>;
+	get_users: ActorMethod<[GetUsersRequest], GetUsersResponse>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
 	list_user_tokens: ActorMethod<[], Array<UserToken>>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -1,10 +1,21 @@
 // @ts-ignore
 export const idlFactory = ({ IDL }) => {
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Text,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Text,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		allowed_callers: IDL.Vec(IDL.Principal)
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
+	const AddUserCredentialRequest = IDL.Record({ credential_jwt: IDL.Text });
 	const CanisterStatusType = IDL.Variant({
 		stopped: IDL.Null,
 		stopping: IDL.Null,
@@ -27,6 +38,30 @@ export const idlFactory = ({ IDL }) => {
 		settings: DefiniteCanisterSettingsArgs,
 		idle_cycles_burned_per_day: IDL.Nat,
 		module_hash: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const UserCredential = IDL.Record({
+		verified_date_timestamp: IDL.Opt(IDL.Nat64),
+		expire_date_timestamp: IDL.Opt(IDL.Nat64),
+		credential_type: CredentialType
+	});
+	const UserProfile = IDL.Record({
+		credentials: IDL.Vec(UserCredential),
+		version: IDL.Opt(IDL.Nat64),
+		created_timestamp: IDL.Nat64,
+		updated_timestamp: IDL.Nat64
+	});
+	const GetUsersRequest = IDL.Record({
+		updated_after_timestamp: IDL.Opt(IDL.Nat64),
+		matches_max_length: IDL.Opt(IDL.Nat64)
+	});
+	const OisyUser = IDL.Record({
+		principal: IDL.Principal,
+		pouh_verified: IDL.Bool,
+		updated_timestamp: IDL.Nat64
+	});
+	const GetUsersResponse = IDL.Record({
+		users: IDL.Vec(OisyUser),
+		matches_max_length: IDL.Nat64
 	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
@@ -72,9 +107,12 @@ export const idlFactory = ({ IDL }) => {
 		nonce: IDL.Nat
 	});
 	return IDL.Service({
+		add_user_credential: IDL.Func([AddUserCredentialRequest], [], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
+		get_or_create_user_profile: IDL.Func([], [UserProfile]),
+		get_users: IDL.Func([GetUsersRequest], [GetUsersResponse]),
 		http_request: IDL.Func([HttpRequest], [HttpResponse]),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)]),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)]),
@@ -90,9 +128,19 @@ export const idlFactory = ({ IDL }) => {
 };
 // @ts-ignore
 export const init = ({ IDL }) => {
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Text,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Text,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		allowed_callers: IDL.Vec(IDL.Principal)
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	return [Arg];

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -1,10 +1,21 @@
 // @ts-ignore
 export const idlFactory = ({ IDL }) => {
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Text,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Text,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		allowed_callers: IDL.Vec(IDL.Principal)
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
+	const AddUserCredentialRequest = IDL.Record({ credential_jwt: IDL.Text });
 	const CanisterStatusType = IDL.Variant({
 		stopped: IDL.Null,
 		stopping: IDL.Null,
@@ -27,6 +38,30 @@ export const idlFactory = ({ IDL }) => {
 		settings: DefiniteCanisterSettingsArgs,
 		idle_cycles_burned_per_day: IDL.Nat,
 		module_hash: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const UserCredential = IDL.Record({
+		verified_date_timestamp: IDL.Opt(IDL.Nat64),
+		expire_date_timestamp: IDL.Opt(IDL.Nat64),
+		credential_type: CredentialType
+	});
+	const UserProfile = IDL.Record({
+		credentials: IDL.Vec(UserCredential),
+		version: IDL.Opt(IDL.Nat64),
+		created_timestamp: IDL.Nat64,
+		updated_timestamp: IDL.Nat64
+	});
+	const GetUsersRequest = IDL.Record({
+		updated_after_timestamp: IDL.Opt(IDL.Nat64),
+		matches_max_length: IDL.Opt(IDL.Nat64)
+	});
+	const OisyUser = IDL.Record({
+		principal: IDL.Principal,
+		pouh_verified: IDL.Bool,
+		updated_timestamp: IDL.Nat64
+	});
+	const GetUsersResponse = IDL.Record({
+		users: IDL.Vec(OisyUser),
+		matches_max_length: IDL.Nat64
 	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
@@ -72,9 +107,12 @@ export const idlFactory = ({ IDL }) => {
 		nonce: IDL.Nat
 	});
 	return IDL.Service({
+		add_user_credential: IDL.Func([AddUserCredentialRequest], [], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
+		get_or_create_user_profile: IDL.Func([], [UserProfile], ['query']),
+		get_users: IDL.Func([GetUsersRequest], [GetUsersResponse], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], ['query']),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)], ['query']),
@@ -90,9 +128,19 @@ export const idlFactory = ({ IDL }) => {
 };
 // @ts-ignore
 export const init = ({ IDL }) => {
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Text,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Text,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		allowed_callers: IDL.Vec(IDL.Principal)
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	return [Arg];

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -1,10 +1,11 @@
+import type { UserCredential, UserProfile } from '$declarations/backend/backend.did';
 import {
 	INTERNET_IDENTITY_ORIGIN,
 	POUH_ISSUER_CANISTER_ID,
 	POUH_ISSUER_ORIGIN
 } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
-import { userProfileStore, type UserProfile } from '$lib/stores/settings.store';
+import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -23,17 +24,16 @@ const handleSuccess = async (
 	const { auth: authI18n } = get(i18n);
 	if ('Ok' in response) {
 		// TODO: GIX-2646 Add credential to backend and load user profile
-		const fakeTemporaryCredentialSummary = {
-			credential_type: POUH_CREDENTIAL_TYPE,
-			verified_date_timestamp: BigInt(Date.now()),
-			expire_date_timestamp: BigInt(Date.now() + 1000 * 60 * 60 * 24 * 365)
+		const fakeTemporaryCredentialSummary: UserCredential = {
+			credential_type: { [POUH_CREDENTIAL_TYPE]: null },
+			verified_date_timestamp: [BigInt(Date.now())],
+			expire_date_timestamp: [BigInt(Date.now() + 1000 * 60 * 60 * 24 * 365)]
 		};
 		const fakeUserProfile: UserProfile = {
-			credentials: {
-				[POUH_CREDENTIAL_TYPE]: fakeTemporaryCredentialSummary
-			},
+			credentials: [fakeTemporaryCredentialSummary],
 			created_timestamp: BigInt(Date.now()),
-			updated_timestamp: BigInt(Date.now())
+			updated_timestamp: BigInt(Date.now()),
+			version: [0n]
 		};
 		userProfileStore.set({ key: 'user-profile', value: fakeUserProfile });
 		return { success: true };

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -1,25 +1,9 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
 import { initStorageStore } from '$lib/stores/storage.store';
 
 export interface SettingsData {
 	enabled: boolean;
 }
-
-/**
- * These types will come from Candid interface definitions once agreed and implemented in the backend.
- *
- * TODO: https://dfinity.atlassian.net/browse/GIX-2642
- */
-type UserCredentialSummary = {
-	credential_type: string;
-	verified_date_timestamp: bigint;
-	expire_date_timestamp: bigint;
-};
-type CredentialMap = Record<string, UserCredentialSummary>;
-export type UserProfile = {
-	credentials: CredentialMap;
-	created_timestamp: bigint;
-	updated_timestamp: bigint;
-};
 
 export const testnetsStore = initStorageStore<SettingsData>({ key: 'testnets' });
 export const hideZeroBalancesStore = initStorageStore<SettingsData>({ key: 'hide-zero-balances' });


### PR DESCRIPTION
# Motivation

We want to use the new endpoints introduced #1743 in the frontend.

In this PR, I recreated the types for the JS client with `npm run generate` and also used one of the types in the userProfileStore.

# Changes

* Changes in `.did` files and related done with `npm run generate`.
* Change the type of userProfileStore to the UserProfile from the generated files.
* Change the faked user profile in requestPouhCredentials.

# Tests

Not necessary. No new functionality added, only some types (that are not used yet) have changed.
