### PR TITLE
fix(devops): Deploying the signer without env was failing

### DIFF
--- a/scripts/deploy.signer.sh
+++ b/scripts/deploy.signer.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-dfx deploy signer --network "$ENV"
+dfx deploy signer --network "${ENV:-local}" 


### PR DESCRIPTION
# Motivation

Running `npm run deploy` wasn't installing the signer canister.

The reason was that when using `--network` you can't pass an empty string.

# Changes

* Add `local` as default value when deploying the signer.

# Tests

Tested locally.
