### PR TITLE
fix(frontend): auto load token only for erc20

### DIFF
--- a/src/frontend/src/icp-eth/services/user-token.services.ts
+++ b/src/frontend/src/icp-eth/services/user-token.services.ts
@@ -10,7 +10,7 @@ import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Token } from '$lib/types/token';
 import type { Identity } from '@dfinity/agent';
-import { assertNonNullish, isNullish, toNullable } from '@dfinity/utils';
+import { assertNonNullish, toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 /**
@@ -41,7 +41,8 @@ export const autoLoadUserToken = async ({
 	}
 
 	const twinToken = (sendToken as OptionIcCkToken)?.twinToken;
-	if (isNullish(twinToken)) {
+
+	if (twinToken?.standard !== 'erc20') {
 		return { result: 'skipped' };
 	}
 


### PR DESCRIPTION
# Motivation

ckETH is also linked with a twin token. As a result, the function to `autoLoadUserToken`  interprets it as an Erc20 token an try to match a contract address while there is no such thing leading to an error which prevents user to open the "Receive" modal. 

# Changes

- Auto load token only for Erc20
