### PR TITLE
style(frontend): remove focus state if button is clicked

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -63,6 +63,20 @@ button {
 				0 0 0 2px var(--color-white),
 				0 0 0 4px var(--color-blue-ribbon);
 		}
+
+		&:focus:not(:focus-visible) {
+			outline: none;
+			box-shadow: none;
+		}
+
+		&[active],
+		&:active {
+			&[focus],
+			&:focus {
+				outline: none;
+				box-shadow: none;
+			}
+		}
 	}
 
 	&.primary {


### PR DESCRIPTION
# Motivation

Opinionated PR: when a button is clicked, it should not show the `focus` state colors. The `focus` state is visible only when the button is selection interaction.

### Before

https://github.com/user-attachments/assets/c08c79a8-ee4e-4ea7-bf88-2e3cbbcb2d97

### After

https://github.com/user-attachments/assets/290770dd-ace8-4b25-9886-f1f6431ad212


