### PR TITLE
feat(frontend): move certified default value to BE canister

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -14,7 +14,7 @@ let canister: BackendCanister | undefined = undefined;
 
 export const listUserTokens = async ({
 	identity,
-	certified = true
+	certified
 }: CommonCanisterApiFunctionParams<QueryParams>): Promise<UserToken[]> => {
 	const { listUserTokens } = await backendCanister({ identity });
 
@@ -23,7 +23,7 @@ export const listUserTokens = async ({
 
 export const listCustomTokens = async ({
 	identity,
-	certified = true
+	certified
 }: CommonCanisterApiFunctionParams<QueryParams>): Promise<CustomToken[]> => {
 	const { listCustomTokens } = await backendCanister({ identity });
 
@@ -82,7 +82,7 @@ export const createUserProfile = async ({
 
 export const getUserProfile = async ({
 	identity,
-	certified = true
+	certified
 }: CommonCanisterApiFunctionParams<QueryParams>): Promise<GetUserProfileResponse> => {
 	const { getUserProfile } = await backendCanister({ identity });
 

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -31,13 +31,13 @@ export class BackendCanister extends Canister<BackendService> {
 		return new BackendCanister(canisterId, service, certifiedService);
 	}
 
-	listUserTokens = async ({ certified }: QueryParams): Promise<UserToken[]> => {
+	listUserTokens = async ({ certified = true }: QueryParams): Promise<UserToken[]> => {
 		const { list_user_tokens } = this.caller({ certified });
 
 		return list_user_tokens();
 	};
 
-	listCustomTokens = async ({ certified }: QueryParams): Promise<CustomToken[]> => {
+	listCustomTokens = async ({ certified = true }: QueryParams): Promise<CustomToken[]> => {
 		const { list_custom_tokens } = this.caller({ certified });
 
 		return list_custom_tokens();
@@ -73,7 +73,7 @@ export class BackendCanister extends Canister<BackendService> {
 		return create_user_profile();
 	};
 
-	getUserProfile = async ({ certified }: QueryParams): Promise<GetUserProfileResponse> => {
+	getUserProfile = async ({ certified = true }: QueryParams): Promise<GetUserProfileResponse> => {
 		const { get_user_profile } = this.caller({ certified });
 
 		return get_user_profile();


### PR DESCRIPTION
# Motivation

Follow-up PR to move default `certified` value from BE API to Canister.
