### PR TITLE
fix(frontend): Fix Header slot in IcTransactions

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -87,7 +87,7 @@
 <Info />
 
 <Header>
-	<h2 class="text-base">{$i18n.transactions.text.title}</h2>
+	{$i18n.transactions.text.title}
 
 	<svelte:fragment slot="end">
 		{#if $tokenCkBtcLedger}


### PR DESCRIPTION
# Motivation

Remove unnecessary `h2` in IcTransactions.

# Changes

* Pass only the text without `h2` to `Header` in IcTransactions.

# Tests

Tested locally
