### PR TITLE
style(frontend): center the login group when signed out [GIX-3044]

### DIFF
--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -11,14 +11,12 @@
 </script>
 
 <div
-	class="m-auto grid w-full max-w-screen-2.5xl grid-cols-1 flex-col items-center gap-12 overflow-hidden px-5 md:grid-cols-2 md:grid-rows-1 md:items-start md:gap-8 md:overflow-visible"
+	class="m-auto grid w-full max-w-screen-2.5xl grid-cols-1 flex-col items-center gap-12 overflow-hidden px-5 md:grid-cols-2 md:grid-rows-1 md:gap-8 md:overflow-visible"
 >
 	<div
 		class="flex w-full flex-1 flex-col items-center text-center md:items-start md:pl-8 md:pt-12 md:text-left"
 	>
-		<div class="md:absolute md:top-1/3">
-			<HeroSignIn />
-		</div>
+		<HeroSignIn />
 	</div>
 
 	<!-- TODO: determine if this value is specific/permanent or can be changed -->


### PR DESCRIPTION
# Motivation

We want the main header when signed out central.

<img width="1248" alt="Screenshot 2024-10-04 at 11 27 02" src="https://github.com/user-attachments/assets/429ab123-f8f2-4b6e-9cb1-96b093c27d22">
<img width="1740" alt="Screenshot 2024-10-04 at 11 27 21" src="https://github.com/user-attachments/assets/1515cb22-9783-4dae-99a0-0aea7ad140e9">

