### PR TITLE
style(frontend): new style for modals [GIX-3021]

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -127,6 +127,7 @@ div.modal {
 	}
 
 	div.wrapper.dialog div.header {
+		// TODO: Improve padding definition when the Modal of GIX Components has an updated way of setting it and not being hard-coded (https://github.com/dfinity/gix-components/blob/1c4ab390f9cab1d0e3ec73a23384e045679eb6b8/src/lib/components/Modal.svelte#L195)
 		--padding-3x: 0;
 		--padding: var(--padding-2x);
 		--dialog-padding-y: 0;

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -141,7 +141,6 @@ div.modal {
 
 		div.container {
 			border-radius: 0;
-			padding-right: var(--scrollbar-width);
 
 			div.content {
 				padding-inline: var(--padding-2_5x);

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -131,11 +131,10 @@ div.modal {
 		--padding: var(--padding-2x);
 		--dialog-padding-y: 0;
 
-		margin-inline:  calc( 3 / 2 * var(--padding));
+		margin-inline: calc(3 / 2 * var(--padding));
 
 		--color-grey: rgba(0, 0, 0, 0.05);
 		border-bottom: 1px solid var(--color-grey);
-
 	}
 
 	div.wrapper.dialog div.container-wrapper {

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -122,12 +122,12 @@ div.modal {
 
 	div.wrapper.dialog {
 		color: var(--color-secondary);
-		padding: var(--padding-3x);
+		padding-block: var(--padding-3x);
+		padding-inline: var(--padding-0_5x);
 	}
 
 	div.wrapper.dialog div.header {
 		--padding: var(--padding-2x);
-		--padding-3x: 0;
 		--dialog-padding-y: 0;
 
 		margin: 0;
@@ -141,6 +141,11 @@ div.modal {
 
 		div.container {
 			border-radius: 0;
+			padding-right: var(--scrollbar-width);
+
+			div.content {
+				padding-inline: var(--padding-2_5x);
+			}
 		}
 	}
 

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -127,13 +127,15 @@ div.modal {
 	}
 
 	div.wrapper.dialog div.header {
+		--padding-3x: 0;
 		--padding: var(--padding-2x);
 		--dialog-padding-y: 0;
 
-		margin: 0;
+		margin-inline:  calc( 3 / 2 * var(--padding));
 
 		--color-grey: rgba(0, 0, 0, 0.05);
 		border-bottom: 1px solid var(--color-grey);
+
 	}
 
 	div.wrapper.dialog div.container-wrapper {

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -58,15 +58,17 @@
 	--alert-max-width: calc(100vw - var(--padding-4x));
 	--alert-max-height: calc(100vh - var(--padding-4x));
 	--alert-border-radius: var(--border-radius-xs);
-	--alert-padding-y: var(--padding-4x);
-	--alert-padding-x: var(--padding-2x);
+	--alert-padding-y: 0;
+	--alert-padding-x: 0;
 
-	--dialog-width: 100vw;
-	--dialog-max-width: 100vw;
-	--dialog-height: 100vh;
-	--dialog-border-radius: 0;
-	--dialog-padding-y: var(--padding-3x);
-	--dialog-padding-x: var(--padding-3x);
+	--dialog-width: 464px;
+	--dialog-max-width: var(--alert-max-width);
+	--dialog-max-height: var(--alert-max-height);
+	--dialog-min-height: calc(100vh - var(--padding-4x));
+	--dialog-height: initial;
+	--dialog-border-radius: calc(var(--border-radius-sm) * 3);
+	--dialog-padding-y: 0;
+	--dialog-padding-x: 0;
 
 	// CSS variables used when the content needs to fit the maximum height as when a QR-Code reader is embedded in a modal
 	--dialog-header-height: 74px;
@@ -81,13 +83,6 @@
 
 	@include media.min-width(medium) {
 		--alert-width: 464px;
-
-		--dialog-width: 464px;
-		--dialog-max-width: var(--alert-max-width);
-		--dialog-min-height: calc(100vh - var(--padding-8x));
-		--dialog-height: initial;
-		--dialog-max-height: var(--alert-max-height);
-		--dialog-border-radius: var(--alert-border-radius);
 
 		--section-max-width: 576px;
 	}
@@ -117,7 +112,7 @@ div.input-field input[id]::placeholder {
 }
 
 div.modal {
-	--overlay-background: var(--color-cetacean-blue);
+	--overlay-background: var(--color-white);
 	--overlay-background-contrast: var(--color-secondary);
 	--overlay-content-background: var(--color-white);
 	--overlay-content-background-contrast: var(--color-secondary);
@@ -126,14 +121,26 @@ div.modal {
 	font-weight: var(--font-weight-normal);
 
 	div.wrapper.dialog {
-		color: var(--color-white);
+		color: var(--color-secondary);
+		padding: var(--padding-3x);
+	}
+
+	div.wrapper.dialog div.header {
+		--padding: var(--padding-2x);
+		--padding-3x: 0;
+		--dialog-padding-y: 0;
+
+		margin: 0;
+
+		--color-grey: rgba(0, 0, 0, 0.05);
+		border-bottom: 1px solid var(--color-grey);
 	}
 
 	div.wrapper.dialog div.container-wrapper {
-		margin: var(--padding-1_5x) var(--padding-1_5x) auto;
+		margin: var(--padding-3x) 0 0;
 
 		div.container {
-			border-radius: var(--border-radius-0_5x);
+			border-radius: 0;
 		}
 	}
 

--- a/src/frontend/src/lib/styles/global/layout.scss
+++ b/src/frontend/src/lib/styles/global/layout.scss
@@ -3,7 +3,7 @@
 main,
 .main {
 	margin: 0 auto;
-	padding-inline: calc(2.5 * var(--padding));
+	padding-inline: var(--padding-2_5x);
 
 	max-width: media.$breakpoint-small;
 }

--- a/src/frontend/src/lib/styles/global/variables.scss
+++ b/src/frontend/src/lib/styles/global/variables.scss
@@ -8,6 +8,7 @@
 	--padding-1_25x: calc(var(--padding) * 1.25);
 	--padding-1_5x: calc(var(--padding) * 1.5);
 	--padding-2x: calc(var(--padding) * 2);
+	--padding-2_5x: calc(var(--padding) * 2.5);
 	--padding-3x: calc(var(--padding) * 3);
 	--padding-4x: calc(var(--padding) * 4);
 	--padding-6x: calc(var(--padding) * 6);


### PR DESCRIPTION
# Motivation

The modal style changes: we remove the dark frame and we adjust the layout a bit. Furthermore, for mobile version we leave a bit of margin to sho the backdrop.

UNRELATED: since we are creating a new CSS variable for `--padding-2_5x`, we use it in another similar instance.

### Before

<img width="1281" alt="Screenshot 2024-09-25 at 13 29 26" src="https://github.com/user-attachments/assets/8671163a-cf12-490b-bfa2-f78b9dd37584">
<img width="1279" alt="Screenshot 2024-09-25 at 13 27 48" src="https://github.com/user-attachments/assets/c336eebd-db1b-4386-a571-e877468c5a19">
<img width="374" alt="Screenshot 2024-09-25 at 13 28 27" src="https://github.com/user-attachments/assets/563bc90b-6cac-46ac-a8bb-a65aba0e3cb3">


### After

Desktop
<img width="1026" alt="Screenshot 2024-09-25 at 13 16 45" src="https://github.com/user-attachments/assets/fb6db62a-92b3-46f6-8365-5f9cbf486fcb">
<img width="1027" alt="Screenshot 2024-09-25 at 13 17 10" src="https://github.com/user-attachments/assets/2a5ccccf-601f-48d9-841f-6d8c8bfdbca7">
<img width="683" alt="Screenshot 2024-09-25 at 13 17 17" src="https://github.com/user-attachments/assets/5e245c2c-3049-4e41-b46b-b67df5d8b69f">

Mobile with large screen
<img width="429" alt="Screenshot 2024-09-25 at 13 17 33" src="https://github.com/user-attachments/assets/9b330596-4281-4547-80af-f1caf473abe6">
<img width="434" alt="Screenshot 2024-09-25 at 13 17 43" src="https://github.com/user-attachments/assets/604eba45-118c-4bd6-a662-d43075505851">

Mobile with small screen
<img width="377" alt="Screenshot 2024-09-25 at 13 18 05" src="https://github.com/user-attachments/assets/48f98787-da5d-450e-a639-b55d05f43c41">
<img width="376" alt="Screenshot 2024-09-25 at 15 01 50" src="https://github.com/user-attachments/assets/46f7734f-c31e-4418-80e5-8997ca7baac3">


