### PR TITLE
refactor(frontend): Rename btc pending transactions to "sent transactions"

### DIFF
--- a/src/frontend/src/btc/derived/has-pending-sent-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/has-pending-sent-transactions.derived.ts
@@ -1,4 +1,4 @@
-import { pendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { LOCAL } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnet,
@@ -16,7 +16,7 @@ export const initHasPendingSentTransactions = (address: string): Readable<boolea
 			btcAddressTestnet,
 			btcAddressRegtest,
 			testnets,
-			pendingSentTransactionsStore
+			btcPendingSentTransactionsStore
 		],
 		([
 			$btcAddressMainnet,

--- a/src/frontend/src/btc/derived/has-pending-sent-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/has-pending-sent-transactions.derived.ts
@@ -1,4 +1,4 @@
-import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
+import { pendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { LOCAL } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnet,
@@ -9,9 +9,15 @@ import { testnets } from '$lib/derived/testnets.derived';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const initHasPendingTransactions = (address: string): Readable<boolean | 'loading'> =>
+export const initHasPendingSentTransactions = (address: string): Readable<boolean | 'loading'> =>
 	derived(
-		[btcAddressMainnet, btcAddressTestnet, btcAddressRegtest, testnets, pendingTransactionsStore],
+		[
+			btcAddressMainnet,
+			btcAddressTestnet,
+			btcAddressRegtest,
+			testnets,
+			pendingSentTransactionsStore
+		],
 		([
 			$btcAddressMainnet,
 			$btcAddressTestnet,

--- a/src/frontend/src/btc/stores/btc-pending-sent-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-sent-transactions.store.ts
@@ -51,4 +51,4 @@ const initBtcPendingSentTransactionsStore = (): BtcPendingSentTransactionsStore 
 	};
 };
 
-export const pendingSentTransactionsStore = initBtcPendingSentTransactionsStore();
+export const btcPendingSentTransactionsStore = initBtcPendingSentTransactionsStore();

--- a/src/frontend/src/btc/stores/btc-pending-sent-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-sent-transactions.store.ts
@@ -3,13 +3,13 @@ import type { AlwaysCertifiedData } from '$lib/types/store';
 import { writable, type Readable } from 'svelte/store';
 
 type Address = string;
-type BtcPendingTransactionsStoreData = Record<
+type BtcPendingSentTransactionsStoreData = Record<
 	Address,
 	// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
 	AlwaysCertifiedData<Array<PendingTransaction>>
 >;
 
-interface BtcPendingTransactionsStore extends Readable<BtcPendingTransactionsStoreData> {
+interface BtcPendingSentTransactionsStore extends Readable<BtcPendingSentTransactionsStoreData> {
 	setPendingTransactions: (params: {
 		address: Address;
 		pendingTransactions: Array<PendingTransaction>;
@@ -19,13 +19,14 @@ interface BtcPendingTransactionsStore extends Readable<BtcPendingTransactionsSto
 
 /**
  * Bitcoin transations take time to confirm.
- * While a transaction is pending, its utxos cannot be used, but they might still be available.
+ * After a user sends a transaction, while a transaction is pending,
+ * its utxos cannot be used, but they might still be available.
  * Instead of trying ot be smart, for now we'll disable transactions until they are confirmed.
  *
  * This store is used to keep track of pending transactions.
  */
-const initBtcPendingTransactionsStore = (): BtcPendingTransactionsStore => {
-	const { update, set, subscribe } = writable<BtcPendingTransactionsStoreData>({});
+const initBtcPendingSentTransactionsStore = (): BtcPendingSentTransactionsStore => {
+	const { update, set, subscribe } = writable<BtcPendingSentTransactionsStoreData>({});
 
 	return {
 		subscribe,
@@ -50,4 +51,4 @@ const initBtcPendingTransactionsStore = (): BtcPendingTransactionsStore => {
 	};
 };
 
-export const pendingTransactionsStore = initBtcPendingTransactionsStore();
+export const pendingSentTransactionsStore = initBtcPendingSentTransactionsStore();

--- a/src/frontend/src/tests/btc/derived/has-pending-sent-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/has-pending-sent-transactions.derived.spec.ts
@@ -1,5 +1,5 @@
 import { initHasPendingSentTransactions } from '$btc/derived/has-pending-sent-transactions.derived';
-import { pendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -25,12 +25,12 @@ const pendingTransactionMock = {
 	]
 };
 
-describe('hasPendingTransactions', () => {
+describe('initHasPendingSentTransactions', () => {
 	beforeEach(() => {
 		btcAddressMainnetStore.reset();
 		btcAddressTestnetStore.reset();
 		btcAddressRegtestStore.reset();
-		pendingSentTransactionsStore.reset();
+		btcPendingSentTransactionsStore.reset();
 		testnetsStore.reset({ key: 'testnets' });
 	});
 
@@ -58,7 +58,7 @@ describe('hasPendingTransactions', () => {
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingSentTransactionsStore.setPendingTransactions({
+			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
@@ -68,7 +68,7 @@ describe('hasPendingTransactions', () => {
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingSentTransactionsStore.setPendingTransactions({
+			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: []
 			});
@@ -115,7 +115,7 @@ describe('hasPendingTransactions', () => {
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			loadAllAddresses();
-			pendingSentTransactionsStore.setPendingTransactions({
+			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressTestnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
@@ -124,7 +124,7 @@ describe('hasPendingTransactions', () => {
 
 		it('should return "false" if pending transactions are present and empty', () => {
 			loadAllAddresses();
-			pendingSentTransactionsStore.setPendingTransactions({
+			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressTestnet,
 				pendingTransactions: []
 			});
@@ -133,7 +133,7 @@ describe('hasPendingTransactions', () => {
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingSentTransactionsStore.setPendingTransactions({
+			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
@@ -143,7 +143,7 @@ describe('hasPendingTransactions', () => {
 
 		it('should return "false" if there is empty pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingSentTransactionsStore.setPendingTransactions({
+			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: []
 			});

--- a/src/frontend/src/tests/btc/derived/has-pending-sent-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/has-pending-sent-transactions.derived.spec.ts
@@ -1,5 +1,5 @@
-import { initHasPendingTransactions } from '$btc/derived/has-pending-transactions.derived';
-import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
+import { initHasPendingSentTransactions } from '$btc/derived/has-pending-sent-transactions.derived';
+import { pendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -30,7 +30,7 @@ describe('hasPendingTransactions', () => {
 		btcAddressMainnetStore.reset();
 		btcAddressTestnetStore.reset();
 		btcAddressRegtestStore.reset();
-		pendingTransactionsStore.reset();
+		pendingSentTransactionsStore.reset();
 		testnetsStore.reset({ key: 'testnets' });
 	});
 
@@ -40,39 +40,39 @@ describe('hasPendingTransactions', () => {
 		});
 
 		it('should return "loading" if BTC address mainnet is not loaded', () => {
-			const store = initHasPendingTransactions(mockAddressMainnet);
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
 			expect(get(store)).toBe('loading');
 		});
 
 		it('should return "loading" if pending transactions are not loaded yet for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			const store = initHasPendingTransactions(mockAddressMainnet);
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
 			expect(get(store)).toBe('loading');
 		});
 
 		it('should return "false" if address is not the mainnet bitcoin address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			const store = initHasPendingTransactions('another-address');
+			const store = initHasPendingSentTransactions('another-address');
 			expect(get(store)).toBe(false);
 		});
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingTransactionsStore.setPendingTransactions({
+			pendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
-			const store = initHasPendingTransactions(mockAddressMainnet);
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
 			expect(get(store)).toBe(true);
 		});
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingTransactionsStore.setPendingTransactions({
+			pendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: []
 			});
-			const store = initHasPendingTransactions(mockAddressMainnet);
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
 			expect(get(store)).toBe(false);
 		});
 	});
@@ -89,65 +89,65 @@ describe('hasPendingTransactions', () => {
 		};
 
 		it('should return "loading" if some btc address is not loaded', () => {
-			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+			expect(get(initHasPendingSentTransactions(mockAddressMainnet))).toBe('loading');
 
 			btcAddressTestnetStore.set({ certified: true, data: mockAddressMainnet });
-			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+			expect(get(initHasPendingSentTransactions(mockAddressMainnet))).toBe('loading');
 
 			btcAddressTestnetStore.set({ certified: true, data: mockAddressRegtest });
-			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+			expect(get(initHasPendingSentTransactions(mockAddressMainnet))).toBe('loading');
 
 			btcAddressTestnetStore.reset();
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe('loading');
+			expect(get(initHasPendingSentTransactions(mockAddressTestnet))).toBe('loading');
 		});
 
 		it('should return "loading" if pending transactions are not loaded yet for the address', () => {
 			loadAllAddresses();
-			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe('loading');
-			expect(get(initHasPendingTransactions(mockAddressMainnet))).toBe('loading');
+			expect(get(initHasPendingSentTransactions(mockAddressTestnet))).toBe('loading');
+			expect(get(initHasPendingSentTransactions(mockAddressMainnet))).toBe('loading');
 		});
 
 		it('should return "false" if address is not a bitcoin address', () => {
 			loadAllAddresses();
-			expect(get(initHasPendingTransactions('another-address'))).toBe(false);
+			expect(get(initHasPendingSentTransactions('another-address'))).toBe(false);
 		});
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			loadAllAddresses();
-			pendingTransactionsStore.setPendingTransactions({
+			pendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressTestnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
-			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe(true);
+			expect(get(initHasPendingSentTransactions(mockAddressTestnet))).toBe(true);
 		});
 
 		it('should return "false" if pending transactions are present and empty', () => {
 			loadAllAddresses();
-			pendingTransactionsStore.setPendingTransactions({
+			pendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressTestnet,
 				pendingTransactions: []
 			});
-			expect(get(initHasPendingTransactions(mockAddressTestnet))).toBe(false);
+			expect(get(initHasPendingSentTransactions(mockAddressTestnet))).toBe(false);
 		});
 
 		it('should return "true" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingTransactionsStore.setPendingTransactions({
+			pendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
-			const store = initHasPendingTransactions(mockAddressMainnet);
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
 			expect(get(store)).toBe(true);
 		});
 
 		it('should return "false" if there is empty pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
-			pendingTransactionsStore.setPendingTransactions({
+			pendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: []
 			});
-			const store = initHasPendingTransactions(mockAddressMainnet);
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
 			expect(get(store)).toBe(false);
 		});
 	});

--- a/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
@@ -1,4 +1,4 @@
-import { pendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import type { PendingTransaction } from '$declarations/backend/backend.did';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -30,13 +30,13 @@ const pendingTransactionMock2 = {
 	]
 };
 
-describe('BtcPendingTransactionsStore', () => {
+describe('pendingSentTransactionsStore', () => {
 	beforeEach(() => {
-		pendingSentTransactionsStore.reset();
+		btcPendingSentTransactionsStore.reset();
 	});
 
 	it('should initialize with an empty store', () => {
-		const storeData = get(pendingSentTransactionsStore);
+		const storeData = get(btcPendingSentTransactionsStore);
 		expect(storeData).toEqual({});
 	});
 
@@ -44,9 +44,9 @@ describe('BtcPendingTransactionsStore', () => {
 		const address = 'test-address';
 		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
 
-		pendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+		btcPendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
-		const storeData = get(pendingSentTransactionsStore);
+		const storeData = get(btcPendingSentTransactionsStore);
 		expect(storeData[address].data).toEqual(pendingTransactions);
 	});
 
@@ -54,9 +54,9 @@ describe('BtcPendingTransactionsStore', () => {
 		const address = 'test-address';
 		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
 
-		pendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+		btcPendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
-		const storeData = get(pendingSentTransactionsStore);
+		const storeData = get(btcPendingSentTransactionsStore);
 		expect(storeData[address].certified).toEqual(true);
 	});
 
@@ -66,17 +66,17 @@ describe('BtcPendingTransactionsStore', () => {
 
 		const newPendingTransactions: Array<PendingTransaction> = [pendingTransactionMock2];
 
-		pendingSentTransactionsStore.setPendingTransactions({
+		btcPendingSentTransactionsStore.setPendingTransactions({
 			address,
 			pendingTransactions: initialPendingTransactions
 		});
 
-		pendingSentTransactionsStore.setPendingTransactions({
+		btcPendingSentTransactionsStore.setPendingTransactions({
 			address,
 			pendingTransactions: newPendingTransactions
 		});
 
-		const storeData = get(pendingSentTransactionsStore);
+		const storeData = get(btcPendingSentTransactionsStore);
 		expect(storeData[address].data).toEqual(newPendingTransactions);
 	});
 
@@ -87,17 +87,17 @@ describe('BtcPendingTransactionsStore', () => {
 
 		const pendingTransactions2: Array<PendingTransaction> = [pendingTransactionMock2];
 
-		pendingSentTransactionsStore.setPendingTransactions({
+		btcPendingSentTransactionsStore.setPendingTransactions({
 			address: address1,
 			pendingTransactions: pendingTransactions1
 		});
 
-		pendingSentTransactionsStore.setPendingTransactions({
+		btcPendingSentTransactionsStore.setPendingTransactions({
 			address: address2,
 			pendingTransactions: pendingTransactions2
 		});
 
-		const storeData = get(pendingSentTransactionsStore);
+		const storeData = get(btcPendingSentTransactionsStore);
 		expect(storeData[address1].data).toEqual(pendingTransactions1);
 		expect(storeData[address2].data).toEqual(pendingTransactions2);
 	});

--- a/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
@@ -1,4 +1,4 @@
-import { pendingTransactionsStore } from '$btc/stores/btc-pending-transactions.store';
+import { pendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import type { PendingTransaction } from '$declarations/backend/backend.did';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -32,11 +32,11 @@ const pendingTransactionMock2 = {
 
 describe('BtcPendingTransactionsStore', () => {
 	beforeEach(() => {
-		pendingTransactionsStore.reset();
+		pendingSentTransactionsStore.reset();
 	});
 
 	it('should initialize with an empty store', () => {
-		const storeData = get(pendingTransactionsStore);
+		const storeData = get(pendingSentTransactionsStore);
 		expect(storeData).toEqual({});
 	});
 
@@ -44,9 +44,9 @@ describe('BtcPendingTransactionsStore', () => {
 		const address = 'test-address';
 		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
 
-		pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+		pendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
-		const storeData = get(pendingTransactionsStore);
+		const storeData = get(pendingSentTransactionsStore);
 		expect(storeData[address].data).toEqual(pendingTransactions);
 	});
 
@@ -54,9 +54,9 @@ describe('BtcPendingTransactionsStore', () => {
 		const address = 'test-address';
 		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
 
-		pendingTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+		pendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
-		const storeData = get(pendingTransactionsStore);
+		const storeData = get(pendingSentTransactionsStore);
 		expect(storeData[address].certified).toEqual(true);
 	});
 
@@ -66,17 +66,17 @@ describe('BtcPendingTransactionsStore', () => {
 
 		const newPendingTransactions: Array<PendingTransaction> = [pendingTransactionMock2];
 
-		pendingTransactionsStore.setPendingTransactions({
+		pendingSentTransactionsStore.setPendingTransactions({
 			address,
 			pendingTransactions: initialPendingTransactions
 		});
 
-		pendingTransactionsStore.setPendingTransactions({
+		pendingSentTransactionsStore.setPendingTransactions({
 			address,
 			pendingTransactions: newPendingTransactions
 		});
 
-		const storeData = get(pendingTransactionsStore);
+		const storeData = get(pendingSentTransactionsStore);
 		expect(storeData[address].data).toEqual(newPendingTransactions);
 	});
 
@@ -87,17 +87,17 @@ describe('BtcPendingTransactionsStore', () => {
 
 		const pendingTransactions2: Array<PendingTransaction> = [pendingTransactionMock2];
 
-		pendingTransactionsStore.setPendingTransactions({
+		pendingSentTransactionsStore.setPendingTransactions({
 			address: address1,
 			pendingTransactions: pendingTransactions1
 		});
 
-		pendingTransactionsStore.setPendingTransactions({
+		pendingSentTransactionsStore.setPendingTransactions({
 			address: address2,
 			pendingTransactions: pendingTransactions2
 		});
 
-		const storeData = get(pendingTransactionsStore);
+		const storeData = get(pendingSentTransactionsStore);
 		expect(storeData[address1].data).toEqual(pendingTransactions1);
 		expect(storeData[address2].data).toEqual(pendingTransactions2);
 	});


### PR DESCRIPTION
# Motivation

As discussed in [this comment](https://github.com/dfinity/oisy-wallet/pull/2652#issuecomment-2393808608) this PR renames the BTC pending transactions to pending "sent" transactions.

# Changes

* Rename file and store types and variables.
* Rename file and derived store.

# Tests

* Rename test files and imports.
