### PR TITLE
refactor(frontend): move token.services to lib folder

### DIFF
--- a/src/frontend/src/eth/components/send/EthSend.svelte
+++ b/src/frontend/src/eth/components/send/EthSend.svelte
@@ -4,7 +4,7 @@
 	import { modalEthSend } from '$lib/derived/modal.derived';
 	import EthSendModal from '$eth/components/send/EthSendModal.svelte';
 	import { waitWalletReady } from '$lib/services/actions.services';
-	import { loadTokenAndRun } from '$icp/services/token.services';
+	import { loadTokenAndRun } from '$lib/services/token.services';
 	import type { Token } from '$lib/types/token';
 	import SendButtonWithModal from '$lib/components/send/SendButtonWithModal.svelte';
 

--- a/src/frontend/src/icp/components/receive/IcReceive.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceive.svelte
@@ -19,7 +19,7 @@
 		type ReceiveTokenContext
 	} from '$icp/stores/receive-token.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { loadTokenAndRun } from '$icp/services/token.services';
+	import { loadTokenAndRun } from '$lib/services/token.services';
 
 	export let token: Token;
 

--- a/src/frontend/src/icp/components/send/IcSend.svelte
+++ b/src/frontend/src/icp/components/send/IcSend.svelte
@@ -4,7 +4,7 @@
 	import IcSendModal from '$icp/components/send/IcSendModal.svelte';
 	import { ICP_NETWORK_ID } from '$env/networks.env';
 	import type { Token } from '$lib/types/token';
-	import { loadTokenAndRun } from '$icp/services/token.services';
+	import { loadTokenAndRun } from '$lib/services/token.services';
 	import SendButtonWithModal from '$lib/components/send/SendButtonWithModal.svelte';
 
 	export let token: Token;

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -7,7 +7,7 @@
 	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
 	import type { Token } from '$lib/types/token';
 	import { waitWalletReady } from '$lib/services/actions.services';
-	import { loadTokenAndRun } from '$icp/services/token.services';
+	import { loadTokenAndRun } from '$lib/services/token.services';
 	import { addressNotLoaded } from '$lib/derived/address.derived';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';

--- a/src/frontend/src/lib/services/token.services.ts
+++ b/src/frontend/src/lib/services/token.services.ts
@@ -11,8 +11,3 @@ export const loadTokenAndRun = async ({
 	tokenStore.set(token);
 	await callback();
 };
-
-export const runAndResetToken = (callback: () => void) => {
-	callback();
-	tokenStore.set(null);
-};


### PR DESCRIPTION
# Motivation

Since `loadTokenAndRun` is used both by components in `eth`, `icp` and `lib` folder, we move it to the `lib` folder.

Unrelated: we remove unused `runAndResetToken` function.
