### PR TITLE
feat(backend): Update migration states

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -79,17 +79,30 @@ type ListUsersResponse = record {
   users : vec OisyUser;
   matches_max_length : nat64;
 };
+type MigrationError = variant {
+  TargetLockFailed;
+  TargetUnlockFailed;
+  CouldNotGetTargetPostStats;
+  CouldNotGetTargetPriorStats;
+  DataMigrationFailed;
+  TargetStatsMismatch : record { Stats; Stats };
+  Unknown;
+  TargetCanisterNotEmpty : Stats;
+  NoMigrationInProgress;
+};
 type MigrationProgress = variant {
   MigratedUserTokensUpTo : opt principal;
+  Failed : MigrationError;
   MigratedUserTimestampsUpTo : opt principal;
-  TargetPreCheckOk;
   MigratedCustomTokensUpTo : opt principal;
-  Locked;
+  CheckingDataMigration;
   MigratedUserProfilesUpTo : opt record { nat64; principal };
-  CheckingTargetCanister;
-  TargetLocked;
+  UnlockingTarget;
+  Unlocking;
   Completed;
   Pending;
+  LockingTarget;
+  CheckingTarget;
 };
 type MigrationReport = record { to : principal; progress : MigrationProgress };
 type OisyUser = record {

--- a/src/backend/tests/it/migration.rs
+++ b/src/backend/tests/it/migration.rs
@@ -194,24 +194,19 @@ fn test_migration() {
         // Migration should be in progress.
         pic_setup.assert_migration_progress_is(MigrationProgress::Pending);
     }
-    // Step the timer: User data writing should be locked.
+    // Step the migration: User data writing should be locked.
     {
         pic_setup.step_migration();
-        pic_setup.assert_migration_progress_is(MigrationProgress::Locked);
+        pic_setup.assert_migration_progress_is(MigrationProgress::LockingTarget);
         // TODO: Check that the old backend really is locked.
     }
-    // Step the timer: Target canister should be locked.
+    // Step the migration: Target canister should be locked.
     {
         pic_setup.step_migration();
-        pic_setup.assert_migration_progress_is(MigrationProgress::TargetLocked);
+        pic_setup.assert_migration_progress_is(MigrationProgress::CheckingTarget);
         // TODO: Check that the target really is locked:
     }
-    // Step the timer: Should have found the target canister to be empty.
-    {
-        pic_setup.step_migration();
-        pic_setup.assert_migration_progress_is(MigrationProgress::TargetPreCheckOk);
-    }
-    // Step the timer: Should have started the user token migration.
+    // Step the migration: Should have started the user token migration.
     {
         pic_setup.step_migration();
         pic_setup.assert_migration_progress_is(MigrationProgress::MigratedUserTokensUpTo(None));
@@ -270,9 +265,22 @@ fn test_migration() {
     }
     // Should be checking the migration.
     {
-        pic_setup.assert_migration_progress_is(MigrationProgress::CheckingTargetCanister);
+        pic_setup.assert_migration_progress_is(MigrationProgress::CheckingDataMigration);
     }
-    // Step the timer: Migration should be complete, and stay complete.
+    // Step the migration.  Should be unlocking the target.
+    {
+        pic_setup.step_migration();
+        pic_setup.assert_migration_progress_is(MigrationProgress::UnlockingTarget);
+    }
+    // Step the migration.  Should be unlocking the source.
+    {
+        pic_setup.step_migration();
+        // TODO: Verify that the target has been unlocked.
+        pic_setup.assert_migration_progress_is(MigrationProgress::Unlocking);
+        pic_setup.step_migration();
+        // TODO: Verify that the source has been unlocked
+    }
+    // Step the migration: Migration should be complete, and stay complete.
     {
         for _ in 0..5 {
             pic_setup.step_migration();

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -79,17 +79,30 @@ type ListUsersResponse = record {
   users : vec OisyUser;
   matches_max_length : nat64;
 };
+type MigrationError = variant {
+  TargetLockFailed;
+  TargetUnlockFailed;
+  CouldNotGetTargetPostStats;
+  CouldNotGetTargetPriorStats;
+  DataMigrationFailed;
+  TargetStatsMismatch : record { Stats; Stats };
+  Unknown;
+  TargetCanisterNotEmpty : Stats;
+  NoMigrationInProgress;
+};
 type MigrationProgress = variant {
   MigratedUserTokensUpTo : opt principal;
+  Failed : MigrationError;
   MigratedUserTimestampsUpTo : opt principal;
-  TargetPreCheckOk;
   MigratedCustomTokensUpTo : opt principal;
-  Locked;
+  CheckingDataMigration;
   MigratedUserProfilesUpTo : opt record { nat64; principal };
-  CheckingTargetCanister;
-  TargetLocked;
+  UnlockingTarget;
+  Unlocking;
   Completed;
   Pending;
+  LockingTarget;
+  CheckingTarget;
 };
 type MigrationReport = record { to : principal; progress : MigrationProgress };
 type OisyUser = record {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -88,19 +88,31 @@ export interface ListUsersResponse {
 	users: Array<OisyUser>;
 	matches_max_length: bigint;
 }
+export type MigrationError =
+	| { TargetLockFailed: null }
+	| { TargetUnlockFailed: null }
+	| { CouldNotGetTargetPostStats: null }
+	| { CouldNotGetTargetPriorStats: null }
+	| { DataMigrationFailed: null }
+	| { TargetStatsMismatch: [Stats, Stats] }
+	| { Unknown: null }
+	| { TargetCanisterNotEmpty: Stats }
+	| { NoMigrationInProgress: null };
 export type MigrationProgress =
 	| {
 			MigratedUserTokensUpTo: [] | [Principal];
 	  }
+	| { Failed: MigrationError }
 	| { MigratedUserTimestampsUpTo: [] | [Principal] }
-	| { TargetPreCheckOk: null }
 	| { MigratedCustomTokensUpTo: [] | [Principal] }
-	| { Locked: null }
+	| { CheckingDataMigration: null }
 	| { MigratedUserProfilesUpTo: [] | [[bigint, Principal]] }
-	| { CheckingTargetCanister: null }
-	| { TargetLocked: null }
+	| { UnlockingTarget: null }
+	| { Unlocking: null }
 	| { Completed: null }
-	| { Pending: null };
+	| { Pending: null }
+	| { LockingTarget: null }
+	| { CheckingTarget: null };
 export interface MigrationReport {
 	to: Principal;
 	progress: MigrationProgress;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -139,17 +139,36 @@ export const idlFactory = ({ IDL }) => {
 		users: IDL.Vec(OisyUser),
 		matches_max_length: IDL.Nat64
 	});
+	const Stats = IDL.Record({
+		user_profile_count: IDL.Nat64,
+		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
+		user_token_count: IDL.Nat64
+	});
+	const MigrationError = IDL.Variant({
+		TargetLockFailed: IDL.Null,
+		TargetUnlockFailed: IDL.Null,
+		CouldNotGetTargetPostStats: IDL.Null,
+		CouldNotGetTargetPriorStats: IDL.Null,
+		DataMigrationFailed: IDL.Null,
+		TargetStatsMismatch: IDL.Tuple(Stats, Stats),
+		Unknown: IDL.Null,
+		TargetCanisterNotEmpty: Stats,
+		NoMigrationInProgress: IDL.Null
+	});
 	const MigrationProgress = IDL.Variant({
 		MigratedUserTokensUpTo: IDL.Opt(IDL.Principal),
+		Failed: MigrationError,
 		MigratedUserTimestampsUpTo: IDL.Opt(IDL.Principal),
-		TargetPreCheckOk: IDL.Null,
 		MigratedCustomTokensUpTo: IDL.Opt(IDL.Principal),
-		Locked: IDL.Null,
+		CheckingDataMigration: IDL.Null,
 		MigratedUserProfilesUpTo: IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Principal)),
-		CheckingTargetCanister: IDL.Null,
-		TargetLocked: IDL.Null,
+		UnlockingTarget: IDL.Null,
+		Unlocking: IDL.Null,
 		Completed: IDL.Null,
-		Pending: IDL.Null
+		Pending: IDL.Null,
+		LockingTarget: IDL.Null,
+		CheckingTarget: IDL.Null
 	});
 	const MigrationReport = IDL.Record({
 		to: IDL.Principal,
@@ -170,12 +189,6 @@ export const idlFactory = ({ IDL }) => {
 		max_fee_per_gas: IDL.Nat,
 		chain_id: IDL.Nat,
 		nonce: IDL.Nat
-	});
-	const Stats = IDL.Record({
-		user_profile_count: IDL.Nat64,
-		custom_token_count: IDL.Nat64,
-		user_timestamps_count: IDL.Nat64,
-		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -139,17 +139,36 @@ export const idlFactory = ({ IDL }) => {
 		users: IDL.Vec(OisyUser),
 		matches_max_length: IDL.Nat64
 	});
+	const Stats = IDL.Record({
+		user_profile_count: IDL.Nat64,
+		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
+		user_token_count: IDL.Nat64
+	});
+	const MigrationError = IDL.Variant({
+		TargetLockFailed: IDL.Null,
+		TargetUnlockFailed: IDL.Null,
+		CouldNotGetTargetPostStats: IDL.Null,
+		CouldNotGetTargetPriorStats: IDL.Null,
+		DataMigrationFailed: IDL.Null,
+		TargetStatsMismatch: IDL.Tuple(Stats, Stats),
+		Unknown: IDL.Null,
+		TargetCanisterNotEmpty: Stats,
+		NoMigrationInProgress: IDL.Null
+	});
 	const MigrationProgress = IDL.Variant({
 		MigratedUserTokensUpTo: IDL.Opt(IDL.Principal),
+		Failed: MigrationError,
 		MigratedUserTimestampsUpTo: IDL.Opt(IDL.Principal),
-		TargetPreCheckOk: IDL.Null,
 		MigratedCustomTokensUpTo: IDL.Opt(IDL.Principal),
-		Locked: IDL.Null,
+		CheckingDataMigration: IDL.Null,
 		MigratedUserProfilesUpTo: IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Principal)),
-		CheckingTargetCanister: IDL.Null,
-		TargetLocked: IDL.Null,
+		UnlockingTarget: IDL.Null,
+		Unlocking: IDL.Null,
 		Completed: IDL.Null,
-		Pending: IDL.Null
+		Pending: IDL.Null,
+		LockingTarget: IDL.Null,
+		CheckingTarget: IDL.Null
 	});
 	const MigrationReport = IDL.Record({
 		to: IDL.Principal,
@@ -170,12 +189,6 @@ export const idlFactory = ({ IDL }) => {
 		max_fee_per_gas: IDL.Nat,
 		chain_id: IDL.Nat,
 		nonce: IDL.Nat
-	});
-	const Stats = IDL.Record({
-		user_profile_count: IDL.Nat64,
-		custom_token_count: IDL.Nat64,
-		user_timestamps_count: IDL.Nat64,
-		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -79,17 +79,30 @@ type ListUsersResponse = record {
   users : vec OisyUser;
   matches_max_length : nat64;
 };
+type MigrationError = variant {
+  TargetLockFailed;
+  TargetUnlockFailed;
+  CouldNotGetTargetPostStats;
+  CouldNotGetTargetPriorStats;
+  DataMigrationFailed;
+  TargetStatsMismatch : record { Stats; Stats };
+  Unknown;
+  TargetCanisterNotEmpty : Stats;
+  NoMigrationInProgress;
+};
 type MigrationProgress = variant {
   MigratedUserTokensUpTo : opt principal;
+  Failed : MigrationError;
   MigratedUserTimestampsUpTo : opt principal;
-  TargetPreCheckOk;
   MigratedCustomTokensUpTo : opt principal;
-  Locked;
+  CheckingDataMigration;
   MigratedUserProfilesUpTo : opt record { nat64; principal };
-  CheckingTargetCanister;
-  TargetLocked;
+  UnlockingTarget;
+  Unlocking;
   Completed;
   Pending;
+  LockingTarget;
+  CheckingTarget;
 };
 type MigrationReport = record { to : principal; progress : MigrationProgress };
 type OisyUser = record {

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -88,19 +88,31 @@ export interface ListUsersResponse {
 	users: Array<OisyUser>;
 	matches_max_length: bigint;
 }
+export type MigrationError =
+	| { TargetLockFailed: null }
+	| { TargetUnlockFailed: null }
+	| { CouldNotGetTargetPostStats: null }
+	| { CouldNotGetTargetPriorStats: null }
+	| { DataMigrationFailed: null }
+	| { TargetStatsMismatch: [Stats, Stats] }
+	| { Unknown: null }
+	| { TargetCanisterNotEmpty: Stats }
+	| { NoMigrationInProgress: null };
 export type MigrationProgress =
 	| {
 			MigratedUserTokensUpTo: [] | [Principal];
 	  }
+	| { Failed: MigrationError }
 	| { MigratedUserTimestampsUpTo: [] | [Principal] }
-	| { TargetPreCheckOk: null }
 	| { MigratedCustomTokensUpTo: [] | [Principal] }
-	| { Locked: null }
+	| { CheckingDataMigration: null }
 	| { MigratedUserProfilesUpTo: [] | [[bigint, Principal]] }
-	| { CheckingTargetCanister: null }
-	| { TargetLocked: null }
+	| { UnlockingTarget: null }
+	| { Unlocking: null }
 	| { Completed: null }
-	| { Pending: null };
+	| { Pending: null }
+	| { LockingTarget: null }
+	| { CheckingTarget: null };
 export interface MigrationReport {
 	to: Principal;
 	progress: MigrationProgress;

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -139,17 +139,36 @@ export const idlFactory = ({ IDL }) => {
 		users: IDL.Vec(OisyUser),
 		matches_max_length: IDL.Nat64
 	});
+	const Stats = IDL.Record({
+		user_profile_count: IDL.Nat64,
+		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
+		user_token_count: IDL.Nat64
+	});
+	const MigrationError = IDL.Variant({
+		TargetLockFailed: IDL.Null,
+		TargetUnlockFailed: IDL.Null,
+		CouldNotGetTargetPostStats: IDL.Null,
+		CouldNotGetTargetPriorStats: IDL.Null,
+		DataMigrationFailed: IDL.Null,
+		TargetStatsMismatch: IDL.Tuple(Stats, Stats),
+		Unknown: IDL.Null,
+		TargetCanisterNotEmpty: Stats,
+		NoMigrationInProgress: IDL.Null
+	});
 	const MigrationProgress = IDL.Variant({
 		MigratedUserTokensUpTo: IDL.Opt(IDL.Principal),
+		Failed: MigrationError,
 		MigratedUserTimestampsUpTo: IDL.Opt(IDL.Principal),
-		TargetPreCheckOk: IDL.Null,
 		MigratedCustomTokensUpTo: IDL.Opt(IDL.Principal),
-		Locked: IDL.Null,
+		CheckingDataMigration: IDL.Null,
 		MigratedUserProfilesUpTo: IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Principal)),
-		CheckingTargetCanister: IDL.Null,
-		TargetLocked: IDL.Null,
+		UnlockingTarget: IDL.Null,
+		Unlocking: IDL.Null,
 		Completed: IDL.Null,
-		Pending: IDL.Null
+		Pending: IDL.Null,
+		LockingTarget: IDL.Null,
+		CheckingTarget: IDL.Null
 	});
 	const MigrationReport = IDL.Record({
 		to: IDL.Principal,
@@ -170,12 +189,6 @@ export const idlFactory = ({ IDL }) => {
 		max_fee_per_gas: IDL.Nat,
 		chain_id: IDL.Nat,
 		nonce: IDL.Nat
-	});
-	const Stats = IDL.Record({
-		user_profile_count: IDL.Nat64,
-		custom_token_count: IDL.Nat64,
-		user_timestamps_count: IDL.Nat64,
-		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -139,17 +139,36 @@ export const idlFactory = ({ IDL }) => {
 		users: IDL.Vec(OisyUser),
 		matches_max_length: IDL.Nat64
 	});
+	const Stats = IDL.Record({
+		user_profile_count: IDL.Nat64,
+		custom_token_count: IDL.Nat64,
+		user_timestamps_count: IDL.Nat64,
+		user_token_count: IDL.Nat64
+	});
+	const MigrationError = IDL.Variant({
+		TargetLockFailed: IDL.Null,
+		TargetUnlockFailed: IDL.Null,
+		CouldNotGetTargetPostStats: IDL.Null,
+		CouldNotGetTargetPriorStats: IDL.Null,
+		DataMigrationFailed: IDL.Null,
+		TargetStatsMismatch: IDL.Tuple(Stats, Stats),
+		Unknown: IDL.Null,
+		TargetCanisterNotEmpty: Stats,
+		NoMigrationInProgress: IDL.Null
+	});
 	const MigrationProgress = IDL.Variant({
 		MigratedUserTokensUpTo: IDL.Opt(IDL.Principal),
+		Failed: MigrationError,
 		MigratedUserTimestampsUpTo: IDL.Opt(IDL.Principal),
-		TargetPreCheckOk: IDL.Null,
 		MigratedCustomTokensUpTo: IDL.Opt(IDL.Principal),
-		Locked: IDL.Null,
+		CheckingDataMigration: IDL.Null,
 		MigratedUserProfilesUpTo: IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Principal)),
-		CheckingTargetCanister: IDL.Null,
-		TargetLocked: IDL.Null,
+		UnlockingTarget: IDL.Null,
+		Unlocking: IDL.Null,
 		Completed: IDL.Null,
-		Pending: IDL.Null
+		Pending: IDL.Null,
+		LockingTarget: IDL.Null,
+		CheckingTarget: IDL.Null
 	});
 	const MigrationReport = IDL.Record({
 		to: IDL.Principal,
@@ -170,12 +189,6 @@ export const idlFactory = ({ IDL }) => {
 		max_fee_per_gas: IDL.Nat,
 		chain_id: IDL.Nat,
 		nonce: IDL.Nat
-	});
-	const Stats = IDL.Record({
-		user_profile_count: IDL.Nat64,
-		custom_token_count: IDL.Nat64,
-		user_timestamps_count: IDL.Nat64,
-		user_token_count: IDL.Nat64
 	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -236,10 +236,9 @@ impl MigrationProgress {
     #[must_use]
     pub fn next(&self) -> Self {
         match self {
-            MigrationProgress::Pending => MigrationProgress::Locked,
-            MigrationProgress::Locked => MigrationProgress::TargetLocked,
-            MigrationProgress::TargetLocked => MigrationProgress::TargetPreCheckOk,
-            MigrationProgress::TargetPreCheckOk => MigrationProgress::MigratedUserTokensUpTo(None),
+            MigrationProgress::Pending => MigrationProgress::LockingTarget,
+            MigrationProgress::LockingTarget => MigrationProgress::CheckingTarget,
+            MigrationProgress::CheckingTarget => MigrationProgress::MigratedUserTokensUpTo(None),
             MigrationProgress::MigratedUserTokensUpTo(_) => {
                 MigrationProgress::MigratedCustomTokensUpTo(None)
             }
@@ -250,11 +249,14 @@ impl MigrationProgress {
                 MigrationProgress::MigratedUserProfilesUpTo(None)
             }
             MigrationProgress::MigratedUserProfilesUpTo(_) => {
-                MigrationProgress::CheckingTargetCanister
+                MigrationProgress::CheckingDataMigration
             }
-            MigrationProgress::CheckingTargetCanister | MigrationProgress::Completed => {
+            MigrationProgress::CheckingDataMigration => MigrationProgress::UnlockingTarget,
+            MigrationProgress::UnlockingTarget => MigrationProgress::Unlocking,
+            &MigrationProgress::Unlocking | MigrationProgress::Completed => {
                 MigrationProgress::Completed
             }
+            MigrationProgress::Failed(e) => MigrationProgress::Failed(*e),
         }
     }
 }

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -238,17 +238,13 @@ pub mod user_profile {
     CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Default, EnumCountMacro, EnumIter,
 )]
 pub enum MigrationProgress {
-    // WARNING: The following are subject to change.  The migration has NOT been implemented yet.
-    // TODO: Remove warning once the migration has been implemented.
     /// Migration has been requested.
     #[default]
     Pending,
-    /// APIs have been locked on the current canister.
-    Locked,
-    /// APIs have been locked on the target canister.
-    TargetLocked,
-    /// Target canister was empty.
-    TargetPreCheckOk,
+    /// APIs are being locked on the target canister.
+    LockingTarget,
+    /// Checking that the target canister is empty.
+    CheckingTarget,
     /// Tokens have been migrated up to (but excluding) the given principal.
     MigratedUserTokensUpTo(Option<Principal>),
     /// Custom tokens have been migrated up to (but excluding) the given principal.
@@ -258,9 +254,39 @@ pub enum MigrationProgress {
     /// Migrated user profiles up to the given timestamp/user pair.
     MigratedUserProfilesUpTo(Option<(Timestamp, Principal)>),
     /// Checking that the target canister has all the data.
-    CheckingTargetCanister,
+    CheckingDataMigration,
+    /// Unlock user data operations in the target canister.
+    UnlockingTarget,
+    // Unlock signing operations in the current canister.
+    Unlocking,
     /// Migration has been completed.
     Completed,
+    /// Migration failed.
+    Failed(MigrationError),
+}
+
+#[derive(
+    CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Default, EnumCountMacro, EnumIter,
+)]
+pub enum MigrationError {
+    #[default]
+    Unknown,
+    /// No migration is in progress.
+    NoMigrationInProgress,
+    /// Failed to lock target canister.
+    TargetLockFailed,
+    /// Could not get target stats before starting migration.
+    CouldNotGetTargetPriorStats,
+    /// There were already user profiles in the target canister.
+    TargetCanisterNotEmpty(Stats),
+    /// Failed to migrate data.
+    DataMigrationFailed,
+    /// Could not get target stats after migration.
+    CouldNotGetTargetPostStats,
+    /// Target stats do not match source stats.
+    TargetStatsMismatch(Stats, Stats),
+    /// Could not unlock target canister.
+    TargetUnlockFailed,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
# Motivation
Testing migrations showed that:
- Some naming was potentially confusing.
- When testing error conditions, it would be useful to have a formal error variant for the migration state.

# Changes
- Modify the (as yet unused in main) migration state enum:
  - Some steps have been renamed or reorganized for clarity.
  - A failed state has been added, with various reasons for failure.

- Updated code to match

# Tests
Tests have been updated to match the changes.