### PR TITLE
refactor(frontend): use object param for formatUSD

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -13,9 +13,9 @@
 		class={`break-all text-5xl font-bold ${totalUsd === 0 ? 'opacity-50' : 'opacity-100'} mt-8 inline-block`}
 	>
 		{#if $exchangeInitialized}
-			{formatUSD(totalUsd)}
+			{formatUSD({ value: totalUsd })}
 		{:else}
-			<span class="animate-pulse">{formatUSD(0)}</span>
+			<span class="animate-pulse">{formatUSD({ value: 0 })}</span>
 		{/if}
 	</output>
 </span>

--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -10,9 +10,9 @@
 <TokenExchangeValueSkeleton {token}>
 	<output class="break-all">
 		{#if nonNullish(token.balance) && nonNullish(token.usdBalance)}
-			{formatUSD(token.usdBalance)}
+			{formatUSD({ value: token.usdBalance })}
 		{:else}
-			{formatUSD(0, { minFraction: 0, maxFraction: 0 }).replace('0', '-')}
+			{formatUSD({ value: 0, options: { minFraction: 0, maxFraction: 0 } }).replace('0', '-')}
 		{/if}
 	</output>
 </TokenExchangeValueSkeleton>

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -34,7 +34,7 @@
 		{name}
 		{icon}
 		logo="start"
-		description={nonNullish(usdBalance) ? formatUSD(usdBalance) : undefined}
+		description={nonNullish(usdBalance) ? formatUSD({ value: usdBalance }) : undefined}
 	/>
 
 	{#if id === $networkId}

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -67,17 +67,18 @@ export const formatNanosecondsToDate = (nanoseconds: bigint): string => {
 	return date.toLocaleDateString('en', DATE_TIME_FORMAT_OPTIONS);
 };
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-export const formatUSD = (
-	value: number,
+export const formatUSD = ({
+	value,
+	options
+}: {
+	value: number;
 	options?: {
 		minFraction?: number;
 		maxFraction?: number;
 		maximumSignificantDigits?: number;
 		symbol?: boolean;
-	}
-): string => {
+	};
+}): string => {
 	const {
 		minFraction = 2,
 		maxFraction = 2,


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning util `formatUSD`.
