### PR TITLE
refactor(frontend): Extract payment type as a constant

### DIFF
--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -8,7 +8,7 @@ import type {
 import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
 import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
-import { SIGNER_PAYMENT_TYPE } from '$lib/constants/app.constants';
+import { SIGNER_PAYMENT_TYPE } from '$lib/canisters/signer.constants';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { SendBtcParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -8,7 +8,7 @@ import type {
 import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
 import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
-import { BACKEND_CANISTER_PRINCIPAL } from '$lib/constants/app.constants';
+import { SIGNER_PAYMENT_TYPE } from '$lib/constants/app.constants';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
 import type { SendBtcParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
@@ -78,14 +78,7 @@ export class SignerCanister extends Canister<SignerService> {
 
 		/* Note: `eth_address` gets the Ethereum address of a given principal, defaulting to the caller if not provided. */
 		/*       In OISY, we derive the ETH address from the caller. Therefore, we are not providing a principal as an argument. */
-		const response = await eth_address({ principal: [] }, [
-			{
-				PatronPaysIcrc2Cycles: {
-					owner: BACKEND_CANISTER_PRINCIPAL,
-					subaccount: []
-				}
-			}
-		]);
+		const response = await eth_address({ principal: [] }, [SIGNER_PAYMENT_TYPE]);
 
 		if ('Err' in response) {
 			throw mapSignerCanisterGetEthAddressError(response.Err);

--- a/src/frontend/src/lib/canisters/signer.constants.ts
+++ b/src/frontend/src/lib/canisters/signer.constants.ts
@@ -1,0 +1,9 @@
+import type { Account } from '$declarations/signer/signer.did';
+import { BACKEND_CANISTER_PRINCIPAL } from '$lib/constants/app.constants';
+
+export const SIGNER_PAYMENT_TYPE = {
+	PatronPaysIcrc2Cycles: {
+		owner: BACKEND_CANISTER_PRINCIPAL,
+		subaccount: []
+	} as Account
+};

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -1,4 +1,3 @@
-import type { Account } from '$declarations/signer/signer.did';
 import { Principal } from '@dfinity/principal';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -57,13 +56,6 @@ export const SIGNER_CANISTER_ID = LOCAL
 	: STAGING
 		? import.meta.env.VITE_STAGING_SIGNER_CANISTER_ID
 		: import.meta.env.VITE_IC_SIGNER_CANISTER_ID;
-
-export const SIGNER_PAYMENT_TYPE = {
-	PatronPaysIcrc2Cycles: {
-		owner: BACKEND_CANISTER_PRINCIPAL,
-		subaccount: []
-	} as Account
-};
 
 // How long the delegation identity should remain valid?
 // e.g. BigInt(60 * 60 * 1000 * 1000 * 1000) = 1 hour in nanoseconds

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -1,3 +1,4 @@
+import type { Account } from '$declarations/signer/signer.did';
 import { Principal } from '@dfinity/principal';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -56,6 +57,13 @@ export const SIGNER_CANISTER_ID = LOCAL
 	: STAGING
 		? import.meta.env.VITE_STAGING_SIGNER_CANISTER_ID
 		: import.meta.env.VITE_IC_SIGNER_CANISTER_ID;
+
+export const SIGNER_PAYMENT_TYPE = {
+	PatronPaysIcrc2Cycles: {
+		owner: BACKEND_CANISTER_PRINCIPAL,
+		subaccount: []
+	} as Account
+};
 
 // How long the delegation identity should remain valid?
 // e.g. BigInt(60 * 60 * 1000 * 1000 * 1000) = 1 hour in nanoseconds

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -6,8 +6,8 @@ import type {
 } from '$declarations/signer/signer.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { SignerCanister } from '$lib/canisters/signer.canister';
+import { SIGNER_PAYMENT_TYPE } from '$lib/canisters/signer.constants';
 import { SignerCanisterPaymentError } from '$lib/canisters/signer.errors';
-import { BACKEND_CANISTER_ID } from '$lib/constants/app.constants';
 import type { SendBtcParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockedAgent } from '$tests/mocks/agents.mock';
@@ -241,14 +241,7 @@ describe('signer.canister', () => {
 
 			await getEthAddress();
 
-			expect(spy).toHaveBeenNthCalledWith(1, { principal: [] }, [
-				{
-					PatronPaysIcrc2Cycles: {
-						owner: Principal.fromText(BACKEND_CANISTER_ID),
-						subaccount: []
-					}
-				}
-			]);
+			expect(spy).toHaveBeenNthCalledWith(1, { principal: [] }, [SIGNER_PAYMENT_TYPE]);
 		});
 
 		it('should throw an error if eth_address throws', async () => {


### PR DESCRIPTION
# Motivation
The payment type is the same for every paid signer API call.

# Changes
- Move the payment type into a constants file.

# Tests
Existing CI should suffice.