### PR TITLE
feat(backend): Class to manage btc pending transactions

### DIFF
--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -27,7 +27,7 @@ type PendingTransactionsMap = HashMap<BitcoinAddress, Vec<StoredPendingTransacti
 pub struct BtcUserPendingTransactions {
     /// Map of `user_principal` to `PendingTransactionsMap`;
     pending_transactions_map: HashMap<Principal, PendingTransactionsMap>,
-    /// Maximum number of transactions stored per principal.
+    /// Maximum number of transactions that will be stored per `(principal, address)` tuple.
     max_pending_transactions: usize,
     /// Maxumum number of addresses per user.
     max_addresses_per_user: usize,
@@ -127,7 +127,7 @@ impl BtcUserPendingTransactions {
                     *transactions = pruned_list;
                 }
             }
-            for address in addresses_to_remove.iter() {
+            for address in &addresses_to_remove {
                 address_map.remove(address.as_str());
             }
         }

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -2,6 +2,7 @@ use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::Utxo;
 use std::collections::HashMap;
 
+#[allow(dead_code)]
 const MAX_PENDING_TRANSACTIONS: usize = 1000;
 #[allow(dead_code)]
 const DAY_IN_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
@@ -20,6 +21,7 @@ pub struct BtcUserPendingTransactions {
 }
 
 impl BtcUserPendingTransactions {
+    #[allow(dead_code)]
     pub fn new(max_pending_txs: Option<usize>) -> Self {
         Self {
             pending_transactions_map: HashMap::new(),

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -67,12 +67,12 @@ impl BtcUserPendingTransactions {
     /// - Transaction is older than 1 day.
     ///   We consider that if a pending transaction is older than one day
     ///   it means it failed and we can free to utxos to be used again.
-    /// - The transaction has still `current_utxos` are not present in the current utxos list.
+    /// - None of the transaction's utxos are present in the current utxos list.
     ///   We use the pending transactions to avoid double spending.
     ///   Once we know that a utxos is not available, we can remove the pending transaction.
     ///   Normally, all utxos of a pending transaction should be present or not.
-    ///   Partial presence could be a sign of a bug somewhere, but there is no reason to fail.
-    ///   In the end, partial presence will be temporary for one day.
+    ///   Partial presence could happen if the utxos of a pending transaction were not really used in the transaction.
+    ///   We don't remove in partial presence because, in the end, partial presence will be temporary for one day.
     #[allow(dead_code)]
     pub fn prune_pending_transactions(
         &mut self,

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -1,0 +1,301 @@
+use candid::Principal;
+use ic_cdk::api::management_canister::bitcoin::Utxo;
+use std::collections::HashMap;
+
+const MAX_PENDING_TRANSACTIONS: usize = 1000;
+#[allow(dead_code)]
+const DAY_IN_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StoredPendingTransaction {
+    txid: Vec<u8>,
+    utxos: Vec<Utxo>,
+    created_at_timestamp_ns: u64,
+}
+
+#[allow(dead_code)]
+pub struct BtcUserPendingTransactions {
+    pending_transactions_map: HashMap<Principal, Vec<StoredPendingTransaction>>,
+    max_pending_transactions: usize,
+}
+
+impl BtcUserPendingTransactions {
+    pub fn new(max_pending_txs: Option<usize>) -> Self {
+        Self {
+            pending_transactions_map: HashMap::new(),
+            max_pending_transactions: max_pending_txs.unwrap_or(MAX_PENDING_TRANSACTIONS),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn get_pending_transactions(
+        &self,
+        principal: &Principal,
+    ) -> &Vec<StoredPendingTransaction> {
+        static EMPTY_VEC: Vec<StoredPendingTransaction> = Vec::new();
+        self.pending_transactions_map
+            .get(principal)
+            .unwrap_or(&EMPTY_VEC)
+    }
+
+    #[allow(dead_code)]
+    pub fn add_pending_transaction(
+        &mut self,
+        principal: Principal,
+        new_transaction: StoredPendingTransaction,
+    ) -> Result<(), String> {
+        if let Some(list) = self.pending_transactions_map.get_mut(&principal) {
+            if list.len() >= self.max_pending_transactions {
+                return Err("Maximum pending transactions reached".to_string());
+            }
+            list.push(new_transaction);
+        } else {
+            let list: Vec<StoredPendingTransaction> = vec![new_transaction];
+            self.pending_transactions_map.insert(principal, list);
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn prune_pending_transactions(
+        &mut self,
+        principal: Principal,
+        utxos: &[Utxo],
+        now_ns: u64,
+    ) {
+        if let Some(list) = self.pending_transactions_map.get(&principal) {
+            let pruned_list: Vec<StoredPendingTransaction> = list
+                .clone()
+                .into_iter()
+                .filter(|pending_transaction| {
+                    // We assume that if a pending transaction has been pending for longer than a day, it has been rejected.
+                    let is_old = pending_transaction.created_at_timestamp_ns + DAY_IN_NS < now_ns;
+                    let utxo_found = pending_transaction
+                        .utxos
+                        .iter()
+                        .find(|utxo| utxos.contains(utxo));
+                    !is_old && utxo_found.is_none()
+                })
+                .collect();
+            self.pending_transactions_map.insert(principal, pruned_list);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_cdk::api::management_canister::bitcoin::Outpoint;
+
+    const UTXO_1: Utxo = Utxo {
+        outpoint: Outpoint {
+            txid: vec![],
+            vout: 0,
+        },
+        value: 1000,
+        height: 100,
+    };
+    const UTXO_2: Utxo = Utxo {
+        outpoint: Outpoint {
+            txid: vec![],
+            vout: 1,
+        },
+        value: 2000,
+        height: 120,
+    };
+    const UTXO_3: Utxo = Utxo {
+        outpoint: Outpoint {
+            txid: vec![],
+            vout: 2,
+        },
+        value: 3000,
+        height: 150,
+    };
+    const UTXO_4: Utxo = Utxo {
+        outpoint: Outpoint {
+            txid: vec![],
+            vout: 2,
+        },
+        value: 8000,
+        height: 160,
+    };
+
+    const PRINCIPAL_TEXT_1: &str =
+        "7blps-itamd-lzszp-7lbda-4nngn-fev5u-2jvpn-6y3ap-eunp7-kz57e-fqe";
+    const PRINCIPAL_TEXT_2: &str =
+        "xzg7k-thc6c-idntg-knmtz-2fbhh-utt3e-snqw6-5xph3-54pbp-7axl5-tae";
+
+    #[test]
+    fn test_get_pending_transactions_empty() {
+        let btc_user_pending_transactions = BtcUserPendingTransactions::new(None);
+        let principal = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
+
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
+        assert!(pending_txs.is_empty());
+    }
+
+    #[test]
+    fn test_add_pending_transaction() {
+        let mut btc_user_pending_transactions = BtcUserPendingTransactions::new(None);
+        let principal = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
+        let tx = StoredPendingTransaction {
+            txid: vec![],
+            utxos: vec![UTXO_1],
+            created_at_timestamp_ns: 1_000_000,
+        };
+
+        // Add the pending transaction
+        let result =
+            btc_user_pending_transactions.add_pending_transaction(principal.clone(), tx.clone());
+        assert!(result.is_ok());
+
+        // Check that the transaction was added
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
+        assert_eq!(pending_txs.len(), 1);
+        assert_eq!(pending_txs[0], tx);
+    }
+
+    #[test]
+    fn test_add_pending_transaction_does_not_add_other_principal() {
+        let mut btc_user_pending_transactions = BtcUserPendingTransactions::new(None);
+        let principal1 = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
+        let principal2 = Principal::from_text(PRINCIPAL_TEXT_2).unwrap();
+        let tx = StoredPendingTransaction {
+            txid: vec![],
+            utxos: vec![UTXO_1],
+            created_at_timestamp_ns: 1_000_000,
+        };
+
+        let result =
+            btc_user_pending_transactions.add_pending_transaction(principal1.clone(), tx.clone());
+        assert!(result.is_ok());
+
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal2);
+        assert!(pending_txs.is_empty());
+    }
+
+    // Test for add_pending_transaction when MAX_PENDING_TRANSACTIONS is reached
+    #[test]
+    fn test_add_pending_transaction_max_limit() {
+        let mut btc_user_pending_transactions = BtcUserPendingTransactions::new(Some(3));
+        let principal = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
+
+        let tx1 = StoredPendingTransaction {
+            txid: vec![1, 2, 3],
+            utxos: vec![UTXO_1],
+            created_at_timestamp_ns: 1_000_000,
+        };
+        let tx2 = StoredPendingTransaction {
+            txid: vec![4, 5, 6],
+            utxos: vec![UTXO_2],
+            created_at_timestamp_ns: 2_000_000,
+        };
+        let tx3 = StoredPendingTransaction {
+            txid: vec![7, 8, 9],
+            utxos: vec![UTXO_3],
+            created_at_timestamp_ns: 3_000_000,
+        };
+        let tx4 = StoredPendingTransaction {
+            txid: vec![10, 11, 12],
+            utxos: vec![UTXO_4],
+            created_at_timestamp_ns: 4_000_000,
+        };
+
+        // Add 3 transactions (MAX_PENDING_TRANSACTIONS = 3)
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), tx1)
+            .unwrap();
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), tx2)
+            .unwrap();
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), tx3)
+            .unwrap();
+
+        // Try adding a 4th transaction and expect an error
+        let result = btc_user_pending_transactions.add_pending_transaction(principal.clone(), tx4);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Maximum pending transactions reached");
+    }
+
+    // Test pruning of old transactions
+    #[test]
+    fn test_prune_pending_transactions() {
+        let mut btc_user_pending_transactions = BtcUserPendingTransactions::new(None);
+        let principal = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
+
+        let yesterday_ns = 1_000_000;
+        let now_ns = yesterday_ns + DAY_IN_NS;
+
+        let old_transaction = StoredPendingTransaction {
+            txid: vec![1, 2, 3],
+            utxos: vec![UTXO_1],
+            created_at_timestamp_ns: yesterday_ns,
+        };
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), old_transaction.clone())
+            .unwrap();
+
+        let valid_transaction = StoredPendingTransaction {
+            txid: vec![4, 5, 6],
+            utxos: vec![UTXO_2],
+            created_at_timestamp_ns: now_ns,
+        };
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), valid_transaction.clone())
+            .unwrap();
+
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
+        assert_eq!(pending_txs.len(), 2);
+
+        btc_user_pending_transactions.prune_pending_transactions(
+            principal.clone(),
+            &[],
+            now_ns + 1,
+        );
+
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
+        assert_eq!(pending_txs.len(), 1);
+        assert_eq!(pending_txs[0], valid_transaction);
+    }
+
+    #[test]
+    fn test_prune_with_matching_utxos() {
+        let mut btc_user_pending_transactions = BtcUserPendingTransactions::new(None);
+        let principal = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
+
+        let now_ns = 1_000_000_000_000;
+
+        let transaction_1 = StoredPendingTransaction {
+            txid: vec![1, 2, 3],
+            utxos: vec![UTXO_1],
+            created_at_timestamp_ns: now_ns,
+        };
+        let transaction_2 = StoredPendingTransaction {
+            txid: vec![4, 5, 6],
+            utxos: vec![UTXO_2],
+            created_at_timestamp_ns: now_ns,
+        };
+
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), transaction_1.clone())
+            .unwrap();
+        btc_user_pending_transactions
+            .add_pending_transaction(principal.clone(), transaction_2.clone())
+            .unwrap();
+
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
+        assert_eq!(pending_txs.len(), 2);
+
+        let matching_utxos = &[UTXO_1];
+        btc_user_pending_transactions.prune_pending_transactions(
+            principal.clone(),
+            matching_utxos,
+            now_ns,
+        );
+
+        let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
+        assert_eq!(pending_txs.len(), 1);
+        assert_eq!(pending_txs[0], transaction_2);
+    }
+}

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -263,9 +263,11 @@ mod tests {
         let pending_txs = btc_user_pending_transactions.get_pending_transactions(&principal);
         assert_eq!(pending_txs.len(), 2);
 
+        let all_utxos = &[UTXO_1, UTXO_2];
+
         btc_user_pending_transactions.prune_pending_transactions(
             principal.clone(),
-            &[],
+            all_utxos,
             now_ns + 1,
         );
 

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -164,8 +164,8 @@ mod tests {
         let btc_user_pending_transactions = BtcUserPendingTransactions::new(None);
         let principal = Principal::from_text(PRINCIPAL_TEXT_1).unwrap();
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert!(pending_txs.is_empty());
     }
 
@@ -188,14 +188,14 @@ mod tests {
         assert!(result.is_ok());
 
         // Check that the transaction was added
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 1);
         assert_eq!(pending_txs[0], tx);
 
         // Check that the transaction was added to the proper address
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address2.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address2);
         assert!(pending_txs.is_empty());
     }
 
@@ -217,8 +217,8 @@ mod tests {
         );
         assert!(result.is_ok());
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal2, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal2, address1);
         assert!(pending_txs.is_empty());
     }
 
@@ -304,8 +304,8 @@ mod tests {
             )
             .unwrap();
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 2);
 
         let all_utxos = &[UTXO_1, UTXO_2];
@@ -316,8 +316,8 @@ mod tests {
             now_ns + 1,
         );
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 1);
         assert_eq!(pending_txs[0], valid_transaction);
     }
@@ -355,8 +355,8 @@ mod tests {
             )
             .unwrap();
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 2);
 
         let available_utxos = &[UTXO_1];
@@ -366,8 +366,8 @@ mod tests {
             now_ns,
         );
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 1);
         assert_eq!(pending_txs[0], transaction_1);
     }
@@ -405,8 +405,8 @@ mod tests {
             )
             .unwrap();
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 2);
 
         let available_utxos = &[UTXO_1, UTXO_3];
@@ -416,8 +416,8 @@ mod tests {
             now_ns,
         );
 
-        let pending_txs = btc_user_pending_transactions
-            .get_pending_transactions(&principal, address1.to_string());
+        let pending_txs =
+            btc_user_pending_transactions.get_pending_transactions(&principal, address1);
         assert_eq!(pending_txs.len(), 2);
     }
 }

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -34,7 +34,7 @@ impl BtcUserPendingTransactions {
         }
     }
 
-    /// Returns the pending transactions of a specific principal.
+    /// Returns the pending transactions of a specific principal per address.
     #[allow(dead_code)]
     pub fn get_pending_transactions(
         &self,
@@ -47,7 +47,7 @@ impl BtcUserPendingTransactions {
             .map_or(&EMPTY_VEC, |map| map.get(address).unwrap_or(&EMPTY_VEC))
     }
 
-    /// Adds a pending transaction for a specific principal.
+    /// Adds a pending transaction for a specific principal and address.
     /// It has a limit of storable transactions set on init.
     #[allow(dead_code)]
     pub fn add_pending_transaction(

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -39,13 +39,12 @@ impl BtcUserPendingTransactions {
     pub fn get_pending_transactions(
         &self,
         principal: &Principal,
-        address: String,
+        address: &str,
     ) -> &Vec<StoredPendingTransaction> {
         static EMPTY_VEC: Vec<StoredPendingTransaction> = Vec::new();
         self.pending_transactions_map
             .get(principal)
-            .map(|map| map.get(&address).unwrap_or(&EMPTY_VEC))
-            .unwrap_or(&EMPTY_VEC)
+            .map_or(&EMPTY_VEC, |map| map.get(address).unwrap_or(&EMPTY_VEC))
     }
 
     /// Adds a pending transaction for a specific principal.
@@ -95,7 +94,7 @@ impl BtcUserPendingTransactions {
         now_ns: u64,
     ) {
         if let Some(address_map) = self.pending_transactions_map.get_mut(&principal) {
-            for (_, transactions) in address_map.into_iter() {
+            for (_, transactions) in address_map.iter_mut() {
                 let pruned_list: Vec<StoredPendingTransaction> = transactions
                     .clone()
                     .into_iter()

--- a/src/backend/src/heap_state/btc_user_pending_tx_state.rs
+++ b/src/backend/src/heap_state/btc_user_pending_tx_state.rs
@@ -67,7 +67,7 @@ impl BtcUserPendingTransactions {
     /// - Transaction is older than 1 day.
     ///   We consider that if a pending transaction is older than one day
     ///   it means it failed and we can free to utxos to be used again.
-    /// - The transaction has still current_utxos are not present in the current utxos list.
+    /// - The transaction has still `current_utxos` are not present in the current utxos list.
     ///   We use the pending transactions to avoid double spending.
     ///   Once we know that a utxos is not available, we can remove the pending transaction.
     ///   Normally, all utxos of a pending transaction should be present or not.

--- a/src/backend/src/heap_state/mod.rs
+++ b/src/backend/src/heap_state/mod.rs
@@ -1,0 +1,2 @@
+pub mod btc_user_pending_tx_state;
+pub mod heap_state;

--- a/src/backend/src/heap_state/mod.rs
+++ b/src/backend/src/heap_state/mod.rs
@@ -1,2 +1,1 @@
 pub mod btc_user_pending_tx_state;
-pub mod heap_state;

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -45,6 +45,7 @@ mod bitcoin_api;
 mod bitcoin_utils;
 mod config;
 mod guards;
+mod heap_state;
 mod impls;
 mod migrate;
 mod oisy_user;


### PR DESCRIPTION
# Motivation

We want to store pending btc transactions to disable users from making transactions while there is one that hasn't finished.

In this PR, I introduce the module to manage the pending transactions. It adds functionality to add, read and prune the pending transaction.

This struc will then be added to the heap, (hence that I put it inside a directory `heap_state`) and used in the backend endpoints.

# Changes

* New class `BtcUserPendingTransactions` in module `heap_state/btc_user_pending_tx_state`.
* Add new module to lib.

# Tests

* Test class functionality.
