### PR TITLE
feat(frontend): change Buy modal title based on Onramper env [GIX-3024]

### DIFF
--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
+	import { isOnRamperDev } from '$env/onramper.env';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
-	<svelte:fragment slot="title">{$i18n.buy.text.buy}</svelte:fragment>
+	<svelte:fragment slot="title"
+		>{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}</svelte:fragment
+	>
 </Modal>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -320,7 +320,8 @@
 	},
 	"buy": {
 		"text": {
-			"buy": "Buy"
+			"buy": "Buy",
+			"buy_dev": "Buy (Dev Environment)"
 		}
 	},
 	"tokens": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -280,7 +280,7 @@ interface I18nConvert {
 }
 
 interface I18nBuy {
-	text: { buy: string };
+	text: { buy: string; buy_dev: string };
 }
 
 interface I18nTokens {


### PR DESCRIPTION
# Motivation

We would prefer to have a clear indication that Onramper is in DEV mode when an user clicks on the Buy button: we adapt the modal title based on the ENV.
