### PR TITLE
fix(frontend): Fix local bitcoin node setup

### DIFF
--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -110,7 +110,6 @@ else
     mkdir -p $DATA_DIR
   fi
   # -debug=0 Disables debug logging to reduce the size and frequency of log files.
-  # -prune=550 If don’t need the full historical blockchain, you can use pruned mode to limit how much of the blockchain is stored on disk
   # -maxmempool=50 The memory pool holds unconfirmed transactions. Limiting its size can reduce the memory usage and slow the cache increase
   ./$BITCOIN_DIR/bin/bitcoind -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444 -debug=0 -maxmempool=50
 fi

--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -112,5 +112,5 @@ else
   # -debug=0 Disables debug logging to reduce the size and frequency of log files.
   # -prune=550 If don’t need the full historical blockchain, you can use pruned mode to limit how much of the blockchain is stored on disk
   # -maxmempool=50 The memory pool holds unconfirmed transactions. Limiting its size can reduce the memory usage and slow the cache increase
-  ./$BITCOIN_DIR/bin/bitcoind -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444 -debug=0 -prune=550 -maxmempool=50
+  ./$BITCOIN_DIR/bin/bitcoind -conf="$(pwd)/$BITCOIN_CONF" -datadir="$(pwd)/$DATA_DIR" --port=18444 -debug=0 -maxmempool=50
 fi


### PR DESCRIPTION
# Motivation

New minted blocks were not adding balance to the address.

The reason seemed to be a config parameter when setting up the local node.

# Changes

* Remove the parameter (it was there to reduce the amount of memory, which is a premature optimization).

# Tests

Tested locally.
