### PR TITLE
build(frontend): update dependencies and pin to fix minor vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@junobuild/analytics": "^0.0.24",
 				"@metamask/detect-provider": "^2.0.0",
 				"@walletconnect/web3wallet": "^1.14.0",
-				"alchemy-sdk": "^3.3.1",
+				"alchemy-sdk": "^3.4.1",
 				"buffer": "^6.0.3",
 				"ethers": "^5.7.0",
 				"idb-keyval": "^6.2.1",
@@ -4181,9 +4181,9 @@
 			}
 		},
 		"node_modules/alchemy-sdk": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-3.3.1.tgz",
-			"integrity": "sha512-iH/wIhBsHr18NTV9G9WrNsk/ofBOrhKaxH1vG9IZN3t+sTrB5uKAMMgmKvvJHDnOJ2Fo/bTnYPgUWNqhQxEfCQ==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-3.4.1.tgz",
+			"integrity": "sha512-GeL8J6VIiE7tIgXevkcm0VqdZnhO0EpOXQQCzUMsoMrj92hBKj9ZmUjyPxXF8tUdsHYixQApng2eJXoRWmv5lw==",
 			"license": "MIT",
 			"dependencies": {
 				"@ethersproject/abi": "^5.7.0",
@@ -4197,7 +4197,7 @@
 				"@ethersproject/units": "^5.7.0",
 				"@ethersproject/wallet": "^5.7.0",
 				"@ethersproject/web": "^5.7.0",
-				"axios": "^1.6.5",
+				"axios": "^1.7.4",
 				"sturdy-websocket": "^0.2.1",
 				"websocket": "^1.0.34"
 			}
@@ -4488,6 +4488,7 @@
 			"version": "1.7.4",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
 			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
@@ -5120,6 +5121,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
 			"integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+			"license": "ISC",
 			"dependencies": {
 				"es5-ext": "^0.10.64",
 				"type": "^2.7.2"
@@ -5233,6 +5235,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -5656,6 +5659,7 @@
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
 			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
 			"hasInstallScript": true,
+			"license": "ISC",
 			"dependencies": {
 				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.3",
@@ -5670,6 +5674,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"license": "MIT",
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "^0.10.35",
@@ -5686,6 +5691,7 @@
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
 			"integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+			"license": "ISC",
 			"dependencies": {
 				"d": "^1.0.2",
 				"ext": "^1.7.0"
@@ -6176,6 +6182,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
 			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+			"license": "ISC",
 			"dependencies": {
 				"d": "^1.0.1",
 				"es5-ext": "^0.10.62",
@@ -6314,6 +6321,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"license": "MIT",
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -6354,6 +6362,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
 			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"license": "ISC",
 			"dependencies": {
 				"type": "^2.7.2"
 			}
@@ -6490,6 +6499,7 @@
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -7553,7 +7563,8 @@
 		"node_modules/is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+			"license": "MIT"
 		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
@@ -8158,7 +8169,8 @@
 		"node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
 		},
 		"node_modules/multiformats": {
 			"version": "9.9.0",
@@ -8204,7 +8216,8 @@
 		"node_modules/next-tick": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+			"license": "ISC"
 		},
 		"node_modules/node-addon-api": {
 			"version": "7.1.1",
@@ -9003,7 +9016,8 @@
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
 		},
 		"node_modules/psl": {
 			"version": "1.9.0",
@@ -9834,7 +9848,8 @@
 		"node_modules/sturdy-websocket": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/sturdy-websocket/-/sturdy-websocket-0.2.1.tgz",
-			"integrity": "sha512-NnzSOEKyv4I83qbuKw9ROtJrrT6Z/Xt7I0HiP/e6H6GnpeTDvzwGIGeJ8slai+VwODSHQDooW2CAilJwT9SpRg=="
+			"integrity": "sha512-NnzSOEKyv4I83qbuKw9ROtJrrT6Z/Xt7I0HiP/e6H6GnpeTDvzwGIGeJ8slai+VwODSHQDooW2CAilJwT9SpRg==",
+			"license": "MIT"
 		},
 		"node_modules/sucrase": {
 			"version": "3.34.0",
@@ -10394,9 +10409,10 @@
 			"license": "0BSD"
 		},
 		"node_modules/type": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+			"integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+			"license": "ISC"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -10513,6 +10529,7 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"license": "MIT",
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
 			}
@@ -11030,13 +11047,14 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/websocket": {
-			"version": "1.0.34",
-			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-			"integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+			"version": "1.0.35",
+			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
+			"integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"bufferutil": "^4.0.1",
 				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
+				"es5-ext": "^0.10.63",
 				"typedarray-to-buffer": "^3.1.5",
 				"utf-8-validate": "^5.0.2",
 				"yaeti": "^0.0.6"
@@ -11188,6 +11206,7 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
 			"integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.32"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@dfinity/verifiable-credentials": "^0.0.2",
 				"@junobuild/analytics": "^0.0.24",
 				"@metamask/detect-provider": "^2.0.0",
-				"@walletconnect/web3wallet": "^1.12.3",
+				"@walletconnect/web3wallet": "^1.14.0",
 				"alchemy-sdk": "^3.3.1",
 				"buffer": "^6.0.3",
 				"ethers": "^5.7.0",
@@ -2201,6 +2201,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
 			"integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+			"license": "MIT",
 			"dependencies": {
 				"detect-libc": "^1.0.3",
 				"is-glob": "^4.0.3",
@@ -2236,6 +2237,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
@@ -2255,6 +2257,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -2274,6 +2277,7 @@
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -2293,6 +2297,7 @@
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -2312,6 +2317,7 @@
 			"cpu": [
 				"arm"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -2331,6 +2337,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -2350,6 +2357,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -2369,6 +2377,7 @@
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -2388,6 +2397,7 @@
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
@@ -2407,6 +2417,7 @@
 			"bundleDependencies": [
 				"napi-wasm"
 			],
+			"license": "MIT",
 			"dependencies": {
 				"is-glob": "^4.0.3",
 				"micromatch": "^4.0.5",
@@ -2432,6 +2443,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -2451,6 +2463,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -2470,6 +2483,7 @@
 			"cpu": [
 				"x64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -2807,12 +2821,14 @@
 		"node_modules/@stablelib/aead": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
-			"integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
+			"integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==",
+			"license": "MIT"
 		},
 		"node_modules/@stablelib/binary": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
 			"integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/int": "^1.0.1"
 			}
@@ -2820,12 +2836,14 @@
 		"node_modules/@stablelib/bytes": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
-			"integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+			"integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==",
+			"license": "MIT"
 		},
 		"node_modules/@stablelib/chacha": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
 			"integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/binary": "^1.0.1",
 				"@stablelib/wipe": "^1.0.1"
@@ -2835,6 +2853,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
 			"integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/aead": "^1.0.1",
 				"@stablelib/binary": "^1.0.1",
@@ -2847,12 +2866,14 @@
 		"node_modules/@stablelib/constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
-			"integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+			"integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
+			"license": "MIT"
 		},
 		"node_modules/@stablelib/ed25519": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
 			"integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/random": "^1.0.2",
 				"@stablelib/sha512": "^1.0.1",
@@ -2862,12 +2883,14 @@
 		"node_modules/@stablelib/hash": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-			"integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+			"integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
+			"license": "MIT"
 		},
 		"node_modules/@stablelib/hkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
 			"integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/hash": "^1.0.1",
 				"@stablelib/hmac": "^1.0.1",
@@ -2878,6 +2901,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
 			"integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/constant-time": "^1.0.1",
 				"@stablelib/hash": "^1.0.1",
@@ -2887,12 +2911,14 @@
 		"node_modules/@stablelib/int": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-			"integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+			"integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+			"license": "MIT"
 		},
 		"node_modules/@stablelib/keyagreement": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
 			"integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/bytes": "^1.0.1"
 			}
@@ -2901,6 +2927,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
 			"integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/constant-time": "^1.0.1",
 				"@stablelib/wipe": "^1.0.1"
@@ -2910,6 +2937,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
 			"integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/binary": "^1.0.1",
 				"@stablelib/wipe": "^1.0.1"
@@ -2919,6 +2947,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
 			"integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/binary": "^1.0.1",
 				"@stablelib/hash": "^1.0.1",
@@ -2929,6 +2958,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
 			"integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/binary": "^1.0.1",
 				"@stablelib/hash": "^1.0.1",
@@ -2938,12 +2968,14 @@
 		"node_modules/@stablelib/wipe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
+			"license": "MIT"
 		},
 		"node_modules/@stablelib/x25519": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
 			"integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/keyagreement": "^1.0.1",
 				"@stablelib/random": "^1.0.2",
@@ -3719,6 +3751,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/@walletconnect/auth-client/-/auth-client-2.1.2.tgz",
 			"integrity": "sha512-ubJLn+vGb8sTdBFX6xAh4kjR5idrtS3RBngQWaJJJpEPBQmxMb8pM2q0FIRs8Is4K6jKy+uEhusMV+7ZBmTzjw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@ethersproject/hash": "^5.7.0",
 				"@ethersproject/transactions": "^5.7.0",
@@ -3739,9 +3772,9 @@
 			}
 		},
 		"node_modules/@walletconnect/core": {
-			"version": "2.13.3",
-			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.13.3.tgz",
-			"integrity": "sha512-TdF+rC6rONJGyOUtt/nLkbyQWjnkwbD3kXq3ZA0Q7+tYtmSjTDE4wbArlLbHIbtf69g+9/DpEVEQimWWcEOn2g==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.15.0.tgz",
+			"integrity": "sha512-QekYQlpxyn2bcQXMkMxo0+v7nUOQKyu3j5ZKzTg/HGU1eSgTRLIvYIEkC8VVflIgOw7meOAb5pFChX51wShksQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@walletconnect/heartbeat": "1.2.2",
@@ -3751,31 +3784,25 @@
 				"@walletconnect/jsonrpc-ws-connection": "1.0.14",
 				"@walletconnect/keyvaluestorage": "1.1.1",
 				"@walletconnect/logger": "2.1.2",
-				"@walletconnect/relay-api": "1.0.10",
+				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.0.4",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.13.3",
-				"@walletconnect/utils": "2.13.3",
+				"@walletconnect/types": "2.15.0",
+				"@walletconnect/utils": "2.15.0",
 				"events": "3.3.0",
-				"isomorphic-unfetch": "3.1.0",
 				"lodash.isequal": "4.5.0",
 				"uint8arrays": "3.1.0"
-			}
-		},
-		"node_modules/@walletconnect/core/node_modules/uint8arrays": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-			"integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-			"license": "MIT",
-			"dependencies": {
-				"multiformats": "^9.4.2"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@walletconnect/environment": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
 			"integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "1.14.1"
 			}
@@ -3783,12 +3810,14 @@
 		"node_modules/@walletconnect/environment/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/events": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
 			"integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+			"license": "MIT",
 			"dependencies": {
 				"keyvaluestorage-interface": "^1.0.0",
 				"tslib": "1.14.1"
@@ -3797,7 +3826,8 @@
 		"node_modules/@walletconnect/events/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/heartbeat": {
 			"version": "1.2.2",
@@ -3835,6 +3865,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
 			"integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+			"license": "MIT",
 			"dependencies": {
 				"@walletconnect/environment": "^1.0.1",
 				"@walletconnect/jsonrpc-types": "^1.0.3",
@@ -3844,12 +3875,14 @@
 		"node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/jsonrpc-ws-connection": {
 			"version": "1.0.14",
 			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
 			"integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
+			"license": "MIT",
 			"dependencies": {
 				"@walletconnect/jsonrpc-utils": "^1.0.6",
 				"@walletconnect/safe-json": "^1.0.2",
@@ -3861,6 +3894,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
 			"integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+			"license": "MIT",
 			"dependencies": {
 				"@walletconnect/safe-json": "^1.0.1",
 				"idb-keyval": "^6.2.1",
@@ -3886,9 +3920,9 @@
 			}
 		},
 		"node_modules/@walletconnect/relay-api": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.10.tgz",
-			"integrity": "sha512-tqrdd4zU9VBNqUaXXQASaexklv6A54yEyQQEXYOCr+Jz8Ket0dmPBDyg19LVSNUN2cipAghQc45/KVmfFJ0cYw==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+			"integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@walletconnect/jsonrpc-types": "^1.0.2"
@@ -3898,6 +3932,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
 			"integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@stablelib/ed25519": "^1.0.2",
 				"@stablelib/random": "^1.0.1",
@@ -3910,12 +3945,14 @@
 		"node_modules/@walletconnect/relay-auth/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/safe-json": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
 			"integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "1.14.1"
 			}
@@ -3923,22 +3960,23 @@
 		"node_modules/@walletconnect/safe-json/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/sign-client": {
-			"version": "2.13.3",
-			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.13.3.tgz",
-			"integrity": "sha512-3Pcq6trHWdBZn5X0VUFQ3zJaaqyEbMW9WNVKcZ2SakIpQAwySd08Mztvq48G98jfucdgP3tjGPbBvzHX9vJX7w==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.15.0.tgz",
+			"integrity": "sha512-efwrPfIwKWKeku44TGBCnQqPZGCILI1wBKK9bTF0F0/qrLR/zRe6RWpM3/L4+jOMr/BktxPZ5lRozBh+c2U7Pg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@walletconnect/core": "2.13.3",
+				"@walletconnect/core": "2.15.0",
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/logger": "2.1.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.13.3",
-				"@walletconnect/utils": "2.13.3",
+				"@walletconnect/types": "2.15.0",
+				"@walletconnect/utils": "2.15.0",
 				"events": "3.3.0"
 			}
 		},
@@ -3946,6 +3984,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
 			"integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "1.14.1"
 			}
@@ -3953,12 +3992,13 @@
 		"node_modules/@walletconnect/time/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/types": {
-			"version": "2.13.3",
-			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.13.3.tgz",
-			"integrity": "sha512-9UdtLoQqwGFfepCPprUAXeUbKg9zyDarPRmEJVco51OWXHCOpvRgroWk54fQHDhCUIfDELjObY6XNAzNrmNYUA==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.15.0.tgz",
+			"integrity": "sha512-hLffDKKe70jIrK+YcLkAnzi6vqNki1SDBWjV+M/72mKcU2KzXxk0G2STFsWsQDx8DoqxMiuGehd0DlD1jwQmBg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
@@ -3970,9 +4010,9 @@
 			}
 		},
 		"node_modules/@walletconnect/utils": {
-			"version": "2.13.3",
-			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.13.3.tgz",
-			"integrity": "sha512-hjyyNhnhTCezGNr6OCfKRzqRsiak+p+YP57iRo1Tsf222fsj/9JD++MP97YiDwc4e4xXaZp/boiLB+8hJHsCog==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.15.0.tgz",
+			"integrity": "sha512-xaazgCMyr5fUPm2QuZ76G+W8beDfKMILqJ3INL6wyuaLil2YQNdsCSvWMNhSP+EZeKD3SUqqBmQaM/maP0YHTg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@stablelib/chacha20poly1305": "1.0.1",
@@ -3980,46 +4020,60 @@
 				"@stablelib/random": "1.0.2",
 				"@stablelib/sha256": "1.0.1",
 				"@stablelib/x25519": "1.0.3",
-				"@walletconnect/relay-api": "1.0.10",
+				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.13.3",
+				"@walletconnect/types": "2.15.0",
 				"@walletconnect/window-getters": "1.0.1",
 				"@walletconnect/window-metadata": "1.0.1",
 				"detect-browser": "5.3.0",
+				"elliptic": "^6.5.7",
 				"query-string": "7.1.3",
 				"uint8arrays": "3.1.0"
 			}
 		},
-		"node_modules/@walletconnect/utils/node_modules/uint8arrays": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-			"integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
+		"node_modules/@walletconnect/utils/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"license": "MIT"
+		},
+		"node_modules/@walletconnect/utils/node_modules/elliptic": {
+			"version": "6.5.7",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+			"integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
 			"license": "MIT",
 			"dependencies": {
-				"multiformats": "^9.4.2"
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/@walletconnect/web3wallet": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/@walletconnect/web3wallet/-/web3wallet-1.12.3.tgz",
-			"integrity": "sha512-HBzYDjf3ZVzyTCqycyMjJnn/1sQtRe0beGc3qtq9bLX/dmezkO6Oc1lg1WlvxT7KtTqKx41usw5tjiwfNZ2+ug==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/web3wallet/-/web3wallet-1.14.0.tgz",
+			"integrity": "sha512-vBBicK4PJGwmiU1NgxSnflTJlbbZjmuTlbdTGCCL4w6eW/CtsY4zNnTNmrGhlej0CkGr0M+Jw6RbFtxpMEYqZA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@walletconnect/auth-client": "2.1.2",
-				"@walletconnect/core": "2.13.3",
+				"@walletconnect/core": "2.15.0",
 				"@walletconnect/jsonrpc-provider": "1.0.14",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/logger": "2.1.2",
-				"@walletconnect/sign-client": "2.13.3",
-				"@walletconnect/types": "2.13.3",
-				"@walletconnect/utils": "2.13.3"
+				"@walletconnect/sign-client": "2.15.0",
+				"@walletconnect/types": "2.15.0",
+				"@walletconnect/utils": "2.15.0"
 			}
 		},
 		"node_modules/@walletconnect/window-getters": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
 			"integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "1.14.1"
 			}
@@ -4027,12 +4081,14 @@
 		"node_modules/@walletconnect/window-getters/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/window-metadata": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
 			"integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+			"license": "MIT",
 			"dependencies": {
 				"@walletconnect/window-getters": "^1.0.1",
 				"tslib": "1.14.1"
@@ -4041,7 +4097,8 @@
 		"node_modules/@walletconnect/window-metadata/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -4369,6 +4426,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
 			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4869,6 +4927,7 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
 			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+			"license": "MIT",
 			"dependencies": {
 				"consola": "^3.2.3"
 			}
@@ -4877,6 +4936,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
 			"integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
+			"license": "MIT",
 			"dependencies": {
 				"execa": "^8.0.1",
 				"is-wsl": "^3.1.0",
@@ -4945,6 +5005,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
 			"integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+			"license": "MIT",
 			"engines": {
 				"node": "^14.18.0 || >=16.10.0"
 			}
@@ -4967,9 +5028,10 @@
 			}
 		},
 		"node_modules/cookie-es": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.1.0.tgz",
-			"integrity": "sha512-L2rLOcK0wzWSfSDA33YR+PUHDG10a8px7rUHKWbGLP4YfbsMed2KFUw5fczvDPbT98DDe3LEzviswl810apTEw=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+			"integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+			"license": "MIT"
 		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
@@ -5002,6 +5064,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/crossws/-/crossws-0.2.4.tgz",
 			"integrity": "sha512-DAxroI2uSOgUKLz00NX6A8U/8EE3SZHmIND+10jkVSaypvyt57J5JEOxAQOL6lQxyzi/wZbTIwssU1uy69h5Vg==",
+			"license": "MIT",
 			"peerDependencies": {
 				"uWebSockets.js": "*"
 			},
@@ -5184,6 +5247,7 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
 			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -5255,7 +5319,8 @@
 		"node_modules/defu": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+			"license": "MIT"
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
@@ -5281,12 +5346,14 @@
 		"node_modules/destr": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
-			"integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
+			"integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==",
+			"license": "MIT"
 		},
 		"node_modules/detect-browser": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-			"integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+			"integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+			"license": "MIT"
 		},
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
@@ -5301,6 +5368,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"license": "Apache-2.0",
 			"bin": {
 				"detect-libc": "bin/detect-libc.js"
 			},
@@ -5389,6 +5457,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
 			"integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.4.1",
 				"inherits": "^2.0.3",
@@ -5425,6 +5494,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
 			}
@@ -6253,6 +6323,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -6337,6 +6408,7 @@
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
 			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -6384,6 +6456,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
 			"integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6563,7 +6636,8 @@
 		"node_modules/get-port-please": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
-			"integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
+			"integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==",
+			"license": "MIT"
 		},
 		"node_modules/get-stream": {
 			"version": "8.0.1",
@@ -6716,18 +6790,19 @@
 			"dev": true
 		},
 		"node_modules/h3": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/h3/-/h3-1.11.1.tgz",
-			"integrity": "sha512-AbaH6IDnZN6nmbnJOH72y3c5Wwh9P97soSVdGSBbcDACRdkC0FEWf25pzx4f/NuOCK6quHmW18yF2Wx+G4Zi1A==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/h3/-/h3-1.12.0.tgz",
+			"integrity": "sha512-Zi/CcNeWBXDrFNlV0hUBJQR9F7a96RjMeAZweW/ZWkR9fuXrMcvKnSA63f/zZ9l0GgQOZDVHGvXivNN9PWOwhA==",
+			"license": "MIT",
 			"dependencies": {
-				"cookie-es": "^1.0.0",
-				"crossws": "^0.2.2",
+				"cookie-es": "^1.1.0",
+				"crossws": "^0.2.4",
 				"defu": "^6.1.4",
 				"destr": "^2.0.3",
-				"iron-webcrypto": "^1.0.0",
+				"iron-webcrypto": "^1.1.1",
 				"ohash": "^1.1.3",
-				"radix3": "^1.1.0",
-				"ufo": "^1.4.0",
+				"radix3": "^1.1.2",
+				"ufo": "^1.5.3",
 				"uncrypto": "^0.1.3",
 				"unenv": "^1.9.0"
 			}
@@ -6956,6 +7031,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
 			"integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
+			"license": "MIT",
 			"engines": {
 				"iojs": ">= 1.0.0",
 				"node": ">= 0.12.0"
@@ -7147,9 +7223,10 @@
 			}
 		},
 		"node_modules/iron-webcrypto": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.1.0.tgz",
-			"integrity": "sha512-5vgYsCakNlaQub1orZK5QmNYhwYtcllTkZBp5sfIaCqY93Cf6l+v2rtE+E4TMbcfjxDMCdrO8wmp7+ZvhDECLA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+			"integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/brc-dd"
 			}
@@ -7273,6 +7350,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
 			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
@@ -7306,6 +7384,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
 			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^3.0.0"
 			},
@@ -7493,6 +7572,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
 			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"license": "MIT",
 			"dependencies": {
 				"is-inside-container": "^1.0.0"
 			},
@@ -7507,6 +7587,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
 			"integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
+			"license": "MIT",
 			"dependencies": {
 				"system-architecture": "^0.1.0"
 			},
@@ -7549,6 +7630,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
 			"integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+			"license": "MIT",
 			"dependencies": {
 				"node-fetch": "^2.6.1",
 				"unfetch": "^4.2.0"
@@ -7745,7 +7827,8 @@
 		"node_modules/keyvaluestorage-interface": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-			"integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
+			"integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+			"license": "MIT"
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -7794,6 +7877,7 @@
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/listhen/-/listhen-1.7.2.tgz",
 			"integrity": "sha512-7/HamOm5YD9Wb7CFgAZkKgVPA96WwhcTQoqtm2VTZGVbVVn3IWKRBTgrU7cchA3Q8k9iCsG8Osoi9GX4JsGM9g==",
+			"license": "MIT",
 			"dependencies": {
 				"@parcel/watcher": "^2.4.1",
 				"@parcel/watcher-wasm": "^2.4.1",
@@ -7849,7 +7933,8 @@
 		"node_modules/lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -7952,6 +8037,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
 			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -8077,7 +8163,8 @@
 		"node_modules/multiformats": {
 			"version": "9.9.0",
 			"resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+			"license": "(Apache-2.0 AND MIT)"
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
@@ -8120,17 +8207,16 @@
 			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"node_modules/node-addon-api": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-			"integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-			"engines": {
-				"node": "^16 || ^18 || >= 20"
-			}
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
 		},
 		"node_modules/node-fetch": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
 			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -8149,12 +8235,14 @@
 		"node_modules/node-fetch-native": {
 			"version": "1.6.4",
 			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
-			"integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
+			"integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
+			"license": "MIT"
 		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
 			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+			"license": "(BSD-3-Clause OR GPL-2.0)",
 			"engines": {
 				"node": ">= 6.13.0"
 			}
@@ -8339,6 +8427,7 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.3.4.tgz",
 			"integrity": "sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==",
+			"license": "MIT",
 			"dependencies": {
 				"destr": "^2.0.3",
 				"node-fetch-native": "^1.6.3",
@@ -8348,12 +8437,14 @@
 		"node_modules/ohash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.3.tgz",
-			"integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw=="
+			"integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==",
+			"license": "MIT"
 		},
 		"node_modules/on-exit-leak-free": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-			"integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+			"integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+			"license": "MIT"
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -8536,6 +8627,7 @@
 			"version": "7.11.0",
 			"resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
 			"integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0",
 				"fast-redact": "^3.0.0",
@@ -8557,6 +8649,7 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
 			"integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+			"license": "MIT",
 			"dependencies": {
 				"duplexify": "^4.1.2",
 				"split2": "^4.0.0"
@@ -8565,7 +8658,8 @@
 		"node_modules/pino-std-serializers": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-			"integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+			"integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+			"license": "MIT"
 		},
 		"node_modules/pirates": {
 			"version": "4.0.6",
@@ -8903,7 +8997,8 @@
 		"node_modules/process-warning": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-			"integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+			"integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+			"license": "MIT"
 		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
@@ -8953,6 +9048,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
 			"integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+			"license": "MIT",
 			"dependencies": {
 				"decode-uri-component": "^0.2.2",
 				"filter-obj": "^1.1.0",
@@ -8995,12 +9091,14 @@
 		"node_modules/quick-format-unescaped": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+			"license": "MIT"
 		},
 		"node_modules/radix3": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
-			"integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
+			"integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+			"license": "MIT"
 		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
@@ -9046,6 +9144,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
 			"integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 12.13.0"
 			}
@@ -9282,6 +9381,7 @@
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
 			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -9530,6 +9630,7 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
 			"integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
 			}
@@ -9561,6 +9662,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
 			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -9569,6 +9671,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"license": "ISC",
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -9587,12 +9690,14 @@
 		"node_modules/stream-shift": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-			"integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
+			"integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+			"license": "MIT"
 		},
 		"node_modules/strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
 			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -9999,6 +10104,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
 			"integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -10128,6 +10234,7 @@
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
 			"integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+			"license": "MIT",
 			"dependencies": {
 				"real-require": "^0.1.0"
 			}
@@ -10233,7 +10340,8 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
 		},
 		"node_modules/ts-api-utils": {
 			"version": "1.2.1",
@@ -10429,9 +10537,10 @@
 			"integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw=="
 		},
 		"node_modules/uint8arrays": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
+			"integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
+			"license": "MIT",
 			"dependencies": {
 				"multiformats": "^9.4.2"
 			}
@@ -10455,7 +10564,8 @@
 		"node_modules/uncrypto": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-			"integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+			"integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+			"license": "MIT"
 		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
@@ -10464,21 +10574,23 @@
 			"dev": true
 		},
 		"node_modules/unenv": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/unenv/-/unenv-1.9.0.tgz",
-			"integrity": "sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+			"integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+			"license": "MIT",
 			"dependencies": {
 				"consola": "^3.2.3",
-				"defu": "^6.1.3",
+				"defu": "^6.1.4",
 				"mime": "^3.0.0",
-				"node-fetch-native": "^1.6.1",
-				"pathe": "^1.1.1"
+				"node-fetch-native": "^1.6.4",
+				"pathe": "^1.1.2"
 			}
 		},
 		"node_modules/unfetch": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-			"integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+			"integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
+			"license": "MIT"
 		},
 		"node_modules/universalify": {
 			"version": "0.2.0",
@@ -10493,6 +10605,7 @@
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.10.2.tgz",
 			"integrity": "sha512-cULBcwDqrS8UhlIysUJs2Dk0Mmt8h7B0E6mtR+relW9nZvsf/u4SkAYyNliPiPW7XtFNb5u3IUMkxGxFTTRTgQ==",
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "^3.1.3",
 				"chokidar": "^3.6.0",
@@ -10563,17 +10676,16 @@
 			}
 		},
 		"node_modules/unstorage/node_modules/lru-cache": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-			"integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
-			"engines": {
-				"node": "14 || >=16.14"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
 		},
 		"node_modules/untun": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
 			"integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
+			"license": "MIT",
 			"dependencies": {
 				"citty": "^0.1.5",
 				"consola": "^3.2.3",
@@ -10616,7 +10728,8 @@
 		"node_modules/uqr": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
-			"integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
+			"integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
+			"license": "MIT"
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -10913,7 +11026,8 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/websocket": {
 			"version": "1.0.34",
@@ -10956,6 +11070,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4032,27 +4032,6 @@
 				"uint8arrays": "3.1.0"
 			}
 		},
-		"node_modules/@walletconnect/utils/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-			"license": "MIT"
-		},
-		"node_modules/@walletconnect/utils/node_modules/elliptic": {
-			"version": "6.5.7",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-			"integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
 		"node_modules/@walletconnect/web3wallet": {
 			"version": "1.14.0",
 			"resolved": "https://registry.npmjs.org/@walletconnect/web3wallet/-/web3wallet-1.14.0.tgz",
@@ -5475,9 +5454,10 @@
 			"dev": true
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"version": "6.5.7",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+			"integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.11.9",
 				"brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"@dfinity/verifiable-credentials": "^0.0.2",
 		"@junobuild/analytics": "^0.0.24",
 		"@metamask/detect-provider": "^2.0.0",
-		"@walletconnect/web3wallet": "^1.12.3",
+		"@walletconnect/web3wallet": "^1.14.0",
 		"alchemy-sdk": "^3.3.1",
 		"buffer": "^6.0.3",
 		"ethers": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"@junobuild/analytics": "^0.0.24",
 		"@metamask/detect-provider": "^2.0.0",
 		"@walletconnect/web3wallet": "^1.14.0",
-		"alchemy-sdk": "^3.3.1",
+		"alchemy-sdk": "^3.4.1",
 		"buffer": "^6.0.3",
 		"ethers": "^5.7.0",
 		"idb-keyval": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
 	},
 	"type": "module",
 	"overrides": {
-		"ws": "^7.5.10"
+		"ws": "^7.5.10",
+		"elliptic": "^6.5.7"
 	},
 	"engines": {
 		"node": ">=20"


### PR DESCRIPTION
# Motivation

We want to stay up-to-date and resolve some npm audit warnings.

# Changes

- Pin `elliptic` to inherit various fix of security vunerabilities
- Update WalletConnect last version v1.14.0
- Update Alchemy sdk v3.4.1 which officially inherit axios security fix (issue #2024 still not solved though)

