### PR TITLE
refactor(frontend): generalize usage of HowToConvertEthereumModal

### DIFF
--- a/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
+++ b/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
@@ -71,5 +71,5 @@
 </div>
 
 {#if $modalHowToConvertToTwinTokenEth}
-	<HowToConvertEthereumModal />
+	<HowToConvertEthereumModal {twinToken} />
 {/if}

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -11,13 +11,13 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		ckEthereumNativeToken,
-		ckEthereumNativeTokenBalance,
-		ckEthereumTwinToken
+		ckEthereumNativeTokenBalance
 	} from '$icp-eth/derived/cketh.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { tokenCkErc20Ledger } from '$icp/derived/ic-token.derived';
 
 	export let formCancelAction: 'back' | 'close' = 'back';
+	export let twinTokenSymbol: string;
 
 	let ckErc20 = false;
 	$: ckErc20 = $tokenCkErc20Ledger;
@@ -33,7 +33,7 @@
 			{replacePlaceholders(
 				replaceOisyPlaceholders($i18n.convert.text.how_to_convert_eth_to_cketh),
 				{
-					$token: $ckEthereumTwinToken.symbol,
+					$token: twinTokenSymbol,
 					$ckToken: $tokenWithFallback.symbol
 				}
 			)}:
@@ -85,7 +85,7 @@
 		>
 			<svelte:fragment slot="title"
 				>{replacePlaceholders(replaceOisyPlaceholders($i18n.convert.text.send_eth), {
-					$token: $ckEthereumTwinToken.symbol
+					$token: twinTokenSymbol
 				})}</svelte:fragment
 			>
 		</ReceiveAddress>
@@ -103,7 +103,7 @@
 			<Value element="div">
 				<svelte:fragment slot="label"
 					>{replacePlaceholders($i18n.convert.text.wait_eth_current_balance, {
-						$token: $ckEthereumTwinToken.symbol
+						$token: twinTokenSymbol
 					})}</svelte:fragment
 				>
 
@@ -129,7 +129,7 @@
 			<Value element="div">
 				<svelte:fragment slot="label"
 					>{replacePlaceholders($i18n.convert.text.convert_eth_to_cketh, {
-						$token: $ckEthereumTwinToken.symbol,
+						$token: twinTokenSymbol,
 						$ckToken: $tokenWithFallback.symbol
 					})}</svelte:fragment
 				>

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -7,12 +7,7 @@
 	import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { ICP_NETWORK } from '$env/networks.env';
-	import {
-		ckEthereumTwinTokenStandard,
-		ckEthereumTwinToken,
-		ckEthereumNativeTokenId,
-		ckEthereumNativeToken
-	} from '$icp-eth/derived/cketh.derived';
+	import { ckEthereumNativeTokenId, ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		toCkErc20HelperContractAddress,
@@ -20,6 +15,9 @@
 	} from '$icp-eth/utils/cketh.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import type { Token } from '$lib/types/token';
+
+	export let twinToken: Token;
 
 	/**
 	 * Props
@@ -27,7 +25,7 @@
 
 	let destination = '';
 	$: destination =
-		$ckEthereumTwinTokenStandard === 'erc20'
+		twinToken.standard === 'erc20'
 			? toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]) ?? ''
 			: toCkEthHelperContractAddress(
 					$ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
@@ -44,7 +42,7 @@
 	 */
 
 	let steps: WizardSteps;
-	$: steps = howToConvertWizardSteps({ i18n: $i18n, twinToken: $ckEthereumTwinToken });
+	$: steps = howToConvertWizardSteps({ i18n: $i18n, twinToken });
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
@@ -85,6 +83,7 @@
 			on:icQRCode={modal.next}
 			on:icConvert={() => modal.set(2)}
 			formCancelAction="close"
+			twinTokenSymbol={twinToken.symbol}
 		/>
 	</ConvertETHToCkETHWizard>
 </WizardModal>

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -107,6 +107,7 @@
 				on:icBack={() => modal.set(0)}
 				on:icQRCode={modal.next}
 				on:icConvert={() => modal.set(4)}
+				twinTokenSymbol={$ckEthereumTwinToken.symbol}
 			/>
 		{:else if currentStep?.name === steps[1].name}
 			<ReceiveAddressQRCode on:icBack={modal.back} address={$icrcAccountIdentifierText ?? ''} />


### PR DESCRIPTION
# Motivation

Since we are going to re-use `InfoEthereum`, we make the children component dependent on its prop. For example, we pass `twinToken` to the modals and we use it in cascade.

# Changes

- Pass `twinToken` to `HowToConvertEthereumModal`.
- Adapt usage in `HowToConvertEthereumModal`.
- Pass `twinTokenSymbol` to `HowToConvertEthereumInfo`.
- Adapt usage in `HowToConvertEthereumInfo` and `IcReceiveCkEthereumModal`.

# Tests

No changes in local replica.