### PR TITLE
feat(frontend): implement BTC wallet address component

### DIFF
--- a/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
+++ b/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { isNetworkIdBTCMainnet } from '$icp/utils/ic-send.utils.js';
+	import Copy from '$lib/components/ui/Copy.svelte';
+	import { btcAddressMainnet, btcAddressTestnet } from '$lib/derived/address.derived';
+	import { networkId } from '$lib/derived/network.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+
+	// Regtest and Testnet BTC wallets have the same address
+	const address = isNetworkIdBTCMainnet($networkId) ? btcAddressMainnet : btcAddressTestnet;
+</script>
+
+<div>
+	<label class="block text-sm font-bold" for="btc-wallet-address"
+		>{$i18n.wallet.text.wallet_address}:</label
+	>
+
+	<output id="btc-wallet-address" class="break-all"
+		>{shortenWithMiddleEllipsis({ text: $address ?? '' })}</output
+	><Copy color="inherit" inline value={$address ?? ''} text={$i18n.wallet.text.address_copied} />
+</div>

--- a/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
+++ b/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNetworkIdBTCMainnet } from '$icp/utils/ic-send.utils.js';
+	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$icp/utils/ic-send.utils.js';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { btcAddressMainnet, btcAddressTestnet } from '$lib/derived/address.derived';
 	import { networkId } from '$lib/derived/network.derived';
@@ -7,7 +7,10 @@
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
 	// Regtest and Testnet BTC wallets have the same address
-	const address = isNetworkIdBTCMainnet($networkId) ? btcAddressMainnet : btcAddressTestnet;
+	const address =
+		isNetworkIdBTCTestnet($networkId) || isNetworkIdBTCRegtest($networkId)
+			? $btcAddressTestnet
+			: $btcAddressMainnet;
 </script>
 
 <div>
@@ -16,6 +19,6 @@
 	>
 
 	<output id="btc-wallet-address" class="break-all"
-		>{shortenWithMiddleEllipsis({ text: $address ?? '' })}</output
-	><Copy color="inherit" inline value={$address ?? ''} text={$i18n.wallet.text.address_copied} />
+		>{shortenWithMiddleEllipsis({ text: address ?? '' })}</output
+	><Copy color="inherit" inline value={address ?? ''} text={$i18n.wallet.text.address_copied} />
 </div>

--- a/src/frontend/src/lib/components/core/MenuWallet.svelte
+++ b/src/frontend/src/lib/components/core/MenuWallet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
+	import BtcWalletAddress from '$btc/components/core/BtcWalletAddress.svelte';
 	import EthWalletAddress from '$eth/components/core/EthWalletAddress.svelte';
 	import { walletConnectPaired } from '$eth/stores/wallet-connect.store';
 	import IcWalletAddress from '$icp/components/core/IcWalletAddress.svelte';
@@ -9,6 +10,7 @@
 	import Hr from '$lib/components/ui/Hr.svelte';
 	import { TRACK_COUNT_WALLET_CONNECT_MENU_OPEN } from '$lib/constants/analytics.contants';
 	import {
+		networkBitcoin,
 		networkEthereum,
 		networkICP,
 		pseudoNetworkChainFusion
@@ -35,6 +37,8 @@
 	<IcWalletAddress />
 {:else if $networkEthereum}
 	<EthWalletAddress />
+{:else if $networkBitcoin}
+	<BtcWalletAddress />
 {:else if $pseudoNetworkChainFusion}
 	<WalletAddresses on:icReceiveTriggered={click} />
 {/if}


### PR DESCRIPTION
# Motivation

The goal is to display BTC addresses in the way as it's done for other networks.

Desktop:
<img width="1594" alt="Screenshot 2024-09-25 at 11 21 03" src="https://github.com/user-attachments/assets/a4b710ba-9abe-4faa-9106-adfc55b3d30e">

Mobile:
<img width="494" alt="Screenshot 2024-09-25 at 11 21 16" src="https://github.com/user-attachments/assets/cd0682e4-809b-4e3c-9f61-66c0858297c3">
