### PR TITLE
feat(frontend): implement Receive modal for BTC

### DIFF
--- a/src/frontend/src/btc/components/receive/BtcReceive.svelte
+++ b/src/frontend/src/btc/components/receive/BtcReceive.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$icp/utils/ic-send.utils';
+	import ReceiveButtonWithModal from '$lib/components/receive/ReceiveButtonWithModal.svelte';
+	import ReceiveModal from '$lib/components/receive/ReceiveModal.svelte';
+	import { modalBtcReceive } from '$lib/derived/modal.derived';
+	import { networkId } from '$lib/derived/network.derived';
+	import { waitWalletReady } from '$lib/services/actions.services';
+	import {
+		btcAddressMainnetStore,
+		btcAddressRegtestStore,
+		btcAddressTestnetStore,
+		type StorageAddressData
+	} from '$lib/stores/address.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { BtcAddress } from '$lib/types/address';
+
+	let addressData: StorageAddressData<BtcAddress>;
+	$: addressData = isNetworkIdBTCTestnet($networkId)
+		? $btcAddressTestnetStore
+		: isNetworkIdBTCRegtest($networkId)
+			? $btcAddressRegtestStore
+			: $btcAddressMainnetStore;
+
+	const isDisabled = (): boolean => isNullish(addressData) || !addressData.certified;
+
+	const openReceive = async (modalId: symbol) => {
+		if (isDisabled()) {
+			const status = await waitWalletReady(isDisabled);
+
+			if (status === 'timeout') {
+				return;
+			}
+		}
+
+		modalStore.openBtcReceive(modalId);
+	};
+</script>
+
+<ReceiveButtonWithModal open={openReceive} isOpen={$modalBtcReceive}>
+	<ReceiveModal slot="modal" address={addressData?.data} />
+</ReceiveButtonWithModal>

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import BtcReceive from '$btc/components/receive/BtcReceive.svelte';
 	import EthReceive from '$eth/components/receive/EthReceive.svelte';
 	import ConvertToCkERC20 from '$eth/components/send/ConvertToCkERC20.svelte';
 	import ConvertToCkETH from '$eth/components/send/ConvertToCkETH.svelte';
@@ -16,6 +17,7 @@
 	import {
 		networkEthereum,
 		networkICP,
+		networkBitcoin,
 		pseudoNetworkChainFusion
 	} from '$lib/derived/network.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
@@ -40,6 +42,8 @@
 			<IcReceive token={$tokenWithFallback} />
 		{:else if $networkEthereum}
 			<EthReceive />
+		{:else if $networkBitcoin}
+			<BtcReceive />
 		{:else if $pseudoNetworkChainFusion}
 			<Receive />
 		{/if}

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -21,6 +21,10 @@ export const modalCkETHReceive: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'cketh-receive'
 );
+export const modalBtcReceive: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'btc-receive'
+);
 export const modalReceive: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'receive'

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -8,6 +8,7 @@ export interface Modal<T> {
 		| 'icrc-receive'
 		| 'ckbtc-receive'
 		| 'cketh-receive'
+		| 'btc-receive'
 		| 'receive'
 		| 'send'
 		| 'buy'
@@ -39,6 +40,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openIcrcReceive: <D extends T>(data: D) => void;
 	openCkBTCReceive: <D extends T>(data: D) => void;
 	openCkETHReceive: <D extends T>(data: D) => void;
+	openBtcReceive: <D extends T>(data: D) => void;
 	openReceive: <D extends T>(data: D) => void;
 	openSend: <D extends T>(data: D) => void;
 	openBuy: <D extends T>(data: D) => void;
@@ -71,6 +73,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openIcrcReceive: <D extends T>(data: D) => set({ type: 'icrc-receive', data }),
 		openCkBTCReceive: <D extends T>(data: D) => set({ type: 'ckbtc-receive', data }),
 		openCkETHReceive: <D extends T>(data: D) => set({ type: 'cketh-receive', data }),
+		openBtcReceive: <D extends T>(data: D) => set({ type: 'btc-receive', data }),
 		openReceive: <D extends T>(data: D) => set({ type: 'receive', data }),
 		openSend: <D extends T>(data: D) => set({ type: 'send', data }),
 		openBuy: <D extends T>(data: D) => set({ type: 'buy', data }),


### PR DESCRIPTION
# Motivation

In this PR, I have added the Receive modal for BTC. It has the same appearance as the respective ETH modal.

<img width="662" alt="Screenshot 2024-09-30 at 18 34 24" src="https://github.com/user-attachments/assets/b4e28e2b-36f1-4b06-8377-530c62c4ae3c">
