### PR TITLE
refactor(ci): use object param for scripts

### DIFF
--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -96,9 +96,7 @@ const DATA_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'env');
 
 const LOGO_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'icp-eth', 'assets');
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-const saveTokenLogo = async (canisterId, name) => {
+const saveTokenLogo = async ({ canisterId, name }) => {
 	const logoName = name.toLowerCase().replace('ck', '').replace('sepolia', '');
 	const file = join(LOGO_FOLDER, `${logoName}.svg`);
 
@@ -148,7 +146,7 @@ const findCkErc20 = async () => {
 			...tokens.staging
 		})
 			.filter(([_, { ledgerCanisterId }]) => !SKIP_CANISTER_IDS_LOGOS.includes(ledgerCanisterId))
-			.map(([name, { ledgerCanisterId }]) => saveTokenLogo(ledgerCanisterId, name))
+			.map(([name, { ledgerCanisterId }]) => saveTokenLogo({ canisterId: ledgerCanisterId, name }))
 	);
 };
 

--- a/scripts/check.i18n.mjs
+++ b/scripts/check.i18n.mjs
@@ -8,12 +8,10 @@ const PATH_FROM_ROOT = join(process.cwd(), 'src', 'frontend', 'src');
 const PATH_TO_EN_JSON = join(PATH_FROM_ROOT, 'lib', 'i18n', 'en.json');
 const PATH_TO_CODEBASE = join(PATH_FROM_ROOT);
 
-// TODO: Remove ESLint exception and use object params
-// eslint-disable-next-line local-rules/prefer-object-params
-const extractKeys = (obj, prefix = '') =>
+const extractKeys = ({ obj, prefix = '' }) =>
 	Object.keys(obj).reduce((res, el) => {
 		if (typeof obj[el] === 'object') {
-			return [...res, ...extractKeys(obj[el], `${prefix}${el}.`)];
+			return [...res, ...extractKeys({ obj: obj[el], prefix: `${prefix}${el}.` })];
 		}
 		return [...res, `${prefix}${el}`];
 	}, []);
@@ -26,7 +24,7 @@ const checkKeyUsage = ({ key, content }) =>
 const main = async () => {
 	const en = JSON.parse(readFileSync(PATH_TO_EN_JSON, 'utf8'));
 
-	let potentialUnusedKeys = extractKeys(en);
+	let potentialUnusedKeys = extractKeys({ obj: en });
 
 	const files = findFiles({ dir: PATH_TO_CODEBASE, extensions: ['.svelte', '.ts'] });
 


### PR DESCRIPTION
# Motivation

We remove one of the "temporary" exceptions to the new custom ES lint rule introduced by PR #2416 , and adapt the code. Specifically the one concerning scripts.
