### PR TITLE
refactor(backend): Change SupportedCredential type

### DIFF
--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -45,9 +45,9 @@ if [ -n "${ENV+1}" ]; then
             record {
               credential_type = variant { ProofOfUniqueness };
               ii_origin = \"$II_VC_URL\";
-              ii_canister_id = \"$II_CANISTER_ID\";
+              ii_canister_id = principal \"$II_CANISTER_ID\";
               issuer_origin = \"$POUH_ISSUER_VC_URL\";
-              issuer_canister_id = \"$POUH_ISSUER_CANISTER_ID\";
+              issuer_canister_id = principal \"$POUH_ISSUER_CANISTER_ID\";
             }
          };
          ic_root_key_der = $ic_root_key_der;
@@ -62,9 +62,9 @@ else
             record {
               credential_type = variant { ProofOfUniqueness };
               ii_origin = \"$II_VC_URL\";
-              ii_canister_id = \"$II_CANISTER_ID\";
+              ii_canister_id = principal \"$II_CANISTER_ID\";
               issuer_origin = \"$POUH_ISSUER_VC_URL\";
-              issuer_canister_id = \"$POUH_ISSUER_CANISTER_ID\";
+              issuer_canister_id = principal \"$POUH_ISSUER_CANISTER_ID\";
             }
          };
          ic_root_key_der = $ic_root_key_der;

--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -26,8 +26,8 @@ case $ENV in
     ;;
 esac
 
-II_CANISTER_ID="$(dfx canister id internet_identity --network "$ENV")"
-POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "$ENV")"
+II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
+POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
 # URL used by II-issuer in the id_alias-verifiable credentials (hard-coded in II)
 # Represents more an ID than a URL
 II_VC_URL="https://identity.ic0.app"

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -86,9 +86,9 @@ type SignRequest = record {
   nonce : nat;
 };
 type SupportedCredential = record {
-  ii_canister_id : text;
+  ii_canister_id : principal;
   issuer_origin : text;
-  issuer_canister_id : text;
+  issuer_canister_id : principal;
   ii_origin : text;
   credential_type : CredentialType;
 };

--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -1,4 +1,3 @@
-use candid::Principal;
 use ic_verifiable_credentials::VcFlowSigners;
 use shared::types::{user_profile::AddUserCredentialRequest, CredentialType};
 
@@ -15,23 +14,15 @@ pub fn get_credential_config(
             supported_credentials
                 .iter()
                 .find_map(|supported_credential| {
-                    let supported_issuer_canister_id =
-                        Principal::from_text(&supported_credential.issuer_canister_id).ok()?;
                     if supported_credential.credential_type.to_string()
                         == request.credential_spec.credential_type
-                        && supported_issuer_canister_id == request.issuer_canister_id
+                        && supported_credential.issuer_canister_id == request.issuer_canister_id
                     {
                         Some((
                             VcFlowSigners {
-                                ii_canister_id: Principal::from_text(
-                                    &supported_credential.ii_canister_id,
-                                )
-                                .ok()?,
+                                ii_canister_id: supported_credential.ii_canister_id,
                                 ii_origin: supported_credential.ii_origin.clone(),
-                                issuer_canister_id: Principal::from_text(
-                                    &supported_credential.issuer_canister_id,
-                                )
-                                .ok()?,
+                                issuer_canister_id: supported_credential.issuer_canister_id,
                                 issuer_origin: supported_credential.issuer_origin.clone(),
                             },
                             config

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -102,9 +102,11 @@ fn init_arg() -> Arg {
         allowed_callers: vec![Principal::from_text(CALLER).unwrap()],
         ic_root_key_der: None,
         supported_credentials: Some(vec![SupportedCredential {
-            ii_canister_id: II_CANISTER_ID.to_string(),
+            ii_canister_id: Principal::from_text(II_CANISTER_ID.to_string())
+                .expect("wrong ii canister id"),
             ii_origin: II_ORIGIN.to_string(),
-            issuer_canister_id: ISSUER_CANISTER_ID.to_string(),
+            issuer_canister_id: Principal::from_text(ISSUER_CANISTER_ID.to_string())
+                .expect("wrong issuer canister id"),
             issuer_origin: ISSUER_ORIGIN.to_string(),
             credential_type: CredentialType::ProofOfUniqueness,
         }]),

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -86,9 +86,9 @@ type SignRequest = record {
   nonce : nat;
 };
 type SupportedCredential = record {
-  ii_canister_id : text;
+  ii_canister_id : principal;
   issuer_origin : text;
-  issuer_canister_id : text;
+  issuer_canister_id : principal;
   ii_origin : text;
   credential_type : CredentialType;
 };

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -92,9 +92,9 @@ export interface SignRequest {
 	nonce: bigint;
 }
 export interface SupportedCredential {
-	ii_canister_id: string;
+	ii_canister_id: Principal;
 	issuer_origin: string;
-	issuer_canister_id: string;
+	issuer_canister_id: Principal;
 	ii_origin: string;
 	credential_type: CredentialType;
 }

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -2,9 +2,9 @@
 export const idlFactory = ({ IDL }) => {
 	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
 	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Text,
+		ii_canister_id: IDL.Principal,
 		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Text,
+		issuer_canister_id: IDL.Principal,
 		ii_origin: IDL.Text,
 		credential_type: CredentialType
 	});
@@ -155,9 +155,9 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
 	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
 	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Text,
+		ii_canister_id: IDL.Principal,
 		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Text,
+		issuer_canister_id: IDL.Principal,
 		ii_origin: IDL.Text,
 		credential_type: CredentialType
 	});

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -2,9 +2,9 @@
 export const idlFactory = ({ IDL }) => {
 	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
 	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Text,
+		ii_canister_id: IDL.Principal,
 		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Text,
+		issuer_canister_id: IDL.Principal,
 		ii_origin: IDL.Text,
 		credential_type: CredentialType
 	});
@@ -155,9 +155,9 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
 	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
 	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Text,
+		ii_canister_id: IDL.Principal,
 		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Text,
+		issuer_canister_id: IDL.Principal,
 		ii_origin: IDL.Text,
 		credential_type: CredentialType
 	});

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -12,9 +12,9 @@ pub enum CredentialType {
 pub struct SupportedCredential {
     pub credential_type: CredentialType,
     pub ii_origin: String,
-    pub ii_canister_id: String,
+    pub ii_canister_id: Principal,
     pub issuer_origin: String,
-    pub issuer_canister_id: String,
+    pub issuer_canister_id: Principal,
 }
 
 #[derive(CandidType, Deserialize)]


### PR DESCRIPTION
# Motivation

Set the config with the proper type (Principal) as soon as possible. In this case, when the init arguments are passed on deploy.

# Changes

* Set ii_canister_id and issuer_canister_id fields of SupportedCredentials from InitArg as Principal instead of a string.
* Change client types.
* Remove unnecessary conversion to Principal.

# Tests

* Fix init args in tests.
* Tested deploy to the local replica.
