### PR TITLE
refactor(frontend): move BTC address utils to lib

### DIFF
--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -10,30 +10,15 @@ import type { CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenStandard } from '$lib/types/token';
 import { invalidIcpAddress, isEthAddress } from '$lib/utils/account.utils';
+import { invalidBtcAddress } from '$lib/utils/address.utils';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
 import {
 	isNetworkIdBTCMainnet,
 	isNetworkIdBitcoin,
 	isNetworkIdEthereum
 } from '$lib/utils/network.utils';
-import { BtcNetwork, parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';
-import { isNullish, nonNullish } from '@dfinity/utils';
-
-export const isBtcAddress = (address: BtcAddress | undefined): boolean => {
-	if (isNullish(address)) {
-		return false;
-	}
-
-	try {
-		parseBtcAddress(address);
-		return true;
-	} catch (_: unknown) {
-		return false;
-	}
-};
-
-export const invalidBtcAddress = (address: BtcAddress | undefined): boolean =>
-	!isBtcAddress(address);
+import { BtcNetwork } from '@dfinity/ckbtc';
+import { nonNullish } from '@dfinity/utils';
 
 const isTokenLedger = ({
 	token: { ledgerCanisterId },

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -1,7 +1,25 @@
 import type { StorageAddressData } from '$lib/stores/address.store';
 import type { Address, OptionAddress } from '$lib/types/address';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
+import { parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';
+import { isNullish } from '@dfinity/utils';
 
 export const mapAddress = <T extends Address>(
 	$addressStore: StorageAddressData<T>
 ): OptionAddress<Address> => mapCertifiedData($addressStore);
+
+export const isBtcAddress = (address: BtcAddress | undefined): boolean => {
+	if (isNullish(address)) {
+		return false;
+	}
+
+	try {
+		parseBtcAddress(address);
+		return true;
+	} catch (_: unknown) {
+		return false;
+	}
+};
+
+export const invalidBtcAddress = (address: BtcAddress | undefined): boolean =>
+	!isBtcAddress(address);


### PR DESCRIPTION
# Motivation

One of the steps to move shared between BTC and IC code to $lib.
