### PR TITLE
fix(frontend): signed out transactions text

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsSignedOut.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsSignedOut.svelte
@@ -1,19 +1,11 @@
 <script lang="ts">
 	import { i18n } from '$lib/stores/i18n.store';
 	import Header from '$lib/components/ui/Header.svelte';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { token } from '$lib/stores/token.store';
-	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 </script>
 
 <Header>{$i18n.transactions.text.title}</Header>
 
-{#if nonNullish($token)}
-	<p class="mt-4 text-dark opacity-50" in:fade>
-		{replacePlaceholders($i18n.transactions.text.sign_in, {
-			$token: $token.name,
-			$symbol: $token.symbol
-		})}
-	</p>
-{/if}
+<p class="mt-4 text-dark opacity-50" in:fade>
+	{$i18n.transactions.text.sign_in}
+</p>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -538,7 +538,7 @@
 		"text": {
 			"title": "Transactions",
 			"no_transactions": "You have no transactions.",
-			"sign_in": "Sign in to access your $token ($symbol) transactions.",
+			"sign_in": "Sign in to view your transactions.",
 			"open_transactions": "Open the list of $token transactions"
 		},
 		"error": {


### PR DESCRIPTION
# Motivation

Only a subset of the tokens is loaded by default when the user is signed out. As a result, the text that should be displayed on the transactions page when not logged in is not necessarily displayed if the token in the URL is not one of those.

# Changes

- Display a generic non token related text.

# Tests

<img width="1536" alt="Capture d’écran 2024-08-12 à 06 50 13" src="https://github.com/user-attachments/assets/4d8d8978-847f-4142-8e71-f9485ad6d8e1">

