### PR TITLE
fix(frontend): rollback pin tokens with balance at top PR #1779

### DIFF
--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -4,9 +4,8 @@ import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import { exchanges } from '$lib/derived/exchange.derived';
-import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenToPin } from '$lib/types/token';
-import { pinTokensAtTop, pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
+import { pinTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
@@ -32,10 +31,7 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 );
 
 export const sortedTokens: Readable<Token[]> = derived(
-	[tokens, tokensToPin, exchanges, balancesStore],
-	([$tokens, $tokensToPin, $exchanges, $balancesStore]) =>
-		pinTokensWithBalanceAtTop({
-			$tokens: pinTokensAtTop({ $tokens: sortTokens({ $tokens, $exchanges }), $tokensToPin }),
-			$balancesStore: $balancesStore
-		})
+	[tokens, tokensToPin, exchanges],
+	([$tokens, $tokensToPin, $exchanges]) =>
+		pinTokensAtTop({ $tokens: sortTokens({ $tokens, $exchanges }), $tokensToPin })
 );

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -1,29 +1,16 @@
 import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
-import type { BalancesData } from '$lib/stores/balances.store';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
-import type { Token, TokenUi } from '$lib/types/token';
-import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
-import { BigNumber } from '@ethersproject/bignumber';
+import type { Token } from '$lib/types/token';
+import { sortTokens } from '$lib/utils/tokens.utils';
 import { describe, expect, it } from 'vitest';
 
 const usd = 1;
 
-const bn0 = BigNumber.from(0);
-const bn50 = BigNumber.from(50);
-const bn100 = BigNumber.from(100);
-const bn200 = BigNumber.from(200);
-
 const tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
-
-vi.mock('$lib/utils/exchange.utils', () => ({
-	usdValue: vi.fn()
-}));
 
 describe('sortTokens', () => {
 	it('should sort tokens by market cap, then by name, and finally by network name', () => {
-		const tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
 		const exchanges: ExchangesData = {
 			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
 			[BTC_MAINNET_TOKEN.id]: { usd },
@@ -34,7 +21,6 @@ describe('sortTokens', () => {
 	});
 
 	it('should sort tokens with same market cap by name', () => {
-		const tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
 		const exchanges: ExchangesData = {
 			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
 			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
@@ -55,16 +41,13 @@ describe('sortTokens', () => {
 	});
 
 	it('should sort tokens with same market cap and name by network name', () => {
-		const tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN].map((token) => ({
-			...token,
-			name: 'Test Token'
-		}));
+		const newTokens: Token[] = tokens.map((token) => ({ ...token, name: 'Test Token' }));
 		const exchanges: ExchangesData = {
 			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
 			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: newTokens, $exchanges: exchanges });
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
 				...token,
@@ -74,118 +57,18 @@ describe('sortTokens', () => {
 	});
 
 	it('should sort tokens with same name by network name if market cap is not provided', () => {
-		const tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN].map((token) => ({
-			...token,
-			name: 'Test Token'
-		}));
+		const newTokens: Token[] = tokens.map((token) => ({ ...token, name: 'Test Token' }));
 		const exchanges: ExchangesData = {
 			[ICP_TOKEN.id]: { usd },
 			[BTC_MAINNET_TOKEN.id]: { usd },
 			[ETHEREUM_TOKEN.id]: { usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: newTokens, $exchanges: exchanges });
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
 				...token,
 				name: 'Test Token'
 			}))
 		);
-	});
-});
-
-describe('pinTokensWithBalanceAtTop', () => {
-	beforeEach(() => {
-		vi.resetAllMocks();
-	});
-
-	it('should pin tokens with balance at the top', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn100, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn50, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn200, certified: true }
-		};
-
-		const tokens: TokenUi[] = [
-			{ ...ICP_TOKEN, usdBalance: 100 },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			{ ...ETHEREUM_TOKEN, usdBalance: 200 }
-		];
-
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
-		expect(result).toEqual([
-			{ ...ETHEREUM_TOKEN, usdBalance: 200 },
-			{ ...ICP_TOKEN, usdBalance: 100 },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 }
-		]);
-	});
-
-	it('should return the same array if no tokens have balance', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn0, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn0, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn0, certified: true }
-		};
-
-		const tokens: TokenUi[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN].map((token) => ({
-			...token,
-			usdBalance: 0
-		}));
-
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
-		expect(result).toEqual(tokens);
-	});
-
-	it('should handle tokens with mixed balances correctly', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn0, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn50, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn0, certified: true }
-		};
-
-		const tokens: TokenUi[] = [
-			{ ...ICP_TOKEN, usdBalance: 0 },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			{ ...ETHEREUM_TOKEN, usdBalance: 0 }
-		];
-
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
-		expect(result).toEqual([
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			{ ...ICP_TOKEN, usdBalance: 0 },
-			{ ...ETHEREUM_TOKEN, usdBalance: 0 }
-		]);
-	});
-
-	it('should put tokens with no exchange price (undefined balance) after tokens with balance', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn200, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn100, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn100, certified: true }
-		};
-
-		const tokens: TokenUi[] = [
-			{ ...ICP_TOKEN },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			{ ...ETHEREUM_TOKEN, usdBalance: 200 }
-		];
-
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
-		expect(result).toEqual([
-			{ ...ETHEREUM_TOKEN, usdBalance: 200 },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			ICP_TOKEN
-		]);
 	});
 });


### PR DESCRIPTION
# Motivation

Rollback PR #1779 - Pin tokens with balance at the top - which introduces an endless loop. The sorting updates the stores, which in turn triggers Infura, which re-triggers the store, which re-triggers Infura, etc.

As a result, we are facing many Infura 429 errors and have exceeded the daily quota of requests.

# Changes

- Rollback PR #1779

# Screenshots

<img width="1535" alt="Capture d’écran 2024-07-30 à 17 35 55" src="https://github.com/user-attachments/assets/b30c5eac-7dc8-4728-aad4-8eb0a1abccef">




