### PR TITLE
refactor(frontend): extract label in transaction component

### DIFF
--- a/src/frontend/src/eth/components/transactions/Transaction.svelte
+++ b/src/frontend/src/eth/components/transactions/Transaction.svelte
@@ -23,10 +23,16 @@
 	let timestamp: number | undefined;
 	let displayTimestamp: number | undefined;
 
+	let pending: boolean;
+	$: pending = isTransactionPending(transaction);
+
 	$: ({ from, value, timestamp, displayTimestamp } = transaction);
 
 	let type: EthTransactionType;
 	$: type = from?.toLowerCase() === $ethAddress?.toLowerCase() ? 'send' : 'receive';
+
+	let label: string;
+	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
 
 	let icon: ComponentType;
 	$: icon = type === 'send' ? IconSend : IconReceive;
@@ -34,16 +40,13 @@
 	let amount: BigNumber;
 	$: amount = type == 'send' ? value.mul(BigNumber.from(-1)) : value;
 
-	let pending: boolean;
-	$: pending = isTransactionPending(transaction);
-
 	let transactionDate: number | undefined;
 	$: transactionDate = timestamp ?? displayTimestamp;
 </script>
 
 <button on:click={() => modalStore.openTransaction(transaction)} class="contents">
 	<Card>
-		{`${type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}`}
+		{label}
 
 		<RoundedIcon slot="icon" {icon} iconStyleClass={pending ? 'opacity-10' : ''} />
 


### PR DESCRIPTION
# Motivation

For better readability, we extract the logic of the label in the `Transaction` component. That will come useful for a future PR.

For the same reason, unrelated, we move the `pending` variable definition above.