### PR TITLE
feat(frontend): derive auth identity

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -33,6 +33,7 @@
 		TRACK_DURATION_ETH_SEND
 	} from '$lib/constants/analytics.contants';
 	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import {
@@ -41,7 +42,6 @@
 		trackTimedEventSuccess,
 		trackEvent
 	} from '$lib/services/analytics.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { Network } from '$lib/types/network';
@@ -195,7 +195,7 @@
 				gas,
 				sourceNetwork,
 				targetNetwork,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				minterInfo: $ckEthMinterInfoStore?.[nativeEthereumToken.id]
 			});
 

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -34,9 +34,9 @@
 	import { toCkEthHelperContractAddress } from '$icp-eth/utils/cketh.utils';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Network } from '$lib/types/network';
@@ -156,7 +156,7 @@
 			modalNext: modal.next,
 			token: $sendToken,
 			progress: (step: ProgressStepsSend) => (sendProgressStep = step),
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			minterInfo: $ckEthMinterInfoStore?.[$ethereumTokenId],
 			sourceNetwork,
 			targetNetwork

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -23,9 +23,9 @@
 		toCkEthHelperContractAddress
 	} from '$icp-eth/utils/cketh.utils';
 	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { balance } from '$lib/derived/balances.derived';
 	import { tokenId } from '$lib/derived/token.derived';
-	import { authStore } from '$lib/stores/auth.store';
 	import { token } from '$lib/stores/token.store';
 	import type { OptionEthAddress } from '$lib/types/address';
 	import type { NetworkId } from '$lib/types/network';
@@ -70,7 +70,7 @@
 		await loadCkEthereumPendingTransactions({
 			token: $tokenAsIcToken,
 			lastObservedBlockNumber,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			toAddress,
 			twinToken: $ckEthereumTwinToken
 		});

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokensModal.svelte
@@ -19,9 +19,9 @@
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { addTokenSteps } from '$lib/constants/steps.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
@@ -130,7 +130,7 @@
 			modalNext: () => modal.set(3),
 			onSuccess: close,
 			onError: () => modal.set(0),
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 	const saveErc20 = (tokens: SaveUserToken[]): Promise<void> =>
@@ -140,7 +140,7 @@
 			modalNext: () => modal.set(3),
 			onSuccess: close,
 			onError: () => modal.set(0),
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 	const close = () => {

--- a/src/frontend/src/icp/components/fee/BitcoinFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinFeeContext.svelte
@@ -5,8 +5,8 @@
 	import { queryEstimateFee } from '$icp/services/ckbtc.services';
 	import { BITCOIN_FEE_CONTEXT_KEY, type BitcoinFeeContext } from '$icp/stores/bitcoin-fee.store';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { tokenDecimals } from '$lib/derived/token.derived';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
@@ -35,7 +35,7 @@
 		}
 
 		const { fee, result } = await queryEstimateFee({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			amount: parseToken({
 				value: `${amount}`,
 				unitName: $tokenDecimals

--- a/src/frontend/src/icp/components/receive/IcReceiveCkBTC.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkBTC.svelte
@@ -12,8 +12,8 @@
 	} from '$icp/stores/receive-token.store';
 	import ReceiveAddressModal from '$lib/components/receive/ReceiveAddressModal.svelte';
 	import ReceiveButtonWithModal from '$lib/components/receive/ReceiveButtonWithModal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalCkBTCReceive } from '$lib/derived/modal.derived';
-	import { authStore } from '$lib/stores/auth.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
 	const { token, tokenId, ckEthereumTwinToken, open, close } =
@@ -33,7 +33,7 @@
 
 		await loadAllCkBtcInfo({
 			...$token,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		modalStore.openCkBTCReceive(modalId);

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -9,9 +9,9 @@
 	import { autoLoadUserToken } from '$icp-eth/services/user-token.services';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import ReceiveButtonWithModal from '$lib/components/receive/ReceiveButtonWithModal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalCkETHReceive } from '$lib/derived/modal.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
-	import { authStore } from '$lib/stores/auth.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
 	const { ckEthereumTwinToken, open, close } =
@@ -36,7 +36,7 @@
 		const { result } = await autoLoadUserToken({
 			erc20UserTokens: $erc20UserTokens,
 			sendToken: $tokenWithFallback,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		if (result === 'error') {

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -40,6 +40,7 @@
 		TRACK_DURATION_CONVERT_CKETH_TO_ETH,
 		TRACK_DURATION_IC_SEND
 	} from '$lib/constants/analytics.contants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import {
@@ -48,7 +49,6 @@
 		trackEvent,
 		trackTimedEventError
 	} from '$lib/services/analytics.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { token } from '$lib/stores/token.store';
@@ -126,7 +126,7 @@
 					value: `${amount}`,
 					unitName: $token.decimals
 				}),
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				progress: (step: ProgressStepsSendIc) => (sendProgressStep = step),
 				ckErc20ToErc20MaxCkEthFees
 			};

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -14,7 +14,7 @@
 	import SkeletonCardWithoutAmount from '$lib/components/ui/SkeletonCardWithoutAmount.svelte';
 	import TextWithLogo from '$lib/components/ui/TextWithLogo.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { authStore } from '$lib/stores/auth.store';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
@@ -33,7 +33,7 @@
 		const { result, data } = await loadAndAssertAddCustomToken({
 			ledgerCanisterId,
 			indexCanisterId,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			icrcTokens: $icrcTokens
 		});
 

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -24,9 +24,9 @@
 	import { loadNextTransactions } from '$icp/services/ic-transactions.services';
 	import type { IcTransactionUi } from '$icp/types/ic';
 	import Header from '$lib/components/ui/Header.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalIcToken, modalIcTransaction } from '$lib/derived/modal.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { token } from '$lib/stores/token.store';
@@ -45,7 +45,7 @@
 	let disableInfiniteScroll = false;
 
 	const onIntersect = async () => {
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			await nullishSignOut();
 			return;
 		}
@@ -69,8 +69,8 @@
 		}
 
 		await loadNextTransactions({
-			owner: $authStore.identity.getPrincipal(),
-			identity: $authStore.identity,
+			owner: $authIdentity.getPrincipal(),
+			identity: $authIdentity,
 			maxResults: WALLET_PAGINATION,
 			start: lastId,
 			token: $tokenAsIcToken,

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -7,9 +7,9 @@
 	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 	import { updateBalance } from '$icp/services/ckbtc.services';
 	import IconSync from '$lib/components/icons/IconSync.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalReceiveBitcoin } from '$lib/derived/modal.derived';
 	import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
@@ -33,7 +33,7 @@
 		try {
 			await updateBalance({
 				token: $tokenAsIcToken,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				progress: (step: ProgressStepsUpdateBalanceCkBtc) => (receiveProgressStep = step)
 			});
 

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -7,10 +7,10 @@
 	import banner from '$lib/assets/banner.svg';
 	import Img from '$lib/components/ui/Img.svelte';
 	import InProgress from '$lib/components/ui/InProgress.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
 	import { loadAddresses, loadIdbAddresses } from '$lib/services/address.services';
 	import { signOut } from '$lib/services/auth.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
 
@@ -43,10 +43,10 @@
 		// Load Erc20 contracts and ICRC metadata before loading balances and transactions
 		await Promise.all([
 			loadErc20Tokens({
-				identity: $authStore.identity
+				identity: $authIdentity
 			}),
 			loadIcrcTokens({
-				identity: $authStore.identity
+				identity: $authIdentity
 			})
 		]);
 	};

--- a/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
@@ -7,11 +7,11 @@
 	import TokensZeroBalanceToggle from '$lib/components/tokens/TokensZeroBalanceToggle.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { POUH_ENABLED } from '$lib/constants/credentials.constants';
-	import { authSignedIn } from '$lib/derived/auth.derived';
+	import { authSignedIn, authIdentity } from '$lib/derived/auth.derived';
 	import { userHasPouhCredential } from '$lib/derived/has-pouh-credential';
 	import { loadUserProfile } from '$lib/services/load-user-profile.services';
 	import { requestPouhCredential } from '$lib/services/request-pouh-credential.services';
-	import { authRemainingTimeStore, authStore } from '$lib/stores/auth.store';
+	import { authRemainingTimeStore } from '$lib/stores/auth.store';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
@@ -23,7 +23,7 @@
 	$: remainingTimeMilliseconds = $authRemainingTimeStore;
 
 	let identity: OptionIdentity;
-	$: identity = $authStore?.identity;
+	$: identity = $authIdentity;
 
 	let principal: Principal | undefined | null;
 	$: principal = identity?.getPrincipal();

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -9,10 +9,10 @@
 	import { isNullish } from '@dfinity/utils';
 	import HideTokenReview from '$lib/components/tokens/HideTokenReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { tokenToggleable } from '$lib/derived/token.derived';
 	import { ProgressStepsHideToken } from '$lib/enums/progress-steps';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
@@ -36,7 +36,7 @@
 			return;
 		}
 
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			await nullishSignOut();
 			return;
 		}
@@ -47,7 +47,7 @@
 			hideProgressStep = ProgressStepsHideToken.HIDE;
 
 			await hideToken({
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
 			hideProgressStep = ProgressStepsHideToken.UPDATE_UI;
@@ -56,7 +56,7 @@
 			await gotoReplaceRoot();
 
 			await updateUi({
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
 			hideProgressStep = ProgressStepsHideToken.DONE;

--- a/src/frontend/src/lib/derived/auth.derived.ts
+++ b/src/frontend/src/lib/derived/auth.derived.ts
@@ -1,4 +1,5 @@
 import { authStore } from '$lib/stores/auth.store';
+import type { OptionIdentity } from '$lib/types/identity';
 import { derived, type Readable } from 'svelte/store';
 
 export const authSignedIn: Readable<boolean> = derived(
@@ -9,4 +10,9 @@ export const authSignedIn: Readable<boolean> = derived(
 export const authNotSignedIn: Readable<boolean> = derived(
 	authSignedIn,
 	($authSignedIn) => !$authSignedIn
+);
+
+export const authIdentity: Readable<OptionIdentity> = derived(
+	authStore,
+	({ identity }) => identity
 );

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 		TRACK_SYNC_AUTH_NOT_AUTHENTICATED_COUNT
 	} from '$lib/constants/analytics.contants';
 	import { nonNullish } from '@dfinity/utils';
+	import { authIdentity } from '$lib/derived/auth.derived';
 
 	/**
 	 * Init dApp
@@ -34,7 +35,7 @@
 			await authStore.sync();
 
 			await trackEvent({
-				name: nonNullish($authStore.identity)
+				name: nonNullish($authIdentity)
 					? TRACK_SYNC_AUTH_AUTHENTICATED_COUNT
 					: TRACK_SYNC_AUTH_NOT_AUTHENTICATED_COUNT
 			});


### PR DESCRIPTION
# Motivation

Instead of accessing `$authStore.identity` in our components we can derive the optional identity `$authIdentity`. 

No big reasons, just a bit cuter to read.

# Changes

- Derive identity
- Use derived information instead of accessing store
