### PR TITLE
refactor(frontend): move test mock values to specific folders

### DIFF
--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -14,29 +14,10 @@ import {
 	sumMainnetTokensUsdBalance,
 	sumTokensUiUsdBalance
 } from '$lib/utils/tokens.utils';
-import { BigNumber } from 'alchemy-sdk';
 import { describe, expect, it, type MockedFunction } from 'vitest';
-
-const usd = 1;
-
-const certified = true;
-
-const bn1 = BigNumber.from(1n);
-const bn2 = BigNumber.from(2n);
-const bn3 = BigNumber.from(3n);
-
-const $tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
-
-const $balances: CertifiedStoreData<BalancesData> = {
-	[ICP_TOKEN.id]: { data: bn1, certified },
-	[BTC_MAINNET_TOKEN.id]: { data: bn2, certified },
-	[ETHEREUM_TOKEN.id]: { data: bn3, certified }
-};
-
-const $exchanges: ExchangesData = $tokens.reduce<ExchangesData>((acc, token) => {
-	acc[token.id] = { usd };
-	return acc;
-}, {});
+import { $balances, bn1, bn2, bn3, certified } from '../../mocks/balances.mock';
+import { $exchanges, usd } from '../../mocks/exchanges.mock';
+import { $tokens } from '../../mocks/tokens.mock';
 
 vi.mock('$lib/utils/exchange.utils', () => ({
 	usdValue: vi.fn()

--- a/src/frontend/src/tests/mocks/balances.mock.ts
+++ b/src/frontend/src/tests/mocks/balances.mock.ts
@@ -1,0 +1,17 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import type { BalancesData } from '$lib/stores/balances.store';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
+import { BigNumber } from 'alchemy-sdk';
+
+export const certified = true;
+
+export const bn1 = BigNumber.from(1n);
+export const bn2 = BigNumber.from(2n);
+export const bn3 = BigNumber.from(3n);
+
+export const $balances: CertifiedStoreData<BalancesData> = {
+	[ICP_TOKEN.id]: { data: bn1, certified },
+	[BTC_MAINNET_TOKEN.id]: { data: bn2, certified },
+	[ETHEREUM_TOKEN.id]: { data: bn3, certified }
+};

--- a/src/frontend/src/tests/mocks/exchanges.mock.ts
+++ b/src/frontend/src/tests/mocks/exchanges.mock.ts
@@ -1,0 +1,9 @@
+import type { ExchangesData } from '$lib/types/exchange';
+import { $tokens } from './tokens.mock';
+
+export const usd = 1;
+
+export const $exchanges: ExchangesData = $tokens.reduce<ExchangesData>((acc, token) => {
+	acc[token.id] = { usd };
+	return acc;
+}, {});

--- a/src/frontend/src/tests/mocks/tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/tokens.mock.ts
@@ -1,0 +1,5 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import type { Token } from '$lib/types/token';
+
+export const $tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];


### PR DESCRIPTION
# Motivation

For readability and reusability we move the mocked values of tokens, balances and exchanges stores in their specific modules.
