### PR TITLE
feat(frontend): add BTC folder among aliases

### DIFF
--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -1,8 +1,8 @@
+import { enabledBitcoinNetworks } from '$btc/derived/networks.derived';
 import { ICP_NETWORK } from '$env/networks.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
-import { enabledBitcoinNetworks } from '../../btc/derived/networks.derived';
 
 export const networks: Readable<Network[]> = derived(
 	[enabledBitcoinNetworks, enabledEthereumNetworks],

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -1,3 +1,4 @@
+import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
 import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
@@ -7,7 +8,6 @@ import { exchanges } from '$lib/derived/exchange.derived';
 import type { Token, TokenToPin } from '$lib/types/token';
 import { pinTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
-import { enabledBitcoinTokens } from '../../btc/derived/tokens.derived';
 
 const tokens: Readable<Token[]> = derived(
 	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,6 +26,7 @@ const config = {
 		},
 		alias: {
 			$declarations: './src/declarations',
+			$btc: './src/frontend/src/btc',
 			$eth: './src/frontend/src/eth',
 			$icp: './src/frontend/src/icp',
 			'$icp-eth': './src/frontend/src/icp-eth',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,10 @@ export default defineConfig(
 					replacement: resolve(__dirname, 'src/frontend/src/routes')
 				},
 				{
+					find: '$btc',
+					replacement: resolve(__dirname, 'src/frontend/src/btc')
+				},
+				{
 					find: '$eth',
 					replacement: resolve(__dirname, 'src/frontend/src/eth')
 				},


### PR DESCRIPTION
# Motivation

To be consistent, we add the BTC folder among the aliases of the project. And we adapt the imports referring to such folder.

