### PR TITLE
fix(devops): Rename test-fe-X to test_fe_X

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -12,7 +12,7 @@
 		"ic": "cha4i-riaaa-aaaan-qeccq-cai",
 		"beta": "v7iq7-yiaaa-aaaan-qmrtq-cai",
 		"staging": "tewsx-xaaaa-aaaad-aadia-cai",
-		"test-fe-1": "6qzfn-gyaaa-aaaar-qaisa-cai",
-		"test-fe-2": "6xydz-laaaa-aaaar-qaisq-cai"
+		"test_fe_1": "6qzfn-gyaaa-aaaar-qaisa-cai",
+		"test_fe_2": "6xydz-laaaa-aaaar-qaisq-cai"
 	}
 }

--- a/dfx.json
+++ b/dfx.json
@@ -13,8 +13,8 @@
 				"id": {
 					"ic": "grghe-syaaa-aaaar-qabyq-cai",
 					"beta": "grghe-syaaa-aaaar-qabyq-cai",
-					"test-fe-1": "tdxud-2yaaa-aaaad-aadiq-cai",
-					"test-fe-2": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_1": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_2": "tdxud-2yaaa-aaaad-aadiq-cai",
 					"staging": "tdxud-2yaaa-aaaad-aadiq-cai"
 				}
 			}
@@ -27,8 +27,8 @@
 			"gzip": true,
 			"remote": {
 				"id": {
-					"test-fe-1": "d3nvo-aaaaa-aaaar-qagzq-cai",
-					"test-fe-2": "d3nvo-aaaaa-aaaar-qagzq-cai"
+					"test_fe_1": "d3nvo-aaaaa-aaaar-qagzq-cai",
+					"test_fe_2": "d3nvo-aaaaa-aaaar-qagzq-cai"
 				}
 			}
 		},
@@ -61,8 +61,8 @@
 			"remote": {
 				"candid": "internet_identity.did",
 				"id": {
-					"test-fe-1": "rdmx6-jaaaa-aaaaa-aaadq-cai",
-					"test-fe-2": "rdmx6-jaaaa-aaaaa-aaadq-cai",
+					"test_fe_1": "rdmx6-jaaaa-aaaaa-aaadq-cai",
+					"test_fe_2": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"staging": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"beta": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
@@ -77,8 +77,8 @@
 			"specified_id": "um5iw-rqaaa-aaaaq-qaaba-cai",
 			"remote": {
 				"id": {
-					"test-fe-1": "um5iw-rqaaa-aaaaq-qaaba-cai",
-					"test-fe-2": "um5iw-rqaaa-aaaaq-qaaba-cai",
+					"test_fe_1": "um5iw-rqaaa-aaaaq-qaaba-cai",
+					"test_fe_2": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"staging": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"beta": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"ic": "um5iw-rqaaa-aaaaq-qaaba-cai"
@@ -93,8 +93,8 @@
 			"candid": "out/cycles_depositor.did",
 			"remote": {
 				"id": {
-					"test-fe-1": "2vxsx-fae",
-					"test-fe-2": "2vxsx-fae",
+					"test_fe_1": "2vxsx-fae",
+					"test_fe_2": "2vxsx-fae",
 					"staging": "2vxsx-fae",
 					"beta": "2vxsx-fae",
 					"ic": "2vxsx-fae"
@@ -108,8 +108,8 @@
 			"shrink": false,
 			"remote": {
 				"id": {
-					"test-fe-1": "qbw6f-caaaa-aaaah-qdcwa-cai",
-					"test-fe-2": "qbw6f-caaaa-aaaah-qdcwa-cai",
+					"test_fe_1": "qbw6f-caaaa-aaaah-qdcwa-cai",
+					"test_fe_2": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"staging": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"beta": "qgxyr-pyaaa-aaaah-qdcwq-cai",
 					"ic": "qgxyr-pyaaa-aaaah-qdcwq-cai"
@@ -122,8 +122,8 @@
 			"wasm": "target/ic/icp_ledger.wasm",
 			"remote": {
 				"id": {
-					"test-fe-1": "ryjl3-tyaaa-aaaaa-aaaba-cai",
-					"test-fe-2": "ryjl3-tyaaa-aaaaa-aaaba-cai",
+					"test_fe_1": "ryjl3-tyaaa-aaaaa-aaaba-cai",
+					"test_fe_2": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"staging": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"beta": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"ic": "ryjl3-tyaaa-aaaaa-aaaba-cai"
@@ -136,8 +136,8 @@
 			"wasm": "target/ic/icp_index.wasm",
 			"remote": {
 				"id": {
-					"test-fe-1": "qhbym-qaaaa-aaaaa-aaafq-cai",
-					"test-fe-2": "qhbym-qaaaa-aaaaa-aaafq-cai",
+					"test_fe_1": "qhbym-qaaaa-aaaaa-aaafq-cai",
+					"test_fe_2": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"staging": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"beta": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"ic": "qhbym-qaaaa-aaaaa-aaafq-cai"
@@ -151,8 +151,8 @@
 			"remote": {
 				"id": {
 					"ic": "mqygn-kiaaa-aaaar-qaadq-cai",
-					"test-fe-1": "ml52i-qqaaa-aaaar-qaaba-cai",
-					"test-fe-2": "ml52i-qqaaa-aaaar-qaaba-cai",
+					"test_fe_1": "ml52i-qqaaa-aaaar-qaaba-cai",
+					"test_fe_2": "ml52i-qqaaa-aaaar-qaaba-cai",
 					"staging": "ml52i-qqaaa-aaaar-qaaba-cai"
 				}
 			}
@@ -164,8 +164,8 @@
 			"remote": {
 				"id": {
 					"ic": "mxzaz-hqaaa-aaaar-qaada-cai",
-					"test-fe-1": "mc6ru-gyaaa-aaaar-qaaaq-cai",
-					"test-fe-2": "mc6ru-gyaaa-aaaar-qaaaq-cai",
+					"test_fe_1": "mc6ru-gyaaa-aaaar-qaaaq-cai",
+					"test_fe_2": "mc6ru-gyaaa-aaaar-qaaaq-cai",
 					"staging": "mc6ru-gyaaa-aaaar-qaaaq-cai"
 				}
 			}
@@ -177,8 +177,8 @@
 			"remote": {
 				"id": {
 					"ic": "n5wcd-faaaa-aaaar-qaaea-cai",
-					"test-fe-1": "mm444-5iaaa-aaaar-qaabq-cai",
-					"test-fe-2": "mm444-5iaaa-aaaar-qaabq-cai",
+					"test_fe_1": "mm444-5iaaa-aaaar-qaabq-cai",
+					"test_fe_2": "mm444-5iaaa-aaaar-qaabq-cai",
 					"staging": "mm444-5iaaa-aaaar-qaabq-cai"
 				}
 			}
@@ -190,8 +190,8 @@
 			"remote": {
 				"id": {
 					"ic": "pjihx-aaaaa-aaaar-qaaka-cai",
-					"test-fe-1": "pvm5g-xaaaa-aaaar-qaaia-cai",
-					"test-fe-2": "pvm5g-xaaaa-aaaar-qaaia-cai",
+					"test_fe_1": "pvm5g-xaaaa-aaaar-qaaia-cai",
+					"test_fe_2": "pvm5g-xaaaa-aaaar-qaaia-cai",
 					"staging": "pvm5g-xaaaa-aaaar-qaaia-cai"
 				}
 			}
@@ -203,8 +203,8 @@
 			"remote": {
 				"id": {
 					"ic": "sv3dd-oaaaa-aaaar-qacoa-cai",
-					"test-fe-1": "jzenf-aiaaa-aaaar-qaa7q-cai",
-					"test-fe-2": "jzenf-aiaaa-aaaar-qaa7q-cai",
+					"test_fe_1": "jzenf-aiaaa-aaaar-qaa7q-cai",
+					"test_fe_2": "jzenf-aiaaa-aaaar-qaa7q-cai",
 					"staging": "jzenf-aiaaa-aaaar-qaa7q-cai"
 				}
 			}
@@ -216,8 +216,8 @@
 			"remote": {
 				"id": {
 					"ic": "ss2fx-dyaaa-aaaar-qacoq-cai",
-					"test-fe-1": "apia6-jaaaa-aaaar-qabma-cai",
-					"test-fe-2": "apia6-jaaaa-aaaar-qabma-cai",
+					"test_fe_1": "apia6-jaaaa-aaaar-qabma-cai",
+					"test_fe_2": "apia6-jaaaa-aaaar-qabma-cai",
 					"staging": "apia6-jaaaa-aaaar-qabma-cai"
 				}
 			}
@@ -229,8 +229,8 @@
 			"remote": {
 				"id": {
 					"ic": "s3zol-vqaaa-aaaar-qacpa-cai",
-					"test-fe-1": "sh5u2-cqaaa-aaaar-qacna-cai",
-					"test-fe-2": "sh5u2-cqaaa-aaaar-qacna-cai",
+					"test_fe_1": "sh5u2-cqaaa-aaaar-qacna-cai",
+					"test_fe_2": "sh5u2-cqaaa-aaaar-qacna-cai",
 					"staging": "sh5u2-cqaaa-aaaar-qacna-cai"
 				}
 			}
@@ -258,11 +258,11 @@
 			"providers": ["https://icp0.io"],
 			"type": "persistent"
 		},
-		"test-fe-1": {
+		"test_fe_1": {
 			"providers": ["https://icp0.io"],
 			"type": "persistent"
 		},
-		"test-fe-2": {
+		"test_fe_2": {
 			"providers": ["https://icp0.io"],
 			"type": "persistent"
 		},


### PR DESCRIPTION
# Motivation

`vite build` was broken with:

```
error during build:
[commonjs--resolver] Transform failed with 32 errors:
error: The define key "import.meta.env.VITE_TEST-FE-1_ICP_LEDGER_CANISTER_ID" contains invalid identifier "VITE_TEST-FE-1_ICP_LEDGER_CANISTER_ID"
error: The define key "import.meta.env.VITE_TEST-FE-1_BACKEND_CANISTER_ID" contains invalid identifier "VITE_TEST-FE-1_BACKEND_CANISTER_ID"
error: The define key "import.meta.env.VITE_TEST-FE-1_INTERNET_IDENTITY_CANISTER_ID" contains invalid identifier "VITE_TEST-FE-1_INTERNET_IDENTITY_CANISTER_ID"
error: The define key "import.meta.env.VITE_TEST-FE-2_CKBTC_MINTER_CANISTER_ID" contains invalid identifier "VITE_TEST-FE-2_CKBTC_MINTER_CANISTER_ID"
error: The define key "import.meta.env.VITE_TEST-FE-1_CYCLES_LEDGER_CANISTER_ID" contains invalid identifier "VITE_TEST-FE-1_CYCLES_LEDGER_CANISTER_ID"
...
```

The `-` can't be present in identifiers.

# Changes

* Rename `test-fe-1` and `test-fe-2` to `test_fe_1` and `test_fe_2`.

# Tests

Tested locally that `npm run build` still works.
