### PR TITLE
build(test): missing $declarations

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,10 @@ export default defineConfig(
 				{
 					find: '$env',
 					replacement: resolve(__dirname, 'src/frontend/src/env')
+				},
+				{
+					find: '$declarations',
+					replacement: resolve(__dirname, 'src/declarations')
 				}
 			]
 		},


### PR DESCRIPTION
# Motivation

I noticed that the import shorthand `$declarations` was missing for the tests.

