### PR TITLE
chore(signer): Bump signer release

### DIFF
--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -20,7 +20,7 @@ print_help() {
 
 DFX_NETWORK="${DFX_NETWORK:-local}"
 
-SIGNER_RELEASE="v0.1.1"
+SIGNER_RELEASE="v0.1.2"
 CANDID_URL="https://raw.githubusercontent.com/dfinity/chain-fusion-signer/${SIGNER_RELEASE}/src/signer/signer.did"
 WASM_URL="https://github.com/dfinity/chain-fusion-signer/releases/download/${SIGNER_RELEASE}/signer.wasm.gz"
 

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -44,6 +44,7 @@ type SignRequest = record {
 };
 service : (Arg) -> {
   caller_btc_address : (BitcoinNetwork) -> (text);
+  caller_btc_balance : (BitcoinNetwork) -> (nat64);
   caller_eth_address : () -> (text);
   config : () -> (Config) query;
   eth_address_of : (principal) -> (text);

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -54,6 +54,7 @@ export interface SignRequest {
 }
 export interface _SERVICE {
 	caller_btc_address: ActorMethod<[BitcoinNetwork], string>;
+	caller_btc_balance: ActorMethod<[BitcoinNetwork], bigint>;
 	caller_eth_address: ActorMethod<[], string>;
 	config: ActorMethod<[], Config>;
 	eth_address_of: ActorMethod<[Principal], string>;

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -60,6 +60,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		caller_btc_address: IDL.Func([BitcoinNetwork], [IDL.Text], []),
+		caller_btc_balance: IDL.Func([BitcoinNetwork], [IDL.Nat64], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		config: IDL.Func([], [Config]),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -60,6 +60,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		caller_btc_address: IDL.Func([BitcoinNetwork], [IDL.Text], []),
+		caller_btc_balance: IDL.Func([BitcoinNetwork], [IDL.Nat64], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		config: IDL.Func([], [Config], ['query']),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),


### PR DESCRIPTION
# Motivation
The signer has a new method "caller_btc_balance" that we would like to use.

# Changes
* Update the downloaded signer version from 0.1.1 to 0.1.2.

Note: This is NOT available in production yet, but is expected to be soon.

# Tests
See CI