### PR TITLE
build(frontend): update gix-cmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@dfinity/candid": "^1.4.0",
 				"@dfinity/ckbtc": "^2.5.0",
 				"@dfinity/cketh": "^3.2.0",
-				"@dfinity/gix-components": "^4.5.0",
+				"@dfinity/gix-components": "^4.6.0",
 				"@dfinity/ic-management": "^5.1.0",
 				"@dfinity/ledger-icp": "^2.4.0",
 				"@dfinity/ledger-icrc": "^2.4.0",
@@ -687,12 +687,12 @@
 			}
 		},
 		"node_modules/@dfinity/gix-components": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.5.0.tgz",
-			"integrity": "sha512-AU79vJHzD6amDY7yZcNHdH2ztm5apo5uaLkrGadCTGYTzj4pY0YF31xlN9K1psCXuo97dgXn5U3KsKQY9OzKLg==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.6.0.tgz",
+			"integrity": "sha512-/J/UGCwi1ci7++8680+A+4jCFsx7W0LcohphFODLamMilTqmpZL2tPfP1aZFb1BotkCStN4Yj9Mz3WWEo5FAWQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"dompurify": "^3.1.5",
+				"dompurify": "^3.1.6",
 				"html5-qrcode": "^2.3.8",
 				"qr-creator": "^1.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@dfinity/candid": "^1.4.0",
 		"@dfinity/ckbtc": "^2.5.0",
 		"@dfinity/cketh": "^3.2.0",
-		"@dfinity/gix-components": "^4.5.0",
+		"@dfinity/gix-components": "^4.6.0",
 		"@dfinity/ic-management": "^5.1.0",
 		"@dfinity/ledger-icp": "^2.4.0",
 		"@dfinity/ledger-icrc": "^2.4.0",


### PR DESCRIPTION
# Motivation

We have released `gix-cmp` which supports `sass` v1.77.8. So it might become useful the day we also bump sass.
