### PR TITLE
refactor(frontend): Move source address in Send modal

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -19,6 +19,7 @@
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
+	export let source: string;
 
 	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
@@ -41,7 +42,7 @@
 
 		<IcSendAmount bind:amount bind:amountError {networkId} />
 
-		<SendSource token={$sendToken} balance={$balance} source={$icrcAccountIdentifierText ?? ''} />
+		<SendSource token={$sendToken} balance={$balance} {source} />
 
 		<IcFeeDisplay {networkId} />
 

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -4,7 +4,6 @@
 	import IcFeeDisplay from '$icp/components/send/IcFeeDisplay.svelte';
 	import IcSendAmount from '$icp/components/send/IcSendAmount.svelte';
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
-	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import type { IcAmountAssertionError } from '$icp/types/ic-send';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendSource from '$lib/components/send/SendSource.svelte';

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -14,6 +14,7 @@
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
+	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 
 	/**
 	 * Props
@@ -68,6 +69,9 @@
 
 			dispatch('nnsClose');
 		});
+
+	let source: string;
+	$: source = $icrcAccountIdentifierText ?? '';
 </script>
 
 <WizardModal
@@ -81,6 +85,7 @@
 
 	<SendTokenContext token={$token}>
 		<IcSendTokenWizard
+			{source}
 			{currentStep}
 			bind:destination
 			bind:networkId

--- a/src/frontend/src/icp/components/send/IcSendModal.svelte
+++ b/src/frontend/src/icp/components/send/IcSendModal.svelte
@@ -3,6 +3,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import SendTokenContext from '$eth/components/send/SendTokenContext.svelte';
 	import IcSendTokenWizard from '$icp/components/send/IcSendTokenWizard.svelte';
+	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import { ckEthereumTwinToken } from '$icp-eth/derived/cketh.derived';
 	import { sendWizardStepsWithQrCodeScan } from '$lib/config/send.config';
 	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
@@ -14,7 +15,6 @@
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
-	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 
 	/**
 	 * Props

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -19,6 +19,7 @@
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
+	export let sourceAddress: string;
 
 	const { sendToken, sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
@@ -34,14 +35,11 @@
 		invalidAmount(amount);
 
 	const dispatch = createEventDispatcher();
-
-	let source: string;
-	$: source = $icrcAccountIdentifierText ?? '';
 </script>
 
 <ContentWithToolbar>
 	{#if nonNullish($sendToken)}
-		<SendData {amount} {destination} token={$sendToken} balance={$balance} {source}>
+		<SendData {amount} {destination} token={$sendToken} balance={$balance} source={sourceAddress}>
 			<IcFeeDisplay slot="fee" {networkId} />
 			<IcReviewNetwork {networkId} slot="network" />
 		</SendData>

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -3,7 +3,6 @@
 	import { createEventDispatcher, getContext } from 'svelte';
 	import IcFeeDisplay from '$icp/components/send/IcFeeDisplay.svelte';
 	import IcReviewNetwork from '$icp/components/send/IcReviewNetwork.svelte';
-	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendData from '$lib/components/send/SendData.svelte';
@@ -19,7 +18,7 @@
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
-	export let sourceAddress: string;
+	export let source: string;
 
 	const { sendToken, sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
@@ -39,7 +38,7 @@
 
 <ContentWithToolbar>
 	{#if nonNullish($sendToken)}
-		<SendData {amount} {destination} token={$sendToken} balance={$balance} source={sourceAddress}>
+		<SendData {amount} {destination} token={$sendToken} balance={$balance} {source}>
 			<IcFeeDisplay slot="fee" {networkId} />
 			<IcReviewNetwork {networkId} slot="network" />
 		</SendData>

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -63,6 +63,7 @@
 	 * Props
 	 */
 
+	export let sourceAddress: string;
 	export let currentStep: WizardStep | undefined;
 	export let networkId: NetworkId | undefined = undefined;
 	export let destination = '';

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -63,7 +63,7 @@
 	 * Props
 	 */
 
-	export let sourceAddress: string;
+	export let source: string;
 	export let currentStep: WizardStep | undefined;
 	export let networkId: NetworkId | undefined = undefined;
 	export let destination = '';
@@ -220,11 +220,11 @@
 <EthereumFeeContext {networkId}>
 	<BitcoinFeeContext {amount} {networkId}>
 		{#if currentStep?.name === WizardStepsSend.REVIEW}
-			<IcSendReview on:icBack on:icSend={send} {destination} {amount} {networkId} />
+			<IcSendReview on:icBack on:icSend={send} {destination} {amount} {networkId} {source} />
 		{:else if currentStep?.name === WizardStepsSend.SENDING}
 			<IcSendProgress bind:sendProgressStep {networkId} />
 		{:else if currentStep?.name === WizardStepsSend.SEND}
-			<IcSendForm on:icNext bind:destination bind:amount bind:networkId on:icQRCodeScan>
+			<IcSendForm on:icNext bind:destination bind:amount bind:networkId on:icQRCodeScan {source}>
 				<svelte:fragment slot="cancel">
 					{#if formCancelAction === 'back'}
 						<ButtonBack on:click={back} />

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -14,6 +14,7 @@
 	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
+	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 
 	export let destination = '';
 	export let targetNetwork: Network | undefined = undefined;
@@ -64,6 +65,9 @@
 		};
 		await loadTokenAndRun({ token, callback });
 	};
+
+	let sourceAddress: string;
+	$: sourceAddress = $icrcAccountIdentifierText ?? '';
 </script>
 
 <WizardModal
@@ -79,6 +83,7 @@
 		<SendTokensList on:icSendToken={nextStep} />
 	{:else}
 		<SendWizard
+			{sourceAddress}
 			{currentStep}
 			bind:destination
 			bind:networkId

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -66,6 +66,7 @@
 		await loadTokenAndRun({ token, callback });
 	};
 
+	// TODO: Use network id to get the address to support bitcoin.
 	let source: string;
 	$: source = $icrcAccountIdentifierText ?? '';
 </script>

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -66,8 +66,8 @@
 		await loadTokenAndRun({ token, callback });
 	};
 
-	let sourceAddress: string;
-	$: sourceAddress = $icrcAccountIdentifierText ?? '';
+	let source: string;
+	$: source = $icrcAccountIdentifierText ?? '';
 </script>
 
 <WizardModal
@@ -83,7 +83,7 @@
 		<SendTokensList on:icSendToken={nextStep} />
 	{:else}
 		<SendWizard
-			{sourceAddress}
+			{source}
 			{currentStep}
 			bind:destination
 			bind:networkId

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { createEventDispatcher } from 'svelte';
+	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 	import SendWizard from '$lib/components/send/SendWizard.svelte';
 	import { allSendWizardSteps, sendWizardStepsWithQrCodeScan } from '$lib/config/send.config';
@@ -14,7 +15,6 @@
 	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
-	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 
 	export let destination = '';
 	export let targetNetwork: Network | undefined = undefined;

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -9,6 +9,7 @@
 	import type { Network, NetworkId } from '$lib/types/network';
 	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 
+	export let sourceAddress: string;
 	export let destination: string;
 	export let targetNetwork: Network | undefined;
 	export let networkId: NetworkId | undefined;
@@ -38,6 +39,7 @@
 		/>
 	{:else if isNetworkIdICP($token?.network.id)}
 		<IcSendTokenWizard
+			{sourceAddress}
 			{currentStep}
 			{formCancelAction}
 			bind:destination

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -9,7 +9,7 @@
 	import type { Network, NetworkId } from '$lib/types/network';
 	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 
-	export let sourceAddress: string;
+	export let source: string;
 	export let destination: string;
 	export let targetNetwork: Network | undefined;
 	export let networkId: NetworkId | undefined;
@@ -39,7 +39,7 @@
 		/>
 	{:else if isNetworkIdICP($token?.network.id)}
 		<IcSendTokenWizard
-			{sourceAddress}
+			{source}
 			{currentStep}
 			{formCancelAction}
 			bind:destination


### PR DESCRIPTION
# Motivation

We want to reuse the `SendModal` component for Bitcoin transactions.

There is one part that is specific to IC, which is the address shown in the form and review steps.

In this PR, I move this part up the chain so that we can pass later the bitcoin address instead of the IC one.

This will also help me find pending transactions, which will be keyed by address in a store and disable the form if any is present. This way, the idea of pending transactions doesn't need to be specific to BTC.

# Changes

* Add prop `source` to `IcSendReview` and `IcSendForm` and use it instead of `icrcAccountIdentifierText` store.
* Add prop `IcSendTokenWizard` and `SendWizard` to pass it down.
* Create local variable `source` using `icrcAccountIdentifierText` store in `SendModal` and `IcSendModal` to then pass it down.

# Tests

Still working locally.
