### PR TITLE
refactor(frontend): fixed width for logo

### DIFF
--- a/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
+++ b/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
@@ -24,7 +24,7 @@
 	</svg>
 </div>
 
-<picture aria-label={ariaLabel}>
+<picture aria-label={ariaLabel} class="w-24">
 	<source srcset={oisyLogoSmall} media="(max-width: 640px)" />
 	<Img src={oisyLogoLarge} alt={ariaLabel} />
 </picture>


### PR DESCRIPTION
# Motivation

For good form (and to avoid strange behavior during screen re-sizing), we set the width of the logo to a fixed value (that is the same as the SVG that defines it).
