### PR TITLE
feat(frontend): calculate and display tokens total USD values

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -2,10 +2,10 @@
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { exchangeInitialized } from '$lib/derived/exchange.derived';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
-	import { sumTokensUsdBalance } from '$lib/utils/tokens.utils';
+	import { sumTokensUiUsdBalance } from '$lib/utils/tokens.utils';
 
 	let totalUsd: number;
-	$: totalUsd = sumTokensUsdBalance($combinedDerivedSortedNetworkTokensUi);
+	$: totalUsd = sumTokensUiUsdBalance($combinedDerivedSortedNetworkTokensUi);
 </script>
 
 <span class="text-off-white block">

--- a/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
+++ b/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { Network } from '$lib/types/network';
+	import NetworkComponent from '$lib/components/networks/Network.svelte';
+	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
+	import {
+		enabledMainnetIcTokensTotalUsd,
+		enabledMainnetErc20TokensTotalUsd
+	} from '$lib/derived/tokens.derived';
+
+	export let network: Network;
+
+	let totalUsd: number | undefined;
+	$: totalUsd = isNetworkIdICP(network.id)
+		? $enabledMainnetIcTokensTotalUsd
+		: isNetworkIdEthereum(network.id)
+			? $enabledMainnetErc20TokensTotalUsd
+			: undefined;
+</script>
+
+<NetworkComponent {network} {totalUsd} on:icSelected />

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -3,6 +3,7 @@
 	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
 
 	export let network: Network;
+	export let totalUsd: number | undefined = undefined;
 
 	let id: NetworkId;
 	let name: string;
@@ -10,4 +11,4 @@
 	$: ({ id, name, icon } = network);
 </script>
 
-<NetworkButton {id} {name} {icon} on:icSelected />
+<NetworkButton {id} {name} {icon} {totalUsd} on:icSelected />

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -4,14 +4,16 @@
 	import { fade } from 'svelte/transition';
 	import type { NetworkId } from '$lib/types/network';
 	import { networkId } from '$lib/derived/network.derived';
+	import { formatUSD } from '$lib/utils/format.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
 	import { page } from '$app/stores';
 	import TextWithLogo from '$lib/components/ui/TextWithLogo.svelte';
+	import { nonNullish } from '@dfinity/utils';
 
 	export let id: NetworkId | undefined;
 	export let name: string;
 	export let icon: string | undefined;
-	export let description: string | undefined = undefined;
+	export let totalUsd: number | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -28,7 +30,12 @@
 </script>
 
 <button class="w-full flex justify-between" on:click={onClick}>
-	<TextWithLogo {name} {description} {icon} logo="start" />
+	<TextWithLogo
+		{name}
+		{icon}
+		logo="start"
+		description={nonNullish(totalUsd) ? formatUSD(totalUsd) : undefined}
+	/>
 
 	{#if id === $networkId}
 		<span in:fade><IconCheck size="20px" /></span>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -13,6 +13,8 @@
 	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
 	import chainFusion from '$lib/assets/chain_fusion.svg';
 	import ButtonSwitcher from '$lib/components/ui/ButtonSwitcher.svelte';
+	import { enabledMainnetTokensTotalUsd } from '$lib/derived/tokens.derived';
+	import MainnetNetwork from '$lib/components/networks/MainnetNetwork.svelte';
 
 	export let disabled = false;
 
@@ -23,6 +25,9 @@
 
 	let testnets: boolean;
 	$: testnets = $testnetsStore?.enabled ?? false;
+
+	let mainnetTokensTotalUsd: number;
+	$: mainnetTokensTotalUsd = $enabledMainnetTokensTotalUsd;
 </script>
 
 <ButtonSwitcher
@@ -40,13 +45,14 @@
 				id={undefined}
 				name={$i18n.networks.chain_fusion}
 				icon={chainFusion}
+				totalUsd={mainnetTokensTotalUsd}
 				on:icSelected={close}
 			/>
 		</li>
 
 		{#each $networksMainnets as network}
 			<li>
-				<Network {network} on:icSelected={close} />
+				<MainnetNetwork {network} on:icSelected={close} />
 			</li>
 		{/each}
 	</ul>

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -6,8 +6,10 @@ import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { Erc20Token } from '$eth/types/erc20';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcToken } from '$icp/types/ic';
+import { exchanges } from '$lib/derived/exchange.derived';
+import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenToPin } from '$lib/types/token';
-import { filterEnabledTokens } from '$lib/utils/tokens.utils';
+import { filterEnabledTokens, sumMainnetTokensUsdBalance } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const tokens: Readable<Token[]> = derived(
@@ -54,4 +56,21 @@ export const enabledIcTokens: Readable<IcToken[]> = derived(
 	[enabledTokens],
 	([$enabledTokens]) =>
 		$enabledTokens.filter(({ standard }) => standard === 'icp' || standard === 'icrc') as IcToken[]
+);
+
+export const enabledMainnetErc20TokensTotalUsd: Readable<number> = derived(
+	[enabledErc20Tokens, balancesStore, exchanges],
+	([$enabledErc20Tokens, $balances, $exchanges]) =>
+		sumMainnetTokensUsdBalance({ $tokens: $enabledErc20Tokens, $balances, $exchanges })
+);
+
+export const enabledMainnetIcTokensTotalUsd: Readable<number> = derived(
+	[enabledIcTokens, balancesStore, exchanges],
+	([$enabledIcTokens, $balances, $exchanges]) =>
+		sumMainnetTokensUsdBalance({ $tokens: $enabledIcTokens, $balances, $exchanges })
+);
+
+export const enabledMainnetTokensTotalUsd: Readable<number> = derived(
+	[enabledMainnetErc20TokensTotalUsd, enabledMainnetIcTokensTotalUsd],
+	([$erc20TokensTotalUsd, $icTokensTotalUsd]) => $erc20TokensTotalUsd + $icTokensTotalUsd
 );


### PR DESCRIPTION
# Motivation

Step 4 of updating the chain selector with aggregate USD balance values: calculate and display total USD values for Chain Fusion and all other Mainnet networks.

<img width="300" alt="Screenshot 2024-09-05 at 18 09 12" src="https://github.com/user-attachments/assets/84e32888-c0f6-492b-b49e-69f007d142e2">

