### PR TITLE
feat(frontend): Add BTC to manage tokens

### DIFF
--- a/src/frontend/src/btc/components/BtcManageTokenToggle.svelte
+++ b/src/frontend/src/btc/components/BtcManageTokenToggle.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Toggle } from '@dfinity/gix-components';
+	import { i18n } from '$lib/stores/i18n.store';
+</script>
+
+<!-- Bitcoin tokens are not manageable. -->
+<Toggle disabled ariaLabel={$i18n.tokens.text.hide_token} checked />

--- a/src/frontend/src/btc/utils/token.utils.ts
+++ b/src/frontend/src/btc/utils/token.utils.ts
@@ -1,0 +1,3 @@
+import type { Token } from '$lib/types/token';
+
+export const isBitcoinToken = (token: Token): boolean => token.standard === 'bitcoin';

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -85,7 +85,6 @@
 	let manageEthereumTokens = false;
 	$: manageEthereumTokens = $pseudoNetworkChainFusion || $networkEthereum;
 
-	// TODO: Bitcoin tokens ($enabledBitcoinTokens) are not included yet.
 	let allTokens: TokenToggleable<Token>[] = [];
 	$: allTokens = filterTokensForSelectedNetwork([
 		[

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -38,6 +38,9 @@
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
+	import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
+	import BtcManageTokenToggle from '$btc/components/BtcManageTokenToggle.svelte';
+	import { isBitcoinToken } from '$btc/utils/token.utils';
 
 	const dispatch = createEventDispatcher();
 
@@ -90,6 +93,7 @@
 				...ICP_TOKEN,
 				enabled: true
 			},
+			...$enabledBitcoinTokens.map((token) => ({ ...token, enabled: true })),
 			...$enabledEthereumTokens.map((token) => ({ ...token, enabled: true })),
 			...(manageEthereumTokens ? allErc20Tokens : []),
 			...(manageIcTokens ? allIcrcTokens : [])
@@ -243,6 +247,8 @@
 						<IcManageTokenToggle {token} on:icToken={onToggle} />
 					{:else if icTokenEthereumUserToken(token)}
 						<ManageTokenToggle {token} on:icShowOrHideToken={onToggle} />
+					{:else if isBitcoinToken(token)}
+						<BtcManageTokenToggle />
 					{/if}
 				</svelte:fragment>
 			</Card>

--- a/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
+++ b/src/frontend/src/icp-eth/components/tokens/ManageTokens.svelte
@@ -3,6 +3,9 @@
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import BtcManageTokenToggle from '$btc/components/BtcManageTokenToggle.svelte';
+	import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
+	import { isBitcoinToken } from '$btc/utils/token.utils';
 	import { ICP_TOKEN } from '$env/tokens.env';
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
@@ -38,9 +41,6 @@
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
-	import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
-	import BtcManageTokenToggle from '$btc/components/BtcManageTokenToggle.svelte';
-	import { isBitcoinToken } from '$btc/utils/token.utils';
 
 	const dispatch = createEventDispatcher();
 


### PR DESCRIPTION
# Motivation

Add BTC to ManageTokens modal.

# Changes

* New component for toggle of BTC tokens. It's a dummy component which renders a disabled toggle.
* Btc token util to identify bitcoin tokens.
* Add `enabledBitcoinTokens` in the list of tokens in ManageToken and manage the scenario in the toggle for bitcoin tokens.

# Tests

Tested locally.
