### PR TITLE
style(frontend): adjust button class for Receive modal

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -99,6 +99,6 @@
 	</ReceiveAddressWithLogo>
 </div>
 
-<button class="primary full center text-center" on:click={modalStore.close}
+<button class="secondary full center text-center" on:click={modalStore.close}
 	>{$i18n.core.text.done}</button
 >


### PR DESCRIPTION
# Motivation

With the new modal style introduced with PR #2291  , we adjust the button of the Receive modal to match the rest.

### Before

<img width="481" alt="Screenshot 2024-09-09 at 17 04 05" src="https://github.com/user-attachments/assets/f514448e-8912-4d2e-b5ab-c0803e62d086">

### After

<img width="493" alt="Screenshot 2024-09-09 at 17 03 53" src="https://github.com/user-attachments/assets/894555b5-4973-47e9-bb31-d72c6a8bcbb8">

