### PR TITLE
chore(replica): bump ICP ledger and index version for development

### DIFF
--- a/scripts/download.icp.sh
+++ b/scripts/download.icp.sh
@@ -8,7 +8,7 @@ if [ ! -d "$DIR" ]; then
   mkdir "$DIR"
 fi
 
-IC_VERSION=d87954601e4b22972899e9957e800406a0a6b929
+IC_VERSION=b0ade55f7e8999e2842fe3f49df163ba224b71a2
 
 curl -o "$DIR"/icp_index.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ic-icp-index-canister.wasm.gz"
 gunzip "$DIR"/icp_index.wasm.gz


### PR DESCRIPTION
# Motivation

For the Oisy signer we will need few new features, notable the consent message ICRC-21, which are available in the newest version of the ICP ledger.

# Changes

- Bump commit hash to download ICP ledger and index for local development.
