### PR TITLE
feat(devops): Add npm command to list tags ordered by semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"format:backend": "./scripts/format.sh",
 		"generate": "scripts/generate.sh",
 		"deploy": "scripts/deploy.sh",
+		"tags": "node_modules/.bin/semver $(git tag)",
 		"i18n": "node scripts/i18n.mjs && prettier --write ./src/frontend/src/lib/types/i18n.d.ts",
 		"e2e": "playwright test",
 		"e2e:dev": "NODE_ENV=development playwright test",


### PR DESCRIPTION
# Motivation
When discussing release tagging, it was visible that `git tag` is not sorted by semantic version.

Given that we already have the `npm` `semver` package installed, this is an easy pain point to address.

# Changes
- Add an `npm` command to print git tags sorted by semver.

# Tests
```
$ npm run tags

> @dfinity/oisy-wallet@0.0.37 tags    <--- Note: This is added by `npm run`.
> node_modules/.bin/semver $(git tag) <--- Without `npm run` we get just the tags and no header.

0.0.1
0.0.2
0.0.3
0.0.4
0.0.5
0.0.6
0.0.7
0.0.8
0.0.9
0.0.10
0.0.11
0.0.12
0.0.13
0.0.14
0.0.15
0.0.16
0.0.17
0.0.18
0.0.19
0.0.20
0.0.21
0.0.22
0.0.23
0.0.24
0.0.25
0.0.26
0.0.27
0.0.28
0.0.29
0.0.30
0.0.31
0.0.32
0.0.33
0.0.34
0.0.35-0
0.0.35
0.0.36
0.0.37
```