### PR TITLE
style(frontend): adjust color of about buttons [GIX-2955]

### DIFF
--- a/src/frontend/src/lib/components/hero/about/AboutItem.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutItem.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <button
-	class={asMenuItem ? 'text' : 'text-center font-bold whitespace-nowrap'}
+	class={asMenuItem ? 'text' : 'text-center text-primary font-bold whitespace-nowrap'}
 	on:click
 	data-tid={testId}
 >


### PR DESCRIPTION
# Motivation

Set color of about buttons to primary.

### Before

<img width="1505" alt="Screenshot 2024-09-20 at 08 45 56" src="https://github.com/user-attachments/assets/4296fa5b-7249-4485-be5b-51a3c136d99e">

### After

<img width="1507" alt="Screenshot 2024-09-20 at 08 45 40" src="https://github.com/user-attachments/assets/d3d2e6d6-4364-4359-956c-537e4c2f8494">
