### PR TITLE
chore(frontend): remove unused token type

### DIFF
--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -54,5 +54,3 @@ interface TokenFinancialData {
 }
 
 export type TokenUi = Token & TokenFinancialData;
-
-export type TokenIndexKey = string;


### PR DESCRIPTION
# Motivation

Type `TokenIndexKey` was not used anymore.
