### PR TITLE
feat(backend): Get canister IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,8 @@ dependencies = [
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
  "ic-cdk-timers",
+ "ic-cycles-ledger-client",
+ "ic-ledger-types",
  "ic-stable-structures 0.6.5",
  "ic-verifiable-credentials",
  "k256",
@@ -1595,6 +1597,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
+dependencies = [
+ "candid",
+ "ic-cdk-macros 0.16.0",
+ "ic0 0.23.0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-cdk-macros"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1642,20 @@ name = "ic-cdk-macros"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af44fb4ec3a4b18831c9d3303ca8fa2ace846c4022d50cb8df4122635d3782e"
+dependencies = [
+ "candid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream 0.2.1",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4d857135deef20cc7ea8f3869a30cd9cfeb1392b3a81043790b2cd82adc3e0"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -2051,6 +2080,21 @@ dependencies = [
  "serde_cbor",
  "strum 0.25.0",
  "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "ic-ledger-types"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a144b5b4c9e4b164b338440cfbdcf9f30ff45e3d48a3be62d2424996dc93d6f"
+dependencies = [
+ "candid",
+ "crc32fast",
+ "hex",
+ "ic-cdk 0.16.0",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -15,9 +15,12 @@ hex = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-cdk-timers = { workspace = true }
+ic-cycles-ledger-client = { workspace = true }
+ic-ledger-types = { workspace = true }
 ic-stable-structures = { workspace = true }
 ic-verifiable-credentials = { workspace = true }
 k256 = { workspace = true }
+lazy_static = { workspace = true }
 pretty_assertions = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -49,6 +49,7 @@ mod heap_state;
 mod impls;
 mod migrate;
 mod oisy_user;
+mod state;
 mod token;
 mod types;
 mod user_profile;

--- a/src/backend/src/state.rs
+++ b/src/backend/src/state.rs
@@ -4,6 +4,11 @@ use lazy_static::lazy_static;
 const MAINNET_CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
 const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
 
+// This gets canister IDs:
+// - `dfx` sets an environment variable with the canister ID.  If this is available, we use it.
+//    See: https://internetcomputer.org/docs/current/developer-docs/developer-tools/cli-tools/cli-reference/dfx-envars#canister_id_canistername
+// -  If that variable is not set for any reason, e.g. because we are not building with dfx, we default to the
+//    mainnet canister ID, which is also the recommended ID to use in test environments.
 lazy_static! {
     pub static ref CYCLES_LEDGER: Principal = Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
         .unwrap_or_else(|e| unreachable!("The cycles canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"));

--- a/src/backend/src/state.rs
+++ b/src/backend/src/state.rs
@@ -4,7 +4,6 @@ use lazy_static::lazy_static;
 const MAINNET_CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
 const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
 
-
 lazy_static! {
     pub static ref CYCLES_LEDGER: Principal = Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
         .unwrap_or_else(|e| unreachable!("The cycles canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"));

--- a/src/backend/src/state.rs
+++ b/src/backend/src/state.rs
@@ -11,7 +11,7 @@ const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
 //    mainnet canister ID, which is also the recommended ID to use in test environments.
 lazy_static! {
     pub static ref CYCLES_LEDGER: Principal = Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
-        .unwrap_or_else(|e| unreachable!("The cycles canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
+        .unwrap_or_else(|e| unreachable!("The cycles_ledger canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
     pub static ref SIGNER: Principal = Principal::from_text(option_env!("CANISTER_ID_SIGNER").unwrap_or(MAINNET_SIGNER_CANISTER_ID))
         .unwrap_or_else(|e| unreachable!("The signer canister ID from mainnet or dfx valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
 }

--- a/src/backend/src/state.rs
+++ b/src/backend/src/state.rs
@@ -1,0 +1,13 @@
+use candid::Principal;
+use lazy_static::lazy_static;
+
+const MAINNET_CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
+const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
+
+
+lazy_static! {
+    pub static ref CYCLES_LEDGER: Principal = Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
+        .unwrap_or_else(|e| unreachable!("The cycles canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
+    pub static ref SIGNER: Principal = Principal::from_text(option_env!("CANISTER_ID_SIGNER").unwrap_or(MAINNET_SIGNER_CANISTER_ID))
+        .unwrap_or_else(|e| unreachable!("The signer canister ID from mainnet or dfx valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
+}


### PR DESCRIPTION
# Motivation
The backend will need to  call the cycles ledger.  The PR is a bit large so here are a couple of small  preparation steps we can take:

- We will need the signer and cycles ledger canister IDs in the backend.
- We will need a couple of dependencies.

# Changes
- Add the parsed canister principals as lazy static variables.
- Add dependencies in cargo.toml

# Tests
None; these variables are still unused.