### PR TITLE
style(frontend): move Alpha warning to header [GIX-2981]

### DIFF
--- a/src/frontend/src/lib/components/core/Alpha.svelte
+++ b/src/frontend/src/lib/components/core/Alpha.svelte
@@ -8,7 +8,7 @@
 	href={OISY_ALPHA_WARNING_URL}
 	rel="external noopener noreferrer"
 	target="_blank"
-	class="mx-auto inline-flex max-w-72 items-center gap-2 px-6 py-2 text-xs font-bold no-underline md:max-w-[100%] md:text-base"
+	class="mx-auto inline-flex w-full items-center justify-center gap-2 px-6 py-2 text-xs font-bold no-underline sm:w-fit md:text-base"
 >
 	<IconWarning inline />
 	<span>{$i18n.hero.text.use_with_caution}</span>

--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <header
-	class="flex justify-between md:px-4 relative z-10 pointer-events-none"
+	class="grid grid-cols-2 xl:grid-cols-3 items-center md:px-4 relative z-10 pointer-events-none"
 	style="min-height: 78px"
 >
 	{#if back}
@@ -29,7 +29,7 @@
 	{/if}
 
 	<div
-		class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 flex items-center"
+		class="col-span-3 col-start-1 row-start-2 xl:col-span-1 xl:col-start-2 xl:row-start-1 flex px-4"
 	>
 		<Alpha />
 	</div>

--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import WalletConnect from '$eth/components/wallet-connect/WalletConnect.svelte';
+	import Alpha from '$lib/components/core/Alpha.svelte';
 	import Back from '$lib/components/core/Back.svelte';
 	import Menu from '$lib/components/core/Menu.svelte';
 	import AboutHowModal from '$lib/components/hero/about/AboutHowModal.svelte';
@@ -26,6 +27,12 @@
 			<OisyWalletLogo />
 		</div>
 	{/if}
+
+	<div
+		class="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 flex items-center"
+	>
+		<Alpha />
+	</div>
 
 	<div class="flex m-4 gap-4 pointer-events-auto ml-auto">
 		{#if $authSignedIn}

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Alpha from '$lib/components/core/Alpha.svelte';
 	import Header from '$lib/components/hero/Header.svelte';
 	import HeroContent from '$lib/components/hero/HeroContent.svelte';
 	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
@@ -22,8 +21,6 @@
 		class="flex flex-col rounded-lg pt-1 sm:pt-3 px-8 relative main 2xl:mt-[-70px] items-center"
 		style="padding-bottom: 32px"
 	>
-		<Alpha />
-
 		{#if $authSignedIn}
 			<HeroContent {usdTotal} {summary} {actions} {more} />
 		{:else if heroContent}


### PR DESCRIPTION
# Motivation

We move the Alpha warning in the header, but with the condition that is only for large screens (>1280px).

### Before

<img width="1507" alt="Screenshot 2024-09-20 at 08 38 50" src="https://github.com/user-attachments/assets/99362d15-ddb6-48b4-9d9f-7bbe6bf6c7f0">
<img width="1142" alt="Screenshot 2024-09-20 at 08 38 36" src="https://github.com/user-attachments/assets/f5ab9a90-98ac-44b8-8500-566bd742e21a">
<img width="358" alt="Screenshot 2024-09-20 at 08 38 43" src="https://github.com/user-attachments/assets/5a86925f-1ed5-4049-9786-62f74dd92b00">

### After

<img width="1506" alt="Screenshot 2024-09-20 at 08 28 31" src="https://github.com/user-attachments/assets/a6cee85c-7115-497a-952c-1f8c06425d47">
<img width="908" alt="Screenshot 2024-09-20 at 08 28 39" src="https://github.com/user-attachments/assets/39fdba40-90ba-476f-b46e-ab77b4d6f3a4">
<img width="296" alt="Screenshot 2024-09-20 at 08 30 59" src="https://github.com/user-attachments/assets/9a1d5a77-764b-470b-8d49-f2e42b3019b5">
<img width="357" alt="Screenshot 2024-09-20 at 08 31 06" src="https://github.com/user-attachments/assets/33f834c2-75a1-439e-9cef-3b3ffff4a5ea">
