### PR TITLE
feat(frontend): create store for tokens keys

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import type { Token, TokenUi } from '$lib/types/token';
+	import type { Token, TokenIndexKey, TokenUi } from '$lib/types/token';
 	import { pointerEventStore } from '$lib/stores/events.store';
 	import { pointerEventsHandler } from '$lib/utils/events.utils';
 	import { debounce } from '@dfinity/utils';
 	import { hideZeroBalancesStore } from '$lib/stores/settings.store';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
+	import { tokensUiStore } from '$lib/stores/tokens-ui.store';
 
 	// We start it as undefined to avoid showing an empty list before the first update.
 	export let tokens: Token[] | undefined = undefined;
@@ -19,22 +20,23 @@
 
 	const parseTokenKey = (token: Token) => `${token.id.description}-${token.network.id.description}`;
 
-	let tokenKeys: string;
-	$: tokenKeys = tokens?.map(parseTokenKey).join(',') ?? '';
-
-	let sortedTokensKeys: string;
-	$: sortedTokensKeys = sortedTokens?.map(parseTokenKey).join(',') ?? '';
+	let sortedTokensKeys: TokenIndexKey[];
+	$: sortedTokensKeys = sortedTokens?.map(parseTokenKey);
 
 	const updateTokensToDisplay = () => {
 		if (!$pointerEventStore) {
 			// No pointer events, so we are not worried about possible glitches on user's interaction.
+			tokensUiStore.set({ tokensKeys: sortedTokensKeys });
 			tokens = sortedTokens;
 			return;
 		}
 
 		// If there are pointer events, we need to avoid visually re-sorting the tokens, to prevent glitches on user's interaction.
 
-		if (tokenKeys === sortedTokensKeys) {
+		// We are imperatively getting the current tokens keys, as it should not trigger any reactivity.
+		const currentTokensKeys: TokenIndexKey[] = $tokensUiStore.tokensKeys;
+
+		if (currentTokensKeys.join(',') === sortedTokensKeys.join(',')) {
 			// The order is the same, so there will be no re-sorting and no possible glitches on user's interaction.
 			// However, we need to update the tokensToDisplay to make sure the balances are up-to-date.
 			tokens = sortedTokens;

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -21,7 +21,7 @@
 	const parseTokenKey = (token: Token) => `${token.id.description}-${token.network.id.description}`;
 
 	let sortedTokensKeys: TokenIndexKey[];
-	$: sortedTokensKeys = sortedTokens?.map(parseTokenKey);
+	$: sortedTokensKeys = sortedTokens.map(parseTokenKey);
 
 	const updateTokensToDisplay = () => {
 		if (!$pointerEventStore) {

--- a/src/frontend/src/lib/stores/tokens-ui.store.ts
+++ b/src/frontend/src/lib/stores/tokens-ui.store.ts
@@ -1,0 +1,8 @@
+import type { TokenIndexKey } from '$lib/types/token';
+import { writable } from 'svelte/store';
+
+export interface TokensUiData {
+	tokensKeys: TokenIndexKey[];
+}
+
+export const tokensUiStore = writable<TokensUiData>({ tokensKeys: [] });

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -47,3 +47,5 @@ interface TokenFinancialData {
 }
 
 export type TokenUi = Token & TokenFinancialData;
+
+export type TokenIndexKey = string;


### PR DESCRIPTION
# Motivation

This PR aims at saving the last order of the tokens list that is displayed: we are using this state internally in the component, however, it can become useful to transform into a store to be called externally.

Either way, it is set only during the process to update the tokens to be displayed.

Just to clarify, the scope of this variable is to compare if the new order is different from the old one, after re-sorting.

# Changes

- Create new type for the keys of the list.
- New store for generic `TokenUi[]` data, including the list of tokens keys.
- Adapt component `TokensDisplayHandler` to use and set the new store.

# Tests

No changes in local replica.
