### PR TITLE
refactor(frontend): blurred transactions page when signed out

### DIFF
--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -5,10 +5,11 @@
 	import TokensSignedIn from '$lib/components/tokens/TokensSignedIn.svelte';
 	import TokensSignedOut from '$lib/components/tokens/TokensSignedOut.svelte';
 	import Header from '$lib/components/ui/Header.svelte';
+	import SignedOutBlur from '$lib/components/ui/SignedOutBlur.svelte';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 </script>
 
-<div class:pointer-events-none={$authNotSignedIn} class:blur-[1.5px]={$authNotSignedIn}>
+<SignedOutBlur>
 	<Header>
 		<NetworksSwitcher disabled={$authNotSignedIn} />
 
@@ -22,4 +23,4 @@
 	{/if}
 
 	<ManageTokensButton />
-</div>
+</SignedOutBlur>

--- a/src/frontend/src/lib/components/transactions/Transactions.svelte
+++ b/src/frontend/src/lib/components/transactions/Transactions.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import TransactionsSignedIn from '$lib/components/transactions/TransactionsSignedIn.svelte';
 	import TransactionsSignedOut from '$lib/components/transactions/TransactionsSignedOut.svelte';
+	import SignedOutBlur from '$lib/components/ui/SignedOutBlur.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 </script>
 
 {#if $authSignedIn}
 	<TransactionsSignedIn />
 {:else}
-	<TransactionsSignedOut />
+	<SignedOutBlur>
+		<TransactionsSignedOut />
+	</SignedOutBlur>
 {/if}

--- a/src/frontend/src/lib/components/ui/SignedOutBlur.svelte
+++ b/src/frontend/src/lib/components/ui/SignedOutBlur.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { authNotSignedIn } from '$lib/derived/auth.derived';
+</script>
+
+<div class:pointer-events-none={$authNotSignedIn} class:blur-[1.5px]={$authNotSignedIn}>
+	<slot />
+</div>


### PR DESCRIPTION
# Motivation

The transactions page should be blurred like the main page when the user is not signed in.

# Changes

- Created new component to blur a slot.
- Use the component for `Transactions`.
- Replace and use it in the code of `Tokens`, to avoid repetition.

# Tests

### Before

<img width="1188" alt="Screenshot 2024-09-23 at 22 42 05" src="https://github.com/user-attachments/assets/35245e40-20d5-451c-b36f-a8d4438e854e">
<img width="356" alt="Screenshot 2024-09-23 at 22 42 12" src="https://github.com/user-attachments/assets/f5739e8e-e36c-45ae-bb4d-c2a0d3664c11">
<img width="296" alt="Screenshot 2024-09-23 at 22 42 18" src="https://github.com/user-attachments/assets/efc6c88a-1f34-4e17-8631-ed14d8fb0449">


### After

<img width="1187" alt="Screenshot 2024-09-23 at 22 41 38" src="https://github.com/user-attachments/assets/d5506370-1bce-4358-ab28-259bab8f8183">
<img width="358" alt="Screenshot 2024-09-23 at 22 41 46" src="https://github.com/user-attachments/assets/1f02b497-15ce-4389-9100-31ad4790e1b7">
<img width="295" alt="Screenshot 2024-09-23 at 22 41 53" src="https://github.com/user-attachments/assets/2c2f4fdd-ee41-4390-9dbf-5eb3561c3308">

