### PR TITLE
fix(frontend): util formatToken was removing trailing zeros

### DIFF
--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -18,7 +18,8 @@ export const formatToken = ({
 	const res = Utils.formatUnits(value, unitName);
 	const formatted = (+res).toLocaleString('en-US', {
 		useGrouping: false,
-		maximumFractionDigits: displayDecimals
+		maximumFractionDigits: displayDecimals,
+		minimumFractionDigits: trailingZeros ? displayDecimals : undefined
 	});
 
 	if (trailingZeros) {

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,0 +1,67 @@
+import { ZERO } from '$lib/constants/app.constants';
+import { formatToken } from '$lib/utils/format.utils';
+import { BigNumber } from 'ethers';
+
+const value = BigNumber.from('1000000000000000000');
+
+describe('formatToken', () => {
+	it('formats value with default parameters', () => {
+		expect(formatToken({ value })).toBe('1.0000');
+	});
+
+	it('formats value with specified displayDecimals', () => {
+		expect(formatToken({ value, displayDecimals: 2 })).toBe('1.00');
+	});
+
+	it('formats value with specified displayDecimals and removes trailing zeros', () => {
+		expect(formatToken({ value, displayDecimals: 2, trailingZeros: false })).toBe('1');
+	});
+
+	it('formats non-rounded value with trailing zeros', () => {
+		const value = BigNumber.from('1200000000000000000');
+
+		expect(formatToken({ value, displayDecimals: 6 })).toBe('1.200000');
+
+		expect(formatToken({ value, displayDecimals: 2 })).toBe('1.20');
+	});
+
+	it('formats non-rounded value with specified displayDecimals and removes trailing zeros', () => {
+		const value = BigNumber.from('1234000000000000000');
+
+		expect(formatToken({ value, displayDecimals: 6, trailingZeros: false })).toBe('1.234');
+
+		expect(formatToken({ value, displayDecimals: 2, trailingZeros: false })).toBe('1.23');
+	});
+
+	it('formats zero with default parameters', () => {
+		expect(formatToken({ value: ZERO })).toBe('0.0000');
+	});
+
+	it('formats zero with specified displayDecimals', () => {
+		expect(formatToken({ value: ZERO, displayDecimals: 2 })).toBe('0.00');
+	});
+
+	it('formats zero with specified displayDecimals and removes trailing zeros', () => {
+		expect(formatToken({ value: ZERO, displayDecimals: 2, trailingZeros: false })).toBe('0');
+	});
+
+	it('formats value with different unitName', () => {
+		expect(formatToken({ value, unitName: '20' })).toBe('0.0100');
+	});
+
+	it('formats value with different unitName and displayDecimals', () => {
+		expect(formatToken({ value, unitName: '20', displayDecimals: 3 })).toBe('0.010');
+
+		expect(formatToken({ value, unitName: '20', displayDecimals: 1 })).toBe('0.0');
+	});
+
+	it('formats value with different unitName and displayDecimals and removes trailing zeros', () => {
+		expect(formatToken({ value, unitName: '20', displayDecimals: 3, trailingZeros: false })).toBe(
+			'0.01'
+		);
+
+		expect(formatToken({ value, unitName: '20', displayDecimals: 1, trailingZeros: false })).toBe(
+			'0'
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

The util formatToken was not formatting correctly the trailing zeros when the user wants to show them. We adjust it a bit and create tests to verify the effectiveness.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
