### PR TITLE
feat(lint): create lint rule to use Option type wrapper

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,8 @@ module.exports = {
 		}
 	],
 	rules: {
-		'no-unused-vars': 'off',
+		'@typescript-eslint/no-inferrable-types': 'error',
+		'@typescript-eslint/no-unnecessary-type-assertion': 'error',
 		'@typescript-eslint/no-unused-vars': [
 			'warn',
 			{
@@ -55,17 +56,17 @@ module.exports = {
 				caughtErrorsIgnorePattern: '^_'
 			}
 		],
-		'no-console': ['error', { allow: ['error', 'warn'] }],
-		'no-else-return': ['warn', { allowElseIf: false }],
-		'local-rules/no-svelte-store-in-api': 'error',
 		'@typescript-eslint/prefer-nullish-coalescing': 'error',
-		'no-continue': 'warn',
-		'@typescript-eslint/no-unnecessary-type-assertion': 'error',
-		'no-delete-var': 'error',
-		curly: 'error',
 		'arrow-body-style': ['warn', 'as-needed'],
+		curly: 'error',
+		'local-rules/no-svelte-store-in-api': 'error',
+		'local-rules/use-option-type-wrapper': 'warn',
 		'import/no-duplicates': ['error', { 'prefer-inline': true }],
-		'@typescript-eslint/no-inferrable-types': 'error',
+		'no-console': ['error', { allow: ['error', 'warn'] }],
+		'no-continue': 'warn',
+		'no-delete-var': 'error',
+		'no-else-return': ['warn', { allowElseIf: false }],
+		'no-unused-vars': 'off',
 		'prefer-template': 'error'
 	},
 	globals: {

--- a/src/frontend/src/icp/stores/bitcoin-fee.store.ts
+++ b/src/frontend/src/icp/stores/bitcoin-fee.store.ts
@@ -1,12 +1,10 @@
+import type { Option } from '$lib/types/utils';
 import type { EstimateWithdrawalFee } from '@dfinity/ckbtc';
 import { writable, type Readable } from 'svelte/store';
 
-export type BitcoinFeeStoreData =
-	| {
-			bitcoinFee?: EstimateWithdrawalFee;
-	  }
-	| undefined
-	| null;
+export type BitcoinFeeStoreData = Option<{
+	bitcoinFee?: EstimateWithdrawalFee;
+}>;
 
 export interface BitcoinFeeStore extends Readable<BitcoinFeeStoreData> {
 	setFee: (data: BitcoinFeeStoreData) => void;

--- a/src/frontend/src/icp/stores/ethereum-fee.store.ts
+++ b/src/frontend/src/icp/stores/ethereum-fee.store.ts
@@ -1,11 +1,9 @@
+import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
-export type EthereumFeeStoreData =
-	| {
-			maxTransactionFee?: bigint | undefined;
-	  }
-	| undefined
-	| null;
+export type EthereumFeeStoreData = Option<{
+	maxTransactionFee?: bigint | undefined;
+}>;
 
 export interface EthereumFeeStore extends Readable<EthereumFeeStoreData> {
 	setFee: (data: EthereumFeeStoreData) => void;

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -4,4 +4,6 @@ export type ResultSuccess<T = unknown> = { success: boolean; err?: T };
 
 export type ResultSuccessReduced<T = unknown> = ResultSuccess<T[]>;
 
+// We disable the eslint rule here because this is the utility type that we use to define such rule.
+// eslint-disable-next-line local-rules/use-option-type-wrapper
 export type Option<T> = T | null | undefined;


### PR DESCRIPTION
# Motivation

We create a custom lint rule to use the type wrapper Option introduced in PR #2326 , and we fiz related issues.

UNRELATED: I sorted alphabetically the rules in `eslintrc` file, for better readability.
