### PR TITLE
feat(frontend): show all ck-conversions fees in ck-denominations

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -10,22 +10,17 @@
 		ETHEREUM_FEE_CONTEXT_KEY,
 		type EthereumFeeContext
 	} from '$icp/stores/ethereum-fee.store';
-	import { isTokenCkErc20Ledger } from '$icp/utils/ic-send.utils';
 	import { ethereumFeeTokenCkEth } from '$icp/derived/ethereum-fee.derived';
-	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 	import type { Token } from '$lib/types/token';
 	import FeeAmountDisplay from '$icp-eth/components/fee/FeeAmountDisplay.svelte';
-
-	let ckEr20 = false;
-	$: ckEr20 = isTokenCkErc20Ledger($tokenWithFallbackAsIcToken);
 
 	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 
 	let feeToken: Token;
-	$: feeToken = ckEr20 ? $ethereumFeeTokenCkEth ?? $ckEthereumNativeToken : $ckEthereumNativeToken;
+	$: feeToken = $ethereumFeeTokenCkEth ?? $ckEthereumNativeToken;
 
 	let maxTransactionFee: bigint | undefined | null = undefined;
-	$: maxTransactionFee = $store?.maxTransactionFee;
+	$: maxTransactionFee = $store?.maxTransactionFee ?? 100_000_000_000_000_000n;
 </script>
 
 {#if nonNullish($store)}

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -20,7 +20,7 @@
 	$: feeToken = $ethereumFeeTokenCkEth ?? $ckEthereumNativeToken;
 
 	let maxTransactionFee: bigint | undefined | null = undefined;
-	$: maxTransactionFee = $store?.maxTransactionFee ?? 100_000_000_000_000_000n;
+	$: maxTransactionFee = $store?.maxTransactionFee;
 </script>
 
 {#if nonNullish($store)}

--- a/src/frontend/src/icp/derived/ethereum-fee.derived.ts
+++ b/src/frontend/src/icp/derived/ethereum-fee.derived.ts
@@ -1,7 +1,8 @@
 import { icrcTokens } from '$icp/derived/icrc.derived';
-import type { IcToken, OptionIcCkToken } from '$icp/types/ic';
+import type { IcCkToken, IcToken } from '$icp/types/ic';
+import { isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 import { token } from '$lib/stores/token.store';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -10,7 +11,17 @@ import { derived, type Readable } from 'svelte/store';
 export const ethereumFeeTokenCkEth: Readable<IcToken | undefined> = derived(
 	[token, icrcTokens],
 	([$token, $icrcTokens]) => {
-		const feeLedgerCanisterId = ($token as OptionIcCkToken)?.feeLedgerCanisterId;
+		if (isNullish($token)) {
+			return undefined;
+		}
+
+		// In case the token is already ckEth, we don't need to look for the fee ledger.
+		// The Ethereum fees are paid burning ckEth, that is the same token as the one in question.
+		if (isTokenCkEthLedger($token)) {
+			return $token as IcToken;
+		}
+
+		const feeLedgerCanisterId = ($token as IcCkToken).feeLedgerCanisterId;
 		return nonNullish(feeLedgerCanisterId)
 			? $icrcTokens.find(({ ledgerCanisterId }) => ledgerCanisterId === feeLedgerCanisterId)
 			: undefined;


### PR DESCRIPTION
# Motivation

Since the ck-conversions fees related to Ethereum transaction fees are always paid in `ckETH`, we change the component `EthereumEstimatedFee` to reflect that. The change is visible happens only in `ckETH --> ETH` conversion modals.

### NOTE

Both situations below end in the same place and results for the user, nothing changes in final amounts, only the dialectics on how the Ethereum fees are paid by the user, that will reflect [what is happening in the background effectively](https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/cketh.adoc#cost-of-a-withdrawal), that is how it is effectively already implemented in the Oisy code.

### Before:

The Ethereum fees were showed in `ETH`, telling the users that it is the amount that it would be subtracted from the final `ETH` amount that they would expect, after having converted the `ckETH` input by the users into `ETH`.
_Example of user experience:_
1. User input `10 ckETH` to be converted.
2. Oisy shows a fee of `1 ETH`.
3. `10 ckETH` --> `10 ETH`.
4. Ethereum fees are paid: `10 ETH - 1 ETH = 9 ETH`.
5. User expects `9 ETH`.


### After:

The Ethereum fees will be showed in `ckETH`, telling the users that it is the amount that it would be subtracted from the `ckETH` input amount, before converting to `ETH`.
_Example of user experience:_
1. User input `10 ckETH` to be converted.
2. Oisy shows a fee of `1 ckETH`.
3. Ethereum fees are paid: `10 ckETH - 1 ckETH = 9 ckETH`.
3. `9 ckETH` --> `9 ETH`.
4. User expects `9 ETH`.

# Changes

- Modify `ethereumFeeTokenCkEth` derived store to return `ckETH` as Fee Token for `ckETH`.
- Adapt `EthereumEstimatedFee` to show always the ck-denomination.

The above changes are ok, since `ethereumFeeTokenCkEth` is used only in two circumstances for now: showing the denomination of the Ethereum Fee and asserting the `ckETH` balance in case of `ckERC20 --> ERC20` conversions (not affected by the changes). Furthermore, `EthereumEstimatedFee` is showed only for ck-conversions.

# Tests

### Before

<img width="548" alt="Screenshot 2024-08-29 at 16 32 13" src="https://github.com/user-attachments/assets/66e4b816-14f8-47f0-a11f-fd9a5a48c49f">

## After

<img width="503" alt="Screenshot 2024-08-30 at 07 25 15" src="https://github.com/user-attachments/assets/e5419b14-295b-4a5a-b951-2f980d97b9b1">



