### PR TITLE
style(frontend): avoid showing empty tokens list on loading

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensSkeletons.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSkeletons.svelte
@@ -3,9 +3,11 @@
 	import { fade } from 'svelte/transition';
 	import SkeletonCards from '$lib/components/ui/SkeletonCards.svelte';
 	import { TOKENS_SKELETONS_INITIALIZED } from '$lib/constants/test-ids.constants';
+
+	export let loading = false;
 </script>
 
-{#if $erc20UserTokensNotInitialized}
+{#if $erc20UserTokensNotInitialized || loading}
 	<SkeletonCards rows={5} />
 {:else}
 	<div in:fade data-tid={TOKENS_SKELETONS_INITIALIZED}>


### PR DESCRIPTION
# Motivation

We aim to show a non-empty tokens list as first, and avoid showing an empty list just because it is loading, thus reducing glitches.

### Before

https://github.com/user-attachments/assets/b67eacb5-4553-4882-9f98-4bd847afaaa0

### After

https://github.com/user-attachments/assets/6937aa12-702f-49ab-8431-2cb31561f79a

