### PR TITLE
feat(frontend): store tokenAsIcToken can be nullish

### DIFF
--- a/src/frontend/src/icp/derived/ic-token.derived.ts
+++ b/src/frontend/src/icp/derived/ic-token.derived.ts
@@ -1,4 +1,4 @@
-import type { IcToken } from '$icp/types/ic';
+import type { IcToken, OptionIcToken } from '$icp/types/ic';
 import {
 	isTokenCkBtcLedger,
 	isTokenCkErc20Ledger,
@@ -8,7 +8,10 @@ import { tokenWithFallback } from '$lib/derived/token.derived';
 import { token } from '$lib/stores/token.store';
 import { derived, type Readable } from 'svelte/store';
 
-export const tokenAsIcToken: Readable<IcToken> = derived([token], ([$token]) => $token as IcToken);
+export const tokenAsIcToken: Readable<OptionIcToken> = derived(
+	[token],
+	([$token]) => $token as IcToken
+);
 
 export const tokenWithFallbackAsIcToken: Readable<IcToken> = derived(
 	[tokenWithFallback],

--- a/src/frontend/src/icp/derived/ic-token.derived.ts
+++ b/src/frontend/src/icp/derived/ic-token.derived.ts
@@ -10,7 +10,7 @@ import { derived, type Readable } from 'svelte/store';
 
 export const tokenAsIcToken: Readable<OptionIcToken> = derived(
 	[token],
-	([$token]) => $token as IcToken
+	([$token]) => $token as OptionIcToken
 );
 
 export const tokenWithFallbackAsIcToken: Readable<IcToken> = derived(

--- a/src/frontend/src/tests/icp/utils/ic-token.derived.spec.ts
+++ b/src/frontend/src/tests/icp/utils/ic-token.derived.spec.ts
@@ -1,0 +1,39 @@
+import { ICP_TOKEN } from '$env/tokens.env';
+import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
+import { token } from '$lib/stores/token.store';
+import { get } from 'svelte/store';
+import { expect } from 'vitest';
+
+describe('Derived store tokenAsIcToken', () => {
+	it('should return undefined when token is not set', () => {
+		expect(get(tokenAsIcToken)).toBeUndefined();
+	});
+
+	it('should return token as IcToken when token is set', () => {
+		token.set(ICP_TOKEN);
+
+		expect(get(tokenAsIcToken)).toBe(ICP_TOKEN);
+
+		expect(get(tokenAsIcToken)).toHaveProperty('ledgerCanisterId');
+		expect(get(tokenAsIcToken)).toHaveProperty('indexCanisterId');
+	});
+
+	it('should return undefined when token is set to undefined', () => {
+		token.set(undefined);
+
+		expect(get(tokenAsIcToken)).toBeUndefined();
+	});
+
+	it('should return null when token is set to null', () => {
+		token.set(null);
+
+		expect(get(tokenAsIcToken)).toBeNull();
+	});
+
+	it('should return null when token is reset', () => {
+		token.set(ICP_TOKEN);
+		token.reset();
+
+		expect(get(tokenAsIcToken)).toBeNull();
+	});
+});

--- a/src/frontend/src/tests/icp/utils/ic-token.derived.spec.ts
+++ b/src/frontend/src/tests/icp/utils/ic-token.derived.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_TOKEN } from '$env/tokens.env';
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 import { token } from '$lib/stores/token.store';
 import { get } from 'svelte/store';
@@ -9,13 +9,10 @@ describe('Derived store tokenAsIcToken', () => {
 		expect(get(tokenAsIcToken)).toBeUndefined();
 	});
 
-	it('should return token as IcToken when token is set', () => {
-		token.set(ICP_TOKEN);
+	it('should return token when token is set', () => {
+		token.set(ETHEREUM_TOKEN);
 
-		expect(get(tokenAsIcToken)).toBe(ICP_TOKEN);
-
-		expect(get(tokenAsIcToken)).toHaveProperty('ledgerCanisterId');
-		expect(get(tokenAsIcToken)).toHaveProperty('indexCanisterId');
+		expect(get(tokenAsIcToken)).toBe(ETHEREUM_TOKEN);
 	});
 
 	it('should return undefined when token is set to undefined', () => {


### PR DESCRIPTION
# Motivation

The correct type of store `tokenAsIcToken` is an optional `IcToken` type, since `token` store is an `OptionToken`.

We created tests to check it too.