### PR TITLE
chore(build): remove three from chunk-able dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,7 @@ const config: UserConfig = {
 					const lazy = ['@dfinity/nns', '@dfinity/nns-proto', 'html5-qrcode', 'qr-creator'];
 
 					if (
-						['@sveltejs', 'svelte', '@dfinity/gix-components', 'three', ...lazy].find((lib) =>
+						['@sveltejs', 'svelte', '@dfinity/gix-components', ...lazy].find((lib) =>
 							folder.includes(lib)
 						) === undefined &&
 						folder.includes('node_modules')


### PR DESCRIPTION
# Motivation

Dependency `three` was deprecated so we don't need to chunk it anymore.