### PR TITLE
style(frontend): expand manage button on smaller screens

### DIFF
--- a/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-	class="tertiary mx-auto mt-12 mb-4"
+	class="tertiary mx-auto mt-12 mb-4 w-full center sm:w-auto"
 	class:text-grey={disabled}
 	class:text-blue={!disabled}
 	class:hover:text-dark-blue={!disabled}


### PR DESCRIPTION
# Motivation

To have a more uniform UI, we expand the manage buttons for smaller screens.

### Before

<img width="357" alt="Screenshot 2024-09-20 at 22 51 50" src="https://github.com/user-attachments/assets/8523b254-517e-44db-89dd-9d9e04e87521">

### After

<img width="358" alt="Screenshot 2024-09-20 at 22 51 39" src="https://github.com/user-attachments/assets/8afc920b-bc1e-46e8-8b43-f6ce341c4f04">
