### PR TITLE
fix(frontend): tokens not showing when loading

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -37,8 +37,8 @@
 	$: loading = $erc20UserTokensNotInitialized || isNullish(tokens);
 </script>
 
-<TokensSkeletons {loading}>
-	<TokensDisplayHandler bind:tokens>
+<TokensDisplayHandler bind:tokens>
+	<TokensSkeletons {loading}>
 		{#each tokens ?? [] as token (token.id)}
 			<div
 				transition:fade
@@ -54,13 +54,13 @@
 				</Listener>
 			</div>
 		{/each}
-	</TokensDisplayHandler>
 
-	{#if tokens?.length === 0}
-		<p class="mt-4 text-dark opacity-50">{$i18n.tokens.text.all_tokens_with_zero_hidden}</p>
-	{/if}
+		{#if tokens?.length === 0}
+			<p class="mt-4 text-dark opacity-50">{$i18n.tokens.text.all_tokens_with_zero_hidden}</p>
+		{/if}
 
-	{#if $modalManageTokens}
-		<ManageTokensModal />
-	{/if}
-</TokensSkeletons>
+		{#if $modalManageTokens}
+			<ManageTokensModal />
+		{/if}
+	</TokensSkeletons>
+</TokensDisplayHandler>


### PR DESCRIPTION
# Motivation

There is a concurrency issue: when starting the `TokensSkeleton`, component `TokensDisplayHandler` is not mounted on loading, meaning that `tokens` variable is not updated, and it remains `undefined`. That affects `loading` itself and it keeps being `true`. 

# Changes

Moved `TokensDisplayHandler` above `TokensSkeletons`.

# Tests

### Before

Screen was stuck to this:

<img width="1254" alt="Screenshot 2024-08-27 at 13 59 05" src="https://github.com/user-attachments/assets/076c4f14-8c1f-4882-bba4-2a5014d95299">

### After

It updates correctly:

<img width="1278" alt="Screenshot 2024-08-27 at 14 03 57" src="https://github.com/user-attachments/assets/6c5136e5-161f-48a8-b209-e69dc40f7c3b">

