### PR TITLE
chore(frontend): remove unnecessary IcToken casting

### DIFF
--- a/src/frontend/src/icp/components/receive/IcReceive.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceive.svelte
@@ -25,10 +25,10 @@
 	export let compact = false;
 
 	let ckEthereum = false;
-	$: ckEthereum = isTokenCkEthLedger(token as IcToken) || isTokenCkErc20Ledger(token as IcToken);
+	$: ckEthereum = isTokenCkEthLedger(token) || isTokenCkErc20Ledger(token);
 
 	let ckBTC = false;
-	$: ckBTC = isTokenCkBtcLedger(token as IcToken);
+	$: ckBTC = isTokenCkBtcLedger(token);
 
 	let icrc = false;
 	$: icrc = token.standard === 'icrc';


### PR DESCRIPTION
# Motivation

I noticed that casting the token as `IcToken` it is not really necessary since those function accepts `Partial<IcToken>` as type.