### PR TITLE
fix(frontend): adjust ButtonHero of ConvertToBTC

### DIFF
--- a/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
@@ -37,7 +37,7 @@
 	on:click={async () => await openSend()}
 	ariaLabel={$i18n.convert.text.convert_to_btc}
 >
-	<IconBurn size="28" />
+	<IconBurn size="28" slot="icon" />
 	{$i18n.convert.text.convert_to_btc}
 </ButtonHero>
 


### PR DESCRIPTION
# Motivation

During PR #1830 , I forgot to adjust the slot of the icon in `ButtonHero` for component `ConvertToBTC`.
