### PR TITLE
feat(frontend): use Send context for IcSend flow too

### DIFF
--- a/src/frontend/src/icp-eth/stores/send.store.ts
+++ b/src/frontend/src/icp-eth/stores/send.store.ts
@@ -30,6 +30,7 @@ export const initSendContext = ({
 	const sendTokenDecimals = derived(sendToken, ({ decimals }) => decimals);
 	const sendTokenId = derived(sendToken, ({ id }) => id);
 	const sendTokenStandard = derived(sendToken, ({ standard }) => standard);
+	const sendTokenSymbol = derived(sendToken, ({ symbol }) => symbol);
 
 	const sendBalance = derived(
 		[balancesStore, sendTokenId],
@@ -41,6 +42,7 @@ export const initSendContext = ({
 		sendTokenDecimals,
 		sendTokenId,
 		sendTokenStandard,
+		sendTokenSymbol,
 		sendBalance,
 		...staticContext
 	};
@@ -53,6 +55,7 @@ export interface SendContext {
 	sendTokenDecimals: Readable<number>;
 	sendTokenId: Readable<TokenId>;
 	sendTokenStandard: Readable<TokenStandard>;
+	sendTokenSymbol: Readable<string>;
 	sendBalance: Readable<OptionBalance>;
 	sendPurpose: SendContextPurpose;
 }

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { createEventDispatcher } from 'svelte';
+	import SendTokenContext from '$eth/components/send/SendTokenContext.svelte';
 	import IcSendTokenWizard from '$icp/components/send/IcSendTokenWizard.svelte';
 	import { ckEthereumTwinToken } from '$icp-eth/derived/cketh.derived';
 	import { sendWizardStepsWithQrCodeScan } from '$lib/config/send.config';
 	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
@@ -77,26 +79,28 @@
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
-	<IcSendTokenWizard
-		{currentStep}
-		bind:destination
-		bind:networkId
-		bind:amount
-		bind:sendProgressStep
-		on:icBack={modal.back}
-		on:icNext={modal.next}
-		on:icClose={close}
-		on:icQRCodeScan={() =>
-			goToWizardSendStep({
-				modal,
-				steps,
-				stepName: WizardStepsSend.QR_CODE_SCAN
-			})}
-		on:icQRCodeBack={() =>
-			goToWizardSendStep({
-				modal,
-				steps,
-				stepName: WizardStepsSend.SEND
-			})}
-	/>
+	<SendTokenContext token={$token}>
+		<IcSendTokenWizard
+			{currentStep}
+			bind:destination
+			bind:networkId
+			bind:amount
+			bind:sendProgressStep
+			on:icBack={modal.back}
+			on:icNext={modal.next}
+			on:icClose={close}
+			on:icQRCodeScan={() =>
+				goToWizardSendStep({
+					modal,
+					steps,
+					stepName: WizardStepsSend.QR_CODE_SCAN
+				})}
+			on:icQRCodeBack={() =>
+				goToWizardSendStep({
+					modal,
+					steps,
+					stepName: WizardStepsSend.SEND
+				})}
+		/>
+	</SendTokenContext>
 </WizardModal>

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -18,9 +18,8 @@
 	export let formCancelAction: 'back' | 'close' = 'back';
 </script>
 
-{#if isNetworkIdEthereum($token?.network.id)}
-	<!-- TODO: Move the context one level down -->
-	<SendTokenContext token={$token}>
+<SendTokenContext token={$token}>
+	{#if isNetworkIdEthereum($token?.network.id)}
 		<EthSendTokenWizard
 			{currentStep}
 			{formCancelAction}
@@ -37,21 +36,21 @@
 			on:icQRCodeScan
 			on:icQRCodeBack
 		/>
-	</SendTokenContext>
-{:else if isNetworkIdICP($token?.network.id)}
-	<IcSendTokenWizard
-		{currentStep}
-		{formCancelAction}
-		bind:destination
-		bind:networkId
-		bind:amount
-		bind:sendProgressStep
-		on:icBack
-		on:icNext
-		on:icClose
-		on:icQRCodeScan
-		on:icQRCodeBack
-	/>
-{:else}
-	<slot />
-{/if}
+	{:else if isNetworkIdICP($token?.network.id)}
+		<IcSendTokenWizard
+			{currentStep}
+			{formCancelAction}
+			bind:destination
+			bind:networkId
+			bind:amount
+			bind:sendProgressStep
+			on:icBack
+			on:icNext
+			on:icClose
+			on:icQRCodeScan
+			on:icQRCodeBack
+		/>
+	{:else}
+		<slot />
+	{/if}
+</SendTokenContext>


### PR DESCRIPTION
# Motivation

We would like to slowly decommission the `token` store. As one of the first step, we provide a context in the entire Send flow. That means, including the Send context used by Ethereum into the IC Send wizard.

Note: for this PR we just change the immediate child that is `IcSendModal`, but in future PR we will slowly go deeper.

# Changes

- Add `sendTokenSymbol` to the Send context.
- Move `SendTokenContext` component one level up in the `SendWizard` (to include IC flow).
- Add `SendTokenContext` in `IcSendModal` too, for consistency.
- Modify `IcSendWizard` to deprecate token stores and use Send token context.

# Tests

I tried a few transactions in the local replica and they worked.


https://github.com/user-attachments/assets/d1f810ba-82b1-4ae7-9df4-618bc1d78edf


https://github.com/user-attachments/assets/d85c345c-3b84-43e7-b60c-5fe16dfdaed8






