### PR TITLE
docs(frontend): Comment on eth address derivation

### DIFF
--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -71,6 +71,7 @@ export class SignerCanister extends Canister<SignerService> {
 		});
 
 		/* Note: `eth_address` gets the Ethereum address of a given principal, defaulting to the caller if not provided. */
+		/*       In OISY, we derive the ETH address from the caller. Therefore, we are not providing a principal as an argument. */
 		const response = await eth_address({ principal: [] }, [
 			{
 				PatronPaysIcrc2Cycles: {


### PR DESCRIPTION
# Motivation
The reason why the caller address is needed isn't clear.

# Changes
- Explain why the caller principal is important when getting the user eth address.

# Tests
N/A