### PR TITLE
build(test): import fake-indexeddb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
 				"@types/node": "^20.14.9",
 				"autoprefixer": "^10.4.20",
 				"dotenv": "^16.4.5",
+				"fake-indexeddb": "^6.0.0",
 				"jimp": "^1.6.0",
 				"jsdom": "^25.0.1",
 				"jsqr": "^1.4.0",
@@ -6602,6 +6603,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"type": "^2.7.2"
+			}
+		},
+		"node_modules/fake-indexeddb": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.0.tgz",
+			"integrity": "sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"@types/node": "^20.14.9",
 		"autoprefixer": "^10.4.20",
 		"dotenv": "^16.4.5",
+		"fake-indexeddb": "^6.0.0",
 		"jimp": "^1.6.0",
 		"jsdom": "^25.0.1",
 		"jsqr": "^1.4.0",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import 'fake-indexeddb/auto';


### PR DESCRIPTION
# Motivation

When we start testing features around the addresses that are saved on the client side with Idb, we will need to fake Idb.
So, similarly as in NNS dapp, we can use `fake-indexeddb`

# Changes

- `npm i fake-indexeddb -D`
- Add related import in vitest setup
