### PR TITLE
feat(frontend): expose backend allow_signing function

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -6,6 +6,7 @@ import type {
 	AddUserCredentialResponse,
 	GetUserProfileResponse
 } from '$lib/types/api';
+import type { AllowSigningResponse } from '$lib/types/backend';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish, type QueryParams } from '@dfinity/utils';
@@ -88,6 +89,7 @@ export const getUserProfile = async ({
 
 	return getUserProfile({ certified });
 };
+
 export const addUserCredential = async ({
 	identity,
 	...params
@@ -95,6 +97,14 @@ export const addUserCredential = async ({
 	const { addUserCredential } = await backendCanister({ identity });
 
 	return addUserCredential(params);
+};
+
+export const allowSigning = async ({
+	identity
+}: CanisterApiFunctionParams): Promise<AllowSigningResponse> => {
+	const { allowSigning } = await backendCanister({ identity });
+
+	return allowSigning();
 };
 
 const backendCanister = async ({

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -12,6 +12,7 @@ import type {
 	AddUserCredentialResponse,
 	GetUserProfileResponse
 } from '$lib/types/api';
+import type { AllowSigningResponse } from '$lib/types/backend';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices, toNullable, type QueryParams } from '@dfinity/utils';
 
@@ -93,5 +94,11 @@ export class BackendCanister extends Canister<BackendService> {
 			current_user_version: toNullable(currentUserVersion),
 			credential_spec: credentialSpec
 		});
+	};
+
+	allowSigning = async (): Promise<AllowSigningResponse> => {
+		const { allow_signing } = this.caller({ certified: true });
+
+		return allow_signing();
 	};
 }

--- a/src/frontend/src/lib/types/backend.ts
+++ b/src/frontend/src/lib/types/backend.ts
@@ -1,0 +1,3 @@
+import type { Result_1 } from '$declarations/backend/backend.did';
+
+export type AllowSigningResponse = Result_1;

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -353,4 +353,35 @@ describe('backend.canister', () => {
 
 		await expect(res).rejects.toThrow(mockResponseError);
 	});
+
+	describe('allowSigning', () => {
+		it('should allow signing', async () => {
+			const response = { Ok: null };
+
+			service.allow_signing.mockResolvedValue(response);
+
+			const { allowSigning } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await allowSigning();
+
+			expect(service.allow_signing).toHaveBeenCalledTimes(1);
+			expect(res).toEqual(response);
+		});
+
+		it('should throw an error if allowSigning throws', async () => {
+			service.allow_signing.mockImplementation(async () => {
+				throw mockResponseError;
+			});
+
+			const { allowSigning } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = allowSigning();
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

We need to expose the new `allow_signing` function at the API level for #2632.

# Changes

- Adding `allowSigning` to backend canister and API
