### PR TITLE
style(frontend): slight changes to Hero layout

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -28,7 +28,8 @@
 	<Header />
 
 	<article
-		class="flex flex-col text-off-white rounded-lg pt-1 sm:pt-3 pb-2 px-8 relative main 2xl:mt-[-70px] items-center"
+		class="flex flex-col text-off-white rounded-lg pt-1 sm:pt-3 px-8 relative main 2xl:mt-[-70px] items-center"
+		style="padding-bottom: 32px"
 	>
 		<Alpha />
 

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -13,7 +13,7 @@
 	<IconHeaderETH />
 </div>
 
-<div class="mt-5 mb-10 pt-2">
+<div class="mt-5 mb-7 pt-2">
 	<h1 class="text-off-white text-4xl text-center">
 		{$i18n.auth.text.title}
 	</h1>

--- a/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
@@ -6,7 +6,7 @@
 <div class="rounded-full border-overlay">
 	<button
 		on:click
-		class="authenticate h-[72px] px-[74px] py-2 rounded-full border-0 gap-4 font-bold text-lg leading-6 bg-brandeis-blue"
+		class="authenticate h-16 px-12 py-2 rounded-full border-0 gap-4 font-bold text-lg leading-6 bg-brandeis-blue"
 		data-tid="login-button"
 	>
 		<slot />


### PR DESCRIPTION
# Motivation

Slight changes to `Hero` layout:

- Reduce `ButtonAuthenticate` height and width.
- Increase padding at the bottom.
- Reduce distance between title and authentication button.


<img width="1026" alt="Screenshot 2024-08-23 at 13 39 57" src="https://github.com/user-attachments/assets/c43e6ddd-1edb-4081-bc9c-c256f5893e17">
