### PR TITLE
feat(frontend): expose btc_caller_send via signer canister

### DIFF
--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -1,7 +1,8 @@
-import type { BitcoinNetwork, SignRequest } from '$declarations/signer/signer.did';
+import type { BitcoinNetwork, SendBtcResponse, SignRequest } from '$declarations/signer/signer.did';
 import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
+import type { SendBtcParams } from '$lib/types/api';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
@@ -68,6 +69,15 @@ export const signPrehash = async ({
 	const { signPrehash } = await signerCanister({ identity });
 
 	return signPrehash({ hash });
+};
+
+export const sendBtc = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<SendBtcParams>): Promise<SendBtcResponse> => {
+	const { sendBtc } = await signerCanister({ identity });
+
+	return sendBtc(params);
 };
 
 const signerCanister = async ({

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,12 +1,14 @@
 import type {
 	BitcoinNetwork,
-	_SERVICE as SignerService,
-	SignRequest
+	SendBtcResponse,
+	SignRequest,
+	_SERVICE as SignerService
 } from '$declarations/signer/signer.did';
 import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
 import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
+import type { SendBtcParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices } from '@dfinity/utils';
 import { mapSignerCanisterBtcError } from './signer.errors';
@@ -85,5 +87,33 @@ export class SignerCanister extends Canister<SignerService> {
 		});
 
 		return sign_prehash(hash);
+	};
+
+	sendBtc = async ({
+		addressType,
+		feeSatoshis,
+		utxosToSpend,
+		...rest
+	}: SendBtcParams): Promise<SendBtcResponse> => {
+		const { btc_caller_send } = this.caller({
+			certified: true
+		});
+
+		const response = await btc_caller_send(
+			{
+				address_type: addressType,
+				utxos_to_spend: utxosToSpend,
+				fee_satoshis: feeSatoshis,
+				...rest
+			},
+			// TODO: Pass a payment type
+			[]
+		);
+
+		if ('Err' in response) {
+			throw mapSignerCanisterBtcError(response.Err);
+		}
+
+		return response.Ok;
 	};
 }

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -21,12 +21,13 @@ export class SignerCanisterPaymentError extends Error {
 	}
 }
 
-export const mapSignerCanisterBtcError = (response: GetAddressError) => {
+type SignerCanisterBtcError = GetAddressError;
+export const mapSignerCanisterBtcError = (response: SignerCanisterBtcError) => {
 	if ('InternalError' in response) {
 		return new CanisterInternalError(response.InternalError.msg);
 	}
 	if ('PaymentError' in response) {
 		return new SignerCanisterPaymentError(response.PaymentError);
 	}
-	return new CanisterInternalError('Unknown GetAddressError');
+	return new CanisterInternalError('Unknown SignerCanisterBtcError');
 };

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -6,6 +6,12 @@ import type {
 	UserProfile,
 	Utxo
 } from '$declarations/backend/backend.did';
+import type {
+	BitcoinAddressType,
+	BtcTxOutput,
+	BitcoinNetwork as SignerBitcoinNetwork,
+	Utxo as SignerUtxo
+} from '$declarations/signer/signer.did';
 import type { BtcAddress } from '$lib/types/address';
 import { Principal } from '@dfinity/principal';
 
@@ -34,4 +40,12 @@ export interface BtcGetPendingTransactionParams {
 export interface BtcAddPendingTransactionParams extends BtcGetPendingTransactionParams {
 	txId: Uint8Array | number[];
 	utxos: Utxo[];
+}
+
+export interface SendBtcParams {
+	feeSatoshis: [] | [bigint];
+	network: SignerBitcoinNetwork;
+	utxosToSpend: SignerUtxo[];
+	addressType: BitcoinAddressType;
+	outputs: BtcTxOutput[];
 }


### PR DESCRIPTION
# Motivation

Another method needed to send BTC is `btc_caller_send`.
