### PR TITLE
refactor(frontend): move defineTokensToDisplay to separate module

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -5,6 +5,7 @@
 	import { debounce } from '@dfinity/utils';
 	import { hideZeroBalancesStore } from '$lib/stores/settings.store';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
+	import { defineTokensToDisplay } from '$lib/utils/tokens-ui.utils';
 
 	// We start it as undefined to avoid showing an empty list before the first update.
 	export let tokens: Token[] | undefined = undefined;
@@ -17,35 +18,12 @@
 		({ usdBalance }) => (usdBalance ?? 0) || displayZeroBalance
 	);
 
-	const parseTokenKey = (token: Token) => `${token.id.description}-${token.network.id.description}`;
-
-	let tokenKeys: string;
-	$: tokenKeys = tokens?.map(parseTokenKey).join(',') ?? '';
-
-	let sortedTokensKeys: string;
-	$: sortedTokensKeys = sortedTokens?.map(parseTokenKey).join(',') ?? '';
-
-	const updateTokensToDisplay = () => {
-		if (!$pointerEventStore) {
-			// No pointer events, so we are not worried about possible glitches on user's interaction.
-			tokens = sortedTokens;
-			return;
-		}
-
-		// If there are pointer events, we need to avoid visually re-sorting the tokens, to prevent glitches on user's interaction.
-
-		if (tokenKeys === sortedTokensKeys) {
-			// The order is the same, so there will be no re-sorting and no possible glitches on user's interaction.
-			// However, we need to update the tokensToDisplay to make sure the balances are up-to-date.
-			tokens = sortedTokens;
-			return;
-		}
-
-		// The order is not the same, so the list is kept the same as the one currently showed, but the balances are updated.
-		const tokenMap = new Map(sortedTokens.map((token) => [parseTokenKey(token), token]));
-
-		tokens = tokens?.map((token) => tokenMap.get(parseTokenKey(token)) ?? token) ?? [];
-	};
+	const updateTokensToDisplay = () =>
+		(tokens = defineTokensToDisplay({
+			currentTokens: tokens,
+			sortedTokens,
+			$pointerEventStore: $pointerEventStore
+		}));
 
 	const debounceUpdateTokensToDisplay = debounce(updateTokensToDisplay, 500);
 

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -47,3 +47,5 @@ interface TokenFinancialData {
 }
 
 export type TokenUi = Token & TokenFinancialData;
+
+export type TokenIndexKey = string;

--- a/src/frontend/src/lib/utils/tokens-ui.utils.ts
+++ b/src/frontend/src/lib/utils/tokens-ui.utils.ts
@@ -1,0 +1,43 @@
+import type { Token, TokenIndexKey, TokenUi } from '$lib/types/token';
+import { nonNullish } from '@dfinity/utils';
+
+const parseTokenKey = (token: Token): TokenIndexKey =>
+	`${token.id.description}-${token.network.id.description}`;
+
+export const defineTokensToDisplay = ({
+	currentTokens,
+	sortedTokens,
+	$pointerEventStore
+}: {
+	currentTokens: TokenUi[] | undefined;
+	sortedTokens: TokenUi[];
+	$pointerEventStore: boolean;
+}): TokenUi[] => {
+	const sortedTokensKeys: TokenIndexKey[] = sortedTokens.map((token) => parseTokenKey(token));
+
+	if (!$pointerEventStore) {
+		// No pointer events, so we are not worried about possible glitches on user's interaction.
+		return sortedTokens;
+	}
+
+	// If there are pointer events, we need to avoid visually re-sorting the tokens, to prevent glitches on user's interaction.
+
+	const currentTokensKeys: TokenIndexKey[] = currentTokens?.map(parseTokenKey) ?? [];
+
+	if (currentTokensKeys.join(',') === sortedTokensKeys.join(',')) {
+		// The order is the same, so there will be no re-sorting and no possible glitches on user's interaction.
+		// However, we need to update the tokensToDisplay to make sure the balances are up-to-date.
+		return sortedTokens;
+	}
+
+	// The order is not the same, so the list is kept the same as the one currently showed, but the balances are updated.
+	const tokenMap: Map<string, TokenUi> = new Map(
+		sortedTokens.map((token) => [parseTokenKey(token), token])
+	);
+
+	// return $tokensKeys.map((tokenKey) => tokenMap.get(tokenKey) ?? undefined).filter(nonNullish);
+	return currentTokensKeys.reduce<TokenUi[]>((acc, tokenKey) => {
+		const token = tokenMap.get(tokenKey);
+		return nonNullish(token) ? [...acc, token] : acc;
+	}, []);
+};

--- a/src/frontend/src/tests/lib/utils/tokens-ui.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens-ui.utils.spec.ts
@@ -1,0 +1,84 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import type { TokenUi } from '$lib/types/token';
+import { defineTokensToDisplay } from '$lib/utils/tokens-ui.utils';
+import { expect } from 'vitest';
+
+const sortedTokens: TokenUi[] = [
+	{ ...ICP_TOKEN, usdBalance: 300 },
+	{ ...BTC_MAINNET_TOKEN, usdBalance: 200 },
+	{ ...ETHEREUM_TOKEN, usdBalance: 100 }
+];
+
+describe('defineTokensToDisplay', () => {
+	it('should return sorted tokens when current list is undefined', () => {
+		const result: TokenUi[] = defineTokensToDisplay({
+			currentTokens: undefined,
+			sortedTokens: sortedTokens,
+			$pointerEventStore: false
+		});
+
+		expect(result).toEqual(sortedTokens);
+	});
+
+	it('should return sorted tokens when there are no pointer events', () => {
+		const result: TokenUi[] = defineTokensToDisplay({
+			currentTokens: [],
+			sortedTokens: sortedTokens,
+			$pointerEventStore: false
+		});
+
+		expect(result).toEqual(sortedTokens);
+	});
+
+	it('should return sorted tokens when order has not changed and there are pointer events', () => {
+		const currentTokens: TokenUi[] = defineTokensToDisplay({
+			currentTokens: undefined,
+			sortedTokens,
+			$pointerEventStore: false
+		});
+
+		expect(currentTokens).toEqual(sortedTokens);
+
+		const newSortedTokens: TokenUi[] = sortedTokens.map((token) => ({
+			...token,
+			usdBalance: (token.usdBalance ?? 0) + 100
+		}));
+
+		const result: TokenUi[] = defineTokensToDisplay({
+			currentTokens,
+			sortedTokens: newSortedTokens,
+			$pointerEventStore: true
+		});
+
+		expect(result).toEqual(newSortedTokens);
+	});
+
+	it('should preserve the original order but update balances when order has changed and there are pointer events', () => {
+		const currentTokens: TokenUi[] = defineTokensToDisplay({
+			currentTokens: undefined,
+			sortedTokens,
+			$pointerEventStore: false
+		});
+
+		expect(currentTokens).toEqual(sortedTokens);
+
+		const newSortedTokens: TokenUi[] = [
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 300 },
+			{ ...ETHEREUM_TOKEN, usdBalance: 200 },
+			{ ...ICP_TOKEN, usdBalance: 100 }
+		];
+
+		const result: TokenUi[] = defineTokensToDisplay({
+			currentTokens,
+			sortedTokens: newSortedTokens,
+			$pointerEventStore: true
+		});
+
+		expect(result).toEqual([
+			{ ...ICP_TOKEN, usdBalance: 100 },
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 300 },
+			{ ...ETHEREUM_TOKEN, usdBalance: 200 }
+		]);
+	});
+});


### PR DESCRIPTION
# Motivation

We move, to a separate module, the definition of the tokens list to be displayed when re-sorting. Furthermore, there are some tests to verify the actual workflow of the logic.