### PR TITLE
feat(frontend): expose new BE endpoints

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -1,9 +1,18 @@
-import type { CustomToken, UserProfile, UserToken } from '$declarations/backend/backend.did';
+import type {
+	CustomToken,
+	PendingTransaction,
+	SelectedUtxosFeeResponse,
+	UserProfile,
+	UserToken
+} from '$declarations/backend/backend.did';
 import { BackendCanister } from '$lib/canisters/backend.canister';
 import { BACKEND_CANISTER_ID } from '$lib/constants/app.constants';
 import type {
 	AddUserCredentialParams,
 	AddUserCredentialResponse,
+	BtcAddPendingTransactionParams,
+	BtcGetPendingTransactionParams,
+	BtcSelectUserUtxosFeeParams,
 	GetUserProfileResponse
 } from '$lib/types/api';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';
@@ -88,6 +97,7 @@ export const getUserProfile = async ({
 
 	return getUserProfile({ certified });
 };
+
 export const addUserCredential = async ({
 	identity,
 	...params
@@ -95,6 +105,33 @@ export const addUserCredential = async ({
 	const { addUserCredential } = await backendCanister({ identity });
 
 	return addUserCredential(params);
+};
+
+export const addPendingBtcTransaction = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<BtcAddPendingTransactionParams>): Promise<boolean> => {
+	const { btcAddPendingTransaction } = await backendCanister({ identity });
+
+	return btcAddPendingTransaction(params);
+};
+
+export const getPendingBtcTransactions = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<BtcGetPendingTransactionParams>): Promise<PendingTransaction[]> => {
+	const { btcGetPendingTransaction } = await backendCanister({ identity });
+
+	return btcGetPendingTransaction(params);
+};
+
+export const selectUserUtxosFee = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<BtcSelectUserUtxosFeeParams>): Promise<SelectedUtxosFeeResponse> => {
+	const { btcSelectUserUtxosFee } = await backendCanister({ identity });
+
+	return btcSelectUserUtxosFee(params);
 };
 
 const backendCanister = async ({

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -1,15 +1,21 @@
 import type {
 	_SERVICE as BackendService,
 	CustomToken,
+	PendingTransaction,
+	SelectedUtxosFeeResponse,
 	UserProfile,
 	UserToken
 } from '$declarations/backend/backend.did';
 import { idlFactory as idlCertifiedFactoryBackend } from '$declarations/backend/backend.factory.certified.did';
 import { idlFactory as idlFactoryBackend } from '$declarations/backend/backend.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
+import { backendCanisterError } from '$lib/canisters/backend.errors';
 import type {
 	AddUserCredentialParams,
 	AddUserCredentialResponse,
+	BtcAddPendingTransactionParams,
+	BtcGetPendingTransactionParams,
+	BtcSelectUserUtxosFeeParams,
 	GetUserProfileResponse
 } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
@@ -93,5 +99,67 @@ export class BackendCanister extends Canister<BackendService> {
 			current_user_version: toNullable(currentUserVersion),
 			credential_spec: credentialSpec
 		});
+	};
+
+	btcAddPendingTransaction = async ({
+		txId,
+		network,
+		address,
+		utxos
+	}: BtcAddPendingTransactionParams): Promise<boolean> => {
+		const { btc_add_pending_transaction } = this.caller({ certified: true });
+
+		const response = await btc_add_pending_transaction({
+			txid: txId,
+			network,
+			address,
+			utxos
+		});
+
+		if ('Err' in response) {
+			throw backendCanisterError(response.Err);
+		}
+
+		return 'Ok' in response;
+	};
+
+	btcGetPendingTransaction = async ({
+		network,
+		address
+	}: BtcGetPendingTransactionParams): Promise<PendingTransaction[]> => {
+		const { btc_get_pending_transactions } = this.caller({ certified: true });
+
+		const response = await btc_get_pending_transactions({
+			network,
+			address
+		});
+
+		if ('Err' in response) {
+			throw backendCanisterError(response.Err);
+		}
+
+		return response.Ok.transactions;
+	};
+
+	btcSelectUserUtxosFee = async ({
+		network,
+		minConfirmations,
+		amountSatoshis,
+		sourceAddress
+	}: BtcSelectUserUtxosFeeParams): Promise<SelectedUtxosFeeResponse> => {
+		const { btc_select_user_utxos_fee } = this.caller({ certified: true });
+
+		const response = await btc_select_user_utxos_fee({
+			network,
+			min_confirmations: minConfirmations,
+			amount_satoshis: amountSatoshis,
+			source_address: sourceAddress
+		});
+
+		if ('Err' in response) {
+			throw backendCanisterError(response.Err);
+		}
+
+		return response.Ok;
 	};
 }

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -9,7 +9,10 @@ import type {
 import { idlFactory as idlCertifiedFactoryBackend } from '$declarations/backend/backend.factory.certified.did';
 import { idlFactory as idlFactoryBackend } from '$declarations/backend/backend.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
-import { backendCanisterError } from '$lib/canisters/backend.errors';
+import {
+	mapBtcPendingTransactionError,
+	mapBtcSelectUserUtxosFeeError
+} from '$lib/canisters/backend.errors';
 import type {
 	AddUserCredentialParams,
 	AddUserCredentialResponse,
@@ -103,21 +106,17 @@ export class BackendCanister extends Canister<BackendService> {
 
 	btcAddPendingTransaction = async ({
 		txId,
-		network,
-		address,
-		utxos
+		...rest
 	}: BtcAddPendingTransactionParams): Promise<boolean> => {
 		const { btc_add_pending_transaction } = this.caller({ certified: true });
 
 		const response = await btc_add_pending_transaction({
 			txid: txId,
-			network,
-			address,
-			utxos
+			...rest
 		});
 
 		if ('Err' in response) {
-			throw backendCanisterError(response.Err);
+			throw mapBtcPendingTransactionError(response.Err);
 		}
 
 		return 'Ok' in response;
@@ -135,7 +134,7 @@ export class BackendCanister extends Canister<BackendService> {
 		});
 
 		if ('Err' in response) {
-			throw backendCanisterError(response.Err);
+			throw mapBtcPendingTransactionError(response.Err);
 		}
 
 		return response.Ok.transactions;
@@ -157,7 +156,7 @@ export class BackendCanister extends Canister<BackendService> {
 		});
 
 		if ('Err' in response) {
-			throw backendCanisterError(response.Err);
+			throw mapBtcSelectUserUtxosFeeError(response.Err);
 		}
 
 		return response.Ok;

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -1,9 +1,12 @@
 import type {
 	AddUserCredentialError,
+	BitcoinNetwork,
 	CredentialSpec,
 	GetUserProfileError,
-	UserProfile
+	UserProfile,
+	Utxo
 } from '$declarations/backend/backend.did';
+import type { BtcAddress } from '$lib/types/address';
 import { Principal } from '@dfinity/principal';
 
 export interface AddUserCredentialParams {
@@ -15,3 +18,20 @@ export interface AddUserCredentialParams {
 export type AddUserCredentialResponse = { Ok: null } | { Err: AddUserCredentialError };
 
 export type GetUserProfileResponse = { Ok: UserProfile } | { Err: GetUserProfileError };
+
+export interface BtcSelectUserUtxosFeeParams {
+	network: BitcoinNetwork;
+	amountSatoshis: bigint;
+	sourceAddress: BtcAddress;
+	minConfirmations: [number];
+}
+
+export interface BtcGetPendingTransactionParams {
+	network: BitcoinNetwork;
+	address: BtcAddress;
+}
+
+export interface BtcAddPendingTransactionParams extends BtcGetPendingTransactionParams {
+	txId: Uint8Array | number[];
+	utxos: Utxo[];
+}

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -415,7 +415,7 @@ describe('backend.canister', () => {
 		expect(res).toEqual(true);
 	});
 
-	it('should throw an error if btc_add_pending_transaction throws', async () => {
+	it('should throw an error if btc_add_pending_transaction returns an internal error', async () => {
 		service.btc_add_pending_transaction.mockResolvedValue(errorResponse);
 
 		const { btcAddPendingTransaction } = await createBackendCanister({
@@ -427,6 +427,20 @@ describe('backend.canister', () => {
 		await expect(res).rejects.toThrow(
 			new CanisterInternalError(errorResponse.Err.InternalError.msg)
 		);
+	});
+
+	it('should throw an error if btc_add_pending_transaction throws', async () => {
+		service.btc_add_pending_transaction.mockImplementation(async () => {
+			throw mockResponseError;
+		});
+
+		const { btcAddPendingTransaction } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = btcAddPendingTransaction(btcAddPendingTransactionParams);
+
+		await expect(res).rejects.toThrow(mockResponseError);
 	});
 
 	it('should return pending btc transactions with success response', async () => {
@@ -452,7 +466,7 @@ describe('backend.canister', () => {
 		expect(res).toEqual(response.Ok.transactions);
 	});
 
-	it('should throw an error if btc_get_pending_transactions throws', async () => {
+	it('should throw an error if btc_get_pending_transactions returns an internal error', async () => {
 		service.btc_get_pending_transactions.mockResolvedValue(errorResponse);
 
 		const { btcGetPendingTransaction } = await createBackendCanister({
@@ -464,6 +478,20 @@ describe('backend.canister', () => {
 		await expect(res).rejects.toThrow(
 			new CanisterInternalError(errorResponse.Err.InternalError.msg)
 		);
+	});
+
+	it('should throw an error if btc_get_pending_transactions throws', async () => {
+		service.btc_get_pending_transactions.mockImplementation(async () => {
+			throw mockResponseError;
+		});
+
+		const { btcGetPendingTransaction } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = btcGetPendingTransaction(btcGetPendingTransactionParams);
+
+		await expect(res).rejects.toThrow(mockResponseError);
 	});
 
 	it('should return user utxos fee with success response', async () => {
@@ -488,7 +516,7 @@ describe('backend.canister', () => {
 		expect(res).toEqual(response.Ok);
 	});
 
-	it('should throw an error if btc_select_user_utxos_fee throws', async () => {
+	it('should throw an error if btc_select_user_utxos_fee returns an internal error', async () => {
 		service.btc_select_user_utxos_fee.mockResolvedValue(errorResponse);
 
 		const { btcSelectUserUtxosFee } = await createBackendCanister({
@@ -500,5 +528,19 @@ describe('backend.canister', () => {
 		await expect(res).rejects.toThrow(
 			new CanisterInternalError(errorResponse.Err.InternalError.msg)
 		);
+	});
+
+	it('should throw an error if btc_select_user_utxos_fee throws', async () => {
+		service.btc_select_user_utxos_fee.mockImplementation(async () => {
+			throw mockResponseError;
+		});
+
+		const { btcSelectUserUtxosFee } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
+
+		await expect(res).rejects.toThrow(mockResponseError);
 	});
 });

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -6,12 +6,14 @@ import type {
 	UserToken
 } from '$declarations/backend/backend.did';
 import { BackendCanister } from '$lib/canisters/backend.canister';
-import type { AddUserCredentialParams } from '$lib/types/api';
+import { CanisterInternalError } from '$lib/canisters/errors';
+import type { AddUserCredentialParams, BtcSelectUserUtxosFeeParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { toNullable } from '@dfinity/utils';
 import { mock } from 'vitest-mock-extended';
+import { btcAddress } from '../../mocks/btc.mock';
 import { mockIdentity, mockPrincipal } from '../../mocks/identity.mock';
 
 vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
@@ -54,6 +56,46 @@ describe('backend.canister', () => {
 		credential_spec: addUserCredentialParams.credentialSpec
 	};
 
+	const btcAddPendingTransactionParams = {
+		txId: [1, 2, 3],
+		network: { testnet: null },
+		address: btcAddress,
+		utxos: [
+			{
+				height: 1000,
+				value: 1n,
+				outpoint: {
+					txid: [1, 2, 3],
+					vout: 1
+				}
+			}
+		]
+	};
+	const btcAddPendingTransactionEndpointParams = {
+		txid: btcAddPendingTransactionParams.txId,
+		network: btcAddPendingTransactionParams.network,
+		address: btcAddPendingTransactionParams.address,
+		utxos: btcAddPendingTransactionParams.utxos
+	};
+
+	const btcGetPendingTransactionParams = {
+		network: btcAddPendingTransactionParams.network,
+		address: btcAddPendingTransactionParams.address
+	};
+
+	const btcSelectUserUtxosFeeParams = {
+		network: btcAddPendingTransactionParams.network,
+		minConfirmations: [100],
+		amountSatoshis: 100n,
+		sourceAddress: btcAddress
+	} as BtcSelectUserUtxosFeeParams;
+	const btcSelectUserUtxosFeeEndpointParams = {
+		network: btcSelectUserUtxosFeeParams.network,
+		min_confirmations: btcSelectUserUtxosFeeParams.minConfirmations,
+		amount_satoshis: btcSelectUserUtxosFeeParams.amountSatoshis,
+		source_address: btcSelectUserUtxosFeeParams.sourceAddress
+	};
+
 	const mockedUserProfile = {
 		credentials: [
 			{
@@ -88,6 +130,8 @@ describe('backend.canister', () => {
 		enabled: false
 	} as CustomToken;
 	const customTokens = [mockedCustomToken];
+
+	const errorResponse = { Err: { InternalError: { msg: 'Test error' } } };
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -352,5 +396,109 @@ describe('backend.canister', () => {
 		const res = addUserCredential(addUserCredentialParams);
 
 		await expect(res).rejects.toThrow(mockResponseError);
+	});
+
+	it('adds btc pending transactions with success response', async () => {
+		const response = { Ok: null };
+
+		service.btc_add_pending_transaction.mockResolvedValue(response);
+
+		const { btcAddPendingTransaction } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = await btcAddPendingTransaction(btcAddPendingTransactionParams);
+
+		expect(service.btc_add_pending_transaction).toHaveBeenCalledWith(
+			btcAddPendingTransactionEndpointParams
+		);
+		expect(res).toEqual(true);
+	});
+
+	it('should throw an error if btc_add_pending_transaction throws', async () => {
+		service.btc_add_pending_transaction.mockResolvedValue(errorResponse);
+
+		const { btcAddPendingTransaction } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = btcAddPendingTransaction(btcAddPendingTransactionParams);
+
+		await expect(res).rejects.toThrow(
+			new CanisterInternalError(errorResponse.Err.InternalError.msg)
+		);
+	});
+
+	it('should return pending btc transactions with success response', async () => {
+		const response = {
+			Ok: {
+				transactions: [
+					{ utxos: btcAddPendingTransactionParams.utxos, txid: btcAddPendingTransactionParams.txId }
+				]
+			}
+		};
+
+		service.btc_get_pending_transactions.mockResolvedValue(response);
+
+		const { btcGetPendingTransaction } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = await btcGetPendingTransaction(btcGetPendingTransactionParams);
+
+		expect(service.btc_get_pending_transactions).toHaveBeenCalledWith(
+			btcGetPendingTransactionParams
+		);
+		expect(res).toEqual(response.Ok.transactions);
+	});
+
+	it('should throw an error if btc_get_pending_transactions throws', async () => {
+		service.btc_get_pending_transactions.mockResolvedValue(errorResponse);
+
+		const { btcGetPendingTransaction } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = btcGetPendingTransaction(btcGetPendingTransactionParams);
+
+		await expect(res).rejects.toThrow(
+			new CanisterInternalError(errorResponse.Err.InternalError.msg)
+		);
+	});
+
+	it('should return user utxos fee with success response', async () => {
+		const response = {
+			Ok: {
+				fee_satoshis: 1n,
+				utxos: btcAddPendingTransactionParams.utxos
+			}
+		};
+
+		service.btc_select_user_utxos_fee.mockResolvedValue(response);
+
+		const { btcSelectUserUtxosFee } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = await btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
+
+		expect(service.btc_select_user_utxos_fee).toHaveBeenCalledWith(
+			btcSelectUserUtxosFeeEndpointParams
+		);
+		expect(res).toEqual(response.Ok);
+	});
+
+	it('should throw an error if btc_select_user_utxos_fee throws', async () => {
+		service.btc_select_user_utxos_fee.mockResolvedValue(errorResponse);
+
+		const { btcSelectUserUtxosFee } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
+
+		await expect(res).rejects.toThrow(
+			new CanisterInternalError(errorResponse.Err.InternalError.msg)
+		);
 	});
 });


### PR DESCRIPTION
# Motivation

The goal is to expose BTC-related backend endpoint via the BE canister.

Note: the base branch of this PR will be changed to `main` after we merge https://github.com/dfinity/oisy-wallet/pull/2629.
