### PR TITLE
fix(ci): Run the bindings check when build commands are updated

### DIFF
--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -15,6 +15,8 @@ on:
       - # Rust files such as Cargo.lock, Cargo.toml and rust-toolchain.toml
         '**/Cargo*'
       - '**/*rust*'
+      - # Scripts that download external Candid files, with false positives.
+        'scripts/build.*.sh'
       - # This workflow
         '.github/workflows/binding-checks.yml'
   workflow_dispatch:

--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -2,48 +2,57 @@ name: Binding Checks
 
 on:
   pull_request:
-    paths:
-      - # Any new or changed canisters
-        'dfx.json'
-      - # Any new or changed .did files
-        '**/*.did'
-      - # Scripts, GitHub actions that contain 'backend' in their path.
-        '**/*backend*'
-      - # The backend source code
-        'src/backend/**'
-      - 'src/shared/**'
-      - # Rust files such as Cargo.lock, Cargo.toml and rust-toolchain.toml
-        '**/Cargo*'
-      - '**/*rust*'
-      - # Scripts that download external Candid files, with false positives.
-        'scripts/build.*.sh'
-      - # This workflow
-        '.github/workflows/binding-checks.yml'
   workflow_dispatch:
-
 jobs:
-
   generate:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - # Any new or changed canisters
+                'dfx.json'
+              - # Any new or changed .did files
+                '**/*.did'
+              - # Scripts, GitHub actions that contain 'backend' in their path.
+                '**/*backend*'
+              - # The backend source code
+                'src/backend/**'
+              - 'src/shared/**'
+              - # Rust files such as Cargo.lock, Cargo.toml and rust-toolchain.toml
+                '**/Cargo*'
+              - '**/*rust*'
+              - # Scripts that download external Candid files, with false positives.
+                'scripts/build.*.sh'
+              - # This workflow
+                '.github/workflows/binding-checks.yml'
       - name: Build oisy-backend WASM
+        if: steps.changes.outputs.src == 'true'
         uses: ./.github/actions/oisy-backend
       - name: Prepare
+        if: steps.changes.outputs.src == 'true'
         uses: ./.github/actions/prepare
       - name: Install dfx
+        if: steps.changes.outputs.src == 'true'
         uses: dfinity/setup-dfx@main
       - name: Install binstall
+        if: steps.changes.outputs.src == 'true'
         run: |
           BINSTALL_VERSION="1.8.0"
           curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf - cargo-binstall
           ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"
           rm cargo-binstall
       - name: Install candid-extractor
+        if: steps.changes.outputs.src == 'true'
         run: cargo binstall --no-confirm candid-extractor@0.1.4 && candid-extractor --version
       - name: Generate bindings
+        if: steps.changes.outputs.src == 'true'
         run: npm run generate
       - name: Check bindings
+        if: steps.changes.outputs.src == 'true'
         run: |
           test -z "$(git status --porcelain | tee /dev/stderr)" || {
                   echo "FIX: Please execute npm run generate"


### PR DESCRIPTION
# Motivation
The version of the signer was updated in #2592 but CI did not check the bindings.

# Changes
- Include the build scripts in the list of files that cause the bindings check to run.  The build scripts include the external canister version number.

Alternative considered:
- We could add the canister release number in `dfx.json`.  This would be outside the schema, but dfx has never objected to additional useful data being stored in `dfx.json`.  Theoretically the release number and the location of the candid file are all that are needed to specify the candid exactly and if those are both in `dfx.json` we can keep the list of triggers small, leading to faster CI.
  - I leave it up to the reviewer which they prefer.  In the PR I have gone for "conservative but slow" but would be very happy to use this instead.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
