### PR TITLE
style(frontend): fix negative padding in Hero for larger screens [GIX-3022]

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -18,7 +18,7 @@
 	<Header back={back === 'header'} />
 
 	<article
-		class="flex flex-col rounded-lg pt-10 pb-6 relative main 2xl:mt-[-70px] items-center"
+		class="flex flex-col rounded-lg pt-10 pb-6 relative main items-center"
 		class:pb-16={$authNotSignedIn}
 	>
 		{#if $authSignedIn}


### PR DESCRIPTION
# Motivation

The padding for the Hero for larger screen should be adapted to not be negative.

### Before

<img width="3840" alt="Screenshot 2024-09-25 at 18 37 00" src="https://github.com/user-attachments/assets/325b05fd-e4ac-4c10-8fbc-65f7ac1849e8">
<img width="3838" alt="Screenshot 2024-09-25 at 18 36 51" src="https://github.com/user-attachments/assets/07db837d-d1cd-4692-ac8c-e30e2a09555f">
<img width="3838" alt="Screenshot 2024-09-25 at 18 36 42" src="https://github.com/user-attachments/assets/48fc25f1-58e2-4eb3-82dc-187ea7b65d69">

### After

<img width="3839" alt="Screenshot 2024-09-25 at 18 15 10" src="https://github.com/user-attachments/assets/cadd9ddc-1370-4567-a086-e0342385dce3">
<img width="3837" alt="Screenshot 2024-09-25 at 18 35 04" src="https://github.com/user-attachments/assets/ddb04fa2-c50b-4add-ba99-a02307980e6d">
<img width="3836" alt="Screenshot 2024-09-25 at 18 35 47" src="https://github.com/user-attachments/assets/ef8c3117-07b2-43fe-abc2-3ddada0e828a">
