### PR TITLE
style(frontend): remove hard-coded colors in app.html

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -56,11 +56,6 @@
 		%sveltekit.head%
 
 		<style>
-			body {
-				background: #fcfaf6;
-				color: #0e002d;
-			}
-
 			#app-spinner {
 				--spinner-size: 30px;
 


### PR DESCRIPTION
# Motivation

Since the new defaults background and color are respectively white and black (the browser's default), we remove it as from `app.html`