### PR TITLE
refactor(frontend): common type for optional-nullable CanisterId

### DIFF
--- a/src/frontend/src/env/networks.icp.env.ts
+++ b/src/frontend/src/env/networks.icp.env.ts
@@ -1,14 +1,14 @@
 import { LOCAL } from '$lib/constants/app.constants';
-import type { OptionalNullableCanisterIdText } from '$lib/types/canister';
+import type { OptionCanisterIdText } from '$lib/types/canister';
 
 export const ICP_LEDGER_CANISTER_ID =
 	(LOCAL
-		? (import.meta.env.VITE_LOCAL_ICP_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText)
-		: (import.meta.env.VITE_IC_ICP_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText)) ??
+		? (import.meta.env.VITE_LOCAL_ICP_LEDGER_CANISTER_ID as OptionCanisterIdText)
+		: (import.meta.env.VITE_IC_ICP_LEDGER_CANISTER_ID as OptionCanisterIdText)) ??
 	'ryjl3-tyaaa-aaaaa-aaaba-cai';
 
 export const ICP_INDEX_CANISTER_ID =
 	(LOCAL
-		? (import.meta.env.VITE_LOCAL_ICP_INDEX_CANISTER_ID as OptionalNullableCanisterIdText)
-		: (import.meta.env.VITE_IC_ICP_INDEX_CANISTER_ID as OptionalNullableCanisterIdText)) ??
+		? (import.meta.env.VITE_LOCAL_ICP_INDEX_CANISTER_ID as OptionCanisterIdText)
+		: (import.meta.env.VITE_IC_ICP_INDEX_CANISTER_ID as OptionCanisterIdText)) ??
 	'qhbym-qaaaa-aaaaa-aaafq-cai';

--- a/src/frontend/src/env/networks.icp.env.ts
+++ b/src/frontend/src/env/networks.icp.env.ts
@@ -1,14 +1,13 @@
 import { LOCAL } from '$lib/constants/app.constants';
-import type { CanisterIdText } from '$lib/types/canister';
 
 export const ICP_LEDGER_CANISTER_ID =
 	(LOCAL
-		? (import.meta.env.VITE_LOCAL_ICP_LEDGER_CANISTER_ID as CanisterIdText | null | undefined)
-		: (import.meta.env.VITE_IC_ICP_LEDGER_CANISTER_ID as CanisterIdText | null | undefined)) ??
+		? (import.meta.env.VITE_LOCAL_ICP_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText)
+		: (import.meta.env.VITE_IC_ICP_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText)) ??
 	'ryjl3-tyaaa-aaaaa-aaaba-cai';
 
 export const ICP_INDEX_CANISTER_ID =
 	(LOCAL
-		? (import.meta.env.VITE_LOCAL_ICP_INDEX_CANISTER_ID as CanisterIdText | null | undefined)
-		: (import.meta.env.VITE_IC_ICP_INDEX_CANISTER_ID as CanisterIdText | null | undefined)) ??
+		? (import.meta.env.VITE_LOCAL_ICP_INDEX_CANISTER_ID as OptionalNullableCanisterIdText)
+		: (import.meta.env.VITE_IC_ICP_INDEX_CANISTER_ID as OptionalNullableCanisterIdText)) ??
 	'qhbym-qaaaa-aaaaa-aaafq-cai';

--- a/src/frontend/src/env/networks.icp.env.ts
+++ b/src/frontend/src/env/networks.icp.env.ts
@@ -1,4 +1,5 @@
 import { LOCAL } from '$lib/constants/app.constants';
+import type { OptionalNullableCanisterIdText } from '$lib/types/canister';
 
 export const ICP_LEDGER_CANISTER_ID =
 	(LOCAL

--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -22,37 +22,37 @@ import { type EnvTokenSymbol, type EnvTokens } from '$env/types/env-token-ckerc2
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcCkInterface } from '$icp/types/ic';
 import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
-import type { CanisterIdText } from '$lib/types/canister';
+import type { CanisterIdText, OptionalNullableCanisterIdText } from '$lib/types/canister';
 import type { NetworkEnvironment } from '$lib/types/network';
 import { nonNullish } from '@dfinity/utils';
 
 export const IC_CKBTC_LEDGER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKBTC_LEDGER_CANISTER_ID as CanisterIdText | null | undefined) ??
+	(import.meta.env.VITE_IC_CKBTC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText) ??
 	'mxzaz-hqaaa-aaaar-qaada-cai';
 
 export const IC_CKBTC_INDEX_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKBTC_INDEX_CANISTER_ID as CanisterIdText | null | undefined) ??
+	(import.meta.env.VITE_IC_CKBTC_INDEX_CANISTER_ID as OptionalNullableCanisterIdText) ??
 	'n5wcd-faaaa-aaaar-qaaea-cai';
 
 export const IC_CKBTC_MINTER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKBTC_MINTER_CANISTER_ID as CanisterIdText | null | undefined) ??
+	(import.meta.env.VITE_IC_CKBTC_MINTER_CANISTER_ID as OptionalNullableCanisterIdText) ??
 	'mqygn-kiaaa-aaaar-qaadq-cai';
 
 export const STAGING_CKBTC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKBTC_LEDGER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_STAGING_CKBTC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
 export const STAGING_CKBTC_INDEX_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKBTC_INDEX_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_STAGING_CKBTC_INDEX_CANISTER_ID as OptionalNullableCanisterIdText;
 export const STAGING_CKBTC_MINTER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKBTC_MINTER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_STAGING_CKBTC_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
 
 export const LOCAL_CKBTC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKBTC_LEDGER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_LOCAL_CKBTC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
 export const LOCAL_CKBTC_INDEX_CANISTER_ID = import.meta.env.VITE_LOCAL_CKBTC_INDEX_CANISTER_ID as
 	| CanisterIdText
 	| null
 	| undefined;
 export const LOCAL_CKBTC_MINTER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKBTC_MINTER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_LOCAL_CKBTC_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
 
 const CKBTC_LOCAL_DATA: IcCkInterface | undefined =
 	LOCAL &&
@@ -113,32 +113,32 @@ export const CKBTC_LEDGER_CANISTER_IDS: [CanisterIdText, ...CanisterIdText[]] = 
  */
 
 export const IC_CKETH_LEDGER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKETH_LEDGER_CANISTER_ID as CanisterIdText | null | undefined) ??
+	(import.meta.env.VITE_IC_CKETH_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText) ??
 	'ss2fx-dyaaa-aaaar-qacoq-cai';
 
 export const IC_CKETH_INDEX_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKETH_INDEX_CANISTER_ID as CanisterIdText | null | undefined) ??
+	(import.meta.env.VITE_IC_CKETH_INDEX_CANISTER_ID as OptionalNullableCanisterIdText) ??
 	's3zol-vqaaa-aaaar-qacpa-cai';
 
 export const IC_CKETH_MINTER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKETH_MINTER_CANISTER_ID as CanisterIdText | null | undefined) ??
+	(import.meta.env.VITE_IC_CKETH_MINTER_CANISTER_ID as OptionalNullableCanisterIdText) ??
 	'sv3dd-oaaaa-aaaar-qacoa-cai';
 
 export const STAGING_CKETH_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKETH_LEDGER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_STAGING_CKETH_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
 export const STAGING_CKETH_INDEX_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKETH_INDEX_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_STAGING_CKETH_INDEX_CANISTER_ID as OptionalNullableCanisterIdText;
 export const STAGING_CKETH_MINTER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKETH_MINTER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_STAGING_CKETH_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
 
 export const LOCAL_CKETH_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKETH_LEDGER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_LOCAL_CKETH_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
 export const LOCAL_CKETH_INDEX_CANISTER_ID = import.meta.env.VITE_LOCAL_CKETH_INDEX_CANISTER_ID as
 	| CanisterIdText
 	| null
 	| undefined;
 export const LOCAL_CKETH_MINTER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKETH_MINTER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_LOCAL_CKETH_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
 
 const CKETH_LOCAL_DATA: IcCkInterface | undefined =
 	LOCAL &&
@@ -199,9 +199,9 @@ export const CKETH_LEDGER_CANISTER_IDS: [CanisterIdText, ...CanisterIdText[]] = 
  */
 
 export const LOCAL_CKUSDC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
 export const LOCAL_CKUSDC_INDEX_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKUSDC_INDEX_CANISTER_ID as CanisterIdText | null | undefined;
+	.VITE_LOCAL_CKUSDC_INDEX_CANISTER_ID as OptionalNullableCanisterIdText;
 
 const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
 	LOCAL &&
@@ -228,8 +228,8 @@ const mapCkErc20Data = ({
 	env
 }: {
 	ckErc20Tokens: EnvTokens;
-	minterCanisterId: string | null | undefined;
-	ledgerCanisterId: string | null | undefined;
+	minterCanisterId: OptionalNullableCanisterIdText;
+	ledgerCanisterId: OptionalNullableCanisterIdText;
 	env: NetworkEnvironment;
 }): Record<EnvTokenSymbol, Omit<IcCkInterface, 'twinToken' | 'position'>> =>
 	Object.entries(ckErc20Tokens).reduce(

--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -22,37 +22,37 @@ import { type EnvTokenSymbol, type EnvTokens } from '$env/types/env-token-ckerc2
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcCkInterface } from '$icp/types/ic';
 import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
-import type { CanisterIdText, OptionalNullableCanisterIdText } from '$lib/types/canister';
+import type { CanisterIdText, OptionCanisterIdText } from '$lib/types/canister';
 import type { NetworkEnvironment } from '$lib/types/network';
 import { nonNullish } from '@dfinity/utils';
 
 export const IC_CKBTC_LEDGER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKBTC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText) ??
+	(import.meta.env.VITE_IC_CKBTC_LEDGER_CANISTER_ID as OptionCanisterIdText) ??
 	'mxzaz-hqaaa-aaaar-qaada-cai';
 
 export const IC_CKBTC_INDEX_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKBTC_INDEX_CANISTER_ID as OptionalNullableCanisterIdText) ??
+	(import.meta.env.VITE_IC_CKBTC_INDEX_CANISTER_ID as OptionCanisterIdText) ??
 	'n5wcd-faaaa-aaaar-qaaea-cai';
 
 export const IC_CKBTC_MINTER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKBTC_MINTER_CANISTER_ID as OptionalNullableCanisterIdText) ??
+	(import.meta.env.VITE_IC_CKBTC_MINTER_CANISTER_ID as OptionCanisterIdText) ??
 	'mqygn-kiaaa-aaaar-qaadq-cai';
 
 export const STAGING_CKBTC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKBTC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_STAGING_CKBTC_LEDGER_CANISTER_ID as OptionCanisterIdText;
 export const STAGING_CKBTC_INDEX_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKBTC_INDEX_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_STAGING_CKBTC_INDEX_CANISTER_ID as OptionCanisterIdText;
 export const STAGING_CKBTC_MINTER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKBTC_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_STAGING_CKBTC_MINTER_CANISTER_ID as OptionCanisterIdText;
 
 export const LOCAL_CKBTC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKBTC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_LOCAL_CKBTC_LEDGER_CANISTER_ID as OptionCanisterIdText;
 export const LOCAL_CKBTC_INDEX_CANISTER_ID = import.meta.env.VITE_LOCAL_CKBTC_INDEX_CANISTER_ID as
 	| CanisterIdText
 	| null
 	| undefined;
 export const LOCAL_CKBTC_MINTER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKBTC_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_LOCAL_CKBTC_MINTER_CANISTER_ID as OptionCanisterIdText;
 
 const CKBTC_LOCAL_DATA: IcCkInterface | undefined =
 	LOCAL &&
@@ -113,32 +113,32 @@ export const CKBTC_LEDGER_CANISTER_IDS: [CanisterIdText, ...CanisterIdText[]] = 
  */
 
 export const IC_CKETH_LEDGER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKETH_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText) ??
+	(import.meta.env.VITE_IC_CKETH_LEDGER_CANISTER_ID as OptionCanisterIdText) ??
 	'ss2fx-dyaaa-aaaar-qacoq-cai';
 
 export const IC_CKETH_INDEX_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKETH_INDEX_CANISTER_ID as OptionalNullableCanisterIdText) ??
+	(import.meta.env.VITE_IC_CKETH_INDEX_CANISTER_ID as OptionCanisterIdText) ??
 	's3zol-vqaaa-aaaar-qacpa-cai';
 
 export const IC_CKETH_MINTER_CANISTER_ID =
-	(import.meta.env.VITE_IC_CKETH_MINTER_CANISTER_ID as OptionalNullableCanisterIdText) ??
+	(import.meta.env.VITE_IC_CKETH_MINTER_CANISTER_ID as OptionCanisterIdText) ??
 	'sv3dd-oaaaa-aaaar-qacoa-cai';
 
 export const STAGING_CKETH_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKETH_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_STAGING_CKETH_LEDGER_CANISTER_ID as OptionCanisterIdText;
 export const STAGING_CKETH_INDEX_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKETH_INDEX_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_STAGING_CKETH_INDEX_CANISTER_ID as OptionCanisterIdText;
 export const STAGING_CKETH_MINTER_CANISTER_ID = import.meta.env
-	.VITE_STAGING_CKETH_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_STAGING_CKETH_MINTER_CANISTER_ID as OptionCanisterIdText;
 
 export const LOCAL_CKETH_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKETH_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_LOCAL_CKETH_LEDGER_CANISTER_ID as OptionCanisterIdText;
 export const LOCAL_CKETH_INDEX_CANISTER_ID = import.meta.env.VITE_LOCAL_CKETH_INDEX_CANISTER_ID as
 	| CanisterIdText
 	| null
 	| undefined;
 export const LOCAL_CKETH_MINTER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKETH_MINTER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_LOCAL_CKETH_MINTER_CANISTER_ID as OptionCanisterIdText;
 
 const CKETH_LOCAL_DATA: IcCkInterface | undefined =
 	LOCAL &&
@@ -199,9 +199,9 @@ export const CKETH_LEDGER_CANISTER_IDS: [CanisterIdText, ...CanisterIdText[]] = 
  */
 
 export const LOCAL_CKUSDC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as OptionCanisterIdText;
 export const LOCAL_CKUSDC_INDEX_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKUSDC_INDEX_CANISTER_ID as OptionalNullableCanisterIdText;
+	.VITE_LOCAL_CKUSDC_INDEX_CANISTER_ID as OptionCanisterIdText;
 
 const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
 	LOCAL &&
@@ -228,8 +228,8 @@ const mapCkErc20Data = ({
 	env
 }: {
 	ckErc20Tokens: EnvTokens;
-	minterCanisterId: OptionalNullableCanisterIdText;
-	ledgerCanisterId: OptionalNullableCanisterIdText;
+	minterCanisterId: OptionCanisterIdText;
+	ledgerCanisterId: OptionCanisterIdText;
 	env: NetworkEnvironment;
 }): Record<EnvTokenSymbol, Omit<IcCkInterface, 'twinToken' | 'position'>> =>
 	Object.entries(ckErc20Tokens).reduce(

--- a/src/frontend/src/lib/types/canister.ts
+++ b/src/frontend/src/lib/types/canister.ts
@@ -1,1 +1,3 @@
 export type CanisterIdText = string;
+
+export type OptionalNullableCanisterIdText = CanisterIdText | null | undefined;

--- a/src/frontend/src/lib/types/canister.ts
+++ b/src/frontend/src/lib/types/canister.ts
@@ -1,3 +1,3 @@
 export type CanisterIdText = string;
 
-export type OptionalNullableCanisterIdText = CanisterIdText | null | undefined;
+export type OptionCanisterIdText = CanisterIdText | null | undefined;


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we create a common type for optional-nullable type `CanisterIdText`.