### PR TITLE
fix(frontend): missing event icSendBack in SendModal

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -83,6 +83,7 @@
 			bind:amount
 			bind:sendProgressStep
 			on:icBack={modal.back}
+			on:icSendBack={modal.back}
 			on:icNext={modal.next}
 			on:icClose={close}
 			on:icQRCodeScan={() =>

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -30,6 +30,7 @@
 			bind:amount
 			bind:sendProgressStep
 			on:icBack
+			on:icSendBack
 			on:icNext
 			on:icClose
 			on:icQRCodeScan


### PR DESCRIPTION
# Motivation

I forgot event `icSendBack` in the `SendModal` component.
