### PR TITLE
style(frontend): change secondary button to have lower contrast [GIX-3021]

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if $metamaskAvailable && $networkEthereum && tokenStandardEth}
-	<button class="secondary full center my-4" on:click={receiveModal}>
+	<button class="secondary-alt full center my-4" on:click={receiveModal}>
 		<IconMetamask />
 		<span class="text-dark-slate-blue font-bold">{$i18n.receive.ethereum.text.metamask}</span>
 	</button>

--- a/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
@@ -125,7 +125,7 @@
 							{$i18n.settings.text.pouh_credential_verified}
 						</output>
 					{:else}
-						<button type="button" class="secondary" on:click={getPouhCredential}
+						<button type="button" class="secondary-alt" on:click={getPouhCredential}
 							>{$i18n.settings.text.present_pouh_credential}</button
 						>
 					{/if}

--- a/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-	class="tertiary mx-auto mt-12 mb-4 w-full center sm:w-auto"
+	class="secondary mx-auto mt-12 mb-4 w-full center sm:w-auto"
 	class:text-grey={disabled}
 	class:text-blue={!disabled}
 	class:hover:text-dark-blue={!disabled}

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -25,20 +25,20 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.tertiary {
+	&.secondary-alt {
 		justify-content: flex-start;
 
 		padding: var(--button-padding);
 	}
 
-	&.secondary,
+	&.secondary-alt,
 	&.user {
 		border: 1px solid var(--color-blue);
 	}
 
 	&.primary,
 	&.secondary,
-	&.tertiary {
+	&.secondary-alt {
 		font-weight: var(--font-weight-bold);
 
 		&[disabled],
@@ -59,13 +59,13 @@ button {
 	}
 
 	&.secondary {
-		background: var(--color-cetacean-blue);
-		color: var(--color-white);
-	}
-
-	&.tertiary {
 		background: var(--color-alice-blue);
 		color: var(--color-primary);
+	}
+
+	&.secondary-alt {
+		background: var(--color-cetacean-blue);
+		color: var(--color-white);
 	}
 
 	&.hero {
@@ -81,7 +81,7 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.tertiary {
+	&.secondary-alt {
 		&.full {
 			width: 100%;
 		}

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -31,6 +31,7 @@ button {
 		padding: var(--button-padding);
 	}
 
+	// TODO: check with Design team if this class is still needed
 	&.secondary-alt,
 	&.user {
 		border: 1px solid var(--color-blue);


### PR DESCRIPTION
# Motivation

We want to change the secondary buttons to have the style of what we were calling tertiary. However, as discussed with the Design team, we keep the "old" secondary button (now called secondary-alt) to be re-used too.

# Changes

- Rename button class `secondary` to `secondary-alt`
- Rename button class `tertiary` to `secondary`
- Adjust all instances of `secondary-alt` that should use the new `secondary`

# Results

### New class

<img width="664" alt="Screenshot 2024-09-25 at 18 57 22" src="https://github.com/user-attachments/assets/7ad118a9-2d67-4809-8a2b-647301885684">
<img width="638" alt="Screenshot 2024-09-25 at 18 57 28" src="https://github.com/user-attachments/assets/cb261a45-075c-499b-a94d-2f984b950ad4">
<img width="623" alt="Screenshot 2024-09-25 at 18 57 35" src="https://github.com/user-attachments/assets/df7dfe9f-e91d-4491-b1d3-78f6e28054e5">
<img width="598" alt="Screenshot 2024-09-25 at 18 57 42" src="https://github.com/user-attachments/assets/2c3b54a7-8db6-4c14-9304-f72c1c9fcb4a">

### Old class

<img width="1280" alt="Screenshot 2024-09-25 at 18 57 12" src="https://github.com/user-attachments/assets/f87160ae-5dae-4940-80f8-a6d830b4a426">



