### PR TITLE
style(frontend): change buttons borders and spacing [GIX-3021]

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -11,7 +11,7 @@ button {
 		cursor: pointer;
 	}
 
-	--button-border-radius: var(--border-radius-xs);
+	--button-border-radius: var(--border-radius-md);
 	border-radius: var(--button-border-radius);
 
 	transition:
@@ -21,7 +21,7 @@ button {
 
 	border: 1px solid transparent;
 
-	--button-padding: var(--padding) var(--padding-3x);
+	--button-padding: var(--padding-2x) var(--padding-3x);
 
 	&.primary,
 	&.secondary,


### PR DESCRIPTION
# Motivation

New borders and spacing for buttons.

### Before

<img width="647" alt="Screenshot 2024-09-25 at 19 43 04" src="https://github.com/user-attachments/assets/b2c624b4-29fd-4822-b170-ea7fa9d5265c">
<img width="534" alt="Screenshot 2024-09-25 at 19 43 11" src="https://github.com/user-attachments/assets/27e9344a-e285-4bdc-94a4-1d6c13bfe9f7">
<img width="596" alt="Screenshot 2024-09-25 at 19 43 16" src="https://github.com/user-attachments/assets/13c22976-cd6b-4032-a994-b49634e11011">


### After

<img width="614" alt="Screenshot 2024-09-25 at 19 44 02" src="https://github.com/user-attachments/assets/469c76db-7191-4f7c-8826-15657eca586b">
<img width="609" alt="Screenshot 2024-09-25 at 19 44 41" src="https://github.com/user-attachments/assets/6833ac0f-300b-4737-a8c5-80719069471d">
<img width="644" alt="Screenshot 2024-09-25 at 19 44 45" src="https://github.com/user-attachments/assets/61fb4195-7afd-44f7-a874-7fd1c2b84c84">

