### PR TITLE
ci(e2e): fix update-snapshots workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,9 @@ jobs:
   oisy-backend-wasm:
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Build oisy-backend WASM
         uses: ./.github/actions/oisy-backend
 

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -8,6 +8,9 @@ jobs:
   oisy-backend-wasm:
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Build oisy-backend WASM
         uses: ./.github/actions/oisy-backend
 


### PR DESCRIPTION
# Motivation

To fix the `update-snapshots` workflow as well as to make sure that `e2e-tests` always works as expected, we need to add back the checkout step before building oisy-backend (even though the `oisy-backend` action also has the checkout step inside).
