### PR TITLE
test(e2e): add canister ids as env vars for e2e tests

### DIFF
--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -114,8 +114,7 @@ export class HomepageLoggedIn extends Homepage {
 	async waitForAuthentication(): Promise<void> {
 		await this.#iiPage.waitReady({
 			url: LOCAL_REPLICA_URL,
-			// TODO: take this value from env vars
-			canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai'
+			canisterId: process.env.E2E_LOCAL_INTERNET_IDENTITY_CANISTER_ID
 		});
 
 		await this.waitForHomepageReady();

--- a/env.utils.ts
+++ b/env.utils.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 /**
  * Read a JSON file with canister IDs and transform it into a dictionary. Optionally add prefix to all dictionary keys.
  */
-export const readCanisterIdsFromJSONFile = ({
+export const readCanisterIds = ({
 	filePath,
 	prefix
 }: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 import dotenv, { type DotenvPopulateInput } from 'dotenv';
 import { join } from 'node:path';
-import { readCanisterIdsFromJSONFile } from './shared.utils';
+import { readCanisterIds } from './env.utils';
 
 dotenv.populate(
 	process.env as DotenvPopulateInput,
-	readCanisterIdsFromJSONFile({
+	readCanisterIds({
 		filePath: join(process.cwd(), 'canister_e2e_ids.json'),
 		prefix: 'E2E_'
 	})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv, { type DotenvPopulateInput } from 'dotenv';
+import { join } from 'node:path';
+import { readCanisterIdsFromJSONFile } from './shared.utils';
+
+dotenv.populate(
+	process.env as DotenvPopulateInput,
+	readCanisterIdsFromJSONFile({
+		filePath: join(process.cwd(), 'canister_e2e_ids.json'),
+		prefix: 'E2E_'
+	})
+);
 
 const DEV = (process.env.NODE_ENV ?? 'production') === 'development';
 

--- a/shared.utils.ts
+++ b/shared.utils.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Read a JSON file with canister IDs and transform it into a dictionary. Optionally add prefix to all dictionary keys.
+ */
+export const readCanisterIdsFromJSONFile = ({
+	filePath,
+	prefix
+}: {
+	filePath: string;
+	prefix?: string;
+}): Record<string, string> => {
+	try {
+		type Details = {
+			ic?: string;
+			staging?: string;
+			local?: string;
+		};
+
+		const config: Record<string, Details> = JSON.parse(readFileSync(filePath, 'utf8'));
+
+		return Object.entries(config).reduce((acc, current: [string, Details]) => {
+			const [canisterName, canisterDetails] = current;
+
+			const ids = Object.entries(canisterDetails).reduce(
+				(acc, [network, id]) => ({
+					...acc,
+					[`${prefix ?? ''}${network.toUpperCase()}_${canisterName
+						.replaceAll('-', '_')
+						.replaceAll("'", '')
+						.toUpperCase()}_CANISTER_ID`]: id
+				}),
+				{}
+			);
+
+			return {
+				...acc,
+				...ids
+			};
+		}, {});
+	} catch (e) {
+		console.warn(`Could not get canister ID from ${filePath}: ${e}`);
+		return {};
+	}
+};

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -9,6 +9,7 @@
 		"./src/**/*.js",
 		"./src/**/*.ts",
 		"./src/**/*.svelte",
+		"./shared.utils.ts",
 		"./vitest.setup.ts",
 		"./vitest.config.ts",
 		"./tailwind.config.js",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -9,7 +9,7 @@
 		"./src/**/*.js",
 		"./src/**/*.ts",
 		"./src/**/*.svelte",
-		"./shared.utils.ts",
+		"./env.utils.ts",
 		"./vitest.setup.ts",
 		"./vitest.config.ts",
 		"./tailwind.config.js",

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -1,47 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-const readIds = ({
-	filePath,
-	prefix
-}: {
-	filePath: string;
-	prefix?: string;
-}): Record<string, string> => {
-	try {
-		type Details = {
-			ic?: string;
-			staging?: string;
-			local?: string;
-		};
-
-		const config: Record<string, Details> = JSON.parse(readFileSync(filePath, 'utf8'));
-
-		return Object.entries(config).reduce((acc, current: [string, Details]) => {
-			const [canisterName, canisterDetails] = current;
-
-			const ids = Object.entries(canisterDetails).reduce(
-				(acc, [network, id]) => ({
-					...acc,
-					[`${prefix ?? ''}${network.toUpperCase()}_${canisterName
-						.replaceAll('-', '_')
-						.replaceAll("'", '')
-						.toUpperCase()}_CANISTER_ID`]: id
-				}),
-				{}
-			);
-
-			return {
-				...acc,
-				...ids
-			};
-		}, {});
-	} catch (e) {
-		console.warn(`Could not get canister ID from ${filePath}: ${e}`);
-		return {};
-	}
-};
+import { readCanisterIdsFromJSONFile } from './shared.utils';
 
 /**
  * Read all the locally deployed canister IDs. For example Oisy backend, ckBTC|ETH, ICP etc.
@@ -50,7 +10,7 @@ const readIds = ({
 const readLocalCanisterIds = ({ prefix }: { prefix?: string }): Record<string, string> => {
 	const dfxCanisterIdsJsonFile = join(process.cwd(), '.dfx', 'local', 'canister_ids.json');
 	const e2eCanisterIdsJsonFile = join(process.cwd(), 'canister_e2e_ids.json');
-	return readIds({
+	return readCanisterIdsFromJSONFile({
 		filePath: existsSync(dfxCanisterIdsJsonFile) ? dfxCanisterIdsJsonFile : e2eCanisterIdsJsonFile,
 		prefix
 	});
@@ -62,7 +22,7 @@ const readLocalCanisterIds = ({ prefix }: { prefix?: string }): Record<string, s
  */
 const readOisyCanisterIds = ({ prefix }: { prefix?: string }): Record<string, string> => {
 	const canisterIdsJsonFile = join(process.cwd(), 'canister_ids.json');
-	return readIds({ filePath: canisterIdsJsonFile, prefix });
+	return readCanisterIdsFromJSONFile({ filePath: canisterIdsJsonFile, prefix });
 };
 
 /**

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { readCanisterIdsFromJSONFile } from './shared.utils';
+import { readCanisterIds as readIds } from './env.utils';
 
 /**
  * Read all the locally deployed canister IDs. For example Oisy backend, ckBTC|ETH, ICP etc.
@@ -10,7 +10,7 @@ import { readCanisterIdsFromJSONFile } from './shared.utils';
 const readLocalCanisterIds = ({ prefix }: { prefix?: string }): Record<string, string> => {
 	const dfxCanisterIdsJsonFile = join(process.cwd(), '.dfx', 'local', 'canister_ids.json');
 	const e2eCanisterIdsJsonFile = join(process.cwd(), 'canister_e2e_ids.json');
-	return readCanisterIdsFromJSONFile({
+	return readIds({
 		filePath: existsSync(dfxCanisterIdsJsonFile) ? dfxCanisterIdsJsonFile : e2eCanisterIdsJsonFile,
 		prefix
 	});
@@ -22,7 +22,7 @@ const readLocalCanisterIds = ({ prefix }: { prefix?: string }): Record<string, s
  */
 const readOisyCanisterIds = ({ prefix }: { prefix?: string }): Record<string, string> => {
 	const canisterIdsJsonFile = join(process.cwd(), 'canister_ids.json');
-	return readCanisterIdsFromJSONFile({ filePath: canisterIdsJsonFile, prefix });
+	return readIds({ filePath: canisterIdsJsonFile, prefix });
 };
 
 /**


### PR DESCRIPTION
# Motivation

The goal is to access canister_e2e_ids.json in e2e tests as env vars.
