### PR TITLE
fix(frontend): adjust ETH explorer for ck tokens

### DIFF
--- a/src/frontend/src/icp/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/cketh-transactions.utils.ts
@@ -5,6 +5,7 @@ import {
 	SEPOLIA_EXPLORER_URL
 } from '$env/explorers.env';
 import {
+	ICRC_LEDGER_CANISTER_TESTNET_IDS,
 	IC_CKETH_LEDGER_CANISTER_ID,
 	STAGING_CKETH_LEDGER_CANISTER_ID
 } from '$env/networks.icrc.env';
@@ -67,8 +68,9 @@ export const mapCkEthereumTransaction = ({
 	const mint = fromNullable(rawMint);
 	const burn = fromNullable(rawBurn);
 
-	const ethExplorerUrl =
-		IC_CKETH_LEDGER_CANISTER_ID === ledgerCanisterId ? ETHEREUM_EXPLORER_URL : SEPOLIA_EXPLORER_URL;
+	const ethExplorerUrl = ICRC_LEDGER_CANISTER_TESTNET_IDS.includes(ledgerCanisterId)
+		? SEPOLIA_EXPLORER_URL
+		: ETHEREUM_EXPLORER_URL;
 
 	if (nonNullish(mint)) {
 		const memo = fromNullable(mint.memo);


### PR DESCRIPTION
# Motivation

The ETH explorer for ck-conversion transaction was pointing always to Sepolia for ckERC20 tokens that were not ckETH. This fixes it keeping the same logic based on the `ledgerCanisterId` being staging or prod.