### PR TITLE
fix(frontend): add walletconnect.org to connect-src CSP

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -143,7 +143,8 @@ const updateCSP = (indexHtml) => {
 	const ethSepoliaConnectSrc =
 		'https://api-sepolia.etherscan.io https://sepolia.infura.io wss://eth-sepolia.g.alchemy.com https://eth-sepolia.g.alchemy.com';
 
-	const walletConnectSrc = 'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org';
+	const walletConnectSrc =
+		'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org';
 	const walletConnectFrameSrc = 'https://verify.walletconnect.com https://verify.walletconnect.org';
 
 	const csp = `<meta

--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -143,7 +143,7 @@ const updateCSP = (indexHtml) => {
 	const ethSepoliaConnectSrc =
 		'https://api-sepolia.etherscan.io https://sepolia.infura.io wss://eth-sepolia.g.alchemy.com https://eth-sepolia.g.alchemy.com';
 
-	const walletConnectSrc = 'wss://relay.walletconnect.com https://verify.walletconnect.com';
+	const walletConnectSrc = 'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org';
 	const walletConnectFrameSrc = 'https://verify.walletconnect.com https://verify.walletconnect.org';
 
 	const csp = `<meta


### PR DESCRIPTION
# Motivation

I'm not sure if it the issue is related to bumping `@walletconnect/web3wallet` from v1.12.3 to 1.14.0 - given that nothing related is specified in the [release notes](https://github.com/WalletConnect/walletconnect-monorepo/releases) -  or if the issue started out of the blue but, WalletConnect has started using `walletconnect.org` instead of `walletconnect.com` which lead to Oisy not being able to connect WalletConnect as we are protective about the list of services we are allowing in the dApp CSP.

# Changes

- Add `wss://relay.walletconnect.org https://verify.walletconnect.org` to `connect-src` in CSP

# Screenshots

Issue identified in production:

![image](https://github.com/user-attachments/assets/02b87d15-4530-46d6-9a3b-1beab17440c2)

