### PR TITLE
refactor(tokens): adjust sumTokensUsdBalance method name

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -2,10 +2,10 @@
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { exchangeInitialized } from '$lib/derived/exchange.derived';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
-	import { sumTokensUsdBalance } from '$lib/utils/tokens.utils';
+	import { sumTokensUiUsdBalance } from '$lib/utils/tokens.utils';
 
 	let totalUsd: number;
-	$: totalUsd = sumTokensUsdBalance($combinedDerivedSortedNetworkTokensUi);
+	$: totalUsd = sumTokensUiUsdBalance($combinedDerivedSortedNetworkTokensUi);
 </script>
 
 <span class="text-off-white block">

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -118,12 +118,12 @@ export const pinTokensWithBalanceAtTop = ({
 };
 
 /**
- * Calculates total USD balance of the provided tokens list.
+ * Calculates total USD balance of the provided UI tokens list.
  *
- * @param tokens - The list of tokens for total USD balance calculation.
- * @returns The sum of tokens USD balance.
+ * @param tokens - The list of UI tokens for total USD balance calculation.
+ * @returns The sum of UI tokens USD balance.
  */
-export const sumTokensUsdBalance = (tokens: TokenUi[]): number =>
+export const sumTokensUiUsdBalance = (tokens: TokenUi[]): number =>
 	tokens.reduce((acc, token) => acc + (token.usdBalance ?? 0), 0);
 
 /**

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -10,7 +10,7 @@ import {
 	filterEnabledTokens,
 	pinTokensWithBalanceAtTop,
 	sortTokens,
-	sumTokensUsdBalance
+	sumTokensUiUsdBalance
 } from '$lib/utils/tokens.utils';
 import { BigNumber } from 'alchemy-sdk';
 import { describe, expect, it, type MockedFunction } from 'vitest';
@@ -282,7 +282,7 @@ describe('pinTokensWithBalanceAtTop', () => {
 	});
 });
 
-describe('sumTokensTotalUsdBalance', () => {
+describe('sumTokensUiUsdBalance', () => {
 	it('should correctly calculate USD total balance when tokens have usdBalance', () => {
 		const tokens: TokenUi[] = [
 			{ ...ICP_TOKEN, usdBalance: 50 },
@@ -290,7 +290,7 @@ describe('sumTokensTotalUsdBalance', () => {
 			{ ...ETHEREUM_TOKEN, usdBalance: 100 }
 		];
 
-		const result = sumTokensUsdBalance(tokens);
+		const result = sumTokensUiUsdBalance(tokens);
 		expect(result).toEqual(200);
 	});
 
@@ -301,12 +301,12 @@ describe('sumTokensTotalUsdBalance', () => {
 			{ ...ETHEREUM_TOKEN }
 		];
 
-		const result = sumTokensUsdBalance(tokens);
+		const result = sumTokensUiUsdBalance(tokens);
 		expect(result).toEqual(50);
 	});
 
 	it('should correctly calculate USD total balance when tokens list is empty', () => {
-		const result = sumTokensUsdBalance([]);
+		const result = sumTokensUiUsdBalance([]);
 		expect(result).toEqual(0);
 	});
 });


### PR DESCRIPTION
# Motivation

The idea is to highlight that `sumTokensUiUsdBalance` expects a list of `TokenUi`, where `usdBalance` is already pre-calculated. In the following PRs, a new method (`sumTokensUsdBalance`) will be created to do the same but for `Token` (no `usdBalance` available).