### PR TITLE
feat(frontend): statically define II alternative origins for beta.oisy.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "0.0.26",
+			"version": "0.0.27",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/agent": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {

--- a/src/frontend/static/.well-known/ii-alternative-origins
+++ b/src/frontend/static/.well-known/ii-alternative-origins
@@ -1,0 +1,1 @@
+{"alternativeOrigins":["https://beta.oisy.com","https://v7iq7-yiaaa-aaaan-qmrtq-cai.icp0.io"]}


### PR DESCRIPTION
# Motivation

We were requested to create and deploy today `beta.oisy.com` with a derivation origin poiting to `oisy.com`.
Therefore we have to patch production to unleash a `./well-known/ic-alternative-origins` file that allows the derivation.

# Notes

This PR won't be merged in main and is meant for patching only.

# Changes

- add static `./well-known/ic-alternative-origins`
- bump version for release
