### PR TITLE
refactor(frontend): rename type ETH_ADDRESS to EthAddress

### DIFF
--- a/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
@@ -5,7 +5,7 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20Transaction } from '$eth/types/erc20-transaction';
 import type { WebSocketListener } from '$eth/types/listener';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -30,7 +30,7 @@ export class AlchemyErc20Provider {
 		listener
 	}: {
 		contract: Erc20Token;
-		address: ETH_ADDRESS;
+		address: EthAddress;
 		listener: (params: { hash: string; value: BigNumber }) => Promise<void>;
 	}): WebSocketListener => {
 		const erc20Contract = new ethers.Contract(contract.address, ERC20_ABI, this.provider);

--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -2,7 +2,7 @@ import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks.env';
 import { ALCHEMY_NETWORK_MAINNET, ALCHEMY_NETWORK_SEPOLIA } from '$env/networks.eth.env';
 import type { WebSocketListener } from '$eth/types/listener';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -68,7 +68,7 @@ export const initPendingTransactionsListener = ({
 	networkId,
 	hashesOnly = false
 }: {
-	toAddress: ETH_ADDRESS;
+	toAddress: EthAddress;
 	listener: Listener;
 	networkId: NetworkId;
 	hashesOnly?: boolean;

--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -1,7 +1,7 @@
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks.env';
 import { ETHERSCAN_NETWORK_HOMESTEAD, ETHERSCAN_NETWORK_SEPOLIA } from '$env/networks.eth.env';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -26,7 +26,7 @@ export class EtherscanProvider {
 		address,
 		startBlock
 	}: {
-		address: ETH_ADDRESS;
+		address: EthAddress;
 		startBlock?: BlockTag;
 	}): Promise<TransactionResponse[]> => this.provider.getHistory(address, startBlock);
 }

--- a/src/frontend/src/eth/providers/infura-ckerc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-ckerc20.providers.ts
@@ -3,7 +3,7 @@ import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks.
 import { CKERC20_ABI } from '$eth/constants/ckerc20.constants';
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -31,7 +31,7 @@ export class InfuraCkErc20Provider {
 	}: {
 		contract: Erc20ContractAddress;
 		erc20Contract: Erc20ContractAddress;
-		to: ETH_ADDRESS;
+		to: EthAddress;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const ckEthContract = new ethers.Contract(contractAddress, CKERC20_ABI, this.provider);
@@ -46,7 +46,7 @@ export class InfuraCkErc20Provider {
 	}: {
 		contract: Erc20ContractAddress;
 		erc20Contract: Erc20ContractAddress;
-		to: ETH_ADDRESS;
+		to: EthAddress;
 		amount: BigNumber;
 	}): Promise<PopulatedTransaction> => {
 		const erc20Contract = new ethers.Contract(contractAddress, CKERC20_ABI, this.provider);

--- a/src/frontend/src/eth/providers/infura-cketh.providers.ts
+++ b/src/frontend/src/eth/providers/infura-cketh.providers.ts
@@ -5,7 +5,7 @@ import type { ContractAddress } from '$eth/types/address';
 import type { Erc20Provider } from '$eth/types/contracts-providers';
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -33,8 +33,8 @@ export class InfuraCkETHProvider implements Erc20Provider {
 		to
 	}: {
 		contract: Erc20ContractAddress;
-		from: ETH_ADDRESS;
-		to: ETH_ADDRESS;
+		from: EthAddress;
+		to: EthAddress;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const ckEthContract = new ethers.Contract(contractAddress, CKETH_ABI, this.provider);
@@ -46,7 +46,7 @@ export class InfuraCkETHProvider implements Erc20Provider {
 		to
 	}: {
 		contract: ContractAddress;
-		to: ETH_ADDRESS;
+		to: EthAddress;
 	}): Promise<PopulatedTransaction> => {
 		const ckEthContract = new ethers.Contract(contractAddress, CKETH_ABI, this.provider);
 		return ckEthContract.populateTransaction.deposit(to);

--- a/src/frontend/src/eth/providers/infura-erc20-icp.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20-icp.providers.ts
@@ -4,7 +4,7 @@ import { ERC20_ICP_ABI } from '$eth/constants/erc20-icp.constants';
 import type { Erc20Provider, PopulateTransactionParams } from '$eth/types/contracts-providers';
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -31,8 +31,8 @@ export class InfuraErc20IcpProvider implements Erc20Provider {
 		amount
 	}: {
 		contract: Erc20ContractAddress;
-		to: ETH_ADDRESS;
-		from: ETH_ADDRESS;
+		to: EthAddress;
+		from: EthAddress;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ICP_ABI, this.provider);

--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -4,7 +4,7 @@ import { ERC20_ABI } from '$eth/constants/erc20.constants';
 import type { Erc20Provider } from '$eth/types/contracts-providers';
 import type { Erc20ContractAddress, Erc20Metadata } from '$eth/types/erc20';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -45,7 +45,7 @@ export class InfuraErc20Provider implements Erc20Provider {
 		address
 	}: {
 		contract: Erc20ContractAddress;
-		address: ETH_ADDRESS;
+		address: EthAddress;
 	}): Promise<BigNumber> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);
 		return erc20Contract.balanceOf(address);
@@ -58,8 +58,8 @@ export class InfuraErc20Provider implements Erc20Provider {
 		amount
 	}: {
 		contract: Erc20ContractAddress;
-		from: ETH_ADDRESS;
-		to: ETH_ADDRESS;
+		from: EthAddress;
+		to: EthAddress;
 		amount: BigNumber;
 	}): Promise<BigNumber> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);
@@ -74,7 +74,7 @@ export class InfuraErc20Provider implements Erc20Provider {
 		amount
 	}: {
 		contract: Erc20ContractAddress;
-		to: ETH_ADDRESS;
+		to: EthAddress;
 		amount: BigNumber;
 	}): Promise<PopulatedTransaction> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);
@@ -87,7 +87,7 @@ export class InfuraErc20Provider implements Erc20Provider {
 		amount
 	}: {
 		contract: Erc20ContractAddress;
-		spender: ETH_ADDRESS;
+		spender: EthAddress;
 		amount: BigNumber;
 	}): Promise<PopulatedTransaction> => {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);

--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -1,7 +1,7 @@
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks.env';
 import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks.eth.env';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -23,14 +23,14 @@ export class InfuraProvider {
 		this.provider = new InfuraProviderLib(this.network, API_KEY);
 	}
 
-	balance = (address: ETH_ADDRESS): Promise<BigNumber> => this.provider.getBalance(address);
+	balance = (address: EthAddress): Promise<BigNumber> => this.provider.getBalance(address);
 
 	getFeeData = (): Promise<FeeData> => this.provider.getFeeData();
 
 	sendTransaction = (signedTransaction: string): Promise<TransactionResponse> =>
 		this.provider.sendTransaction(signedTransaction);
 
-	getTransactionCount = (address: ETH_ADDRESS): Promise<number> =>
+	getTransactionCount = (address: EthAddress): Promise<number> =>
 		this.provider.getTransactionCount(address, 'pending');
 
 	getBlockNumber = (): Promise<number> => this.provider.getBlockNumber();

--- a/src/frontend/src/eth/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/eth/providers/wallet-connect.providers.ts
@@ -7,7 +7,7 @@ import {
 	WALLET_CONNECT_METADATA
 } from '$eth/constants/wallet-connect.constants';
 import type { WalletConnectListener } from '$eth/types/wallet-connect';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import { Core } from '@walletconnect/core';
 import type { JsonRpcResponse } from '@walletconnect/jsonrpc-utils';
 import { formatJsonRpcResult, type ErrorResponse } from '@walletconnect/jsonrpc-utils';
@@ -21,7 +21,7 @@ export const initWalletConnect = async ({
 	address
 }: {
 	uri: string;
-	address: ETH_ADDRESS;
+	address: EthAddress;
 }): Promise<WalletConnectListener> => {
 	const clearLocalStorage = () => {
 		const keys = Object.keys(localStorage).filter((key) => key.startsWith('wc@'));

--- a/src/frontend/src/eth/rest/etherscan.rest.ts
+++ b/src/frontend/src/eth/rest/etherscan.rest.ts
@@ -3,7 +3,7 @@ import { ETHERSCAN_API_URL_HOMESTEAD, ETHERSCAN_API_URL_SEPOLIA } from '$env/net
 import type { Erc20Token } from '$eth/types/erc20';
 import type { EtherscanRestTransaction } from '$eth/types/etherscan-transaction';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Transaction } from '$lib/types/transaction';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -20,7 +20,7 @@ export class EtherscanRest {
 		address,
 		contract: { address: contractAddress }
 	}: {
-		address: ETH_ADDRESS;
+		address: EthAddress;
 		contract: Erc20Token;
 	}): Promise<Transaction[]> => {
 		const url = new URL(this.apiUrl);

--- a/src/frontend/src/eth/services/eth-listener.services.ts
+++ b/src/frontend/src/eth/services/eth-listener.services.ts
@@ -8,7 +8,7 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { WebSocketListener } from '$eth/types/listener';
 import type { WalletConnectListener } from '$eth/types/wallet-connect';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { BigNumber } from '@ethersproject/bignumber';
@@ -19,7 +19,7 @@ export const initTransactionsListener = ({
 	address
 }: {
 	token: Token;
-	address: ETH_ADDRESS;
+	address: EthAddress;
 }): WebSocketListener => {
 	if (isSupportedEthTokenId(token.id)) {
 		return initEthPendingTransactionsListenerProvider({
@@ -55,5 +55,5 @@ export const initMinedTransactionsListener = ({
 
 export const initWalletConnectListener = async (params: {
 	uri: string;
-	address: ETH_ADDRESS;
+	address: EthAddress;
 }): Promise<WalletConnectListener> => initWalletConnect(params);

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -7,15 +7,15 @@ import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import { isDestinationContractAddress } from '$eth/utils/send.utils';
-import type { ETH_ADDRESS, OptionAddress } from '$lib/types/address';
+import type { EthAddress, OptionAddress } from '$lib/types/address';
 import type { Network } from '$lib/types/network';
 import { isNetworkICP } from '$lib/utils/network.utils';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export interface GetFeeData {
-	from: ETH_ADDRESS;
-	to: ETH_ADDRESS;
+	from: EthAddress;
+	to: EthAddress;
 }
 
 export const getEthFeeData = async ({

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -23,7 +23,7 @@ import { signTransaction } from '$lib/api/backend.api';
 import { DEFAULT_ETHEREUM_NETWORK } from '$lib/constants/networks.constants';
 import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { TransferParams } from '$lib/types/send';
 import type { TransactionFeeData } from '$lib/types/transaction';
@@ -187,7 +187,7 @@ const erc20ContractPrepareApprove = async ({
 		nonce: number;
 		gas: bigint;
 		networkId: NetworkId;
-		spender: ETH_ADDRESS;
+		spender: EthAddress;
 	} & Pick<SendParams, 'token'>): Promise<SignRequest> => {
 	const { populateApprove } = infuraErc20Providers(networkId);
 

--- a/src/frontend/src/eth/types/contracts-providers.ts
+++ b/src/frontend/src/eth/types/contracts-providers.ts
@@ -1,11 +1,11 @@
 import type { Erc20ContractAddress } from '$eth/types/erc20';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { BigNumber } from '@ethersproject/bignumber';
 import type { PopulatedTransaction } from '@ethersproject/contracts';
 
 export interface PopulateTransactionParams {
 	contract: Erc20ContractAddress;
-	to: ETH_ADDRESS;
+	to: EthAddress;
 }
 
 export type CkEthPopulateTransaction = (
@@ -23,8 +23,8 @@ export interface Erc20Provider {
 
 	getFeeData(params: {
 		contract: Erc20ContractAddress;
-		from: ETH_ADDRESS;
-		to: ETH_ADDRESS;
+		from: EthAddress;
+		to: EthAddress;
 		amount: BigNumber;
 	}): Promise<BigNumber>;
 }

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -16,7 +16,7 @@ import type { IcCkLinkedAssets, IcToken, IcTransactionUi } from '$icp/types/ic';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
 import { emit } from '$lib/utils/events.utils';
@@ -31,7 +31,7 @@ export const loadCkEthereumPendingTransactions = async ({
 	twinToken,
 	...rest
 }: {
-	toAddress: ETH_ADDRESS;
+	toAddress: EthAddress;
 	token: IcToken;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
@@ -57,12 +57,12 @@ const loadCkETHPendingTransactions = async ({
 	twinToken,
 	...rest
 }: {
-	toAddress: ETH_ADDRESS;
+	toAddress: EthAddress;
 	token: IcToken;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
 } & IcCkLinkedAssets) => {
-	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
+	const logsTopics = (to: EthAddress): (string | null)[] => [
 		CKETH_HELPER_CONTRACT_SIGNATURE,
 		null,
 		to
@@ -82,12 +82,12 @@ const loadCkErc20PendingTransactions = async ({
 	twinToken,
 	...rest
 }: {
-	toAddress: ETH_ADDRESS;
+	toAddress: EthAddress;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
 	token: IcToken;
 } & IcCkLinkedAssets) => {
-	const logsTopics = (to: ETH_ADDRESS): (string | null)[] => [
+	const logsTopics = (to: EthAddress): (string | null)[] => [
 		CKERC20_HELPER_CONTRACT_SIGNATURE,
 		null,
 		null,
@@ -112,10 +112,10 @@ const loadPendingTransactions = async ({
 	token,
 	mapPendingTransaction
 }: {
-	toAddress: ETH_ADDRESS;
+	toAddress: EthAddress;
 	lastObservedBlockNumber: bigint;
 	identity: OptionIdentity;
-	logsTopics: (to: ETH_ADDRESS) => (string | null)[];
+	logsTopics: (to: EthAddress) => (string | null)[];
 	token: IcToken;
 	mapPendingTransaction: (params: MapCkEthereumPendingTransactionParams) => IcTransactionUi;
 } & IcCkLinkedAssets) => {

--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -8,13 +8,13 @@ import type {
 	UserToken
 } from '$declarations/backend/backend.did';
 import { getBackendActor } from '$lib/actors/actors.ic';
-import type { ECDSA_PUBLIC_KEY } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
 import type { Principal } from '@dfinity/principal';
 import { toNullable, type QueryParams } from '@dfinity/utils';
 
-export const getEthAddress = async (identity: OptionIdentity): Promise<ECDSA_PUBLIC_KEY> => {
+export const getEthAddress = async (identity: OptionIdentity): Promise<EthAddress> => {
 	const { caller_eth_address } = await getBackendActor({ identity });
 	return caller_eth_address();
 };

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -3,7 +3,7 @@ import { getIdbEthAddress, setIdbEthAddress, updateIdbEthAddressLastUsage } from
 import { addressStore } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -35,7 +35,7 @@ const saveEthAddressForFutureSignIn = async ({
 	address
 }: {
 	identity: OptionIdentity;
-	address: ETH_ADDRESS;
+	address: EthAddress;
 }) => {
 	// Should not happen given the current layout and guards. Moreover, the backend throws an error if the caller is anonymous.
 	assertNonNullish(identity, 'Cannot continue without an identity.');

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -1,8 +1,8 @@
-import type { ECDSA_PUBLIC_KEY } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 import { writable, type Readable } from 'svelte/store';
 
 export interface CertifiedAddressData {
-	address: ECDSA_PUBLIC_KEY;
+	address: EthAddress;
 	certified: boolean;
 }
 

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -1,4 +1,3 @@
-export type ETH_ADDRESS = string;
-export type ECDSA_PUBLIC_KEY = ETH_ADDRESS;
+export type EthAddress = string;
 
-export type OptionAddress = ECDSA_PUBLIC_KEY | undefined | null;
+export type OptionAddress = EthAddress | undefined | null;

--- a/src/frontend/src/lib/types/idb.ts
+++ b/src/frontend/src/lib/types/idb.ts
@@ -1,7 +1,7 @@
-import type { ETH_ADDRESS } from '$lib/types/address';
+import type { EthAddress } from '$lib/types/address';
 
 export interface IdbEthAddress {
-	address: ETH_ADDRESS;
+	address: EthAddress;
 	createdAtTimestamp: number;
 	lastUsedTimestamp: number;
 }


### PR DESCRIPTION
# Motivation

`ETH_ADDRESS`  all capitals does not make sense anymore. `ECDSA_PUBLIC_KEY` is not that useful anymore.

# Changes

- Remove `ECDSA_PUBLIC_KEY`.
- Rename `ETH_ADDRESS` into `EthAddress`.
