### PR TITLE
feat(frontend): revert unused prop formattedBalance

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -5,7 +5,6 @@ import { tokens, tokensToPin } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
-import { formatToken } from '$lib/utils/format.utils';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -53,13 +52,6 @@ export const combinedDerivedEnabledNetworkTokensUi: Readable<TokenUi[]> = derive
 			return {
 				...token,
 				balance,
-				formattedBalance: nonNullish(balance)
-					? formatToken({
-							value: balance,
-							unitName: token.decimals,
-							displayDecimals: token.decimals
-						})
-					: undefined,
 				usdBalance: nonNullish($exchanges?.[token.id]?.usd)
 					? usdValue({
 							token,

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -42,7 +42,6 @@ export type TokenToPin = Pick<Token, 'id'> & { network: Pick<Token['network'], '
 
 interface TokenFinancialData {
 	balance?: BigNumber;
-	formattedBalance?: string;
 	usdBalance?: number;
 }
 

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -143,16 +143,16 @@ describe('pinTokensWithBalanceAtTop', () => {
 
 	it('should put tokens with no exchange price (undefined balance) after tokens with balance', () => {
 		const tokens: TokenUi[] = [
-			{ ...ICP_TOKEN, formattedBalance: '200' },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50, formattedBalance: '100' },
-			{ ...ETHEREUM_TOKEN, usdBalance: 200, formattedBalance: '100' }
+			ICP_TOKEN,
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
+			{ ...ETHEREUM_TOKEN, usdBalance: 200 }
 		];
 
 		const result = pinTokensWithBalanceAtTop(tokens);
 		expect(result).toEqual([
-			{ ...ETHEREUM_TOKEN, usdBalance: 200, formattedBalance: '100' },
-			{ ...BTC_MAINNET_TOKEN, usdBalance: 50, formattedBalance: '100' },
-			{ ...ICP_TOKEN, formattedBalance: '200' }
+			{ ...ETHEREUM_TOKEN, usdBalance: 200 },
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
+			ICP_TOKEN
 		]);
 	});
 });


### PR DESCRIPTION
# Motivation

Prop `formattedBalance` (introduced in PR #2150 ) of `TokenUI` is not used, since there is prop `balance` that is the most straightforward way of getting a token balance value. Plus, we slightly reduce computational time.