### PR TITLE
feat(frontend): BTC transaction stores

### DIFF
--- a/src/frontend/src/btc/derived/btc-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/btc-transactions.derived.ts
@@ -1,0 +1,20 @@
+import { btcTransactionsStore, type BtcTransactionsData } from '$btc/stores/btc-transactions.store';
+import { tokenWithFallback } from '$lib/derived/token.derived';
+import { nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+// TODO: decide how BTC transactions should be sorted and apply it here
+export const sortedTransactions: Readable<BtcTransactionsData> = derived(
+	[btcTransactionsStore, tokenWithFallback],
+	([$transactionsStore, $token]) => $transactionsStore?.[$token.id] ?? []
+);
+
+export const transactionsInitialized: Readable<boolean> = derived(
+	[btcTransactionsStore, tokenWithFallback],
+	([$transactionsStore, { id: $tokenId }]) => nonNullish($transactionsStore?.[$tokenId])
+);
+
+export const transactionsNotInitialized: Readable<boolean> = derived(
+	[transactionsInitialized],
+	([$transactionsInitialized]) => !$transactionsInitialized
+);

--- a/src/frontend/src/btc/stores/btc-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-transactions.store.ts
@@ -1,0 +1,41 @@
+import type { BtcTransactionUi } from '$btc/types/btc';
+import { initCertifiedStore, type CertifiedStore } from '$lib/stores/certified.store';
+import type { CertifiedData } from '$lib/types/store';
+import type { TokenId } from '$lib/types/token';
+import { nonNullish } from '@dfinity/utils';
+
+export type BtcCertifiedTransaction = CertifiedData<BtcTransactionUi>;
+
+export type BtcTransactionsData = BtcCertifiedTransaction[];
+
+export interface BtcTransactionsStore extends CertifiedStore<BtcTransactionsData> {
+	prepend: (params: { tokenId: TokenId; transactions: BtcCertifiedTransaction[] }) => void;
+}
+
+const initBtcTransactionsStore = (): BtcTransactionsStore => {
+	const { subscribe, update, reset } = initCertifiedStore<BtcTransactionsData>();
+
+	return {
+		prepend: ({
+			tokenId,
+			transactions
+		}: {
+			tokenId: TokenId;
+			transactions: BtcCertifiedTransaction[];
+		}) =>
+			update((state) => ({
+				...(nonNullish(state) && state),
+				[tokenId]: [
+					...transactions,
+					...((state ?? {})[tokenId] ?? []).filter(
+						({ data: { hash } }) =>
+							!transactions.some(({ data: { hash: txHash } }) => txHash === hash)
+					)
+				]
+			})),
+		reset,
+		subscribe
+	};
+};
+
+export const btcTransactionsStore = initBtcTransactionsStore();

--- a/src/frontend/src/btc/stores/btc-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-transactions.store.ts
@@ -1,41 +1,4 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
-import { initCertifiedStore, type CertifiedStore } from '$lib/stores/certified.store';
-import type { CertifiedData } from '$lib/types/store';
-import type { TokenId } from '$lib/types/token';
-import { nonNullish } from '@dfinity/utils';
+import { initTransactionsStore } from '$lib/stores/transactions.store';
 
-export type BtcCertifiedTransaction = CertifiedData<BtcTransactionUi>;
-
-export type BtcTransactionsData = BtcCertifiedTransaction[];
-
-export interface BtcTransactionsStore extends CertifiedStore<BtcTransactionsData> {
-	prepend: (params: { tokenId: TokenId; transactions: BtcCertifiedTransaction[] }) => void;
-}
-
-const initBtcTransactionsStore = (): BtcTransactionsStore => {
-	const { subscribe, update, reset } = initCertifiedStore<BtcTransactionsData>();
-
-	return {
-		prepend: ({
-			tokenId,
-			transactions
-		}: {
-			tokenId: TokenId;
-			transactions: BtcCertifiedTransaction[];
-		}) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: [
-					...transactions,
-					...((state ?? {})[tokenId] ?? []).filter(
-						({ data: { hash } }) =>
-							!transactions.some(({ data: { hash: txHash } }) => txHash === hash)
-					)
-				]
-			})),
-		reset,
-		subscribe
-	};
-};
-
-export const btcTransactionsStore = initBtcTransactionsStore();
+export const btcTransactionsStore = initTransactionsStore<BtcTransactionUi>();


### PR DESCRIPTION
# Motivation

Add BTC transaction stores. It will be later extended with additional methods, similar to other related stores (e.g. `cleanUp`).
