### PR TITLE
fix(devops): Add Wasm and did file for orbit

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -24,6 +24,9 @@
 			"gzip": true
 		},
 		"orbit": {
+			"type": "custom",
+			"candid": "https://raw.githubusercontent.com/dfinity/orbit/%40orbit/station-v0.0.2-alpha.5/apps/wallet/src/generated/station/station.did",
+			"wasm": "https://github.com/dfinity/orbit/releases/download/%40orbit%2Fstation-v0.0.2-alpha.5/station.wasm.gz",
 			"remote": {
 				"id": {
 					"staging": "4jngj-yiaaa-aaaal-ajk5q-cai",


### PR DESCRIPTION
# Motivation
The `orbit` canister entry in `dfx.json` was missing candid data, causing `npm run generate` to fail.

# Changes
* Add Candid and Wasm information for the Orbit canister.

# Tests
* I have run `npm run generate` locally, with success.  (After deploying canisters locally!)

It would be nice to run this in CI but at present we run `dfx start` and deploy canisters only in docker, which complicates this.