### PR TITLE
refactor(frontend): rename parameters of waitReady

### DIFF
--- a/src/frontend/src/lib/services/actions.services.ts
+++ b/src/frontend/src/lib/services/actions.services.ts
@@ -15,7 +15,7 @@ export const waitWalletReady = async (isDisabled: () => boolean): Promise<'ready
 	busy.start({ msg: hold_loading_wallet });
 
 	// 20 tries with a delay of 500ms each = max 10 seconds
-	const result = await waitReady({ count: 20, isDisabled });
+	const result = await waitReady({ retries: 20, isDisabled });
 
 	busy.stop();
 

--- a/src/frontend/src/lib/utils/timeout.utils.ts
+++ b/src/frontend/src/lib/utils/timeout.utils.ts
@@ -24,7 +24,7 @@ export const waitReady = async ({
 		return 'timeout';
 	}
 
-	await new Promise((resolve) => setTimeout(resolve, intervalInMs));
+	await waitForMilliseconds(intervalInMs);
 
 	return waitReady({ retries: remainingRetries, isDisabled });
 };

--- a/src/frontend/src/lib/utils/timeout.utils.ts
+++ b/src/frontend/src/lib/utils/timeout.utils.ts
@@ -4,11 +4,13 @@ export const waitForMilliseconds = (milliseconds: number): Promise<void> =>
 	});
 
 export const waitReady = async ({
-	count,
-	isDisabled
+	retries,
+	isDisabled,
+	intervalInMs = 500
 }: {
-	count: number;
+	retries: number;
 	isDisabled: () => boolean;
+	intervalInMs?: number;
 }): Promise<'ready' | 'timeout'> => {
 	const disabled = isDisabled();
 
@@ -16,13 +18,13 @@ export const waitReady = async ({
 		return 'ready';
 	}
 
-	const nextCount = count - 1;
+	const remainingRetries = retries - 1;
 
-	if (nextCount === 0) {
+	if (remainingRetries === 0) {
 		return 'timeout';
 	}
 
-	await new Promise((resolve) => setTimeout(resolve, 500));
+	await new Promise((resolve) => setTimeout(resolve, intervalInMs));
 
-	return waitReady({ count: nextCount, isDisabled });
+	return waitReady({ retries: remainingRetries, isDisabled });
 };


### PR DESCRIPTION
# Motivation

I was having a look at the code and just felt like renaming the parameters of `waitReady` could improve readability.

Also noticed that we could eliminate duplicate code by reusing `waitForMilliseconds` function.