### PR TITLE
feat(frontend): remove tab selector when signed out

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
@@ -5,6 +5,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	export let token: Token;
+	export let disableTabSelector: boolean = false;
 
 	let url: string;
 	$: url = transactionsUrl({ token });
@@ -17,7 +18,7 @@
 		aria-label={replacePlaceholders($i18n.transactions.text.open_transactions, {
 			token: token.symbol
 		})}
-		tabindex="-1"
+		tabindex={disableTabSelector ? -1 : 0}
 	>
 		<slot />
 	</a>

--- a/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
@@ -17,6 +17,7 @@
 		aria-label={replacePlaceholders($i18n.transactions.text.open_transactions, {
 			token: token.symbol
 		})}
+		tabindex="-1"
 	>
 		<slot />
 	</a>

--- a/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
@@ -9,7 +9,7 @@
 </script>
 
 {#each $combinedDerivedSortedNetworkTokens as token (token.id)}
-	<TokenCardWithUrl {token}>
+	<TokenCardWithUrl {token} disableTabSelector>
 		<TokenCardSignedOut {token} />
 	</TokenCardWithUrl>
 {/each}


### PR DESCRIPTION
# Motivation

When signed out it was possible to select the blurred tokens list using `Tab` clicks. We remove this possibility.

<img width="1505" alt="Screenshot 2024-09-01 at 08 32 00" src="https://github.com/user-attachments/assets/6e50c843-cf96-4446-a5ae-b3e550e31d8d">

# Tests

In local replica, clicking in loop `Tab`, will never reach the tokens list.
