### PR TITLE
feat(frontend): Service to load btc pending sent txs

### DIFF
--- a/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
+++ b/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
@@ -18,7 +18,10 @@ export const loadBtcPendingSentTransactions = async ({
 	try {
 		const network = mapNetworkIdToBitcoinNetwork(networkId);
 		if (isNullish(network)) {
-			throw new Error(`Invalid networkId: ${networkId.toString}`);
+			return {
+				success: false,
+				err: new Error(`Invalid networkId: ${networkId.toString}`)
+			};
 		}
 		const pendingTransactions = await getPendingBtcTransactions({
 			identity,

--- a/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
+++ b/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
@@ -1,8 +1,10 @@
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { getPendingBtcTransactions } from '$lib/api/backend.api';
 import type { NetworkId } from '$lib/types/network';
+import type { ResultSuccess } from '$lib/types/utils';
 import { mapNetworkIdToBitcoinNetwork, mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import type { Identity } from '@dfinity/agent';
+import { isNullish } from '@dfinity/utils';
 
 export const loadBtcPendingSentTransactions = async ({
 	address,
@@ -12,10 +14,10 @@ export const loadBtcPendingSentTransactions = async ({
 	address: string;
 	identity: Identity;
 	networkId: NetworkId;
-}) => {
+}): Promise<ResultSuccess> => {
 	try {
 		const network = mapNetworkIdToBitcoinNetwork(networkId);
-		if (!network) {
+		if (isNullish(network)) {
 			throw new Error(`Invalid networkId: ${networkId.toString}`);
 		}
 		const pendingTransactions = await getPendingBtcTransactions({
@@ -27,8 +29,10 @@ export const loadBtcPendingSentTransactions = async ({
 			address,
 			pendingTransactions
 		});
+		return { success: true };
 	} catch (err: unknown) {
 		console.error('Error loading pending transactions', err);
 		btcPendingSentTransactionsStore.setPendingTransactionsError({ address });
+		return { success: false, err };
 	}
 };

--- a/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
+++ b/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
@@ -1,0 +1,34 @@
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { getPendingBtcTransactions } from '$lib/api/backend.api';
+import type { NetworkId } from '$lib/types/network';
+import { mapNetworkIdToBitcoinNetwork, mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
+import type { Identity } from '@dfinity/agent';
+
+export const loadBtcPendingSentTransactions = async ({
+	address,
+	identity,
+	networkId
+}: {
+	address: string;
+	identity: Identity;
+	networkId: NetworkId;
+}) => {
+	try {
+		const network = mapNetworkIdToBitcoinNetwork(networkId);
+		if (!network) {
+			throw new Error(`Invalid networkId: ${networkId.toString}`);
+		}
+		const pendingTransactions = await getPendingBtcTransactions({
+			identity,
+			address,
+			network: mapToSignerBitcoinNetwork({ network })
+		});
+		btcPendingSentTransactionsStore.setPendingTransactions({
+			address,
+			pendingTransactions
+		});
+	} catch (err: unknown) {
+		console.error('Error loading pending transactions', err);
+		btcPendingSentTransactionsStore.setPendingTransactionsError({ address });
+	}
+};


### PR DESCRIPTION
# Motivation

We want to load the btc pending sent transactions when the user visits the form to send tokens.

In this PR, I introduce the service that will be used by the component to load it.

# Changes

* New service `loadBtcPendingSentTransactions`.

# Tests

Tested locally by loading them in the IcSendForm
