### PR TITLE
feat(backend): Add migration state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk-timers"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fdca8e1d9ffb65ae68019b342c182009de9dc206fd849db0b0e90ee19f6fa4"
+dependencies = [
+ "futures",
+ "ic-cdk 0.15.0",
+ "ic0 0.23.0",
+ "serde",
+ "serde_bytes",
+ "slotmap",
+]
+
+[[package]]
 name = "ic-certification"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=e69bcc7b319cbb3ebc22ec55af35287741244db6#e69bcc7b319cbb3ebc22ec55af35287741244db6"
@@ -3710,6 +3724,7 @@ dependencies = [
  "ic-canister-sig-creation",
  "ic-cdk 0.15.0",
  "ic-cdk-macros 0.15.0",
+ "ic-cdk-timers",
  "ic-metrics-encoder",
  "ic-verifiable-credentials",
  "serde",
@@ -3763,6 +3778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
  "erased-serde",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 [workspace.dependencies]
 ic-cdk = "0.15.0"
 ic-cdk-macros = "0.15.0"
+ic-cdk-timers = "0.9.0"
 ic-stable-structures = "0.6.4"
 ic-metrics-encoder = "1.1.1"
 ic-canister-sig-creation = "1.0.1"

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -78,6 +78,17 @@ type ListUsersResponse = record {
   users : vec OisyUser;
   matches_max_length : nat64;
 };
+type MigrationProgress = variant {
+  MigratedUserTokensUpTo : principal;
+  TargetPreCheckOk;
+  MigratedCustomTokensUpTo : principal;
+  Locked;
+  CheckingTargetCanister;
+  TargetLocked;
+  Completed;
+  Pending;
+};
+type MigrationReport = record { to : principal; progress : MigrationProgress };
 type OisyUser = record {
   "principal" : principal;
   pouh_verified : bool;
@@ -140,6 +151,7 @@ service : (Arg) -> {
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
   list_users : (ListUsersRequest) -> (ListUsersResponse) query;
+  migration : () -> (opt MigrationReport) query;
   personal_sign : (text) -> (text);
   remove_user_token : (UserTokenId) -> ();
   set_custom_token : (CustomToken) -> ();

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -78,6 +78,17 @@ type ListUsersResponse = record {
   users : vec OisyUser;
   matches_max_length : nat64;
 };
+type MigrationProgress = variant {
+  MigratedUserTokensUpTo : principal;
+  TargetPreCheckOk;
+  MigratedCustomTokensUpTo : principal;
+  Locked;
+  CheckingTargetCanister;
+  TargetLocked;
+  Completed;
+  Pending;
+};
+type MigrationReport = record { to : principal; progress : MigrationProgress };
 type OisyUser = record {
   "principal" : principal;
   pouh_verified : bool;
@@ -140,6 +151,7 @@ service : (Arg) -> {
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
   list_users : (ListUsersRequest) -> (ListUsersResponse) query;
+  migration : () -> (opt MigrationReport) query;
   personal_sign : (text) -> (text);
   remove_user_token : (UserTokenId) -> ();
   set_custom_token : (CustomToken) -> ();

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -87,6 +87,19 @@ export interface ListUsersResponse {
 	users: Array<OisyUser>;
 	matches_max_length: bigint;
 }
+export type MigrationProgress =
+	| { MigratedUserTokensUpTo: Principal }
+	| { TargetPreCheckOk: null }
+	| { MigratedCustomTokensUpTo: Principal }
+	| { Locked: null }
+	| { CheckingTargetCanister: null }
+	| { TargetLocked: null }
+	| { Completed: null }
+	| { Pending: null };
+export interface MigrationReport {
+	to: Principal;
+	progress: MigrationProgress;
+}
 export interface OisyUser {
 	principal: Principal;
 	pouh_verified: boolean;
@@ -152,6 +165,7 @@ export interface _SERVICE {
 	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
 	list_user_tokens: ActorMethod<[], Array<UserToken>>;
 	list_users: ActorMethod<[ListUsersRequest], ListUsersResponse>;
+	migration: ActorMethod<[], [] | [MigrationReport]>;
 	personal_sign: ActorMethod<[string], string>;
 	remove_user_token: ActorMethod<[UserTokenId], undefined>;
 	set_custom_token: ActorMethod<[CustomToken], undefined>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -134,6 +134,20 @@ export const idlFactory = ({ IDL }) => {
 		users: IDL.Vec(OisyUser),
 		matches_max_length: IDL.Nat64
 	});
+	const MigrationProgress = IDL.Variant({
+		MigratedUserTokensUpTo: IDL.Principal,
+		TargetPreCheckOk: IDL.Null,
+		MigratedCustomTokensUpTo: IDL.Principal,
+		Locked: IDL.Null,
+		CheckingTargetCanister: IDL.Null,
+		TargetLocked: IDL.Null,
+		Completed: IDL.Null,
+		Pending: IDL.Null
+	});
+	const MigrationReport = IDL.Record({
+		to: IDL.Principal,
+		progress: MigrationProgress
+	});
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -165,6 +179,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)]),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)]),
 		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse]),
+		migration: IDL.Func([], [IDL.Opt(MigrationReport)]),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -134,6 +134,20 @@ export const idlFactory = ({ IDL }) => {
 		users: IDL.Vec(OisyUser),
 		matches_max_length: IDL.Nat64
 	});
+	const MigrationProgress = IDL.Variant({
+		MigratedUserTokensUpTo: IDL.Principal,
+		TargetPreCheckOk: IDL.Null,
+		MigratedCustomTokensUpTo: IDL.Principal,
+		Locked: IDL.Null,
+		CheckingTargetCanister: IDL.Null,
+		TargetLocked: IDL.Null,
+		Completed: IDL.Null,
+		Pending: IDL.Null
+	});
+	const MigrationReport = IDL.Record({
+		to: IDL.Principal,
+		progress: MigrationProgress
+	});
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
@@ -165,6 +179,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], ['query']),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)], ['query']),
 		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse], ['query']),
+		migration: IDL.Func([], [IDL.Opt(MigrationReport)], ['query']),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -8,6 +8,7 @@ candid = { workspace = true }
 ic-canister-sig-creation = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
+ic-cdk-timers = { workspace = true }
 ic-metrics-encoder = { workspace = true }
 ic-verifiable-credentials = { workspace = true }
 serde = { workspace = true }

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -3,7 +3,10 @@ use crate::types::token::UserToken;
 use crate::types::user_profile::{
     AddUserCredentialError, OisyUser, StoredUserProfile, UserCredential, UserProfile,
 };
-use crate::types::{Config, CredentialType, InitArg, Timestamp, TokenVersion, Version};
+use crate::types::{
+    ApiEnabled, Config, CredentialType, InitArg, Migration, MigrationReport, Timestamp,
+    TokenVersion, Version,
+};
 use candid::Principal;
 use ic_canister_sig_creation::{extract_raw_root_pk_from_der, IC_ROOT_PK_DER};
 use std::collections::BTreeMap;
@@ -175,4 +178,38 @@ impl OisyUser {
             updated_timestamp: user.updated_timestamp,
         }
     }
+}
+
+impl From<&Migration> for MigrationReport {
+    fn from(migration: &Migration) -> Self {
+        MigrationReport {
+            to: migration.to,
+            progress: migration.progress,
+        }
+    }
+}
+
+impl Default for ApiEnabled {
+    fn default() -> Self {
+        Self::Enabled
+    }
+}
+impl ApiEnabled {
+    #[must_use]
+    pub fn readable(&self) -> bool {
+        matches!(self, Self::Enabled | Self::ReadOnly)
+    }
+    #[must_use]
+    pub fn writable(&self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+}
+#[test]
+fn test_api_enabled() {
+    assert_eq!(ApiEnabled::Enabled.readable(), true);
+    assert_eq!(ApiEnabled::Enabled.writable(), true);
+    assert_eq!(ApiEnabled::ReadOnly.readable(), true);
+    assert_eq!(ApiEnabled::ReadOnly.writable(), false);
+    assert_eq!(ApiEnabled::Disabled.readable(), false);
+    assert_eq!(ApiEnabled::Disabled.writable(), false);
 }

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -243,6 +243,7 @@ pub mod user_profile {
 #[derive(CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum MigrationProgress {
     // WARNING: The following are subject to change.  The migration has NOT been implemented yet.
+    // TODO: Remove warning once the migration has been implemented.
     /// Migration has been requested.
     #[default]
     Pending,

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -36,30 +36,6 @@ pub enum ApiEnabled {
     ReadOnly,
     Disabled,
 }
-impl Default for ApiEnabled {
-    fn default() -> Self {
-        Self::Enabled
-    }
-}
-impl ApiEnabled {
-    #[must_use]
-    pub fn readable(&self) -> bool {
-        matches!(self, Self::Enabled | Self::ReadOnly)
-    }
-    #[must_use]
-    pub fn writable(&self) -> bool {
-        matches!(self, Self::Enabled)
-    }
-}
-#[test]
-fn test_api_enabled() {
-    assert_eq!(ApiEnabled::Enabled.readable(), true);
-    assert_eq!(ApiEnabled::Enabled.writable(), true);
-    assert_eq!(ApiEnabled::ReadOnly.readable(), true);
-    assert_eq!(ApiEnabled::ReadOnly.writable(), false);
-    assert_eq!(ApiEnabled::Disabled.readable(), false);
-    assert_eq!(ApiEnabled::Disabled.writable(), false);
-}
 
 #[derive(CandidType, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Guards {
@@ -301,15 +277,6 @@ pub struct Migration {
 pub struct MigrationReport {
     pub to: Principal,
     pub progress: MigrationProgress,
-}
-
-impl From<&Migration> for MigrationReport {
-    fn from(migration: &Migration) -> Self {
-        MigrationReport {
-            to: migration.to,
-            progress: migration.progress,
-        }
-    }
 }
 
 #[derive(CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
# Motivation
The user data migration is performed by a timer, in multiple steps.  The timer ID and current progress need to be stored in the canister.

# Changes
- Define a data structure to store the migration state.
- Add an API to read the canister state.
- Tidy: In accordance with the convention of this repository, the `ApiEnabled` struct implementations have been moved into ` impls.rs`

# Tests
None, this data is not used yet.