### PR TITLE
feat(frontend): Add warning if btc pending transactions

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
@@ -6,7 +6,7 @@
 	export let pendingTransactionsStatus: boolean | 'loading' | 'error';
 </script>
 
-<div in:fade></div>
+<div in:fade>
 	{#if pendingTransactionsStatus === true}
 		<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
 	{:else if pendingTransactionsStatus === 'error'}

--- a/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
@@ -6,8 +6,8 @@
 	export let pendingTransactionsStatus: boolean | 'loading' | 'error';
 </script>
 
-<div in:fade>
-	{#if pendingTransactionsStatus === true || true}
+<div in:fade></div>
+	{#if pendingTransactionsStatus === true}
 		<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
 	{:else if pendingTransactionsStatus === 'error'}
 		<WarningBanner>{$i18n.send.error.no_pending_bitcoin_transaction}</WarningBanner>

--- a/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
+	import { fade } from 'svelte/transition';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	export let pendingTransactionsStatus: boolean | 'loading' | 'error';
+</script>
+
+<div in:fade>
+	{#if pendingTransactionsStatus === true || true}
+		<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
+	{:else if pendingTransactionsStatus === 'error'}
+		<WarningBanner>{$i18n.send.error.no_pending_bitcoin_transaction}</WarningBanner>
+	{/if}
+</div>

--- a/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
@@ -6,10 +6,12 @@
 	export let pendingTransactionsStatus: boolean | 'loading' | 'error';
 </script>
 
-<div in:fade>
-	{#if pendingTransactionsStatus === true}
+{#if pendingTransactionsStatus === true}
+	<div in:fade>
 		<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
-	{:else if pendingTransactionsStatus === 'error'}
+	</div>
+{:else if pendingTransactionsStatus === 'error'}
+	<div in:fade>
 		<WarningBanner>{$i18n.send.error.no_pending_bitcoin_transaction}</WarningBanner>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { fade } from 'svelte/transition';
+	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	export let pendingTransactionsStatus: boolean | 'loading' | 'error';

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import type { Readable } from 'svelte/store';
+	import BtcSendHasPendingTransactions from './BtcSendHasPendingTransactions.svelte';
 	import { initHasPendingSentTransactions } from '$btc/derived/has-pending-sent-transactions.derived';
 	import SendReview from '$lib/components/send/SendReview.svelte';
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
-	import BtcSendHasPendingTransactions from './BtcSendHasPendingTransactions.svelte';
 
 	export let destination = '';
 	export let amount: number | undefined = undefined;

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
+	import { initHasPendingSentTransactions } from '$btc/derived/has-pending-sent-transactions.derived';
 	import SendReview from '$lib/components/send/SendReview.svelte';
+	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
+	import type { Readable } from 'svelte/store';
 
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
 	export let source: string;
+
+	let hasPendingTransactionsStore: Readable<boolean | 'loading' | 'error'>;
+	$: hasPendingTransactionsStore = initHasPendingSentTransactions(source);
+
+	let disableSend: boolean;
+	// We want to disable send if pending transactions are loading, there was an error or there are pending transactions.
+	$: disableSend = $hasPendingTransactionsStore !== false || invalid;
 
 	// Should never happen given that the same checks are performed on previous wizard step
 	let invalid = true;
@@ -18,4 +29,12 @@
 		}) || invalidAmount(amount);
 </script>
 
-<SendReview on:icBack on:icSend {source} {amount} {destination} disabled={invalid} />
+<SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
+	<svelte:fragment slot="info">
+		{#if $hasPendingTransactionsStore === true}
+			<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
+		{:else if $hasPendingTransactionsStore === 'error'}
+			<WarningBanner>{$i18n.send.error.no_pending_bitcoin_transaction}</WarningBanner>
+		{/if}
+	</svelte:fragment>
+</SendReview>

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -2,11 +2,10 @@
 	import type { Readable } from 'svelte/store';
 	import { initHasPendingSentTransactions } from '$btc/derived/has-pending-sent-transactions.derived';
 	import SendReview from '$lib/components/send/SendReview.svelte';
-	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
-	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
+	import BtcSendHasPendingTransactions from './BtcSendHasPendingTransactions.svelte';
 
 	export let destination = '';
 	export let amount: number | undefined = undefined;
@@ -30,11 +29,8 @@
 </script>
 
 <SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
-	<svelte:fragment slot="info">
-		{#if $hasPendingTransactionsStore === true}
-			<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
-		{:else if $hasPendingTransactionsStore === 'error'}
-			<WarningBanner>{$i18n.send.error.no_pending_bitcoin_transaction}</WarningBanner>
-		{/if}
-	</svelte:fragment>
+	<BtcSendHasPendingTransactions
+		slot="info"
+		pendingTransactionsStatus={$hasPendingTransactionsStore}
+	/>
 </SendReview>

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Readable } from 'svelte/store';
 	import { initHasPendingSentTransactions } from '$btc/derived/has-pending-sent-transactions.derived';
 	import SendReview from '$lib/components/send/SendReview.svelte';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
@@ -6,7 +7,6 @@
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
-	import type { Readable } from 'svelte/store';
 
 	export let destination = '';
 	export let amount: number | undefined = undefined;

--- a/src/frontend/src/lib/components/send/SendReview.svelte
+++ b/src/frontend/src/lib/components/send/SendReview.svelte
@@ -28,6 +28,8 @@
 		</SendData>
 	{/if}
 
+	<slot name="info" />
+
 	<ButtonGroup slot="toolbar">
 		<ButtonBack on:click={() => dispatch('icBack')} />
 		<Button {disabled} on:click={() => dispatch('icSend')}>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -281,7 +281,8 @@
 		},
 		"info": {
 			"ckbtc_certified": "Please wait until the ckBTC parameters have been certified.",
-			"cketh_certified": "Please wait until the ckETH parameters have been certified."
+			"cketh_certified": "Please wait until the ckETH parameters have been certified.",
+			"pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete."
 		},
 		"assertion": {
 			"invalid_destination_address": "Invalid destination address",
@@ -317,7 +318,8 @@
 			"no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
 			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
 			"incompatible_token": "The token is incompatible. Please try again with a compatible token.",
-			"no_btc_network_id": "Current network ($networkId) is not a bitcoin network."
+			"no_btc_network_id": "Current network ($networkId) is not a bitcoin network.",
+			"no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later."
 		}
 	},
 	"convert": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -244,7 +244,7 @@ interface I18nSend {
 		enter_wallet_address: string;
 		select_network: string;
 	};
-	info: { ckbtc_certified: string; cketh_certified: string };
+	info: { ckbtc_certified: string; cketh_certified: string; pending_bitcoin_transaction: string };
 	assertion: {
 		invalid_destination_address: string;
 		insufficient_funds: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -280,6 +280,7 @@ interface I18nSend {
 		invalid_destination: string;
 		incompatible_token: string;
 		no_btc_network_id: string;
+		no_pending_bitcoin_transaction: string;
 	};
 }
 


### PR DESCRIPTION
# Motivation

We want to avoid users double spending their utxos. Therefore, we disable sending Bitcoin if there is any pending sent transaction.

In this PR, we show a warning and disable the "Send" button in the review step.

# Changes

* Use `initHasPendingSentTransactions` to get the state of the btc pending sent transactions, disable the button accordingly and show warning.
* Add a slot in `SendReview` that can be used to add feedback to the user.
* Add two new messages in i18n.

# Tests

Tested locally by filling up the store with the different scenarios.
