### PR TITLE
refactor(frontend): remove redundant dependency from network filter util

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -93,8 +93,7 @@
 			...(manageEthereumTokens ? allErc20Tokens : []),
 			...(manageIcTokens ? allIcrcTokens : [])
 		],
-		$selectedNetwork,
-		$pseudoNetworkChainFusion
+		$selectedNetwork
 	]);
 
 	let allTokensSorted: Token[] = [];

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,5 +1,5 @@
 import { exchanges } from '$lib/derived/exchange.derived';
-import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
+import { selectedNetwork } from '$lib/derived/network.derived';
 import { enabledTokens, tokensToPin } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
@@ -11,7 +11,7 @@ import { derived, type Readable } from 'svelte/store';
  * All user-enabled tokens matching the selected network or chain fusion.
  */
 const enabledNetworkTokens: Readable<Token[]> = derived(
-	[enabledTokens, selectedNetwork, pseudoNetworkChainFusion],
+	[enabledTokens, selectedNetwork],
 	filterTokensForSelectedNetwork
 );
 

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -6,7 +6,7 @@ import {
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const isNetworkICP = (network: Network | undefined): boolean => isNetworkIdICP(network?.id);
 
@@ -22,18 +22,17 @@ export const isNetworkIdBitcoin = (id: NetworkId | undefined): boolean =>
 /**
  * Filter the tokens that either lives on the selected network or, if no network is provided, pseud Chain Fusion, then those that are not testnets.
  */
-export const filterTokensForSelectedNetwork = ([
-	$tokens,
-	$selectedNetwork,
-	$pseudoNetworkChainFusion
-]: [Token[], Network | undefined, boolean]) =>
+export const filterTokensForSelectedNetwork = ([$tokens, $selectedNetwork]: [
+	Token[],
+	Network | undefined
+]) =>
 	$tokens.filter((token) => {
 		const {
 			network: { id: networkId, env }
 		} = token;
 
 		return (
-			($pseudoNetworkChainFusion && !isTokenIcrcTestnet(token) && env !== 'testnet') ||
+			(isNullish($selectedNetwork) && !isTokenIcrcTestnet(token) && env !== 'testnet') ||
 			$selectedNetwork?.id === networkId
 		);
 	});


### PR DESCRIPTION
# Motivation

The store `pseudoNetworkChainFusion` already uses the store `selectedNetwork`, so we simplify the logic re-using it.
