### PR TITLE
chore(frontend): remove unused bubble event in IcSend

### DIFF
--- a/src/frontend/src/icp/components/send/IcSend.svelte
+++ b/src/frontend/src/icp/components/send/IcSend.svelte
@@ -16,5 +16,5 @@
 </script>
 
 <SendButtonWithModal open={openSend} isOpen={$modalIcSend}>
-	<IcSendModal networkId={ICP_NETWORK_ID} on:nnsClose slot="modal" />
+	<IcSendModal networkId={ICP_NETWORK_ID} slot="modal" />
 </SendButtonWithModal>


### PR DESCRIPTION
# Motivation

I checked and the `nnsClose` event is not used in the parent components where `IcSend` is used, so we remove it.
