### PR TITLE
refactor(frontend): use padding calculated variable instead of calculate

### DIFF
--- a/src/frontend/src/lib/components/ui/StaticSteps.svelte
+++ b/src/frontend/src/lib/components/ui/StaticSteps.svelte
@@ -103,7 +103,7 @@
 
 	.line {
 		height: 100%;
-		min-height: calc(4 * var(--padding));
+		min-height: var(--padding-4x);
 		--line-color: var(--positive-emphasis);
 		background: linear-gradient(var(--line-color), var(--line-color)) no-repeat center/1.5px 100%;
 	}

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -170,7 +170,7 @@ div.popover {
 
 		--border-radius: 16px;
 
-		max-width: calc(100vw - (2 * var(--padding)));
+		max-width: calc(100vw - var(--padding-2x));
 
 		@include media.min-width(xsmall) {
 			max-width: 300px;

--- a/src/frontend/src/lib/styles/global/layout.scss
+++ b/src/frontend/src/lib/styles/global/layout.scss
@@ -3,7 +3,7 @@
 main,
 .main {
 	margin: 0 auto;
-	padding-inline: calc(2.5 * var(--padding));
+	padding-inline: var(--padding-2_5x);
 
 	max-width: media.$breakpoint-small;
 }

--- a/src/frontend/src/lib/styles/global/variables.scss
+++ b/src/frontend/src/lib/styles/global/variables.scss
@@ -8,6 +8,7 @@
 	--padding-1_25x: calc(var(--padding) * 1.25);
 	--padding-1_5x: calc(var(--padding) * 1.5);
 	--padding-2x: calc(var(--padding) * 2);
+	--padding-2_5x: calc(var(--padding) * 2.5);
 	--padding-3x: calc(var(--padding) * 3);
 	--padding-4x: calc(var(--padding) * 4);
 	--padding-6x: calc(var(--padding) * 6);


### PR DESCRIPTION
# Motivation

For consistency, we use calculated padding variables instead of calculate them directly.