### PR TITLE
feat(frontend): add exporerUrl to BTC networks [GIX-2795]

### DIFF
--- a/src/frontend/src/btc/types/network.ts
+++ b/src/frontend/src/btc/types/network.ts
@@ -1,0 +1,7 @@
+import type { Network } from '$lib/types/network';
+
+export interface BitcoinAppMetadata {
+	explorerUrl?: string;
+}
+
+export type BitcoinNetwork = Network & BitcoinAppMetadata;

--- a/src/frontend/src/btc/types/network.ts
+++ b/src/frontend/src/btc/types/network.ts
@@ -1,7 +1,3 @@
-import type { Network } from '$lib/types/network';
+import type { Network, NetworkAppMetadata } from '$lib/types/network';
 
-export interface BitcoinAppMetadata {
-	explorerUrl?: string;
-}
-
-export type BitcoinNetwork = Network & BitcoinAppMetadata;
+export type BitcoinNetwork = Network & Partial<Pick<NetworkAppMetadata, 'explorerUrl'>>;

--- a/src/frontend/src/btc/types/network.ts
+++ b/src/frontend/src/btc/types/network.ts
@@ -1,3 +1,3 @@
 import type { Network, NetworkAppMetadata } from '$lib/types/network';
 
-export type BitcoinNetwork = Network & Partial<Pick<NetworkAppMetadata, 'explorerUrl'>>;
+export type BitcoinNetwork = Network & Partial<NetworkAppMetadata>;

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -1,4 +1,10 @@
-import { ETHEREUM_EXPLORER_URL, SEPOLIA_EXPLORER_URL } from '$env/explorers.env';
+import type { BitcoinNetwork } from '$btc/types/network';
+import {
+	BTC_MAINNET_EXPLORER_URL,
+	BTC_TESTNET_EXPLORER_URL,
+	ETHEREUM_EXPLORER_URL,
+	SEPOLIA_EXPLORER_URL
+} from '$env/explorers.env';
 import { ETH_MAINNET_ENABLED } from '$env/networks.eth.env';
 import sepolia from '$eth/assets/sepolia.svg';
 import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
@@ -82,11 +88,12 @@ export const BTC_MAINNET_NETWORK_SYMBOL = 'BTC';
 
 export const BTC_MAINNET_NETWORK_ID = Symbol(BTC_MAINNET_NETWORK_SYMBOL);
 
-export const BTC_MAINNET_NETWORK: Network = {
+export const BTC_MAINNET_NETWORK: BitcoinNetwork = {
 	id: BTC_MAINNET_NETWORK_ID,
 	env: 'mainnet',
 	name: 'Bitcoin',
 	icon: bitcoin,
+	explorerUrl: BTC_MAINNET_EXPLORER_URL,
 	buy: { onramperId: 'bitcoin' }
 };
 
@@ -94,10 +101,11 @@ export const BTC_TESTNET_NETWORK_SYMBOL = 'BTC (Testnet)';
 
 export const BTC_TESTNET_NETWORK_ID = Symbol(BTC_TESTNET_NETWORK_SYMBOL);
 
-export const BTC_TESTNET_NETWORK: Network = {
+export const BTC_TESTNET_NETWORK: BitcoinNetwork = {
 	id: BTC_TESTNET_NETWORK_ID,
 	env: 'testnet',
 	name: 'Bitcoin',
+	explorerUrl: BTC_TESTNET_EXPLORER_URL,
 	icon: bitcoinTestnet
 };
 
@@ -105,7 +113,7 @@ export const BTC_REGTEST_NETWORK_SYMBOL = 'BTC (Regtest)';
 
 export const BTC_REGTEST_NETWORK_ID = Symbol(BTC_REGTEST_NETWORK_SYMBOL);
 
-export const BTC_REGTEST_NETWORK: Network = {
+export const BTC_REGTEST_NETWORK: BitcoinNetwork = {
 	id: BTC_REGTEST_NETWORK_ID,
 	env: 'testnet',
 	name: 'Bitcoin (Regtest)'

--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -119,7 +119,7 @@ export const BTC_REGTEST_NETWORK: BitcoinNetwork = {
 	name: 'Bitcoin (Regtest)'
 };
 
-export const BITCOIN_NETWORKS: Network[] = [
+export const BITCOIN_NETWORKS: BitcoinNetwork[] = [
 	BTC_MAINNET_NETWORK,
 	BTC_TESTNET_NETWORK,
 	...(LOCAL ? [BTC_REGTEST_NETWORK] : [])

--- a/src/frontend/src/eth/types/network.ts
+++ b/src/frontend/src/eth/types/network.ts
@@ -1,4 +1,4 @@
-import type { Network } from '$lib/types/network';
+import type { Network, NetworkAppMetadata } from '$lib/types/network';
 
 export type EthereumChainId = bigint;
 
@@ -6,8 +6,4 @@ export interface NetworkChainId {
 	chainId: EthereumChainId;
 }
 
-export interface EthereumAppMetadata {
-	explorerUrl: string;
-}
-
-export type EthereumNetwork = Network & NetworkChainId & EthereumAppMetadata;
+export type EthereumNetwork = Network & NetworkChainId & NetworkAppMetadata;

--- a/src/frontend/src/lib/types/network.ts
+++ b/src/frontend/src/lib/types/network.ts
@@ -16,3 +16,7 @@ export interface Network {
 export interface NetworkBuy {
 	onramperId?: OnramperNetworkId;
 }
+
+export interface NetworkAppMetadata {
+	explorerUrl: string;
+}


### PR DESCRIPTION
# Motivation

The goal is to extend BTC networks with already defined explorer URLs. It will be used in the BTC transaction detail modal.
