### PR TITLE
test(e2e): fix current issues with e2e

### DIFF
--- a/e2e/utils/qr-code.utils.ts
+++ b/e2e/utils/qr-code.utils.ts
@@ -1,5 +1,5 @@
 import { nonNullish } from '@dfinity/utils';
-import Jimp from 'jimp';
+import { Jimp } from 'jimp';
 import jsQR from 'jsqr';
 
 export const getQRCodeValueFromDataURL = async ({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
 	},
 	testDir: 'e2e',
 	testMatch: ['**/*.e2e.ts', '**/*.spec.ts'],
+	// TODO: Remove the increased timeout after improving tokens loading time
+	timeout: 60000,
 	use: {
 		testIdAttribute: 'data-tid',
 		trace: 'on',


### PR DESCRIPTION
# Motivation

Fix issue that appeared after the `jimp` package got updated. Also, temporary increased timeout value due to tokens not being fully loaded with the default value (30s).
