### PR TITLE
chore(frontend): simplify button class removing center sub-class

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if $metamaskAvailable && $networkEthereum && tokenStandardEth}
-	<button class="primary full center my-4" on:click={receiveModal}>
+	<button class="primary full my-4" on:click={receiveModal}>
 		<IconMetamask />
 		<span class="text-dark-slate-blue font-bold">{$i18n.receive.ethereum.text.metamask}</span>
 	</button>

--- a/src/frontend/src/eth/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/TokenModal.svelte
@@ -43,7 +43,7 @@
 			</Token>
 		{/if}
 
-		<button class="primary full center text-center" on:click={modalStore.close} slot="toolbar"
+		<button class="primary full text-center" on:click={modalStore.close} slot="toolbar"
 			>{$i18n.core.text.done}</button
 		>
 	</ContentWithToolbar>

--- a/src/frontend/src/eth/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/TransactionModal.svelte
@@ -133,7 +133,7 @@
 			</output>
 		</Value>
 
-		<button class="primary full center text-center" on:click={modalStore.close} slot="toolbar"
+		<button class="primary full text-center" on:click={modalStore.close} slot="toolbar"
 			>{$i18n.core.text.close}</button
 		>
 	</ContentWithToolbar>

--- a/src/frontend/src/icp/components/receive/IcReceiveInfoCkBTC.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveInfoCkBTC.svelte
@@ -65,7 +65,7 @@
 		</ReceiveAddress>
 	{/if}
 
-	<button class="primary full center text-center" on:click={close} slot="toolbar"
+	<button class="primary full text-center" on:click={close} slot="toolbar"
 		>{$i18n.core.text.done}</button
 	>
 </ContentWithToolbar>

--- a/src/frontend/src/icp/components/receive/IcReceiveInfoICP.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveInfoICP.svelte
@@ -53,7 +53,7 @@
 		<svelte:fragment slot="text">{$i18n.receive.icp.text.use_for_icp_deposit}</svelte:fragment>
 	</ReceiveAddress>
 
-	<button class="primary full center text-center" on:click={close} slot="toolbar">
+	<button class="primary full text-center" on:click={close} slot="toolbar">
 		{$i18n.core.text.done}
 	</button>
 </ContentWithToolbar>

--- a/src/frontend/src/icp/components/receive/IcReceiveInfoIcrc.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveInfoIcrc.svelte
@@ -14,7 +14,7 @@
 <ContentWithToolbar>
 	<IcReceiveWalletAddress on:icQRCode />
 
-	<button class="primary full center text-center" on:click={close} slot="toolbar"
+	<button class="primary full text-center" on:click={close} slot="toolbar"
 		>{$i18n.core.text.done}</button
 	>
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/hero/about/AboutHowModal.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutHowModal.svelte
@@ -47,7 +47,7 @@
 		</p>
 	</div>
 
-	<button class="secondary full center text-center" on:click={modalStore.close}
+	<button class="secondary full text-center" on:click={modalStore.close}
 		>{$i18n.core.text.close}</button
 	>
 </Modal>

--- a/src/frontend/src/lib/components/hero/about/AboutWhatModal.svelte
+++ b/src/frontend/src/lib/components/hero/about/AboutWhatModal.svelte
@@ -34,7 +34,7 @@
 		</p>
 	</div>
 
-	<button class="secondary full center text-center" on:click={modalStore.close}
+	<button class="secondary full text-center" on:click={modalStore.close}
 		>{$i18n.core.text.close}</button
 	>
 </Modal>

--- a/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
@@ -24,6 +24,6 @@
 	<ReceiveQRCode address={address ?? ''} />
 </div>
 
-<button class="secondary full center mt-8 text-center" on:click={() => dispatch('icBack')}
+<button class="secondary full mt-8 text-center" on:click={() => dispatch('icBack')}
 	>{$i18n.core.text.back}</button
 >

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -143,7 +143,7 @@
 		{$i18n.receive.ethereum.text.ethereum}
 	</ReceiveAddressWithLogo>
 
-	<button class="primary full center text-center" on:click={modalStore.close} slot="toolbar"
+	<button class="primary full text-center" on:click={modalStore.close} slot="toolbar"
 		>{$i18n.core.text.done}</button
 	>
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -37,7 +37,7 @@
 		{/if}
 	</TokensSkeletons>
 
-	<button class="secondary full center mb-2 text-center" on:click={modalStore.close} slot="toolbar">
+	<button class="secondary full mb-2 text-center" on:click={modalStore.close} slot="toolbar">
 		{$i18n.core.text.close}
 	</button>
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionModal.svelte
@@ -124,7 +124,7 @@
 			</Value>
 		{/if}
 
-		<button class="primary full center text-center" on:click={modalStore.close} slot="toolbar"
+		<button class="primary full text-center" on:click={modalStore.close} slot="toolbar"
 			>{$i18n.core.text.close}</button
 		>
 	</ContentWithToolbar>

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -26,7 +26,7 @@ button {
 	&.primary,
 	&.secondary,
 	&.tertiary {
-		justify-content: flex-start;
+		justify-content: center;
 
 		padding: var(--button-padding);
 
@@ -138,10 +138,6 @@ button {
 	&.secondary {
 		&.full {
 			width: 100%;
-		}
-
-		&.center {
-			justify-content: center;
 		}
 	}
 


### PR DESCRIPTION
# Motivation

The buttons classes `primary`, `secondary` and `tertiary` were using the sub-class `center` in all the instances. Furthermore, it makes sense that, as default, the button have centered content (according to new design too).

This PR removes the sub-class `center` and set the centered content directly in the classes.