### PR TITLE
refactor(frontend): common zod type for IC tokens in env folder

### DIFF
--- a/src/frontend/src/env/types/env-icrc-token.ts
+++ b/src/frontend/src/env/types/env-icrc-token.ts
@@ -11,10 +11,13 @@ export const envIcrcTokenMetadata = z.object({
 
 const indexCanisterVersion = z.union([z.literal('up-to-date'), z.literal('outdated')]);
 
-export const envIcrcToken = z.object({
+export const envIcToken = z.object({
 	ledgerCanisterId: z.string(),
+	indexCanisterId: z.string()
+});
+
+export const envIcrcToken = envIcToken.extend({
 	rootCanisterId: z.string(),
-	indexCanisterId: z.string(),
 	metadata: envIcrcTokenMetadata,
 	indexCanisterVersion
 });

--- a/src/frontend/src/env/types/env-token-ckerc20.ts
+++ b/src/frontend/src/env/types/env-token-ckerc20.ts
@@ -1,17 +1,13 @@
+import { envIcToken } from '$env/types/env-icrc-token';
+import { envTokenSymbol } from '$env/types/env-token-common';
 import { isEthAddress } from '$lib/utils/account.utils';
 import { z } from 'zod';
 
 const envErc20ContractAddress = z.custom<string>(isEthAddress, 'Invalid ERC20 Contract Address');
 
-const envTokenData = z.object({
-	ledgerCanisterId: z.string(),
-	indexCanisterId: z.string(),
+const envTokenData = envIcToken.extend({
 	erc20ContractAddress: envErc20ContractAddress
 });
-
-const envTokenSymbol = z.string();
-
-export type EnvTokenSymbol = z.infer<typeof envTokenSymbol>;
 
 const envTokens = z.record(envTokenSymbol, z.union([z.undefined(), envTokenData]));
 

--- a/src/frontend/src/env/types/env-token-common.ts
+++ b/src/frontend/src/env/types/env-token-common.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const envTokenSymbol = z.string();


### PR DESCRIPTION
# Motivation

We make a new `zod` object with base data for IC tokens and we move `envTokenSymbol` to another module, to be re-used.
