### PR TITLE
style(frontend): new class for tertiary buttons

### DIFF
--- a/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-	class="  mx-auto mt-12 mb-4 font-bold"
+	class="tertiary mx-auto mt-12 mb-4"
 	class:text-grey={disabled}
 	class:text-blue={!disabled}
 	class:hover:text-dark-blue={!disabled}

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -23,7 +23,8 @@ button {
 	--button-padding: var(--padding) var(--padding-3x);
 
 	&.primary,
-	&.secondary {
+	&.secondary,
+	&.tertiary {
 		justify-content: flex-start;
 
 		padding: var(--button-padding);
@@ -35,7 +36,8 @@ button {
 	}
 
 	&.primary,
-	&.secondary {
+	&.secondary,
+	&.tertiary {
 		font-weight: var(--font-weight-bold);
 
 		&[disabled],
@@ -60,6 +62,11 @@ button {
 		color: var(--color-white);
 	}
 
+	&.tertiary {
+		background: var(--color-alice-blue);
+		color: var(--color-primary);
+	}
+
 	&.hero {
 		justify-content: center;
 
@@ -72,7 +79,8 @@ button {
 	}
 
 	&.primary,
-	&.secondary {
+	&.secondary,
+	&.tertiary {
 		&.full {
 			width: 100%;
 		}

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -24,6 +24,7 @@
 	--color-cetacean-blue: theme(colors.cetacean-blue);
 	--color-brilliant-azure: theme(colors.brilliant-azure);
 	--color-blue-ribbon: theme(colors.blue-ribbon);
+	--color-alice-blue: theme(colors.alice-blue);
 
 	// Brand
 	--color-wallet-connect: #3b99fc;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,7 +34,8 @@ export default {
 			platinum: '#e4e4e4',
 			'mountain-meadow': '#30af91',
 			'dodger-blue': '#1e90ff',
-			turquoise: '#59e7d6'
+			turquoise: '#59e7d6',
+			'alice-blue': '#ecf3fb'
 		}
 	},
 	plugins: []


### PR DESCRIPTION
# Motivation

There is a new class for `tertiary` buttons (settings, manage, options). We apply it to the button "Manage your tokens".

### Before

<img width="684" alt="Screenshot 2024-09-19 at 10 50 55" src="https://github.com/user-attachments/assets/0feb6b99-fc89-421c-8b27-069fbf33e14e">

### After

<img width="650" alt="Screenshot 2024-09-19 at 10 50 35" src="https://github.com/user-attachments/assets/7a443cc3-1983-49e4-b9e6-ad45207abef0">
<img width="379" alt="Screenshot 2024-09-19 at 10 51 21" src="https://github.com/user-attachments/assets/35e09a18-423a-4874-8c47-49dd9600d180">

