### PR TITLE
test(e2e): wait for balance to appear

### DIFF
--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -6,6 +6,7 @@ import {
 	RECEIVE_TOKENS_MODAL,
 	RECEIVE_TOKENS_MODAL_OPEN_BUTTON,
 	RECEIVE_TOKENS_MODAL_QR_CODE_OUTPUT,
+	TOKEN_BALANCE,
 	TOKEN_CARD
 } from '$lib/constants/test-ids.constants';
 import { type InternetIdentityPage } from '@dfinity/internet-identity-playwright';
@@ -137,6 +138,9 @@ abstract class Homepage {
 	protected async waitForTokensInitialization(options?: WaitForLocatorOptions): Promise<void> {
 		await this.#page.getByTestId(`${TOKEN_CARD}-ICP`).waitFor(options);
 		await this.#page.getByTestId(`${TOKEN_CARD}-ETH`).waitFor(options);
+
+		await this.#page.getByTestId(`${TOKEN_BALANCE}-ICP`).waitFor(options);
+		await this.#page.getByTestId(`${TOKEN_BALANCE}-ETH`).waitFor(options);
 	}
 
 	protected async clickMenuItem({ menuItemTestId }: ClickMenuItemParams): Promise<void> {

--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -4,12 +4,13 @@
 	import { ZERO } from '$lib/constants/app.constants';
 	import type { TokenUi } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
+	import { TOKEN_BALANCE } from '$lib/constants/test-ids.constants';
 
 	export let token: TokenUi;
 </script>
 
 <TokenBalanceSkeleton {token}>
-	<output class="break-all">
+	<output class="break-all" data-tid={`${TOKEN_BALANCE}-${token.symbol}`}>
 		{#if nonNullish(token.balance)}
 			{formatToken({
 				value: token.balance,

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -5,6 +5,7 @@ export const LOGOUT_BUTTON = 'logout-button';
 export const LOGIN_BUTTON = 'login-button';
 
 export const TOKEN_CARD = 'token-card';
+export const TOKEN_BALANCE = 'token-balance';
 
 export const ABOUT_WHAT_MODAL_OPEN_BUTTON = 'about-what-modal-open-button';
 export const ABOUT_WHAT_MODAL = 'about-what-modal';


### PR DESCRIPTION
# Motivation

The Update snapshots script would always save a different image because it would not wait for the balance to appear. So sometimes it would snapshot with the skeleton and sometimes without.