### PR TITLE
fix(frontend): avoid multiple balance refresh periodically

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -30,7 +30,7 @@ export const enabledNetworkTokens: Readable<Token[]> = derived(
 );
 
 /**
- * It isn't performant to post filter again the Erc20 tokens that are enabled for the specific selected network or no network selected but, it's code wise convenient to avoid duplication of logic.
+ * This list is used only to refresh the balances of the enabled ERC20 tokens, so it should be agnostic from any combined derived.
  */
 export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
 	[networkEthereum, pseudoNetworkChainFusion, enabledErc20Tokens],

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,6 +1,11 @@
+import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import type { Erc20Token } from '$eth/types/erc20';
 import { exchanges } from '$lib/derived/exchange.derived';
-import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
+import {
+	networkEthereum,
+	pseudoNetworkChainFusion,
+	selectedNetwork
+} from '$lib/derived/network.derived';
 import { combinedDerivedSortedTokens } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
@@ -28,9 +33,9 @@ export const enabledNetworkTokens: Readable<Token[]> = derived(
  * It isn't performant to post filter again the Erc20 tokens that are enabled for the specific selected network or no network selected but, it's code wise convenient to avoid duplication of logic.
  */
 export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
-	[enabledNetworkTokens],
-	([$enabledNetworkTokens]) =>
-		$enabledNetworkTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
+	[networkEthereum, pseudoNetworkChainFusion, enabledErc20Tokens],
+	([$networkEthereum, $pseudoNetworkChainFusion, $enabledErc20Tokens]) =>
+		$networkEthereum || $pseudoNetworkChainFusion ? $enabledErc20Tokens : ([] as Erc20Token[])
 );
 
 /**

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,11 +1,7 @@
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import type { Erc20Token } from '$eth/types/erc20';
 import { exchanges } from '$lib/derived/exchange.derived';
-import {
-	networkEthereum,
-	pseudoNetworkChainFusion,
-	selectedNetwork
-} from '$lib/derived/network.derived';
+import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 import { combinedDerivedSortedTokens } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
@@ -33,9 +29,13 @@ export const enabledNetworkTokens: Readable<Token[]> = derived(
  * This list is used only to refresh the balances of the enabled ERC20 tokens, so it should be agnostic from any combined derived.
  */
 export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
-	[networkEthereum, pseudoNetworkChainFusion, enabledErc20Tokens],
-	([$networkEthereum, $pseudoNetworkChainFusion, $enabledErc20Tokens]) =>
-		$networkEthereum || $pseudoNetworkChainFusion ? $enabledErc20Tokens : ([] as Erc20Token[])
+	[enabledErc20Tokens, selectedNetwork, pseudoNetworkChainFusion],
+	([$tokens, $selectedNetwork, $pseudoNetworkChainFusion]) =>
+		filterTokensForSelectedNetwork([
+			$tokens,
+			$selectedNetwork,
+			$pseudoNetworkChainFusion
+		]) as Erc20Token[]
 );
 
 /**


### PR DESCRIPTION
# Motivation

As spotted by @peterpeterparker , the ETH/ERC20 balance was being refreshed periodically and that could cause asynchronous information between the balance and the transactions.

The cause is most likely a cascade refresh caused by the periodic refresh of `exchanges` store:

`exchanges --> combinedDerivedSortedTokens --> networkTokens --> enabledNetworkTokens --> enabledErc20NetworkTokens --> LoaderBalances`

Since `enabledErc20NetworkTokens` is used only in `LoaderBalances`, the solution I thought would be to simply derive it directly from the `enabledErc20Tokens` and filter by network.
