### PR TITLE
fix(frontend): pass class stretch to content of ContentWithToolbar

### DIFF
--- a/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
+++ b/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
@@ -1,3 +1,5 @@
-<slot class="stretch" />
+<div class="stretch">
+	<slot />
+</div>
 
 <slot name="toolbar" />


### PR DESCRIPTION
# Motivation

On mobile (when the screen is longer) it is noticeable that the buttons are not at the bottom of the modal, as they should.

That is because the `stretch` class is not correctly set in component `ContentWithToolbar`: it was passed to `<slot>` that does not accept it.

### Before

<img width="374" alt="Screenshot 2024-09-25 at 13 33 06" src="https://github.com/user-attachments/assets/1843289f-f927-4bd9-808b-3597706bcf73">

### After

<img width="373" alt="Screenshot 2024-09-25 at 13 32 57" src="https://github.com/user-attachments/assets/6c7d3c8b-4670-4ce2-988b-b82f275742a4">
