### PR TITLE
refactor(frontend): simplify code to calculate USD balance

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -49,6 +49,7 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
 	([$enabledNetworkTokens, $balancesStore, $exchanges]) =>
 		$enabledNetworkTokens.map((token) => {
 			const balance: BigNumber | undefined = $balancesStore?.[token.id]?.data;
+			const exchangeRate: number | undefined = $exchanges?.[token.id]?.usd;
 
 			return {
 				...token,
@@ -60,11 +61,11 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
 							displayDecimals: token.decimals
 						})
 					: undefined,
-				usdBalance: nonNullish($exchanges?.[token.id]?.usd)
+				usdBalance: nonNullish(exchangeRate)
 					? usdValue({
 							token,
-							balances: $balancesStore,
-							exchanges: $exchanges
+							balance,
+							exchangeRate
 						})
 					: undefined
 			};

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,23 +1,21 @@
 import { ZERO } from '$lib/constants/app.constants';
-import type { BalancesData } from '$lib/stores/balances.store';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';
 import { formatToken } from '$lib/utils/format.utils';
+import type { BigNumber } from '@ethersproject/bignumber';
 
 export const usdValue = ({
-	token: { id, decimals },
-	balances,
-	exchanges
+	token: { decimals },
+	balance,
+	exchangeRate
 }: {
 	token: Token;
-	balances: CertifiedStoreData<BalancesData>;
-	exchanges: ExchangesData;
+	balance: BigNumber | undefined;
+	exchangeRate: number;
 }): number =>
 	Number(
 		formatToken({
-			value: balances?.[id]?.data ?? ZERO,
+			value: balance ?? ZERO,
 			unitName: decimals,
 			displayDecimals: decimals
 		})
-	) * (exchanges?.[id]?.usd ?? 0);
+	) * exchangeRate;


### PR DESCRIPTION
# Motivation

To reduce repetition of codes and optimize processing, function `usdValue` will accepts direct values instead of stores.
