### PR TITLE
fix(frontend): issue with loading BTC txs

### DIFF
--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -110,7 +110,7 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 		const bitcoinNetwork = data?.bitcoinNetwork;
 		assertNonNullish(bitcoinNetwork, 'No BTC network provided to get BTC certified balance.');
 
-		const btcAddress = data?.btcAddress;
+		const btcAddress = data?.btcAddress.data;
 		assertNonNullish(btcAddress, 'No BTC address provided to get BTC transactions.');
 
 		const balance = await this.loadBtcBalance({ identity, bitcoinNetwork });

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -58,7 +58,7 @@ export type PostMessageDataRequestIcCkBTCUpdateBalance = PostMessageDataRequestI
 };
 
 export interface PostMessageDataRequestBtc {
-	btcAddress: BtcAddress;
+	btcAddress: CertifiedData<BtcAddress>;
 	shouldFetchTransactions: boolean;
 	bitcoinNetwork: SignerBitcoinNetwork;
 }


### PR DESCRIPTION
# Motivation

Another example of why we need to have zod for typing worker-client communication - there was an issue with the way of how BTC address was passed to the wallet worker.
