### PR TITLE
ci(frontend): exclude EURC and XAUT from fetching logo

### DIFF
--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -20,7 +20,11 @@ const SKIP_CANISTER_IDS_LOGOS = [
 	// ckUSDT
 	'cngnf-vqaaa-aaaar-qag4q-cai',
 	// ckSepoliaUSDC
-	'yfumr-cyaaa-aaaar-qaela-cai'
+	'yfumr-cyaaa-aaaar-qaela-cai',
+	// ckEURC
+	'pe5t5-diaaa-aaaar-qahwa-cai',
+	// ckXAUT
+	'nza5v-qaaaa-aaaar-qahzq-cai'
 ];
 
 const orchestratorInfo = async ({ orchestratorId: canisterId }) => {


### PR DESCRIPTION
# Motivation

We include `EURC` and `XAUT` among the ERC20 tokens that have different logo between them and their ck-counterparty.

# Tests

Ran the workflow `Update Tokens` on this branch and [there was no change](https://github.com/dfinity/oisy-wallet/actions/runs/10611870136/job/29412334576).
