### PR TITLE
ci(e2e): issue with missing signer canister id

### DIFF
--- a/canister_e2e_ids.json
+++ b/canister_e2e_ids.json
@@ -2,6 +2,9 @@
 	"backend": {
 		"local": "tdxud-2yaaa-aaaad-aadiq-cai"
 	},
+	"signer": {
+		"local": "tdxud-2yaaa-aaaad-aadiq-cai"
+	},
 	"ckbtc_index": {
 		"local": "mm444-5iaaa-aaaar-qaabq-cai"
 	},

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,7 @@ dfx canister create internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
 dfx canister create pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
 
 ./scripts/deploy.backend.sh
+./scripts/deploy.signer.sh
 
 mkdir -p ./target/ic
 


### PR DESCRIPTION
# Motivation

Fix issue with missing signer canister id for e2e docker image.
