### PR TITLE
fix(frontend): correct fallback string when converting ckERC20

### DIFF
--- a/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
@@ -25,21 +25,21 @@
 	});
 	setContext<SendContext>(SEND_CONTEXT_KEY, context);
 
-	let converToSymbol: string;
-	$: converToSymbol = ($token as OptionErc20Token)?.twinTokenSymbol ?? 'ckETH';
+	let convertToSymbol: string;
+	$: convertToSymbol = ($token as OptionErc20Token)?.twinTokenSymbol ?? '';
 </script>
 
 <ConvertETH
 	nativeTokenId={$ethereumTokenId}
 	nativeNetworkId={$selectedEthereumNetwork.id}
 	ariaLabel={replacePlaceholders($i18n.convert.text.convert_to_ckerc20, {
-		$ckErc20: converToSymbol
+		$ckErc20: convertToSymbol
 	})}
 >
 	<IconConvert size="28" slot="icon" />
 	<span>
 		{replacePlaceholders($i18n.convert.text.convert_to_ckerc20, {
-			$ckErc20: converToSymbol
+			$ckErc20: convertToSymbol
 		})}
 	</span>
 </ConvertETH>


### PR DESCRIPTION
# Motivation

As discussed in PR #2104 ([comment](https://github.com/dfinity/oisy-wallet/pull/2104#discussion_r1732623091)), it is better to make the token symbol to fallback on an empty string `''`.

Unrelated: there is a slight mispelling in one of the variables.
