### PR TITLE
build(frontend): bump gix-cmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@dfinity/candid": "^2.0.0",
 				"@dfinity/ckbtc": "^3.0.0",
 				"@dfinity/cketh": "^3.3.0",
-				"@dfinity/gix-components": "^4.6.0-next-2024-08-26",
+				"@dfinity/gix-components": "^4.7.0",
 				"@dfinity/ic-management": "^5.2.0",
 				"@dfinity/ledger-icp": "^2.5.0",
 				"@dfinity/ledger-icrc": "^2.5.0",
@@ -690,9 +690,9 @@
 			}
 		},
 		"node_modules/@dfinity/gix-components": {
-			"version": "4.6.0-next-2024-08-26",
-			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.6.0-next-2024-08-26.tgz",
-			"integrity": "sha512-AphK9bs9yrYu+M488/QXwZGJAxWLtDPHoc7YSLxkJSEiDfTOyp2mymc8Et2XHubeilodaYsGzuM4LXfUk+r6SA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.7.0.tgz",
+			"integrity": "sha512-mC0ZvUBwQO9krNI2Zg+ueaFMuKCcrDl6kaoVIvhv13oznomUT00nEiSyO7DYC5vFMciiCKT5rBM+XelevH+jOg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"dompurify": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@dfinity/candid": "^2.0.0",
 		"@dfinity/ckbtc": "^3.0.0",
 		"@dfinity/cketh": "^3.3.0",
-		"@dfinity/gix-components": "^4.6.0-next-2024-08-26",
+		"@dfinity/gix-components": "^4.7.0",
 		"@dfinity/ic-management": "^5.2.0",
 		"@dfinity/ledger-icp": "^2.5.0",
 		"@dfinity/ledger-icrc": "^2.5.0",


### PR DESCRIPTION
# Motivation

A new official version of gix-cmp was released. We can use v4.7.0 instead of a "next" version.
