### PR TITLE
feat(frontend): Set up Bitcoin transactions page

### DIFF
--- a/src/frontend/src/btc/components/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/BtcTransactions.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import Header from '$lib/components/ui/Header.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+</script>
+
+<Header>
+	<h2 class="text-base">{$i18n.transactions.text.title}</h2>
+</Header>
+
+<!-- TODO: Implement https://dfinity.atlassian.net/browse/GIX-2883 -->

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -49,6 +49,11 @@
 			background: radial-gradient(66.11% 97.11% at 50% 115.28%, #300097 0%, #1f005e 100%);
 		}
 
+		&.btc {
+			// TODO: Choose background for bitcoin
+			background: radial-gradient(66.11% 97.11% at 50% 115.28%, #300097 0%, #1f005e 100%);
+		}
+
 		&.eth {
 			background: linear-gradient(61.79deg, #321469 62.5%, var(--color-misty-rose) 100%);
 		}

--- a/src/frontend/src/lib/components/transactions/TransactionsSignedIn.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsSignedIn.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { routeNetwork, routeToken } from '$lib/derived/nav.derived';
-	import { networkICP } from '$lib/derived/network.derived';
+	import { networkBitcoin, networkICP } from '$lib/derived/network.derived';
 	import IcTransactions from '$icp/components/transactions/IcTransactions.svelte';
 	import Transactions from '$eth/components/transactions/Transactions.svelte';
+	import BtcTransactions from '$btc/components/BtcTransactions.svelte';
 </script>
 
 {#if nonNullish($routeNetwork)}
 	{#if $networkICP}
 		<IcTransactions />
+	{:else if $networkBitcoin}
+		<BtcTransactions />
 	{:else if nonNullish($routeToken)}
 		<Transactions />
 	{/if}

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -4,7 +4,7 @@ import { routeNetwork } from '$lib/derived/nav.derived';
 import { networks } from '$lib/derived/networks.derived';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { Network, NetworkId } from '$lib/types/network';
-import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
+import { isNetworkIdBitcoin, isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -23,6 +23,10 @@ export const selectedNetwork: Readable<Network | undefined> = derived(
 
 export const networkICP: Readable<boolean> = derived([networkId], ([$networkId]) =>
 	isNetworkIdICP($networkId)
+);
+
+export const networkBitcoin: Readable<boolean> = derived([networkId], ([$networkId]) =>
+	isNetworkIdBitcoin($networkId)
 );
 
 export const networkEthereum: Readable<boolean> = derived([networkId], ([$networkId]) =>

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -1,3 +1,4 @@
+import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
 import { ETHEREUM_TOKEN, ICP_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
@@ -10,8 +11,8 @@ import { derived, type Readable } from 'svelte/store';
  * A token derived from the route URL - i.e. if the URL contains a query parameters "token", then this store tries to derive the object from it.
  */
 export const pageToken: Readable<OptionToken> = derived(
-	[routeToken, enabledErc20Tokens, enabledIcrcTokens],
-	([$routeToken, $erc20Tokens, $icrcTokens]) => {
+	[routeToken, enabledBitcoinTokens, enabledErc20Tokens, enabledIcrcTokens],
+	([$routeToken, $enabledBitcoinTokens, $erc20Tokens, $icrcTokens]) => {
 		if (isNullish($routeToken)) {
 			return undefined;
 		}
@@ -20,8 +21,12 @@ export const pageToken: Readable<OptionToken> = derived(
 			return ICP_TOKEN;
 		}
 
-		return [...$erc20Tokens, ...$icrcTokens, ETHEREUM_TOKEN, SEPOLIA_TOKEN].find(
-			({ name }) => name === $routeToken
-		);
+		return [
+			...$enabledBitcoinTokens,
+			...$erc20Tokens,
+			...$icrcTokens,
+			ETHEREUM_TOKEN,
+			SEPOLIA_TOKEN
+		].find(({ name }) => name === $routeToken);
 	}
 );


### PR DESCRIPTION
# Motivation

The transactions page for Bitcoin was not showing balance, nor logo, nor nice background.

The error was that it didn't find any token in the pageToken derived store and that the btc didn't have any assigned background.

# Changes

* Add the bitcoin tokens as the tokens to search the pageToken.
* Set up a BtcTransactions component.
* Add a background in the Hero for the Bitcoin network. (To be determined with design which one, but for now, same as ICP).
* Render BtcTransactions if network is BTC.
* New derived store `networkBitcoin`.

# Tests

Tested manually that Hero appears as expected.
