### PR TITLE
feat(frontend): util for tokens total USD balance calculation

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -2,10 +2,10 @@
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { exchangeInitialized } from '$lib/derived/exchange.derived';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
-	import { getTokensTotalUsdBalance } from '$lib/utils/tokens.utils';
+	import { sumTokensUsdBalance } from '$lib/utils/tokens.utils';
 
 	let totalUsd: number;
-	$: totalUsd = getTokensTotalUsdBalance($combinedDerivedSortedNetworkTokensUi);
+	$: totalUsd = sumTokensUsdBalance($combinedDerivedSortedNetworkTokensUi);
 </script>
 
 <span class="text-off-white block">

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -2,12 +2,10 @@
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { exchangeInitialized } from '$lib/derived/exchange.derived';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
+	import { getTokensTotalUsdBalance } from '$lib/utils/tokens.utils';
 
 	let totalUsd: number;
-	$: totalUsd = $combinedDerivedSortedNetworkTokensUi.reduce(
-		(acc, token) => acc + (token.usdBalance ?? 0),
-		0
-	);
+	$: totalUsd = getTokensTotalUsdBalance($combinedDerivedSortedNetworkTokensUi);
 </script>
 
 <span class="text-off-white block">

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -84,8 +84,8 @@ export const pinTokensWithBalanceAtTop = ($tokens: TokenUi[]): TokenUi[] => {
 /**
  * Calculates total USD balance of the provided tokens list.
  *
- * @param $tokens - The list of tokens for total USD balance calculation.
+ * @param tokens - The list of tokens for total USD balance calculation.
  * @returns The sum of tokens USD balance.
  */
-export const sumTokensUsdBalance = ($tokens: TokenUi[]): number =>
-	$tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);
+export const sumTokensUsdBalance = (tokens: TokenUi[]): number =>
+	tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -80,3 +80,11 @@ export const pinTokensWithBalanceAtTop = ($tokens: TokenUi[]): TokenUi[] => {
 		...nonPositiveBalances
 	];
 };
+
+/**
+ * Calculates total USD balance of the provided tokens list.
+ *
+ * @param $tokens - The list of tokens for total USD balance calculation.
+ */
+export const getTokensTotalUsdBalance = ($tokens: TokenUi[]): number =>
+	$tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -85,6 +85,7 @@ export const pinTokensWithBalanceAtTop = ($tokens: TokenUi[]): TokenUi[] => {
  * Calculates total USD balance of the provided tokens list.
  *
  * @param $tokens - The list of tokens for total USD balance calculation.
+ * @returns The sum of tokens USD balance.
  */
-export const getTokensTotalUsdBalance = ($tokens: TokenUi[]): number =>
+export const sumTokensUsdBalance = ($tokens: TokenUi[]): number =>
 	$tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -3,9 +3,9 @@ import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import {
-	getTokensTotalUsdBalance,
 	pinTokensWithBalanceAtTop,
-	sortTokens
+	sortTokens,
+	sumTokensUsdBalance
 } from '$lib/utils/tokens.utils';
 import { describe, expect, it } from 'vitest';
 
@@ -161,15 +161,31 @@ describe('pinTokensWithBalanceAtTop', () => {
 	});
 });
 
-describe('getTokensTotalUsdBalance', () => {
-	it('should correctly calculate tokens USD total balance', () => {
+describe('sumTokensTotalUsdBalance', () => {
+	it('should correctly calculate USD total balance when tokens have usdBalance', () => {
 		const tokens: TokenUi[] = [
 			{ ...ICP_TOKEN, usdBalance: 50 },
 			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
 			{ ...ETHEREUM_TOKEN, usdBalance: 100 }
 		];
 
-		const result = getTokensTotalUsdBalance(tokens);
+		const result = sumTokensUsdBalance(tokens);
 		expect(result).toEqual(200);
+	});
+
+	it('should correctly calculate USD total balance when some tokens do not have usdBalance', () => {
+		const tokens: TokenUi[] = [
+			{ ...ICP_TOKEN, usdBalance: 50 },
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 0 },
+			{ ...ETHEREUM_TOKEN }
+		];
+
+		const result = sumTokensUsdBalance(tokens);
+		expect(result).toEqual(50);
+	});
+
+	it('should correctly calculate USD total balance when tokens list is empty', () => {
+		const result = sumTokensUsdBalance([]);
+		expect(result).toEqual(0);
 	});
 });

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -2,7 +2,11 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
-import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
+import {
+	getTokensTotalUsdBalance,
+	pinTokensWithBalanceAtTop,
+	sortTokens
+} from '$lib/utils/tokens.utils';
 import { describe, expect, it } from 'vitest';
 
 const usd = 1;
@@ -154,5 +158,18 @@ describe('pinTokensWithBalanceAtTop', () => {
 			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
 			ICP_TOKEN
 		]);
+	});
+});
+
+describe('getTokensTotalUsdBalance', () => {
+	it('should correctly calculate tokens USD total balance', () => {
+		const tokens: TokenUi[] = [
+			{ ...ICP_TOKEN, usdBalance: 50 },
+			{ ...BTC_MAINNET_TOKEN, usdBalance: 50 },
+			{ ...ETHEREUM_TOKEN, usdBalance: 100 }
+		];
+
+		const result = getTokensTotalUsdBalance(tokens);
+		expect(result).toEqual(200);
 	});
 });


### PR DESCRIPTION
# Motivation

Step 1 of updating the chain selector with aggregate USD balance values: re-use util for calculation tokens total USD balance. In the next steps, it will be used to calculate this value for different networks (as shown on the screenshot).

<img width="466" alt="Screenshot 2024-09-03 at 13 39 05" src="https://github.com/user-attachments/assets/084b7df0-f819-47cc-9df4-d8f05bc6118b">
