### PR TITLE
build(frontend): chunk three.js into index

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ const config: UserConfig = {
 					const lazy = ['@dfinity/nns', '@dfinity/nns-proto', 'html5-qrcode', 'qr-creator'];
 
 					if (
-						['@sveltejs', 'svelte', '@dfinity/gix-components', ...lazy].find((lib) =>
+						['@sveltejs', 'svelte', '@dfinity/gix-components', 'three', ...lazy].find((lib) =>
 							folder.includes(lib)
 						) === undefined &&
 						folder.includes('node_modules')


### PR DESCRIPTION
# Motivation

After some test on mainnet we decided to move three.js chunk from `vendor` to `index` that way it is load with other UI chunks.

# Changes

- Update rollup config to chunk three.