### PR TITLE
refactor(frontend): use prop balance to sort tokens

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -76,10 +76,6 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
  * All tokens matching the selected network or Chain Fusion, with the ones with non-null balance at the top of the list.
  */
 export const combinedDerivedSortedNetworkTokensUi: Readable<TokenUi[]> = derived(
-	[combinedDerivedEnabledNetworkTokensUi, balancesStore],
-	([$enabledNetworkTokensUi, $balancesStore]) =>
-		pinTokensWithBalanceAtTop({
-			$tokens: $enabledNetworkTokensUi,
-			$balancesStore: $balancesStore
-		})
+	[combinedDerivedEnabledNetworkTokensUi],
+	([$enabledNetworkTokensUi]) => pinTokensWithBalanceAtTop($enabledNetworkTokensUi)
 );

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -1,19 +1,11 @@
 import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
-import type { BalancesData } from '$lib/stores/balances.store';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenUi } from '$lib/types/token';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
-import { BigNumber } from 'ethers';
 import { describe, expect, it } from 'vitest';
 
 const usd = 1;
-
-const bn0 = BigNumber.from(0);
-const bn50 = BigNumber.from(50);
-const bn100 = BigNumber.from(100);
-const bn200 = BigNumber.from(200);
 
 const tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
 
@@ -87,22 +79,13 @@ describe('pinTokensWithBalanceAtTop', () => {
 	});
 
 	it('should pin tokens with balance at the top', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn100, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn50, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn200, certified: true }
-		};
-
 		const tokens: TokenUi[] = [
 			{ ...ICP_TOKEN, usdBalance: 100 },
 			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
 			{ ...ETHEREUM_TOKEN, usdBalance: 200 }
 		];
 
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
+		const result = pinTokensWithBalanceAtTop(tokens);
 		expect(result).toEqual([
 			{ ...ETHEREUM_TOKEN, usdBalance: 200 },
 			{ ...ICP_TOKEN, usdBalance: 100 },
@@ -111,41 +94,23 @@ describe('pinTokensWithBalanceAtTop', () => {
 	});
 
 	it('should return the same array if no tokens have balance', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn0, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn0, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn0, certified: true }
-		};
-
 		const tokens: TokenUi[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN].map((token) => ({
 			...token,
 			usdBalance: 0
 		}));
 
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
+		const result = pinTokensWithBalanceAtTop(tokens);
 		expect(result).toEqual(tokens);
 	});
 
 	it('should handle tokens with mixed balances correctly', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn0, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn50, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn0, certified: true }
-		};
-
 		const tokens: TokenUi[] = [
 			{ ...ICP_TOKEN, usdBalance: 0 },
 			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
 			{ ...ETHEREUM_TOKEN, usdBalance: 0 }
 		];
 
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
+		const result = pinTokensWithBalanceAtTop(tokens);
 		expect(result).toEqual([
 			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
 			{ ...ICP_TOKEN, usdBalance: 0 },
@@ -154,26 +119,17 @@ describe('pinTokensWithBalanceAtTop', () => {
 	});
 
 	it('should put tokens with no exchange price (undefined balance) after tokens with balance', () => {
-		const balancesStore: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: bn200, certified: true },
-			[BTC_MAINNET_TOKEN.id]: { data: bn100, certified: true },
-			[ETHEREUM_TOKEN.id]: { data: bn100, certified: true }
-		};
-
 		const tokens: TokenUi[] = [
-			{ ...ICP_TOKEN },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			{ ...ETHEREUM_TOKEN, usdBalance: 200 }
+			{ ...ICP_TOKEN, formattedBalance: '200' },
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 50, formattedBalance: '100' },
+			{ ...ETHEREUM_TOKEN, usdBalance: 200, formattedBalance: '100' }
 		];
 
-		const result = pinTokensWithBalanceAtTop({
-			$tokens: tokens,
-			$balancesStore: balancesStore
-		});
+		const result = pinTokensWithBalanceAtTop(tokens);
 		expect(result).toEqual([
-			{ ...ETHEREUM_TOKEN, usdBalance: 200 },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
-			ICP_TOKEN
+			{ ...ETHEREUM_TOKEN, usdBalance: 200, formattedBalance: '100' },
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 50, formattedBalance: '100' },
+			{ ...ICP_TOKEN, formattedBalance: '200' }
 		]);
 	});
 });


### PR DESCRIPTION
# Motivation

The dependency of `balanceStore` is removed from `pinTokensWithBalanceAtTop` since we can use directly the `formattedBalance` prop of TokenUi introduced in PR #2150.

# Changes

<!-- List the changes that have been developed -->

# Tests

Adapted tests worked as expected and no changes in local replica.
