### PR TITLE
refactor(frontend): rename derived 'address' to 'ethAddress'

### DIFF
--- a/src/frontend/src/eth/components/core/EthListener.svelte
+++ b/src/frontend/src/eth/components/core/EthListener.svelte
@@ -4,7 +4,7 @@
 	import { initTransactionsListener } from '$eth/services/eth-listener.services';
 	import type { WebSocketListener } from '$eth/types/listener';
 	import type { Token } from '$lib/types/token';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import type { OptionEthAddress } from '$lib/types/address';
 
 	export let token: Token;
@@ -21,7 +21,7 @@
 		listener = initTransactionsListener({ address, token });
 	};
 
-	$: (async () => initListener({ address: $address }))();
+	$: (async () => initListener({ address: $ethAddress }))();
 
 	onDestroy(async () => await listener?.disconnect());
 </script>

--- a/src/frontend/src/eth/components/core/EthWalletAddress.svelte
+++ b/src/frontend/src/eth/components/core/EthWalletAddress.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import Copy from '$lib/components/ui/Copy.svelte';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import { explorerUrl as explorerUrlStore } from '$eth/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	let explorerUrl: string | undefined = notEmptyString($address)
-		? `${$explorerUrlStore}/address/${$address}`
+	let explorerUrl: string | undefined = notEmptyString($ethAddress)
+		? `${$explorerUrlStore}/address/${$ethAddress}`
 		: undefined;
 </script>
 
@@ -18,8 +18,8 @@
 	>
 
 	<output class="break-all" id="eth-wallet-address"
-		>{shortenWithMiddleEllipsis($address ?? '')}</output
-	><Copy inline color="inherit" value={$address ?? ''} text={$i18n.wallet.text.address_copied} />
+		>{shortenWithMiddleEllipsis($ethAddress ?? '')}</output
+	><Copy inline color="inherit" value={$ethAddress ?? ''} text={$i18n.wallet.text.address_copied} />
 </div>
 
 {#if nonNullish(explorerUrl)}

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { WebSocketListener } from '$eth/types/listener';
 	import type { Erc20Token } from '$eth/types/erc20';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { toastsError, toastsHide } from '$lib/stores/toasts.store';
 	import { debounce } from '@dfinity/utils';
 	import { initMinedTransactionsListener } from '$eth/services/eth-listener.services';
@@ -52,9 +52,9 @@
 		try {
 			const params: GetFeeData = {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				to: mapAddressStartsWith0x(destination !== '' ? destination : $address!),
+				to: mapAddressStartsWith0x(destination !== '' ? destination : $ethAddress!),
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				from: mapAddressStartsWith0x($address!)
+				from: mapAddressStartsWith0x($ethAddress!)
 			};
 
 			const { getFeeData } = infuraProviders($sendToken.network.id);

--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { openMetamaskTransaction } from '$eth/services/metamask.services';
 	import { metamaskAvailable } from '$eth/derived/metamask.derived';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import IconMetamask from '$lib/components/icons/IconMetamask.svelte';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { networkEthereum } from '$lib/derived/network.derived';
@@ -17,7 +17,7 @@
 		}
 
 		await openMetamaskTransaction({
-			address: $address,
+			address: $ethAddress,
 			network: $selectedEthereumNetwork
 		});
 	};

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -7,7 +7,7 @@
 	import SendReview from './SendReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import {
 		FEE_CONTEXT_KEY,
@@ -153,7 +153,7 @@
 		}
 
 		// Unexpected errors
-		if (isNullish($address)) {
+		if (isNullish($ethAddress)) {
 			toastsError({
 				msg: { text: $i18n.send.assertion.address_unknown }
 			});
@@ -164,7 +164,7 @@
 
 		try {
 			await executeSend({
-				from: $address,
+				from: $ethAddress,
 				to: mapAddressStartsWith0x(destination),
 				progress: (step: ProgressStepsSend) => (sendProgressStep = step),
 				token: $sendToken,

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -4,7 +4,7 @@
 	import FeeDisplay from '$eth/components/fee/FeeDisplay.svelte';
 	import SendNetworkICP from './SendNetworkICP.svelte';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import type { Network } from '$lib/types/network';
 	import SendAmount from '$eth/components/send/SendAmount.svelte';
 	import { isNullish } from '@dfinity/utils';
@@ -45,7 +45,7 @@
 
 		<SendAmount {nativeEthereumToken} bind:amount bind:insufficientFunds />
 
-		<SendSource token={$sendToken} balance={$sendBalance} source={$address ?? ''} />
+		<SendSource token={$sendToken} balance={$sendBalance} source={$ethAddress ?? ''} />
 
 		<FeeDisplay />
 	</div>

--- a/src/frontend/src/eth/components/send/SendReview.svelte
+++ b/src/frontend/src/eth/components/send/SendReview.svelte
@@ -4,7 +4,7 @@
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import SendData from '$lib/components/send/SendData.svelte';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import FeeDisplay from '$eth/components/fee/FeeDisplay.svelte';
 	import type { Network } from '$lib/types/network';
 	import SendReviewNetwork from '$eth/components/send/SendReviewNetwork.svelte';
@@ -40,7 +40,7 @@
 		destination={destinationEditable ? destination : null}
 		token={$sendToken}
 		balance={$sendBalance}
-		source={$address ?? ''}
+		source={$ethAddress ?? ''}
 	>
 		<FeeDisplay slot="fee" />
 

--- a/src/frontend/src/eth/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/eth/components/tokens/TokenMenu.svelte
@@ -4,7 +4,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import { explorerUrl as explorerUrlStore } from '$eth/derived/network.derived';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { tokenStandard } from '$lib/derived/token.derived';
 	import type { Erc20Token } from '$eth/types/erc20';
 	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
@@ -15,8 +15,8 @@
 	$: explorerUrl =
 		$tokenStandard === 'erc20' && nonNullish($token)
 			? `${$explorerUrlStore}/token/${($token as Erc20Token).address}`
-			: notEmptyString($address)
-				? `${$explorerUrlStore}/address/${$address}`
+			: notEmptyString($ethAddress)
+				? `${$explorerUrlStore}/address/${$ethAddress}`
 				: undefined;
 </script>
 

--- a/src/frontend/src/eth/components/transactions/Transaction.svelte
+++ b/src/frontend/src/eth/components/transactions/Transaction.svelte
@@ -4,7 +4,7 @@
 	import { isTransactionPending } from '$eth/utils/transactions.utils';
 	import IconReceive from '$lib/components/icons/IconReceive.svelte';
 	import type { ComponentType } from 'svelte';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import IconSend from '$lib/components/icons/IconSend.svelte';
 	import { nonNullish } from '@dfinity/utils';
 	import Card from '$lib/components/ui/Card.svelte';
@@ -25,7 +25,7 @@
 	$: ({ from, value, timestamp, displayTimestamp } = transaction);
 
 	let type: 'send' | 'receive';
-	$: type = from?.toLowerCase() === $address?.toLowerCase() ? 'send' : 'receive';
+	$: type = from?.toLowerCase() === $ethAddress?.toLowerCase() ? 'send' : 'receive';
 
 	let icon: ComponentType;
 	$: icon = type === 'send' ? IconSend : IconReceive;

--- a/src/frontend/src/eth/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/TransactionModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Transaction } from '$lib/types/transaction';
 	import type { BigNumber } from '@ethersproject/bignumber';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { Modal } from '@dfinity/gix-components';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
@@ -31,7 +31,7 @@
 	$: ({ from, value, timestamp, hash, blockNumber, to } = transaction);
 
 	let type: 'send' | 'receive';
-	$: type = from?.toLowerCase() === $address?.toLowerCase() ? 'send' : 'receive';
+	$: type = from?.toLowerCase() === $ethAddress?.toLowerCase() ? 'send' : 'receive';
 
 	let explorerUrl: string | undefined;
 	$: explorerUrl = notEmptyString(hash) ? `${$explorerUrlStore}/tx/${hash}` : undefined;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
@@ -5,7 +5,7 @@
 	import WalletConnectActions from './WalletConnectActions.svelte';
 	import { nonNullish } from '@dfinity/utils';
 	import WalletConnectSendData from './WalletConnectSendData.svelte';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import FeeDisplay from '$eth/components/fee/FeeDisplay.svelte';
 	import type { Network } from '$lib/types/network';
 	import SendReviewNetwork from '$eth/components/send/SendReviewNetwork.svelte';
@@ -34,7 +34,7 @@
 		{destination}
 		token={$sendToken}
 		balance={$balance}
-		source={$address ?? ''}
+		source={$ethAddress ?? ''}
 	>
 		<WalletConnectSendData {data} />
 

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -14,7 +14,7 @@
 		initFeeContext,
 		initFeeStore
 	} from '$eth/stores/fee.store';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import WalletConnectSendReview from './WalletConnectSendReview.svelte';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
@@ -146,7 +146,7 @@
 		const { success } = await sendServices({
 			request,
 			listener,
-			address: $address,
+			address: $ethAddress,
 			amount,
 			fee: $feeStore,
 			modalNext: modal.next,

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -3,7 +3,7 @@
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import { onDestroy } from 'svelte';
 	import { initWalletConnectListener } from '$eth/services/eth-listener.services';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import WalletConnectForm from './WalletConnectForm.svelte';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
@@ -87,14 +87,14 @@
 
 		try {
 			// Connect and disconnect buttons are disabled until the address is loaded therefore this should never happens.
-			if (isNullish($address)) {
+			if (isNullish($ethAddress)) {
 				toastsError({
 					msg: { text: $i18n.send.assertion.address_unknown }
 				});
 				return;
 			}
 
-			listener = await initWalletConnectListener({ uri, address: $address });
+			listener = await initWalletConnectListener({ uri, address: $ethAddress });
 		} catch (err: unknown) {
 			toastsError({
 				msg: { text: $i18n.wallet_connect.error.connect },
@@ -132,7 +132,7 @@
 		}
 
 		// Address is not defined. We need it.
-		if (isNullish($address)) {
+		if (isNullish($ethAddress)) {
 			return;
 		}
 
@@ -156,7 +156,7 @@
 		await connect($walletConnectUri);
 	};
 
-	$: $address, $walletConnectUri, $loading, (async () => await uriConnect())();
+	$: $ethAddress, $walletConnectUri, $loading, (async () => await uriConnect())();
 
 	const connect = async (uri: string): Promise<{ result: 'success' | 'error' | 'critical' }> => {
 		await initListener(uri);

--- a/src/frontend/src/eth/services/balance.services.ts
+++ b/src/frontend/src/eth/services/balance.services.ts
@@ -3,7 +3,7 @@ import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import type { Erc20Token } from '$eth/types/erc20';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
-import { address as addressStore } from '$lib/derived/address.derived';
+import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';

--- a/src/frontend/src/eth/services/transactions.services.ts
+++ b/src/frontend/src/eth/services/transactions.services.ts
@@ -3,7 +3,7 @@ import { etherscanProviders } from '$eth/providers/etherscan.providers';
 import { etherscanRests } from '$eth/rest/etherscan.rest';
 import { transactionsStore } from '$eth/stores/transactions.store';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
-import { address as addressStore } from '$lib/derived/address.derived';
+import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -6,7 +6,7 @@
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { tokenId } from '$lib/derived/token.derived';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { icPendingTransactionsStore } from '$icp/stores/ic-pending-transactions.store';
 	import { balance } from '$lib/derived/balances.derived';
 	import type { BigNumber } from '@ethersproject/bignumber';
@@ -93,7 +93,7 @@
 			return;
 		}
 
-		if (isNullish($address)) {
+		if (isNullish($ethAddress)) {
 			return;
 		}
 
@@ -102,7 +102,7 @@
 			listener: async ({ hash, from }: TransactionResponse) => {
 				// Filtering from and to with Alchemy (see initEthPendingTransactionsListenerProvider) at the same time does not work according our observations.
 				// Therefore, we are observing the `to` address and filtering the `from` on each event.
-				if ($address?.toLowerCase() !== from.toLowerCase()) {
+				if ($ethAddress?.toLowerCase() !== from.toLowerCase()) {
 					return;
 				}
 

--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { debounce } from '@dfinity/utils';
 	import { enabledErc20NetworkTokens } from '$lib/derived/network-tokens.derived';
 
@@ -9,7 +9,7 @@
 			// We might require Ethereum balance on IC network as well given that one can convert ckETH to ETH.
 			loadBalances(),
 			loadErc20Balances({
-				address: $address,
+				address: $ethAddress,
 				erc20Tokens: $enabledErc20NetworkTokens
 			})
 		]);
@@ -17,7 +17,7 @@
 
 	const debounceLoad = debounce(load, 500);
 
-	$: $address, $enabledErc20NetworkTokens, debounceLoad();
+	$: $ethAddress, $enabledErc20NetworkTokens, debounceLoad();
 </script>
 
 <slot />

--- a/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
+++ b/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
 	import ReceiveAddressQRCode from '$lib/components/receive/ReceiveAddressQRCode.svelte';
 	import type { Network } from '$lib/types/network';
@@ -37,7 +37,7 @@
 	formCancelAction="back"
 >
 	{#if currentStep?.name === steps[1].name}
-		<ReceiveAddressQRCode address={$address ?? ''} on:icBack />
+		<ReceiveAddressQRCode address={$ethAddress ?? ''} on:icBack />
 	{:else}
 		<slot />
 	{/if}

--- a/src/frontend/src/icp/components/convert/ConvertToEthereum.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToEthereum.svelte
@@ -3,7 +3,7 @@
 	import IconBurn from '$lib/components/icons/IconBurn.svelte';
 	import { modalConvertToTwinTokenEth } from '$lib/derived/modal.derived';
 	import IcSendModal from '$icp/components/send/IcSendModal.svelte';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import {
 		ckEthereumTwinTokenNetworkId,
 		ckEthereumTwinToken,
@@ -30,5 +30,5 @@
 </ConvertETH>
 
 {#if $modalConvertToTwinTokenEth}
-	<IcSendModal networkId={$ckEthereumTwinTokenNetworkId} destination={$address ?? ''} />
+	<IcSendModal networkId={$ckEthereumTwinTokenNetworkId} destination={$ethAddress ?? ''} />
 {/if}

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ReceiveAddress from '$lib/components/receive/ReceiveAddress.svelte';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { formatToken } from '$lib/utils/format.utils';
@@ -78,7 +78,7 @@
 
 		<ReceiveAddress
 			labelRef="eth-wallet-address"
-			address={$address ?? ''}
+			address={$ethAddress ?? ''}
 			qrCodeAriaLabel={$i18n.wallet.text.display_wallet_address_qr}
 			copyAriaLabel={$i18n.wallet.text.wallet_address_copied}
 			on:click={() => dispatch('icQRCode')}

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -5,7 +5,7 @@
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 	import ReceiveAddressWithLogo from '$lib/components/receive/ReceiveAddressWithLogo.svelte';
-	import { address } from '$lib/derived/address.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import Hr from '$lib/components/ui/Hr.svelte';
 
 	const dispatch = createEventDispatcher();
@@ -55,10 +55,10 @@
 	<ReceiveAddressWithLogo
 		on:click={() =>
 			displayQRCode({
-				address: $address ?? '',
+				address: $ethAddress ?? '',
 				addressLabel: $i18n.receive.ethereum.text.ethereum_address
 			})}
-		address={$address ?? ''}
+		address={$ethAddress ?? ''}
 		token={ETHEREUM_TOKEN}
 		qrCodeAriaLabel={$i18n.receive.ethereum.text.display_ethereum_address_qr}
 		copyAriaLabel={$i18n.receive.ethereum.text.ethereum_address_copied}

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -7,7 +7,7 @@ export const addressNotLoaded: Readable<boolean> = derived([addressStore], ([$ad
 	isNullish($addressStore)
 );
 
-export const address: Readable<OptionEthAddress> = derived([addressStore], ([$addressStore]) =>
+export const ethAddress: Readable<OptionEthAddress> = derived([addressStore], ([$addressStore]) =>
 	$addressStore === null ? null : $addressStore?.address
 );
 

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -1,5 +1,5 @@
 import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
-import { address } from '$lib/derived/address.derived';
+import { ethAddress } from '$lib/derived/address.derived';
 import { routeNetwork } from '$lib/derived/nav.derived';
 import { networks } from '$lib/derived/networks.derived';
 import type { OptionEthAddress } from '$lib/types/address';
@@ -40,7 +40,7 @@ export const notPseudoNetworkChainFusion: Readable<boolean> = derived(
 );
 
 export const networkAddress: Readable<OptionEthAddress | string> = derived(
-	[address, icrcAccountIdentifierText, networkICP],
+	[ethAddress, icrcAccountIdentifierText, networkICP],
 	([$address, $icrcAccountIdentifierStore, $networkICP]) =>
 		$networkICP ? $icrcAccountIdentifierStore : $address
 );


### PR DESCRIPTION
# Motivation

To be more consistent with the scope of the derived store, we rename it `ethAddress`.

