### PR TITLE
feat(tests): Deploy the cycles ledger & depositor

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,5 +21,7 @@ mkdir -p ./target/ic
 
 dfx deploy internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
 dfx deploy pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
+dfx deploy cycles_ledger
+dfx deploy cycles_depositor
 
 scripts/top-up-cycles-ledger-account backend 10000000000000


### PR DESCRIPTION
# Motivation
The cycles ledger is not deployed into test environments.  We will need it there.

# Changes
- Add `dfx deploy cycles_{ledger,depositor}` to `scripts/deploy.sh`

Alternatives considered:
- Replace the whole contents of `deploy.sh` with `dfx deploy` to deploy everything in one stroke.
  - There are probably details why this is not currently possible.  Maybe something to look into after launch.

# Tests
See existing CI.  Presumably `deplpoy.sh` is exercised and will fail if the new deployments fail.