### PR TITLE
test(e2e): nested selectors generation

### DIFF
--- a/e2e/receive-tokens-modal.spec.ts
+++ b/e2e/receive-tokens-modal.spec.ts
@@ -9,7 +9,7 @@ import {
 import { testWithII } from '@dfinity/internet-identity-playwright';
 import { MODALS_VIEWPORT_WIDTH } from './utils/constants/e2e.constants';
 import { HomepageLoggedIn } from './utils/pages/homepage.page';
-import { getReceiveTokensModalAddressLabelSelectorBySection } from './utils/selectors.utils';
+import { getReceiveTokensModalAddressLabelSelector } from './utils/selectors.utils';
 
 const RECEIVE_TOKENS_MODAL_VIEWPORT_HEIGHT = 900;
 
@@ -29,16 +29,16 @@ testWithII('should display receive-tokens modal', async ({ page, iiPage }) => {
 		modalOpenButtonTestId: RECEIVE_TOKENS_MODAL_OPEN_BUTTON,
 		modalTestId: RECEIVE_TOKENS_MODAL,
 		selectorsToMock: [
-			getReceiveTokensModalAddressLabelSelectorBySection({
+			getReceiveTokensModalAddressLabelSelector({
 				sectionSelector: RECEIVE_TOKENS_MODAL_ICRC_SECTION
 			}),
-			getReceiveTokensModalAddressLabelSelectorBySection({
+			getReceiveTokensModalAddressLabelSelector({
 				sectionSelector: RECEIVE_TOKENS_MODAL_ICP_SECTION
 			}),
-			getReceiveTokensModalAddressLabelSelectorBySection({
+			getReceiveTokensModalAddressLabelSelector({
 				sectionSelector: RECEIVE_TOKENS_MODAL_ETH_SECTION
 			}),
-			getReceiveTokensModalAddressLabelSelectorBySection({
+			getReceiveTokensModalAddressLabelSelector({
 				sectionSelector: RECEIVE_TOKENS_MODAL_BTC_SECTION
 			})
 		]

--- a/e2e/receive-tokens-modal.spec.ts
+++ b/e2e/receive-tokens-modal.spec.ts
@@ -1,6 +1,5 @@
 import {
 	RECEIVE_TOKENS_MODAL,
-	RECEIVE_TOKENS_MODAL_ADDRESS_LABEL,
 	RECEIVE_TOKENS_MODAL_BTC_SECTION,
 	RECEIVE_TOKENS_MODAL_ETH_SECTION,
 	RECEIVE_TOKENS_MODAL_ICP_SECTION,
@@ -10,13 +9,9 @@ import {
 import { testWithII } from '@dfinity/internet-identity-playwright';
 import { MODALS_VIEWPORT_WIDTH } from './utils/constants/e2e.constants';
 import { HomepageLoggedIn } from './utils/pages/homepage.page';
+import { getReceiveTokensModalAddressLabelSelectorBySection } from './utils/selectors.utils';
 
 const RECEIVE_TOKENS_MODAL_VIEWPORT_HEIGHT = 900;
-
-const ICRC_ADDRESS_LABEL_SELECTOR = `[data-tid="${RECEIVE_TOKENS_MODAL_ICRC_SECTION}"] >> [data-tid="${RECEIVE_TOKENS_MODAL_ADDRESS_LABEL}"]`;
-const ICP_ADDRESS_LABEL_SELECTOR = `[data-tid="${RECEIVE_TOKENS_MODAL_ICP_SECTION}"] >> [data-tid="${RECEIVE_TOKENS_MODAL_ADDRESS_LABEL}"]`;
-const ETH_ADDRESS_LABEL_SELECTOR = `[data-tid="${RECEIVE_TOKENS_MODAL_ETH_SECTION}"] >> [data-tid="${RECEIVE_TOKENS_MODAL_ADDRESS_LABEL}"]`;
-const BTC_ADDRESS_LABEL_SELECTOR = `[data-tid="${RECEIVE_TOKENS_MODAL_BTC_SECTION}"] >> [data-tid="${RECEIVE_TOKENS_MODAL_ADDRESS_LABEL}"]`;
 
 testWithII('should display receive-tokens modal', async ({ page, iiPage }) => {
 	const homepageLoggedIn = new HomepageLoggedIn({
@@ -34,10 +29,18 @@ testWithII('should display receive-tokens modal', async ({ page, iiPage }) => {
 		modalOpenButtonTestId: RECEIVE_TOKENS_MODAL_OPEN_BUTTON,
 		modalTestId: RECEIVE_TOKENS_MODAL,
 		selectorsToMock: [
-			ICRC_ADDRESS_LABEL_SELECTOR,
-			ICP_ADDRESS_LABEL_SELECTOR,
-			ETH_ADDRESS_LABEL_SELECTOR,
-			BTC_ADDRESS_LABEL_SELECTOR
+			getReceiveTokensModalAddressLabelSelectorBySection({
+				sectionSelector: RECEIVE_TOKENS_MODAL_ICRC_SECTION
+			}),
+			getReceiveTokensModalAddressLabelSelectorBySection({
+				sectionSelector: RECEIVE_TOKENS_MODAL_ICP_SECTION
+			}),
+			getReceiveTokensModalAddressLabelSelectorBySection({
+				sectionSelector: RECEIVE_TOKENS_MODAL_ETH_SECTION
+			}),
+			getReceiveTokensModalAddressLabelSelectorBySection({
+				sectionSelector: RECEIVE_TOKENS_MODAL_BTC_SECTION
+			})
 		]
 	});
 });

--- a/e2e/utils/selectors.utils.ts
+++ b/e2e/utils/selectors.utils.ts
@@ -1,0 +1,22 @@
+import { RECEIVE_TOKENS_MODAL_ADDRESS_LABEL } from '$lib/constants/test-ids.constants';
+
+/**
+ * Generates a selector that can be used to query an inner element by specifying its parent
+ */
+export const getNestedSelector = ({
+	parentSelector,
+	innerSelector
+}: {
+	parentSelector: string;
+	innerSelector: string;
+}) => `[data-tid="${parentSelector}"] >> [data-tid="${innerSelector}"]`;
+
+export const getReceiveTokensModalAddressLabelSelectorBySection = ({
+	sectionSelector
+}: {
+	sectionSelector: string;
+}) =>
+	getNestedSelector({
+		parentSelector: sectionSelector,
+		innerSelector: RECEIVE_TOKENS_MODAL_ADDRESS_LABEL
+	});

--- a/e2e/utils/selectors.utils.ts
+++ b/e2e/utils/selectors.utils.ts
@@ -11,7 +11,7 @@ export const getNestedSelector = ({
 	innerSelector: string;
 }) => `[data-tid="${parentSelector}"] >> [data-tid="${innerSelector}"]`;
 
-export const getReceiveTokensModalAddressLabelSelectorBySection = ({
+export const getReceiveTokensModalAddressLabelSelector = ({
 	sectionSelector
 }: {
 	sectionSelector: string;


### PR DESCRIPTION
# Motivation

As agreed in one of the previous PRs, I moved nested selectors generation in a separate util
