### PR TITLE
refactor(frontend): common type for balance as BigNumber

### DIFF
--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { fromNullable, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { TransactionResponse } from '@ethersproject/abstract-provider';
-	import type { BigNumber } from '@ethersproject/bignumber';
 	import { onDestroy } from 'svelte';
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
 	import type { WebSocketListener } from '$eth/types/listener';
@@ -28,11 +27,12 @@
 	import { tokenId } from '$lib/derived/token.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { OptionEthAddress } from '$lib/types/address';
+	import type { OptionalNullableBalance } from '$lib/types/balance';
 	import type { NetworkId } from '$lib/types/network';
 
 	let listener: WebSocketListener | undefined = undefined;
 
-	let loadBalance: BigNumber | undefined | null = undefined;
+	let loadBalance: OptionalNullableBalance = undefined;
 
 	// TODO: this is way too much work for a component and for the UI. Defer all that mumbo jumbo to a worker.
 

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -27,12 +27,12 @@
 	import { tokenId } from '$lib/derived/token.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { OptionEthAddress } from '$lib/types/address';
-	import type { OptionalNullableBalance } from '$lib/types/balance';
+	import type { OptionBalance } from '$lib/types/balance';
 	import type { NetworkId } from '$lib/types/network';
 
 	let listener: WebSocketListener | undefined = undefined;
 
-	let loadBalance: OptionalNullableBalance = undefined;
+	let loadBalance: OptionBalance = undefined;
 
 	// TODO: this is way too much work for a component and for the UI. Defer all that mumbo jumbo to a worker.
 

--- a/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
+++ b/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
@@ -5,6 +5,7 @@
 	import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionalNullableBalance } from '$lib/types/balance';
 	import type { TokenId } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -14,7 +15,7 @@
 	export let feeTokenId: TokenId;
 	export let feeDecimals: number;
 
-	let balance: BigNumber | undefined;
+	let balance: Exclude<OptionalNullableBalance, null>;
 	$: balance = nonNullish($balancesStore) ? $balancesStore[feeTokenId]?.data ?? ZERO : undefined;
 
 	let insufficientFeeFunds = false;

--- a/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
+++ b/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
@@ -5,7 +5,7 @@
 	import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { OptionalNullableBalance } from '$lib/types/balance';
+	import type { OptionBalance } from '$lib/types/balance';
 	import type { TokenId } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -15,7 +15,7 @@
 	export let feeTokenId: TokenId;
 	export let feeDecimals: number;
 
-	let balance: Exclude<OptionalNullableBalance, null>;
+	let balance: Exclude<OptionBalance, null>;
 	$: balance = nonNullish($balancesStore) ? $balancesStore[feeTokenId]?.data ?? ZERO : undefined;
 
 	let insufficientFeeFunds = false;

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -15,9 +15,9 @@ import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import { tokenStandard, tokenWithFallback } from '$lib/derived/token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { OptionEthAddress } from '$lib/types/address';
+import type { OptionalNullableBalance } from '$lib/types/balance';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId, TokenStandard } from '$lib/types/token';
-import type { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -92,7 +92,7 @@ export const ckEthereumNativeTokenId: Readable<TokenId> = derived(
 	([{ id }]) => id
 );
 
-export const ckEthereumNativeTokenBalance: Readable<BigNumber | undefined | null> = derived(
+export const ckEthereumNativeTokenBalance: Readable<OptionalNullableBalance> = derived(
 	[balancesStore, ckEthereumNativeToken],
 	([$balanceStore, { id }]) => $balanceStore?.[id]?.data
 );

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -15,7 +15,7 @@ import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import { tokenStandard, tokenWithFallback } from '$lib/derived/token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { OptionEthAddress } from '$lib/types/address';
-import type { OptionalNullableBalance } from '$lib/types/balance';
+import type { OptionBalance } from '$lib/types/balance';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId, TokenStandard } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
@@ -92,7 +92,7 @@ export const ckEthereumNativeTokenId: Readable<TokenId> = derived(
 	([{ id }]) => id
 );
 
-export const ckEthereumNativeTokenBalance: Readable<OptionalNullableBalance> = derived(
+export const ckEthereumNativeTokenBalance: Readable<OptionBalance> = derived(
 	[balancesStore, ckEthereumNativeToken],
 	([$balanceStore, { id }]) => $balanceStore?.[id]?.data
 );

--- a/src/frontend/src/icp-eth/stores/send.store.ts
+++ b/src/frontend/src/icp-eth/stores/send.store.ts
@@ -1,5 +1,5 @@
 import { balancesStore } from '$lib/stores/balances.store';
-import type { OptionalNullableBalance } from '$lib/types/balance';
+import type { OptionBalance } from '$lib/types/balance';
 import type { Token, TokenId, TokenStandard } from '$lib/types/token';
 import { derived, writable, type Readable } from 'svelte/store';
 
@@ -53,7 +53,7 @@ export interface SendContext {
 	sendTokenDecimals: Readable<number>;
 	sendTokenId: Readable<TokenId>;
 	sendTokenStandard: Readable<TokenStandard>;
-	sendBalance: Readable<OptionalNullableBalance>;
+	sendBalance: Readable<OptionBalance>;
 	sendPurpose: SendContextPurpose;
 }
 

--- a/src/frontend/src/icp-eth/stores/send.store.ts
+++ b/src/frontend/src/icp-eth/stores/send.store.ts
@@ -1,6 +1,6 @@
 import { balancesStore } from '$lib/stores/balances.store';
+import type { OptionalNullableBalance } from '$lib/types/balance';
 import type { Token, TokenId, TokenStandard } from '$lib/types/token';
-import type { BigNumber } from '@ethersproject/bignumber';
 import { derived, writable, type Readable } from 'svelte/store';
 
 export type SendData = Token;
@@ -53,7 +53,7 @@ export interface SendContext {
 	sendTokenDecimals: Readable<number>;
 	sendTokenId: Readable<TokenId>;
 	sendTokenStandard: Readable<TokenStandard>;
-	sendBalance: Readable<BigNumber | undefined | null>;
+	sendBalance: Readable<OptionalNullableBalance>;
 	sendPurpose: SendContextPurpose;
 }
 

--- a/src/frontend/src/icp/utils/cketh.utils.ts
+++ b/src/frontend/src/icp/utils/cketh.utils.ts
@@ -3,6 +3,7 @@ import type { EthereumFeeStoreData } from '$icp/stores/ethereum-fee.store';
 import type { IcToken } from '$icp/types/ic';
 import { IcAmountAssertionError } from '$icp/types/ic-send';
 import { ZERO } from '$lib/constants/app.constants';
+import type { OptionalNullableBalance } from '$lib/types/balance';
 import { formatToken } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { fromNullable, isNullish } from '@dfinity/utils';
@@ -93,7 +94,7 @@ export const assertCkETHBalanceEstimatedFee = ({
 	feeStoreData,
 	i18n
 }: {
-	balance: BigNumber | undefined | null;
+	balance: OptionalNullableBalance;
 	tokenCkEth: IcToken | undefined;
 	feeStoreData: EthereumFeeStoreData;
 	i18n: I18n;

--- a/src/frontend/src/icp/utils/cketh.utils.ts
+++ b/src/frontend/src/icp/utils/cketh.utils.ts
@@ -3,7 +3,7 @@ import type { EthereumFeeStoreData } from '$icp/stores/ethereum-fee.store';
 import type { IcToken } from '$icp/types/ic';
 import { IcAmountAssertionError } from '$icp/types/ic-send';
 import { ZERO } from '$lib/constants/app.constants';
-import type { OptionalNullableBalance } from '$lib/types/balance';
+import type { OptionBalance } from '$lib/types/balance';
 import { formatToken } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { fromNullable, isNullish } from '@dfinity/utils';
@@ -94,7 +94,7 @@ export const assertCkETHBalanceEstimatedFee = ({
 	feeStoreData,
 	i18n
 }: {
-	balance: OptionalNullableBalance;
+	balance: OptionBalance;
 	tokenCkEth: IcToken | undefined;
 	feeStoreData: EthereumFeeStoreData;
 	i18n: I18n;

--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -3,13 +3,13 @@
 	import SendDataDestination from './SendDataDestination.svelte';
 	import SendDataAmount from '$lib/components/send/SendDataAmount.svelte';
 	import SendSource from '$lib/components/send/SendSource.svelte';
-	import type { OptionalNullableBalance } from '$lib/types/balance';
+	import type { OptionBalance } from '$lib/types/balance';
 	import type { Token } from '$lib/types/token';
 
 	export let destination: string | null;
 	export let amount: string | number | undefined = undefined;
 	export let token: Token;
-	export let balance: OptionalNullableBalance;
+	export let balance: OptionBalance;
 	export let source: string;
 </script>
 

--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import SendDataDestination from './SendDataDestination.svelte';
 	import SendDataAmount from '$lib/components/send/SendDataAmount.svelte';
 	import SendSource from '$lib/components/send/SendSource.svelte';
+	import type { OptionalNullableBalance } from '$lib/types/balance';
 	import type { Token } from '$lib/types/token';
 
 	export let destination: string | null;
 	export let amount: string | number | undefined = undefined;
 	export let token: Token;
-	export let balance: BigNumber | undefined | null;
+	export let balance: OptionalNullableBalance;
 	export let source: string;
 </script>
 

--- a/src/frontend/src/lib/components/send/SendSource.svelte
+++ b/src/frontend/src/lib/components/send/SendSource.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionalNullableBalance } from '$lib/types/balance';
 	import type { OptionToken } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 
 	export let token: OptionToken;
-	export let balance: BigNumber | undefined | null;
+	export let balance: OptionalNullableBalance;
 	export let source: string;
 </script>
 

--- a/src/frontend/src/lib/components/send/SendSource.svelte
+++ b/src/frontend/src/lib/components/send/SendSource.svelte
@@ -3,12 +3,12 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { OptionalNullableBalance } from '$lib/types/balance';
+	import type { OptionBalance } from '$lib/types/balance';
 	import type { OptionToken } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 
 	export let token: OptionToken;
-	export let balance: OptionalNullableBalance;
+	export let balance: OptionBalance;
 	export let source: string;
 </script>
 

--- a/src/frontend/src/lib/derived/balances.derived.ts
+++ b/src/frontend/src/lib/derived/balances.derived.ts
@@ -1,10 +1,10 @@
 import { balancesStore } from '$lib/stores/balances.store';
 import { token } from '$lib/stores/token.store';
+import type { OptionalNullableBalance } from '$lib/types/balance';
 import { nonNullish } from '@dfinity/utils';
-import type { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
 
-export const balance: Readable<BigNumber | undefined | null> = derived(
+export const balance: Readable<OptionalNullableBalance> = derived(
 	[balancesStore, token],
 	([$balanceStore, $token]) => (nonNullish($token) ? $balanceStore?.[$token.id]?.data : undefined)
 );

--- a/src/frontend/src/lib/derived/balances.derived.ts
+++ b/src/frontend/src/lib/derived/balances.derived.ts
@@ -1,10 +1,10 @@
 import { balancesStore } from '$lib/stores/balances.store';
 import { token } from '$lib/stores/token.store';
-import type { OptionalNullableBalance } from '$lib/types/balance';
+import type { OptionBalance } from '$lib/types/balance';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const balance: Readable<OptionalNullableBalance> = derived(
+export const balance: Readable<OptionBalance> = derived(
 	[balancesStore, token],
 	([$balanceStore, $token]) => (nonNullish($token) ? $balanceStore?.[$token.id]?.data : undefined)
 );

--- a/src/frontend/src/lib/types/balance.ts
+++ b/src/frontend/src/lib/types/balance.ts
@@ -2,6 +2,4 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 export type Balance = BigNumber;
 
-export type NullableBalance = Balance | null;
-
-export type OptionalNullableBalance = NullableBalance | undefined;
+export type OptionBalance = Balance | null | undefined;

--- a/src/frontend/src/lib/types/balance.ts
+++ b/src/frontend/src/lib/types/balance.ts
@@ -1,0 +1,5 @@
+import { BigNumber } from '@ethersproject/bignumber';
+
+export type Balance = BigNumber;
+
+export type OptionalNullableBalance = Balance | null | undefined;

--- a/src/frontend/src/lib/types/balance.ts
+++ b/src/frontend/src/lib/types/balance.ts
@@ -2,4 +2,6 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 export type Balance = BigNumber;
 
-export type OptionalNullableBalance = Balance | null | undefined;
+export type NullableBalance = Balance | null;
+
+export type OptionalNullableBalance = NullableBalance | undefined;

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,4 +1,4 @@
-import type { NullableBalance } from '$lib/types/balance';
+import type { OptionBalance } from '$lib/types/balance';
 import type { Network } from '$lib/types/network';
 import type { RequiredExcept } from '$lib/types/utils';
 
@@ -41,7 +41,7 @@ export type OptionTokenStandard = TokenStandard | undefined | null;
 export type TokenToPin = Pick<Token, 'id'> & { network: Pick<Token['network'], 'id'> };
 
 interface TokenFinancialData {
-	balance?: NullableBalance;
+	balance?: Exclude<OptionBalance, undefined>;
 	usdBalance?: number;
 }
 

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,6 +1,6 @@
+import type { NullableBalance } from '$lib/types/balance';
 import type { Network } from '$lib/types/network';
 import type { RequiredExcept } from '$lib/types/utils';
-import type { BigNumber } from '@ethersproject/bignumber';
 
 export type TokenId = symbol;
 
@@ -41,7 +41,7 @@ export type OptionTokenStandard = TokenStandard | undefined | null;
 export type TokenToPin = Pick<Token, 'id'> & { network: Pick<Token['network'], 'id'> };
 
 interface TokenFinancialData {
-	balance?: BigNumber | null;
+	balance?: NullableBalance;
 	usdBalance?: number;
 }
 

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,5 +1,5 @@
 import { ZERO } from '$lib/constants/app.constants';
-import type { OptionalNullableBalance } from '$lib/types/balance';
+import type { OptionBalance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
 import { formatToken } from '$lib/utils/format.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -10,7 +10,7 @@ export const usdValue = ({
 	exchangeRate
 }: {
 	token: Token;
-	balance: Exclude<OptionalNullableBalance, null>;
+	balance: Exclude<OptionBalance, null>;
 	exchangeRate: number;
 }): number =>
 	nonNullish(balance)

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,8 +1,8 @@
 import { ZERO } from '$lib/constants/app.constants';
+import type { OptionalNullableBalance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
 import { formatToken } from '$lib/utils/format.utils';
 import { nonNullish } from '@dfinity/utils';
-import type { BigNumber } from '@ethersproject/bignumber';
 
 export const usdValue = ({
 	token: { decimals },
@@ -10,7 +10,7 @@ export const usdValue = ({
 	exchangeRate
 }: {
 	token: Token;
-	balance: BigNumber | undefined;
+	balance: Exclude<OptionalNullableBalance, null>;
 	exchangeRate: number;
 }): number =>
 	nonNullish(balance)


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we create a common type for balance when is defined as `BigNumber`.