### PR TITLE
refactor(frontend): extract loader guards component

### DIFF
--- a/src/frontend/src/lib/components/core/LoadersGuard.svelte
+++ b/src/frontend/src/lib/components/core/LoadersGuard.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { ComponentType } from 'svelte';
+	import Loaders from '$lib/components/core/Loaders.svelte';
+	import NoLoaders from '$lib/components/core/NoLoaders.svelte';
+	import { authSignedIn } from '$lib/derived/auth.derived';
+
+	let cmpLoaders: ComponentType;
+	$: cmpLoaders = $authSignedIn ? Loaders : NoLoaders;
+</script>
+
+<svelte:component this={cmpLoaders}>
+	<slot />
+</svelte:component>

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -5,10 +5,7 @@
 	import Modals from '$lib/components/core/Modals.svelte';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
-	import type { ComponentType } from 'svelte';
-	import { authSignedIn } from '$lib/derived/auth.derived';
-	import Loaders from '$lib/components/core/Loaders.svelte';
-	import NoLoaders from '$lib/components/core/NoLoaders.svelte';
+	import LoadersGuard from '$lib/components/core/LoadersGuard.svelte';
 
 	let route: 'transactions' | 'tokens' | 'settings' = 'tokens';
 	$: route = isRouteSettings($page)
@@ -18,9 +15,6 @@
 			: 'tokens';
 
 	$: token.set($pageToken);
-
-	let cmpLoaders: ComponentType;
-	$: cmpLoaders = $authSignedIn ? Loaders : NoLoaders;
 </script>
 
 <Hero
@@ -31,9 +25,9 @@
 />
 
 <main class="pt-12">
-	<svelte:component this={cmpLoaders}>
+	<LoadersGuard>
 		<slot />
-	</svelte:component>
+	</LoadersGuard>
 </main>
 
 <Modals />


### PR DESCRIPTION
# Motivation

Extract a component for the loader guards which can ultimately be used in various routes - such as the new route in #2293 - as well.

# Changes

- Move `Loaders` and `NoLoaders` mount according auth in a dedicated module.