### PR TITLE
feat(backend): Add endpoint to select utxos and fee for bitcoin transaction.

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -112,13 +112,13 @@ type OisyUser = record {
 };
 type Outpoint = record { txid : blob; vout : nat32 };
 type Result = variant { Ok; Err : AddUserCredentialError };
-type Result_1 = variant { Ok : UserProfile; Err : GetUserProfileError };
-type Result_2 = variant { Ok : MigrationReport; Err : text };
-type Result_3 = variant { Ok; Err : text };
-type Result_4 = variant {
+type Result_1 = variant {
   Ok : SelectedUtxosFeeResponse;
   Err : SelectedUtxosFeeError;
 };
+type Result_2 = variant { Ok : UserProfile; Err : GetUserProfileError };
+type Result_3 = variant { Ok : MigrationReport; Err : text };
+type Result_4 = variant { Ok; Err : text };
 type SelectedUtxosFeeError = variant { InternalError : record { msg : text } };
 type SelectedUtxosFeeRequest = record {
   network : BitcoinNetwork;
@@ -166,20 +166,20 @@ type UserTokenId = record { chain_id : nat64; contract_address : text };
 type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
 service : (Arg) -> {
   add_user_credential : (AddUserCredentialRequest) -> (Result);
+  btc_select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (Result_1);
   bulk_up : (blob) -> ();
   config : () -> (Config) query;
   create_user_profile : () -> (UserProfile);
   get_canister_status : () -> (CanisterStatusResultV2);
-  get_user_profile : () -> (Result_1) query;
+  get_user_profile : () -> (Result_2) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
   list_users : (ListUsersRequest) -> (ListUsersResponse) query;
-  migrate_user_data_to : (principal) -> (Result_2);
+  migrate_user_data_to : (principal) -> (Result_3);
   migration : () -> (opt MigrationReport) query;
-  migration_stop_timer : () -> (Result_3);
+  migration_stop_timer : () -> (Result_4);
   remove_user_token : (UserTokenId) -> ();
-  select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (Result_4);
   set_custom_token : (CustomToken) -> ();
   set_guards : (Guards) -> ();
   set_many_custom_tokens : (vec CustomToken) -> ();

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -13,6 +13,7 @@ type AddUserCredentialRequest = record {
 type ApiEnabled = variant { ReadOnly; Enabled; Disabled };
 type Arg = variant { Upgrade; Init : InitArg };
 type ArgumentValue = variant { Int : int32; String : text };
+type BitcoinNetwork = variant { mainnet; regtest; testnet };
 type CanisterStatusResultV2 = record {
   controller : principal;
   status : CanisterStatusType;
@@ -109,10 +110,25 @@ type OisyUser = record {
   pouh_verified : bool;
   updated_timestamp : nat64;
 };
+type Outpoint = record { txid : blob; vout : nat32 };
 type Result = variant { Ok; Err : AddUserCredentialError };
 type Result_1 = variant { Ok : UserProfile; Err : GetUserProfileError };
 type Result_2 = variant { Ok : MigrationReport; Err : text };
 type Result_3 = variant { Ok; Err : text };
+type Result_4 = variant {
+  Ok : SelectedUtxosFeeResponse;
+  Err : SelectedUtxosFeeError;
+};
+type SelectedUtxosFeeError = variant { InternalError : record { msg : text } };
+type SelectedUtxosFeeRequest = record {
+  network : BitcoinNetwork;
+  amount_satoshis : nat64;
+  source_address : text;
+};
+type SelectedUtxosFeeResponse = record {
+  fee_satoshis : nat64;
+  utxos : vec Utxo;
+};
 type Stats = record {
   user_profile_count : nat64;
   custom_token_count : nat64;
@@ -147,6 +163,7 @@ type UserToken = record {
   symbol : opt text;
 };
 type UserTokenId = record { chain_id : nat64; contract_address : text };
+type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
 service : (Arg) -> {
   add_user_credential : (AddUserCredentialRequest) -> (Result);
   bulk_up : (blob) -> ();
@@ -162,6 +179,7 @@ service : (Arg) -> {
   migration : () -> (opt MigrationReport) query;
   migration_stop_timer : () -> (Result_3);
   remove_user_token : (UserTokenId) -> ();
+  select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (Result_4);
   set_custom_token : (CustomToken) -> ();
   set_guards : (Guards) -> ();
   set_many_custom_tokens : (vec CustomToken) -> ();

--- a/src/backend/src/bitcoin_api.rs
+++ b/src/backend/src/bitcoin_api.rs
@@ -7,7 +7,7 @@ use ic_cdk::api::management_canister::bitcoin::{
 /// Returns the UTXOs of the given bitcoin address.
 ///
 /// NOTE: Relies on the `bitcoin_get_utxos` endpoint.
-/// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_utxos
+/// See [IC Interface](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_utxos)
 async fn get_utxos(
     network: BitcoinNetwork,
     address: String,
@@ -16,7 +16,7 @@ async fn get_utxos(
     let utxos_res = bitcoin_get_utxos(GetUtxosRequest {
         address,
         network,
-        filter: maybe_next_page.map(|next_page| UtxoFilter::Page(next_page)),
+        filter: maybe_next_page.map(UtxoFilter::Page),
     })
     .await
     .map_err(|err| err.1)?;

--- a/src/backend/src/bitcoin_api.rs
+++ b/src/backend/src/bitcoin_api.rs
@@ -1,0 +1,71 @@
+use ic_cdk::api::management_canister::bitcoin::{
+    bitcoin_get_current_fee_percentiles, bitcoin_get_utxos, BitcoinNetwork,
+    GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, MillisatoshiPerByte, Utxo,
+    UtxoFilter,
+};
+
+/// Returns the UTXOs of the given bitcoin address.
+///
+/// NOTE: Relies on the `bitcoin_get_utxos` endpoint.
+/// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_utxos
+async fn get_utxos(
+    network: BitcoinNetwork,
+    address: String,
+    maybe_next_page: Option<Vec<u8>>,
+) -> Result<GetUtxosResponse, String> {
+    let utxos_res = bitcoin_get_utxos(GetUtxosRequest {
+        address,
+        network,
+        filter: maybe_next_page.map(|next_page| UtxoFilter::Page(next_page)),
+    })
+    .await
+    .map_err(|err| err.1)?;
+
+    Ok(utxos_res.0)
+}
+/// Returns all the UTXOs of a specific address.
+/// API interface returns a paginated view of the utxos but we need to get them all.
+pub async fn get_all_utxos(network: BitcoinNetwork, address: String) -> Result<Vec<Utxo>, String> {
+    let mut utxos_response = get_utxos(network, address.clone(), None).await?;
+
+    let mut all_utxos: Vec<Utxo> = utxos_response.utxos;
+    let mut next_page: Option<Vec<u8>> = utxos_response.next_page;
+    while next_page.is_some() {
+        utxos_response = get_utxos(network, address.clone(), next_page).await?;
+        all_utxos.extend(utxos_response.utxos);
+        next_page = utxos_response.next_page;
+    }
+
+    Ok(all_utxos)
+}
+
+/// Returns the 100 fee percentiles measured in millisatoshi/byte.
+/// Percentiles are computed from the last 10,000 transactions (if available).
+///
+/// Relies on the `bitcoin_get_current_fee_percentiles` endpoint.
+/// See [Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_current_fee_percentiles)
+async fn get_current_fee_percentiles(
+    network: BitcoinNetwork,
+) -> Result<Vec<MillisatoshiPerByte>, String> {
+    let res = bitcoin_get_current_fee_percentiles(GetCurrentFeePercentilesRequest { network })
+        .await
+        .map_err(|err| err.1)?;
+
+    Ok(res.0)
+}
+
+/// Returns the 50th percentile for sending fees.
+pub async fn get_fee_per_byte(network: BitcoinNetwork) -> Result<u64, String> {
+    // Get fee percentiles from previous transactions to estimate our own fee.
+    let fee_percentiles = get_current_fee_percentiles(network).await?;
+
+    if fee_percentiles.is_empty() {
+        // There are no fee percentiles. This case can only happen on a regtest
+        // network where there are no non-coinbase transactions. In this case,
+        // we use a default of 2000 millisatoshis/byte (i.e. 2 satoshi/byte)
+        Ok(2000)
+    } else {
+        let middle = fee_percentiles.len() / 2;
+        Ok(fee_percentiles[middle])
+    }
+}

--- a/src/backend/src/bitcoin_utils.rs
+++ b/src/backend/src/bitcoin_utils.rs
@@ -10,7 +10,7 @@ use ic_cdk::api::management_canister::bitcoin::Utxo;
 /// Iteratively either:
 /// - Chooses the smallest UTXO larger than the target, or, that failing,
 /// - Chooses the largest UTXO smaller than the target.
-/// Until the target value has been reached.
+///   Until the target value has been reached.
 ///
 /// PROPERTY: `sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()`
 /// POSTCONDITION: `!solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target`

--- a/src/backend/src/bitcoin_utils.rs
+++ b/src/backend/src/bitcoin_utils.rs
@@ -6,6 +6,11 @@ use ic_cdk::api::management_canister::bitcoin::Utxo;
 /// the selected UTXOs from the available set.
 ///
 /// If there are no UTXOs matching the criteria, returns an empty vector.
+/// # Implementation
+/// Iteratively either:
+/// - Chooses the smallest UTXO larger than the target, or, that failing,
+/// - Chooses the largest UTXO smaller than the target.
+/// Until the target value has been reached.
 ///
 /// PROPERTY: `sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()`
 /// POSTCONDITION: `!solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target`
@@ -81,7 +86,7 @@ pub fn utxos_selection(
     input_utxos
 }
 
-/// Computes an estimate for the size of transaction (in vbytes) with the given number of inputs and outputs.
+/// Estimates the size of transaction (in vbytes) with the given number of inputs and outputs.
 // See [MediaWiki](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
 // for the transaction structure and
 // [Stack Exchange](https://bitcoin.stackexchange.com/questions/92587/calculate-transaction-fee-for-external-addresses-which-doesnt-belong-to-my-loca/92600#92600)
@@ -93,7 +98,7 @@ fn tx_vsize_estimate(input_count: u64, output_count: u64) -> u64 {
     input_count * INPUT_SIZE_VBYTES + output_count * OUTPUT_SIZE_VBYTES + TX_OVERHEAD_VBYTES
 }
 
-/// Computes an estimate for the transaction based on the number of utxos and outputs
+/// Estimates the transaction fee, in satoshi, based on the number of utxos and outputs
 ///
 /// Arguments:
 ///   * `selected_utxos_count` - the number of UTXOs used for the transaction.

--- a/src/backend/src/bitcoun_utils.rs
+++ b/src/backend/src/bitcoun_utils.rs
@@ -1,0 +1,252 @@
+use ic_cdk::api::management_canister::bitcoin::Utxo;
+
+/// Functions [inspired by ckBTC Minter](https://github.com/dfinity/ic/blob/285a5db07da50a4e350ec43bf3b488cc6fe36102/rs/bitcoin/ckbtc/minter/src/lib.rs#L1258)
+
+/// Selects a subset of UTXOs with the specified total target value and removes
+/// the selected UTXOs from the available set.
+///
+/// If there are no UTXOs matching the criteria, returns an empty vector.
+///
+/// PROPERTY: sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()
+/// POSTCONDITION: !solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target
+/// POSTCONDITION:  solution.is_empty() ⇒ available_utxos did not change.
+fn greedy(target: u64, available_utxos: &mut Vec<Utxo>) -> Vec<Utxo> {
+    let mut solution = vec![];
+    let mut goal = target;
+    while goal > 0 {
+        let utxo = match available_utxos.iter().max_by_key(|u| u.value) {
+            Some(max_utxo) if max_utxo.value < goal => max_utxo.clone(),
+            Some(_) => available_utxos
+                .iter()
+                .filter(|u| u.value >= goal)
+                .min_by_key(|u| u.value)
+                .cloned()
+                .expect("bug: there must be at least one UTXO matching the criteria"),
+            None => {
+                // Not enough available UTXOs to satisfy the request.
+                for u in solution {
+                    available_utxos.push(u);
+                }
+                return vec![];
+            }
+        };
+        goal = goal.saturating_sub(utxo.value);
+        available_utxos.retain(|x| *x != utxo);
+        solution.push(utxo);
+    }
+
+    debug_assert!(solution.is_empty() || solution.iter().map(|u| u.value).sum::<u64>() >= target);
+
+    solution
+}
+
+/// The threshold for the number of UTXOs under management before
+/// trying to match the number of outputs with the number of inputs
+/// when building transactions.
+const UTXOS_COUNT_THRESHOLD: usize = 1_000;
+
+/// The algorithm greedily selects the smallest UTXO(s) with a value that is at least the given `target` in a first step.
+///
+/// If the minter manages more than [UTXOS_COUNT_THRESHOLD], it will then try to match the number of inputs with the
+/// number of outputs + 1 (where the additional output corresponds to the change output).
+///
+/// If there are no UTXOs matching the criteria, returns an empty vector.
+///
+/// PROPERTY: sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()
+/// POSTCONDITION: !solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target
+/// POSTCONDITION:  solution.is_empty() ⇒ available_utxos did not change.
+pub fn utxos_selection(
+    target: u64,
+    available_utxos: &mut Vec<Utxo>,
+    output_count: usize,
+) -> Vec<Utxo> {
+    let mut input_utxos = greedy(target, available_utxos);
+
+    if input_utxos.is_empty() {
+        return vec![];
+    }
+
+    if available_utxos.len() > UTXOS_COUNT_THRESHOLD {
+        while input_utxos.len() < output_count + 1 {
+            if let Some(min_utxo) = available_utxos.iter().min_by_key(|u| u.value) {
+                let min_utxo = min_utxo.clone();
+                input_utxos.push(min_utxo.clone());
+                available_utxos.retain(|x| *x != min_utxo);
+            } else {
+                break;
+            }
+        }
+    }
+
+    input_utxos
+}
+
+/// Computes an estimate for the size of transaction (in vbytes) with the given number of inputs and outputs.
+// See [MediaWiki](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
+// for the transaction structure and
+// [Stack Exchange](https://bitcoin.stackexchange.com/questions/92587/calculate-transaction-fee-for-external-addresses-which-doesnt-belong-to-my-loca/92600#92600)
+// for transaction size estimate.
+const INPUT_SIZE_VBYTES: u64 = 68;
+const OUTPUT_SIZE_VBYTES: u64 = 31;
+const TX_OVERHEAD_VBYTES: u64 = 11;
+fn tx_vsize_estimate(input_count: u64, output_count: u64) -> u64 {
+    input_count * INPUT_SIZE_VBYTES + output_count * OUTPUT_SIZE_VBYTES + TX_OVERHEAD_VBYTES
+}
+
+/// Computes an estimate for the retrieve_btc fee.
+///
+/// Arguments:
+///   * `selected_utxos_count` - the count of UTXOs used for the transaction.
+///   * `median_fee_millisatoshi_per_vbyte` - the median network fee, in millisatoshi per vbyte.
+pub fn estimate_fee(
+    selected_utxos_count: u64,
+    median_fee_millisatoshi_per_vbyte: u64,
+    output_count: u64,
+) -> u64 {
+    tx_vsize_estimate(selected_utxos_count, output_count) * median_fee_millisatoshi_per_vbyte / 1000
+}
+
+#[cfg(test)]
+mod tests {
+    use ic_cdk::api::management_canister::bitcoin::Outpoint;
+
+    // Import the outer scope
+    use super::*;
+
+    fn assert_utxos_eq(result_utxos: Vec<Utxo>, expected_utxos: Vec<Utxo>) {
+        assert_eq!(result_utxos.len(), expected_utxos.len(),);
+
+        for (user, expected) in result_utxos.iter().zip(expected_utxos.iter()) {
+            assert_eq!(
+                user, expected,
+                "Result utxos differs from expected user: {:?} vs {:?}",
+                user, expected
+            );
+        }
+    }
+
+    #[test]
+    fn utxos_selection_returns_empty_vector() {
+        let mut empty_utxos: Vec<Utxo> = Vec::new();
+        assert_eq!(
+            utxos_selection(100_000_000u64, &mut empty_utxos, 2).len(),
+            0
+        );
+    }
+
+    #[test]
+    fn utxos_selection_returns_biggest_closest() {
+        let target = 100u64;
+
+        let utxo_50 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 0u32,
+            },
+            value: 50u64,
+            height: 32u32,
+        };
+        let utxo_120 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 1u32,
+            },
+            value: 120u64,
+            height: 33u32,
+        };
+        let utxo_200 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 2u32,
+            },
+            value: 200u64,
+            height: 34u32,
+        };
+        let mut available_utxos: Vec<Utxo> = vec![utxo_50, utxo_120.clone(), utxo_200];
+        let selected_utxos = utxos_selection(target, &mut available_utxos, 2);
+        assert_utxos_eq(selected_utxos, vec![utxo_120]);
+    }
+
+    #[test]
+    fn utxos_selection_returns_empty_vector_if_not_enough_funds() {
+        let target = 100u64;
+
+        let utxo_50 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 0u32,
+            },
+            value: 50u64,
+            height: 32u32,
+        };
+        let utxo_10 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 1u32,
+            },
+            value: 10u64,
+            height: 33u32,
+        };
+        let utxo_20 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 2u32,
+            },
+            value: 20u64,
+            height: 34u32,
+        };
+        let mut available_utxos: Vec<Utxo> = vec![utxo_50, utxo_10, utxo_20];
+        let selected_utxos = utxos_selection(target, &mut available_utxos, 2);
+        assert_eq!(selected_utxos.len(), 0);
+    }
+
+    #[test]
+    fn utxos_selection_returns_smaller_utxos() {
+        let target = 100u64;
+
+        let utxo_50 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 0u32,
+            },
+            value: 50u64,
+            height: 32u32,
+        };
+        let utxo_80 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 1u32,
+            },
+            value: 80u64,
+            height: 33u32,
+        };
+        let utxo_60 = Utxo {
+            outpoint: Outpoint {
+                txid: Vec::new(),
+                vout: 2u32,
+            },
+            value: 60u64,
+            height: 34u32,
+        };
+        let mut available_utxos: Vec<Utxo> = vec![utxo_50.clone(), utxo_80.clone(), utxo_60];
+        let selected_utxos = utxos_selection(target, &mut available_utxos, 2);
+        assert_utxos_eq(selected_utxos, vec![utxo_80, utxo_50]);
+    }
+
+    #[test]
+    fn estimate_fee_returns_overhead_if_no_input_nor_output() {
+        assert_eq!(estimate_fee(0, 1000, 0), TX_OVERHEAD_VBYTES);
+    }
+
+    #[test]
+    fn estimate_fee_incrases_per_input_count() {
+        assert_eq!(estimate_fee(2, 1000, 2), 209);
+        assert_eq!(estimate_fee(4, 1000, 2), 345);
+    }
+
+    #[test]
+    fn estimate_fee_incrases_per_output_count() {
+        assert_eq!(estimate_fee(2, 1000, 2), 209);
+        assert_eq!(estimate_fee(2, 1000, 4), 271);
+    }
+}

--- a/src/backend/src/bitcoun_utils.rs
+++ b/src/backend/src/bitcoun_utils.rs
@@ -7,9 +7,9 @@ use ic_cdk::api::management_canister::bitcoin::Utxo;
 ///
 /// If there are no UTXOs matching the criteria, returns an empty vector.
 ///
-/// PROPERTY: sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()
-/// POSTCONDITION: !solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target
-/// POSTCONDITION:  solution.is_empty() ⇒ available_utxos did not change.
+/// PROPERTY: `sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()`
+/// POSTCONDITION: `!solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target`
+/// POSTCONDITION:  `solution.is_empty() ⇒ available_utxos did not change.`
 fn greedy(target: u64, available_utxos: &mut Vec<Utxo>) -> Vec<Utxo> {
     let mut solution = vec![];
     let mut goal = target;
@@ -47,14 +47,14 @@ const UTXOS_COUNT_THRESHOLD: usize = 1_000;
 
 /// The algorithm greedily selects the smallest UTXO(s) with a value that is at least the given `target` in a first step.
 ///
-/// If the minter manages more than [UTXOS_COUNT_THRESHOLD], it will then try to match the number of inputs with the
+/// If the minter manages more than `UTXOS_COUNT_THRESHOLD`, it will then try to match the number of inputs with the
 /// number of outputs + 1 (where the additional output corresponds to the change output).
 ///
 /// If there are no UTXOs matching the criteria, returns an empty vector.
 ///
-/// PROPERTY: sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()
-/// POSTCONDITION: !solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target
-/// POSTCONDITION:  solution.is_empty() ⇒ available_utxos did not change.
+/// PROPERTY: `sum(u.value for u in available_set) ≥ target ⇒ !solution.is_empty()`
+/// POSTCONDITION: `!solution.is_empty() ⇒ sum(u.value for u in solution) ≥ target`
+/// POSTCONDITION:  `solution.is_empty() ⇒ available_utxos did not change.`
 pub fn utxos_selection(
     target: u64,
     available_utxos: &mut Vec<Utxo>,
@@ -93,11 +93,12 @@ fn tx_vsize_estimate(input_count: u64, output_count: u64) -> u64 {
     input_count * INPUT_SIZE_VBYTES + output_count * OUTPUT_SIZE_VBYTES + TX_OVERHEAD_VBYTES
 }
 
-/// Computes an estimate for the retrieve_btc fee.
+/// Computes an estimate for the transaction based on the number of utxos and outputs
 ///
 /// Arguments:
-///   * `selected_utxos_count` - the count of UTXOs used for the transaction.
+///   * `selected_utxos_count` - the number of UTXOs used for the transaction.
 ///   * `median_fee_millisatoshi_per_vbyte` - the median network fee, in millisatoshi per vbyte.
+///   * `output_count` - the number of outputs of the bitcoin transaction.
 pub fn estimate_fee(
     selected_utxos_count: u64,
     median_fee_millisatoshi_per_vbyte: u64,

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -286,7 +286,7 @@ fn list_custom_tokens() -> Vec<CustomToken> {
 }
 
 #[update(guard = "may_read_user_data")]
-async fn select_user_utxos_fee(
+async fn btc_select_user_utxos_fee(
     params: SelectedUtxosFeeRequest,
 ) -> Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError> {
     let all_utxos = bitcoin_api::get_all_utxos(params.network, params.source_address)

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -299,7 +299,7 @@ async fn select_user_utxos_fee(
     // We support sending to one destination only.
     // Therefore, the outputs are the destination and the source address for the change.
     let output_count = 2;
-    let mut available_utxos = all_utxos.to_vec();
+    let mut available_utxos = all_utxos.clone();
     let selected_utxos =
         bitcoun_utils::utxos_selection(params.amount_satoshis, &mut available_utxos, output_count);
     let fee_satoshis = estimate_fee(

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -302,6 +302,16 @@ async fn select_user_utxos_fee(
     let mut available_utxos = all_utxos.clone();
     let selected_utxos =
         bitcoun_utils::utxos_selection(params.amount_satoshis, &mut available_utxos, output_count);
+
+    // Fee calculation might still take into account default tx size and expected output.
+    // But if there are no selcted utxos, no tx is possible. Therefore, no fee should be present.
+    if selected_utxos.is_empty() {
+        return Ok(SelectedUtxosFeeResponse {
+            utxos: selected_utxos,
+            fee_satoshis: 0,
+        });
+    }
+
     let fee_satoshis = estimate_fee(
         selected_utxos.len() as u64,
         median_fee_millisatoshi_per_vbyte,

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::assertions::{assert_token_enabled_is_some, assert_token_symbol_length};
 use crate::guards::{caller_is_allowed, may_read_user_data, may_write_user_data};
 use crate::token::{add_to_user_token, remove_from_user_token};
+use bitcoun_utils::estimate_fee;
 use candid::Principal;
 use config::find_credential_config;
 use ethers_core::abi::ethereum_types::H160;
@@ -18,6 +19,9 @@ use serde_bytes::ByteBuf;
 use shared::http::{HttpRequest, HttpResponse};
 use shared::metrics::get_metrics;
 use shared::std_canister_status;
+use shared::types::bitcoin::{
+    SelectedUtxosFeeError, SelectedUtxosFeeRequest, SelectedUtxosFeeResponse,
+};
 use shared::types::custom_token::{CustomToken, CustomTokenId};
 use shared::types::token::{UserToken, UserTokenId};
 use shared::types::user_profile::{
@@ -37,6 +41,8 @@ use user_profile::{add_credential, create_profile, find_profile};
 use user_profile_model::UserProfileModel;
 
 mod assertions;
+mod bitcoin_api;
+mod bitcoun_utils;
 mod config;
 mod guards;
 mod impls;
@@ -277,6 +283,35 @@ fn set_many_custom_tokens(tokens: Vec<CustomToken>) {
 fn list_custom_tokens() -> Vec<CustomToken> {
     let stored_principal = StoredPrincipal(ic_cdk::caller());
     read_state(|s| s.custom_token.get(&stored_principal).unwrap_or_default().0)
+}
+
+#[update(guard = "may_read_user_data")]
+async fn select_user_utxos_fee(
+    params: SelectedUtxosFeeRequest,
+) -> Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError> {
+    let all_utxos = bitcoin_api::get_all_utxos(params.network, params.source_address)
+        .await
+        .map_err(|msg| SelectedUtxosFeeError::InternalError { msg })?;
+
+    let median_fee_millisatoshi_per_vbyte = bitcoin_api::get_fee_per_byte(params.network)
+        .await
+        .map_err(|msg| SelectedUtxosFeeError::InternalError { msg })?;
+    // We support sending to one destination only.
+    // Therefore, the outputs are the destination and the source address for the change.
+    let output_count = 2;
+    let mut available_utxos = all_utxos.to_vec();
+    let selected_utxos =
+        bitcoun_utils::utxos_selection(params.amount_satoshis, &mut available_utxos, output_count);
+    let fee_satoshis = estimate_fee(
+        selected_utxos.len() as u64,
+        median_fee_millisatoshi_per_vbyte,
+        output_count as u64,
+    );
+
+    Ok(SelectedUtxosFeeResponse {
+        utxos: selected_utxos,
+        fee_satoshis,
+    })
 }
 
 #[update(guard = "may_write_user_data")]

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::assertions::{assert_token_enabled_is_some, assert_token_symbol_length};
 use crate::guards::{caller_is_allowed, may_read_user_data, may_write_user_data};
 use crate::token::{add_to_user_token, remove_from_user_token};
-use bitcoun_utils::estimate_fee;
+use bitcoin_utils::estimate_fee;
 use candid::Principal;
 use config::find_credential_config;
 use ethers_core::abi::ethereum_types::H160;
@@ -42,7 +42,7 @@ use user_profile_model::UserProfileModel;
 
 mod assertions;
 mod bitcoin_api;
-mod bitcoun_utils;
+mod bitcoin_utils;
 mod config;
 mod guards;
 mod impls;
@@ -301,7 +301,7 @@ async fn btc_select_user_utxos_fee(
     let output_count = 2;
     let mut available_utxos = all_utxos.clone();
     let selected_utxos =
-        bitcoun_utils::utxos_selection(params.amount_satoshis, &mut available_utxos, output_count);
+        bitcoin_utils::utxos_selection(params.amount_satoshis, &mut available_utxos, output_count);
 
     // Fee calculation might still take into account default tx size and expected output.
     // But if there are no selcted utxos, no tx is possible. Therefore, no fee should be present.

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -10,7 +10,7 @@ use crate::utils::{
 };
 
 #[test]
-fn test_select_user_utxos_fee() {
+fn test_select_user_utxos_fee_returns_zero_when_user_has_insufficient_funds() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -10,7 +10,6 @@ use crate::utils::{
 };
 
 #[test]
-#[ignore]
 fn test_select_user_utxos_fee() {
     let pic_setup = setup();
 
@@ -18,7 +17,7 @@ fn test_select_user_utxos_fee() {
 
     let request = SelectedUtxosFeeRequest {
         amount_satoshis: 100_000_000u64,
-        source_address: "bcrt1qpc7lq5vpchqjhd7q6ql6j2xqx8z3fr8nh880kk".to_string(),
+        source_address: "bcrt1qpg7udjvq7gx2fp480pgt4hnhj3qc4nhrkstc33".to_string(),
         network: BitcoinNetwork::Regtest,
     };
     let response = pic_setup.update::<Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError>>(

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -22,7 +22,7 @@ fn test_select_user_utxos_fee_returns_zero_when_user_has_insufficient_funds() {
     };
     let response = pic_setup.update::<Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError>>(
         caller,
-        "select_user_utxos_fee",
+        "btc_select_user_utxos_fee",
         request,
     );
 

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -1,0 +1,37 @@
+use candid::Principal;
+use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+use shared::types::bitcoin::{
+    SelectedUtxosFeeError, SelectedUtxosFeeRequest, SelectedUtxosFeeResponse,
+};
+
+use crate::utils::{
+    mock::CALLER,
+    pocketic::{setup, PicCanisterTrait},
+};
+
+#[test]
+fn test_select_user_utxos_fee() {
+    let pic_setup = setup();
+
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let request = SelectedUtxosFeeRequest {
+        amount_satoshis: 100_000_000u64,
+        source_address: "bcrt1qpc7lq5vpchqjhd7q6ql6j2xqx8z3fr8nh880kk".to_string(),
+        network: BitcoinNetwork::Regtest,
+    };
+    let response = pic_setup.update::<Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError>>(
+        caller,
+        "select_user_utxos_fee",
+        request,
+    );
+
+    assert!(response.is_ok());
+
+    let response = response
+        .expect("Call failed")
+        .expect("Request was not successful");
+
+    assert_eq!(response.utxos.len(), 0);
+    assert_eq!(response.fee_satoshis, 0);
+}

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -10,6 +10,7 @@ use crate::utils::{
 };
 
 #[test]
+#[ignore]
 fn test_select_user_utxos_fee() {
     let pic_setup = setup();
 

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod bitcoin;
 mod config;
 mod custom_token;
 mod guard;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -112,13 +112,13 @@ type OisyUser = record {
 };
 type Outpoint = record { txid : blob; vout : nat32 };
 type Result = variant { Ok; Err : AddUserCredentialError };
-type Result_1 = variant { Ok : UserProfile; Err : GetUserProfileError };
-type Result_2 = variant { Ok : MigrationReport; Err : text };
-type Result_3 = variant { Ok; Err : text };
-type Result_4 = variant {
+type Result_1 = variant {
   Ok : SelectedUtxosFeeResponse;
   Err : SelectedUtxosFeeError;
 };
+type Result_2 = variant { Ok : UserProfile; Err : GetUserProfileError };
+type Result_3 = variant { Ok : MigrationReport; Err : text };
+type Result_4 = variant { Ok; Err : text };
 type SelectedUtxosFeeError = variant { InternalError : record { msg : text } };
 type SelectedUtxosFeeRequest = record {
   network : BitcoinNetwork;
@@ -166,20 +166,20 @@ type UserTokenId = record { chain_id : nat64; contract_address : text };
 type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
 service : (Arg) -> {
   add_user_credential : (AddUserCredentialRequest) -> (Result);
+  btc_select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (Result_1);
   bulk_up : (blob) -> ();
   config : () -> (Config) query;
   create_user_profile : () -> (UserProfile);
   get_canister_status : () -> (CanisterStatusResultV2);
-  get_user_profile : () -> (Result_1) query;
+  get_user_profile : () -> (Result_2) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   list_custom_tokens : () -> (vec CustomToken) query;
   list_user_tokens : () -> (vec UserToken) query;
   list_users : (ListUsersRequest) -> (ListUsersResponse) query;
-  migrate_user_data_to : (principal) -> (Result_2);
+  migrate_user_data_to : (principal) -> (Result_3);
   migration : () -> (opt MigrationReport) query;
-  migration_stop_timer : () -> (Result_3);
+  migration_stop_timer : () -> (Result_4);
   remove_user_token : (UserTokenId) -> ();
-  select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (Result_4);
   set_custom_token : (CustomToken) -> ();
   set_guards : (Guards) -> ();
   set_many_custom_tokens : (vec CustomToken) -> ();

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -13,6 +13,7 @@ type AddUserCredentialRequest = record {
 type ApiEnabled = variant { ReadOnly; Enabled; Disabled };
 type Arg = variant { Upgrade; Init : InitArg };
 type ArgumentValue = variant { Int : int32; String : text };
+type BitcoinNetwork = variant { mainnet; regtest; testnet };
 type CanisterStatusResultV2 = record {
   controller : principal;
   status : CanisterStatusType;
@@ -109,10 +110,25 @@ type OisyUser = record {
   pouh_verified : bool;
   updated_timestamp : nat64;
 };
+type Outpoint = record { txid : blob; vout : nat32 };
 type Result = variant { Ok; Err : AddUserCredentialError };
 type Result_1 = variant { Ok : UserProfile; Err : GetUserProfileError };
 type Result_2 = variant { Ok : MigrationReport; Err : text };
 type Result_3 = variant { Ok; Err : text };
+type Result_4 = variant {
+  Ok : SelectedUtxosFeeResponse;
+  Err : SelectedUtxosFeeError;
+};
+type SelectedUtxosFeeError = variant { InternalError : record { msg : text } };
+type SelectedUtxosFeeRequest = record {
+  network : BitcoinNetwork;
+  amount_satoshis : nat64;
+  source_address : text;
+};
+type SelectedUtxosFeeResponse = record {
+  fee_satoshis : nat64;
+  utxos : vec Utxo;
+};
 type Stats = record {
   user_profile_count : nat64;
   custom_token_count : nat64;
@@ -147,6 +163,7 @@ type UserToken = record {
   symbol : opt text;
 };
 type UserTokenId = record { chain_id : nat64; contract_address : text };
+type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
 service : (Arg) -> {
   add_user_credential : (AddUserCredentialRequest) -> (Result);
   bulk_up : (blob) -> ();
@@ -162,6 +179,7 @@ service : (Arg) -> {
   migration : () -> (opt MigrationReport) query;
   migration_stop_timer : () -> (Result_3);
   remove_user_token : (UserTokenId) -> ();
+  select_user_utxos_fee : (SelectedUtxosFeeRequest) -> (Result_4);
   set_custom_token : (CustomToken) -> ();
   set_guards : (Guards) -> ();
   set_many_custom_tokens : (vec CustomToken) -> ();

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -127,10 +127,10 @@ export interface Outpoint {
 	vout: number;
 }
 export type Result = { Ok: null } | { Err: AddUserCredentialError };
-export type Result_1 = { Ok: UserProfile } | { Err: GetUserProfileError };
-export type Result_2 = { Ok: MigrationReport } | { Err: string };
-export type Result_3 = { Ok: null } | { Err: string };
-export type Result_4 = { Ok: SelectedUtxosFeeResponse } | { Err: SelectedUtxosFeeError };
+export type Result_1 = { Ok: SelectedUtxosFeeResponse } | { Err: SelectedUtxosFeeError };
+export type Result_2 = { Ok: UserProfile } | { Err: GetUserProfileError };
+export type Result_3 = { Ok: MigrationReport } | { Err: string };
+export type Result_4 = { Ok: null } | { Err: string };
 export type SelectedUtxosFeeError = { InternalError: { msg: string } };
 export interface SelectedUtxosFeeRequest {
 	network: BitcoinNetwork;
@@ -185,20 +185,20 @@ export interface Utxo {
 }
 export interface _SERVICE {
 	add_user_credential: ActorMethod<[AddUserCredentialRequest], Result>;
+	btc_select_user_utxos_fee: ActorMethod<[SelectedUtxosFeeRequest], Result_1>;
 	bulk_up: ActorMethod<[Uint8Array | number[]], undefined>;
 	config: ActorMethod<[], Config>;
 	create_user_profile: ActorMethod<[], UserProfile>;
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
-	get_user_profile: ActorMethod<[], Result_1>;
+	get_user_profile: ActorMethod<[], Result_2>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
 	list_user_tokens: ActorMethod<[], Array<UserToken>>;
 	list_users: ActorMethod<[ListUsersRequest], ListUsersResponse>;
-	migrate_user_data_to: ActorMethod<[Principal], Result_2>;
+	migrate_user_data_to: ActorMethod<[Principal], Result_3>;
 	migration: ActorMethod<[], [] | [MigrationReport]>;
-	migration_stop_timer: ActorMethod<[], Result_3>;
+	migration_stop_timer: ActorMethod<[], Result_4>;
 	remove_user_token: ActorMethod<[UserTokenId], undefined>;
-	select_user_utxos_fee: ActorMethod<[SelectedUtxosFeeRequest], Result_4>;
 	set_custom_token: ActorMethod<[CustomToken], undefined>;
 	set_guards: ActorMethod<[Guards], undefined>;
 	set_many_custom_tokens: ActorMethod<[Array<CustomToken>], undefined>;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -16,6 +16,7 @@ export interface AddUserCredentialRequest {
 export type ApiEnabled = { ReadOnly: null } | { Enabled: null } | { Disabled: null };
 export type Arg = { Upgrade: null } | { Init: InitArg };
 export type ArgumentValue = { Int: number } | { String: string };
+export type BitcoinNetwork = { mainnet: null } | { regtest: null } | { testnet: null };
 export interface CanisterStatusResultV2 {
 	controller: Principal;
 	status: CanisterStatusType;
@@ -121,10 +122,25 @@ export interface OisyUser {
 	pouh_verified: boolean;
 	updated_timestamp: bigint;
 }
+export interface Outpoint {
+	txid: Uint8Array | number[];
+	vout: number;
+}
 export type Result = { Ok: null } | { Err: AddUserCredentialError };
 export type Result_1 = { Ok: UserProfile } | { Err: GetUserProfileError };
 export type Result_2 = { Ok: MigrationReport } | { Err: string };
 export type Result_3 = { Ok: null } | { Err: string };
+export type Result_4 = { Ok: SelectedUtxosFeeResponse } | { Err: SelectedUtxosFeeError };
+export type SelectedUtxosFeeError = { InternalError: { msg: string } };
+export interface SelectedUtxosFeeRequest {
+	network: BitcoinNetwork;
+	amount_satoshis: bigint;
+	source_address: string;
+}
+export interface SelectedUtxosFeeResponse {
+	fee_satoshis: bigint;
+	utxos: Array<Utxo>;
+}
 export interface Stats {
 	user_profile_count: bigint;
 	custom_token_count: bigint;
@@ -162,6 +178,11 @@ export interface UserTokenId {
 	chain_id: bigint;
 	contract_address: string;
 }
+export interface Utxo {
+	height: number;
+	value: bigint;
+	outpoint: Outpoint;
+}
 export interface _SERVICE {
 	add_user_credential: ActorMethod<[AddUserCredentialRequest], Result>;
 	bulk_up: ActorMethod<[Uint8Array | number[]], undefined>;
@@ -177,6 +198,7 @@ export interface _SERVICE {
 	migration: ActorMethod<[], [] | [MigrationReport]>;
 	migration_stop_timer: ActorMethod<[], Result_3>;
 	remove_user_token: ActorMethod<[UserTokenId], undefined>;
+	select_user_utxos_fee: ActorMethod<[SelectedUtxosFeeRequest], Result_4>;
 	set_custom_token: ActorMethod<[CustomToken], undefined>;
 	set_guards: ActorMethod<[Guards], undefined>;
 	set_many_custom_tokens: ActorMethod<[Array<CustomToken>], undefined>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -46,6 +46,36 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Null,
 		Err: AddUserCredentialError
 	});
+	const BitcoinNetwork = IDL.Variant({
+		mainnet: IDL.Null,
+		regtest: IDL.Null,
+		testnet: IDL.Null
+	});
+	const SelectedUtxosFeeRequest = IDL.Record({
+		network: BitcoinNetwork,
+		amount_satoshis: IDL.Nat64,
+		source_address: IDL.Text
+	});
+	const Outpoint = IDL.Record({
+		txid: IDL.Vec(IDL.Nat8),
+		vout: IDL.Nat32
+	});
+	const Utxo = IDL.Record({
+		height: IDL.Nat32,
+		value: IDL.Nat64,
+		outpoint: Outpoint
+	});
+	const SelectedUtxosFeeResponse = IDL.Record({
+		fee_satoshis: IDL.Nat64,
+		utxos: IDL.Vec(Utxo)
+	});
+	const SelectedUtxosFeeError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text })
+	});
+	const Result_1 = IDL.Variant({
+		Ok: SelectedUtxosFeeResponse,
+		Err: SelectedUtxosFeeError
+	});
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
@@ -88,7 +118,7 @@ export const idlFactory = ({ IDL }) => {
 		module_hash: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const GetUserProfileError = IDL.Variant({ NotFound: IDL.Null });
-	const Result_1 = IDL.Variant({
+	const Result_2 = IDL.Variant({
 		Ok: UserProfile,
 		Err: GetUserProfileError
 	});
@@ -169,58 +199,28 @@ export const idlFactory = ({ IDL }) => {
 		to: IDL.Principal,
 		progress: MigrationProgress
 	});
-	const Result_2 = IDL.Variant({ Ok: MigrationReport, Err: IDL.Text });
-	const Result_3 = IDL.Variant({ Ok: IDL.Null, Err: IDL.Text });
+	const Result_3 = IDL.Variant({ Ok: MigrationReport, Err: IDL.Text });
+	const Result_4 = IDL.Variant({ Ok: IDL.Null, Err: IDL.Text });
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
 	});
-	const BitcoinNetwork = IDL.Variant({
-		mainnet: IDL.Null,
-		regtest: IDL.Null,
-		testnet: IDL.Null
-	});
-	const SelectedUtxosFeeRequest = IDL.Record({
-		network: BitcoinNetwork,
-		amount_satoshis: IDL.Nat64,
-		source_address: IDL.Text
-	});
-	const Outpoint = IDL.Record({
-		txid: IDL.Vec(IDL.Nat8),
-		vout: IDL.Nat32
-	});
-	const Utxo = IDL.Record({
-		height: IDL.Nat32,
-		value: IDL.Nat64,
-		outpoint: Outpoint
-	});
-	const SelectedUtxosFeeResponse = IDL.Record({
-		fee_satoshis: IDL.Nat64,
-		utxos: IDL.Vec(Utxo)
-	});
-	const SelectedUtxosFeeError = IDL.Variant({
-		InternalError: IDL.Record({ msg: IDL.Text })
-	});
-	const Result_4 = IDL.Variant({
-		Ok: SelectedUtxosFeeResponse,
-		Err: SelectedUtxosFeeError
-	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
+		btc_select_user_utxos_fee: IDL.Func([SelectedUtxosFeeRequest], [Result_1], []),
 		bulk_up: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
 		config: IDL.Func([], [Config]),
 		create_user_profile: IDL.Func([], [UserProfile], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
-		get_user_profile: IDL.Func([], [Result_1]),
+		get_user_profile: IDL.Func([], [Result_2]),
 		http_request: IDL.Func([HttpRequest], [HttpResponse]),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)]),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)]),
 		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse]),
-		migrate_user_data_to: IDL.Func([IDL.Principal], [Result_2], []),
+		migrate_user_data_to: IDL.Func([IDL.Principal], [Result_3], []),
 		migration: IDL.Func([], [IDL.Opt(MigrationReport)]),
-		migration_stop_timer: IDL.Func([], [Result_3], []),
+		migration_stop_timer: IDL.Func([], [Result_4], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
-		select_user_utxos_fee: IDL.Func([SelectedUtxosFeeRequest], [Result_4], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
 		set_guards: IDL.Func([Guards], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -175,6 +175,36 @@ export const idlFactory = ({ IDL }) => {
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
 	});
+	const BitcoinNetwork = IDL.Variant({
+		mainnet: IDL.Null,
+		regtest: IDL.Null,
+		testnet: IDL.Null
+	});
+	const SelectedUtxosFeeRequest = IDL.Record({
+		network: BitcoinNetwork,
+		amount_satoshis: IDL.Nat64,
+		source_address: IDL.Text
+	});
+	const Outpoint = IDL.Record({
+		txid: IDL.Vec(IDL.Nat8),
+		vout: IDL.Nat32
+	});
+	const Utxo = IDL.Record({
+		height: IDL.Nat32,
+		value: IDL.Nat64,
+		outpoint: Outpoint
+	});
+	const SelectedUtxosFeeResponse = IDL.Record({
+		fee_satoshis: IDL.Nat64,
+		utxos: IDL.Vec(Utxo)
+	});
+	const SelectedUtxosFeeError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text })
+	});
+	const Result_4 = IDL.Variant({
+		Ok: SelectedUtxosFeeResponse,
+		Err: SelectedUtxosFeeError
+	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
 		bulk_up: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
@@ -190,6 +220,7 @@ export const idlFactory = ({ IDL }) => {
 		migration: IDL.Func([], [IDL.Opt(MigrationReport)]),
 		migration_stop_timer: IDL.Func([], [Result_3], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
+		select_user_utxos_fee: IDL.Func([SelectedUtxosFeeRequest], [Result_4], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
 		set_guards: IDL.Func([Guards], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -46,6 +46,36 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Null,
 		Err: AddUserCredentialError
 	});
+	const BitcoinNetwork = IDL.Variant({
+		mainnet: IDL.Null,
+		regtest: IDL.Null,
+		testnet: IDL.Null
+	});
+	const SelectedUtxosFeeRequest = IDL.Record({
+		network: BitcoinNetwork,
+		amount_satoshis: IDL.Nat64,
+		source_address: IDL.Text
+	});
+	const Outpoint = IDL.Record({
+		txid: IDL.Vec(IDL.Nat8),
+		vout: IDL.Nat32
+	});
+	const Utxo = IDL.Record({
+		height: IDL.Nat32,
+		value: IDL.Nat64,
+		outpoint: Outpoint
+	});
+	const SelectedUtxosFeeResponse = IDL.Record({
+		fee_satoshis: IDL.Nat64,
+		utxos: IDL.Vec(Utxo)
+	});
+	const SelectedUtxosFeeError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text })
+	});
+	const Result_1 = IDL.Variant({
+		Ok: SelectedUtxosFeeResponse,
+		Err: SelectedUtxosFeeError
+	});
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
@@ -88,7 +118,7 @@ export const idlFactory = ({ IDL }) => {
 		module_hash: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const GetUserProfileError = IDL.Variant({ NotFound: IDL.Null });
-	const Result_1 = IDL.Variant({
+	const Result_2 = IDL.Variant({
 		Ok: UserProfile,
 		Err: GetUserProfileError
 	});
@@ -169,58 +199,28 @@ export const idlFactory = ({ IDL }) => {
 		to: IDL.Principal,
 		progress: MigrationProgress
 	});
-	const Result_2 = IDL.Variant({ Ok: MigrationReport, Err: IDL.Text });
-	const Result_3 = IDL.Variant({ Ok: IDL.Null, Err: IDL.Text });
+	const Result_3 = IDL.Variant({ Ok: MigrationReport, Err: IDL.Text });
+	const Result_4 = IDL.Variant({ Ok: IDL.Null, Err: IDL.Text });
 	const UserTokenId = IDL.Record({
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
 	});
-	const BitcoinNetwork = IDL.Variant({
-		mainnet: IDL.Null,
-		regtest: IDL.Null,
-		testnet: IDL.Null
-	});
-	const SelectedUtxosFeeRequest = IDL.Record({
-		network: BitcoinNetwork,
-		amount_satoshis: IDL.Nat64,
-		source_address: IDL.Text
-	});
-	const Outpoint = IDL.Record({
-		txid: IDL.Vec(IDL.Nat8),
-		vout: IDL.Nat32
-	});
-	const Utxo = IDL.Record({
-		height: IDL.Nat32,
-		value: IDL.Nat64,
-		outpoint: Outpoint
-	});
-	const SelectedUtxosFeeResponse = IDL.Record({
-		fee_satoshis: IDL.Nat64,
-		utxos: IDL.Vec(Utxo)
-	});
-	const SelectedUtxosFeeError = IDL.Variant({
-		InternalError: IDL.Record({ msg: IDL.Text })
-	});
-	const Result_4 = IDL.Variant({
-		Ok: SelectedUtxosFeeResponse,
-		Err: SelectedUtxosFeeError
-	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
+		btc_select_user_utxos_fee: IDL.Func([SelectedUtxosFeeRequest], [Result_1], []),
 		bulk_up: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
 		config: IDL.Func([], [Config], ['query']),
 		create_user_profile: IDL.Func([], [UserProfile], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
-		get_user_profile: IDL.Func([], [Result_1], ['query']),
+		get_user_profile: IDL.Func([], [Result_2], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], ['query']),
 		list_user_tokens: IDL.Func([], [IDL.Vec(UserToken)], ['query']),
 		list_users: IDL.Func([ListUsersRequest], [ListUsersResponse], ['query']),
-		migrate_user_data_to: IDL.Func([IDL.Principal], [Result_2], []),
+		migrate_user_data_to: IDL.Func([IDL.Principal], [Result_3], []),
 		migration: IDL.Func([], [IDL.Opt(MigrationReport)], ['query']),
-		migration_stop_timer: IDL.Func([], [Result_3], []),
+		migration_stop_timer: IDL.Func([], [Result_4], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
-		select_user_utxos_fee: IDL.Func([SelectedUtxosFeeRequest], [Result_4], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
 		set_guards: IDL.Func([Guards], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -175,6 +175,36 @@ export const idlFactory = ({ IDL }) => {
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
 	});
+	const BitcoinNetwork = IDL.Variant({
+		mainnet: IDL.Null,
+		regtest: IDL.Null,
+		testnet: IDL.Null
+	});
+	const SelectedUtxosFeeRequest = IDL.Record({
+		network: BitcoinNetwork,
+		amount_satoshis: IDL.Nat64,
+		source_address: IDL.Text
+	});
+	const Outpoint = IDL.Record({
+		txid: IDL.Vec(IDL.Nat8),
+		vout: IDL.Nat32
+	});
+	const Utxo = IDL.Record({
+		height: IDL.Nat32,
+		value: IDL.Nat64,
+		outpoint: Outpoint
+	});
+	const SelectedUtxosFeeResponse = IDL.Record({
+		fee_satoshis: IDL.Nat64,
+		utxos: IDL.Vec(Utxo)
+	});
+	const SelectedUtxosFeeError = IDL.Variant({
+		InternalError: IDL.Record({ msg: IDL.Text })
+	});
+	const Result_4 = IDL.Variant({
+		Ok: SelectedUtxosFeeResponse,
+		Err: SelectedUtxosFeeError
+	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
 		bulk_up: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
@@ -190,6 +220,7 @@ export const idlFactory = ({ IDL }) => {
 		migration: IDL.Func([], [IDL.Opt(MigrationReport)], ['query']),
 		migration_stop_timer: IDL.Func([], [Result_3], []),
 		remove_user_token: IDL.Func([UserTokenId], [], []),
+		select_user_utxos_fee: IDL.Func([SelectedUtxosFeeRequest], [Result_4], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
 		set_guards: IDL.Func([Guards], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -160,6 +160,30 @@ pub mod custom_token {
     }
 }
 
+pub mod bitcoin {
+    use candid::CandidType;
+    use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};
+    use serde::Deserialize;
+
+    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+    pub struct SelectedUtxosFeeRequest {
+        pub amount_satoshis: u64,
+        pub source_address: String,
+        pub network: BitcoinNetwork,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+    pub struct SelectedUtxosFeeResponse {
+        pub utxos: Vec<Utxo>,
+        pub fee_satoshis: u64,
+    }
+
+    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+    pub enum SelectedUtxosFeeError {
+        InternalError { msg: String },
+    }
+}
+
 /// Types specifics to the user profile.
 pub mod user_profile {
     use super::{CredentialType, Timestamp};


### PR DESCRIPTION
# Motivation

To make a bitcoin transaction utxos and a fee must be selected.

In this PR, I introduce an endpoint that calculates the utxos for a transaction with a specific amount and then the fee related to it.

# Changes

## Manual changes

* New bitcoin_api module with exposed functions: `get_all_utxos` and `get_fee_per_byte`.
* New bitcoin_utils module with expose functions: `estimate_fee` and `utxos_selection`. These utils are based on the ckBTC minter's code.
* New endpoint `btc_select_user_utxos_fee` that uses helpers to calculate and return utxos and fees.
* New endpoint types.

## Automatic changes

* Changes in `backend.did` with `./scripts.did.sh`.
* Changes in `src/declarations/backend/*` with `npm run generate`.

# Tests

* Unit tests for the bitcoin_utils.
* Dummy integration test for the new endpoint. Pocket-ic doesn't support (yet) bitcoin.
