### PR TITLE
chore(frontend): use aliases for relative imports

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -3,9 +3,9 @@
 	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
-	import SendForm from './SendForm.svelte';
-	import SendReview from './SendReview.svelte';
 	import FeeContext from '$eth/components/fee/FeeContext.svelte';
+	import SendForm from '$eth/components/send/SendForm.svelte';
+	import SendReview from '$eth/components/send/SendReview.svelte';
 	import { sendSteps } from '$eth/constants/steps.constants';
 	import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';

--- a/src/frontend/src/eth/components/send/SendForm.svelte
+++ b/src/frontend/src/eth/components/send/SendForm.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
-	import SendNetworkICP from './SendNetworkICP.svelte';
 	import FeeDisplay from '$eth/components/fee/FeeDisplay.svelte';
 	import SendAmount from '$eth/components/send/SendAmount.svelte';
 	import SendDestination from '$eth/components/send/SendDestination.svelte';
 	import SendInfo from '$eth/components/send/SendInfo.svelte';
+	import SendNetworkICP from '$eth/components/send/SendNetworkICP.svelte';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendSource from '$lib/components/send/SendSource.svelte';

--- a/src/frontend/src/eth/components/send/SendNetworkICP.svelte
+++ b/src/frontend/src/eth/components/send/SendNetworkICP.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import SendNetwork from './SendNetwork.svelte';
+	import SendNetwork from '$eth/components/send/SendNetwork.svelte';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { isErc20Icp } from '$eth/utils/token.utils';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';

--- a/src/frontend/src/eth/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/TransactionModal.svelte
@@ -2,7 +2,7 @@
 	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { BigNumber } from '@ethersproject/bignumber';
-	import TransactionStatus from './TransactionStatus.svelte';
+	import TransactionStatus from '$eth/components/transactions/TransactionStatus.svelte';
 	import { explorerUrl as explorerUrlStore } from '$eth/derived/network.derived';
 	import type { EthTransactionType } from '$eth/types/eth-transaction';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';

--- a/src/frontend/src/eth/components/transactions/Transactions.svelte
+++ b/src/frontend/src/eth/components/transactions/Transactions.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
-	import Transaction from './Transaction.svelte';
-	import TransactionModal from './TransactionModal.svelte';
-	import TransactionsSkeletons from './TransactionsSkeletons.svelte';
 	import TokenModal from '$eth/components/tokens/TokenModal.svelte';
+	import Transaction from '$eth/components/transactions/Transaction.svelte';
+	import TransactionModal from '$eth/components/transactions/TransactionModal.svelte';
+	import TransactionsSkeletons from '$eth/components/transactions/TransactionsSkeletons.svelte';
 	import { tokenNotInitialized } from '$eth/derived/nav.derived';
 	import { ethereumTokenId, ethereumToken } from '$eth/derived/token.derived';
 	import { sortedTransactions } from '$eth/derived/transactions.derived';

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnect.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import WalletConnectSend from './WalletConnectSend.svelte';
-	import WalletConnectSession from './WalletConnectSession.svelte';
-	import WalletConnectSign from './WalletConnectSign.svelte';
+	import WalletConnectSend from '$eth/components/wallet-connect/WalletConnectSend.svelte';
+	import WalletConnectSession from '$eth/components/wallet-connect/WalletConnectSession.svelte';
+	import WalletConnectSign from '$eth/components/wallet-connect/WalletConnectSign.svelte';
 	import type { OptionWalletConnectListener } from '$eth/types/wallet-connect';
 
 	let listener: OptionWalletConnectListener;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectReview.svelte
@@ -5,9 +5,9 @@
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
-	import WalletConnectActions from './WalletConnectActions.svelte';
-	import WalletConnectDomainVerification from './WalletConnectDomainVerification.svelte';
 	import { EIP155_CHAINS } from '$env/eip155-chains.env';
+	import WalletConnectActions from '$eth/components/wallet-connect/WalletConnectActions.svelte';
+	import WalletConnectDomainVerification from '$eth/components/wallet-connect/WalletConnectDomainVerification.svelte';
 	import { acceptedContext } from '$eth/utils/wallet-connect.utils';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSend.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSend.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
-	import WalletConnectSendModal from './WalletConnectSendModal.svelte';
 	import { EIP155_CHAINS } from '$env/eip155-chains.env';
+	import WalletConnectSendModal from '$eth/components/wallet-connect/WalletConnectSendModal.svelte';
 	import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import type {

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
@@ -2,10 +2,10 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { BigNumber } from '@ethersproject/bignumber';
 	import { getContext } from 'svelte';
-	import WalletConnectActions from './WalletConnectActions.svelte';
-	import WalletConnectSendData from './WalletConnectSendData.svelte';
 	import FeeDisplay from '$eth/components/fee/FeeDisplay.svelte';
 	import SendReviewNetwork from '$eth/components/send/SendReviewNetwork.svelte';
+	import WalletConnectActions from '$eth/components/wallet-connect/WalletConnectActions.svelte';
+	import WalletConnectSendData from '$eth/components/wallet-connect/WalletConnectSendData.svelte';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { decodeErc20AbiDataValue } from '$eth/utils/transactions.utils';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -4,10 +4,10 @@
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 	import { getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
-	import WalletConnectModalTitle from './WalletConnectModalTitle.svelte';
-	import WalletConnectSendReview from './WalletConnectSendReview.svelte';
 	import { ICP_NETWORK } from '$env/networks.env';
 	import FeeContext from '$eth/components/fee/FeeContext.svelte';
+	import WalletConnectModalTitle from '$eth/components/wallet-connect/WalletConnectModalTitle.svelte';
+	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
 	import {

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -4,10 +4,10 @@
 	import { getSdkError } from '@walletconnect/utils';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 	import { onDestroy } from 'svelte';
-	import WalletConnectButton from './WalletConnectButton.svelte';
-	import WalletConnectForm from './WalletConnectForm.svelte';
-	import WalletConnectModalTitle from './WalletConnectModalTitle.svelte';
-	import WalletConnectReview from './WalletConnectReview.svelte';
+	import WalletConnectButton from '$eth/components/wallet-connect/WalletConnectButton.svelte';
+	import WalletConnectForm from '$eth/components/wallet-connect/WalletConnectForm.svelte';
+	import WalletConnectModalTitle from '$eth/components/wallet-connect/WalletConnectModalTitle.svelte';
+	import WalletConnectReview from '$eth/components/wallet-connect/WalletConnectReview.svelte';
 	import {
 		SESSION_REQUEST_SEND_TRANSACTION,
 		SESSION_REQUEST_PERSONAL_SIGN,

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSign.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSign.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
-	import WalletConnectSignModal from './WalletConnectSignModal.svelte';
+	import WalletConnectSignModal from '$eth/components/wallet-connect/WalletConnectSignModal.svelte';
 	import type { OptionWalletConnectListener } from '$eth/types/wallet-connect';
 	import { modalWalletConnectSign } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
-	import WalletConnectModalTitle from './WalletConnectModalTitle.svelte';
-	import WalletConnectSignReview from './WalletConnectSignReview.svelte';
+	import WalletConnectModalTitle from '$eth/components/wallet-connect/WalletConnectModalTitle.svelte';
+	import WalletConnectSignReview from '$eth/components/wallet-connect/WalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$eth/constants/steps.constants';
 	import { signMessage, reject as rejectServices } from '$eth/services/wallet-connect.services';
 	import type { OptionWalletConnectListener } from '$eth/types/wallet-connect';

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
-	import WalletConnectActions from './WalletConnectActions.svelte';
+	import WalletConnectActions from '$eth/components/wallet-connect/WalletConnectActions.svelte';
 	import {
 		getSignParamsMessageUtf8,
 		getSignParamsMessageHex

--- a/src/frontend/src/eth/constants/erc20-icp.constants.ts
+++ b/src/frontend/src/eth/constants/erc20-icp.constants.ts
@@ -1,4 +1,4 @@
-import { ERC20_ABI } from './erc20.constants';
+import { ERC20_ABI } from '$eth/constants/erc20.constants';
 
 // Burn ETH ICP ERC20 to ICP
 // - the amount of wrapped ICP to unwrap, e.g. 100_000_000_000_000_000 corresponds to exactly 0.1 ICP

--- a/src/frontend/src/eth/services/eth-listener.services.ts
+++ b/src/frontend/src/eth/services/eth-listener.services.ts
@@ -1,6 +1,7 @@
 import { alchemyErc20Providers } from '$eth/providers/alchemy-erc20.providers';
 import { initMinedTransactionsListener as initMinedTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
 import { initWalletConnect } from '$eth/providers/wallet-connect.providers';
+import { processErc20Transaction, processEthTransaction } from '$eth/services/transaction.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { WebSocketListener } from '$eth/types/listener';
 import type { WalletConnectListener } from '$eth/types/wallet-connect';
@@ -9,7 +10,6 @@ import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { BigNumber } from '@ethersproject/bignumber';
-import { processErc20Transaction, processEthTransaction } from './transaction.services';
 
 export const initTransactionsListener = ({
 	token,

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -5,6 +5,7 @@ import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
 import { infuraErc20IcpProviders } from '$eth/providers/infura-erc20-icp.providers';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
+import { processTransactionSent } from '$eth/services/transaction.services';
 import type {
 	CkEthPopulateTransaction,
 	Erc20PopulateTransaction
@@ -32,7 +33,6 @@ import { assertNonNullish, isNullish, nonNullish, toNullable } from '@dfinity/ut
 import type { BigNumber } from '@ethersproject/bignumber';
 import type { TransactionResponse } from '@ethersproject/providers';
 import { get } from 'svelte/store';
-import { processTransactionSent } from './transaction.services';
 
 const ethPrepareTransaction = async ({
 	to,

--- a/src/frontend/src/eth/services/transaction.services.ts
+++ b/src/frontend/src/eth/services/transaction.services.ts
@@ -1,4 +1,5 @@
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
+import { reloadBalance } from '$eth/services/balance.services';
 import { transactionsStore } from '$eth/stores/transactions.store';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { decodeErc20AbiDataValue } from '$eth/utils/transactions.utils';
@@ -10,7 +11,6 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
 import type { BigNumber } from '@ethersproject/bignumber';
 import { get } from 'svelte/store';
-import { reloadBalance } from './balance.services';
 
 export const processTransactionSent = async ({
 	token,

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -1,4 +1,5 @@
 import { UNEXPECTED_ERROR } from '$eth/constants/wallet-connect.constants';
+import { send as executeSend } from '$eth/services/send.services';
 import type { FeeStoreData } from '$eth/stores/fee.store';
 import type { SendParams } from '$eth/types/send';
 import type { OptionWalletConnectListener, WalletConnectListener } from '$eth/types/wallet-connect';
@@ -31,7 +32,6 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { getSdkError } from '@walletconnect/utils';
 import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 import { get } from 'svelte/store';
-import { send as executeSend } from './send.services';
 
 export interface WalletConnectCallBackParams {
 	request: Web3WalletTypes.SessionRequest;

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
-	import IcFeeDisplay from './IcFeeDisplay.svelte';
+	import IcFeeDisplay from '$icp/components/send/IcFeeDisplay.svelte';
 	import IcSendAmount from '$icp/components/send/IcSendAmount.svelte';
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
-	import IcFeeDisplay from './IcFeeDisplay.svelte';
+	import IcFeeDisplay from '$icp/components/send/IcFeeDisplay.svelte';
 	import IcReviewNetwork from '$icp/components/send/IcReviewNetwork.svelte';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -2,11 +2,11 @@
 	import { type WizardStep } from '@dfinity/gix-components';
 	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
-	import IcSendForm from './IcSendForm.svelte';
-	import IcSendReview from './IcSendReview.svelte';
 	import BitcoinFeeContext from '$icp/components/fee/BitcoinFeeContext.svelte';
 	import EthereumFeeContext from '$icp/components/fee/EthereumFeeContext.svelte';
+	import IcSendForm from '$icp/components/send/IcSendForm.svelte';
 	import IcSendProgress from '$icp/components/send/IcSendProgress.svelte';
+	import IcSendReview from '$icp/components/send/IcSendReview.svelte';
 	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 	import { sendIc } from '$icp/services/ic-send.services';
 	import {

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -3,16 +3,16 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { ComponentType } from 'svelte';
 	import { slide } from 'svelte/transition';
-	import IcTransaction from './IcTransaction.svelte';
-	import IcpTransactionModal from './IcTransactionModal.svelte';
-	import IcTransactionsSkeletons from './IcTransactionsSkeletons.svelte';
 	import Info from '$icp/components/info/Info.svelte';
 	import IcTokenModal from '$icp/components/tokens/IcTokenModal.svelte';
+	import IcTransaction from '$icp/components/transactions/IcTransaction.svelte';
+	import IcTransactionModal from '$icp/components/transactions/IcTransactionModal.svelte';
 	import IcTransactionsBitcoinStatus from '$icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte';
 	import IcTransactionsBtcListeners from '$icp/components/transactions/IcTransactionsCkBTCListeners.svelte';
 	import IcTransactionsCkEthereumListeners from '$icp/components/transactions/IcTransactionsCkEthereumListeners.svelte';
 	import IcTransactionsEthereumStatus from '$icp/components/transactions/IcTransactionsEthereumStatus.svelte';
 	import IcTransactionsNoListener from '$icp/components/transactions/IcTransactionsNoListener.svelte';
+	import IcTransactionsSkeletons from '$icp/components/transactions/IcTransactionsSkeletons.svelte';
 	import {
 		tokenAsIcToken,
 		tokenCkBtcLedger,
@@ -117,7 +117,7 @@
 </IcTransactionsSkeletons>
 
 {#if $modalIcTransaction && nonNullish(selectedTransaction)}
-	<IcpTransactionModal transaction={selectedTransaction} />
+	<IcTransactionModal transaction={selectedTransaction} />
 {:else if $modalIcToken}
 	<IcTokenModal />
 {/if}

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -1,4 +1,5 @@
 import { ICP_TOKEN_ID } from '$env/tokens.env';
+import { syncWallet } from '$icp/services/ic-listener.services';
 import {
 	onLoadTransactionsError,
 	onTransactionsCleanUp
@@ -11,7 +12,6 @@ import type {
 	PostMessageDataResponseWalletCleanUp
 } from '$lib/types/post-message';
 import type { GetAccountIdentifierTransactionsResponse } from '@dfinity/ledger-icp';
-import { syncWallet } from './ic-listener.services';
 
 export const initIcpWalletWorker = async (): Promise<WalletWorker> => {
 	const WalletWorker = await import('$icp/workers/icp-wallet.worker?worker');

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -1,3 +1,4 @@
+import { syncWallet } from '$icp/services/ic-listener.services';
 import {
 	onLoadTransactionsError,
 	onTransactionsCleanUp
@@ -11,7 +12,6 @@ import type {
 	PostMessageDataResponseWalletCleanUp
 } from '$lib/types/post-message';
 import type { IcrcGetTransactions } from '@dfinity/ledger-icrc';
-import { syncWallet } from './ic-listener.services';
 
 export const initIcrcWalletWorker = async ({
 	indexCanisterId,

--- a/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import SkeletonText from '../ui/SkeletonText.svelte';
 	import ReceiveActions from '$lib/components/receive/ReceiveActions.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { RECEIVE_TOKENS_MODAL_ADDRESS_LABEL } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionString } from '$lib/types/string';

--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import SendDataDestination from './SendDataDestination.svelte';
 	import SendDataAmount from '$lib/components/send/SendDataAmount.svelte';
+	import SendDataDestination from '$lib/components/send/SendDataDestination.svelte';
 	import SendSource from '$lib/components/send/SendSource.svelte';
 	import type { OptionBalance } from '$lib/types/balance';
 	import type { Token } from '$lib/types/token';

--- a/src/frontend/src/lib/services/request-pouh-credential.services.ts
+++ b/src/frontend/src/lib/services/request-pouh-credential.services.ts
@@ -7,6 +7,7 @@ import {
 	VC_POPUP_WIDTH
 } from '$lib/constants/app.constants';
 import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
+import { loadCertifiedUserProfile } from '$lib/services/load-user-profile.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
@@ -22,7 +23,6 @@ import {
 	type VerifiablePresentationResponse
 } from '@dfinity/verifiable-credentials/request-verifiable-presentation';
 import { get } from 'svelte/store';
-import { loadCertifiedUserProfile } from './load-user-profile.services';
 
 const addPouhCredential = async ({
 	identity,

--- a/src/frontend/src/lib/types/balance.ts
+++ b/src/frontend/src/lib/types/balance.ts
@@ -1,5 +1,5 @@
+import type { Option } from '$lib/types/utils';
 import { BigNumber } from '@ethersproject/bignumber';
-import type { Option } from './utils';
 
 export type Balance = BigNumber;
 


### PR DESCRIPTION
# Motivation

For consistency, we replace the relative imports with aliases.
