### PR TITLE
chore(frontend): Upgrade ckbtc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@dfinity/agent": "^2.0.0",
 				"@dfinity/auth-client": "^2.0.0",
 				"@dfinity/candid": "^2.0.0",
-				"@dfinity/ckbtc": "^3.0.0",
+				"@dfinity/ckbtc": "3.0.0-next-2024-09-09",
 				"@dfinity/cketh": "^3.3.0",
 				"@dfinity/gix-components": "^4.7.0",
 				"@dfinity/ic-management": "^5.2.0",
@@ -655,9 +655,9 @@
 			}
 		},
 		"node_modules/@dfinity/ckbtc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.0.0.tgz",
-			"integrity": "sha512-OHmgqIlBbCfsGRDEBveCst39WY16YIxioWrY8aH5VNA05yDpoJXdsfowacaSMC39cHJPzKln7ocGAHweKS5nvg==",
+			"version": "3.0.0-next-2024-09-09",
+			"resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.0.0-next-2024-09-09.tgz",
+			"integrity": "sha512-1AdE3TeT8TsKtFJfD7Fq4EZmTHknZMNXTtjGF0swhMQhuSXC1/JLbwW0WQEVgEgVG4oZ9aktMRLbZKGljutkMg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "^1.3.2",
@@ -665,10 +665,10 @@
 				"bech32": "^2.0.0"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.0.0",
-				"@dfinity/candid": "^2.0.0",
-				"@dfinity/principal": "^2.0.0",
-				"@dfinity/utils": "^2.5.0"
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/principal": "*",
+				"@dfinity/utils": "*"
 			}
 		},
 		"node_modules/@dfinity/ckbtc/node_modules/bech32": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@dfinity/agent": "^2.0.0",
 		"@dfinity/auth-client": "^2.0.0",
 		"@dfinity/candid": "^2.0.0",
-		"@dfinity/ckbtc": "^3.0.0",
+		"@dfinity/ckbtc": "3.0.0-next-2024-09-09",
 		"@dfinity/cketh": "^3.3.0",
 		"@dfinity/gix-components": "^4.7.0",
 		"@dfinity/ic-management": "^5.2.0",


### PR DESCRIPTION
# Motivation

I want to use `"regtest"` from `BitcoinNetwork` type. The new entry was added in https://github.com/dfinity/ic-js/pull/713 and it hasn't been published in any version but next yet.

# Changes

* Upgrade ckbtc to `3.0.0-next-2024-09-09`

# Tests

I checked that the new entry is accessible in node_modules.
