### PR TITLE
test(devops): Add upgrade test for new credentials init args

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 POCKET_IC_SERVER_VERSION=3.0.1
-OISY_UPGRADE_VERSIONS="v0.0.13,v0.0.19"
+OISY_UPGRADE_VERSIONS="v0.0.13,v0.0.19,v0.0.25"
 
 # If a backend wasm file exists at the root, it will be used for the tests.
 

--- a/src/backend/tests/it/upgrade/constants.rs
+++ b/src/backend/tests/it/upgrade/constants.rs
@@ -1,2 +1,3 @@
 pub const BACKEND_V0_0_13_WASM_PATH: &str = "../../backend-v0.0.13.wasm.gz";
 pub const BACKEND_V0_0_19_WASM_PATH: &str = "../../backend-v0.0.19.wasm.gz";
+pub const BACKEND_V0_0_25_WASM_PATH: &str = "../../backend-v0.0.25.wasm.gz";

--- a/src/backend/tests/it/upgrade/credentials_init_args.rs
+++ b/src/backend/tests/it/upgrade/credentials_init_args.rs
@@ -1,0 +1,32 @@
+use crate::upgrade::constants::BACKEND_V0_0_25_WASM_PATH;
+use crate::upgrade::types::{ArgV0_0_25, InitArgV0_0_25};
+use crate::utils::mock::CALLER;
+use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade_latest_wasm};
+use candid::{encode_one, Principal};
+use shared::types::token::UserToken;
+use shared::types::user_profile::UserProfile;
+
+#[test]
+fn test_upgrade_credential_init_args() {
+    // Deploy a released canister
+    let arg = ArgV0_0_25::Init(InitArgV0_0_25 {
+        ecdsa_key_name: "master_ecdsa_public_key_fscpm-uiaaa-aaaaa-aaaap-yai".to_string(),
+        allowed_callers: vec![Principal::from_text(CALLER).unwrap()],
+    });
+    let encoded_arg = encode_one(arg).unwrap();
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_25_WASM_PATH, Some(encoded_arg));
+
+    // Test a call
+    let caller = Principal::from_text(CALLER).unwrap();
+    let result = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
+
+    assert!(result.is_ok());
+
+    // Upgrade canister with new wasm
+    upgrade_latest_wasm(&pic_setup)
+        .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
+
+    let results = update_call::<UserProfile>(&pic_setup, caller, "get_or_create_user_profile", ());
+
+    assert!(results.is_ok());
+}

--- a/src/backend/tests/it/upgrade/credentials_init_args.rs
+++ b/src/backend/tests/it/upgrade/credentials_init_args.rs
@@ -17,7 +17,7 @@ fn test_upgrade_credential_init_args() {
     let encoded_initial_arg = encode_one(initial_arg).unwrap();
     let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_25_WASM_PATH, Some(encoded_initial_arg));
 
-    // Test a call
+    // Get ETH address before upgrade for post-upgrade test
     let caller = Principal::from_text(CALLER).unwrap();
     let initial_result = update_call::<String>(&pic_setup, caller, "caller_eth_address", ());
 
@@ -35,5 +35,5 @@ fn test_upgrade_credential_init_args() {
 
     let after_upgrade_result = update_call::<String>(&pic_setup, caller, "caller_eth_address", ());
 
-    assert_eq!(initial_result.unwrap(), after_upgrade_result.unwrap());
+    assert_eq!(initial_result.expect("Initial ETH address err"), after_upgrade_result.expect("Post-upgrade ETH address err"));
 }

--- a/src/backend/tests/it/upgrade/credentials_init_args.rs
+++ b/src/backend/tests/it/upgrade/credentials_init_args.rs
@@ -35,5 +35,8 @@ fn test_upgrade_credential_init_args() {
 
     let after_upgrade_result = update_call::<String>(&pic_setup, caller, "caller_eth_address", ());
 
-    assert_eq!(initial_result.expect("Initial ETH address err"), after_upgrade_result.expect("Post-upgrade ETH address err"));
+    assert_eq!(
+        initial_result.expect("Initial ETH address err"),
+        after_upgrade_result.expect("Post-upgrade ETH address err")
+    );
 }

--- a/src/backend/tests/it/upgrade/credentials_init_args.rs
+++ b/src/backend/tests/it/upgrade/credentials_init_args.rs
@@ -3,30 +3,37 @@ use crate::upgrade::types::{ArgV0_0_25, InitArgV0_0_25};
 use crate::utils::mock::CALLER;
 use crate::utils::pocketic::{setup_with_custom_wasm, update_call, upgrade_latest_wasm};
 use candid::{encode_one, Principal};
-use shared::types::token::UserToken;
-use shared::types::user_profile::UserProfile;
+use shared::types::{Arg, InitArg};
 
 #[test]
 fn test_upgrade_credential_init_args() {
+    let ecdsa_key_name = "master_ecdsa_public_key_fscpm-uiaaa-aaaaa-aaaap-yai".to_string();
+    let allowed_callers = vec![Principal::from_text(CALLER).unwrap()];
     // Deploy a released canister
-    let arg = ArgV0_0_25::Init(InitArgV0_0_25 {
-        ecdsa_key_name: "master_ecdsa_public_key_fscpm-uiaaa-aaaaa-aaaap-yai".to_string(),
-        allowed_callers: vec![Principal::from_text(CALLER).unwrap()],
+    let initial_arg = ArgV0_0_25::Init(InitArgV0_0_25 {
+        ecdsa_key_name: ecdsa_key_name.clone(),
+        allowed_callers: allowed_callers.clone(),
     });
-    let encoded_arg = encode_one(arg).unwrap();
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_25_WASM_PATH, Some(encoded_arg));
+    let encoded_initial_arg = encode_one(initial_arg).unwrap();
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_25_WASM_PATH, Some(encoded_initial_arg));
 
     // Test a call
     let caller = Principal::from_text(CALLER).unwrap();
-    let result = update_call::<Vec<UserToken>>(&pic_setup, caller, "list_user_tokens", ());
+    let initial_result = update_call::<String>(&pic_setup, caller, "caller_eth_address", ());
 
-    assert!(result.is_ok());
+    let updated_arg = Arg::Init(InitArg {
+        ecdsa_key_name: ecdsa_key_name.clone(),
+        allowed_callers: allowed_callers.clone(),
+        ic_root_key_der: None,
+        supported_credentials: None,
+    });
+    let encoded_updated_arg = encode_one(updated_arg).unwrap();
 
     // Upgrade canister with new wasm
-    upgrade_latest_wasm(&pic_setup)
+    upgrade_latest_wasm(&pic_setup, Some(encoded_updated_arg))
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
-    let results = update_call::<UserProfile>(&pic_setup, caller, "get_or_create_user_profile", ());
+    let after_upgrade_result = update_call::<String>(&pic_setup, caller, "caller_eth_address", ());
 
-    assert!(results.is_ok());
+    assert_eq!(initial_result.unwrap(), after_upgrade_result.unwrap());
 }

--- a/src/backend/tests/it/upgrade/mod.rs
+++ b/src/backend/tests/it/upgrade/mod.rs
@@ -1,4 +1,5 @@
 mod constants;
+mod credentials_init_args;
 mod impls;
 mod token_enabled;
 mod token_version;

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -44,7 +44,7 @@ fn test_upgrade_user_token() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_latest_wasm(&pic_setup)
+    upgrade_latest_wasm(&pic_setup, None)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade
@@ -77,7 +77,7 @@ fn test_update_user_token_after_upgrade() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_latest_wasm(&pic_setup)
+    upgrade_latest_wasm(&pic_setup, None)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -29,7 +29,7 @@ lazy_static! {
 #[test]
 fn test_upgrade_user_token() {
     // Deploy a released canister
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH);
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH, None);
 
     // Add a user token
     let caller = Principal::from_text(CALLER).unwrap();
@@ -62,7 +62,7 @@ fn test_upgrade_user_token() {
 #[test]
 fn test_update_user_token_after_upgrade() {
     // Deploy a released canister
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH);
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_19_WASM_PATH, None);
 
     // Add a user token
     let caller = Principal::from_text(CALLER).unwrap();

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -31,7 +31,7 @@ lazy_static! {
 #[test]
 fn test_upgrade_user_token() {
     // Deploy a released canister
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH, None);
 
     // Add a user token
     let caller = Principal::from_text(CALLER).unwrap();
@@ -64,7 +64,7 @@ fn test_upgrade_user_token() {
 #[test]
 fn test_upgrade_allowed_caller_eth_address_of() {
     // Deploy a released canister
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH, None);
 
     // Caller is allowed to call eth_address_of
     let caller = Principal::from_text(CALLER).unwrap();
@@ -97,7 +97,7 @@ fn test_add_user_token_after_upgrade_should_ignore_premature_increments() {
 
 fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgradeOptions) {
     // Deploy a released canister
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH, None);
 
     pic_setup.0.tick();
 
@@ -135,7 +135,7 @@ fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgr
 #[test]
 fn test_update_user_token_after_upgrade() {
     // Deploy a released canister
-    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH);
+    let pic_setup = setup_with_custom_wasm(BACKEND_V0_0_13_WASM_PATH, None);
 
     // Add a user token
     let caller = Principal::from_text(CALLER).unwrap();

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -46,7 +46,7 @@ fn test_upgrade_user_token() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_with_wasm(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string())
+    upgrade_with_wasm(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string(), None)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade
@@ -73,7 +73,7 @@ fn test_upgrade_allowed_caller_eth_address_of() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_latest_wasm(&pic_setup)
+    upgrade_latest_wasm(&pic_setup, None)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Caller is still allowed to call eth_address_of
@@ -102,7 +102,7 @@ fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgr
     pic_setup.0.tick();
 
     // Upgrade canister with new wasm
-    upgrade_with_wasm(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string())
+    upgrade_with_wasm(&pic_setup, &BACKEND_V0_0_19_WASM_PATH.to_string(), None)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Add a user token
@@ -150,7 +150,7 @@ fn test_update_user_token_after_upgrade() {
     assert!(result.is_ok());
 
     // Upgrade canister with new wasm
-    upgrade_latest_wasm(&pic_setup)
+    upgrade_latest_wasm(&pic_setup, None)
         .unwrap_or_else(|e| panic!("Upgrade canister failed with error: {}", e));
 
     // Get the list of token and check that it still contains the one we added before upgrade

--- a/src/backend/tests/it/upgrade/types.rs
+++ b/src/backend/tests/it/upgrade/types.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Deserialize};
+use candid::{CandidType, Deserialize, Principal};
 use shared::types::token::ChainId;
 use shared::types::Version;
 
@@ -24,4 +24,16 @@ pub struct UserTokenV0_0_19 {
 pub struct AddUserTokenAfterUpgradeOptions {
     /// The version number should be None but we can set it to Some(n) for a few small values to check that.
     pub premature_increments: u8,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct InitArgV0_0_25 {
+    pub ecdsa_key_name: String,
+    pub allowed_callers: Vec<Principal>,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum ArgV0_0_25 {
+    Init(InitArgV0_0_25),
+    Upgrade,
 }

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -31,14 +31,17 @@ pub fn setup() -> (PocketIc, Principal) {
     (pic, canister_id)
 }
 
-pub fn setup_with_custom_wasm(wasm_path: &str) -> (PocketIc, Principal) {
+pub fn setup_with_custom_wasm(
+    wasm_path: &str,
+    encoded_arg: Option<Vec<u8>>,
+) -> (PocketIc, Principal) {
     let (pic, canister_id) = init();
 
     let wasm_bytes = read(wasm_path).expect(&format!("Could not find the wasm: {}", wasm_path));
 
-    let arg = init_arg();
+    let arg = encoded_arg.unwrap_or(encode_one(&init_arg()).unwrap());
 
-    pic.install_canister(canister_id, wasm_bytes, encode_one(&arg).unwrap(), None);
+    pic.install_canister(canister_id, wasm_bytes, arg, None);
 
     (pic, canister_id)
 }

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -46,7 +46,10 @@ pub fn setup_with_custom_wasm(
     (pic, canister_id)
 }
 
-pub fn upgrade_latest_wasm(pocket_ic: &(PocketIc, Principal), encoded_arg: Option<Vec<u8>>) -> Result<(), String> {
+pub fn upgrade_latest_wasm(
+    pocket_ic: &(PocketIc, Principal),
+    encoded_arg: Option<Vec<u8>>,
+) -> Result<(), String> {
     let backend_wasm_path =
         env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string());
 

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -46,23 +46,24 @@ pub fn setup_with_custom_wasm(
     (pic, canister_id)
 }
 
-pub fn upgrade_latest_wasm(pocket_ic: &(PocketIc, Principal)) -> Result<(), String> {
+pub fn upgrade_latest_wasm(pocket_ic: &(PocketIc, Principal), encoded_arg: Option<Vec<u8>>) -> Result<(), String> {
     let backend_wasm_path =
         env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string());
 
-    upgrade_with_wasm(pocket_ic, &backend_wasm_path)
+    upgrade_with_wasm(pocket_ic, &backend_wasm_path, encoded_arg)
 }
 
 pub fn upgrade_with_wasm(
     (pic, canister_id): &(PocketIc, Principal),
     backend_wasm_path: &String,
+    encoded_arg: Option<Vec<u8>>,
 ) -> Result<(), String> {
     let wasm_bytes = read(backend_wasm_path.clone()).expect(&format!(
         "Could not find the backend wasm: {}",
         backend_wasm_path
     ));
 
-    let arg = init_arg();
+    let arg = encoded_arg.unwrap_or(encode_one(&init_arg()).unwrap());
 
     pic.upgrade_canister(
         canister_id.clone(),


### PR DESCRIPTION
# Motivation

We introduced new init args and we'd like to test that the canister is upgradable from a previous canister without them.

# Changes

* Add an optional argument to `setup_with_custom_wasm` and `upgrade_latest_wasm` which are the arguments and set it to `None` in all current calls.
* Add v0.0.25 backend wasm.
* New init types for the v0.0.25 canister.
* New upgrade test credentials_init_args.

# Tests

Only test changes.
