### PR TITLE
refactor(frontend): rename config with all send steps

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -28,7 +28,7 @@
 	$: steps = allSendWizardSteps({ i18n: $i18n });
 
 	let currentStep: WizardStep | undefined;
-	let modal: WizardModal;§
+	let modal: WizardModal;
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -3,7 +3,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 	import SendWizard from '$lib/components/send/SendWizard.svelte';
-	import { sendWizardStepsComplete } from '$lib/config/send.config';
+	import { allSendWizardSteps } from '$lib/config/send.config';
 	import { ethAddressNotLoaded } from '$lib/derived/address.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
@@ -25,10 +25,10 @@
 	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	let steps: WizardSteps;
-	$: steps = sendWizardStepsComplete({ i18n: $i18n });
+	$: steps = allSendWizardSteps({ i18n: $i18n });
 
 	let currentStep: WizardStep | undefined;
-	let modal: WizardModal;
+	let modal: WizardModal;§
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -29,7 +29,7 @@ export const sendWizardStepsWithQrCodeScan = (params: SendWizardStepsParams): Wi
 	}
 ];
 
-export const sendWizardStepsComplete = (params: SendWizardStepsParams): WizardSteps => [
+export const allSendWizardSteps = (params: SendWizardStepsParams): WizardSteps => [
 	{
 		name: WizardStepsSend.TOKENS_LIST,
 		title: params.i18n.send.text.send


### PR DESCRIPTION
# Motivation

Renamed config `sendWizardStepsComplete` to `allSendWizardSteps`, since it is more clear.
