### PR TITLE
refactor(frontend): use Send context instead of token store in IcSendWizard

### DIFF
--- a/src/frontend/src/icp/components/fee/BitcoinKYTFee.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinKYTFee.svelte
@@ -1,19 +1,22 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
+	import { getContext } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { BTC_DECIMALS } from '$env/tokens.btc.env';
 	import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 	import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { tokenId } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 
 	export let networkId: NetworkId | undefined = undefined;
+
+	const { sendTokenId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let ckBTC = false;
 	$: ckBTC = isTokenCkBtcLedger($tokenWithFallbackAsIcToken);
@@ -22,7 +25,9 @@
 	$: btcNetwork = isNetworkIdBitcoin(networkId);
 
 	let kytFee: bigint | undefined = undefined;
-	$: kytFee = nonNullish($tokenId) ? $ckBtcMinterInfoStore?.[$tokenId]?.data.kyt_fee : undefined;
+	$: kytFee = nonNullish($sendTokenId)
+		? $ckBtcMinterInfoStore?.[$sendTokenId]?.data.kyt_fee
+		: undefined;
 </script>
 
 {#if ckBTC && btcNetwork && nonNullish(kytFee)}

--- a/src/frontend/src/icp/components/fee/IcTokenFee.svelte
+++ b/src/frontend/src/icp/components/fee/IcTokenFee.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
+	import { getContext } from 'svelte';
 	import type { OptionIcToken } from '$icp/types/ic';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { tokenDecimals } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { token } from '$lib/stores/token.store';
 	import { formatToken } from '$lib/utils/format.utils';
 
+	const { sendToken, sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
 	let decimals: number | undefined;
-	$: decimals = $token?.decimals;
+	$: decimals = $sendToken?.decimals;
 
 	let symbol: string | undefined;
-	$: symbol = $token?.symbol;
+	$: symbol = $sendToken?.symbol;
 
 	let fee: bigint | undefined;
-	$: fee = ($token as OptionIcToken)?.fee;
+	$: fee = ($sendToken as OptionIcToken)?.fee;
 </script>
 
 <Value ref="fee">
@@ -25,7 +27,7 @@
 		{formatToken({
 			value: BigNumber.from(fee),
 			unitName: decimals,
-			displayDecimals: $tokenDecimals
+			displayDecimals: $sendTokenDecimals
 		})}
 		{symbol}
 	{/if}

--- a/src/frontend/src/icp/components/send/IcSendDestination.svelte
+++ b/src/frontend/src/icp/components/send/IcSendDestination.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { debounce, isNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
-	import { tokenStandard } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
@@ -14,20 +14,22 @@
 
 	const dispatch = createEventDispatcher();
 
+	const { sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
 	let isInvalidDestination: () => boolean;
 
 	const init = () =>
 		(isInvalidDestination = (): boolean =>
-			isNullish($tokenStandard) ||
+			isNullish($sendTokenStandard) ||
 			isInvalidDestinationIc({
 				destination,
-				tokenStandard: $tokenStandard,
+				tokenStandard: $sendTokenStandard,
 				networkId
 			}));
 
 	const debounceValidateInit = debounce(init);
 
-	$: destination, $tokenStandard, networkId, debounceValidateInit();
+	$: destination, $sendTokenStandard, networkId, debounceValidateInit();
 
 	let inputPlaceholder: string;
 	$: inputPlaceholder = isNetworkIdEthereum(networkId)

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -1,24 +1,26 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import IcFeeDisplay from '$icp/components/send/IcFeeDisplay.svelte';
 	import IcSendAmount from '$icp/components/send/IcSendAmount.svelte';
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import type { IcAmountAssertionError } from '$icp/types/ic-send';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendSource from '$lib/components/send/SendSource.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import { balance } from '$lib/derived/balances.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
+
+	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let amountError: IcAmountAssertionError | undefined;
 	let invalidDestination: boolean;
@@ -39,7 +41,7 @@
 
 		<IcSendAmount bind:amount bind:amountError {networkId} />
 
-		<SendSource token={$token} balance={$balance} source={$icrcAccountIdentifierText ?? ''} />
+		<SendSource token={$sendToken} balance={$balance} source={$icrcAccountIdentifierText ?? ''} />
 
 		<IcFeeDisplay {networkId} />
 

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import IcFeeDisplay from '$icp/components/send/IcFeeDisplay.svelte';
 	import IcReviewNetwork from '$icp/components/send/IcReviewNetwork.svelte';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendData from '$lib/components/send/SendData.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import { balance } from '$lib/derived/balances.derived';
-	import { tokenStandard } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
@@ -21,13 +20,15 @@
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
 
+	const { sendToken, sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
 	// Should never happen given that the same checks are performed on previous wizard step
 	let invalid = true;
 	$: invalid =
-		isNullish($tokenStandard) ||
+		isNullish($sendTokenStandard) ||
 		isInvalidDestinationIc({
 			destination,
-			tokenStandard: $tokenStandard,
+			tokenStandard: $sendTokenStandard,
 			networkId
 		}) ||
 		invalidAmount(amount);
@@ -39,8 +40,8 @@
 </script>
 
 <ContentWithToolbar>
-	{#if nonNullish($token)}
-		<SendData {amount} {destination} token={$token} balance={$balance} {source}>
+	{#if nonNullish($sendToken)}
+		<SendData {amount} {destination} token={$sendToken} balance={$balance} {source}>
 			<IcFeeDisplay slot="fee" {networkId} />
 			<IcReviewNetwork {networkId} slot="network" />
 		</SendData>


### PR DESCRIPTION
# Motivation

We replace the token store (and its derived) in all the child components of IcSendWizard that are used ONLY in its tree.

NOTE: in some instances, we could have used the Send context derived (for example `$sendToken.decimals` could be `$sendTokenDecimals`), but to avoid any possible disruption or unexpected behavior I kept the same logic.

# Tests

Local replica send flow worked as expected.
