### PR TITLE
fix(frontend): BTC testnet addresss was not loaded

### DIFF
--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Modal, type ProgressStep } from '@dfinity/gix-components';
-	import { debounce, nonNullish } from '@dfinity/utils';
+	import { debounce, isNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { loadErc20Tokens } from '$eth/services/erc20.services';
@@ -71,7 +71,7 @@
 	const debounceLoadBtcAddressTestnet = debounce(loadBtcAddressTestnet);
 
 	$: {
-		if ($testnets && nonNullish($btcAddressTestnet)) {
+		if ($testnets && isNullish($btcAddressTestnet)) {
 			debounceLoadBtcAddressTestnet();
 		}
 	}


### PR DESCRIPTION
# Motivation

Render the BTC test addresses.

There was a bug in when the address was loaded. It was loaded only when it was present, which doesn't make sense. It should be loaded when not present.

# Changes

* Change the check to load the address when it's not in the store.

# Tests

Tested that it's loaded properly now.
