### PR TITLE
fix(backend): test.backend uses consistent pocket-ic version

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-POCKET_IC_SERVER_VERSION=3.0.1
+POCKET_IC_SERVER_VERSION="$(yq -oy '.workspace.dependencies["pocket-ic"]' Cargo.toml)"
 OISY_UPGRADE_VERSIONS="v0.0.13,v0.0.19,v0.0.25"
 
 # If a backend wasm file exists at the root, it will be used for the tests.


### PR DESCRIPTION
TODO: Update pocket-ic in Cargo.toml
TODO: Update tests for the newer pocket-ic

# Motivation
The pocket-ic server used in the backend tests and the library are out of sync.  This works, but is fragile and debugging that can cause problems!

<!-- Describe the motivation that lead to the PR -->

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
