### PR TITLE
refactor(frontend): mapping util to convert to UserToken

### DIFF
--- a/src/frontend/src/eth/services/erc20-user-tokens-services.ts
+++ b/src/frontend/src/eth/services/erc20-user-tokens-services.ts
@@ -1,11 +1,11 @@
 import { loadUserTokens } from '$eth/services/erc20.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
-import type { EthereumNetwork } from '$eth/types/network';
+import { toUserToken } from '$icp-eth/services/user-token.services';
 import { setManyUserTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import type { Identity } from '@dfinity/agent';
-import { nonNullish, toNullable } from '@dfinity/utils';
+import { nonNullish } from '@dfinity/utils';
 
 export type SaveUserToken = Pick<
 	Erc20UserToken,
@@ -26,16 +26,7 @@ export const saveUserTokens = async ({
 
 	await setManyUserTokens({
 		identity,
-		tokens: tokens.map(
-			({ enabled, version, symbol, decimals, address: contract_address, network }) => ({
-				contract_address,
-				chain_id: (network as EthereumNetwork).chainId,
-				decimals: toNullable(decimals),
-				symbol: toNullable(symbol),
-				enabled: toNullable(enabled),
-				version: toNullable(version)
-			})
-		)
+		tokens: tokens.map(toUserToken)
 	});
 
 	progress(ProgressStepsAddToken.UPDATE_UI);

--- a/src/frontend/src/icp-eth/services/user-token.services.ts
+++ b/src/frontend/src/icp-eth/services/user-token.services.ts
@@ -1,3 +1,5 @@
+import type { UserToken } from '$declarations/backend/backend.did';
+import type { SaveUserToken } from '$eth/services/erc20-user-tokens-services';
 import { loadUserTokens } from '$eth/services/erc20.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
@@ -85,6 +87,22 @@ export const autoLoadUserToken = async ({
 	return { result: 'loaded' };
 };
 
+export const toUserToken = ({
+	address,
+	network,
+	decimals,
+	symbol,
+	version,
+	enabled
+}: SaveUserToken): UserToken => ({
+	contract_address: address,
+	chain_id: (network as EthereumNetwork).chainId,
+	decimals: toNullable(decimals),
+	symbol: toNullable(symbol),
+	version: toNullable(version),
+	enabled: toNullable(enabled)
+});
+
 export const setUserToken = async ({
 	token,
 	identity,
@@ -93,19 +111,11 @@ export const setUserToken = async ({
 	identity: Identity;
 	token: Erc20UserToken;
 	enabled: boolean;
-}) => {
-	const { version, symbol, network, address, decimals } = token;
-	const { chainId } = network as EthereumNetwork;
-
+}) =>
 	await setUserTokenApi({
 		identity,
-		token: {
-			chain_id: chainId,
-			decimals: toNullable(decimals),
-			contract_address: address,
-			symbol: toNullable(symbol),
-			version: toNullable(version),
-			enabled: toNullable(enabled)
-		}
+		token: toUserToken({
+			...token,
+			enabled
+		})
 	});
-};

--- a/src/frontend/src/icp-eth/services/user-token.services.ts
+++ b/src/frontend/src/icp-eth/services/user-token.services.ts
@@ -88,14 +88,14 @@ export const autoLoadUserToken = async ({
 };
 
 export const toUserToken = ({
-	address,
+	address: contract_address,
 	network,
 	decimals,
 	symbol,
 	version,
 	enabled
 }: SaveUserToken): UserToken => ({
-	contract_address: address,
+	contract_address,
 	chain_id: (network as EthereumNetwork).chainId,
 	decimals: toNullable(decimals),
 	symbol: toNullable(symbol),


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we create a function to convert a `SaveUserToken` type to `UserToken`.
