### PR TITLE
feat(backend): Implement get_users endpoint

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -42,14 +42,6 @@ type DefiniteCanisterSettingsArgs = record {
   compute_allocation : nat;
 };
 type GetUserProfileError = variant { NotFound };
-type GetUsersRequest = record {
-  updated_after_timestamp : opt nat64;
-  matches_max_length : opt nat64;
-};
-type GetUsersResponse = record {
-  users : vec OisyUser;
-  matches_max_length : nat64;
-};
 type HttpRequest = record {
   url : text;
   method : text;
@@ -67,6 +59,14 @@ type InitArg = record {
   allowed_callers : vec principal;
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_der : opt blob;
+};
+type ListUsersRequest = record {
+  updated_after_timestamp : opt nat64;
+  matches_max_length : opt nat64;
+};
+type ListUsersResponse = record {
+  users : vec OisyUser;
+  matches_max_length : nat64;
 };
 type OisyUser = record {
   "principal" : principal;
@@ -119,10 +119,10 @@ service : (Arg) -> {
   eth_address_of : (principal) -> (text);
   get_canister_status : () -> (CanisterStatusResultV2);
   get_user_profile : () -> (Result_1) query;
-  get_users : (GetUsersRequest) -> (GetUsersResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
+  list_users : (ListUsersRequest) -> (ListUsersResponse) query;
   personal_sign : (text) -> (text);
   remove_user_token : (UserTokenId) -> ();
   set_custom_token : (CustomToken) -> ();

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -31,8 +31,8 @@ use shared::types::custom_token::{CustomToken, CustomTokenId};
 use shared::types::token::{UserToken, UserTokenId};
 use shared::types::transaction::SignRequest;
 use shared::types::user_profile::{
-    AddUserCredentialError, AddUserCredentialRequest, GetUserProfileError, GetUsersRequest,
-    GetUsersResponse, OisyUser, StoredUserProfile, UserProfile,
+    AddUserCredentialError, AddUserCredentialRequest, GetUserProfileError, ListUsersRequest,
+    ListUsersResponse, OisyUser, StoredUserProfile, UserProfile,
 };
 use shared::types::{Arg, InitArg, SupportedCredential, Timestamp};
 use std::borrow::Cow;
@@ -580,15 +580,15 @@ fn get_user_profile() -> Result<UserProfile, GetUserProfileError> {
 
 #[query(guard = "caller_is_allowed")]
 #[allow(clippy::needless_pass_by_value)]
-fn get_users(request: GetUsersRequest) -> GetUsersResponse {
-    // WARNING: The value `DEFAULT_LIMIT_GET_USERS_RESPONSE` must also be determined by the cycles consumption when reading BTreeMap.
+fn list_users(request: ListUsersRequest) -> ListUsersResponse {
+    // WARNING: The value `DEFAULT_LIMIT_LIST_USERS_RESPONSE` must also be determined by the cycles consumption when reading BTreeMap.
 
-    let (users, limit_users_size): (Vec<OisyUser>, u64) =
+    let (users, matches_max_length): (Vec<OisyUser>, u64) =
         read_state(|s| get_oisy_users(&request, &s.user_profile));
 
-    GetUsersResponse {
+    ListUsersResponse {
         users,
-        matches_max_length: limit_users_size,
+        matches_max_length,
     }
 }
 

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -166,12 +166,6 @@ impl Storable for StoredPrincipal {
     }
 }
 
-impl StoredPrincipal {
-    fn clone_principal(self) -> Principal {
-        self.0.clone()
-    }
-}
-
 #[derive(CandidType, Deserialize)]
 pub struct Config {
     pub ecdsa_key_name: String,
@@ -590,7 +584,7 @@ fn get_users(request: GetUsersRequest) -> GetUsersResponse {
     // WARNING: The value `DEFAULT_LIMIT_GET_USERS_RESPONSE` must also be determined by the cycles consumption when reading BTreeMap.
 
     let (users, limit_users_size): (Vec<OisyUser>, u64) =
-        read_state(|s| get_oisy_users(request, &s.user_profile));
+        read_state(|s| get_oisy_users(&request, &s.user_profile));
 
     GetUsersResponse {
         users,

--- a/src/backend/src/oisy_user.rs
+++ b/src/backend/src/oisy_user.rs
@@ -2,27 +2,32 @@ use crate::{Candid, StoredPrincipal, VMem};
 use candid::Principal;
 use ic_stable_structures::StableBTreeMap;
 use shared::types::{
-    user_profile::{GetUsersRequest, OisyUser, StoredUserProfile},
+    user_profile::{ListUsersRequest, OisyUser, StoredUserProfile},
     Timestamp,
 };
 use std::ops::Bound;
 
-const DEFAULT_LIMIT_GET_USERS_RESPONSE: usize = 10_000;
+const DEFAULT_LIMIT_LIST_USERS_RESPONSE: usize = 10_000;
+pub const PRINCIPAL_MIN: Principal = Principal::from_slice(&[]);
+
+fn get_limit_users_size(request: &ListUsersRequest) -> usize {
+    match request.matches_max_length {
+        Some(num) => match usize::try_from(num) {
+            Ok(val) if val <= DEFAULT_LIMIT_LIST_USERS_RESPONSE => val,
+            _ => DEFAULT_LIMIT_LIST_USERS_RESPONSE,
+        },
+        None => DEFAULT_LIMIT_LIST_USERS_RESPONSE,
+    }
+}
 
 pub fn get_oisy_users(
-    request: &GetUsersRequest,
+    request: &ListUsersRequest,
     user_profile_map: &StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
 ) -> (Vec<OisyUser>, u64) {
-    let limit_users_size: usize = match request.matches_max_length {
-        Some(num) => match usize::try_from(num) {
-            Ok(val) if val <= DEFAULT_LIMIT_GET_USERS_RESPONSE => val,
-            _ => DEFAULT_LIMIT_GET_USERS_RESPONSE,
-        },
-        None => DEFAULT_LIMIT_GET_USERS_RESPONSE,
-    };
+    let limit_users_size: usize = get_limit_users_size(&request);
 
     let start_bound: Bound<(Timestamp, StoredPrincipal)> = match request.updated_after_timestamp {
-        Some(updated) => Bound::Included((updated, StoredPrincipal(Principal::anonymous()))),
+        Some(updated) => Bound::Included((updated, StoredPrincipal(PRINCIPAL_MIN))),
         None => Bound::Unbounded,
     };
     let users: Vec<OisyUser> = user_profile_map

--- a/src/backend/src/oisy_user.rs
+++ b/src/backend/src/oisy_user.rs
@@ -8,7 +8,7 @@ use shared::types::{
 use std::ops::Bound;
 
 const DEFAULT_LIMIT_LIST_USERS_RESPONSE: usize = 10_000;
-pub const PRINCIPAL_MIN: Principal = Principal::from_slice(&[]);
+const PRINCIPAL_MIN: Principal = Principal::from_slice(&[]);
 
 fn get_limit_users_size(request: &ListUsersRequest) -> usize {
     match request.matches_max_length {

--- a/src/backend/src/oisy_user.rs
+++ b/src/backend/src/oisy_user.rs
@@ -1,0 +1,35 @@
+use crate::{Candid, StoredPrincipal, VMem};
+use candid::Principal;
+use ic_stable_structures::StableBTreeMap;
+use shared::types::{
+    user_profile::{GetUsersRequest, OisyUser, StoredUserProfile},
+    Timestamp,
+};
+use std::ops::Bound;
+
+const DEFAULT_LIMIT_GET_USERS_RESPONSE: u64 = 10_000;
+
+pub fn get_oisy_users(
+    request: GetUsersRequest,
+    user_profile_map: &StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
+) -> (Vec<OisyUser>, u64) {
+    let limit_users_size = match request.matches_max_length {
+        Some(num) if num <= DEFAULT_LIMIT_GET_USERS_RESPONSE => num,
+        _ => DEFAULT_LIMIT_GET_USERS_RESPONSE,
+    };
+
+    let start_bound: Bound<(Timestamp, StoredPrincipal)> = match request.updated_after_timestamp {
+        Some(updated) => Bound::Included((updated, StoredPrincipal(Principal::anonymous()))),
+        None => Bound::Unbounded,
+    };
+    let users: Vec<OisyUser> = user_profile_map
+        .range((start_bound, Bound::Unbounded))
+        .take(limit_users_size as usize)
+        .into_iter()
+        .map(|((_, principal), profile)| {
+            OisyUser::from_profile(profile.clone(), principal.clone_principal())
+        })
+        .collect();
+
+    (users, limit_users_size)
+}

--- a/src/backend/src/oisy_user.rs
+++ b/src/backend/src/oisy_user.rs
@@ -24,7 +24,7 @@ pub fn get_oisy_users(
     request: &ListUsersRequest,
     user_profile_map: &StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
 ) -> (Vec<OisyUser>, u64) {
-    let limit_users_size: usize = get_limit_users_size(&request);
+    let limit_users_size: usize = get_limit_users_size(request);
 
     let start_bound: Bound<(Timestamp, StoredPrincipal)> = match request.updated_after_timestamp {
         Some(updated) => Bound::Included((updated, StoredPrincipal(PRINCIPAL_MIN))),

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -3,8 +3,23 @@ use ic_cdk::api::time;
 use ic_stable_structures::StableBTreeMap;
 use shared::types::{
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
-    CredentialType, Version,
+    CredentialType, Timestamp, Version,
 };
+
+fn store_user(
+    principal: StoredPrincipal,
+    timestamp: Timestamp,
+    user: &StoredUserProfile,
+    user_profile_map: &mut StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
+    user_profile_updated_map: &mut StableBTreeMap<StoredPrincipal, u64, VMem>,
+) {
+    if let Some(old_updated) = user_profile_updated_map.get(&principal) {
+        // Clean up old entries
+        user_profile_map.remove(&(old_updated, principal));
+    }
+    user_profile_updated_map.insert(principal, timestamp);
+    user_profile_map.insert((timestamp, principal), Candid(user.clone()));
+}
 
 pub fn get_profile(
     principal: StoredPrincipal,
@@ -33,8 +48,13 @@ pub fn create_profile(
     } else {
         let now = time();
         let default_profile = StoredUserProfile::from_timestamp(now);
-        user_profile_updated_map.insert(principal, now);
-        user_profile_map.insert((now, principal), Candid(default_profile.clone()));
+        store_user(
+            principal,
+            now,
+            &default_profile,
+            user_profile_map,
+            user_profile_updated_map,
+        );
         default_profile
     }
 }
@@ -50,8 +70,13 @@ pub fn add_credential(
         let now = time();
         if let Ok(new_profile) = user_profile.add_credential(profile_version, now, credential_type)
         {
-            user_profile_updated_map.insert(principal, now);
-            user_profile_map.insert((now, principal), Candid(new_profile));
+            store_user(
+                principal,
+                now,
+                &new_profile,
+                user_profile_map,
+                user_profile_updated_map,
+            );
             Ok(())
         } else {
             Err(AddUserCredentialError::VersionMismatch)

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -6,7 +6,7 @@ use shared::types::{
     CredentialType, Timestamp, Version,
 };
 
-fn store_user(
+fn store_user_profile(
     principal: StoredPrincipal,
     timestamp: Timestamp,
     user: &StoredUserProfile,
@@ -48,7 +48,7 @@ pub fn create_profile(
     } else {
         let now = time();
         let default_profile = StoredUserProfile::from_timestamp(now);
-        store_user(
+        store_user_profile(
             principal,
             now,
             &default_profile,
@@ -70,7 +70,7 @@ pub fn add_credential(
         let now = time();
         if let Ok(new_profile) = user_profile.add_credential(profile_version, now, credential_type)
         {
-            store_user(
+            store_user_profile(
                 principal,
                 now,
                 &new_profile,

--- a/src/backend/tests/it/get_users.rs
+++ b/src/backend/tests/it/get_users.rs
@@ -1,0 +1,24 @@
+use crate::utils::{
+    mock::CALLER,
+    pocketic::{query_call, setup, update_call},
+};
+use candid::Principal;
+use shared::types::user_profile::{GetUsersRequest, GetUsersResponse, UserProfile};
+
+#[test]
+fn test_get_users_returns_oisy_users() {
+    let pic_setup = setup();
+
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let _create_response =
+        update_call::<UserProfile>(&pic_setup, caller, "create_user_profile", ());
+
+    let arg = GetUsersRequest {
+        matches_max_length: None,
+        updated_after_timestamp: None,
+    };
+    let get_users_response = query_call::<GetUsersResponse>(&pic_setup, caller, "get_users", arg);
+
+    assert_eq!(get_users_response.expect("Call failed").users.len(), 1);
+}

--- a/src/backend/tests/it/get_users.rs
+++ b/src/backend/tests/it/get_users.rs
@@ -1,18 +1,33 @@
+use std::time::{Duration, UNIX_EPOCH};
+
 use crate::utils::{
-    mock::CALLER,
+    mock::{CALLER, ISSUER_CANISTER_ID, VC_HOLDER, VP_JWT},
     pocketic::{query_call, setup, update_call},
 };
 use candid::Principal;
-use shared::types::user_profile::{GetUsersRequest, GetUsersResponse, UserProfile};
+use ic_verifiable_credentials::issuer_api::CredentialSpec;
+use pocket_ic::PocketIc;
+use shared::types::user_profile::{
+    AddUserCredentialError, AddUserCredentialRequest, GetUsersRequest, GetUsersResponse, OisyUser,
+    UserProfile,
+};
+
+fn create_users(pic_setup: &(PocketIc, Principal), start: u8, end: u8) {
+    for i in start..=end {
+        let caller = Principal::self_authenticating(i.to_string());
+        let response = update_call::<UserProfile>(pic_setup, caller, "create_user_profile", ());
+        assert!(response.is_ok());
+    }
+}
 
 #[test]
-fn test_get_users_returns_oisy_users() {
+fn test_get_users_returns_users() {
     let pic_setup = setup();
 
-    let caller = Principal::from_text(CALLER).unwrap();
+    let users_count = 5;
+    create_users(&pic_setup, 1, users_count);
 
-    let _create_response =
-        update_call::<UserProfile>(&pic_setup, caller, "create_user_profile", ());
+    let caller = Principal::from_text(CALLER).unwrap();
 
     let arg = GetUsersRequest {
         matches_max_length: None,
@@ -20,5 +35,152 @@ fn test_get_users_returns_oisy_users() {
     };
     let get_users_response = query_call::<GetUsersResponse>(&pic_setup, caller, "get_users", arg);
 
-    assert_eq!(get_users_response.expect("Call failed").users.len(), 1);
+    assert_eq!(
+        get_users_response.expect("Call failed").users.len(),
+        users_count as usize
+    );
+}
+
+#[test]
+fn test_get_users_returns_filtered_users_by_updated() {
+    let pic_setup = setup();
+
+    // Add 10 users
+    let users_count_initial = 10;
+    create_users(&pic_setup, 1, users_count_initial);
+
+    // Add one user that will be updated after the desired timestamp
+    let vc_holder = Principal::from_text(VC_HOLDER).expect("VC Holder principal is invalid");
+
+    let create_profile_response =
+        update_call::<UserProfile>(&pic_setup, vc_holder, "create_user_profile", ());
+    let initial_profile = create_profile_response.expect("Create failed");
+
+    // Advance time before creating more users
+    let (pic, principal) = pic_setup;
+    pic.advance_time(Duration::new(10, 0));
+    let timestamp = pic.get_time();
+    let new_pic_setup = (pic, principal);
+    let timestamp_nanos = timestamp
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_nanos();
+
+    // Add 10 more users
+    let users_count_after_timestamp = 10;
+    create_users(
+        &new_pic_setup,
+        users_count_initial + 1,
+        users_count_initial + users_count_after_timestamp,
+    );
+
+    // Update one of the users created before timestamp
+    let add_user_cred_arg = AddUserCredentialRequest {
+        credential_jwt: VP_JWT.to_string(),
+        current_user_version: initial_profile.version,
+        credential_spec: CredentialSpec {
+            credential_type: "ProofOfUniqueness".to_string(),
+            arguments: None,
+        },
+        issuer_canister_id: Principal::from_text(ISSUER_CANISTER_ID)
+            .expect("VC Holder principal is invalid"),
+    };
+
+    let _ = update_call::<Result<(), AddUserCredentialError>>(
+        &new_pic_setup,
+        vc_holder,
+        "add_user_credential",
+        add_user_cred_arg.clone(),
+    );
+
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let arg = GetUsersRequest {
+        matches_max_length: None,
+        updated_after_timestamp: Some(timestamp_nanos as u64),
+    };
+    let get_users_response =
+        query_call::<GetUsersResponse>(&new_pic_setup, caller, "get_users", arg);
+
+    assert_eq!(
+        get_users_response
+            .expect("Call get_users failed")
+            .users
+            .len(),
+        users_count_after_timestamp as usize + 1
+    );
+}
+
+#[test]
+fn test_get_users_returns_requested_users_count() {
+    let pic_setup = setup();
+
+    let users_count = 20;
+    create_users(&pic_setup, 1, users_count);
+
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let requested_count = 5;
+    let arg = GetUsersRequest {
+        matches_max_length: Some(requested_count),
+        updated_after_timestamp: None,
+    };
+    let get_users_response = query_call::<GetUsersResponse>(&pic_setup, caller, "get_users", arg);
+
+    assert_eq!(
+        get_users_response.expect("Call failed").users.len(),
+        requested_count as usize,
+    );
+}
+
+#[test]
+fn test_get_users_returns_pouh_credential() {
+    let pic_setup = setup();
+
+    // Add one user that will be updated after the desired timestamp
+    let vc_holder = Principal::from_text(VC_HOLDER).expect("VC Holder principal is invalid");
+
+    let create_profile_response =
+        update_call::<UserProfile>(&pic_setup, vc_holder, "create_user_profile", ());
+    let initial_profile = create_profile_response.expect("Create failed");
+
+    // Add 10 more users
+    let users_count = 10;
+    create_users(&pic_setup, 1, users_count);
+
+    // Update one of the users created before timestamp
+    let add_user_cred_arg = AddUserCredentialRequest {
+        credential_jwt: VP_JWT.to_string(),
+        current_user_version: initial_profile.version,
+        credential_spec: CredentialSpec {
+            credential_type: "ProofOfUniqueness".to_string(),
+            arguments: None,
+        },
+        issuer_canister_id: Principal::from_text(ISSUER_CANISTER_ID)
+            .expect("VC Holder principal is invalid"),
+    };
+
+    let _ = update_call::<Result<(), AddUserCredentialError>>(
+        &pic_setup,
+        vc_holder,
+        "add_user_credential",
+        add_user_cred_arg.clone(),
+    );
+
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let arg = GetUsersRequest {
+        matches_max_length: None,
+        updated_after_timestamp: None,
+    };
+    let get_users_response = query_call::<GetUsersResponse>(&pic_setup, caller, "get_users", arg);
+    let users = get_users_response.expect("Call get_users failed").users;
+
+    assert_eq!(users.len(), 11);
+
+    let pouh_holders: Vec<&OisyUser> = users.iter().filter(|user| user.pouh_verified).collect();
+    assert_eq!(pouh_holders.len(), 1);
+
+    let pouh_holder_principal = pouh_holders.first().unwrap().principal;
+    assert_eq!(pouh_holder_principal.to_text(), VC_HOLDER);
 }

--- a/src/backend/tests/it/list_users.rs
+++ b/src/backend/tests/it/list_users.rs
@@ -8,8 +8,8 @@ use candid::Principal;
 use ic_verifiable_credentials::issuer_api::CredentialSpec;
 use pocket_ic::PocketIc;
 use shared::types::user_profile::{
-    AddUserCredentialError, AddUserCredentialRequest, ListUsersRequest, ListUsersResponse, OisyUser,
-    UserProfile,
+    AddUserCredentialError, AddUserCredentialRequest, ListUsersRequest, ListUsersResponse,
+    OisyUser, UserProfile,
 };
 
 fn create_users(pic_setup: &(PocketIc, Principal), start: u8, end: u8) {
@@ -30,7 +30,8 @@ fn test_list_users_cannot_be_called_if_not_allowed() {
         matches_max_length: None,
         updated_after_timestamp: None,
     };
-    let list_users_response = query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
+    let list_users_response =
+        query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
 
     assert!(list_users_response.is_err(),);
 }
@@ -64,7 +65,8 @@ fn test_list_users_returns_users() {
         matches_max_length: None,
         updated_after_timestamp: None,
     };
-    let list_users_response = query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
+    let list_users_response =
+        query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
 
     let results_users = list_users_response.expect("Call failed").users;
     assert_eq!(results_users.len(), expected_users.len(),);
@@ -183,10 +185,10 @@ fn test_list_users_returns_requested_users_count() {
     let list_users_response =
         query_call::<ListUsersResponse>(&new_pic_setup, caller, "list_users", arg);
 
-    assert_eq!(
-        list_users_response.expect("Call failed").users.len(),
-        requested_count as usize,
-    );
+    let users_response_count = list_users_response.expect("Call failed").users.len();
+
+    assert!(users_response_count < requested_count as usize,);
+    assert_eq!(users_response_count, users_count_after_timestamp as usize,);
 }
 
 #[test]
@@ -203,7 +205,8 @@ fn test_list_users_returns_less_than_requested_users_count() {
         matches_max_length: Some(requested_count),
         updated_after_timestamp: None,
     };
-    let list_users_response = query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
+    let list_users_response =
+        query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
 
     assert_eq!(
         list_users_response.expect("Call failed").users.len(),
@@ -251,7 +254,8 @@ fn test_list_users_returns_pouh_credential() {
         matches_max_length: None,
         updated_after_timestamp: None,
     };
-    let list_users_response = query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
+    let list_users_response =
+        query_call::<ListUsersResponse>(&pic_setup, caller, "list_users", arg);
     let users = list_users_response.expect("Call list_users failed").users;
 
     assert_eq!(users.len(), 11);

--- a/src/backend/tests/it/list_users.rs
+++ b/src/backend/tests/it/list_users.rs
@@ -84,8 +84,8 @@ fn test_list_users_returns_users() {
 fn test_list_users_returns_filtered_users_by_updated() {
     let pic_setup = setup();
 
-    // Add 10 users
-    let users_count_initial = 10;
+    // Add 15 users
+    let users_count_initial = 15;
     create_users(&pic_setup, 1, users_count_initial);
 
     // Add one user that will be updated after the desired timestamp
@@ -169,8 +169,8 @@ fn test_list_users_returns_requested_users_count() {
         .expect("Time went backwards")
         .as_nanos();
 
-    // Add 5 more users
-    let users_count_after_timestamp = 5;
+    // Add 15 more users
+    let users_count_after_timestamp = 15;
     create_users(
         &new_pic_setup,
         users_count_initial + 1,
@@ -187,8 +187,7 @@ fn test_list_users_returns_requested_users_count() {
 
     let users_response_count = list_users_response.expect("Call failed").users.len();
 
-    assert!(users_response_count < requested_count as usize,);
-    assert_eq!(users_response_count, users_count_after_timestamp as usize,);
+    assert_eq!(users_response_count, requested_count as usize);
 }
 
 #[test]

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -1,6 +1,6 @@
 mod address;
 mod custom_token;
-mod get_users;
+mod list_users;
 mod sign;
 mod token;
 mod upgrade;

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -1,5 +1,6 @@
 mod address;
 mod custom_token;
+mod get_users;
 mod sign;
 mod token;
 mod upgrade;

--- a/src/backend/tests/it/user_profile.rs
+++ b/src/backend/tests/it/user_profile.rs
@@ -1,11 +1,9 @@
 use crate::utils::{
     mock::CALLER,
-    pocketic::{query_call, setup, update_call},
+    pocketic::{setup, update_call},
 };
 use candid::Principal;
-use shared::types::user_profile::{
-    GetUserProfileError, GetUsersRequest, GetUsersResponse, UserProfile,
-};
+use shared::types::user_profile::{GetUserProfileError, UserProfile};
 use std::time::Duration;
 
 #[test]
@@ -84,20 +82,4 @@ fn test_get_user_profile_returns_not_found() {
         response.expect("Create failed").unwrap_err(),
         GetUserProfileError::NotFound,
     );
-}
-
-#[test]
-fn test_get_users() {
-    let pic_setup = setup();
-
-    let caller = Principal::from_text(CALLER).unwrap();
-
-    let request = GetUsersRequest {
-        updated_after_timestamp: None,
-        matches_max_length: None,
-    };
-
-    let before_set = query_call::<GetUsersResponse>(&pic_setup, caller, "get_users", request);
-
-    assert!(before_set.is_ok());
 }

--- a/src/backend/tests/it/utils/assertion.rs
+++ b/src/backend/tests/it/utils/assertion.rs
@@ -1,4 +1,4 @@
-use shared::types::custom_token::CustomToken;
+use shared::types::{custom_token::CustomToken, user_profile::OisyUser};
 
 pub fn assert_tokens_data_eq<T: PartialEq + std::fmt::Debug>(
     results_tokens: &[T],
@@ -34,6 +34,18 @@ pub fn assert_custom_tokens_eq(
             token, expected,
             "Result custom token differs from expected custom token: {:?} vs {:?}",
             token, expected
+        );
+    }
+}
+
+pub fn assert_user_profiles_eq(results_users: Vec<OisyUser>, expected_users: Vec<OisyUser>) {
+    assert_eq!(results_users.len(), expected_users.len(),);
+
+    for (user, expected) in results_users.iter().zip(expected_users.iter()) {
+        assert_eq!(
+            user, expected,
+            "Result users differs from expected user: {:?} vs {:?}",
+            user, expected
         );
     }
 }

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -42,14 +42,6 @@ type DefiniteCanisterSettingsArgs = record {
   compute_allocation : nat;
 };
 type GetUserProfileError = variant { NotFound };
-type GetUsersRequest = record {
-  updated_after_timestamp : opt nat64;
-  matches_max_length : opt nat64;
-};
-type GetUsersResponse = record {
-  users : vec OisyUser;
-  matches_max_length : nat64;
-};
 type HttpRequest = record {
   url : text;
   method : text;
@@ -67,6 +59,14 @@ type InitArg = record {
   allowed_callers : vec principal;
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_der : opt blob;
+};
+type ListUsersRequest = record {
+  updated_after_timestamp : opt nat64;
+  matches_max_length : opt nat64;
+};
+type ListUsersResponse = record {
+  users : vec OisyUser;
+  matches_max_length : nat64;
 };
 type OisyUser = record {
   "principal" : principal;
@@ -119,10 +119,10 @@ service : (Arg) -> {
   eth_address_of : (principal) -> (text);
   get_canister_status : () -> (CanisterStatusResultV2);
   get_user_profile : () -> (Result_1) query;
-  get_users : (GetUsersRequest) -> (GetUsersResponse) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
+  list_users : (ListUsersRequest) -> (ListUsersResponse) query;
   personal_sign : (text) -> (text);
   remove_user_token : (UserTokenId) -> ();
   set_custom_token : (CustomToken) -> ();

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -45,14 +45,6 @@ export interface DefiniteCanisterSettingsArgs {
 	compute_allocation: bigint;
 }
 export type GetUserProfileError = { NotFound: null };
-export interface GetUsersRequest {
-	updated_after_timestamp: [] | [bigint];
-	matches_max_length: [] | [bigint];
-}
-export interface GetUsersResponse {
-	users: Array<OisyUser>;
-	matches_max_length: bigint;
-}
 export interface HttpRequest {
 	url: string;
 	method: string;
@@ -73,6 +65,14 @@ export interface InitArg {
 	allowed_callers: Array<Principal>;
 	supported_credentials: [] | [Array<SupportedCredential>];
 	ic_root_key_der: [] | [Uint8Array | number[]];
+}
+export interface ListUsersRequest {
+	updated_after_timestamp: [] | [bigint];
+	matches_max_length: [] | [bigint];
+}
+export interface ListUsersResponse {
+	users: Array<OisyUser>;
+	matches_max_length: bigint;
 }
 export interface OisyUser {
 	principal: Principal;
@@ -128,10 +128,10 @@ export interface _SERVICE {
 	eth_address_of: ActorMethod<[Principal], string>;
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
 	get_user_profile: ActorMethod<[], Result_1>;
-	get_users: ActorMethod<[GetUsersRequest], GetUsersResponse>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
 	list_user_tokens: ActorMethod<[], Array<UserToken>>;
+	list_users: ActorMethod<[ListUsersRequest], ListUsersResponse>;
 	personal_sign: ActorMethod<[string], string>;
 	remove_user_token: ActorMethod<[UserTokenId], undefined>;
 	set_custom_token: ActorMethod<[CustomToken], undefined>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -74,19 +74,6 @@ export const idlFactory = ({ IDL }) => {
 		Ok: UserProfile,
 		Err: GetUserProfileError
 	});
-	const GetUsersRequest = IDL.Record({
-		updated_after_timestamp: IDL.Opt(IDL.Nat64),
-		matches_max_length: IDL.Opt(IDL.Nat64)
-	});
-	const OisyUser = IDL.Record({
-		principal: IDL.Principal,
-		pouh_verified: IDL.Bool,
-		updated_timestamp: IDL.Nat64
-	});
-	const GetUsersResponse = IDL.Record({
-		users: IDL.Vec(OisyUser),
-		matches_max_length: IDL.Nat64
-	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
 		method: IDL.Text,
@@ -116,6 +103,19 @@ export const idlFactory = ({ IDL }) => {
 		contract_address: IDL.Text,
 		symbol: IDL.Opt(IDL.Text)
 	});
+	const ListUsersRequest = IDL.Record({
+		updated_after_timestamp: IDL.Opt(IDL.Nat64),
+		matches_max_length: IDL.Opt(IDL.Nat64)
+	});
+	const OisyUser = IDL.Record({
+		principal: IDL.Principal,
+		pouh_verified: IDL.Bool,
+		updated_timestamp: IDL.Nat64
+	});
+	const ListUsersResponse = IDL.Record({
+		users: IDL.Vec(OisyUser),
+		matches_max_length: IDL.Nat64
+	});
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -137,10 +137,10 @@ export const idlFactory = ({ IDL }) => {
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		get_user_profile: IDL.Func([], [Result_1]),
-		get_users: IDL.Func([GetUsersRequest], [GetUsersResponse]),
 		http_request: IDL.Func([HttpRequest], [HttpResponse]),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)]),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)]),
+		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse]),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -74,19 +74,6 @@ export const idlFactory = ({ IDL }) => {
 		Ok: UserProfile,
 		Err: GetUserProfileError
 	});
-	const GetUsersRequest = IDL.Record({
-		updated_after_timestamp: IDL.Opt(IDL.Nat64),
-		matches_max_length: IDL.Opt(IDL.Nat64)
-	});
-	const OisyUser = IDL.Record({
-		principal: IDL.Principal,
-		pouh_verified: IDL.Bool,
-		updated_timestamp: IDL.Nat64
-	});
-	const GetUsersResponse = IDL.Record({
-		users: IDL.Vec(OisyUser),
-		matches_max_length: IDL.Nat64
-	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
 		method: IDL.Text,
@@ -116,6 +103,19 @@ export const idlFactory = ({ IDL }) => {
 		contract_address: IDL.Text,
 		symbol: IDL.Opt(IDL.Text)
 	});
+	const ListUsersRequest = IDL.Record({
+		updated_after_timestamp: IDL.Opt(IDL.Nat64),
+		matches_max_length: IDL.Opt(IDL.Nat64)
+	});
+	const OisyUser = IDL.Record({
+		principal: IDL.Principal,
+		pouh_verified: IDL.Bool,
+		updated_timestamp: IDL.Nat64
+	});
+	const ListUsersResponse = IDL.Record({
+		users: IDL.Vec(OisyUser),
+		matches_max_length: IDL.Nat64
+	});
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -137,10 +137,10 @@ export const idlFactory = ({ IDL }) => {
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		get_user_profile: IDL.Func([], [Result_1], ['query']),
-		get_users: IDL.Func([GetUsersRequest], [GetUsersResponse], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], ['query']),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)], ['query']),
+		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse], ['query']),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+use candid::Principal;
+
 use crate::types::custom_token::{CustomToken, CustomTokenId, Token};
 use crate::types::token::UserToken;
 use crate::types::user_profile::{
-    AddUserCredentialError, StoredUserProfile, UserCredential, UserProfile,
+    AddUserCredentialError, OisyUser, StoredUserProfile, UserCredential, UserProfile,
 };
 use crate::types::{CredentialType, Timestamp, TokenVersion, Version};
 
@@ -128,6 +130,19 @@ impl From<&StoredUserProfile> for UserProfile {
             updated_timestamp: *updated_timestamp,
             version: *version,
             credentials: credentials.clone().into_values().collect(),
+        }
+    }
+}
+
+impl OisyUser {
+    #[must_use]
+    pub fn from_profile(user: StoredUserProfile, principal: Principal) -> OisyUser {
+        OisyUser {
+            principal,
+            pouh_verified: user
+                .credentials
+                .contains_key(&CredentialType::ProofOfUniqueness),
+            updated_timestamp: user.updated_timestamp,
         }
     }
 }

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -136,7 +136,7 @@ impl From<&StoredUserProfile> for UserProfile {
 
 impl OisyUser {
     #[must_use]
-    pub fn from_profile(user: StoredUserProfile, principal: Principal) -> OisyUser {
+    pub fn from_profile(user: &StoredUserProfile, principal: Principal) -> OisyUser {
         OisyUser {
             principal,
             pouh_verified: user

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -168,7 +168,7 @@ pub mod user_profile {
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct GetUsersRequest {
+    pub struct ListUsersRequest {
         pub updated_after_timestamp: Option<Timestamp>,
         pub matches_max_length: Option<u64>,
     }
@@ -181,7 +181,7 @@ pub mod user_profile {
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct GetUsersResponse {
+    pub struct ListUsersResponse {
         pub users: Vec<OisyUser>,
         pub matches_max_length: u64,
     }


### PR DESCRIPTION
# Motivation

The Rewards canister needs to have the list of Oisy users and whether they have a verified POUH credential or not.

In this PR, get_users is implemented, which is the endpoint that Rewards canister will call to get Oisy users.

# Changes

* New helper `get_oisy_users`.
* New helper in user_profile `store_user` to avoid code duplication.
* New implementation of OisyUser `from_profile` to convert one from a StoredUserProfile.
* Implement `get_users`.

# Tests

* Test the new endpoint.
