### PR TITLE
feat(tokens): display mainnet tokens total USD

### DIFF
--- a/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
+++ b/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import NetworkComponent from '$lib/components/networks/Network.svelte';
+	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
+	import type { Network } from '$lib/types/network';
+
+	export let network: Network;
+
+	let totalUsd: number;
+	$: totalUsd = $enabledMainnetTokensUsdBalancesPerNetwork[network.id];
+</script>
+
+<NetworkComponent {network} {totalUsd} on:icSelected />

--- a/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
+++ b/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
@@ -5,8 +5,8 @@
 
 	export let network: Network;
 
-	let totalUsd: number;
-	$: totalUsd = $enabledMainnetTokensUsdBalancesPerNetwork[network.id];
+	let usdBalance: number;
+	$: usdBalance = $enabledMainnetTokensUsdBalancesPerNetwork[network.id] ?? 0;
 </script>
 
-<NetworkComponent {network} {totalUsd} on:icSelected />
+<NetworkComponent {network} {usdBalance} on:icSelected />

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -3,6 +3,7 @@
 	import type { Network, NetworkId } from '$lib/types/network';
 
 	export let network: Network;
+	export let totalUsd: number | undefined = undefined;
 
 	let id: NetworkId;
 	let name: string;
@@ -10,4 +11,4 @@
 	$: ({ id, name, icon } = network);
 </script>
 
-<NetworkButton {id} {name} {icon} on:icSelected />
+<NetworkButton {id} {name} {totalUsd} {icon} on:icSelected />

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -3,7 +3,7 @@
 	import type { Network, NetworkId } from '$lib/types/network';
 
 	export let network: Network;
-	export let totalUsd: number | undefined = undefined;
+	export let usdBalance: number | undefined = undefined;
 
 	let id: NetworkId;
 	let name: string;
@@ -11,4 +11,4 @@
 	$: ({ id, name, icon } = network);
 </script>
 
-<NetworkButton {id} {name} {totalUsd} {icon} on:icSelected />
+<NetworkButton {id} {name} {usdBalance} {icon} on:icSelected />

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -13,7 +13,7 @@
 	export let id: NetworkId | undefined;
 	export let name: string;
 	export let icon: string | undefined;
-	export let totalUsd: number | undefined = undefined;
+	export let usdBalance: number | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -34,7 +34,7 @@
 		{name}
 		{icon}
 		logo="start"
-		description={nonNullish(totalUsd) ? formatUSD(totalUsd) : undefined}
+		description={nonNullish(usdBalance) ? formatUSD(usdBalance) : undefined}
 	/>
 
 	{#if id === $networkId}

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -29,7 +29,7 @@
 	};
 </script>
 
-<button class="w-full flex justify-between" on:click={onClick}>
+<button class="w-full flex justify-between items-start" on:click={onClick}>
 	<TextWithLogo
 		{name}
 		{icon}

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
 	import { IconCheck } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { page } from '$app/stores';
 	import TextWithLogo from '$lib/components/ui/TextWithLogo.svelte';
 	import { networkId } from '$lib/derived/network.derived';
 	import type { NetworkId } from '$lib/types/network';
+	import { formatUSD } from '$lib/utils/format.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
 
 	export let id: NetworkId | undefined;
 	export let name: string;
 	export let icon: string | undefined;
-	export let description: string | undefined = undefined;
+	export let totalUsd: number | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -28,7 +30,12 @@
 </script>
 
 <button class="w-full flex justify-between" on:click={onClick}>
-	<TextWithLogo {name} {description} {icon} logo="start" />
+	<TextWithLogo
+		{name}
+		{icon}
+		logo="start"
+		description={nonNullish(totalUsd) ? formatUSD(totalUsd) : undefined}
+	/>
 
 	{#if id === $networkId}
 		<span in:fade><IconCheck size="20px" /></span>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -26,9 +26,9 @@
 	let testnets: boolean;
 	$: testnets = $testnetsStore?.enabled ?? false;
 
-	let mainnetTokensTotalUsd: number;
-	$: mainnetTokensTotalUsd = $networksMainnets.reduce(
-		(acc, { id }) => acc + $enabledMainnetTokensUsdBalancesPerNetwork[id],
+	let mainnetTokensUsdBalance: number;
+	$: mainnetTokensUsdBalance = $networksMainnets.reduce(
+		(acc, { id }) => acc + ($enabledMainnetTokensUsdBalancesPerNetwork[id] ?? 0),
 		0
 	);
 </script>
@@ -48,7 +48,7 @@
 				id={undefined}
 				name={$i18n.networks.chain_fusion}
 				icon={chainFusion}
-				totalUsd={mainnetTokensTotalUsd}
+				usdBalance={mainnetTokensUsdBalance}
 				on:icSelected={close}
 			/>
 		</li>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -5,12 +5,14 @@
 	import chainFusion from '$lib/assets/chain_fusion.svg';
 	import IconChevronDown from '$lib/components/icons/IconChevronDown.svelte';
 	import IconMorePlain from '$lib/components/icons/IconMorePlain.svelte';
+	import MainnetNetwork from '$lib/components/networks/MainnetNetwork.svelte';
 	import Network from '$lib/components/networks/Network.svelte';
 	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
 	import NetworksTestnetsToggle from '$lib/components/networks/NetworksTestnetsToggle.svelte';
 	import ButtonSwitcher from '$lib/components/ui/ButtonSwitcher.svelte';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
+	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnetsStore } from '$lib/stores/settings.store';
 
@@ -23,6 +25,12 @@
 
 	let testnets: boolean;
 	$: testnets = $testnetsStore?.enabled ?? false;
+
+	let mainnetTokensTotalUsd: number;
+	$: mainnetTokensTotalUsd = $networksMainnets.reduce(
+		(acc, { id }) => acc + $enabledMainnetTokensUsdBalancesPerNetwork[id],
+		0
+	);
 </script>
 
 <ButtonSwitcher
@@ -40,13 +48,14 @@
 				id={undefined}
 				name={$i18n.networks.chain_fusion}
 				icon={chainFusion}
+				totalUsd={mainnetTokensTotalUsd}
 				on:icSelected={close}
 			/>
 		</li>
 
 		{#each $networksMainnets as network}
 			<li>
-				<Network {network} on:icSelected={close} />
+				<MainnetNetwork {network} on:icSelected={close} />
 			</li>
 		{/each}
 	</ul>


### PR DESCRIPTION
# Motivation

The goal is to display mainnet tokens total USD balances in `NetworkSwitscher`.


<img width="324" alt="Screenshot 2024-09-06 at 17 00 56" src="https://github.com/user-attachments/assets/d4546250-064a-4a7b-9cf6-4cf93d538e81">

