### PR TITLE
refactor(backend): Add UserProfileModel to interact with user profiles in stable memory

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -38,7 +38,7 @@ use types::{
     Candid, ConfigCell, CustomTokenMap, StoredPrincipal, UserProfileMap, UserProfileUpdatedMap,
     UserTokenMap,
 };
-use user_profile::{add_credential, create_profile, get_profile};
+use user_profile::{add_credential, create_profile, find_profile};
 use user_profile_model::UserProfileModel;
 
 mod assertions;
@@ -493,7 +493,7 @@ fn get_user_profile() -> Result<UserProfile, GetUserProfileError> {
     mutate_state(|s| {
         let mut user_profile_model =
             UserProfileModel::new(&mut s.user_profile, &mut s.user_profile_updated);
-        match get_profile(stored_principal, &mut user_profile_model) {
+        match find_profile(stored_principal, &mut user_profile_model) {
             Ok(stored_user) => Ok(UserProfile::from(&stored_user)),
             Err(err) => Err(err),
         }

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -39,6 +39,7 @@ use types::{
     UserTokenMap,
 };
 use user_profile::{add_credential, create_profile, get_profile};
+use user_profile_model::UserProfileModel;
 
 mod assertions;
 mod config;
@@ -48,6 +49,7 @@ mod oisy_user;
 mod token;
 mod types;
 mod user_profile;
+mod user_profile_model;
 
 const CONFIG_MEMORY_ID: MemoryId = MemoryId::new(0);
 const USER_TOKEN_MEMORY_ID: MemoryId = MemoryId::new(1);
@@ -67,6 +69,7 @@ thread_local! {
             config: ConfigCell::init(mm.borrow().get(CONFIG_MEMORY_ID), None).expect("config cell initialization should succeed"),
             user_token: UserTokenMap::init(mm.borrow().get(USER_TOKEN_MEMORY_ID)),
             custom_token: CustomTokenMap::init(mm.borrow().get(USER_CUSTOM_TOKEN_MEMORY_ID)),
+            // Use `UserProfileModel` to access and manage access to these states
             user_profile: UserProfileMap::init(mm.borrow().get(USER_PROFILE_MEMORY_ID)),
             user_profile_updated: UserProfileUpdatedMap::init(mm.borrow().get(USER_PROFILE_UPDATED_MEMORY_ID)),
         })
@@ -455,13 +458,14 @@ fn add_user_credential(request: AddUserCredentialRequest) -> Result<(), AddUserC
         current_time_ns as u128,
     ) {
         Ok(()) => mutate_state(|s| {
+            let mut user_profile_model =
+                UserProfileModel::new(&mut s.user_profile, &mut s.user_profile_updated);
             add_credential(
                 stored_principal,
                 request.current_user_version,
                 &credential_type,
                 vc_flow_signers.issuer_origin,
-                &mut s.user_profile,
-                &mut s.user_profile_updated,
+                &mut user_profile_model,
             )
         }),
         Err(_) => Err(AddUserCredentialError::InvalidCredential),
@@ -475,11 +479,9 @@ fn create_user_profile() -> UserProfile {
     let stored_principal = StoredPrincipal(ic_cdk::caller());
 
     mutate_state(|s| {
-        let stored_user = create_profile(
-            stored_principal,
-            &mut s.user_profile,
-            &mut s.user_profile_updated,
-        );
+        let mut user_profile_model =
+            UserProfileModel::new(&mut s.user_profile, &mut s.user_profile_updated);
+        let stored_user = create_profile(stored_principal, &mut user_profile_model);
         UserProfile::from(&stored_user)
     })
 }
@@ -489,11 +491,9 @@ fn get_user_profile() -> Result<UserProfile, GetUserProfileError> {
     let stored_principal = StoredPrincipal(ic_cdk::caller());
 
     mutate_state(|s| {
-        match get_profile(
-            stored_principal,
-            &mut s.user_profile,
-            &mut s.user_profile_updated,
-        ) {
+        let mut user_profile_model =
+            UserProfileModel::new(&mut s.user_profile, &mut s.user_profile_updated);
+        match get_profile(stored_principal, &mut user_profile_model) {
             Ok(stored_user) => Ok(UserProfile::from(&stored_user)),
             Err(err) => Err(err),
         }

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -25,7 +25,7 @@ pub fn create_profile(
     } else {
         let now = time();
         let default_profile = StoredUserProfile::from_timestamp(now);
-        user_profile_model.stor_new(principal, now, &default_profile);
+        user_profile_model.store_new(principal, now, &default_profile);
         default_profile
     }
 }
@@ -42,7 +42,7 @@ pub fn add_credential(
         if let Ok(new_profile) =
             user_profile.add_credential(profile_version, now, credential_type, issuer)
         {
-            user_profile_model.stor_new(principal, now, &new_profile);
+            user_profile_model.store_new(principal, now, &new_profile);
             Ok(())
         } else {
             Err(AddUserCredentialError::VersionMismatch)

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -1,62 +1,31 @@
-use crate::{
-    types::{UserProfileMap, UserProfileUpdatedMap},
-    Candid, StoredPrincipal,
-};
+use crate::{user_profile_model::UserProfileModel, StoredPrincipal};
 use ic_cdk::api::time;
 use shared::types::{
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
-    CredentialType, Timestamp, Version,
+    CredentialType, Version,
 };
-
-fn store_user_profile(
-    principal: StoredPrincipal,
-    timestamp: Timestamp,
-    user: &StoredUserProfile,
-    user_profile_map: &mut UserProfileMap,
-    user_profile_updated_map: &mut UserProfileUpdatedMap,
-) {
-    if let Some(old_updated) = user_profile_updated_map.get(&principal) {
-        // Clean up old entries
-        user_profile_map.remove(&(old_updated, principal));
-    }
-    user_profile_updated_map.insert(principal, timestamp);
-    user_profile_map.insert((timestamp, principal), Candid(user.clone()));
-}
 
 pub fn get_profile(
     principal: StoredPrincipal,
-    user_profile_map: &mut UserProfileMap,
-    user_profile_updated_map: &mut UserProfileUpdatedMap,
+    user_profile_model: &mut UserProfileModel,
 ) -> Result<StoredUserProfile, GetUserProfileError> {
-    if let Some(updated) = user_profile_updated_map.get(&principal) {
-        return Ok(user_profile_map
-            .get(&(updated, principal))
-            .expect("Failed to fetch user from user profile map but it's present in updated map")
-            .clone());
+    if let Some(profile) = user_profile_model.find_by_principal(principal) {
+        Ok(profile)
+    } else {
+        Err(GetUserProfileError::NotFound)
     }
-    Err(GetUserProfileError::NotFound)
 }
 
 pub fn create_profile(
     principal: StoredPrincipal,
-    user_profile_map: &mut UserProfileMap,
-    user_profile_updated_map: &mut UserProfileUpdatedMap,
+    user_profile_model: &mut UserProfileModel,
 ) -> StoredUserProfile {
-    if let Some(updated) = user_profile_updated_map.get(&principal) {
-        user_profile_map
-            .get(&(updated, principal))
-            .expect("Failed to fetch user from user profile map but it's present in updated map")
-            .clone()
+    if let Some(profile) = user_profile_model.find_by_principal(principal) {
+        profile
     } else {
         let now = time();
         let default_profile = StoredUserProfile::from_timestamp(now);
-        store_user_profile(
-            principal,
-            now,
-            &default_profile,
-            user_profile_map,
-            user_profile_updated_map,
-        );
+        user_profile_model.stor_new(principal, now, &default_profile);
         default_profile
     }
 }
@@ -66,21 +35,14 @@ pub fn add_credential(
     profile_version: Option<Version>,
     credential_type: &CredentialType,
     issuer: String,
-    user_profile_map: &mut UserProfileMap,
-    user_profile_updated_map: &mut UserProfileUpdatedMap,
+    user_profile_model: &mut UserProfileModel,
 ) -> Result<(), AddUserCredentialError> {
-    if let Ok(user_profile) = get_profile(principal, user_profile_map, user_profile_updated_map) {
+    if let Ok(user_profile) = get_profile(principal, user_profile_model) {
         let now = time();
         if let Ok(new_profile) =
             user_profile.add_credential(profile_version, now, credential_type, issuer)
         {
-            store_user_profile(
-                principal,
-                now,
-                &new_profile,
-                user_profile_map,
-                user_profile_updated_map,
-            );
+            user_profile_model.stor_new(principal, now, &new_profile);
             Ok(())
         } else {
             Err(AddUserCredentialError::VersionMismatch)

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -5,7 +5,7 @@ use shared::types::{
     CredentialType, Version,
 };
 
-pub fn get_profile(
+pub fn find_profile(
     principal: StoredPrincipal,
     user_profile_model: &mut UserProfileModel,
 ) -> Result<StoredUserProfile, GetUserProfileError> {
@@ -37,7 +37,7 @@ pub fn add_credential(
     issuer: String,
     user_profile_model: &mut UserProfileModel,
 ) -> Result<(), AddUserCredentialError> {
-    if let Ok(user_profile) = get_profile(principal, user_profile_model) {
+    if let Ok(user_profile) = find_profile(principal, user_profile_model) {
         let now = time();
         if let Ok(new_profile) =
             user_profile.add_credential(profile_version, now, credential_type, issuer)

--- a/src/backend/src/user_profile_model.rs
+++ b/src/backend/src/user_profile_model.rs
@@ -20,10 +20,9 @@ impl<'a> UserProfileModel<'a> {
 
     pub fn find_by_principal(&self, user_principal: StoredPrincipal) -> Option<StoredUserProfile> {
         if let Some(updated) = self.user_profile_updated_map.get(&user_principal) {
-            return self
-                .user_profile_map
+            self.user_profile_map
                 .get(&(updated, user_principal))
-                .map(|p| p.0);
+                .map(|p| p.0)
         } else {
             None
         }

--- a/src/backend/src/user_profile_model.rs
+++ b/src/backend/src/user_profile_model.rs
@@ -43,6 +43,23 @@ impl<'a> UserProfileModel<'a> {
         self.user_profile_map
             .insert((timestamp, user_principal), Candid(new_user.clone()));
     }
+
+    #[cfg(test)]
+    fn assert_consistent(&self) {
+        assert_eq!(
+            self.user_profile_map.len(),
+            self.user_profile_updated_map.len(),
+            "The number of entries should be the same"
+        );
+        for (user_principal, timestamp) in self.user_profile_updated_map.iter() {
+            assert!(
+                self.user_profile_map
+                    .contains_key(&(timestamp, user_principal)),
+                "Profile map is missing user {}",
+                user_principal.0.to_text()
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -107,6 +124,7 @@ mod tests {
                 .unwrap(),
             user_profile_2
         );
+        user_profile_model.assert_consistent();
     }
 
     #[test]
@@ -159,5 +177,6 @@ mod tests {
                 .unwrap(),
             user_profile
         );
+        user_profile_model.assert_consistent();
     }
 }

--- a/src/backend/src/user_profile_model.rs
+++ b/src/backend/src/user_profile_model.rs
@@ -1,0 +1,47 @@
+use crate::types::{Candid, StoredPrincipal, UserProfileMap, UserProfileUpdatedMap};
+use shared::types::{user_profile::StoredUserProfile, Timestamp};
+
+pub struct UserProfileModel<'a> {
+    user_profile_map: &'a mut UserProfileMap,
+    user_profile_updated_map: &'a mut UserProfileUpdatedMap,
+}
+
+/// `UserProfileModel` should be used to access and manage the state to user profiles in the stable memory
+impl<'a> UserProfileModel<'a> {
+    pub fn new(
+        user_profile_map: &'a mut UserProfileMap,
+        user_profile_updated_map: &'a mut UserProfileUpdatedMap,
+    ) -> UserProfileModel<'a> {
+        UserProfileModel {
+            user_profile_map,
+            user_profile_updated_map,
+        }
+    }
+
+    pub fn find_by_principal(&self, user_principal: StoredPrincipal) -> Option<StoredUserProfile> {
+        if let Some(updated) = self.user_profile_updated_map.get(&user_principal) {
+            return self
+                .user_profile_map
+                .get(&(updated, user_principal))
+                .map(|p| p.0);
+        } else {
+            None
+        }
+    }
+
+    pub fn stor_new(
+        &mut self,
+        user_principal: StoredPrincipal,
+        timestamp: Timestamp,
+        new_user: &StoredUserProfile,
+    ) {
+        if let Some(old_updated) = self.user_profile_updated_map.get(&user_principal) {
+            // Clean up old entries
+            self.user_profile_map.remove(&(old_updated, user_principal));
+        }
+        self.user_profile_updated_map
+            .insert(user_principal, timestamp);
+        self.user_profile_map
+            .insert((timestamp, user_principal), Candid(new_user.clone()));
+    }
+}

--- a/src/backend/src/user_profile_model.rs
+++ b/src/backend/src/user_profile_model.rs
@@ -29,7 +29,7 @@ impl<'a> UserProfileModel<'a> {
         }
     }
 
-    pub fn stor_new(
+    pub fn store_new(
         &mut self,
         user_principal: StoredPrincipal,
         timestamp: Timestamp,
@@ -43,5 +43,122 @@ impl<'a> UserProfileModel<'a> {
             .insert(user_principal, timestamp);
         self.user_profile_map
             .insert((timestamp, user_principal), Candid(new_user.clone()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+    use ic_stable_structures::{
+        memory_manager::{MemoryId, MemoryManager},
+        DefaultMemoryImpl,
+    };
+    use shared::types::{user_profile::StoredUserProfile, Timestamp};
+    use std::cell::RefCell;
+
+    const USER_1: &str = "xzg7k-thc6c-idntg-knmtz-2fbhh-utt3e-snqw6-5xph3-54pbp-7axl5-tae";
+    const USER_2: &str = "ufjdl-kewp5-bgfaq-d7k34-e5w62-nyad4-7r3s5-m2pt2-owqga-kcr5z-jae";
+
+    fn prepare_btrees() -> (UserProfileMap, UserProfileUpdatedMap) {
+        const USER_PROFILE_MEMORY_ID: MemoryId = MemoryId::new(3);
+        const USER_PROFILE_UPDATED_MEMORY_ID: MemoryId = MemoryId::new(4);
+        let memory = RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+        let user_profile_map = UserProfileMap::new(memory.borrow().get(USER_PROFILE_MEMORY_ID));
+        let user_profile_updated_map =
+            UserProfileUpdatedMap::new(memory.borrow().get(USER_PROFILE_UPDATED_MEMORY_ID));
+
+        (user_profile_map, user_profile_updated_map)
+    }
+
+    #[test]
+    fn test_find_by_principal_returns_profiles() {
+        let (mut user_profile_map, mut user_profile_updated_map) = prepare_btrees();
+
+        let user_principal =
+            StoredPrincipal(Principal::from_text(USER_1).expect("invalid user principal"));
+        let now: Timestamp = 12345667788223;
+        let user_profile = StoredUserProfile::from_timestamp(now);
+        user_profile_map.insert((now, user_principal), Candid(user_profile.clone()));
+        user_profile_updated_map.insert(user_principal, now);
+
+        let user_principal_2 =
+            StoredPrincipal(Principal::from_text(USER_2).expect("invalid user principal"));
+        let another_now: Timestamp = now + 400000000;
+        let user_profile_2 = StoredUserProfile::from_timestamp(another_now);
+        user_profile_map.insert(
+            (another_now, user_principal_2),
+            Candid(user_profile_2.clone()),
+        );
+        user_profile_updated_map.insert(user_principal_2, another_now);
+
+        let user_profile_model =
+            UserProfileModel::new(&mut user_profile_map, &mut user_profile_updated_map);
+
+        assert_eq!(
+            user_profile_model
+                .find_by_principal(user_principal)
+                .unwrap(),
+            user_profile
+        );
+
+        assert_eq!(
+            user_profile_model
+                .find_by_principal(user_principal_2)
+                .unwrap(),
+            user_profile_2
+        );
+    }
+
+    #[test]
+    fn test_store_new_saves_profiles() {
+        let (mut user_profile_map, mut user_profile_updated_map) = prepare_btrees();
+
+        let user_principal =
+            StoredPrincipal(Principal::from_text(USER_1).expect("invalid user principal"));
+        let now: Timestamp = 12345667788223;
+        let user_profile = StoredUserProfile::from_timestamp(now);
+        user_profile_map.insert((now, user_principal), Candid(user_profile.clone()));
+        user_profile_updated_map.insert(user_principal, now);
+
+        let user_principal_2 =
+            StoredPrincipal(Principal::from_text(USER_2).expect("invalid user principal"));
+        let another_now: Timestamp = now + 400000000;
+        let user_profile_2 = StoredUserProfile::from_timestamp(another_now);
+        user_profile_map.insert(
+            (another_now, user_principal_2),
+            Candid(user_profile_2.clone()),
+        );
+        user_profile_updated_map.insert(user_principal_2, another_now);
+
+        let mut user_profile_model =
+            UserProfileModel::new(&mut user_profile_map, &mut user_profile_updated_map);
+
+        let mut user_profile_2_updated = user_profile_2.clone();
+        let later_timestamp = another_now + 400000000;
+        user_profile_2_updated.updated_timestamp = later_timestamp;
+        user_profile_model.store_new(user_principal_2, later_timestamp, &user_profile_2_updated);
+
+        assert_eq!(
+            user_profile_model
+                .find_by_principal(user_principal_2)
+                .unwrap(),
+            user_profile_2_updated
+        );
+
+        assert_ne!(
+            user_profile_model
+                .find_by_principal(user_principal_2)
+                .unwrap(),
+            user_profile_2
+        );
+
+        // Check that first user is still there untouched
+        assert_eq!(
+            user_profile_model
+                .find_by_principal(user_principal)
+                .unwrap(),
+            user_profile
+        );
     }
 }


### PR DESCRIPTION
# Motivation

Refactor the code so that the different maps managing user profiles are not mismanaged and we introduce bugs and inconsistent data.

This was requested in https://github.com/dfinity/oisy-wallet/pull/1827/files#r1695268288

# Changes

* Create a new struct UserProfileModel and implement it. This entity will have the responsibility to interact with the stable memory to retrieve and store user profiles.
* Use the new struct in the user_profile module instead of expecting the stable memory structures.

# Tests

Not yet. I want to check that the implementation is the requested one.
