### PR TITLE
feat(frontend): do not pass address_type as a param

### DIFF
--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -165,7 +165,6 @@ export class SignerCanister extends Canister<SignerService> {
 	};
 
 	sendBtc = async ({
-		addressType,
 		feeSatoshis,
 		utxosToSpend,
 		...rest
@@ -176,7 +175,7 @@ export class SignerCanister extends Canister<SignerService> {
 
 		const response = await btc_caller_send(
 			{
-				address_type: addressType,
+				address_type: { P2WPKH: null },
 				utxos_to_spend: utxosToSpend,
 				fee_satoshis: feeSatoshis,
 				...rest

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -7,7 +7,6 @@ import type {
 	Utxo
 } from '$declarations/backend/backend.did';
 import type {
-	BitcoinAddressType,
 	BtcTxOutput,
 	BitcoinNetwork as SignerBitcoinNetwork,
 	Utxo as SignerUtxo
@@ -46,6 +45,5 @@ export interface SendBtcParams {
 	feeSatoshis: [] | [bigint];
 	network: SignerBitcoinNetwork;
 	utxosToSpend: SignerUtxo[];
-	addressType: BitcoinAddressType;
 	outputs: BtcTxOutput[];
 }

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -80,7 +80,6 @@ describe('signer.canister', () => {
 				}
 			}
 		],
-		addressType: { P2WPKH: null },
 		outputs: [
 			{
 				destination_address: 'test-address',
@@ -431,7 +430,7 @@ describe('signer.canister', () => {
 					fee_satoshis: sendBtcParams.feeSatoshis,
 					network: sendBtcParams.network,
 					utxos_to_spend: sendBtcParams.utxosToSpend,
-					address_type: sendBtcParams.addressType,
+					address_type: { P2WPKH: null },
 					outputs: sendBtcParams.outputs
 				},
 				[SIGNER_PAYMENT_TYPE]


### PR DESCRIPTION
# Motivation

For the consistency sake, let's keep hardcoded `adrdress_type` inside of `signer.canister` (same as it's done in `getBtcBalance`) instead of passing this value all the way down from the related service.