### PR TITLE
refactor(frontend): extract replica host

### DIFF
--- a/src/frontend/src/lib/actors/agents.ic.ts
+++ b/src/frontend/src/lib/actors/agents.ic.ts
@@ -1,4 +1,4 @@
-import { LOCAL } from '$lib/constants/app.constants';
+import { LOCAL, REPLICA_HOST } from '$lib/constants/app.constants';
 import type { Option } from '$lib/types/utils';
 import type { HttpAgent, Identity } from '@dfinity/agent';
 import { createAgent as createAgentUtils, isNullish } from '@dfinity/utils';
@@ -32,7 +32,7 @@ export const createAgent = ({
 	createAgentUtils({
 		identity,
 		fetchRootKey: LOCAL,
-		host: LOCAL ? 'http://localhost:4943/' : 'https://icp-api.io',
+		host: REPLICA_HOST,
 		verifyQuerySignatures
 	});
 

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -11,6 +11,8 @@ export const PROD = MODE === 'ic';
 
 const MAINNET_DOMAIN = 'icp0.io';
 
+export const REPLICA_HOST = LOCAL ? 'http://localhost:4943/' : 'https://icp-api.io';
+
 export const INTERNET_IDENTITY_CANISTER_ID = LOCAL
 	? import.meta.env.VITE_LOCAL_INTERNET_IDENTITY_CANISTER_ID
 	: undefined;


### PR DESCRIPTION
# Motivation

Given that we have a constant file, it's a bit cleaner to also have the DFX replica host set there rather than at the agent level.

# Changes

- Extract `REPLICA_HOST` constant
