### PR TITLE
fix(frontend): background was not hiding overflow

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -176,7 +176,7 @@
 				}
 			}
 
-			#app-background {
+			#app-background-container {
 				position: absolute;
 				top: 0;
 				left: 50%;
@@ -184,134 +184,147 @@
 				transform: translateX(-50%);
 
 				width: 100%;
-				min-width: 1728px;
 
 				z-index: -1;
+
+				overflow: hidden;
+			}
+
+			#app-background {
+				width: 100%;
+				min-width: 1728px;
 			}
 		</style>
 
 		<!-- LINKS_PRELOADER -->
 	</head>
 	<body data-sveltekit-preload-data="hover">
-		<svg id="app-background" viewBox="0 0 1728 610" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<g clip-path="url(#clip0_76_16273)">
-				<rect width="1728" height="610" fill="url(#paint0_linear_76_16273)" />
-				<g filter="url(#filter0_f_76_16273)">
-					<path
-						d="M1423.89 183.561L1265 225.928L1441.06 886.222L1599.95 843.855L1423.89 183.561Z"
-						fill="url(#paint1_linear_76_16273)"
-						fill-opacity="0.52"
-					/>
-					<path
-						d="M1621.89 129L1463 171.367L1639.06 831.66L1797.95 789.294L1621.89 129Z"
-						fill="url(#paint2_linear_76_16273)"
-						fill-opacity="0.52"
-					/>
+		<div id="app-background-container">
+			<svg
+				id="app-background"
+				viewBox="0 0 1728 610"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<g clip-path="url(#clip0_76_16273)">
+					<rect width="1728" height="610" fill="url(#paint0_linear_76_16273)" />
+					<g filter="url(#filter0_f_76_16273)">
+						<path
+							d="M1423.89 183.561L1265 225.928L1441.06 886.222L1599.95 843.855L1423.89 183.561Z"
+							fill="url(#paint1_linear_76_16273)"
+							fill-opacity="0.52"
+						/>
+						<path
+							d="M1621.89 129L1463 171.367L1639.06 831.66L1797.95 789.294L1621.89 129Z"
+							fill="url(#paint2_linear_76_16273)"
+							fill-opacity="0.52"
+						/>
+					</g>
+					<g filter="url(#filter1_f_76_16273)">
+						<path
+							fill-rule="evenodd"
+							clip-rule="evenodd"
+							d="M493.517 443.974L487.576 466.714C450.005 618.885 319.073 612.132 173.049 573.847C27.4243 531.24 -89.1034 469.357 -47.4537 318.317L-41.5121 295.577C-4.12141 144.095 126.81 150.848 273.515 189.321C418.459 231.74 534.987 293.623 493.517 443.974ZM385.602 418.643L382.045 432.258C359.553 523.368 280.966 519.27 193.309 496.285C105.89 470.711 35.9275 433.606 60.8675 343.176L64.4248 329.56C86.8084 238.863 165.395 242.961 253.461 266.059C340.471 291.52 410.434 328.625 385.602 418.643Z"
+							fill="url(#paint3_linear_76_16273)"
+							fill-opacity="0.52"
+						/>
+						<path
+							d="M492.559 443.709L492.556 443.722L486.614 466.463L486.611 466.476C477.251 504.386 462.096 532.324 442.407 552.338C422.722 572.348 398.451 584.493 370.764 590.732C315.338 603.222 246.31 592.027 173.314 572.89C100.52 551.59 35.1913 525.52 -6.7492 486.021C-27.7015 466.288 -42.8014 443.217 -50.0893 415.718C-57.3782 388.214 -56.8719 356.209 -46.4959 318.582L-46.4925 318.569L-40.5509 295.828L-40.5477 295.815C-31.2329 258.078 -16.1116 230.27 3.56141 210.356C23.2311 190.445 47.5064 178.37 75.2249 172.185C130.714 159.805 199.913 171.047 273.249 190.279C345.702 211.484 410.862 237.507 452.74 276.897C473.662 296.575 488.757 319.576 496.06 346.976C503.363 374.379 502.89 406.255 492.559 443.709ZM193.03 497.238L193.044 497.242L193.057 497.246C236.897 508.741 278.663 515.574 312.331 508.026C329.193 504.246 344.045 496.855 356.1 484.629C368.151 472.407 377.351 455.41 383.007 432.504C383.008 432.501 383.008 432.499 383.009 432.496L386.56 418.907C386.56 418.904 386.561 418.902 386.561 418.9C392.805 396.265 393.107 376.886 388.626 360.149C384.144 343.406 374.895 329.378 362.152 317.418C336.704 293.533 297.258 277.84 253.74 265.106L253.726 265.102L253.713 265.098C209.669 253.546 167.802 246.685 134.097 254.167C117.217 257.913 102.362 265.262 90.3146 277.428C78.2719 289.59 69.091 306.511 63.462 329.316C63.4614 329.318 63.4609 329.32 63.4603 329.322L59.9098 342.912C59.9092 342.914 59.9086 342.916 59.908 342.918C53.6381 365.656 53.315 385.111 57.7866 401.909C62.2596 418.711 71.5111 432.782 84.2734 444.775C109.759 468.726 149.308 484.448 193.03 497.238Z"
+							stroke="url(#paint4_linear_76_16273)"
+							stroke-opacity="0.6"
+							stroke-width="1.98687"
+						/>
+					</g>
 				</g>
-				<g filter="url(#filter1_f_76_16273)">
-					<path
-						fill-rule="evenodd"
-						clip-rule="evenodd"
-						d="M493.517 443.974L487.576 466.714C450.005 618.885 319.073 612.132 173.049 573.847C27.4243 531.24 -89.1034 469.357 -47.4537 318.317L-41.5121 295.577C-4.12141 144.095 126.81 150.848 273.515 189.321C418.459 231.74 534.987 293.623 493.517 443.974ZM385.602 418.643L382.045 432.258C359.553 523.368 280.966 519.27 193.309 496.285C105.89 470.711 35.9275 433.606 60.8675 343.176L64.4248 329.56C86.8084 238.863 165.395 242.961 253.461 266.059C340.471 291.52 410.434 328.625 385.602 418.643Z"
-						fill="url(#paint3_linear_76_16273)"
-						fill-opacity="0.52"
-					/>
-					<path
-						d="M492.559 443.709L492.556 443.722L486.614 466.463L486.611 466.476C477.251 504.386 462.096 532.324 442.407 552.338C422.722 572.348 398.451 584.493 370.764 590.732C315.338 603.222 246.31 592.027 173.314 572.89C100.52 551.59 35.1913 525.52 -6.7492 486.021C-27.7015 466.288 -42.8014 443.217 -50.0893 415.718C-57.3782 388.214 -56.8719 356.209 -46.4959 318.582L-46.4925 318.569L-40.5509 295.828L-40.5477 295.815C-31.2329 258.078 -16.1116 230.27 3.56141 210.356C23.2311 190.445 47.5064 178.37 75.2249 172.185C130.714 159.805 199.913 171.047 273.249 190.279C345.702 211.484 410.862 237.507 452.74 276.897C473.662 296.575 488.757 319.576 496.06 346.976C503.363 374.379 502.89 406.255 492.559 443.709ZM193.03 497.238L193.044 497.242L193.057 497.246C236.897 508.741 278.663 515.574 312.331 508.026C329.193 504.246 344.045 496.855 356.1 484.629C368.151 472.407 377.351 455.41 383.007 432.504C383.008 432.501 383.008 432.499 383.009 432.496L386.56 418.907C386.56 418.904 386.561 418.902 386.561 418.9C392.805 396.265 393.107 376.886 388.626 360.149C384.144 343.406 374.895 329.378 362.152 317.418C336.704 293.533 297.258 277.84 253.74 265.106L253.726 265.102L253.713 265.098C209.669 253.546 167.802 246.685 134.097 254.167C117.217 257.913 102.362 265.262 90.3146 277.428C78.2719 289.59 69.091 306.511 63.462 329.316C63.4614 329.318 63.4609 329.32 63.4603 329.322L59.9098 342.912C59.9092 342.914 59.9086 342.916 59.908 342.918C53.6381 365.656 53.315 385.111 57.7866 401.909C62.2596 418.711 71.5111 432.782 84.2734 444.775C109.759 468.726 149.308 484.448 193.03 497.238Z"
-						stroke="url(#paint4_linear_76_16273)"
-						stroke-opacity="0.6"
-						stroke-width="1.98687"
-					/>
-				</g>
-			</g>
-			<defs>
-				<filter
-					id="filter0_f_76_16273"
-					x="1241"
-					y="105"
-					width="580.952"
-					height="805.222"
-					filterUnits="userSpaceOnUse"
-					color-interpolation-filters="sRGB"
-				>
-					<feFlood flood-opacity="0" result="BackgroundImageFix" />
-					<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-					<feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur_76_16273" />
-				</filter>
-				<filter
-					id="filter1_f_76_16273"
-					x="-80"
-					y="142"
-					width="606"
-					height="479"
-					filterUnits="userSpaceOnUse"
-					color-interpolation-filters="sRGB"
-				>
-					<feFlood flood-opacity="0" result="BackgroundImageFix" />
-					<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-					<feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur_76_16273" />
-				</filter>
-				<linearGradient
-					id="paint0_linear_76_16273"
-					x1="864"
-					y1="610"
-					x2="864"
-					y2="0"
-					gradientUnits="userSpaceOnUse"
-				>
-					<stop stop-color="white" stop-opacity="0" />
-					<stop offset="0.65" stop-color="#ECF3FB" />
-				</linearGradient>
-				<linearGradient
-					id="paint1_linear_76_16273"
-					x1="1421"
-					y1="129"
-					x2="1411.22"
-					y2="521.45"
-					gradientUnits="userSpaceOnUse"
-				>
-					<stop stop-color="#92C2FA" />
-					<stop offset="1" stop-color="white" stop-opacity="0" />
-				</linearGradient>
-				<linearGradient
-					id="paint2_linear_76_16273"
-					x1="1421"
-					y1="129"
-					x2="1411.22"
-					y2="521.45"
-					gradientUnits="userSpaceOnUse"
-				>
-					<stop stop-color="#92C2FA" />
-					<stop offset="1" stop-color="white" stop-opacity="0" />
-				</linearGradient>
-				<linearGradient
-					id="paint3_linear_76_16273"
-					x1="259.695"
-					y1="118.13"
-					x2="175.594"
-					y2="497.984"
-					gradientUnits="userSpaceOnUse"
-				>
-					<stop stop-color="#92C2FA" />
-					<stop offset="1" stop-color="white" stop-opacity="0" />
-				</linearGradient>
-				<linearGradient
-					id="paint4_linear_76_16273"
-					x1="-56"
-					y1="166"
-					x2="503.705"
-					y2="594.775"
-					gradientUnits="userSpaceOnUse"
-				>
-					<stop stop-color="white" />
-					<stop offset="0.5" stop-color="white" stop-opacity="0" />
-					<stop offset="1" stop-color="white" />
-				</linearGradient>
-				<clipPath id="clip0_76_16273">
-					<rect width="1728" height="610" fill="white" />
-				</clipPath>
-			</defs>
-		</svg>
+				<defs>
+					<filter
+						id="filter0_f_76_16273"
+						x="1241"
+						y="105"
+						width="580.952"
+						height="805.222"
+						filterUnits="userSpaceOnUse"
+						color-interpolation-filters="sRGB"
+					>
+						<feFlood flood-opacity="0" result="BackgroundImageFix" />
+						<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+						<feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur_76_16273" />
+					</filter>
+					<filter
+						id="filter1_f_76_16273"
+						x="-80"
+						y="142"
+						width="606"
+						height="479"
+						filterUnits="userSpaceOnUse"
+						color-interpolation-filters="sRGB"
+					>
+						<feFlood flood-opacity="0" result="BackgroundImageFix" />
+						<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+						<feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur_76_16273" />
+					</filter>
+					<linearGradient
+						id="paint0_linear_76_16273"
+						x1="864"
+						y1="610"
+						x2="864"
+						y2="0"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="white" stop-opacity="0" />
+						<stop offset="0.65" stop-color="#ECF3FB" />
+					</linearGradient>
+					<linearGradient
+						id="paint1_linear_76_16273"
+						x1="1421"
+						y1="129"
+						x2="1411.22"
+						y2="521.45"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#92C2FA" />
+						<stop offset="1" stop-color="white" stop-opacity="0" />
+					</linearGradient>
+					<linearGradient
+						id="paint2_linear_76_16273"
+						x1="1421"
+						y1="129"
+						x2="1411.22"
+						y2="521.45"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#92C2FA" />
+						<stop offset="1" stop-color="white" stop-opacity="0" />
+					</linearGradient>
+					<linearGradient
+						id="paint3_linear_76_16273"
+						x1="259.695"
+						y1="118.13"
+						x2="175.594"
+						y2="497.984"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#92C2FA" />
+						<stop offset="1" stop-color="white" stop-opacity="0" />
+					</linearGradient>
+					<linearGradient
+						id="paint4_linear_76_16273"
+						x1="-56"
+						y1="166"
+						x2="503.705"
+						y2="594.775"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="white" />
+						<stop offset="0.5" stop-color="white" stop-opacity="0" />
+						<stop offset="1" stop-color="white" />
+					</linearGradient>
+					<clipPath id="clip0_76_16273">
+						<rect width="1728" height="610" fill="white" />
+					</clipPath>
+				</defs>
+			</svg>
+		</div>
 
 		<div style="display: contents">%sveltekit.body%</div>
 


### PR DESCRIPTION
# Motivation

After PR #2621 , there is an error in the background. Since the big background is used for smaller screen, there is no overflow control and the screen ends up being larger and longer.

To solve it we wrap the background in a container that will manage the overflow (and the general position), while the background image keeps its dimensions.

### Before

https://github.com/user-attachments/assets/56c4d4b1-e37a-467c-8c0d-3bf8876294d1

### After

https://github.com/user-attachments/assets/9d37af36-f159-45ad-9172-7af762c21b7b


