### PR TITLE
style(frontend): increase header text when signed out on mobile [GIX-3044]

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <div class="mb-7 mt-5 pt-2">
-	<h1 class="md:text-5xl md:leading-tight">
+	<h1 class="text-4xl md:text-5xl md:leading-tight">
 		{$i18n.auth.text.title_part_1}<br /><span class="text-primary"
 			>{$i18n.auth.text.title_part_2}</span
 		>


### PR DESCRIPTION
# Motivation

Larger text in header when signed out on mobile.

### Before

<img width="432" alt="Screenshot 2024-10-04 at 11 30 10" src="https://github.com/user-attachments/assets/04d61548-0bcb-4a7b-ad78-bffcea469e80">
<img width="374" alt="Screenshot 2024-10-04 at 11 30 15" src="https://github.com/user-attachments/assets/48c5d6ab-89ac-4962-ba56-3d1cabd382e5">

### After

<img width="432" alt="Screenshot 2024-10-04 at 11 29 53" src="https://github.com/user-attachments/assets/90cacbb2-212b-4a45-94e6-f7e4fb2d5703">
<img width="374" alt="Screenshot 2024-10-04 at 11 29 58" src="https://github.com/user-attachments/assets/d34e43b7-071e-45e5-93da-ce9167c10f7e">
