### PR TITLE
feat(devops): Set expected POUH issuer id

### DIFF
--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
 
+II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
+POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
+
 case $ENV in
   "staging")
     ECDSA_KEY_NAME="test_key_1"
     WALLET="cvthj-wyaaa-aaaad-aaaaq-cai"
     # For security reasons, mainnet root key will be hardcoded in the backend canister.
     ic_root_key_der="null"
+    # URL used by issuer in the issued verifiable credentials (tipically hard-coded)
+    # Represents more an ID than a URL
+    POUH_ISSUER_VC_URL="https://${POUH_ISSUER_CANISTER_ID}.icp0.io/"
     ;;
   "ic")
     ECDSA_KEY_NAME="key_1"
     WALLET="yit3i-lyaaa-aaaan-qeavq-cai"
     # For security reasons, mainnet root key will be hardcoded in the backend canister.
     ic_root_key_der="null"
+    # URL used by issuer in the issued verifiable credentials (tipically hard-coded)
+    # Represents more an ID than a URL
+    POUH_ISSUER_VC_URL="https://id.decideai.xyz/"
     ;;
   *)
     ECDSA_KEY_NAME="dfx_test_key"
@@ -23,18 +32,18 @@ case $ENV in
         | jq -r '.root_key | reduce .[] as $item ("{ "; "\(.) \($item):nat8;") + " }"')
     echo "Parsed rootkey: ${rootkey_did:0:20}..." >&2
     ic_root_key_der="opt vec $rootkey_did"
+    # URL used by issuer in the issued verifiable credentials (tipically hard-coded)
+    # We use the dummy issuer canister for local development
+    POUH_ISSUER_VC_URL="https://dummy-issuer.vc/"
     ;;
 esac
 
-II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
-POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
+
 # URL used by II-issuer in the id_alias-verifiable credentials (hard-coded in II)
 # Represents more an ID than a URL
 II_VC_URL="https://identity.ic0.app"
-# URL used by issuer in the issued verifiable credentials (tipically hard-coded)
-# Represents more an ID than a URL
-# TODO: To be confirmed by DECIDE AI team
-POUH_ISSUER_VC_URL="https://www.elna.ai"
+
+echo "Deploying backend with the following arguments: ${POUH_ISSUER_VC_URL}"
 
 if [ -n "${ENV+1}" ]; then
   dfx deploy backend --argument "(variant {


### PR DESCRIPTION
# Motivation

We want to be able to validate the credentials semantically (check the data is the expected one). One of the fields is `iss`, which is the issuer id (which a url is used most of the times).

In this PR, I change the hardcoded `POUH_ISSUER_VC_URL` and set it depending on the environment.

The values were confirmed by Decide AI team.

# Changes

* Change `deploy.backend.sh` to set `POUH_ISSUER_VC_URL` per environment.

# Tests

I tested deploying it locally and it was working.
