### PR TITLE
refactor(frontend): move wallet utils to lib

### DIFF
--- a/src/frontend/src/icp/components/core/IcLoaderWallets.svelte
+++ b/src/frontend/src/icp/components/core/IcLoaderWallets.svelte
@@ -2,6 +2,7 @@
 	import { debounce } from '@dfinity/utils';
 	import { onDestroy } from 'svelte';
 	import type { IcToken } from '$icp/types/ic';
+	import { initWalletWorker } from '$icp/utils/wallet.utils';
 	import { enabledIcTokens } from '$lib/derived/tokens.derived';
 	import type { WalletWorker } from '$lib/types/listener';
 	import type { TokenId } from '$lib/types/token';
@@ -13,7 +14,9 @@
 		cleanWorkers({ workers, tokens: $enabledIcTokens });
 
 		await Promise.allSettled(
-			$enabledIcTokens.map(async (token: IcToken) => await loadWorker({ workers, token }))
+			$enabledIcTokens.map(
+				async (token: IcToken) => await loadWorker({ workers, token, initWalletWorker })
+			)
 		);
 	};
 

--- a/src/frontend/src/icp/components/core/IcLoaderWallets.svelte
+++ b/src/frontend/src/icp/components/core/IcLoaderWallets.svelte
@@ -2,10 +2,10 @@
 	import { debounce } from '@dfinity/utils';
 	import { onDestroy } from 'svelte';
 	import type { IcToken } from '$icp/types/ic';
-	import { cleanWorkers, loadWorker } from '$icp/utils/ic-wallet.utils';
 	import { enabledIcTokens } from '$lib/derived/tokens.derived';
 	import type { WalletWorker } from '$lib/types/listener';
 	import type { TokenId } from '$lib/types/token';
+	import { cleanWorkers, loadWorker } from '$lib/utils/wallet.utils';
 
 	const workers: Map<TokenId, WalletWorker> = new Map<TokenId, WalletWorker>();
 

--- a/src/frontend/src/icp/constants/ic.constants.ts
+++ b/src/frontend/src/icp/constants/ic.constants.ts
@@ -1,11 +1,5 @@
 import { SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
 
-// From FI team:
-// On mainnet, the index runs its indexing function every second. The time to see a new transaction in the index is <=1 second plus the time required by the indexing function
-// (however)
-// ICP Index has not been upgraded yet so right know for ICP is variable between 0 and 2 seconds. Leo has changed the ckBTC and ckETH to run every second and we want to change the ICP one too eventually. We just didn't get to work on it yet
-export const INDEX_RELOAD_DELAY = 2000;
-
 // Wallet
 export const WALLET_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 2) * 1000; // 30 seconds in milliseconds
 export const WALLET_PAGINATION = 10n;

--- a/src/frontend/src/icp/services/ckbtc-listener.services.ts
+++ b/src/frontend/src/icp/services/ckbtc-listener.services.ts
@@ -4,7 +4,6 @@ import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 import type { BtcWithdrawalStatuses } from '$icp/types/btc';
 import type { SyncCkMinterInfoError, SyncCkMinterInfoSuccess } from '$icp/types/ck';
 import type { UtxoTxidText } from '$icp/types/ckbtc';
-import { waitAndTriggerWallet } from '$icp/utils/ic-wallet.utils';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type {
@@ -15,6 +14,7 @@ import type { CertifiedData } from '$lib/types/store';
 import type { SyncState } from '$lib/types/sync';
 import type { TokenId } from '$lib/types/token';
 import { emit } from '$lib/utils/events.utils';
+import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import type { MinterInfo, PendingUtxo } from '@dfinity/ckbtc';
 import { jsonReviver } from '@dfinity/utils';
 import { get } from 'svelte/store';

--- a/src/frontend/src/icp/services/ckbtc.services.ts
+++ b/src/frontend/src/icp/services/ckbtc.services.ts
@@ -8,7 +8,6 @@ import { ckBtcPendingUtxosStore } from '$icp/stores/ckbtc-utxos.store';
 import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 import type { CkBtcUpdateBalanceParams } from '$icp/types/ckbtc';
 import type { IcCkMetadata, IcCkToken, IcToken } from '$icp/types/ic';
-import { waitAndTriggerWallet } from '$icp/utils/ic-wallet.utils';
 import { queryAndUpdate, type QueryAndUpdateRequestParams } from '$lib/actors/query.ic';
 import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
 import { waitWalletReady } from '$lib/services/actions.services';
@@ -19,6 +18,7 @@ import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { CertifiedData } from '$lib/types/store';
 import type { TokenId } from '$lib/types/token';
+import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import {
 	MinterNoNewUtxosError,
 	type EstimateWithdrawalFee,

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -14,13 +14,13 @@ import {
 } from '$icp/services/ck.services';
 import type { IcToken } from '$icp/types/ic';
 import type { IcTransferParams } from '$icp/types/ic-send';
-import { waitAndTriggerWallet } from '$icp/utils/ic-wallet.utils';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
 import { invalidIcpAddress } from '$lib/utils/account.utils';
 import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
+import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import type { BlockHeight } from '@dfinity/ledger-icp';
 import { decodeIcrcAccount, type IcrcBlockIndex } from '@dfinity/ledger-icrc';
 import { get } from 'svelte/store';

--- a/src/frontend/src/icp/utils/wallet.utils.ts
+++ b/src/frontend/src/icp/utils/wallet.utils.ts
@@ -1,8 +1,7 @@
 import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
 import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
 import type { IcToken } from '$icp/types/ic';
-import type { WalletWorker } from '$lib/types/listener';
-import type { Token } from '$lib/types/token';
+import type { InitWallerWorkerParams, WalletWorker } from '$lib/types/listener';
 
-export const initWalletWorker = async ({ token }: { token: Token }): Promise<WalletWorker> =>
+export const initWalletWorker = async ({ token }: InitWallerWorkerParams): Promise<WalletWorker> =>
 	token.standard === 'icrc' ? initIcrcWalletWorker(token as IcToken) : initIcpWalletWorker();

--- a/src/frontend/src/icp/utils/wallet.utils.ts
+++ b/src/frontend/src/icp/utils/wallet.utils.ts
@@ -1,7 +1,7 @@
 import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
 import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
 import type { IcToken } from '$icp/types/ic';
-import type { InitWallerWorkerParams, WalletWorker } from '$lib/types/listener';
+import type { InitWalletWorkerFn } from '$lib/types/listener';
 
-export const initWalletWorker = async ({ token }: InitWallerWorkerParams): Promise<WalletWorker> =>
+export const initWalletWorker: InitWalletWorkerFn = ({ token }) =>
 	token.standard === 'icrc' ? initIcrcWalletWorker(token as IcToken) : initIcpWalletWorker();

--- a/src/frontend/src/icp/utils/wallet.utils.ts
+++ b/src/frontend/src/icp/utils/wallet.utils.ts
@@ -1,0 +1,8 @@
+import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
+import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
+import type { IcToken } from '$icp/types/ic';
+import type { WalletWorker } from '$lib/types/listener';
+import type { Token } from '$lib/types/token';
+
+export const initWalletWorker = async ({ token }: { token: Token }): Promise<WalletWorker> =>
+	token.standard === 'icrc' ? initIcrcWalletWorker(token as IcToken) : initIcpWalletWorker();

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -65,6 +65,11 @@ export const VC_POPUP_HEIGHT = 900;
 
 // Workers
 export const AUTH_TIMER_INTERVAL = 1000;
+// From FI team:
+// On mainnet, the index runs its indexing function every second. The time to see a new transaction in the index is <=1 second plus the time required by the indexing function
+// (however)
+// ICP Index has not been upgraded yet so right know for ICP is variable between 0 and 2 seconds. Leo has changed the ckBTC and ckETH to run every second and we want to change the ICP one too eventually. We just didn't get to work on it yet
+export const INDEX_RELOAD_DELAY = 2000;
 
 // Date and time
 export const SECONDS_IN_MINUTE = 60;

--- a/src/frontend/src/lib/types/listener.ts
+++ b/src/frontend/src/lib/types/listener.ts
@@ -1,5 +1,9 @@
+import type { Token } from '$lib/types/token';
+
 export interface WalletWorker {
 	start: () => void;
 	stop: () => void;
 	trigger: () => void;
 }
+
+export type InitWallerWorkerParams = { token: Token };

--- a/src/frontend/src/lib/types/listener.ts
+++ b/src/frontend/src/lib/types/listener.ts
@@ -6,4 +6,4 @@ export interface WalletWorker {
 	trigger: () => void;
 }
 
-export type InitWallerWorkerParams = { token: Token };
+export type InitWalletWorkerFn = (params: { token: Token }) => Promise<WalletWorker>;

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -1,6 +1,5 @@
-import { initWalletWorker as initIcWalletWorker } from '$icp/utils/wallet.utils';
 import { INDEX_RELOAD_DELAY } from '$lib/constants/app.constants';
-import type { WalletWorker } from '$lib/types/listener';
+import type { InitWallerWorkerParams, WalletWorker } from '$lib/types/listener';
 import type { Token, TokenId } from '$lib/types/token';
 import { emit } from '$lib/utils/events.utils';
 import { waitForMilliseconds } from '$lib/utils/timeout.utils';
@@ -44,16 +43,19 @@ export const cleanWorkers = ({
  *
  * @param workers The map of workers defined as `Map<TokenId, WalletWorker>`.
  * @param token The token to load the worker for.
+ * @param initWalletWorker The initialisation function of a wallet worker.
  */
 export const loadWorker = async ({
 	workers,
-	token
+	token,
+	initWalletWorker
 }: {
 	workers: Map<TokenId, WalletWorker>;
 	token: Token;
+	initWalletWorker: (params: InitWallerWorkerParams) => Promise<WalletWorker>;
 }) => {
 	if (!workers.has(token.id)) {
-		const worker = await initIcWalletWorker({ token });
+		const worker = await initWalletWorker({ token });
 
 		worker.stop();
 		worker.start();

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -1,6 +1,4 @@
-import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
-import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
-import type { IcToken } from '$icp/types/ic';
+import { initWalletWorker as initIcWalletWorker } from '$icp/utils/wallet.utils';
 import { INDEX_RELOAD_DELAY } from '$lib/constants/app.constants';
 import type { WalletWorker } from '$lib/types/listener';
 import type { Token, TokenId } from '$lib/types/token';
@@ -55,9 +53,7 @@ export const loadWorker = async ({
 	token: Token;
 }) => {
 	if (!workers.has(token.id)) {
-		const worker = await (token.standard === 'icrc'
-			? initIcrcWalletWorker(token as IcToken)
-			: initIcpWalletWorker());
+		const worker = await initIcWalletWorker({ token });
 
 		worker.stop();
 		worker.start();

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -1,9 +1,9 @@
-import { INDEX_RELOAD_DELAY } from '$icp/constants/ic.constants';
 import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
 import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
 import type { IcToken } from '$icp/types/ic';
+import { INDEX_RELOAD_DELAY } from '$lib/constants/app.constants';
 import type { WalletWorker } from '$lib/types/listener';
-import type { TokenId } from '$lib/types/token';
+import type { Token, TokenId } from '$lib/types/token';
 import { emit } from '$lib/utils/events.utils';
 import { waitForMilliseconds } from '$lib/utils/timeout.utils';
 
@@ -31,10 +31,10 @@ export const cleanWorkers = ({
 	tokens
 }: {
 	workers: Map<TokenId, WalletWorker>;
-	tokens: IcToken[];
+	tokens: Token[];
 }) =>
 	Array.from(workers.keys())
-		.filter((tokenId) => !tokens.some(({ id: icTokenId }) => icTokenId === tokenId))
+		.filter((workerTokenId) => !tokens.some(({ id: tokenId }) => workerTokenId === tokenId))
 		.forEach((tokenId) => {
 			// TODO: use a more functional approach instead of deleting the worker from the map.
 			workers.get(tokenId)?.stop();
@@ -45,18 +45,18 @@ export const cleanWorkers = ({
  * Load the worker for the token if it is not already loaded.
  *
  * @param workers The map of workers defined as `Map<TokenId, WalletWorker>`.
- * @param token The IC token to load the worker for.
+ * @param token The token to load the worker for.
  */
 export const loadWorker = async ({
 	workers,
 	token
 }: {
 	workers: Map<TokenId, WalletWorker>;
-	token: IcToken;
+	token: Token;
 }) => {
 	if (!workers.has(token.id)) {
 		const worker = await (token.standard === 'icrc'
-			? initIcrcWalletWorker(token)
+			? initIcrcWalletWorker(token as IcToken)
 			: initIcpWalletWorker());
 
 		worker.stop();

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -1,5 +1,5 @@
 import { INDEX_RELOAD_DELAY } from '$lib/constants/app.constants';
-import type { InitWallerWorkerParams, WalletWorker } from '$lib/types/listener';
+import type { InitWalletWorkerFn, WalletWorker } from '$lib/types/listener';
 import type { Token, TokenId } from '$lib/types/token';
 import { emit } from '$lib/utils/events.utils';
 import { waitForMilliseconds } from '$lib/utils/timeout.utils';
@@ -52,7 +52,7 @@ export const loadWorker = async ({
 }: {
 	workers: Map<TokenId, WalletWorker>;
 	token: Token;
-	initWalletWorker: (params: InitWallerWorkerParams) => Promise<WalletWorker>;
+	initWalletWorker: InitWalletWorkerFn;
 }) => {
 	if (!workers.has(token.id)) {
 		const worker = await initWalletWorker({ token });


### PR DESCRIPTION
# Motivation

Move wallet utils from `icp` to `lib` to re-use them for both BTC and IC wallet workers.