### PR TITLE
feat(backend): Expose and use min_confirmations filter to get utxos

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -124,6 +124,7 @@ type SelectedUtxosFeeRequest = record {
   network : BitcoinNetwork;
   amount_satoshis : nat64;
   source_address : text;
+  min_confirmations : opt nat32;
 };
 type SelectedUtxosFeeResponse = record {
   fee_satoshis : nat64;

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -294,7 +294,11 @@ async fn btc_select_user_utxos_fee(
     let all_utxos = bitcoin_api::get_all_utxos(
         params.network,
         params.source_address,
-        Some(MIN_CONFIRMATIONS_ACCEPTED_BTC_TX),
+        Some(
+            params
+                .min_confirmations
+                .unwrap_or(MIN_CONFIRMATIONS_ACCEPTED_BTC_TX),
+        ),
     )
     .await
     .map_err(|msg| SelectedUtxosFeeError::InternalError { msg })?;

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -285,13 +285,19 @@ fn list_custom_tokens() -> Vec<CustomToken> {
     read_state(|s| s.custom_token.get(&stored_principal).unwrap_or_default().0)
 }
 
+const MIN_CONFIRMATIONS_ACCEPTED_BTC_TX: u32 = 6;
+
 #[update(guard = "may_read_user_data")]
 async fn btc_select_user_utxos_fee(
     params: SelectedUtxosFeeRequest,
 ) -> Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError> {
-    let all_utxos = bitcoin_api::get_all_utxos(params.network, params.source_address)
-        .await
-        .map_err(|msg| SelectedUtxosFeeError::InternalError { msg })?;
+    let all_utxos = bitcoin_api::get_all_utxos(
+        params.network,
+        params.source_address,
+        Some(MIN_CONFIRMATIONS_ACCEPTED_BTC_TX),
+    )
+    .await
+    .map_err(|msg| SelectedUtxosFeeError::InternalError { msg })?;
 
     let median_fee_millisatoshi_per_vbyte = bitcoin_api::get_fee_per_byte(params.network)
         .await

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -19,6 +19,8 @@ fn test_select_user_utxos_fee_returns_zero_when_user_has_insufficient_funds() {
         amount_satoshis: 100_000_000u64,
         source_address: "bcrt1qpg7udjvq7gx2fp480pgt4hnhj3qc4nhrkstc33".to_string(),
         network: BitcoinNetwork::Regtest,
+        // Until bitcoin is supported in pocket-ic it only works with 1.
+        min_confirmations: Some(1),
     };
     let response = pic_setup.update::<Result<SelectedUtxosFeeResponse, SelectedUtxosFeeError>>(
         caller,

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -124,6 +124,7 @@ type SelectedUtxosFeeRequest = record {
   network : BitcoinNetwork;
   amount_satoshis : nat64;
   source_address : text;
+  min_confirmations : opt nat32;
 };
 type SelectedUtxosFeeResponse = record {
   fee_satoshis : nat64;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -136,6 +136,7 @@ export interface SelectedUtxosFeeRequest {
 	network: BitcoinNetwork;
 	amount_satoshis: bigint;
 	source_address: string;
+	min_confirmations: [] | [number];
 }
 export interface SelectedUtxosFeeResponse {
 	fee_satoshis: bigint;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -54,7 +54,8 @@ export const idlFactory = ({ IDL }) => {
 	const SelectedUtxosFeeRequest = IDL.Record({
 		network: BitcoinNetwork,
 		amount_satoshis: IDL.Nat64,
-		source_address: IDL.Text
+		source_address: IDL.Text,
+		min_confirmations: IDL.Opt(IDL.Nat32)
 	});
 	const Outpoint = IDL.Record({
 		txid: IDL.Vec(IDL.Nat8),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -54,7 +54,8 @@ export const idlFactory = ({ IDL }) => {
 	const SelectedUtxosFeeRequest = IDL.Record({
 		network: BitcoinNetwork,
 		amount_satoshis: IDL.Nat64,
-		source_address: IDL.Text
+		source_address: IDL.Text,
+		min_confirmations: IDL.Opt(IDL.Nat32)
 	});
 	const Outpoint = IDL.Record({
 		txid: IDL.Vec(IDL.Nat8),

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -170,6 +170,7 @@ pub mod bitcoin {
         pub amount_satoshis: u64,
         pub source_address: String,
         pub network: BitcoinNetwork,
+        pub min_confirmations: Option<u32>,
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
# Motivation

The bitcoin API to get utxos exposes a filter for the mininum confirmations of the transaction.

In this PR, I expose this filter in `get_all_utxos` and use it in the `btc_select_user_utxos_fee` endpoint.

# Changes

* Add optional parameter min_confirmations to `get_all_utxos`.
* Change page for filter parameter for helper `get_utxos`.
* Call `get_all_utxos` with 6 minimum confirmations.

# Tests

We can't add integration tests for bitcoin api until pocket-ic supports bitcoin.
