### PR TITLE
style(frontend): change background of transaction card icon

### DIFF
--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -3,7 +3,7 @@
 
 	export let icon: ComponentType;
 	export let iconSize = '2.9rem';
-	export let backgroundStyleClass = 'bg-dark-blue opacity-10';
+	export let backgroundStyleClass = 'bg-alice-blue';
 	export let iconStyleClass = '';
 	export let additionalStyleClass = '';
 </script>


### PR DESCRIPTION
# Motivation

New background color for the icon in the transaction card. Since RoundedIcon component is used only in the transactions card, we change directly the default prop.

### Before

<img width="686" alt="Screenshot 2024-09-20 at 23 47 43" src="https://github.com/user-attachments/assets/31ba5aab-bdbd-4bb6-99c6-e0c066405993">

### After

<img width="668" alt="Screenshot 2024-09-20 at 23 47 31" src="https://github.com/user-attachments/assets/a591d80d-d281-43fb-b5cd-744061af939c">

