### PR TITLE
style(frontend): change colors of ExternalLink component

### DIFF
--- a/src/frontend/src/lib/components/ui/Copy.svelte
+++ b/src/frontend/src/lib/components/ui/Copy.svelte
@@ -25,11 +25,9 @@
 	class="pl-0.5"
 	class:py-2={!inline}
 	class:inline-block={inline}
-	class:text-blue={color === 'blue'}
-	class:hover:text-dark-blue={color === 'blue'}
-	class:active:text-dark-blue={color === 'blue'}
-	class:hover:text-blue={color === 'inherit'}
-	class:active:text-blue={color === 'inherit'}
+	class:text-primary={color === 'blue'}
+	class:hover:text-inherit={color === 'blue'}
+	class:active:text-inherit={color === 'blue'}
 	style={`${inline ? 'vertical-align: sub;' : ''}`}
 >
 	<IconCopy />

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -17,11 +17,9 @@
 	class="inline-flex items-center gap-2 no-underline"
 	aria-label={ariaLabel}
 	style={`${inline ? 'vertical-align: sub;' : ''}`}
-	class:text-blue={color === 'blue'}
-	class:hover:text-dark-blue={color === 'blue'}
-	class:active:text-dark-blue={color === 'blue'}
-	class:hover:text-blue={color === 'inherit'}
-	class:active:text-blue={color === 'inherit'}
+	class:text-primary={color === 'blue'}
+	class:hover:text-inherit={color === 'blue'}
+	class:active:text-inherit={color === 'blue'}
 	class:w-full={fullWidth}
 >
 	{#if iconVisible}


### PR DESCRIPTION
# Motivation

We change the "blue" colors of `ExternalLink` component.

### Normal

<img width="365" alt="Screenshot 2024-10-07 at 16 00 34" src="https://github.com/user-attachments/assets/d9e13bdd-ef8c-4005-80c0-a30a44ae8ada">
<img width="632" alt="Screenshot 2024-10-07 at 16 26 24" src="https://github.com/user-attachments/assets/bf2e99be-134f-4073-8162-343a05a9dc27">


### Hover and Active

<img width="347" alt="Screenshot 2024-10-07 at 16 00 39" src="https://github.com/user-attachments/assets/fda1c281-6c05-4821-b842-edefa7230f41">
<img width="629" alt="Screenshot 2024-10-07 at 16 27 16" src="https://github.com/user-attachments/assets/238784e6-0151-43ee-b6f0-8ab209e53bdc">

