### PR TITLE
refactor(frontend): move WalletConnect inside the main menu

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -25,6 +25,7 @@
 	import { loading } from '$lib/stores/loader.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { walletConnectStore } from '$eth/stores/wallet-connect.store';
 
 	export let listener: WalletConnectListener | undefined | null;
 
@@ -330,6 +331,8 @@
 
 		close();
 	};
+
+	$: listener, walletConnectStore.set(nonNullish(listener));
 </script>
 
 {#if nonNullish(listener)}

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -332,11 +332,7 @@
 	};
 </script>
 
-{#if isNullish(listener)}
-	<WalletConnectButton on:click={modalStore.openWalletConnectAuth}
-		>{$i18n.wallet_connect.text.connect}</WalletConnectButton
-	>
-{:else}
+{#if nonNullish(listener)}
 	<WalletConnectButton on:click={disconnect}
 		>{$i18n.wallet_connect.text.disconnect}</WalletConnectButton
 	>

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -25,7 +25,7 @@
 	import { loading } from '$lib/stores/loader.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { walletConnectStore } from '$eth/stores/wallet-connect.store';
+	import { walletConnectPaired } from '$eth/stores/wallet-connect.store';
 
 	export let listener: WalletConnectListener | undefined | null;
 
@@ -332,7 +332,7 @@
 		close();
 	};
 
-	$: listener, walletConnectStore.set(nonNullish(listener));
+	$: walletConnectPaired.set(nonNullish(listener));
 </script>
 
 {#if nonNullish(listener)}

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -333,6 +333,8 @@
 	};
 
 	$: walletConnectPaired.set(nonNullish(listener));
+
+	onDestroy(() => walletConnectPaired.set(false));
 </script>
 
 {#if nonNullish(listener)}

--- a/src/frontend/src/eth/stores/wallet-connect.store.ts
+++ b/src/frontend/src/eth/stores/wallet-connect.store.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const walletConnectStore = writable(false);

--- a/src/frontend/src/eth/stores/wallet-connect.store.ts
+++ b/src/frontend/src/eth/stores/wallet-connect.store.ts
@@ -1,3 +1,3 @@
 import { writable } from 'svelte/store';
 
-export const walletConnectStore = writable(false);
+export const walletConnectPaired = writable(false);

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -23,7 +23,7 @@
 	import WalletAddresses from '$lib/components/core/WalletAddresses.svelte';
 	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { walletConnectStore } from '$eth/stores/wallet-connect.store';
+	import { walletConnectPaired } from '$eth/stores/wallet-connect.store';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -63,7 +63,7 @@
 		<ButtonMenu
 			ariaLabel={$i18n.wallet_connect.text.name}
 			on:click={openWalletConnectAuth}
-			disabled={$walletConnectStore}
+			disabled={$walletConnectPaired}
 		>
 			<IconWalletConnect />
 			{$i18n.wallet_connect.text.name}

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -23,6 +23,7 @@
 	import WalletAddresses from '$lib/components/core/WalletAddresses.svelte';
 	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { walletConnectStore } from '$eth/stores/wallet-connect.store';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -59,7 +60,11 @@
 
 		<Hr />
 
-		<ButtonMenu ariaLabel={$i18n.wallet_connect.text.name} on:click={openWalletConnectAuth}>
+		<ButtonMenu
+			ariaLabel={$i18n.wallet_connect.text.name}
+			on:click={openWalletConnectAuth}
+			disabled={$walletConnectStore}
+		>
 			<IconWalletConnect />
 			{$i18n.wallet_connect.text.name}
 		</ButtonMenu>

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -21,6 +21,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
 	import WalletAddresses from '$lib/components/core/WalletAddresses.svelte';
+	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
+	import { modalStore } from '$lib/stores/modal.store';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -28,6 +30,11 @@
 	const gotoSettings = async () => {
 		visible = false;
 		await goto(`/settings?${networkParam($networkId)}`);
+	};
+
+	const openWalletConnectAuth = () => {
+		visible = false;
+		modalStore.openWalletConnectAuth();
 	};
 </script>
 
@@ -49,6 +56,13 @@
 		{:else if $pseudoNetworkChainFusion}
 			<WalletAddresses on:icReceiveTriggered={() => (visible = false)} />
 		{/if}
+
+		<Hr />
+
+		<ButtonMenu ariaLabel={$i18n.wallet_connect.text.name} on:click={openWalletConnectAuth}>
+			<IconWalletConnect />
+			{$i18n.wallet_connect.text.name}
+		</ButtonMenu>
 
 		<Hr />
 

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -8,6 +8,7 @@
 	aria-label={ariaLabel}
 	on:click
 	{disabled}
+	class:opacity-50={disabled}
 >
 	<slot />
 </button>

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	export let disabled = false;
 	export let ariaLabel: string;
 </script>
 
@@ -6,6 +7,7 @@
 	class="no-underline hover:text-blue active:text-blue w-full text-left"
 	aria-label={ariaLabel}
 	on:click
+	{disabled}
 >
 	<slot />
 </button>


### PR DESCRIPTION
# Motivation

We move the connect button of WalletConnect inside the items in the main menu. However we want to leave the disconnect button in the same place.

