### PR TITLE
feat(frontend): IDB functions for Bitcoin address

### DIFF
--- a/src/frontend/src/lib/types/idb.ts
+++ b/src/frontend/src/lib/types/idb.ts
@@ -1,4 +1,10 @@
-import type { EthAddress } from '$lib/types/address';
+import type { BtcAddress, EthAddress } from '$lib/types/address';
+
+export interface IdbBtcAddress {
+	address: BtcAddress;
+	createdAtTimestamp: number;
+	lastUsedTimestamp: number;
+}
 
 export interface IdbEthAddress {
 	address: EthAddress;


### PR DESCRIPTION
# Motivation

We replicate the IDB functions for Bitcoin Mainnet address, as they are used for Ethereum.

