### PR TITLE
fix(frontend): Send modal will provide info if there are no tokens in the list

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -26,6 +26,10 @@
 	{/each}
 </TokensSkeletons>
 
+{#if tokens.length === 0}
+	<p class="mt-4 text-dark opacity-50">{$i18n.tokens.manage.text.all_tokens_zero_balance}</p>
+{/if}
+
 <button class="secondary full center text-center" on:click={modalStore.close}>
 	{$i18n.core.text.close}
 </button>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -356,7 +356,8 @@
 				"do_not_see_import": "Don’t see your token? Import",
 				"clear_filter": "Clear filter",
 				"manage_for_network": "Managing tokens for $network",
-				"network": "Network"
+				"network": "Network",
+				"all_tokens_zero_balance": "All tokens have zero balance."
 			},
 			"placeholder": {
 				"select_network": "Select the network"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -324,6 +324,7 @@ interface I18nTokens {
 			clear_filter: string;
 			manage_for_network: string;
 			network: string;
+			all_tokens_zero_balance: string;
 		};
 		placeholder: { select_network: string };
 		info: { outdated_index_canister: string; no_changes: string };


### PR DESCRIPTION
# Motivation

The `Send` modal was providing no feedback when there are no tokens with a non-zero balance, so that the list is empty.
