### PR TITLE
feat(frontend): Load testnet btc address

### DIFF
--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -9,7 +9,11 @@
 	import InProgress from '$lib/components/ui/InProgress.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
-	import { loadAddresses, loadIdbAddresses } from '$lib/services/address.services';
+	import {
+		listenTestnetNetworksToAddBtcTestnetAddresses,
+		loadAddresses,
+		loadIdbAddresses
+	} from '$lib/services/address.services';
 	import { signOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
@@ -63,6 +67,10 @@
 
 	onMount(async () => {
 		const { success: addressIdbSuccess, err } = await loadIdbAddresses();
+
+		// Listen to the user changing the testnets flag to load testnet btc addresses.
+		// We don't load them on init to avoid unnecessary requests.
+		listenTestnetNetworksToAddBtcTestnetAddresses();
 
 		if (addressIdbSuccess) {
 			loading.set(false);

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -68,11 +68,11 @@
 
 	let progressModal = false;
 
-	const debounceLadBtcAddressTestnet = debounce(loadBtcAddressTestnet);
+	const debounceLoadBtcAddressTestnet = debounce(loadBtcAddressTestnet);
 
 	$: {
 		if ($testnets && nonNullish($btcAddressTestnet)) {
-			debounceLadBtcAddressTestnet();
+			debounceLoadBtcAddressTestnet();
 		}
 	}
 

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Modal, type ProgressStep } from '@dfinity/gix-components';
+	import { debounce, nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { loadErc20Tokens } from '$eth/services/erc20.services';
@@ -19,7 +20,6 @@
 	import { signOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
-	import { debounce, nonNullish } from '@dfinity/utils';
 
 	let progressStep: string = ProgressStepsLoader.ADDRESSES;
 

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -19,6 +19,7 @@
 	import { signOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
+	import { debounce, nonNullish } from '@dfinity/utils';
 
 	let progressStep: string = ProgressStepsLoader.ADDRESSES;
 
@@ -67,9 +68,11 @@
 
 	let progressModal = false;
 
+	const debounceLadBtcAddressTestnet = debounce(loadBtcAddressTestnet);
+
 	$: {
-		if ($testnets && !$btcAddressTestnet) {
-			loadBtcAddressTestnet();
+		if ($testnets && nonNullish($btcAddressTestnet)) {
+			debounceLadBtcAddressTestnet();
 		}
 	}
 

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -7,11 +7,13 @@
 	import banner from '$lib/assets/banner.svg';
 	import Img from '$lib/components/ui/Img.svelte';
 	import InProgress from '$lib/components/ui/InProgress.svelte';
+	import { btcAddressTestnet } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { testnets } from '$lib/derived/testnets.derived';
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
 	import {
-		listenTestnetNetworksToAddBtcTestnetAddresses,
 		loadAddresses,
+		loadBtcAddressTestnet,
 		loadIdbAddresses
 	} from '$lib/services/address.services';
 	import { signOut } from '$lib/services/auth.services';
@@ -65,12 +67,14 @@
 
 	let progressModal = false;
 
+	$: {
+		if ($testnets && !$btcAddressTestnet) {
+			loadBtcAddressTestnet();
+		}
+	}
+
 	onMount(async () => {
 		const { success: addressIdbSuccess, err } = await loadIdbAddresses();
-
-		// Listen to the user changing the testnets flag to load testnet btc addresses.
-		// We don't load them on init to avoid unnecessary requests.
-		listenTestnetNetworksToAddBtcTestnetAddresses();
 
 		if (addressIdbSuccess) {
 			loading.set(false);

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -114,6 +114,12 @@ const loadBtcAddress = async ({
 		...bitcoinMapper[network]
 	});
 
+export const loadBtcAddressTestnet = async (): Promise<ResultSuccess> =>
+	loadBtcAddress({
+		tokenId: BTC_TESTNET_TOKEN_ID,
+		network: 'testnet'
+	});
+
 const loadBtcAddressMainnet = async (): Promise<ResultSuccess> =>
 	loadBtcAddress({
 		tokenId: BTC_MAINNET_TOKEN_ID,


### PR DESCRIPTION
# Motivation

Each Bitcoin network has a different address for the user.

Therefore, we need to show Testnet (if testnts) and Regtest (if testnets and local) in the addresses list.

In this PR, we create a listener of the testnets store to load the btc testnet address in the store and set it up in the `Loader` component.

# Changes

* New service `listenTestnetNetworksToAddBtcTestnetAddresses` to listen to changes in the testnets store.
* Load the testnet address by listening to the testnet store with listenTestnetNetworksToAddBtcTestnetAddresses used in Loader.

# Tests

Tested together with the rest of the changes in #2298 
