### PR TITLE
chore(devops): Update the chain fusion signer version.

### DIFF
--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -20,7 +20,7 @@ print_help() {
 
 DFX_NETWORK="${DFX_NETWORK:-local}"
 
-SIGNER_RELEASE="v0.2.3"
+SIGNER_RELEASE="v0.2.5"
 SIGNER_RELEASE_URL="https://github.com/dfinity/chain-fusion-signer/releases/download/${SIGNER_RELEASE}"
 CANDID_URL="${SIGNER_RELEASE_URL}/signer.did"
 WASM_URL="${SIGNER_RELEASE_URL}/signer.wasm.gz"

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -51,7 +51,7 @@ type EthAddressRequest = record { "principal" : opt principal };
 type EthAddressResponse = record { address : text };
 type EthPersonalSignRequest = record { message : text };
 type EthPersonalSignResponse = record { signature : text };
-type EthSignPrehashRequest = record { message : text };
+type EthSignPrehashRequest = record { hash : text };
 type EthSignPrehashResponse = record { signature : text };
 type EthSignTransactionRequest = record {
   to : text;
@@ -72,6 +72,11 @@ type GetAddressRequest = record {
   address_type : BitcoinAddressType;
 };
 type GetAddressResponse = record { address : text };
+type GetBalanceRequest = record {
+  network : BitcoinNetwork;
+  address_type : BitcoinAddressType;
+  min_confirmations : opt nat32;
+};
 type GetBalanceResponse = record { balance : nat64 };
 type HttpRequest = record {
   url : text;
@@ -203,7 +208,7 @@ type WithdrawFromError = variant {
 };
 service : (Arg) -> {
   btc_caller_address : (GetAddressRequest, opt PaymentType) -> (Result);
-  btc_caller_balance : (GetAddressRequest, opt PaymentType) -> (Result_1);
+  btc_caller_balance : (GetBalanceRequest, opt PaymentType) -> (Result_1);
   btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
   caller_eth_address : () -> (text);
   config : () -> (Config) query;

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -78,7 +78,7 @@ export interface EthPersonalSignResponse {
 	signature: string;
 }
 export interface EthSignPrehashRequest {
-	message: string;
+	hash: string;
 }
 export interface EthSignPrehashResponse {
 	signature: string;
@@ -100,6 +100,11 @@ export interface GetAddressRequest {
 }
 export interface GetAddressResponse {
 	address: string;
+}
+export interface GetBalanceRequest {
+	network: BitcoinNetwork;
+	address_type: BitcoinAddressType;
+	min_confirmations: [] | [number];
 }
 export interface GetBalanceResponse {
 	balance: bigint;
@@ -245,7 +250,7 @@ export type WithdrawFromError =
 	| { InsufficientFunds: { balance: bigint } };
 export interface _SERVICE {
 	btc_caller_address: ActorMethod<[GetAddressRequest, [] | [PaymentType]], Result>;
-	btc_caller_balance: ActorMethod<[GetAddressRequest, [] | [PaymentType]], Result_1>;
+	btc_caller_balance: ActorMethod<[GetBalanceRequest, [] | [PaymentType]], Result_1>;
 	btc_caller_send: ActorMethod<[SendBtcRequest, [] | [PaymentType]], Result_2>;
 	caller_eth_address: ActorMethod<[], string>;
 	config: ActorMethod<[], Config>;

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -100,6 +100,11 @@ export const idlFactory = ({ IDL }) => {
 		Ok: GetAddressResponse,
 		Err: GetAddressError
 	});
+	const GetBalanceRequest = IDL.Record({
+		network: BitcoinNetwork,
+		address_type: BitcoinAddressType,
+		min_confirmations: IDL.Opt(IDL.Nat32)
+	});
 	const GetBalanceResponse = IDL.Record({ balance: IDL.Nat64 });
 	const Result_1 = IDL.Variant({
 		Ok: GetBalanceResponse,
@@ -168,7 +173,7 @@ export const idlFactory = ({ IDL }) => {
 		Ok: EthPersonalSignResponse,
 		Err: EthAddressError
 	});
-	const EthSignPrehashRequest = IDL.Record({ message: IDL.Text });
+	const EthSignPrehashRequest = IDL.Record({ hash: IDL.Text });
 	const EthSignPrehashResponse = IDL.Record({ signature: IDL.Text });
 	const Result_5 = IDL.Variant({
 		Ok: EthSignPrehashResponse,
@@ -255,7 +260,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		btc_caller_address: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result], []),
-		btc_caller_balance: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result_1], []),
+		btc_caller_balance: IDL.Func([GetBalanceRequest, IDL.Opt(PaymentType)], [Result_1], []),
 		btc_caller_send: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_2], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		config: IDL.Func([], [Config]),

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -100,6 +100,11 @@ export const idlFactory = ({ IDL }) => {
 		Ok: GetAddressResponse,
 		Err: GetAddressError
 	});
+	const GetBalanceRequest = IDL.Record({
+		network: BitcoinNetwork,
+		address_type: BitcoinAddressType,
+		min_confirmations: IDL.Opt(IDL.Nat32)
+	});
 	const GetBalanceResponse = IDL.Record({ balance: IDL.Nat64 });
 	const Result_1 = IDL.Variant({
 		Ok: GetBalanceResponse,
@@ -168,7 +173,7 @@ export const idlFactory = ({ IDL }) => {
 		Ok: EthPersonalSignResponse,
 		Err: EthAddressError
 	});
-	const EthSignPrehashRequest = IDL.Record({ message: IDL.Text });
+	const EthSignPrehashRequest = IDL.Record({ hash: IDL.Text });
 	const EthSignPrehashResponse = IDL.Record({ signature: IDL.Text });
 	const Result_5 = IDL.Variant({
 		Ok: EthSignPrehashResponse,
@@ -255,7 +260,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		btc_caller_address: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result], []),
-		btc_caller_balance: IDL.Func([GetAddressRequest, IDL.Opt(PaymentType)], [Result_1], []),
+		btc_caller_balance: IDL.Func([GetBalanceRequest, IDL.Opt(PaymentType)], [Result_1], []),
 		btc_caller_send: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_2], []),
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
 		config: IDL.Func([], [Config], ['query']),

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,5 +1,6 @@
 import type {
 	BitcoinNetwork,
+	GetBalanceRequest,
 	SendBtcResponse,
 	SignRequest,
 	_SERVICE as SignerService
@@ -56,7 +57,12 @@ export class SignerCanister extends Canister<SignerService> {
 			certified: true
 		});
 
-		const response = await btc_caller_balance({ network, address_type: { P2WPKH: null } }, []);
+		const request: GetBalanceRequest = {
+			network,
+			address_type: { P2WPKH: null },
+			min_confirmations: []
+		};
+		const response = await btc_caller_balance(request, []);
 
 		if ('Err' in response) {
 			throw mapSignerCanisterBtcError(response.Err);

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -170,7 +170,7 @@ describe('signer.canister', () => {
 
 		expect(res).toEqual(balance);
 		expect(service.btc_caller_balance).toHaveBeenCalledWith(
-			{ network: btcParams.network, address_type: { P2WPKH: null } },
+			{ network: btcParams.network, address_type: { P2WPKH: null }, min_confirmations: [] },
 			[]
 		);
 	});


### PR DESCRIPTION
# Motivation
A new version of the chain fusion signer is available.

# Changes
- Update the chain fusion signer version to 0.2.5
- Update the frontend to use the new API

# Tests
Existing CI should suffice.