### PR TITLE
refactor(frontend): create common return type for success

### DIFF
--- a/src/frontend/src/eth/services/balance.services.ts
+++ b/src/frontend/src/eth/services/balance.services.ts
@@ -10,11 +10,12 @@ import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId } from '$lib/types/token';
+import type { SuccessOrNot } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export const reloadBalance = async (token: Token): Promise<{ success: boolean }> => {
+export const reloadBalance = async (token: Token): Promise<SuccessOrNot> => {
 	if (isSupportedEthTokenId(token.id)) {
 		return loadBalance({ networkId: token.network.id, tokenId: token.id });
 	}
@@ -28,7 +29,7 @@ export const loadBalance = async ({
 }: {
 	networkId: NetworkId;
 	tokenId: TokenId;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const address = get(addressStore);
 
 	const {
@@ -70,7 +71,7 @@ const loadErc20Balance = async ({
 }: {
 	token: Erc20Token;
 	address?: OptionEthAddress;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const address = optionAddress ?? get(addressStore);
 
 	const {
@@ -109,7 +110,7 @@ const loadErc20Balance = async ({
 	return { success: true };
 };
 
-export const loadBalances = async (): Promise<{ success: boolean }> => {
+export const loadBalances = async (): Promise<SuccessOrNot> => {
 	const results = await Promise.all([
 		...SUPPORTED_ETHEREUM_TOKENS.map(({ network: { id: networkId }, id: tokenId }) =>
 			loadBalance({ networkId, tokenId })
@@ -125,7 +126,7 @@ export const loadErc20Balances = async ({
 }: {
 	address: OptionEthAddress;
 	erc20Tokens: Erc20Token[];
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const results = await Promise.all([
 		...erc20Tokens.map((token) => loadErc20Balance({ token, address }))
 	]);

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -29,7 +29,7 @@ export const loadErc20Tokens = async ({
 };
 
 // TODO(GIX-2740): use environment static metadata
-const loadDefaultErc20Tokens = async (): Promise<{ success: boolean }> => {
+const loadDefaultErc20Tokens = async (): Promise<SuccessOrNot> => {
 	try {
 		type ContractData = Erc20Contract &
 			Erc20Metadata & { network: EthereumNetwork } & Pick<Erc20Token, 'category'> &

--- a/src/frontend/src/eth/services/transactions.services.ts
+++ b/src/frontend/src/eth/services/transactions.services.ts
@@ -8,6 +8,7 @@ import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenId } from '$lib/types/token';
+import type { SuccessOrNot } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -18,7 +19,7 @@ export const loadTransactions = async ({
 }: {
 	tokenId: TokenId;
 	networkId: NetworkId;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	if (isSupportedEthTokenId(tokenId)) {
 		return loadEthTransactions({ networkId, tokenId });
 	}
@@ -32,7 +33,7 @@ const loadEthTransactions = async ({
 }: {
 	networkId: NetworkId;
 	tokenId: TokenId;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const address = get(addressStore);
 
 	if (isNullish(address)) {
@@ -78,7 +79,7 @@ export const loadErc20Transactions = async ({
 }: {
 	networkId: NetworkId;
 	tokenId: TokenId;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const address = get(addressStore);
 
 	if (isNullish(address)) {

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -25,6 +25,7 @@ import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { OptionEthAddress } from '$lib/types/address';
+import type { SuccessOrNot } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { getSdkError } from '@walletconnect/utils';
@@ -55,15 +56,10 @@ export type WalletConnectSignMessageParams = WalletConnectExecuteParams & {
 	progress: (step: ProgressStepsSign) => void;
 };
 
-export const reject = (
-	params: WalletConnectExecuteParams
-): Promise<{ success: boolean; err?: unknown }> =>
+export const reject = (params: WalletConnectExecuteParams): Promise<SuccessOrNot> =>
 	execute({
 		params,
-		callback: async ({
-			request,
-			listener
-		}: WalletConnectCallBackParams): Promise<{ success: boolean; err?: unknown }> => {
+		callback: async ({ request, listener }: WalletConnectCallBackParams): Promise<SuccessOrNot> => {
 			busy.start();
 
 			const { id, topic } = request;
@@ -92,13 +88,10 @@ export const send = ({
 	sourceNetwork,
 	targetNetwork,
 	...params
-}: WalletConnectSendParams): Promise<{ success: boolean; err?: unknown }> =>
+}: WalletConnectSendParams): Promise<SuccessOrNot> =>
 	execute({
 		params,
-		callback: async ({
-			request,
-			listener
-		}: WalletConnectCallBackParams): Promise<{ success: boolean; err?: unknown }> => {
+		callback: async ({ request, listener }: WalletConnectCallBackParams): Promise<SuccessOrNot> => {
 			const { id, topic } = request;
 
 			const firstParam = request?.params.request.params?.[0];
@@ -242,13 +235,10 @@ export const signMessage = ({
 	modalNext,
 	progress,
 	...params
-}: WalletConnectSignMessageParams): Promise<{ success: boolean; err?: unknown }> =>
+}: WalletConnectSignMessageParams): Promise<SuccessOrNot> =>
 	execute({
 		params,
-		callback: async ({
-			request,
-			listener
-		}: WalletConnectCallBackParams): Promise<{ success: boolean; err?: unknown }> => {
+		callback: async ({ request, listener }: WalletConnectCallBackParams): Promise<SuccessOrNot> => {
 			const {
 				id,
 				topic,
@@ -301,9 +291,9 @@ const execute = async ({
 	toastMsg
 }: {
 	params: WalletConnectExecuteParams;
-	callback: (params: WalletConnectCallBackParams) => Promise<{ success: boolean; err?: unknown }>;
+	callback: (params: WalletConnectCallBackParams) => Promise<SuccessOrNot>;
 	toastMsg: string;
-}): Promise<{ success: boolean; err?: unknown }> => {
+}): Promise<SuccessOrNot> => {
 	const {
 		wallet_connect: {
 			error: { no_connection_opened, request_not_defined, unexpected_processing_request }

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -15,6 +15,7 @@ import type { Address, BtcAddress, EthAddress } from '$lib/types/address';
 import type { SetIdbAddressParams } from '$lib/types/idb';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenId } from '$lib/types/token';
+import type { SuccessOrNot } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
@@ -28,7 +29,7 @@ const loadTokenAddress = async <T extends Address>({
 	tokenId: TokenId;
 	getAddress: (identity: OptionIdentity) => Promise<T>;
 	setIdbAddress: (params: SetIdbAddressParams<T>) => Promise<void>;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	try {
 		const { identity } = get(authStore);
 
@@ -60,7 +61,7 @@ const loadBtcAddress = async ({
 }: {
 	tokenId: typeof BTC_MAINNET_TOKEN_ID;
 	network: BitcoinNetwork;
-}): Promise<{ success: boolean }> =>
+}): Promise<SuccessOrNot> =>
 	loadTokenAddress<BtcAddress>({
 		tokenId,
 		getAddress: (identity) =>
@@ -71,13 +72,13 @@ const loadBtcAddress = async ({
 		setIdbAddress: setIdbBtcAddressMainnet
 	});
 
-export const loadBtcAddressMainnet = async (): Promise<{ success: boolean }> =>
+export const loadBtcAddressMainnet = async (): Promise<SuccessOrNot> =>
 	loadBtcAddress({
 		tokenId: BTC_MAINNET_TOKEN_ID,
 		network: 'mainnet'
 	});
 
-export const loadEthAddress = async (): Promise<{ success: boolean }> =>
+export const loadEthAddress = async (): Promise<SuccessOrNot> =>
 	loadTokenAddress<EthAddress>({
 		tokenId: ETHEREUM_TOKEN_ID,
 		getAddress: getEthAddress,
@@ -108,7 +109,7 @@ const saveTokenAddressForFutureSignIn = async <T extends Address>({
 	});
 };
 
-export const loadIdbAddress = async (): Promise<{ success: boolean }> => {
+export const loadIdbAddress = async (): Promise<SuccessOrNot> => {
 	const tokenId = ETHEREUM_TOKEN_ID;
 
 	try {
@@ -143,9 +144,7 @@ export const loadIdbAddress = async (): Promise<{ success: boolean }> => {
 	return { success: true };
 };
 
-export const certifyAddress = async (
-	address: string
-): Promise<{ success: boolean; err?: string }> => {
+export const certifyAddress = async (address: string): Promise<SuccessOrNot<string>> => {
 	const tokenId = ETHEREUM_TOKEN_ID;
 
 	try {

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -10,6 +10,7 @@ import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import type { SuccessOrNot } from '$lib/types/utils';
 import { getOptionalDerivationOrigin } from '$lib/utils/auth.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { popupCenter } from '$lib/utils/window.utils';
@@ -31,7 +32,7 @@ const addPouhCredential = async ({
 	identity: Identity;
 	credentialJwt: string;
 	issuerCanisterId: Principal;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const { auth: authI18n } = get(i18n);
 	try {
 		const userProfile = get(userProfileStore);
@@ -81,7 +82,7 @@ const handleSuccess = async ({
 	response: VerifiablePresentationResponse;
 	identity: Identity;
 	issuerCanisterId: Principal;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const { auth: authI18n } = get(i18n);
 	if ('Ok' in response) {
 		const { success } = await addPouhCredential({
@@ -104,7 +105,7 @@ export const requestPouhCredential = async ({
 	identity
 }: {
 	identity: Identity;
-}): Promise<{ success: boolean }> => {
+}): Promise<SuccessOrNot> => {
 	const credentialSubject = identity.getPrincipal();
 	const { auth: authI18n } = get(i18n);
 	return new Promise((resolve, reject) => {

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -1,1 +1,3 @@
 export type RequiredExcept<T, K extends keyof T> = Required<Omit<T, K>> & Pick<T, K>;
+
+export type SuccessOrNot<T = unknown> = { success: boolean; err?: T };


### PR DESCRIPTION
# Motivation

Just to avoid repetition of code and to optimize a little, we create a common type for the return of a successful (or not) function.