### PR TITLE
refactor(frontend): use object param for autoLoadToken util

### DIFF
--- a/src/frontend/src/icp-eth/services/custom-token.services.ts
+++ b/src/frontend/src/icp-eth/services/custom-token.services.ts
@@ -19,12 +19,14 @@ const assertErc20SendTokenData = (sendToken: Erc20Token): AutoLoadTokenResult | 
 	}
 };
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-const findCustomToken = (
-	tokens: IcrcCustomToken[],
-	sendToken: Erc20Token
-): IcrcCustomToken | undefined => tokens.find(({ symbol }) => symbol === sendToken.twinTokenSymbol);
+const findCustomToken = ({
+	tokens,
+	sendToken
+}: {
+	tokens: IcrcCustomToken[];
+	sendToken: Erc20Token;
+}): IcrcCustomToken | undefined =>
+	tokens.find(({ symbol }) => symbol === sendToken.twinTokenSymbol);
 
 /**
  * When a user converts a ckERC20 token to an ERC20 twin token, the UI needs information about the counterpart token (ckERC20).

--- a/src/frontend/src/icp-eth/services/user-token.services.ts
+++ b/src/frontend/src/icp-eth/services/user-token.services.ts
@@ -20,12 +20,13 @@ const assertIcrcSendTokenData = (sendToken: IcCkToken): AutoLoadTokenResult | un
 	}
 };
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-const findUserToken = (
-	tokens: Erc20UserToken[],
-	sendToken: IcCkToken
-): Erc20UserToken | undefined =>
+const findUserToken = ({
+	tokens,
+	sendToken
+}: {
+	tokens: Erc20UserToken[];
+	sendToken: IcCkToken;
+}): Erc20UserToken | undefined =>
 	tokens.find(
 		({ address }) =>
 			address.toLowerCase() === (sendToken.twinToken as Erc20Token).address.toLowerCase()

--- a/src/frontend/src/lib/services/token.services.ts
+++ b/src/frontend/src/lib/services/token.services.ts
@@ -30,7 +30,7 @@ interface AutoLoadTokenParams<
 	identity: OptionIdentity;
 	expectedSendTokenStandard: TokenStandard;
 	assertSendTokenData: (sendToken: K) => AutoLoadTokenResult | undefined;
-	findToken: (tokens: T[], sendToken: K) => T | undefined;
+	findToken: (params: { tokens: T[]; sendToken: K }) => T | undefined;
 	setToken: (params: { identity: Identity; token: T; enabled: boolean }) => Promise<void>;
 	loadTokens: (params: { identity: OptionIdentity }) => Promise<void>;
 	errorMessage: string;
@@ -81,7 +81,7 @@ export const autoLoadToken = async <
 		return { result: resultAssertData };
 	}
 
-	const counterpartToken = findToken(tokens, sendToken);
+	const counterpartToken = findToken({ tokens, sendToken });
 
 	if (isNullish(counterpartToken)) {
 		return { result: 'skipped' };


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning util `autoLoadToken`'s param `findToken`. Two different functions are fed there: `findCustomToken` and `findUserToken`.
