### PR TITLE
ci(e2e): improve e2e workflow

### DIFF
--- a/.github/actions/docker-build-e2e/action.yml
+++ b/.github/actions/docker-build-e2e/action.yml
@@ -15,6 +15,10 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Delete unnecessary tools folder to prevent "out of space" error
+      run: rm -rf /opt/hostedtoolcache
+      shell: bash
+
     - name: Update system packages
       run: sudo apt-get update
       shell: bash

--- a/.github/workflows/e2e-tests-build-docker-image.yml
+++ b/.github/workflows/e2e-tests-build-docker-image.yml
@@ -1,0 +1,16 @@
+name: Docker Image Builder For E2E Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker-build-e2e:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build E2E Docker Image
+        uses: ./.github/actions/docker-build-e2e
+        with:
+          name: oisy-e2e-image

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,32 +8,19 @@ on:
 
 jobs:
 
-  docker-build-e2e:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Delete unnecessary tools folder to prevent "out of space" error
-        run: rm -rf /opt/hostedtoolcache
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build E2E Docker Image
-        uses: ./.github/actions/docker-build-e2e
-        with:
-          name: oisy-e2e-image
-
   e2e:
     runs-on: ubuntu-latest
-    needs: docker-build-e2e
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Download E2E Docker image artifact
-        uses: actions/download-artifact@v4
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v6
         with:
-          name: oisy-e2e-image
-          path: .
+          workflow: e2e-tests-build-docker-image.yml
+          branch: main
+          if_no_artifact_found: fail
 
       - name: Load Docker image
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: e2e-tests-build-docker-image.yml
+          name: oisy-e2e-image
           branch: main
           if_no_artifact_found: fail
 

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -5,26 +5,6 @@ on:
 
 jobs:
 
-  docker-build-e2e:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Fail if branch is main
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          echo "This workflow should not be triggered with workflow_dispatch on main"
-          exit 1
-
-      - name: Delete unnecessary tools folder to prevent "out of space" error
-        run: rm -rf /opt/hostedtoolcache
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build E2E Docker Image
-        uses: ./.github/actions/docker-build-e2e
-        with:
-          name: oisy-e2e-image
-
   update_snapshots:
     runs-on: ubuntu-latest
     needs: docker-build-e2e
@@ -39,10 +19,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download E2E Docker image artifact
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v6
         with:
-          name: oisy-e2e-image
-          path: .
+          workflow: e2e-tests-build-docker-image.yml
+          branch: main
+          if_no_artifact_found: fail
 
       - name: Load Docker image
         run: |

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -22,6 +22,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: e2e-tests-build-docker-image.yml
+          name: oisy-e2e-image
           branch: main
           if_no_artifact_found: fail
 


### PR DESCRIPTION
# Motivation

The goal is to avoid the creation of an e2e docker image on every pull request. Instead, we can re-use artifacts between the workflows. 

The next steps are:
1. Update snapshots inside a PR in case e2e failed with related error.
2. Enable e2e tests on all PRs that contain changed frontend files.
3. Enable e2e tests for all PRs with rebuild of the artifact if backend files were changed.
