### PR TITLE
feat(frontend): Load and render regtest address

### DIFF
--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -15,12 +15,14 @@
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
 	import {
 		loadAddresses,
+		loadBtcAddressRegtest,
 		loadBtcAddressTestnet,
 		loadIdbAddresses
 	} from '$lib/services/address.services';
 	import { signOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
+	import { LOCAL } from '$lib/constants/app.constants';
 
 	let progressStep: string = ProgressStepsLoader.ADDRESSES;
 
@@ -70,10 +72,14 @@
 	let progressModal = false;
 
 	const debounceLoadBtcAddressTestnet = debounce(loadBtcAddressTestnet);
+	const debounceLoadBtcAddressRegtest = debounce(loadBtcAddressRegtest);
 
 	$: {
 		if (NETWORK_BITCOIN_ENABLED && $testnets && isNullish($btcAddressTestnet)) {
 			debounceLoadBtcAddressTestnet();
+			if (LOCAL) {
+				debounceLoadBtcAddressRegtest();
+			}
 		}
 	}
 

--- a/src/frontend/src/lib/components/core/Loader.svelte
+++ b/src/frontend/src/lib/components/core/Loader.svelte
@@ -9,6 +9,7 @@
 	import banner from '$lib/assets/banner.svg';
 	import Img from '$lib/components/ui/Img.svelte';
 	import InProgress from '$lib/components/ui/InProgress.svelte';
+	import { LOCAL } from '$lib/constants/app.constants';
 	import { btcAddressTestnet } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { testnets } from '$lib/derived/testnets.derived';
@@ -22,7 +23,6 @@
 	import { signOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
-	import { LOCAL } from '$lib/constants/app.constants';
 
 	let progressStep: string = ProgressStepsLoader.ADDRESSES;
 

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -14,7 +14,12 @@
 		RECEIVE_TOKENS_MODAL_ETH_SECTION,
 		RECEIVE_TOKENS_MODAL_BTC_SECTION
 	} from '$lib/constants/test-ids.constants';
-	import { btcAddressMainnet, btcAddressTestnet, ethAddress } from '$lib/derived/address.derived';
+	import {
+		btcAddressMainnet,
+		btcAddressRegtest,
+		btcAddressTestnet,
+		ethAddress
+	} from '$lib/derived/address.derived';
 	import { testnets } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -105,10 +110,10 @@
 				<ReceiveAddressWithLogo
 					on:click={() =>
 						displayQRCode({
-							address: $btcAddressTestnet ?? '',
+							address: $btcAddressRegtest ?? '',
 							addressLabel: $i18n.receive.bitcoin.text.bitcoin_regtest_address
 						})}
-					address={$btcAddressTestnet}
+					address={$btcAddressRegtest}
 					token={BTC_REGTEST_TOKEN}
 					qrCodeAriaLabel={$i18n.receive.bitcoin.text.display_bitcoin_address_qr}
 					copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}


### PR DESCRIPTION
# Motivation

Regtest and Testnet addresses are not the same for P2WPKH address type.

We already introduced the stores and services for the regtest address. In this PR, I use them.

# Changes

* Load the regtest address if local and testnets in `Loader`.
* User regtest derived store in ReceiveAddresses instead of the testnet.

# Tests

Tested locally.
