### PR TITLE
refactor(frontend): merge functions to sort and pin

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -32,7 +32,7 @@
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 	import type { IcCkToken } from '$icp/types/ic';
-	import { pinTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
+	import { sortTokens } from '$lib/utils/tokens.utils';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { tokensToPin } from '$lib/derived/tokens.derived';
 	import type { ExchangesData } from '$lib/types/exchange';
@@ -99,9 +99,10 @@
 
 	let allTokensSorted: Token[] = [];
 	$: allTokensSorted = nonNullish(exchangesStaticData)
-		? pinTokensAtTop({
-				$tokens: sortTokens({ $tokens: allTokens, $exchanges: exchangesStaticData }),
-				$tokensToPin: $tokensToPin
+		? sortTokens({
+				$tokens: allTokens,
+				$tokensToPin: $tokensToPin,
+				$exchanges: exchangesStaticData
 			})
 		: [];
 

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -101,8 +101,8 @@
 	$: allTokensSorted = nonNullish(exchangesStaticData)
 		? sortTokens({
 				$tokens: allTokens,
-				$tokensToPin: $tokensToPin,
-				$exchanges: exchangesStaticData
+				$exchanges: exchangesStaticData,
+				$tokensToPin: $tokensToPin
 			})
 		: [];
 

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -38,7 +38,7 @@ export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
  */
 export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
 	[enabledNetworkTokens, tokensToPin, exchanges],
-	([$tokens, $tokensToPin, $exchanges]) => sortTokens({ $tokens, $tokensToPin, $exchanges })
+	([$tokens, $tokensToPin, $exchanges]) => sortTokens({ $tokens, $exchanges, $tokensToPin })
 );
 
 /**

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -7,7 +7,7 @@ import type { Token, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-import { pinTokensAtTop, pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
+import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
@@ -38,8 +38,7 @@ export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
  */
 export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
 	[enabledNetworkTokens, tokensToPin, exchanges],
-	([$tokens, $tokensToPin, $exchanges]) =>
-		pinTokensAtTop({ $tokens: sortTokens({ $tokens, $exchanges }), $tokensToPin })
+	([$tokens, $tokensToPin, $exchanges]) => sortTokens({ $tokens, $tokensToPin, $exchanges })
 );
 
 /**

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -6,12 +6,21 @@ import { formatToken } from '$lib/utils/format.utils';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 
-export const pinTokensAtTop = ({
+/**
+ * Sorts tokens by market cap, name and network name, pinning the specified ones at the top of the list in the order they are provided.
+ *
+ * @param $tokens - The list of tokens to sort.
+ * @param $tokensToPin - The list of tokens to pin at the top of the list.
+ * @param $exchanges - The exchange rates for the tokens.
+ */
+export const sortTokens = ({
 	$tokens,
-	$tokensToPin
+	$tokensToPin,
+	$exchanges
 }: {
 	$tokens: Token[];
 	$tokensToPin: TokenToPin[];
+	$exchanges: ExchangesData;
 }): Token[] => {
 	const pinnedTokens = $tokensToPin
 		.map(({ id: pinnedId, network: { id: pinnedNetworkId } }) =>
@@ -28,28 +37,16 @@ export const pinTokensAtTop = ({
 			)
 	);
 
-	return [...pinnedTokens, ...otherTokens];
+	return [
+		...pinnedTokens,
+		...otherTokens.sort(
+			(a, b) =>
+				($exchanges[b.id]?.usd_market_cap ?? 0) - ($exchanges[a.id]?.usd_market_cap ?? 0) ||
+				a.name.localeCompare(b.name) ||
+				a.network.name.localeCompare(b.network.name)
+		)
+	];
 };
-
-/**
- * Sorts tokens by market cap, name and network name.
- *
- * @param $tokens - The list of tokens to sort.
- * @param $exchanges - The exchange rates for the tokens.
- */
-export const sortTokens = ({
-	$tokens,
-	$exchanges
-}: {
-	$tokens: Token[];
-	$exchanges: ExchangesData;
-}) =>
-	$tokens.sort(
-		(a, b) =>
-			($exchanges[b.id]?.usd_market_cap ?? 0) - ($exchanges[a.id]?.usd_market_cap ?? 0) ||
-			a.name.localeCompare(b.name) ||
-			a.network.name.localeCompare(b.network.name)
-	);
 
 /**
  * Pins tokens by USD value, balance and name.

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -15,12 +15,12 @@ import { BigNumber } from '@ethersproject/bignumber';
  */
 export const sortTokens = ({
 	$tokens,
-	$tokensToPin,
-	$exchanges
+	$exchanges,
+	$tokensToPin
 }: {
 	$tokens: Token[];
-	$tokensToPin: TokenToPin[];
 	$exchanges: ExchangesData;
+	$tokensToPin: TokenToPin[];
 }): Token[] => {
 	const pinnedTokens = $tokensToPin
 		.map(({ id: pinnedId, network: { id: pinnedNetworkId } }) =>

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -24,7 +24,7 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd },
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $tokensToPin: [], $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges, $tokensToPin: [] });
 		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, ICP_TOKEN, BTC_MAINNET_TOKEN]);
 	});
 
@@ -34,7 +34,7 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $tokensToPin: [], $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges, $tokensToPin: [] });
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
@@ -44,7 +44,7 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd },
 			[ETHEREUM_TOKEN.id]: { usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $tokensToPin: [], $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges, $tokensToPin: [] });
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
@@ -57,8 +57,8 @@ describe('sortTokens', () => {
 		};
 		const sortedTokens = sortTokens({
 			$tokens: newTokens,
-			$tokensToPin: [],
-			$exchanges: exchanges
+			$exchanges: exchanges,
+			$tokensToPin: []
 		});
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
@@ -77,8 +77,8 @@ describe('sortTokens', () => {
 		};
 		const sortedTokens = sortTokens({
 			$tokens: newTokens,
-			$tokensToPin: [],
-			$exchanges: exchanges
+			$exchanges: exchanges,
+			$tokensToPin: []
 		});
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
@@ -97,8 +97,8 @@ describe('sortTokens', () => {
 		const tokensToPin: TokenToPin[] = [ETHEREUM_TOKEN, BTC_MAINNET_TOKEN];
 		const sortedTokens = sortTokens({
 			$tokens: tokens,
-			$tokensToPin: tokensToPin,
-			$exchanges: exchanges
+			$exchanges: exchanges,
+			$tokensToPin: tokensToPin
 		});
 		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, BTC_MAINNET_TOKEN, ICP_TOKEN]);
 	});

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -3,7 +3,7 @@ import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
-import type { Token, TokenUi } from '$lib/types/token';
+import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { BigNumber } from 'ethers';
 import { describe, expect, it } from 'vitest';
@@ -24,7 +24,7 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd },
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: tokens, $tokensToPin: [], $exchanges: exchanges });
 		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, ICP_TOKEN, BTC_MAINNET_TOKEN]);
 	});
 
@@ -34,7 +34,7 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: tokens, $tokensToPin: [], $exchanges: exchanges });
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
@@ -44,7 +44,7 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd },
 			[ETHEREUM_TOKEN.id]: { usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: tokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({ $tokens: tokens, $tokensToPin: [], $exchanges: exchanges });
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
@@ -55,7 +55,11 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: newTokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({
+			$tokens: newTokens,
+			$tokensToPin: [],
+			$exchanges: exchanges
+		});
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
 				...token,
@@ -71,13 +75,32 @@ describe('sortTokens', () => {
 			[BTC_MAINNET_TOKEN.id]: { usd },
 			[ETHEREUM_TOKEN.id]: { usd }
 		};
-		const sortedTokens = sortTokens({ $tokens: newTokens, $exchanges: exchanges });
+		const sortedTokens = sortTokens({
+			$tokens: newTokens,
+			$tokensToPin: [],
+			$exchanges: exchanges
+		});
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
 				...token,
 				name: 'Test Token'
 			}))
 		);
+	});
+
+	it('should pin tokens at the top of the list', () => {
+		const exchanges: ExchangesData = {
+			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
+			[BTC_MAINNET_TOKEN.id]: { usd },
+			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd }
+		};
+		const tokensToPin: TokenToPin[] = [ETHEREUM_TOKEN, BTC_MAINNET_TOKEN];
+		const sortedTokens = sortTokens({
+			$tokens: tokens,
+			$tokensToPin: tokensToPin,
+			$exchanges: exchanges
+		});
+		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, BTC_MAINNET_TOKEN, ICP_TOKEN]);
 	});
 });
 


### PR DESCRIPTION
# Motivation

We aim to simplify the sorting logic and reduce the iterations. As first step we merge the functions that were sorting by marketcap and pinning a pre-determined list of tokens on top.
