### PR TITLE
refactor(frontend): rename type to OptionEthAddress

### DIFF
--- a/src/frontend/src/eth/components/core/EthListener.svelte
+++ b/src/frontend/src/eth/components/core/EthListener.svelte
@@ -5,13 +5,13 @@
 	import type { WebSocketListener } from '$eth/types/listener';
 	import type { Token } from '$lib/types/token';
 	import { address } from '$lib/derived/address.derived';
-	import type { OptionAddress } from '$lib/types/address';
+	import type { OptionEthAddress } from '$lib/types/address';
 
 	export let token: Token;
 
 	let listener: WebSocketListener | undefined = undefined;
 
-	const initListener = async ({ address }: { address: OptionAddress }) => {
+	const initListener = async ({ address }: { address: OptionEthAddress }) => {
 		await listener?.disconnect();
 
 		if (isNullish(address)) {

--- a/src/frontend/src/eth/services/balance.services.ts
+++ b/src/frontend/src/eth/services/balance.services.ts
@@ -7,7 +7,7 @@ import { address as addressStore } from '$lib/derived/address.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId } from '$lib/types/token';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -69,7 +69,7 @@ const loadErc20Balance = async ({
 	address: optionAddress
 }: {
 	token: Erc20Token;
-	address?: OptionAddress;
+	address?: OptionEthAddress;
 }): Promise<{ success: boolean }> => {
 	const address = optionAddress ?? get(addressStore);
 
@@ -123,7 +123,7 @@ export const loadErc20Balances = async ({
 	address,
 	erc20Tokens
 }: {
-	address: OptionAddress;
+	address: OptionEthAddress;
 	erc20Tokens: Erc20Token[];
 }): Promise<{ success: boolean }> => {
 	const results = await Promise.all([

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -7,7 +7,7 @@ import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import { isDestinationContractAddress } from '$eth/utils/send.utils';
-import type { EthAddress, OptionAddress } from '$lib/types/address';
+import type { EthAddress, OptionEthAddress } from '$lib/types/address';
 import type { Network } from '$lib/types/network';
 import { isNetworkICP } from '$lib/utils/network.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -22,7 +22,7 @@ export const getEthFeeData = async ({
 	to,
 	helperContractAddress
 }: GetFeeData & {
-	helperContractAddress: OptionAddress;
+	helperContractAddress: OptionEthAddress;
 }): Promise<BigNumber> => {
 	if (isDestinationContractAddress({ destination: to, contractAddress: helperContractAddress })) {
 		return BigNumber.from(CKETH_FEE);
@@ -72,7 +72,7 @@ export const getCkErc20FeeData = async ({
 	contract: Erc20ContractAddress;
 	amount: BigNumber;
 	sourceNetwork: EthereumNetwork;
-	erc20HelperContractAddress: OptionAddress;
+	erc20HelperContractAddress: OptionEthAddress;
 }): Promise<BigNumber> => {
 	const estimateGasForApprove = await getErc20FeeData({
 		to,

--- a/src/frontend/src/eth/services/metamask.services.ts
+++ b/src/frontend/src/eth/services/metamask.services.ts
@@ -8,7 +8,7 @@ import { metamaskStore } from '$eth/stores/metamask.store';
 import type { EthereumNetwork } from '$eth/types/network';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish } from '@dfinity/utils';
 import detectEthereumProvider from '@metamask/detect-provider';
@@ -26,7 +26,7 @@ export const openMetamaskTransaction = async ({
 	address,
 	network: { chainId, name: networkName }
 }: {
-	address: OptionAddress;
+	address: OptionEthAddress;
 	network: EthereumNetwork;
 }): Promise<{
 	success: 'ok' | 'error';

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -18,7 +18,7 @@ import { authStore } from '$lib/stores/auth.store';
 import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { getSdkError } from '@walletconnect/utils';
@@ -37,7 +37,7 @@ export type WalletConnectExecuteParams = Pick<WalletConnectCallBackParams, 'requ
 
 export type WalletConnectSendParams = WalletConnectExecuteParams & {
 	listener: WalletConnectListener | null | undefined;
-	address: OptionAddress;
+	address: OptionEthAddress;
 	fee: FeeStoreData;
 	modalNext: () => void;
 	amount: BigNumber;

--- a/src/frontend/src/eth/utils/send.utils.ts
+++ b/src/frontend/src/eth/utils/send.utils.ts
@@ -1,5 +1,5 @@
 import { isNotSupportedErc20TwinTokenId } from '$eth/utils/token.utils';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import type { TokenId } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
 
@@ -7,8 +7,8 @@ export const isDestinationContractAddress = ({
 	contractAddress,
 	destination
 }: {
-	contractAddress: OptionAddress;
-	destination: OptionAddress;
+	contractAddress: OptionEthAddress;
+	destination: OptionEthAddress;
 }): boolean =>
 	nonNullish(contractAddress) && destination?.toLowerCase() === contractAddress.toLowerCase();
 
@@ -19,7 +19,7 @@ export const shouldSendWithApproval = ({
 }: {
 	to: string;
 	tokenId: TokenId;
-	erc20HelperContractAddress: OptionAddress;
+	erc20HelperContractAddress: OptionEthAddress;
 }): boolean => {
 	// Approve happens before send currently only for ckERC20 -> ERC20.
 	// See Deposit schema: https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/ckerc20.adoc

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -2,7 +2,7 @@
 	import { fromNullable, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import { onDestroy } from 'svelte';
 	import type { WebSocketListener } from '$eth/types/listener';
-	import type { OptionAddress } from '$lib/types/address';
+	import type { OptionEthAddress } from '$lib/types/address';
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { tokenId } from '$lib/derived/token.derived';
@@ -36,7 +36,7 @@
 
 	// TODO: this is way too much work for a component and for the UI. Defer all that mumbo jumbo to a worker.
 
-	const loadPendingTransactions = async ({ toAddress }: { toAddress: OptionAddress }) => {
+	const loadPendingTransactions = async ({ toAddress }: { toAddress: OptionEthAddress }) => {
 		if (isNullish($tokenId) || isNullish($token)) {
 			return;
 		}
@@ -80,7 +80,7 @@
 		toAddress,
 		networkId
 	}: {
-		toAddress: OptionAddress;
+		toAddress: OptionEthAddress;
 		networkId: NetworkId | undefined;
 	}) => {
 		await listener?.disconnect();

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -15,7 +15,7 @@ import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.uti
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import { tokenStandard, tokenWithFallback } from '$lib/derived/token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId, TokenStandard } from '$lib/types/token';
 import type { BigNumber } from '@ethersproject/bignumber';
@@ -101,7 +101,7 @@ export const ckEthereumNativeTokenBalance: Readable<BigNumber | undefined | null
 /**
  * The contract helper used to convert ETH -> ckETH.
  */
-export const ckEthHelperContractAddress: Readable<OptionAddress> = derived(
+export const ckEthHelperContractAddress: Readable<OptionEthAddress> = derived(
 	[ckEthMinterInfoStore, ethereumTokenId, ethereumToken],
 	([$ckEthMinterInfoStore, $ethereumTokenId, $ethereumToken]) =>
 		toCkEthHelperContractAddress(
@@ -113,7 +113,7 @@ export const ckEthHelperContractAddress: Readable<OptionAddress> = derived(
 /**
  * The contract helper used to convert Erc20 -> ckErc20.
  */
-export const ckErc20HelperContractAddress: Readable<OptionAddress> = derived(
+export const ckErc20HelperContractAddress: Readable<OptionEthAddress> = derived(
 	[ckEthMinterInfoStore, ethereumTokenId],
 	([$ckEthMinterInfoStore, $ethereumTokenId]) =>
 		toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ethereumTokenId])

--- a/src/frontend/src/icp-eth/utils/cketh.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh.utils.ts
@@ -1,7 +1,7 @@
 import { CKETH_HELPER_CONTRACT_ADDRESS_MAINNET } from '$env/networks.cketh.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks.env';
 import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { fromNullable } from '@dfinity/utils';
 
@@ -9,11 +9,11 @@ export const toCkEthHelperContractAddress = (
 	minterInfo: OptionCertifiedMinterInfo,
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	networkId: NetworkId
-): OptionAddress =>
+): OptionEthAddress =>
 	fromNullable(minterInfo?.data.eth_helper_contract_address ?? []) ??
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	(networkId === ETHEREUM_NETWORK_ID ? CKETH_HELPER_CONTRACT_ADDRESS_MAINNET : undefined);
 
 export const toCkErc20HelperContractAddress = (
 	minterInfo: OptionCertifiedMinterInfo
-): OptionAddress => fromNullable(minterInfo?.data.erc20_helper_contract_address ?? []);
+): OptionEthAddress => fromNullable(minterInfo?.data.erc20_helper_contract_address ?? []);

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,5 +1,5 @@
 import { addressStore } from '$lib/stores/address.store';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -7,7 +7,7 @@ export const addressNotLoaded: Readable<boolean> = derived([addressStore], ([$ad
 	isNullish($addressStore)
 );
 
-export const address: Readable<OptionAddress> = derived([addressStore], ([$addressStore]) =>
+export const address: Readable<OptionEthAddress> = derived([addressStore], ([$addressStore]) =>
 	$addressStore === null ? null : $addressStore?.address
 );
 

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -2,7 +2,7 @@ import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 import { address } from '$lib/derived/address.derived';
 import { routeNetwork } from '$lib/derived/nav.derived';
 import { networks } from '$lib/derived/networks.derived';
-import type { OptionAddress } from '$lib/types/address';
+import type { OptionEthAddress } from '$lib/types/address';
 import type { Network, NetworkId } from '$lib/types/network';
 import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -39,7 +39,7 @@ export const notPseudoNetworkChainFusion: Readable<boolean> = derived(
 	([$pseudoNetworkChainFusion]) => !$pseudoNetworkChainFusion
 );
 
-export const networkAddress: Readable<OptionAddress | string> = derived(
+export const networkAddress: Readable<OptionEthAddress | string> = derived(
 	[address, icrcAccountIdentifierText, networkICP],
 	([$address, $icrcAccountIdentifierStore, $networkICP]) =>
 		$networkICP ? $icrcAccountIdentifierStore : $address

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -1,3 +1,3 @@
 export type EthAddress = string;
 
-export type OptionAddress = EthAddress | undefined | null;
+export type OptionEthAddress = EthAddress | undefined | null;


### PR DESCRIPTION
# Motivation

To be more consistent (and expecting to integrate BTC too), we rename type `OptionAddress` to `OptionEthAddress`.