### PR TITLE
chore(frontend): mistype in inline comment

### DIFF
--- a/src/frontend/src/eth/constants/ckerc20.constants.ts
+++ b/src/frontend/src/eth/constants/ckerc20.constants.ts
@@ -36,5 +36,5 @@ export const CKERC20_ABI = [
 	}
 ];
 
-// As discussed with cross-chain team, we decided to hardcode gas estimation for ERC20 to ckERC29 deposit for now.
+// As discussed with cross-chain team, we decided to hardcode gas estimation for ERC20 to ckERC20 deposit for now.
 export const CKERC20_FEE = 60_000n;


### PR DESCRIPTION
# Motivation

Small mistype, just to reduce the spelling errors.

