### PR TITLE
feat(frontend): Improve error mgt signer canister

### DIFF
--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -9,6 +9,7 @@ import { getAgent } from '$lib/actors/agents.ic';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices } from '@dfinity/utils';
+import { signerCanisterError } from './signer.errors';
 
 export class SignerCanister extends Canister<SignerService> {
 	static async create({ identity, ...options }: CreateCanisterOptions<SignerService>) {
@@ -34,8 +35,7 @@ export class SignerCanister extends Canister<SignerService> {
 		const response = await btc_caller_address({ network, address_type: { P2WPKH: null } }, []);
 
 		if ('Err' in response) {
-			// TODO: Manage different error types
-			throw new Error("Couldn't get BTC address");
+			throw signerCanisterError(response.Err);
 		}
 
 		return response.Ok.address;
@@ -49,8 +49,7 @@ export class SignerCanister extends Canister<SignerService> {
 		const response = await btc_caller_balance({ network, address_type: { P2WPKH: null } }, []);
 
 		if ('Err' in response) {
-			// TODO: Manage different error types
-			throw new Error("Couldn't get BTC balance");
+			throw signerCanisterError(response.Err);
 		}
 
 		return response.Ok.balance;

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -1,6 +1,6 @@
 import type { GetAddressError, PaymentError } from '$declarations/signer/signer.did';
 
-export class CanisterPaymentError extends Error {
+export class SignerCanisterPaymentError extends Error {
 	constructor(response: PaymentError) {
 		if ('LedgerUnreachable' in response) {
 			super(`Ledger unreachable ${response.LedgerUnreachable.ledger}`);
@@ -18,7 +18,7 @@ export class CanisterPaymentError extends Error {
 	}
 }
 
-export class InternalError extends Error {
+export class SignerCanisterInternalError extends Error {
 	constructor(msg: string) {
 		super(msg);
 	}
@@ -26,10 +26,10 @@ export class InternalError extends Error {
 
 export const signerCanisterError = (response: GetAddressError) => {
 	if ('InternalError' in response) {
-		return new InternalError(response.InternalError.msg);
+		return new SignerCanisterInternalError(response.InternalError.msg);
 	}
 	if ('PaymentError' in response) {
-		return new CanisterPaymentError(response.PaymentError);
+		return new SignerCanisterPaymentError(response.PaymentError);
 	}
 	return new Error('Unknown GetAddressError');
 };

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -1,0 +1,35 @@
+import type { GetAddressError, PaymentError } from '$declarations/signer/signer.did';
+
+export class CanisterPaymentError extends Error {
+	constructor(response: PaymentError) {
+		if ('LedgerUnreachable' in response) {
+			super(`Ledger unreachable ${response.LedgerUnreachable.ledger}`);
+		} else if ('UnsupportedPaymentType' in response) {
+			super('Unsupported payment type');
+		} else if ('LedgerError' in response) {
+			super(`Ledger error: ${JSON.stringify(response.LedgerError.error)}`);
+		} else if ('InsufficientFunds' in response) {
+			super(
+				`Insufficient funds needed ${response.InsufficientFunds.needed} but available ${response.InsufficientFunds.available}`
+			);
+		} else {
+			super('Unknown PaymentError');
+		}
+	}
+}
+
+export class InternalError extends Error {
+	constructor(msg: string) {
+		super(msg);
+	}
+}
+
+export const signerCanisterError = (response: GetAddressError) => {
+	if ('InternalError' in response) {
+		return new InternalError(response.InternalError.msg);
+	}
+	if ('PaymentError' in response) {
+		return new CanisterPaymentError(response.PaymentError);
+	}
+	return new Error('Unknown GetAddressError');
+};

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,5 +1,6 @@
 import type { _SERVICE as SignerService, SignRequest } from '$declarations/signer/signer.did';
 import { SignerCanister } from '$lib/canisters/signer.canister';
+import { CanisterPaymentError, InternalError } from '$lib/canisters/signer.errors';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
@@ -70,7 +71,7 @@ describe('signer.canister', () => {
 		);
 	});
 
-	it('should throw an error if btc_caller_address returns an error', async () => {
+	it('should throw an error if btc_caller_address returns an internal error', async () => {
 		const response = { Err: { InternalError: { msg: 'Test error' } } };
 		service.btc_caller_address.mockResolvedValue(response);
 
@@ -80,7 +81,20 @@ describe('signer.canister', () => {
 
 		const res = getBtcAddress(btcParams);
 
-		await expect(res).rejects.toThrow(new Error("Couldn't get BTC address"));
+		await expect(res).rejects.toThrow(new InternalError(response.Err.InternalError.msg));
+	});
+
+	it('should throw an error if btc_caller_address returns a payment error', async () => {
+		const response = { Err: { PaymentError: { UnsupportedPaymentType: null } } };
+		service.btc_caller_address.mockResolvedValue(response);
+
+		const { getBtcAddress } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = getBtcAddress(btcParams);
+
+		await expect(res).rejects.toThrow(new CanisterPaymentError(response.Err.PaymentError));
 	});
 
 	it('should throw an error if btc_caller_address throws', async () => {
@@ -115,7 +129,7 @@ describe('signer.canister', () => {
 		);
 	});
 
-	it('should throw an error if btc_caller_balance returns an error', async () => {
+	it('should throw an error if btc_caller_balance returns an internal error', async () => {
 		const response = { Err: { InternalError: { msg: 'Test error' } } };
 		service.btc_caller_balance.mockResolvedValue(response);
 
@@ -125,7 +139,20 @@ describe('signer.canister', () => {
 
 		const res = getBtcBalance(btcParams);
 
-		await expect(res).rejects.toThrow(new Error("Couldn't get BTC balance"));
+		await expect(res).rejects.toThrow(new InternalError(response.Err.InternalError.msg));
+	});
+
+	it('should throw an error if btc_caller_balance returns a payment error', async () => {
+		const response = { Err: { PaymentError: { UnsupportedPaymentType: null } } };
+		service.btc_caller_balance.mockResolvedValue(response);
+
+		const { getBtcBalance } = await createSignerCanister({
+			serviceOverride: service
+		});
+
+		const res = getBtcBalance(btcParams);
+
+		await expect(res).rejects.toThrow(new CanisterPaymentError(response.Err.PaymentError));
 	});
 
 	it('should throw an error if btc_caller_balance throws', async () => {

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,6 +1,9 @@
 import type { _SERVICE as SignerService, SignRequest } from '$declarations/signer/signer.did';
 import { SignerCanister } from '$lib/canisters/signer.canister';
-import { CanisterPaymentError, InternalError } from '$lib/canisters/signer.errors';
+import {
+	SignerCanisterInternalError,
+	SignerCanisterPaymentError
+} from '$lib/canisters/signer.errors';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
@@ -81,7 +84,9 @@ describe('signer.canister', () => {
 
 		const res = getBtcAddress(btcParams);
 
-		await expect(res).rejects.toThrow(new InternalError(response.Err.InternalError.msg));
+		await expect(res).rejects.toThrow(
+			new SignerCanisterInternalError(response.Err.InternalError.msg)
+		);
 	});
 
 	it('should throw an error if btc_caller_address returns a payment error', async () => {
@@ -94,7 +99,7 @@ describe('signer.canister', () => {
 
 		const res = getBtcAddress(btcParams);
 
-		await expect(res).rejects.toThrow(new CanisterPaymentError(response.Err.PaymentError));
+		await expect(res).rejects.toThrow(new SignerCanisterPaymentError(response.Err.PaymentError));
 	});
 
 	it('should throw an error if btc_caller_address throws', async () => {
@@ -139,7 +144,9 @@ describe('signer.canister', () => {
 
 		const res = getBtcBalance(btcParams);
 
-		await expect(res).rejects.toThrow(new InternalError(response.Err.InternalError.msg));
+		await expect(res).rejects.toThrow(
+			new SignerCanisterInternalError(response.Err.InternalError.msg)
+		);
 	});
 
 	it('should throw an error if btc_caller_balance returns a payment error', async () => {
@@ -152,7 +159,7 @@ describe('signer.canister', () => {
 
 		const res = getBtcBalance(btcParams);
 
-		await expect(res).rejects.toThrow(new CanisterPaymentError(response.Err.PaymentError));
+		await expect(res).rejects.toThrow(new SignerCanisterPaymentError(response.Err.PaymentError));
 	});
 
 	it('should throw an error if btc_caller_balance throws', async () => {


### PR DESCRIPTION
# Motivation

Have clearer understanding of the errors coming from the signer canister.

This PR doesn't improve UX, but only the logging of the errors. But now, improving the UX could be done by checking the error thrown.

# Changes

* Create a new helper `signerCanisterError` and two new errors `CanisterSignerPaymentError` and `CanisterSignerInternalError`.
* Use the new helper in the btc endpoints to get balance and address.

# Tests

* Change and add tests to prove that the helpers will throw as expected.
