### PR TITLE
feat(frontend): handle backend and signer canisters errors

### DIFF
--- a/src/frontend/src/lib/canisters/backend.errors.ts
+++ b/src/frontend/src/lib/canisters/backend.errors.ts
@@ -4,15 +4,15 @@ import type {
 } from '$declarations/backend/backend.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
-export const btcPendingTransactionError = (response: BtcAddPendingTransactionError) => {
+export const mapBtcPendingTransactionError = (response: BtcAddPendingTransactionError) => {
 	if ('InternalError' in response) {
 		return new CanisterInternalError(response.InternalError.msg);
 	}
 
-	return new Error('Unknown BtcAddPendingTransactionError');
+	return new CanisterInternalError('Unknown BtcAddPendingTransactionError');
 };
 
-export const btcSelectUserUtxosFeeError = (response: SelectedUtxosFeeError) => {
+export const mapBtcSelectUserUtxosFeeError = (response: SelectedUtxosFeeError) => {
 	if ('InternalError' in response) {
 		return new CanisterInternalError(response.InternalError.msg);
 	}
@@ -23,5 +23,5 @@ export const btcSelectUserUtxosFeeError = (response: SelectedUtxosFeeError) => {
 		);
 	}
 
-	return new Error('Unknown BtcSelectUserUtxosFeeError');
+	return new CanisterInternalError('Unknown BtcSelectUserUtxosFeeError');
 };

--- a/src/frontend/src/lib/canisters/backend.errors.ts
+++ b/src/frontend/src/lib/canisters/backend.errors.ts
@@ -1,0 +1,19 @@
+import type {
+	BtcAddPendingTransactionError,
+	SelectedUtxosFeeError
+} from '$declarations/backend/backend.did';
+import { CanisterInternalError } from '$lib/canisters/errors';
+
+export const backendCanisterError = (
+	response: BtcAddPendingTransactionError | SelectedUtxosFeeError
+) => {
+	if ('InternalError' in response) {
+		return new CanisterInternalError(response.InternalError.msg);
+	}
+
+	if ('PendingTransactions' in response) {
+		return new CanisterInternalError('Action is not possible - pending transactions found.');
+	}
+
+	return new Error('Unknown BackendError');
+};

--- a/src/frontend/src/lib/canisters/backend.errors.ts
+++ b/src/frontend/src/lib/canisters/backend.errors.ts
@@ -4,16 +4,24 @@ import type {
 } from '$declarations/backend/backend.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
-export const backendCanisterError = (
-	response: BtcAddPendingTransactionError | SelectedUtxosFeeError
-) => {
+export const btcPendingTransactionError = (response: BtcAddPendingTransactionError) => {
+	if ('InternalError' in response) {
+		return new CanisterInternalError(response.InternalError.msg);
+	}
+
+	return new Error('Unknown BtcAddPendingTransactionError');
+};
+
+export const btcSelectUserUtxosFeeError = (response: SelectedUtxosFeeError) => {
 	if ('InternalError' in response) {
 		return new CanisterInternalError(response.InternalError.msg);
 	}
 
 	if ('PendingTransactions' in response) {
-		return new CanisterInternalError('Action is not possible - pending transactions found.');
+		return new CanisterInternalError(
+			'Selecting utxos fee is not possible - pending transactions found.'
+		);
 	}
 
-	return new Error('Unknown BackendError');
+	return new Error('Unknown BtcSelectUserUtxosFeeError');
 };

--- a/src/frontend/src/lib/canisters/errors.ts
+++ b/src/frontend/src/lib/canisters/errors.ts
@@ -1,0 +1,5 @@
+export class CanisterInternalError extends Error {
+	constructor(msg: string) {
+		super(msg);
+	}
+}

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -9,7 +9,7 @@ import { getAgent } from '$lib/actors/agents.ic';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices } from '@dfinity/utils';
-import { signerCanisterBtcError } from './signer.errors';
+import { mapSignerCanisterBtcError } from './signer.errors';
 
 export class SignerCanister extends Canister<SignerService> {
 	static async create({ identity, ...options }: CreateCanisterOptions<SignerService>) {
@@ -35,7 +35,7 @@ export class SignerCanister extends Canister<SignerService> {
 		const response = await btc_caller_address({ network, address_type: { P2WPKH: null } }, []);
 
 		if ('Err' in response) {
-			throw signerCanisterBtcError(response.Err);
+			throw mapSignerCanisterBtcError(response.Err);
 		}
 
 		return response.Ok.address;
@@ -49,7 +49,7 @@ export class SignerCanister extends Canister<SignerService> {
 		const response = await btc_caller_balance({ network, address_type: { P2WPKH: null } }, []);
 
 		if ('Err' in response) {
-			throw signerCanisterBtcError(response.Err);
+			throw mapSignerCanisterBtcError(response.Err);
 		}
 
 		return response.Ok.balance;

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -9,7 +9,7 @@ import { getAgent } from '$lib/actors/agents.ic';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices } from '@dfinity/utils';
-import { signerCanisterError } from './signer.errors';
+import { signerCanisterBtcError } from './signer.errors';
 
 export class SignerCanister extends Canister<SignerService> {
 	static async create({ identity, ...options }: CreateCanisterOptions<SignerService>) {
@@ -35,7 +35,7 @@ export class SignerCanister extends Canister<SignerService> {
 		const response = await btc_caller_address({ network, address_type: { P2WPKH: null } }, []);
 
 		if ('Err' in response) {
-			throw signerCanisterError(response.Err);
+			throw signerCanisterBtcError(response.Err);
 		}
 
 		return response.Ok.address;
@@ -49,7 +49,7 @@ export class SignerCanister extends Canister<SignerService> {
 		const response = await btc_caller_balance({ network, address_type: { P2WPKH: null } }, []);
 
 		if ('Err' in response) {
-			throw signerCanisterError(response.Err);
+			throw signerCanisterBtcError(response.Err);
 		}
 
 		return response.Ok.balance;

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -21,7 +21,7 @@ export class SignerCanisterPaymentError extends Error {
 	}
 }
 
-export const signerCanisterError = (response: GetAddressError) => {
+export const signerCanisterBtcError = (response: GetAddressError) => {
 	if ('InternalError' in response) {
 		return new CanisterInternalError(response.InternalError.msg);
 	}

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -1,4 +1,5 @@
 import type { GetAddressError, PaymentError } from '$declarations/signer/signer.did';
+import { CanisterInternalError } from '$lib/canisters/errors';
 
 export class SignerCanisterPaymentError extends Error {
 	constructor(response: PaymentError) {
@@ -20,15 +21,9 @@ export class SignerCanisterPaymentError extends Error {
 	}
 }
 
-export class SignerCanisterInternalError extends Error {
-	constructor(msg: string) {
-		super(msg);
-	}
-}
-
 export const signerCanisterError = (response: GetAddressError) => {
 	if ('InternalError' in response) {
-		return new SignerCanisterInternalError(response.InternalError.msg);
+		return new CanisterInternalError(response.InternalError.msg);
 	}
 	if ('PaymentError' in response) {
 		return new SignerCanisterPaymentError(response.PaymentError);

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -21,12 +21,12 @@ export class SignerCanisterPaymentError extends Error {
 	}
 }
 
-export const signerCanisterBtcError = (response: GetAddressError) => {
+export const mapSignerCanisterBtcError = (response: GetAddressError) => {
 	if ('InternalError' in response) {
 		return new CanisterInternalError(response.InternalError.msg);
 	}
 	if ('PaymentError' in response) {
 		return new SignerCanisterPaymentError(response.PaymentError);
 	}
-	return new Error('Unknown GetAddressError');
+	return new CanisterInternalError('Unknown GetAddressError');
 };

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,9 +1,7 @@
 import type { _SERVICE as SignerService, SignRequest } from '$declarations/signer/signer.did';
+import { CanisterInternalError } from '$lib/canisters/errors';
 import { SignerCanister } from '$lib/canisters/signer.canister';
-import {
-	SignerCanisterInternalError,
-	SignerCanisterPaymentError
-} from '$lib/canisters/signer.errors';
+import { SignerCanisterPaymentError } from '$lib/canisters/signer.errors';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
@@ -84,9 +82,7 @@ describe('signer.canister', () => {
 
 		const res = getBtcAddress(btcParams);
 
-		await expect(res).rejects.toThrow(
-			new SignerCanisterInternalError(response.Err.InternalError.msg)
-		);
+		await expect(res).rejects.toThrow(new CanisterInternalError(response.Err.InternalError.msg));
 	});
 
 	it('should throw an error if btc_caller_address returns a payment error', async () => {
@@ -144,9 +140,7 @@ describe('signer.canister', () => {
 
 		const res = getBtcBalance(btcParams);
 
-		await expect(res).rejects.toThrow(
-			new SignerCanisterInternalError(response.Err.InternalError.msg)
-		);
+		await expect(res).rejects.toThrow(new CanisterInternalError(response.Err.InternalError.msg));
 	});
 
 	it('should throw an error if btc_caller_balance returns a payment error', async () => {


### PR DESCRIPTION
# Motivation

The goal is to handle Backend canister errors, for now only for BTC endpoints.
