### PR TITLE
ci(e2e): fix e2e tests pipeline

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,9 @@ jobs:
   docker-build-e2e:
     runs-on: ubuntu-20.04
     steps:
+      - name: Delete unnecessary tools folder to prevent "out of space" error
+        run: rm -rf /opt/hostedtoolcache
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -9,6 +9,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     netcat \
     ca-certificates \
     build-essential \
+    llvm-dev \
+    clang \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install NodeJS

--- a/docker/deploy
+++ b/docker/deploy
@@ -6,6 +6,7 @@ dfx start --background --quiet
 
 ./docker/wait-port "$DFX_PORT"
 
+# TODO: Remove these lines after the dependency problem is solved by ic-terraform
 dfx canister create internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
 dfx canister create pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
 

--- a/docker/deploy
+++ b/docker/deploy
@@ -6,10 +6,6 @@ dfx start --background --quiet
 
 ./docker/wait-port "$DFX_PORT"
 
-# TODO: Remove these lines after the dependency problem is solved by ic-terraform
-dfx canister create internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
-dfx canister create pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
-
 npm run deploy
 
 dfx stop

--- a/docker/deploy
+++ b/docker/deploy
@@ -6,6 +6,9 @@ dfx start --background --quiet
 
 ./docker/wait-port "$DFX_PORT"
 
+dfx canister create internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
+dfx canister create pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
+
 npm run deploy
 
 dfx stop


### PR DESCRIPTION
# Motivation

The goal of this PR is to fix e2e tests pipeline.

# Changes

1. To prevent "out of space" error while building an e2e docker image, added a small command to remove cache folder.
2. Dockerfile.e2e was missing a few tools required to build and deploy backend canister.
3. To fix the issue described [here](https://dfinity.slack.com/archives/C072H2FMW1F/p1723737578374699), we need to create some canisters before running the deploy script.
