### PR TITLE
feat(frontend): create specific BitcoinNetwork type

### DIFF
--- a/src/frontend/src/btc/types/network.ts
+++ b/src/frontend/src/btc/types/network.ts
@@ -1,0 +1,8 @@
+import type { BitcoinNetwork as BitcoinNetworkBackend } from '$declarations/backend/backend.did';
+import type { Network } from '$lib/types/network';
+
+interface BitcoinBackendData {
+	backendEnv: BitcoinNetworkBackend;
+}
+
+export type BitcoinNetwork = Network & BitcoinBackendData;

--- a/src/frontend/src/btc/types/network.ts
+++ b/src/frontend/src/btc/types/network.ts
@@ -1,5 +1,6 @@
-import type { BitcoinNetwork as BitcoinNetworkBackend } from '$declarations/backend/backend.did';
 import type { Network } from '$lib/types/network';
+
+type BitcoinNetworkBackend = { mainnet: null } | { regtest: null } | { testnet: null };
 
 interface BitcoinBackendData {
 	backendEnv: BitcoinNetworkBackend;

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -1,3 +1,4 @@
+import type { BitcoinNetwork } from '$btc/types/network';
 import { ETHEREUM_EXPLORER_URL, SEPOLIA_EXPLORER_URL } from '$env/explorers.env';
 import { ETH_MAINNET_ENABLED } from '$env/networks.eth.env';
 import sepolia from '$eth/assets/sepolia.svg';
@@ -7,7 +8,6 @@ import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import icpLight from '$icp/assets/icp_light.svg';
 import type { Network } from '$lib/types/network';
-import type { BitcoinNetwork } from '../btc/types/network';
 
 /**
  * Ethereum

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -7,6 +7,7 @@ import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import icpLight from '$icp/assets/icp_light.svg';
 import type { Network } from '$lib/types/network';
+import type { BitcoinNetwork } from '../btc/types/network';
 
 /**
  * Ethereum
@@ -79,22 +80,24 @@ export const BTC_MAINNET_NETWORK_SYMBOL = 'BTC';
 
 export const BTC_MAINNET_NETWORK_ID = Symbol(BTC_MAINNET_NETWORK_SYMBOL);
 
-export const BTC_MAINNET_NETWORK: Network = {
+export const BTC_MAINNET_NETWORK: BitcoinNetwork = {
 	id: BTC_MAINNET_NETWORK_ID,
 	env: 'mainnet',
 	name: 'Bitcoin',
-	icon: bitcoin
+	icon: bitcoin,
+	backendEnv: { mainnet: null }
 };
 
 export const BTC_TESTNET_NETWORK_SYMBOL = 'BTC (Testnet)';
 
 export const BTC_TESTNET_NETWORK_ID = Symbol(BTC_TESTNET_NETWORK_SYMBOL);
 
-export const BTC_TESTNET_NETWORK: Network = {
+export const BTC_TESTNET_NETWORK: BitcoinNetwork = {
 	id: BTC_TESTNET_NETWORK_ID,
 	env: 'testnet',
 	name: 'Bitcoin',
-	icon: bitcoinTestnet
+	icon: bitcoinTestnet,
+	backendEnv: { testnet: null }
 };
 
 export const BITCOIN_NETWORKS: Network[] = [BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK];


### PR DESCRIPTION
# Motivation

We create a specific type for the Bitcoin network, to include the environment corresponding to the backend mapping.