### PR TITLE
feat(frontend): Load btc pending sent txs in BtcSendForm

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -6,6 +6,9 @@
 	import { balance } from '$lib/derived/balances.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { nonNullish } from '@dfinity/utils';
+	import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 
 	export let networkId: NetworkId | undefined = undefined;
 	export let amount: number | undefined = undefined;
@@ -14,6 +17,16 @@
 
 	let amountError: BtcAmountAssertionError | undefined;
 	let invalidDestination: boolean;
+
+	$: {
+		if (nonNullish($authIdentity) && nonNullish(networkId)) {
+			loadBtcPendingSentTransactions({
+				identity: $authIdentity,
+				networkId,
+				address: source
+			});
+		}
+	}
 </script>
 
 <SendForm {source} token={$token} balance={$balance}>

--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
 	import BtcSendAmount from './BtcSendAmount.svelte';
 	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
 	import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
@@ -9,7 +9,6 @@
 	import { balance } from '$lib/derived/balances.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
-	import { onMount } from 'svelte';
 
 	export let networkId: NetworkId | undefined = undefined;
 	export let amount: number | undefined = undefined;

--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -9,7 +9,6 @@
 	import { balance } from '$lib/derived/balances.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
-	import { onMount } from 'svelte';
 
 	export let networkId: NetworkId | undefined = undefined;
 	export let amount: number | undefined = undefined;

--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -9,6 +9,7 @@
 	import { balance } from '$lib/derived/balances.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
+	import { onMount } from 'svelte';
 
 	export let networkId: NetworkId | undefined = undefined;
 	export let amount: number | undefined = undefined;
@@ -18,17 +19,15 @@
 	let amountError: BtcAmountAssertionError | undefined;
 	let invalidDestination: boolean;
 
-	$: {
-		if (nonNullish($authIdentity) && nonNullish(networkId)) {
-			// This call will load the pending sent transactions for the source address in the store.
-			// This data will then be used in the review step. That's why we don't wait here.
-			loadBtcPendingSentTransactions({
-				identity: $authIdentity,
-				networkId,
-				address: source
-			});
-		}
-	}
+	onMount(() => {
+		// This call will load the pending sent transactions for the source address in the store.
+		// This data will then be used in the review step. That's why we don't wait here.
+		loadBtcPendingSentTransactions({
+			identity: $authIdentity,
+			networkId,
+			address: source
+		});
+	});
 </script>
 
 <SendForm {source} token={$token} balance={$balance}>

--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import BtcSendAmount from './BtcSendAmount.svelte';
 	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
+	import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 	import type { BtcAmountAssertionError } from '$btc/types/btc-send';
 	import SendForm from '$lib/components/send/SendForm.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { balance } from '$lib/derived/balances.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
-	import { authIdentity } from '$lib/derived/auth.derived';
-	import { nonNullish } from '@dfinity/utils';
-	import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 
 	export let networkId: NetworkId | undefined = undefined;
 	export let amount: number | undefined = undefined;

--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -9,6 +9,7 @@
 	import { balance } from '$lib/derived/balances.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
+	import { onMount } from 'svelte';
 
 	export let networkId: NetworkId | undefined = undefined;
 	export let amount: number | undefined = undefined;
@@ -20,6 +21,8 @@
 
 	$: {
 		if (nonNullish($authIdentity) && nonNullish(networkId)) {
+			// This call will load the pending sent transactions for the source address in the store.
+			// This data will then be used in the review step. That's why we don't wait here.
 			loadBtcPendingSentTransactions({
 				identity: $authIdentity,
 				networkId,


### PR DESCRIPTION
# Motivation

We want to disable the review step if the user has pending sent transactions. Therefore, we load them in the form step so that they will be present in the review step.

# Changes

* Use `loadBtcPendingSentTransactions` in `BtcSendForm`.

# Tests

Tested manually that it does indeed load the data in the store.
