### PR TITLE
feat(frontend): use PostMessageDataResponseWallet for BTC wallet [GIX-2795]

### DIFF
--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -1,11 +1,12 @@
 import { getBtcBalance } from '$lib/api/signer.api';
 import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { SchedulerTimer, type Scheduler, type SchedulerJobData } from '$lib/schedulers/scheduler';
+import type { BitcoinTransaction } from '$lib/types/blockchain';
 import type {
 	PostMessageDataRequestBtc,
 	PostMessageDataResponseWallet
 } from '$lib/types/post-message';
-import { assertNonNullish } from '@dfinity/utils';
+import { assertNonNullish, jsonReplacer } from '@dfinity/utils';
 
 export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> {
 	private timer = new SchedulerTimer('syncBtcWalletStatus');
@@ -44,14 +45,16 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 			network: bitcoinNetwork
 		});
 
+		// TODO: Fetch and parse transactions
+		const transactions: BitcoinTransaction[] = [];
+
 		this.postMessageWallet({
 			wallet: {
 				balance: {
 					data: balance,
 					certified: true
 				},
-				// TODO: Send parsed transactions
-				newTransactions: ''
+				newTransactions: JSON.stringify(transactions, jsonReplacer)
 			}
 		});
 	};

--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -3,7 +3,7 @@ import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { SchedulerTimer, type Scheduler, type SchedulerJobData } from '$lib/schedulers/scheduler';
 import type {
 	PostMessageDataRequestBtc,
-	PostMessageDataResponseBtcWallet
+	PostMessageDataResponseWallet
 } from '$lib/types/post-message';
 import { assertNonNullish } from '@dfinity/utils';
 
@@ -49,13 +49,15 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 				balance: {
 					data: balance,
 					certified: true
-				}
+				},
+				// TODO: Send parsed transactions
+				newTransactions: ''
 			}
 		});
 	};
 
-	private postMessageWallet(data: PostMessageDataResponseBtcWallet) {
-		this.timer.postMsg<PostMessageDataResponseBtcWallet>({
+	private postMessageWallet(data: PostMessageDataResponseWallet) {
+		this.timer.postMsg<PostMessageDataResponseWallet>({
 			msg: 'syncBtcWallet',
 			data
 		});

--- a/src/frontend/src/btc/services/btc-listener.services.ts
+++ b/src/frontend/src/btc/services/btc-listener.services.ts
@@ -1,5 +1,5 @@
 import { balancesStore } from '$lib/stores/balances.store';
-import type { PostMessageDataResponseBtcWallet } from '$lib/types/post-message';
+import type { PostMessageDataResponseWallet } from '$lib/types/post-message';
 import type { TokenId } from '$lib/types/token';
 import { BigNumber } from '@ethersproject/bignumber';
 
@@ -7,7 +7,7 @@ export const syncWallet = ({
 	data,
 	tokenId
 }: {
-	data: PostMessageDataResponseBtcWallet;
+	data: PostMessageDataResponseWallet;
 	tokenId: TokenId;
 }) => {
 	const {

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -1,7 +1,7 @@
 import { syncWallet } from '$btc/services/btc-listener.services';
 import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$icp/utils/ic-send.utils';
 import type { WalletWorker } from '$lib/types/listener';
-import type { PostMessage, PostMessageDataResponseBtcWallet } from '$lib/types/post-message';
+import type { PostMessage, PostMessageDataResponseWallet } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 
@@ -12,16 +12,14 @@ export const initBtcWalletWorker = async ({
 	const WalletWorker = await import('$btc/workers/btc-wallet.worker?worker');
 	const worker: Worker = new WalletWorker.default();
 
-	worker.onmessage = async ({
-		data
-	}: MessageEvent<PostMessage<PostMessageDataResponseBtcWallet>>) => {
+	worker.onmessage = async ({ data }: MessageEvent<PostMessage<PostMessageDataResponseWallet>>) => {
 		const { msg } = data;
 
 		switch (msg) {
 			case 'syncBtcWallet':
 				syncWallet({
 					tokenId,
-					data: data.data as PostMessageDataResponseBtcWallet
+					data: data.data as PostMessageDataResponseWallet
 				});
 				return;
 		}

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -107,18 +107,13 @@ export interface PostMessageDataResponseExchangeError extends PostMessageDataRes
 // Transactions & {certified: boolean}
 type JsonTransactionsText = string;
 
-type PostMessageWalletData<T = unknown> = Omit<T, 'transactions' | 'balance'> & {
+type PostMessageWalletData<T> = Omit<T, 'transactions' | 'balance'> & {
 	balance: CertifiedData<bigint>;
 	newTransactions: JsonTransactionsText;
 };
 
-export interface PostMessageDataResponseWallet<T> extends PostMessageDataResponse {
+export interface PostMessageDataResponseWallet<T = unknown> extends PostMessageDataResponse {
 	wallet: PostMessageWalletData<T>;
-}
-
-// TODO: use common PostMessageDataResponseWallet interface after BTC transactions added to the worker
-export interface PostMessageDataResponseBtcWallet extends PostMessageDataResponse {
-	wallet: Omit<PostMessageWalletData, 'newTransactions'>;
 }
 
 export interface PostMessageDataResponseError extends PostMessageDataResponse {


### PR DESCRIPTION
# Motivation

Removing the temporary type for BTC wallet since we are going to re-use `PostMessageDataResponseWallet`.