### PR TITLE
feat(lint): sort svelte imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,17 @@ module.exports = {
 			rules: {
 				'no-console': 'off'
 			}
+		},
+		{
+			files: ['*.svelte'],
+			rules: {
+				'import/order': [
+					'error',
+					{
+						alphabetize: { order: 'asc' }
+					}
+				]
+			}
 		}
 	],
 	rules: {
@@ -55,8 +66,7 @@ module.exports = {
 		'arrow-body-style': ['warn', 'as-needed'],
 		'import/no-duplicates': ['error', { 'prefer-inline': true }],
 		'@typescript-eslint/no-inferrable-types': 'error',
-		'prefer-template': 'error',
-		'import/order': ['error', { alphabetize: { order: 'asc' } }]
+		'prefer-template': 'error'
 	},
 	globals: {
 		NodeJS: true

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,17 @@ module.exports = {
 			rules: {
 				'no-console': 'off'
 			}
+		},
+		{
+			files: ['*.svelte'],
+			rules: {
+				'import/order': [
+					'error',
+					{
+						alphabetize: { order: 'asc' }
+					}
+				]
+			}
 		}
 	],
 	rules: {
@@ -45,12 +56,6 @@ module.exports = {
 			}
 		],
 		'no-console': ['error', { allow: ['error', 'warn'] }],
-		'import/order': [
-			'error',
-			{
-				alphabetize: { order: 'asc' }
-			}
-		],
 		'no-else-return': ['warn', { allowElseIf: false }],
 		'local-rules/no-svelte-store-in-api': 'error',
 		'@typescript-eslint/prefer-nullish-coalescing': 'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,23 +32,6 @@ module.exports = {
 			rules: {
 				'no-console': 'off'
 			}
-		},
-		{
-			// TODO: slowly add all related folders, and ultimately remove this override and include the rule in the main rules
-			files: [
-				'src/frontend/src/eth/**/*.svelte',
-				'src/frontend/src/icp/**/*.svelte',
-				'src/frontend/src/icp-eth/**/*.svelte',
-				'src/frontend/src/lib/**/*.svelte'
-			],
-			rules: {
-				'import/order': [
-					'error',
-					{
-						alphabetize: { order: 'asc' }
-					}
-				]
-			}
 		}
 	],
 	rules: {
@@ -72,7 +55,8 @@ module.exports = {
 		'arrow-body-style': ['warn', 'as-needed'],
 		'import/no-duplicates': ['error', { 'prefer-inline': true }],
 		'@typescript-eslint/no-inferrable-types': 'error',
-		'prefer-template': 'error'
+		'prefer-template': 'error',
+		'import/order': ['error', { alphabetize: { order: 'asc' } }]
 	},
 	globals: {
 		NodeJS: true

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,17 +32,6 @@ module.exports = {
 			rules: {
 				'no-console': 'off'
 			}
-		},
-		{
-			files: ['*.svelte'],
-			rules: {
-				'import/order': [
-					'error',
-					{
-						alphabetize: { order: 'asc' }
-					}
-				]
-			}
 		}
 	],
 	rules: {
@@ -56,6 +45,12 @@ module.exports = {
 			}
 		],
 		'no-console': ['error', { allow: ['error', 'warn'] }],
+		'import/order': [
+			'error',
+			{
+				alphabetize: { order: 'asc' }
+			}
+		],
 		'no-else-return': ['warn', { allowElseIf: false }],
 		'local-rules/no-svelte-store-in-api': 'error',
 		'@typescript-eslint/prefer-nullish-coalescing': 'error',

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-	import Hero from '$lib/components/hero/Hero.svelte';
-	import { isRouteSettings, isRouteTransactions } from '$lib/utils/nav.utils';
+	import type { ComponentType } from 'svelte';
 	import { page } from '$app/stores';
+	import Loaders from '$lib/components/core/Loaders.svelte';
 	import Modals from '$lib/components/core/Modals.svelte';
+	import NoLoaders from '$lib/components/core/NoLoaders.svelte';
+	import Hero from '$lib/components/hero/Hero.svelte';
+	import { authSignedIn } from '$lib/derived/auth.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
-	import type { ComponentType } from 'svelte';
-	import { authSignedIn } from '$lib/derived/auth.derived';
-	import Loaders from '$lib/components/core/Loaders.svelte';
-	import NoLoaders from '$lib/components/core/NoLoaders.svelte';
+	import { isRouteSettings, isRouteTransactions } from '$lib/utils/nav.utils';
 
 	let route: 'transactions' | 'tokens' | 'settings' = 'tokens';
 	$: route = isRouteSettings($page)

--- a/src/frontend/src/routes/(app)/transactions/+page.svelte
+++ b/src/frontend/src/routes/(app)/transactions/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { routeNetwork } from '$lib/derived/nav.derived';
 	import { isNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { networks } from '$lib/derived/networks.derived';
 	import Transactions from '$lib/components/transactions/Transactions.svelte';
+	import { routeNetwork } from '$lib/derived/nav.derived';
+	import { networks } from '$lib/derived/networks.derived';
 
 	onMount(async () => {
 		// We need to know the network on which the transactions should be loaded.

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Spinner, Toasts } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { browser } from '$app/environment';
@@ -17,7 +18,6 @@
 	import '$lib/styles/global.scss';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
-	import { nonNullish } from '@dfinity/utils';
 
 	/**
 	 * Init dApp

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
-	import { authStore, type AuthStoreData } from '$lib/stores/auth.store';
-	import { onMount } from 'svelte';
-	import { initAuthWorker } from '$lib/services/worker.auth.services';
-	import { fade } from 'svelte/transition';
 	import { Spinner, Toasts } from '@dfinity/gix-components';
-	import Busy from '$lib/components/ui/Busy.svelte';
-	import '$lib/styles/global.scss';
+	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
+	import { browser } from '$app/environment';
 	import Banner from '$lib/components/core/Banner.svelte';
-	import { displayAndCleanLogoutMsg } from '$lib/services/auth.services';
-	import { toastsError } from '$lib/stores/toasts.store';
-	import { initAnalytics, trackEvent } from '$lib/services/analytics.services';
-	import { i18n } from '$lib/stores/i18n.store';
+	import Busy from '$lib/components/ui/Busy.svelte';
 	import {
 		TRACK_SYNC_AUTH_AUTHENTICATED_COUNT,
 		TRACK_SYNC_AUTH_ERROR_COUNT,
 		TRACK_SYNC_AUTH_NOT_AUTHENTICATED_COUNT
 	} from '$lib/constants/analytics.contants';
+	import { initAnalytics, trackEvent } from '$lib/services/analytics.services';
+	import { displayAndCleanLogoutMsg } from '$lib/services/auth.services';
+	import { initAuthWorker } from '$lib/services/worker.auth.services';
+	import { authStore, type AuthStoreData } from '$lib/stores/auth.store';
+	import '$lib/styles/global.scss';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { toastsError } from '$lib/stores/toasts.store';
 	import { nonNullish } from '@dfinity/utils';
 
 	/**


### PR DESCRIPTION
# Motivation

As final step of sorting Svelte imports, we make the rule include all the `.svelte` files.