### PR TITLE
fix(frontend): ICP Erc20 to native ICP destination account identifier

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -48,6 +48,7 @@
 	import { decodeQrCode } from '$eth/utils/qr-code.utils';
 	import type { QrResponse, QrStatus } from '$lib/types/qr-code';
 	import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
+	import { isErc20Icp } from '$eth/utils/token.utils';
 
 	export let currentStep: WizardStep | undefined;
 	export let formCancelAction: 'back' | 'close' = 'close';
@@ -178,7 +179,7 @@
 		try {
 			await executeSend({
 				from: $ethAddress,
-				to: mapAddressStartsWith0x(destination),
+				to: isErc20Icp($sendToken) ? destination : mapAddressStartsWith0x(destination),
 				progress: (step: ProgressStepsSend) => (sendProgressStep = step),
 				token: $sendToken,
 				amount: parseToken({

--- a/src/frontend/src/eth/components/send/SendDestination.svelte
+++ b/src/frontend/src/eth/components/send/SendDestination.svelte
@@ -5,9 +5,24 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
+	import type { OptionToken } from '$lib/types/token';
+	import { isErc20Icp } from '$eth/utils/token.utils';
+	import { invalidIcpAddress } from '$icp/utils/icp-account.utils';
+	import type { Network } from '$lib/types/network';
+	import { isNetworkICP } from '$lib/utils/network.utils';
+	import { DEFAULT_ETHEREUM_NETWORK } from '$lib/constants/networks.constants';
+	import { isNullish } from '@dfinity/utils';
 
+	export let token: OptionToken;
+	export let network: Network | undefined = undefined;
 	export let destination = '';
 	export let invalidDestination = false;
+
+	let networkICP = false;
+	$: networkICP = isNetworkICP(network ?? DEFAULT_ETHEREUM_NETWORK);
+
+	let erc20Icp = false;
+	$: erc20Icp = isErc20Icp(token);
 
 	const dispatch = createEventDispatcher();
 
@@ -15,6 +30,15 @@
 	$: isInvalidDestination = (): boolean => {
 		if (isNullishOrEmpty(destination)) {
 			return false;
+		}
+
+		// Avoid flickering when user enter an address and the network is about to being selected automatically.
+		if (erc20Icp && isNullish(network)) {
+			return false;
+		}
+
+		if (erc20Icp && networkICP) {
+			return invalidIcpAddress(destination);
 		}
 
 		return !isEthAddress(destination);

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -38,7 +38,13 @@
 <form on:submit={() => dispatch('icNext')} method="POST">
 	<div class="stretch">
 		{#if destinationEditable}
-			<SendDestination bind:destination bind:invalidDestination on:icQRCodeScan />
+			<SendDestination
+				token={$sendToken}
+				{network}
+				bind:destination
+				bind:invalidDestination
+				on:icQRCodeScan
+			/>
 
 			<SendNetworkICP {destination} {sourceNetwork} bind:network />
 		{/if}


### PR DESCRIPTION
# Motivation

To enable the conversion of "ICP ERC20" tokens to native ICP tokens, users should be able to input an "old" ICP account identifier in hexadecimal format. Previously, this function worked as expected. However, due to an assertion introduced in early 2024, the destination field in the ETH "Send" wizard now requires a properly formatted ETH address. To accommodate this specific use case, we need to modify the validation process to recognize and accept ICP account identifiers as valid inputs in the destination field.

# Notes

There might be some more abstracted ways to solve this but, to prevent issues, I rather liked to bit a bit verbose given that it is a really particular use case. 

# Changes

- Improve `isInvalidDestination` to throw if the address is an invalid account identifier on "ICP Erc20"
- Do not map to Eth address prefixed with `0x` on send
- Do not map to Eth address prefixed with `0x` when calculating fee
