### PR TITLE
chore(frontend): remove CSS class 'ic' that is deprecated

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -24,8 +24,7 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.token,
-	&.ic {
+	&.token {
 		justify-content: flex-start;
 
 		padding: var(--button-padding);
@@ -33,8 +32,7 @@ button {
 
 	&.secondary,
 	&.user,
-	&.token,
-	&.ic {
+	&.token {
 		border: 1px solid var(--color-blue);
 	}
 


### PR DESCRIPTION
# Motivation

The CSS class `ic` is deprecated.