### PR TITLE
fix(frontend): z-index of header logo was overlapping modals

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -9,10 +9,10 @@
 </script>
 
 <div class="flex -space-x-2.5 mt-6 xl:mt-12">
-	<div class="z-0"><IconHeaderICP /></div>
-	<div class="z-10"><IconHeaderBTC /></div>
-	<div class="z-20"><IconHeaderETH /></div>
-	<div class="z-30"><IconHeaderUSDC /></div>
+	<div><IconHeaderICP /></div>
+	<div><IconHeaderBTC /></div>
+	<div><IconHeaderETH /></div>
+	<div><IconHeaderUSDC /></div>
 </div>
 
 <div class="mt-5 mb-10 pt-2">


### PR DESCRIPTION
# Motivation

As suggested by @peterpeterparker , the z-index was not necessary and could lead to possible issues in conflicting positions. In our case it was giving the issue below:

<img width="1121" alt="Screenshot 2024-07-22 at 14 42 33" src="https://github.com/user-attachments/assets/9d15b841-4ac6-4906-b54e-553de8ca61bf">
