### PR TITLE
chore(frontend): correct exception to lint rule about object param

### DIFF
--- a/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
@@ -35,8 +35,7 @@ export class AlchemyErc20Provider {
 	}): WebSocketListener => {
 		const erc20Contract = new ethers.Contract(contract.address, ERC20_ABI, this.provider);
 
-		// TODO: Remove ESLint exception and use object params
-		// eslint-disable-next-line local-rules/prefer-object-params
+		// eslint-disable-next-line local-rules/prefer-object-params -- This function needs to have listed arguments to match the Listener type passed to ethers.js providers
 		const filterListener = async (
 			_from: string,
 			_address: string,


### PR DESCRIPTION
# Motivation

Correction on an "temporary" exception create by to the new custom ES lint rule introduced by PR https://github.com/dfinity/oisy-wallet/pull/2416: instead of being temporary, it should be a real exception since the function needs to have sequential arguments.