### PR TITLE
style(frontend): change color of header title when signed out [GIX-2955]

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -15,7 +15,7 @@
 
 <div class="mt-5 mb-7 pt-2">
 	<h1 class="text-4xl text-center">
-		{$i18n.auth.text.title}
+		{$i18n.auth.text.title_part_1} <span class="text-primary">{$i18n.auth.text.title_part_2}</span>
 	</h1>
 </div>
 

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -39,7 +39,8 @@
 	},
 	"auth": {
 		"text": {
-			"title": "100% on-chain wallet for full decentralization",
+			"title_part_1": "A wallet that lives on-chain for",
+			"title_part_2": "100% decentralization",
 			"authenticate": "Authenticate",
 			"logout": "Logout"
 		},

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -23,7 +23,11 @@
 	--color-spiro-disco-ball: theme(colors.spiro-disco-ball);
 	--color-cetacean-blue: theme(colors.cetacean-blue);
 	--color-brilliant-azure: theme(colors.brilliant-azure);
+	--color-blue-ribbon: theme(colors.blue-ribbon);
 
 	// Brand
 	--color-wallet-connect: #3b99fc;
+
+	// Theme
+	--color-primary: var(--color-blue-ribbon);
 }

--- a/src/frontend/src/lib/styles/global/text.scss
+++ b/src/frontend/src/lib/styles/global/text.scss
@@ -7,3 +7,7 @@
 .clamp-4 {
 	@include text.clamp(2);
 }
+
+.text-primary {
+	color: var(--color-primary);
+}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -34,7 +34,7 @@ interface I18nNavigation {
 }
 
 interface I18nAuth {
-	text: { title: string; authenticate: string; logout: string };
+	text: { title_part_1: string; title_part_2: string; authenticate: string; logout: string };
 	alt: { sign_in: string };
 	warning: { not_signed_in: string; session_expired: string };
 	error: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,7 @@ export default {
 			grey: '#c0bbc4',
 			'light-blue': '#ede7fb',
 			blue: '#3b00b9',
+			'blue-ribbon': '#0066ff',
 			dark: '#0e002d',
 			'dark-blue': '#321469',
 			'navy-blue': '#01016d',


### PR DESCRIPTION
# Motivation

New style for the header title when signed out.

<img width="966" alt="Screenshot 2024-09-17 at 14 24 14" src="https://github.com/user-attachments/assets/c59cae3b-be2b-4d6a-986d-75adf7f497bd">
<img width="431" alt="Screenshot 2024-09-17 at 14 24 21" src="https://github.com/user-attachments/assets/99518661-7f99-437b-84f2-7526df790594">
