### PR TITLE
refactor(frontend): extract balance component from TokenCard

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
-	import { BigNumber } from '@ethersproject/bignumber';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import { sortedNetworkTokensUiNonZeroBalance } from '$lib/derived/network-tokens.derived';
 	import type { TokenUi } from '$lib/types/token';
-	import { formatToken } from '$lib/utils/format.utils';
-	import CardAmount from '$lib/components/ui/CardAmount.svelte';
-	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
-	import { balancesStore } from '$lib/stores/balances.store';
 	import { createEventDispatcher } from 'svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -20,18 +16,8 @@
 
 <TokensSkeletons>
 	{#each tokens as token (token.id)}
-		<TokenCardWithOnClick {token} on:click={() => dispatch('icSendToken', token)}>
-			<output class="break-all" slot="description">
-				{formatToken({
-					value: $balancesStore?.[token.id]?.data ?? BigNumber.from(0n),
-					unitName: token.decimals
-				})}
-				{token.symbol}
-			</output>
-
-			<CardAmount slot="exchange">
-				<ExchangeTokenValue {token} />
-			</CardAmount>
+		<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
+			<TokenCardContent {token} />
 		</TokenCardWithOnClick>
 	{/each}
 </TokensSkeletons>

--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { formatToken } from '$lib/utils/format.utils.js';
+	import { balancesStore } from '$lib/stores/balances.store.js';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import type { Token } from '$lib/types/token';
+
+	export let token: Token;
+</script>
+
+<output class="break-all">
+	{formatToken({
+		value: $balancesStore?.[token.id]?.data ?? BigNumber.from(0n),
+		unitName: token.decimals
+	})}
+	{token.symbol}
+</output>

--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
+	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
+	import CardAmount from '$lib/components/ui/CardAmount.svelte';
+	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
+	import type { Token } from '$lib/types/token';
+
+	export let token: Token;
+</script>
+
+<TokenCard {token}>
+	<TokenBalance {token} slot="description" />
+
+	<CardAmount slot="exchange">
+		<ExchangeTokenValue {token} />
+	</CardAmount>
+</TokenCard>

--- a/src/frontend/src/lib/components/tokens/TokenCardSignedOut.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardSignedOut.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
+	import type { Token } from '$lib/types/token';
+
+	export let token: Token;
+</script>
+
+<TokenCard {token}>
+	<span class="break-all" slot="description">
+		-/- {token.symbol}
+	</span>
+
+	<span slot="exchange" class="mr-[3px] font-bold">-/-</span>
+</TokenCard>

--- a/src/frontend/src/lib/components/tokens/TokenCardWithOnClick.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithOnClick.svelte
@@ -1,17 +1,7 @@
-<script lang="ts">
-	import type { Token } from '$lib/types/token';
-	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
-
-	export let token: Token;
-</script>
-
 <div class="flex gap-3 sm:gap-8 mb-6">
 	<button class="flex-1" on:click>
 		<div class="w-full">
-			<TokenCard {token}>
-				<slot name="description" slot="description" />
-				<slot name="exchange" slot="exchange" />
-			</TokenCard>
+			<slot />
 		</div>
 	</button>
 

--- a/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { Token } from '$lib/types/token';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
-	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -19,10 +18,7 @@
 			token: token.symbol
 		})}
 	>
-		<TokenCard {token}>
-			<slot name="description" slot="description" />
-			<slot name="exchange" slot="exchange" />
-		</TokenCard>
+		<slot />
 	</a>
 
 	<slot name="actions" />

--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { BigNumber } from '@ethersproject/bignumber';
 	import Listener from '$lib/components/core/Listener.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import {
@@ -13,10 +12,7 @@
 	import { modalManageTokens } from '$lib/derived/modal.derived';
 	import ManageTokensModal from '$icp-eth/components/tokens/ManageTokensModal.svelte';
 	import TokenCardWithUrl from '$lib/components/tokens/TokenCardWithUrl.svelte';
-	import { formatToken } from '$lib/utils/format.utils';
-	import CardAmount from '$lib/components/ui/CardAmount.svelte';
-	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
-	import { balancesStore } from '$lib/stores/balances.store';
+	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 
 	let displayZeroBalance: boolean;
 	$: displayZeroBalance = $hideZeroBalancesStore?.enabled !== true;
@@ -30,17 +26,7 @@
 		<Listener {token}>
 			<div in:fade>
 				<TokenCardWithUrl {token}>
-					<output class="break-all" slot="description">
-						{formatToken({
-							value: $balancesStore?.[token.id]?.data ?? BigNumber.from(0n),
-							unitName: token.decimals
-						})}
-						{token.symbol}
-					</output>
-
-					<CardAmount slot="exchange">
-						<ExchangeTokenValue {token} />
-					</CardAmount>
+					<TokenCardContent {token} />
 				</TokenCardWithUrl>
 			</div>
 		</Listener>

--- a/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
@@ -3,16 +3,13 @@
 	import TokenCardWithUrl from '$lib/components/tokens/TokenCardWithUrl.svelte';
 	import { onMount } from 'svelte';
 	import { unsafeLoadDefaultPublicIcrcTokens } from '$icp/services/icrc.services';
+	import TokenCardSignedOut from '$lib/components/tokens/TokenCardSignedOut.svelte';
 
 	onMount(unsafeLoadDefaultPublicIcrcTokens);
 </script>
 
 {#each $enabledNetworkTokens as token (token.id)}
 	<TokenCardWithUrl {token}>
-		<span class="break-all" slot="description">
-			-/- {token.symbol}
-		</span>
-
-		<span slot="actions" class="mr-[3px] font-bold">-/-</span>
+		<TokenCardSignedOut {token} />
 	</TokenCardWithUrl>
 {/each}


### PR DESCRIPTION
# Motivation

This PR aims at extracting re-used components from the `TokenCard` component and its parent/child.

# Changes

- Create component `TokenBalance` to show formatted balance with symbol.
- Create `TokenCardContent` to show the balance and the exchange value, inside a `TokenCard`.
- Create `TokenCardSignedOut` that shows no values.
- Adapt code in the parent components that were using `TokenCard`.

# Tests

No changes on local replica.
