### PR TITLE
chore(frontend): set more correct types for Ethereum native tokens

### DIFF
--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -1,13 +1,13 @@
 import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
-import type { RequiredToken, TokenId } from '$lib/types/token';
+import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
 /**
  * Ethereum (Ethereum or Sepolia) token - i.e. not ERC20.
  */
-export const ethereumToken: Readable<RequiredToken> = derived(
+export const ethereumToken: Readable<RequiredTokenWithLinkedData> = derived(
 	[enabledEthereumTokens, selectedEthereumNetwork],
 	([$enabledEthereumTokens, { id }]) =>
 		$enabledEthereumTokens.find(({ network: { id: networkId } }) => id === networkId) ??

--- a/src/frontend/src/eth/derived/tokens.derived.ts
+++ b/src/frontend/src/eth/derived/tokens.derived.ts
@@ -1,10 +1,10 @@
 import { ETH_MAINNET_ENABLED } from '$env/networks.eth.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
 import { testnets } from '$lib/derived/testnets.derived';
-import type { RequiredToken } from '$lib/types/token';
+import type { RequiredTokenWithLinkedData } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
-export const enabledEthereumTokens: Readable<RequiredToken[]> = derived(
+export const enabledEthereumTokens: Readable<RequiredTokenWithLinkedData[]> = derived(
 	[testnets],
 	([$testnets]) => [
 		...(ETH_MAINNET_ENABLED ? [ETHEREUM_TOKEN] : []),


### PR DESCRIPTION
# Motivation

To be more precise, the correct type of the Ethereum tokens are now `RequiredTokenWithLinkedData`.