### PR TITLE
fix(ci): job to remove unused files does not print separate lines

### DIFF
--- a/.github/workflows/frontend-remove-unused-components.yml
+++ b/.github/workflows/frontend-remove-unused-components.yml
@@ -27,7 +27,9 @@ jobs:
           if ! git diff --cached --quiet; then
             echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
             DELETED_FILES=$(git diff --cached --name-only)
-            echo "DELETED_FILES=${DELETED_FILES}" >> $GITHUB_ENV
+            echo "DELETED_FILES<<EOF" >> $GITHUB_ENV
+            echo "$DELETED_FILES" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
           fi
 
       # This action creates a PR only if there are changes.


### PR DESCRIPTION
# Motivation

The GitHub Action` frontend-remove-unused-components` was updated to use a Here Document (`<<EOF`) for setting the `DELETED_FILES` environment variable, ensuring that files in separate lines are correctly printed in the PR body.