### PR TITLE
chore(backend): Refactor and reuse types

### DIFF
--- a/src/backend/src/impls.rs
+++ b/src/backend/src/impls.rs
@@ -1,0 +1,50 @@
+use crate::types::{Candid, StoredPrincipal};
+use candid::{CandidType, Deserialize, Principal};
+use core::ops::Deref;
+use ic_stable_structures::storable::{Blob, Bound, Storable};
+use std::borrow::Cow;
+
+impl<T> Storable for Candid<T>
+where
+    T: CandidType + for<'de> Deserialize<'de>,
+{
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(candid::encode_one(&self.0).expect("encoding should always succeed"))
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        Self(candid::decode_one(bytes.as_ref()).expect("decoding should succeed"))
+    }
+}
+
+impl<T> Deref for Candid<T>
+where
+    T: CandidType + for<'de> Deserialize<'de>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl Storable for StoredPrincipal {
+    const BOUND: Bound = Blob::<29>::BOUND;
+
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(
+            Blob::<29>::try_from(self.0.as_slice())
+                .expect("principal length should not exceed 29 bytes")
+                .to_bytes()
+                .into_owned(),
+        )
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        Self(Principal::from_slice(
+            Blob::<29>::from_bytes(bytes).as_slice(),
+        ))
+    }
+}

--- a/src/backend/src/oisy_user.rs
+++ b/src/backend/src/oisy_user.rs
@@ -1,8 +1,7 @@
-use crate::{Candid, StoredPrincipal, VMem};
+use crate::{types::UserProfileMap, StoredPrincipal};
 use candid::Principal;
-use ic_stable_structures::StableBTreeMap;
 use shared::types::{
-    user_profile::{ListUsersRequest, OisyUser, StoredUserProfile},
+    user_profile::{ListUsersRequest, OisyUser},
     Timestamp,
 };
 use std::ops::Bound;
@@ -22,7 +21,7 @@ fn get_limit_users_size(request: &ListUsersRequest) -> usize {
 
 pub fn get_oisy_users(
     request: &ListUsersRequest,
-    user_profile_map: &StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
+    user_profile_map: &UserProfileMap,
 ) -> (Vec<OisyUser>, u64) {
     let limit_users_size: usize = get_limit_users_size(request);
 

--- a/src/backend/src/token.rs
+++ b/src/backend/src/token.rs
@@ -1,4 +1,4 @@
-use crate::{Candid, StoredPrincipal, VMem};
+use crate::types::{Candid, StoredPrincipal, VMem};
 use candid::{CandidType, Deserialize};
 use ic_stable_structures::StableBTreeMap;
 use shared::types::TokenVersion;

--- a/src/backend/src/types.rs
+++ b/src/backend/src/types.rs
@@ -1,0 +1,26 @@
+use crate::Config;
+use candid::{CandidType, Deserialize, Principal};
+use ic_stable_structures::{
+    memory_manager::VirtualMemory, DefaultMemoryImpl, StableBTreeMap, StableCell,
+};
+use shared::types::{
+    custom_token::CustomToken, token::UserToken, user_profile::StoredUserProfile, Timestamp,
+};
+
+pub type VMem = VirtualMemory<DefaultMemoryImpl>;
+pub type ConfigCell = StableCell<Option<Candid<Config>>, VMem>;
+pub type UserTokenMap = StableBTreeMap<StoredPrincipal, Candid<Vec<UserToken>>, VMem>;
+pub type CustomTokenMap = StableBTreeMap<StoredPrincipal, Candid<Vec<CustomToken>>, VMem>;
+/// Map of (`updated_timestamp`, `user_principal`) to `UserProfile`
+pub type UserProfileMap =
+    StableBTreeMap<(Timestamp, StoredPrincipal), Candid<StoredUserProfile>, VMem>;
+/// Map of `user_principal` to `updated_timestamp` (in `UserProfile`)
+pub type UserProfileUpdatedMap = StableBTreeMap<StoredPrincipal, Timestamp, VMem>;
+
+#[derive(Default)]
+pub struct Candid<T>(pub T)
+where
+    T: CandidType + for<'de> Deserialize<'de>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StoredPrincipal(pub Principal);

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -1,6 +1,8 @@
-use crate::{Candid, StoredPrincipal, VMem};
+use crate::{
+    types::{UserProfileMap, UserProfileUpdatedMap},
+    Candid, StoredPrincipal,
+};
 use ic_cdk::api::time;
-use ic_stable_structures::StableBTreeMap;
 use shared::types::{
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
     CredentialType, Timestamp, Version,
@@ -10,8 +12,8 @@ fn store_user_profile(
     principal: StoredPrincipal,
     timestamp: Timestamp,
     user: &StoredUserProfile,
-    user_profile_map: &mut StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
-    user_profile_updated_map: &mut StableBTreeMap<StoredPrincipal, u64, VMem>,
+    user_profile_map: &mut UserProfileMap,
+    user_profile_updated_map: &mut UserProfileUpdatedMap,
 ) {
     if let Some(old_updated) = user_profile_updated_map.get(&principal) {
         // Clean up old entries
@@ -23,8 +25,8 @@ fn store_user_profile(
 
 pub fn get_profile(
     principal: StoredPrincipal,
-    user_profile_map: &mut StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
-    user_profile_updated_map: &mut StableBTreeMap<StoredPrincipal, u64, VMem>,
+    user_profile_map: &mut UserProfileMap,
+    user_profile_updated_map: &mut UserProfileUpdatedMap,
 ) -> Result<StoredUserProfile, GetUserProfileError> {
     if let Some(updated) = user_profile_updated_map.get(&principal) {
         return Ok(user_profile_map
@@ -37,8 +39,8 @@ pub fn get_profile(
 
 pub fn create_profile(
     principal: StoredPrincipal,
-    user_profile_map: &mut StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
-    user_profile_updated_map: &mut StableBTreeMap<StoredPrincipal, u64, VMem>,
+    user_profile_map: &mut UserProfileMap,
+    user_profile_updated_map: &mut UserProfileUpdatedMap,
 ) -> StoredUserProfile {
     if let Some(updated) = user_profile_updated_map.get(&principal) {
         user_profile_map
@@ -63,8 +65,8 @@ pub fn add_credential(
     principal: StoredPrincipal,
     profile_version: Option<Version>,
     credential_type: &CredentialType,
-    user_profile_map: &mut StableBTreeMap<(u64, StoredPrincipal), Candid<StoredUserProfile>, VMem>,
-    user_profile_updated_map: &mut StableBTreeMap<StoredPrincipal, u64, VMem>,
+    user_profile_map: &mut UserProfileMap,
+    user_profile_updated_map: &mut UserProfileUpdatedMap,
 ) -> Result<(), AddUserCredentialError> {
     if let Ok(user_profile) = get_profile(principal, user_profile_map, user_profile_updated_map) {
         let now = time();


### PR DESCRIPTION
# Motivation

Restructure where types are defined so that they can be reused and grow in complexity.

# Changes

* Move the stable structure types to a module called "types" in the backend and the implementation to a module calles "impls". Following the pattern of "shared".
* Import the new types where needed.
* Use the new types instead of defining the whole type again in user_profile and oisy_user modules.

# Tests

No new tests needed, code was just moved.
