### PR TITLE
fix(frontend): back

### DIFF
--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -3,8 +3,8 @@
 	import { back } from '$lib/utils/nav.utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate } from '$app/navigation';
-	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { nonNullish } from '@dfinity/utils';
 
 	let fromRoute: NavigationTarget | null;
 
@@ -15,6 +15,6 @@
 
 <button
 	class="flex gap-0.5 text-white font-bold pointer-events-auto ml-2"
-	on:click={async () => back({ networkId: $networkId, fromUrl: fromRoute?.url })}
-	><IconBack /> {$i18n.navigation.text.back_to_wallet}</button
+	on:click={async () => back({ pop: nonNullish(fromRoute) })}
+	><IconBack /> {$i18n.core.text.back}</button
 >

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -4,7 +4,7 @@
 	import { fade } from 'svelte/transition';
 	import type { NetworkId } from '$lib/types/network';
 	import { networkId } from '$lib/derived/network.derived';
-	import { back, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
+	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
 	import { page } from '$app/stores';
 	import TextWithLogo from '$lib/components/ui/TextWithLogo.svelte';
 
@@ -18,7 +18,7 @@
 		await switchNetwork(id);
 
 		if (isRouteTransactions($page)) {
-			await back({ networkId: $networkId });
+			await gotoReplaceRoot();
 		}
 
 		// A small delay to give the user a visual feedback that the network is checked

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -14,9 +14,8 @@
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import HideTokenReview from '$lib/components/tokens/HideTokenReview.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { back } from '$lib/utils/nav.utils';
+	import { gotoReplaceRoot } from '$lib/utils/nav.utils';
 	import type { Identity } from '@dfinity/agent';
-	import { networkId } from '$lib/derived/network.derived';
 	import { tokenToggleable } from '$lib/derived/token.derived';
 
 	export let assertHide: () => { valid: boolean };
@@ -54,7 +53,7 @@
 			hideProgressStep = ProgressStepsHideToken.UPDATE_UI;
 
 			// We must navigate first otherwise we might land on the default token Ethereum selected while being on network ICP.
-			await back({ networkId: $networkId });
+			await gotoReplaceRoot();
 
 			await updateUi({
 				identity: $authStore.identity

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -26,8 +26,7 @@
 			"source_code_on_github": "Source code on GitHub",
 			"view_on_explorer": "View on explorer",
 			"source_code": "Source code",
-			"manage_internet_identity": "Manage Internet Identity",
-			"back_to_wallet": "Back to Wallet"
+			"manage_internet_identity": "Manage Internet Identity"
 		},
 		"alt": {
 			"manage_internet_identity": "Administrate your Internet Identity",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -27,7 +27,6 @@ interface I18nNavigation {
 		view_on_explorer: string;
 		source_code: string;
 		manage_internet_identity: string;
-		back_to_wallet: string;
 	};
 	alt: { manage_internet_identity: string; more_settings: string; menu: string };
 }

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -35,11 +35,17 @@ const tokenUrl = ({
 export const networkParam = (networkId: NetworkId | undefined): string =>
 	isNullish(networkId) ? '' : `network=${networkId.description ?? ''}`;
 
-export const back = async (params: { networkId: NetworkId | undefined; fromUrl?: URL }) => {
-	const { networkId, fromUrl } = params;
-	const rootUrl =
-		fromUrl?.toString() ?? `/${nonNullish(networkId) ? `?${networkParam(networkId)}` : ''}`;
-	await goto(rootUrl, { replaceState: 'fromUrl' in params ? nonNullish(fromUrl) : true });
+export const back = async ({ pop }: { pop: boolean }) => {
+	if (pop) {
+		history.back();
+		return;
+	}
+
+	await goto('/');
+};
+
+export const gotoReplaceRoot = async () => {
+	await goto('/', { replaceState: true });
 };
 
 export type RouteParams = {


### PR DESCRIPTION
# Motivation

There was a bug so that the `Back` component would always go in loop between the last two navigational page (transactions and settings).

# Changes

- Rename `Back to wallet` to `Back`
- Use native navigation history and goto to execute browser's back on, back
- Replace specific call to function back that were actually meant as navigation with a new function that navigate and replace the history with the root
