### PR TITLE
style(frontend): new color for selection

### DIFF
--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -15,6 +15,7 @@
 	--color-mountain-meadow: theme(colors.mountain-meadow);
 	--color-brandeis-blue: theme(colors.brandeis-blue);
 	--color-cetacean-blue: theme(colors.cetacean-blue);
+	--color-pale-cornflower-blue: theme(colors.pale-cornflower-blue);
 	--color-brilliant-azure: theme(colors.brilliant-azure);
 	--color-blue-ribbon-rgb: theme(colors.blue-ribbon-rgb);
 	--color-alice-blue: theme(colors.alice-blue);

--- a/src/frontend/src/lib/styles/global/theme.scss
+++ b/src/frontend/src/lib/styles/global/theme.scss
@@ -112,13 +112,11 @@ figcaption {
 }
 
 ::selection {
-	background: var(--color-misty-rose);
-	color: var(--color-off-white);
+	background: var(--color-pale-cornflower-blue);
 }
 
 ::-moz-selection {
-	background: var(--color-misty-rose);
-	color: var(--color-off-white);
+	background: var(--color-pale-cornflower-blue);
 }
 
 ::-webkit-scrollbar-thumb {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ export default {
 			'dark-blue': '#321469',
 			'brandeis-blue': '#016dfc',
 			'cetacean-blue': '#0e002d',
+			'pale-cornflower-blue': '#b0cdff',
 			'brilliant-azure': '#348afd',
 			'misty-rose': '#937993',
 			goldenrod: '#dfa81b',


### PR DESCRIPTION
# Motivation

New background color for the selection, without forcing the text color to change.

### Before

<img width="631" alt="Screenshot 2024-09-24 at 18 16 45" src="https://github.com/user-attachments/assets/04f9815b-eb4c-44ff-9d1a-937235928565">
<img width="573" alt="Screenshot 2024-09-24 at 18 16 51" src="https://github.com/user-attachments/assets/bd7cd8e3-5b0a-418e-a938-8a83df9f7a60">

### After

<img width="660" alt="Screenshot 2024-09-24 at 18 02 49" src="https://github.com/user-attachments/assets/0f074d63-3a05-4918-93bf-fbbb3ad2848d">
<img width="509" alt="Screenshot 2024-09-24 at 18 02 57" src="https://github.com/user-attachments/assets/fb5a3457-553c-4097-affa-5aa1441c3fe3">
