### PR TITLE
feat(frontend): remove estimated fee from ckETH conversions

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -20,9 +20,6 @@
 
 	export let networkId: NetworkId | undefined = undefined;
 
-	let ckETH = false;
-	$: ckETH = isTokenCkEthLedger($tokenWithFallbackAsIcToken);
-
 	let ckErc20 = false;
 	$: ckErc20 = isTokenCkErc20Ledger($tokenWithFallbackAsIcToken);
 
@@ -56,7 +53,7 @@
 	$: store.setFee({ maxTransactionFee });
 
 	const updateContext = () => {
-		if ((ckETH || ckErc20) && ethNetwork) {
+		if (ckErc20 && ethNetwork) {
 			store.setFee({ maxTransactionFee });
 			return;
 		}
@@ -69,7 +66,7 @@
 	const loadFee = async () => {
 		clearTimer();
 
-		if ((!ckETH && !ckErc20) || !ethNetwork) {
+		if (!ckErc20 || !ethNetwork) {
 			updateContext();
 			return;
 		}


### PR DESCRIPTION
# Motivation

During a `ckETH --> ETH` conversion, the estimated `ETH` fee was being showed. We remove it in this PR.

### Before

![694d01b5-b684-4cd6-9eee-e3e9881a7cf3](https://github.com/user-attachments/assets/00fe07f5-5053-4b59-9547-8ac8ff84d35f)

### After

<img width="524" alt="Screenshot 2024-08-28 at 21 42 27" src="https://github.com/user-attachments/assets/b4441a82-625a-45df-ab09-a749ca9dffb4">

