### PR TITLE
build(frontend): migrate to scss modern-compiler

### DIFF
--- a/src/frontend/src/lib/components/core/Erc20Icp.svelte
+++ b/src/frontend/src/lib/components/core/Erc20Icp.svelte
@@ -15,6 +15,8 @@
 </a>
 
 <style lang="scss">
+	@use '../../styles/mixins/media';
+
 	a {
 		color: var(--alpha-color, var(--color-misty-rose));
 		margin: 0 auto;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,10 +22,7 @@ const config: UserConfig = {
 	css: {
 		preprocessorOptions: {
 			scss: {
-				additionalData: `
-          @use "./node_modules/@dfinity/gix-components/dist/styles/mixins/media";
-          @use "./node_modules/@dfinity/gix-components/dist/styles/mixins/text";
-        `
+				api: 'modern-compiler'
 			}
 		}
 	},


### PR DESCRIPTION
# Motivation

Resolve the warnings:

```
Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

etc.
```

Source: https://stackoverflow.com/a/79003101/5404186

# Changes

- Use modern compiler for sass
- Remove unused and incompatible `@use` additional data
- Adapt the remaining media reference (we might resolve it with Tailwind but just followed a compatibility path)
