### PR TITLE
refactor(frontend): mapping util to convert to CustomToken

### DIFF
--- a/src/frontend/src/icp-eth/services/custom-token.services.ts
+++ b/src/frontend/src/icp-eth/services/custom-token.services.ts
@@ -1,4 +1,6 @@
+import type { CustomToken } from '$declarations/backend/backend.did';
 import type { OptionErc20Token } from '$eth/types/erc20';
+import type { SaveCustomToken } from '$icp/services/ic-custom-tokens.services';
 import { loadCustomTokens } from '$icp/services/icrc.services';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setCustomToken as setCustomTokenasApi } from '$lib/api/backend.api';
@@ -84,6 +86,22 @@ export const autoLoadCustomToken = async ({
 	return { result: 'loaded' };
 };
 
+export const toCustomToken = ({
+	enabled,
+	version,
+	ledgerCanisterId,
+	indexCanisterId
+}: SaveCustomToken): CustomToken => ({
+	enabled,
+	version: toNullable(version),
+	token: {
+		Icrc: {
+			ledger_id: Principal.fromText(ledgerCanisterId),
+			index_id: toNullable(Principal.fromText(indexCanisterId))
+		}
+	}
+});
+
 export const setCustomToken = async ({
 	token,
 	identity,
@@ -92,20 +110,8 @@ export const setCustomToken = async ({
 	identity: Identity;
 	token: IcrcCustomToken;
 	enabled: boolean;
-}) => {
-	const { version, ledgerCanisterId, indexCanisterId } = token;
-
+}) =>
 	await setCustomTokenasApi({
 		identity,
-		token: {
-			enabled,
-			version: toNullable(version),
-			token: {
-				Icrc: {
-					ledger_id: Principal.fromText(ledgerCanisterId),
-					index_id: toNullable(Principal.fromText(indexCanisterId))
-				}
-			}
-		}
+		token: toCustomToken({ ...token, enabled })
 	});
-};

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -1,11 +1,10 @@
+import { toCustomToken } from '$icp-eth/services/custom-token.services';
 import { loadCustomTokens } from '$icp/services/icrc.services';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setManyCustomTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import type { Identity } from '@dfinity/agent';
-import { Principal } from '@dfinity/principal';
-import { toNullable } from '@dfinity/utils';
 
 export type SaveCustomToken = Pick<
 	IcrcCustomToken,
@@ -25,16 +24,7 @@ export const saveCustomTokens = async ({
 
 	await setManyCustomTokens({
 		identity,
-		tokens: tokens.map(({ enabled, version, ledgerCanisterId, indexCanisterId }) => ({
-			enabled,
-			version: toNullable(version),
-			token: {
-				Icrc: {
-					ledger_id: Principal.fromText(ledgerCanisterId),
-					index_id: toNullable(Principal.fromText(indexCanisterId))
-				}
-			}
-		}))
+		tokens: tokens.map(toCustomToken)
 	});
 
 	progress(ProgressStepsAddToken.UPDATE_UI);


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we create a function to convert a `SaveCustomToken` type to `CustomToken`.