### PR TITLE
feat(frontend): add prefix tag to tokens in ManageModal

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -36,6 +36,8 @@
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { tokensToPin } from '$lib/derived/tokens.derived';
 	import type { ExchangesData } from '$lib/types/exchange';
+	import Tag from '$lib/components/ui/Tag.svelte';
+	import TokenName from '$lib/components/tokens/TokenName.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -225,7 +227,7 @@
 	<div class="container md:max-h-[26rem] pr-2 pt-1 overflow-y-auto overscroll-contain">
 		{#each tokens as token (`${token.network.id.description}-${token.id.description}`)}
 			<Card>
-				{token.name}
+				<TokenName {token} />
 
 				<TokenLogo slot="icon" color="white" {token} />
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -36,7 +36,6 @@
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { tokensToPin } from '$lib/derived/tokens.derived';
 	import type { ExchangesData } from '$lib/types/exchange';
-	import Tag from '$lib/components/ui/Tag.svelte';
 	import TokenName from '$lib/components/tokens/TokenName.svelte';
 
 	const dispatch = createEventDispatcher();

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -2,23 +2,13 @@
 	import Card from '$lib/components/ui/Card.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import type { Token } from '$lib/types/token';
-	import Tag from '$lib/components/ui/Tag.svelte';
-	import { nonNullish } from '@dfinity/utils';
+	import TokenName from '$lib/components/tokens/TokenName.svelte';
 
 	export let token: Token;
-
-	const ariaLabel = nonNullish(token.oisyName)
-		? `${token.oisyName.prefix ?? ''}${token.oisyName.oisyName}`
-		: token.name;
 </script>
 
 <Card noMargin>
-	<span aria-label={ariaLabel}>
-		{#if nonNullish(token.oisyName?.prefix)}
-			<Tag ariaHidden>{token.oisyName.prefix}</Tag>
-		{/if}
-		<span aria-hidden="true">{token.oisyName?.oisyName ?? token.name}</span>
-	</span>
+	<TokenName {token} />
 
 	<TokenLogo {token} slot="icon" color="white" />
 

--- a/src/frontend/src/lib/components/tokens/TokenName.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenName.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Token } from '$lib/types/token';
+	import { nonNullish } from '@dfinity/utils';
+	import Tag from '$lib/components/ui/Tag.svelte';
+
+	export let token: Token;
+
+	const ariaLabel = nonNullish(token.oisyName)
+		? `${token.oisyName.prefix ?? ''}${token.oisyName.oisyName}`
+		: token.name;
+</script>
+
+<span aria-label={ariaLabel}>
+	{#if nonNullish(token.oisyName?.prefix)}
+		<Tag ariaHidden>{token.oisyName.prefix}</Tag>
+	{/if}
+	<span aria-hidden="true">{token.oisyName?.oisyName ?? token.name}</span>
+</span>


### PR DESCRIPTION
# Motivation

To be consistent, we add the `ck` tag in the token list of the `ManageModal`.

# Changes

- Separate component specific for the `TokenName`.
- Use such component in `ManageModal`.

# Tests

### Manage modal

<img width="517" alt="Screenshot 2024-08-27 at 20 16 03" src="https://github.com/user-attachments/assets/309d7fd1-e6ec-4c39-9a8b-c98ba7373b1f">

### Token list (unchanged)

<img width="669" alt="Screenshot 2024-08-27 at 20 16 09" src="https://github.com/user-attachments/assets/af4ba3b2-5ee6-410a-b21d-d8c13cc17020">

