### PR TITLE
feat(devops): Add signer canister

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -3,6 +3,12 @@
 		"ic": "fiefn-syaaa-aaaan-qectq-cai",
 		"staging": "t7tos-nyaaa-aaaad-aadkq-cai"
 	},
+	"signer": {
+		"ic": "grghe-syaaa-aaaar-qabyq-cai",
+		"beta": "grghe-syaaa-aaaar-qabyq-cai",
+		"old_backend": "cab24-4qaaa-aaaan-qecca-cai",
+		"staging": "tdxud-2yaaa-aaaad-aadiq-cai"
+	},
 	"backend": {
 		"ic": "grghe-syaaa-aaaar-qabyq-cai",
 		"beta": "grghe-syaaa-aaaar-qabyq-cai",

--- a/dfx.json
+++ b/dfx.json
@@ -1,6 +1,13 @@
 {
 	"dfx": "0.20.0",
 	"canisters": {
+		"signer": {
+			"candid": "src/backend/backend.did",
+			"package": "backend",
+			"type": "rust",
+			"optimize": "cycles",
+			"gzip": true
+		},
 		"backend": {
 			"candid": "src/backend/backend.did",
 			"package": "backend",


### PR DESCRIPTION
# Motivation
The backend will be split into a signer and a user data canister.  The first step in this process, according to [the plan](https://www.notion.so/dfinityorg/Oisy-frontend-uses-separate-backend-and-signer-6a84a876f6ec434891eafcb56756937c), is to have separate canister names, even though they initially refer to the same canister.

# Changes
- Add a `signer` canister to `dfx.json` and `canister_ids.json`.

# Tests
- Existing CI should pass.
- Reviewers should manually verify that, at the time of writing, the canister IDs are identical for the `backend` and `signer`.