### PR TITLE
feat(frontend): Add mapNetworkIdToBitcoinNetwork util

### DIFF
--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -33,6 +33,15 @@ export const isNetworkIdBTCTestnet = (networkId: NetworkId | undefined): boolean
 export const isNetworkIdBTCRegtest = (networkId: NetworkId | undefined): boolean =>
 	BTC_REGTEST_NETWORK_ID === networkId;
 
+const mapper: Record<symbol, BitcoinNetwork> = {
+	[BTC_MAINNET_NETWORK_ID]: 'mainnet',
+	[BTC_TESTNET_NETWORK_ID]: 'testnet',
+	[BTC_REGTEST_NETWORK_ID]: 'regtest'
+};
+
+export const mapNetworkIdToBitcoinNetwork = (networkId: NetworkId): BitcoinNetwork | undefined =>
+	mapper[networkId];
+
 /**
  * Filter the tokens that either lives on the selected network or, if no network is provided, pseud Chain Fusion, then those that are not testnets.
  */

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -1,0 +1,16 @@
+import {
+	BTC_MAINNET_NETWORK_ID,
+	BTC_REGTEST_NETWORK_ID,
+	BTC_TESTNET_NETWORK_ID
+} from '$env/networks.env';
+import { mapNetworkIdToBitcoinNetwork } from '$lib/utils/network.utils';
+
+describe('network utils', () => {
+	describe('mapNetworkIdToBitcoinNetwork', () => {
+		it('should map network id to bitcoin network', () => {
+			expect(mapNetworkIdToBitcoinNetwork(BTC_MAINNET_NETWORK_ID)).toBe('mainnet');
+			expect(mapNetworkIdToBitcoinNetwork(BTC_TESTNET_NETWORK_ID)).toBe('testnet');
+			expect(mapNetworkIdToBitcoinNetwork(BTC_REGTEST_NETWORK_ID)).toBe('regtest');
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -1,7 +1,10 @@
 import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
-	BTC_TESTNET_NETWORK_ID
+	BTC_TESTNET_NETWORK_ID,
+	ETHEREUM_NETWORK_ID,
+	ICP_NETWORK_ID,
+	SEPOLIA_NETWORK_ID
 } from '$env/networks.env';
 import { mapNetworkIdToBitcoinNetwork } from '$lib/utils/network.utils';
 
@@ -11,6 +14,12 @@ describe('network utils', () => {
 			expect(mapNetworkIdToBitcoinNetwork(BTC_MAINNET_NETWORK_ID)).toBe('mainnet');
 			expect(mapNetworkIdToBitcoinNetwork(BTC_TESTNET_NETWORK_ID)).toBe('testnet');
 			expect(mapNetworkIdToBitcoinNetwork(BTC_REGTEST_NETWORK_ID)).toBe('regtest');
+		});
+
+		it('should return `undefined` with non bitcoin network', () => {
+			expect(mapNetworkIdToBitcoinNetwork(ETHEREUM_NETWORK_ID)).toBeUndefined();
+			expect(mapNetworkIdToBitcoinNetwork(SEPOLIA_NETWORK_ID)).toBeUndefined();
+			expect(mapNetworkIdToBitcoinNetwork(ICP_NETWORK_ID)).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

In the components I'll have a network id, but other levels need the `BitcoinNetwork`.

In this PR, I add an util to convert a network id into a `BitcoinNetwork` if it's one of the known bitcoin network ids.

# Changes

* New util `mapNetworkIdToBitcoinNetwork`.

# Tests

* Test new util `mapNetworkIdToBitcoinNetwork`.
