### PR TITLE
feat(test): Install bitcoin canister to pocket-ic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ internet_identity.did
 codes.txt
 
 backend.wasm.gz
+ic-btc-canister.wasm.gz
 backend-v*.wasm.gz
 /test-results/
 /playwright-report/

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -2,6 +2,8 @@
 
 POCKET_IC_SERVER_VERSION=6.0.0
 OISY_UPGRADE_VERSIONS="v0.0.13,v0.0.19"
+BITCOIN_CANISTER_RELEASE="2024-08-30"
+BITCON_CANISTER_WASM="ic-btc-canister.wasm.gz"
 
 # If a backend wasm file exists at the root, it will be used for the tests.
 
@@ -14,6 +16,15 @@ else
   echo "Building backend canister."
   cargo build --locked --target wasm32-unknown-unknown --release -p backend
 fi
+
+if [ -f "./$BITCON_CANISTER_WASM" ]; then
+  echo "Use existing $BITCON_CANISTER_WASM canister."
+else
+  echo "Downloading bitcoin_canister canister."
+  curl -sSL "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F$BITCOIN_CANISTER_RELEASE/ic-btc-canister.wasm.gz" -o $BITCON_CANISTER_WASM
+fi
+# Setting the environment variable that will be used in the test to load that particular file relative to the cargo workspace.
+export BITCOIN_CANISTER_WASM_FILE="../../$BITCON_CANISTER_WASM"
 
 # We use a previous version of the release to ensure upgradability
 

--- a/src/backend/tests/it/migration.rs
+++ b/src/backend/tests/it/migration.rs
@@ -24,6 +24,7 @@ impl Default for MigrationTestEnv {
     fn default() -> Self {
         let mut pic = Arc::new(
             PocketIcBuilder::new()
+                .with_bitcoin_subnet()
                 .with_ii_subnet()
                 .with_fiduciary_subnet()
                 .build(),
@@ -41,7 +42,7 @@ impl Default for MigrationTestEnv {
             pic: pic.clone(),
             canister_id: BackendBuilder::default()
                 .with_controllers(new_controllers)
-                .deploy_to(&mut pic),
+                .deploy_backend(&mut pic),
         };
         MigrationTestEnv {
             old_backend,


### PR DESCRIPTION
# Motivation

Bitcoin canister is needed to perform integration tests in the backend that interact with the bitcoin api.

In this PR, the bitcoin canister is installed as part of the pocket ic setup.

# Changes

* Download the bitcoin canister if not present during test setup.
* Ignore bitcoin canister wasm.
* Refactor `deploy_to` with `deploy_backend` so that we can only install the backend which is needed in the migration test.
* Add bitcoin wasm and canister during the pocket-ic setup.

# Tests

Only test changes.
