### PR TITLE
feat(frontend): add about modals buttons in the main Menu

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -17,9 +17,6 @@
 	import { page } from '$app/stores';
 	import AboutHow from '$lib/components/hero/about/AboutHow.svelte';
 	import AboutWhat from '$lib/components/hero/about/AboutWhat.svelte';
-	import { modalAboutHow, modalAboutWhat } from '$lib/derived/modal.derived';
-	import AboutWhatModal from '$lib/components/hero/about/AboutWhatModal.svelte';
-	import AboutHowModal from '$lib/components/hero/about/AboutHowModal.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -83,9 +80,3 @@
 		<SignOut on:icLogoutTriggered={hidePopover} />
 	</div>
 </Popover>
-
-{#if $modalAboutWhat}
-	<AboutWhatModal />
-{:else if $modalAboutHow}
-	<AboutHowModal />
-{/if}

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -15,12 +15,16 @@
 	import ButtonHero from '$lib/components/ui/ButtonHero.svelte';
 	import MenuWallet from '$lib/components/core/MenuWallet.svelte';
 	import { page } from '$app/stores';
+	import AboutHow from '$lib/components/hero/about/AboutHow.svelte';
+	import AboutWhat from '$lib/components/hero/about/AboutWhat.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
 
+	const hidePopover = () => (visible = false);
+
 	const gotoSettings = async () => {
-		visible = false;
+		hidePopover();
 		await goto(`/settings?${networkParam($networkId)}`);
 	};
 
@@ -38,7 +42,7 @@
 <Popover bind:visible anchor={button} direction="rtl">
 	<div class="flex flex-col gap-4">
 		{#if walletOptions}
-			<MenuWallet on:icMenuClick={() => (visible = false)} />
+			<MenuWallet on:icMenuClick={hidePopover} />
 		{/if}
 
 		{#if !settingsRoute}
@@ -68,6 +72,11 @@
 
 		<Hr />
 
-		<SignOut on:icLogoutTriggered={() => (visible = false)} />
+		<AboutWhat asMenuItem on:icOpenAboutModal={hidePopover} />
+		<AboutHow asMenuItem on:icOpenAboutModal={hidePopover} />
+
+		<Hr />
+
+		<SignOut on:icLogoutTriggered={hidePopover} />
 	</div>
 </Popover>

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -17,6 +17,9 @@
 	import { page } from '$app/stores';
 	import AboutHow from '$lib/components/hero/about/AboutHow.svelte';
 	import AboutWhat from '$lib/components/hero/about/AboutWhat.svelte';
+	import { modalAboutHow, modalAboutWhat } from '$lib/derived/modal.derived';
+	import AboutWhatModal from '$lib/components/hero/about/AboutWhatModal.svelte';
+	import AboutHowModal from '$lib/components/hero/about/AboutHowModal.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -80,3 +83,9 @@
 		<SignOut on:icLogoutTriggered={hidePopover} />
 	</div>
 </Popover>
+
+{#if $modalAboutWhat}
+	<AboutWhatModal />
+{:else if $modalAboutHow}
+	<AboutHowModal />
+{/if}

--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -8,6 +8,9 @@
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import AboutMenu from '$lib/components/hero/about/AboutMenu.svelte';
+	import { modalAboutHow, modalAboutWhat } from '$lib/derived/modal.derived';
+	import AboutWhatModal from '$lib/components/hero/about/AboutWhatModal.svelte';
+	import AboutHowModal from '$lib/components/hero/about/AboutHowModal.svelte';
 
 	let back = false;
 	$: back = isSubRoute($page);
@@ -44,3 +47,9 @@
 		{/if}
 	</div>
 </header>
+
+{#if $modalAboutWhat}
+	<AboutWhatModal />
+{:else if $modalAboutHow}
+	<AboutHowModal />
+{/if}

--- a/src/frontend/src/lib/components/hero/about/AboutItem.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutItem.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+	import IconInfo from '$lib/components/icons/IconInfo.svelte';
+
 	export let asMenuItem = false;
 </script>
 
-<button
-	class={asMenuItem ? '' : 'text-center text-white text-lg font-bold px-4 whitespace-nowrap'}
-	on:click
->
-	<slot name="label"></slot>
+<button class={asMenuItem ? '' : 'text-center text-white font-bold whitespace-nowrap'} on:click>
+	<div class="flex gap-2 items-center">
+		{#if asMenuItem}
+			<IconInfo />
+		{/if}
+		<slot name="label"></slot>
+	</div>
 </button>

--- a/src/frontend/src/lib/components/hero/about/AboutMenu.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutMenu.svelte
@@ -15,7 +15,7 @@
 	const hidePopover = () => (visible = false);
 </script>
 
-<div class="hidden md:flex gap-4">
+<div class="hidden md:flex gap-5">
 	<AboutWhat />
 	<AboutHow />
 </div>

--- a/src/frontend/src/lib/components/hero/about/AboutMenu.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutMenu.svelte
@@ -5,9 +5,6 @@
 	import IconMenu from '$lib/components/icons/IconMenu.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
-	import { modalAboutHow, modalAboutWhat } from '$lib/derived/modal.derived';
-	import AboutWhatModal from '$lib/components/hero/about/AboutWhatModal.svelte';
-	import AboutHowModal from '$lib/components/hero/about/AboutHowModal.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -35,9 +32,3 @@
 		</ul>
 	</Popover>
 </div>
-
-{#if $modalAboutWhat}
-	<AboutWhatModal />
-{:else if $modalAboutHow}
-	<AboutHowModal />
-{/if}

--- a/src/frontend/src/lib/components/icons/IconInfo.svelte
+++ b/src/frontend/src/lib/components/icons/IconInfo.svelte
@@ -1,0 +1,17 @@
+<!-- source: DFINITY foundation -->
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<g clip-path="url(#clip0_2754_3457)">
+		<path
+			d="M10 9.16667V13.3333M10 17.5C5.85786 17.5 2.5 14.1421 2.5 10C2.5 5.85786 5.85786 2.5 10 2.5C14.1421 2.5 17.5 5.85786 17.5 10C17.5 14.1421 14.1421 17.5 10 17.5ZM10.0415 6.66667V6.75L9.9585 6.75016V6.66667H10.0415Z"
+			stroke="black"
+			stroke-width="1.5"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+	</g>
+	<defs>
+		<clipPath id="clip0_2754_3457">
+			<rect width="20" height="20" fill="white" />
+		</clipPath>
+	</defs>
+</svg>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -554,7 +554,7 @@
 		},
 		"what": {
 			"text": {
-				"label": "What can I do with my tokens?",
+				"label": "What I can do with my tokens",
 				"title": "Utility",
 				"hold_crypto": "<strong>Hold crypto across networks</strong><br>Manage and transact with native Ethereum, Bitcoin <i>(coming soon)</i>, and Internet Computer assets. Powered by <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/chainfusion\">Chain Fusion</a>.",
 				"use_eth_dapps": "<strong>Use with Ethereum dapps</strong><br>$oisy_name is fully compatible with Ethereum Defi like <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://uniswap.org/\">Uniswap</a> thanks to the <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://walletconnect.com/\">WalletConnect</a> framework.",
@@ -563,7 +563,7 @@
 		},
 		"how": {
 			"text": {
-				"label": "How does $oisy_name work?",
+				"label": "How $oisy_name works",
 				"title": "Magic",
 				"self_custody": "<strong>Self-custody</strong><br>The key controlling your multi-chain assets is not controlled by a single entity nor has it ever existed as such. The key was generated using advanced cryptography that distributed key-shares among dedicated ICP replica nodes and signatures are created using <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/docs/current/developer-docs/smart-contracts/signatures/t-ecdsa\">threshold ECDSA</a>.",
 				"fully_on_chain": "<strong>Fully on-chain</strong><br>Not only the keys but the entire wallet application is <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/capabilities\">stored on chain</a> and served directly into users’ browsers from ICP. Therefore the entire wallet is secured by a decentralized trust model making it tamper-proof.",


### PR DESCRIPTION
# Motivation

We add `AboutWhat` and `AboutHow` buttons among the items in `Menu`. Furthermore, we include an icon in both of them: it will be used both for the menu when logged in and the menu when logged out (in small screen).

# Changes

- Add `IconInfo` to both button `AboutItem`.
- Include `AboutWhat` and `AboutHow` among the `Menu` items.
- Update the labels: from question to affirmation.
- Unrelated: adjust the spacing and the font size of the buttons.

# Tests

<img width="742" alt="Screenshot 2024-07-30 at 17 19 45" src="https://github.com/user-attachments/assets/5b65fcf7-8abb-496a-ab72-7371f55700ed">
<img width="284" alt="Screenshot 2024-07-30 at 17 19 53" src="https://github.com/user-attachments/assets/07ee32ea-fd63-4a9c-80c0-cb83761a9f7e">
<img width="744" alt="Screenshot 2024-07-30 at 17 20 18" src="https://github.com/user-attachments/assets/946ef8a5-3d15-43b6-9b5b-442dca84a6af">
<img width="290" alt="Screenshot 2024-07-30 at 17 20 24" src="https://github.com/user-attachments/assets/cdf552fc-7d9f-432c-8961-b71e95578058">
