### PR TITLE
feat(btc): add Btc Regtest network and token

### DIFF
--- a/src/frontend/src/btc/derived/networks.derived.ts
+++ b/src/frontend/src/btc/derived/networks.derived.ts
@@ -1,5 +1,6 @@
 import { BTC_MAINNET_ENABLED, NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
 import { BTC_MAINNET_NETWORK, BTC_REGTEST_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
+import { LOCAL } from '$lib/constants/app.constants';
 import { testnets } from '$lib/derived/testnets.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
@@ -8,7 +9,7 @@ export const enabledBitcoinNetworks: Readable<Network[]> = derived([testnets], (
 	NETWORK_BITCOIN_ENABLED
 		? [
 				...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
-				...($testnets ? [BTC_TESTNET_NETWORK, BTC_REGTEST_NETWORK] : [])
+				...($testnets ? [BTC_TESTNET_NETWORK, ...(LOCAL ? [BTC_REGTEST_NETWORK] : [])] : [])
 			]
 		: []
 );

--- a/src/frontend/src/btc/derived/networks.derived.ts
+++ b/src/frontend/src/btc/derived/networks.derived.ts
@@ -1,5 +1,5 @@
 import { BTC_MAINNET_ENABLED, NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
-import { BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
+import { BTC_MAINNET_NETWORK, BTC_REGTEST_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
 import { testnets } from '$lib/derived/testnets.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
@@ -8,7 +8,7 @@ export const enabledBitcoinNetworks: Readable<Network[]> = derived([testnets], (
 	NETWORK_BITCOIN_ENABLED
 		? [
 				...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
-				...($testnets ? [BTC_TESTNET_NETWORK] : [])
+				...($testnets ? [BTC_TESTNET_NETWORK, BTC_REGTEST_NETWORK] : [])
 			]
 		: []
 );

--- a/src/frontend/src/btc/derived/tokens.derived.ts
+++ b/src/frontend/src/btc/derived/tokens.derived.ts
@@ -1,5 +1,6 @@
 import { BTC_MAINNET_ENABLED, NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
 import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
+import { LOCAL } from '$lib/constants/app.constants';
 import { testnets } from '$lib/derived/testnets.derived';
 import type { Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
@@ -8,7 +9,7 @@ export const enabledBitcoinTokens: Readable<Token[]> = derived([testnets], ([$te
 	NETWORK_BITCOIN_ENABLED
 		? [
 				...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
-				...($testnets ? [BTC_TESTNET_TOKEN, BTC_REGTEST_TOKEN] : [])
+				...($testnets ? [BTC_TESTNET_TOKEN, ...(LOCAL ? [BTC_REGTEST_TOKEN] : [])] : [])
 			]
 		: []
 );

--- a/src/frontend/src/btc/derived/tokens.derived.ts
+++ b/src/frontend/src/btc/derived/tokens.derived.ts
@@ -1,5 +1,5 @@
 import { BTC_MAINNET_ENABLED, NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
-import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
+import { BTC_MAINNET_TOKEN, BTC_REGSTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 import { testnets } from '$lib/derived/testnets.derived';
 import type { Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
@@ -8,7 +8,7 @@ export const enabledBitcoinTokens: Readable<Token[]> = derived([testnets], ([$te
 	NETWORK_BITCOIN_ENABLED
 		? [
 				...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
-				...($testnets ? [BTC_TESTNET_TOKEN] : [])
+				...($testnets ? [BTC_TESTNET_TOKEN, BTC_REGSTEST_TOKEN] : [])
 			]
 		: []
 );

--- a/src/frontend/src/btc/derived/tokens.derived.ts
+++ b/src/frontend/src/btc/derived/tokens.derived.ts
@@ -1,5 +1,5 @@
 import { BTC_MAINNET_ENABLED, NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
-import { BTC_MAINNET_TOKEN, BTC_REGSTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
+import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 import { testnets } from '$lib/derived/testnets.derived';
 import type { Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
@@ -8,7 +8,7 @@ export const enabledBitcoinTokens: Readable<Token[]> = derived([testnets], ([$te
 	NETWORK_BITCOIN_ENABLED
 		? [
 				...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
-				...($testnets ? [BTC_TESTNET_TOKEN, BTC_REGSTEST_TOKEN] : [])
+				...($testnets ? [BTC_TESTNET_TOKEN, BTC_REGTEST_TOKEN] : [])
 			]
 		: []
 );

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -6,6 +6,7 @@ import eth from '$icp-eth/assets/eth.svg';
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import icpLight from '$icp/assets/icp_light.svg';
+import { LOCAL } from '$lib/constants/app.constants';
 import type { Network } from '$lib/types/network';
 
 /**
@@ -104,14 +105,13 @@ export const BTC_REGTEST_NETWORK_ID = Symbol(BTC_REGTEST_NETWORK_SYMBOL);
 export const BTC_REGTEST_NETWORK: Network = {
 	id: BTC_REGTEST_NETWORK_ID,
 	env: 'testnet',
-	name: 'Bitcoin (Regtest)',
-	icon: bitcoinTestnet
+	name: 'Bitcoin (Regtest)'
 };
 
 export const BITCOIN_NETWORKS: Network[] = [
 	BTC_MAINNET_NETWORK,
 	BTC_TESTNET_NETWORK,
-	BTC_REGTEST_NETWORK
+	...(LOCAL ? [BTC_REGTEST_NETWORK] : [])
 ];
 
 export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -97,6 +97,21 @@ export const BTC_TESTNET_NETWORK: Network = {
 	icon: bitcoinTestnet
 };
 
-export const BITCOIN_NETWORKS: Network[] = [BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK];
+export const BTC_REGTEST_NETWORK_SYMBOL = 'BTC (Regtest)';
+
+export const BTC_REGTEST_NETWORK_ID = Symbol(BTC_REGTEST_NETWORK_SYMBOL);
+
+export const BTC_REGTEST_NETWORK: Network = {
+	id: BTC_REGTEST_NETWORK_ID,
+	env: 'testnet',
+	name: 'Bitcoin (Regtest)',
+	icon: bitcoinTestnet
+};
+
+export const BITCOIN_NETWORKS: Network[] = [
+	BTC_MAINNET_NETWORK,
+	BTC_TESTNET_NETWORK,
+	BTC_REGTEST_NETWORK
+];
 
 export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -46,5 +46,6 @@ export const BTC_REGTEST_TOKEN: Token = {
 	category: 'default',
 	name: 'Bitcoin (Regtest)',
 	symbol: BTC_REGTEST_SYMBOL,
-	decimals: BTC_DECIMALS
+	decimals: BTC_DECIMALS,
+	icon: bitcoinTestnet
 };

--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -46,6 +46,5 @@ export const BTC_REGTEST_TOKEN: Token = {
 	category: 'default',
 	name: 'Bitcoin (Regtest)',
 	symbol: BTC_REGTEST_SYMBOL,
-	decimals: BTC_DECIMALS,
-	icon: bitcoinTestnet
+	decimals: BTC_DECIMALS
 };

--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -1,4 +1,4 @@
-import { BTC_MAINNET_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
+import { BTC_MAINNET_NETWORK, BTC_REGTEST_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import type { Token } from '$lib/types/token';
@@ -15,7 +15,7 @@ export const BTC_MAINNET_TOKEN: Token = {
 	standard: 'bitcoin',
 	category: 'default',
 	name: 'Bitcoin',
-	symbol: 'BTC',
+	symbol: BTC_MAINNET_SYMBOL,
 	decimals: BTC_DECIMALS,
 	icon: bitcoin
 };
@@ -30,7 +30,22 @@ export const BTC_TESTNET_TOKEN: Token = {
 	standard: 'bitcoin',
 	category: 'default',
 	name: 'Bitcoin (Testnet)',
-	symbol: 'BTC (Testnet)',
+	symbol: BTC_TESTNET_SYMBOL,
+	decimals: BTC_DECIMALS,
+	icon: bitcoinTestnet
+};
+
+export const BTC_REGSTEST_SYMBOL = 'BTC (Regtest)';
+
+export const BTC_REGSTEST_TOKEN_ID: unique symbol = Symbol(BTC_REGSTEST_SYMBOL);
+
+export const BTC_REGSTEST_TOKEN: Token = {
+	id: BTC_REGSTEST_TOKEN_ID,
+	network: BTC_REGTEST_NETWORK,
+	standard: 'bitcoin',
+	category: 'default',
+	name: 'Bitcoin (Regtest)',
+	symbol: BTC_REGSTEST_SYMBOL,
 	decimals: BTC_DECIMALS,
 	icon: bitcoinTestnet
 };

--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -35,17 +35,17 @@ export const BTC_TESTNET_TOKEN: Token = {
 	icon: bitcoinTestnet
 };
 
-export const BTC_REGSTEST_SYMBOL = 'BTC (Regtest)';
+export const BTC_REGTEST_SYMBOL = 'BTC (Regtest)';
 
-export const BTC_REGSTEST_TOKEN_ID: unique symbol = Symbol(BTC_REGSTEST_SYMBOL);
+export const BTC_REGTEST_TOKEN_ID: unique symbol = Symbol(BTC_REGTEST_SYMBOL);
 
-export const BTC_REGSTEST_TOKEN: Token = {
-	id: BTC_REGSTEST_TOKEN_ID,
+export const BTC_REGTEST_TOKEN: Token = {
+	id: BTC_REGTEST_TOKEN_ID,
 	network: BTC_REGTEST_NETWORK,
 	standard: 'bitcoin',
 	category: 'default',
 	name: 'Bitcoin (Regtest)',
-	symbol: BTC_REGSTEST_SYMBOL,
+	symbol: BTC_REGTEST_SYMBOL,
 	decimals: BTC_DECIMALS,
 	icon: bitcoinTestnet
 };


### PR DESCRIPTION
# Motivation

The goal is to create a new test network and token (`BTC (Regtest` / `Bitcoin (Regtest)`) that are gonna be used for local BTC development.
