### PR TITLE
fix(frontend): Add more contrast to the icons in the transaction list

### DIFF
--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -3,7 +3,7 @@
 
 	export let icon: ComponentType;
 	export let iconSize = '2.9rem';
-	export let backgroundStyleClass = 'bg-alice-blue';
+	export let backgroundStyleClass = 'bg-onahau';
 	export let iconStyleClass = '';
 	export let additionalStyleClass = '';
 </script>


### PR DESCRIPTION
# Motivation

As noted by @DenysKarmazynDFINITY , I forgot to adjust the contrast between the background and the icons in the transaction list.

### Before

<img width="1029" alt="Screenshot 2024-10-08 at 18 49 45" src="https://github.com/user-attachments/assets/c9241f77-61cb-4b5f-9e39-44221aaffca1">

### After

<img width="1030" alt="Screenshot 2024-10-08 at 18 49 33" src="https://github.com/user-attachments/assets/1b012358-8f47-4e9c-9331-a0524a430eff">


