### PR TITLE
refactor(frontend): remove fallback from ic-token derived stores

### DIFF
--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -8,12 +8,13 @@ import {
 	toCkErc20HelperContractAddress,
 	toCkEthHelperContractAddress
 } from '$icp-eth/utils/cketh.utils';
-import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
+import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 import type { IcCkToken } from '$icp/types/ic';
 import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
-import { tokenStandard, tokenWithFallback } from '$lib/derived/token.derived';
+import { tokenStandard } from '$lib/derived/token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
+import { token } from '$lib/stores/token.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { OptionBalance } from '$lib/types/balance';
 import type { NetworkId } from '$lib/types/network';
@@ -26,9 +27,9 @@ import { derived, type Readable } from 'svelte/store';
  * - on network ICP if the token is ckETH
  */
 export const ethToCkETHEnabled: Readable<boolean> = derived(
-	[tokenStandard, tokenWithFallbackAsIcToken],
-	([$tokenStandard, $tokenWithFallbackAsIcToken]) =>
-		$tokenStandard === 'ethereum' || isTokenCkEthLedger($tokenWithFallbackAsIcToken)
+	[tokenStandard, tokenAsIcToken],
+	([$tokenStandard, $tokenAsIcToken]) =>
+		$tokenStandard === 'ethereum' || isTokenCkEthLedger($tokenAsIcToken)
 );
 
 /**
@@ -37,18 +38,17 @@ export const ethToCkETHEnabled: Readable<boolean> = derived(
  * - on network ICP if the token is ckErc20
  */
 export const erc20ToCkErc20Enabled: Readable<boolean> = derived(
-	[tokenWithFallbackAsIcToken],
-	([$tokenWithFallbackAsIcToken]) =>
-		ERC20_TWIN_TOKENS_IDS.includes($tokenWithFallbackAsIcToken.id) ||
-		isTokenCkErc20Ledger($tokenWithFallbackAsIcToken)
+	[tokenAsIcToken],
+	([$tokenAsIcToken]) =>
+		ERC20_TWIN_TOKENS_IDS.includes($tokenAsIcToken.id) || isTokenCkErc20Ledger($tokenAsIcToken)
 );
 
 /**
  * On ckETH, we need to know if the target for conversion is Ethereum mainnet or Sepolia.
  */
 export const ckEthereumTwinToken: Readable<Token> = derived(
-	[tokenWithFallback],
-	([$tokenWithFallback]) => ($tokenWithFallback as IcCkToken)?.twinToken ?? ETHEREUM_TOKEN
+	[token],
+	([$token]) => ($token as IcCkToken)?.twinToken ?? ETHEREUM_TOKEN
 );
 
 export const ckEthereumTwinTokenId: Readable<TokenId> = derived(

--- a/src/frontend/src/icp/components/fee/BitcoinFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinFeeContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { debounce, isNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
+	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 	import { queryEstimateFee } from '$icp/services/ckbtc.services';
 	import { BITCOIN_FEE_CONTEXT_KEY, type BitcoinFeeContext } from '$icp/stores/bitcoin-fee.store';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
@@ -15,7 +15,7 @@
 	export let networkId: NetworkId | undefined = undefined;
 
 	let ckBTC = false;
-	$: ckBTC = isTokenCkBtcLedger($tokenWithFallbackAsIcToken);
+	$: ckBTC = isTokenCkBtcLedger($tokenAsIcToken);
 
 	const { store } = getContext<BitcoinFeeContext>(BITCOIN_FEE_CONTEXT_KEY);
 
@@ -40,7 +40,7 @@
 				value: `${amount}`,
 				unitName: $tokenDecimals
 			}).toBigInt(),
-			...$tokenWithFallbackAsIcToken
+			...$tokenAsIcToken
 		});
 
 		if (isNullish(fee) || result === 'error') {

--- a/src/frontend/src/icp/components/fee/BitcoinKYTFee.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinKYTFee.svelte
@@ -3,7 +3,7 @@
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { slide } from 'svelte/transition';
 	import { BTC_DECIMALS } from '$env/tokens.btc.env';
-	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
+	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 	import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
 	import Value from '$lib/components/ui/Value.svelte';
@@ -16,7 +16,7 @@
 	export let networkId: NetworkId | undefined = undefined;
 
 	let ckBTC = false;
-	$: ckBTC = isTokenCkBtcLedger($tokenWithFallbackAsIcToken);
+	$: ckBTC = isTokenCkBtcLedger($tokenAsIcToken);
 
 	let btcNetwork = false;
 	$: btcNetwork = isNetworkIdBitcoin(networkId);

--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, onDestroy } from 'svelte';
-	import { tokenAsIcToken, tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
+	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
 	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
@@ -23,10 +23,10 @@
 	export let networkId: NetworkId | undefined = undefined;
 
 	let ckEthConvert = false;
-	$: ckEthConvert = isConvertCkEthToEth({ token: $tokenWithFallbackAsIcToken, networkId });
+	$: ckEthConvert = isConvertCkEthToEth({ token: $tokenAsIcToken, networkId });
 
 	let ckErc20Convert = false;
-	$: ckErc20Convert = isConvertCkErc20ToErc20({ token: $tokenWithFallbackAsIcToken, networkId });
+	$: ckErc20Convert = isConvertCkErc20ToErc20({ token: $tokenAsIcToken, networkId });
 
 	// This is the amount of ckETH to be burned to cover for the fees of the transaction eth_sendRawTransaction(destination_eth_address, amount) described in the withdrawal scheme.
 	// It will be requested to be approved using the transaction icrc2_approve(minter, tx_fee) described in the first step of the withdrawal scheme.

--- a/src/frontend/src/icp/derived/ic-token.derived.ts
+++ b/src/frontend/src/icp/derived/ic-token.derived.ts
@@ -15,17 +15,14 @@ export const tokenWithFallbackAsIcToken: Readable<IcToken> = derived(
 	([$token]) => $token as IcToken
 );
 
-export const tokenCkBtcLedger: Readable<boolean> = derived(
-	[tokenWithFallbackAsIcToken],
-	([$token]) => isTokenCkBtcLedger($token)
+export const tokenCkBtcLedger: Readable<boolean> = derived([tokenAsIcToken], ([$token]) =>
+	isTokenCkBtcLedger($token)
 );
 
-export const tokenCkEthLedger: Readable<boolean> = derived(
-	[tokenWithFallbackAsIcToken],
-	([$token]) => isTokenCkEthLedger($token)
+export const tokenCkEthLedger: Readable<boolean> = derived([tokenAsIcToken], ([$token]) =>
+	isTokenCkEthLedger($token)
 );
 
-export const tokenCkErc20Ledger: Readable<boolean> = derived(
-	[tokenWithFallbackAsIcToken],
-	([$token]) => isTokenCkErc20Ledger($token)
+export const tokenCkErc20Ledger: Readable<boolean> = derived([tokenAsIcToken], ([$token]) =>
+	isTokenCkErc20Ledger($token)
 );


### PR DESCRIPTION
# Motivation

The derived store `tokenWithFallback` falls back on ETH (or SepoliaETH) and consequently even the store `tokenWithFallbackAsIcToken`.

However, it is unnecessary for the derived stores that checks if a particular `token` is a ck-token, since ETH will never have a prop `ledgerCanisterId` (and the util functions checks for a non-nullish token).

So we remove that particular usage from the code substituting `tokenWithFallbackAsIcToken` with `tokenAsIcToken`.