### PR TITLE
feat(frontend): re-use BTC address listener service

### DIFF
--- a/src/frontend/src/icp/services/ckbtc-listener.services.ts
+++ b/src/frontend/src/icp/services/ckbtc-listener.services.ts
@@ -1,4 +1,4 @@
-import { btcAddressStore, btcStatusesStore } from '$icp/stores/btc.store';
+import { btcStatusesStore } from '$icp/stores/btc.store';
 import { ckBtcPendingUtxosStore } from '$icp/stores/ckbtc-utxos.store';
 import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 import type { BtcWithdrawalStatuses } from '$icp/types/btc';
@@ -6,10 +6,7 @@ import type { SyncCkMinterInfoError, SyncCkMinterInfoSuccess } from '$icp/types/
 import type { UtxoTxidText } from '$icp/types/ckbtc';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
-import type {
-	PostMessageDataResponseBTCAddress,
-	PostMessageJsonDataResponse
-} from '$lib/types/post-message';
+import type { PostMessageJsonDataResponse } from '$lib/types/post-message';
 import type { CertifiedData } from '$lib/types/store';
 import type { SyncState } from '$lib/types/sync';
 import type { TokenId } from '$lib/types/token';
@@ -69,19 +66,6 @@ export const syncBtcPendingUtxos = ({
 	const data: CertifiedData<PendingUtxo[]> = JSON.parse(json, jsonReviver);
 
 	ckBtcPendingUtxosStore.set({
-		tokenId,
-		data
-	});
-};
-
-export const syncBtcAddress = ({
-	data: { address: data },
-	tokenId
-}: {
-	data: PostMessageDataResponseBTCAddress;
-	tokenId: TokenId;
-}) => {
-	btcAddressStore.set({
 		tokenId,
 		data
 	});

--- a/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
+++ b/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
@@ -1,11 +1,8 @@
-import {
-	syncBtcAddress,
-	syncBtcPendingUtxos,
-	syncCkBTCUpdateOk
-} from '$icp/services/ckbtc-listener.services';
+import { syncBtcPendingUtxos, syncCkBTCUpdateOk } from '$icp/services/ckbtc-listener.services';
 import { btcAddressStore } from '$icp/stores/btc.store';
 import type { IcCkWorker, IcCkWorkerInitResult, IcCkWorkerParams } from '$icp/types/ck-listener';
 import { isNetworkIdBTCMainnet } from '$icp/utils/ic-send.utils';
+import { syncBtcAddress } from '$lib/services/listener.services';
 import type {
 	PostMessage,
 	PostMessageDataResponseBTCAddress,

--- a/src/frontend/src/lib/services/listener.services.ts
+++ b/src/frontend/src/lib/services/listener.services.ts
@@ -1,0 +1,16 @@
+import { btcAddressStore } from '$icp/stores/btc.store';
+import type { PostMessageDataResponseBTCAddress } from '$lib/types/post-message';
+import type { TokenId } from '$lib/types/token';
+
+export const syncBtcAddress = ({
+	data: { address: data },
+	tokenId
+}: {
+	data: PostMessageDataResponseBTCAddress;
+	tokenId: TokenId;
+}) => {
+	btcAddressStore.set({
+		tokenId,
+		data
+	});
+};


### PR DESCRIPTION
# Motivation

The goal is to re-use `syncBtcAddress` listener service between ckBTC and BTC workers.