### PR TITLE
refactor(frontend): move util function calculateTokenUsdBalance

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -1,7 +1,12 @@
 import { ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS } from '$env/networks.icrc.env';
+import type { BalancesData } from '$lib/stores/balances.store';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { CanisterIdText } from '$lib/types/canister';
+import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenStandard } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import { usdValue } from '$lib/utils/exchange.utils';
+import { nonNullish } from '@dfinity/utils';
 
 /**
  * Calculates the maximum amount for a transaction.
@@ -54,3 +59,32 @@ export const mapDefaultTokenToToggleable = <T extends Token>({
 		userToken?.enabled === true,
 	version: userToken?.version
 });
+
+/**
+ * Calculates USD balance for the provided token.
+ *
+ * @param token - Token for which USD balance will be calculated.
+ * @param $balancesStore - The balances data for the tokens.
+ * @param $exchanges - The exchange rates data for the tokens.
+ * @returns The USD balance or undefined in case the number cannot be calculated.
+ *
+ */
+export const calculateTokenUsdBalance = ({
+	token,
+	$balances,
+	$exchanges
+}: {
+	token: Token;
+	$balances: CertifiedStoreData<BalancesData>;
+	$exchanges: ExchangesData;
+}): number | undefined => {
+	const exchangeRate: number | undefined = $exchanges?.[token.id]?.usd;
+
+	return nonNullish(exchangeRate)
+		? usdValue({
+				token,
+				balance: $balances?.[token.id]?.data,
+				exchangeRate
+			})
+		: undefined;
+};

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -3,7 +3,7 @@ import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
-import { usdValue } from '$lib/utils/exchange.utils';
+import { calculateTokenUsdBalance } from '$lib/utils/token.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { BigNumber } from '@ethersproject/bignumber';
 
@@ -47,35 +47,6 @@ export const sortTokens = ({
 				a.network.name.localeCompare(b.network.name)
 		)
 	];
-};
-
-/**
- * Calculates USD balance for the provided token.
- *
- * @param token - Token for which USD balance will be calculated.
- * @param $balancesStore - The balances data for the tokens.
- * @param $exchanges - The exchange rates data for the tokens.
- * @returns The USD balance or undefined in case the number cannot be calculated.
- *
- */
-export const calculateTokenUsdBalance = ({
-	token,
-	$balances,
-	$exchanges
-}: {
-	token: Token;
-	$balances: CertifiedStoreData<BalancesData>;
-	$exchanges: ExchangesData;
-}): number | undefined => {
-	const exchangeRate: number | undefined = $exchanges?.[token.id]?.usd;
-
-	return nonNullish(exchangeRate)
-		? usdValue({
-				token,
-				balance: $balances?.[token.id]?.data,
-				exchangeRate
-			})
-		: undefined;
 };
 
 /**

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -12,6 +12,10 @@ const tokenStandards: TokenStandard[] = ['ethereum', 'icp', 'icrc', 'bitcoin'];
 const balance = 1000000000n;
 const fee = 10000000n;
 
+vi.mock('$lib/utils/exchange.utils', () => ({
+	usdValue: vi.fn()
+}));
+
 describe('getMaxTransactionAmount', () => {
 	it('should return the correct maximum amount for a transaction for each token standard', () => {
 		tokenStandards.forEach((tokenStandard) => {

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,5 +1,10 @@
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import type { TokenStandard } from '$lib/types/token';
-import { getMaxTransactionAmount } from '$lib/utils/token.utils';
+import { usdValue } from '$lib/utils/exchange.utils';
+import { calculateTokenUsdBalance, getMaxTransactionAmount } from '$lib/utils/token.utils';
+import { describe, expect, it, type MockedFunction } from 'vitest';
+import { $balances, bn3 } from '../../mocks/balances.mock';
+import { $exchanges } from '../../mocks/exchanges.mock';
 
 const tokenDecimals = 8;
 const tokenStandards: TokenStandard[] = ['ethereum', 'icp', 'icrc', 'bitcoin'];
@@ -72,5 +77,32 @@ describe('getMaxTransactionAmount', () => {
 			tokenStandard: 'erc20'
 		});
 		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
+	});
+});
+
+describe('calculateTokenUsdBalance', () => {
+	const mockUsdValue = usdValue as MockedFunction<typeof usdValue>;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		mockUsdValue.mockImplementation(
+			({ balance, exchangeRate }) => Number(balance ?? 0) * exchangeRate
+		);
+	});
+
+	it('should correctly calculate USD balance for the token', () => {
+		const result = calculateTokenUsdBalance({ token: ETHEREUM_TOKEN, $balances, $exchanges });
+		expect(result).toEqual(bn3.toNumber());
+	});
+
+	it('should return undefined if exchange rate is not available', () => {
+		const result = calculateTokenUsdBalance({ token: ICP_TOKEN, $balances, $exchanges: {} });
+		expect(result).toEqual(undefined);
+	});
+
+	it('should return 0 if balances store is not available', () => {
+		const result = calculateTokenUsdBalance({ token: ETHEREUM_TOKEN, $balances: {}, $exchanges });
+		expect(result).toEqual(0);
 	});
 });

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -7,7 +7,6 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
-	calculateTokenUsdBalance,
 	filterEnabledTokens,
 	pinTokensWithBalanceAtTop,
 	sortTokens,
@@ -321,33 +320,6 @@ describe('filterEnabledTokens', () => {
 
 		const result = filterEnabledTokens([tokens]);
 		expect(result).toEqual([ENABLED_BY_DEFAULT_ICP_TOKEN, ENABLED_BY_DEFAULT_ETHEREUM_TOKEN]);
-	});
-});
-
-describe('calculateTokenUsdBalance', () => {
-	const mockUsdValue = usdValue as MockedFunction<typeof usdValue>;
-
-	beforeEach(() => {
-		vi.resetAllMocks();
-
-		mockUsdValue.mockImplementation(
-			({ balance, exchangeRate }) => Number(balance ?? 0) * exchangeRate
-		);
-	});
-
-	it('should correctly calculate USD balance for the token', () => {
-		const result = calculateTokenUsdBalance({ token: ETHEREUM_TOKEN, $balances, $exchanges });
-		expect(result).toEqual(bn3.toNumber());
-	});
-
-	it('should return undefined if exchange rate is not available', () => {
-		const result = calculateTokenUsdBalance({ token: ICP_TOKEN, $balances, $exchanges: {} });
-		expect(result).toEqual(undefined);
-	});
-
-	it('should return 0 if balances store is not available', () => {
-		const result = calculateTokenUsdBalance({ token: ETHEREUM_TOKEN, $balances: {}, $exchanges });
-		expect(result).toEqual(0);
 	});
 });
 


### PR DESCRIPTION
# Motivation

Just for coherence, we move the function `calculateTokenUsdBalance` to the `token.util` module.
