### PR TITLE
feat(frontend): HTTP cache-control for assets (css, png, webp etc.)

### DIFF
--- a/src/frontend/static/.ic-assets.json
+++ b/src/frontend/static/.ic-assets.json
@@ -24,5 +24,11 @@
 		"headers": {
 			"Cache-Control": "public, max-age=31536000"
 		}
+	},
+	{
+		"match": "**/_app/immutable/assets/**/*",
+		"headers": {
+			"Cache-Control": "public, max-age=31536000"
+		}
 	}
 ]


### PR DESCRIPTION
# Motivation

I propose to start caching on the client side the assets that are generated from the `$lib/assets` directory. The assets are generated with a hash name.

For example: https://oisy.com/_app/immutable/assets/cover-features.BNqeslTw.png

# Notes

Given that assets are hashed, I think we can try to use a long living cache - i.e. a year.

# Changes

- Define a `Cache-Control` header for `_app/immutable/assets`
