### PR TITLE
feat(frontend): Add regtest to IcSendBtcNetwork

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendBtcNetwork.svelte
+++ b/src/frontend/src/icp/components/send/IcSendBtcNetwork.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { BTC_MAINNET_NETWORK_ID } from '$env/networks.env';
-	import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
+	import { BTC_MAINNET_NETWORK_ID, BTC_TESTNET_NETWORK_ID } from '$env/networks.env';
+	import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 	import type { NetworkId } from '$lib/types/network';
 
 	export let networkId: NetworkId;
@@ -8,6 +8,8 @@
 
 {#if BTC_MAINNET_NETWORK_ID === networkId}
 	{BTC_MAINNET_TOKEN.name}
-{:else}
+{:else if BTC_TESTNET_NETWORK_ID === networkId}
 	{BTC_TESTNET_TOKEN.name}
+{:else}
+	{BTC_REGTEST_TOKEN.name}
 {/if}


### PR DESCRIPTION
# Motivation

The component displaying the network name wasn't taking into account regtest.

# Changes

* Add a condition to check testnet instead of falling back to testnet if not mainnet.

# Tests

Works locally in #2528 
