### PR TITLE
refactor(frontend): use object param for toCkMinterInfoAddresses util

### DIFF
--- a/src/frontend/src/eth/components/transactions/Transactions.svelte
+++ b/src/frontend/src/eth/components/transactions/Transactions.svelte
@@ -25,10 +25,10 @@
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
 
 	let ckMinterInfoAddresses: OptionEthAddress[] = [];
-	$: ckMinterInfoAddresses = toCkMinterInfoAddresses(
-		$ckEthMinterInfoStore?.[$ethereumTokenId],
-		$ethereumToken.network.id
-	);
+	$: ckMinterInfoAddresses = toCkMinterInfoAddresses({
+		minterInfo: $ckEthMinterInfoStore?.[$ethereumTokenId],
+		networkId: $ethereumToken.network.id
+	});
 
 	let sortedTransactionsUi: EthTransactionUi[];
 	$: sortedTransactionsUi = $sortedTransactions.map((transaction) =>

--- a/src/frontend/src/icp-eth/utils/cketh.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh.utils.ts
@@ -23,12 +23,13 @@ export const toCkErc20HelperContractAddress = (
 const toCkMinterAddress = (minterInfo: OptionCertifiedMinterInfo): OptionEthAddress =>
 	fromNullable(minterInfo?.data.minter_address ?? []);
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-export const toCkMinterInfoAddresses = (
-	minterInfo: OptionCertifiedMinterInfo,
-	networkId: NetworkId
-): OptionEthAddress[] =>
+export const toCkMinterInfoAddresses = ({
+	minterInfo,
+	networkId
+}: {
+	minterInfo: OptionCertifiedMinterInfo;
+	networkId: NetworkId;
+}): OptionEthAddress[] =>
 	nonNullish(minterInfo)
 		? [
 				toCkEthHelperContractAddress(minterInfo, networkId),


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning util `toCkMinterInfoAddresses`.
