### PR TITLE
feat(frontend): implement BtcSendAmount component

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import type { BtcAmountAssertionError } from '$btc/types/btc-send';
+	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
+	import { tokenDecimals } from '$lib/derived/token.derived';
+
+	export let amount: number | undefined = undefined;
+	export let amountError: BtcAmountAssertionError | undefined;
+</script>
+
+<SendInputAmount bind:amount tokenDecimals={$tokenDecimals} bind:error={amountError} />

--- a/src/frontend/src/btc/types/btc-send.ts
+++ b/src/frontend/src/btc/types/btc-send.ts
@@ -1,0 +1,1 @@
+export class BtcAmountAssertionError extends Error {}


### PR DESCRIPTION
# Motivation

As a part of BTC send UX flow, we need to implement `BtcSendAmount`.
