### PR TITLE
feat(frontend): expose an imperative identity setter for test

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -9,6 +9,8 @@ export const STAGING = MODE === 'staging';
 export const BETA = MODE === 'beta';
 export const PROD = MODE === 'ic';
 
+export const TEST = import.meta.env.TEST === true;
+
 const MAINNET_DOMAIN = 'icp0.io';
 
 export const REPLICA_HOST = LOCAL ? 'http://localhost:4943/' : 'https://icp-api.io';

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -9,7 +9,7 @@ export const STAGING = MODE === 'staging';
 export const BETA = MODE === 'beta';
 export const PROD = MODE === 'ic';
 
-export const TEST = import.meta.env.TEST === true;
+export const TEST = JSON.parse(import.meta.env.TEST ?? 'false') === true;
 
 const MAINNET_DOMAIN = 'icp0.io';
 

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -3,7 +3,6 @@ import {
 	AUTH_POPUP_HEIGHT,
 	AUTH_POPUP_WIDTH,
 	INTERNET_IDENTITY_CANISTER_ID,
-	LOCAL,
 	TEST
 } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -92,8 +91,8 @@ const initAuthStore = (): AuthStore => {
 		},
 
 		setForTesting: (identity) => {
-			if (!LOCAL && !TEST) {
-				throw new Error('This function should only be used in local environment');
+			if (!TEST) {
+				throw new Error('This function should only be used in npm run test environment');
 			}
 
 			set({ identity });

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -2,12 +2,15 @@ import {
 	AUTH_MAX_TIME_TO_LIVE,
 	AUTH_POPUP_HEIGHT,
 	AUTH_POPUP_WIDTH,
-	INTERNET_IDENTITY_CANISTER_ID
+	INTERNET_IDENTITY_CANISTER_ID,
+	LOCAL,
+	TEST
 } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Option } from '$lib/types/utils';
 import { createAuthClient, getOptionalDerivationOrigin } from '$lib/utils/auth.utils';
 import { popupCenter } from '$lib/utils/window.utils';
+import type { Identity } from '@dfinity/agent';
 import type { AuthClient } from '@dfinity/auth-client';
 import { nonNullish } from '@dfinity/utils';
 import { writable, type Readable } from 'svelte/store';
@@ -26,6 +29,7 @@ export interface AuthStore extends Readable<AuthStoreData> {
 	sync: () => Promise<void>;
 	signIn: (params: AuthSignInParams) => Promise<void>;
 	signOut: () => Promise<void>;
+	setForTesting: (identity: Identity) => void;
 }
 
 const initAuthStore = (): AuthStore => {
@@ -85,6 +89,14 @@ const initAuthStore = (): AuthStore => {
 				...state,
 				identity: null
 			}));
+		},
+
+		setForTesting: (identity) => {
+			if (!LOCAL && !TEST) {
+				throw new Error('This function should only be used in local environment');
+			}
+
+			set({ identity });
 		}
 	};
 };

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -90,7 +90,23 @@ const initAuthStore = (): AuthStore => {
 			}));
 		},
 
-		setForTesting: (identity) => {
+		/**
+		 * ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+		 * ⚠️          **Warning:**       ⚠️
+		 * ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+		 *
+		 * Sets a mock identity for testing purposes.
+		 *
+		 * This function allows to manually set a test identity in the `authStore`,
+		 * This is a hack and should **only** be used in a testing environment.
+		 *
+		 * Ensure that the `TEST` flag is enabled (e.g., via `npm run test`) before using this function.
+		 * If invoked outside of the testing environment, it will throw an error.
+		 *
+		 * @param {Identity} identity - The mock identity object to be set for testing.
+		 * @throws {Error} Throws an error if the function is called outside the test environment.
+		 */
+		setForTesting: (identity: Identity) => {
 			if (!TEST) {
 				throw new Error('This function should only be used in npm run test environment');
 			}

--- a/src/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -1,0 +1,27 @@
+import * as constants from '$lib/constants/app.constants';
+import { authStore } from '$lib/stores/auth.store';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { get } from 'svelte/store';
+
+describe('auth.store', () => {
+	describe('setForTesting', () => {
+		const identity = Ed25519KeyIdentity.generate();
+
+		it('should set the identity for testing', () => {
+			expect(() => authStore.setForTesting(identity)).not.toThrow();
+
+			const storeIdentity = get(authStore).identity;
+			expect(storeIdentity).toBe(identity);
+		});
+
+		it('should set the identity for testing', () => {
+			const spy = vi.spyOn(constants, 'TEST', 'get').mockReturnValue(false);
+
+			expect(() => authStore.setForTesting(identity)).toThrow(
+				'This function should only be used in npm run test environment'
+			);
+
+			spy.mockRestore();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -14,7 +14,7 @@ describe('auth.store', () => {
 			expect(storeIdentity).toBe(identity);
 		});
 
-		it('should set the identity for testing', () => {
+		it('should throw an error if not TEST environment', () => {
 			const spy = vi.spyOn(constants, 'TEST', 'get').mockReturnValue(false);
 
 			expect(() => authStore.setForTesting(identity)).toThrow(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,7 +60,7 @@ export default defineConfig(
 			environment: 'jsdom',
 			globals: true,
 			watch: false,
-			silent: true,
+			silent: false,
 			setupFiles: ['./vitest.setup.ts'],
 			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)']
 		}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,7 +60,7 @@ export default defineConfig(
 			environment: 'jsdom',
 			globals: true,
 			watch: false,
-			silent: false,
+			silent: true,
 			setupFiles: ['./vitest.setup.ts'],
 			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)']
 		}


### PR DESCRIPTION
# Motivation

I'm not the fan numero uno of this pattern used in NNS dapp but, I have to admint that it is super handy for test purposes to be able to mock the `identity` in the `auth.store`. Given that I need to mock the identity in #2673, I guess to replicate the pattern.

# Changes

- Add a flag `TEST` in `app.constant`
- Extend `auth.store` with `setForTesting` which set an identity only if `TEST` and `LOCAL` are `true`
