### PR TITLE
fix(devops): Fix shell quoting in signer args file

### DIFF
--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -78,12 +78,12 @@ esac
 rm -f "$ARG_FILE"
 mkdir -p "$(dirname "$ARG_FILE")"
 cat <<EOF >"$ARG_FILE"
-"(variant {
+(variant {
     Init = record {
-         ecdsa_key_name = \"$ECDSA_KEY_NAME\";
+         ecdsa_key_name = "$ECDSA_KEY_NAME";
          ic_root_key_der = $ic_root_key_der;
      }
-  })"
+  })
 EOF
 
 ####


### PR DESCRIPTION
# Motivation
The command that creates the signer args file leaves unintended characters in the argument file.  The code was moved from a shell variable to a heredoc, thereby introducing these errors.

# Changes
- Remove quotes and escapes from the signer args heredoc.

# Tests
Running `scripts/build.signer.sh` now creates a valid candid file.