### PR TITLE
chore(frontend): remove redundant opacity class [GIX-2929]

### DIFF
--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -61,12 +61,7 @@
 
 	<ButtonGroup>
 		<slot name="cancel" />
-		<button
-			class="primary block flex-1"
-			type="submit"
-			disabled={invalid}
-			class:opacity-10={invalid}
-		>
+		<button class="primary block flex-1" type="submit" disabled={invalid}>
 			{$i18n.core.text.next}
 		</button>
 	</ButtonGroup>

--- a/src/frontend/src/eth/components/send/SendReview.svelte
+++ b/src/frontend/src/eth/components/send/SendReview.svelte
@@ -55,12 +55,7 @@
 	<button class="secondary block flex-1" on:click={() => dispatch('icBack')}
 		>{$i18n.core.text.back}</button
 	>
-	<button
-		class="primary block flex-1"
-		disabled={invalid}
-		class:opacity-10={invalid}
-		on:click={() => dispatch('icSend')}
-	>
+	<button class="primary block flex-1" disabled={invalid} on:click={() => dispatch('icSend')}>
 		{$i18n.send.text.send}
 	</button>
 </ButtonGroup>

--- a/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/AddTokenReview.svelte
@@ -138,12 +138,7 @@
 	<button class="secondary block flex-1" on:click={() => dispatch('icBack')}
 		>{$i18n.core.text.back}</button
 	>
-	<button
-		class="primary block flex-1"
-		disabled={invalid}
-		class:opacity-10={invalid}
-		on:click={() => dispatch('icSave')}
-	>
+	<button class="primary block flex-1" disabled={invalid} on:click={() => dispatch('icSave')}>
 		{$i18n.tokens.import.text.add_the_token}
 	</button>
 </ButtonGroup>

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectForm.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectForm.svelte
@@ -91,12 +91,7 @@
 </div>
 
 <ButtonGroup>
-	<button
-		class="primary block flex-1"
-		disabled={invalid}
-		class:opacity-10={invalid}
-		on:click={onClick}
-	>
+	<button class="primary block flex-1" disabled={invalid} on:click={onClick}>
 		{$i18n.wallet_connect.text.connect}
 	</button>
 </ButtonGroup>

--- a/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
+++ b/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
@@ -63,7 +63,7 @@
 		})}
 	</p>
 
-	<button class="primary mt-6" disabled={$isBusy} class:opacity-50={$isBusy} on:click={openReceive}>
+	<button class="primary mt-6" disabled={$isBusy} on:click={openReceive}>
 		{replacePlaceholders($i18n.info.ethereum.how_to, {
 			$ckToken: ckTokenSymbol
 		})}</button

--- a/src/frontend/src/icp/components/info/InfoBitcoin.svelte
+++ b/src/frontend/src/icp/components/info/InfoBitcoin.svelte
@@ -22,7 +22,7 @@
 		{$i18n.info.bitcoin.note}
 	</p>
 
-	<button class="primary mt-6" disabled={$isBusy} class:opacity-50={$isBusy} on:click={openReceive}>
+	<button class="primary mt-6" disabled={$isBusy} on:click={openReceive}>
 		{$i18n.info.bitcoin.how_to}</button
 	>
 </div>

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -44,12 +44,7 @@
 
 	<ButtonGroup>
 		<slot name="cancel" />
-		<button
-			class="primary block flex-1"
-			type="submit"
-			disabled={invalid}
-			class:opacity-10={invalid}
-		>
+		<button class="primary block flex-1" type="submit" disabled={invalid}>
 			{$i18n.core.text.next}
 		</button>
 	</ButtonGroup>

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -48,12 +48,7 @@
 	<button class="secondary block flex-1" on:click={() => dispatch('icBack')}
 		>{$i18n.core.text.back}</button
 	>
-	<button
-		class="primary block flex-1"
-		disabled={invalid}
-		class:opacity-10={invalid}
-		on:click={() => dispatch('icSend')}
-	>
+	<button class="primary block flex-1" disabled={invalid} on:click={() => dispatch('icSend')}>
 		{$i18n.send.text.send}
 	</button>
 </ButtonGroup>

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -98,12 +98,7 @@
 	<div in:fade>
 		<ButtonGroup>
 			<button class="secondary block flex-1" on:click={back}>{$i18n.core.text.back}</button>
-			<button
-				class="primary block flex-1"
-				disabled={invalid}
-				class:opacity-10={invalid}
-				on:click={() => dispatch('icSave')}
-			>
+			<button class="primary block flex-1" disabled={invalid} on:click={() => dispatch('icSave')}>
 				{$i18n.tokens.import.text.add_the_token}
 			</button>
 		</ButtonGroup>

--- a/src/frontend/src/lib/components/manage/AddTokenByNetworkToolbar.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetworkToolbar.svelte
@@ -12,7 +12,7 @@
 	<button type="button" class="secondary block flex-1" on:click={() => dispatch('icBack')}
 		>{$i18n.core.text.back}</button
 	>
-	<button class="primary block flex-1" type="submit" disabled={invalid} class:opacity-10={invalid}>
+	<button class="primary block flex-1" type="submit" disabled={invalid}>
 		{$i18n.core.text.next}
 	</button>
 </ButtonGroup>

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -268,12 +268,7 @@
 		<button class="secondary block flex-1" on:click={() => dispatch('icClose')}
 			>{$i18n.core.text.cancel}</button
 		>
-		<button
-			class="primary block flex-1"
-			on:click={save}
-			class:opacity-10={saveDisabled}
-			disabled={saveDisabled}
-		>
+		<button class="primary block flex-1" on:click={save} disabled={saveDisabled}>
 			{$i18n.core.text.save}
 		</button>
 	</ButtonGroup>


### PR DESCRIPTION
# Motivation

With the introduction of a determined opacity for class `disabled` of `primary` and `secondary` buttons (PR #2345 ), we can remove the `opacity` class in the components, since they will be superseded by the CSS definition.

