### PR TITLE
refactor(frontend): common type for optional-nullable string

### DIFF
--- a/src/frontend/src/eth/derived/wallet-connect.derived.ts
+++ b/src/frontend/src/eth/derived/wallet-connect.derived.ts
@@ -1,13 +1,11 @@
 import { page } from '$app/stores';
+import type { OptionalNullableString } from '$lib/types/string';
 import { derived, type Readable } from 'svelte/store';
 
-export const walletConnectUri: Readable<OptionalNullableCanisterIdText> = derived(
-	[page],
-	([$page]) => {
-		const {
-			data: { uri }
-		} = $page;
+export const walletConnectUri: Readable<OptionalNullableString> = derived([page], ([$page]) => {
+	const {
+		data: { uri }
+	} = $page;
 
-		return uri;
-	}
-);
+	return uri;
+});

--- a/src/frontend/src/eth/derived/wallet-connect.derived.ts
+++ b/src/frontend/src/eth/derived/wallet-connect.derived.ts
@@ -1,10 +1,13 @@
 import { page } from '$app/stores';
 import { derived, type Readable } from 'svelte/store';
 
-export const walletConnectUri: Readable<string | null | undefined> = derived([page], ([$page]) => {
-	const {
-		data: { uri }
-	} = $page;
+export const walletConnectUri: Readable<OptionalNullableCanisterIdText> = derived(
+	[page],
+	([$page]) => {
+		const {
+			data: { uri }
+		} = $page;
 
-	return uri;
-});
+		return uri;
+	}
+);

--- a/src/frontend/src/eth/derived/wallet-connect.derived.ts
+++ b/src/frontend/src/eth/derived/wallet-connect.derived.ts
@@ -1,8 +1,8 @@
 import { page } from '$app/stores';
-import type { OptionalNullableString } from '$lib/types/string';
+import type { OptionString } from '$lib/types/string';
 import { derived, type Readable } from 'svelte/store';
 
-export const walletConnectUri: Readable<OptionalNullableString> = derived([page], ([$page]) => {
+export const walletConnectUri: Readable<OptionString> = derived([page], ([$page]) => {
 	const {
 		data: { uri }
 	} = $page;

--- a/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
@@ -13,7 +13,7 @@ import { MINT_MEMO_KYT_FAIL, decodeBurnMemo, decodeMintMemo } from '$icp/utils/c
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Network } from '$lib/types/network';
-import type { OptionalNullableString } from '$lib/types/string';
+import type { OptionString } from '$lib/types/string';
 import type { PendingUtxo, RetrieveBtcStatusV2 } from '@dfinity/ckbtc';
 import { fromNullable, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 
@@ -191,7 +191,7 @@ const isMemoReimbursement = (memo: Uint8Array | number[]) => {
 	}
 };
 
-const burnMemoAddress = (memo: Uint8Array | number[]): OptionalNullableString => {
+const burnMemoAddress = (memo: Uint8Array | number[]): OptionString => {
 	try {
 		const [_, [toAddress]] = decodeBurnMemo(memo);
 		return toAddress;

--- a/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
@@ -13,6 +13,7 @@ import { MINT_MEMO_KYT_FAIL, decodeBurnMemo, decodeMintMemo } from '$icp/utils/c
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Network } from '$lib/types/network';
+import type { OptionalNullableString } from '$lib/types/string';
 import type { PendingUtxo, RetrieveBtcStatusV2 } from '@dfinity/ckbtc';
 import { fromNullable, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 
@@ -190,7 +191,7 @@ const isMemoReimbursement = (memo: Uint8Array | number[]) => {
 	}
 };
 
-const burnMemoAddress = (memo: Uint8Array | number[]): string | undefined | null => {
+const burnMemoAddress = (memo: Uint8Array | number[]): OptionalNullableString => {
 	try {
 		const [_, [toAddress]] = decodeBurnMemo(memo);
 		return toAddress;

--- a/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
@@ -6,12 +6,13 @@
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { RECEIVE_TOKENS_MODAL_ADDRESS_LABEL } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionalNullableString } from '$lib/types/string';
 	import type { Token } from '$lib/types/token';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let token: Token;
-	export let address: string | undefined | null;
+	export let address: OptionalNullableString;
 	export let qrCodeAriaLabel: string;
 	export let copyAriaLabel: string;
 	export let invisibleLogo = false;

--- a/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
@@ -6,13 +6,13 @@
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { RECEIVE_TOKENS_MODAL_ADDRESS_LABEL } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { OptionalNullableString } from '$lib/types/string';
+	import type { OptionString } from '$lib/types/string';
 	import type { Token } from '$lib/types/token';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let token: Token;
-	export let address: OptionalNullableString;
+	export let address: OptionString;
 	export let qrCodeAriaLabel: string;
 	export let copyAriaLabel: string;
 	export let invisibleLogo = false;

--- a/src/frontend/src/lib/derived/nav.derived.ts
+++ b/src/frontend/src/lib/derived/nav.derived.ts
@@ -1,8 +1,8 @@
 import { page } from '$app/stores';
-import type { OptionalNullableString } from '$lib/types/string';
+import type { OptionString } from '$lib/types/string';
 import { derived, type Readable } from 'svelte/store';
 
-export const routeToken: Readable<OptionalNullableString> = derived(
+export const routeToken: Readable<OptionString> = derived(
 	[page],
 	([
 		{
@@ -11,7 +11,7 @@ export const routeToken: Readable<OptionalNullableString> = derived(
 	]) => token
 );
 
-export const routeNetwork: Readable<OptionalNullableString> = derived(
+export const routeNetwork: Readable<OptionString> = derived(
 	[page],
 	([
 		{

--- a/src/frontend/src/lib/derived/nav.derived.ts
+++ b/src/frontend/src/lib/derived/nav.derived.ts
@@ -1,7 +1,8 @@
 import { page } from '$app/stores';
+import type { OptionalNullableString } from '$lib/types/string';
 import { derived, type Readable } from 'svelte/store';
 
-export const routeToken: Readable<string | undefined | null> = derived(
+export const routeToken: Readable<OptionalNullableString> = derived(
 	[page],
 	([
 		{
@@ -10,7 +11,7 @@ export const routeToken: Readable<string | undefined | null> = derived(
 	]) => token
 );
 
-export const routeNetwork: Readable<string | undefined | null> = derived(
+export const routeNetwork: Readable<OptionalNullableString> = derived(
 	[page],
 	([
 		{

--- a/src/frontend/src/lib/types/string.ts
+++ b/src/frontend/src/lib/types/string.ts
@@ -1,0 +1,1 @@
+export type OptionalNullableString = string | null | undefined;

--- a/src/frontend/src/lib/types/string.ts
+++ b/src/frontend/src/lib/types/string.ts
@@ -1,1 +1,1 @@
-export type OptionalNullableString = string | null | undefined;
+export type OptionString = string | null | undefined;

--- a/src/frontend/src/lib/utils/input.utils.ts
+++ b/src/frontend/src/lib/utils/input.utils.ts
@@ -1,6 +1,7 @@
+import type { OptionalNullableString } from '$lib/types/string';
 import { isNullish } from '@dfinity/utils';
 
-export const isNullishOrEmpty = (value: string | undefined | null): value is undefined | null =>
+export const isNullishOrEmpty = (value: OptionalNullableString): value is undefined | null =>
 	isNullish(value) || value === '';
 
 export const invalidAmount = (amount: number | undefined): boolean =>

--- a/src/frontend/src/lib/utils/input.utils.ts
+++ b/src/frontend/src/lib/utils/input.utils.ts
@@ -1,7 +1,7 @@
-import type { OptionalNullableString } from '$lib/types/string';
+import type { OptionString } from '$lib/types/string';
 import { isNullish } from '@dfinity/utils';
 
-export const isNullishOrEmpty = (value: OptionalNullableString): value is undefined | null =>
+export const isNullishOrEmpty = (value: OptionString): value is undefined | null =>
 	isNullish(value) || value === '';
 
 export const invalidAmount = (amount: number | undefined): boolean =>

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -49,10 +49,10 @@ export const gotoReplaceRoot = async () => {
 };
 
 export type RouteParams = {
-	token: OptionalNullableCanisterIdText;
-	network: OptionalNullableCanisterIdText;
+	token: string | null | undefined;
+	network: string | null | undefined;
 	// WalletConnect URI parameter
-	uri: OptionalNullableCanisterIdText;
+	uri: string | null | undefined;
 };
 
 export const loadRouteParams = ($event: LoadEvent): RouteParams => {

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -49,10 +49,10 @@ export const gotoReplaceRoot = async () => {
 };
 
 export type RouteParams = {
-	token: string | null | undefined;
-	network: string | null | undefined;
+	token: OptionalNullableCanisterIdText;
+	network: OptionalNullableCanisterIdText;
 	// WalletConnect URI parameter
-	uri: string | null | undefined;
+	uri: OptionalNullableCanisterIdText;
 };
 
 export const loadRouteParams = ($event: LoadEvent): RouteParams => {

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -1,7 +1,7 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import type { NetworkId } from '$lib/types/network';
-import type { OptionalNullableString } from '$lib/types/string';
+import type { OptionString } from '$lib/types/string';
 import type { Token } from '$lib/types/token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { LoadEvent, Page } from '@sveltejs/kit';
@@ -50,10 +50,10 @@ export const gotoReplaceRoot = async () => {
 };
 
 export type RouteParams = {
-	token: OptionalNullableString;
-	network: OptionalNullableString;
+	token: OptionString;
+	network: OptionString;
 	// WalletConnect URI parameter
-	uri: OptionalNullableString;
+	uri: OptionString;
 };
 
 export const loadRouteParams = ($event: LoadEvent): RouteParams => {

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import type { NetworkId } from '$lib/types/network';
+import type { OptionalNullableString } from '$lib/types/string';
 import type { Token } from '$lib/types/token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { LoadEvent, Page } from '@sveltejs/kit';
@@ -49,10 +50,10 @@ export const gotoReplaceRoot = async () => {
 };
 
 export type RouteParams = {
-	token: string | null | undefined;
-	network: string | null | undefined;
+	token: OptionalNullableString;
+	network: OptionalNullableString;
 	// WalletConnect URI parameter
-	uri: string | null | undefined;
+	uri: OptionalNullableString;
 };
 
 export const loadRouteParams = ($event: LoadEvent): RouteParams => {


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we create a common type for optional-nullable type `string`.
