### PR TITLE
ci(frontend): add ckUSDC to local send.tokens script

### DIFF
--- a/scripts/send.tokens.sh
+++ b/scripts/send.tokens.sh
@@ -13,4 +13,5 @@ DFX_NETWORK=local
 
 dfx canister call ckbtc_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"$PRINCIPAL\";}; amount=1000000000; fee=null; memo=null; created_at_time=null;})"
 dfx canister call cketh_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"$PRINCIPAL\";}; amount=77000000000; fee=null; memo=null; created_at_time=null;})"
+dfx canister call ckusdc_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"$PRINCIPAL\";}; amount=90000000; fee=null; memo=null; created_at_time=null;})"
 dfx canister call icp_ledger --network "$DFX_NETWORK" icrc1_transfer "(record {from=null; to=record { owner= principal \"$PRINCIPAL\";}; amount=120000000; fee=null; memo=null; created_at_time=null;})"


### PR DESCRIPTION
# Motivation

Since we are testing in local replica some ckERC20 related features, it is useful to have the send.token script send some ckSepoliaUSDC locally.

# Tests

<img width="360" alt="Screenshot 2024-08-28 at 07 59 06" src="https://github.com/user-attachments/assets/7cafd726-7ef2-4a88-aa07-c2aea85c743f">

