### PR TITLE
fix(frontend): remove unnecessary BTC network type

### DIFF
--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -1,3 +1,0 @@
-import type { BitcoinNetwork as BitcoinNetworkLib } from '@dfinity/ckbtc';
-
-export type BitcoinNetwork = BitcoinNetworkLib | 'regtest';

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -1,4 +1,3 @@
-import type { BitcoinNetwork } from '$btc/types/btc';
 import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
 import {
 	BTC_MAINNET_TOKEN_ID,
@@ -37,6 +36,7 @@ import type { ResultSuccess, ResultSuccessReduced } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { reduceResults } from '$lib/utils/results.utils';
+import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import type { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,4 +1,3 @@
-import type { BitcoinNetwork } from '$btc/types/btc';
 import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import {
 	BITCOIN_NETWORKS_IDS,
@@ -8,6 +7,7 @@ import {
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
+import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import { nonNullish } from '@dfinity/utils';
 
 export const isNetworkICP = (network: Network | undefined): boolean => isNetworkIdICP(network?.id);


### PR DESCRIPTION
# Motivation

Since the `BitcoinNetowrk` type from `@dfinity/ckbtc` now includes `regtest`, the type that I created previously is redundant.
