### PR TITLE
fix(ci): distinguish same-name imports in the script to check unused components

### DIFF
--- a/scripts/check.unused.mjs
+++ b/scripts/check.unused.mjs
@@ -29,9 +29,17 @@ const main = async () => {
 
 	allSvelteFiles.forEach((file) => {
 		const content = readFileSync(file, 'utf-8');
-		potentialUnusedFiles = potentialUnusedFiles.filter(
-			(potentialUnusedFile) => !content.includes(basename(potentialUnusedFile))
-		);
+
+		potentialUnusedFiles = potentialUnusedFiles.filter((potentialUnusedFile) => {
+			const fileBasename = basename(potentialUnusedFile);
+
+			if (content.includes(`./${fileBasename}`)) {
+				console.log(`${RED}Relative import of '${fileBasename}' found in '${file}${NC}'`);
+				return false;
+			}
+
+			return !content.includes(`${basename(dirname(potentialUnusedFile))}/${fileBasename}`);
+		});
 
 		if (potentialUnusedFiles.length === 0) {
 			noUnusedFiles();


### PR DESCRIPTION
# Motivation

The script to check for unused components was not taking in count components with same name. For example, let's suppose we have two components `CustomButton`, one in folder `eth` and one in folder `lib`; however, only one is used, so it would be imported as:

```typescript
import CustomButton from 'eth/CustomButton.svelte';
```

The script will not flag the one in `lib` (that is unused) because it matches the same name in the file.

So we check not only for the component name but for its direct parent folder too.

Furthermore, as utility, we print a warn for relative imports that should be using aliases.
 

