### PR TITLE
style(frontend): resize Hero buttons group for smaller screens

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <button
-	class="flex w-full min-w-[72px] flex-col gap-3.5 overflow-hidden text-ellipsis break-words rounded-none border border-r-white border-opacity-25 px-2 text-center text-lg font-bold text-white last:border-none"
+	class="flex w-full min-w-[72px] flex-col gap-2 sm:gap-3.5 overflow-hidden text-ellipsis break-words rounded-none border border-r-white border-opacity-25 px-2 text-center text-base sm:text-lg font-bold text-white last:border-none"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}

--- a/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
+++ b/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
@@ -1,6 +1,6 @@
 <div
 	role="toolbar"
-	class="w-full px-4 py-6 text-secondary inline-flex justify-between rounded-[32px] bg-[var(--color-primary)]"
+	class="w-full px-4 py-4 sm:py-5 text-secondary inline-flex justify-between rounded-3xl sm:rounded-[32px] bg-[var(--color-primary)]"
 >
 	<slot />
 </div>


### PR DESCRIPTION
# Motivation

We reduce a little the size of the Hero button group for smaller screens. Plus we slightly reduce the padding for the other screens too.

### Before

<img width="293" alt="Screenshot 2024-09-24 at 15 41 38" src="https://github.com/user-attachments/assets/60179f99-9322-47be-9112-00c2c8d1e916">
<img width="356" alt="Screenshot 2024-09-24 at 15 41 45" src="https://github.com/user-attachments/assets/6bb739a1-190d-4cec-9e53-c9da2baa7274">

### After

<img width="294" alt="Screenshot 2024-09-24 at 15 41 11" src="https://github.com/user-attachments/assets/16118c36-75a6-4ce9-9a64-fb4390285265">
<img width="358" alt="Screenshot 2024-09-24 at 15 41 21" src="https://github.com/user-attachments/assets/3dd1dae9-852e-4243-b074-1dd5dcd219de">
