### PR TITLE
feat(frontend): render Metamask receive button for ETH only (for now)

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -7,6 +7,7 @@
 	import { networkEthereum } from '$lib/derived/network.derived';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { tokenStandard } from '$lib/derived/token.derived';
 
 	const receiveModal = async () => {
 		if (!$metamaskAvailable) {
@@ -21,9 +22,14 @@
 			network: $selectedEthereumNetwork
 		});
 	};
+
+	// TODO: The Metamask button currently does not support sending ERC20 tokens - it always populates an ETH transaction.
+	// We aim to fix this, but for now, the functionality is commented out.
+	let tokenStandardEth = true;
+	$: tokenStandardEth = $tokenStandard === 'ethereum';
 </script>
 
-{#if $metamaskAvailable && $networkEthereum}
+{#if $metamaskAvailable && $networkEthereum && tokenStandardEth}
 	<button class="secondary full center my-4" on:click={receiveModal}>
 		<IconMetamask />
 		<span class="text-dark-slate-blue font-bold">{$i18n.receive.ethereum.text.metamask}</span>


### PR DESCRIPTION
# Motivation

The Metamask button currently does not support sending ERC20 tokens - it always populates an ETH transaction.
We aim to fix this, but for now, the functionality is commented out.

# Changes

- if standard === ethereum then button
