### PR TITLE
ci(deploy): prevent "out of space" error in update-snapshots.yml

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -14,6 +14,9 @@ jobs:
           echo "This workflow should not be triggered with workflow_dispatch on main"
           exit 1
 
+      - name: Delete unnecessary tools folder to prevent "out of space" error
+        run: rm -rf /opt/hostedtoolcache
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
# Motivation

Same as in e2e-test.yml, before building an e2e docker image, we need to free some space to prevent "out of space" error.
