### PR TITLE
feat(frontend): save selected network in local storage

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -9,6 +9,7 @@
 	import type { NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
+	import { saveSelectedNetwork } from '$lib/utils/network.utils';
 
 	export let id: NetworkId | undefined;
 	export let name: string;
@@ -18,6 +19,7 @@
 	const dispatch = createEventDispatcher();
 
 	const onClick = async () => {
+		saveSelectedNetwork(id);
 		await switchNetwork(id);
 
 		if (isRouteTransactions($page)) {

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -8,7 +8,7 @@ import { trackEvent } from '$lib/services/analytics.services';
 import { authStore, type AuthSignInParams } from '$lib/stores/auth.store';
 import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
-import { testnetsStore } from '$lib/stores/settings.store';
+import { selectedNetworkStore, testnetsStore } from '$lib/stores/settings.store';
 import { toastsClean, toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { ToastMsg } from '$lib/types/toast';
 import { replaceHistory } from '$lib/utils/route.utils';
@@ -104,6 +104,10 @@ const clearTestnetsOption = async () => {
 	testnetsStore.reset({ key: 'testnets' });
 };
 
+const clearSelectedNetwork = async () => {
+	selectedNetworkStore.reset({ key: 'selected-network' });
+};
+
 const logout = async ({
 	msg = undefined,
 	clearStorages = true
@@ -115,7 +119,12 @@ const logout = async ({
 	busy.start();
 
 	if (clearStorages) {
-		await Promise.all([emptyIdbBtcAddressMainnet(), emptyIdbEthAddress(), clearTestnetsOption()]);
+		await Promise.all([
+			emptyIdbBtcAddressMainnet(),
+			emptyIdbEthAddress(),
+			clearTestnetsOption(),
+			clearSelectedNetwork()
+		]);
 	}
 
 	await authStore.signOut();

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -1,8 +1,17 @@
 import { initStorageStore } from '$lib/stores/storage.store';
 
-export interface SettingsData {
+interface ToggleableSettingsData {
 	enabled: boolean;
 }
 
-export const testnetsStore = initStorageStore<SettingsData>({ key: 'testnets' });
-export const hideZeroBalancesStore = initStorageStore<SettingsData>({ key: 'hide-zero-balances' });
+interface SelectableSettingsData {
+	option: string;
+}
+
+export const testnetsStore = initStorageStore<ToggleableSettingsData>({ key: 'testnets' });
+export const hideZeroBalancesStore = initStorageStore<ToggleableSettingsData>({
+	key: 'hide-zero-balances'
+});
+export const selectedNetworkStore = initStorageStore<SelectableSettingsData>({
+	key: 'selected-network'
+});

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -4,6 +4,7 @@ import {
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
 } from '$env/networks.env';
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+import { selectedNetworkStore } from '$lib/stores/settings.store';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
@@ -37,3 +38,15 @@ export const filterTokensForSelectedNetwork = ([
 			$selectedNetwork?.id === networkId
 		);
 	});
+
+export const saveSelectedNetwork = (networkId: NetworkId | undefined) => {
+	const params = {
+		key: 'selected-network'
+	};
+
+	if (nonNullish(networkId) && nonNullish(networkId.description)) {
+		selectedNetworkStore.set({ ...params, value: { option: networkId.description } });
+	} else {
+		selectedNetworkStore.reset(params);
+	}
+};

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -1,5 +1,24 @@
 <script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
 	import Tokens from '$lib/components/tokens/Tokens.svelte';
+	import { routeNetwork } from '$lib/derived/nav.derived';
+	import { networks } from '$lib/derived/networks.derived';
+	import { selectedNetworkStore } from '$lib/stores/settings.store';
+	import { switchNetwork } from '$lib/utils/nav.utils';
+
+	onMount(async () => {
+		const savedSelectedNetwork = $selectedNetworkStore?.option;
+
+		// switch to saved selected network only if it's not already available as URL param
+		if (nonNullish(savedSelectedNetwork) && isNullish($routeNetwork)) {
+			const network = $networks.find(({ id }) => id.description === savedSelectedNetwork);
+
+			if (nonNullish(network)) {
+				await switchNetwork(network.id);
+			}
+		}
+	});
 </script>
 
 <Tokens />


### PR DESCRIPTION
# Motivation

The goal is to save selected network in local storage and update related URL param if it's needed. 

A few use-cases when it's gonna be used:
1. User selects a network -> user navigates to a token transactions page -> user refreshes the browser tab -> user goes back to the home page -> pre-selected network from local storage will be used (previously: network selection was always reset to Chain Fusion).
2. User selects a network -> user closes the browser tab -> user comes back to Oisy -> pre-selected network from local storage will be used (previously: Chain Fusion was always selected as the default option).

Same as with other `settings` from local storage, the selected network value will be reset on logout.

The UX aspect of these changes is discussed and agreed with Artem.