### PR TITLE
feat(frontend): display regtest BTC address

### DIFF
--- a/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
+++ b/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
 	import Copy from '$lib/components/ui/Copy.svelte';
-	import { btcAddressMainnet, btcAddressTestnet } from '$lib/derived/address.derived';
+	import {
+		btcAddressMainnet,
+		btcAddressTestnet,
+		btcAddressRegtest
+	} from '$lib/derived/address.derived';
 	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
 
-	// Regtest and Testnet BTC wallets have the same address
-	const address =
-		isNetworkIdBTCTestnet($networkId) || isNetworkIdBTCRegtest($networkId)
-			? $btcAddressTestnet
+	const address = isNetworkIdBTCTestnet($networkId)
+		? $btcAddressTestnet
+		: isNetworkIdBTCRegtest($networkId)
+			? $btcAddressRegtest
 			: $btcAddressMainnet;
 </script>
 


### PR DESCRIPTION
# Motivation

We now need to display a separate BTC address for regtest (previously, it was always the same with testnet).
