### PR TITLE
fix(frontend): BTC transaction modal

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -16,7 +16,7 @@
 	let to: string | undefined;
 	let type: TransactionType;
 	let value: bigint | undefined;
-	let timestamp: number | undefined;
+	let timestamp: bigint | undefined;
 	let id: string;
 	let blockNumber: number | undefined;
 	let status: BtcTransactionStatus;
@@ -30,6 +30,8 @@
 				: BTC_MAINNET_EXPLORER_URL;
 	}
 
+	$: ({ from, value, timestamp, id, blockNumber, to, type, status } = transaction);
+
 	let txExplorerUrl: string | undefined;
 	$: txExplorerUrl = nonNullish(explorerUrl) ? `${explorerUrl}/tx/${id}` : undefined;
 
@@ -39,21 +41,22 @@
 	let fromExplorerUrl: string | undefined;
 	$: fromExplorerUrl =
 		nonNullish(explorerUrl) && nonNullish(to) ? `${explorerUrl}/address/${from}` : undefined;
-
-	$: ({ from, value, timestamp, id, blockNumber, to, type, status } = transaction);
 </script>
 
 <TransactionModal
-	{from}
-	{to}
-	{timestamp}
-	{blockNumber}
+	commonData={{
+		to,
+		from,
+		timestamp,
+		blockNumber,
+		txExplorerUrl,
+		toExplorerUrl,
+		fromExplorerUrl
+	}}
 	hash={id}
-	{txExplorerUrl}
-	{toExplorerUrl}
-	{fromExplorerUrl}
-	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
 	value={nonNullish(value) ? BigNumber.from(value) : undefined}
+	sendToLabel={$i18n.transaction.text.to}
+	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
 >
 	<!--	TODO: Implement BtcTransactionStatus component	-->
 	<Value ref="status" slot="transaction-status">

--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import type { BtcTransactionStatus, BtcTransactionUi } from '$btc/types/btc';
+	import { BTC_MAINNET_EXPLORER_URL, BTC_TESTNET_EXPLORER_URL } from '$env/explorers.env';
+	import { isNetworkIdBTCTestnet, isNetworkIdBTCRegtest } from '$icp/utils/ic-send.utils';
+	import TransactionModal from '$lib/components/transactions/TransactionModal.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { TransactionType } from '$lib/types/transaction';
+
+	export let transaction: BtcTransactionUi;
+
+	let from: string;
+	let to: string | undefined;
+	let type: TransactionType;
+	let value: bigint | undefined;
+	let timestamp: number | undefined;
+	let id: string;
+	let blockNumber: number | undefined;
+	let status: BtcTransactionStatus;
+
+	let explorerUrl: string | undefined;
+	$: {
+		explorerUrl = isNetworkIdBTCTestnet($tokenWithFallback.network.id)
+			? BTC_TESTNET_EXPLORER_URL
+			: isNetworkIdBTCRegtest($tokenWithFallback.network.id)
+				? undefined
+				: BTC_MAINNET_EXPLORER_URL;
+	}
+
+	let txExplorerUrl: string | undefined;
+	$: txExplorerUrl = nonNullish(explorerUrl) ? `${explorerUrl}/tx/${id}` : undefined;
+
+	let toExplorerUrl: string | undefined;
+	$: toExplorerUrl = nonNullish(explorerUrl) ? `${explorerUrl}/address/${to}` : undefined;
+
+	let fromExplorerUrl: string | undefined;
+	$: fromExplorerUrl =
+		nonNullish(explorerUrl) && nonNullish(to) ? `${explorerUrl}/address/${from}` : undefined;
+
+	$: ({ from, value, timestamp, id, blockNumber, to, type, status } = transaction);
+</script>
+
+<TransactionModal
+	{from}
+	{to}
+	{timestamp}
+	{blockNumber}
+	hash={id}
+	{txExplorerUrl}
+	{toExplorerUrl}
+	{fromExplorerUrl}
+	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
+	value={nonNullish(value) ? BigNumber.from(value) : undefined}
+>
+	<!--	TODO: Implement BtcTransactionStatus component	-->
+	<Value ref="status" slot="transaction-status">
+		<svelte:fragment slot="label">{$i18n.transaction.text.status}</svelte:fragment>
+		{`${status === 'pending' ? $i18n.transaction.text.pending : 'Confirmed'}`}
+	</Value>
+</TransactionModal>

--- a/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import BtcTransaction from '$btc/components/transactions/BtcTransaction.svelte';
+	import BtcTransactionModal from '$btc/components/transactions/BtcTransactionModal.svelte';
 	import {
 		sortedBtcTransactions,
 		btcTransactionsNotInitialized
 	} from '$btc/derived/btc-transactions.derived';
+	import type { BtcTransactionUi } from '$btc/types/btc';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
+	import { modalBtcTransaction } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+
+	let selectedTransaction: BtcTransactionUi | undefined;
+	$: selectedTransaction = $modalBtcTransaction
+		? ($modalStore?.data as BtcTransactionUi | undefined)
+		: undefined;
 </script>
 
 <TokensSkeletons loading={$btcTransactionsNotInitialized}>
@@ -20,3 +30,7 @@
 		<p class="text-secondary mt-4 opacity-50">{$i18n.transactions.text.no_transactions}</p>
 	{/if}
 </TokensSkeletons>
+
+{#if $modalBtcTransaction && nonNullish(selectedTransaction)}
+	<BtcTransactionModal transaction={selectedTransaction} />
+{/if}

--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -1,17 +1,12 @@
-import type { TransactionType } from '$lib/types/transaction';
+import type { TransactionType, TransactionUiCommon } from '$lib/types/transaction';
 
 export type BtcTransactionStatus = 'confirmed' | 'pending';
 
-export interface BtcTransactionUi {
+export interface BtcTransactionUi extends TransactionUiCommon {
 	id: string;
-	timestamp?: bigint;
-	value?: bigint;
 	type: TransactionType;
 	status: BtcTransactionStatus;
-	from: string;
-	to?: string;
-	// The block number available only if a transaction has been confirmed
-	blockNumber?: number;
+	value?: bigint;
 
 	/* TODO: add one more field "confirmations", a number that represents the acceptance of a new block by the blockchain network.
 	 1. Use https://blockchain.info/latestblock to get info about the latest block height.

--- a/src/frontend/src/lib/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionModal.svelte
@@ -9,6 +9,7 @@
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { TransactionUiCommon } from '$lib/types/transaction';
 	import {
 		formatSecondsToDate,
 		formatToken,
@@ -16,16 +17,21 @@
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let from: string;
-	export let typeLabel: string;
-	export let to: string | undefined;
-	export let value: BigNumber | undefined;
-	export let timestamp: number | undefined;
+	export let commonData: TransactionUiCommon;
 	export let hash: string | undefined;
-	export let blockNumber: number | undefined;
-	export let txExplorerUrl: string | undefined;
-	export let fromExplorerUrl: string | undefined;
-	export let toExplorerUrl: string | undefined;
+	export let value: BigNumber | undefined;
+	export let typeLabel: string;
+	export let sendToLabel: string | undefined;
+
+	let from: string;
+	let to: string | undefined;
+	let timestamp: bigint | undefined;
+	let blockNumber: number | undefined;
+	let txExplorerUrl: string | undefined;
+	let fromExplorerUrl: string | undefined;
+	let toExplorerUrl: string | undefined;
+	$: ({ from, blockNumber, timestamp, to, fromExplorerUrl, toExplorerUrl, txExplorerUrl } =
+		commonData);
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
@@ -63,7 +69,7 @@
 		{#if nonNullish(timestamp)}
 			<Value ref="timestamp">
 				<svelte:fragment slot="label">{$i18n.transaction.text.timestamp}</svelte:fragment>
-				<output>{formatSecondsToDate(timestamp)}</output>
+				<output>{formatSecondsToDate(Number(timestamp))}</output>
 			</Value>
 		{/if}
 
@@ -89,7 +95,7 @@
 
 		{#if nonNullish(to)}
 			<Value ref="to">
-				<svelte:fragment slot="label">{$i18n.transaction.text.interacted_with}</svelte:fragment>
+				<svelte:fragment slot="label">{sendToLabel}</svelte:fragment>
 				<output>{to}</output><Copy
 					value={to}
 					text={$i18n.transaction.text.to_copied}

--- a/src/frontend/src/lib/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionModal.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { Modal } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import type { BigNumber } from '@ethersproject/bignumber';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Copy from '$lib/components/ui/Copy.svelte';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import {
+		formatSecondsToDate,
+		formatToken,
+		shortenWithMiddleEllipsis
+	} from '$lib/utils/format.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	export let from: string;
+	export let typeLabel: string;
+	export let to: string | undefined;
+	export let value: BigNumber | undefined;
+	export let timestamp: number | undefined;
+	export let hash: string | undefined;
+	export let blockNumber: number | undefined;
+	export let txExplorerUrl: string | undefined;
+	export let fromExplorerUrl: string | undefined;
+	export let toExplorerUrl: string | undefined;
+</script>
+
+<Modal on:nnsClose={modalStore.close}>
+	<svelte:fragment slot="title">{$i18n.transaction.text.details}</svelte:fragment>
+
+	<ContentWithToolbar>
+		{#if nonNullish(hash)}
+			<Value ref="hash">
+				<svelte:fragment slot="label">{$i18n.transaction.text.hash}</svelte:fragment>
+				<output>{shortenWithMiddleEllipsis({ text: hash })}</output><Copy
+					value={hash}
+					text={replacePlaceholders($i18n.transaction.text.hash_copied, {
+						$hash: hash
+					})}
+					inline
+				/>{#if nonNullish(txExplorerUrl)}<ExternalLink
+						iconSize="18"
+						href={txExplorerUrl}
+						ariaLabel={$i18n.transaction.alt.open_block_explorer}
+						inline
+						color="blue"
+					/>{/if}
+			</Value>
+		{/if}
+
+		{#if nonNullish(blockNumber)}
+			<Value ref="blockNumber">
+				<svelte:fragment slot="label">{$i18n.transaction.text.block}</svelte:fragment>
+				<output>{blockNumber}</output>
+			</Value>
+		{/if}
+
+		<slot name="transaction-status" />
+
+		{#if nonNullish(timestamp)}
+			<Value ref="timestamp">
+				<svelte:fragment slot="label">{$i18n.transaction.text.timestamp}</svelte:fragment>
+				<output>{formatSecondsToDate(timestamp)}</output>
+			</Value>
+		{/if}
+
+		<Value ref="type">
+			<svelte:fragment slot="label">{$i18n.transaction.text.type}</svelte:fragment>
+			<p class="first-letter:capitalize">{typeLabel}</p>
+		</Value>
+
+		<Value ref="from">
+			<svelte:fragment slot="label">{$i18n.transaction.text.from}</svelte:fragment>
+			<output>{from}</output><Copy
+				value={from}
+				text={$i18n.transaction.text.from_copied}
+				inline
+			/>{#if nonNullish(fromExplorerUrl)}<ExternalLink
+					iconSize="18"
+					href={fromExplorerUrl}
+					ariaLabel={$i18n.transaction.alt.open_from_block_explorer}
+					inline
+					color="blue"
+				/>{/if}
+		</Value>
+
+		{#if nonNullish(to)}
+			<Value ref="to">
+				<svelte:fragment slot="label">{$i18n.transaction.text.interacted_with}</svelte:fragment>
+				<output>{to}</output><Copy
+					value={to}
+					text={$i18n.transaction.text.to_copied}
+					inline
+				/>{#if nonNullish(toExplorerUrl)}<ExternalLink
+						iconSize="18"
+						href={toExplorerUrl}
+						ariaLabel={$i18n.transaction.alt.open_to_block_explorer}
+						inline
+						color="blue"
+					/>{/if}
+			</Value>
+		{/if}
+
+		{#if nonNullish(value)}
+			<Value ref="amount">
+				<svelte:fragment slot="label">{$i18n.core.text.amount}</svelte:fragment>
+				<output>
+					{formatToken({
+						value,
+						unitName: $tokenWithFallback.decimals,
+						displayDecimals: $tokenWithFallback.decimals
+					})}
+					{$tokenWithFallback.symbol}
+				</output>
+			</Value>
+		{/if}
+
+		<button class="primary full center text-center" on:click={modalStore.close} slot="toolbar"
+			>{$i18n.core.text.close}</button
+		>
+	</ContentWithToolbar>
+</Modal>

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -14,3 +14,10 @@ export type TransactionFeeData = Pick<FeeData, 'maxFeePerGas' | 'maxPriorityFeeP
 };
 
 export type TransactionType = 'send' | 'receive';
+
+export type TransactionUiCommon = Pick<Transaction, 'blockNumber' | 'from' | 'to'> & {
+	timestamp?: bigint;
+	txExplorerUrl?: string;
+	toExplorerUrl?: string;
+	fromExplorerUrl?: string;
+};


### PR DESCRIPTION
# Motivation

The goal is to have the BTC modal implemented with basic info (e.g. it's missing confirmations number, or a proper component for displaying a tx status). Also, I added a common `TransactionModal` which will be later for IC and ETH cases too.

The further data will be added in separate PRs.


<img width="480" alt="Screenshot 2024-10-02 at 13 21 35" src="https://github.com/user-attachments/assets/b42f8921-1aa4-47db-a1da-a96e9468240a">
