### PR TITLE
feat(frontend): add multi-token send modal to networks

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -2,12 +2,10 @@
 	import EthReceive from '$eth/components/receive/EthReceive.svelte';
 	import ConvertToCkERC20 from '$eth/components/send/ConvertToCkERC20.svelte';
 	import ConvertToCkETH from '$eth/components/send/ConvertToCkETH.svelte';
-	import EthSend from '$eth/components/send/EthSend.svelte';
 	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
 	import ConvertToBTC from '$icp/components/convert/ConvertToBTC.svelte';
 	import ConvertToEthereum from '$icp/components/convert/ConvertToEthereum.svelte';
 	import IcReceive from '$icp/components/receive/IcReceive.svelte';
-	import IcSend from '$icp/components/send/IcSend.svelte';
 	import { tokenCkBtcLedger } from '$icp/derived/ic-token.derived';
 	import { erc20ToCkErc20Enabled, ethToCkETHEnabled } from '$icp-eth/derived/cketh.derived';
 	import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
@@ -41,13 +39,7 @@
 		<Receive />
 	{/if}
 
-	{#if $networkICP}
-		<IcSend token={$tokenWithFallback} />
-	{:else if $networkEthereum}
-		<EthSend token={$tokenWithFallback} />
-	{:else if $pseudoNetworkChainFusion}
-		<Send />
-	{/if}
+	<Send />
 
 	{#if convertEth}
 		{#if $networkICP}

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 	import SendWizard from '$lib/components/send/SendWizard.svelte';
-	import { sendWizardStepsComplete } from '$lib/config/send.config';
+	import { sendWizardStepsComplete, sendWizardStepsWithQrCodeScan } from '$lib/config/send.config';
 	import { ethAddressNotLoaded } from '$lib/derived/address.derived';
+	import { pageToken } from '$lib/derived/page-token.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import { waitWalletReady } from '$lib/services/actions.services';
@@ -25,7 +27,9 @@
 	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	let steps: WizardSteps;
-	$: steps = sendWizardStepsComplete({ i18n: $i18n });
+	$: steps = isNullish($pageToken)
+		? sendWizardStepsComplete({ i18n: $i18n })
+		: sendWizardStepsWithQrCodeScan({ i18n: $i18n });
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
@@ -82,6 +86,7 @@
 			bind:targetNetwork
 			bind:amount
 			bind:sendProgressStep
+			formCancelAction={isNullish($pageToken) ? 'back' : 'close'}
 			on:icBack={modal.back}
 			on:icSendBack={modal.back}
 			on:icNext={modal.next}

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -15,6 +15,7 @@
 	export let amount: number | undefined;
 	export let sendProgressStep: string;
 	export let currentStep: WizardStep | undefined;
+	export let formCancelAction: 'back' | 'close' = 'back';
 </script>
 
 {#if isNetworkIdEthereum($token?.network.id)}
@@ -22,7 +23,7 @@
 	<SendTokenContext token={$token}>
 		<EthSendTokenWizard
 			{currentStep}
-			formCancelAction="back"
+			{formCancelAction}
 			sourceNetwork={$selectedEthereumNetwork}
 			nativeEthereumToken={$ethereumToken}
 			bind:destination
@@ -40,7 +41,7 @@
 {:else if isNetworkIdICP($token?.network.id)}
 	<IcSendTokenWizard
 		{currentStep}
-		formCancelAction="back"
+		{formCancelAction}
 		bind:destination
 		bind:networkId
 		bind:amount


### PR DESCRIPTION
# Motivation

When the user selects a specific network, it would be useful that the Send button shows an initial step to choose the token from (like it is done in Chain Fusion).
The generic Send button already provides this feature with a small change: remove the initial step to choose the token, when we are already in the page of a token.

# Tests


https://github.com/user-attachments/assets/d15539fd-1430-4248-a9e1-9478d5632bb9


