### PR TITLE
feat(frontend): add balance to TokenUi

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -5,9 +5,11 @@ import { tokens, tokensToPin } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
+import { formatToken } from '$lib/utils/format.utils';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensAtTop, pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
+import { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -46,16 +48,29 @@ export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
 export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derived(
 	[combinedDerivedSortedNetworkTokens, balancesStore, exchanges],
 	([$enabledNetworkTokens, $balancesStore, $exchanges]) =>
-		$enabledNetworkTokens.map((token) => ({
-			...token,
-			usdBalance: nonNullish($exchanges?.[token.id]?.usd)
-				? usdValue({
-						token,
-						balances: $balancesStore,
-						exchanges: $exchanges
-					})
-				: undefined
-		}))
+		$enabledNetworkTokens.map((token) => {
+			const balance = $balancesStore?.[token.id]?.data;
+
+			return {
+				...token,
+				balance: nonNullish(balance)
+					? Number(
+							formatToken({
+								value: balance,
+								unitName: token.decimals,
+								displayDecimals: token.decimals
+							})
+						)
+					: undefined,
+				usdBalance: nonNullish($exchanges?.[token.id]?.usd)
+					? usdValue({
+							token,
+							balance: balance ?? BigNumber.from(0),
+							exchanges: $exchanges
+						})
+					: undefined
+			};
+		})
 );
 
 /**

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -9,6 +9,7 @@ import { formatToken } from '$lib/utils/format.utils';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensAtTop, pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
+import type { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -48,18 +49,17 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
 	[combinedDerivedSortedNetworkTokens, balancesStore, exchanges],
 	([$enabledNetworkTokens, $balancesStore, $exchanges]) =>
 		$enabledNetworkTokens.map((token) => {
-			const balance = $balancesStore?.[token.id]?.data;
+			const balance: BigNumber | undefined = $balancesStore?.[token.id]?.data;
 
 			return {
 				...token,
+				balance,
 				formattedBalance: nonNullish(balance)
-					? Number(
-							formatToken({
-								value: balance,
-								unitName: token.decimals,
-								displayDecimals: token.decimals
-							})
-						)
+					? formatToken({
+							value: balance,
+							unitName: token.decimals,
+							displayDecimals: token.decimals
+						})
 					: undefined,
 				usdBalance: nonNullish($exchanges?.[token.id]?.usd)
 					? usdValue({

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -9,7 +9,6 @@ import { formatToken } from '$lib/utils/format.utils';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensAtTop, pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
-import { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -65,7 +64,7 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
 				usdBalance: nonNullish($exchanges?.[token.id]?.usd)
 					? usdValue({
 							token,
-							balance: balance ?? BigNumber.from(0),
+							balances: $balancesStore,
 							exchanges: $exchanges
 						})
 					: undefined

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -52,7 +52,7 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
 
 			return {
 				...token,
-				balance: nonNullish(balance)
+				formattedBalance: nonNullish(balance)
 					? Number(
 							formatToken({
 								value: balance,

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -40,6 +40,7 @@ export type OptionTokenStandard = TokenStandard | undefined | null;
 export type TokenToPin = Pick<Token, 'id'> & { network: Pick<Token['network'], 'id'> };
 
 interface TokenFinancialData {
+	balance?: number;
 	usdBalance?: number;
 }
 

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,5 +1,6 @@
 import type { Network } from '$lib/types/network';
 import type { RequiredExcept } from '$lib/types/utils';
+import type { BigNumber } from '@ethersproject/bignumber';
 
 export type TokenId = symbol;
 
@@ -40,7 +41,8 @@ export type OptionTokenStandard = TokenStandard | undefined | null;
 export type TokenToPin = Pick<Token, 'id'> & { network: Pick<Token['network'], 'id'> };
 
 interface TokenFinancialData {
-	formattedBalance?: number;
+	balance?: BigNumber;
+	formattedBalance?: string;
 	usdBalance?: number;
 }
 

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -40,7 +40,7 @@ export type OptionTokenStandard = TokenStandard | undefined | null;
 export type TokenToPin = Pick<Token, 'id'> & { network: Pick<Token['network'], 'id'> };
 
 interface TokenFinancialData {
-	balance?: number;
+	formattedBalance?: number;
 	usdBalance?: number;
 }
 

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,3 +1,5 @@
+import type { BalancesData } from '$lib/stores/balances.store';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';
 import { formatToken } from '$lib/utils/format.utils';
@@ -5,16 +7,16 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 export const usdValue = ({
 	token: { id, decimals },
-	balance,
+	balances,
 	exchanges
 }: {
 	token: Token;
-	balance: BigNumber;
+	balances: CertifiedStoreData<BalancesData>;
 	exchanges: ExchangesData;
 }): number =>
 	Number(
 		formatToken({
-			value: balance,
+			value: balances?.[id]?.data ?? BigNumber.from(0),
 			unitName: decimals,
 			displayDecimals: decimals
 		})

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,5 +1,3 @@
-import type { BalancesData } from '$lib/stores/balances.store';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';
 import { formatToken } from '$lib/utils/format.utils';
@@ -7,16 +5,16 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 export const usdValue = ({
 	token: { id, decimals },
-	balances,
+	balance,
 	exchanges
 }: {
 	token: Token;
-	balances: CertifiedStoreData<BalancesData>;
+	balance: BigNumber;
 	exchanges: ExchangesData;
 }): number =>
 	Number(
 		formatToken({
-			value: balances?.[id]?.data ?? BigNumber.from(0),
+			value: balance,
 			unitName: decimals,
 			displayDecimals: decimals
 		})

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -73,16 +73,19 @@ export const pinTokensWithBalanceAtTop = ({
 	$tokens: TokenUi[];
 	$balancesStore: CertifiedStoreData<BalancesData>;
 }): TokenUi[] => {
-	const tokensWithBalance: TokenWithBalance[] = $tokens.map((token) => ({
-		...token,
-		balance: Number(
-			formatToken({
-				value: $balancesStore?.[token.id]?.data ?? BigNumber.from(0),
-				unitName: token.decimals,
-				displayDecimals: token.decimals
-			})
-		)
-	}));
+	const tokensWithBalance: TokenWithBalance[] = $tokens.map(
+		(token) =>
+			({
+				...token,
+				balance: Number(
+					formatToken({
+						value: $balancesStore?.[token.id]?.data ?? BigNumber.from(0),
+						unitName: token.decimals,
+						displayDecimals: token.decimals
+					})
+				)
+			}) as TokenWithBalance
+	);
 
 	const [positiveBalances, nonPositiveBalances] = tokensWithBalance.reduce<
 		[TokenWithBalance[], TokenWithBalance[]]


### PR DESCRIPTION
# Motivation

The balance store is called a few times in the code, related to derived store `combinedDerivedEnabledNetworkTokensUi`. So, to simplify the code, we add the prop `balance` to type `TokenUi`.
After this PR, we will make use of the new prop throughout the code.

# Changes

- Add `balance` to `TokenUi`.
- Calculate balance in store `combinedDerivedEnabledNetworkTokensUi`.

# Tests

No changes in local replica, just more loading time (that should be compensated once we use the new prop).

