### PR TITLE
refactor(frontend): unify IcToken casting under a global store

### DIFF
--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -22,13 +22,13 @@
 		ckEthereumTwinTokenStandard
 	} from '$icp-eth/derived/cketh.derived';
 	import type { NetworkId } from '$lib/types/network';
-	import type { IcToken } from '$icp/types/ic';
 	import {
 		toCkErc20HelperContractAddress,
 		toCkEthHelperContractAddress
 	} from '$icp-eth/utils/cketh.utils';
 	import type { TransactionResponse } from '@ethersproject/abstract-provider';
 	import { token } from '$lib/stores/token.store';
+	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 
 	let listener: WebSocketListener | undefined = undefined;
 
@@ -68,7 +68,7 @@
 		loadBalance = $balance;
 
 		await loadCkEthereumPendingTransactions({
-			token: $token as IcToken,
+			token: $tokenAsIcToken,
 			lastObservedBlockNumber,
 			identity: $authStore.identity,
 			toAddress,
@@ -108,7 +108,7 @@
 
 				await loadPendingCkEthereumTransaction({
 					hash,
-					token: $token as IcToken,
+					token: $tokenAsIcToken,
 					twinToken: $ckEthereumTwinToken,
 					networkId
 				});

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -9,7 +9,8 @@ import {
 	toCkErc20HelperContractAddress,
 	toCkEthHelperContractAddress
 } from '$icp-eth/utils/cketh.utils';
-import type { IcCkToken, IcToken } from '$icp/types/ic';
+import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
+import type { IcCkToken } from '$icp/types/ic';
 import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import { tokenStandard, tokenWithFallback } from '$lib/derived/token.derived';
@@ -26,9 +27,9 @@ import { derived, type Readable } from 'svelte/store';
  * - on network ICP if the token is ckETH
  */
 export const ethToCkETHEnabled: Readable<boolean> = derived(
-	[tokenStandard, tokenWithFallback],
-	([$tokenStandard, $tokenWithFallback]) =>
-		$tokenStandard === 'ethereum' || isTokenCkEthLedger($tokenWithFallback as IcToken)
+	[tokenStandard, tokenWithFallbackAsIcToken],
+	([$tokenStandard, $tokenWithFallbackAsIcToken]) =>
+		$tokenStandard === 'ethereum' || isTokenCkEthLedger($tokenWithFallbackAsIcToken)
 );
 
 /**
@@ -37,10 +38,10 @@ export const ethToCkETHEnabled: Readable<boolean> = derived(
  * - on network ICP if the token is ckErc20
  */
 export const erc20ToCkErc20Enabled: Readable<boolean> = derived(
-	[tokenWithFallback],
-	([$tokenWithFallback]) =>
-		ERC20_TWIN_TOKENS_IDS.includes($tokenWithFallback.id) ||
-		isTokenCkErc20Ledger($tokenWithFallback as IcToken)
+	[tokenWithFallbackAsIcToken],
+	([$tokenWithFallbackAsIcToken]) =>
+		ERC20_TWIN_TOKENS_IDS.includes($tokenWithFallbackAsIcToken.id) ||
+		isTokenCkErc20Ledger($tokenWithFallbackAsIcToken)
 );
 
 /**

--- a/src/frontend/src/icp/components/fee/BitcoinFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinFeeContext.svelte
@@ -4,18 +4,18 @@
 	import { BITCOIN_FEE_CONTEXT_KEY, type BitcoinFeeContext } from '$icp/stores/bitcoin-fee.store';
 	import { debounce, isNullish } from '@dfinity/utils';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
-	import { tokenDecimals, tokenWithFallback } from '$lib/derived/token.derived';
-	import type { IcToken } from '$icp/types/ic';
+	import { tokenDecimals } from '$lib/derived/token.derived';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { authStore } from '$lib/stores/auth.store';
 	import { queryEstimateFee } from '$icp/services/ckbtc.services';
 	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
+	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 
 	export let amount: string | number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
 
 	let ckBTC = false;
-	$: ckBTC = isTokenCkBtcLedger($tokenWithFallback as IcToken);
+	$: ckBTC = isTokenCkBtcLedger($tokenWithFallbackAsIcToken);
 
 	const { store } = getContext<BitcoinFeeContext>(BITCOIN_FEE_CONTEXT_KEY);
 
@@ -40,7 +40,7 @@
 				value: `${amount}`,
 				unitName: $tokenDecimals
 			}).toBigInt(),
-			...($tokenWithFallback as IcToken)
+			...$tokenWithFallbackAsIcToken
 		});
 
 		if (isNullish(fee) || result === 'error') {

--- a/src/frontend/src/icp/components/fee/BitcoinKYTFee.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinKYTFee.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
 	import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
-	import { tokenId, tokenWithFallback } from '$lib/derived/token.derived';
+	import { tokenId } from '$lib/derived/token.derived';
 	import { nonNullish } from '@dfinity/utils';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
-	import type { IcToken } from '$icp/types/ic';
 	import type { NetworkId } from '$lib/types/network';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { BigNumber } from '@ethersproject/bignumber';
@@ -12,11 +11,12 @@
 	import { BTC_DECIMALS } from '$env/tokens.btc.env';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
+	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 
 	export let networkId: NetworkId | undefined = undefined;
 
 	let ckBTC = false;
-	$: ckBTC = isTokenCkBtcLedger($tokenWithFallback as IcToken);
+	$: ckBTC = isTokenCkBtcLedger($tokenWithFallbackAsIcToken);
 
 	let btcNetwork = false;
 	$: btcNetwork = isNetworkIdBitcoin(networkId);

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -13,12 +13,11 @@
 		type EthereumFeeContext
 	} from '$icp/stores/ethereum-fee.store';
 	import { isTokenCkErc20Ledger } from '$icp/utils/ic-send.utils';
-	import type { IcToken } from '$icp/types/ic';
 	import { ethereumFeeTokenCkEth } from '$icp/derived/ethereum-fee.derived';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 
 	let ckEr20 = false;
-	$: ckEr20 = isTokenCkErc20Ledger($tokenWithFallback as IcToken);
+	$: ckEr20 = isTokenCkErc20Ledger($tokenWithFallbackAsIcToken);
 
 	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 

--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { NetworkId } from '$lib/types/network';
 	import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
-	import { tokenId, tokenWithFallback } from '$lib/derived/token.derived';
+	import { tokenId } from '$lib/derived/token.derived';
 	import type { IcToken } from '$icp/types/ic';
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
@@ -16,14 +16,15 @@
 	} from '$icp/stores/ethereum-fee.store';
 	import { token } from '$lib/stores/token.store';
 	import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+	import { tokenAsIcToken, tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 
 	export let networkId: NetworkId | undefined = undefined;
 
 	let ckETH = false;
-	$: ckETH = isTokenCkEthLedger($tokenWithFallback as IcToken);
+	$: ckETH = isTokenCkEthLedger($tokenWithFallbackAsIcToken);
 
 	let ckEr20 = false;
-	$: ckEr20 = isTokenCkErc20Ledger($tokenWithFallback as IcToken);
+	$: ckEr20 = isTokenCkErc20Ledger($tokenWithFallbackAsIcToken);
 
 	let ethNetwork = false;
 	$: ethNetwork = isNetworkIdEthereum(networkId);
@@ -78,7 +79,7 @@
 			return;
 		}
 
-		const load = async () => await loadEip1559TransactionPrice($token as IcToken);
+		const load = async () => await loadEip1559TransactionPrice($tokenAsIcToken);
 
 		await load();
 

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -10,7 +10,6 @@
 	import { sendIc } from '$icp/services/ic-send.services';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { authStore } from '$lib/stores/auth.store';
-	import type { IcToken } from '$icp/types/ic';
 	import type { NetworkId } from '$lib/types/network';
 	import IcSendProgress from '$icp/components/send/IcSendProgress.svelte';
 	import type { IcTransferParams } from '$icp/types/ic-send';
@@ -54,6 +53,7 @@
 	import SendQRCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
 	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
 	import { token } from '$lib/stores/token.store';
+	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 
 	/**
 	 * Props
@@ -106,7 +106,7 @@
 
 			await sendIc({
 				...params,
-				token: $token as IcToken,
+				token: $tokenAsIcToken,
 				targetNetworkId: networkId
 			});
 

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -8,13 +8,14 @@
 	import { modalIcToken, modalIcTransaction } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 	import IcpTransactionModal from './IcTransactionModal.svelte';
-	import type { IcToken, IcTransactionUi } from '$icp/types/ic';
+	import type { IcTransactionUi } from '$icp/types/ic';
 	import { loadNextTransactions } from '$icp/services/ic-transactions.services';
 	import IcTransactionsBitcoinStatus from '$icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte';
 	import Info from '$icp/components/info/Info.svelte';
 	import { WALLET_PAGINATION } from '$icp/constants/ic.constants';
 	import type { ComponentType } from 'svelte';
 	import {
+		tokenAsIcToken,
 		tokenCkBtcLedger,
 		tokenCkErc20Ledger,
 		tokenCkEthLedger
@@ -72,7 +73,7 @@
 			identity: $authStore.identity,
 			maxResults: WALLET_PAGINATION,
 			start: lastId,
-			token: $token as IcToken,
+			token: $tokenAsIcToken,
 			signalEnd: () => (disableInfiniteScroll = true)
 		});
 	};

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { IcToken } from '$icp/types/ic';
 	import IconSync from '$lib/components/icons/IconSync.svelte';
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import { updateBalance } from '$icp/services/ckbtc.services';
@@ -15,6 +14,7 @@
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { token } from '$lib/stores/token.store';
+	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 
 	let receiveProgressStep: string | undefined = undefined;
 
@@ -32,7 +32,7 @@
 
 		try {
 			await updateBalance({
-				token: $token as IcToken,
+				token: $tokenAsIcToken,
 				identity: $authStore.identity,
 				progress: (step: ProgressStepsUpdateBalanceCkBtc) => (receiveProgressStep = step)
 			});

--- a/src/frontend/src/icp/derived/ic-token.derived.ts
+++ b/src/frontend/src/icp/derived/ic-token.derived.ts
@@ -5,16 +5,27 @@ import {
 	isTokenCkEthLedger
 } from '$icp/utils/ic-send.utils';
 import { tokenWithFallback } from '$lib/derived/token.derived';
+import { token } from '$lib/stores/token.store';
 import { derived, type Readable } from 'svelte/store';
 
-export const tokenCkBtcLedger: Readable<boolean> = derived([tokenWithFallback], ([$token]) =>
-	isTokenCkBtcLedger($token as IcToken)
+export const tokenAsIcToken: Readable<IcToken> = derived([token], ([$token]) => $token as IcToken);
+
+export const tokenWithFallbackAsIcToken: Readable<IcToken> = derived(
+	[tokenWithFallback],
+	([$token]) => $token as IcToken
 );
 
-export const tokenCkEthLedger: Readable<boolean> = derived([tokenWithFallback], ([$token]) =>
-	isTokenCkEthLedger($token as IcToken)
+export const tokenCkBtcLedger: Readable<boolean> = derived(
+	[tokenWithFallbackAsIcToken],
+	([$token]) => isTokenCkBtcLedger($token)
 );
 
-export const tokenCkErc20Ledger: Readable<boolean> = derived([tokenWithFallback], ([$token]) =>
-	isTokenCkErc20Ledger($token as IcToken)
+export const tokenCkEthLedger: Readable<boolean> = derived(
+	[tokenWithFallbackAsIcToken],
+	([$token]) => isTokenCkEthLedger($token)
+);
+
+export const tokenCkErc20Ledger: Readable<boolean> = derived(
+	[tokenWithFallbackAsIcToken],
+	([$token]) => isTokenCkErc20Ledger($token)
 );


### PR DESCRIPTION
# Motivation

Since we cast global stores `token` and `tokenWithFallback` to IcToken a few times, it is better to unify under a global store, so that it is easier to control it, and eventually remove it in future.

# Changes

- Create global store `tokenAsIcToken`.
- Create global store `tokenWithFallbackAsIcToken`.
- Adapt the code.
