### PR TITLE
refactor(frontend): use twinTokenSymbol prop for Ethereum native tokens

### DIFF
--- a/src/frontend/src/env/tokens.env.ts
+++ b/src/frontend/src/env/tokens.env.ts
@@ -6,7 +6,7 @@ import eth from '$icp-eth/assets/eth.svg';
 import icpLight from '$icp/assets/icp_light.svg';
 import { ICP_TRANSACTION_FEE_E8S } from '$icp/constants/icp.constants';
 import type { IcToken } from '$icp/types/ic';
-import type { RequiredToken, TokenWithLinkedData } from '$lib/types/token';
+import type { RequiredToken, RequiredTokenWithLinkedData } from '$lib/types/token';
 
 /**
  * Ethereum
@@ -17,7 +17,7 @@ const ETHEREUM_SYMBOL = 'ETH';
 
 export const ETHEREUM_TOKEN_ID: unique symbol = Symbol(ETHEREUM_SYMBOL);
 
-export const ETHEREUM_TOKEN: RequiredToken<TokenWithLinkedData> = {
+export const ETHEREUM_TOKEN: RequiredTokenWithLinkedData = {
 	id: ETHEREUM_TOKEN_ID,
 	network: ETHEREUM_NETWORK,
 	standard: 'ethereum',
@@ -33,7 +33,7 @@ export const SEPOLIA_SYMBOL = 'SepoliaETH';
 
 export const SEPOLIA_TOKEN_ID: unique symbol = Symbol(SEPOLIA_SYMBOL);
 
-export const SEPOLIA_TOKEN: RequiredToken<TokenWithLinkedData> = {
+export const SEPOLIA_TOKEN: RequiredTokenWithLinkedData = {
 	id: SEPOLIA_TOKEN_ID,
 	network: SEPOLIA_NETWORK,
 	standard: 'ethereum',
@@ -49,10 +49,10 @@ export const SEPOLIA_TOKEN: RequiredToken<TokenWithLinkedData> = {
  * The tokens store is useful for enabling and disabling features based on the testnets flag. However, constants are handy and not too verbose for testing if a token ID belongs to an Ethereum token.
  *
  */
-export const SUPPORTED_ETHEREUM_TOKENS: [...RequiredToken[], RequiredToken] = [
-	...(ETH_MAINNET_ENABLED ? [ETHEREUM_TOKEN] : []),
-	SEPOLIA_TOKEN
-];
+export const SUPPORTED_ETHEREUM_TOKENS: [
+	...RequiredTokenWithLinkedData[],
+	RequiredTokenWithLinkedData
+] = [...(ETH_MAINNET_ENABLED ? [ETHEREUM_TOKEN] : []), SEPOLIA_TOKEN];
 
 export const SUPPORTED_ETHEREUM_TOKEN_IDS: symbol[] = SUPPORTED_ETHEREUM_TOKENS.map(({ id }) => id);
 

--- a/src/frontend/src/eth/components/transactions/Transaction.svelte
+++ b/src/frontend/src/eth/components/transactions/Transaction.svelte
@@ -4,7 +4,7 @@
 	import type { ComponentType } from 'svelte';
 	import type { Erc20Token } from '$eth/types/erc20';
 	import type { EthTransactionType, EthTransactionUi } from '$eth/types/eth-transaction';
-	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
+	import { isSupportedEthToken } from '$eth/utils/eth.utils';
 	import { isTransactionPending } from '$eth/utils/transactions.utils';
 	import IconConvert from '$lib/components/icons/IconConvert.svelte';
 	import IconConvertFrom from '$lib/components/icons/IconConvertFrom.svelte';
@@ -15,7 +15,7 @@
 	import Amount from '$lib/components/ui/Amount.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import RoundedIcon from '$lib/components/ui/RoundedIcon.svelte';
-	import { tokenId, tokenSymbol } from '$lib/derived/token.derived';
+	import { tokenSymbol } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { token } from '$lib/stores/token.store';
@@ -35,12 +35,10 @@
 	$: ({ value, timestamp, displayTimestamp, uiType: type } = transaction);
 
 	let ckTokenSymbol: string;
-	$: ckTokenSymbol =
-		nonNullish($tokenId) && isSupportedEthTokenId($tokenId)
-			? // TODO: improve the way we link ETH and SepoliaETH to their twin tokens
-				`ck${$tokenSymbol}`
-			: // TODO: $token could be undefined, that's why we cast as `Erc20Token | undefined`; adjust the cast once we're sure that $token is never undefined
-				($token as Erc20Token | undefined)?.twinTokenSymbol ?? '';
+	$: ckTokenSymbol = isSupportedEthToken($token)
+		? $token.twinTokenSymbol
+		: // TODO: $token could be undefined, that's why we cast as `Erc20Token | undefined`; adjust the cast once we're sure that $token is never undefined
+			($token as Erc20Token | undefined)?.twinTokenSymbol ?? '';
 
 	let label: string;
 	$: label =

--- a/src/frontend/src/eth/utils/eth.utils.ts
+++ b/src/frontend/src/eth/utils/eth.utils.ts
@@ -1,8 +1,14 @@
-import { SUPPORTED_ETHEREUM_TOKEN_IDS } from '$env/tokens.env';
-import type { TokenId } from '$lib/types/token';
+import { SUPPORTED_ETHEREUM_TOKEN_IDS, SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens.env';
+import type { OptionToken, TokenId } from '$lib/types/token';
+import { nonNullish } from '@dfinity/utils';
 
 export const isSupportedEthTokenId = (tokenId: TokenId): boolean =>
 	SUPPORTED_ETHEREUM_TOKEN_IDS.includes(tokenId);
+
+export const isSupportedEthToken = (
+	token: OptionToken
+): token is (typeof SUPPORTED_ETHEREUM_TOKENS)[0] =>
+	nonNullish(token) && isSupportedEthTokenId(token.id);
 
 export const isNotSupportedEthTokenId = (tokenId: TokenId): boolean =>
 	!isSupportedEthTokenId(tokenId);

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -40,6 +40,8 @@ export type TokenWithLinkedData = Token & TokenLinkedData;
 
 export type RequiredToken<T extends Token = Token> = RequiredExcept<T, keyof TokenAppearance>;
 
+export type RequiredTokenWithLinkedData = RequiredToken<TokenWithLinkedData>;
+
 export type OptionToken = Option<Token>;
 export type OptionTokenId = Option<TokenId>;
 export type OptionTokenStandard = Option<TokenStandard>;


### PR DESCRIPTION
# Motivation

With PR #2350 , we can use the twinTokenSymbol prop of ETH and SepoliaETH.

# Changes

- Create common type for token that is required and have linked data.
- Create util to check if a token can be one of the supported Ethereum native tokens.
- Adapt usage in `Transaction` component.

# Tests

Local replica worked as usual.
