### PR TITLE
chore(devops): Update signer release version

### DIFF
--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -20,7 +20,7 @@ print_help() {
 
 DFX_NETWORK="${DFX_NETWORK:-local}"
 
-SIGNER_RELEASE="v0.1.2"
+SIGNER_RELEASE="v0.2.1"
 SIGNER_RELEASE_URL="https://github.com/dfinity/chain-fusion-signer/releases/download/${SIGNER_RELEASE}"
 CANDID_URL="${SIGNER_RELEASE_URL}/signer.did"
 WASM_URL="${SIGNER_RELEASE_URL}/signer.wasm.gz"

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -1,5 +1,9 @@
+type Account = record { owner : principal; subaccount : opt blob };
 type Arg = variant { Upgrade; Init : InitArg };
+type BitcoinAddressType = variant { P2WPKH };
 type BitcoinNetwork = variant { mainnet; regtest; testnet };
+type BtcTxOutput = record { destination_address : text; sent_satoshis : nat64 };
+type CallerPaysIcrc2Tokens = record { ledger : principal };
 type CanisterStatusResultV2 = record {
   controller : principal;
   status : CanisterStatusType;
@@ -12,7 +16,11 @@ type CanisterStatusResultV2 = record {
   module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
-type Config = record { ecdsa_key_name : text; ic_root_key_raw : opt blob };
+type Config = record {
+  ecdsa_key_name : text;
+  ic_root_key_raw : opt blob;
+  cycles_ledger : principal;
+};
 type DefiniteCanisterSettingsArgs = record {
   controller : principal;
   freezing_threshold : nat;
@@ -20,6 +28,28 @@ type DefiniteCanisterSettingsArgs = record {
   memory_allocation : nat;
   compute_allocation : nat;
 };
+type EcdsaCurve = variant { secp256k1 };
+type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
+type EcdsaPublicKeyArgument = record {
+  key_id : EcdsaKeyId;
+  canister_id : opt principal;
+  derivation_path : vec blob;
+};
+type EcdsaPublicKeyResponse = record { public_key : blob; chain_code : blob };
+type GenericSigningError = variant {
+  SigningError : record { RejectionCode_1; text };
+  PaymentError : PaymentError;
+};
+type GetAddressError = variant {
+  InternalError : record { msg : text };
+  PaymentError : PaymentError;
+};
+type GetAddressRequest = record {
+  network : BitcoinNetwork;
+  address_type : BitcoinAddressType;
+};
+type GetAddressResponse = record { address : text };
+type GetBalanceResponse = record { balance : nat64 };
 type HttpRequest = record {
   url : text;
   method : text;
@@ -31,7 +61,68 @@ type HttpResponse = record {
   headers : vec record { text; text };
   status_code : nat16;
 };
-type InitArg = record { ecdsa_key_name : text; ic_root_key_der : opt blob };
+type InitArg = record {
+  ecdsa_key_name : text;
+  ic_root_key_der : opt blob;
+  cycles_ledger : opt principal;
+};
+type Outpoint = record { txid : blob; vout : nat32 };
+type PatronPaysIcrc2Tokens = record { ledger : principal; patron : Account };
+type PaymentError = variant {
+  LedgerUnreachable : CallerPaysIcrc2Tokens;
+  UnsupportedPaymentType;
+  LedgerError : record { error : WithdrawFromError; ledger : principal };
+  InsufficientFunds : record { needed : nat64; available : nat64 };
+};
+type PaymentType = variant {
+  PatronPaysIcrc2Tokens : PatronPaysIcrc2Tokens;
+  AttachedCycles;
+  CallerPaysIcrc2Cycles;
+  CallerPaysIcrc2Tokens : CallerPaysIcrc2Tokens;
+  PatronPaysIcrc2Cycles : Account;
+};
+type RejectionCode = variant {
+  NoError;
+  CanisterError;
+  SysTransient;
+  DestinationInvalid;
+  Unknown;
+  SysFatal;
+  CanisterReject;
+};
+type RejectionCode_1 = variant {
+  NoError;
+  CanisterError;
+  SysTransient;
+  DestinationInvalid;
+  Unknown;
+  SysFatal;
+  CanisterReject;
+};
+type Result = variant { Ok : GetAddressResponse; Err : GetAddressError };
+type Result_1 = variant { Ok : GetBalanceResponse; Err : GetAddressError };
+type Result_2 = variant { Ok : SendBtcResponse; Err : SendBtcError };
+type Result_3 = variant { Ok : text; Err : GenericSigningError };
+type Result_4 = variant {
+  Ok : record { EcdsaPublicKeyResponse };
+  Err : GenericSigningError;
+};
+type Result_5 = variant {
+  Ok : record { SignWithEcdsaResponse };
+  Err : GenericSigningError;
+};
+type SendBtcError = variant {
+  InternalError : record { msg : text };
+  PaymentError : PaymentError;
+};
+type SendBtcRequest = record {
+  fee_satoshis : opt nat64;
+  network : BitcoinNetwork;
+  utxos_to_spend : vec Utxo;
+  address_type : BitcoinAddressType;
+  outputs : vec BtcTxOutput;
+};
+type SendBtcResponse = record { txid : text };
 type SignRequest = record {
   to : text;
   gas : nat;
@@ -42,12 +133,48 @@ type SignRequest = record {
   chain_id : nat;
   nonce : nat;
 };
+type SignWithEcdsaArgument = record {
+  key_id : EcdsaKeyId;
+  derivation_path : vec blob;
+  message_hash : blob;
+};
+type SignWithEcdsaResponse = record { signature : blob };
+type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
+type WithdrawFromError = variant {
+  GenericError : record { message : text; error_code : nat };
+  TemporarilyUnavailable;
+  InsufficientAllowance : record { allowance : nat };
+  Duplicate : record { duplicate_of : nat };
+  InvalidReceiver : record { receiver : principal };
+  CreatedInFuture : record { ledger_time : nat64 };
+  TooOld;
+  FailedToWithdrawFrom : record {
+    withdraw_from_block : opt nat;
+    rejection_code : RejectionCode_1;
+    refund_block : opt nat;
+    approval_refund_block : opt nat;
+    rejection_reason : text;
+  };
+  InsufficientFunds : record { balance : nat };
+};
 service : (Arg) -> {
-  caller_btc_address : (BitcoinNetwork) -> (text);
-  caller_btc_balance : (BitcoinNetwork) -> (nat64);
+  btc_caller_address : (GetAddressRequest, opt PaymentType) -> (Result);
+  btc_caller_balance : (GetAddressRequest, opt PaymentType) -> (Result_1);
+  btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
   caller_eth_address : () -> (text);
   config : () -> (Config) query;
   eth_address_of : (principal) -> (text);
+  eth_address_of_caller : (opt PaymentType) -> (Result_3);
+  eth_address_of_principal : (principal, opt PaymentType) -> (Result_3);
+  eth_personal_sign : (text, opt PaymentType) -> (Result_3);
+  eth_sign_transaction : (SignRequest, opt PaymentType) -> (Result_3);
+  generic_caller_ecdsa_public_key : (
+      EcdsaPublicKeyArgument,
+      opt PaymentType,
+    ) -> (Result_4);
+  generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgument) -> (
+      Result_5,
+    );
   get_canister_status : () -> (CanisterStatusResultV2);
   http_request : (HttpRequest) -> (HttpResponse) query;
   personal_sign : (text) -> (text);

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -2,8 +2,20 @@ import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 import type { Principal } from '@dfinity/principal';
 
+export interface Account {
+	owner: Principal;
+	subaccount: [] | [Uint8Array | number[]];
+}
 export type Arg = { Upgrade: null } | { Init: InitArg };
+export type BitcoinAddressType = { P2WPKH: null };
 export type BitcoinNetwork = { mainnet: null } | { regtest: null } | { testnet: null };
+export interface BtcTxOutput {
+	destination_address: string;
+	sent_satoshis: bigint;
+}
+export interface CallerPaysIcrc2Tokens {
+	ledger: Principal;
+}
 export interface CanisterStatusResultV2 {
 	controller: Principal;
 	status: CanisterStatusType;
@@ -19,6 +31,7 @@ export type CanisterStatusType = { stopped: null } | { stopping: null } | { runn
 export interface Config {
 	ecdsa_key_name: string;
 	ic_root_key_raw: [] | [Uint8Array | number[]];
+	cycles_ledger: Principal;
 }
 export interface DefiniteCanisterSettingsArgs {
 	controller: Principal;
@@ -26,6 +39,36 @@ export interface DefiniteCanisterSettingsArgs {
 	controllers: Array<Principal>;
 	memory_allocation: bigint;
 	compute_allocation: bigint;
+}
+export type EcdsaCurve = { secp256k1: null };
+export interface EcdsaKeyId {
+	name: string;
+	curve: EcdsaCurve;
+}
+export interface EcdsaPublicKeyArgument {
+	key_id: EcdsaKeyId;
+	canister_id: [] | [Principal];
+	derivation_path: Array<Uint8Array | number[]>;
+}
+export interface EcdsaPublicKeyResponse {
+	public_key: Uint8Array | number[];
+	chain_code: Uint8Array | number[];
+}
+export type GenericSigningError =
+	| {
+			SigningError: [RejectionCode_1, string];
+	  }
+	| { PaymentError: PaymentError };
+export type GetAddressError = { InternalError: { msg: string } } | { PaymentError: PaymentError };
+export interface GetAddressRequest {
+	network: BitcoinNetwork;
+	address_type: BitcoinAddressType;
+}
+export interface GetAddressResponse {
+	address: string;
+}
+export interface GetBalanceResponse {
+	balance: bigint;
 }
 export interface HttpRequest {
 	url: string;
@@ -41,6 +84,59 @@ export interface HttpResponse {
 export interface InitArg {
 	ecdsa_key_name: string;
 	ic_root_key_der: [] | [Uint8Array | number[]];
+	cycles_ledger: [] | [Principal];
+}
+export interface Outpoint {
+	txid: Uint8Array | number[];
+	vout: number;
+}
+export interface PatronPaysIcrc2Tokens {
+	ledger: Principal;
+	patron: Account;
+}
+export type PaymentError =
+	| { LedgerUnreachable: CallerPaysIcrc2Tokens }
+	| { UnsupportedPaymentType: null }
+	| { LedgerError: { error: WithdrawFromError; ledger: Principal } }
+	| { InsufficientFunds: { needed: bigint; available: bigint } };
+export type PaymentType =
+	| { PatronPaysIcrc2Tokens: PatronPaysIcrc2Tokens }
+	| { AttachedCycles: null }
+	| { CallerPaysIcrc2Cycles: null }
+	| { CallerPaysIcrc2Tokens: CallerPaysIcrc2Tokens }
+	| { PatronPaysIcrc2Cycles: Account };
+export type RejectionCode =
+	| { NoError: null }
+	| { CanisterError: null }
+	| { SysTransient: null }
+	| { DestinationInvalid: null }
+	| { Unknown: null }
+	| { SysFatal: null }
+	| { CanisterReject: null };
+export type RejectionCode_1 =
+	| { NoError: null }
+	| { CanisterError: null }
+	| { SysTransient: null }
+	| { DestinationInvalid: null }
+	| { Unknown: null }
+	| { SysFatal: null }
+	| { CanisterReject: null };
+export type Result = { Ok: GetAddressResponse } | { Err: GetAddressError };
+export type Result_1 = { Ok: GetBalanceResponse } | { Err: GetAddressError };
+export type Result_2 = { Ok: SendBtcResponse } | { Err: SendBtcError };
+export type Result_3 = { Ok: string } | { Err: GenericSigningError };
+export type Result_4 = { Ok: [EcdsaPublicKeyResponse] } | { Err: GenericSigningError };
+export type Result_5 = { Ok: [SignWithEcdsaResponse] } | { Err: GenericSigningError };
+export type SendBtcError = { InternalError: { msg: string } } | { PaymentError: PaymentError };
+export interface SendBtcRequest {
+	fee_satoshis: [] | [bigint];
+	network: BitcoinNetwork;
+	utxos_to_spend: Array<Utxo>;
+	address_type: BitcoinAddressType;
+	outputs: Array<BtcTxOutput>;
+}
+export interface SendBtcResponse {
+	txid: string;
 }
 export interface SignRequest {
 	to: string;
@@ -52,12 +148,55 @@ export interface SignRequest {
 	chain_id: bigint;
 	nonce: bigint;
 }
+export interface SignWithEcdsaArgument {
+	key_id: EcdsaKeyId;
+	derivation_path: Array<Uint8Array | number[]>;
+	message_hash: Uint8Array | number[];
+}
+export interface SignWithEcdsaResponse {
+	signature: Uint8Array | number[];
+}
+export interface Utxo {
+	height: number;
+	value: bigint;
+	outpoint: Outpoint;
+}
+export type WithdrawFromError =
+	| {
+			GenericError: { message: string; error_code: bigint };
+	  }
+	| { TemporarilyUnavailable: null }
+	| { InsufficientAllowance: { allowance: bigint } }
+	| { Duplicate: { duplicate_of: bigint } }
+	| { InvalidReceiver: { receiver: Principal } }
+	| { CreatedInFuture: { ledger_time: bigint } }
+	| { TooOld: null }
+	| {
+			FailedToWithdrawFrom: {
+				withdraw_from_block: [] | [bigint];
+				rejection_code: RejectionCode_1;
+				refund_block: [] | [bigint];
+				approval_refund_block: [] | [bigint];
+				rejection_reason: string;
+			};
+	  }
+	| { InsufficientFunds: { balance: bigint } };
 export interface _SERVICE {
-	caller_btc_address: ActorMethod<[BitcoinNetwork], string>;
-	caller_btc_balance: ActorMethod<[BitcoinNetwork], bigint>;
+	btc_caller_address: ActorMethod<[GetAddressRequest, [] | [PaymentType]], Result>;
+	btc_caller_balance: ActorMethod<[GetAddressRequest, [] | [PaymentType]], Result_1>;
+	btc_caller_send: ActorMethod<[SendBtcRequest, [] | [PaymentType]], Result_2>;
 	caller_eth_address: ActorMethod<[], string>;
 	config: ActorMethod<[], Config>;
 	eth_address_of: ActorMethod<[Principal], string>;
+	eth_address_of_caller: ActorMethod<[[] | [PaymentType]], Result_3>;
+	eth_address_of_principal: ActorMethod<[Principal, [] | [PaymentType]], Result_3>;
+	eth_personal_sign: ActorMethod<[string, [] | [PaymentType]], Result_3>;
+	eth_sign_transaction: ActorMethod<[SignRequest, [] | [PaymentType]], Result_3>;
+	generic_caller_ecdsa_public_key: ActorMethod<
+		[EcdsaPublicKeyArgument, [] | [PaymentType]],
+		Result_4
+	>;
+	generic_sign_with_ecdsa: ActorMethod<[[] | [PaymentType], SignWithEcdsaArgument], Result_5>;
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	personal_sign: ActorMethod<[string], string>;

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -2,7 +2,8 @@
 export const idlFactory = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		cycles_ledger: IDL.Opt(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	const BitcoinNetwork = IDL.Variant({
@@ -10,9 +11,158 @@ export const idlFactory = ({ IDL }) => {
 		regtest: IDL.Null,
 		testnet: IDL.Null
 	});
+	const BitcoinAddressType = IDL.Variant({ P2WPKH: IDL.Null });
+	const GetAddressRequest = IDL.Record({
+		network: BitcoinNetwork,
+		address_type: BitcoinAddressType
+	});
+	const Account = IDL.Record({
+		owner: IDL.Principal,
+		subaccount: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const PatronPaysIcrc2Tokens = IDL.Record({
+		ledger: IDL.Principal,
+		patron: Account
+	});
+	const CallerPaysIcrc2Tokens = IDL.Record({ ledger: IDL.Principal });
+	const PaymentType = IDL.Variant({
+		PatronPaysIcrc2Tokens: PatronPaysIcrc2Tokens,
+		AttachedCycles: IDL.Null,
+		CallerPaysIcrc2Cycles: IDL.Null,
+		CallerPaysIcrc2Tokens: CallerPaysIcrc2Tokens,
+		PatronPaysIcrc2Cycles: Account
+	});
+	const GetAddressResponse = IDL.Record({ address: IDL.Text });
+	const RejectionCode_1 = IDL.Variant({
+		NoError: IDL.Null,
+		CanisterError: IDL.Null,
+		SysTransient: IDL.Null,
+		DestinationInvalid: IDL.Null,
+		Unknown: IDL.Null,
+		SysFatal: IDL.Null,
+		CanisterReject: IDL.Null
+	});
+	const WithdrawFromError = IDL.Variant({
+		GenericError: IDL.Record({
+			message: IDL.Text,
+			error_code: IDL.Nat
+		}),
+		TemporarilyUnavailable: IDL.Null,
+		InsufficientAllowance: IDL.Record({ allowance: IDL.Nat }),
+		Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+		InvalidReceiver: IDL.Record({ receiver: IDL.Principal }),
+		CreatedInFuture: IDL.Record({ ledger_time: IDL.Nat64 }),
+		TooOld: IDL.Null,
+		FailedToWithdrawFrom: IDL.Record({
+			withdraw_from_block: IDL.Opt(IDL.Nat),
+			rejection_code: RejectionCode_1,
+			refund_block: IDL.Opt(IDL.Nat),
+			approval_refund_block: IDL.Opt(IDL.Nat),
+			rejection_reason: IDL.Text
+		}),
+		InsufficientFunds: IDL.Record({ balance: IDL.Nat })
+	});
+	const PaymentError = IDL.Variant({
+		LedgerUnreachable: CallerPaysIcrc2Tokens,
+		UnsupportedPaymentType: IDL.Null,
+		LedgerError: IDL.Record({
+			error: WithdrawFromError,
+			ledger: IDL.Principal
+		}),
+		InsufficientFunds: IDL.Record({
+			needed: IDL.Nat64,
+			available: IDL.Nat64
+		})
+	});
+	const GetAddressError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text }),
+		PaymentError: PaymentError
+	});
+	const Result = IDL.Variant({
+		Ok: GetAddressResponse,
+		Err: GetAddressError
+	});
+	const GetBalanceResponse = IDL.Record({ balance: IDL.Nat64 });
+	const Result_1 = IDL.Variant({
+		Ok: GetBalanceResponse,
+		Err: GetAddressError
+	});
+	const Outpoint = IDL.Record({
+		txid: IDL.Vec(IDL.Nat8),
+		vout: IDL.Nat32
+	});
+	const Utxo = IDL.Record({
+		height: IDL.Nat32,
+		value: IDL.Nat64,
+		outpoint: Outpoint
+	});
+	const BtcTxOutput = IDL.Record({
+		destination_address: IDL.Text,
+		sent_satoshis: IDL.Nat64
+	});
+	const SendBtcRequest = IDL.Record({
+		fee_satoshis: IDL.Opt(IDL.Nat64),
+		network: BitcoinNetwork,
+		utxos_to_spend: IDL.Vec(Utxo),
+		address_type: BitcoinAddressType,
+		outputs: IDL.Vec(BtcTxOutput)
+	});
+	const SendBtcResponse = IDL.Record({ txid: IDL.Text });
+	const SendBtcError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text }),
+		PaymentError: PaymentError
+	});
+	const Result_2 = IDL.Variant({
+		Ok: SendBtcResponse,
+		Err: SendBtcError
+	});
 	const Config = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		cycles_ledger: IDL.Principal
+	});
+	const GenericSigningError = IDL.Variant({
+		SigningError: IDL.Tuple(RejectionCode_1, IDL.Text),
+		PaymentError: PaymentError
+	});
+	const Result_3 = IDL.Variant({
+		Ok: IDL.Text,
+		Err: GenericSigningError
+	});
+	const SignRequest = IDL.Record({
+		to: IDL.Text,
+		gas: IDL.Nat,
+		value: IDL.Nat,
+		max_priority_fee_per_gas: IDL.Nat,
+		data: IDL.Opt(IDL.Text),
+		max_fee_per_gas: IDL.Nat,
+		chain_id: IDL.Nat,
+		nonce: IDL.Nat
+	});
+	const EcdsaCurve = IDL.Variant({ secp256k1: IDL.Null });
+	const EcdsaKeyId = IDL.Record({ name: IDL.Text, curve: EcdsaCurve });
+	const EcdsaPublicKeyArgument = IDL.Record({
+		key_id: EcdsaKeyId,
+		canister_id: IDL.Opt(IDL.Principal),
+		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8))
+	});
+	const EcdsaPublicKeyResponse = IDL.Record({
+		public_key: IDL.Vec(IDL.Nat8),
+		chain_code: IDL.Vec(IDL.Nat8)
+	});
+	const Result_4 = IDL.Variant({
+		Ok: IDL.Tuple(EcdsaPublicKeyResponse),
+		Err: GenericSigningError
+	});
+	const SignWithEcdsaArgument = IDL.Record({
+		key_id: EcdsaKeyId,
+		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
+		message_hash: IDL.Vec(IDL.Nat8)
+	});
+	const SignWithEcdsaResponse = IDL.Record({ signature: IDL.Vec(IDL.Nat8) });
+	const Result_5 = IDL.Variant({
+		Ok: IDL.Tuple(SignWithEcdsaResponse),
+		Err: GenericSigningError
 	});
 	const CanisterStatusType = IDL.Variant({
 		stopped: IDL.Null,
@@ -48,22 +198,27 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
-	const SignRequest = IDL.Record({
-		to: IDL.Text,
-		gas: IDL.Nat,
-		value: IDL.Nat,
-		max_priority_fee_per_gas: IDL.Nat,
-		data: IDL.Opt(IDL.Text),
-		max_fee_per_gas: IDL.Nat,
-		chain_id: IDL.Nat,
-		nonce: IDL.Nat
-	});
 	return IDL.Service({
-		caller_btc_address: IDL.Func([BitcoinNetwork], [IDL.Text], []),
-		caller_btc_balance: IDL.Func([BitcoinNetwork], [IDL.Nat64], []),
+		btc_caller_address: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result], []),
+		btc_caller_balance: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result_1], []),
+		btc_caller_send: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_2], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		config: IDL.Func([], [Config]),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
+		eth_address_of_caller: IDL.Func([IDL.Opt(PaymentType)], [Result_3], []),
+		eth_address_of_principal: IDL.Func([IDL.Principal, IDL.Opt(PaymentType)], [Result_3], []),
+		eth_personal_sign: IDL.Func([IDL.Text, IDL.Opt(PaymentType)], [Result_3], []),
+		eth_sign_transaction: IDL.Func([SignRequest, IDL.Opt(PaymentType)], [Result_3], []),
+		generic_caller_ecdsa_public_key: IDL.Func(
+			[EcdsaPublicKeyArgument, IDL.Opt(PaymentType)],
+			[Result_4],
+			[]
+		),
+		generic_sign_with_ecdsa: IDL.Func(
+			[IDL.Opt(PaymentType), SignWithEcdsaArgument],
+			[Result_5],
+			[]
+		),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		http_request: IDL.Func([HttpRequest], [HttpResponse]),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
@@ -75,7 +230,8 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		cycles_ledger: IDL.Opt(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	return [Arg];

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -2,7 +2,8 @@
 export const idlFactory = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		cycles_ledger: IDL.Opt(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	const BitcoinNetwork = IDL.Variant({
@@ -10,9 +11,158 @@ export const idlFactory = ({ IDL }) => {
 		regtest: IDL.Null,
 		testnet: IDL.Null
 	});
+	const BitcoinAddressType = IDL.Variant({ P2WPKH: IDL.Null });
+	const GetAddressRequest = IDL.Record({
+		network: BitcoinNetwork,
+		address_type: BitcoinAddressType
+	});
+	const Account = IDL.Record({
+		owner: IDL.Principal,
+		subaccount: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const PatronPaysIcrc2Tokens = IDL.Record({
+		ledger: IDL.Principal,
+		patron: Account
+	});
+	const CallerPaysIcrc2Tokens = IDL.Record({ ledger: IDL.Principal });
+	const PaymentType = IDL.Variant({
+		PatronPaysIcrc2Tokens: PatronPaysIcrc2Tokens,
+		AttachedCycles: IDL.Null,
+		CallerPaysIcrc2Cycles: IDL.Null,
+		CallerPaysIcrc2Tokens: CallerPaysIcrc2Tokens,
+		PatronPaysIcrc2Cycles: Account
+	});
+	const GetAddressResponse = IDL.Record({ address: IDL.Text });
+	const RejectionCode_1 = IDL.Variant({
+		NoError: IDL.Null,
+		CanisterError: IDL.Null,
+		SysTransient: IDL.Null,
+		DestinationInvalid: IDL.Null,
+		Unknown: IDL.Null,
+		SysFatal: IDL.Null,
+		CanisterReject: IDL.Null
+	});
+	const WithdrawFromError = IDL.Variant({
+		GenericError: IDL.Record({
+			message: IDL.Text,
+			error_code: IDL.Nat
+		}),
+		TemporarilyUnavailable: IDL.Null,
+		InsufficientAllowance: IDL.Record({ allowance: IDL.Nat }),
+		Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+		InvalidReceiver: IDL.Record({ receiver: IDL.Principal }),
+		CreatedInFuture: IDL.Record({ ledger_time: IDL.Nat64 }),
+		TooOld: IDL.Null,
+		FailedToWithdrawFrom: IDL.Record({
+			withdraw_from_block: IDL.Opt(IDL.Nat),
+			rejection_code: RejectionCode_1,
+			refund_block: IDL.Opt(IDL.Nat),
+			approval_refund_block: IDL.Opt(IDL.Nat),
+			rejection_reason: IDL.Text
+		}),
+		InsufficientFunds: IDL.Record({ balance: IDL.Nat })
+	});
+	const PaymentError = IDL.Variant({
+		LedgerUnreachable: CallerPaysIcrc2Tokens,
+		UnsupportedPaymentType: IDL.Null,
+		LedgerError: IDL.Record({
+			error: WithdrawFromError,
+			ledger: IDL.Principal
+		}),
+		InsufficientFunds: IDL.Record({
+			needed: IDL.Nat64,
+			available: IDL.Nat64
+		})
+	});
+	const GetAddressError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text }),
+		PaymentError: PaymentError
+	});
+	const Result = IDL.Variant({
+		Ok: GetAddressResponse,
+		Err: GetAddressError
+	});
+	const GetBalanceResponse = IDL.Record({ balance: IDL.Nat64 });
+	const Result_1 = IDL.Variant({
+		Ok: GetBalanceResponse,
+		Err: GetAddressError
+	});
+	const Outpoint = IDL.Record({
+		txid: IDL.Vec(IDL.Nat8),
+		vout: IDL.Nat32
+	});
+	const Utxo = IDL.Record({
+		height: IDL.Nat32,
+		value: IDL.Nat64,
+		outpoint: Outpoint
+	});
+	const BtcTxOutput = IDL.Record({
+		destination_address: IDL.Text,
+		sent_satoshis: IDL.Nat64
+	});
+	const SendBtcRequest = IDL.Record({
+		fee_satoshis: IDL.Opt(IDL.Nat64),
+		network: BitcoinNetwork,
+		utxos_to_spend: IDL.Vec(Utxo),
+		address_type: BitcoinAddressType,
+		outputs: IDL.Vec(BtcTxOutput)
+	});
+	const SendBtcResponse = IDL.Record({ txid: IDL.Text });
+	const SendBtcError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text }),
+		PaymentError: PaymentError
+	});
+	const Result_2 = IDL.Variant({
+		Ok: SendBtcResponse,
+		Err: SendBtcError
+	});
 	const Config = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		cycles_ledger: IDL.Principal
+	});
+	const GenericSigningError = IDL.Variant({
+		SigningError: IDL.Tuple(RejectionCode_1, IDL.Text),
+		PaymentError: PaymentError
+	});
+	const Result_3 = IDL.Variant({
+		Ok: IDL.Text,
+		Err: GenericSigningError
+	});
+	const SignRequest = IDL.Record({
+		to: IDL.Text,
+		gas: IDL.Nat,
+		value: IDL.Nat,
+		max_priority_fee_per_gas: IDL.Nat,
+		data: IDL.Opt(IDL.Text),
+		max_fee_per_gas: IDL.Nat,
+		chain_id: IDL.Nat,
+		nonce: IDL.Nat
+	});
+	const EcdsaCurve = IDL.Variant({ secp256k1: IDL.Null });
+	const EcdsaKeyId = IDL.Record({ name: IDL.Text, curve: EcdsaCurve });
+	const EcdsaPublicKeyArgument = IDL.Record({
+		key_id: EcdsaKeyId,
+		canister_id: IDL.Opt(IDL.Principal),
+		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8))
+	});
+	const EcdsaPublicKeyResponse = IDL.Record({
+		public_key: IDL.Vec(IDL.Nat8),
+		chain_code: IDL.Vec(IDL.Nat8)
+	});
+	const Result_4 = IDL.Variant({
+		Ok: IDL.Tuple(EcdsaPublicKeyResponse),
+		Err: GenericSigningError
+	});
+	const SignWithEcdsaArgument = IDL.Record({
+		key_id: EcdsaKeyId,
+		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
+		message_hash: IDL.Vec(IDL.Nat8)
+	});
+	const SignWithEcdsaResponse = IDL.Record({ signature: IDL.Vec(IDL.Nat8) });
+	const Result_5 = IDL.Variant({
+		Ok: IDL.Tuple(SignWithEcdsaResponse),
+		Err: GenericSigningError
 	});
 	const CanisterStatusType = IDL.Variant({
 		stopped: IDL.Null,
@@ -48,22 +198,27 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
-	const SignRequest = IDL.Record({
-		to: IDL.Text,
-		gas: IDL.Nat,
-		value: IDL.Nat,
-		max_priority_fee_per_gas: IDL.Nat,
-		data: IDL.Opt(IDL.Text),
-		max_fee_per_gas: IDL.Nat,
-		chain_id: IDL.Nat,
-		nonce: IDL.Nat
-	});
 	return IDL.Service({
-		caller_btc_address: IDL.Func([BitcoinNetwork], [IDL.Text], []),
-		caller_btc_balance: IDL.Func([BitcoinNetwork], [IDL.Nat64], []),
+		btc_caller_address: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result], []),
+		btc_caller_balance: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result_1], []),
+		btc_caller_send: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_2], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		config: IDL.Func([], [Config], ['query']),
 		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
+		eth_address_of_caller: IDL.Func([IDL.Opt(PaymentType)], [Result_3], []),
+		eth_address_of_principal: IDL.Func([IDL.Principal, IDL.Opt(PaymentType)], [Result_3], []),
+		eth_personal_sign: IDL.Func([IDL.Text, IDL.Opt(PaymentType)], [Result_3], []),
+		eth_sign_transaction: IDL.Func([SignRequest, IDL.Opt(PaymentType)], [Result_3], []),
+		generic_caller_ecdsa_public_key: IDL.Func(
+			[EcdsaPublicKeyArgument, IDL.Opt(PaymentType)],
+			[Result_4],
+			[]
+		),
+		generic_sign_with_ecdsa: IDL.Func(
+			[IDL.Opt(PaymentType), SignWithEcdsaArgument],
+			[Result_5],
+			[]
+		),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),
@@ -75,7 +230,8 @@ export const idlFactory = ({ IDL }) => {
 export const init = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		ecdsa_key_name: IDL.Text,
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		cycles_ledger: IDL.Opt(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	return [Arg];

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -33,20 +33,34 @@ export class SignerCanister extends Canister<SignerService> {
 		return new SignerCanister(canisterId, service, certifiedService);
 	}
 
-	getBtcAddress = ({ network }: { network: BitcoinNetwork }): Promise<BtcAddress> => {
-		const { caller_btc_address } = this.caller({
+	getBtcAddress = async ({ network }: { network: BitcoinNetwork }): Promise<BtcAddress> => {
+		const { btc_caller_address } = this.caller({
 			certified: true
 		});
 
-		return caller_btc_address(network);
+		const response = await btc_caller_address({ network, address_type: { P2WPKH: null } }, []);
+
+		if ('Err' in response) {
+			// TODO: Manage different error types
+			throw new Error("Couldn't get BTC address");
+		}
+
+		return response.Ok.address;
 	};
 
-	getBtcBalance = ({ network }: { network: BitcoinNetwork }): Promise<bigint> => {
-		const { caller_btc_balance } = this.caller({
+	getBtcBalance = async ({ network }: { network: BitcoinNetwork }): Promise<bigint> => {
+		const { btc_caller_balance } = this.caller({
 			certified: true
 		});
 
-		return caller_btc_balance(network);
+		const response = await btc_caller_balance({ network, address_type: { P2WPKH: null } }, []);
+
+		if ('Err' in response) {
+			// TODO: Manage different error types
+			throw new Error("Couldn't get BTC balance");
+		}
+
+		return response.Ok.balance;
 	};
 
 	getEthAddress = (): Promise<EthAddress> => {

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -52,8 +52,9 @@ describe('signer.canister', () => {
 	});
 
 	it('returns correct BTC address', async () => {
-		const response = 'test-bitcoin-address';
-		service.caller_btc_address.mockResolvedValue(response);
+		const address = 'test-bitcoin-address';
+		const response = { Ok: { address } };
+		service.btc_caller_address.mockResolvedValue(response);
 
 		const { getBtcAddress } = await createSignerCanister({
 			serviceOverride: service
@@ -61,12 +62,28 @@ describe('signer.canister', () => {
 
 		const res = await getBtcAddress(btcParams);
 
-		expect(res).toEqual(response);
-		expect(service.caller_btc_address).toHaveBeenCalledWith(btcParams.network);
+		expect(res).toEqual(address);
+		expect(service.btc_caller_address).toHaveBeenCalledWith(
+			{ network: btcParams.network, address_type: { P2WPKH: null } },
+			[]
+		);
 	});
 
-	it('should throw an error if caller_btc_address throws', async () => {
-		service.caller_btc_address.mockImplementation(async () => {
+	it('should throw an error if btc_caller_address returns an error', async () => {
+		const response = { Err: { InternalError: { msg: 'Test error' } } };
+		service.btc_caller_address.mockResolvedValue(response);
+
+		const { getBtcAddress } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = getBtcAddress(btcParams);
+
+		await expect(res).rejects.toThrow(new Error("Couldn't get BTC address"));
+	});
+
+	it('should throw an error if btc_caller_address throws', async () => {
+		service.btc_caller_address.mockImplementation(async () => {
 			throw mockResponseError;
 		});
 
@@ -80,8 +97,9 @@ describe('signer.canister', () => {
 	});
 
 	it('returns correct BTC balance', async () => {
-		const response = 2n;
-		service.caller_btc_balance.mockResolvedValue(response);
+		const balance = 2n;
+		const response = { Ok: { balance } };
+		service.btc_caller_balance.mockResolvedValue(response);
 
 		const { getBtcBalance } = await createSignerCanister({
 			serviceOverride: service
@@ -89,12 +107,28 @@ describe('signer.canister', () => {
 
 		const res = await getBtcBalance(btcParams);
 
-		expect(res).toEqual(response);
-		expect(service.caller_btc_balance).toHaveBeenCalledWith(btcParams.network);
+		expect(res).toEqual(balance);
+		expect(service.btc_caller_balance).toHaveBeenCalledWith(
+			{ network: btcParams.network, address_type: { P2WPKH: null } },
+			[]
+		);
 	});
 
-	it('should throw an error if caller_btc_balance throws', async () => {
-		service.caller_btc_balance.mockImplementation(async () => {
+	it('should throw an error if btc_caller_balance returns an error', async () => {
+		const response = { Err: { InternalError: { msg: 'Test error' } } };
+		service.btc_caller_balance.mockResolvedValue(response);
+
+		const { getBtcBalance } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = getBtcBalance(btcParams);
+
+		await expect(res).rejects.toThrow(new Error("Couldn't get BTC balance"));
+	});
+
+	it('should throw an error if btc_caller_balance throws', async () => {
+		service.btc_caller_balance.mockImplementation(async () => {
 			throw mockResponseError;
 		});
 


### PR DESCRIPTION
# Motivation

We introduced breaking changes and new endpoints in CFS.

In this PR, I updated the release version of the signer canister which in turn updates the declaration files.

I also fixed the breaking changes with minimal edits. Proper error management will be added in subsequent PRs.

# Changes

## Manual changes

* Change signer release to `0.2.1`.
* Fix breaking changes in the declarations in `canisters/signer.canister.ts`.

## Automatic changes

All changes within `src/declarations/signer/*` were created by executing `npm run generate` after running `./scripts/build.signer.sh` with the new release.

# Tests

I deployed the signer to the local replica with `./scrtips/deploy.signer.sh` using `--mode reinstall` because I already had one signer installed and I had to force the reinstallation.

After reinstallation I was able to run Oisy locally.
