### PR TITLE
feat(frontend): create SendModal with initial step of choosing the token

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -75,10 +75,6 @@
 
 	{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
 		<SendTokensList on:icSendToken={nextStep} />
-
-		<button class="secondary full center text-center" on:click={modalStore.close}
-			>{$i18n.core.text.close}</button
-		>
 	{:else}
 		<SendWizard
 			{currentStep}

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import { sendWizardSteps } from '$lib/config/send.config';
+	import { createEventDispatcher } from 'svelte';
+	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
+	import type { Token } from '$lib/types/token';
+	import { waitWalletReady } from '$lib/services/actions.services';
+	import { loadTokenAndRun } from '$icp/services/token.services';
+	import { addressNotLoaded } from '$lib/derived/address.derived';
+	import { closeModal } from '$lib/utils/modal.utils';
+	import { ProgressStepsSend } from '$lib/enums/progress-steps';
+	import type { Network, NetworkId } from '$lib/types/network';
+	import SendTokensList from '$lib/components/send/SendTokensList.svelte';
+	import SendWizard from '$lib/components/send/SendWizard.svelte';
+
+	export let destination = '';
+	export let targetNetwork: Network | undefined = undefined;
+
+	let networkId: NetworkId | undefined = undefined;
+	$: networkId = targetNetwork?.id;
+
+	let amount: number | undefined = undefined;
+	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
+
+	let steps: WizardSteps;
+	$: steps = sendWizardSteps($i18n);
+
+	let currentStep: WizardStep | undefined;
+	let modal: WizardModal;
+
+	const dispatch = createEventDispatcher();
+
+	const close = () =>
+		closeModal(() => {
+			destination = '';
+			amount = undefined;
+			targetNetwork = undefined;
+
+			sendProgressStep = ProgressStepsSend.INITIALIZATION;
+
+			currentStep = undefined;
+
+			dispatch('nnsClose');
+		});
+
+	const isDisabled = (): boolean => $addressNotLoaded;
+
+	const nextStep = async ({ detail: token }: CustomEvent<Token>) => {
+		if (isDisabled()) {
+			const status = await waitWalletReady(isDisabled);
+
+			if (status === 'timeout') {
+				return;
+			}
+		}
+
+		const callback = async () => {
+			modal.next();
+		};
+		await loadTokenAndRun({ token, callback });
+	};
+</script>
+
+<WizardModal
+	{steps}
+	bind:currentStep
+	bind:this={modal}
+	on:nnsClose={close}
+	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
+>
+	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
+
+	{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
+		<SendTokensList on:icSendToken={nextStep} />
+
+		<button class="secondary full center text-center" on:click={modalStore.close}
+			>{$i18n.core.text.close}</button
+		>
+	{:else}
+		<SendWizard
+			{currentStep}
+			bind:destination
+			bind:networkId
+			bind:targetNetwork
+			bind:amount
+			bind:sendProgressStep
+			on:icBack={modal.back}
+			on:icNext={modal.next}
+			on:icClose={close}
+			on:icQRCodeScan={() =>
+				goToWizardSendStep({
+					modal,
+					steps,
+					stepName: WizardStepsSend.QR_CODE_SCAN
+				})}
+			on:icQRCodeBack={() =>
+				goToWizardSendStep({
+					modal,
+					steps,
+					stepName: WizardStepsSend.SEND
+				})}
+		/>
+	{/if}
+</WizardModal>

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import { sendWizardSteps } from '$lib/config/send.config';
 	import { createEventDispatcher } from 'svelte';

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -9,6 +9,8 @@
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { createEventDispatcher } from 'svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
+	import { modalStore } from '$lib/stores/modal.store';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	const dispatch = createEventDispatcher();
 
@@ -33,3 +35,7 @@
 		</TokenCardWithOnClick>
 	{/each}
 </TokensSkeletons>
+
+<button class="secondary full center text-center" on:click={modalStore.close}>
+	{$i18n.core.text.close}
+</button>

--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -1,6 +1,7 @@
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
 import type { WizardSteps } from '@dfinity/gix-components';
 
+// TODO: Merge with the sendWizardSteps used for IC and ETH
 export const sendWizardSteps = (i18n: I18n): WizardSteps => [
 	{
 		name: WizardStepsSend.TOKENS_LIST,

--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -1,0 +1,21 @@
+import { WizardStepsSend } from '$lib/enums/wizard-steps';
+import type { WizardSteps } from '@dfinity/gix-components';
+
+export const sendWizardSteps = (i18n: I18n): WizardSteps => [
+	{
+		name: WizardStepsSend.TOKENS_LIST,
+		title: i18n.send.text.send
+	},
+	{
+		name: WizardStepsSend.SEND,
+		title: i18n.send.text.send
+	},
+	{
+		name: WizardStepsSend.REVIEW,
+		title: i18n.send.text.review
+	},
+	{
+		name: WizardStepsSend.SENDING,
+		title: i18n.send.text.sending
+	}
+];

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -1,4 +1,5 @@
 export enum WizardStepsSend {
+	TOKENS_LIST = 'Tokens List',
 	SEND = 'Send',
 	REVIEW = 'Review',
 	SENDING = 'Sending',


### PR DESCRIPTION
# Motivation

The following is the generic `SendModal` that has as first step the choice of token. The rest will be the same as the modals for ETH and IC.