### PR TITLE
feat(frontend): Add support for error in btc pending sent txs

### DIFF
--- a/src/frontend/src/btc/derived/has-pending-sent-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/has-pending-sent-transactions.derived.ts
@@ -9,7 +9,9 @@ import { testnets } from '$lib/derived/testnets.derived';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const initHasPendingSentTransactions = (address: string): Readable<boolean | 'loading'> =>
+export const initHasPendingSentTransactions = (
+	address: string
+): Readable<boolean | 'loading' | 'error'> =>
 	derived(
 		[
 			btcAddressMainnet,
@@ -28,7 +30,9 @@ export const initHasPendingSentTransactions = (address: string): Readable<boolea
 			const pendingTransactionsData = $pendingTransactionsStore[address];
 
 			if (nonNullish(pendingTransactionsData)) {
-				return pendingTransactionsData.data.length > 0;
+				return pendingTransactionsData.data === null
+					? 'error'
+					: pendingTransactionsData.data.length > 0;
 			}
 
 			if (!$testnets) {

--- a/src/frontend/src/btc/stores/btc-pending-sent-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-pending-sent-transactions.store.ts
@@ -6,7 +6,8 @@ type Address = string;
 type BtcPendingSentTransactionsStoreData = Record<
 	Address,
 	// The endpoint can't be called with a query. Therefore, the information is always certified with an update call.
-	AlwaysCertifiedData<Array<PendingTransaction>>
+	// `null` is used to indicate that the data is not available. Due to an error or connection issues.
+	AlwaysCertifiedData<Array<PendingTransaction> | null>
 >;
 
 interface BtcPendingSentTransactionsStore extends Readable<BtcPendingSentTransactionsStoreData> {
@@ -14,6 +15,7 @@ interface BtcPendingSentTransactionsStore extends Readable<BtcPendingSentTransac
 		address: Address;
 		pendingTransactions: Array<PendingTransaction>;
 	}) => void;
+	setPendingTransactionsError(params: { address: Address }): void;
 	reset: () => void;
 }
 
@@ -42,6 +44,15 @@ const initBtcPendingSentTransactionsStore = (): BtcPendingSentTransactionsStore 
 				[address]: {
 					certified: true,
 					data: pendingTransactions
+				}
+			}));
+		},
+		setPendingTransactionsError({ address }: { address: Address }) {
+			update((state) => ({
+				...state,
+				[address]: {
+					certified: true,
+					data: null
 				}
 			}));
 		},

--- a/src/frontend/src/tests/btc/derived/has-pending-sent-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/has-pending-sent-transactions.derived.spec.ts
@@ -50,6 +50,13 @@ describe('initHasPendingSentTransactions', () => {
 			expect(get(store)).toBe('loading');
 		});
 
+		it('should return "error" if pending transactions are not `null` for the address', () => {
+			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+			btcPendingSentTransactionsStore.setPendingTransactionsError({ address: mockAddressMainnet });
+			const store = initHasPendingSentTransactions(mockAddressMainnet);
+			expect(get(store)).toBe('error');
+		});
+
 		it('should return "false" if address is not the mainnet bitcoin address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			const store = initHasPendingSentTransactions('another-address');
@@ -106,6 +113,14 @@ describe('initHasPendingSentTransactions', () => {
 			loadAllAddresses();
 			expect(get(initHasPendingSentTransactions(mockAddressTestnet))).toBe('loading');
 			expect(get(initHasPendingSentTransactions(mockAddressMainnet))).toBe('loading');
+		});
+
+		it('should return "error" if pending transactions are `null`', () => {
+			loadAllAddresses();
+			btcPendingSentTransactionsStore.setPendingTransactionsError({ address: mockAddressTestnet });
+			expect(get(initHasPendingSentTransactions(mockAddressTestnet))).toBe('error');
+			btcPendingSentTransactionsStore.setPendingTransactionsError({ address: mockAddressMainnet });
+			expect(get(initHasPendingSentTransactions(mockAddressMainnet))).toBe('error');
 		});
 
 		it('should return "false" if address is not a bitcoin address', () => {

--- a/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
@@ -30,7 +30,7 @@ const pendingTransactionMock2 = {
 	]
 };
 
-describe('pendingSentTransactionsStore', () => {
+describe('btcPendingSentTransactionsStore', () => {
 	beforeEach(() => {
 		btcPendingSentTransactionsStore.reset();
 	});
@@ -48,6 +48,25 @@ describe('pendingSentTransactionsStore', () => {
 
 		const storeData = get(btcPendingSentTransactionsStore);
 		expect(storeData[address].data).toEqual(pendingTransactions);
+	});
+
+	it('should set pending transactions to `null` for a specific address', () => {
+		const address = 'test-address';
+		btcPendingSentTransactionsStore.setPendingTransactionsError({ address });
+
+		const storeData = get(btcPendingSentTransactionsStore);
+		expect(storeData[address].data).toBeNull();
+	});
+
+	it('should reset pending transactions to a `null`', () => {
+		const address = 'test-address';
+		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
+
+		btcPendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+		expect(get(btcPendingSentTransactionsStore)[address].data).toEqual(pendingTransactions);
+
+		btcPendingSentTransactionsStore.setPendingTransactionsError({ address });
+		expect(get(btcPendingSentTransactionsStore)[address].data).toBeNull();
 	});
 
 	it('should set certified to `true`', () => {


### PR DESCRIPTION
# Motivation

We want to show a different message to the user if loading the pending sent transactions of bitcoin failed.

In this PR, I add the `null` type of the bitcoin pending sent transactions store.

# Changes

* Add `null` in `BtcPendingSentTransactionsStoreData`.
* Add specific method to set it to `null`: `setPendingTransactionsError`. This should allow us to easily change the inner type.
* Support the new type in `initHasPendingSentTransactions` and return `"error"`. This will also allow us to easily change the implementation details of the error.

# Tests

* Test the new type in `btcPendingSentTransactionsStore` tests.
* Test the new type in `initHasPendingSentTransactions` tests.
