### PR TITLE
feat(devops): Add scripts to set up Bitcoin local node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # dfx temporary files
 .dfx/
 
+# bitcoin
+bitcoin-core/
+bitcoin*.gz
+
 # rust and downloaded wasm|did files
 target/
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -133,3 +133,86 @@ Note that setting up the twin token counterpart or collecting their logo is unne
 To help with steps 3 to 5, one can use the script [./scripts/add.tokens.erc20.mjs] (or [./scripts/add.tokens.erc20.sh]) to generate the environment files for the new tokens. It requires the EtherScan API key to fetch the token information from the Ethereum network, to be set in the `.env` file as `VITE_ETHERSCAN_API_KEY`.
 The script will run through the supported ckERC20 tokens in the production dashboard and will automatically generate the necessary environment files for the new tokens that have a respective testnet token, and that do not yet exist in the repository.
 Please be aware of the instructions provided by the script and follow them accordingly, if there are any, and possibly double-check the generated files.
+
+## Bitcoin
+
+Some setup is necessary to be able to develop locally with Bitcoin tokens.
+
+There are three necessary items before starting to develop locally:
+
+- Environment variables.
+- Local Bitcoin node running (regtest).
+- Start dfx with bitcoin.
+
+### Bitcoin Environment Variables
+
+You need to set the following variables to `true` in the file `.env.development`.
+
+```
+VITE_NETWORK_BITCOIN_ENABLED=true
+VITE_BITCOIN_MAINNET=true
+```
+
+### Local Bitcoin Node (Or Regtest)
+
+To interact with a Bitcoun network, we can set up a local test node.
+
+The script to set it up and start running it is `./scripts/setup.bitcoin-node.sh`.
+
+The first time you will run it withuot arguments:
+
+```bash
+./scripts/setup.bitcoin-node.sh
+```
+
+This script will download and set up a local bitcoin node from [Bitcoin.org](https://bitcoin.org/en/download).
+
+Running this script again will start the node without doing the initial setup again.
+
+**Resetting Node:**
+
+It's recommended to reset the node from time to time:
+
+```bash
+./scripts/setup.bitcoin-node.sh --reset
+```
+
+### Start dfx with Bitcoin
+
+Dfx needs to be aware that a Bitcoin node is running.
+
+There is a script to run dfx with Bitcoin:
+
+```bash
+./scripts/dfx.start-with-bitcoin.sh
+```
+
+You can also run it by cleaning up the state:
+
+```bash
+./scripts/dfx.start-with-bitcoin.sh --clean
+```
+
+You would normally do this along resetting the bitcoin node as mentioned before.
+
+### Mining Bitcoins
+
+To start testing Bitcoin feature you'll need some tokens.
+
+For that, you can get the address of your test user from the UI and get yourlsef some bitcoins:
+
+```bash
+./scripts/add.tokens.bitcoin.sh --amount <amount-in-blocks> --address <test-user-address>
+```
+
+**One block equals 50 Bitcoin.**
+
+### Mining After Transactions
+
+Tokens transferred are not immediately available in the new destination.
+
+Before they become available, there must be a new block mined. You can mine one:
+
+```bash
+./scripts/add.tokens.bitcoin.sh
+```

--- a/HACKING.md
+++ b/HACKING.md
@@ -195,6 +195,8 @@ You can also run it by cleaning up the state:
 
 You would normally do this along resetting the bitcoin node as mentioned before.
 
+**IMPORTANT: If you were running a local replica before without bitcoin, use the `--clean` flag.**
+
 ### Mining Bitcoins
 
 To start testing Bitcoin feature you'll need some tokens.

--- a/scripts/add.tokens.bitcoin.sh
+++ b/scripts/add.tokens.bitcoin.sh
@@ -8,22 +8,30 @@ address=""
 
 # Loop through the parameters
 while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --amount) amount="$2"; shift 2;;  # Assign the next argument to amount and shift
-        --address) address="$2"; shift 2;; # Assign the next argument to address and shift
-        *) echo "Unknown parameter passed: $1"; exit 1;;
-    esac
+  case $1 in
+  --amount)
+    amount="$2"
+    shift 2
+    ;; # Assign the next argument to amount and shift
+  --address)
+    address="$2"
+    shift 2
+    ;; # Assign the next argument to address and shift
+  *)
+    echo "Unknown parameter passed: $1"
+    exit 1
+    ;;
+  esac
 done
 
-
 if [ -n "$amount" ] && [ -n "$address" ]; then
-    # Reference: https://internetcomputer.org/docs/current/developer-docs/multi-chain/bitcoin/using-btc/local-development
-    ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress $amount $address
-    # One caveat of the previous block rewards is that they are subject to the Coinbase maturity rule
-    # which states that, in order for you to spend them, you will first need to mine 100 additional blocks.
-    # Therefore, we will generate 100 blocks to a random address.
-    ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress 100 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
+  # Reference: https://internetcomputer.org/docs/current/developer-docs/multi-chain/bitcoin/using-btc/local-development
+  ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress $amount $address
+  # One caveat of the previous block rewards is that they are subject to the Coinbase maturity rule
+  # which states that, in order for you to spend them, you will first need to mine 100 additional blocks.
+  # Therefore, we will generate 100 blocks to a random address.
+  ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress 100 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
 else
-    # Step necessary after making a transaction so that it becomes part of the blockchain
-    ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress 1 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
+  # Step necessary after making a transaction so that it becomes part of the blockchain
+  ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress 1 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
 fi

--- a/scripts/add.tokens.bitcoin.sh
+++ b/scripts/add.tokens.bitcoin.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+BITCOIN_DIR="bitcoin-core"
+
+# Initialize variables for the parameters
+amount=""
+address=""
+
+# Loop through the parameters
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --amount) amount="$2"; shift 2;;  # Assign the next argument to amount and shift
+        --address) address="$2"; shift 2;; # Assign the next argument to address and shift
+        *) echo "Unknown parameter passed: $1"; exit 1;;
+    esac
+done
+
+# Reference: https://internetcomputer.org/docs/current/developer-docs/multi-chain/bitcoin/using-btc/local-development
+.$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/bitcoin.conf generatetoaddress $amount $address
+
+# One caveat of the previous block rewards is that they are subject to the Coinbase maturity rule
+# which states that, in order for you to spend them, you will first need to mine 100 additional blocks.
+# Therefore, we will generate 100 blocks to a random address.
+.$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/bitcoin.conf generatetoaddress 100 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M

--- a/scripts/add.tokens.bitcoin.sh
+++ b/scripts/add.tokens.bitcoin.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+print_help() {
+  cat <<-EOF
+
+	Mines blocks to a given address.
+
+Arguments:
+--amount <amount>  Amount of BTC to mine.
+--address <address>  Address to mine to.
+
+If no amount and no address are provided, it will mine a block to a random address.
+	EOF
+  # TODO: Consider using clap for argument parsing.  If not, describe the flags here.
+}
+
 BITCOIN_DIR="bitcoin-core"
 
 # Initialize variables for the parameters
@@ -9,6 +23,7 @@ address=""
 # Loop through the parameters
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+  --help) print_help && exit 0 ;;
   --amount)
     amount="$2"
     shift 2

--- a/scripts/add.tokens.bitcoin.sh
+++ b/scripts/add.tokens.bitcoin.sh
@@ -15,10 +15,15 @@ while [[ "$#" -gt 0 ]]; do
     esac
 done
 
-# Reference: https://internetcomputer.org/docs/current/developer-docs/multi-chain/bitcoin/using-btc/local-development
-.$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/bitcoin.conf generatetoaddress $amount $address
 
-# One caveat of the previous block rewards is that they are subject to the Coinbase maturity rule
-# which states that, in order for you to spend them, you will first need to mine 100 additional blocks.
-# Therefore, we will generate 100 blocks to a random address.
-.$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/bitcoin.conf generatetoaddress 100 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
+if [ -n "$amount" ] && [ -n "$address" ]; then
+    # Reference: https://internetcomputer.org/docs/current/developer-docs/multi-chain/bitcoin/using-btc/local-development
+    ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress $amount $address
+    # One caveat of the previous block rewards is that they are subject to the Coinbase maturity rule
+    # which states that, in order for you to spend them, you will first need to mine 100 additional blocks.
+    # Therefore, we will generate 100 blocks to a random address.
+    ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress 100 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
+else
+    # Step necessary after making a transaction so that it becomes part of the blockchain
+    ./$BITCOIN_DIR/bin/bitcoin-cli -conf=$(pwd)/$BITCOIN_DIR/bitcoin.conf generatetoaddress 1 mtbZzVBwLnDmhH4pE9QynWAgh6H3aC1E6M
+fi

--- a/scripts/dfx.start-with-bitcoin.sh
+++ b/scripts/dfx.start-with-bitcoin.sh
@@ -6,7 +6,7 @@ print_help() {
 	Starts local replica with dfx supporting bitcoin.
 
 This script assumes a local Regtest Bitcoin Core node is running.
-You can run one by executing the `setup.bitcoin-node.sh` script.
+You can run one by executing the "setup.bitcoin-node.sh" script.
 
 Arguments:
 

--- a/scripts/dfx.start-with-bitcoin.sh
+++ b/scripts/dfx.start-with-bitcoin.sh
@@ -3,4 +3,5 @@
 # This script assumes a local Regtest Bitcoin Core node is running.
 # You can run one by executing the `setup.bitcoin-node.sh` script.
 
+# TODO: Remove `--clean`
 dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444" --clean

--- a/scripts/dfx.start-with-bitcoin.sh
+++ b/scripts/dfx.start-with-bitcoin.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This script assumes a local Regtest Bitcoin Core node is running.
+# You can run one by executing the `setup.bitcoin-node.sh` script.
+
+dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444" --clean

--- a/scripts/dfx.start-with-bitcoin.sh
+++ b/scripts/dfx.start-with-bitcoin.sh
@@ -3,5 +3,25 @@
 # This script assumes a local Regtest Bitcoin Core node is running.
 # You can run one by executing the `setup.bitcoin-node.sh` script.
 
-# TODO: Remove `--clean`
-dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444" --clean
+# Initialize a flag for the --reset option
+clean_flag=false
+
+# Loop through the arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --clean)
+            clean_flag=true  # Set the reset flag to true if --reset is provided
+            shift            # Move to the next argument
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$clean_flag" = true ]; then
+    dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444" --clean
+else
+    dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444"
+fi

--- a/scripts/dfx.start-with-bitcoin.sh
+++ b/scripts/dfx.start-with-bitcoin.sh
@@ -8,20 +8,20 @@ clean_flag=false
 
 # Loop through the arguments
 while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --clean)
-            clean_flag=true  # Set the reset flag to true if --reset is provided
-            shift            # Move to the next argument
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
-    esac
+  case $1 in
+  --clean)
+    clean_flag=true # Set the reset flag to true if --reset is provided
+    shift           # Move to the next argument
+    ;;
+  *)
+    echo "Unknown option: $1"
+    exit 1
+    ;;
+  esac
 done
 
 if [ "$clean_flag" = true ]; then
-    dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444" --clean
+  dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444" --clean
 else
-    dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444"
+  dfx start --enable-bitcoin --bitcoin-node "127.0.0.1:18444"
 fi

--- a/scripts/dfx.start-with-bitcoin.sh
+++ b/scripts/dfx.start-with-bitcoin.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 
-# This script assumes a local Regtest Bitcoin Core node is running.
-# You can run one by executing the `setup.bitcoin-node.sh` script.
+print_help() {
+  cat <<-EOF
+
+	Starts local replica with dfx supporting bitcoin.
+
+This script assumes a local Regtest Bitcoin Core node is running.
+You can run one by executing the `setup.bitcoin-node.sh` script.
+
+Arguments:
+
+--clean resets the replica state. Needed if you were running another replica before without bitcoin.
+	EOF
+  # TODO: Consider using clap for argument parsing.  If not, describe the flags here.
+}
 
 # Initialize a flag for the --reset option
 clean_flag=false
@@ -9,6 +21,7 @@ clean_flag=false
 # Loop through the arguments
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+  --help) print_help && exit 0 ;;
   --clean)
     clean_flag=true # Set the reset flag to true if --reset is provided
     shift           # Move to the next argument

--- a/scripts/reset.bitcoin-node.sh
+++ b/scripts/reset.bitcoin-node.sh
@@ -1,0 +1,5 @@
+BITCOIN_DIR="bitcoin-core"
+DATA_DIR="$BITCOIN_DIR/data"
+
+rm -r $DATA_DIR
+mkdir -p $DATA_DIR

--- a/scripts/reset.bitcoin-node.sh
+++ b/scripts/reset.bitcoin-node.sh
@@ -1,5 +1,0 @@
-BITCOIN_DIR="bitcoin-core"
-DATA_DIR="$BITCOIN_DIR/data"
-
-rm -r $DATA_DIR
-mkdir -p $DATA_DIR

--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Determine the OS
+OS="$(uname -s)"
+case "$OS" in
+    Linux*)     OS_TYPE="linux";;
+    Darwin*)    OS_TYPE="darwin";;
+    CYGWIN*|MINGW*|MSYS*) OS_TYPE="windows";;
+    *)          echo "Unsupported OS: $OS"; exit 1;;
+esac
+
+# Define variables
+BITCOIN_URL="https://bitcoin.org/bin"
+BITCOIN_CORE_VERSION="27.0"
+BITCOIN_DIR="bitcoin-core"
+BITCOIN_CONF="$BITCOIN_DIR/bitcoin.conf"
+DATA_DIR="$BITCOIN_DIR/data"
+
+# https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-apple-darwin.tar.gz
+# https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-arm64-apple-darwin.tar.gz
+
+# Download Bitcoin Core based on OS type (only if not already downloaded)
+if [ ! -d $BITCOIN_DIR ]; then
+    case "$OS_TYPE" in
+        linux)
+            echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Linux..."
+            curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz
+            tar -xzf bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz
+            mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+            ;;
+        darwin)
+            echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for macOS..."
+            curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
+            tar -xzf bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
+            mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+            ;;
+        windows)
+            echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Windows..."
+            curl -O $BITCOIN_URL//bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-win64.zip
+            unzip bitcoin-$BITCOIN_CORE_VERSION-win64.zip
+            mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+            ;;
+        *)
+            echo "Unsupported OS type: $OS_TYPE"
+            exit 1
+            ;;
+    esac
+    # Create the data directory
+    if [ ! -d "$DATA_DIR" ]; then
+        echo "Creating data directory..."
+        mkdir -p "$DATA_DIR"
+    fi
+    # Create the bitcoin.conf file
+    if [ ! -f "$BITCOIN_CONF" ]; then
+        echo "Creating bitcoin.conf..."
+        cat <<EOL > "$BITCOIN_CONF"
+# Enable regtest mode. This is required to setup a private bitcoin network.
+regtest=1
+# Dummy credentials that are required by \`bitcoin-cli\`.
+rpcuser=ic-btc-integration
+rpcpassword=QPQiNaph19FqUsCrBRN0FII7lyM26B51fAMeBQzCb-E=
+rpcauth=ic-btc-integration:cdf2741387f3a12438f69092f0fdad8e\$62081498c98bee09a0dce2b30671123fa561932992ce377585e8e08bb0c11dfa
+EOL
+    fi
+fi
+
+
+
+# Start bitcoind with the specified configuration
+echo "Starting bitcoind..."
+if [ "$OS_TYPE" = "windows" ]; then
+    ./bitcoin-core/bin/bitcoind.exe -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444
+else
+    if [ "$(uname -m)" = "arm64" ]; then
+        codesign -s - ./bitcoin-core/bin/bitcoind
+    fi
+    ./bitcoin-core/bin/bitcoind -conf="$(pwd)/bitcoin-core/bitcoin.conf" -datadir="$(pwd)/bitcoin-core/data" --port=18444
+fi

--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -5,25 +5,28 @@ reset_flag=false
 
 # Loop through the arguments
 while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --reset)
-            reset_flag=true  # Set the reset flag to true if --reset is provided
-            shift            # Move to the next argument
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
-    esac
+  case $1 in
+  --reset)
+    reset_flag=true # Set the reset flag to true if --reset is provided
+    shift           # Move to the next argument
+    ;;
+  *)
+    echo "Unknown option: $1"
+    exit 1
+    ;;
+  esac
 done
 
 # Determine the OS
 OS="$(uname -s)"
 case "$OS" in
-    Linux*)     OS_TYPE="linux";;
-    Darwin*)    OS_TYPE="darwin";;
-    CYGWIN*|MINGW*|MSYS*) OS_TYPE="windows";;
-    *)          echo "Unsupported OS: $OS"; exit 1;;
+Linux*) OS_TYPE="linux" ;;
+Darwin*) OS_TYPE="darwin" ;;
+CYGWIN* | MINGW* | MSYS*) OS_TYPE="windows" ;;
+*)
+  echo "Unsupported OS: $OS"
+  exit 1
+  ;;
 esac
 
 # Define variables
@@ -35,43 +38,43 @@ DATA_DIR="$BITCOIN_DIR/data"
 
 # Download and set up Bitcoin Local Node
 if [ ! -d $BITCOIN_DIR ]; then
-    case "$OS_TYPE" in
-        linux)
-            echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Linux..."
-            curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz
-            tar -xzf bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz
-            mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
-            ;;
-        darwin)
-            echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for macOS..."
-            curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
-            tar -xzf bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
-            mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
-            # Reference: 
-            if [ "$(uname -m)" = "arm64" ]; then
-                codesign -s - ./$BITCOIN_DIR/bin/bitcoind
-                codesign -s - ./$BITCOIN_DIR/bin/bitcoin-cli
-            fi
-            ;;
-        windows)
-            echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Windows..."
-            curl -O $BITCOIN_URL//bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-win64.zip
-            unzip bitcoin-$BITCOIN_CORE_VERSION-win64.zip
-            mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
-            ;;
-        *)
-            echo "Unsupported OS type: $OS_TYPE"
-            exit 1
-            ;;
-    esac
-    # Create the data directory
-    if [ ! -d "$DATA_DIR" ]; then
-        echo "Creating data directory..."
-        mkdir -p "$DATA_DIR"
-        # Create the bitcoin.conf file
-        # This file needs to be created initially, we take advantage of the fact that the DATA_DIR is not present after initial setup.
-        echo "Creating bitcoin.conf..."
-        cat <<EOL > "$BITCOIN_CONF"
+  case "$OS_TYPE" in
+  linux)
+    echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Linux..."
+    curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz
+    tar -xzf bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz
+    mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+    ;;
+  darwin)
+    echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for macOS..."
+    curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
+    tar -xzf bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
+    mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+    # Reference:
+    if [ "$(uname -m)" = "arm64" ]; then
+      codesign -s - ./$BITCOIN_DIR/bin/bitcoind
+      codesign -s - ./$BITCOIN_DIR/bin/bitcoin-cli
+    fi
+    ;;
+  windows)
+    echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Windows..."
+    curl -O $BITCOIN_URL//bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-win64.zip
+    unzip bitcoin-$BITCOIN_CORE_VERSION-win64.zip
+    mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+    ;;
+  *)
+    echo "Unsupported OS type: $OS_TYPE"
+    exit 1
+    ;;
+  esac
+  # Create the data directory
+  if [ ! -d "$DATA_DIR" ]; then
+    echo "Creating data directory..."
+    mkdir -p "$DATA_DIR"
+    # Create the bitcoin.conf file
+    # This file needs to be created initially, we take advantage of the fact that the DATA_DIR is not present after initial setup.
+    echo "Creating bitcoin.conf..."
+    cat <<EOL >"$BITCOIN_CONF"
 # Enable regtest mode. This is required to setup a private bitcoin network.
 regtest=1
 # Dummy credentials that are required by \`bitcoin-cli\`.
@@ -79,22 +82,20 @@ rpcuser=ic-btc-integration
 rpcpassword=QPQiNaph19FqUsCrBRN0FII7lyM26B51fAMeBQzCb-E=
 rpcauth=ic-btc-integration:cdf2741387f3a12438f69092f0fdad8e\$62081498c98bee09a0dce2b30671123fa561932992ce377585e8e08bb0c11dfa
 EOL
-    fi
+  fi
 fi
-
-
 
 # Start bitcoind with the specified configuration
 echo "Starting bitcoind..."
 if [ "$OS_TYPE" = "windows" ]; then
-    ./$BITCOIN_DIR/bin/bitcoind.exe -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444
+  ./$BITCOIN_DIR/bin/bitcoind.exe -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444
 else
-    if [ "$reset_flag" = true ]; then
-        rm -r $DATA_DIR
-        mkdir -p $DATA_DIR
-    fi
-    # -debug=0 Disables debug logging to reduce the size and frequency of log files.
-    # -prune=550 If don’t need the full historical blockchain, you can use pruned mode to limit how much of the blockchain is stored on disk
-    # -maxmempool=50 The memory pool holds unconfirmed transactions. Limiting its size can reduce the memory usage and slow the cache increase
-    ./$BITCOIN_DIR/bin/bitcoind -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444 -debug=0 -prune=550 -maxmempool=50
+  if [ "$reset_flag" = true ]; then
+    rm -r $DATA_DIR
+    mkdir -p $DATA_DIR
+  fi
+  # -debug=0 Disables debug logging to reduce the size and frequency of log files.
+  # -prune=550 If don’t need the full historical blockchain, you can use pruned mode to limit how much of the blockchain is stored on disk
+  # -maxmempool=50 The memory pool holds unconfirmed transactions. Limiting its size can reduce the memory usage and slow the cache increase
+  ./$BITCOIN_DIR/bin/bitcoind -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444 -debug=0 -prune=550 -maxmempool=50
 fi

--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -16,10 +16,7 @@ BITCOIN_DIR="bitcoin-core"
 BITCOIN_CONF="$BITCOIN_DIR/bitcoin.conf"
 DATA_DIR="$BITCOIN_DIR/data"
 
-# https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-x86_64-apple-darwin.tar.gz
-# https://bitcoin.org/bin/bitcoin-core-27.0/bitcoin-27.0-arm64-apple-darwin.tar.gz
-
-# Download Bitcoin Core based on OS type (only if not already downloaded)
+# Download and set up Bitcoin Local Node
 if [ ! -d $BITCOIN_DIR ]; then
     case "$OS_TYPE" in
         linux)
@@ -33,6 +30,11 @@ if [ ! -d $BITCOIN_DIR ]; then
             curl -O $BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
             tar -xzf bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz
             mv bitcoin-$BITCOIN_CORE_VERSION $BITCOIN_DIR
+            # Reference: 
+            if [ "$(uname -m)" = "arm64" ]; then
+                codesign -s - ./$BITCOIN_DIR/bin/bitcoind
+                codesign -s - ./$BITCOIN_DIR/bin/bitcoin-cli
+            fi
             ;;
         windows)
             echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Windows..."
@@ -69,10 +71,7 @@ fi
 # Start bitcoind with the specified configuration
 echo "Starting bitcoind..."
 if [ "$OS_TYPE" = "windows" ]; then
-    ./bitcoin-core/bin/bitcoind.exe -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444
+    ./$BITCOIN_DIR/bin/bitcoind.exe -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444
 else
-    if [ "$(uname -m)" = "arm64" ]; then
-        codesign -s - ./bitcoin-core/bin/bitcoind
-    fi
-    ./bitcoin-core/bin/bitcoind -conf="$(pwd)/bitcoin-core/bitcoin.conf" -datadir="$(pwd)/bitcoin-core/data" --port=18444
+    ./$BITCOIN_DIR/bin/bitcoind -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444
 fi

--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 
+print_help() {
+  cat <<-EOF
+
+	Sets up and starts a local bitcoin node.
+
+If the bitcoin node artifacts are not present, it will download them.
+
+Arguments:
+
+--reset Resets the bitcoin node.
+	EOF
+  # TODO: Consider using clap for argument parsing.  If not, describe the flags here.
+}
+
 # Initialize a flag for the --reset option
 reset_flag=false
 
 # Loop through the arguments
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+  --help) print_help && exit 0 ;;
   --reset)
     reset_flag=true # Set the reset flag to true if --reset is provided
     shift           # Move to the next argument


### PR DESCRIPTION
# Motivation

We want to be able to test that the development of the Bitcoin integration works as expected.

In order to do that, we need a local Bitcoin node.

This PR provides two main scripts to set up the local node and start dfx with Bitcoin. As well as some other utilities to be used while testing.

# Changes

* Add a couple of entries to `.gitignore`.
* Add a script to set up the local Bitcoin node.
* Add a script to start dfx with Bitcoin.
* Add a script to mine tokens.
* Add a section in Hacking.md to explain how to use the scripts.

# Tests

I and Denys tested locally that the scripts worked as expected.
