### PR TITLE
feat(frontend): parse ic-domains at build time for staging.oisy.com

### DIFF
--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -7,9 +7,9 @@ import { ENV, findHtmlFiles } from './build.utils.mjs';
 
 config({ path: `.env.${ENV}` });
 
-const replaceEnv = ({ html, pattern, value }) => {
+const replaceEnv = ({ content, pattern, value }) => {
 	const regex = new RegExp(pattern, 'g');
-	return html.replace(regex, value);
+	return content.replace(regex, value);
 };
 
 const parseDomain = (targetFile) => {
@@ -18,7 +18,7 @@ const parseDomain = (targetFile) => {
 	// For information such as custom domains, only the domain without protocol is required
 	const { host: value } = new URL(process.env['VITE_OISY_URL'] ?? 'https://oisy.com');
 	content = replaceEnv({
-		html: content,
+		content,
 		pattern: `{{VITE_OISY_DOMAIN}}`,
 		value
 	});
@@ -38,13 +38,12 @@ const parseMetadata = (targetFile) => {
 	];
 
 	METADATA_KEYS.forEach(
-		(key) =>
-			(content = replaceEnv({ html: content, pattern: `{{${key}}}`, value: process.env[key] }))
+		(key) => (content = replaceEnv({ content, pattern: `{{${key}}}`, value: process.env[key] }))
 	);
 
 	// Special use case. We need to build the dapp with a real URL within app.html other build fails.
 	content = replaceEnv({
-		html: content,
+		content,
 		pattern: `https://oisy.com`,
 		value: process.env.VITE_OISY_URL
 	});
@@ -56,7 +55,7 @@ const parseUrl = (filePath) => {
 	let content = readFileSync(filePath, 'utf8');
 
 	content = replaceEnv({
-		html: content,
+		content,
 		pattern: `https://oisy.com`,
 		value: process.env.VITE_OISY_URL
 	});

--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -12,6 +12,20 @@ const replaceEnv = ({ html, pattern, value }) => {
 	return html.replace(regex, value);
 };
 
+const parseDomain = (targetFile) => {
+	let content = readFileSync(targetFile, 'utf8');
+
+	// For information such as custom domains, only the domain without protocol is required
+	const { host: value } = new URL(process.env['VITE_OISY_URL'] ?? 'https://oisy.com');
+	content = replaceEnv({
+		html: content,
+		pattern: `{{VITE_OISY_DOMAIN}}`,
+		value
+	});
+
+	writeFileSync(targetFile, content);
+};
+
 const parseMetadata = (targetFile) => {
 	let content = readFileSync(targetFile, 'utf8');
 
@@ -80,6 +94,7 @@ htmlFiles.forEach((htmlFile) => parseMetadata(htmlFile));
 
 parseUrl(join(process.cwd(), 'build', 'sitemap.xml'));
 parseMetadata(join(process.cwd(), 'build', 'manifest.webmanifest'));
+parseDomain(join(process.cwd(), 'build', '.well-known', 'ic-domains'));
 
 // SEO
 htmlFiles.forEach((htmlFile) => removeMetaRobots(htmlFile));

--- a/src/frontend/static/.well-known/ic-domains
+++ b/src/frontend/static/.well-known/ic-domains
@@ -1,1 +1,1 @@
-oisy.com
+{{VITE_OISY_DOMAIN}}


### PR DESCRIPTION
# Motivation

We were requested to setup a custom domain `staging.oisy.com` therefore we need such domain in the `./well-known/ic-domains`. While it might works out having both `oisy.com` and staging within the file, I find it cleaner to have distinctive file per domains given that both dapps are configured differently and live on two different canisters.

# Changes

- Update static file with a markup `{{VITE_OISY_DOMAIN}}`
- Replace markup at build time similarly to what we already do to populate environment variables within html or json files.

+ unrelated to the PR, I renamed a parameter `html` to content in the script as it was already use for other purpose than stricly html.
