### PR TITLE
feat(frontend): extract warning component

### DIFF
--- a/src/frontend/src/lib/components/core/Alpha.svelte
+++ b/src/frontend/src/lib/components/core/Alpha.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import IconWarning from '$lib/components/icons/IconWarning.svelte';
+	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { OISY_ALPHA_WARNING_URL } from '$lib/constants/oisy.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
@@ -8,17 +8,9 @@
 	href={OISY_ALPHA_WARNING_URL}
 	rel="external noopener noreferrer"
 	target="_blank"
-	class="mx-auto inline-flex w-full items-center justify-center gap-2 px-6 py-2 text-xs font-bold no-underline sm:w-fit md:text-base"
+	class="mx-auto no-underline"
 >
-	<IconWarning inline />
-	<span>{$i18n.hero.text.use_with_caution}</span>
+	<WarningBanner>
+		{$i18n.hero.text.use_with_caution}
+	</WarningBanner>
 </a>
-
-<style lang="scss">
-	a {
-		color: var(--alpha-color, var(--color-american-orange));
-		background-color: var(--alpha-bg-color, var(--color-cornsilk));
-		border: 1px solid var(--alpha-border-color, var(--color-crayola-yellow));
-		border-radius: 8px;
-	}
-</style>

--- a/src/frontend/src/lib/components/ui/WarningBanner.svelte
+++ b/src/frontend/src/lib/components/ui/WarningBanner.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div
-	class="mx-auto inline-flex w-full items-center justify-center gap-2 px-6 py-2 text-xs font-bold sm:w-fit md:text-base text-american-orange bg-cornsilk border border-crayola-yellow rounded-lg"
+	class="inline-flex w-full items-center justify-center gap-2 px-6 py-2 text-xs font-bold sm:w-fit md:text-base text-american-orange bg-cornsilk border border-crayola-yellow rounded-lg"
 >
 	<IconWarning inline />
 	<span><slot /></span>

--- a/src/frontend/src/lib/components/ui/WarningBanner.svelte
+++ b/src/frontend/src/lib/components/ui/WarningBanner.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import IconWarning from '$lib/components/icons/IconWarning.svelte';
+</script>
+
+<div
+	class="mx-auto inline-flex w-full items-center justify-center gap-2 px-6 py-2 text-xs font-bold sm:w-fit md:text-base text-american-orange bg-cornsilk border border-crayola-yellow rounded-lg"
+>
+	<IconWarning inline />
+	<span><slot /></span>
+</div>


### PR DESCRIPTION
# Motivation

The warning banner has been styled so we may reuse it to present some warning message such as currently in the signer branch. That's why this PR extract a component.

# Changes

- Extract warning container from existing `Alpha` message
