### PR TITLE
feat(frontend): Add service to load user profile

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -1,12 +1,12 @@
 import type {
 	CustomToken,
+	GetUserProfileError,
 	SignRequest,
 	UserProfile,
 	UserToken
 } from '$declarations/backend/backend.did';
 import { getBackendActor } from '$lib/actors/actors.ic';
 import type { ECDSA_PUBLIC_KEY } from '$lib/types/address';
-import { UserProfileNotFoundError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
 import type { QueryParams } from '@dfinity/utils';
@@ -121,15 +121,9 @@ export const createUserProfile = async ({
 export const getUserProfile = async ({
 	identity,
 	certified = true
-}: { identity: Identity } & QueryParams): Promise<UserProfile> => {
+}: { identity: Identity } & QueryParams): Promise<
+	{ Ok: UserProfile } | { Err: GetUserProfileError }
+> => {
 	const { get_user_profile } = await getBackendActor({ identity, certified });
-	const response = await get_user_profile();
-	if ('Ok' in response) {
-		return response.Ok;
-	}
-	const err = response.Err;
-	if ('NotFound' in err) {
-		throw new UserProfileNotFoundError();
-	}
-	throw new Error('Unknown error');
+	return get_user_profile();
 };

--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -1,6 +1,12 @@
-import type { CustomToken, SignRequest, UserToken } from '$declarations/backend/backend.did';
+import type {
+	CustomToken,
+	SignRequest,
+	UserProfile,
+	UserToken
+} from '$declarations/backend/backend.did';
 import { getBackendActor } from '$lib/actors/actors.ic';
 import type { ECDSA_PUBLIC_KEY } from '$lib/types/address';
+import { UserProfileNotFoundError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
 import type { QueryParams } from '@dfinity/utils';
@@ -101,4 +107,29 @@ export const setUserToken = async ({
 }): Promise<void> => {
 	const { set_user_token } = await getBackendActor({ identity });
 	return set_user_token(token);
+};
+
+export const createUserProfile = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<UserProfile> => {
+	const { create_user_profile } = await getBackendActor({ identity });
+	return create_user_profile();
+};
+
+export const getUserProfile = async ({
+	identity,
+	certified = true
+}: { identity: Identity } & QueryParams): Promise<UserProfile> => {
+	const { get_user_profile } = await getBackendActor({ identity, certified });
+	const response = await get_user_profile();
+	if ('Ok' in response) {
+		return response.Ok;
+	}
+	const err = response.Err;
+	if ('NotFound' in err) {
+		throw new UserProfileNotFoundError();
+	}
+	throw new Error('Unknown error');
 };

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -138,6 +138,9 @@
 		},
 		"alt": {
 			"testnets_toggle": "Toggle to show or hide testnets"
+		},
+		"error": {
+			"loading_profile": "Error while loading the profile. Please refresh the page to have the full experience."
 		}
 	},
 	"networks": {

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -56,12 +56,14 @@ export const loadUserProfile = async ({ identity }: { identity: Identity }): Pro
 		let profile = await queryUnsaveProfile({ identity });
 		if (isNullish(profile)) {
 			profile = await createUserProfile({ identity });
+			userProfileStore.set({ key: 'user-profile', value: profile });
 		} else {
+			// We set the store before the call to load the certified profile.
+			userProfileStore.set({ key: 'user-profile', value: profile });
 			// We don't wait for this to complete because we want a smooth UX
 			// the uncertified data is enough for the user to start using the app.
 			loadCertifiedUserProfile({ identity });
 		}
-		userProfileStore.set({ key: 'user-profile', value: profile });
 	} catch (err: unknown) {
 		const { settings } = get(i18n);
 		toastsError({

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -1,0 +1,54 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
+import { createUserProfile, getUserProfile } from '$lib/api/backend.api';
+import { i18n } from '$lib/stores/i18n.store';
+import { userProfileStore } from '$lib/stores/settings.store';
+import { toastsError } from '$lib/stores/toasts.store';
+import { UserProfileNotFoundError } from '$lib/types/errors';
+import type { Identity } from '@dfinity/agent';
+import { isNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+const getUncertifiedProfile = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<UserProfile | undefined> => {
+	try {
+		return await getUserProfile({ identity, certified: false });
+	} catch (err) {
+		if (err instanceof UserProfileNotFoundError) {
+			return undefined;
+		}
+		throw err;
+	}
+};
+
+const loadCertifiedUserProfile = async ({ identity }: { identity: Identity }): Promise<void> => {
+	try {
+		const profile = await getUserProfile({ identity, certified: true });
+		userProfileStore.set({ key: 'user-profile', value: profile });
+	} catch (err) {
+		// We ignore the error because this is a background task.
+		console.error('Failed to load certified user profile.', err);
+	}
+};
+
+export const loadUserProfile = async ({ identity }: { identity: Identity }): Promise<void> => {
+	try {
+		let profile = await getUncertifiedProfile({ identity });
+		if (isNullish(profile)) {
+			profile = await createUserProfile({ identity });
+		} else {
+			// We don't wait for this to complete because we want a smooth UX
+			// the uncertified data is enough for the user to start using the app.
+			loadCertifiedUserProfile({ identity });
+		}
+		userProfileStore.set({ key: 'user-profile', value: profile });
+	} catch (err) {
+		const { settings } = get(i18n);
+		toastsError({
+			msg: { text: settings.error.loading_profile }
+		});
+		console.error('Failed to load user profile.', err);
+	}
+};

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -26,7 +26,7 @@ const queryProfile = async ({
 	throw new Error('Unknown error');
 };
 
-const queryUnsaveProfile = async ({
+const queryUnsafeProfile = async ({
 	identity
 }: {
 	identity: Identity;
@@ -53,7 +53,7 @@ const loadCertifiedUserProfile = async ({ identity }: { identity: Identity }): P
 
 export const loadUserProfile = async ({ identity }: { identity: Identity }): Promise<void> => {
 	try {
-		let profile = await queryUnsaveProfile({ identity });
+		let profile = await queryUnsafeProfile({ identity });
 		if (isNullish(profile)) {
 			profile = await createUserProfile({ identity });
 			userProfileStore.set({ key: 'user-profile', value: profile });

--- a/src/frontend/src/lib/types/errors.ts
+++ b/src/frontend/src/lib/types/errors.ts
@@ -1,5 +1,1 @@
-export class UserProfileNotFoundError extends Error {
-	constructor() {
-		super('User profile not found');
-	}
-}
+export class UserProfileNotFoundError extends Error {}

--- a/src/frontend/src/lib/types/errors.ts
+++ b/src/frontend/src/lib/types/errors.ts
@@ -1,0 +1,5 @@
+export class UserProfileNotFoundError extends Error {
+	constructor() {
+		super('User profile not found');
+	}
+}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -128,6 +128,7 @@ interface I18nSettings {
 		sign_in: string;
 	};
 	alt: { testnets_toggle: string };
+	error: { loading_profile: string };
 }
 
 interface I18nNetworks {

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -2,7 +2,6 @@ import type { UserProfile } from '$declarations/backend/backend.did';
 import * as backendApi from '$lib/api/backend.api';
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/settings.store';
-import { UserProfileNotFoundError } from '$lib/types/errors';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { beforeEach } from 'node:test';
@@ -32,7 +31,9 @@ describe('loadUserProfile', () => {
 	});
 
 	it("doesn't create a user profile if uncertified profile is found", async () => {
-		const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile').mockResolvedValue(mockProfile);
+		const getUserProfileSpy = vi
+			.spyOn(backendApi, 'getUserProfile')
+			.mockResolvedValue({ Ok: mockProfile });
 		const createUserProfileSpy = vi.spyOn(backendApi, 'createUserProfile');
 
 		await loadUserProfile({ identity: mockIdentity });
@@ -48,7 +49,7 @@ describe('loadUserProfile', () => {
 	it('creates a user profile if uncertified profile is not found', async () => {
 		const getUserProfileSpy = vi
 			.spyOn(backendApi, 'getUserProfile')
-			.mockRejectedValue(new UserProfileNotFoundError());
+			.mockResolvedValue({ Err: { NotFound: null } });
 		const createUserProfileSpy = vi
 			.spyOn(backendApi, 'createUserProfile')
 			.mockResolvedValue(mockProfile);
@@ -66,7 +67,9 @@ describe('loadUserProfile', () => {
 	});
 
 	it('loads the store with certified data when uncertified profile is found', async () => {
-		const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile').mockResolvedValue(mockProfile);
+		const getUserProfileSpy = vi
+			.spyOn(backendApi, 'getUserProfile')
+			.mockResolvedValue({ Ok: mockProfile });
 
 		await loadUserProfile({ identity: mockIdentity });
 

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -1,0 +1,82 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
+import * as backendApi from '$lib/api/backend.api';
+import { loadUserProfile } from '$lib/services/load-user-profile.services';
+import { userProfileStore } from '$lib/stores/settings.store';
+import { UserProfileNotFoundError } from '$lib/types/errors';
+import type { Identity } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+import { beforeEach } from 'node:test';
+import { get } from 'svelte/store';
+
+vi.mock('$lib/api/backend.api');
+
+const mockProfile: UserProfile = {
+	credentials: [],
+	version: [1n],
+	created_timestamp: 1234n,
+	updated_timestamp: 1234n
+};
+
+const mockPrincipalText = 'xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe';
+
+const mockPrincipal = Principal.fromText(mockPrincipalText);
+
+const mockIdentity = {
+	getPrincipal: () => mockPrincipal
+} as unknown as Identity;
+
+describe('loadUserProfile', () => {
+	beforeEach(() => {
+		userProfileStore.reset({ key: 'user-profile' });
+		vi.clearAllMocks();
+	});
+
+	it("doesn't create a user profile if uncertified profile is found", async () => {
+		const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile').mockResolvedValue(mockProfile);
+		const createUserProfileSpy = vi.spyOn(backendApi, 'createUserProfile');
+
+		await loadUserProfile({ identity: mockIdentity });
+
+		expect(getUserProfileSpy).toHaveBeenCalledWith({
+			identity: mockIdentity,
+			certified: false
+		});
+		expect(createUserProfileSpy).not.toHaveBeenCalled();
+		expect(get(userProfileStore)).toEqual(mockProfile);
+	});
+
+	it('creates a user profile if uncertified profile is not found', async () => {
+		const getUserProfileSpy = vi
+			.spyOn(backendApi, 'getUserProfile')
+			.mockRejectedValue(new UserProfileNotFoundError());
+		const createUserProfileSpy = vi
+			.spyOn(backendApi, 'createUserProfile')
+			.mockResolvedValue(mockProfile);
+
+		await loadUserProfile({ identity: mockIdentity });
+
+		expect(getUserProfileSpy).toHaveBeenCalledWith({
+			identity: mockIdentity,
+			certified: false
+		});
+		expect(createUserProfileSpy).toHaveBeenCalledWith({
+			identity: mockIdentity
+		});
+		expect(get(userProfileStore)).toEqual(mockProfile);
+	});
+
+	it('loads the store with certified data when uncertified profile is found', async () => {
+		const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile').mockResolvedValue(mockProfile);
+
+		await loadUserProfile({ identity: mockIdentity });
+
+		expect(getUserProfileSpy).toHaveBeenCalledWith({
+			identity: mockIdentity,
+			certified: false
+		});
+		expect(getUserProfileSpy).toHaveBeenCalledWith({
+			identity: mockIdentity,
+			certified: true
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We want to use the profile stored in the backend in the frontend.

In this PR, a new service is introduced `loadUserProfile` which loads gets or creates a profile and stores it in the store. It also performs an update call to store the certified data in the background.

# Changes

* New api function `getUserProfile` and `createUserProfile`.
* New error `UserProfileNotFoundError`.
* New service `loadUserProfile`.

# Tests

* Unit tests for `loadUserProfile`.
* I also tested triggering the service when the user visited settings and it worked as expected.
