### PR TITLE
feat(frontend): track analytics when IC send completed

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -131,27 +131,30 @@
 				ckErc20ToErc20MaxCkEthFees
 			};
 
+			const trackAnalyticsOnSendComplete = async () => {
+				await Promise.allSettled([
+					trackTimedEventSuccess(timedEvent),
+					trackEvent({
+						name: isNetworkIdBitcoin(networkId)
+							? TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS
+							: isConvertCkEthToEth({ token: $token, networkId })
+								? TRACK_COUNT_CONVERT_CKETH_TO_ETH_SUCCESS
+								: isConvertCkErc20ToErc20({ token: $token, networkId })
+									? TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_SUCCESS
+									: TRACK_COUNT_IC_SEND_SUCCESS,
+						metadata: {
+							token: $token.symbol
+						}
+					})
+				]);
+			};
+
 			await sendIc({
 				...params,
 				token: $tokenAsIcToken,
-				targetNetworkId: networkId
+				targetNetworkId: networkId,
+				sendCompleted: trackAnalyticsOnSendComplete
 			});
-
-			await Promise.allSettled([
-				trackTimedEventSuccess(timedEvent),
-				trackEvent({
-					name: isNetworkIdBitcoin(networkId)
-						? TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS
-						: isConvertCkEthToEth({ token: $token, networkId })
-							? TRACK_COUNT_CONVERT_CKETH_TO_ETH_SUCCESS
-							: isConvertCkErc20ToErc20({ token: $token, networkId })
-								? TRACK_COUNT_CONVERT_CKERC20_TO_ERC20_SUCCESS
-								: TRACK_COUNT_IC_SEND_SUCCESS,
-					metadata: {
-						token: $token.symbol
-					}
-				})
-			]);
 
 			sendProgressStep = ProgressStepsSendIc.DONE;
 

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -27,15 +27,19 @@ import { get } from 'svelte/store';
 
 export const sendIc = async ({
 	progress,
+	sendCompleted,
 	...rest
 }: IcTransferParams & {
 	token: IcToken;
 	targetNetworkId: NetworkId | undefined;
+	sendCompleted: () => Promise<void>;
 }): Promise<void> => {
 	await send({
 		progress,
 		...rest
 	});
+
+	await sendCompleted();
 
 	progress(ProgressStepsSendIc.RELOAD);
 


### PR DESCRIPTION
# Motivation

There is a 2s timeout after an IC send transactions is complemented to optimistically fetch the transactions. Given that we are interested to get to know how long does a send least, it's not really correct to count that timeout within the overall send. Therefore we can track the anonymous metrics when the send is over.

# Changes

- Pass the analytics as callback for `sendIc` and collect analytics when send is done.
