### PR TITLE
style(frontend): adjust button position in QR receive modal

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
@@ -21,8 +21,8 @@
 	</p>
 
 	<ReceiveQRCode address={address ?? ''} />
-
-	<button class="secondary full center text-center mt-8" on:click={() => dispatch('icBack')}
-		>{$i18n.core.text.back}</button
-	>
 </div>
+
+<button class="secondary full center text-center mt-8" on:click={() => dispatch('icBack')}
+	>{$i18n.core.text.back}</button
+>


### PR DESCRIPTION
# Motivation

The button of the QR receive modal was inside the stretched `<div>`.

### Before

<img width="499" alt="Screenshot 2024-09-16 at 10 14 21" src="https://github.com/user-attachments/assets/fec1967d-309f-46bc-ae78-c6fb07c8de86">
Mobile:
<img width="431" alt="Screenshot 2024-09-16 at 10 14 15" src="https://github.com/user-attachments/assets/848519b9-9776-438c-89ea-520c7fde5339">

### After

<img width="554" alt="Screenshot 2024-09-16 at 10 11 52" src="https://github.com/user-attachments/assets/8e2fb635-26a4-44c0-ad64-5e31e6028121">
Mobile:
<img width="363" alt="Screenshot 2024-09-16 at 10 11 58" src="https://github.com/user-attachments/assets/7513bcd0-0de8-4125-bcaa-d06ee2b42c66">
<img width="378" alt="Screenshot 2024-09-16 at 10 12 06" src="https://github.com/user-attachments/assets/90b41e0f-2f63-4195-a358-a159fa5a6b64">
<img width="432" alt="Screenshot 2024-09-16 at 10 12 28" src="https://github.com/user-attachments/assets/651ae0e7-38a2-46e2-9df7-ef0832289dfc">
