### PR TITLE
chore(deploy): gzip wasm for deployment

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -5,20 +5,23 @@
 			"candid": "src/backend/backend.did",
 			"package": "backend",
 			"type": "rust",
-			"optimize": "cycles"
+			"optimize": "cycles",
+			"gzip": true
 		},
 		"frontend": {
 			"frontend": {
 				"entrypoint": "build/index.html"
 			},
 			"source": ["build/"],
-			"type": "assets"
+			"type": "assets",
+			"gzip": true
 		},
 		"new_backend": {
 			"candid": "src/backend/backend.did",
 			"package": "backend",
 			"type": "rust",
-			"optimize": "cycles"
+			"optimize": "cycles",
+			"gzip": true
 		},
 		"orbit": {
 			"remote": {


### PR DESCRIPTION
# Motivation

With the addition of verifiable credentials, the `backend` WASM resulted in a size above 2.5 MB which lead to us to not being able to deploy the backend.

```
Upgrading code for canister backend, with canister ID tdxud-2yaaa-aaaad-aadiq-cai
Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to deploy canisters.
  Failed while trying to install all canisters.
    Failed to install wasm module to canister 'backend'.
      Failed during wasm installation call: The replica returned an HTTP Error: Http Error: status 413 Payload Too Large, content type "text/plain; charset=utf-8", content: Request 0xdf849e021bf0e64ef22ad4f0f7c5001edf26aa5332ae42745164c1b70bba56d5 is too large. Message byte size 2485012 is larger than the max allowed 2097152.
```

To resolve the issue we set the [gzip](https://internetcomputer.org/docs/current/developer-docs/developer-tools/cli-tools/dfx-json-reference/#overview) option of DFX which for some reason, is not the default.

# Changes

- set `gzip` in `dfx.json`