### PR TITLE
test(frontend): cleanup imports and mocks

### DIFF
--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -1,13 +1,16 @@
 import { mapBtcTransaction } from '$btc/utils/btc-transactions.utils';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
 import { expect } from 'vitest';
-import { btcAddress, btcTransaction, btcTransactionUi } from '../../mocks/btc.mock';
+import { mockBtcAddress, mockBtcTransaction, mockBtcTransactionUi } from '../../mocks/btc.mock';
 
 describe('mapBtcTransaction', () => {
 	it('should map correctly when receive transaction is pending', () => {
-		const result = mapBtcTransaction({ transaction: btcTransaction, btcAddress });
+		const result = mapBtcTransaction({
+			transaction: mockBtcTransaction,
+			btcAddress: mockBtcAddress
+		});
 		const expectedResult = {
-			...btcTransactionUi,
+			...mockBtcTransactionUi,
 			blockNumber: undefined,
 			status: 'pending'
 		};
@@ -17,26 +20,26 @@ describe('mapBtcTransaction', () => {
 
 	it('should map correctly when receive transaction is confirmed', () => {
 		const transaction = {
-			...btcTransaction,
-			block_index: btcTransactionUi.blockNumber
+			...mockBtcTransaction,
+			block_index: mockBtcTransactionUi.blockNumber
 		} as BitcoinTransaction;
 
-		const result = mapBtcTransaction({ transaction, btcAddress });
+		const result = mapBtcTransaction({ transaction, btcAddress: mockBtcAddress });
 
-		expect(result).toEqual(btcTransactionUi);
+		expect(result).toEqual(mockBtcTransactionUi);
 	});
 
 	it('should map correctly when send transaction is pending', () => {
 		const transaction = {
-			...btcTransaction,
-			inputs: [...btcTransaction.inputs, { prev_out: { addr: btcAddress } }]
+			...mockBtcTransaction,
+			inputs: [...mockBtcTransaction.inputs, { prev_out: { addr: mockBtcAddress } }]
 		} as BitcoinTransaction;
-		const result = mapBtcTransaction({ transaction, btcAddress });
+		const result = mapBtcTransaction({ transaction, btcAddress: mockBtcAddress });
 		const expectedResult = {
-			...btcTransactionUi,
-			from: btcAddress,
-			to: btcTransaction.out[0].addr,
-			value: BigInt(btcTransaction.out[0].value),
+			...mockBtcTransactionUi,
+			from: mockBtcAddress,
+			to: mockBtcTransaction.out[0].addr,
+			value: BigInt(mockBtcTransaction.out[0].value),
 			type: 'send',
 			blockNumber: undefined,
 			status: 'pending'
@@ -47,16 +50,16 @@ describe('mapBtcTransaction', () => {
 
 	it('should map correctly when send transaction is confirmed', () => {
 		const transaction = {
-			...btcTransaction,
-			block_index: btcTransactionUi.blockNumber,
-			inputs: [...btcTransaction.inputs, { prev_out: { addr: btcAddress } }]
+			...mockBtcTransaction,
+			block_index: mockBtcTransactionUi.blockNumber,
+			inputs: [...mockBtcTransaction.inputs, { prev_out: { addr: mockBtcAddress } }]
 		} as BitcoinTransaction;
-		const result = mapBtcTransaction({ transaction, btcAddress });
+		const result = mapBtcTransaction({ transaction, btcAddress: mockBtcAddress });
 		const expectedResult = {
-			...btcTransactionUi,
-			from: btcAddress,
-			to: btcTransaction.out[0].addr,
-			value: BigInt(btcTransaction.out[0].value),
+			...mockBtcTransactionUi,
+			from: mockBtcAddress,
+			to: mockBtcTransaction.out[0].addr,
+			value: BigInt(mockBtcTransaction.out[0].value),
 			type: 'send'
 		};
 

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -10,14 +10,14 @@ import { BackendCanister } from '$lib/canisters/backend.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import type { AddUserCredentialParams, BtcSelectUserUtxosFeeParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import { type ActorSubclass } from '@dfinity/agent';
 import { mapIcrc2ApproveError } from '@dfinity/ledger-icp';
 import { Principal } from '@dfinity/principal';
 import { toNullable } from '@dfinity/utils';
 import { describe } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-import { btcAddress } from '../../mocks/btc.mock';
-import { mockIdentity, mockPrincipal } from '../../mocks/identity.mock';
 
 vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
 	const actual = await importOriginal();
@@ -62,7 +62,7 @@ describe('backend.canister', () => {
 	const btcAddPendingTransactionParams = {
 		txId: [1, 2, 3],
 		network: { testnet: null },
-		address: btcAddress,
+		address: mockBtcAddress,
 		utxos: [
 			{
 				height: 1000,
@@ -90,7 +90,7 @@ describe('backend.canister', () => {
 		network: btcAddPendingTransactionParams.network,
 		minConfirmations: [100],
 		amountSatoshis: 100n,
-		sourceAddress: btcAddress
+		sourceAddress: mockBtcAddress
 	} as BtcSelectUserUtxosFeeParams;
 	const btcSelectUserUtxosFeeEndpointParams = {
 		network: btcSelectUserUtxosFeeParams.network,

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -4,11 +4,11 @@ import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SignerCanisterPaymentError } from '$lib/canisters/signer.errors';
 import type { SendBtcParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { describe } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-import { mockIdentity } from '../../mocks/identity.mock';
 
 vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
 	const actual = await importOriginal();

--- a/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
@@ -8,6 +8,8 @@ import * as loaderServices from '$lib/services/loader.services';
 import { btcAddressMainnetStore, ethAddressStore } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
 import { emit } from '$lib/utils/events.utils';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { render } from '@testing-library/svelte';
 import { expect, type MockInstance } from 'vitest';
@@ -71,9 +73,6 @@ describe('AddressGuard', () => {
 	});
 
 	describe('Validate addresses', () => {
-		const mockEthAddress = '0x1d638414860ed08dd31fae848e527264f20512fa75d7d63cea9bbb372f020000';
-		const mockBtcAddress = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem';
-
 		beforeEach(() => {
 			// TODO: to be removed when the flag NETWORK_BITCOIN_ENABLED gets removed and Bitcoin becomes default.
 			vi.spyOn(btcEnv, 'NETWORK_BITCOIN_ENABLED', 'get').mockReturnValue(true);

--- a/src/frontend/src/tests/lib/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendInputAmount.spec.ts
@@ -1,8 +1,8 @@
 import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
+import en from '$tests/mocks/i18n.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { expect } from 'vitest';
-import en from '../../../mocks/i18n.mock';
 
 describe('SendInputAmount', () => {
 	const amount = 10.25;

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -2,11 +2,11 @@ import type { UserProfile } from '$declarations/backend/backend.did';
 import * as backendApi from '$lib/api/backend.api';
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import en from '$tests/mocks/i18n.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { waitFor } from '@testing-library/svelte';
 import { beforeEach } from 'node:test';
 import { get } from 'svelte/store';
-import en from '../../mocks/i18n.mock';
-import { mockIdentity } from '../../mocks/identity.mock';
 
 vi.mock('$lib/api/backend.api');
 

--- a/src/frontend/src/tests/lib/stores/balances.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/balances.store.spec.ts
@@ -1,9 +1,9 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { balancesStore } from '$lib/stores/balances.store';
+import { mockPageStore } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.utils';
 import { BigNumber } from 'alchemy-sdk';
 import { describe, it } from 'vitest';
-import { mockPageStore } from '../../mocks/page.store.mock';
-import { testDerivedUpdates } from '../../utils/derived.utils';
 
 mockPageStore();
 

--- a/src/frontend/src/tests/lib/stores/token.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/token.store.spec.ts
@@ -1,8 +1,8 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { token } from '$lib/stores/token.store';
+import { mockPageStore } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.utils';
 import { describe, it } from 'vitest';
-import { mockPageStore } from '../../mocks/page.store.mock';
-import { testDerivedUpdates } from '../../utils/derived.utils';
 
 mockPageStore();
 

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -2,9 +2,9 @@ import type { EthereumNetwork } from '$eth/types/network';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
+import { generateUrn } from '$tests/mocks/qr-generator.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import { generateUrn } from '../../mocks/qr-generator.mock';
 
 describe('decodeUrn', () => {
 	const tokenList = get(tokens);

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -6,10 +6,10 @@ import {
 	getMaxTransactionAmount,
 	mapTokenUi
 } from '$lib/utils/token.utils';
+import { $balances, bn3 } from '$tests/mocks/balances.mock';
+import { $exchanges } from '$tests/mocks/exchanges.mock';
 import { BigNumber } from 'alchemy-sdk';
 import { describe, expect, it, type MockedFunction } from 'vitest';
-import { $balances, bn3 } from '../../mocks/balances.mock';
-import { $exchanges } from '../../mocks/exchanges.mock';
 
 const tokenDecimals = 8;
 const tokenStandards: TokenStandard[] = ['ethereum', 'icp', 'icrc', 'bitcoin'];

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -16,10 +16,10 @@ import {
 	sumMainnetTokensUsdBalancesPerNetwork,
 	sumTokensUiUsdBalance
 } from '$lib/utils/tokens.utils';
+import { $balances, bn1, bn2, bn3, certified } from '$tests/mocks/balances.mock';
+import { $exchanges, usd } from '$tests/mocks/exchanges.mock';
+import { $tokens } from '$tests/mocks/tokens.mock';
 import { describe, expect, it, type MockedFunction } from 'vitest';
-import { $balances, bn1, bn2, bn3, certified } from '../../mocks/balances.mock';
-import { $exchanges, usd } from '../../mocks/exchanges.mock';
-import { $tokens } from '../../mocks/tokens.mock';
 
 vi.mock('$lib/utils/exchange.utils', () => ({
 	usdValue: vi.fn()

--- a/src/frontend/src/tests/mocks/btc.mock.ts
+++ b/src/frontend/src/tests/mocks/btc.mock.ts
@@ -1,9 +1,9 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
 
-export const btcAddress = 'bc1qt0nkp96r7p95xfacyp98pww2eu64yzuf78l4a2wy0sttt83hux4q6u2nl7';
+export const mockBtcAddress = 'bc1qt0nkp96r7p95xfacyp98pww2eu64yzuf78l4a2wy0sttt83hux4q6u2nl7';
 
-export const btcTransactionUi: BtcTransactionUi = {
+export const mockBtcTransactionUi: BtcTransactionUi = {
 	blockNumber: 123213,
 	from: 'bc1q3jlulk7pw9p5tjqcrwdec9a6vdaw9pqhw0wg4g',
 	id: 'e793cab7e155a0e8f825c4609548faf759c57715fecac587580a1d716bb2b89e',
@@ -14,7 +14,7 @@ export const btcTransactionUi: BtcTransactionUi = {
 	value: 126527n
 };
 
-export const btcTransaction: BitcoinTransaction = {
+export const mockBtcTransaction: BitcoinTransaction = {
 	hash: 'e793cab7e155a0e8f825c4609548faf759c57715fecac587580a1d716bb2b89e',
 	ver: 1,
 	vin_sz: 1,

--- a/src/frontend/src/tests/mocks/eth.mocks.ts
+++ b/src/frontend/src/tests/mocks/eth.mocks.ts
@@ -1,0 +1,1 @@
+export const mockEthAddress = '0x1d638414860ed08dd31fae848e527264f20512fa75d7d63cea9bbb372f020000';

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,6 +1,24 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
+		"paths": {
+			"$declarations": ["./src/declarations"],
+			"$declarations/*": ["./src/declarations/*"],
+			"$btc": ["./src/frontend/src/btc"],
+			"$btc/*": ["./src/frontend/src/btc/*"],
+			"$eth": ["./src/frontend/src/eth"],
+			"$eth/*": ["./src/frontend/src/eth/*"],
+			"$icp": ["./src/frontend/src/icp"],
+			"$icp/*": ["./src/frontend/src/icp/*"],
+			"$icp-eth": ["./src/frontend/src/icp-eth"],
+			"$icp-eth/*": ["./src/frontend/src/icp-eth/*"],
+			"$env": ["./src/frontend/src/env"],
+			"$env/*": ["./src/frontend/src/env/*"],
+			"$lib": ["./src/frontend/src/lib"],
+			"$lib/*": ["./src/frontend/src/lib/*"],
+			"$tests": ["./src/frontend/src/tests"],
+			"$tests/*": ["./src/frontend/src/tests/*"]
+		},
 		"types": ["vitest/globals", "@testing-library/jest-dom"]
 	},
 	"exclude": [],


### PR DESCRIPTION
# Motivation

Both our mocks and imports of our tests would beneficit of a bit of cleaning.

# Notes

This can probably be multiple PRs but, it all has the same goal: cleaning up the tests. Therefore I allowed myself to provide a single PR. Let me know if you rather like me to split it.

# Changes

- Replace relative imports with `$tests/...` 
- Setup support for `$tests`, which was already configured in `vitest`, in `tsconfig.spec.json` - i.e. finish the configuration
- The Btc mocks weren^tprefixed with `mock...` while other mocks were prefixed. So prefix the mocks.
- Since we can reuse the `mockBtcAdress` we can also extract the `mockEthAdress` in a dedicated module.

