### PR TITLE
refactor(frontend): move invalidIcpAddress to lib folder

### DIFF
--- a/src/frontend/src/eth/components/send/SendDestination.svelte
+++ b/src/frontend/src/eth/components/send/SendDestination.svelte
@@ -7,7 +7,7 @@
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import type { OptionToken } from '$lib/types/token';
 	import { isErc20Icp } from '$eth/utils/token.utils';
-	import { invalidIcpAddress } from '$icp/utils/icp-account.utils';
+	import { invalidIcpAddress } from '$icp-eth/utils/icp-account.utils';
 	import type { Network } from '$lib/types/network';
 	import { isNetworkICP } from '$lib/utils/network.utils';
 	import { isNullish } from '@dfinity/utils';

--- a/src/frontend/src/eth/components/send/SendDestination.svelte
+++ b/src/frontend/src/eth/components/send/SendDestination.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
-	import { isEthAddress } from '$lib/utils/account.utils';
+	import { invalidIcpAddress, isEthAddress } from '$lib/utils/account.utils';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import type { OptionToken } from '$lib/types/token';
 	import { isErc20Icp } from '$eth/utils/token.utils';
-	import { invalidIcpAddress } from '$icp-eth/utils/icp-account.utils';
 	import type { Network } from '$lib/types/network';
 	import { isNetworkICP } from '$lib/utils/network.utils';
 	import { isNullish } from '@dfinity/utils';

--- a/src/frontend/src/icp-eth/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp-eth/utils/icp-account.utils.ts
@@ -1,0 +1,4 @@
+import { isIcpAccountIdentifier } from '$lib/utils/account.utils';
+
+export const invalidIcpAddress = (address: string | undefined): boolean =>
+	!isIcpAccountIdentifier(address);

--- a/src/frontend/src/icp-eth/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp-eth/utils/icp-account.utils.ts
@@ -1,4 +1,0 @@
-import { isIcpAccountIdentifier } from '$lib/utils/account.utils';
-
-export const invalidIcpAddress = (address: string | undefined): boolean =>
-	!isIcpAccountIdentifier(address);

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -2,6 +2,7 @@ import {
 	isConvertCkErc20ToErc20,
 	isConvertCkEthToEth
 } from '$icp-eth/utils/cketh-transactions.utils';
+import { invalidIcpAddress } from '$icp-eth/utils/icp-account.utils';
 import {
 	icrc1Transfer as icrc1TransferIcp,
 	transfer as transferIcp
@@ -15,7 +16,6 @@ import {
 import type { IcToken } from '$icp/types/ic';
 import type { IcTransferParams } from '$icp/types/ic-send';
 import { waitAndTriggerWallet } from '$icp/utils/ic-wallet.utils';
-import { invalidIcpAddress } from '$icp/utils/icp-account.utils';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -2,7 +2,6 @@ import {
 	isConvertCkErc20ToErc20,
 	isConvertCkEthToEth
 } from '$icp-eth/utils/cketh-transactions.utils';
-import { invalidIcpAddress } from '$icp-eth/utils/icp-account.utils';
 import {
 	icrc1Transfer as icrc1TransferIcp,
 	transfer as transferIcp
@@ -20,6 +19,7 @@ import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
+import { invalidIcpAddress } from '$lib/utils/account.utils';
 import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 import type { BlockHeight } from '@dfinity/ledger-icp';
 import { decodeIcrcAccount, type IcrcBlockIndex } from '@dfinity/ledger-icrc';

--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -4,8 +4,8 @@ import {
 	CKERC20_LEDGER_CANISTER_IDS,
 	CKETH_LEDGER_CANISTER_IDS
 } from '$env/networks.icrc.env';
+import { invalidIcpAddress } from '$icp-eth/utils/icp-account.utils';
 import type { IcToken } from '$icp/types/ic';
-import { invalidIcpAddress } from '$icp/utils/icp-account.utils';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenStandard } from '$lib/types/token';

--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -4,12 +4,11 @@ import {
 	CKERC20_LEDGER_CANISTER_IDS,
 	CKETH_LEDGER_CANISTER_IDS
 } from '$env/networks.icrc.env';
-import { invalidIcpAddress } from '$icp-eth/utils/icp-account.utils';
 import type { IcToken } from '$icp/types/ic';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenStandard } from '$lib/types/token';
-import { isEthAddress } from '$lib/utils/account.utils';
+import { invalidIcpAddress, isEthAddress } from '$lib/utils/account.utils';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
 import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 import { BtcNetwork, parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -1,9 +1,5 @@
-import { isIcpAccountIdentifier } from '$lib/utils/account.utils';
 import { AccountIdentifier } from '@dfinity/ledger-icp';
 import type { Principal } from '@dfinity/principal';
 
 export const getAccountIdentifier = (principal: Principal): AccountIdentifier =>
 	AccountIdentifier.fromPrincipal({ principal, subAccount: undefined });
-
-export const invalidIcpAddress = (address: string | undefined): boolean =>
-	!isIcpAccountIdentifier(address);

--- a/src/frontend/src/lib/utils/account.utils.ts
+++ b/src/frontend/src/lib/utils/account.utils.ts
@@ -24,3 +24,6 @@ export const isEthAddress = (address: string | undefined): boolean => {
 
 	return isAddress(address);
 };
+
+export const invalidIcpAddress = (address: string | undefined): boolean =>
+	!isIcpAccountIdentifier(address);


### PR DESCRIPTION
# Motivation

Since it is being used both by ETH and ICP components/functions, we move `invalidIcpAddress` to folder `lib`. This is the same practice that other functions in the same module have: for example `isEthAddress` is used both by ETH and ICP modules.


As side effect of this, we have one less possible loop dependency inside `icp` folder.
