### PR TITLE
refactor(frontend): move i18n approve and reject keys

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectActions.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectActions.svelte
@@ -11,12 +11,12 @@
 
 <ButtonGroup>
 	<button class="secondary block flex-1" on:click={() => dispatch('icReject')} disabled={$isBusy}
-		>{$i18n.wallet_connect.text.reject}</button
+		>{$i18n.core.text.reject}</button
 	>
 
 	{#if approve}
 		<button class="primary block flex-1" on:click={() => dispatch('icApprove')} disabled={$isBusy}>
-			{$i18n.wallet_connect.text.approve}
+			{$i18n.core.text.approve}
 		</button>
 	{/if}
 </ButtonGroup>

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -173,9 +173,7 @@
 	{@const data = firstTransaction.data}
 
 	<WalletConnectModalTitle slot="title"
-		>{erc20Approve
-			? $i18n.wallet_connect.text.approve
-			: $i18n.send.text.send}</WalletConnectModalTitle
+		>{erc20Approve ? $i18n.core.text.approve : $i18n.send.text.send}</WalletConnectModalTitle
 	>
 
 	<FeeContext

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -13,7 +13,9 @@
 			"decimals": "Decimals",
 			"amount": "Amount",
 			"max": "Max",
-			"more": "More"
+			"more": "More",
+			"reject": "Reject",
+			"approve": "Approve"
 		},
 		"info": {
 			"test_banner": "For testing purposes only!"
@@ -459,8 +461,6 @@
 		"text": {
 			"name": "WalletConnect",
 			"session_proposal": "Session Proposal",
-			"approve": "Approve",
-			"reject": "Reject",
 			"connect": "Connect",
 			"connecting": "Connecting...",
 			"disconnect": "Disconnect",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -17,6 +17,8 @@ interface I18nCore {
 		amount: string;
 		max: string;
 		more: string;
+		reject: string;
+		approve: string;
 	};
 	info: { test_banner: string };
 	alt: { logo: string; background: string; go_to_home: string };
@@ -396,8 +398,6 @@ interface I18nWallet_connect {
 	text: {
 		name: string;
 		session_proposal: string;
-		approve: string;
-		reject: string;
 		connect: string;
 		connecting: string;
 		disconnect: string;


### PR DESCRIPTION
# Motivation

"Approve" or "Reject" are generic and will be reused in the signer so we can move the keys to "core" in the i18n file.

# Changes

- Move keys and update references
