### PR TITLE
feat(frontend): Set up bitcoin listener

### DIFF
--- a/src/frontend/src/btc/components/BitcoinListener.svelte
+++ b/src/frontend/src/btc/components/BitcoinListener.svelte
@@ -1,0 +1,2 @@
+<!-- TODO: Implement https://dfinity.atlassian.net/browse/GIX-2884 -->
+<slot />

--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -3,10 +3,11 @@
 	import type { OptionToken } from '$lib/types/token';
 	import EthListener from '$eth/components/core/EthListener.svelte';
 	import IcListener from '$icp/components/core/IcListener.svelte';
-	import { isNetworkIdICP } from '$lib/utils/network.utils';
+	import { isNetworkIdBitcoin, isNetworkIdICP } from '$lib/utils/network.utils';
 	import { isNullish } from '@dfinity/utils';
 	import NoListener from '$lib/components/core/NoListener.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
+	import BitcoinListener from '$btc/components/BitcoinListener.svelte';
 
 	export let token: OptionToken;
 
@@ -16,7 +17,9 @@
 			? NoListener
 			: isNetworkIdICP(token.network.id)
 				? IcListener
-				: EthListener;
+				: isNetworkIdBitcoin(token.network.id)
+					? BitcoinListener
+					: EthListener;
 </script>
 
 <svelte:component this={cmp} {token}>


### PR DESCRIPTION
# Motivation

There was an error in the console when the Bitcoin token was present in the list of tokens.

The error came because the EthListener was used in the Bitcoin token.

This PR provides the component that must implement the listener for bitcoin. But it doesn't implement it yet.

# Changes

* New empty BitcoinListener component.
* Check also for bitcoin network in Listener project.

# Tests

Tested locally that the error is not raised anymore.
