### PR TITLE
build(local): remove dfx.json dependencies

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -8,7 +8,6 @@
 			"wasm": "target/signer.wasm.gz",
 			"init_arg_file": "target/signer.arg.did",
 			"shrink": false,
-			"dependencies": ["cycles_ledger"],
 			"specified_id": "grghe-syaaa-aaaar-qabyq-cai",
 			"remote": {
 				"id": {
@@ -20,7 +19,6 @@
 			}
 		},
 		"backend": {
-			"dependencies": ["cycles_ledger", "signer"],
 			"candid": "src/backend/backend.did",
 			"package": "backend",
 			"type": "rust",
@@ -73,7 +71,6 @@
 			}
 		},
 		"cycles_depositor": {
-			"dependencies": ["cycles_ledger"],
 			"type": "custom",
 			"build": "scripts/build.cycles_depositor.sh",
 			"init_arg_file": "out/cycles_depositor.args.did",


### PR DESCRIPTION
# Motivation

The canister `dependencies` specified in the `dfx.json` lead to issue when deploying locally the project. This is because it's spaghetti. Given that we are deploying with a pre-defined scripts and order, `npm run deploy` or `./scripts/deploy.sh`, I think we should remove the inter-dependencies at the dfx level. 

# Error

The error when running the deploy script:

```
Creating canister cycles_ledger...
WARN: Canister 'cycles_ledger' has a specified ID in dfx.json: um5iw-rqaaa-aaaaq-qaaba-cai,
which is different from the one specified in the command line: d3nvo-aaaaa-aaaar-qagzq-cai.
The command line value will be used.
Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to register all canisters.
Caused by: Failed to create canister 'cycles_ledger'.
Caused by: Canister creation call failed.
Caused by: The replica returned a rejection error: reject code CanisterError, reject message Canister d3nvo-aaaaa-aaaar-qagzq-cai is already installed, error code None
Deploying: cycles_ledger signer
Creating canisters...
```

# Changes

- Remove `dfx.json` fields `dependencies`.