### PR TITLE
chore(frontend): add i18n keys for a few errors and warnings

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -46,6 +46,10 @@
 		"alt": {
 			"sign_in": "Sign in with Internet Identity to start using Oisy Wallet."
 		},
+		"warning": {
+			"not_signed_in": "You are not signed in. Please sign in to continue.",
+			"session_expired": "You have been logged out because your session has expired."
+		},
 		"error": {
 			"no_internet_identity": "No internet identity.",
 			"invalid_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential. Please contact the issuer and request the credential again.",
@@ -53,7 +57,9 @@
 			"error_validating_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential.",
 			"error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
 			"missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
-			"no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?"
+			"no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?",
+			"error_while_signing_in": "Something went wrong while sign-in.",
+			"unexpected_issue_with_syncing": "Unexpected issue while syncing the status of your authentication."
 		}
 	},
 	"wallet": {
@@ -93,6 +99,7 @@
 			"no_infura_erc20_provider": "No Infura ERC20 provider for network $network",
 			"no_infura_erc20_icp_provider": "No Infura ERC20 Icp provider for network $network",
 			"eth_address_unknown": "ETH address is unknown.",
+			"loading_address": "Error while loading the $symbol address.",
 			"loading_balance": "Error while loading the ETH balance.",
 			"loading_balance_symbol": "Error while loading $symbol balance.",
 			"erc20_contracts": "Error while loading the ERC20 contracts.",

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -1,10 +1,13 @@
+import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks.env';
 import { getEthAddress } from '$lib/api/backend.api';
 import { getIdbEthAddress, setIdbEthAddress, updateIdbEthAddressLastUsage } from '$lib/api/idb.api';
 import { addressStore } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
+import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -20,7 +23,11 @@ export const loadAddress = async (): Promise<{ success: boolean }> => {
 		addressStore.reset();
 
 		toastsError({
-			msg: { text: 'Error while loading the ETH address.' },
+			msg: {
+				text: replacePlaceholders(get(i18n).init.error.loading_address, {
+					$symbol: ETHEREUM_NETWORK_SYMBOL
+				})
+			},
 			err
 		});
 

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -7,6 +7,7 @@ import {
 import { trackEvent } from '$lib/services/analytics.services';
 import { authStore, type AuthSignInParams } from '$lib/stores/auth.store';
 import { busy } from '$lib/stores/busy.store';
+import { i18n } from '$lib/stores/i18n.store';
 import { testnetsStore } from '$lib/stores/settings.store';
 import { toastsClean, toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { ToastMsg } from '$lib/types/toast';
@@ -46,7 +47,7 @@ export const signIn = async (
 		});
 
 		toastsError({
-			msg: { text: `Something went wrong while sign-in.` },
+			msg: { text: get(i18n).auth.error.error_while_signing_in },
 			err
 		});
 
@@ -67,12 +68,12 @@ export const warnSignOut = (text: string): Promise<void> =>
 	});
 
 export const nullishSignOut = (): Promise<void> =>
-	warnSignOut('You are not signed in. Please sign in to continue.');
+	warnSignOut(get(i18n).auth.warning.not_signed_in);
 
 export const idleSignOut = (): Promise<void> =>
 	logout({
 		msg: {
-			text: 'You have been logged out because your session has expired.',
+			text: get(i18n).auth.warning.session_expired,
 			level: 'warn'
 		},
 		clearStorages: false

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -36,6 +36,7 @@ interface I18nNavigation {
 interface I18nAuth {
 	text: { title: string; authenticate: string; logout: string };
 	alt: { sign_in: string };
+	warning: { not_signed_in: string; session_expired: string };
 	error: {
 		no_internet_identity: string;
 		invalid_pouh_credential: string;
@@ -44,6 +45,8 @@ interface I18nAuth {
 		error_requesting_pouh_credential: string;
 		missing_pouh_issuer_origin: string;
 		no_pouh_credential: string;
+		error_while_signing_in: string;
+		unexpected_issue_with_syncing: string;
 	};
 }
 
@@ -76,6 +79,7 @@ interface I18nInit {
 		no_infura_erc20_provider: string;
 		no_infura_erc20_icp_provider: string;
 		eth_address_unknown: string;
+		loading_address: string;
 		loading_balance: string;
 		loading_balance_symbol: string;
 		erc20_contracts: string;

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -44,7 +44,7 @@
 			});
 
 			toastsError({
-				msg: { text: 'Unexpected issue while syncing the status of your authentication.' },
+				msg: { text: $i18n.auth.error.unexpected_issue_with_syncing },
 				err
 			});
 		}


### PR DESCRIPTION
# Motivation

We substitute hard-coded strings with `i18n` keys.
