### PR TITLE
chore(frontend): localize label of ETH fee

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { Html } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { getContext, onDestroy } from 'svelte';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import FeeAmountDisplay from '$icp-eth/components/fee/FeeAmountDisplay.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	const { maxGasFee, feeSymbolStore, feeTokenIdStore, feeDecimalsStore }: FeeContext =
 		getContext<FeeContext>(FEE_CONTEXT_KEY);
@@ -41,9 +43,8 @@
 	});
 </script>
 
-<label for="balance" class="font-bold px-4.5"
-	>Max fee <small>(likely in &lt; 30 seconds)</small>:</label
->
+<label for="balance" class="font-bold px-4.5"><Html text={$i18n.fee.text.max_fee_eth} /></label>
+
 <div id="balance" class="font-normal px-4.5 mb-4 break-all min-h-6">
 	{#if nonNullish(fee) && nonNullish($feeSymbolStore) && nonNullish($feeTokenIdStore) && nonNullish($feeDecimalsStore)}
 		<FeeAmountDisplay

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -422,7 +422,8 @@
 			"fee": "Fee",
 			"estimated_btc": "Estimated BTC Network Fee",
 			"estimated_inter_network": "Estimated Inter-network Fee",
-			"estimated_eth": "Estimated Ethereum Fee"
+			"estimated_eth": "Estimated Ethereum Fee",
+			"max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>:"
 		},
 		"error": {
 			"cannot_fetch_gas_fee": "Cannot fetch gas fee."

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -368,6 +368,7 @@ interface I18nFee {
 		estimated_btc: string;
 		estimated_inter_network: string;
 		estimated_eth: string;
+		max_fee_eth: string;
 	};
 	error: { cannot_fetch_gas_fee: string };
 }


### PR DESCRIPTION
# Motivation

The label for the ETH fees is localized:

<img width="513" alt="Screenshot 2024-09-09 at 08 54 04" src="https://github.com/user-attachments/assets/836abca2-f812-4c53-a159-a128a36a0110">
