### PR TITLE
refactor(frontend): use Img component in modals About

### DIFF
--- a/src/frontend/src/lib/components/hero/about/AboutHowModal.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutHowModal.svelte
@@ -9,6 +9,7 @@
 	import IconWorld from '$lib/components/icons/IconWorld.svelte';
 	import IconIdCard from '$lib/components/icons/IconIdCard.svelte';
 	import CoverHow from '$lib/assets/cover-how-it-works.png';
+	import Img from '$lib/components/ui/Img.svelte';
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
@@ -16,8 +17,8 @@
 		><p class="text-xl">{replaceOisyPlaceholders($i18n.about.how.text.title)}</p>
 	</svelte:fragment>
 
-	<div class="stretch">
-		<img src={CoverHow} alt={$i18n.about.how.text.title} class="mt-4" />
+	<div class="stretch pt-4">
+		<Img src={CoverHow} alt={$i18n.about.how.text.title} />
 
 		<p class="mt-6">
 			<IconKey />

--- a/src/frontend/src/lib/components/hero/about/AboutWhatModal.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutWhatModal.svelte
@@ -7,6 +7,7 @@
 	import IconCrypto from '$lib/components/icons/IconCrypto.svelte';
 	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
 	import CoverWhat from '$lib/assets/cover-features.png';
+	import Img from '$lib/components/ui/Img.svelte';
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
@@ -14,8 +15,8 @@
 		><p class="text-xl">{replaceOisyPlaceholders($i18n.about.what.text.title)}</p></svelte:fragment
 	>
 
-	<div class="stretch">
-		<img src={CoverWhat} alt={$i18n.about.what.text.title} class="mt-4" />
+	<div class="stretch pt-4">
+		<Img src={CoverWhat} alt={$i18n.about.what.text.title} />
 
 		<p class="mt-6">
 			<IconCrypto />


### PR DESCRIPTION
# Motivation

We use the dedicated `Img` component in the new `About` modals.