### PR TITLE
refactor(frontend): move ContextMenu as More button among Hero buttons

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -17,8 +17,10 @@
 	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import Receive from '$lib/components/receive/Receive.svelte';
+	import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
 
 	export let send = false;
+	export let more = false;
 
 	let convertEth = false;
 	$: convertEth = send && $ethToCkETHEnabled && $erc20UserTokensInitialized;
@@ -65,5 +67,9 @@
 
 	{#if convertBtc}
 		<ConvertToBTC />
+	{/if}
+
+	{#if more}
+		<ContextMenu />
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -32,7 +32,7 @@
 	$: convertBtc = send && $tokenCkBtcLedger && $erc20UserTokensInitialized;
 </script>
 
-<div role="toolbar" class="flex gap-4 text-deep-violet font-bold pt-10 pb-3">
+<div role="toolbar" class="flex w-full gap-4 justify-between pt-10 pb-3 px-10 max-w-96">
 	{#if $networkICP}
 		<IcReceive token={$tokenWithFallback} />
 	{:else if $networkEthereum}

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -10,6 +10,7 @@
 	export let summary = false;
 	export let actions = true;
 	export let send = false;
+	export let more = false;
 
 	let background: string;
 	$: background = ($selectedNetwork?.id.description ?? 'chainfusion').toLowerCase();
@@ -28,7 +29,7 @@
 		<Alpha />
 
 		{#if $authSignedIn}
-			<HeroContent {usdTotal} {summary} {actions} {send} />
+			<HeroContent {usdTotal} {summary} {actions} {send} {more} />
 		{:else if heroContent}
 			<HeroSignIn />
 		{/if}

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -8,7 +8,6 @@
 	import ExchangeBalance from '$lib/components/exchange/ExchangeBalance.svelte';
 	import { isErc20Icp } from '$eth/utils/token.utils';
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
-	import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { token } from '$lib/stores/token.store';
@@ -18,6 +17,7 @@
 	export let summary = false;
 	export let actions = true;
 	export let send = false;
+	export let more = false;
 
 	let displayTokenSymbol = false;
 	$: displayTokenSymbol = summary && $erc20UserTokensInitialized;
@@ -25,7 +25,7 @@
 
 {#if summary}
 	<div transition:slide={{ delay: 0, duration: 250, easing: quintOut, axis: 'y' }}>
-		<div class="icon flex justify-between items-start mt-6 md:mt-12 mb-0.5 pt-2">
+		<div class="icon flex justify-between items-center mt-6 md:mt-12 mb-0.5 pt-2">
 			<div>
 				{#if displayTokenSymbol}
 					<div in:fade>
@@ -40,8 +40,6 @@
 					<SkeletonLogo size="big" />
 				{/if}
 			</div>
-
-			<ContextMenu />
 		</div>
 
 		<Balance />
@@ -56,7 +54,7 @@
 
 {#if actions}
 	<div transition:slide={{ delay: 0, duration: 250, easing: quintOut, axis: 'y' }}>
-		<Actions {send} />
+		<Actions {send} {more} />
 	</div>
 {/if}
 

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -53,7 +53,10 @@
 {/if}
 
 {#if actions}
-	<div transition:slide={{ delay: 0, duration: 250, easing: quintOut, axis: 'y' }}>
+	<div
+		transition:slide={{ delay: 0, duration: 250, easing: quintOut, axis: 'y' }}
+		class="flex w-full justify-center"
+	>
 		<Actions {send} {more} />
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -41,6 +41,7 @@
 	disabled={$erc20UserTokensNotInitialized}
 >
 	<IconMore size="28" slot="icon" />
+	{$i18n.core.text.more}
 </ButtonHero>
 
 <Popover bind:visible anchor={button} invisibleBackdrop direction="rtl">

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -12,7 +12,8 @@
 			"symbol": "Symbol",
 			"decimals": "Decimals",
 			"amount": "Amount",
-			"max": "Max"
+			"max": "Max",
+			"more": "More"
 		},
 		"info": {
 			"test_banner": "For testing purposes only!"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -16,6 +16,7 @@ interface I18nCore {
 		decimals: string;
 		amount: string;
 		max: string;
+		more: string;
 	};
 	info: { test_banner: string };
 	alt: { logo: string };

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -27,6 +27,7 @@
 	usdTotal={route === 'tokens'}
 	summary={route === 'transactions'}
 	send={route === 'transactions'}
+	more={route === 'transactions'}
 	actions={route !== 'settings'}
 />
 


### PR DESCRIPTION
# Motivation

We move the `ContextMenu` component among the Hero buttons.


<img width="1510" alt="Screenshot 2024-07-23 at 13 19 05" src="https://github.com/user-attachments/assets/ebe5ce71-0a9b-4dfc-ae87-2b4a40702b7c">
<img width="1510" alt="Screenshot 2024-07-23 at 13 19 24" src="https://github.com/user-attachments/assets/0eb04bac-7b04-45ae-aa3f-592753e1ea91">


<img width="356" alt="Screenshot 2024-07-23 at 13 19 40" src="https://github.com/user-attachments/assets/a1d69a06-d858-443d-94c6-43ec2bc267cf">
<img width="361" alt="Screenshot 2024-07-23 at 13 20 03" src="https://github.com/user-attachments/assets/1790299e-e875-4381-9d2a-99b7337962d5">
