### PR TITLE
refactor(frontend): remove redundant address data type

### DIFF
--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,5 +1,10 @@
 import { btcAddressMainnetStore, ethAddressStore } from '$lib/stores/address.store';
-import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
+import type {
+	BtcAddress,
+	EthAddress,
+	OptionBtcAddress,
+	OptionEthAddress
+} from '$lib/types/address';
 import { mapAddress } from '$lib/utils/address.utils';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -12,12 +17,12 @@ export const addressNotLoaded: Readable<boolean> = derived(
 
 export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
 	[btcAddressMainnetStore],
-	([$btcAddressMainnetStore]) => mapAddress($btcAddressMainnetStore)
+	([$btcAddressMainnetStore]) => mapAddress<BtcAddress>($btcAddressMainnetStore)
 );
 
 export const ethAddress: Readable<OptionEthAddress> = derived(
 	[ethAddressStore],
-	([$ethAddressStore]) => mapAddress($ethAddressStore)
+	([$ethAddressStore]) => mapAddress<EthAddress>($ethAddressStore)
 );
 
 export const ethAddressCertified: Readable<boolean> = derived(

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -3,19 +3,17 @@ import type { Address, BtcAddress, EthAddress } from '$lib/types/address';
 import type { CertifiedData } from '$lib/types/store';
 import { writable, type Readable } from 'svelte/store';
 
-type AddressData<T extends Address = Address> = CertifiedData<T>;
+type AddressData<T extends Address> = CertifiedData<T>;
 
-export type OptionAddressData = StorageStoreData<AddressData>;
+export type OptionAddressData<T extends Address> = StorageStoreData<AddressData<T>>;
 
-export type OptionCertifiedAddressData<T extends Address> = AddressData<T> | undefined | null;
-
-export interface AddressStore<T extends Address> extends Readable<OptionCertifiedAddressData<T>> {
+export interface AddressStore<T extends Address> extends Readable<OptionAddressData<T>> {
 	set: (data: AddressData<T>) => void;
 	reset: () => void;
 }
 
 const initAddressStore = <T extends Address>(): AddressStore<T> => {
-	const { subscribe, set } = writable<OptionCertifiedAddressData<T>>(undefined);
+	const { subscribe, set } = writable<OptionAddressData<T>>(undefined);
 
 	return {
 		set: (data: AddressData<T>) => set(data),

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -3,20 +3,20 @@ import type { Address, BtcAddress, EthAddress } from '$lib/types/address';
 import type { CertifiedData } from '$lib/types/store';
 import { writable, type Readable } from 'svelte/store';
 
-type AddressData<T extends Address> = CertifiedData<T>;
+type CertifiedAddressData<T extends Address> = CertifiedData<T>;
 
-export type OptionAddressData<T extends Address> = StorageStoreData<AddressData<T>>;
+export type StorageAddressData<T extends Address> = StorageStoreData<CertifiedAddressData<T>>;
 
-export interface AddressStore<T extends Address> extends Readable<OptionAddressData<T>> {
-	set: (data: AddressData<T>) => void;
+export interface AddressStore<T extends Address> extends Readable<StorageAddressData<T>> {
+	set: (data: CertifiedAddressData<T>) => void;
 	reset: () => void;
 }
 
 const initAddressStore = <T extends Address>(): AddressStore<T> => {
-	const { subscribe, set } = writable<OptionAddressData<T>>(undefined);
+	const { subscribe, set } = writable<StorageAddressData<T>>(undefined);
 
 	return {
-		set: (data: AddressData<T>) => set(data),
+		set: (data: CertifiedAddressData<T>) => set(data),
 		reset: () => set(null),
 		subscribe
 	};

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -1,6 +1,6 @@
-import type { OptionAddressData } from '$lib/stores/address.store';
+import type { StorageAddressData } from '$lib/stores/address.store';
 import type { Address, OptionAddress } from '$lib/types/address';
 
 export const mapAddress = <T extends Address>(
-	$addressStore: OptionAddressData<T>
+	$addressStore: StorageAddressData<T>
 ): OptionAddress<Address> => ($addressStore === null ? null : $addressStore?.data);

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -1,5 +1,6 @@
 import type { OptionAddressData } from '$lib/stores/address.store';
 import type { Address, OptionAddress } from '$lib/types/address';
 
-export const mapAddress = ($addressStore: OptionAddressData): OptionAddress<Address> =>
-	$addressStore === null ? null : $addressStore?.data;
+export const mapAddress = <T extends Address>(
+	$addressStore: OptionAddressData<T>
+): OptionAddress<Address> => ($addressStore === null ? null : $addressStore?.data);


### PR DESCRIPTION
# Motivation

`OptionAddressData` and `OptionCertifiedAddressData` are basically the same thing, so we adapt `OptionAddressData` to "fill the shoes" of `OptionCertifiedAddressData`.
