### PR TITLE
fix(frontend): Fix mainnet domain

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -7,7 +7,7 @@ export const LOCAL = MODE === 'local';
 export const STAGING = MODE === 'staging';
 export const PROD = MODE === 'ic';
 
-const MAINNET_DOMAIN = 'ic0.app';
+const MAINNET_DOMAIN = 'icp0.io';
 
 export const INTERNET_IDENTITY_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_INTERNET_IDENTITY_CANISTER_ID


### PR DESCRIPTION
# Motivation

The mainnet domain for the issuer was set to ic0.app but it should be the new icp0.io

# Changes

* Change `MAINNET_DOMAIN`.

# Tests

Only testeable not in local.
