### PR TITLE
fix(ci): remove txt file and using env variables for deleted files

### DIFF
--- a/.github/workflows/frontend-remove-unused-components.yml
+++ b/.github/workflows/frontend-remove-unused-components.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           if ! git diff --cached --quiet; then
             echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            git diff --cached --name-only > deleted_files.txt
+            DELETED_FILES=$(git diff --cached --name-only)
+            echo "DELETED_FILES=${DELETED_FILES}" >> $GITHUB_ENV
           fi
 
       # This action creates a PR only if there are changes.
@@ -40,5 +41,5 @@ jobs:
           body: |
             The following files were removed because they were not used in the project anymore:
             ```
-            $(cat deleted_files.txt)
+            ${{ env.DELETED_FILES }}
             ```


### PR DESCRIPTION
# Motivation

Having tested the workflow with PR #1883 , I noticed that the `.txt` file used to store the deleted files is included in the PR. Furthermore, the list is not printed in the PR body.

So we change it to use ENV variables instead.