### PR TITLE
refactor(frontend): use object param for stringifyJson

### DIFF
--- a/src/frontend/src/lib/components/ui/Json.svelte
+++ b/src/frontend/src/lib/components/ui/Json.svelte
@@ -47,7 +47,7 @@
 	$: {
 		valueType = getValueType(json);
 		isExpandable = valueType === 'object';
-		value = isExpandable ? json : stringifyJson(json);
+		value = isExpandable ? json : stringifyJson({ value: json });
 		keyLabel = `${_key}${_key.length > 0 ? ': ' : ''}`;
 		children = isExpandable ? Object.entries(json as object) : [];
 		hasChildren = children.length > 0;

--- a/src/frontend/src/lib/utils/json.utils.ts
+++ b/src/frontend/src/lib/utils/json.utils.ts
@@ -16,15 +16,16 @@ export const isPrincipal = (value: unknown): value is Principal =>
  * Transform bigint to string to avoid serialization error.
  * devMode transforms 123n -> "BigInt(123)"
  */
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-export const stringifyJson = (
-	value: unknown,
+export const stringifyJson = ({
+	value,
+	options
+}: {
+	value: unknown;
 	options?: {
 		indentation?: number;
 		devMode?: boolean;
-	}
-): string =>
+	};
+}): string =>
 	JSON.stringify(
 		value,
 		(_, value) => {


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning util `stringifyJson`.
