### PR TITLE
feat(frontend): pin enabled tokens at top in ManageTokens

### DIFF
--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -33,10 +33,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ExchangesData } from '$lib/types/exchange';
 	import type { Token } from '$lib/types/token';
+	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-	import { sortTokens } from '$lib/utils/tokens.utils';
+	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 
 	const dispatch = createEventDispatcher();
 
@@ -82,7 +83,7 @@
 	$: manageEthereumTokens = $pseudoNetworkChainFusion || $networkEthereum;
 
 	// TODO: Bitcoin tokens ($enabledBitcoinTokens) are not included yet.
-	let allTokens: Token[] = [];
+	let allTokens: TokenToggleable[] = [];
 	$: allTokens = filterTokensForSelectedNetwork([
 		[
 			{
@@ -99,11 +100,13 @@
 
 	let allTokensSorted: Token[] = [];
 	$: allTokensSorted = nonNullish(exchangesStaticData)
-		? sortTokens({
-				$tokens: allTokens,
-				$exchanges: exchangesStaticData,
-				$tokensToPin: $tokensToPin
-			})
+		? pinEnabledTokensAtTop(
+				sortTokens({
+					$tokens: allTokens,
+					$exchanges: exchangesStaticData,
+					$tokensToPin: $tokensToPin
+				})
+			)
 		: [];
 
 	let filterTokens = '';

--- a/src/frontend/src/lib/types/token-toggleable.ts
+++ b/src/frontend/src/lib/types/token-toggleable.ts
@@ -10,4 +10,4 @@ export type UserTokenState = Omit<
 	enabled: boolean;
 };
 
-export type TokenToggleable<T extends Token> = T & UserTokenState;
+export type TokenToggleable<T extends Token = Token> = T & UserTokenState;

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -22,11 +22,11 @@ export const isNetworkIdBitcoin = (id: NetworkId | undefined): boolean =>
 /**
  * Filter the tokens that either lives on the selected network or, if no network is provided, pseud Chain Fusion, then those that are not testnets.
  */
-export const filterTokensForSelectedNetwork = ([
+export const filterTokensForSelectedNetwork = <T extends Token>([
 	$tokens,
 	$selectedNetwork,
 	$pseudoNetworkChainFusion
-]: [Token[], Network | undefined, boolean]) =>
+]: [T[], Network | undefined, boolean]): T[] =>
 	$tokens.filter((token) => {
 		const {
 			network: { id: networkId, env }

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -4,6 +4,7 @@ import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
+import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { calculateTokenUsdBalance, mapTokenUi } from '$lib/utils/token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
@@ -14,15 +15,15 @@ import { isNullish, nonNullish } from '@dfinity/utils';
  * @param $tokensToPin - The list of tokens to pin at the top of the list.
  * @param $exchanges - The exchange rates for the tokens.
  */
-export const sortTokens = ({
+export const sortTokens = <T extends Token>({
 	$tokens,
 	$exchanges,
 	$tokensToPin
 }: {
-	$tokens: Token[];
+	$tokens: T[];
 	$exchanges: ExchangesData;
 	$tokensToPin: TokenToPin[];
-}): Token[] => {
+}): T[] => {
 	const pinnedTokens = $tokensToPin
 		.map(({ id: pinnedId, network: { id: pinnedNetworkId } }) =>
 			$tokens.find(
@@ -155,3 +156,17 @@ export const sumMainnetTokensUsdBalancesPerNetwork = ({
  */
 export const filterEnabledTokens = ([$tokens]: [$tokens: Token[]]): Token[] =>
 	$tokens.filter((token) => ('enabled' in token ? token.enabled : true));
+
+/** Pins enabled tokens at the top of the list, preserving the order of the parts.
+ *
+ * @param $tokens - The list of tokens.
+ * @returns The list of tokens with enabled tokens at the top.
+ * */
+export const pinEnabledTokensAtTop = <T extends Token>(
+	$tokens: TokenToggleable<T>[]
+): TokenToggleable<T>[] =>
+	$tokens
+		.reduce<
+			[TokenToggleable<T>[], TokenToggleable<T>[]]
+		>(([active, inactive], token) => (token.enabled ? [[...active, token], inactive] : [active, [...inactive, token]]), [[], []])
+		.flat();

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -6,9 +6,11 @@ import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
+import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
 	filterEnabledTokens,
+	pinEnabledTokensAtTop,
 	pinTokensWithBalanceAtTop,
 	sortTokens,
 	sumMainnetTokensUsdBalancesPerNetwork,
@@ -331,5 +333,39 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			$exchanges
 		});
 		expect(result).toEqual({});
+	});
+});
+
+describe('pinEnabledTokensAtTop', () => {
+	it('should pin enabled tokens at the top while preserving the order', () => {
+		const tokens: TokenToggleable[] = [
+			{ ...ICP_TOKEN, enabled: false },
+			{ ...BTC_MAINNET_TOKEN, enabled: true },
+			{ ...ETHEREUM_TOKEN, enabled: true }
+		];
+
+		const result = pinEnabledTokensAtTop(tokens);
+
+		expect(result).toEqual([
+			{ ...BTC_MAINNET_TOKEN, enabled: true },
+			{ ...ETHEREUM_TOKEN, enabled: true },
+			{ ...ICP_TOKEN, enabled: false }
+		]);
+	});
+
+	it('should return the same array when all tokens are enabled', () => {
+		const tokens: TokenToggleable[] = $tokens.map((t) => ({ ...t, enabled: true }));
+
+		const result = pinEnabledTokensAtTop(tokens);
+
+		expect(result).toEqual(tokens);
+	});
+
+	it('should return the same array when all tokens are disabled', () => {
+		const tokens: TokenToggleable[] = $tokens.map((t) => ({ ...t, enabled: false }));
+
+		const result = pinEnabledTokensAtTop(tokens);
+
+		expect(result).toEqual(tokens);
 	});
 });


### PR DESCRIPTION
# Motivation

To make it easier, we pin the enabled tokens on top of the manage modal.

# Changes

- Create util function to pin enabled tokens on top.
- Create tests.
- Change type of token list in `ManageTokens` to be toggleable.
- Use new util after normal sorting.

# Tests

### Before

<img width="493" alt="Screenshot 2024-09-10 at 21 29 06" src="https://github.com/user-attachments/assets/cb15d11e-adc7-49d1-81d5-080d341a9bb2">

### After

<img width="496" alt="Screenshot 2024-09-10 at 21 28 47" src="https://github.com/user-attachments/assets/278d264f-6f56-4065-bfee-6f039d37374c">

