### PR TITLE
test(frontend): hide console.error logs for query.ic methods

### DIFF
--- a/src/frontend/src/tests/lib/actors/query.ic.spec.ts
+++ b/src/frontend/src/tests/lib/actors/query.ic.spec.ts
@@ -5,6 +5,9 @@ import { tick } from 'svelte';
 describe('query.ic', () => {
 	const identity = new AnonymousIdentity();
 
+	// we mock console.error just to avoid unnecessary logs while running the tests
+	vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});


### PR DESCRIPTION
# Motivation

As agreed with David offline, we want to keep unit tests log clean and therefore need to mock console.error for query.ic methods.
