### PR TITLE
chore(frontend): improve canister error code

### DIFF
--- a/src/frontend/src/lib/canisters/backend.errors.ts
+++ b/src/frontend/src/lib/canisters/backend.errors.ts
@@ -4,20 +4,20 @@ import type {
 } from '$declarations/backend/backend.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
-export const mapBtcPendingTransactionError = (response: BtcAddPendingTransactionError) => {
-	if ('InternalError' in response) {
-		return new CanisterInternalError(response.InternalError.msg);
+export const mapBtcPendingTransactionError = (err: BtcAddPendingTransactionError): CanisterInternalError => {
+	if ('InternalError' in err) {
+		return new CanisterInternalError(err.InternalError.msg);
 	}
 
 	return new CanisterInternalError('Unknown BtcAddPendingTransactionError');
 };
 
-export const mapBtcSelectUserUtxosFeeError = (response: SelectedUtxosFeeError) => {
-	if ('InternalError' in response) {
-		return new CanisterInternalError(response.InternalError.msg);
+export const mapBtcSelectUserUtxosFeeError = (err: SelectedUtxosFeeError): CanisterInternalError => {
+	if ('InternalError' in err) {
+		return new CanisterInternalError(err.InternalError.msg);
 	}
 
-	if ('PendingTransactions' in response) {
+	if ('PendingTransactions' in err) {
 		return new CanisterInternalError(
 			'Selecting utxos fee is not possible - pending transactions found.'
 		);

--- a/src/frontend/src/lib/canisters/backend.errors.ts
+++ b/src/frontend/src/lib/canisters/backend.errors.ts
@@ -4,7 +4,9 @@ import type {
 } from '$declarations/backend/backend.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
-export const mapBtcPendingTransactionError = (err: BtcAddPendingTransactionError): CanisterInternalError => {
+export const mapBtcPendingTransactionError = (
+	err: BtcAddPendingTransactionError
+): CanisterInternalError => {
 	if ('InternalError' in err) {
 		return new CanisterInternalError(err.InternalError.msg);
 	}
@@ -12,7 +14,9 @@ export const mapBtcPendingTransactionError = (err: BtcAddPendingTransactionError
 	return new CanisterInternalError('Unknown BtcAddPendingTransactionError');
 };
 
-export const mapBtcSelectUserUtxosFeeError = (err: SelectedUtxosFeeError): CanisterInternalError => {
+export const mapBtcSelectUserUtxosFeeError = (
+	err: SelectedUtxosFeeError
+): CanisterInternalError => {
 	if ('InternalError' in err) {
 		return new CanisterInternalError(err.InternalError.msg);
 	}

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -1,19 +1,22 @@
-import type { GetAddressError, PaymentError } from '$declarations/signer/signer.did';
+import type {
+	PaymentError,
+	GetAddressError as SignerCanisterBtcError
+} from '$declarations/signer/signer.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
-export class SignerCanisterPaymentError extends Error {
-	constructor(response: PaymentError) {
-		if ('UnsupportedPaymentType' in response) {
+export class SignerCanisterPaymentError extends CanisterInternalError {
+	constructor(err: PaymentError) {
+		if ('UnsupportedPaymentType' in err) {
 			super('Unsupported payment type');
-		} else if ('LedgerWithdrawFromError' in response) {
-			super(`Ledger error: ${JSON.stringify(response.LedgerWithdrawFromError.error)}`);
-		} else if ('LedgerUnreachable' in response) {
-			super(`Ledger unreachable: ${JSON.stringify(response.LedgerUnreachable)}`);
-		} else if ('LedgerTransferFromError' in response) {
-			super(`Ledger error: ${JSON.stringify(response.LedgerTransferFromError)}`);
-		} else if ('InsufficientFunds' in response) {
+		} else if ('LedgerWithdrawFromError' in err) {
+			super(`Ledger error: ${JSON.stringify(err.LedgerWithdrawFromError.error)}`);
+		} else if ('LedgerUnreachable' in err) {
+			super(`Ledger unreachable: ${JSON.stringify(err.LedgerUnreachable)}`);
+		} else if ('LedgerTransferFromError' in err) {
+			super(`Ledger error: ${JSON.stringify(err.LedgerTransferFromError)}`);
+		} else if ('InsufficientFunds' in err) {
 			super(
-				`Insufficient funds needed ${response.InsufficientFunds.needed} but available ${response.InsufficientFunds.available}`
+				`Insufficient funds needed ${err.InsufficientFunds.needed} but available ${err.InsufficientFunds.available}`
 			);
 		} else {
 			super('Unknown PaymentError');
@@ -21,13 +24,12 @@ export class SignerCanisterPaymentError extends Error {
 	}
 }
 
-type SignerCanisterBtcError = GetAddressError;
-export const mapSignerCanisterBtcError = (response: SignerCanisterBtcError) => {
-	if ('InternalError' in response) {
-		return new CanisterInternalError(response.InternalError.msg);
+export const mapSignerCanisterBtcError = (err: SignerCanisterBtcError): CanisterInternalError => {
+	if ('InternalError' in err) {
+		return new CanisterInternalError(err.InternalError.msg);
 	}
-	if ('PaymentError' in response) {
-		return new SignerCanisterPaymentError(response.PaymentError);
+	if ('PaymentError' in err) {
+		return new SignerCanisterPaymentError(err.PaymentError);
 	}
 	return new CanisterInternalError('Unknown SignerCanisterBtcError');
 };


### PR DESCRIPTION
# Changes

- `response` is of type error so rename to `err`
- `SignerCanisterBtcError` type is not needed and can be inlined in its import
- Return types are missing
- `SignerCanisterPaymentError` should extend `CanisterInternalError`
