### PR TITLE
chore(frontend):change Chain Fusion name in NetworksSwitcher

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -139,7 +139,7 @@
 		"title": "Current network. Access to selection.",
 		"show_testnets": "Show test networks",
 		"more": "More networks coming soon...",
-		"chain_fusion": "Chain Fusion"
+		"chain_fusion": "Chain Fusion (all networks)"
 	},
 	"receive": {
 		"text": {


### PR DESCRIPTION
# Motivation

In `NetworksSwitcher` we change the visual name of Chain Fusion.