### PR TITLE
feat(frontend): Add btc pending transactions store

### DIFF
--- a/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
@@ -1,6 +1,7 @@
 import type { PendingTransaction } from '$declarations/backend/backend.did';
 import { writable, type Readable } from 'svelte/store';
 
+// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
 type Address = string;
 type BtcPendingTransactionsStoreData = Record<Address, Array<PendingTransaction>>;
 

--- a/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
@@ -1,9 +1,9 @@
 import type { PendingTransaction } from '$declarations/backend/backend.did';
+import type { CertifiedData } from '$lib/types/store';
 import { writable, type Readable } from 'svelte/store';
 
-// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
 type Address = string;
-type BtcPendingTransactionsStoreData = Record<Address, Array<PendingTransaction>>;
+type BtcPendingTransactionsStoreData = Record<Address, CertifiedData<Array<PendingTransaction>>>;
 
 interface BtcPendingTransactionsStore extends Readable<BtcPendingTransactionsStoreData> {
 	setPendingTransactions: (params: {
@@ -34,7 +34,11 @@ const initBtcPendingTransactionsStore = (): BtcPendingTransactionsStore => {
 		}) {
 			update((state) => ({
 				...state,
-				[address]: pendingTransactions
+				[address]: {
+					// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
+					certified: true,
+					data: pendingTransactions
+				}
 			}));
 		},
 		reset() {

--- a/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
@@ -1,0 +1,47 @@
+import type { PendingTransaction } from '$declarations/backend/backend.did';
+import { writable, type Readable } from 'svelte/store';
+
+type Address = string;
+type BtcPendingTransactionsStoreData = Record<Address, Array<PendingTransaction>>;
+
+interface BtcPendingTransactionsStore extends Readable<BtcPendingTransactionsStoreData> {
+	setPendingTransactions: (params: {
+		address: Address;
+		pendingTransactions: Array<PendingTransaction>;
+	}) => void;
+	reset: () => void;
+}
+
+/**
+ * Bitcoin transations take time to confirm.
+ * While a transaction is pending, its utxos cannot be used, but they might still be available.
+ * Instead of trying ot be smart, for now we'll disable transactions until they are confirmed.
+ *
+ * This store is used to keep track of pending transactions.
+ */
+const initBtcPendingTransactionsStore = (): BtcPendingTransactionsStore => {
+	const { update, set, subscribe } = writable<BtcPendingTransactionsStoreData>({});
+
+	return {
+		subscribe,
+		setPendingTransactions({
+			address,
+			pendingTransactions: pendingTransactions
+		}: {
+			address: Address;
+			pendingTransactions: Array<PendingTransaction>;
+		}) {
+			update((state) => {
+				return {
+					...state,
+					[address]: pendingTransactions
+				};
+			});
+		},
+		reset() {
+			set({});
+		}
+	};
+};
+
+export const pendingTransactionsStore = initBtcPendingTransactionsStore();

--- a/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
@@ -31,12 +31,10 @@ const initBtcPendingTransactionsStore = (): BtcPendingTransactionsStore => {
 			address: Address;
 			pendingTransactions: Array<PendingTransaction>;
 		}) {
-			update((state) => {
-				return {
-					...state,
-					[address]: pendingTransactions
-				};
-			});
+			update((state) => ({
+				...state,
+				[address]: pendingTransactions
+			}));
 		},
 		reset() {
 			set({});

--- a/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-transactions.store.ts
@@ -1,9 +1,13 @@
 import type { PendingTransaction } from '$declarations/backend/backend.did';
-import type { CertifiedData } from '$lib/types/store';
+import type { AlwaysCertifiedData } from '$lib/types/store';
 import { writable, type Readable } from 'svelte/store';
 
 type Address = string;
-type BtcPendingTransactionsStoreData = Record<Address, CertifiedData<Array<PendingTransaction>>>;
+type BtcPendingTransactionsStoreData = Record<
+	Address,
+	// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
+	AlwaysCertifiedData<Array<PendingTransaction>>
+>;
 
 interface BtcPendingTransactionsStore extends Readable<BtcPendingTransactionsStoreData> {
 	setPendingTransactions: (params: {
@@ -35,7 +39,6 @@ const initBtcPendingTransactionsStore = (): BtcPendingTransactionsStore => {
 			update((state) => ({
 				...state,
 				[address]: {
-					// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
 					certified: true,
 					data: pendingTransactions
 				}

--- a/src/frontend/src/lib/types/store.ts
+++ b/src/frontend/src/lib/types/store.ts
@@ -2,3 +2,5 @@ export interface CertifiedData<T> {
 	data: T;
 	certified: boolean;
 }
+
+export type AlwaysCertifiedData<T> = Omit<CertifiedData<T>, 'certified'> & { certified: true };

--- a/src/frontend/src/tests/btc/stores/btc-pending-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-transactions.store.spec.ts
@@ -47,7 +47,17 @@ describe('BtcPendingTransactionsStore', () => {
 		pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
 		const storeData = get(pendingTransactionsStore);
-		expect(storeData[address]).toEqual(pendingTransactions);
+		expect(storeData[address].data).toEqual(pendingTransactions);
+	});
+
+	it('should set certified to `true`', () => {
+		const address = 'test-address';
+		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
+
+		pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+
+		const storeData = get(pendingTransactionsStore);
+		expect(storeData[address].certified).toEqual(true);
 	});
 
 	it('should update pending transactions for an existing address', () => {
@@ -67,7 +77,7 @@ describe('BtcPendingTransactionsStore', () => {
 		});
 
 		const storeData = get(pendingTransactionsStore);
-		expect(storeData[address]).toEqual(newPendingTransactions);
+		expect(storeData[address].data).toEqual(newPendingTransactions);
 	});
 
 	it('should update pending transactions for an different addresses', () => {
@@ -88,7 +98,7 @@ describe('BtcPendingTransactionsStore', () => {
 		});
 
 		const storeData = get(pendingTransactionsStore);
-		expect(storeData[address1]).toEqual(pendingTransactions1);
-		expect(storeData[address2]).toEqual(pendingTransactions2);
+		expect(storeData[address1].data).toEqual(pendingTransactions1);
+		expect(storeData[address2].data).toEqual(pendingTransactions2);
 	});
 });

--- a/src/frontend/src/tests/btc/stores/btc-pending-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-transactions.store.spec.ts
@@ -1,0 +1,94 @@
+import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
+import type { PendingTransaction } from '$declarations/backend/backend.did';
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const pendingTransactionMock1 = {
+	txid: new Uint8Array([1, 2, 3]),
+	utxos: [
+		{
+			height: 100,
+			value: BigInt(5000),
+			outpoint: {
+				txid: new Uint8Array([1, 2, 3]),
+				vout: 0
+			}
+		}
+	]
+};
+const pendingTransactionMock2 = {
+	txid: new Uint8Array([4, 5, 6]),
+	utxos: [
+		{
+			height: 101,
+			value: BigInt(6000),
+			outpoint: {
+				txid: new Uint8Array([4, 5, 6]),
+				vout: 1
+			}
+		}
+	]
+};
+
+describe('BtcPendingTransactionsStore', () => {
+	beforeEach(() => {
+		pendingTransactionsStore.reset();
+	});
+
+	it('should initialize with an empty store', () => {
+		const storeData = get(pendingTransactionsStore);
+		expect(storeData).toEqual({});
+	});
+
+	it('should add pending transactions to a specific address', () => {
+		const address = 'test-address';
+		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
+
+		pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+
+		const storeData = get(pendingTransactionsStore);
+		expect(storeData[address]).toEqual(pendingTransactions);
+	});
+
+	it('should update pending transactions for an existing address', () => {
+		const address = 'test-address';
+		const initialPendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
+
+		const newPendingTransactions: Array<PendingTransaction> = [pendingTransactionMock2];
+
+		pendingTransactionsStore.setPendingTransactions({
+			address,
+			pendingTransactions: initialPendingTransactions
+		});
+
+		pendingTransactionsStore.setPendingTransactions({
+			address,
+			pendingTransactions: newPendingTransactions
+		});
+
+		const storeData = get(pendingTransactionsStore);
+		expect(storeData[address]).toEqual(newPendingTransactions);
+	});
+
+	it('should update pending transactions for an different addresses', () => {
+		const address1 = 'test-address-2';
+		const address2 = 'test-address-1';
+		const pendingTransactions1: Array<PendingTransaction> = [pendingTransactionMock1];
+
+		const pendingTransactions2: Array<PendingTransaction> = [pendingTransactionMock2];
+
+		pendingTransactionsStore.setPendingTransactions({
+			address: address1,
+			pendingTransactions: pendingTransactions1
+		});
+
+		pendingTransactionsStore.setPendingTransactions({
+			address: address2,
+			pendingTransactions: pendingTransactions2
+		});
+
+		const storeData = get(pendingTransactionsStore);
+		expect(storeData[address1]).toEqual(pendingTransactions1);
+		expect(storeData[address2]).toEqual(pendingTransactions2);
+	});
+});


### PR DESCRIPTION
# Motivation

We will disable sending BTC tokens while the user has pending transaction. Pending transactions will come from Oisy backend.

In this PR, I created a store to save the pending transactions per address.

# Changes

* New store `pendingTransactionsStore`.

# Tests

* Test new store.
