### PR TITLE
fix(frontend): image banner default size

### DIFF
--- a/src/frontend/src/lib/components/ui/ImgBanner.svelte
+++ b/src/frontend/src/lib/components/ui/ImgBanner.svelte
@@ -4,7 +4,7 @@
 	export let src: string;
 	export let alt = '';
 	export let width: string | undefined = undefined;
-	export let size: 'small' | 'big' = 'small';
+	export let size: 'small' | 'big' = 'big';
 </script>
 
 <div class="relative block" class:h-56={size === 'big'} class:h-40={size === 'small'}>


### PR DESCRIPTION
# Motivation

I'm an idiot. 

Follow-up of #2647

# Changes

- default size is `big`

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-04 à 14 54 56" src="https://github.com/user-attachments/assets/4bcd2800-da52-4a99-9a19-f6b60f87a470">
<img width="1536" alt="Capture d’écran 2024-10-04 à 14 54 58" src="https://github.com/user-attachments/assets/0a567b42-b9b9-4b81-9d1d-913b09001188">

After:

<img width="1536" alt="Capture d’écran 2024-10-04 à 14 55 19" src="https://github.com/user-attachments/assets/0a536218-80fa-46ff-9797-6d3ba72a589f">
<img width="1536" alt="Capture d’écran 2024-10-04 à 14 55 21" src="https://github.com/user-attachments/assets/9880a75d-f22c-4f83-9c75-03bad9998259">

