### PR TITLE
feat(frontend): formCancelAction prop for BtcSendTokenWizard

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
-	import { getContext } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import BtcSendForm from '$btc/components/send/BtcSendForm.svelte';
 	import BtcSendProgress from '$btc/components/send/BtcSendProgress.svelte';
 	import BtcSendReview from '$btc/components/send/BtcSendReview.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendQrCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import {
 		btcAddressMainnet,
 		btcAddressRegtest,
@@ -21,6 +23,7 @@
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let sendProgressStep: string;
+	export let formCancelAction: 'back' | 'close' = 'close';
 
 	let source: string;
 	$: source =
@@ -31,6 +34,11 @@
 				: $btcAddressMainnet) ?? '';
 
 	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const dispatch = createEventDispatcher();
+
+	const close = () => dispatch('icClose');
+	const back = () => dispatch('icSendBack');
 
 	// TODO: implement send function when related services are ready
 	const send = () => {};
@@ -49,7 +57,15 @@
 		bind:networkId
 		on:icQRCodeScan
 		{source}
-	/>
+	>
+		<svelte:fragment slot="cancel">
+			{#if formCancelAction === 'back'}
+				<ButtonBack on:click={back} />
+			{:else}
+				<ButtonCancel on:click={close} />
+			{/if}
+		</svelte:fragment>
+	</BtcSendForm>
 {:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
 	<SendQrCodeScan
 		expectedToken={$sendToken}


### PR DESCRIPTION
# Motivation

Extending BtcSendTokenWizard with an additional prop that tells component which button should it render - close or back.
