### PR TITLE
fix(frontend): avoid multiple balance refresh periodically

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived.js';
+	import { combinedDerivedSortedNetworkTokens } from '$lib/derived/network-tokens.derived.js';
 	import TokenCardWithUrl from '$lib/components/tokens/TokenCardWithUrl.svelte';
 	import { onMount } from 'svelte';
 	import { unsafeLoadDefaultPublicIcrcTokens } from '$icp/services/icrc.services';
@@ -8,7 +8,7 @@
 	onMount(unsafeLoadDefaultPublicIcrcTokens);
 </script>
 
-{#each $enabledNetworkTokens as token (token.id)}
+{#each $combinedDerivedSortedNetworkTokens as token (token.id)}
 	<TokenCardWithUrl {token}>
 		<TokenCardSignedOut {token} />
 	</TokenCardWithUrl>

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -4,12 +4,10 @@ import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
-import { exchanges } from '$lib/derived/exchange.derived';
 import type { Token, TokenToPin } from '$lib/types/token';
-import { pinTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 
-const tokens: Readable<Token[]> = derived(
+export const tokens: Readable<Token[]> = derived(
 	[erc20Tokens, sortedIcrcTokens, enabledEthereumTokens, enabledBitcoinTokens],
 	([$erc20Tokens, $icrcTokens, $enabledEthereumTokens, $enabledBitcoinTokens]) => [
 		ICP_TOKEN,
@@ -28,13 +26,4 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 		ETHEREUM_TOKEN,
 		...$icrcChainFusionDefaultTokens
 	]
-);
-
-/**
- * All tokens sorted by market cap, with the ones to pin at the top of the list.
- */
-export const combinedDerivedSortedTokens: Readable<Token[]> = derived(
-	[tokens, tokensToPin, exchanges],
-	([$tokens, $tokensToPin, $exchanges]) =>
-		pinTokensAtTop({ $tokens: sortTokens({ $tokens, $exchanges }), $tokensToPin })
 );

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -1,5 +1,5 @@
 import type { EthereumNetwork } from '$eth/types/network';
-import { combinedDerivedSortedTokens } from '$lib/derived/tokens.derived';
+import { tokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { assertNonNullish } from '@dfinity/utils';
@@ -7,7 +7,7 @@ import { get } from 'svelte/store';
 import { generateUrn } from '../../mocks/qr-generator.mock';
 
 describe('decodeUrn', () => {
-	const tokenList = get(combinedDerivedSortedTokens);
+	const tokenList = get(tokens);
 	const destination = 'some-destination';
 	const amount = 1.23;
 


### PR DESCRIPTION
# Motivation

As spotted by @peterpeterparker , the ETH/ERC20 balance was being refreshed periodically and that could cause incoherent and asynchronous information between the balance and the transactions.

The cause is most likely a cascade refresh caused by the periodic refresh of `exchanges` store:

`exchanges --> combinedDerivedSortedTokens --> networkTokens --> enabledNetworkTokens --> enabledErc20NetworkTokens --> LoaderBalances`

This PR tries to solve that issue removing the exchanges dependency from `enabledErc20NetworkTokens` dependencies.

To do that, we move `combinedDerivedSortedTokens`, so that the sorting happens after having filtered for `network` and `enabled`. This has the additional effect of potentially reducing the computational work for sorting.
