### PR TITLE
refactor(frontend): use object param for shortenWithMiddleEllipsis util

### DIFF
--- a/src/frontend/src/eth/components/core/EthWalletAddress.svelte
+++ b/src/frontend/src/eth/components/core/EthWalletAddress.svelte
@@ -18,7 +18,7 @@
 	>
 
 	<output class="break-all" id="eth-wallet-address"
-		>{shortenWithMiddleEllipsis($ethAddress ?? '')}</output
+		>{shortenWithMiddleEllipsis({ text: $ethAddress ?? '' })}</output
 	><Copy inline color="inherit" value={$ethAddress ?? ''} text={$i18n.wallet.text.address_copied} />
 </div>
 

--- a/src/frontend/src/eth/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/TransactionModal.svelte
@@ -52,7 +52,7 @@
 		{#if nonNullish(hash)}
 			<Value ref="hash">
 				<svelte:fragment slot="label">{$i18n.transaction.text.hash}</svelte:fragment>
-				<output>{shortenWithMiddleEllipsis(hash)}</output><Copy
+				<output>{shortenWithMiddleEllipsis({ text: hash })}</output><Copy
 					value={hash}
 					text={replacePlaceholders($i18n.transaction.text.hash_copied, {
 						$hash: hash

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendData.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendData.svelte
@@ -10,7 +10,7 @@
 {#if nonNullish(data)}
 	<label for="data" class="font-bold px-4.5">{$i18n.wallet_connect.text.hex_data}:</label>
 	<div id="data" class="font-normal mb-4 px-4.5 flex items-center gap-1">
-		{shortenWithMiddleEllipsis(data)}<Copy
+		{shortenWithMiddleEllipsis({ text: data })}<Copy
 			inline
 			value={data}
 			text={$i18n.wallet_connect.text.raw_copied}

--- a/src/frontend/src/icp/components/core/IcWalletAddress.svelte
+++ b/src/frontend/src/icp/components/core/IcWalletAddress.svelte
@@ -11,7 +11,7 @@
 	>
 
 	<output id="ic-wallet-address" class="break-all"
-		>{shortenWithMiddleEllipsis($icrcAccountIdentifierText ?? '')}</output
+		>{shortenWithMiddleEllipsis({ text: $icrcAccountIdentifierText ?? '' })}</output
 	><Copy
 		color="inherit"
 		inline

--- a/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
@@ -42,7 +42,7 @@
 							<span class="mt-2 w-full max-w-[150px]"><SkeletonText /></span>
 						{:else}
 							<span class="break-all" data-tid={RECEIVE_TOKENS_MODAL_ADDRESS_LABEL}>
-								{shortenWithMiddleEllipsis(address)}
+								{shortenWithMiddleEllipsis({ text: address })}
 							</span>
 						{/if}
 					</svelte:fragment>

--- a/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
@@ -52,7 +52,9 @@
 		><span class="font-bold">{$i18n.settings.text.principal}:</span></svelte:fragment
 	>
 	<svelte:fragment slot="value"
-		><output class="break-all">{shortenWithMiddleEllipsis(principal?.toText() ?? '')}</output><Copy
+		><output class="break-all"
+			>{shortenWithMiddleEllipsis({ text: principal?.toText() ?? '' })}</output
+		><Copy
 			inline
 			value={principal?.toText() ?? ''}
 			text={$i18n.settings.text.principal_copied}

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -34,9 +34,13 @@ export const formatToken = ({
  * @param splitLength An optional length for the split. e.g. 12345678 becomes, if splitLength = 2, 12...78
  * @returns text
  */
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-export const shortenWithMiddleEllipsis = (text: string, splitLength = 7): string => {
+export const shortenWithMiddleEllipsis = ({
+	text,
+	splitLength = 7
+}: {
+	text: string;
+	splitLength?: number;
+}): string => {
 	// Original min length was 16 to extract 7 split
 	const minLength = splitLength * 2 + 2;
 	return text.length > minLength


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning util `shortenWithMiddleEllipsis`.
