### PR TITLE
refactor(devops): Get signer.did path from release

### DIFF
--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -21,8 +21,9 @@ print_help() {
 DFX_NETWORK="${DFX_NETWORK:-local}"
 
 SIGNER_RELEASE="v0.1.2"
-CANDID_URL="https://raw.githubusercontent.com/dfinity/chain-fusion-signer/${SIGNER_RELEASE}/src/signer/signer.did"
-WASM_URL="https://github.com/dfinity/chain-fusion-signer/releases/download/${SIGNER_RELEASE}/signer.wasm.gz"
+SIGNER_RELEASE_URL="https://github.com/dfinity/chain-fusion-signer/releases/download/${SIGNER_RELEASE}"
+CANDID_URL="${SIGNER_RELEASE_URL}/signer.did"
+WASM_URL="${SIGNER_RELEASE_URL}/signer.wasm.gz"
 
 CANDID_FILE="$(jq -r .canisters.signer.candid dfx.json)"
 WASM_FILE="$(jq -r .canisters.signer.wasm dfx.json)"


### PR DESCRIPTION
# Motivation
The `signer.did` file is included in new cf signer releases, as it should be.  It can be added manually to old releases.  Previously the candid file was taken from within the codebase but that breaks across versions (when the file moves).  Also the release files should contain all files needed to work with that version; users should not have to search through the codebase to find the candid.

# Changes
- Update the download URL for the `signer.did`.

# Tests
See CI