### PR TITLE
feat(frontend): Credentials section in settings

### DIFF
--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -24,9 +24,12 @@
 
 	const getPouhCredential = async () => {
 		if (nonNullish(principal)) {
-			busy.show();
-			await requestPouhCredential({ credentialSubject: principal });
-			busy.stop();
+			try {
+				busy.show();
+				await requestPouhCredential({ credentialSubject: principal });
+			} finally {
+				busy.stop();
+			}
 		}
 	};
 </script>

--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -10,11 +10,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import TokensZeroBalanceToggle from '$lib/components/tokens/TokensZeroBalanceToggle.svelte';
-	import { POUH_ENABLED } from '$lib/constants/app.constants';
 	import { userHasPouhCredential } from '$lib/derived/has-pouh-credential';
 	import { requestPouhCredential } from '$lib/services/request-pouh-credential.services';
 	import { fade } from 'svelte/transition';
 	import { busy } from '$lib/stores/busy.store';
+	import { POUH_ENABLED } from '$lib/constants/credentials.constants';
 
 	let remainingTimeMilliseconds: number | undefined;
 	$: remainingTimeMilliseconds = $authRemainingTimeStore;

--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-	import { KeyValuePairInfo, Spinner } from '@dfinity/gix-components';
+	import { KeyValuePairInfo } from '@dfinity/gix-components';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { authRemainingTimeStore, authStore } from '$lib/stores/auth.store';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import { secondsToDuration } from '@dfinity/utils';
 	import type { Principal } from '@dfinity/principal';
 	import NetworksTestnetsToggle from '$lib/components/networks/NetworksTestnetsToggle.svelte';

--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -102,11 +102,8 @@
 			<KeyValuePairInfo>
 				<span slot="key" class="font-bold">{$i18n.settings.text.pouh_credential}:</span>
 				<svelte:fragment slot="value">
-					{#if isNullish($userHasPouhCredential)}
-						<div class="mr-1.5">
-							<Spinner size="small" inline />
-						</div>
-					{:else if $userHasPouhCredential}
+					<!-- TODO: Render spinner if no user profile -->
+					{#if $userHasPouhCredential}
 						<output in:fade class="mr-1.5">
 							{$i18n.settings.text.pouh_credential_verified}
 						</output>

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -43,6 +43,9 @@ export const AUTH_MAX_TIME_TO_LIVE = BigInt(60 * 60 * 1000 * 1000 * 1000);
 
 export const AUTH_POPUP_WIDTH = 576;
 export const AUTH_POPUP_HEIGHT = 625;
+export const VC_POPUP_WIDTH = AUTH_POPUP_WIDTH;
+// Screen to allow credential presentation is longer than the authentication screen.
+export const VC_POPUP_HEIGHT = 900;
 
 // Workers
 export const AUTH_TIMER_INTERVAL = 1000;

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -43,6 +43,9 @@ export const AUTH_MAX_TIME_TO_LIVE = BigInt(60 * 60 * 1000 * 1000 * 1000);
 
 export const AUTH_POPUP_WIDTH = 576;
 export const AUTH_POPUP_HEIGHT = 625;
+export const VC_POPUP_WIDTH = AUTH_POPUP_WIDTH;
+// The screen to present the credential is higher than the screen to authenticate the user.
+export const VC_POPUP_HEIGHT = 900;
 
 // Workers
 export const AUTH_TIMER_INTERVAL = 1000;
@@ -59,3 +62,5 @@ export const NANO_SECONDS_IN_MINUTE = NANO_SECONDS_IN_MILLISECOND * 1_000n * 60n
 // For some use case we want to display some amount to a maximal number of decimals which is not related to the number of decimals of the selected token.
 // Just a value that looks good visually.
 export const EIGHT_DECIMALS = 8;
+
+export const POUH_ENABLED = JSON.parse(import.meta.env.VITE_POUH_ENABLED ?? false) === true;

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -43,9 +43,6 @@ export const AUTH_MAX_TIME_TO_LIVE = BigInt(60 * 60 * 1000 * 1000 * 1000);
 
 export const AUTH_POPUP_WIDTH = 576;
 export const AUTH_POPUP_HEIGHT = 625;
-export const VC_POPUP_WIDTH = AUTH_POPUP_WIDTH;
-// The screen to present the credential is higher than the screen to authenticate the user.
-export const VC_POPUP_HEIGHT = 900;
 
 // Workers
 export const AUTH_TIMER_INTERVAL = 1000;

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -62,5 +62,3 @@ export const NANO_SECONDS_IN_MINUTE = NANO_SECONDS_IN_MILLISECOND * 1_000n * 60n
 // For some use case we want to display some amount to a maximal number of decimals which is not related to the number of decimals of the selected token.
 // Just a value that looks good visually.
 export const EIGHT_DECIMALS = 8;
-
-export const POUH_ENABLED = JSON.parse(import.meta.env.VITE_POUH_ENABLED ?? false) === true;

--- a/src/frontend/src/lib/constants/credentials.constants.ts
+++ b/src/frontend/src/lib/constants/credentials.constants.ts
@@ -1,0 +1,2 @@
+// This credential type is defined by the issuer Decide AI
+export const POUH_CREDENTIAL_TYPE = 'ProofOfUniqueness';

--- a/src/frontend/src/lib/constants/credentials.constants.ts
+++ b/src/frontend/src/lib/constants/credentials.constants.ts
@@ -1,2 +1,3 @@
 // This credential type is defined by the issuer Decide AI
 export const POUH_CREDENTIAL_TYPE = 'ProofOfUniqueness';
+export const POUH_ENABLED = JSON.parse(import.meta.env.VITE_POUH_ENABLED ?? false) === true;

--- a/src/frontend/src/lib/derived/has-pouh-credential.ts
+++ b/src/frontend/src/lib/derived/has-pouh-credential.ts
@@ -1,0 +1,8 @@
+import { userProfileStore } from '$lib/stores/settings.store';
+import { hasPouhCredential } from '$lib/utils/credentials.utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const userHasPouhCredential: Readable<boolean | undefined> = derived(
+	[userProfileStore],
+	([$profile]) => hasPouhCredential($profile)
+);

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -129,6 +129,11 @@
 			"testnets": "Show test networks",
 			"testnets_description": "Display the test networks (Sepolia) and twin tokens on testnets (ckTESTBTC and ckSepolia).",
 			"hide_zero_balances_description": "Enable this feature to declutter your wallet view by hiding all tokens with a zero balance.",
+			"credentials_title": "Credentials",
+			"pouh_credential": "Humanity Credential",
+			"pouh_credential_description": "The Humanity Credential is a proof of humanity. It is issued by Decide AI.",
+			"present_pouh_credential": "Present",
+			"pouh_credential_verified": "Verified ✅",
 			"sign_in": "Sign in to start using Oisy Wallet."
 		},
 		"alt": {

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -2,12 +2,15 @@ import type { UserCredential, UserProfile } from '$declarations/backend/backend.
 import {
 	INTERNET_IDENTITY_ORIGIN,
 	POUH_ISSUER_CANISTER_ID,
-	POUH_ISSUER_ORIGIN
+	POUH_ISSUER_ORIGIN,
+	VC_POPUP_HEIGHT,
+	VC_POPUP_WIDTH
 } from '$lib/constants/app.constants';
 import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
+import { popupCenter } from '$lib/utils/window.utils';
 import { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import {
@@ -79,7 +82,8 @@ export const requestPouhCredential = async ({
 			},
 			onSuccess: async (response: VerifiablePresentationResponse) => {
 				resolve(await handleSuccess(response));
-			}
+			},
+			windowOpenerFeatures: popupCenter({ width: VC_POPUP_WIDTH, height: VC_POPUP_HEIGHT })
 		});
 	});
 };

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -2,16 +2,13 @@ import type { UserCredential, UserProfile } from '$declarations/backend/backend.
 import {
 	INTERNET_IDENTITY_ORIGIN,
 	POUH_ISSUER_CANISTER_ID,
-	POUH_ISSUER_ORIGIN,
-	VC_POPUP_HEIGHT,
-	VC_POPUP_WIDTH
+	POUH_ISSUER_ORIGIN
 } from '$lib/constants/app.constants';
 import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import { popupCenter } from '$lib/utils/window.utils';
 import { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import {
@@ -50,7 +47,6 @@ export const requestPouhCredential = async ({
 }: {
 	credentialSubject: Principal;
 }): Promise<{ success: boolean }> => {
-	busy.show();
 	const { auth: authI18n } = get(i18n);
 	return new Promise((resolve, reject) => {
 		const issuerCanisterId = nonNullish(POUH_ISSUER_CANISTER_ID)
@@ -84,10 +80,8 @@ export const requestPouhCredential = async ({
 				reject();
 			},
 			onSuccess: async (response: VerifiablePresentationResponse) => {
-				busy.stop();
 				resolve(await handleSuccess(response));
-			},
-			windowOpenerFeatures: popupCenter({ width: VC_POPUP_WIDTH, height: VC_POPUP_HEIGHT })
+			}
 		});
 	});
 };

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -5,7 +5,6 @@ import {
 	POUH_ISSUER_ORIGIN
 } from '$lib/constants/app.constants';
 import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
-import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -73,7 +72,6 @@ export const requestPouhCredential = async ({
 				credentialSubject
 			},
 			onError() {
-				busy.stop();
 				toastsError({
 					msg: { text: authI18n.error.error_requesting_pouh_credential }
 				});

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -120,6 +120,11 @@ interface I18nSettings {
 		testnets: string;
 		testnets_description: string;
 		hide_zero_balances_description: string;
+		credentials_title: string;
+		pouh_credential: string;
+		pouh_credential_description: string;
+		present_pouh_credential: string;
+		pouh_credential_verified: string;
 		sign_in: string;
 	};
 	alt: { testnets_toggle: string };

--- a/src/frontend/src/lib/utils/credentials.utils.ts
+++ b/src/frontend/src/lib/utils/credentials.utils.ts
@@ -2,9 +2,11 @@ import type { UserCredential, UserProfile } from '$declarations/backend/backend.
 import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { isNullish } from '@dfinity/utils';
 
-const isValidPouhCredential = (credential: UserCredential): boolean =>
-	POUH_CREDENTIAL_TYPE in credential.credential_type &&
+const isVerifiedCredential = (credential: UserCredential): boolean =>
 	credential.verified_date_timestamp.length > 0;
+
+const isVerifiedPouhCredential = (credential: UserCredential): boolean =>
+	POUH_CREDENTIAL_TYPE in credential.credential_type && isVerifiedCredential(credential);
 
 /**
  * Returns true if the user has a verified proof of uniqueness credential
@@ -18,5 +20,5 @@ export const hasPouhCredential = (profile: UserProfile | null | undefined): bool
 	if (isNullish(profile)) {
 		return undefined;
 	}
-	return profile.credentials.some(isValidPouhCredential);
+	return profile.credentials.some(isVerifiedPouhCredential);
 };

--- a/src/frontend/src/lib/utils/credentials.utils.ts
+++ b/src/frontend/src/lib/utils/credentials.utils.ts
@@ -1,5 +1,10 @@
-import type { UserProfile } from '$declarations/backend/backend.did';
+import type { UserCredential, UserProfile } from '$declarations/backend/backend.did';
+import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { isNullish } from '@dfinity/utils';
+
+const isValidPouhCredential = (credential: UserCredential): boolean =>
+	POUH_CREDENTIAL_TYPE in credential.credential_type &&
+	credential.verified_date_timestamp.length > 0;
 
 /**
  * Returns true if the user has a verified proof of uniqueness credential
@@ -13,7 +18,5 @@ export const hasPouhCredential = (profile: UserProfile | null | undefined): bool
 	if (isNullish(profile)) {
 		return undefined;
 	}
-	return profile.credentials.some(
-		(cred) => 'ProofOfUniqueness' in cred.credential_type && cred.verified_date_timestamp.length > 0
-	);
+	return profile.credentials.some(isValidPouhCredential);
 };

--- a/src/frontend/src/lib/utils/credentials.utils.ts
+++ b/src/frontend/src/lib/utils/credentials.utils.ts
@@ -1,0 +1,19 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
+import { isNullish } from '@dfinity/utils';
+
+/**
+ * Returns true if the user has a verified proof of uniqueness credential
+ * Returns false if the user has no verified proof of uniqueness credential
+ * Returns undefined if the user has no profile yet. It means it's loading.
+ *
+ * @param profile {UserProfile | null | undefined} The user profile.
+ * @returns {boolean | undefined}
+ */
+export const hasPouhCredential = (profile: UserProfile | null | undefined): boolean | undefined => {
+	if (isNullish(profile)) {
+		return undefined;
+	}
+	return profile.credentials.some(
+		(cred) => 'ProofOfUniqueness' in cred.credential_type && cred.verified_date_timestamp.length > 0
+	);
+};

--- a/src/frontend/src/tests/lib/utils/credentials.spec.ts
+++ b/src/frontend/src/tests/lib/utils/credentials.spec.ts
@@ -1,0 +1,51 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
+import { hasPouhCredential } from '$lib/utils/credentials.utils';
+
+describe('credentials utils', () => {
+	describe('hasPouhCredential', () => {
+		it('should return undefined if the user has no profile yet', () => {
+			expect(hasPouhCredential(undefined)).toBeUndefined();
+			expect(hasPouhCredential(null)).toBeUndefined();
+		});
+
+		it('should return true if the user has verified credential', () => {
+			const profile: UserProfile = {
+				credentials: [
+					{
+						credential_type: { ProofOfUniqueness: null },
+						verified_date_timestamp: [123456n]
+					}
+				],
+				created_timestamp: 123456n,
+				updated_timestamp: 123456n,
+				version: [0n]
+			};
+			expect(hasPouhCredential(profile)).toBe(true);
+		});
+
+		it('should return false if the user has credential but not verified', () => {
+			const profile: UserProfile = {
+				credentials: [
+					{
+						credential_type: { ProofOfUniqueness: null },
+						verified_date_timestamp: []
+					}
+				],
+				created_timestamp: 123456n,
+				updated_timestamp: 123456n,
+				version: [0n]
+			};
+			expect(hasPouhCredential(profile)).toBe(false);
+		});
+
+		it('should return false if the user has no credentials', () => {
+			const profile: UserProfile = {
+				credentials: [],
+				created_timestamp: 123456n,
+				updated_timestamp: 123456n,
+				version: [0n]
+			};
+			expect(hasPouhCredential(profile)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We want users to present the POUH credetial to Oisy.

In this PR, I introduce the different UIs that will be rendered in the Settings page based on the value of the user profile store.

# Changes

* New env var `VITE_POUH_ENABLED` and app feature flag `POUH_ENABLED`.
* Move `POUH_CREDENTIAL_TYPE` to a credentials constants file.
* New util `hasPouhCredential`.
* New derived store `userHasPouhCredential`.
* New i18n keys for new copy.
* New UI section in SettingsSignedIn.

# Tests

* Tested manually the different UIs.
* Add test for the new util.
