### PR TITLE
fix(frontend): ckXAUT not available in the list of tokens

### DIFF
--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -445,7 +445,8 @@ export const ICRC_TOKENS: IcCkInterface[] = [
 	...(nonNullish(CKUSDT_IC_DATA) ? [CKUSDT_IC_DATA] : []),
 	...(nonNullish(CKWSTETH_IC_DATA) ? [CKWSTETH_IC_DATA] : []),
 	...(nonNullish(CKUNI_IC_DATA) ? [CKUNI_IC_DATA] : []),
-	...(nonNullish(CKEURC_IC_DATA) ? [CKEURC_IC_DATA] : [])
+	...(nonNullish(CKEURC_IC_DATA) ? [CKEURC_IC_DATA] : []),
+	...(nonNullish(CKXAUT_IC_DATA) ? [CKXAUT_IC_DATA] : [])
 ];
 
 export const ICRC_TOKENS_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = ICRC_TOKENS.map(


### PR DESCRIPTION
# Motivation

An entry in `ICRC_TOKENS` was missing which lead the support for ckXAUT to be partial - i.e. ckXAUT is not available in the list of tokens on production.

# Screenshot

Before

<img width="1536" alt="Capture d’écran 2024-08-29 à 07 12 05" src="https://github.com/user-attachments/assets/587fa22e-3745-4c7e-a6fe-03e3ce714b80">

After

<img width="1536" alt="Capture d’écran 2024-08-29 à 07 11 58" src="https://github.com/user-attachments/assets/64500665-fba6-46ff-9bd5-1f8757725bc3">
