### PR TITLE
feat(frontend): Test and add i18n in errors in loadBtcPendingSentTransactions

### DIFF
--- a/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
+++ b/src/frontend/src/btc/services/btc-pending-sent-transactions.services.ts
@@ -1,10 +1,13 @@
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { getPendingBtcTransactions } from '$lib/api/backend.api';
+import { i18n } from '$lib/stores/i18n.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
 import type { ResultSuccess } from '$lib/types/utils';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mapNetworkIdToBitcoinNetwork, mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
 
 export const loadBtcPendingSentTransactions = async ({
 	address,
@@ -16,19 +19,21 @@ export const loadBtcPendingSentTransactions = async ({
 	networkId?: NetworkId;
 }): Promise<ResultSuccess> => {
 	try {
+		const copy = get(i18n);
 		if (isNullish(identity)) {
 			return {
 				success: false,
-				err: new Error('Identity not found')
+				err: new Error(copy.auth.error.no_internet_identity)
 			};
 		}
 		const network = nonNullish(networkId) ? mapNetworkIdToBitcoinNetwork(networkId) : undefined;
 		if (isNullish(network)) {
+			const errMessage = replacePlaceholders(copy.send.error.no_btc_network_id, {
+				$networkId: networkId?.toString() ?? 'undefined'
+			});
 			return {
 				success: false,
-				err: new Error(
-					`Invalid networkId: ${nonNullish(networkId) ? networkId.toString : 'undefined'}`
-				)
+				err: new Error(errMessage)
 			};
 		}
 		const pendingTransactions = await getPendingBtcTransactions({

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -314,7 +314,8 @@
 			"data_undefined": "Transaction Data cannot be undefined or null.",
 			"no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
 			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
-			"incompatible_token": "The token is incompatible. Please try again with a compatible token."
+			"incompatible_token": "The token is incompatible. Please try again with a compatible token.",
+			"no_btc_network_id": "Current network ($networkId) is not a bitcoin network."
 		}
 	},
 	"convert": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -273,6 +273,7 @@ interface I18nSend {
 		no_identity_calculate_fee: string;
 		invalid_destination: string;
 		incompatible_token: string;
+		no_btc_network_id: string;
 	};
 }
 

--- a/src/frontend/src/tests/btc/services/btc-pending-sent-transactions.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-pending-sent-transactions.services.spec.ts
@@ -1,0 +1,75 @@
+import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import type { PendingTransaction } from '$declarations/backend/backend.did';
+import { BTC_MAINNET_NETWORK_ID, ETHEREUM_NETWORK_ID } from '$env/networks.env';
+import * as backendAPI from '$lib/api/backend.api';
+import { get } from 'svelte/store';
+import { mockIdentity } from '../../mocks/identity.mock';
+
+describe('BTC Pending Sent Transactions Services', () => {
+	const mockPendingTransaction: PendingTransaction = {
+		txid: [],
+		utxos: []
+	};
+	const address = 'test-address';
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		btcPendingSentTransactionsStore.reset();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	describe('loadBtcPendingSentTransactions', () => {
+		it('should store the pending transactions', async () => {
+			vi.spyOn(backendAPI, 'getPendingBtcTransactions').mockResolvedValue([mockPendingTransaction]);
+
+			const result = await loadBtcPendingSentTransactions({
+				address,
+				identity: mockIdentity,
+				networkId: BTC_MAINNET_NETWORK_ID
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(get(btcPendingSentTransactionsStore)[address].data).toEqual([mockPendingTransaction]);
+		});
+
+		it('should return an error if the identity is nullish', async () => {
+			const result = await loadBtcPendingSentTransactions({
+				address,
+				identity: null,
+				networkId: BTC_MAINNET_NETWORK_ID
+			});
+
+			expect(result).toEqual({ success: false, err: new Error('No internet identity.') });
+			expect(get(btcPendingSentTransactionsStore)[address]).toBeUndefined();
+		});
+
+		it('should return an error if the network is not a bitcoin network', async () => {
+			const result = await loadBtcPendingSentTransactions({
+				address,
+				identity: mockIdentity,
+				networkId: ETHEREUM_NETWORK_ID
+			});
+
+			expect(result).toEqual({
+				success: false,
+				err: new Error('Current network (Symbol(ETH)) is not a bitcoin network.')
+			});
+			expect(get(btcPendingSentTransactionsStore)[address]).toBeUndefined();
+		});
+
+		it('should store `null` in the pending transactions if the api fails', async () => {
+			const err = new Error('test');
+			vi.spyOn(backendAPI, 'getPendingBtcTransactions').mockRejectedValue(err);
+
+			const result = await loadBtcPendingSentTransactions({
+				address,
+				identity: mockIdentity,
+				networkId: BTC_MAINNET_NETWORK_ID
+			});
+
+			expect(result).toEqual({ success: false, err });
+			expect(get(btcPendingSentTransactionsStore)[address].data).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Requested in comments:

* i18n in erros https://github.com/dfinity/oisy-wallet/pull/2721#discussion_r1791377537
* Add tests for services: https://github.com/dfinity/oisy-wallet/pull/2709#pullrequestreview-2352644773

# Changes

* Use i18n for the errors in `loadBtcPendingSentTransactions`.

# Tests

Add tests for `loadBtcPendingSentTransactions`
