### PR TITLE
feat(frontend): display Oisy version on Settings page

### DIFF
--- a/src/frontend/src/lib/components/pages/Settings.svelte
+++ b/src/frontend/src/lib/components/pages/Settings.svelte
@@ -2,6 +2,7 @@
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import SettingsSignedIn from '$lib/components/pages/SettingsSignedIn.svelte';
 	import SettingsSignedOut from '$lib/components/pages/SettingsSignedOut.svelte';
+	import SettingsVersion from '$lib/components/pages/SettingsVersion.svelte';
 </script>
 
 {#if $authSignedIn}
@@ -9,3 +10,5 @@
 {:else}
 	<SettingsSignedOut />
 {/if}
+
+<SettingsVersion />

--- a/src/frontend/src/lib/components/pages/SettingsVersion.svelte
+++ b/src/frontend/src/lib/components/pages/SettingsVersion.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import { APP_VERSION } from '$lib/constants/app.constants';
+	import { OISY_NAME } from '$lib/constants/oisy.constants';
+</script>
+
+<p class="mt-24 text-dark opacity-50 text-xs text-center">{OISY_NAME} v{APP_VERSION}</p>


### PR DESCRIPTION
# Motivation

Let's display the app version on the settings page.

# Screenshots

<img width="1536" alt="Capture d’écran 2024-08-21 à 13 12 58" src="https://github.com/user-attachments/assets/f0a3ae7a-23ac-4ece-a0be-d5f2a24da73f">
<img width="1536" alt="Capture d’écran 2024-08-21 à 13 12 53" src="https://github.com/user-attachments/assets/3783e0ca-aa3a-4da0-8eb3-26de4efe3a9c">

