### PR TITLE
fix(frontend): Remove the back button when logged out

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -19,7 +19,7 @@
 	class:sm:grid-cols-[1fr_auto_1fr]={$authSignedIn}
 	class:xl:grid-cols-[1fr_auto_1fr]={$authNotSignedIn}
 >
-	{#if back}
+	{#if back && $authSignedIn}
 		<Back />
 	{:else}
 		<OisyWalletLogoLink />


### PR DESCRIPTION
# Motivation

There was a bug so that when an User logs out from the setting page, the `Back` button will stay there in the `Header`. We check for logged in to display it now.