### PR TITLE
fix(frontend): solved navigational loop between /settings and /transactions

### DIFF
--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -37,8 +37,11 @@ export const networkParam = (networkId: NetworkId | undefined): string =>
 
 export const back = async (params: { networkId: NetworkId | undefined; fromUrl?: URL }) => {
 	const { networkId, fromUrl } = params;
+	const fromUrlExceptSettings = fromUrl?.pathname.includes('settings')
+		? undefined
+		: fromUrl?.toString();
 	const rootUrl =
-		fromUrl?.toString() ?? `/${nonNullish(networkId) ? `?${networkParam(networkId)}` : ''}`;
+		fromUrlExceptSettings ?? `/${nonNullish(networkId) ? `?${networkParam(networkId)}` : ''}`;
 	await goto(rootUrl, { replaceState: 'fromUrl' in params ? nonNullish(fromUrl) : true });
 };
 


### PR DESCRIPTION
# Motivation

There was a bug so that the `Back` component would always go in loop between the last two navigational page. That was not acceptable when going back from `/settings` to `/transactions`, then from `/transactions` to the main page, since it would go back to `/settings`.