### PR TITLE
feat(frontend): add BTC address to receive modal

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -5,8 +5,10 @@
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 	import ReceiveAddressWithLogo from '$lib/components/receive/ReceiveAddressWithLogo.svelte';
-	import { ethAddress } from '$lib/derived/address.derived';
+	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
 	import Hr from '$lib/components/ui/Hr.svelte';
+	import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
+	import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 
 	const dispatch = createEventDispatcher();
 
@@ -47,6 +49,26 @@
 
 		<p slot="notes" class="text-sm text-dark">{$i18n.receive.icp.text.use_for_icp_deposit}</p>
 	</ReceiveAddressWithLogo>
+
+	{#if NETWORK_BITCOIN_ENABLED}
+		<div class="mb-6">
+			<Hr />
+		</div>
+
+		<ReceiveAddressWithLogo
+			on:click={() =>
+				displayQRCode({
+					address: $btcAddressMainnet ?? '',
+					addressLabel: $i18n.receive.bitcoin.text.bitcoin_address
+				})}
+			address={$btcAddressMainnet ?? ''}
+			token={BTC_MAINNET_TOKEN}
+			qrCodeAriaLabel={$i18n.receive.bitcoin.text.display_bitcoin_address_qr}
+			copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
+		>
+			{$i18n.receive.bitcoin.text.bitcoin_address}
+		</ReceiveAddressWithLogo>
+	{/if}
 
 	<div class="mb-6">
 		<Hr />

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,11 +1,20 @@
+import { BTC_MAINNET_TOKEN_ID } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens.env';
 import { addressStore } from '$lib/stores/address.store';
-import type { OptionEthAddress } from '$lib/types/address';
+import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const addressNotLoaded: Readable<boolean> = derived([addressStore], ([$addressStore]) =>
 	isNullish($addressStore)
+);
+
+export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
+	[addressStore],
+	([$addressStore]) =>
+		$addressStore?.[BTC_MAINNET_TOKEN_ID] === null
+			? null
+			: $addressStore?.[BTC_MAINNET_TOKEN_ID]?.data
 );
 
 export const ethAddress: Readable<OptionEthAddress> = derived([addressStore], ([$addressStore]) =>

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -4,4 +4,8 @@ export type BtcAddress = Address;
 
 export type EthAddress = Address;
 
-export type OptionEthAddress = EthAddress | undefined | null;
+export type OptionAddress<T extends Address> = T | undefined | null;
+
+export type OptionBtcAddress = OptionAddress<BtcAddress>;
+
+export type OptionEthAddress = OptionAddress<EthAddress>;


### PR DESCRIPTION
# Motivation

Similar to ETH, we add the BTC address to the `Receive` modal.
