### PR TITLE
refactor(frontend): adapt ThreeBackground size to container

### DIFF
--- a/src/frontend/src/lib/components/ui/ThreeBackground.svelte
+++ b/src/frontend/src/lib/components/ui/ThreeBackground.svelte
@@ -159,6 +159,7 @@ void main(){
 		return {
 			destroy() {
 				resizeObserver.unobserve(node);
+				resizeObserver.disconnect();
 			}
 		};
 	};

--- a/src/frontend/src/lib/components/ui/ThreeBackground.svelte
+++ b/src/frontend/src/lib/components/ui/ThreeBackground.svelte
@@ -112,7 +112,8 @@ void main(){
 		scene = new Scene();
 		camera = new PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
 		renderer = new WebGLRenderer();
-		renderer.setSize(container.clientWidth, container.clientHeight);
+		renderer.domElement.style.width = '100%';
+		renderer.domElement.style.height = '100%';
 		container.appendChild(renderer.domElement);
 
 		material = new ShaderMaterial({
@@ -148,23 +149,11 @@ void main(){
 		if (isNullish(container)) {
 			return;
 		}
-		renderer.setSize(container.clientWidth, container.clientHeight);
 		camera.aspect = container.clientWidth / container.clientHeight;
 		camera.updateProjectionMatrix();
-	};
-
-	const resizeAction = (node: HTMLElement) => {
-		const resizeObserver = new ResizeObserver(handleResize);
-		resizeObserver.observe(node);
-		return {
-			destroy() {
-				resizeObserver.unobserve(node);
-				resizeObserver.disconnect();
-			}
-		};
 	};
 </script>
 
 <svelte:window on:resize={handleResize} />
 
-<div use:resizeAction bind:this={container} class="absolute inset-0 bg-navy-blue"></div>
+<div bind:this={container} class="absolute inset-0 bg-navy-blue"></div>

--- a/src/frontend/src/lib/components/ui/ThreeBackground.svelte
+++ b/src/frontend/src/lib/components/ui/ThreeBackground.svelte
@@ -152,8 +152,18 @@ void main(){
 		camera.aspect = container.clientWidth / container.clientHeight;
 		camera.updateProjectionMatrix();
 	};
+
+	const resizeAction = (node: HTMLElement) => {
+		const resizeObserver = new ResizeObserver(handleResize);
+		resizeObserver.observe(node);
+		return {
+			destroy() {
+				resizeObserver.unobserve(node);
+			}
+		};
+	};
 </script>
 
 <svelte:window on:resize={handleResize} />
 
-<div bind:this={container} class="absolute inset-0 bg-navy-blue"></div>
+<div use:resizeAction bind:this={container} class="absolute inset-0 bg-navy-blue"></div>


### PR DESCRIPTION
# Motivation

The component ThreeBackground was not refreshing its size when the container changed (for example, when the user comes back from a token page). It was not clearly visible, but the height of the waves was smaller.