### PR TITLE
feat(frontend): avoid sorting if no balances store

### DIFF
--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -37,5 +37,5 @@ export const combinedDerivedSortedNetworkTokensUi: Readable<TokenUi[]> = derived
 					$balances,
 					$exchanges
 				})
-			: $enabledNetworkTokens
+			: ($enabledNetworkTokens as TokenUi[])
 );

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -25,7 +25,6 @@ export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
 
 /**
  * All tokens matching the selected network or Chain Fusion, with the ones with non-null balance at the top of the list.
- * It will not execute the sorting if the balance store is not yet initiated to avoid looping without data.
  */
 export const combinedDerivedSortedNetworkTokensUi: Readable<TokenUi[]> = derived(
 	[combinedDerivedSortedNetworkTokens, balancesStore, exchanges],

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -5,6 +5,7 @@ import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
+import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -25,13 +26,16 @@ export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
 
 /**
  * All tokens matching the selected network or Chain Fusion, with the ones with non-null balance at the top of the list.
+ * It will not execute the sorting if the balance store is not yet initiated to avoid looping without data.
  */
 export const combinedDerivedSortedNetworkTokensUi: Readable<TokenUi[]> = derived(
 	[combinedDerivedSortedNetworkTokens, balancesStore, exchanges],
 	([$enabledNetworkTokens, $balances, $exchanges]) =>
-		pinTokensWithBalanceAtTop({
-			$tokens: $enabledNetworkTokens,
-			$balances,
-			$exchanges
-		})
+		nonNullish($balances)
+			? pinTokensWithBalanceAtTop({
+					$tokens: $enabledNetworkTokens,
+					$balances,
+					$exchanges
+				})
+			: $enabledNetworkTokens
 );

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -5,7 +5,6 @@ import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
-import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -31,11 +30,9 @@ export const combinedDerivedSortedNetworkTokens: Readable<Token[]> = derived(
 export const combinedDerivedSortedNetworkTokensUi: Readable<TokenUi[]> = derived(
 	[combinedDerivedSortedNetworkTokens, balancesStore, exchanges],
 	([$enabledNetworkTokens, $balances, $exchanges]) =>
-		nonNullish($balances)
-			? pinTokensWithBalanceAtTop({
-					$tokens: $enabledNetworkTokens,
-					$balances,
-					$exchanges
-				})
-			: ($enabledNetworkTokens as TokenUi[])
+		pinTokensWithBalanceAtTop({
+			$tokens: $enabledNetworkTokens,
+			$balances,
+			$exchanges
+		})
 );

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -5,7 +5,7 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
 import { calculateTokenUsdBalance, mapTokenUi } from '$lib/utils/token.utils';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 /**
  * Sorts tokens by market cap, name and network name, pinning the specified ones at the top of the list in the order they are provided.
@@ -73,6 +73,11 @@ export const pinTokensWithBalanceAtTop = ({
 	$balances: CertifiedStoreData<BalancesData>;
 	$exchanges: ExchangesData;
 }): TokenUi[] => {
+	// If balances data are nullish, there is no need to sort.
+	if (isNullish($balances)) {
+		return $tokens.map((token) => mapTokenUi({ token, $balances, $exchanges }));
+	}
+
 	const [positiveBalances, nonPositiveBalances] = $tokens.reduce<[TokenUi[], TokenUi[]]>(
 		(acc, token) => {
 			const tokenUI: TokenUi = mapTokenUi({


### PR DESCRIPTION
# Motivation

It does not make sense to run the sorting by balance if the balance store is not initiated.