### PR TITLE
chore(frontend): Update ckbtc dep in package.lock and package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@dfinity/agent": "^2.1.1",
 				"@dfinity/auth-client": "^2.1.1",
 				"@dfinity/candid": "^2.1.1",
-				"@dfinity/ckbtc": "^3.0.0-next-2024-09-17",
+				"@dfinity/ckbtc": "^3.0.0-next-2024-09-26",
 				"@dfinity/cketh": "^3.3.0-next-2024-09-17",
 				"@dfinity/gix-components": "^4.7.0-next-2024-09-17",
 				"@dfinity/ic-management": "^5.2.0-next-2024-09-17",
@@ -261,27 +261,25 @@
 			}
 		},
 		"node_modules/@dfinity/ckbtc": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.0.0.tgz",
-			"integrity": "sha512-OHmgqIlBbCfsGRDEBveCst39WY16YIxioWrY8aH5VNA05yDpoJXdsfowacaSMC39cHJPzKln7ocGAHweKS5nvg==",
-			"license": "Apache-2.0",
+			"version": "3.0.0-next-2024-09-26",
+			"resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.0.0-next-2024-09-26.tgz",
+			"integrity": "sha512-Km4+tLCHagilR4Qjh0y3u/8PVOWsL0HpGaWFeKhYGGpVAs4frVlBlwOfnjtwNQaPLJ7erJDec3KvlN46xm6KOg==",
 			"dependencies": {
 				"@noble/hashes": "^1.3.2",
 				"base58-js": "^1.0.5",
 				"bech32": "^2.0.0"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.0.0",
-				"@dfinity/candid": "^2.0.0",
-				"@dfinity/principal": "^2.0.0",
-				"@dfinity/utils": "^2.5.0"
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/principal": "*",
+				"@dfinity/utils": "*"
 			}
 		},
 		"node_modules/@dfinity/ckbtc/node_modules/bech32": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-			"license": "MIT"
+			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
 		},
 		"node_modules/@dfinity/cketh": {
 			"version": "3.3.0",
@@ -4577,7 +4575,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
 			"integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
-			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
 			}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@dfinity/agent": "^2.1.1",
 		"@dfinity/auth-client": "^2.1.1",
 		"@dfinity/candid": "^2.1.1",
-		"@dfinity/ckbtc": "^3.0.0-next-2024-09-17",
+		"@dfinity/ckbtc": "^3.0.0-next-2024-09-26",
 		"@dfinity/cketh": "^3.3.0-next-2024-09-17",
 		"@dfinity/gix-components": "^4.7.0-next-2024-09-17",
 		"@dfinity/ic-management": "^5.2.0-next-2024-09-17",


### PR DESCRIPTION
# Motivation

I realized that the BitcoinNetwork from ckbtc didn't have the latest changes. Specifically, it didn't include "regtest" in the Bitcoin networks.

The problem was that even though the package.json indicated a next version, package-lock was still pointing to 3.0.0

In this PR I updated both package.json 

# Changes

* Change the package.json and package.lock.json with `npm rm @dfinity/ckbtc && npm i @dfinity/ckbtc@next`.

# Tests

Code still works.
