### PR TITLE
feat(frontend): New user profile store not persisted in localStorage

### DIFF
--- a/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsSignedIn.svelte
@@ -17,7 +17,7 @@
 	import { POUH_ENABLED } from '$lib/constants/credentials.constants';
 	import type { OptionIdentity } from '$lib/types/identity';
 	import { loadUserProfile } from '$lib/services/load-user-profile.services';
-	import { userProfileStore } from '$lib/stores/settings.store';
+	import { userProfileStore } from '$lib/stores/user-profile.store';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 
 	let remainingTimeMilliseconds: number | undefined;

--- a/src/frontend/src/lib/derived/has-pouh-credential.ts
+++ b/src/frontend/src/lib/derived/has-pouh-credential.ts
@@ -4,5 +4,5 @@ import { derived, type Readable } from 'svelte/store';
 
 export const userHasPouhCredential: Readable<boolean | undefined> = derived(
 	[userProfileStore],
-	([$profile]) => hasPouhCredential($profile)
+	([$profile]) => hasPouhCredential($profile?.profile)
 );

--- a/src/frontend/src/lib/derived/has-pouh-credential.ts
+++ b/src/frontend/src/lib/derived/has-pouh-credential.ts
@@ -1,4 +1,4 @@
-import { userProfileStore } from '$lib/stores/settings.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import { hasPouhCredential } from '$lib/utils/credentials.utils';
 import { derived, type Readable } from 'svelte/store';
 

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -48,7 +48,7 @@ export const loadCertifiedUserProfile = async ({
 }): Promise<void> => {
 	try {
 		const profile = await queryProfile({ identity, certified: true });
-		userProfileStore.set(profile);
+		userProfileStore.set({ certified: true, profile });
 	} catch (err) {
 		// We ignore the error because this is a background task.
 		console.error('Failed to load certified user profile.', err);
@@ -64,10 +64,10 @@ export const loadUserProfile = async ({
 		let profile = await queryUnsafeProfile({ identity });
 		if (isNullish(profile)) {
 			profile = await createUserProfile({ identity });
-			userProfileStore.set(profile);
+			userProfileStore.set({ certified: true, profile });
 		} else {
 			// We set the store before the call to load the certified profile.
-			userProfileStore.set(profile);
+			userProfileStore.set({ certified: false, profile });
 			// We don't wait for this to complete because we want a smooth UX
 			// the uncertified data is enough for the user to start using the app.
 			loadCertifiedUserProfile({ identity });

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -1,8 +1,8 @@
 import type { UserProfile } from '$declarations/backend/backend.did';
 import { createUserProfile, getUserProfile } from '$lib/api/backend.api';
 import { i18n } from '$lib/stores/i18n.store';
-import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import { UserProfileNotFoundError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/identity';
 import { isNullish } from '@dfinity/utils';
@@ -48,7 +48,7 @@ export const loadCertifiedUserProfile = async ({
 }): Promise<void> => {
 	try {
 		const profile = await queryProfile({ identity, certified: true });
-		userProfileStore.set({ key: 'user-profile', value: profile });
+		userProfileStore.set(profile);
 	} catch (err) {
 		// We ignore the error because this is a background task.
 		console.error('Failed to load certified user profile.', err);
@@ -64,10 +64,10 @@ export const loadUserProfile = async ({
 		let profile = await queryUnsafeProfile({ identity });
 		if (isNullish(profile)) {
 			profile = await createUserProfile({ identity });
-			userProfileStore.set({ key: 'user-profile', value: profile });
+			userProfileStore.set(profile);
 		} else {
 			// We set the store before the call to load the certified profile.
-			userProfileStore.set({ key: 'user-profile', value: profile });
+			userProfileStore.set(profile);
 			// We don't wait for this to complete because we want a smooth UX
 			// the uncertified data is enough for the user to start using the app.
 			loadCertifiedUserProfile({ identity });

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -42,7 +42,7 @@ const addPouhCredential = async ({
 				arguments: []
 			},
 			issuerCanisterId,
-			currentUserVersion: fromNullable(userProfile?.version ?? [])
+			currentUserVersion: fromNullable(userProfile?.profile.version ?? [])
 		});
 		if ('Ok' in response) {
 			return { success: true };

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -8,8 +8,8 @@ import {
 } from '$lib/constants/app.constants';
 import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { i18n } from '$lib/stores/i18n.store';
-import { userProfileStore } from '$lib/stores/settings.store';
 import { toastsError } from '$lib/stores/toasts.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { popupCenter } from '$lib/utils/window.utils';
 import type { Identity } from '@dfinity/agent';

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -1,4 +1,3 @@
-import type { UserProfile } from '$declarations/backend/backend.did';
 import { initStorageStore } from '$lib/stores/storage.store';
 
 export interface SettingsData {
@@ -7,4 +6,3 @@ export interface SettingsData {
 
 export const testnetsStore = initStorageStore<SettingsData>({ key: 'testnets' });
 export const hideZeroBalancesStore = initStorageStore<SettingsData>({ key: 'hide-zero-balances' });
-export const userProfileStore = initStorageStore<UserProfile>({ key: 'user-profile' });

--- a/src/frontend/src/lib/stores/user-profile.store.ts
+++ b/src/frontend/src/lib/stores/user-profile.store.ts
@@ -1,0 +1,24 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
+import { writable, type Readable } from 'svelte/store';
+
+// * `undefined` means the store is not loaded yet.
+// * `null` means there was an error.
+// * `UserProfile` is the data.
+export type UserProfileStoreData = UserProfile | undefined | null;
+
+export interface UserProfileStore extends Readable<UserProfileStoreData> {
+	set: (data: UserProfileStoreData) => void;
+	reset: () => void;
+}
+
+const initUserProfileStore = (): UserProfileStore => {
+	const { subscribe, set } = writable<UserProfileStoreData>(undefined);
+
+	return {
+		set: (data: UserProfileStoreData | null) => set(data),
+		reset: () => set(undefined),
+		subscribe
+	};
+};
+
+export const userProfileStore = initUserProfileStore();

--- a/src/frontend/src/lib/stores/user-profile.store.ts
+++ b/src/frontend/src/lib/stores/user-profile.store.ts
@@ -1,13 +1,18 @@
 import type { UserProfile } from '$declarations/backend/backend.did';
 import { writable, type Readable } from 'svelte/store';
 
+type CertifiedUserProfileData = {
+	profile: UserProfile;
+	certified: boolean;
+};
+
 // * `undefined` means the store is not loaded yet.
 // * `null` means there was an error.
 // * `UserProfile` is the data.
-export type UserProfileStoreData = UserProfile | undefined | null;
+export type UserProfileStoreData = CertifiedUserProfileData | undefined | null;
 
 export interface UserProfileStore extends Readable<UserProfileStoreData> {
-	set: (data: UserProfileStoreData) => void;
+	set: (data: CertifiedUserProfileData | null) => void;
 	reset: () => void;
 }
 
@@ -15,7 +20,7 @@ const initUserProfileStore = (): UserProfileStore => {
 	const { subscribe, set } = writable<UserProfileStoreData>(undefined);
 
 	return {
-		set: (data: UserProfileStoreData | null) => set(data),
+		set: (data: CertifiedUserProfileData | null) => set(data),
 		reset: () => set(undefined),
 		subscribe
 	};

--- a/src/frontend/src/lib/stores/user-profile.store.ts
+++ b/src/frontend/src/lib/stores/user-profile.store.ts
@@ -21,7 +21,7 @@ const initUserProfileStore = (): UserProfileStore => {
 
 	return {
 		set: (data: CertifiedUserProfileData | null) => set(data),
-		reset: () => set(undefined),
+		reset: () => set(null),
 		subscribe
 	};
 };

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -43,7 +43,7 @@ describe('loadUserProfile', () => {
 			certified: false
 		});
 		expect(createUserProfileSpy).not.toHaveBeenCalled();
-		expect(get(userProfileStore)).toEqual(mockProfile);
+		expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
 	});
 
 	it('creates a user profile if uncertified profile is not found', async () => {
@@ -63,7 +63,7 @@ describe('loadUserProfile', () => {
 		expect(createUserProfileSpy).toHaveBeenCalledWith({
 			identity: mockIdentity
 		});
-		expect(get(userProfileStore)).toEqual(mockProfile);
+		expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile });
 	});
 
 	it('loads the store with certified data when uncertified profile is found', async () => {

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -1,7 +1,7 @@
 import type { UserProfile } from '$declarations/backend/backend.did';
 import * as backendApi from '$lib/api/backend.api';
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
-import { userProfileStore } from '$lib/stores/settings.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { beforeEach } from 'node:test';
@@ -26,7 +26,7 @@ const mockIdentity = {
 
 describe('loadUserProfile', () => {
 	beforeEach(() => {
-		userProfileStore.reset({ key: 'user-profile' });
+		userProfileStore.reset();
 		vi.clearAllMocks();
 	});
 

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -4,6 +4,7 @@ import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
+import { waitFor } from '@testing-library/svelte';
 import { beforeEach } from 'node:test';
 import { get } from 'svelte/store';
 
@@ -81,5 +82,8 @@ describe('loadUserProfile', () => {
 			identity: mockIdentity,
 			certified: true
 		});
+		await waitFor(() =>
+			expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile })
+		);
 	});
 });


### PR DESCRIPTION
# Motivation

Simplify how user profile is stored in the frontend.

In this PR, create and use a new userProfileStore that doesn't persist data in localStorage.

# Changes

* New store user-profile.store
* User the new userProfileStore instead of the one from settings.store.
* Remove the userProfileStore from settings.store

# Tests

Tested manually.

