### PR TITLE
feat(frontend): use signer API via canister

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,8 @@
 				"typescript": "^5.4.5",
 				"vite": "^5.4.7",
 				"vite-node": "^2.1.1",
-				"vitest": "^2.1.1"
+				"vitest": "^2.1.1",
+				"vitest-mock-extended": "^2.0.2"
 			},
 			"engines": {
 				"node": "^20"
@@ -10426,6 +10427,21 @@
 				"typescript": ">=4.2.0"
 			}
 		},
+		"node_modules/ts-essentials": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.2.tgz",
+			"integrity": "sha512-Xwag0TULqriaugXqVdDiGZ5wuZpqABZlpwQ2Ho4GDyiu/R2Xjkp/9+zcFxL7uzeLl/QCPrflnvpVYyS3ouT7Zw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": ">=4.5.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -11005,6 +11021,20 @@
 				"jsdom": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest-mock-extended": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/vitest-mock-extended/-/vitest-mock-extended-2.0.2.tgz",
+			"integrity": "sha512-n3MBqVITKyclZ0n0y66hkT4UiiEYFQn9tteAnIxT0MPz1Z8nFcPUG3Cf0cZOyoPOj/cq6Ab1XFw2lM/qM5EDWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ts-essentials": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"typescript": "3.x || 4.x || 5.x",
+				"vitest": ">=2.0.0"
 			}
 		},
 		"node_modules/vitest/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
 		"typescript": "^5.4.5",
 		"vite": "^5.4.7",
 		"vite-node": "^2.1.1",
-		"vitest": "^2.1.1"
+		"vitest": "^2.1.1",
+		"vitest-mock-extended": "^2.0.2"
 	},
 	"type": "module",
 	"overrides": {

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -403,7 +403,11 @@ const sendTransaction = async ({
 
 	progress(ProgressStepsSend.SIGN_TRANSFER);
 
-	const rawTransaction = await signTransaction({ identity, transaction });
+	const rawTransaction = await signTransaction({
+		identity,
+		transaction,
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	});
 
 	progress(ProgressStepsSend.TRANSFER);
 

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -266,13 +266,21 @@ export const signMessage = ({
 
 					try {
 						const hash = getSignParamsMessageTypedDataV4Hash(params);
-						return signPrehash({ hash, identity });
+						return signPrehash({
+							hash,
+							identity,
+							nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+						});
 					} catch (err: unknown) {
 						// If the above failed, it's because JSON.parse throw an exception.
 						// We are assuming that it did so because it tried to parse a string that does not represent an object.
 						// Therefore, we continue with a message as hex string.
 						const message = getSignParamsMessageHex(params);
-						return signMessageApi({ message, identity });
+						return signMessageApi({
+							message,
+							identity,
+							nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+						});
 					}
 				};
 

--- a/src/frontend/src/lib/actors/actors.ic.ts
+++ b/src/frontend/src/lib/actors/actors.ic.ts
@@ -1,10 +1,7 @@
 import type { _SERVICE as BackendActor } from '$declarations/backend/backend.did';
 import { idlFactory as idlCertifiedFactoryBackend } from '$declarations/backend/backend.factory.certified.did';
 import { idlFactory as idlFactoryBackend } from '$declarations/backend/backend.factory.did';
-import type { _SERVICE as SignerActor } from '$declarations/signer/signer.did';
-import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
-import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
-import { BACKEND_CANISTER_ID, SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
+import { BACKEND_CANISTER_ID } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Option } from '$lib/types/utils';
@@ -15,7 +12,7 @@ import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 import { getAgent } from './agents.ic';
 
-let actors: Option<{ backend?: BackendActor; signer?: SignerActor }> = undefined;
+let actors: Option<{ backend?: BackendActor }> = undefined;
 
 export const getBackendActor = async ({
 	identity,
@@ -44,36 +41,6 @@ export const getBackendActor = async ({
 	}
 
 	return backend;
-};
-
-export const getSignerActor = async ({
-	identity,
-	certified = true
-}: {
-	identity: OptionIdentity;
-	certified?: boolean;
-}): Promise<SignerActor> => {
-	// TODO: Delete this dependency once the signer has been stripped down.
-	assertNonNullish(identity, get(i18n).auth.error.no_internet_identity);
-
-	const { signer } = actors ?? { signer: undefined };
-
-	if (isNullish(signer)) {
-		const actor = await createActor<SignerActor>({
-			canisterId: SIGNER_CANISTER_ID,
-			idlFactory: certified ? idlCertifiedFactorySigner : idlFactorySigner,
-			identity
-		});
-
-		actors = {
-			...(actors ?? {}),
-			signer: actor
-		};
-
-		return actor;
-	}
-
-	return signer;
 };
 
 export const clearActors = () => (actors = null);

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -57,11 +57,9 @@ export const signPrehash = async ({
 	return sign_prehash(hash);
 };
 
-export const signerCanister = async ({
-	identity
-}: {
-	identity: Identity;
-}): Promise<SignerCanister> => {
+// TODO: implement updateBtcBalance method
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const signerCanister = async ({ identity }: { identity: Identity }): Promise<SignerCanister> => {
 	const agent = await getAgent({ identity });
 
 	return SignerCanister.create({

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -81,7 +81,6 @@ const signerCanister = async ({
 }: {
 	identity: OptionIdentity;
 }): Promise<SignerCanister> => {
-	// TODO: Delete this dependency once the signer has been stripped down.
 	assertNonNullish(identity);
 
 	if (isNullish(canister)) {

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -1,5 +1,4 @@
 import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.did';
-import { getAgent } from '$lib/actors/agents.ic';
 import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
@@ -84,10 +83,8 @@ const signerCanister = async ({
 	assertNonNullish(identity);
 
 	if (isNullish(canister)) {
-		const agent = await getAgent({ identity });
-
-		canister = SignerCanister.create({
-			agent,
+		canister = await SignerCanister.create({
+			identity,
 			canisterId: Principal.fromText(SIGNER_CANISTER_ID)
 		});
 	}

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -20,19 +20,6 @@ export const getBtcAddress = async ({
 	return getBtcAddress({ network });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const updateBtcBalance = async ({
-	identity,
-	network
-}: {
-	identity: OptionIdentity;
-	network: BitcoinNetwork;
-}): Promise<bigint> => {
-	const { updateBtcBalance } = await signerCanister({ identity });
-
-	return updateBtcBalance({ network });
-};
-
 export const getEthAddress = async (identity: OptionIdentity): Promise<EthAddress> => {
 	const { getEthAddress } = await signerCanister({ identity });
 

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -1,12 +1,13 @@
 import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.did';
-import { getSignerActor } from '$lib/actors/actors.ic';
 import { getAgent } from '$lib/actors/agents.ic';
 import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
-import type { EthAddress } from '$lib/types/address';
+import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
-import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
+
+let canister: SignerCanister | undefined = undefined;
 
 export const getBtcAddress = async ({
 	identity,
@@ -14,14 +15,29 @@ export const getBtcAddress = async ({
 }: {
 	identity: OptionIdentity;
 	network: BitcoinNetwork;
-}): Promise<EthAddress> => {
-	const { caller_btc_address } = await getSignerActor({ identity });
-	return caller_btc_address(network);
+}): Promise<BtcAddress> => {
+	const { getBtcAddress } = await signerCanister({ identity });
+
+	return getBtcAddress({ network });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const updateBtcBalance = async ({
+	identity,
+	network
+}: {
+	identity: OptionIdentity;
+	network: BitcoinNetwork;
+}): Promise<bigint> => {
+	const { updateBtcBalance } = await signerCanister({ identity });
+
+	return updateBtcBalance({ network });
 };
 
 export const getEthAddress = async (identity: OptionIdentity): Promise<EthAddress> => {
-	const { caller_eth_address } = await getSignerActor({ identity });
-	return caller_eth_address();
+	const { getEthAddress } = await signerCanister({ identity });
+
+	return getEthAddress({});
 };
 
 export const signTransaction = async ({
@@ -31,8 +47,9 @@ export const signTransaction = async ({
 	transaction: SignRequest;
 	identity: OptionIdentity;
 }): Promise<string> => {
-	const { sign_transaction } = await getSignerActor({ identity });
-	return sign_transaction(transaction);
+	const { signTransaction } = await signerCanister({ identity });
+
+	return signTransaction({ transaction });
 };
 
 export const signMessage = async ({
@@ -42,8 +59,9 @@ export const signMessage = async ({
 	message: string;
 	identity: OptionIdentity;
 }): Promise<string> => {
-	const { personal_sign } = await getSignerActor({ identity });
-	return personal_sign(message);
+	const { personalSign } = await signerCanister({ identity });
+
+	return personalSign({ message });
 };
 
 export const signPrehash = async ({
@@ -53,17 +71,27 @@ export const signPrehash = async ({
 	hash: string;
 	identity: OptionIdentity;
 }): Promise<string> => {
-	const { sign_prehash } = await getSignerActor({ identity });
-	return sign_prehash(hash);
+	const { signPrehash } = await signerCanister({ identity });
+
+	return signPrehash({ hash });
 };
 
-// TODO: implement updateBtcBalance method
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const signerCanister = async ({ identity }: { identity: Identity }): Promise<SignerCanister> => {
-	const agent = await getAgent({ identity });
+const signerCanister = async ({
+	identity
+}: {
+	identity: OptionIdentity;
+}): Promise<SignerCanister> => {
+	// TODO: Delete this dependency once the signer has been stripped down.
+	assertNonNullish(identity);
 
-	return SignerCanister.create({
-		agent,
-		canisterId: Principal.fromText(SIGNER_CANISTER_ID)
-	});
+	if (isNullish(canister)) {
+		const agent = await getAgent({ identity });
+
+		canister = SignerCanister.create({
+			agent,
+			canisterId: Principal.fromText(SIGNER_CANISTER_ID)
+		});
+	}
+
+	return canister;
 };

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -8,31 +8,34 @@ import { assertNonNullish, isNullish } from '@dfinity/utils';
 
 let canister: SignerCanister | undefined = undefined;
 
+type CommonParams<T = unknown> = T & {
+	nullishIdentityErrorMessage?: string;
+	identity: OptionIdentity;
+};
+
 export const getBtcAddress = async ({
 	identity,
 	network
-}: {
-	identity: OptionIdentity;
+}: CommonParams<{
 	network: BitcoinNetwork;
-}): Promise<BtcAddress> => {
+}>): Promise<BtcAddress> => {
 	const { getBtcAddress } = await signerCanister({ identity });
 
 	return getBtcAddress({ network });
 };
 
-export const getEthAddress = async (identity: OptionIdentity): Promise<EthAddress> => {
+export const getEthAddress = async ({ identity }: CommonParams): Promise<EthAddress> => {
 	const { getEthAddress } = await signerCanister({ identity });
 
-	return getEthAddress({});
+	return getEthAddress();
 };
 
 export const signTransaction = async ({
 	transaction,
 	identity
-}: {
+}: CommonParams<{
 	transaction: SignRequest;
-	identity: OptionIdentity;
-}): Promise<string> => {
+}>): Promise<string> => {
 	const { signTransaction } = await signerCanister({ identity });
 
 	return signTransaction({ transaction });
@@ -41,10 +44,7 @@ export const signTransaction = async ({
 export const signMessage = async ({
 	message,
 	identity
-}: {
-	message: string;
-	identity: OptionIdentity;
-}): Promise<string> => {
+}: CommonParams<{ message: string }>): Promise<string> => {
 	const { personalSign } = await signerCanister({ identity });
 
 	return personalSign({ message });
@@ -53,21 +53,19 @@ export const signMessage = async ({
 export const signPrehash = async ({
 	hash,
 	identity
-}: {
+}: CommonParams<{
 	hash: string;
-	identity: OptionIdentity;
-}): Promise<string> => {
+}>): Promise<string> => {
 	const { signPrehash } = await signerCanister({ identity });
 
 	return signPrehash({ hash });
 };
 
 const signerCanister = async ({
-	identity
-}: {
-	identity: OptionIdentity;
-}): Promise<SignerCanister> => {
-	assertNonNullish(identity);
+	identity,
+	nullishIdentityErrorMessage
+}: CommonParams): Promise<SignerCanister> => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
 
 	if (isNullish(canister)) {
 		canister = await SignerCanister.create({

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -1,7 +1,12 @@
 import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.did';
 import { getSignerActor } from '$lib/actors/actors.ic';
+import { getAgent } from '$lib/actors/agents.ic';
+import { SignerCanister } from '$lib/canisters/signer.canister';
+import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
 import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
+import type { Identity } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
 
 export const getBtcAddress = async ({
 	identity,
@@ -50,4 +55,17 @@ export const signPrehash = async ({
 }): Promise<string> => {
 	const { sign_prehash } = await getSignerActor({ identity });
 	return sign_prehash(hash);
+};
+
+export const signerCanister = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<SignerCanister> => {
+	const agent = await getAgent({ identity });
+
+	return SignerCanister.create({
+		agent,
+		canisterId: Principal.fromText(SIGNER_CANISTER_ID)
+	});
 };

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,0 +1,29 @@
+import type { BitcoinNetwork, _SERVICE as SignerService } from '$declarations/signer/signer.did';
+import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
+import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
+import { Principal } from '@dfinity/principal';
+import { Canister, createServices, type CanisterOptions } from '@dfinity/utils';
+
+interface SignerCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId'> {
+	canisterId: Principal;
+}
+
+export class SignerCanister extends Canister<SignerService> {
+	static create(options: SignerCanisterOptions<SignerService>) {
+		const { service, certifiedService, canisterId } = createServices<SignerService>({
+			options,
+			idlFactory: idlFactorySigner,
+			certifiedIdlFactory: idlCertifiedFactorySigner
+		});
+
+		return new SignerCanister(canisterId, service, certifiedService);
+	}
+
+	updateBtcBalance = ({ network }: { network: BitcoinNetwork }): Promise<bigint> => {
+		const { caller_btc_balance } = this.caller({
+			certified: true
+		});
+
+		return caller_btc_balance(network);
+	};
+}

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -11,12 +11,12 @@ import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { Canister, createServices, type CanisterOptions } from '@dfinity/utils';
 
-interface SignerCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId' | 'agent'> {
+export interface SignerCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId' | 'agent'> {
 	canisterId: Principal;
 	identity: Identity;
 }
 
-type SignerCanisterFunctionParams<T = Record<string, never>> = T & {
+type SignerCanisterFunctionParams<T = unknown> = T & {
 	certified?: boolean;
 };
 
@@ -51,7 +51,7 @@ export class SignerCanister extends Canister<SignerService> {
 
 	updateBtcBalance = ({
 		network,
-		certified = true
+		certified = false
 	}: SignerCanisterFunctionParams<{
 		network: BitcoinNetwork;
 	}>): Promise<bigint> => {

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,12 +1,21 @@
-import type { BitcoinNetwork, _SERVICE as SignerService } from '$declarations/signer/signer.did';
+import type {
+	BitcoinNetwork,
+	_SERVICE as SignerService,
+	SignRequest
+} from '$declarations/signer/signer.did';
 import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
 import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
+import type { BtcAddress, EthAddress } from '$lib/types/address';
 import { Principal } from '@dfinity/principal';
 import { Canister, createServices, type CanisterOptions } from '@dfinity/utils';
 
 interface SignerCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId'> {
 	canisterId: Principal;
 }
+
+type SignerCanisterFunctionParams<T = Record<string, never>> = T & {
+	certified?: boolean;
+};
 
 export class SignerCanister extends Canister<SignerService> {
 	static create(options: SignerCanisterOptions<SignerService>) {
@@ -19,11 +28,76 @@ export class SignerCanister extends Canister<SignerService> {
 		return new SignerCanister(canisterId, service, certifiedService);
 	}
 
-	updateBtcBalance = ({ network }: { network: BitcoinNetwork }): Promise<bigint> => {
+	getBtcAddress = ({
+		network,
+		certified = true
+	}: SignerCanisterFunctionParams<{
+		network: BitcoinNetwork;
+	}>): Promise<BtcAddress> => {
+		const { caller_btc_address } = this.caller({
+			certified
+		});
+
+		return caller_btc_address(network);
+	};
+
+	updateBtcBalance = ({
+		network,
+		certified = true
+	}: SignerCanisterFunctionParams<{
+		network: BitcoinNetwork;
+	}>): Promise<bigint> => {
 		const { caller_btc_balance } = this.caller({
-			certified: true
+			certified
 		});
 
 		return caller_btc_balance(network);
+	};
+
+	getEthAddress = ({ certified = true }: SignerCanisterFunctionParams): Promise<EthAddress> => {
+		const { caller_eth_address } = this.caller({
+			certified
+		});
+
+		return caller_eth_address();
+	};
+
+	signTransaction = ({
+		transaction,
+		certified = true
+	}: SignerCanisterFunctionParams<{
+		transaction: SignRequest;
+	}>): Promise<string> => {
+		const { sign_transaction } = this.caller({
+			certified
+		});
+
+		return sign_transaction(transaction);
+	};
+
+	personalSign = ({
+		message,
+		certified = true
+	}: SignerCanisterFunctionParams<{
+		message: string;
+	}>): Promise<string> => {
+		const { personal_sign } = this.caller({
+			certified
+		});
+
+		return personal_sign(message);
+	};
+
+	signPrehash = ({
+		hash,
+		certified = true
+	}: SignerCanisterFunctionParams<{
+		hash: string;
+	}>): Promise<string> => {
+		const { sign_prehash } = this.caller({
+			certified
+		});
+
+		return sign_prehash(hash);
 	};
 }

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -11,17 +11,14 @@ import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { Canister, createServices, type CanisterOptions } from '@dfinity/utils';
 
-export interface SignerCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId' | 'agent'> {
+export interface SignerCanisterOptions
+	extends Omit<CanisterOptions<SignerService>, 'canisterId' | 'agent'> {
 	canisterId: Principal;
 	identity: Identity;
 }
 
-type SignerCanisterFunctionParams<T = unknown> = T & {
-	certified?: boolean;
-};
-
 export class SignerCanister extends Canister<SignerService> {
-	static async create({ identity, ...options }: SignerCanisterOptions<SignerService>) {
+	static async create({ identity, ...options }: SignerCanisterOptions) {
 		const agent = await getAgent({ identity });
 
 		const { service, certifiedService, canisterId } = createServices<SignerService>({
@@ -36,61 +33,41 @@ export class SignerCanister extends Canister<SignerService> {
 		return new SignerCanister(canisterId, service, certifiedService);
 	}
 
-	getBtcAddress = ({
-		network,
-		certified = true
-	}: SignerCanisterFunctionParams<{
-		network: BitcoinNetwork;
-	}>): Promise<BtcAddress> => {
+	getBtcAddress = ({ network }: { network: BitcoinNetwork }): Promise<BtcAddress> => {
 		const { caller_btc_address } = this.caller({
-			certified
+			certified: true
 		});
 
 		return caller_btc_address(network);
 	};
 
-	getEthAddress = ({ certified = true }: SignerCanisterFunctionParams): Promise<EthAddress> => {
+	getEthAddress = (): Promise<EthAddress> => {
 		const { caller_eth_address } = this.caller({
-			certified
+			certified: true
 		});
 
 		return caller_eth_address();
 	};
 
-	signTransaction = ({
-		transaction,
-		certified = true
-	}: SignerCanisterFunctionParams<{
-		transaction: SignRequest;
-	}>): Promise<string> => {
+	signTransaction = ({ transaction }: { transaction: SignRequest }): Promise<string> => {
 		const { sign_transaction } = this.caller({
-			certified
+			certified: true
 		});
 
 		return sign_transaction(transaction);
 	};
 
-	personalSign = ({
-		message,
-		certified = true
-	}: SignerCanisterFunctionParams<{
-		message: string;
-	}>): Promise<string> => {
+	personalSign = ({ message }: { message: string }): Promise<string> => {
 		const { personal_sign } = this.caller({
-			certified
+			certified: true
 		});
 
 		return personal_sign(message);
 	};
 
-	signPrehash = ({
-		hash,
-		certified = true
-	}: SignerCanisterFunctionParams<{
-		hash: string;
-	}>): Promise<string> => {
+	signPrehash = ({ hash }: { hash: string }): Promise<string> => {
 		const { sign_prehash } = this.caller({
-			certified
+			certified: true
 		});
 
 		return sign_prehash(hash);

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -49,19 +49,6 @@ export class SignerCanister extends Canister<SignerService> {
 		return caller_btc_address(network);
 	};
 
-	updateBtcBalance = ({
-		network,
-		certified = false
-	}: SignerCanisterFunctionParams<{
-		network: BitcoinNetwork;
-	}>): Promise<bigint> => {
-		const { caller_btc_balance } = this.caller({
-			certified
-		});
-
-		return caller_btc_balance(network);
-	};
-
 	getEthAddress = ({ certified = true }: SignerCanisterFunctionParams): Promise<EthAddress> => {
 		const { caller_eth_address } = this.caller({
 			certified

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -109,7 +109,8 @@ const loadBtcAddress = async ({
 		getAddress: (identity: OptionIdentity) =>
 			getBtcAddress({
 				identity,
-				network: bitcoinNetworkMapper[network]
+				network: bitcoinNetworkMapper[network],
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 			}),
 		...bitcoinMapper[network]
 	});
@@ -129,7 +130,11 @@ const loadBtcAddressMainnet = async (): Promise<ResultSuccess> =>
 const loadEthAddress = async (): Promise<ResultSuccess> =>
 	loadTokenAddress<EthAddress>({
 		tokenId: ETHEREUM_TOKEN_ID,
-		getAddress: getEthAddress,
+		getAddress: (identity: OptionIdentity) =>
+			getEthAddress({
+				identity,
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+			}),
 		setIdbAddress: setIdbEthAddress,
 		addressStore: ethAddressStore
 	});
@@ -303,7 +308,11 @@ export const certifyEthAddress = async (address: EthAddress): Promise<ResultSucc
 	certifyAddress<EthAddress>({
 		tokenId: ETHEREUM_TOKEN_ID,
 		address,
-		getAddress: getEthAddress,
+		getAddress: (identity: OptionIdentity) =>
+			getEthAddress({
+				identity,
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+			}),
 		updateIdbAddressLastUsage: updateIdbEthAddressLastUsage,
 		addressStore: ethAddressStore
 	});

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,0 +1,137 @@
+import type { _SERVICE as SignerService, SignRequest } from '$declarations/signer/signer.did';
+import { SignerCanister, type SignerCanisterOptions } from '$lib/canisters/signer.canister';
+import { type ActorSubclass } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+import { mock } from 'vitest-mock-extended';
+import { mockIdentity } from '../../mocks/identity.mock';
+
+vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		LOCAL: false
+	};
+});
+
+describe('signer.canister', () => {
+	const createSignerCanister = async (
+		services: Pick<SignerCanisterOptions<SignerService>, 'serviceOverride'>
+	): Promise<SignerCanister> =>
+		SignerCanister.create({
+			canisterId: Principal.fromText('tdxud-2yaaa-aaaad-aadiq-cai'),
+			identity: mockIdentity,
+			...services
+		});
+	const service = mock<ActorSubclass<SignerService>>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns correct BTC balance', async () => {
+		const response = 2n;
+		const params = {
+			network: { mainnet: null }
+		};
+		service.caller_btc_balance.mockResolvedValue(response);
+
+		const { updateBtcBalance } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = await updateBtcBalance({ ...params, certified: false });
+
+		expect(res).toEqual(response);
+		expect(service.caller_btc_balance).toHaveBeenCalledWith(params.network);
+	});
+
+	it('returns correct BTC address', async () => {
+		const response = 'test-bitcoin-address';
+		const params = {
+			network: { mainnet: null }
+		};
+		service.caller_btc_address.mockResolvedValue(response);
+
+		const { getBtcAddress } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = await getBtcAddress({ ...params, certified: false });
+
+		expect(res).toEqual(response);
+		expect(service.caller_btc_address).toHaveBeenCalledWith(params.network);
+	});
+
+	it('returns correct ETH address', async () => {
+		const response = 'test-eth-address';
+		service.caller_eth_address.mockResolvedValue(response);
+
+		const { getEthAddress } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = await getEthAddress({ certified: false });
+
+		expect(res).toEqual(response);
+	});
+
+	it('signs transaction', async () => {
+		const response = 'signed-transaction';
+		const params = {
+			transaction: {
+				to: 'to',
+				gas: 1n,
+				value: 2n,
+				max_priority_fee_per_gas: 1n,
+				data: [],
+				max_fee_per_gas: 5n,
+				chain_id: 10n,
+				nonce: 10n
+			} as SignRequest
+		};
+		service.sign_transaction.mockResolvedValue(response);
+
+		const { signTransaction } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = await signTransaction({ ...params, certified: false });
+
+		expect(res).toEqual(response);
+		expect(service.sign_transaction).toHaveBeenCalledWith(params.transaction);
+	});
+
+	it('calls personal sign', async () => {
+		const response = 'personal-sign';
+		const params = {
+			message: 'message'
+		};
+		service.personal_sign.mockResolvedValue(response);
+
+		const { personalSign } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = await personalSign({ ...params, certified: false });
+
+		expect(res).toEqual(response);
+		expect(service.personal_sign).toHaveBeenCalledWith(params.message);
+	});
+
+	it('signs prehash', async () => {
+		const response = 'personal-sign';
+		const params = {
+			hash: 'hash'
+		};
+		service.sign_prehash.mockResolvedValue(response);
+
+		const { signPrehash } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = await signPrehash({ ...params, certified: false });
+
+		expect(res).toEqual(response);
+		expect(service.sign_prehash).toHaveBeenCalledWith(params.hash);
+	});
+});

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -14,13 +14,14 @@ vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
 });
 
 describe('signer.canister', () => {
-	const createSignerCanister = async (
-		services: Pick<SignerCanisterOptions<SignerService>, 'serviceOverride'>
-	): Promise<SignerCanister> =>
+	const createSignerCanister = async ({
+		serviceOverride
+	}: Pick<SignerCanisterOptions, 'serviceOverride'>): Promise<SignerCanister> =>
 		SignerCanister.create({
 			canisterId: Principal.fromText('tdxud-2yaaa-aaaad-aadiq-cai'),
 			identity: mockIdentity,
-			...services
+			certifiedServiceOverride: serviceOverride,
+			serviceOverride
 		});
 	const service = mock<ActorSubclass<SignerService>>();
 	const mockResponseError = new Error('Test response error');
@@ -58,7 +59,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = await getBtcAddress({ ...btcParams, certified: false });
+		const res = await getBtcAddress(btcParams);
 
 		expect(res).toEqual(response);
 		expect(service.caller_btc_address).toHaveBeenCalledWith(btcParams.network);
@@ -73,7 +74,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = getBtcAddress({ ...btcParams, certified: false });
+		const res = getBtcAddress(btcParams);
 
 		await expect(res).rejects.toThrow(mockResponseError);
 	});
@@ -86,7 +87,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = await getEthAddress({ certified: false });
+		const res = await getEthAddress();
 
 		expect(res).toEqual(response);
 	});
@@ -100,7 +101,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = getEthAddress({ certified: false });
+		const res = getEthAddress();
 
 		await expect(res).rejects.toThrow(mockResponseError);
 	});
@@ -113,7 +114,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = await signTransaction({ ...signTransactionParams, certified: false });
+		const res = await signTransaction(signTransactionParams);
 
 		expect(res).toEqual(response);
 		expect(service.sign_transaction).toHaveBeenCalledWith(signTransactionParams.transaction);
@@ -128,7 +129,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = signTransaction({ ...signTransactionParams, certified: false });
+		const res = signTransaction(signTransactionParams);
 
 		await expect(res).rejects.toThrow(mockResponseError);
 	});
@@ -141,7 +142,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = await personalSign({ ...personalSignParams, certified: false });
+		const res = await personalSign(personalSignParams);
 
 		expect(res).toEqual(response);
 		expect(service.personal_sign).toHaveBeenCalledWith(personalSignParams.message);
@@ -156,7 +157,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = personalSign({ ...personalSignParams, certified: false });
+		const res = personalSign(personalSignParams);
 
 		await expect(res).rejects.toThrow(mockResponseError);
 	});
@@ -169,7 +170,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = await signPrehash({ ...signPrehashParams, certified: false });
+		const res = await signPrehash(signPrehashParams);
 
 		expect(res).toEqual(response);
 		expect(service.sign_prehash).toHaveBeenCalledWith(signPrehashParams.hash);
@@ -184,7 +185,7 @@ describe('signer.canister', () => {
 			serviceOverride: service
 		});
 
-		const res = signPrehash({ ...signPrehashParams, certified: false });
+		const res = signPrehash(signPrehashParams);
 
 		await expect(res).rejects.toThrow(mockResponseError);
 	});

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -2,11 +2,10 @@ import type { UserProfile } from '$declarations/backend/backend.did';
 import * as backendApi from '$lib/api/backend.api';
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
-import type { Identity } from '@dfinity/agent';
-import { Principal } from '@dfinity/principal';
 import { waitFor } from '@testing-library/svelte';
 import { beforeEach } from 'node:test';
 import { get } from 'svelte/store';
+import { mockIdentity } from '../../mocks/identity.mock';
 
 vi.mock('$lib/api/backend.api');
 
@@ -16,14 +15,6 @@ const mockProfile: UserProfile = {
 	created_timestamp: 1234n,
 	updated_timestamp: 1234n
 };
-
-const mockPrincipalText = 'xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe';
-
-const mockPrincipal = Principal.fromText(mockPrincipalText);
-
-const mockIdentity = {
-	getPrincipal: () => mockPrincipal
-} as unknown as Identity;
 
 describe('loadUserProfile', () => {
 	beforeEach(() => {

--- a/src/frontend/src/tests/mocks/identity.mock.ts
+++ b/src/frontend/src/tests/mocks/identity.mock.ts
@@ -1,0 +1,10 @@
+import type { Identity } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+
+const mockPrincipalText = 'xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe';
+
+const mockPrincipal = Principal.fromText(mockPrincipalText);
+
+export const mockIdentity = {
+	getPrincipal: () => mockPrincipal
+} as unknown as Identity;


### PR DESCRIPTION
# Motivation

The idea is to create a signer canister class (instead of using actors) and refactor `signer.api` methods to use it. 