### PR TITLE
refactor(frontend): use object param for toCkMinterInfoAddresses

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -65,10 +65,10 @@
 					...(await getFeeData()),
 					gas: await getEthFeeData({
 						...params,
-						helperContractAddress: toCkEthHelperContractAddress(
-							$ckEthMinterInfoStore?.[nativeEthereumToken.id],
-							sourceNetwork.id
-						)
+						helperContractAddress: toCkEthHelperContractAddress({
+							minterInfo: $ckEthMinterInfoStore?.[nativeEthereumToken.id],
+							networkId: sourceNetwork.id
+						})
 					})
 				});
 				return;

--- a/src/frontend/src/eth/components/send/SendNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendNetwork.svelte
@@ -35,10 +35,10 @@
 		if (
 			isDestinationContractAddress({
 				destination,
-				contractAddress: toCkEthHelperContractAddress(
-					$ckEthMinterInfoStore?.[$sendTokenId],
-					sourceNetwork.id
-				)
+				contractAddress: toCkEthHelperContractAddress({
+					minterInfo: $ckEthMinterInfoStore?.[$sendTokenId],
+					networkId: sourceNetwork.id
+				})
 			})
 		) {
 			networkName = ICP_NETWORK.name;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -90,7 +90,10 @@
 	let targetNetwork: Network | undefined = undefined;
 	$: targetNetwork =
 		destination ===
-		toCkEthHelperContractAddress($ckEthMinterInfoStore?.[$sendTokenId], sourceNetwork.id)
+		toCkEthHelperContractAddress({
+			minterInfo: $ckEthMinterInfoStore?.[$sendTokenId],
+			networkId: sourceNetwork.id
+		})
 			? ICP_NETWORK
 			: $sendToken.network;
 

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -322,7 +322,10 @@ const sendTransaction = async ({
 		return encodePrincipalToEthAddress(identity.getPrincipal());
 	};
 
-	const ckEthHelperContractAddress = toCkEthHelperContractAddress(minterInfo, sourceNetwork.id);
+	const ckEthHelperContractAddress = toCkEthHelperContractAddress({
+		minterInfo,
+		networkId: sourceNetwork.id
+	});
 	const ckErc20HelperContractAddress = toCkErc20HelperContractAddress(minterInfo);
 
 	const transferStandard: 'ethereum' | 'erc20' = isSupportedEthTokenId(token.id)

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -121,10 +121,10 @@
 	$: toContractAddress =
 		$ckEthereumTwinTokenStandard === 'erc20'
 			? (toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]) ?? '')
-			: (toCkEthHelperContractAddress(
-					$ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
-					$ckEthereumNativeToken.network.id
-				) ?? '');
+			: (toCkEthHelperContractAddress({
+					minterInfo: $ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
+					networkId: $ckEthereumNativeToken.network.id
+				}) ?? '');
 
 	$: (async () =>
 		init({ toAddress: toContractAddress, networkId: $ckEthereumTwinToken?.network.id }))();

--- a/src/frontend/src/icp-eth/components/send/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/send/ConvertETH.svelte
@@ -29,7 +29,10 @@
 		// We can convert to ETH - i.e. we can convert to Ethereum or Sepolia, not an ERC20 token
 		isNotSupportedEthTokenId(nativeTokenId) ||
 		isNullish(
-			toCkEthHelperContractAddress($ckEthMinterInfoStore?.[nativeTokenId], nativeNetworkId)
+			toCkEthHelperContractAddress({
+				minterInfo: $ckEthMinterInfoStore?.[nativeTokenId],
+				networkId: nativeNetworkId
+			})
 		) ||
 		($networkICP && isNullish($ckEthMinterInfoStore?.[nativeTokenId]));
 

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -103,10 +103,10 @@ export const ckEthereumNativeTokenBalance: Readable<OptionBalance> = derived(
 export const ckEthHelperContractAddress: Readable<OptionEthAddress> = derived(
 	[ckEthMinterInfoStore, ethereumTokenId, ethereumToken],
 	([$ckEthMinterInfoStore, $ethereumTokenId, $ethereumToken]) =>
-		toCkEthHelperContractAddress(
-			$ckEthMinterInfoStore?.[$ethereumTokenId],
-			$ethereumToken.network.id
-		)
+		toCkEthHelperContractAddress({
+			minterInfo: $ckEthMinterInfoStore?.[$ethereumTokenId],
+			networkId: $ethereumToken.network.id
+		})
 );
 
 /**

--- a/src/frontend/src/icp-eth/utils/cketh.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh.utils.ts
@@ -5,13 +5,14 @@ import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-export const toCkEthHelperContractAddress = (
-	minterInfo: OptionCertifiedMinterInfo,
+export const toCkEthHelperContractAddress = ({
+	minterInfo,
+	networkId
+}: {
+	minterInfo: OptionCertifiedMinterInfo;
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
-	networkId: NetworkId
-): OptionEthAddress =>
+	networkId: NetworkId;
+}): OptionEthAddress =>
 	fromNullable(minterInfo?.data.eth_helper_contract_address ?? []) ??
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	(networkId === ETHEREUM_NETWORK_ID ? CKETH_HELPER_CONTRACT_ADDRESS_MAINNET : undefined);
@@ -32,7 +33,7 @@ export const toCkMinterInfoAddresses = ({
 }): OptionEthAddress[] =>
 	nonNullish(minterInfo)
 		? [
-				toCkEthHelperContractAddress(minterInfo, networkId),
+				toCkEthHelperContractAddress({ minterInfo, networkId }),
 				toCkErc20HelperContractAddress(minterInfo),
 				toCkMinterAddress(minterInfo)
 			].map((address) => address?.toLowerCase())

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -29,10 +29,10 @@
 	$: destination =
 		$ckEthereumTwinTokenStandard === 'erc20'
 			? (toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]) ?? '')
-			: (toCkEthHelperContractAddress(
-					$ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
-					$ckEthereumNativeToken.network.id
-				) ?? '');
+			: (toCkEthHelperContractAddress({
+					minterInfo: $ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
+					networkId: $ckEthereumNativeToken.network.id
+				}) ?? '');
 
 	let targetNetwork: Network | undefined = ICP_NETWORK;
 

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -33,10 +33,10 @@
 	$: destination =
 		$ckEthereumTwinTokenStandard === 'erc20'
 			? (toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]) ?? '')
-			: (toCkEthHelperContractAddress(
-					$ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
-					$ckEthereumNativeToken.network.id
-				) ?? '');
+			: (toCkEthHelperContractAddress({
+					minterInfo: $ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
+					networkId: $ckEthereumNativeToken.network.id
+				}) ?? '');
 
 	let targetNetwork: Network | undefined = ICP_NETWORK;
 


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning util `toCkMinterInfoAddresses`.
