### PR TITLE
style(frontend): skeleton text for loading exchange value

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { exchangeInitialized } from '$lib/derived/exchange.derived';
+	import TokenExchangeValueSkeleton from '$lib/components/tokens/TokenExchangeValueSkeleton.svelte';
 	import type { TokenUi } from '$lib/types/token';
 	import { formatUSD } from '$lib/utils/format.utils';
 
 	export let token: TokenUi;
 </script>
 
-<output class="break-all">
-	{#if $exchangeInitialized}
+<TokenExchangeValueSkeleton {token}>
+	<output class="break-all">
 		{#if nonNullish(token.usdBalance)}
 			{formatUSD(token.usdBalance)}
 		{:else}
 			{formatUSD(0, { minFraction: 0, maxFraction: 0 }).replace('0', '-')}
 		{/if}
-	{:else}
-		&ZeroWidthSpace;
-	{/if}
-</output>
+	</output>
+</TokenExchangeValueSkeleton>

--- a/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import { exchangeInitialized } from '$lib/derived/exchange.derived';
+	import type { TokenUi } from '$lib/types/token';
+
+	export let token: TokenUi;
+</script>
+
+{#if token.balance === undefined || !$exchangeInitialized}
+	<span class="w-full max-w-[50px]"><SkeletonText /></span>
+{:else}
+	<slot />
+{/if}


### PR DESCRIPTION
# Motivation

Similar to the balance, we want to show a skeleton for the exchange value if there is no balance loader started.

<img width="669" alt="Screenshot 2024-09-12 at 23 43 22" src="https://github.com/user-attachments/assets/e82b329b-2ec3-4a1f-9efe-93b15896a4d9">

