### PR TITLE
style(frontend): adjust text style for AboutItem

### DIFF
--- a/src/frontend/src/lib/components/hero/about/AboutItem.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutItem.svelte
@@ -4,7 +4,7 @@
 	export let asMenuItem = false;
 </script>
 
-<button class={asMenuItem ? '' : 'text-center text-white font-bold whitespace-nowrap'} on:click>
+<button class={asMenuItem ? 'text' : 'text-center text-white font-bold whitespace-nowrap'} on:click>
 	<div class="flex gap-2 items-center">
 		{#if asMenuItem}
 			<IconInfo />


### PR DESCRIPTION
# Motivation

When `AboutItem` is part of a menu, it does not behave as standard item in menu (no change in color when hovering for example). This PR adjusts it.
