### PR TITLE
fix(backend): Add missing issuer field to generated files

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -94,6 +94,7 @@ type SupportedCredential = record {
 };
 type Token = variant { Icrc : IcrcToken };
 type UserCredential = record {
+  issuer : text;
   verified_date_timestamp : opt nat64;
   credential_type : CredentialType;
 };

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -94,6 +94,7 @@ type SupportedCredential = record {
 };
 type Token = variant { Icrc : IcrcToken };
 type UserCredential = record {
+  issuer : text;
   verified_date_timestamp : opt nat64;
   credential_type : CredentialType;
 };

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -100,6 +100,7 @@ export interface SupportedCredential {
 }
 export type Token = { Icrc: IcrcToken };
 export interface UserCredential {
+	issuer: string;
 	verified_date_timestamp: [] | [bigint];
 	credential_type: CredentialType;
 }

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -37,6 +37,7 @@ export const idlFactory = ({ IDL }) => {
 		Err: AddUserCredentialError
 	});
 	const UserCredential = IDL.Record({
+		issuer: IDL.Text,
 		verified_date_timestamp: IDL.Opt(IDL.Nat64),
 		credential_type: CredentialType
 	});

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -37,6 +37,7 @@ export const idlFactory = ({ IDL }) => {
 		Err: AddUserCredentialError
 	});
 	const UserCredential = IDL.Record({
+		issuer: IDL.Text,
 		verified_date_timestamp: IDL.Opt(IDL.Nat64),
 		credential_type: CredentialType
 	});


### PR DESCRIPTION
# Motivation
`npm run generate` was blocked for a while.  In the meantime a new `issuer` field was added to `UserCredential`.  That change was not propagated to the generated files.  Now that generation works again, the field needs to be propagated.

# Changes
* Run `npm run generate` and commit the changes.
  * The changes are only the addition of the `issuer` field in auto-generated files.

# Tests
None.  Existing CI should suffice.