### PR TITLE
fix(frontend): prefix btc-transactions derived stores

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
@@ -2,21 +2,21 @@
 	import { slide } from 'svelte/transition';
 	import BtcTransaction from '$btc/components/transactions/BtcTransaction.svelte';
 	import {
-		sortedTransactions,
-		transactionsNotInitialized
+		sortedBtcTransactions,
+		btcTransactionsNotInitialized
 	} from '$btc/derived/btc-transactions.derived';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
-<TokensSkeletons loading={$transactionsNotInitialized}>
-	{#each $sortedTransactions as transaction (transaction.data.id)}
+<TokensSkeletons loading={$btcTransactionsNotInitialized}>
+	{#each $sortedBtcTransactions as transaction (transaction.data.id)}
 		<div transition:slide={{ duration: 250 }}>
 			<BtcTransaction transaction={transaction.data} />
 		</div>
 	{/each}
 
-	{#if $sortedTransactions.length === 0}
+	{#if $sortedBtcTransactions.length === 0}
 		<p class="text-secondary mt-4 opacity-50">{$i18n.transactions.text.no_transactions}</p>
 	{/if}
 </TokensSkeletons>

--- a/src/frontend/src/btc/derived/btc-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/btc-transactions.derived.ts
@@ -6,17 +6,17 @@ import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 // TODO: decide how BTC transactions should be sorted and apply it here
-export const sortedTransactions: Readable<TransactionsData<BtcTransactionUi>> = derived(
+export const sortedBtcTransactions: Readable<TransactionsData<BtcTransactionUi>> = derived(
 	[btcTransactionsStore, tokenWithFallback],
 	([$transactionsStore, $token]) => $transactionsStore?.[$token.id] ?? []
 );
 
-export const transactionsInitialized: Readable<boolean> = derived(
+export const btcTransactionsInitialized: Readable<boolean> = derived(
 	[btcTransactionsStore, tokenWithFallback],
-	([$transactionsStore, { id: $tokenId }]) => nonNullish($transactionsStore?.[$tokenId])
+	([$btcTransactionsStore, { id: $tokenId }]) => nonNullish($btcTransactionsStore?.[$tokenId])
 );
 
-export const transactionsNotInitialized: Readable<boolean> = derived(
-	[transactionsInitialized],
-	([$transactionsInitialized]) => !$transactionsInitialized
+export const btcTransactionsNotInitialized: Readable<boolean> = derived(
+	[btcTransactionsInitialized],
+	([$btcTransactionsInitialized]) => !$btcTransactionsInitialized
 );


### PR DESCRIPTION
# Motivation

The goal is to prefix all BTC tx derived stores with "btc".
