### PR TITLE
style(frontend): remove deprecated button class secondary-alt

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if $metamaskAvailable && $networkEthereum && tokenStandardEth}
-	<button class="secondary-alt full center my-4" on:click={receiveModal}>
+	<button class="primary full center my-4" on:click={receiveModal}>
 		<IconMetamask />
 		<span class="text-dark-slate-blue font-bold">{$i18n.receive.ethereum.text.metamask}</span>
 	</button>

--- a/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsSignedIn.svelte
@@ -125,7 +125,7 @@
 							{$i18n.settings.text.pouh_credential_verified}
 						</output>
 					{:else}
-						<button type="button" class="secondary-alt" on:click={getPouhCredential}
+						<button type="button" class="primary" on:click={getPouhCredential}
 							>{$i18n.settings.text.present_pouh_credential}</button
 						>
 					{/if}

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -24,22 +24,18 @@ button {
 	--button-padding: var(--padding-2x) var(--padding-3x);
 
 	&.primary,
-	&.secondary,
-	&.secondary-alt {
+	&.secondary {
 		justify-content: flex-start;
 
 		padding: var(--button-padding);
 	}
 
-	// TODO: check with Design team if this class is still needed
-	&.secondary-alt,
 	&.user {
 		border: 1px solid var(--color-blue);
 	}
 
 	&.primary,
-	&.secondary,
-	&.secondary-alt {
+	&.secondary {
 		font-weight: var(--font-weight-bold);
 
 		&[disabled],
@@ -91,11 +87,6 @@ button {
 		}
 	}
 
-	&.secondary-alt {
-		background: var(--color-cetacean-blue);
-		color: var(--color-white);
-	}
-
 	&.hero {
 		justify-content: center;
 
@@ -108,8 +99,7 @@ button {
 	}
 
 	&.primary,
-	&.secondary,
-	&.secondary-alt {
+	&.secondary {
 		&.full {
 			width: 100%;
 		}

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -21,7 +21,6 @@
 	--color-chocolate-cosmos: theme(colors.chocolate-cosmos);
 	--color-upsdell-red: theme(colors.upsdell-red);
 	--color-brandeis-blue: theme(colors.brandeis-blue);
-	--color-cetacean-blue: theme(colors.cetacean-blue);
 	--color-pale-cornflower-blue: theme(colors.pale-cornflower-blue);
 	--color-brilliant-azure: theme(colors.brilliant-azure);
 	--color-blue-ribbon-rgb: theme(colors.blue-ribbon-rgb);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,6 @@ export default {
 			'blue-ribbon-rgb': '0, 102, 255',
 			'dark-blue': '#321469',
 			'brandeis-blue': '#016dfc',
-			'cetacean-blue': '#0e002d',
 			'pale-cornflower-blue': '#b0cdff',
 			'brilliant-azure': '#348afd',
 			'misty-rose': '#937993',


### PR DESCRIPTION
# Motivation

The `secondary-alt` button class could be substituted by `primary` class, according to the design team (the difference is just the background color). So, that class is deprecated.

# Results

Here the only two buttons that still had the deprecated class.

<img width="429" alt="Screenshot 2024-10-02 at 18 49 21" src="https://github.com/user-attachments/assets/c95b61d7-7c75-4a78-bba4-142dbe64327d">
<img width="428" alt="Screenshot 2024-10-02 at 18 50 04" src="https://github.com/user-attachments/assets/f611085b-d1e0-4972-9372-f14841d3a310">


