### PR TITLE
style(frontend): set back button color to primary [GIX-2973]

### DIFF
--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <button
-	class="pointer-events-auto ml-2 flex gap-0.5 font-bold"
+	class="pointer-events-auto ml-2 flex gap-0.5 font-bold text-primary"
 	on:click={async () => back({ pop: nonNullish(fromRoute) })}
 	><IconBack /> {$i18n.core.text.back}</button
 >

--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <button
-	class="pointer-events-auto ml-2 flex gap-0.5 font-bold text-primary"
+	class="text-primary pointer-events-auto ml-2 flex gap-0.5 font-bold"
 	on:click={async () => back({ pop: nonNullish(fromRoute) })}
 	><IconBack /> {$i18n.core.text.back}</button
 >


### PR DESCRIPTION
# Motivation

Set the color of the Back button to primary.

### Before

<img width="638" alt="Screenshot 2024-09-20 at 09 10 03" src="https://github.com/user-attachments/assets/eac97230-accd-4b85-bc26-83bcb8518f54">
<img width="1148" alt="Screenshot 2024-09-20 at 09 10 15" src="https://github.com/user-attachments/assets/c361b60c-e199-48f6-a7c0-15f29f3fd2c0">

### After

<img width="636" alt="Screenshot 2024-09-20 at 09 13 25" src="https://github.com/user-attachments/assets/df3d8d4a-72c0-45c8-984a-23dde2d67204">
<img width="1150" alt="Screenshot 2024-09-20 at 09 10 28" src="https://github.com/user-attachments/assets/81737a5d-21f9-4835-8bc6-6297a2eff369">


