### PR TITLE
feat(frontend): re-use ReceiveModal component

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceive.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceive.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <ReceiveButtonWithModal open={openReceive} isOpen={$modalEthReceive}>
-	<ReceiveModal slot="modal" address={$networkAddress ?? undefined}>
+	<ReceiveModal slot="modal" address={$networkAddress}>
 		<svelte:fragment slot="content">
 			{#if $networkEthereum}
 				<EthReceiveMetamask />

--- a/src/frontend/src/eth/components/receive/EthReceive.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceive.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-	import EthReceiveModal from '$eth/components/receive/EthReceiveModal.svelte';
+	import EthReceiveMetamask from '$eth/components/receive/EthReceiveMetamask.svelte';
 	import { metamaskNotInitialized } from '$eth/derived/metamask.derived';
 	import ReceiveButtonWithModal from '$lib/components/receive/ReceiveButtonWithModal.svelte';
+	import ReceiveModal from '$lib/components/receive/ReceiveModal.svelte';
 	import { ethAddressNotCertified } from '$lib/derived/address.derived';
 	import { modalEthReceive } from '$lib/derived/modal.derived';
+	import { networkAddress, networkEthereum } from '$lib/derived/network.derived';
 	import { waitWalletReady } from '$lib/services/actions.services';
 	import { modalStore } from '$lib/stores/modal.store';
 
@@ -23,5 +25,11 @@
 </script>
 
 <ReceiveButtonWithModal open={openReceive} isOpen={$modalEthReceive}>
-	<EthReceiveModal slot="modal" />
+	<ReceiveModal slot="modal" address={$networkAddress ?? undefined}>
+		<svelte:fragment slot="content">
+			{#if $networkEthereum}
+				<EthReceiveMetamask />
+			{/if}
+		</svelte:fragment>
+	</ReceiveModal>
 </ReceiveButtonWithModal>

--- a/src/frontend/src/lib/components/receive/ReceiveModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveModal.svelte
@@ -5,8 +5,9 @@
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionAddress, Address } from '$lib/types/address';
 
-	export let address: string | undefined = undefined;
+	export let address: OptionAddress<Address> = undefined;
 </script>
 
 <Modal on:nnsClose={modalStore.close}>

--- a/src/frontend/src/lib/components/receive/ReceiveModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveModal.svelte
@@ -1,32 +1,30 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
-	import EthReceiveMetamask from '$eth/components/receive/EthReceiveMetamask.svelte';
 	import ReceiveQRCode from '$lib/components/receive/ReceiveQRCode.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
-	import { networkAddress, networkEthereum } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+
+	export let address: string | undefined = undefined;
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
 	<svelte:fragment slot="title">{$i18n.receive.text.receive}</svelte:fragment>
 
 	<ContentWithToolbar>
-		<p class="font-bold text-center">Address:</p>
-		<p class="mb-4 font-normal text-center px-2 max-w-xs mx-auto">
-			<output class="break-all">{$networkAddress ?? ''}</output><Copy
+		<p class="text-center font-bold">Address:</p>
+		<p class="mx-auto mb-4 max-w-xs px-2 text-center font-normal">
+			<output class="break-all">{address ?? ''}</output><Copy
 				inline
-				value={$networkAddress ?? ''}
+				value={address ?? ''}
 				text={$i18n.wallet.text.address_copied}
 			/>
 		</p>
 
-		<ReceiveQRCode address={$networkAddress ?? ''} />
+		<ReceiveQRCode address={address ?? ''} />
 
-		{#if $networkEthereum}
-			<EthReceiveMetamask />
-		{/if}
+		<slot name="content" />
 
 		<button class="primary full center text-center" on:click={modalStore.close} slot="toolbar"
 			>{$i18n.core.text.done}</button


### PR DESCRIPTION
# Motivation

The goal is to move  the`ReceiveModal` component to lib so it can be reused by both ETH and BTC.
