### PR TITLE
ci(dependabot): add devDependencies auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "cargo"
+  - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: "weekly"
-    target: "dev"
+      interval: weekly
+    allow:
+      - dependency-type: development
     ignore:
       - dependency-name: "@dfinity/*"
       - dependency-name: "@types/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target: "dev"
+    ignore:
+      - dependency-name: "@dfinity/*"
+      - dependency-name: "@types/*"
+      - dependency-name: "@typescript-eslint/*"
+      - dependency-name: "eslint"
+      - dependency-name: "eslint-*"
+      - dependency-name: "sass"
+      - dependency-name: "svelte"
+      - dependency-name: "typescript"
+      - dependency-name: "vite"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,4 @@ updates:
       - dependency-name: "@typescript-eslint/*"
       - dependency-name: "eslint"
       - dependency-name: "eslint-*"
-      - dependency-name: "sass"
-      - dependency-name: "svelte"
       - dependency-name: "typescript"
-      - dependency-name: "vite"


### PR DESCRIPTION
# Motivation

We would like to auto-update devDependencies, with the due exceptions (like `typescript` and `lint`).
