### PR TITLE
chore(frontend): beta configuration

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -31,6 +31,15 @@ ENV=staging dfx deploy frontend --network staging --wallet cvthj-wyaaa-aaaad-aaa
 ENV=staging ./scripts/deploy.backend.sh
 ```
 
+### Beta
+
+> To perform staging development, you'll need a `.env.beta` file.
+> Note that beta frontend points to production (IC) backend.
+
+```bash
+ENV=beta dfx deploy frontend --network beta --wallet yit3i-lyaaa-aaaan-qeavq-cai
+```
+
 ### IC
 
 > To perform production development, you'll need a `.env.production` file.

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -15,6 +15,7 @@
 	},
 	"frontend": {
 		"ic": "cha4i-riaaa-aaaan-qeccq-cai",
+		"beta": "v7iq7-yiaaa-aaaan-qmrtq-cai",
 		"staging": "tewsx-xaaaa-aaaad-aadia-cai"
 	}
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -5,6 +5,7 @@
 	},
 	"backend": {
 		"ic": "grghe-syaaa-aaaar-qabyq-cai",
+		"beta": "grghe-syaaa-aaaar-qabyq-cai",
 		"old_backend": "cab24-4qaaa-aaaan-qecca-cai",
 		"staging": "tdxud-2yaaa-aaaad-aadiq-cai"
 	},

--- a/dfx.json
+++ b/dfx.json
@@ -179,6 +179,10 @@
 			"providers": ["https://icp0.io"],
 			"type": "persistent"
 		},
+		"beta": {
+			"providers": ["https://icp0.io"],
+			"type": "persistent"
+		},
 		"local": {
 			"bind": "127.0.0.1:4943",
 			"type": "ephemeral"

--- a/scripts/build.utils.mjs
+++ b/scripts/build.utils.mjs
@@ -22,6 +22,6 @@ export const findHtmlFiles = (dir = join(process.cwd(), 'build')) => {
 export const ENV =
 	process.env.ENV === 'ic'
 		? 'production'
-		: process.env.ENV === 'staging'
-			? 'staging'
+		: ['staging', 'beta'].includes(process.env.ENV)
+			? process.env.ENV
 			: 'development';

--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -15,7 +15,7 @@ import { ckErc20Production, ckErc20Staging } from '$env/tokens.ckerc20.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
 import { type EnvTokenSymbol, type EnvTokens } from '$env/types/env-token-ckerc20';
 import type { IcCkInterface } from '$icp/types/ic';
-import { LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
+import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { NetworkEnvironment } from '$lib/types/network';
 import { nonNullish } from '@dfinity/utils';
@@ -64,7 +64,7 @@ const CKBTC_LOCAL_DATA: IcCkInterface | undefined =
 		: undefined;
 
 const CKBTC_STAGING_DATA: IcCkInterface | undefined =
-	(STAGING || PROD) &&
+	(STAGING || BETA || PROD) &&
 	nonNullish(STAGING_CKBTC_LEDGER_CANISTER_ID) &&
 	nonNullish(STAGING_CKBTC_INDEX_CANISTER_ID) &&
 	nonNullish(STAGING_CKBTC_MINTER_CANISTER_ID)
@@ -80,7 +80,7 @@ const CKBTC_STAGING_DATA: IcCkInterface | undefined =
 		: undefined;
 
 const CKBTC_IC_DATA: IcCkInterface | undefined =
-	STAGING || PROD
+	STAGING || BETA || PROD
 		? {
 				ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
 				indexCanisterId: IC_CKBTC_INDEX_CANISTER_ID,
@@ -150,7 +150,7 @@ const CKETH_LOCAL_DATA: IcCkInterface | undefined =
 		: undefined;
 
 const CKETH_STAGING_DATA: IcCkInterface | undefined =
-	(STAGING || PROD) &&
+	(STAGING || BETA || PROD) &&
 	nonNullish(STAGING_CKETH_LEDGER_CANISTER_ID) &&
 	nonNullish(STAGING_CKETH_INDEX_CANISTER_ID) &&
 	nonNullish(STAGING_CKETH_MINTER_CANISTER_ID)
@@ -166,7 +166,7 @@ const CKETH_STAGING_DATA: IcCkInterface | undefined =
 		: undefined;
 
 const CKETH_IC_DATA: IcCkInterface | undefined =
-	STAGING || PROD
+	STAGING || BETA || PROD
 		? {
 				ledgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID,
 				indexCanisterId: IC_CKETH_INDEX_CANISTER_ID,
@@ -229,7 +229,7 @@ const mapCkErc20Data = ({
 	Object.entries(ckErc20Tokens).reduce(
 		(acc, [key, value]) => ({
 			...acc,
-			...((STAGING || PROD) &&
+			...((STAGING || BETA || PROD) &&
 				nonNullish(value) &&
 				nonNullish(minterCanisterId) && {
 					[key]: {

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -5,6 +5,7 @@ export const APP_VERSION = VITE_APP_VERSION;
 export const MODE = VITE_DFX_NETWORK;
 export const LOCAL = MODE === 'local';
 export const STAGING = MODE === 'staging';
+export const BETA = MODE === 'beta';
 export const PROD = MODE === 'ic';
 
 const MAINNET_DOMAIN = 'icp0.io';
@@ -21,9 +22,11 @@ export const POUH_ISSUER_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_POUH_ISSUER_CANISTER_ID
 	: STAGING
 		? import.meta.env.VITE_STAGING_POUH_ISSUER_CANISTER_ID
-		: PROD
-			? import.meta.env.VITE_IC_POUH_ISSUER_CANISTER_ID
-			: undefined;
+		: BETA
+			? import.meta.env.VITE_BETA_POUH_ISSUER_CANISTER_ID
+			: PROD
+				? import.meta.env.VITE_IC_POUH_ISSUER_CANISTER_ID
+				: undefined;
 
 export const POUH_ISSUER_ORIGIN = nonNullish(POUH_ISSUER_CANISTER_ID)
 	? LOCAL

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { defineViteReplacements, readCanisterIds } from './vite.utils';
 // npm run build = local
 // dfx deploy = local
 // dfx deploy --network ic = ic
+// dfx deploy --network beta = beta
 // dfx deploy --network staging = staging
 const network = process.env.DFX_NETWORK ?? 'local';
 
@@ -96,7 +97,11 @@ export default defineConfig((): UserConfig => {
 	process.env = {
 		...process.env,
 		...loadEnv(
-			network === 'ic' ? 'production' : network === 'staging' ? 'staging' : 'development',
+			network === 'ic'
+				? 'production'
+				: ['beta', 'staging'].includes(network)
+					? network
+					: 'development',
 			process.cwd()
 		),
 		...readCanisterIds({ prefix: 'VITE_' })


### PR DESCRIPTION
# Motivation

We were requested to deploy a new frontend under `beta.oisy.com` that points to production. For this purpose, the frontend will communicate with the same backend and canisters as production, and we will use a derivation origin to sign in with `oisy.com`.

# Notes

We will use two separate environments because, while they are the same right now, I would not be surprised if "beta" has to be tweaked with different environment properties. Moreover, it is more straightforward to do so.

To make `beta.oisy.com` point to the `oisy.com` backend, we will duplicate the backend ID in `canister_ids.json`.

# Changes

We reviewed the changes offline with @AntonioVentilii-DFINITY 
