### PR TITLE
style(frontend): change About modals title to be span

### DIFF
--- a/src/frontend/src/lib/components/hero/about/AboutHowModal.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutHowModal.svelte
@@ -15,7 +15,7 @@
 
 <Modal on:nnsClose={modalStore.close} testId={ABOUT_HOW_MODAL}>
 	<svelte:fragment slot="title"
-		><p class="text-xl">{replaceOisyPlaceholders($i18n.about.how.text.title)}</p>
+		><span class="text-xl">{replaceOisyPlaceholders($i18n.about.how.text.title)}</span>
 	</svelte:fragment>
 
 	<div class="stretch pt-4">

--- a/src/frontend/src/lib/components/hero/about/AboutWhatModal.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutWhatModal.svelte
@@ -12,7 +12,8 @@
 
 <Modal on:nnsClose={modalStore.close} testId={ABOUT_WHAT_MODAL}>
 	<svelte:fragment slot="title"
-		><p class="text-xl">{replaceOisyPlaceholders($i18n.about.what.text.title)}</p></svelte:fragment
+		><span class="text-xl">{replaceOisyPlaceholders($i18n.about.what.text.title)}</span
+		></svelte:fragment
 	>
 
 	<div class="stretch pt-4">


### PR DESCRIPTION
# Motivation

To be more precise, the title in the About modal should be a `<span>` instead of `<p>`.
