### PR TITLE
fix(frontend): pending ck conversions displayed under incorrect token

### DIFF
--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -4,9 +4,8 @@ import {
 } from '$env/networks.cketh.env';
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
-import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
-
 import type { Erc20Token } from '$eth/types/erc20';
+import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import {
 	mapCkErc20PendingTransaction,
 	mapCkEthPendingTransaction,

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -156,6 +156,9 @@ const loadPendingTransactions = async ({
 
 		const pendingTransactions = await Promise.all(pendingLogs.map(loadTransaction));
 
+		// TODO(fix): filter pendingTransactions which match the token
+		// i.e. do not display pending LINK -> ckLINK as "Converting USDC to ckUSDC"
+
 		icPendingTransactionsStore.set({
 			tokenId,
 			data: pendingTransactions.filter(nonNullish).map((transaction) => ({

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -6,6 +6,7 @@ import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 
+import type { Erc20Token } from '$eth/types/erc20';
 import {
 	mapCkErc20PendingTransaction,
 	mapCkEthPendingTransaction,
@@ -89,7 +90,7 @@ const loadCkErc20PendingTransactions = async ({
 } & IcCkLinkedAssets) => {
 	const logsTopics = (to: EthAddress): (string | null)[] => [
 		CKERC20_HELPER_CONTRACT_SIGNATURE,
-		null,
+		(twinToken as Erc20Token).address,
 		null,
 		to
 	];
@@ -155,9 +156,6 @@ const loadPendingTransactions = async ({
 			getTransaction(transactionHash);
 
 		const pendingTransactions = await Promise.all(pendingLogs.map(loadTransaction));
-
-		// TODO(fix): filter pendingTransactions which match the token
-		// i.e. do not display pending LINK -> ckLINK as "Converting USDC to ckUSDC"
 
 		icPendingTransactionsStore.set({
 			tokenId,


### PR DESCRIPTION
# Motivation

It was reported that pending ck conversions were displayed under the wrong token. e.g. one user converted LINK to ckLINK and then browsed ckUSDC and the frontend was displaying "Pending USDC to ckUSDC". This seems to happens because the pending transactions resolved with logs are not filtered for the selected token.

To solve it, we refine the logs topic including the ERC20 contract address among the parameters.

We can see a practical example [here](https://etherscan.io/tx/0xddbf4aebe292c3d3b33240496db12a1a5622c4edb63017ebcd12ffa32fa5b924#eventlog).

<img width="1302" alt="Screenshot 2024-08-20 at 16 14 30" src="https://github.com/user-attachments/assets/4aa209b4-02f1-4cdc-b1a5-c0be0321020f">
