### PR TITLE
style(frontend): new tertiary-link class for buttons [GIX-3048]

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonIcon.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonIcon.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <button
-	class="tertiary-link icon flex flex-col text-center text-xs font-normal"
+	class="tertiary link icon flex flex-col text-center text-xs font-normal"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}

--- a/src/frontend/src/lib/components/ui/ButtonIcon.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonIcon.svelte
@@ -5,14 +5,12 @@
 </script>
 
 <button
-	class="icon text-primary flex flex-col text-center text-xs font-normal"
+	class="tertiary-link icon flex flex-col text-center text-xs font-normal"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}
 	data-tid={testId}
 >
-	<div class="border-primary rounded-full border bg-white p-2">
-		<slot name="icon" />
-	</div>
+	<slot name="icon" />
 	<span class="visually-hidden"><slot /></span>
 </button>

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -25,7 +25,7 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.tertiary-link {
+	&.tertiary {
 		justify-content: flex-start;
 
 		padding: var(--button-padding);
@@ -42,7 +42,7 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.tertiary-link {
+	&.tertiary {
 		font-weight: var(--font-weight-bold);
 
 		&[disabled],
@@ -108,16 +108,18 @@ button {
 		}
 	}
 
-	&.tertiary-link {
-		background: var(--color-white);
-		color: var(--color-primary);
+	&.tertiary {
+		&.link {
+			background: var(--color-white);
+			color: var(--color-primary);
 
-		&:hover {
-			color: var(--color-secondary);
-		}
+			&:hover {
+				color: var(--color-secondary);
+			}
 
-		&:active {
-			background: var(--color-onahau);
+			&:active {
+				background: var(--color-onahau);
+			}
 		}
 	}
 

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -25,10 +25,15 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.secondary-alt {
+	&.tertiary-link {
 		justify-content: flex-start;
 
 		padding: var(--button-padding);
+
+		&.icon {
+			--button-border-radius: var(--border-radius-sm-1_5x);
+			--button-padding: var(--padding);
+		}
 	}
 
 	// TODO: check with Design team if this class is still needed
@@ -39,7 +44,7 @@ button {
 
 	&.primary,
 	&.secondary,
-	&.secondary-alt {
+	&.tertiary-link {
 		font-weight: var(--font-weight-bold);
 
 		&[disabled],
@@ -94,6 +99,19 @@ button {
 	&.secondary-alt {
 		background: var(--color-cetacean-blue);
 		color: var(--color-white);
+	}
+
+	&.tertiary-link {
+		background: var(--color-white);
+		color: var(--color-primary);
+
+		&:hover {
+			color: var(--color-secondary);
+		}
+
+		&:active {
+			background: var(--color-onahau);
+		}
 	}
 
 	&.hero {

--- a/src/frontend/src/lib/styles/global/variables.scss
+++ b/src/frontend/src/lib/styles/global/variables.scss
@@ -16,6 +16,7 @@
 
 	--border-radius-xs: calc(var(--border-radius-sm) * 0.5);
 	--border-radius-sm: 8px;
+	--border-radius-sm-1_5x: calc(var(--border-radius-sm) * 1.5);
 	--border-radius-md: calc(var(--border-radius-sm) * 2);
 	--border-radius-lg: calc(var(--border-radius-sm) * 4);
 


### PR DESCRIPTION
# Motivation

We introduce a new class of buttons called `tertiary-link`. Its first usage is for the `ButtonIcon` components. 

### Normal state

<img width="742" alt="Screenshot 2024-10-02 at 19 09 28" src="https://github.com/user-attachments/assets/915fa789-634c-464d-9ec2-fcf7284566e8">

### Hover state

<img width="741" alt="Screenshot 2024-10-02 at 19 09 35" src="https://github.com/user-attachments/assets/1b6c1d7a-eb7e-4a46-90e9-237d013ac91e">

### Usage with all states

https://github.com/user-attachments/assets/284bf65d-f9cc-4ecb-b230-cb3654c70bea

