### PR TITLE
chore(frontend): add TODO for ERC20 token conversion issue for approval

### DIFF
--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -264,6 +264,14 @@ export const send = async ({
 
 	const nonce = await getTransactionCount(from);
 
+	// TODO: We may need to add an approve transaction that resets the approved amount to zero, in case of conversion from ERC20.
+	// 			CONTEXT:
+	// 			It may happen that after the approval transaction is done, the transfer transaction may fail for whatever reasons.
+	//			In this case, the next approval transaction will be rejected, since there is already an approved amount.
+	//			So, the next transfer transaction will work only if the amount is below the one already approved.
+	//			Otherwise, the user is blocked until it consumes all the approved amount.
+	//			We had a practical example with USDT. Please check the sender wallet transaction history backwards from this one: https://etherscan.io/tx/0x084432404a919c1ee720c906bb5c7a565b6e1fdcd5bb9da32049dddfa21ad23f
+
 	const { transactionApproved } = await approve({ progress, sourceNetwork, nonce, token, ...rest });
 
 	// If we approved a transaction - as for example in Erc20 -> ckErc20 flow - then we increment the nonce for the next transaction. Otherwise, we can use the nonce we obtained.


### PR DESCRIPTION
# Context

A partner encountered an issue not specific to Oisy, but somehow can be food for thought for improvement.

It may happen that after the approval transaction is done, the transfer transaction may fail for whatever reasons. In this case, the next approval transaction will be rejected, since there is already an approved amount. So, the next transfer transaction will work only if the amount is below the one already approved. Otherwise, the user is blocked until it consumes all the approved amount.

# Example

1. The user wants to convert 10 USDT to ckUSDT:
  1. `approve` transaction for 10 USDT --> successful
  2. `transfer_from` transaction for 10 USDT --> failed (for whatever reason)
2. The user wants to convert 20 USDT to ckUSDT:
  1. `approve` transaction for 20 USDT --> failed (the previous approved amount is still there)
  2. `transfer_from` transaction for 20 USDT --> failed (not enough approved amount)
3. The user wants to convert 7 USDT to ckUSDT:
  1. `approve` transaction for 7 USDT --> failed (the previous approved amount is still there)
  2. `transfer_from` transaction for 7 USDT --> successful (remaining approved amount is 3 USDT)

# Practical example

We had a practical example with USDT. Please check the sender wallet transaction history backwards from this one: https://etherscan.io/tx/0x084432404a919c1ee720c906bb5c7a565b6e1fdcd5bb9da32049dddfa21ad23f