### PR TITLE
style(frontend): show same decimals as balance in fee

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -45,7 +45,7 @@
 	>Max fee <small>(likely in &lt; 30 seconds)</small>:</label
 >
 <div id="balance" class="font-normal px-4.5 mb-4 break-all min-h-6">
-	{#if nonNullish(fee) && nonNullish($feeSymbolStore) && nonNullish($feeTokenIdStore)}
+	{#if nonNullish(fee) && nonNullish($feeSymbolStore) && nonNullish($feeTokenIdStore) && nonNullish($feeDecimalsStore)}
 		<FeeAmountDisplay
 			{fee}
 			feeSymbol={$feeSymbolStore}

--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -5,7 +5,7 @@
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import FeeAmountDisplay from '$icp-eth/components/fee/FeeAmountDisplay.svelte';
 
-	const { maxGasFee, feeSymbolStore, feeTokenIdStore }: FeeContext =
+	const { maxGasFee, feeSymbolStore, feeTokenIdStore, feeDecimalsStore }: FeeContext =
 		getContext<FeeContext>(FEE_CONTEXT_KEY);
 
 	let fee: BigNumber | undefined | null = undefined;
@@ -46,6 +46,11 @@
 >
 <div id="balance" class="font-normal px-4.5 mb-4 break-all min-h-6">
 	{#if nonNullish(fee) && nonNullish($feeSymbolStore) && nonNullish($feeTokenIdStore)}
-		<FeeAmountDisplay {fee} feeSymbol={$feeSymbolStore} feeTokenId={$feeTokenIdStore} />
+		<FeeAmountDisplay
+			{fee}
+			feeSymbol={$feeSymbolStore}
+			feeTokenId={$feeTokenIdStore}
+			feeDecimals={$feeDecimalsStore}
+		/>
 	{/if}
 </div>

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -97,6 +97,9 @@
 	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
 	$: feeTokenIdStore.set(nativeEthereumToken.id);
 
+	let feeDecimalsStore = writable<number | undefined>(undefined);
+	$: feeDecimalsStore.set(nativeEthereumToken.decimals);
+
 	let feeContext: FeeContext | undefined;
 	const evaluateFee = () => feeContext?.triggerUpdateFee();
 
@@ -106,6 +109,7 @@
 			feeStore,
 			feeSymbolStore,
 			feeTokenIdStore,
+			feeDecimalsStore,
 			evaluateFee
 		})
 	);

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -67,12 +67,16 @@
 	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
 	$: feeTokenIdStore.set($sendToken.id);
 
+	let feeDecimalsStore = writable<number | undefined>(undefined);
+	$: feeDecimalsStore.set($sendToken.decimals);
+
 	setContext<FeeContextType>(
 		FEE_CONTEXT_KEY,
 		initFeeContext({
 			feeStore,
 			feeSymbolStore,
-			feeTokenIdStore
+			feeTokenIdStore,
+			feeDecimalsStore
 		})
 	);
 

--- a/src/frontend/src/eth/stores/fee.store.ts
+++ b/src/frontend/src/eth/stores/fee.store.ts
@@ -27,6 +27,7 @@ export interface FeeContext {
 	feeStore: FeeStore;
 	feeSymbolStore: Writable<string | undefined>;
 	feeTokenIdStore: Writable<TokenId | undefined>;
+	feeDecimalsStore: Writable<number | undefined>;
 	maxGasFee: Readable<BigNumber | undefined>;
 	minGasFee: Readable<BigNumber | undefined>;
 	evaluateFee?: () => void;

--- a/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
+++ b/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
@@ -12,6 +12,7 @@
 	export let fee: BigNumber;
 	export let feeSymbol: string;
 	export let feeTokenId: TokenId;
+	export let feeDecimals: number;
 
 	let balance: BigNumber | undefined;
 	$: balance = nonNullish($balancesStore) ? $balancesStore[feeTokenId]?.data ?? ZERO : undefined;
@@ -37,7 +38,7 @@
 		{replacePlaceholders($i18n.send.assertion.not_enough_tokens_for_gas, {
 			$balance: formatToken({
 				value: balance,
-				displayDecimals: EIGHT_DECIMALS
+				displayDecimals: feeDecimals
 			}),
 			$symbol: feeSymbol ?? ''
 		})}

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -39,6 +39,7 @@
 						fee={BigNumber.from(maxTransactionFee)}
 						feeSymbol={feeToken.symbol}
 						feeTokenId={feeToken.id}
+						feeDecimals={feeToken.decimals}
 					/>
 				{:else}
 					&ZeroWidthSpace;


### PR DESCRIPTION
# Motivation

When there is an error for insufficient balance, we would like to show the same number as decimals as the balance already showed.

# Changes

- Add `feeDecimals` to Fee Context.
- Set `feeDecimals` throughout the code using already existing token values used by `feeSymbol` and `feeTokenId`.
- Add prop `feeDecimals` to `FeeAmountDisplay`.

# Tests

### Before

![image](https://github.com/user-attachments/assets/c36935dd-9b1e-4547-a351-699897edd35e)

### After

<img width="513" alt="Screenshot 2024-08-30 at 07 50 19" src="https://github.com/user-attachments/assets/104e4b23-b993-4ce4-890f-a9c8e9c8fbb4">

