### PR TITLE
chore(frontend): adjust Ethereum estimated fee label

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -421,7 +421,7 @@
 			"fee": "Fee",
 			"estimated_btc": "Estimated BTC Network Fee",
 			"estimated_inter_network": "Estimated Inter-network Fee",
-			"estimated_eth": "Estimated Ethereum Fee (Updated ≈30 Seconds)"
+			"estimated_eth": "Estimated Ethereum Fee"
 		},
 		"error": {
 			"cannot_fetch_gas_fee": "Cannot fetch gas fee."


### PR DESCRIPTION
# Motivation

In the code, apart from conservative hard-coded numbers, we calculate the ck-conversion fees related to Ethereum fetched from the minter using the `eip_1559_transaction_price` call.
The `max_transaction_fee` fetched with call `eip_1559_transaction_price` from the minter is not real-time: it is re-calculated everytime there is a new withdrawal request to the minter. The same call provides the last update timestamp.

So, in this PR we remove the `30 seconds` proxy string.