### PR TITLE
style(frontend): change color of icon check in ProgressSteps [GIX-2983]

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -194,3 +194,14 @@ div.segment-button {
 		color: var(--color-white);
 	}
 }
+
+div.step.completed {
+	svg {
+		--icon-check-circle-background: var(--color-primary);
+	}
+
+	div.line {
+		--line-color: var(--color-primary);
+	}
+}
+

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -204,4 +204,3 @@ div.step.completed {
 		--line-color: var(--color-primary);
 	}
 }
-


### PR DESCRIPTION
# Motivation

According to requirements, we use the primary color for the icon and the line of the completed progress steps.

### Before

<img width="439" alt="Screenshot 2024-09-24 at 08 48 21" src="https://github.com/user-attachments/assets/856bfa2c-0ea5-432a-92fc-0bb5867a1e7f">

### After

<img width="442" alt="Screenshot 2024-09-24 at 08 47 36" src="https://github.com/user-attachments/assets/d623da85-1b0e-427a-8d83-ea42476f7808">
