### PR TITLE
feat(backend): Add a separate statistic for timestamp count

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -114,6 +114,7 @@ type SignRequest = record {
 type Stats = record {
   user_profile_count : nat64;
   custom_token_count : nat64;
+  user_timestamps_count : nat64;
   user_token_count : nat64;
 };
 type SupportedCredential = record {

--- a/src/backend/src/impls.rs
+++ b/src/backend/src/impls.rs
@@ -38,6 +38,7 @@ impl From<&State> for Stats {
     fn from(state: &State) -> Self {
         Stats {
             user_profile_count: state.user_profile.len(),
+            user_timestamps_count: state.user_profile_updated.len(),
             user_token_count: state.user_token.len(),
             custom_token_count: state.custom_token.len(),
         }

--- a/src/backend/tests/it/migration.rs
+++ b/src/backend/tests/it/migration.rs
@@ -54,9 +54,11 @@ impl MigrationTestEnv {
         let pic_setup = MigrationTestEnv::default();
         let Stats {
             user_profile_count,
+            user_timestamps_count,
             user_token_count,
             custom_token_count,
         } = stats;
+        assert_eq!(user_profile_count, user_timestamps_count, "Test setup failure: Stats indicate that the database is inconsistent.  Donen't affect the migration but should be fixed.");
         // Create users
         let expected_users = pic_setup.old_backend.create_users(
             0..u8::try_from(*user_profile_count).expect("Test setup requested too many users"),
@@ -140,6 +142,7 @@ fn test_by_default_no_migration_is_in_progress() {
 fn test_migration() {
     let stats = Stats {
         user_profile_count: 20,
+        user_timestamps_count: 20,
         user_token_count: 10,
         custom_token_count: 5,
     };

--- a/src/backend/tests/it/migration.rs
+++ b/src/backend/tests/it/migration.rs
@@ -58,7 +58,7 @@ impl MigrationTestEnv {
             user_token_count,
             custom_token_count,
         } = stats;
-        assert_eq!(user_profile_count, user_timestamps_count, "Test setup failure: Stats indicate that the database is inconsistent.  Donen't affect the migration but should be fixed.");
+        assert_eq!(user_profile_count, user_timestamps_count, "Test setup failure: Stats indicate that the database is inconsistent.  Doesn't affect the migration but should be fixed.");
         // Create users
         let expected_users = pic_setup.old_backend.create_users(
             0..u8::try_from(*user_profile_count).expect("Test setup requested too many users"),

--- a/src/backend/tests/it/stats.rs
+++ b/src/backend/tests/it/stats.rs
@@ -27,6 +27,7 @@ fn stats_returns_correct_number_of_users() {
     // That should give us these stats:
     let expected_stats = Stats {
         user_profile_count: expected_users.len() as u64,
+        user_timestamps_count: expected_users.len() as u64,
         user_token_count: NUM_USERS_WITH_TOKENS as u64,
         custom_token_count: 0,
     };

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -114,6 +114,7 @@ type SignRequest = record {
 type Stats = record {
   user_profile_count : nat64;
   custom_token_count : nat64;
+  user_timestamps_count : nat64;
   user_token_count : nat64;
 };
 type SupportedCredential = record {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -127,6 +127,7 @@ export interface SignRequest {
 export interface Stats {
 	user_profile_count: bigint;
 	custom_token_count: bigint;
+	user_timestamps_count: bigint;
 	user_token_count: bigint;
 }
 export interface SupportedCredential {

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -174,6 +174,7 @@ export const idlFactory = ({ IDL }) => {
 	const Stats = IDL.Record({
 		user_profile_count: IDL.Nat64,
 		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
 		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -174,6 +174,7 @@ export const idlFactory = ({ IDL }) => {
 	const Stats = IDL.Record({
 		user_profile_count: IDL.Nat64,
 		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
 		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -114,6 +114,7 @@ type SignRequest = record {
 type Stats = record {
   user_profile_count : nat64;
   custom_token_count : nat64;
+  user_timestamps_count : nat64;
   user_token_count : nat64;
 };
 type SupportedCredential = record {

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -127,6 +127,7 @@ export interface SignRequest {
 export interface Stats {
 	user_profile_count: bigint;
 	custom_token_count: bigint;
+	user_timestamps_count: bigint;
 	user_token_count: bigint;
 }
 export interface SupportedCredential {

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -174,6 +174,7 @@ export const idlFactory = ({ IDL }) => {
 	const Stats = IDL.Record({
 		user_profile_count: IDL.Nat64,
 		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
 		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -174,6 +174,7 @@ export const idlFactory = ({ IDL }) => {
 	const Stats = IDL.Record({
 		user_profile_count: IDL.Nat64,
 		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
 		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -283,6 +283,7 @@ pub struct MigrationReport {
 #[derive(CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub struct Stats {
     pub user_profile_count: u64,
+    pub user_timestamps_count: u64,
     pub user_token_count: u64,
     pub custom_token_count: u64,
 }


### PR DESCRIPTION
# Motivation
User profiles and user timestamps are stored in separate `BTreeMap`s, and migrated in separate `BTreeMap`s.  As a check that the timestamp migration is complete, it would be useful to have a separate count for the timestamps.

# Changes
- Add `user_timestamps_count` to `Stats`.

# Tests
None here, this field is used in migration tests.