### PR TITLE
refactor(frontend): Remove token global store in Hero

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -6,7 +6,9 @@
 	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
 	import Alpha from '$lib/components/core/Alpha.svelte';
 	import ThreeBackground from '$lib/components/ui/ThreeBackground.svelte';
+	import type { OptionToken } from '$lib/types/token';
 
+	export let token: OptionToken;
 	export let usdTotal = false;
 	export let summary = false;
 	export let actions = true;
@@ -34,7 +36,7 @@
 		<Alpha />
 
 		{#if $authSignedIn}
-			<HeroContent {usdTotal} {summary} {actions} {more} />
+			<HeroContent {token} {usdTotal} {summary} {actions} {more} />
 		{:else if heroContent}
 			<HeroSignIn />
 		{/if}

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -10,9 +10,10 @@
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { token } from '$lib/stores/token.store';
 	import Actions from '$lib/components/hero/Actions.svelte';
+	import type { OptionToken } from '$lib/types/token';
 
+	export let token: OptionToken;
 	export let usdTotal = false;
 	export let summary = false;
 	export let actions = true;
@@ -28,9 +29,9 @@
 			{#if displayTokenSymbol}
 				<div in:fade>
 					<Logo
-						src={$token?.icon}
+						src={token?.icon}
 						size="big"
-						alt={replacePlaceholders($i18n.core.alt.logo, { $name: $token?.name ?? '' })}
+						alt={replacePlaceholders($i18n.core.alt.logo, { $name: token?.name ?? '' })}
 						color="off-white"
 					/>
 				</div>
@@ -58,7 +59,7 @@
 	</div>
 {/if}
 
-{#if isErc20Icp($token)}
+{#if isErc20Icp(token)}
 	<Erc20Icp />
 {/if}
 

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -24,6 +24,7 @@
 </script>
 
 <Hero
+	token={$pageToken}
 	usdTotal={route === 'tokens'}
 	summary={route === 'transactions'}
 	more={route === 'transactions'}


### PR DESCRIPTION
# Motivation

There is a global store `token` that is deprecated.

In this PR, I remove the usage of this store in the `HeroContent` code path starting from the layout.

# Changes

* Add a prop `token` to `Hero` and `HeroContent` and use it instead of relying in the global store `token`.

# Tests

I tested that everything is still working as expected.
