### PR TITLE
feat(frontend): enabled IC network tokens

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,4 +1,5 @@
 import type { Erc20Token } from '$eth/types/erc20';
+import type { IcToken } from '$icp/types/ic';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 import { tokens, tokensToPin } from '$lib/derived/tokens.derived';
@@ -30,6 +31,14 @@ export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
 	[enabledNetworkTokens],
 	([$enabledNetworkTokens]) =>
 		$enabledNetworkTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
+);
+
+export const enabledIcNetworkTokens: Readable<IcToken[]> = derived(
+	[enabledNetworkTokens],
+	([$enabledNetworkTokens]) =>
+		$enabledNetworkTokens.filter(
+			({ standard }) => standard === 'icp' || standard === 'icrc'
+		) as IcToken[]
 );
 
 /**

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -33,6 +33,9 @@ export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
 		$enabledNetworkTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
 );
 
+/**
+ * The following store is use as reference for the list of WalletWorkers that are started/stopped in the main token page.
+ */
 export const enabledIcNetworkTokens: Readable<IcToken[]> = derived(
 	[enabledNetworkTokens],
 	([$enabledNetworkTokens]) =>


### PR DESCRIPTION
# Motivation

To load balances for all enabled IC tokens, it will be useful to have a specific derived store, similar to what we have for ERC20 tokens.

Note that we are not using `['icp', 'icrc'].includes(....` because this is type checked, i.e. it would give an error if there was a mistype in the right-hand side of the comparison that does not match one of the possible values of TokenStandard.
