### PR TITLE
feat(frontend): Add other bitcoin addresses

### DIFF
--- a/src/frontend/src/lib/api/idb.api.ts
+++ b/src/frontend/src/lib/api/idb.api.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks.env';
-import { BTC_MAINNET_SYMBOL } from '$env/tokens.btc.env';
+import { BTC_MAINNET_SYMBOL, BTC_TESTNET_SYMBOL } from '$env/tokens.btc.env';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { IdbBtcAddress, IdbEthAddress, SetIdbAddressParams } from '$lib/types/idb';
 import type { Principal } from '@dfinity/principal';
@@ -12,6 +12,7 @@ const idbAddressesStore = (key: string): UseStore =>
 	browser ? createStore(`oisy-${key}-addresses`, `${key}-addresses`) : ({} as unknown as UseStore);
 
 const idbBtcAddressesStoreMainnet = idbAddressesStore(BTC_MAINNET_SYMBOL.toLowerCase());
+const idbBtcAddressesStoreTestnet = idbAddressesStore(BTC_TESTNET_SYMBOL.toLowerCase());
 
 const idbEthAddressesStore = idbAddressesStore(ETHEREUM_NETWORK_SYMBOL.toLowerCase());
 
@@ -20,6 +21,12 @@ export const setIdbBtcAddressMainnet = ({
 	principal
 }: SetIdbAddressParams<BtcAddress>): Promise<void> =>
 	set(principal.toText(), address, idbBtcAddressesStoreMainnet);
+
+export const setIdbBtcAddressTestnet = ({
+	address,
+	principal
+}: SetIdbAddressParams<BtcAddress>): Promise<void> =>
+	set(principal.toText(), address, idbBtcAddressesStoreTestnet);
 
 export const setIdbEthAddress = ({
 	address,

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -8,7 +8,11 @@
 	import Img from '$lib/components/ui/Img.svelte';
 	import InProgress from '$lib/components/ui/InProgress.svelte';
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
-	import { loadAddresses, loadIdbAddresses } from '$lib/services/address.services';
+	import {
+		listenTestnetNetworksToAddBtcTestnetAddresses,
+		loadAddresses,
+		loadIdbAddresses
+	} from '$lib/services/address.services';
 	import { signOut } from '$lib/services/auth.services';
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -63,6 +67,10 @@
 
 	onMount(async () => {
 		const { success: addressIdbSuccess, err } = await loadIdbAddresses();
+
+		// Listen to the user changing the testnets flag to load testnet btc addresses.
+		// We don't load them on init to avoid unnecessary requests.
+		listenTestnetNetworksToAddBtcTestnetAddresses();
 
 		if (addressIdbSuccess) {
 			loading.set(false);

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -22,6 +22,7 @@
 	import { testnets } from '$lib/derived/testnets.derived';
 	import { LOCAL } from '$lib/constants/app.constants';
 	import { nonNullish } from '@dfinity/utils';
+	import { modalStore } from '$lib/stores/modal.store';
 
 	const dispatch = createEventDispatcher();
 	const displayQRCode = (details: { address: string; addressLabel: string }) =>

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -1,23 +1,28 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
-	import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 	import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import ReceiveAddressWithLogo from '$lib/components/receive/ReceiveAddressWithLogo.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
+	import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 	import {
 		RECEIVE_TOKENS_MODAL_ICRC_SECTION,
 		RECEIVE_TOKENS_MODAL_ICP_SECTION,
 		RECEIVE_TOKENS_MODAL_ETH_SECTION,
 		RECEIVE_TOKENS_MODAL_BTC_SECTION
 	} from '$lib/constants/test-ids.constants';
-	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
+	import {
+		btcAddressMainnet,
+		btcAddressRegtest,
+		btcAddressTestnet,
+		ethAddress
+	} from '$lib/derived/address.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
+	import { testnets } from '$lib/derived/testnets.derived';
+	import { LOCAL } from '$lib/constants/app.constants';
 
 	const dispatch = createEventDispatcher();
-
 	const displayQRCode = (details: { address: string; addressLabel: string }) =>
 		dispatch('icQRCode', details);
 </script>
@@ -77,6 +82,38 @@
 		>
 			{$i18n.receive.bitcoin.text.bitcoin_address}
 		</ReceiveAddressWithLogo>
+
+		{#if $testnets && nonNullish($btcAddressTestnet)}
+			<ReceiveAddressWithLogo
+				on:click={() =>
+					displayQRCode({
+						address: $btcAddressTestnet,
+						addressLabel: $i18n.receive.bitcoin.text.bitcoin_testnet_address
+					})}
+				address={$btcAddressTestnet ?? ''}
+				token={BTC_TESTNET_TOKEN}
+				qrCodeAriaLabel={$i18n.receive.bitcoin.text.display_bitcoin_address_qr}
+				copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
+			>
+				{$i18n.receive.bitcoin.text.bitcoin_testnet_address}
+			</ReceiveAddressWithLogo>
+		{/if}
+
+		{#if LOCAL && nonNullish($btcAddressRegtest)}
+			<ReceiveAddressWithLogo
+				on:click={() =>
+					displayQRCode({
+						address: $btcAddressRegtest,
+						addressLabel: $i18n.receive.bitcoin.text.bitcoin_regtest_address
+					})}
+				address={$btcAddressRegtest}
+				token={BTC_TESTNET_TOKEN}
+				qrCodeAriaLabel={$i18n.receive.bitcoin.text.display_bitcoin_address_qr}
+				copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
+			>
+				{$i18n.receive.bitcoin.text.bitcoin_regtest_address}
+			</ReceiveAddressWithLogo>
+		{/if}
 	{/if}
 
 	<div class="mb-6">

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -5,7 +5,7 @@
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import ReceiveAddressWithLogo from '$lib/components/receive/ReceiveAddressWithLogo.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
-	import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
+	import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 	import {
 		RECEIVE_TOKENS_MODAL_ICRC_SECTION,
 		RECEIVE_TOKENS_MODAL_ICP_SECTION,
@@ -21,6 +21,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnets } from '$lib/derived/testnets.derived';
 	import { LOCAL } from '$lib/constants/app.constants';
+	import { nonNullish } from '@dfinity/utils';
 
 	const dispatch = createEventDispatcher();
 	const displayQRCode = (details: { address: string; addressLabel: string }) =>
@@ -107,7 +108,7 @@
 						addressLabel: $i18n.receive.bitcoin.text.bitcoin_regtest_address
 					})}
 				address={$btcAddressRegtest}
-				token={BTC_TESTNET_TOKEN}
+				token={BTC_REGTEST_TOKEN}
 				qrCodeAriaLabel={$i18n.receive.bitcoin.text.display_bitcoin_address_qr}
 				copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
 			>

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
+	import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 	import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import ReceiveAddressWithLogo from '$lib/components/receive/ReceiveAddressWithLogo.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
-	import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
+	import { LOCAL } from '$lib/constants/app.constants';
 	import {
 		RECEIVE_TOKENS_MODAL_ICRC_SECTION,
 		RECEIVE_TOKENS_MODAL_ICP_SECTION,
@@ -18,10 +20,8 @@
 		btcAddressTestnet,
 		ethAddress
 	} from '$lib/derived/address.derived';
-	import { i18n } from '$lib/stores/i18n.store';
 	import { testnets } from '$lib/derived/testnets.derived';
-	import { LOCAL } from '$lib/constants/app.constants';
-	import { nonNullish } from '@dfinity/utils';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
 	const dispatch = createEventDispatcher();

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -85,7 +85,7 @@
 			{$i18n.receive.bitcoin.text.bitcoin_address}
 		</ReceiveAddressWithLogo>
 
-		{#if $testnets && nonNullish($btcAddressTestnet)}
+		{#if $testnets && nonNullish($btcAddressTestnet) && $testnets}
 			<ReceiveAddressWithLogo
 				on:click={() =>
 					displayQRCode({
@@ -101,7 +101,7 @@
 			</ReceiveAddressWithLogo>
 		{/if}
 
-		{#if LOCAL && nonNullish($btcAddressRegtest)}
+		{#if LOCAL && nonNullish($btcAddressRegtest) && $testnets}
 			<ReceiveAddressWithLogo
 				on:click={() =>
 					displayQRCode({

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,4 +1,9 @@
-import { btcAddressMainnetStore, ethAddressStore } from '$lib/stores/address.store';
+import {
+	btcAddressMainnetStore,
+	btcAddressRegtestStore,
+	btcAddressTestnetStore,
+	ethAddressStore
+} from '$lib/stores/address.store';
 import type {
 	BtcAddress,
 	EthAddress,
@@ -17,6 +22,16 @@ export const ethAddressNotLoaded: Readable<boolean> = derived(
 export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
 	[btcAddressMainnetStore],
 	([$btcAddressMainnetStore]) => mapAddress<BtcAddress>($btcAddressMainnetStore)
+);
+
+export const btcAddressTestnet: Readable<OptionBtcAddress> = derived(
+	[btcAddressTestnetStore],
+	([$btcAddressTestnetStore]) => mapAddress<BtcAddress>($btcAddressTestnetStore)
+);
+
+export const btcAddressRegtest: Readable<OptionBtcAddress> = derived(
+	[btcAddressRegtestStore],
+	([$btcAddressRegtestStore]) => mapAddress<BtcAddress>($btcAddressRegtestStore)
 );
 
 export const ethAddress: Readable<OptionEthAddress> = derived(

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -205,6 +205,8 @@
 				"checking_incoming": "Checking for incoming BTC...",
 				"refreshing_wallet": "Refreshing wallet...",
 				"bitcoin_address": "Bitcoin Address",
+				"bitcoin_testnet_address": "Bitcoin (Testnet) Address",
+				"bitcoin_regtest_address": "Bitcoin (Regtest) Address",
 				"display_bitcoin_address_qr": "Display Bitcoin Address as a QR code",
 				"bitcoin_address_copied": "Bitcoin Address copied to clipboard.",
 				"from_network": "Transfer Bitcoin on the BTC network to this address to receive ckBTC.",

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -1,6 +1,10 @@
 import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
-import { BTC_MAINNET_TOKEN_ID, BTC_TESTNET_TOKEN_ID } from '$env/tokens.btc.env';
+import {
+	BTC_MAINNET_TOKEN_ID,
+	BTC_REGTEST_TOKEN_ID,
+	BTC_TESTNET_TOKEN_ID
+} from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens.env';
 import {
 	getIdbBtcAddressMainnet,
@@ -49,7 +53,7 @@ export const listenTestnetNetworksToAddBtcTestnetAddresses = async (): Promise<v
 		}
 		if (data?.enabled && LOCAL) {
 			loadBtcAddress({
-				tokenId: Symbol('regtest'),
+				tokenId: BTC_REGTEST_TOKEN_ID,
 				network: 'regtest'
 			});
 		}
@@ -94,20 +98,20 @@ const loadTokenAddress = async <T extends Address>({
 	return { success: true };
 };
 
-const bitcoinStoreMapper: Record<BitcoinNetwork | 'regtest', AddressStore<BtcAddress>> = {
+const bitcoinStoreMapper: Record<BitcoinNetwork, AddressStore<BtcAddress>> = {
 	mainnet: btcAddressMainnetStore,
 	testnet: btcAddressTestnetStore,
 	regtest: btcAddressRegtestStore
 };
 
-const bitcoinNetworkMapper: Record<BitcoinNetwork | 'regtest', SignerBitcoinNetwork> = {
+const bitcoinNetworkMapper: Record<BitcoinNetwork, SignerBitcoinNetwork> = {
 	mainnet: { mainnet: null },
 	testnet: { testnet: null },
 	regtest: { regtest: null }
 };
 
 const idbBtcAddressMapper: Record<
-	BitcoinNetwork | 'regtest',
+	BitcoinNetwork,
 	((params: SetIdbAddressParams<BtcAddress>) => Promise<void>) | undefined
 > = {
 	mainnet: setIdbBtcAddressMainnet,
@@ -120,8 +124,7 @@ const loadBtcAddress = async ({
 	network
 }: {
 	tokenId: symbol;
-	// TODO: Add "regtest" to the network type
-	network: BitcoinNetwork | 'regtest';
+	network: BitcoinNetwork;
 }): Promise<ResultSuccess> =>
 	loadTokenAddress<BtcAddress>({
 		tokenId,

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -23,5 +23,7 @@ const initAddressStore = <T extends Address>(): AddressStore<T> => {
 };
 
 export const btcAddressMainnetStore = initAddressStore<BtcAddress>();
+export const btcAddressTestnetStore = initAddressStore<BtcAddress>();
+export const btcAddressRegtestStore = initAddressStore<BtcAddress>();
 
 export const ethAddressStore = initAddressStore<EthAddress>();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -175,6 +175,8 @@ interface I18nReceive {
 			checking_incoming: string;
 			refreshing_wallet: string;
 			bitcoin_address: string;
+			bitcoin_testnet_address: string;
+			bitcoin_regtest_address: string;
 			display_bitcoin_address_qr: string;
 			bitcoin_address_copied: string;
 			from_network: string;


### PR DESCRIPTION
# Motivation

Each Bitcoin network has a different address for the user.

Therefore, we need to show Testnet (if testnts) and Regtest (if testnets and local) in the addresses list.

# Changes

* One more index db store for the testnet address (no need to store the regtest).
* New service `listenTestnetNetworksToAddBtcTestnetAddresses` to listen to changes in the testnets store.
* Load the testnet address by listening to the testnet store with `listenTestnetNetworksToAddBtcTestnetAddresses` used in `Loader`.
* Two new derived stores to get the address for Bitcoin Testnet and Regtest.
* Expand `loadBtcAddress` to support all Bitcoin networks.
* Two new addresses to store Bitcoin testnet addresses.

# Tests

Tested locally.
