### PR TITLE
fix(frontend): toggle should show all non-zero balances

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -15,7 +15,7 @@
 
 	let sortedTokens: TokenUi[];
 	$: sortedTokens = $combinedDerivedSortedNetworkTokensUi.filter(
-		({ usdBalance }) => (usdBalance ?? 0) || displayZeroBalance
+		({ balance, usdBalance }) => Number(balance ?? 0n) || (usdBalance ?? 0) || displayZeroBalance
 	);
 
 	const updateTokensToDisplay = () =>


### PR DESCRIPTION
# Motivation

The "zero balance" toggle should show non-zero balances even for token that have no exchange rate.
