### PR TITLE
chore(frontend): set i18n for TokenCardWithUrl aria label

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
@@ -2,6 +2,8 @@
 	import type { Token } from '$lib/types/token';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	export let token: Token;
 
@@ -13,7 +15,9 @@
 	<a
 		class="no-underline flex-1"
 		href={url}
-		aria-label={`Open the list of ${token.symbol} transactions`}
+		aria-label={replacePlaceholders($i18n.transactions.text.open_transactions, {
+			token: token.symbol
+		})}
 	>
 		<TokenCard {token}>
 			<slot name="description" slot="description" />

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -529,7 +529,8 @@
 		"text": {
 			"title": "Transactions",
 			"no_transactions": "You have no transactions.",
-			"sign_in": "Sign in to access your $token ($symbol) transactions."
+			"sign_in": "Sign in to access your $token ($symbol) transactions.",
+			"open_transactions": "Open the list of $token transactions"
 		},
 		"error": {
 			"loading_transactions": "Error while loading the transactions.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -470,7 +470,7 @@ interface I18nTransaction {
 }
 
 interface I18nTransactions {
-	text: { title: string; no_transactions: string; sign_in: string };
+	text: { title: string; no_transactions: string; sign_in: string; open_transactions: string };
 	error: {
 		loading_transactions: string;
 		loading_transactions_symbol: string;


### PR DESCRIPTION
# Motivation

The aria label for `TokenCardWithUrl` now uses `i18n`.
