### PR TITLE
feat(dvOps): Create signer bindings

### DIFF
--- a/scripts/did.delete.types.mjs
+++ b/scripts/did.delete.types.mjs
@@ -11,7 +11,7 @@ const deleteFolder = async (canister) => {
 };
 
 const promises = Object.keys(canisters)
-	.filter((canister) => !['backend', 'frontend'].includes(canister))
+	.filter((canister) => !['backend', 'frontend', 'signer'].includes(canister))
 	.map(deleteFolder);
 
 await Promise.allSettled(promises);

--- a/src/declarations/signer/index.d.ts
+++ b/src/declarations/signer/index.d.ts
@@ -1,0 +1,45 @@
+import type { ActorConfig, ActorSubclass, Agent, HttpAgentOptions } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@dfinity/principal';
+
+import { _SERVICE } from './signer.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+	/**
+	 * @see {@link Agent}
+	 */
+	agent?: Agent;
+	/**
+	 * @see {@link HttpAgentOptions}
+	 */
+	agentOptions?: HttpAgentOptions;
+	/**
+	 * @see {@link ActorConfig}
+	 */
+	actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+	canisterId: string | Principal,
+	options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const signer: ActorSubclass<_SERVICE>;

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -1,0 +1,170 @@
+type AddUserCredentialError = variant {
+  InvalidCredential;
+  VersionMismatch;
+  ConfigurationError;
+  UserNotFound;
+};
+type AddUserCredentialRequest = record {
+  credential_jwt : text;
+  issuer_canister_id : principal;
+  current_user_version : opt nat64;
+  credential_spec : CredentialSpec;
+};
+type ApiEnabled = variant { ReadOnly; Enabled; Disabled };
+type Arg = variant { Upgrade; Init : InitArg };
+type ArgumentValue = variant { Int : int32; String : text };
+type BitcoinNetwork = variant { mainnet; regtest; testnet };
+type CanisterStatusResultV2 = record {
+  controller : principal;
+  status : CanisterStatusType;
+  freezing_threshold : nat;
+  balance : vec record { blob; nat };
+  memory_size : nat;
+  cycles : nat;
+  settings : DefiniteCanisterSettingsArgs;
+  idle_cycles_burned_per_day : nat;
+  module_hash : opt blob;
+};
+type CanisterStatusType = variant { stopped; stopping; running };
+type Config = record {
+  api : opt Guards;
+  ecdsa_key_name : text;
+  allowed_callers : vec principal;
+  supported_credentials : opt vec SupportedCredential;
+  ic_root_key_raw : opt blob;
+};
+type CredentialSpec = record {
+  arguments : opt vec record { text; ArgumentValue };
+  credential_type : text;
+};
+type CredentialType = variant { ProofOfUniqueness };
+type CustomToken = record {
+  token : Token;
+  version : opt nat64;
+  enabled : bool;
+};
+type DefiniteCanisterSettingsArgs = record {
+  controller : principal;
+  freezing_threshold : nat;
+  controllers : vec principal;
+  memory_allocation : nat;
+  compute_allocation : nat;
+};
+type GetUserProfileError = variant { NotFound };
+type Guards = record { user_data : ApiEnabled; threshold_key : ApiEnabled };
+type HttpRequest = record {
+  url : text;
+  method : text;
+  body : blob;
+  headers : vec record { text; text };
+};
+type HttpResponse = record {
+  body : blob;
+  headers : vec record { text; text };
+  status_code : nat16;
+};
+type IcrcToken = record { ledger_id : principal; index_id : opt principal };
+type InitArg = record {
+  api : opt Guards;
+  ecdsa_key_name : text;
+  allowed_callers : vec principal;
+  supported_credentials : opt vec SupportedCredential;
+  ic_root_key_der : opt blob;
+};
+type ListUsersRequest = record {
+  updated_after_timestamp : opt nat64;
+  matches_max_length : opt nat64;
+};
+type ListUsersResponse = record {
+  users : vec OisyUser;
+  matches_max_length : nat64;
+};
+type MigrationProgress = variant {
+  MigratedUserTokensUpTo : opt principal;
+  MigratedUserTimestampsUpTo : opt principal;
+  TargetPreCheckOk;
+  MigratedCustomTokensUpTo : opt principal;
+  Locked;
+  MigratedUserProfilesUpTo : opt record { nat64; principal };
+  CheckingTargetCanister;
+  TargetLocked;
+  Completed;
+  Pending;
+};
+type MigrationReport = record { to : principal; progress : MigrationProgress };
+type OisyUser = record {
+  "principal" : principal;
+  pouh_verified : bool;
+  updated_timestamp : nat64;
+};
+type Result = variant { Ok; Err : AddUserCredentialError };
+type Result_1 = variant { Ok : UserProfile; Err : GetUserProfileError };
+type SignRequest = record {
+  to : text;
+  gas : nat;
+  value : nat;
+  max_priority_fee_per_gas : nat;
+  data : opt text;
+  max_fee_per_gas : nat;
+  chain_id : nat;
+  nonce : nat;
+};
+type Stats = record {
+  user_profile_count : nat64;
+  custom_token_count : nat64;
+  user_token_count : nat64;
+};
+type SupportedCredential = record {
+  ii_canister_id : principal;
+  issuer_origin : text;
+  issuer_canister_id : principal;
+  ii_origin : text;
+  credential_type : CredentialType;
+};
+type Token = variant { Icrc : IcrcToken };
+type UserCredential = record {
+  issuer : text;
+  verified_date_timestamp : opt nat64;
+  credential_type : CredentialType;
+};
+type UserProfile = record {
+  credentials : vec UserCredential;
+  version : opt nat64;
+  created_timestamp : nat64;
+  updated_timestamp : nat64;
+};
+type UserToken = record {
+  decimals : opt nat8;
+  version : opt nat64;
+  enabled : opt bool;
+  chain_id : nat64;
+  contract_address : text;
+  symbol : opt text;
+};
+type UserTokenId = record { chain_id : nat64; contract_address : text };
+service : (Arg) -> {
+  add_user_credential : (AddUserCredentialRequest) -> (Result);
+  bulk_up : (blob) -> ();
+  caller_btc_address : (BitcoinNetwork) -> (text);
+  caller_eth_address : () -> (text);
+  config : () -> (Config) query;
+  create_user_profile : () -> (UserProfile);
+  eth_address_of : (principal) -> (text);
+  get_canister_status : () -> (CanisterStatusResultV2);
+  get_user_profile : () -> (Result_1) query;
+  http_request : (HttpRequest) -> (HttpResponse) query;
+  list_custom_tokens : () -> (vec CustomToken) query;
+  list_user_tokens : () -> (vec UserToken) query;
+  list_users : (ListUsersRequest) -> (ListUsersResponse) query;
+  migration : () -> (opt MigrationReport) query;
+  personal_sign : (text) -> (text);
+  remove_user_token : (UserTokenId) -> ();
+  set_custom_token : (CustomToken) -> ();
+  set_guards : (Guards) -> ();
+  set_many_custom_tokens : (vec CustomToken) -> ();
+  set_many_user_tokens : (vec UserToken) -> ();
+  set_user_token : (UserToken) -> ();
+  sign_prehash : (text) -> (text);
+  sign_transaction : (SignRequest) -> (text);
+  stats : () -> (Stats) query;
+}

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -1,0 +1,188 @@
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@dfinity/principal';
+
+export type AddUserCredentialError =
+	| { InvalidCredential: null }
+	| { VersionMismatch: null }
+	| { ConfigurationError: null }
+	| { UserNotFound: null };
+export interface AddUserCredentialRequest {
+	credential_jwt: string;
+	issuer_canister_id: Principal;
+	current_user_version: [] | [bigint];
+	credential_spec: CredentialSpec;
+}
+export type ApiEnabled = { ReadOnly: null } | { Enabled: null } | { Disabled: null };
+export type Arg = { Upgrade: null } | { Init: InitArg };
+export type ArgumentValue = { Int: number } | { String: string };
+export type BitcoinNetwork = { mainnet: null } | { regtest: null } | { testnet: null };
+export interface CanisterStatusResultV2 {
+	controller: Principal;
+	status: CanisterStatusType;
+	freezing_threshold: bigint;
+	balance: Array<[Uint8Array | number[], bigint]>;
+	memory_size: bigint;
+	cycles: bigint;
+	settings: DefiniteCanisterSettingsArgs;
+	idle_cycles_burned_per_day: bigint;
+	module_hash: [] | [Uint8Array | number[]];
+}
+export type CanisterStatusType = { stopped: null } | { stopping: null } | { running: null };
+export interface Config {
+	api: [] | [Guards];
+	ecdsa_key_name: string;
+	allowed_callers: Array<Principal>;
+	supported_credentials: [] | [Array<SupportedCredential>];
+	ic_root_key_raw: [] | [Uint8Array | number[]];
+}
+export interface CredentialSpec {
+	arguments: [] | [Array<[string, ArgumentValue]>];
+	credential_type: string;
+}
+export type CredentialType = { ProofOfUniqueness: null };
+export interface CustomToken {
+	token: Token;
+	version: [] | [bigint];
+	enabled: boolean;
+}
+export interface DefiniteCanisterSettingsArgs {
+	controller: Principal;
+	freezing_threshold: bigint;
+	controllers: Array<Principal>;
+	memory_allocation: bigint;
+	compute_allocation: bigint;
+}
+export type GetUserProfileError = { NotFound: null };
+export interface Guards {
+	user_data: ApiEnabled;
+	threshold_key: ApiEnabled;
+}
+export interface HttpRequest {
+	url: string;
+	method: string;
+	body: Uint8Array | number[];
+	headers: Array<[string, string]>;
+}
+export interface HttpResponse {
+	body: Uint8Array | number[];
+	headers: Array<[string, string]>;
+	status_code: number;
+}
+export interface IcrcToken {
+	ledger_id: Principal;
+	index_id: [] | [Principal];
+}
+export interface InitArg {
+	api: [] | [Guards];
+	ecdsa_key_name: string;
+	allowed_callers: Array<Principal>;
+	supported_credentials: [] | [Array<SupportedCredential>];
+	ic_root_key_der: [] | [Uint8Array | number[]];
+}
+export interface ListUsersRequest {
+	updated_after_timestamp: [] | [bigint];
+	matches_max_length: [] | [bigint];
+}
+export interface ListUsersResponse {
+	users: Array<OisyUser>;
+	matches_max_length: bigint;
+}
+export type MigrationProgress =
+	| {
+			MigratedUserTokensUpTo: [] | [Principal];
+	  }
+	| { MigratedUserTimestampsUpTo: [] | [Principal] }
+	| { TargetPreCheckOk: null }
+	| { MigratedCustomTokensUpTo: [] | [Principal] }
+	| { Locked: null }
+	| { MigratedUserProfilesUpTo: [] | [[bigint, Principal]] }
+	| { CheckingTargetCanister: null }
+	| { TargetLocked: null }
+	| { Completed: null }
+	| { Pending: null };
+export interface MigrationReport {
+	to: Principal;
+	progress: MigrationProgress;
+}
+export interface OisyUser {
+	principal: Principal;
+	pouh_verified: boolean;
+	updated_timestamp: bigint;
+}
+export type Result = { Ok: null } | { Err: AddUserCredentialError };
+export type Result_1 = { Ok: UserProfile } | { Err: GetUserProfileError };
+export interface SignRequest {
+	to: string;
+	gas: bigint;
+	value: bigint;
+	max_priority_fee_per_gas: bigint;
+	data: [] | [string];
+	max_fee_per_gas: bigint;
+	chain_id: bigint;
+	nonce: bigint;
+}
+export interface Stats {
+	user_profile_count: bigint;
+	custom_token_count: bigint;
+	user_token_count: bigint;
+}
+export interface SupportedCredential {
+	ii_canister_id: Principal;
+	issuer_origin: string;
+	issuer_canister_id: Principal;
+	ii_origin: string;
+	credential_type: CredentialType;
+}
+export type Token = { Icrc: IcrcToken };
+export interface UserCredential {
+	issuer: string;
+	verified_date_timestamp: [] | [bigint];
+	credential_type: CredentialType;
+}
+export interface UserProfile {
+	credentials: Array<UserCredential>;
+	version: [] | [bigint];
+	created_timestamp: bigint;
+	updated_timestamp: bigint;
+}
+export interface UserToken {
+	decimals: [] | [number];
+	version: [] | [bigint];
+	enabled: [] | [boolean];
+	chain_id: bigint;
+	contract_address: string;
+	symbol: [] | [string];
+}
+export interface UserTokenId {
+	chain_id: bigint;
+	contract_address: string;
+}
+export interface _SERVICE {
+	add_user_credential: ActorMethod<[AddUserCredentialRequest], Result>;
+	bulk_up: ActorMethod<[Uint8Array | number[]], undefined>;
+	caller_btc_address: ActorMethod<[BitcoinNetwork], string>;
+	caller_eth_address: ActorMethod<[], string>;
+	config: ActorMethod<[], Config>;
+	create_user_profile: ActorMethod<[], UserProfile>;
+	eth_address_of: ActorMethod<[Principal], string>;
+	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
+	get_user_profile: ActorMethod<[], Result_1>;
+	http_request: ActorMethod<[HttpRequest], HttpResponse>;
+	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
+	list_user_tokens: ActorMethod<[], Array<UserToken>>;
+	list_users: ActorMethod<[ListUsersRequest], ListUsersResponse>;
+	migration: ActorMethod<[], [] | [MigrationReport]>;
+	personal_sign: ActorMethod<[string], string>;
+	remove_user_token: ActorMethod<[UserTokenId], undefined>;
+	set_custom_token: ActorMethod<[CustomToken], undefined>;
+	set_guards: ActorMethod<[Guards], undefined>;
+	set_many_custom_tokens: ActorMethod<[Array<CustomToken>], undefined>;
+	set_many_user_tokens: ActorMethod<[Array<UserToken>], undefined>;
+	set_user_token: ActorMethod<[UserToken], undefined>;
+	sign_prehash: ActorMethod<[string], string>;
+	sign_transaction: ActorMethod<[SignRequest], string>;
+	stats: ActorMethod<[], Stats>;
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -1,0 +1,232 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const ApiEnabled = IDL.Variant({
+		ReadOnly: IDL.Null,
+		Enabled: IDL.Null,
+		Disabled: IDL.Null
+	});
+	const Guards = IDL.Record({
+		user_data: ApiEnabled,
+		threshold_key: ApiEnabled
+	});
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Principal,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Principal,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
+	const InitArg = IDL.Record({
+		api: IDL.Opt(Guards),
+		ecdsa_key_name: IDL.Text,
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
+	const ArgumentValue = IDL.Variant({ Int: IDL.Int32, String: IDL.Text });
+	const CredentialSpec = IDL.Record({
+		arguments: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, ArgumentValue))),
+		credential_type: IDL.Text
+	});
+	const AddUserCredentialRequest = IDL.Record({
+		credential_jwt: IDL.Text,
+		issuer_canister_id: IDL.Principal,
+		current_user_version: IDL.Opt(IDL.Nat64),
+		credential_spec: CredentialSpec
+	});
+	const AddUserCredentialError = IDL.Variant({
+		InvalidCredential: IDL.Null,
+		VersionMismatch: IDL.Null,
+		ConfigurationError: IDL.Null,
+		UserNotFound: IDL.Null
+	});
+	const Result = IDL.Variant({
+		Ok: IDL.Null,
+		Err: AddUserCredentialError
+	});
+	const BitcoinNetwork = IDL.Variant({
+		mainnet: IDL.Null,
+		regtest: IDL.Null,
+		testnet: IDL.Null
+	});
+	const Config = IDL.Record({
+		api: IDL.Opt(Guards),
+		ecdsa_key_name: IDL.Text,
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const UserCredential = IDL.Record({
+		issuer: IDL.Text,
+		verified_date_timestamp: IDL.Opt(IDL.Nat64),
+		credential_type: CredentialType
+	});
+	const UserProfile = IDL.Record({
+		credentials: IDL.Vec(UserCredential),
+		version: IDL.Opt(IDL.Nat64),
+		created_timestamp: IDL.Nat64,
+		updated_timestamp: IDL.Nat64
+	});
+	const CanisterStatusType = IDL.Variant({
+		stopped: IDL.Null,
+		stopping: IDL.Null,
+		running: IDL.Null
+	});
+	const DefiniteCanisterSettingsArgs = IDL.Record({
+		controller: IDL.Principal,
+		freezing_threshold: IDL.Nat,
+		controllers: IDL.Vec(IDL.Principal),
+		memory_allocation: IDL.Nat,
+		compute_allocation: IDL.Nat
+	});
+	const CanisterStatusResultV2 = IDL.Record({
+		controller: IDL.Principal,
+		status: CanisterStatusType,
+		freezing_threshold: IDL.Nat,
+		balance: IDL.Vec(IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat)),
+		memory_size: IDL.Nat,
+		cycles: IDL.Nat,
+		settings: DefiniteCanisterSettingsArgs,
+		idle_cycles_burned_per_day: IDL.Nat,
+		module_hash: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const GetUserProfileError = IDL.Variant({ NotFound: IDL.Null });
+	const Result_1 = IDL.Variant({
+		Ok: UserProfile,
+		Err: GetUserProfileError
+	});
+	const HttpRequest = IDL.Record({
+		url: IDL.Text,
+		method: IDL.Text,
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))
+	});
+	const HttpResponse = IDL.Record({
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		status_code: IDL.Nat16
+	});
+	const IcrcToken = IDL.Record({
+		ledger_id: IDL.Principal,
+		index_id: IDL.Opt(IDL.Principal)
+	});
+	const Token = IDL.Variant({ Icrc: IcrcToken });
+	const CustomToken = IDL.Record({
+		token: Token,
+		version: IDL.Opt(IDL.Nat64),
+		enabled: IDL.Bool
+	});
+	const UserToken = IDL.Record({
+		decimals: IDL.Opt(IDL.Nat8),
+		version: IDL.Opt(IDL.Nat64),
+		enabled: IDL.Opt(IDL.Bool),
+		chain_id: IDL.Nat64,
+		contract_address: IDL.Text,
+		symbol: IDL.Opt(IDL.Text)
+	});
+	const ListUsersRequest = IDL.Record({
+		updated_after_timestamp: IDL.Opt(IDL.Nat64),
+		matches_max_length: IDL.Opt(IDL.Nat64)
+	});
+	const OisyUser = IDL.Record({
+		principal: IDL.Principal,
+		pouh_verified: IDL.Bool,
+		updated_timestamp: IDL.Nat64
+	});
+	const ListUsersResponse = IDL.Record({
+		users: IDL.Vec(OisyUser),
+		matches_max_length: IDL.Nat64
+	});
+	const MigrationProgress = IDL.Variant({
+		MigratedUserTokensUpTo: IDL.Opt(IDL.Principal),
+		MigratedUserTimestampsUpTo: IDL.Opt(IDL.Principal),
+		TargetPreCheckOk: IDL.Null,
+		MigratedCustomTokensUpTo: IDL.Opt(IDL.Principal),
+		Locked: IDL.Null,
+		MigratedUserProfilesUpTo: IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Principal)),
+		CheckingTargetCanister: IDL.Null,
+		TargetLocked: IDL.Null,
+		Completed: IDL.Null,
+		Pending: IDL.Null
+	});
+	const MigrationReport = IDL.Record({
+		to: IDL.Principal,
+		progress: MigrationProgress
+	});
+	const UserTokenId = IDL.Record({
+		chain_id: IDL.Nat64,
+		contract_address: IDL.Text
+	});
+	const SignRequest = IDL.Record({
+		to: IDL.Text,
+		gas: IDL.Nat,
+		value: IDL.Nat,
+		max_priority_fee_per_gas: IDL.Nat,
+		data: IDL.Opt(IDL.Text),
+		max_fee_per_gas: IDL.Nat,
+		chain_id: IDL.Nat,
+		nonce: IDL.Nat
+	});
+	const Stats = IDL.Record({
+		user_profile_count: IDL.Nat64,
+		custom_token_count: IDL.Nat64,
+		user_token_count: IDL.Nat64
+	});
+	return IDL.Service({
+		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
+		bulk_up: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
+		caller_btc_address: IDL.Func([BitcoinNetwork], [IDL.Text], []),
+		caller_eth_address: IDL.Func([], [IDL.Text], []),
+		config: IDL.Func([], [Config]),
+		create_user_profile: IDL.Func([], [UserProfile], []),
+		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
+		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
+		get_user_profile: IDL.Func([], [Result_1]),
+		http_request: IDL.Func([HttpRequest], [HttpResponse]),
+		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)]),
+		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)]),
+		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse]),
+		migration: IDL.Func([], [IDL.Opt(MigrationReport)]),
+		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
+		remove_user_token: IDL.Func([UserTokenId], [], []),
+		set_custom_token: IDL.Func([CustomToken], [], []),
+		set_guards: IDL.Func([Guards], [], []),
+		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),
+		set_many_user_tokens: IDL.Func([IDL.Vec(UserToken)], [], []),
+		set_user_token: IDL.Func([UserToken], [], []),
+		sign_prehash: IDL.Func([IDL.Text], [IDL.Text], []),
+		sign_transaction: IDL.Func([SignRequest], [IDL.Text], []),
+		stats: IDL.Func([], [Stats])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	const ApiEnabled = IDL.Variant({
+		ReadOnly: IDL.Null,
+		Enabled: IDL.Null,
+		Disabled: IDL.Null
+	});
+	const Guards = IDL.Record({
+		user_data: ApiEnabled,
+		threshold_key: ApiEnabled
+	});
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Principal,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Principal,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
+	const InitArg = IDL.Record({
+		api: IDL.Opt(Guards),
+		ecdsa_key_name: IDL.Text,
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
+	return [Arg];
+};

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -1,0 +1,232 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const ApiEnabled = IDL.Variant({
+		ReadOnly: IDL.Null,
+		Enabled: IDL.Null,
+		Disabled: IDL.Null
+	});
+	const Guards = IDL.Record({
+		user_data: ApiEnabled,
+		threshold_key: ApiEnabled
+	});
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Principal,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Principal,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
+	const InitArg = IDL.Record({
+		api: IDL.Opt(Guards),
+		ecdsa_key_name: IDL.Text,
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
+	const ArgumentValue = IDL.Variant({ Int: IDL.Int32, String: IDL.Text });
+	const CredentialSpec = IDL.Record({
+		arguments: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, ArgumentValue))),
+		credential_type: IDL.Text
+	});
+	const AddUserCredentialRequest = IDL.Record({
+		credential_jwt: IDL.Text,
+		issuer_canister_id: IDL.Principal,
+		current_user_version: IDL.Opt(IDL.Nat64),
+		credential_spec: CredentialSpec
+	});
+	const AddUserCredentialError = IDL.Variant({
+		InvalidCredential: IDL.Null,
+		VersionMismatch: IDL.Null,
+		ConfigurationError: IDL.Null,
+		UserNotFound: IDL.Null
+	});
+	const Result = IDL.Variant({
+		Ok: IDL.Null,
+		Err: AddUserCredentialError
+	});
+	const BitcoinNetwork = IDL.Variant({
+		mainnet: IDL.Null,
+		regtest: IDL.Null,
+		testnet: IDL.Null
+	});
+	const Config = IDL.Record({
+		api: IDL.Opt(Guards),
+		ecdsa_key_name: IDL.Text,
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const UserCredential = IDL.Record({
+		issuer: IDL.Text,
+		verified_date_timestamp: IDL.Opt(IDL.Nat64),
+		credential_type: CredentialType
+	});
+	const UserProfile = IDL.Record({
+		credentials: IDL.Vec(UserCredential),
+		version: IDL.Opt(IDL.Nat64),
+		created_timestamp: IDL.Nat64,
+		updated_timestamp: IDL.Nat64
+	});
+	const CanisterStatusType = IDL.Variant({
+		stopped: IDL.Null,
+		stopping: IDL.Null,
+		running: IDL.Null
+	});
+	const DefiniteCanisterSettingsArgs = IDL.Record({
+		controller: IDL.Principal,
+		freezing_threshold: IDL.Nat,
+		controllers: IDL.Vec(IDL.Principal),
+		memory_allocation: IDL.Nat,
+		compute_allocation: IDL.Nat
+	});
+	const CanisterStatusResultV2 = IDL.Record({
+		controller: IDL.Principal,
+		status: CanisterStatusType,
+		freezing_threshold: IDL.Nat,
+		balance: IDL.Vec(IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat)),
+		memory_size: IDL.Nat,
+		cycles: IDL.Nat,
+		settings: DefiniteCanisterSettingsArgs,
+		idle_cycles_burned_per_day: IDL.Nat,
+		module_hash: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const GetUserProfileError = IDL.Variant({ NotFound: IDL.Null });
+	const Result_1 = IDL.Variant({
+		Ok: UserProfile,
+		Err: GetUserProfileError
+	});
+	const HttpRequest = IDL.Record({
+		url: IDL.Text,
+		method: IDL.Text,
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))
+	});
+	const HttpResponse = IDL.Record({
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		status_code: IDL.Nat16
+	});
+	const IcrcToken = IDL.Record({
+		ledger_id: IDL.Principal,
+		index_id: IDL.Opt(IDL.Principal)
+	});
+	const Token = IDL.Variant({ Icrc: IcrcToken });
+	const CustomToken = IDL.Record({
+		token: Token,
+		version: IDL.Opt(IDL.Nat64),
+		enabled: IDL.Bool
+	});
+	const UserToken = IDL.Record({
+		decimals: IDL.Opt(IDL.Nat8),
+		version: IDL.Opt(IDL.Nat64),
+		enabled: IDL.Opt(IDL.Bool),
+		chain_id: IDL.Nat64,
+		contract_address: IDL.Text,
+		symbol: IDL.Opt(IDL.Text)
+	});
+	const ListUsersRequest = IDL.Record({
+		updated_after_timestamp: IDL.Opt(IDL.Nat64),
+		matches_max_length: IDL.Opt(IDL.Nat64)
+	});
+	const OisyUser = IDL.Record({
+		principal: IDL.Principal,
+		pouh_verified: IDL.Bool,
+		updated_timestamp: IDL.Nat64
+	});
+	const ListUsersResponse = IDL.Record({
+		users: IDL.Vec(OisyUser),
+		matches_max_length: IDL.Nat64
+	});
+	const MigrationProgress = IDL.Variant({
+		MigratedUserTokensUpTo: IDL.Opt(IDL.Principal),
+		MigratedUserTimestampsUpTo: IDL.Opt(IDL.Principal),
+		TargetPreCheckOk: IDL.Null,
+		MigratedCustomTokensUpTo: IDL.Opt(IDL.Principal),
+		Locked: IDL.Null,
+		MigratedUserProfilesUpTo: IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Principal)),
+		CheckingTargetCanister: IDL.Null,
+		TargetLocked: IDL.Null,
+		Completed: IDL.Null,
+		Pending: IDL.Null
+	});
+	const MigrationReport = IDL.Record({
+		to: IDL.Principal,
+		progress: MigrationProgress
+	});
+	const UserTokenId = IDL.Record({
+		chain_id: IDL.Nat64,
+		contract_address: IDL.Text
+	});
+	const SignRequest = IDL.Record({
+		to: IDL.Text,
+		gas: IDL.Nat,
+		value: IDL.Nat,
+		max_priority_fee_per_gas: IDL.Nat,
+		data: IDL.Opt(IDL.Text),
+		max_fee_per_gas: IDL.Nat,
+		chain_id: IDL.Nat,
+		nonce: IDL.Nat
+	});
+	const Stats = IDL.Record({
+		user_profile_count: IDL.Nat64,
+		custom_token_count: IDL.Nat64,
+		user_token_count: IDL.Nat64
+	});
+	return IDL.Service({
+		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
+		bulk_up: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
+		caller_btc_address: IDL.Func([BitcoinNetwork], [IDL.Text], []),
+		caller_eth_address: IDL.Func([], [IDL.Text], []),
+		config: IDL.Func([], [Config], ['query']),
+		create_user_profile: IDL.Func([], [UserProfile], []),
+		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
+		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
+		get_user_profile: IDL.Func([], [Result_1], ['query']),
+		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
+		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], ['query']),
+		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)], ['query']),
+		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse], ['query']),
+		migration: IDL.Func([], [IDL.Opt(MigrationReport)], ['query']),
+		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
+		remove_user_token: IDL.Func([UserTokenId], [], []),
+		set_custom_token: IDL.Func([CustomToken], [], []),
+		set_guards: IDL.Func([Guards], [], []),
+		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),
+		set_many_user_tokens: IDL.Func([IDL.Vec(UserToken)], [], []),
+		set_user_token: IDL.Func([UserToken], [], []),
+		sign_prehash: IDL.Func([IDL.Text], [IDL.Text], []),
+		sign_transaction: IDL.Func([SignRequest], [IDL.Text], []),
+		stats: IDL.Func([], [Stats], ['query'])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	const ApiEnabled = IDL.Variant({
+		ReadOnly: IDL.Null,
+		Enabled: IDL.Null,
+		Disabled: IDL.Null
+	});
+	const Guards = IDL.Record({
+		user_data: ApiEnabled,
+		threshold_key: ApiEnabled
+	});
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
+	const SupportedCredential = IDL.Record({
+		ii_canister_id: IDL.Principal,
+		issuer_origin: IDL.Text,
+		issuer_canister_id: IDL.Principal,
+		ii_origin: IDL.Text,
+		credential_type: CredentialType
+	});
+	const InitArg = IDL.Record({
+		api: IDL.Opt(Guards),
+		ecdsa_key_name: IDL.Text,
+		allowed_callers: IDL.Vec(IDL.Principal),
+		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
+	return [Arg];
+};


### PR DESCRIPTION
# Motivation
The signer canister need separate bindings from the backend canister.  The bindings are currently identical but they will diverge soon.

# Changes
- Add bindings for the signer.  (More accurately, stop deleting them! :slightly_smiling_face: )

# Tests
- See CI