### PR TITLE
feat(frontend): disable buy button if no OnRamper API key is provided [GIX-2854]

### DIFF
--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
+	import { ONRAMPER_API_KEY } from '$env/onramper.env';
 	import IconBuy from '$lib/components/icons/IconBuy.svelte';
 	import ButtonHero from '$lib/components/ui/ButtonHero.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 </script>
 
-<ButtonHero on:click disabled={$isBusy} ariaLabel={$i18n.send.text.send}>
+<ButtonHero
+	on:click
+	disabled={$isBusy || isNullishOrEmpty(ONRAMPER_API_KEY)}
+	ariaLabel={$i18n.send.text.send}
+>
 	<IconBuy size="28" slot="icon" />
 	{$i18n.buy.text.buy}
 </ButtonHero>


### PR DESCRIPTION
# Motivation

Just to be on the safe side, we disable the Buy button in case there is no OnRamper API key provided. This could happen only in case there is some inconsistency on the `.env` file.