### PR TITLE
style(frontend): show a dash for null balances

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -9,7 +9,7 @@
 
 <TokenExchangeValueSkeleton {token}>
 	<output class="break-all">
-		{#if nonNullish(token.usdBalance)}
+		{#if nonNullish(token.balance) && nonNullish(token.usdBalance)}
 			{formatUSD(token.usdBalance)}
 		{:else}
 			{formatUSD(0, { minFraction: 0, maxFraction: 0 }).replace('0', '-')}

--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import TokenBalanceSkeleton from '$lib/components/tokens/TokenBalanceSkeleton.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import type { TokenUi } from '$lib/types/token';
@@ -9,10 +10,17 @@
 
 <TokenBalanceSkeleton {token}>
 	<output class="break-all">
-		{formatToken({
-			value: token.balance ?? ZERO,
-			unitName: token.decimals
-		})}
+		{#if nonNullish(token.balance)}
+			{formatToken({
+				value: token.balance,
+				unitName: token.decimals
+			})}
+		{:else}
+			{formatToken({
+				value: ZERO,
+				unitName: token.decimals
+			}).replace('0', '-')}
+		{/if}
 		{token.symbol}
 	</output>
 </TokenBalanceSkeleton>


### PR DESCRIPTION
# Motivation

In case the `balance` prop of the token is null (meaning that the loader is there but there is an issue/error, or it was stopped), we would like to show a dash `-` instead of `0`, both for the balance and for the USD balance.

# Results

Simulating with random tokens with `null` balance.

<img width="629" alt="Screenshot 2024-09-13 at 17 03 38" src="https://github.com/user-attachments/assets/6f9c0da5-8af0-4007-95a0-aa23678bb312">

