### PR TITLE
chore(prettier): add "prettier-plugin-tailwindcss"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte", "prettier-plugin-organize-imports"],
+	"plugins": ["prettier-plugin-svelte", "prettier-plugin-organize-imports", "prettier-plugin-tailwindcss"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
 				"prettier": "^3.3.3",
 				"prettier-plugin-organize-imports": "^4.0.0",
 				"prettier-plugin-svelte": "^3.2.6",
+				"prettier-plugin-tailwindcss": "^0.6.6",
 				"sass": "^1.77.8",
 				"svelte": "^4.2.19",
 				"svelte-check": "^4.0.2",
@@ -9026,6 +9027,85 @@
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+			}
+		},
+		"node_modules/prettier-plugin-tailwindcss": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.6.tgz",
+			"integrity": "sha512-OPva5S7WAsPLEsOuOWXATi13QrCKACCiIonFgIR6V4lYv4QLp++UXVhZSzRbZxXGimkQtQT86CC6fQqTOybGng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"peerDependencies": {
+				"@ianvs/prettier-plugin-sort-imports": "*",
+				"@prettier/plugin-pug": "*",
+				"@shopify/prettier-plugin-liquid": "*",
+				"@trivago/prettier-plugin-sort-imports": "*",
+				"@zackad/prettier-plugin-twig-melody": "*",
+				"prettier": "^3.0",
+				"prettier-plugin-astro": "*",
+				"prettier-plugin-css-order": "*",
+				"prettier-plugin-import-sort": "*",
+				"prettier-plugin-jsdoc": "*",
+				"prettier-plugin-marko": "*",
+				"prettier-plugin-multiline-arrays": "*",
+				"prettier-plugin-organize-attributes": "*",
+				"prettier-plugin-organize-imports": "*",
+				"prettier-plugin-sort-imports": "*",
+				"prettier-plugin-style-order": "*",
+				"prettier-plugin-svelte": "*"
+			},
+			"peerDependenciesMeta": {
+				"@ianvs/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@prettier/plugin-pug": {
+					"optional": true
+				},
+				"@shopify/prettier-plugin-liquid": {
+					"optional": true
+				},
+				"@trivago/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@zackad/prettier-plugin-twig-melody": {
+					"optional": true
+				},
+				"prettier-plugin-astro": {
+					"optional": true
+				},
+				"prettier-plugin-css-order": {
+					"optional": true
+				},
+				"prettier-plugin-import-sort": {
+					"optional": true
+				},
+				"prettier-plugin-jsdoc": {
+					"optional": true
+				},
+				"prettier-plugin-marko": {
+					"optional": true
+				},
+				"prettier-plugin-multiline-arrays": {
+					"optional": true
+				},
+				"prettier-plugin-organize-attributes": {
+					"optional": true
+				},
+				"prettier-plugin-organize-imports": {
+					"optional": true
+				},
+				"prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"prettier-plugin-style-order": {
+					"optional": true
+				},
+				"prettier-plugin-svelte": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/process-warning": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 		"prettier": "^3.3.3",
 		"prettier-plugin-organize-imports": "^4.0.0",
 		"prettier-plugin-svelte": "^3.2.6",
+		"prettier-plugin-tailwindcss": "^0.6.6",
 		"sass": "^1.77.8",
 		"svelte": "^4.2.19",
 		"svelte-check": "^4.0.2",

--- a/src/frontend/src/lib/components/ui/Card.svelte
+++ b/src/frontend/src/lib/components/ui/Card.svelte
@@ -14,8 +14,8 @@
 <div class="flex items-center gap-4" class:mb-6={!noMargin}>
 	<slot name="icon" />
 
-	<div class="flex-1 flex flex-col justify-center">
-		<div class="flex font-bold gap-1 leading-5" class:items-center={!description}>
+	<div class="flex flex-1 flex-col justify-center">
+		<div class="flex gap-1 font-bold leading-5" class:items-center={!description}>
 			<span
 				class="clamp-4 inline-flex items-center text-left"
 				style={amount ? 'max-width: 60%' : undefined}><slot /></span
@@ -25,7 +25,7 @@
 				<CardAmount><slot name="amount" /></CardAmount>
 			{/if}
 		</div>
-		<p class="text-misty-rose text-left inline-flex items-center">
+		<p class="inline-flex items-center text-left text-misty-rose">
 			<slot name="description" />
 		</p>
 	</div>


### PR DESCRIPTION
# Motivation

I'm not sure if this has already been decided against, but I would like to suggest using `prettier-plugin-tailwindcss` to keep Tailwind class names organized in a consistent order. The plugin also removes duplicate classes, unexpected whitespace, etc. You can find the detailed documentation [here](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).

I've prettified the `Card` component as an example of what the plugin does.

If we decide to use it, I can apply it to all components. My only concern is that most of the pending PRs with UI changes might get merge conflicts.

@peterpeterparker @AntonioVentilii-DFINITY WDYT?

