### PR TITLE
feat(frontend): Verify and add credential to user profile after presentation

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -1,4 +1,6 @@
 import type {
+	AddUserCredentialError,
+	CredentialSpec,
 	CustomToken,
 	GetUserProfileError,
 	SignRequest,
@@ -9,7 +11,8 @@ import { getBackendActor } from '$lib/actors/actors.ic';
 import type { ECDSA_PUBLIC_KEY } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
-import type { QueryParams } from '@dfinity/utils';
+import type { Principal } from '@dfinity/principal';
+import { toNullable, type QueryParams } from '@dfinity/utils';
 
 export const getEthAddress = async (identity: OptionIdentity): Promise<ECDSA_PUBLIC_KEY> => {
 	const { caller_eth_address } = await getBackendActor({ identity });
@@ -126,4 +129,26 @@ export const getUserProfile = async ({
 > => {
 	const { get_user_profile } = await getBackendActor({ identity, certified });
 	return get_user_profile();
+};
+
+export const addUserCredential = async ({
+	identity,
+	credentialJwt,
+	issuerCanisterId,
+	currentUserVersion,
+	credentialSpec
+}: {
+	identity: Identity;
+	credentialJwt: string;
+	issuerCanisterId: Principal;
+	currentUserVersion?: bigint;
+	credentialSpec: CredentialSpec;
+}): Promise<{ Ok: null } | { Err: AddUserCredentialError }> => {
+	const { add_user_credential } = await getBackendActor({ identity });
+	return add_user_credential({
+		credential_jwt: credentialJwt,
+		issuer_canister_id: issuerCanisterId,
+		current_user_version: toNullable(currentUserVersion),
+		credential_spec: credentialSpec
+	});
 };

--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-	import { KeyValuePairInfo } from '@dfinity/gix-components';
+	import { KeyValuePairInfo, Spinner } from '@dfinity/gix-components';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { authRemainingTimeStore, authStore } from '$lib/stores/auth.store';
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { secondsToDuration } from '@dfinity/utils';
 	import type { Principal } from '@dfinity/principal';
 	import NetworksTestnetsToggle from '$lib/components/networks/NetworksTestnetsToggle.svelte';
@@ -15,23 +15,35 @@
 	import { fade } from 'svelte/transition';
 	import { busy } from '$lib/stores/busy.store';
 	import { POUH_ENABLED } from '$lib/constants/credentials.constants';
+	import type { OptionIdentity } from '$lib/types/identity';
+	import { loadUserProfile } from '$lib/services/load-user-profile.services';
+	import { userProfileStore } from '$lib/stores/settings.store';
 
 	let remainingTimeMilliseconds: number | undefined;
 	$: remainingTimeMilliseconds = $authRemainingTimeStore;
 
+	let identity: OptionIdentity;
+	$: identity = $authStore?.identity;
+
 	let principal: Principal | undefined | null;
-	$: principal = $authStore?.identity?.getPrincipal();
+	$: principal = identity?.getPrincipal();
 
 	const getPouhCredential = async () => {
-		if (nonNullish(principal)) {
+		if (nonNullish(identity)) {
 			try {
 				busy.show();
-				await requestPouhCredential({ credentialSubject: principal });
+				await requestPouhCredential({ identity });
 			} finally {
 				busy.stop();
 			}
 		}
 	};
+
+	$: {
+		if (nonNullish(identity) && POUH_ENABLED) {
+			loadUserProfile({ identity });
+		}
+	}
 </script>
 
 <KeyValuePairInfo>
@@ -97,21 +109,20 @@
 	</KeyValuePairInfo>
 </div>
 
-{#if POUH_ENABLED}
-	<div class="mt-8">
+{#if POUH_ENABLED && nonNullish($userProfileStore)}
+	<div class="mt-8" in:fade>
 		<h2 class="text-base mb-6 pb-1">{$i18n.settings.text.credentials_title}</h2>
 
 		<div class="mt-4">
 			<KeyValuePairInfo>
 				<span slot="key" class="font-bold">{$i18n.settings.text.pouh_credential}:</span>
 				<svelte:fragment slot="value">
-					<!-- TODO: Render spinner if no user profile -->
 					{#if $userHasPouhCredential}
-						<output in:fade class="mr-1.5">
+						<output class="mr-1.5">
 							{$i18n.settings.text.pouh_credential_verified}
 						</output>
 					{:else}
-						<button in:fade type="button" class="secondary" on:click={getPouhCredential}
+						<button type="button" class="secondary" on:click={getPouhCredential}
 							>{$i18n.settings.text.present_pouh_credential}</button
 						>
 					{/if}

--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-	import { KeyValuePairInfo, Spinner } from '@dfinity/gix-components';
+	import { KeyValuePairInfo } from '@dfinity/gix-components';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { authRemainingTimeStore, authStore } from '$lib/stores/auth.store';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import { secondsToDuration } from '@dfinity/utils';
 	import type { Principal } from '@dfinity/principal';
 	import NetworksTestnetsToggle from '$lib/components/networks/NetworksTestnetsToggle.svelte';

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -48,6 +48,8 @@
 		},
 		"error": {
 			"no_internet_identity": "No internet identity.",
+			"invalid_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential. Please contact the issuer and request the credential again.",
+			"error_validating_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential.",
 			"error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
 			"missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
 			"no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?"

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -41,7 +41,11 @@ const queryUnsafeProfile = async ({
 	}
 };
 
-const loadCertifiedUserProfile = async ({ identity }: { identity: Identity }): Promise<void> => {
+export const loadCertifiedUserProfile = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<void> => {
 	try {
 		const profile = await queryProfile({ identity, certified: true });
 		userProfileStore.set({ key: 'user-profile', value: profile });

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -1,4 +1,4 @@
-import type { UserCredential, UserProfile } from '$declarations/backend/backend.did';
+import { addUserCredential } from '$lib/api/backend.api';
 import {
 	INTERNET_IDENTITY_ORIGIN,
 	POUH_ISSUER_CANISTER_ID,
@@ -11,31 +11,79 @@ import { i18n } from '$lib/stores/i18n.store';
 import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { popupCenter } from '$lib/utils/window.utils';
+import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
-import { isNullish, nonNullish } from '@dfinity/utils';
+import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 import {
 	requestVerifiablePresentation,
 	type VerifiablePresentationResponse
 } from '@dfinity/verifiable-credentials/request-verifiable-presentation';
 import { get } from 'svelte/store';
+import { loadCertifiedUserProfile } from './load-user-profile.services';
 
-const handleSuccess = async (
-	response: VerifiablePresentationResponse
-): Promise<{ success: boolean }> => {
+const addPouhCredential = async ({
+	identity,
+	credentialJwt,
+	issuerCanisterId
+}: {
+	identity: Identity;
+	credentialJwt: string;
+	issuerCanisterId: Principal;
+}): Promise<{ success: boolean }> => {
+	const { auth: authI18n } = get(i18n);
+	try {
+		const userProfile = get(userProfileStore);
+		const response = await addUserCredential({
+			identity,
+			credentialJwt,
+			credentialSpec: {
+				credential_type: POUH_CREDENTIAL_TYPE,
+				arguments: []
+			},
+			issuerCanisterId,
+			currentUserVersion: fromNullable(userProfile?.version ?? [])
+		});
+		if ('Ok' in response) {
+			return { success: true };
+		}
+		if ('Err' in response) {
+			if ('InvalidCredential' in response.Err) {
+				toastsError({
+					msg: { text: authI18n.error.invalid_pouh_credential }
+				});
+				return { success: false };
+			}
+			// Throw so that it gets handled by the catch block.
+			throw new Error();
+		}
+	} catch (err: unknown) {
+		toastsError({
+			msg: { text: authI18n.error.error_validating_pouh_credential },
+			err
+		});
+	}
+	return { success: false };
+};
+
+const handleSuccess = async ({
+	response,
+	identity,
+	issuerCanisterId
+}: {
+	response: VerifiablePresentationResponse;
+	identity: Identity;
+	issuerCanisterId: Principal;
+}): Promise<{ success: boolean }> => {
 	const { auth: authI18n } = get(i18n);
 	if ('Ok' in response) {
-		// TODO: GIX-2646 Add credential to backend and load user profile
-		const fakeTemporaryCredentialSummary: UserCredential = {
-			credential_type: { [POUH_CREDENTIAL_TYPE]: null },
-			verified_date_timestamp: [BigInt(Date.now())]
-		};
-		const fakeUserProfile: UserProfile = {
-			credentials: [fakeTemporaryCredentialSummary],
-			created_timestamp: BigInt(Date.now()),
-			updated_timestamp: BigInt(Date.now()),
-			version: [0n]
-		};
-		userProfileStore.set({ key: 'user-profile', value: fakeUserProfile });
+		const { success } = await addPouhCredential({
+			credentialJwt: response.Ok,
+			identity,
+			issuerCanisterId
+		});
+		if (success) {
+			await loadCertifiedUserProfile({ identity });
+		}
 		return { success: true };
 	}
 	toastsError({
@@ -45,10 +93,11 @@ const handleSuccess = async (
 };
 
 export const requestPouhCredential = async ({
-	credentialSubject
+	identity
 }: {
-	credentialSubject: Principal;
+	identity: Identity;
 }): Promise<{ success: boolean }> => {
+	const credentialSubject = identity.getPrincipal();
 	const { auth: authI18n } = get(i18n);
 	return new Promise((resolve, reject) => {
 		const issuerCanisterId = nonNullish(POUH_ISSUER_CANISTER_ID)
@@ -81,7 +130,7 @@ export const requestPouhCredential = async ({
 				reject();
 			},
 			onSuccess: async (response: VerifiablePresentationResponse) => {
-				resolve(await handleSuccess(response));
+				resolve(await handleSuccess({ response, identity, issuerCanisterId }));
 			},
 			windowOpenerFeatures: popupCenter({ width: VC_POPUP_WIDTH, height: VC_POPUP_HEIGHT })
 		});

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -43,6 +43,8 @@ interface I18nAuth {
 	alt: { sign_in: string };
 	error: {
 		no_internet_identity: string;
+		invalid_pouh_credential: string;
+		error_validating_pouh_credential: string;
 		error_requesting_pouh_credential: string;
 		missing_pouh_issuer_origin: string;
 		no_pouh_credential: string;


### PR DESCRIPTION
# Motivation

We want to validate the credentials presented by users and store some metadata in their profiles.

In this PR, the service `requestPouhCredential` is connected to the backend.

# Changes

* New api function `addUserCredential`.
* Load the user profile in settings page and render the credentials only when present.
* Change the parameter of `requestPouhCredential` to the `Identity`.
* Add two new i18n messages.
* Export `loadCertifiedUserProfile`.
* Add a helper `addPouhCredential` to be used within the handle success of `requestPouhCredential`.

# Tests

See screencast of the successful flow.
