### PR TITLE
feat(frontend): rename IC wallet scheduler

### DIFF
--- a/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
@@ -23,12 +23,12 @@ type IndexedTransaction<T> = T & IcTransactionAddOnsInfo;
 type IndexedTransactions<T> = Record<string, CertifiedData<IndexedTransaction<T>>>;
 
 // Not reactive, only used to hold values imperatively.
-interface WalletStore<T> {
+interface IcWalletStore<T> {
 	balance: CertifiedData<bigint> | undefined;
 	transactions: IndexedTransactions<T>;
 }
 
-export class WalletScheduler<
+export class IcWalletScheduler<
 	T extends IcrcTransaction | Transaction,
 	TWithId extends IcrcTransactionWithId | TransactionWithId,
 	PostMessageDataRequest
@@ -36,7 +36,7 @@ export class WalletScheduler<
 {
 	private timer = new SchedulerTimer('syncIcWalletStatus');
 
-	private store: WalletStore<T> = {
+	private store: IcWalletStore<T> = {
 		balance: undefined,
 		transactions: {}
 	};

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -1,5 +1,5 @@
 import { getTransactions as getTransactionsApi } from '$icp/api/icp-index.api';
-import { WalletScheduler } from '$icp/schedulers/wallet.scheduler';
+import { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic';
 import { mapIcpTransaction, mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
 import type { SchedulerJobData, SchedulerJobParams } from '$lib/schedulers/scheduler';
@@ -32,8 +32,8 @@ const mapTransaction = ({
 	jobData: SchedulerJobData<PostMessageDataRequest>;
 }): IcTransactionUi => mapIcpTransaction({ transaction, identity });
 
-const scheduler: WalletScheduler<Transaction, TransactionWithId, PostMessageDataRequest> =
-	new WalletScheduler(getTransactions, mapTransactionIcpToSelf, mapTransaction, 'syncIcpWallet');
+const scheduler: IcWalletScheduler<Transaction, TransactionWithId, PostMessageDataRequest> =
+	new IcWalletScheduler(getTransactions, mapTransactionIcpToSelf, mapTransaction, 'syncIcpWallet');
 
 onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;

--- a/src/frontend/src/icp/workers/icrc-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icrc-wallet.worker.ts
@@ -1,5 +1,5 @@
 import { getTransactions as getTransactionsApi } from '$icp/api/icrc-index-ng.api';
-import { WalletScheduler } from '$icp/schedulers/wallet.scheduler';
+import { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import type { IcTransactionUi } from '$icp/types/ic';
 import { mapCkBTCTransaction } from '$icp/utils/ckbtc-transactions.utils';
 import { mapCkEthereumTransaction } from '$icp/utils/cketh-transactions.utils';
@@ -56,11 +56,11 @@ const mapTransaction = ({
 	return mapIcrcTransaction({ transaction, identity });
 };
 
-const scheduler: WalletScheduler<
+const scheduler: IcWalletScheduler<
 	IcrcTransaction,
 	IcrcTransactionWithId,
 	PostMessageDataRequestIcrc
-> = new WalletScheduler(
+> = new IcWalletScheduler(
 	getTransactions,
 	mapTransactionIcrcToSelf,
 	mapTransaction,


### PR DESCRIPTION
# Motivation

Similar to BTC wallet scheduler, we want to rename `ic/wallet.scheduler` to `ic-wallet.scheduler`.
