### PR TITLE
fix(frontend): do not show BTC text before onboard

### DIFF
--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -13,6 +13,7 @@
 	import { loadIcrcTokens } from '$icp/services/icrc.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authStore } from '$lib/stores/auth.store';
+	import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
 
 	let progressStep: string = ProgressStepsLoader.BTC_ETH_ADDRESS;
 
@@ -25,7 +26,9 @@
 		} as ProgressStep,
 		{
 			step: ProgressStepsLoader.BTC_ETH_ADDRESS,
-			text: $i18n.init.text.retrieving_public_keys,
+			text: NETWORK_BITCOIN_ENABLED
+				? $i18n.init.text.retrieving_public_keys
+				: $i18n.init.text.retrieving_public_key_only_eth,
 			state: 'in_progress'
 		} as ProgressStep
 	];

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -81,6 +81,7 @@
 		"text": {
 			"initializing_wallet": "Initializing your wallet",
 			"securing_session": "Securing session with Internet Identity",
+			"retrieving_public_key_only_eth": "Retrieving your Ethereum public key",
 			"retrieving_public_keys": "Retrieving your Bitcoin and Ethereum public keys"
 		},
 		"info": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -65,7 +65,12 @@ interface I18nWallet {
 }
 
 interface I18nInit {
-	text: { initializing_wallet: string; securing_session: string; retrieving_public_keys: string };
+	text: {
+		initializing_wallet: string;
+		securing_session: string;
+		retrieving_public_key_only_eth: string;
+		retrieving_public_keys: string;
+	};
 	info: { hold_loading: string; hold_loading_wallet: string };
 	error: {
 		no_alchemy_config: string;


### PR DESCRIPTION
# Motivation

It was reported that the address loading modal was writing Bitcoin even if it is still not onboarded.

![image](https://github.com/user-attachments/assets/34372569-6e00-4d46-a1e3-5f7d405c9596)

