### PR TITLE
feat(frontend): Derived store to find pending transactions

### DIFF
--- a/src/frontend/src/btc/derived/has-pending-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/has-pending-transactions.derived.ts
@@ -1,0 +1,65 @@
+import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
+import { LOCAL } from '$lib/constants/app.constants';
+import {
+	btcAddressMainnet,
+	btcAddressRegtest,
+	btcAddressTestnet
+} from '$lib/derived/address.derived';
+import { testnets } from '$lib/derived/testnets.derived';
+import { isNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const hasPendingTransactions = (address: string): Readable<boolean | 'loading'> =>
+	derived(
+		[btcAddressMainnet, btcAddressTestnet, btcAddressRegtest, testnets, pendingTransactionsStore],
+		([
+			$btcAddressMainnet,
+			$btcAddressTestnet,
+			$btcAddressRegtest,
+			$testnets,
+			$pendingTransactionsStore
+		]) => {
+			if (!$testnets) {
+				if (isNullish($btcAddressMainnet)) {
+					// Return loading while we don't have btc addresses and we can't tell
+					// whether there are pending transactions for a specific address.
+					return 'loading';
+				}
+				if ($btcAddressMainnet !== address) {
+					// If the address is not a bitcoin address, there are no pending transactions.
+					return false;
+				}
+				const pendingTransactions = $pendingTransactionsStore[address];
+				if (isNullish(pendingTransactions)) {
+					// Address is bitcoin but we pending transactions are not loaded yet.
+					return 'loading';
+				}
+				return pendingTransactions.data.length > 0;
+			}
+			if (
+				isNullish($btcAddressMainnet) ||
+				isNullish($btcAddressTestnet) ||
+				(LOCAL && isNullish($btcAddressRegtest))
+			) {
+				// Return loading while we don't have btc addresses and we can't tell
+				// whether there are pending transactions for a specific address.
+				return 'loading';
+			}
+
+			if (
+				$btcAddressMainnet !== address &&
+				$btcAddressTestnet !== address &&
+				$btcAddressRegtest !== address
+			) {
+				// If the address is not a bitcoin address, there are no pending transactions.
+				return false;
+			}
+
+			const pendingTransactions = $pendingTransactionsStore[address];
+			if (isNullish(pendingTransactions)) {
+				// Address is bitcoin but we pending transactions are not loaded yet.
+				return 'loading';
+			}
+			return pendingTransactions.data.length > 0;
+		}
+	);

--- a/src/frontend/src/btc/derived/has-pending-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/has-pending-transactions.derived.ts
@@ -6,7 +6,7 @@ import {
 	btcAddressTestnet
 } from '$lib/derived/address.derived';
 import { testnets } from '$lib/derived/testnets.derived';
-import { isNullish, nonNullish } from '@dfinity/utils';
+import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const initHasPendingTransactions = (address: string): Readable<boolean | 'loading'> =>
@@ -26,41 +26,27 @@ export const initHasPendingTransactions = (address: string): Readable<boolean | 
 			}
 
 			if (!$testnets) {
-				if (isNullish($btcAddressMainnet)) {
-					// Return loading while we don't have btc addresses and we can't tell
-					// whether there are pending transactions for a specific address.
-					return 'loading';
-				}
-				if ($btcAddressMainnet !== address) {
+				if (nonNullish($btcAddressMainnet) && $btcAddressMainnet !== address) {
 					// If the address is not a bitcoin address, there are no pending transactions.
 					return false;
 				}
 
-				// We already checked that the pendingTransaction are present at the top.
-				// If we reach here is because they are not present.
-				return 'loading';
-			}
-			if (
-				isNullish($btcAddressMainnet) ||
-				isNullish($btcAddressTestnet) ||
-				(LOCAL && isNullish($btcAddressRegtest))
-			) {
 				// Return loading while we don't have btc addresses and we can't tell
 				// whether there are pending transactions for a specific address.
 				return 'loading';
 			}
 
-			if (
-				$btcAddressMainnet !== address &&
-				$btcAddressTestnet !== address &&
-				$btcAddressRegtest !== address
-			) {
+			// Testnets are enabled.
+			const isNotMainnet = nonNullish($btcAddressMainnet) && $btcAddressMainnet !== address;
+			const isNotTestnet = nonNullish($btcAddressTestnet) && $btcAddressTestnet !== address;
+			const isNotRegtest = nonNullish($btcAddressRegtest) && $btcAddressRegtest !== address;
+			const isRegtestEnabled = LOCAL;
+			if (isNotMainnet && isNotTestnet && (isNotRegtest || !isRegtestEnabled)) {
 				// If the address is not a bitcoin address, there are no pending transactions.
 				return false;
 			}
 
-			// We already checked that the pendingTransaction are present at the top.
-			// If we reach here is because they are not present.
+			// If we reach here is because either addresses nor pending transactions are loaded
 			return 'loading';
 		}
 	);

--- a/src/frontend/src/btc/derived/has-pending-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/has-pending-transactions.derived.ts
@@ -6,10 +6,10 @@ import {
 	btcAddressTestnet
 } from '$lib/derived/address.derived';
 import { testnets } from '$lib/derived/testnets.derived';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const hasPendingTransactions = (address: string): Readable<boolean | 'loading'> =>
+export const initHasPendingTransactions = (address: string): Readable<boolean | 'loading'> =>
 	derived(
 		[btcAddressMainnet, btcAddressTestnet, btcAddressRegtest, testnets, pendingTransactionsStore],
 		([
@@ -19,6 +19,12 @@ export const hasPendingTransactions = (address: string): Readable<boolean | 'loa
 			$testnets,
 			$pendingTransactionsStore
 		]) => {
+			const pendingTransactionsData = $pendingTransactionsStore[address];
+
+			if (nonNullish(pendingTransactionsData)) {
+				return pendingTransactionsData.data.length > 0;
+			}
+
 			if (!$testnets) {
 				if (isNullish($btcAddressMainnet)) {
 					// Return loading while we don't have btc addresses and we can't tell
@@ -29,12 +35,10 @@ export const hasPendingTransactions = (address: string): Readable<boolean | 'loa
 					// If the address is not a bitcoin address, there are no pending transactions.
 					return false;
 				}
-				const pendingTransactions = $pendingTransactionsStore[address];
-				if (isNullish(pendingTransactions)) {
-					// Address is bitcoin but we pending transactions are not loaded yet.
-					return 'loading';
-				}
-				return pendingTransactions.data.length > 0;
+
+				// We already checked that the pendingTransaction are present at the top.
+				// If we reach here is because they are not present.
+				return 'loading';
 			}
 			if (
 				isNullish($btcAddressMainnet) ||
@@ -55,11 +59,8 @@ export const hasPendingTransactions = (address: string): Readable<boolean | 'loa
 				return false;
 			}
 
-			const pendingTransactions = $pendingTransactionsStore[address];
-			if (isNullish(pendingTransactions)) {
-				// Address is bitcoin but we pending transactions are not loaded yet.
-				return 'loading';
-			}
-			return pendingTransactions.data.length > 0;
+			// We already checked that the pendingTransaction are present at the top.
+			// If we reach here is because they are not present.
+			return 'loading';
 		}
 	);

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -1,3 +1,4 @@
+import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
 import { NETWORK_BITCOIN_ENABLED } from '$env/networks.btc.env';
 import {
 	BTC_MAINNET_TOKEN_ID,
@@ -5,6 +6,7 @@ import {
 	BTC_TESTNET_TOKEN_ID
 } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens.env';
+import { getPendingBtcTransactions } from '$lib/api/backend.api';
 import {
 	getIdbBtcAddressMainnet,
 	getIdbEthAddress,
@@ -15,6 +17,7 @@ import {
 	updateIdbEthAddressLastUsage
 } from '$lib/api/idb.api';
 import { getBtcAddress, getEthAddress } from '$lib/api/signer.api';
+import { LOCAL } from '$lib/constants/app.constants';
 import { warnSignOut } from '$lib/services/auth.services';
 import {
 	btcAddressMainnetStore,
@@ -115,12 +118,33 @@ const loadBtcAddress = async ({
 }): Promise<ResultSuccess> =>
 	loadTokenAddress<BtcAddress>({
 		tokenId,
-		getAddress: (identity: OptionIdentity) =>
-			getBtcAddress({
+		getAddress: async (identity: OptionIdentity) => {
+			const apiNetwork = mapToSignerBitcoinNetwork({ network });
+			const address = await getBtcAddress({
 				identity,
-				network: mapToSignerBitcoinNetwork({ network }),
+				network: apiNetwork,
 				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
-			}),
+			});
+			try {
+				// Endpoint raises an error locally if network is not regtest.
+				if (!LOCAL || network === 'regtest') {
+					const pendingTransactions = await getPendingBtcTransactions({
+						identity,
+						address,
+						network: apiNetwork
+					});
+					pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+				}
+			} catch (err: unknown) {
+				// Do not throw an error here, as the dapp should still work without pending transactions.
+				console.error('Error while loading pending transactions', err);
+				// We still fill the store with an empty array to enable the UI to work.
+				// Worst case scenario, the user will see an error before submitting a transaction.
+				// The endpoint to select the utxos and fee will return an error if there are pending transactions.
+				pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions: [] });
+			}
+			return address;
+		},
 		...bitcoinMapper[network]
 	});
 

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -115,7 +115,7 @@ const loadBtcAddress = async ({
 }): Promise<ResultSuccess> =>
 	loadTokenAddress<BtcAddress>({
 		tokenId,
-		getAddress: async (identity: OptionIdentity) =>
+		getAddress: (identity: OptionIdentity) =>
 			getBtcAddress({
 				identity,
 				network: mapToSignerBitcoinNetwork({ network }),

--- a/src/frontend/src/tests/btc/derived/has-pending-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/has-pending-transactions.derived.spec.ts
@@ -1,0 +1,154 @@
+import { initHasPendingTransactions } from '$btc/derived/has-pending-transactions.derived';
+import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
+import {
+	btcAddressMainnetStore,
+	btcAddressRegtestStore,
+	btcAddressTestnetStore
+} from '$lib/stores/address.store';
+import { testnetsStore } from '$lib/stores/settings.store';
+import { get } from 'svelte/store';
+
+const mockAddressMainnet = 'mainnet-address';
+const mockAddressTestnet = 'testnet-address';
+const mockAddressRegtest = 'regtest-address';
+const pendingTransactionMock = {
+	txid: new Uint8Array([1, 2, 3]),
+	utxos: [
+		{
+			height: 100,
+			value: BigInt(5000),
+			outpoint: {
+				txid: new Uint8Array([1, 2, 3]),
+				vout: 0
+			}
+		}
+	]
+};
+
+describe('hasPendingTransactions', () => {
+	beforeEach(() => {
+		btcAddressMainnetStore.reset();
+		btcAddressTestnetStore.reset();
+		btcAddressRegtestStore.reset();
+		pendingTransactionsStore.reset();
+		testnetsStore.reset({ key: 'testnets' });
+	});
+
+	describe('testnets disabled', () => {
+		beforeEach(() => {
+			testnetsStore.set({ key: 'testnets', value: { enabled: false } });
+		});
+
+		it('should return "loading" if BTC address mainnet is not loaded', () => {
+			const store = initHasPendingTransactions(mockAddressMainnet);
+			expect(get(store)).toBe('loading');
+		});
+
+		it('should return "loading" if pending transactions are not loaded yet for the address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			const store = initHasPendingTransactions(mockAddressMainnet);
+			expect(get(store)).toBe('loading');
+		});
+
+		it('should return "false" if address is not the mainnet bitcoin address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			const store = initHasPendingTransactions('another-address');
+			expect(get(store)).toBe(false);
+		});
+
+		it('should return "true" if there are pending transactions for the address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			pendingTransactionsStore.setPendingTransactions({
+				address: mockAddressMainnet,
+				pendingTransactions: [pendingTransactionMock]
+			});
+			const store = initHasPendingTransactions(mockAddressMainnet);
+			expect(get(store)).toBe(true);
+		});
+
+		it('should return "true" if there are pending transactions for the address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			pendingTransactionsStore.setPendingTransactions({
+				address: mockAddressMainnet,
+				pendingTransactions: []
+			});
+			const store = initHasPendingTransactions(mockAddressMainnet);
+			expect(get(store)).toBe(false);
+		});
+	});
+
+	describe('testnets enabled', () => {
+		beforeEach(() => {
+			testnetsStore.set({ key: 'testnets', value: { enabled: true } });
+		});
+
+		const loadAllAddresses = () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			btcAddressTestnetStore.set({ certified: true, data: mockAddressTestnet });
+			btcAddressRegtestStore.set({ certified: true, data: mockAddressRegtest });
+		};
+
+		it('should return "loading" if some btc address is missing is not loaded and it doesn\'t find the address', () => {
+			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+
+			btcAddressTestnetStore.set({ certified: true, data: mockAddressMainnet });
+			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+
+			btcAddressTestnetStore.set({ certified: true, data: mockAddressRegtest });
+			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+
+			btcAddressTestnetStore.reset();
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe('loading');
+		});
+
+		it('should return "loading" if pending transactions are not loaded yet for the address', () => {
+			loadAllAddresses();
+			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe('loading');
+			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+		});
+
+		it('should return "false" if address is not a bitcoin address', () => {
+			loadAllAddresses();
+			expect(get(initHasPendingTransactions('another-address'))).toBe(false);
+		});
+
+		it('should return "true" if there are pending transactions for the address', () => {
+			loadAllAddresses();
+			pendingTransactionsStore.setPendingTransactions({
+				address: mockAddressTestnet,
+				pendingTransactions: [pendingTransactionMock]
+			});
+			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe(true);
+		});
+
+		it('should return "false" if pending transactions are present and empty', () => {
+			loadAllAddresses();
+			pendingTransactionsStore.setPendingTransactions({
+				address: mockAddressTestnet,
+				pendingTransactions: []
+			});
+			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe(false);
+		});
+
+		it('should return "true" if there are pending transactions for the address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			pendingTransactionsStore.setPendingTransactions({
+				address: mockAddressMainnet,
+				pendingTransactions: [pendingTransactionMock]
+			});
+			const store = initHasPendingTransactions(mockAddressMainnet);
+			expect(get(store)).toBe(true);
+		});
+
+		it('should return "false" if there is empty pending transactions for the address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			pendingTransactionsStore.setPendingTransactions({
+				address: mockAddressMainnet,
+				pendingTransactions: []
+			});
+			const store = initHasPendingTransactions(mockAddressMainnet);
+			expect(get(store)).toBe(false);
+		});
+	});
+});

--- a/src/frontend/src/tests/btc/derived/has-pending-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/has-pending-transactions.derived.spec.ts
@@ -88,7 +88,7 @@ describe('hasPendingTransactions', () => {
 			btcAddressRegtestStore.set({ certified: true, data: mockAddressRegtest });
 		};
 
-		it('should return "loading" if some btc address is missing is not loaded and it doesn\'t find the address', () => {
+		it('should return "loading" if some btc address is not loaded', () => {
 			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
 
 			btcAddressTestnetStore.set({ certified: true, data: mockAddressMainnet });


### PR DESCRIPTION
# Motivation

We want to display a warning messange and disable the send form if the modal is for bitcoin and the user has pending transactions.

The bitcoin addresses are unique. Therefore, I wanted to take advantage of that instead of checking selected networks or tokens.

The idea is to create a derived store creator that will return `true`, `false` or `"loading"` depending on the address and whether the bitcoin addresses have been loaded:

* Return `true` when the address is a bitcoin address and the pending transactions array is not empty.
* Return `"loading"` if the addresses or the pending transactions are not loaded. This is trickier because we also need to check the `testnets`. If testnets are not enabled, then the addresses for testnet and regtest won't be loaded.
* Return `false` if the pending transactions are present and empty.

This derived store will be used in `IcSendForm`:

```
let hasPendingTransactionsStore: Readable<boolean | "loading">;
$: hasPendingTransactionsStore = initHasPendingTransactionsStore(source);

//...

{#if $hasPendingTransactionsStore}
  <WarningMessage>{...}</>
```

# Changes

* New derived store creator `initHasPendingTransactions`.

# Tests

* Add tests for the new derived store.
