### PR TITLE
feat(frontend): Set up Btc Transactions page

### DIFF
--- a/src/frontend/src/btc/components/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/BtcTransactions.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <Header>
-	<h2 class="text-base">{$i18n.transactions.text.title}</h2>
+	{$i18n.transactions.text.title}
 </Header>
 
 <!-- TODO: Implement https://dfinity.atlassian.net/browse/GIX-2883 -->

--- a/src/frontend/src/btc/components/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/BtcTransactions.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import Header from '$lib/components/ui/Header.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+</script>
+
+<Header>
+	<h2 class="text-base">{$i18n.transactions.text.title}</h2>
+</Header>
+
+<!-- TODO: Implement https://dfinity.atlassian.net/browse/GIX-2883 -->

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -50,8 +50,7 @@
 		}
 
 		&.btc {
-			// TODO: Choose background for bitcoin
-			background: radial-gradient(66.11% 97.11% at 50% 115.28%, #300097 0%, #1f005e 100%);
+			background: radial-gradient(55.76% 76.98% at 52.05% 0%, #7e4600 0%, #000000 100%);
 		}
 
 		&.eth {

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -49,6 +49,11 @@
 			background: radial-gradient(66.11% 97.11% at 50% 115.28%, #300097 0%, #1f005e 100%);
 		}
 
+		&.btc {
+			// TODO: Choose background for bitcoin
+			background: radial-gradient(66.11% 97.11% at 50% 115.28%, #300097 0%, #1f005e 100%);
+		}
+
 		&.eth {
 			background: linear-gradient(61.79deg, #321469 62.5%, var(--color-misty-rose) 100%);
 		}

--- a/src/frontend/src/lib/components/transactions/TransactionsSignedIn.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsSignedIn.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { routeNetwork, routeToken } from '$lib/derived/nav.derived';
-	import { networkICP } from '$lib/derived/network.derived';
+	import { networkBitcoin, networkICP } from '$lib/derived/network.derived';
 	import IcTransactions from '$icp/components/transactions/IcTransactions.svelte';
 	import Transactions from '$eth/components/transactions/Transactions.svelte';
+	import BtcTransactions from '$btc/components/BtcTransactions.svelte';
 </script>
 
 {#if nonNullish($routeNetwork)}
 	{#if $networkICP}
 		<IcTransactions />
+	{:else if $networkBitcoin}
+		<BtcTransactions />
 	{:else if nonNullish($routeToken)}
 		<Transactions />
 	{/if}


### PR DESCRIPTION
# Motivation

The transactions page for Bitcoin was not showing balance, nor nice background.

The error was that it was using the ETH transactions page and that the hero didn't have an assigned background for btc.

# Changes

* Create new component BtcTransactions.
* Use new component in TransactionsSignedIn.
* Add a background when the hero is for "btc".

# Tests

Tested locally.