### PR TITLE
build(test): load canister IDs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,10 +46,6 @@ export default defineConfig(
 				{
 					find: '$env',
 					replacement: resolve(__dirname, 'src/frontend/src/env')
-				},
-				{
-					find: '$declarations',
-					replacement: resolve(__dirname, 'src/declarations')
 				}
 			]
 		},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,12 @@ import { svelteTesting } from '@testing-library/svelte/vite';
 import { resolve } from 'path';
 import { type UserConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
-import { defineViteReplacements } from './vite.utils';
+import { defineViteReplacements, readCanisterIds } from './vite.utils';
+
+process.env = {
+	...process.env,
+	...readCanisterIds({ prefix: 'VITE_' })
+};
 
 export default defineConfig(
 	(): UserConfig => ({
@@ -41,6 +46,10 @@ export default defineConfig(
 				{
 					find: '$env',
 					replacement: resolve(__dirname, 'src/frontend/src/env')
+				},
+				{
+					find: '$declarations',
+					replacement: resolve(__dirname, 'src/declarations')
 				}
 			]
 		},


### PR DESCRIPTION
# Motivation

All canister IDs are currently unknown during test because the vitest config does not load those with our "plugins" in the environment.

# Changes

- Load `readCanisterIds` within `process.env` for vitest config
