### PR TITLE
feat(frontend): include QR code step in new generic SendModal

### DIFF
--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -18,5 +18,9 @@ export const sendWizardSteps = (i18n: I18n): WizardSteps => [
 	{
 		name: WizardStepsSend.SENDING,
 		title: i18n.send.text.sending
+	},
+	{
+		name: WizardStepsSend.QR_CODE_SCAN,
+		title: i18n.send.text.scan_qr
 	}
 ];


### PR DESCRIPTION
# Motivation

During PR #1907  , I forgot to add the QR code step among the `sendWizardSteps`.