### PR TITLE
refactor(frontend): move sorting by balance to network tokens

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { BigNumber } from '@ethersproject/bignumber';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
-	import { enabledNetworkTokensUiNonZeroBalance } from '$lib/derived/network-tokens.derived';
+	import { sortedNetworkTokensUiNonZeroBalance } from '$lib/derived/network-tokens.derived';
 	import type { TokenUi } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 	import CardAmount from '$lib/components/ui/CardAmount.svelte';
@@ -13,7 +13,7 @@
 	const dispatch = createEventDispatcher();
 
 	let tokens: TokenUi[];
-	$: tokens = $enabledNetworkTokensUiNonZeroBalance;
+	$: tokens = $sortedNetworkTokensUiNonZeroBalance;
 </script>
 
 <TokensSkeletons>

--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -3,8 +3,8 @@
 	import Listener from '$lib/components/core/Listener.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import {
-		enabledNetworkTokensUi,
-		enabledNetworkTokensUiNonZeroBalance
+		sortedNetworkTokensUi,
+		sortedNetworkTokensUiNonZeroBalance
 	} from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenUi } from '$lib/types/token';
@@ -22,7 +22,7 @@
 	$: displayZeroBalance = $hideZeroBalancesStore?.enabled !== true;
 
 	let tokens: TokenUi[];
-	$: tokens = displayZeroBalance ? $enabledNetworkTokensUi : $enabledNetworkTokensUiNonZeroBalance;
+	$: tokens = displayZeroBalance ? $sortedNetworkTokensUi : $sortedNetworkTokensUiNonZeroBalance;
 </script>
 
 <TokensSkeletons>

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -6,6 +6,7 @@ import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
+import { pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
@@ -34,7 +35,7 @@ export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
 );
 
 /**
- * All tokens matching the selected network or chain fusion, regardless if they are enabled by the user or not, with their financial data.
+ * All tokens matching the selected network or Chain Fusion, with their financial data.
  */
 export const enabledNetworkTokensUi: Readable<TokenUi[]> = derived(
 	[enabledNetworkTokens, balancesStore, exchanges],
@@ -53,10 +54,22 @@ export const enabledNetworkTokensUi: Readable<TokenUi[]> = derived(
 		})
 );
 
-export const enabledNetworkTokensUiNonZeroBalance: Readable<TokenUi[]> = derived(
+/**
+ * All tokens matching the selected network or Chain Fusion, with the ones with non-null balance at the top of the list.
+ */
+export const sortedNetworkTokensUi: Readable<TokenUi[]> = derived(
 	[enabledNetworkTokensUi, balancesStore],
 	([$enabledNetworkTokensUi, $balancesStore]) =>
-		$enabledNetworkTokensUi.filter(({ id: tokenId }) =>
+		pinTokensWithBalanceAtTop({
+			$tokens: $enabledNetworkTokensUi,
+			$balancesStore: $balancesStore
+		})
+);
+
+export const sortedNetworkTokensUiNonZeroBalance: Readable<TokenUi[]> = derived(
+	[sortedNetworkTokensUi, balancesStore],
+	([$sortedNetworkTokensUi, $balancesStore]) =>
+		$sortedNetworkTokensUi.filter(({ id: tokenId }) =>
 			($balancesStore?.[tokenId]?.data ?? BigNumber.from(0n)).gt(0n)
 		)
 );

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -4,9 +4,8 @@ import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import { exchanges } from '$lib/derived/exchange.derived';
-import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenToPin } from '$lib/types/token';
-import { pinTokensAtTop, pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
+import { pinTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
@@ -31,11 +30,11 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 	]
 );
 
+/**
+ * All tokens sorted by market cap, with the ones to pin at the top of the list.
+ */
 export const sortedTokens: Readable<Token[]> = derived(
-	[tokens, tokensToPin, exchanges, balancesStore],
-	([$tokens, $tokensToPin, $exchanges, $balancesStore]) =>
-		pinTokensWithBalanceAtTop({
-			$tokens: pinTokensAtTop({ $tokens: sortTokens({ $tokens, $exchanges }), $tokensToPin }),
-			$balancesStore: $balancesStore
-		})
+	[tokens, tokensToPin, exchanges],
+	([$tokens, $tokensToPin, $exchanges]) =>
+		pinTokensAtTop({ $tokens: sortTokens({ $tokens, $exchanges }), $tokensToPin })
 );

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -31,6 +31,12 @@ export const pinTokensAtTop = ({
 	return [...pinnedTokens, ...otherTokens];
 };
 
+/**
+ * Sorts tokens by market cap, name and network name.
+ *
+ * @param $tokens - The list of tokens to sort.
+ * @param $exchanges - The exchange rates for the tokens.
+ */
 export const sortTokens = ({
 	$tokens,
 	$exchanges


### PR DESCRIPTION
# Motivation

It is not really necessary to sort by balance (and pin the tokens with balance on top) at the tokens level. To spare computational time we apply the function `pinTokensWithBalanceAtTop` to the list of network tokens (that supposedly is smaller or has the same length).

Unrelated: we add some docstring to the sorting functions.

# Changes

- Remove `pinTokensWithBalanceAtTop` from derived `sortedTokens`.
- Create global derived store `sortedNetworkTokensUi` that pins tokens with balance on top (and sorts them).
- Adapt other stores and usage.

# Tests

No changes on local replica.
