### PR TITLE
style(frontend): update style of primary buttons

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -10,7 +10,7 @@ button {
 		cursor: pointer;
 	}
 
-	--button-border-radius: var(--border-radius-sm);
+	--button-border-radius: var(--border-radius-xs);
 	border-radius: var(--button-border-radius);
 
 	transition:
@@ -40,7 +40,7 @@ button {
 	}
 
 	&.primary {
-		background: var(--color-blue);
+		background: var(--color-dodger-blue);
 		color: var(--color-white);
 	}
 

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -16,7 +16,7 @@
 	--color-medium-purple: theme(colors.medium-purple);
 	--color-platinum: theme(colors.platinum);
 	--color-mountain-meadow: theme(colors.mountain-meadow);
-	--color-dodger-blue: #016dfc;
+	--color-dodger-blue: theme(colors.dodger-blue);
 
 	// Brand
 	--color-wallet-connect: #3b99fc;

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -16,6 +16,7 @@
 	--color-medium-purple: theme(colors.medium-purple);
 	--color-platinum: theme(colors.platinum);
 	--color-mountain-meadow: theme(colors.mountain-meadow);
+	--color-dodger-blue: #016dfc;
 
 	// Brand
 	--color-wallet-connect: #3b99fc;

--- a/src/frontend/src/lib/styles/global/variables.scss
+++ b/src/frontend/src/lib/styles/global/variables.scss
@@ -13,6 +13,7 @@
 	--padding-6x: calc(var(--padding) * 6);
 	--padding-8x: calc(var(--padding) * 8);
 
+	--border-radius-xs: 4px;
 	--border-radius-sm: 8px;
 	--border-radius-md: calc(var(--border-radius-sm) * 2);
 	--border-radius-lg: calc(var(--border-radius-sm) * 4);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,8 @@ export default {
 			cyclamen: '#ea6c99',
 			'medium-purple': '#8969d5',
 			platinum: '#e4e4e4',
-			'mountain-meadow': '#30af91'
+			'mountain-meadow': '#30af91',
+			'dodger-blue': '#1e90ff'
 		}
 	},
 	plugins: []


### PR DESCRIPTION
# Motivation

We update the style of primary buttons. Furthermore, the `border-radius` for every button type is now `4px`.

### Before
![image](https://github.com/user-attachments/assets/b4e22efc-6b49-4c91-b4eb-4d3769a89431)

### After
![image](https://github.com/user-attachments/assets/170d9209-6fe3-409a-a3ee-e81033185d59)
