### PR TITLE
chore(frontend): remove error constructor

### DIFF
--- a/src/frontend/src/lib/canisters/errors.ts
+++ b/src/frontend/src/lib/canisters/errors.ts
@@ -1,5 +1,1 @@
-export class CanisterInternalError extends Error {
-	constructor(msg: string) {
-		super(msg);
-	}
-}
+export class CanisterInternalError extends Error {}


### PR DESCRIPTION
# Motivation

Overriding the constructor in `CanisterInternalError` is not needed given that it overrides the default with the same declaration.