### PR TITLE
feat(frontend): rename syncWalletStatus to syncWalletIcStatus

### DIFF
--- a/src/frontend/src/icp/schedulers/wallet.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/wallet.scheduler.ts
@@ -34,7 +34,7 @@ export class WalletScheduler<
 	PostMessageDataRequest
 > implements Scheduler<PostMessageDataRequest>
 {
-	private timer = new SchedulerTimer('syncWalletStatus');
+	private timer = new SchedulerTimer('syncIcWalletStatus');
 
 	private store: WalletStore<T> = {
 		balance: undefined,

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -53,7 +53,7 @@ export type PostMessageDataRequestIcCkBTCUpdateBalance = PostMessageDataRequestI
 };
 
 export type PostMessageResponseStatus =
-	| 'syncWalletStatus'
+	| 'syncIcWalletStatus'
 	| 'syncBtcStatusesStatus'
 	| 'syncCkMinterInfoStatus'
 	| 'syncCkBTCUpdateBalanceStatus';


### PR DESCRIPTION
# Motivation

Since we are gonna have 2 WalletWorkers, we need to adjust the existing `PostMessageResponseStatus.syncWalletStatus` to make it specific for the IC wallet. The new one for BTC will be called `syncBtcWalletStatus`.
