### PR TITLE
chore(docs): add clang patch to HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -22,6 +22,18 @@ Following terminal commands are useful to deploy `frontend` and `backend`.
 npm run deploy
 ```
 
+**NOTE**: for macOS, you might need to install `llvm` manually and patch `clang`:
+
+```bash
+brew install llvm
+
+export CC=$(brew --prefix llvm)/bin/clang
+export CXX=$(brew --prefix llvm)/bin/clang++
+export AR=$(brew --prefix llvm)/bin/llvm-ar
+export RANLIB=$(brew --prefix llvm)/bin/llvm-ranlib
+export PATH=$(brew --prefix llvm)/bin:$PATH
+```
+
 ### Staging
 
 > To perform staging development, you'll need a `.env.staging` file.

--- a/HACKING.md
+++ b/HACKING.md
@@ -22,16 +22,14 @@ Following terminal commands are useful to deploy `frontend` and `backend`.
 npm run deploy
 ```
 
-**NOTE**: for macOS, you might need to install `llvm` manually and patch `clang`:
+**NOTE**: for macOS, you might need to manually install `llvm` and patch `clang` lib path. See example for `zsh` shell:
 
 ```bash
 brew install llvm
 
-export CC=$(brew --prefix llvm)/bin/clang
-export CXX=$(brew --prefix llvm)/bin/clang++
-export AR=$(brew --prefix llvm)/bin/llvm-ar
-export RANLIB=$(brew --prefix llvm)/bin/llvm-ranlib
-export PATH=$(brew --prefix llvm)/bin:$PATH
+echo 'export CC=$(brew --prefix llvm)/bin/clang' >> ~/.zshrc
+echo 'export AR=$(brew --prefix llvm)/bin/llvm-ar' >> ~/.zshrc
+echo 'export PATH=$(brew --prefix llvm)/bin:$PATH' >> ~/.zshrc
 ```
 
 ### Staging

--- a/HACKING.md
+++ b/HACKING.md
@@ -22,7 +22,8 @@ Following terminal commands are useful to deploy `frontend` and `backend`.
 npm run deploy
 ```
 
-**NOTE**: for macOS, you might need to manually install `llvm` and patch `clang` lib path. See example for `zsh` shell:
+> [!NOTE]
+> For macOS, you might need to manually install `llvm` and patch `clang` lib path. See example for `zsh` shell:
 
 ```bash
 brew install llvm


### PR DESCRIPTION
# Motivation

It was reported that there is an issue when building the backend locally:

```bash
error occurred: Command "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=wasm32-unknown-unknown" "-I" "depend/secp256k1/" "-I" "depend/secp256k1/include" "-I" "depend/secp256k1/src" "-I" "wasm/wasm-sysroot" "-I" "wasm/wasm-sysroot" "-Wall" "-Wextra" "-DSECP256K1_API=" "-DENABLE_MODULE_ECDH=1" "-DENABLE_MODULE_SCHNORRSIG=1" "-DENABLE_MODULE_EXTRAKEYS=1" "-DENABLE_MODULE_ELLSWIFT=1" "-Dprintf(...)=" "-DECMULT_GEN_PREC_BITS=4" "-DECMULT_WINDOW_SIZE=15" "-DUSE_EXTERNAL_DEFAULT_CALLBACKS=1" "-DENABLE_MODULE_RECOVERY=1" "-o" "/Users/userABC/projects/dfinity/oisy-wallet/target/wasm32-unknown-unknown/release/build/secp256k1-sys-67449d6ae1248da9/out/3fec8a5f3c4f77fb-wasm.o" "-c" "wasm/wasm.c" with args clang did not execute successfully (status code exit status: 1).
```

In macOS, we need to manually export the environment variables of the paths to `llvm` and `clang` bin folders (see tip in `llvm` [installation docs](https://learn.sapio-lang.org/ch01-01-installation.html)).
