### PR TITLE
chore(frontend): remove unnecessary undefined condition

### DIFF
--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -51,6 +51,11 @@ export const ckEthereumTwinToken: Readable<Token> = derived(
 	([$tokenWithFallback]) => ($tokenWithFallback as IcCkToken)?.twinToken ?? ETHEREUM_TOKEN
 );
 
+export const ckEthereumTwinTokenId: Readable<TokenId> = derived(
+	[ckEthereumTwinToken],
+	([{ id }]) => id
+);
+
 export const ckEthereumTwinTokenStandard: Readable<TokenStandard> = derived(
 	[ckEthereumTwinToken],
 	([{ standard }]) => standard

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -1,4 +1,3 @@
-import { ETHEREUM_NETWORK } from '$env/networks.env';
 import { ETHEREUM_TOKEN } from '$env/tokens.env';
 import { ERC20_TWIN_TOKENS_IDS } from '$env/tokens.erc20.env';
 import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
@@ -52,11 +51,6 @@ export const ckEthereumTwinToken: Readable<Token> = derived(
 	([$tokenWithFallback]) => ($tokenWithFallback as IcCkToken)?.twinToken ?? ETHEREUM_TOKEN
 );
 
-export const ckEthereumTwinTokenId: Readable<TokenId> = derived(
-	[ckEthereumTwinToken],
-	([{ id }]) => id
-);
-
 export const ckEthereumTwinTokenStandard: Readable<TokenStandard> = derived(
 	[ckEthereumTwinToken],
 	([{ standard }]) => standard
@@ -64,7 +58,7 @@ export const ckEthereumTwinTokenStandard: Readable<TokenStandard> = derived(
 
 export const ckEthereumTwinTokenNetwork: Readable<EthereumNetwork> = derived(
 	[ckEthereumTwinToken],
-	([{ network }]) => (network as EthereumNetwork | undefined) ?? ETHEREUM_NETWORK
+	([{ network }]) => network as EthereumNetwork
 );
 
 export const ckEthereumTwinTokenNetworkId: Readable<NetworkId> = derived(


### PR DESCRIPTION
# Motivation

According to the type, it is unnecessary to fallback `ckEthereumTwinTokenNetwork` since the property `network` of type `Token` cannot be `undefined`.
