### PR TITLE
style(frontend): smaller screens will have the same background as larger ones [GIX-3067]

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -186,8 +186,6 @@
 				width: 100%;
 				min-width: 1728px;
 
-				display: block;
-
 				z-index: -1;
 			}
 		</style>

--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -186,15 +186,9 @@
 				width: 100%;
 				min-width: 1728px;
 
-				display: none;
+				display: block;
 
 				z-index: -1;
-			}
-
-			@media screen and (min-width: 640px) {
-				#app-background {
-					display: block;
-				}
 			}
 		</style>
 


### PR DESCRIPTION
# Motivation

With this PR we allow smaller screens to have the same background as bigger ones.

<img width="570" alt="Screenshot 2024-10-02 at 18 39 27" src="https://github.com/user-attachments/assets/d5682762-b54f-46ff-bdec-8c5dce3d0823">
<img width="377" alt="Screenshot 2024-10-02 at 18 39 43" src="https://github.com/user-attachments/assets/19f6b0a8-c617-4e84-a58d-e509f8f035f4">
<img width="429" alt="Screenshot 2024-10-02 at 18 39 55" src="https://github.com/user-attachments/assets/7cc7c924-b66b-40f2-8b08-322b0e000493">
