### PR TITLE
feat(frontend): add Onramper ID for tokens

### DIFF
--- a/src/frontend/src/env/tokens.env.ts
+++ b/src/frontend/src/env/tokens.env.ts
@@ -26,7 +26,10 @@ export const ETHEREUM_TOKEN: RequiredTokenWithLinkedData = {
 	symbol: ETHEREUM_SYMBOL,
 	decimals: ETHEREUM_DEFAULT_DECIMALS,
 	icon: eth,
-	twinTokenSymbol: 'ckETH'
+	twinTokenSymbol: 'ckETH',
+	buy: {
+		onramperId: 'eth'
+	}
 };
 
 export const SEPOLIA_SYMBOL = 'SepoliaETH';
@@ -77,5 +80,8 @@ export const ICP_TOKEN: RequiredToken<IcToken> = {
 	fee: ICP_TRANSACTION_FEE_E8S,
 	ledgerCanisterId: ICP_LEDGER_CANISTER_ID,
 	indexCanisterId: ICP_INDEX_CANISTER_ID,
-	explorerUrl: ICP_EXPLORER_URL
+	explorerUrl: ICP_EXPLORER_URL,
+	buy: {
+		onramperId: 'icp_icp'
+	}
 };

--- a/src/frontend/src/lib/types/onramper.ts
+++ b/src/frontend/src/lib/types/onramper.ts
@@ -1,3 +1,7 @@
 // The list of networks that are supported by OnRamper can be found here:
 // https://docs.onramper.com/docs/network-support
 export type OnRamperNetworkId = 'icp' | 'bitcoin' | 'ethereum';
+
+// The list of cryptocurrencies that are supported by Onramper can be found here:
+// https://docs.onramper.com/docs/crypto-asset-support
+export type OnramperCryptoId = string;

--- a/src/frontend/src/lib/types/onramper.ts
+++ b/src/frontend/src/lib/types/onramper.ts
@@ -4,4 +4,4 @@ export type OnRamperNetworkId = 'icp' | 'bitcoin' | 'ethereum';
 
 // The list of cryptocurrencies that are supported by Onramper can be found here:
 // https://docs.onramper.com/docs/crypto-asset-support
-export type OnramperCryptoId = string;
+export type OnramperId = string;

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,6 +1,7 @@
 import type { OptionBalance } from '$lib/types/balance';
 import type { Network } from '$lib/types/network';
-import type { Option, RequiredExcept } from '$lib/types/utils';
+import type { OnramperCryptoId } from '$lib/types/onramper';
+import type { AtLeastOne, Option, RequiredExcept } from '$lib/types/utils';
 
 export type TokenId = symbol;
 
@@ -14,7 +15,8 @@ export type Token = {
 	standard: TokenStandard;
 	category: TokenCategory;
 } & TokenMetadata &
-	TokenAppearance;
+	TokenAppearance &
+	TokenBuyable;
 
 export interface TokenMetadata {
 	name: string;
@@ -32,13 +34,23 @@ export interface TokenOisyName {
 	oisyName: string;
 }
 
+export interface TokenBuyable {
+	buy?: AtLeastOne<TokenBuy>;
+}
+
+export interface TokenBuy {
+	onramperId?: OnramperCryptoId;
+}
+
 export interface TokenLinkedData {
 	twinTokenSymbol?: string;
 }
 
 export type TokenWithLinkedData = Token & TokenLinkedData;
 
-export type RequiredToken<T extends Token = Token> = RequiredExcept<T, keyof TokenAppearance>;
+export type NonRequiredProps = TokenAppearance & TokenBuyable;
+
+export type RequiredToken<T extends Token = Token> = RequiredExcept<T, keyof NonRequiredProps>;
 
 export type RequiredTokenWithLinkedData = RequiredToken<TokenWithLinkedData>;
 

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,6 +1,6 @@
 import type { OptionBalance } from '$lib/types/balance';
 import type { Network } from '$lib/types/network';
-import type { OnramperCryptoId } from '$lib/types/onramper';
+import type { OnramperId } from '$lib/types/onramper';
 import type { AtLeastOne, Option, RequiredExcept } from '$lib/types/utils';
 
 export type TokenId = symbol;
@@ -39,7 +39,7 @@ export interface TokenBuyable {
 }
 
 export interface TokenBuy {
-	onramperId?: OnramperCryptoId;
+	onramperId?: OnramperId;
 }
 
 export interface TokenLinkedData {


### PR DESCRIPTION
# Motivation

Another step to onboard Onramper is to map the correspondent Crypto ID to each token based [on this list](https://docs.onramper.com/docs/crypto-asset-support).

For now, we will set it just for ICP and ETH, but, after having tested more, map the rest.

# Changes

- Create new type to define the mapping to Crypto ID.
- Adjust RequiredToken type to excepts new type TokenBuyable.
- Set values for ICP and ETH.

