### PR TITLE
feat(frontend): add Buy button [GIX-2854][GIX-2705]

### DIFF
--- a/src/frontend/src/env/onramper.env.ts
+++ b/src/frontend/src/env/onramper.env.ts
@@ -1,0 +1,2 @@
+// TODO: to be removed when we have finished implementing all the OnRamper features
+export const ONRAMPER_ENABLED = JSON.parse(import.meta.env.VITE_ONRAMPER_ENABLED ?? false) === true;

--- a/src/frontend/src/lib/components/buy/Buy.svelte
+++ b/src/frontend/src/lib/components/buy/Buy.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import BuyButton from '$lib/components/buy/BuyButton.svelte';
+	import BuyModal from '$lib/components/buy/BuyModal.svelte';
+	import { modalBuy } from '$lib/derived/modal.derived';
+	import { modalStore } from '$lib/stores/modal.store';
+
+	const modalId = Symbol();
+</script>
+
+<BuyButton on:click={() => modalStore.openBuy(modalId)} />
+
+{#if $modalBuy && $modalStore?.data === modalId}
+	<BuyModal />
+{/if}

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import IconBuy from '$lib/components/icons/IconBuy.svelte';
+	import ButtonHero from '$lib/components/ui/ButtonHero.svelte';
+	import { isBusy } from '$lib/derived/busy.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+</script>
+
+<ButtonHero on:click disabled={$isBusy} ariaLabel={$i18n.send.text.send}>
+	<IconBuy size="28" slot="icon" />
+	{$i18n.buy.text.buy}
+</ButtonHero>

--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -5,9 +5,5 @@
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
-	<svelte:fragment slot="title"
-		><p class="text-xl">
-			{$i18n.buy.text.buy}
-		</p></svelte:fragment
-	>
+	<svelte:fragment slot="title">{$i18n.buy.text.buy}</svelte:fragment>
 </Modal>

--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { Modal } from '@dfinity/gix-components';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+</script>
+
+<Modal on:nnsClose={modalStore.close}>
+	<svelte:fragment slot="title"
+		><p class="text-xl">
+			{$i18n.buy.text.buy}
+		</p></svelte:fragment
+	>
+</Modal>

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ONRAMPER_ENABLED } from '$env/onramper.env';
 	import EthReceive from '$eth/components/receive/EthReceive.svelte';
 	import ConvertToCkERC20 from '$eth/components/send/ConvertToCkERC20.svelte';
 	import ConvertToCkETH from '$eth/components/send/ConvertToCkETH.svelte';
@@ -10,6 +11,7 @@
 	import IcSend from '$icp/components/send/IcSend.svelte';
 	import { tokenCkBtcLedger } from '$icp/derived/ic-token.derived';
 	import { erc20ToCkErc20Enabled, ethToCkETHEnabled } from '$icp-eth/derived/cketh.derived';
+	import Buy from '$lib/components/buy/Buy.svelte';
 	import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
 	import Receive from '$lib/components/receive/Receive.svelte';
 	import Send from '$lib/components/send/Send.svelte';
@@ -67,6 +69,10 @@
 
 	{#if convertBtc}
 		<ConvertToBTC />
+	{/if}
+
+	{#if ONRAMPER_ENABLED}
+		<Buy />
 	{/if}
 
 	{#if more}

--- a/src/frontend/src/lib/components/icons/IconBuy.svelte
+++ b/src/frontend/src/lib/components/icons/IconBuy.svelte
@@ -1,0 +1,43 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+	export let styleClass: string | undefined = undefined;
+	export let size = '24';
+</script>
+
+<svg
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+	class={styleClass}
+>
+	<path
+		d="M21 5.54077H3C2.58579 5.54077 2.25 5.87656 2.25 6.29077V18.2908C2.25 18.705 2.58579 19.0408 3 19.0408H21C21.4142 19.0408 21.75 18.705 21.75 18.2908V6.29077C21.75 5.87656 21.4142 5.54077 21 5.54077Z"
+		stroke="white"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M15.375 15.6658H18.375"
+		stroke="white"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M10.125 15.6658H11.625"
+		stroke="white"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M2.25 9.37524H21.75"
+		stroke="white"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+</svg>

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -29,6 +29,10 @@ export const modalSend: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'send'
 );
+export const modalBuy: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'buy'
+);
 export const modalEthSend: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'eth-send'

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -316,6 +316,11 @@
 			"loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized."
 		}
 	},
+	"buy": {
+		"text": {
+			"buy": "Buy"
+		}
+	},
 	"tokens": {
 		"text": {
 			"contract_address": "Contract address",

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -10,6 +10,7 @@ export interface Modal<T> {
 		| 'cketh-receive'
 		| 'receive'
 		| 'send'
+		| 'buy'
 		| 'eth-send'
 		| 'convert-ckbtc-btc'
 		| 'convert-to-twin-token-cketh'
@@ -42,6 +43,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openCkETHReceive: <D extends T>(data: D) => void;
 	openReceive: <D extends T>(data: D) => void;
 	openSend: <D extends T>(data: D) => void;
+	openBuy: <D extends T>(data: D) => void;
 	openEthSend: <D extends T>(data: D) => void;
 	openConvertCkBTCToBTC: () => void;
 	openConvertToTwinTokenCkEth: () => void;
@@ -75,6 +77,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openCkETHReceive: <D extends T>(data: D) => set({ type: 'cketh-receive', data }),
 		openReceive: <D extends T>(data: D) => set({ type: 'receive', data }),
 		openSend: <D extends T>(data: D) => set({ type: 'send', data }),
+		openBuy: <D extends T>(data: D) => set({ type: 'buy', data }),
 		openEthSend: <D extends T>(data: D) => set({ type: 'eth-send', data }),
 		openConvertCkBTCToBTC: () => set({ type: 'convert-ckbtc-btc' }),
 		openConvertToTwinTokenCkEth: () => set({ type: 'convert-to-twin-token-cketh' }),

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -279,6 +279,10 @@ interface I18nConvert {
 	error: { loading_cketh_helper: string };
 }
 
+interface I18nBuy {
+	text: { buy: string };
+}
+
 interface I18nTokens {
 	text: {
 		contract_address: string;
@@ -542,6 +546,7 @@ interface I18n {
 	receive: I18nReceive;
 	send: I18nSend;
 	convert: I18nConvert;
+	buy: I18nBuy;
 	tokens: I18nTokens;
 	fee: I18nFee;
 	info: I18nInfo;


### PR DESCRIPTION
# Motivation

As initial step for OnRamper onbarding, we create the `Buy` button and a related modal. The modal will be empty for now and the button visible only through a custom env flag `VITE_ONRAMPER_ENABLED`.

<img width="1271" alt="Screenshot 2024-09-16 at 09 52 57" src="https://github.com/user-attachments/assets/c43f16d1-6c53-4e28-93e5-f951dad6b947">
<img width="355" alt="Screenshot 2024-09-16 at 09 53 31" src="https://github.com/user-attachments/assets/6990b439-4e78-4107-9cec-f38acfd4bd1d">
<img width="363" alt="Screenshot 2024-09-16 at 09 53 44" src="https://github.com/user-attachments/assets/0e58ffd4-3385-4220-a99a-f7507b348cf9">
<img width="814" alt="Screenshot 2024-09-16 at 09 53 50" src="https://github.com/user-attachments/assets/55f9dc4f-6106-409a-a3ee-55ccf67f5347">
<img width="486" alt="Screenshot 2024-09-16 at 09 54 00" src="https://github.com/user-attachments/assets/aa77a6f3-b748-4550-ae78-a9449272058d">
<img width="360" alt="Screenshot 2024-09-16 at 09 54 06" src="https://github.com/user-attachments/assets/b7bb0674-9077-4a12-8c39-5dd130aa9056">
