### PR TITLE
refactor(frontend): derived store for ETH address data

### DIFF
--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,12 +1,17 @@
 import { BTC_MAINNET_TOKEN_ID } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens.env';
-import { addressStore } from '$lib/stores/address.store';
+import { addressStore, type AddressData } from '$lib/stores/address.store';
 import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const addressNotLoaded: Readable<boolean> = derived([addressStore], ([$addressStore]) =>
 	isNullish($addressStore)
+);
+
+const ethAddressData: Readable<AddressData | null | undefined> = derived(
+	[addressStore],
+	([$addressStore]) => $addressStore?.[ETHEREUM_TOKEN_ID]
 );
 
 export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
@@ -17,13 +22,14 @@ export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
 			: $addressStore?.[BTC_MAINNET_TOKEN_ID]?.data
 );
 
-export const ethAddress: Readable<OptionEthAddress> = derived([addressStore], ([$addressStore]) =>
-	$addressStore?.[ETHEREUM_TOKEN_ID] === null ? null : $addressStore?.[ETHEREUM_TOKEN_ID]?.data
+export const ethAddress: Readable<OptionEthAddress> = derived(
+	[ethAddressData],
+	([$ethAddressData]) => ($ethAddressData === null ? null : $ethAddressData?.data)
 );
 
 export const ethAddressCertified: Readable<boolean> = derived(
-	[addressStore],
-	([$addressStore]) => $addressStore?.[ETHEREUM_TOKEN_ID]?.certified === true
+	[ethAddressData],
+	([$ethAddressData]) => $ethAddressData?.certified === true
 );
 
 export const ethAddressNotCertified: Readable<boolean> = derived(

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,6 +1,6 @@
 import { BTC_MAINNET_TOKEN_ID } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens.env';
-import { addressStore, type AddressData } from '$lib/stores/address.store';
+import { addressStore, type OptionAddressData } from '$lib/stores/address.store';
 import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -9,7 +9,7 @@ export const addressNotLoaded: Readable<boolean> = derived([addressStore], ([$ad
 	isNullish($addressStore)
 );
 
-const ethAddressData: Readable<AddressData | null | undefined> = derived(
+const ethAddressData: Readable<OptionAddressData> = derived(
 	[addressStore],
 	([$addressStore]) => $addressStore?.[ETHEREUM_TOKEN_ID]
 );

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -9,17 +9,17 @@ export const addressNotLoaded: Readable<boolean> = derived([addressStore], ([$ad
 	isNullish($addressStore)
 );
 
-const ethAddressData: Readable<OptionAddressData> = derived(
-	[addressStore],
-	([$addressStore]) => $addressStore?.[ETHEREUM_TOKEN_ID]
-);
-
 export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
 	[addressStore],
 	([$addressStore]) =>
 		$addressStore?.[BTC_MAINNET_TOKEN_ID] === null
 			? null
 			: $addressStore?.[BTC_MAINNET_TOKEN_ID]?.data
+);
+
+const ethAddressData: Readable<OptionAddressData> = derived(
+	[addressStore],
+	([$addressStore]) => $addressStore?.[ETHEREUM_TOKEN_ID]
 );
 
 export const ethAddress: Readable<OptionEthAddress> = derived(

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -1,7 +1,10 @@
 import { initCertifiedSetterStore } from '$lib/stores/certified-setter.store';
+import type { StorageStoreData } from '$lib/stores/storage.store';
 import type { Address } from '$lib/types/address';
 import type { CertifiedData } from '$lib/types/store';
 
 export type AddressData = CertifiedData<Address>;
+
+export type OptionAddressData = StorageStoreData<AddressData>;
 
 export const addressStore = initCertifiedSetterStore<AddressData>();


### PR DESCRIPTION
# Motivation

To avoid repeating code and simplify readability, there is a new derived store that determines the ETH address certified data.