### PR TITLE
fix(devops): Deploy signer before backend

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,8 +3,8 @@
 dfx canister create internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
 dfx canister create pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
 
-./scripts/deploy.backend.sh
 ./scripts/deploy.signer.sh
+./scripts/deploy.backend.sh
 
 mkdir -p ./target/ic
 


### PR DESCRIPTION
# Motivation

The backend needs the CFS canister id.

In this PR, first signer is deployed and then the backend in the `deploy.sh`.

# Changes

* Change order of scripts in `deploy.sh`

# Tests

I tested with a clean dfx replica running `npm run deploy`.
