### PR TITLE
style(frontend): new style for Alpha warning [GIX-2981]

### DIFF
--- a/src/frontend/src/lib/components/core/Alpha.svelte
+++ b/src/frontend/src/lib/components/core/Alpha.svelte
@@ -16,6 +16,9 @@
 
 <style lang="scss">
 	a {
-		color: var(--alpha-color, var(--color-misty-rose));
+		color: var(--alpha-color, var(--color-american-orange));
+		background-color: var(--alpha-bg-color, var(--color-cornsilk));
+		border: 1px solid var(--alpha-border-color, var(--color-crayola-yellow));
+		border-radius: 8px;
 	}
 </style>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -125,7 +125,7 @@
 	},
 	"hero": {
 		"text": {
-			"use_with_caution": "Learn more about this alpha version. Use with caution.",
+			"use_with_caution": "This is alpha version. Use with caution.",
 			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
 		}
 	},

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -125,7 +125,7 @@
 	},
 	"hero": {
 		"text": {
-			"use_with_caution": "This is alpha version. Use with caution.",
+			"use_with_caution": "This is an alpha version. Use with caution.",
 			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
 		}
 	},

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -24,6 +24,9 @@
 	--color-cetacean-blue: theme(colors.cetacean-blue);
 	--color-brilliant-azure: theme(colors.brilliant-azure);
 	--color-blue-ribbon: theme(colors.blue-ribbon);
+	--color-american-orange: theme(colors.american-orange);
+	--color-crayola-yellow: theme(colors.crayola-yellow);
+	--color-cornsilk: theme(colors.cornsilk);
 
 	// Brand
 	--color-wallet-connect: #3b99fc;

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -25,7 +25,7 @@
 	--color-brilliant-azure: theme(colors.brilliant-azure);
 	--color-blue-ribbon: theme(colors.blue-ribbon);
 	--color-alice-blue: theme(colors.alice-blue);
-  --color-american-orange: theme(colors.american-orange);
+	--color-american-orange: theme(colors.american-orange);
 	--color-crayola-yellow: theme(colors.crayola-yellow);
 	--color-cornsilk: theme(colors.cornsilk);
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,7 +34,10 @@ export default {
 			platinum: '#e4e4e4',
 			'mountain-meadow': '#30af91',
 			'dodger-blue': '#1e90ff',
-			turquoise: '#59e7d6'
+			turquoise: '#59e7d6',
+			'american-orange': '#ff8a00',
+			'crayola-yellow': '#ffe57f',
+			cornsilk: '#fff7d8'
 		}
 	},
 	plugins: []

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,7 +35,7 @@ export default {
 			'mountain-meadow': '#30af91',
 			'dodger-blue': '#1e90ff',
 			turquoise: '#59e7d6',
-      'alice-blue': '#ecf3fb',
+			'alice-blue': '#ecf3fb',
 			'american-orange': '#ff8a00',
 			'crayola-yellow': '#ffe57f',
 			cornsilk: '#fff7d8'


### PR DESCRIPTION
# Motivation

We update the style for the Alpha warning.

### Before

<img width="568" alt="Screenshot 2024-09-19 at 08 03 03" src="https://github.com/user-attachments/assets/6d2dd269-9610-428a-94a3-264f5a6a4434">

### After

<img width="475" alt="Screenshot 2024-09-19 at 08 02 33" src="https://github.com/user-attachments/assets/4cc34945-8d37-47a8-81a3-3e8471847a1e">



