### PR TITLE
feat(frontend): store with ck twin token for Ethereum tokens

### DIFF
--- a/src/frontend/src/env/tokens.env.ts
+++ b/src/frontend/src/env/tokens.env.ts
@@ -6,7 +6,7 @@ import eth from '$icp-eth/assets/eth.svg';
 import icpLight from '$icp/assets/icp_light.svg';
 import { ICP_TRANSACTION_FEE_E8S } from '$icp/constants/icp.constants';
 import type { IcToken } from '$icp/types/ic';
-import type { RequiredToken, TokenAppearance } from '$lib/types/token';
+import type { RequiredToken, TokenAppearance, TokenId } from '$lib/types/token';
 import type { RequiredExcept } from '$lib/types/utils';
 
 /**
@@ -54,6 +54,12 @@ export const SUPPORTED_ETHEREUM_TOKENS: [...RequiredToken[], RequiredToken] = [
 ];
 
 export const SUPPORTED_ETHEREUM_TOKEN_IDS: symbol[] = SUPPORTED_ETHEREUM_TOKENS.map(({ id }) => id);
+
+export const MAP_SUPPORTED_ETHEREUM_TWIN_TOKEN_SYMBOLS: Record<TokenId, string> =
+	SUPPORTED_ETHEREUM_TOKENS.reduce<Record<TokenId, string>>(
+		(acc, token) => ({ ...acc, [token.id]: `ck${token.symbol}` }),
+		{}
+	);
 
 /**
  * ICP

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -1,8 +1,9 @@
 import { ETHEREUM_NETWORK } from '$env/networks.env';
-import { ETHEREUM_TOKEN } from '$env/tokens.env';
+import { ETHEREUM_TOKEN, MAP_SUPPORTED_ETHEREUM_TWIN_TOKEN_SYMBOLS } from '$env/tokens.env';
 import { ERC20_TWIN_TOKENS_IDS } from '$env/tokens.erc20.env';
 import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import {
@@ -96,6 +97,17 @@ export const ckEthereumNativeTokenId: Readable<TokenId> = derived(
 export const ckEthereumNativeTokenBalance: Readable<BigNumber | undefined | null> = derived(
 	[balancesStore, ckEthereumNativeToken],
 	([$balanceStore, { id }]) => $balanceStore?.[id]?.data
+);
+
+/**
+ * The twin token symbol for the current token if it is an Ethereum token (native or ERC20).
+ */
+export const ckTwinTokenSymbol: Readable<string> = derived(
+	[tokenWithFallback],
+	([$tokenWithFallback]) =>
+		MAP_SUPPORTED_ETHEREUM_TWIN_TOKEN_SYMBOLS[$tokenWithFallback.id] ??
+		($tokenWithFallback as Erc20Token).twinTokenSymbol ??
+		''
 );
 
 /**


### PR DESCRIPTION
# Motivation

It will come useful to have a derived store that provides the possible ck-twin-token for the current selected token.