### PR TITLE
refactor(frontend): use existing balance prop to filter tokens

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -5,8 +5,6 @@
 	import { debounce } from '@dfinity/utils';
 	import { hideZeroBalancesStore } from '$lib/stores/settings.store';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
-	import { balancesStore } from '$lib/stores/balances.store';
-	import { BigNumber } from '@ethersproject/bignumber';
 
 	// We start it as undefined to avoid showing an empty list before the first update.
 	export let tokens: Token[] | undefined = undefined;
@@ -16,8 +14,7 @@
 
 	let sortedTokens: TokenUi[];
 	$: sortedTokens = $combinedDerivedSortedNetworkTokensUi.filter(
-		({ id: tokenId }) =>
-			($balancesStore?.[tokenId]?.data ?? BigNumber.from(0n)).gt(0n) || displayZeroBalance
+		({ usdBalance }) => (usdBalance ?? 0) || displayZeroBalance
 	);
 
 	const parseTokenKey = (token: Token) => `${token.id.description}-${token.network.id.description}`;


### PR DESCRIPTION
# Motivation

Instead of calling again the balances store, we can use directly the `usdBalance` prop of type `TokenUi`.


# Tests

Local replica unchanged:

All balances

<img width="1283" alt="Screenshot 2024-08-28 at 07 36 02" src="https://github.com/user-attachments/assets/ff540b07-cfcd-4092-a945-a655a60ea468">

Only non-zero balances
<img width="1278" alt="Screenshot 2024-08-28 at 07 36 10" src="https://github.com/user-attachments/assets/f6231cb0-c5a1-4be1-81db-7f702db17899">



