### PR TITLE
feat(frontend): add BTC loaders to UX component

### DIFF
--- a/src/frontend/src/lib/api/idb.api.ts
+++ b/src/frontend/src/lib/api/idb.api.ts
@@ -8,7 +8,7 @@ import { isNullish } from '@dfinity/utils';
 import { createStore, del, get, set, update, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
-export const idbAddressesStore = (key: string): UseStore =>
+const idbAddressesStore = (key: string): UseStore =>
 	browser ? createStore(`oisy-${key}-addresses`, `${key}-addresses`) : ({} as unknown as UseStore);
 
 const idbBtcAddressesStoreMainnet = idbAddressesStore(BTC_MAINNET_SYMBOL.toLowerCase());

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -62,7 +62,7 @@
 	let progressModal = false;
 
 	onMount(async () => {
-		const { success: addressIdbSuccess, err: tokenIdsNotLoaded } = await loadIdbAddresses();
+		const { success: addressIdbSuccess, err } = await loadIdbAddresses();
 
 		if (addressIdbSuccess) {
 			loading.set(false);
@@ -75,7 +75,9 @@
 		// We are loading the BTC and ETH address from the backend. Consequently, we aim to animate this operation and offer the user an explanation of what is happening. To achieve this, we will present this information within a modal.
 		progressModal = true;
 
-		const { success: addressSuccess } = await loadAddresses(tokenIdsNotLoaded ?? []);
+		const { success: addressSuccess } = await loadAddresses(
+			err?.map(({ tokenId }) => tokenId) ?? []
+		);
 
 		if (!addressSuccess) {
 			await signOut();

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -69,12 +69,24 @@
 		}
 	};
 
+	let idbBtcMainnetSuccess = false;
+	let idbEthSuccess = false;
+
+	$: {
+		if ($loading && idbBtcMainnetSuccess && idbEthSuccess) {
+			loading.set(false);
+		}
+	}
+
 	onMount(async () => {
 		const results = await Promise.all([
 			NETWORK_BITCOIN_ENABLED
-				? safeLoadBtcAddressMainnet(displayProgressModal)
+				? safeLoadBtcAddressMainnet({
+						displayProgressModal,
+						onIdbSuccess: () => (idbBtcMainnetSuccess = true)
+					})
 				: Promise.resolve({ success: true }),
-			safeLoadEthAddress(displayProgressModal)
+			safeLoadEthAddress({ displayProgressModal, onIdbSuccess: () => (idbEthSuccess = true) })
 		]);
 
 		if (results.every(({ success }) => success)) {

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -63,14 +63,18 @@
 	let progressModal = false;
 
 	// We are loading the BTC and ETH address from the backend. Consequently, we aim to animate this operation and offer the user an explanation of what is happening. To achieve this, we will present this information within a modal.
-	const setProgressModal = () => (progressModal = true);
+	const displayProgressModal = () => {
+		if (!progressModal) {
+			progressModal = true;
+		}
+	};
 
 	onMount(async () => {
 		const results = await Promise.all([
 			NETWORK_BITCOIN_ENABLED
-				? safeLoadBtcAddressMainnet(setProgressModal)
+				? safeLoadBtcAddressMainnet(displayProgressModal)
 				: Promise.resolve({ success: true }),
-			safeLoadEthAddress(setProgressModal)
+			safeLoadEthAddress(displayProgressModal)
 		]);
 
 		if (results.every(({ success }) => success)) {

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -2,7 +2,7 @@
 	import { Modal, type ProgressStep } from '@dfinity/gix-components';
 	import InProgress from '$lib/components/ui/InProgress.svelte';
 	import { onMount } from 'svelte';
-	import { safeLoadBtcAddressMainnet, safeLoadEthAddress } from '$lib/services/address.services';
+	import { loadAddresses, loadIdbAddresses } from '$lib/services/address.services';
 	import { fade } from 'svelte/transition';
 	import { signOut } from '$lib/services/auth.services';
 	import { loadErc20Tokens } from '$eth/services/erc20.services';
@@ -13,7 +13,6 @@
 	import { loadIcrcTokens } from '$icp/services/icrc.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authStore } from '$lib/stores/auth.store';
-	import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
 
 	let progressStep: string = ProgressStepsLoader.BTC_ETH_ADDRESS;
 
@@ -62,36 +61,24 @@
 
 	let progressModal = false;
 
-	// We are loading the BTC and ETH address from the backend. Consequently, we aim to animate this operation and offer the user an explanation of what is happening. To achieve this, we will present this information within a modal.
-	const displayProgressModal = () => {
-		if (!progressModal) {
-			progressModal = true;
-		}
-	};
-
-	let idbBtcMainnetSuccess = false;
-	let idbEthSuccess = false;
-
-	$: {
-		if ($loading && idbBtcMainnetSuccess && idbEthSuccess) {
-			loading.set(false);
-		}
-	}
-
 	onMount(async () => {
-		const results = await Promise.all([
-			NETWORK_BITCOIN_ENABLED
-				? safeLoadBtcAddressMainnet({
-						displayProgressModal,
-						onIdbSuccess: () => (idbBtcMainnetSuccess = true)
-					})
-				: Promise.resolve({ success: true }),
-			safeLoadEthAddress({ displayProgressModal, onIdbSuccess: () => (idbEthSuccess = true) })
-		]);
+		const { success: addressIdbSuccess, err: tokenIdsNotLoaded } = await loadIdbAddresses();
 
-		if (results.every(({ success }) => success)) {
+		if (addressIdbSuccess) {
+			loading.set(false);
+
 			await progressAndLoad();
 
+			return;
+		}
+
+		// We are loading the BTC and ETH address from the backend. Consequently, we aim to animate this operation and offer the user an explanation of what is happening. To achieve this, we will present this information within a modal.
+		progressModal = true;
+
+		const { success: addressSuccess } = await loadAddresses(tokenIdsNotLoaded ?? []);
+
+		if (!addressSuccess) {
+			await signOut();
 			return;
 		}
 

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -82,7 +82,7 @@
 			return;
 		}
 
-		await signOut();
+		await progressAndLoad();
 	});
 </script>
 

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -20,7 +20,7 @@ export enum ProgressStepsSign {
 
 export enum ProgressStepsLoader {
 	INITIALIZATION = 'initialization',
-	ETH_ADDRESS = 'eth_address',
+	BTC_ETH_ADDRESS = 'btc_eth_address',
 	DONE = 'done'
 }
 

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -81,7 +81,7 @@
 		"text": {
 			"initializing_wallet": "Initializing your wallet",
 			"securing_session": "Securing session with Internet Identity",
-			"retrieving_eth_key": "Retrieving your Ethereum public key"
+			"retrieving_public_keys": "Retrieving your Bitcoin and Ethereum public keys"
 		},
 		"info": {
 			"hold_loading": "Hold tight, we are loading some information...",

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -170,11 +170,11 @@ export const loadIdbEthAddress = async (): Promise<ResultSuccess> =>
 const safeLoadTokenAddress = async ({
 	loadIdbTokenAddress,
 	loadTokenAddress,
-	onIdbNotSuccessful
+	displayProgressModal
 }: {
 	loadIdbTokenAddress: () => Promise<ResultSuccess>;
 	loadTokenAddress: () => Promise<ResultSuccess>;
-	onIdbNotSuccessful: () => void;
+	displayProgressModal: () => void;
 }): Promise<ResultSuccess> => {
 	const { success: addressIdbSuccess } = await loadIdbTokenAddress();
 
@@ -182,7 +182,7 @@ const safeLoadTokenAddress = async ({
 		return { success: true };
 	}
 
-	onIdbNotSuccessful();
+	displayProgressModal();
 
 	const { success: addressSuccess } = await loadTokenAddress();
 
@@ -194,19 +194,21 @@ const safeLoadTokenAddress = async ({
 };
 
 export const safeLoadBtcAddressMainnet = async (
-	onIdbNotSuccessful: () => void
+	displayProgressModal: () => void
 ): Promise<ResultSuccess> =>
 	safeLoadTokenAddress({
 		loadIdbTokenAddress: loadIdbBtcAddressMainnet,
 		loadTokenAddress: loadBtcAddressMainnet,
-		onIdbNotSuccessful
+		displayProgressModal
 	});
 
-export const safeLoadEthAddress = async (onIdbNotSuccessful: () => void): Promise<ResultSuccess> =>
+export const safeLoadEthAddress = async (
+	displayProgressModal: () => void
+): Promise<ResultSuccess> =>
 	safeLoadTokenAddress({
 		loadIdbTokenAddress: loadIdbEthAddress,
 		loadTokenAddress: loadEthAddress,
-		onIdbNotSuccessful
+		displayProgressModal
 	});
 
 export const certifyAddress = async (address: string): Promise<ResultSuccess<string>> => {

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -185,21 +185,13 @@ export const loadIdbAddresses = async (): Promise<ResultSuccess<TokenId[]>> => {
 		loadIdbEthAddress()
 	]);
 
-	let success = true;
-	const err: TokenId[] = [];
-
-	results.map(({ success: s, err: e }) => {
-		if (success) {
-			success &&= s;
-			if (s) {
-				return;
-			}
-		}
-
-		if (nonNullish(e)) {
-			err.push(e);
-		}
-	});
+	const { success, err } = results.reduce(
+		(acc, { success: s, err: e }) => ({
+			success: acc.success && s,
+			err: nonNullish(e) ? [...acc.err, e] : acc.err
+		}),
+		{ success: true, err: [] as TokenId[] }
+	);
 
 	return { success, err };
 };

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -167,6 +167,48 @@ export const loadIdbEthAddress = async (): Promise<ResultSuccess> =>
 		updateIdbAddressLastUsage: updateIdbEthAddressLastUsage
 	});
 
+const safeLoadTokenAddress = async ({
+	loadIdbTokenAddress,
+	loadTokenAddress,
+	onIdbNotSuccessful
+}: {
+	loadIdbTokenAddress: () => Promise<ResultSuccess>;
+	loadTokenAddress: () => Promise<ResultSuccess>;
+	onIdbNotSuccessful: () => void;
+}): Promise<ResultSuccess> => {
+	const { success: addressIdbSuccess } = await loadIdbTokenAddress();
+
+	if (addressIdbSuccess) {
+		return { success: true };
+	}
+
+	onIdbNotSuccessful();
+
+	const { success: addressSuccess } = await loadTokenAddress();
+
+	if (addressSuccess) {
+		return { success: true };
+	}
+
+	return { success: false };
+};
+
+export const safeLoadBtcAddressMainnet = async (
+	onIdbNotSuccessful: () => void
+): Promise<ResultSuccess> =>
+	safeLoadTokenAddress({
+		loadIdbTokenAddress: loadIdbBtcAddressMainnet,
+		loadTokenAddress: loadBtcAddressMainnet,
+		onIdbNotSuccessful
+	});
+
+export const safeLoadEthAddress = async (onIdbNotSuccessful: () => void): Promise<ResultSuccess> =>
+	safeLoadTokenAddress({
+		loadIdbTokenAddress: loadIdbEthAddress,
+		loadTokenAddress: loadEthAddress,
+		onIdbNotSuccessful
+	});
+
 export const certifyAddress = async (address: string): Promise<ResultSuccess<string>> => {
 	const tokenId = ETHEREUM_TOKEN_ID;
 

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -91,10 +91,10 @@ const loadEthAddress = async (): Promise<ResultSuccess> =>
 
 export const loadAddresses = async (tokenIds: TokenId[]): Promise<ResultSuccess> => {
 	const results = await Promise.all([
-		...tokenIds
-			.filter((tokenId) => tokenId === BTC_MAINNET_TOKEN_ID)
-			.map(() => loadBtcAddressMainnet()),
-		...tokenIds.filter((tokenId) => tokenId === ETHEREUM_TOKEN_ID).map(() => loadEthAddress())
+		NETWORK_BITCOIN_ENABLED && tokenIds.includes(BTC_MAINNET_TOKEN_ID)
+			? loadBtcAddressMainnet()
+			: Promise.resolve({ success: true }),
+		tokenIds.includes(ETHEREUM_TOKEN_ID) ? loadEthAddress() : Promise.resolve({ success: true })
 	]);
 
 	return { success: results.every(({ success }) => success) };

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -15,7 +15,7 @@ import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { Address, BtcAddress, EthAddress } from '$lib/types/address';
-import { AddressError } from '$lib/types/errors';
+import { LoadIdbAddressError } from '$lib/types/errors';
 import type { IdbAddress, SetIdbAddressParams } from '$lib/types/idb';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenId } from '$lib/types/token';
@@ -133,7 +133,7 @@ const loadIdbTokenAddress = async <T extends Address>({
 	tokenId: TokenId;
 	getIdbAddress: (principal: Principal) => Promise<IdbAddress<T> | undefined>;
 	updateIdbAddressLastUsage: (principal: Principal) => Promise<void>;
-}): Promise<ResultSuccess<AddressError>> => {
+}): Promise<ResultSuccess<LoadIdbAddressError>> => {
 	try {
 		const { identity } = get(authStore);
 
@@ -141,13 +141,13 @@ const loadIdbTokenAddress = async <T extends Address>({
 		assertNonNullish(identity, 'Cannot continue without an identity.');
 
 		if (identity.getPrincipal().isAnonymous()) {
-			return { success: false, err: new AddressError(tokenId) };
+			return { success: false, err: new LoadIdbAddressError(tokenId) };
 		}
 
 		const idbAddress = await getIdbAddress(identity.getPrincipal());
 
 		if (isNullish(idbAddress)) {
-			return { success: false, err: new AddressError(tokenId) };
+			return { success: false, err: new LoadIdbAddressError(tokenId) };
 		}
 
 		const { address } = idbAddress;
@@ -160,40 +160,40 @@ const loadIdbTokenAddress = async <T extends Address>({
 			`Error encountered while searching for locally stored ${tokenId.description} public address in the browser.`
 		);
 
-		return { success: false, err: new AddressError(tokenId) };
+		return { success: false, err: new LoadIdbAddressError(tokenId) };
 	}
 
 	return { success: true };
 };
 
-const loadIdbBtcAddressMainnet = async (): Promise<ResultSuccess<AddressError>> =>
+const loadIdbBtcAddressMainnet = async (): Promise<ResultSuccess<LoadIdbAddressError>> =>
 	loadIdbTokenAddress<BtcAddress>({
 		tokenId: BTC_MAINNET_TOKEN_ID,
 		getIdbAddress: getIdbBtcAddressMainnet,
 		updateIdbAddressLastUsage: updateIdbBtcAddressMainnetLastUsage
 	});
 
-const loadIdbEthAddress = async (): Promise<ResultSuccess<AddressError>> =>
+const loadIdbEthAddress = async (): Promise<ResultSuccess<LoadIdbAddressError>> =>
 	loadIdbTokenAddress<EthAddress>({
 		tokenId: ETHEREUM_TOKEN_ID,
 		getIdbAddress: getIdbEthAddress,
 		updateIdbAddressLastUsage: updateIdbEthAddressLastUsage
 	});
 
-export const loadIdbAddresses = async (): Promise<ResultSuccess<TokenId[]>> => {
+export const loadIdbAddresses = async (): Promise<ResultSuccess<LoadIdbAddressError[]>> => {
 	const results = await Promise.all([
 		NETWORK_BITCOIN_ENABLED
 			? loadIdbBtcAddressMainnet()
-			: Promise.resolve<ResultSuccess<AddressError>>({ success: true }),
+			: Promise.resolve<ResultSuccess<LoadIdbAddressError>>({ success: true }),
 		loadIdbEthAddress()
 	]);
 
 	const { success, err } = results.reduce(
 		(acc, { success: s, err: e }) => ({
 			success: acc.success && s,
-			err: nonNullish(e?.tokenId) ? [...acc.err, e?.tokenId] : acc.err
+			err: nonNullish(e) ? [...acc.err, e] : acc.err
 		}),
-		{ success: true, err: [] as TokenId[] }
+		{ success: true, err: [] as LoadIdbAddressError[] }
 	);
 
 	return { success, err };

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -182,7 +182,9 @@ const loadIdbEthAddress = async (): Promise<ResultSuccess<AddressError>> =>
 
 export const loadIdbAddresses = async (): Promise<ResultSuccess<TokenId[]>> => {
 	const results = await Promise.all([
-		NETWORK_BITCOIN_ENABLED ? loadIdbBtcAddressMainnet() : { success: true, err: null },
+		NETWORK_BITCOIN_ENABLED
+			? loadIdbBtcAddressMainnet()
+			: Promise.resolve<ResultSuccess<AddressError>>({ success: true }),
 		loadIdbEthAddress()
 	]);
 

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -189,9 +189,11 @@ export const loadIdbAddresses = async (): Promise<ResultSuccess<TokenId[]>> => {
 	const err: TokenId[] = [];
 
 	results.map(({ success: s, err: e }) => {
-		if (s) {
+		if (success) {
 			success &&= s;
-			return;
+			if (s) {
+				return;
+			}
 		}
 
 		if (nonNullish(e)) {

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -13,7 +13,12 @@ import { addressStore } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import type { Address, BtcAddress, EthAddress } from '$lib/types/address';
+import type {
+	Address,
+	BtcAddress,
+	EthAddress,
+	SafeLoadTokenAddressParams
+} from '$lib/types/address';
 import type { IdbAddress, SetIdbAddressParams } from '$lib/types/idb';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenId } from '$lib/types/token';
@@ -170,15 +175,16 @@ export const loadIdbEthAddress = async (): Promise<ResultSuccess> =>
 const safeLoadTokenAddress = async ({
 	loadIdbTokenAddress,
 	loadTokenAddress,
-	displayProgressModal
+	displayProgressModal,
+	onIdbSuccess
 }: {
 	loadIdbTokenAddress: () => Promise<ResultSuccess>;
 	loadTokenAddress: () => Promise<ResultSuccess>;
-	displayProgressModal: () => void;
-}): Promise<ResultSuccess> => {
+} & SafeLoadTokenAddressParams): Promise<ResultSuccess> => {
 	const { success: addressIdbSuccess } = await loadIdbTokenAddress();
 
 	if (addressIdbSuccess) {
+		onIdbSuccess();
 		return { success: true };
 	}
 
@@ -194,21 +200,21 @@ const safeLoadTokenAddress = async ({
 };
 
 export const safeLoadBtcAddressMainnet = async (
-	displayProgressModal: () => void
+	params: SafeLoadTokenAddressParams
 ): Promise<ResultSuccess> =>
 	safeLoadTokenAddress({
 		loadIdbTokenAddress: loadIdbBtcAddressMainnet,
 		loadTokenAddress: loadBtcAddressMainnet,
-		displayProgressModal
+		...params
 	});
 
 export const safeLoadEthAddress = async (
-	displayProgressModal: () => void
+	params: SafeLoadTokenAddressParams
 ): Promise<ResultSuccess> =>
 	safeLoadTokenAddress({
 		loadIdbTokenAddress: loadIdbEthAddress,
 		loadTokenAddress: loadEthAddress,
-		displayProgressModal
+		...params
 	});
 
 export const certifyAddress = async (address: string): Promise<ResultSuccess<string>> => {

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -185,12 +185,12 @@ export const loadIdbAddresses = async (): Promise<ResultSuccess<TokenId[]>> => {
 		loadIdbEthAddress()
 	]);
 
-	let success = false;
+	let success = true;
 	const err: TokenId[] = [];
 
 	results.map(({ success: s, err: e }) => {
 		if (s) {
-			success ||= s;
+			success &&= s;
 			return;
 		}
 

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -5,3 +5,8 @@ export type BtcAddress = Address;
 export type EthAddress = Address;
 
 export type OptionEthAddress = EthAddress | undefined | null;
+
+export interface SafeLoadTokenAddressParams {
+	displayProgressModal: () => void;
+	onIdbSuccess: () => void;
+}

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -9,8 +9,3 @@ export type OptionAddress<T extends Address> = T | undefined | null;
 export type OptionBtcAddress = OptionAddress<BtcAddress>;
 
 export type OptionEthAddress = OptionAddress<EthAddress>;
-
-export interface SafeLoadTokenAddressParams {
-	displayProgressModal: () => void;
-	onIdbSuccess: () => void;
-}

--- a/src/frontend/src/lib/types/errors.ts
+++ b/src/frontend/src/lib/types/errors.ts
@@ -1,1 +1,13 @@
+import type { TokenId } from '$lib/types/token';
+
 export class UserProfileNotFoundError extends Error {}
+
+export class AddressError extends Error {
+	tokenId: TokenId;
+
+	constructor(tokenId: TokenId) {
+		super();
+		Object.setPrototypeOf(this, AddressError.prototype);
+		this.tokenId = tokenId;
+	}
+}

--- a/src/frontend/src/lib/types/errors.ts
+++ b/src/frontend/src/lib/types/errors.ts
@@ -2,12 +2,12 @@ import type { TokenId } from '$lib/types/token';
 
 export class UserProfileNotFoundError extends Error {}
 
-export class AddressError extends Error {
-	tokenId: TokenId;
-
-	constructor(tokenId: TokenId) {
+export class LoadIdbAddressError extends Error {
+	constructor(private readonly _tokenId: TokenId) {
 		super();
-		Object.setPrototypeOf(this, AddressError.prototype);
-		this.tokenId = tokenId;
+	}
+
+	get tokenId(): TokenId {
+		return this._tokenId;
 	}
 }

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -65,7 +65,7 @@ interface I18nWallet {
 }
 
 interface I18nInit {
-	text: { initializing_wallet: string; securing_session: string; retrieving_eth_key: string };
+	text: { initializing_wallet: string; securing_session: string; retrieving_public_keys: string };
 	info: { hold_loading: string; hold_loading_wallet: string };
 	error: {
 		no_alchemy_config: string;


### PR DESCRIPTION
# Motivation

We join the BTC address loader with the ETH address loader.

# Changes

- Create function to load all IDB addresses.
- Create function to get addresses from backend by token.
- Make the `Loader` component await **ALL** loading promises of the above functions.
- Adjust the text and the comments.
- Unrelated: remove the useless `export` properties.

# Tests

Bitcoin address is correctly loaded (and/or re-loaded) during login.
