### PR TITLE
feat(frontend): load BTC transactions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -154,6 +154,17 @@ VITE_NETWORK_BITCOIN_ENABLED=true
 VITE_BITCOIN_MAINNET=true
 ```
 
+### Bitcoin Development
+
+There are some important notes related to the BTC development:
+
+1. Wallet workers:
+   - Locally, only the Regex network wallet worker is launched
+   - On all other ens (staging, beta, prod), we launch Testnet and Mainnet workers
+2. Transactions:
+   - To test them locally, you need to hardcode a mainnet BTC address with some txs inside. In the future, we plan to create mocks and use them during the local development.
+   - Currently, only Mainnet transactions (uncertified) can be loaded on staging/beta/prod, since the Blockchain API we're using to fetch this data doesn't provide txs for testnet.
+
 ### Local Bitcoin Node (Or Regtest)
 
 To interact with a Bitcoun network, we can set up a local test node.

--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -51,9 +51,10 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 	}
 
 	/* TODO: The following steps need to be done:
-	 * 1. Fetch uncertified transactions via BTC transaction API.
-	 * 2. Query uncertified balance in oder to improve UX (signer.getBtcBalance takes ~5s to complete).
-	 * 3. Fetch certified transactions via BE endpoint (to be discussed).
+	 * 1. [Required] Fetch uncertified transactions via BTC transaction API.
+	 * 2. [Improvement] Query uncertified balance in oder to improve UX (signer.getBtcBalance takes ~5s to complete).
+	 * 3. [Required] Fetch certified transactions via BE endpoint (to be discussed).
+	 * 4. [Improvement] Receive btcAddress from FE as data param to avoid re-fetching it in a worker. Make sure it's certified.
 	 * */
 	private syncWallet = async ({ identity, data }: SchedulerJobData<PostMessageDataRequestBtc>) => {
 		const bitcoinNetwork = data?.bitcoinNetwork;
@@ -69,11 +70,9 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 
 		if (data?.shouldFetchTransactions) {
 			const btcAddress =
-				data?.btcAddress ??
-				this.btcAddress ??
-				(await this.loadBtcAddress({ identity, bitcoinNetwork }));
+				this.btcAddress ?? (await this.loadBtcAddress({ identity, bitcoinNetwork }));
 
-			const transactions = (await btcAddressData({ btcAddress })).txs;
+			const { txs: transactions } = await btcAddressData({ btcAddress });
 
 			uncertifiedTransactions = transactions.map((transaction) => ({
 				// TODO: Parse transactions to BtcTransactionUi type

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -1,9 +1,19 @@
 import { syncWallet } from '$btc/services/btc-listener.services';
-import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$icp/utils/ic-send.utils';
+import {
+	isNetworkIdBTCMainnet,
+	isNetworkIdBTCRegtest,
+	isNetworkIdBTCTestnet
+} from '$icp/utils/ic-send.utils';
+import {
+	btcAddressMainnet,
+	btcAddressRegtest,
+	btcAddressTestnet
+} from '$lib/derived/address.derived';
 import type { WalletWorker } from '$lib/types/listener';
 import type { PostMessage, PostMessageDataResponseWallet } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
+import { get } from 'svelte/store';
 
 export const initBtcWalletWorker = async ({
 	id: tokenId,
@@ -27,16 +37,25 @@ export const initBtcWalletWorker = async ({
 
 	return {
 		start: () => {
+			const isNetworkTestnet = isNetworkIdBTCTestnet(networkId);
+			const isNetworkRegtest = isNetworkIdBTCRegtest(networkId);
+			const isNetworkMainnet = isNetworkIdBTCMainnet(networkId);
+
 			worker.postMessage({
 				msg: 'startBtcWalletTimer',
 				data: {
+					btcAddress: get(
+						isNetworkTestnet
+							? btcAddressTestnet
+							: isNetworkRegtest
+								? btcAddressRegtest
+								: btcAddressMainnet
+					),
 					bitcoinNetwork: mapToSignerBitcoinNetwork({
-						network: isNetworkIdBTCTestnet(networkId)
-							? 'testnet'
-							: isNetworkIdBTCRegtest(networkId)
-								? 'regtest'
-								: 'mainnet'
-					})
+						network: isNetworkTestnet ? 'testnet' : isNetworkRegtest ? 'regtest' : 'mainnet'
+					}),
+					// only mainnet transactions can be fetched via Blockchain API
+					shouldFetchTransactions: isNetworkMainnet
 				}
 			});
 		},

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -4,16 +4,10 @@ import {
 	isNetworkIdBTCRegtest,
 	isNetworkIdBTCTestnet
 } from '$icp/utils/ic-send.utils';
-import {
-	btcAddressMainnet,
-	btcAddressRegtest,
-	btcAddressTestnet
-} from '$lib/derived/address.derived';
 import type { WalletWorker } from '$lib/types/listener';
 import type { PostMessage, PostMessageDataResponseWallet } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
-import { get } from 'svelte/store';
 
 export const initBtcWalletWorker = async ({
 	id: tokenId,
@@ -37,25 +31,18 @@ export const initBtcWalletWorker = async ({
 
 	return {
 		start: () => {
-			const isNetworkTestnet = isNetworkIdBTCTestnet(networkId);
-			const isNetworkRegtest = isNetworkIdBTCRegtest(networkId);
-			const isNetworkMainnet = isNetworkIdBTCMainnet(networkId);
-
 			worker.postMessage({
 				msg: 'startBtcWalletTimer',
 				data: {
-					btcAddress: get(
-						isNetworkTestnet
-							? btcAddressTestnet
-							: isNetworkRegtest
-								? btcAddressRegtest
-								: btcAddressMainnet
-					),
 					bitcoinNetwork: mapToSignerBitcoinNetwork({
-						network: isNetworkTestnet ? 'testnet' : isNetworkRegtest ? 'regtest' : 'mainnet'
+						network: isNetworkIdBTCTestnet(networkId)
+							? 'testnet'
+							: isNetworkIdBTCRegtest(networkId)
+								? 'regtest'
+								: 'mainnet'
 					}),
 					// only mainnet transactions can be fetched via Blockchain API
-					shouldFetchTransactions: isNetworkMainnet
+					shouldFetchTransactions: isNetworkIdBTCMainnet(networkId)
 				}
 			});
 		},

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -4,10 +4,16 @@ import {
 	isNetworkIdBTCRegtest,
 	isNetworkIdBTCTestnet
 } from '$icp/utils/ic-send.utils';
+import {
+	btcAddressMainnetStore,
+	btcAddressRegtestStore,
+	btcAddressTestnetStore
+} from '$lib/stores/address.store';
 import type { WalletWorker } from '$lib/types/listener';
 import type { PostMessage, PostMessageDataResponseWallet } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
+import { get } from 'svelte/store';
 
 export const initBtcWalletWorker = async ({
 	id: tokenId,
@@ -31,15 +37,21 @@ export const initBtcWalletWorker = async ({
 
 	return {
 		start: () => {
+			const isTestnetNetwork = isNetworkIdBTCTestnet(networkId);
+			const isRegtestNetwork = isNetworkIdBTCRegtest(networkId);
+
 			worker.postMessage({
 				msg: 'startBtcWalletTimer',
 				data: {
+					btcAddress: get(
+						isTestnetNetwork
+							? btcAddressTestnetStore
+							: isRegtestNetwork
+								? btcAddressRegtestStore
+								: btcAddressMainnetStore
+					),
 					bitcoinNetwork: mapToSignerBitcoinNetwork({
-						network: isNetworkIdBTCTestnet(networkId)
-							? 'testnet'
-							: isNetworkIdBTCRegtest(networkId)
-								? 'regtest'
-								: 'mainnet'
+						network: isTestnetNetwork ? 'testnet' : isRegtestNetwork ? 'regtest' : 'mainnet'
 					}),
 					// only mainnet transactions can be fetched via Blockchain API
 					shouldFetchTransactions: isNetworkIdBTCMainnet(networkId)

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -43,6 +43,7 @@ export const initBtcWalletWorker = async ({
 			worker.postMessage({
 				msg: 'startBtcWalletTimer',
 				data: {
+					// TODO: stop/start the worker on address change
 					btcAddress: get(
 						isTestnetNetwork
 							? btcAddressTestnetStore

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -9,6 +9,7 @@ import type { BtcAddressData } from '$icp/stores/btc.store';
 import type { JsonText } from '$icp/types/btc.post-message';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcCanisters, IcCkMetadata } from '$icp/types/ic';
+import type { BtcAddress } from '$lib/types/address';
 import type { Network } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
 import type { SyncState } from '$lib/types/sync';
@@ -57,6 +58,7 @@ export type PostMessageDataRequestIcCkBTCUpdateBalance = PostMessageDataRequestI
 };
 
 export interface PostMessageDataRequestBtc {
+	btcAddress: BtcAddress;
 	shouldFetchTransactions: boolean;
 	bitcoinNetwork: SignerBitcoinNetwork;
 }

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -9,7 +9,6 @@ import type { BtcAddressData } from '$icp/stores/btc.store';
 import type { JsonText } from '$icp/types/btc.post-message';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcCanisters, IcCkMetadata } from '$icp/types/ic';
-import type { OptionBtcAddress } from '$lib/types/address';
 import type { Network } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
 import type { SyncState } from '$lib/types/sync';
@@ -59,7 +58,6 @@ export type PostMessageDataRequestIcCkBTCUpdateBalance = PostMessageDataRequestI
 
 export interface PostMessageDataRequestBtc {
 	shouldFetchTransactions: boolean;
-	btcAddress: OptionBtcAddress;
 	bitcoinNetwork: SignerBitcoinNetwork;
 }
 

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -9,6 +9,7 @@ import type { BtcAddressData } from '$icp/stores/btc.store';
 import type { JsonText } from '$icp/types/btc.post-message';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcCanisters, IcCkMetadata } from '$icp/types/ic';
+import type { OptionBtcAddress } from '$lib/types/address';
 import type { Network } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
 import type { SyncState } from '$lib/types/sync';
@@ -57,6 +58,8 @@ export type PostMessageDataRequestIcCkBTCUpdateBalance = PostMessageDataRequestI
 };
 
 export interface PostMessageDataRequestBtc {
+	shouldFetchTransactions: boolean;
+	btcAddress: OptionBtcAddress;
 	bitcoinNetwork: SignerBitcoinNetwork;
 }
 


### PR DESCRIPTION
# Motivation

The goal is to update the BTC wallet worker to fetch transactions. Similar to other store, we only load a BTC address if it hasn't been already fetched by FE.
