### PR TITLE
style(frontend): remove unnecessary margin bottom in info

### DIFF
--- a/src/frontend/src/eth/components/send/SendInfo.svelte
+++ b/src/frontend/src/eth/components/send/SendInfo.svelte
@@ -17,7 +17,7 @@
 
 {#if displayInfo}
 	<Info>
-		<p>
+		<span>
 			{#if sendPurpose === 'convert-eth-to-cketh'}
 				{$i18n.convert.text.cketh_conversions_may_take}
 			{:else}
@@ -25,6 +25,6 @@
 					$ckErc20: sendTokenAsErc20?.twinTokenSymbol ?? ''
 				})}
 			{/if}
-		</p>
+		</span>
 	</Info>
 {/if}


### PR DESCRIPTION
# Motivation

See screenshots

# Changes

- `span` instead of `p`

# Screenshots

Before

<img width="1536" alt="Capture d’écran 2024-10-04 à 16 45 49" src="https://github.com/user-attachments/assets/64d3cbd7-138c-4a49-b342-933c8cebcb5d">

After

<img width="1536" alt="Capture d’écran 2024-10-04 à 16 45 43" src="https://github.com/user-attachments/assets/163f40c8-9b94-4360-bd2c-713888a74b84">

