### PR TITLE
refactor(frontend): create Link component

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -11,13 +11,13 @@
 	import IconSettings from '$lib/components/icons/IconSettings.svelte';
 	import IconGitHub from '$lib/components/icons/IconGitHub.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
 	import ButtonHero from '$lib/components/ui/ButtonHero.svelte';
 	import MenuWallet from '$lib/components/core/MenuWallet.svelte';
 	import { page } from '$app/stores';
 	import AboutHow from '$lib/components/hero/about/AboutHow.svelte';
 	import AboutWhat from '$lib/components/hero/about/AboutWhat.svelte';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils.js';
+	import Link from '$lib/components/ui/Link.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -47,10 +47,12 @@
 		{/if}
 
 		{#if !settingsRoute}
-			<ButtonMenu ariaLabel={$i18n.navigation.alt.more_settings} on:click={gotoSettings}>
-				<IconSettings />
+			<!-- If the url is passed as href instead of click event, the pages refreshes. -->
+			<!-- After a few tries, it seems it is a behavior that happens only inside the popover. -->
+			<Link href={null} ariaLabel={$i18n.navigation.alt.more_settings} on:click={gotoSettings}>
+				<IconSettings slot="icon" />
 				{$i18n.settings.text.title}
-			</ButtonMenu>
+			</Link>
 
 			<Hr />
 		{/if}
@@ -74,16 +76,10 @@
 
 		<Hr />
 
-		<a
-			href={OISY_REPO_URL}
-			rel="external noopener noreferrer"
-			target="_blank"
-			class="flex gap-2 items-center no-underline"
-			aria-label={$i18n.navigation.text.source_code_on_github}
-		>
-			<IconGitHub />
+		<Link href={OISY_REPO_URL} ariaLabel={$i18n.navigation.text.source_code_on_github} external>
+			<IconGitHub slot="icon" />
 			{$i18n.navigation.text.source_code}
-		</a>
+		</Link>
 
 		<Hr />
 

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -47,7 +47,7 @@
 			<Link
 				href={settingsUrl}
 				ariaLabel={$i18n.navigation.alt.more_settings}
-				on:click={hidePopover}
+				on:icBeforeNavigate={hidePopover}
 			>
 				<IconSettings slot="icon" />
 				{$i18n.settings.text.title}

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -2,7 +2,6 @@
 	import { Popover } from '@dfinity/gix-components';
 	import SignOut from '$lib/components/core/SignOut.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
-	import { goto } from '$app/navigation';
 	import { OISY_REPO_URL } from '$lib/constants/oisy.constants';
 	import IconUser from '$lib/components/icons/IconUser.svelte';
 	import { networkId } from '$lib/derived/network.derived';
@@ -24,10 +23,8 @@
 
 	const hidePopover = () => (visible = false);
 
-	const gotoSettings = async () => {
-		hidePopover();
-		await goto(`/settings?${networkParam($networkId)}`);
-	};
+	let settingsUrl: string;
+	$: settingsUrl = `/settings?${networkParam($networkId)}`;
 
 	let settingsRoute = false;
 	$: settingsRoute = isRouteSettings($page);
@@ -47,9 +44,11 @@
 		{/if}
 
 		{#if !settingsRoute}
-			<!-- If the URL is passed as href instead of click event, the pages refreshes. -->
-			<!-- After a few tries, it seems it is a behavior that happens only inside the popover. -->
-			<Link href={null} ariaLabel={$i18n.navigation.alt.more_settings} on:click={gotoSettings}>
+			<Link
+				href={settingsUrl}
+				ariaLabel={$i18n.navigation.alt.more_settings}
+				on:click={hidePopover}
+			>
 				<IconSettings slot="icon" />
 				{$i18n.settings.text.title}
 			</Link>

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -47,7 +47,7 @@
 		{/if}
 
 		{#if !settingsRoute}
-			<!-- If the url is passed as href instead of click event, the pages refreshes. -->
+			<!-- If the URL is passed as href instead of click event, the pages refreshes. -->
 			<!-- After a few tries, it seems it is a behavior that happens only inside the popover. -->
 			<Link href={null} ariaLabel={$i18n.navigation.alt.more_settings} on:click={gotoSettings}>
 				<IconSettings slot="icon" />

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
+	import Link from '$lib/components/ui/Link.svelte';
 
 	export let href: string;
 	export let ariaLabel: string;
@@ -10,22 +11,9 @@
 	export let fullWidth = false;
 </script>
 
-<a
-	{href}
-	rel="external noopener noreferrer"
-	target="_blank"
-	class="inline-flex gap-2 items-center no-underline"
-	aria-label={ariaLabel}
-	style={`${inline ? 'vertical-align: sub;' : ''}`}
-	class:text-blue={color === 'blue'}
-	class:hover:text-dark-blue={color === 'blue'}
-	class:active:text-dark-blue={color === 'blue'}
-	class:hover:text-blue={color === 'inherit'}
-	class:active:text-blue={color === 'inherit'}
-	class:w-full={fullWidth}
->
+<Link {href} {ariaLabel} {iconVisible} {inline} {color} {fullWidth} external>
 	{#if iconVisible}
-		<IconExternalLink size={iconSize} />
+		<IconExternalLink size={iconSize} slot="icon" />
 	{/if}
 	<slot />
-</a>
+</Link>

--- a/src/frontend/src/lib/components/ui/Link.svelte
+++ b/src/frontend/src/lib/components/ui/Link.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	export let href: string | null;
+	export let ariaLabel: string;
+	export let external = false;
+	export let iconVisible = true;
+	export let inline = false;
+	export let color: 'blue' | 'inherit' = 'inherit';
+	export let fullWidth = false;
+</script>
+
+<a
+	{href}
+	rel={external ? 'external noopener noreferrer' : undefined}
+	target={external ? '_blank' : undefined}
+	class="inline-flex gap-2 items-center no-underline"
+	aria-label={ariaLabel}
+	style={inline ? 'vertical-align: sub;' : ''}
+	class:text-blue={color === 'blue'}
+	class:hover:text-dark-blue={color === 'blue'}
+	class:active:text-dark-blue={color === 'blue'}
+	class:hover:text-blue={color === 'inherit'}
+	class:active:text-blue={color === 'inherit'}
+	class:w-full={fullWidth}
+	on:click
+>
+	{#if iconVisible}
+		<slot name="icon" />
+	{/if}
+	<slot />
+</a>

--- a/src/frontend/src/lib/components/ui/Link.svelte
+++ b/src/frontend/src/lib/components/ui/Link.svelte
@@ -1,11 +1,27 @@
 <script lang="ts">
-	export let href: string | null;
+	import { goto } from '$app/navigation';
+	import { createEventDispatcher } from 'svelte';
+
+	export let href: string;
 	export let ariaLabel: string;
 	export let external = false;
 	export let iconVisible = true;
 	export let inline = false;
 	export let color: 'blue' | 'inherit' = 'inherit';
 	export let fullWidth = false;
+
+	const dispatch = createEventDispatcher();
+
+	// Custom click handler to guarantee that it prevents default browser behaviour (full page reload)
+	// when the link is internal (not external). A practical example is when the <a> tag is used
+	// inside a Popover component.
+	const onClick = (event: MouseEvent) => {
+		if (!external) {
+			event.preventDefault();
+			goto(href);
+		}
+		dispatch('click');
+	};
 </script>
 
 <a
@@ -21,7 +37,7 @@
 	class:hover:text-blue={color === 'inherit'}
 	class:active:text-blue={color === 'inherit'}
 	class:w-full={fullWidth}
-	on:click
+	on:click={onClick}
 >
 	{#if iconVisible}
 		<slot name="icon" />

--- a/src/frontend/src/lib/components/ui/Link.svelte
+++ b/src/frontend/src/lib/components/ui/Link.svelte
@@ -15,11 +15,12 @@
 	// Custom click handler to guarantee that it prevents default browser behaviour (full page reload)
 	// when the link is internal (not external). A practical example is when the <a> tag is used
 	// inside a Popover component.
-	const onClick = () => {
+	const onClick = (event: MouseEvent) => {
 		if (!external) {
+			event.preventDefault();
 			goto(href);
-			dispatch('click');
 		}
+		dispatch('click');
 	};
 </script>
 
@@ -36,7 +37,7 @@
 	class:hover:text-blue={color === 'inherit'}
 	class:active:text-blue={color === 'inherit'}
 	class:w-full={fullWidth}
-	on:click|preventDefault={onClick}
+	on:click={onClick}
 >
 	{#if iconVisible}
 		<slot name="icon" />

--- a/src/frontend/src/lib/components/ui/Link.svelte
+++ b/src/frontend/src/lib/components/ui/Link.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { beforeNavigate } from '$app/navigation';
 	import { createEventDispatcher } from 'svelte';
 
 	export let href: string;
@@ -12,16 +12,9 @@
 
 	const dispatch = createEventDispatcher();
 
-	// Custom click handler to guarantee that it prevents default browser behaviour (full page reload)
-	// when the link is internal (not external). A practical example is when the <a> tag is used
-	// inside a Popover component.
-	const onClick = (event: MouseEvent) => {
-		if (!external) {
-			event.preventDefault();
-			goto(href);
-		}
-		dispatch('click');
-	};
+	beforeNavigate(() => {
+		dispatch('icBeforeNavigate');
+	});
 </script>
 
 <a
@@ -37,7 +30,6 @@
 	class:hover:text-blue={color === 'inherit'}
 	class:active:text-blue={color === 'inherit'}
 	class:w-full={fullWidth}
-	on:click={onClick}
 >
 	{#if iconVisible}
 		<slot name="icon" />

--- a/src/frontend/src/lib/components/ui/Link.svelte
+++ b/src/frontend/src/lib/components/ui/Link.svelte
@@ -15,12 +15,11 @@
 	// Custom click handler to guarantee that it prevents default browser behaviour (full page reload)
 	// when the link is internal (not external). A practical example is when the <a> tag is used
 	// inside a Popover component.
-	const onClick = (event: MouseEvent) => {
+	const onClick = () => {
 		if (!external) {
-			event.preventDefault();
 			goto(href);
+			dispatch('click');
 		}
-		dispatch('click');
 	};
 </script>
 
@@ -37,7 +36,7 @@
 	class:hover:text-blue={color === 'inherit'}
 	class:active:text-blue={color === 'inherit'}
 	class:w-full={fullWidth}
-	on:click={onClick}
+	on:click|preventDefault={onClick}
 >
 	{#if iconVisible}
 		<slot name="icon" />


### PR DESCRIPTION
# Motivation

For readability and to simplify the code, we create `Link` component. Furthermore it is useful for `a11y` reasons. Note that we provide the prop `href` possibly as `null` in case the usage is by design without URL.

# Tests

Local replica behaves as expected as usual.
