### PR TITLE
refactor(frontend): Provide type for payment type

### DIFF
--- a/src/frontend/src/lib/canisters/signer.constants.ts
+++ b/src/frontend/src/lib/canisters/signer.constants.ts
@@ -1,9 +1,9 @@
-import type { Account } from '$declarations/signer/signer.did';
+import type { PaymentType } from '$declarations/signer/signer.did';
 import { BACKEND_CANISTER_PRINCIPAL } from '$lib/constants/app.constants';
 
-export const SIGNER_PAYMENT_TYPE = {
+export const SIGNER_PAYMENT_TYPE: PaymentType = {
 	PatronPaysIcrc2Cycles: {
 		owner: BACKEND_CANISTER_PRINCIPAL,
 		subaccount: []
-	} as Account
+	}
 };


### PR DESCRIPTION
# Motivation
The `SIGNER_PAYMENT_TYPE` inner value was fixed, but cleaner is simply to declare the type of the constant.

# Changes
- Declare the type of `SIGNER_PAYMENT_TYPE` instead of coercing the inner.

# Tests
Existing CI should suffice.