### PR TITLE
fix(frontend): Pass targetNetwork to SendModal

### DIFF
--- a/src/frontend/src/lib/components/send/Send.svelte
+++ b/src/frontend/src/lib/components/send/Send.svelte
@@ -3,10 +3,11 @@
 	import SendModal from '$lib/components/send/SendModal.svelte';
 	import { modalSend } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { token } from '$lib/stores/token.store';
 
 	export let isTransactionsPage: boolean;
 </script>
 
 <SendButtonWithModal open={modalStore.openSend} isOpen={$modalSend}>
-	<SendModal {isTransactionsPage} on:nnsClose slot="modal" />
+	<SendModal {isTransactionsPage} on:nnsClose slot="modal" targetNetwork={$token?.network} />
 </SendButtonWithModal>


### PR DESCRIPTION
# Motivation

The `networkId` was undefined within the Send modal even though there was a network and token selected.

I realized that the `networkId` comes from `targetNetwork` which was never passed, therefore, it was never set.

I wonder whether there is a rule to check that a prop is never passed when using the component. According to ChatGPT there is no such rule.

# Changes

* Pass `targetNetwork` to `SendModal` in the `Send` component using the global store `token`.

# Tests

This was tested in #2528 
