### PR TITLE
feat(frontend): increase debounce time of load balances

### DIFF
--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -15,7 +15,7 @@
 		]);
 	};
 
-	const debounceLoad = debounce(load);
+	const debounceLoad = debounce(load, 500);
 
 	$: $address, $enabledErc20NetworkTokens, debounceLoad();
 </script>


### PR DESCRIPTION
# Motivation

I don't know on mainnet but, at least locally, it seems that bumping the debounce time of the load balances from the default 300ms to 500ms can potentially save up to twice the calls to load the balances. While it is not a super solution nor an awesome engineered solution, it feels like given the current situation it's a pragmatic small improvement worth a shot.
