### PR TITLE
feat(frontend): use common canister/api types for signer

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -6,7 +6,7 @@ import type {
 	AddUserCredentialResponse,
 	GetUserProfileResponse
 } from '$lib/types/api';
-import type { CommonCanisterApiFunctionParams } from '$lib/types/canister';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish, type QueryParams } from '@dfinity/utils';
 
@@ -15,7 +15,7 @@ let canister: BackendCanister | undefined = undefined;
 export const listUserTokens = async ({
 	identity,
 	certified
-}: CommonCanisterApiFunctionParams<QueryParams>): Promise<UserToken[]> => {
+}: CanisterApiFunctionParams<QueryParams>): Promise<UserToken[]> => {
 	const { listUserTokens } = await backendCanister({ identity });
 
 	return listUserTokens({ certified });
@@ -24,7 +24,7 @@ export const listUserTokens = async ({
 export const listCustomTokens = async ({
 	identity,
 	certified
-}: CommonCanisterApiFunctionParams<QueryParams>): Promise<CustomToken[]> => {
+}: CanisterApiFunctionParams<QueryParams>): Promise<CustomToken[]> => {
 	const { listCustomTokens } = await backendCanister({ identity });
 
 	return listCustomTokens({ certified });
@@ -33,7 +33,7 @@ export const listCustomTokens = async ({
 export const setManyCustomTokens = async ({
 	identity,
 	tokens
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	tokens: CustomToken[];
 }>): Promise<void> => {
 	const { setManyCustomTokens } = await backendCanister({ identity });
@@ -44,7 +44,7 @@ export const setManyCustomTokens = async ({
 export const setCustomToken = async ({
 	token,
 	identity
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	token: CustomToken;
 }>): Promise<void> => {
 	const { setCustomToken } = await backendCanister({ identity });
@@ -55,7 +55,7 @@ export const setCustomToken = async ({
 export const setManyUserTokens = async ({
 	identity,
 	tokens
-}: CommonCanisterApiFunctionParams<{ tokens: UserToken[] }>): Promise<void> => {
+}: CanisterApiFunctionParams<{ tokens: UserToken[] }>): Promise<void> => {
 	const { setManyUserTokens } = await backendCanister({ identity });
 
 	return setManyUserTokens({ tokens });
@@ -64,7 +64,7 @@ export const setManyUserTokens = async ({
 export const setUserToken = async ({
 	token,
 	identity
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	token: UserToken;
 }>): Promise<void> => {
 	const { setUserToken } = await backendCanister({ identity });
@@ -74,7 +74,7 @@ export const setUserToken = async ({
 
 export const createUserProfile = async ({
 	identity
-}: CommonCanisterApiFunctionParams): Promise<UserProfile> => {
+}: CanisterApiFunctionParams): Promise<UserProfile> => {
 	const { createUserProfile } = await backendCanister({ identity });
 
 	return createUserProfile();
@@ -83,7 +83,7 @@ export const createUserProfile = async ({
 export const getUserProfile = async ({
 	identity,
 	certified
-}: CommonCanisterApiFunctionParams<QueryParams>): Promise<GetUserProfileResponse> => {
+}: CanisterApiFunctionParams<QueryParams>): Promise<GetUserProfileResponse> => {
 	const { getUserProfile } = await backendCanister({ identity });
 
 	return getUserProfile({ certified });
@@ -91,7 +91,7 @@ export const getUserProfile = async ({
 export const addUserCredential = async ({
 	identity,
 	...params
-}: CommonCanisterApiFunctionParams<AddUserCredentialParams>): Promise<AddUserCredentialResponse> => {
+}: CanisterApiFunctionParams<AddUserCredentialParams>): Promise<AddUserCredentialResponse> => {
 	const { addUserCredential } = await backendCanister({ identity });
 
 	return addUserCredential(params);
@@ -101,7 +101,7 @@ const backendCanister = async ({
 	identity,
 	nullishIdentityErrorMessage,
 	canisterId = BACKEND_CANISTER_ID
-}: CommonCanisterApiFunctionParams): Promise<BackendCanister> => {
+}: CanisterApiFunctionParams): Promise<BackendCanister> => {
 	assertNonNullish(identity, nullishIdentityErrorMessage);
 
 	if (isNullish(canister)) {

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -2,23 +2,16 @@ import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.di
 import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
-import type { CanisterIdText } from '$lib/types/canister';
-import type { OptionIdentity } from '$lib/types/identity';
+import type { CommonCanisterApiFunctionParams } from '$lib/types/canister';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 
 let canister: SignerCanister | undefined = undefined;
 
-type CommonParams<T = unknown> = T & {
-	identity: OptionIdentity;
-	nullishIdentityErrorMessage?: string;
-	signerCanisterId?: CanisterIdText;
-};
-
 export const getBtcAddress = async ({
 	identity,
 	network
-}: CommonParams<{
+}: CommonCanisterApiFunctionParams<{
 	network: BitcoinNetwork;
 }>): Promise<BtcAddress> => {
 	const { getBtcAddress } = await signerCanister({ identity });
@@ -26,7 +19,9 @@ export const getBtcAddress = async ({
 	return getBtcAddress({ network });
 };
 
-export const getEthAddress = async ({ identity }: CommonParams): Promise<EthAddress> => {
+export const getEthAddress = async ({
+	identity
+}: CommonCanisterApiFunctionParams): Promise<EthAddress> => {
 	const { getEthAddress } = await signerCanister({ identity });
 
 	return getEthAddress();
@@ -35,11 +30,11 @@ export const getEthAddress = async ({ identity }: CommonParams): Promise<EthAddr
 export const getBtcBalance = async ({
 	identity,
 	network,
-	signerCanisterId
-}: CommonParams<{
+	canisterId
+}: CommonCanisterApiFunctionParams<{
 	network: BitcoinNetwork;
 }>): Promise<bigint> => {
-	const { getBtcBalance } = await signerCanister({ identity, signerCanisterId });
+	const { getBtcBalance } = await signerCanister({ identity, canisterId });
 
 	return getBtcBalance({ network });
 };
@@ -47,7 +42,7 @@ export const getBtcBalance = async ({
 export const signTransaction = async ({
 	transaction,
 	identity
-}: CommonParams<{
+}: CommonCanisterApiFunctionParams<{
 	transaction: SignRequest;
 }>): Promise<string> => {
 	const { signTransaction } = await signerCanister({ identity });
@@ -58,7 +53,7 @@ export const signTransaction = async ({
 export const signMessage = async ({
 	message,
 	identity
-}: CommonParams<{ message: string }>): Promise<string> => {
+}: CommonCanisterApiFunctionParams<{ message: string }>): Promise<string> => {
 	const { personalSign } = await signerCanister({ identity });
 
 	return personalSign({ message });
@@ -67,7 +62,7 @@ export const signMessage = async ({
 export const signPrehash = async ({
 	hash,
 	identity
-}: CommonParams<{
+}: CommonCanisterApiFunctionParams<{
 	hash: string;
 }>): Promise<string> => {
 	const { signPrehash } = await signerCanister({ identity });
@@ -78,14 +73,14 @@ export const signPrehash = async ({
 const signerCanister = async ({
 	identity,
 	nullishIdentityErrorMessage,
-	signerCanisterId = SIGNER_CANISTER_ID
-}: CommonParams): Promise<SignerCanister> => {
+	canisterId = SIGNER_CANISTER_ID
+}: CommonCanisterApiFunctionParams): Promise<SignerCanister> => {
 	assertNonNullish(identity, nullishIdentityErrorMessage);
 
 	if (isNullish(canister)) {
 		canister = await SignerCanister.create({
 			identity,
-			canisterId: Principal.fromText(signerCanisterId)
+			canisterId: Principal.fromText(canisterId)
 		});
 	}
 

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -2,7 +2,7 @@ import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.di
 import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
-import type { CommonCanisterApiFunctionParams } from '$lib/types/canister';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 
@@ -11,7 +11,7 @@ let canister: SignerCanister | undefined = undefined;
 export const getBtcAddress = async ({
 	identity,
 	network
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	network: BitcoinNetwork;
 }>): Promise<BtcAddress> => {
 	const { getBtcAddress } = await signerCanister({ identity });
@@ -21,7 +21,7 @@ export const getBtcAddress = async ({
 
 export const getEthAddress = async ({
 	identity
-}: CommonCanisterApiFunctionParams): Promise<EthAddress> => {
+}: CanisterApiFunctionParams): Promise<EthAddress> => {
 	const { getEthAddress } = await signerCanister({ identity });
 
 	return getEthAddress();
@@ -31,7 +31,7 @@ export const getBtcBalance = async ({
 	identity,
 	network,
 	canisterId
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	network: BitcoinNetwork;
 }>): Promise<bigint> => {
 	const { getBtcBalance } = await signerCanister({ identity, canisterId });
@@ -42,7 +42,7 @@ export const getBtcBalance = async ({
 export const signTransaction = async ({
 	transaction,
 	identity
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	transaction: SignRequest;
 }>): Promise<string> => {
 	const { signTransaction } = await signerCanister({ identity });
@@ -53,7 +53,7 @@ export const signTransaction = async ({
 export const signMessage = async ({
 	message,
 	identity
-}: CommonCanisterApiFunctionParams<{ message: string }>): Promise<string> => {
+}: CanisterApiFunctionParams<{ message: string }>): Promise<string> => {
 	const { personalSign } = await signerCanister({ identity });
 
 	return personalSign({ message });
@@ -62,7 +62,7 @@ export const signMessage = async ({
 export const signPrehash = async ({
 	hash,
 	identity
-}: CommonCanisterApiFunctionParams<{
+}: CanisterApiFunctionParams<{
 	hash: string;
 }>): Promise<string> => {
 	const { signPrehash } = await signerCanister({ identity });
@@ -74,7 +74,7 @@ const signerCanister = async ({
 	identity,
 	nullishIdentityErrorMessage,
 	canisterId = SIGNER_CANISTER_ID
-}: CommonCanisterApiFunctionParams): Promise<SignerCanister> => {
+}: CanisterApiFunctionParams): Promise<SignerCanister> => {
 	assertNonNullish(identity, nullishIdentityErrorMessage);
 
 	if (isNullish(canister)) {

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -7,18 +7,11 @@ import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/si
 import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
-import type { Identity } from '@dfinity/agent';
-import { Principal } from '@dfinity/principal';
-import { Canister, createServices, type CanisterOptions } from '@dfinity/utils';
-
-export interface SignerCanisterOptions
-	extends Omit<CanisterOptions<SignerService>, 'canisterId' | 'agent'> {
-	canisterId: Principal;
-	identity: Identity;
-}
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { Canister, createServices } from '@dfinity/utils';
 
 export class SignerCanister extends Canister<SignerService> {
-	static async create({ identity, ...options }: SignerCanisterOptions) {
+	static async create({ identity, ...options }: CreateCanisterOptions<SignerService>) {
 		const agent = await getAgent({ identity });
 
 		const { service, certifiedService, canisterId } = createServices<SignerService>({

--- a/src/frontend/src/lib/types/canister.ts
+++ b/src/frontend/src/lib/types/canister.ts
@@ -8,7 +8,7 @@ export type CanisterIdText = string;
 
 export type OptionCanisterIdText = Option<CanisterIdText>;
 
-export type CommonCanisterApiFunctionParams<T = unknown> = T & {
+export type CanisterApiFunctionParams<T = unknown> = T & {
 	nullishIdentityErrorMessage?: string;
 	identity: OptionIdentity;
 	canisterId?: CanisterIdText;

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,5 +1,6 @@
 import type { _SERVICE as SignerService, SignRequest } from '$declarations/signer/signer.did';
-import { SignerCanister, type SignerCanisterOptions } from '$lib/canisters/signer.canister';
+import { SignerCanister } from '$lib/canisters/signer.canister';
+import type { CreateCanisterOptions } from '$lib/types/canister';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { mock } from 'vitest-mock-extended';
@@ -16,7 +17,7 @@ vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
 describe('signer.canister', () => {
 	const createSignerCanister = async ({
 		serviceOverride
-	}: Pick<SignerCanisterOptions, 'serviceOverride'>): Promise<SignerCanister> =>
+	}: Pick<CreateCanisterOptions<SignerService>, 'serviceOverride'>): Promise<SignerCanister> =>
 		SignerCanister.create({
 			canisterId: Principal.fromText('tdxud-2yaaa-aaaad-aadiq-cai'),
 			identity: mockIdentity,


### PR DESCRIPTION
# Motivation

Follow-up PR for using common canister/api types for Signer.
