### PR TITLE
feat(devops): Add and include cfs_canister_id init

### DIFF
--- a/scripts/deploy.args.sh
+++ b/scripts/deploy.args.sh
@@ -2,6 +2,7 @@
 
 II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
 POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
+SIGNER_CANISTER_ID="$(dfx canister id signer --network "${ENV:-local}")"
 
 case $ENV in
 "staging")
@@ -32,6 +33,7 @@ echo "(variant {
   Init = record {
         ecdsa_key_name = \"$ECDSA_KEY_NAME\";
         allowed_callers = vec {};
+        cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
         supported_credentials = opt vec {
           record {
             credential_type = variant { ProofOfUniqueness };

--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -2,6 +2,7 @@
 
 II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
 POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
+SIGNER_CANISTER_ID="$(dfx canister id signer --network "${ENV:-local}")"
 
 case $ENV in
 "staging")
@@ -49,6 +50,7 @@ if [ -n "${ENV+1}" ]; then
     Init = record {
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
+         cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
          supported_credentials = opt vec {
             record {
               credential_type = variant { ProofOfUniqueness };
@@ -67,6 +69,7 @@ else
     Init = record {
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
+         cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
          supported_credentials = opt vec {
             record {
               credential_type = variant { ProofOfUniqueness };

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -61,6 +61,7 @@ type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
   api : opt Guards;
   ecdsa_key_name : text;
+  cfs_canister_id : opt principal;
   allowed_callers : vec principal;
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_raw : opt blob;
@@ -99,6 +100,7 @@ type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   api : opt Guards;
   ecdsa_key_name : text;
+  cfs_canister_id : opt principal;
   allowed_callers : vec principal;
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_der : opt blob;

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -317,6 +317,7 @@ pub(crate) fn init_arg() -> Arg {
             credential_type: CredentialType::ProofOfUniqueness,
         }]),
         api: None,
+        cfs_canister_id: None,
     })
 }
 

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -61,6 +61,7 @@ type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
   api : opt Guards;
   ecdsa_key_name : text;
+  cfs_canister_id : opt principal;
   allowed_callers : vec principal;
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_raw : opt blob;
@@ -99,6 +100,7 @@ type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   api : opt Guards;
   ecdsa_key_name : text;
+  cfs_canister_id : opt principal;
   allowed_callers : vec principal;
   supported_credentials : opt vec SupportedCredential;
   ic_root_key_der : opt blob;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -64,6 +64,7 @@ export type CanisterStatusType = { stopped: null } | { stopping: null } | { runn
 export interface Config {
 	api: [] | [Guards];
 	ecdsa_key_name: string;
+	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
 	supported_credentials: [] | [Array<SupportedCredential>];
 	ic_root_key_raw: [] | [Uint8Array | number[]];
@@ -108,6 +109,7 @@ export interface IcrcToken {
 export interface InitArg {
 	api: [] | [Guards];
 	ecdsa_key_name: string;
+	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
 	supported_credentials: [] | [Array<SupportedCredential>];
 	ic_root_key_der: [] | [Uint8Array | number[]];

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -20,6 +20,7 @@ export const idlFactory = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
+		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
 		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
@@ -129,6 +130,7 @@ export const idlFactory = ({ IDL }) => {
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
+		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
 		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
@@ -305,6 +307,7 @@ export const init = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
+		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
 		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -20,6 +20,7 @@ export const idlFactory = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
+		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
 		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
@@ -129,6 +130,7 @@ export const idlFactory = ({ IDL }) => {
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
+		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
 		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
@@ -305,6 +307,7 @@ export const init = ({ IDL }) => {
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
 		ecdsa_key_name: IDL.Text,
+		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
 		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -52,6 +52,7 @@ impl From<InitArg> for Config {
             supported_credentials,
             ic_root_key_der,
             api,
+            cfs_canister_id,
         } = arg;
         let ic_root_key_raw = match extract_raw_root_pk_from_der(
             &ic_root_key_der.unwrap_or_else(|| IC_ROOT_PK_DER.to_vec()),
@@ -62,6 +63,7 @@ impl From<InitArg> for Config {
         Config {
             ecdsa_key_name,
             allowed_callers,
+            cfs_canister_id,
             supported_credentials,
             ic_root_key_raw: Some(ic_root_key_raw),
             api,

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -28,6 +28,8 @@ pub struct InitArg {
     pub ic_root_key_der: Option<Vec<u8>>,
     /// Enables or disables APIs
     pub api: Option<Guards>,
+    /// Chain Fussion Signer canister id. Used to derive the bitcoin address in `btc_select_user_utxos_fee`
+    pub cfs_canister_id: Option<Principal>,
 }
 
 #[derive(CandidType, Deserialize, Eq, PartialEq, Debug, Copy, Clone)]
@@ -70,6 +72,8 @@ pub struct Config {
     pub ic_root_key_raw: Option<Vec<u8>>,
     /// Enables or disables APIs
     pub api: Option<Guards>,
+    /// Chain Fussion Signer canister id. Used to derive the bitcoin address in `btc_select_user_utxos_fee`
+    pub cfs_canister_id: Option<Principal>,
 }
 
 pub mod transaction {


### PR DESCRIPTION
# Motivation

We want to remove the `address` parameter from the `SelectedUtxosFeeRequest` and derive it from the caller.

In this PR, I included the CFS canister id which will be used to fetch the ECDSA public key before deriving the address.

# Changes

## Manual changes

* New parameter `cfs_canister_id` in `Config` and `InitArg`.
* Add new parameter in deploy scripts `deploy.args.sh` and `deploy.backend.sh`.
* Add it to the move from init to the config.

## Automatic changes

Using `npm run generate`:
* Changes in candid files.
* Changes in declarations files.

# Tests

* Add new `cfx_canister_id` as `None` in the integration tests. It's not yet used.
