### PR TITLE
refactor(frontend): correct media condition in srcset

### DIFF
--- a/src/frontend/src/lib/components/core/Background.svelte
+++ b/src/frontend/src/lib/components/core/Background.svelte
@@ -10,7 +10,7 @@
 		class="absolute left-1/2 top-0 w-full min-w-[1280px] -translate-x-1/2 transform"
 		aria-label={replaceOisyPlaceholders($i18n.core.alt.background)}
 	>
-		<source srcset={background} media="(min-width: 641px)" />
+		<source srcset={background} media="(min-width: 640px)" />
 		<Img src="" />
 	</picture>
 </div>

--- a/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
+++ b/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
@@ -25,6 +25,6 @@
 </div>
 
 <picture aria-label={ariaLabel} class="w-24">
-	<source srcset={oisyLogoSmall} media="(max-width: 640px)" />
+	<source srcset={oisyLogoSmall} media="(max-width: 639px)" />
 	<Img src={oisyLogoLarge} alt={ariaLabel} />
 </picture>


### PR DESCRIPTION
# Motivation

To be more precise and coherent with the Tailwind definition of small-screens, we adjust the `srcset` conditions to have:

- min width from `641` to `640`
- max width from `640` to `639`
