### PR TITLE
style(frontend): secondary hover

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -64,7 +64,7 @@ button {
 		color: var(--color-primary);
 
 		&:hover {
-			filter: brightness(99%);
+			filter: brightness(98%);
 		}
 	}
 

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -62,6 +62,10 @@ button {
 	&.secondary {
 		background: var(--color-alice-blue);
 		color: var(--color-primary);
+
+		&:hover {
+			filter: brightness(99%);
+		}
 	}
 
 	&.secondary-alt {


### PR DESCRIPTION
# Motivation

A quick light hover effect for secondary button for consistency given that primary already has a strong hover effect.

# Screeshots

No hover

<img width="481" alt="Capture d’écran 2024-09-26 à 07 06 06" src="https://github.com/user-attachments/assets/b5c43137-837e-4cbe-94fb-b627f0568075">

Hover

<img width="477" alt="Capture d’écran 2024-09-26 à 07 07 58" src="https://github.com/user-attachments/assets/b9db7ec2-97ab-4161-b76d-11af37446988">


