### PR TITLE
feat(frontend): create signer canister

### DIFF
--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -57,11 +57,9 @@ export const signPrehash = async ({
 	return sign_prehash(hash);
 };
 
-export const signerCanister = async ({
-	identity
-}: {
-	identity: Identity;
-}): Promise<SignerCanister> => {
+// TODO: implement updateBtcBalance method
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const signerCanister = async ({ identity }: { identity: Identity }): Promise<SignerCanister> => {
 	const agent = await getAgent({ identity });
 
 	return SignerCanister.create({

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -1,7 +1,12 @@
 import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.did';
 import { getSignerActor } from '$lib/actors/actors.ic';
+import { getAgent } from '$lib/actors/agents.ic';
+import { SignerCanister } from '$lib/canisters/signer.canister';
+import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
 import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
+import type { Identity } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
 
 export const getBtcAddress = async ({
 	identity,
@@ -50,4 +55,17 @@ export const signPrehash = async ({
 }): Promise<string> => {
 	const { sign_prehash } = await getSignerActor({ identity });
 	return sign_prehash(hash);
+};
+
+export const signerCanister = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<SignerCanister> => {
+	const agent = await getAgent({ identity });
+
+	return SignerCanister.create({
+		agent,
+		canisterId: Principal.fromText(SIGNER_CANISTER_ID)
+	});
 };

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,0 +1,29 @@
+import type { BitcoinNetwork, _SERVICE as SignerService } from '$declarations/signer/signer.did';
+import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
+import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
+import { Principal } from '@dfinity/principal';
+import { Canister, createServices, type CanisterOptions } from '@dfinity/utils';
+
+interface SignerCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId'> {
+	canisterId: Principal;
+}
+
+export class SignerCanister extends Canister<SignerService> {
+	static create(options: SignerCanisterOptions<SignerService>) {
+		const { service, certifiedService, canisterId } = createServices<SignerService>({
+			options,
+			idlFactory: idlFactorySigner,
+			certifiedIdlFactory: idlCertifiedFactorySigner
+		});
+
+		return new SignerCanister(canisterId, service, certifiedService);
+	}
+
+	updateBtcBalance = ({ network }: { network: BitcoinNetwork }): Promise<bigint> => {
+		const { caller_btc_balance } = this.caller({
+			certified: true
+		});
+
+		return caller_btc_balance(network);
+	};
+}


### PR DESCRIPTION
# Motivation

The idea is to make `signer` endpoints (specifically `caller_btc_balance`) available as a canister to use in a web worker.
