### PR TITLE
fix(frontend): wrong overflow-hidden in Hero

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -21,7 +21,7 @@
 	$: heroContent = usdTotal || summary;
 </script>
 
-<div class={`hero pb-4 md:pb-6 ${background} relative`}>
+<div class={`hero pb-4 md:pb-6 ${background}`}>
 	{#if $pseudoNetworkChainFusion}
 		<ThreeBackground />
 	{/if}
@@ -62,7 +62,6 @@
 			background: transparent;
 
 			position: relative;
-			overflow: hidden;
 		}
 	}
 </style>


### PR DESCRIPTION
# Motivation

In Hero component, with ChainFusion background, the overflow was hidden, leading to showing partially the menu popover. This was more clear with bigger menu.

### Before

<img width="1324" alt="Screenshot 2024-07-31 at 13 50 12" src="https://github.com/user-attachments/assets/9a5b7cc2-6d38-4091-8105-52c98b62d096">



### After

<img width="1322" alt="Screenshot 2024-07-31 at 13 49 56" src="https://github.com/user-attachments/assets/882a75a5-5545-4ab3-b4b1-6995398fb834">

