### PR TITLE
style(frontend): fix overflow of About buttons when signed out

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -38,7 +38,7 @@
 		<Alpha />
 	</div>
 
-	<div class="flex gap-4 ml-auto">
+	<div class="flex gap-4 justify-end">
 		{#if $authSignedIn}
 			<WalletConnect />
 		{/if}


### PR DESCRIPTION
# Motivation

There was an issue with displaying the About buttons when signed out that was making them overflow outside.

### Before

<img width="781" alt="Screenshot 2024-09-26 at 11 32 49" src="https://github.com/user-attachments/assets/d4442994-dbba-4bb3-b74b-772c4e4e2c22">

### After

<img width="779" alt="Screenshot 2024-09-26 at 11 32 57" src="https://github.com/user-attachments/assets/043d2f84-a6dc-497b-a4e9-9bbabd780d51">

### The rest is unchanged

<img width="533" alt="Screenshot 2024-09-26 at 11 32 32" src="https://github.com/user-attachments/assets/4228d63e-4c3a-435a-89ba-bdc47b42eb30">
<img width="1281" alt="Screenshot 2024-09-26 at 11 33 08" src="https://github.com/user-attachments/assets/07dd12b1-7cf7-41a2-b599-5d5be4f87267">
<img width="1262" alt="Screenshot 2024-09-26 at 11 33 38" src="https://github.com/user-attachments/assets/2c4f1a56-004e-4366-a009-5c73d0f98518">
<img width="650" alt="Screenshot 2024-09-26 at 11 33 49" src="https://github.com/user-attachments/assets/dac728d2-732d-4302-9d7e-664d0822adf1">
