### PR TITLE
style(frontend): improve Alpha warning position when logged in [GIX-2981]

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -11,10 +11,13 @@
 	import { modalAboutHow, modalAboutWhat } from '$lib/derived/modal.derived';
 
 	export let back = false;
+
+	let mw: 'sm' | 'xl';
+	$: mw = $authSignedIn ? 'sm' : 'xl';
 </script>
 
 <header
-	class="grid grid-cols-2 xl:grid-cols-3 items-center md:px-4 relative z-10 pointer-events-none"
+	class={`grid grid-cols-2 ${mw}:grid-cols-[1fr_auto_1fr] items-center md:px-4 relative z-10 pointer-events-none`}
 	style="min-height: 78px"
 >
 	{#if back}
@@ -26,7 +29,7 @@
 	{/if}
 
 	<div
-		class="col-span-3 col-start-1 row-start-2 xl:col-span-1 xl:col-start-2 xl:row-start-1 flex px-4"
+		class={`col-span-3 col-start-1 row-start-2 ${mw}:col-span-1 ${mw}:col-start-2 ${mw}:row-start-1 ${mw}:w-fit flex px-4`}
 	>
 		<Alpha />
 	</div>


### PR DESCRIPTION
# Motivation

When logged in, the Alpha warning position is not so pretty, since it could fit inside the header. Thir PR fixes it, making its position when logged in exchangable.

### Before

<img width="1178" alt="Screenshot 2024-09-20 at 23 34 39" src="https://github.com/user-attachments/assets/572d4323-dd8f-4136-92ad-f60f7119040b">

### After

<img width="1500" alt="Screenshot 2024-09-20 at 23 28 01" src="https://github.com/user-attachments/assets/f4d75c94-0603-4360-91d3-b5ba501076ec">
<img width="883" alt="Screenshot 2024-09-20 at 23 28 11" src="https://github.com/user-attachments/assets/dfaabdcf-77e4-419a-9e49-43d57f4172bd">
<img width="357" alt="Screenshot 2024-09-20 at 23 28 19" src="https://github.com/user-attachments/assets/1afed4ec-826d-41fd-b574-aec68b64d6f3">
<img width="1509" alt="Screenshot 2024-09-20 at 23 28 34" src="https://github.com/user-attachments/assets/e3e42ce3-3df4-4212-8e5a-051286142227">
<img width="1505" alt="Screenshot 2024-09-20 at 23 28 45" src="https://github.com/user-attachments/assets/e834193e-c1a7-4498-8f5d-4736ae81555b">
<img width="884" alt="Screenshot 2024-09-20 at 23 28 57" src="https://github.com/user-attachments/assets/63afebc2-3fc7-4309-9302-0ca3162c2ac6">
<img width="358" alt="Screenshot 2024-09-20 at 23 29 04" src="https://github.com/user-attachments/assets/f58c01db-bdc6-4f04-8fc8-52d3f96c7f9f">
