### PR TITLE
fix(frontend): networkId always undefined in SendModal

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -19,11 +19,15 @@
 	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 
 	export let currentStep: WizardStep | undefined;
-	export let networkId: NetworkId | undefined = undefined;
 	export let destination = '';
 	export let amount: number | undefined = undefined;
 	export let sendProgressStep: string;
 	export let formCancelAction: 'back' | 'close' = 'close';
+
+	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let networkId: NetworkId | undefined = undefined;
+	$: networkId = $sendToken.network.id;
 
 	let source: string;
 	$: source =
@@ -32,8 +36,6 @@
 			: isNetworkIdBTCRegtest(networkId)
 				? $btcAddressRegtest
 				: $btcAddressMainnet) ?? '';
-
-	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
@@ -54,9 +56,9 @@
 		on:icClose
 		bind:destination
 		bind:amount
-		bind:networkId
 		on:icQRCodeScan
 		{source}
+		{networkId}
 	>
 		<svelte:fragment slot="cancel">
 			{#if formCancelAction === 'back'}

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -62,7 +62,6 @@
 			{currentStep}
 			{formCancelAction}
 			bind:destination
-			bind:networkId
 			bind:amount
 			bind:sendProgressStep
 			on:icBack


### PR DESCRIPTION
# Motivation

The `networkId` prop  that is passed down from `SendModal` is actually only defined when `targetNetwork` is there. Because of that, `BtcSendForm` was never receiving `networkId` even though it is relying on it to identify whether it's a regtest, testnet or mainnet btc. 