### PR TITLE
feat(frontend): create map for TokenUi

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -3,7 +3,7 @@ import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { ExchangesData } from '$lib/types/exchange';
-import type { Token, TokenStandard } from '$lib/types/token';
+import type { Token, TokenStandard, TokenUi } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -88,3 +88,28 @@ export const calculateTokenUsdBalance = ({
 			})
 		: undefined;
 };
+
+/** Maps a Token object to a TokenUi object, meaning it adds the balance and the USD balance to the token.
+ *
+ * @param token - The given token.
+ * @param $balancesStore - The balances data for the tokens.
+ * @param $exchanges - The exchange rates data for the tokens.
+ * @returns The token UI.
+ */
+export const mapTokenUi = ({
+	token,
+	$balances,
+	$exchanges
+}: {
+	token: Token;
+	$balances: CertifiedStoreData<BalancesData>;
+	$exchanges: ExchangesData;
+}): TokenUi => ({
+	...token,
+	balance: $balances?.[token.id]?.data,
+	usdBalance: calculateTokenUsdBalance({
+		token,
+		$balances,
+		$exchanges
+	})
+});

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -3,9 +3,8 @@ import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
-import { calculateTokenUsdBalance } from '$lib/utils/token.utils';
+import { calculateTokenUsdBalance, mapTokenUi } from '$lib/utils/token.utils';
 import { nonNullish } from '@dfinity/utils';
-import type { BigNumber } from '@ethersproject/bignumber';
 
 /**
  * Sorts tokens by market cap, name and network name, pinning the specified ones at the top of the list in the order they are provided.
@@ -75,21 +74,13 @@ export const pinTokensWithBalanceAtTop = ({
 }): TokenUi[] => {
 	const [positiveBalances, nonPositiveBalances] = $tokens.reduce<[TokenUi[], TokenUi[]]>(
 		(acc, token) => {
-			const balance: BigNumber | undefined = $balances?.[token.id]?.data;
-
-			const usdBalance: number | undefined = calculateTokenUsdBalance({
+			const tokenUI: TokenUi = mapTokenUi({
 				token,
 				$balances,
 				$exchanges
 			});
 
-			const tokenUI: TokenUi = {
-				...token,
-				balance,
-				usdBalance
-			};
-
-			if ((usdBalance ?? 0) > 0 || (balance ?? ZERO).gt(0)) {
+			if ((tokenUI.usdBalance ?? 0) > 0 || (tokenUI.balance ?? ZERO).gt(0)) {
 				acc[0] = [...acc[0], tokenUI];
 
 				return acc;


### PR DESCRIPTION
# Motivation

For better readability and reusability, we create a function to map an object `Token` to an object `TokenUi`.