### PR TITLE
style(frontned): adjust spacing of buttons of component Actions

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -32,7 +32,7 @@
 	$: convertBtc = send && $tokenCkBtcLedger && $erc20UserTokensInitialized;
 </script>
 
-<div role="toolbar" class="flex w-full gap-4 justify-between pt-10 pb-3 px-10 max-w-96">
+<div role="toolbar" class="flex w-full gap-6 justify-center pt-10 pb-3 px-1 max-w-96">
 	{#if $networkICP}
 		<IcReceive token={$tokenWithFallback} />
 	{:else if $networkEthereum}

--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <button
-	class="w-12 flex flex-col text-white text-xs font-normal text-center"
+	class="w-16 flex flex-col text-white text-xs font-normal text-center"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}


### PR DESCRIPTION
# Motivation

It is preferable to have equal spacing between the buttons of `Actions` instead of distribute them on the available space.


### Before

<img width="1278" alt="Screenshot 2024-07-24 at 10 15 17" src="https://github.com/user-attachments/assets/d9f81d38-c78a-4a12-a206-f5b183cb755d">
<img width="1280" alt="Screenshot 2024-07-24 at 10 15 24" src="https://github.com/user-attachments/assets/308ab0b4-19a3-442f-b4cc-736fd0c2ce95">
<img width="355" alt="Screenshot 2024-07-24 at 10 15 35" src="https://github.com/user-attachments/assets/259df607-cc2d-4428-842b-afb44ee8fd78">
<img width="358" alt="Screenshot 2024-07-24 at 10 15 42" src="https://github.com/user-attachments/assets/e2e67847-2958-40ed-95d1-c6685c741fb4">

### After

<img width="1275" alt="Screenshot 2024-07-24 at 10 11 48" src="https://github.com/user-attachments/assets/871dec36-aa60-44da-b830-ed11a22b961f">
<img width="1280" alt="Screenshot 2024-07-24 at 10 12 00" src="https://github.com/user-attachments/assets/59f90529-9852-4b51-9c06-f4566303819d">
<img width="357" alt="Screenshot 2024-07-24 at 10 12 17" src="https://github.com/user-attachments/assets/1033a90f-ee4b-4ede-8b55-c37e63661251">
<img width="358" alt="Screenshot 2024-07-24 at 10 12 09" src="https://github.com/user-attachments/assets/b00a20d5-9653-4815-ad8b-ce8799b8cc69">
