### PR TITLE
refactor(frontend): enforce use of interface instead of type

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,7 @@ module.exports = {
 		}
 	],
 	rules: {
+		'@typescript-eslint/consistent-type-definitions': 'error',
 		'@typescript-eslint/no-inferrable-types': 'error',
 		'@typescript-eslint/no-unnecessary-type-assertion': 'error',
 		'@typescript-eslint/no-unused-vars': [

--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -15,39 +15,39 @@ import { HOMEPAGE_URL, LOCAL_REPLICA_URL } from '../constants/e2e.constants';
 import { getQRCodeValueFromDataURL } from '../qr-code.utils';
 import { getReceiveTokensModalQrCodeButtonSelector } from '../selectors.utils';
 
-type HomepageParams = {
+interface HomepageParams {
 	page: Page;
 	viewportSize?: ViewportSize;
-};
+}
 
 type HomepageLoggedInParams = {
 	iiPage: InternetIdentityPage;
 } & HomepageParams;
 
-type SelectorOperationParams = {
+interface SelectorOperationParams {
 	selector: string;
-};
+}
 
-type TestIdOperationParams = {
+interface TestIdOperationParams {
 	testId: string;
-};
+}
 
-type WaitForModalParams = {
+interface WaitForModalParams {
 	modalOpenButtonTestId: string;
 	modalTestId: string;
-};
+}
 
 type TestModalSnapshotParams = {
 	selectorsToMock?: string[];
 } & WaitForModalParams;
 
-type ClickMenuItemParams = {
+interface ClickMenuItemParams {
 	menuItemTestId: string;
-};
+}
 
-type WaitForLocatorOptions = {
+interface WaitForLocatorOptions {
 	state: 'attached' | 'detached' | 'visible' | 'hidden';
-};
+}
 
 abstract class Homepage {
 	readonly #page: Page;

--- a/env.utils.ts
+++ b/env.utils.ts
@@ -11,11 +11,11 @@ export const readCanisterIds = ({
 	prefix?: string;
 }): Record<string, string> => {
 	try {
-		type Details = {
+		interface Details {
 			ic?: string;
 			staging?: string;
 			local?: string;
-		};
+		}
 
 		const config: Record<string, Details> = JSON.parse(readFileSync(filePath, 'utf8'));
 

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -33,10 +33,10 @@ import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 import { get } from 'svelte/store';
 import { send as executeSend } from './send.services';
 
-export type WalletConnectCallBackParams = {
+export interface WalletConnectCallBackParams {
 	request: Web3WalletTypes.SessionRequest;
 	listener: WalletConnectListener;
-};
+}
 
 export type WalletConnectExecuteParams = Pick<WalletConnectCallBackParams, 'request'> & {
 	listener: OptionWalletConnectListener;

--- a/src/frontend/src/eth/types/send.ts
+++ b/src/frontend/src/eth/types/send.ts
@@ -5,7 +5,7 @@ import type { OptionIdentity } from '$lib/types/identity';
 import type { Network } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 
-export type SendParams = {
+export interface SendParams {
 	progress: (step: ProgressStepsSend) => void;
 	lastProgressStep?: ProgressStepsSend;
 	token: Token;
@@ -13,4 +13,4 @@ export type SendParams = {
 	targetNetwork?: Network | undefined;
 	identity: OptionIdentity;
 	minterInfo: OptionCertifiedMinterInfo;
-};
+}

--- a/src/frontend/src/icp/types/ic.ts
+++ b/src/frontend/src/icp/types/ic.ts
@@ -56,13 +56,15 @@ export interface IcTransactionUi {
 export type IcToken = Token & IcFee & IcInterface;
 export type IcTokenWithoutId = Omit<IcToken, 'id'>;
 
-export type IcFee = { fee: bigint };
+export interface IcFee {
+	fee: bigint;
+}
 
 export type IcInterface = IcCanisters & IcAppMetadata;
-export type IcCanisters = {
+export interface IcCanisters {
 	ledgerCanisterId: LedgerCanisterIdText;
 	indexCanisterId: IndexCanisterIdText;
-};
+}
 
 export type IcCkToken = IcToken & Partial<IcCkMetadata>;
 
@@ -72,16 +74,16 @@ export type IcCkMetadata = {
 	minterCanisterId: MinterCanisterIdText;
 } & Partial<IcCkLinkedAssets>;
 
-export type IcCkLinkedAssets = {
+export interface IcCkLinkedAssets {
 	twinToken: Token;
 	feeLedgerCanisterId?: LedgerCanisterIdText;
-};
+}
 
-export type IcAppMetadata = {
+export interface IcAppMetadata {
 	exchangeCoinId?: CoingeckoCoinsId;
 	position: number;
 	explorerUrl?: string;
-};
+}
 
 export type OptionIcToken = Option<IcToken>;
 export type OptionIcCkToken = Option<IcCkToken>;

--- a/src/frontend/src/lib/actors/query.ic.ts
+++ b/src/frontend/src/lib/actors/query.ic.ts
@@ -3,11 +3,11 @@ import { isNullish } from '@dfinity/utils';
 
 export type QueryAndUpdateOnResponse<R> = (options: { certified: boolean; response: R }) => void;
 
-export type QueryAndUpdateOnErrorOptions<E = unknown> = {
+export interface QueryAndUpdateOnErrorOptions<E = unknown> {
 	error: E;
 	// The identity used for the request
 	identity: OptionIdentity;
-};
+}
 
 export type QueryAndUpdateOnError<E = unknown> = (
 	options: {

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -36,12 +36,12 @@ import type { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-type LoadTokenAddressParams<T extends Address> = {
+interface LoadTokenAddressParams<T extends Address> {
 	tokenId: TokenId;
 	getAddress: (identity: OptionIdentity) => Promise<T>;
 	setIdbAddress: (params: SetIdbAddressParams<T>) => Promise<void>;
 	addressStore: AddressStore<T>;
-};
+}
 
 const loadTokenAddress = async <T extends Address>({
 	tokenId,

--- a/src/frontend/src/lib/stores/user-profile.store.ts
+++ b/src/frontend/src/lib/stores/user-profile.store.ts
@@ -2,10 +2,10 @@ import type { UserProfile } from '$declarations/backend/backend.did';
 import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
-type CertifiedUserProfileData = {
+interface CertifiedUserProfileData {
 	profile: UserProfile;
 	certified: boolean;
-};
+}
 
 // * `undefined` means the store is not loaded yet.
 // * `null` means there was an error.

--- a/src/frontend/src/lib/types/network.ts
+++ b/src/frontend/src/lib/types/network.ts
@@ -5,14 +5,14 @@ export type NetworkId = symbol;
 
 export type NetworkEnvironment = 'mainnet' | 'testnet';
 
-export type Network = {
+export interface Network {
 	id: NetworkId;
 	env: NetworkEnvironment;
 	name: string;
 	icon?: string;
 	buy?: AtLeastOne<NetworkBuy>;
-};
+}
 
-export type NetworkBuy = {
+export interface NetworkBuy {
 	onRamperId?: OnRamperNetworkId;
-};
+}

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -27,10 +27,10 @@ export interface TokenAppearance {
 	oisyName?: TokenOisyName;
 }
 
-export type TokenOisyName = {
+export interface TokenOisyName {
 	prefix: string | undefined;
 	oisyName: string;
-};
+}
 
 export interface TokenLinkedData {
 	twinTokenSymbol?: string;

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -1,6 +1,9 @@
 export type RequiredExcept<T, K extends keyof T> = Required<Omit<T, K>> & Pick<T, K>;
 
-export type ResultSuccess<T = unknown> = { success: boolean; err?: T };
+export interface ResultSuccess<T = unknown> {
+	success: boolean;
+	err?: T;
+}
 
 export type ResultSuccessReduced<T = unknown> = ResultSuccess<T[]>;
 

--- a/src/frontend/src/lib/utils/i18n.utils.ts
+++ b/src/frontend/src/lib/utils/i18n.utils.ts
@@ -12,7 +12,9 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 const escapeRegExp = (regExpText: string): string =>
 	regExpText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 
-export type I18nSubstitutions = { [from: string]: string };
+export interface I18nSubstitutions {
+	[from: string]: string;
+}
 
 /**
  * @example

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -50,12 +50,12 @@ export const gotoReplaceRoot = async () => {
 	await goto('/', { replaceState: true });
 };
 
-export type RouteParams = {
+export interface RouteParams {
 	token: OptionString;
 	network: OptionString;
 	// WalletConnect URI parameter
 	uri: OptionString;
-};
+}
 
 export const loadRouteParams = ($event: LoadEvent): RouteParams => {
 	if (!browser) {

--- a/src/frontend/src/tests/lib/utils/certified-store.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/certified-store.utils.spec.ts
@@ -31,7 +31,10 @@ describe('mapCertifiedData', () => {
 	});
 
 	it('should return the data when certifiedData contains an object', () => {
-		type TestData = { prop: string; value: number };
+		interface TestData {
+			prop: string;
+			value: number;
+		}
 		const data: TestData = { prop: 'testData', value: 1 };
 		const certifiedData: Option<CertifiedData<TestData>> = { data, certified };
 

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -33,20 +33,20 @@ const readRemoteCanisterIds = ({ prefix }: { prefix?: string }): Record<string, 
 	const dfxJsonFile = join(process.cwd(), 'dfx.json');
 
 	try {
-		type DetailsId = {
+		interface DetailsId {
 			ic: string;
 			staging?: string;
-		};
+		}
 
-		type Details = {
+		interface Details {
 			remote?: {
 				id: DetailsId;
 			};
-		};
+		}
 
-		type DfxJson = {
+		interface DfxJson {
 			canisters: Record<string, Details>;
-		};
+		}
 
 		const { canisters }: DfxJson = JSON.parse(readFileSync(dfxJsonFile, 'utf8'));
 


### PR DESCRIPTION
# Motivation

We want to add the ES lint rule of [consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions/), that enforces the usage of `interface` instead of `type`.

# Changes

- Add new rule to ESlint configs.
- Fix related new issues.

# Tests

It worked: it flagged new issues that we solved.