### PR TITLE
feat(backend): Check pending transaction before selecting utxos

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -158,7 +158,10 @@ type Result_4 = variant {
 type Result_5 = variant { Ok : UserProfile; Err : GetUserProfileError };
 type Result_6 = variant { Ok : MigrationReport; Err : text };
 type Result_7 = variant { Ok; Err : text };
-type SelectedUtxosFeeError = variant { InternalError : record { msg : text } };
+type SelectedUtxosFeeError = variant {
+  PendingTransactions;
+  InternalError : record { msg : text };
+};
 type SelectedUtxosFeeRequest = record {
   network : BitcoinNetwork;
   amount_satoshis : nat64;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -158,7 +158,10 @@ type Result_4 = variant {
 type Result_5 = variant { Ok : UserProfile; Err : GetUserProfileError };
 type Result_6 = variant { Ok : MigrationReport; Err : text };
 type Result_7 = variant { Ok; Err : text };
-type SelectedUtxosFeeError = variant { InternalError : record { msg : text } };
+type SelectedUtxosFeeError = variant {
+  PendingTransactions;
+  InternalError : record { msg : text };
+};
 type SelectedUtxosFeeRequest = record {
   network : BitcoinNetwork;
   amount_satoshis : nat64;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -172,7 +172,9 @@ export type Result_4 = { Ok: SelectedUtxosFeeResponse } | { Err: SelectedUtxosFe
 export type Result_5 = { Ok: UserProfile } | { Err: GetUserProfileError };
 export type Result_6 = { Ok: MigrationReport } | { Err: string };
 export type Result_7 = { Ok: null } | { Err: string };
-export type SelectedUtxosFeeError = { InternalError: { msg: string } };
+export type SelectedUtxosFeeError =
+	| { PendingTransactions: null }
+	| { InternalError: { msg: string } };
 export interface SelectedUtxosFeeRequest {
 	network: BitcoinNetwork;
 	amount_satoshis: bigint;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -119,6 +119,7 @@ export const idlFactory = ({ IDL }) => {
 		utxos: IDL.Vec(Utxo)
 	});
 	const SelectedUtxosFeeError = IDL.Variant({
+		PendingTransactions: IDL.Null,
 		InternalError: IDL.Record({ msg: IDL.Text })
 	});
 	const Result_4 = IDL.Variant({

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -119,6 +119,7 @@ export const idlFactory = ({ IDL }) => {
 		utxos: IDL.Vec(Utxo)
 	});
 	const SelectedUtxosFeeError = IDL.Variant({
+		PendingTransactions: IDL.Null,
 		InternalError: IDL.Record({ msg: IDL.Text })
 	});
 	const Result_4 = IDL.Variant({

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -182,6 +182,7 @@ pub mod bitcoin {
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
     pub enum SelectedUtxosFeeError {
         InternalError { msg: String },
+        PendingTransactions,
     }
 
     #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]


### PR DESCRIPTION
# Motivation

Avoid users double spending their utxos.

In this PR, before we select the utxos for a transaction, we check whether the user has any pending utxos. If that is the case, then the endpoint fails.

Ideally, we would ignore the pending utxos and use other utxos. But this is an improvement we can do later.

# Changes

* Add one entry to enum `SelectedUtxosFeeError`: `PendingTransactions`.
* Prune pending utxos and check whether there are any within `btc_select_user_utxos_fee`.

# Tests

* I added a test to check the return value of the new error. For this, I checked that if we don't prune, the error is returned.
