### PR TITLE
feat(frontend): update network-tokens to enabled tokens balance

### DIFF
--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -2,7 +2,7 @@
 	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { debounce } from '@dfinity/utils';
-	import { enabledErc20NetworkTokens } from '$lib/derived/network-tokens.derived';
+	import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
 
 	const load = async () => {
 		await Promise.allSettled([
@@ -10,14 +10,14 @@
 			loadBalances(),
 			loadErc20Balances({
 				address: $ethAddress,
-				erc20Tokens: $enabledErc20NetworkTokens
+				erc20Tokens: $enabledErc20Tokens
 			})
 		]);
 	};
 
 	const debounceLoad = debounce(load, 500);
 
-	$: $ethAddress, $enabledErc20NetworkTokens, debounceLoad();
+	$: $ethAddress, $enabledErc20Tokens, debounceLoad();
 </script>
 
 <slot />

--- a/src/frontend/src/icp/components/core/IcLoaderWallets.svelte
+++ b/src/frontend/src/icp/components/core/IcLoaderWallets.svelte
@@ -4,25 +4,25 @@
 	import type { IcToken } from '$icp/types/ic';
 	import type { WalletWorker } from '$icp/types/ic-listener';
 	import { cleanWorkers, loadWorker } from '$icp/utils/ic-wallet.utils';
-	import { enabledIcNetworkTokens } from '$lib/derived/network-tokens.derived';
+	import { enabledIcTokens } from '$lib/derived/tokens.derived';
 	import type { TokenId } from '$lib/types/token';
 
 	const workers: Map<TokenId, WalletWorker> = new Map<TokenId, WalletWorker>();
 
 	const manageWorkers = async () => {
-		cleanWorkers({ workers, tokens: $enabledIcNetworkTokens });
+		cleanWorkers({ workers, tokens: $enabledIcTokens });
 
 		await Promise.allSettled(
-			$enabledIcNetworkTokens.map(async (token: IcToken) => await loadWorker({ workers, token }))
+			$enabledIcTokens.map(async (token: IcToken) => await loadWorker({ workers, token }))
 		);
 	};
 
 	const debounceManageWorkers = debounce(manageWorkers, 500);
 
 	// TODO: here we debounce the manageWorkers function to avoid multiple calls in a short period
-	//  of time due to the several dependencies of enabledIcNetworkTokens, that are not strictly only IC tokens.
+	//  of time due to the several dependencies of enabledIcTokens, that are not strictly only IC tokens.
 	//  This is a temporary solution, and we should find a better way to handle this, improving the store.
-	$: $enabledIcNetworkTokens, debounceManageWorkers();
+	$: $enabledIcTokens, debounceManageWorkers();
 
 	onDestroy(() => {
 		workers.forEach((worker) => worker.stop());

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -7,40 +7,32 @@ import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import {
-	filterEnabledNetworkTokens,
+	filterEnabledTokens,
 	pinTokensWithBalanceAtTop,
 	sortTokens
 } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
+ * All enabled by user tokens.
+ */
+const enabledTokens: Readable<Token[]> = derived([tokens], filterEnabledTokens);
+
+/**
  * All tokens matching the selected network or chain fusion, regardless if they are enabled by the user or not.
  */
-const selectedNetworkTokens: Readable<Token[]> = derived(
-	[tokens, selectedNetwork, pseudoNetworkChainFusion],
+const enabledNetworkTokens: Readable<Token[]> = derived(
+	[enabledTokens, selectedNetwork, pseudoNetworkChainFusion],
 	filterTokensForSelectedNetwork
-);
-
-/**
- * All enabled network tokens, regardless if they are selected by the user or not.
- */
-const enabledNetworkTokens: Readable<Token[]> = derived([tokens], filterEnabledNetworkTokens);
-
-/**
- * All enabled network tokens that matching the selected network or chain fusion and are enabled by user
- */
-const enabledSelectedNetworkTokens: Readable<Token[]> = derived(
-	[selectedNetworkTokens],
-	filterEnabledNetworkTokens
 );
 
 /**
  * It isn't performant to post filter again the Erc20 tokens that are enabled but, it's code wise convenient to avoid duplication of logic.
  */
 export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
-	[enabledNetworkTokens],
-	([$enabledNetworkTokens]) =>
-		$enabledNetworkTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
+	[enabledTokens],
+	([$enabledTokens]) =>
+		$enabledTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
 );
 
 /**
@@ -49,18 +41,16 @@ export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
 // TODO: The several dependencies of enabledIcNetworkTokens are not strictly only IC tokens, but other tokens too.
 //  We should find a better way to handle this, improving the store.
 export const enabledIcNetworkTokens: Readable<IcToken[]> = derived(
-	[enabledNetworkTokens],
-	([$enabledNetworkTokens]) =>
-		$enabledNetworkTokens.filter(
-			({ standard }) => standard === 'icp' || standard === 'icrc'
-		) as IcToken[]
+	[enabledTokens],
+	([$enabledTokens]) =>
+		$enabledTokens.filter(({ standard }) => standard === 'icp' || standard === 'icrc') as IcToken[]
 );
 
 /**
  * Network tokens sorted by market cap, with the ones to pin at the top of the list.
  */
 export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
-	[enabledSelectedNetworkTokens, tokensToPin, exchanges],
+	[enabledNetworkTokens, tokensToPin, exchanges],
 	([$tokens, $tokensToPin, $exchanges]) => sortTokens({ $tokens, $exchanges, $tokensToPin })
 );
 

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -2,24 +2,15 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { IcToken } from '$icp/types/ic';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
-import { tokens, tokensToPin } from '$lib/derived/tokens.derived';
+import { enabledTokens, tokensToPin } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-import {
-	filterEnabledTokens,
-	pinTokensWithBalanceAtTop,
-	sortTokens
-} from '$lib/utils/tokens.utils';
+import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
- * All enabled by user tokens.
- */
-const enabledTokens: Readable<Token[]> = derived([tokens], filterEnabledTokens);
-
-/**
- * All tokens matching the selected network or chain fusion, regardless if they are enabled by the user or not.
+ * All user-enabled tokens matching the selected network or chain fusion.
  */
 const enabledNetworkTokens: Readable<Token[]> = derived(
 	[enabledTokens, selectedNetwork, pseudoNetworkChainFusion],
@@ -27,7 +18,7 @@ const enabledNetworkTokens: Readable<Token[]> = derived(
 );
 
 /**
- * It isn't performant to post filter again the Erc20 tokens that are enabled but, it's code wise convenient to avoid duplication of logic.
+ * It isn't performant to post filter again the Erc20 tokens that are enabled but it's code wise convenient to avoid duplication of logic.
  */
 export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
 	[enabledTokens],

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,5 +1,3 @@
-import type { Erc20Token } from '$eth/types/erc20';
-import type { IcToken } from '$icp/types/ic';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 import { enabledTokens, tokensToPin } from '$lib/derived/tokens.derived';
@@ -15,26 +13,6 @@ import { derived, type Readable } from 'svelte/store';
 const enabledNetworkTokens: Readable<Token[]> = derived(
 	[enabledTokens, selectedNetwork, pseudoNetworkChainFusion],
 	filterTokensForSelectedNetwork
-);
-
-/**
- * It isn't performant to post filter again the Erc20 tokens that are enabled but it's code wise convenient to avoid duplication of logic.
- */
-export const enabledErc20NetworkTokens: Readable<Erc20Token[]> = derived(
-	[enabledTokens],
-	([$enabledTokens]) =>
-		$enabledTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
-);
-
-/**
- * The following store is use as reference for the list of WalletWorkers that are started/stopped in the main token page.
- */
-// TODO: The several dependencies of enabledIcNetworkTokens are not strictly only IC tokens, but other tokens too.
-//  We should find a better way to handle this, improving the store.
-export const enabledIcNetworkTokens: Readable<IcToken[]> = derived(
-	[enabledTokens],
-	([$enabledTokens]) =>
-		$enabledTokens.filter(({ standard }) => standard === 'icp' || standard === 'icrc') as IcToken[]
 );
 
 /**

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -5,6 +5,7 @@ import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { Token, TokenToPin } from '$lib/types/token';
+import { filterEnabledTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const tokens: Readable<Token[]> = derived(
@@ -27,3 +28,8 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 		...$icrcChainFusionDefaultTokens
 	]
 );
+
+/**
+ * All user-enabled tokens.
+ */
+export const enabledTokens: Readable<Token[]> = derived([tokens], filterEnabledTokens);

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -48,7 +48,7 @@ export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
 /**
  * The following store is use as reference for the list of WalletWorkers that are started/stopped in the main token page.
  */
-// TODO: The several dependencies of enabledIcNetworkTokens are not strictly only IC tokens, but other tokens too.
+// TODO: The several dependencies of enabledIcTokens are not strictly only IC tokens, but other tokens too.
 //  We should find a better way to handle this, improving the store.
 export const enabledIcTokens: Readable<IcToken[]> = derived(
 	[enabledTokens],

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -3,7 +3,9 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
+import type { Erc20Token } from '$eth/types/erc20';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
+import type { IcToken } from '$icp/types/ic';
 import type { Token, TokenToPin } from '$lib/types/token';
 import { filterEnabledTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
@@ -33,3 +35,23 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
  * All user-enabled tokens.
  */
 export const enabledTokens: Readable<Token[]> = derived([tokens], filterEnabledTokens);
+
+/**
+ * It isn't performant to post filter again the Erc20 tokens that are enabled, but it's code wise convenient to avoid duplication of logic.
+ */
+export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
+	[enabledTokens],
+	([$enabledTokens]) =>
+		$enabledTokens.filter(({ standard }) => standard === 'erc20') as Erc20Token[]
+);
+
+/**
+ * The following store is use as reference for the list of WalletWorkers that are started/stopped in the main token page.
+ */
+// TODO: The several dependencies of enabledIcNetworkTokens are not strictly only IC tokens, but other tokens too.
+//  We should find a better way to handle this, improving the store.
+export const enabledIcTokens: Readable<IcToken[]> = derived(
+	[enabledTokens],
+	([$enabledTokens]) =>
+		$enabledTokens.filter(({ standard }) => standard === 'icp' || standard === 'icrc') as IcToken[]
+);

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -125,3 +125,12 @@ export const pinTokensWithBalanceAtTop = ({
  */
 export const sumTokensUsdBalance = (tokens: TokenUi[]): number =>
 	tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);
+
+/**
+ * Filters and returns a list of "enabled" by user network tokens
+ *
+ * @param $tokens - The list of network tokens.
+ * @returns The list of "enabled" network tokens.
+ */
+export const filterEnabledNetworkTokens = ([$tokens]: [$tokens: Token[]]): Token[] =>
+	$tokens.filter((token) => ('enabled' in token ? token.enabled : true));

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -127,10 +127,10 @@ export const sumTokensUsdBalance = (tokens: TokenUi[]): number =>
 	tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);
 
 /**
- * Filters and returns a list of "enabled" by user network tokens
+ * Filters and returns a list of "enabled" by user tokens
  *
- * @param $tokens - The list of network tokens.
- * @returns The list of "enabled" network tokens.
+ * @param $tokens - The list of tokens.
+ * @returns The list of "enabled" tokens.
  */
-export const filterEnabledNetworkTokens = ([$tokens]: [$tokens: Token[]]): Token[] =>
+export const filterEnabledTokens = ([$tokens]: [$tokens: Token[]]): Token[] =>
 	$tokens.filter((token) => ('enabled' in token ? token.enabled : true));

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -7,7 +7,7 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
-	filterEnabledNetworkTokens,
+	filterEnabledTokens,
 	pinTokensWithBalanceAtTop,
 	sortTokens,
 	sumTokensUsdBalance
@@ -311,8 +311,8 @@ describe('sumTokensTotalUsdBalance', () => {
 	});
 });
 
-describe('filterEnabledNetworkTokens', () => {
-	it('should correctly return filtered network tokens when all tokens have "enabled" property', () => {
+describe('filterEnabledTokens', () => {
+	it('should correctly return filtered tokens when all tokens have "enabled" property', () => {
 		const ENABLED_ICP_TOKEN = { ...ICP_TOKEN, enabled: true };
 		const ENABLED_ETHEREUM_TOKEN = { ...ENABLED_ICP_TOKEN, enabled: true };
 
@@ -322,11 +322,11 @@ describe('filterEnabledNetworkTokens', () => {
 			{ ...BTC_MAINNET_TOKEN, enabled: false }
 		];
 
-		const result = filterEnabledNetworkTokens([tokens]);
+		const result = filterEnabledTokens([tokens]);
 		expect(result).toEqual([ENABLED_ICP_TOKEN, ENABLED_ETHEREUM_TOKEN]);
 	});
 
-	it('should correctly return filtered network tokens when not all tokens have "enabled" property', () => {
+	it('should correctly return filtered tokens when not all tokens have "enabled" property', () => {
 		const ENABLED_BY_DEFAULT_ICP_TOKEN = ICP_TOKEN;
 		const ENABLED_BY_DEFAULT_ETHEREUM_TOKEN = ETHEREUM_TOKEN;
 
@@ -336,7 +336,7 @@ describe('filterEnabledNetworkTokens', () => {
 			{ ...BTC_MAINNET_TOKEN, enabled: false }
 		];
 
-		const result = filterEnabledNetworkTokens([tokens]);
+		const result = filterEnabledTokens([tokens]);
 		expect(result).toEqual([ENABLED_BY_DEFAULT_ICP_TOKEN, ENABLED_BY_DEFAULT_ETHEREUM_TOKEN]);
 	});
 });

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -7,6 +7,7 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
+	filterEnabledNetworkTokens,
 	pinTokensWithBalanceAtTop,
 	sortTokens,
 	sumTokensUsdBalance
@@ -307,5 +308,35 @@ describe('sumTokensTotalUsdBalance', () => {
 	it('should correctly calculate USD total balance when tokens list is empty', () => {
 		const result = sumTokensUsdBalance([]);
 		expect(result).toEqual(0);
+	});
+});
+
+describe('filterEnabledNetworkTokens', () => {
+	it('should correctly return filtered network tokens when all tokens have "enabled" property', () => {
+		const ENABLED_ICP_TOKEN = { ...ICP_TOKEN, enabled: true };
+		const ENABLED_ETHEREUM_TOKEN = { ...ENABLED_ICP_TOKEN, enabled: true };
+
+		const tokens: (Token & { enabled?: boolean })[] = [
+			ENABLED_ICP_TOKEN,
+			ENABLED_ETHEREUM_TOKEN,
+			{ ...BTC_MAINNET_TOKEN, enabled: false }
+		];
+
+		const result = filterEnabledNetworkTokens([tokens]);
+		expect(result).toEqual([ENABLED_ICP_TOKEN, ENABLED_ETHEREUM_TOKEN]);
+	});
+
+	it('should correctly return filtered network tokens when not all tokens have "enabled" property', () => {
+		const ENABLED_BY_DEFAULT_ICP_TOKEN = ICP_TOKEN;
+		const ENABLED_BY_DEFAULT_ETHEREUM_TOKEN = ETHEREUM_TOKEN;
+
+		const tokens: (Token & { enabled?: boolean })[] = [
+			ENABLED_BY_DEFAULT_ICP_TOKEN,
+			ENABLED_BY_DEFAULT_ETHEREUM_TOKEN,
+			{ ...BTC_MAINNET_TOKEN, enabled: false }
+		];
+
+		const result = filterEnabledNetworkTokens([tokens]);
+		expect(result).toEqual([ENABLED_BY_DEFAULT_ICP_TOKEN, ENABLED_BY_DEFAULT_ETHEREUM_TOKEN]);
 	});
 });


### PR DESCRIPTION
# Motivation

Step 3 of updating the chain selector with aggregate USD balance values: adjust `network-tokens.derived` to load enabled tokens balance regardless if a network selected by user or not. We discussed with @AntonioVentilii-DFINITY the performance aspect of this change, and since it will be basically the amount of data loaded (and hence time needed to load it) as if we were in Chain Fusion, it should not affect the user experience and performance. 