### PR TITLE
build(e2e): bump dfx version used for E2E env

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -25,7 +25,7 @@ WORKDIR /oisy-wallet
 
 # Install dfx
 ENV DFX_PORT=4943
-ENV DFX_VERSION=0.20.0
+ENV DFX_VERSION=0.23.0
 RUN DFXVM_INIT_YES=true DFX_VERSION=$DFX_VERSION sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
 
 # Set permission to .config folder so that dfx can write whatever files are needed


### PR DESCRIPTION
# Motivation

In `dfx.json` we are using the argument `init_arg_file` that was introduced in [v0.20.1](https://github.com/dfinity/sdk/releases/tag/0.20.1)

So, we bump to latest dfx version.
