### PR TITLE
feat(frontned): Add stores and change services for other bitcoin addresses

### DIFF
--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -49,8 +49,3 @@ export const BTC_REGTEST_TOKEN: Token = {
 	decimals: BTC_DECIMALS,
 	icon: bitcoinTestnet
 };
-
-export type BTC_SYMBOL =
-	| typeof BTC_MAINNET_TOKEN_ID
-	| typeof BTC_TESTNET_TOKEN_ID
-	| typeof BTC_REGTEST_TOKEN_ID;

--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -49,3 +49,8 @@ export const BTC_REGTEST_TOKEN: Token = {
 	decimals: BTC_DECIMALS,
 	icon: bitcoinTestnet
 };
+
+export type BTC_SYMBOL =
+	| typeof BTC_MAINNET_TOKEN_ID
+	| typeof BTC_TESTNET_TOKEN_ID
+	| typeof BTC_REGTEST_TOKEN_ID;

--- a/src/frontend/src/lib/api/idb.api.ts
+++ b/src/frontend/src/lib/api/idb.api.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks.env';
-import { BTC_MAINNET_SYMBOL } from '$env/tokens.btc.env';
+import { BTC_MAINNET_SYMBOL, BTC_TESTNET_SYMBOL } from '$env/tokens.btc.env';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { IdbBtcAddress, IdbEthAddress, SetIdbAddressParams } from '$lib/types/idb';
 import type { Principal } from '@dfinity/principal';
@@ -12,6 +12,7 @@ const idbAddressesStore = (key: string): UseStore =>
 	browser ? createStore(`oisy-${key}-addresses`, `${key}-addresses`) : ({} as unknown as UseStore);
 
 const idbBtcAddressesStoreMainnet = idbAddressesStore(BTC_MAINNET_SYMBOL.toLowerCase());
+const idbBtcAddressesStoreTestnet = idbAddressesStore(BTC_TESTNET_SYMBOL.toLowerCase());
 
 const idbEthAddressesStore = idbAddressesStore(ETHEREUM_NETWORK_SYMBOL.toLowerCase());
 
@@ -20,6 +21,12 @@ export const setIdbBtcAddressMainnet = ({
 	principal
 }: SetIdbAddressParams<BtcAddress>): Promise<void> =>
 	set(principal.toText(), address, idbBtcAddressesStoreMainnet);
+
+export const setIdbBtcAddressTestnet = ({
+	address,
+	principal
+}: SetIdbAddressParams<BtcAddress>): Promise<void> =>
+	set(principal.toText(), address, idbBtcAddressesStoreTestnet);
 
 export const setIdbEthAddress = ({
 	address,

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,4 +1,9 @@
-import { btcAddressMainnetStore, ethAddressStore } from '$lib/stores/address.store';
+import {
+	btcAddressMainnetStore,
+	btcAddressRegtestStore,
+	btcAddressTestnetStore,
+	ethAddressStore
+} from '$lib/stores/address.store';
 import type {
 	BtcAddress,
 	EthAddress,
@@ -17,6 +22,16 @@ export const ethAddressNotLoaded: Readable<boolean> = derived(
 export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
 	[btcAddressMainnetStore],
 	([$btcAddressMainnetStore]) => mapAddress<BtcAddress>($btcAddressMainnetStore)
+);
+
+export const btcAddressTestnet: Readable<OptionBtcAddress> = derived(
+	[btcAddressTestnetStore],
+	([$btcAddressTestnetStore]) => mapAddress<BtcAddress>($btcAddressTestnetStore)
+);
+
+export const btcAddressRegtest: Readable<OptionBtcAddress> = derived(
+	[btcAddressRegtestStore],
+	([$btcAddressRegtestStore]) => mapAddress<BtcAddress>($btcAddressRegtestStore)
 );
 
 export const ethAddress: Readable<OptionEthAddress> = derived(

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -1,6 +1,5 @@
 import {
 	btcAddressMainnetStore,
-	btcAddressRegtestStore,
 	btcAddressTestnetStore,
 	ethAddressStore
 } from '$lib/stores/address.store';
@@ -27,11 +26,6 @@ export const btcAddressMainnet: Readable<OptionBtcAddress> = derived(
 export const btcAddressTestnet: Readable<OptionBtcAddress> = derived(
 	[btcAddressTestnetStore],
 	([$btcAddressTestnetStore]) => mapAddress<BtcAddress>($btcAddressTestnetStore)
-);
-
-export const btcAddressRegtest: Readable<OptionBtcAddress> = derived(
-	[btcAddressRegtestStore],
-	([$btcAddressRegtestStore]) => mapAddress<BtcAddress>($btcAddressRegtestStore)
 );
 
 export const ethAddress: Readable<OptionEthAddress> = derived(

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -73,20 +73,20 @@ const loadTokenAddress = async <T extends Address>({
 };
 
 // We use the Testnet address for Regtest.
-type BtcTokenIdsWithAddresses = typeof BTC_MAINNET_TOKEN_ID | typeof BTC_TESTNET_TOKEN_ID;
-type BtcNetworkWithAddresses = Exclude<BitcoinNetwork, 'regtest'>;
-const bitcoinStoreMapper: Record<BtcNetworkWithAddresses, AddressStore<BtcAddress>> = {
+type TokenIdBtcPublicNetwork = typeof BTC_MAINNET_TOKEN_ID | typeof BTC_TESTNET_TOKEN_ID;
+type BtcPublicNetwork = Exclude<BitcoinNetwork, 'regtest'>;
+const bitcoinStoreMapper: Record<BtcPublicNetwork, AddressStore<BtcAddress>> = {
 	mainnet: btcAddressMainnetStore,
 	testnet: btcAddressTestnetStore
 };
 
-const bitcoinNetworkMapper: Record<BtcNetworkWithAddresses, SignerBitcoinNetwork> = {
+const bitcoinNetworkMapper: Record<BtcPublicNetwork, SignerBitcoinNetwork> = {
 	mainnet: { mainnet: null },
 	testnet: { testnet: null }
 };
 
 const idbBtcAddressMapper: Record<
-	BtcNetworkWithAddresses,
+	BtcPublicNetwork,
 	(params: SetIdbAddressParams<BtcAddress>) => Promise<void>
 > = {
 	mainnet: setIdbBtcAddressMainnet,
@@ -97,8 +97,8 @@ const loadBtcAddress = async ({
 	tokenId,
 	network
 }: {
-	tokenId: BtcTokenIdsWithAddresses;
-	network: BtcNetworkWithAddresses;
+	tokenId: TokenIdBtcPublicNetwork;
+	network: BtcPublicNetwork;
 }): Promise<ResultSuccess> =>
 	loadTokenAddress<BtcAddress>({
 		tokenId,

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -72,21 +72,21 @@ const loadTokenAddress = async <T extends Address>({
 	return { success: true };
 };
 
-// We use the Testenet address for Regtest.
+// We use the Testnet address for Regtest.
 type BtcTokenIdsWithAddresses = typeof BTC_MAINNET_TOKEN_ID | typeof BTC_TESTNET_TOKEN_ID;
-type BtcTokenIdsStringWithAddresses = Exclude<BitcoinNetwork, 'regtest'>;
-const bitcoinStoreMapper: Record<BtcTokenIdsStringWithAddresses, AddressStore<BtcAddress>> = {
+type BtcNetworkWithAddresses = Exclude<BitcoinNetwork, 'regtest'>;
+const bitcoinStoreMapper: Record<BtcNetworkWithAddresses, AddressStore<BtcAddress>> = {
 	mainnet: btcAddressMainnetStore,
 	testnet: btcAddressTestnetStore
 };
 
-const bitcoinNetworkMapper: Record<BtcTokenIdsStringWithAddresses, SignerBitcoinNetwork> = {
+const bitcoinNetworkMapper: Record<BtcNetworkWithAddresses, SignerBitcoinNetwork> = {
 	mainnet: { mainnet: null },
 	testnet: { testnet: null }
 };
 
 const idbBtcAddressMapper: Record<
-	BtcTokenIdsStringWithAddresses,
+	BtcNetworkWithAddresses,
 	(params: SetIdbAddressParams<BtcAddress>) => Promise<void>
 > = {
 	mainnet: setIdbBtcAddressMainnet,
@@ -98,7 +98,7 @@ const loadBtcAddress = async ({
 	network
 }: {
 	tokenId: BtcTokenIdsWithAddresses;
-	network: BtcTokenIdsStringWithAddresses;
+	network: BtcNetworkWithAddresses;
 }): Promise<ResultSuccess> =>
 	loadTokenAddress<BtcAddress>({
 		tokenId,

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -22,8 +22,8 @@ const initAddressStore = <T extends Address>(): AddressStore<T> => {
 	};
 };
 
+// We use the Testenet address for Regtest.
+export const btcAddressTestnetStore = initAddressStore<BtcAddress>();
 export const btcAddressMainnetStore = initAddressStore<BtcAddress>();
 
 export const ethAddressStore = initAddressStore<EthAddress>();
-export const btcAddressTestnetStore = initAddressStore<BtcAddress>();
-export const btcAddressRegtestStore = initAddressStore<BtcAddress>();

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -22,7 +22,7 @@ const initAddressStore = <T extends Address>(): AddressStore<T> => {
 	};
 };
 
-// We use the Testenet address for Regtest.
+// We use the Testnet address for Regtest.
 export const btcAddressTestnetStore = initAddressStore<BtcAddress>();
 export const btcAddressMainnetStore = initAddressStore<BtcAddress>();
 

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -25,3 +25,5 @@ const initAddressStore = <T extends Address>(): AddressStore<T> => {
 export const btcAddressMainnetStore = initAddressStore<BtcAddress>();
 
 export const ethAddressStore = initAddressStore<EthAddress>();
+export const btcAddressTestnetStore = initAddressStore<BtcAddress>();
+export const btcAddressRegtestStore = initAddressStore<BtcAddress>();


### PR DESCRIPTION
# Motivation

Each Bitcoin network has a different address for the user.

Therefore, we need to show Testnet (if testnts) and Regtest (if testnets and local) in the addresses list.

In this PR, I introduce stores for the testnet addresses and adapt current services to them.

# Changes

* One more index db store for the testnet address (no need to store the regtest).
* Two new stores to save Bitcoin testnet addresses.
* Two new derived stores to get the address for Bitcoin Testnet and Regtest.
* Expand loadBtcAddress to support all Bitcoin networks.

# Tests

This was tested along the UI code in #2298 
