### PR TITLE
style(frontend): change primary button background color

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -42,8 +42,12 @@ button {
 	}
 
 	&.primary {
-		background: var(--color-dodger-blue);
+		background: var(--color-brandeis-blue);
 		color: var(--color-white);
+
+		&:hover {
+			background: var(--color-brilliant-azure);
+		}
 	}
 
 	&.secondary {

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -22,6 +22,7 @@
 	--color-brandeis-blue: theme(colors.brandeis-blue);
 	--color-spiro-disco-ball: theme(colors.spiro-disco-ball);
 	--color-cetacean-blue: theme(colors.cetacean-blue);
+	--color-brilliant-azure: theme(colors.brilliant-azure);
 
 	// Brand
 	--color-wallet-connect: #3b99fc;


### PR DESCRIPTION
# Motivation

Changed primary button background color (for `hover` too).

### Before

<img width="498" alt="Screenshot 2024-09-13 at 10 40 32" src="https://github.com/user-attachments/assets/1001e210-fada-46c8-ba57-b4f63f0eb90f">
<img width="526" alt="Screenshot 2024-09-13 at 10 40 37" src="https://github.com/user-attachments/assets/394c5690-e25a-4472-87d8-2d2c7675ea46">


### After

<img width="497" alt="Screenshot 2024-09-13 at 10 40 05" src="https://github.com/user-attachments/assets/08ea743a-e920-4321-b55c-a7e1f4400a19">
(hover)
<img width="496" alt="Screenshot 2024-09-13 at 10 40 12" src="https://github.com/user-attachments/assets/4335f565-c461-4703-b739-9ee34b2c3c72">
<img width="516" alt="Screenshot 2024-09-13 at 10 40 20" src="https://github.com/user-attachments/assets/ffd17cfd-cb76-4bb4-be1e-85229fbd9d55">

