### PR TITLE
feat(frontend): Ask balance with 1 confirmations

### DIFF
--- a/src/frontend/src/btc/constants/btc.constants.ts
+++ b/src/frontend/src/btc/constants/btc.constants.ts
@@ -1,0 +1,5 @@
+// We want to show the latest balance.
+// Even if it's not totally confirmed (6 confirmations).
+// There is no difference between 0 and 1
+// because the bitcoin canister doesn't know about the mempool and unconfirmed transactions.
+export const BTC_BALANCE_MIN_CONFIRMATIONS = 1;

--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -1,3 +1,4 @@
+import { BTC_BALANCE_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
 import { mapBtcTransaction } from '$btc/utils/btc-transactions.utils';
 import type { BitcoinNetwork } from '$declarations/signer/signer.did';
 import { getBtcBalance } from '$lib/api/signer.api';
@@ -86,7 +87,8 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 	}): Promise<CertifiedData<bigint>> {
 		const balance = await getBtcBalance({
 			identity,
-			network: bitcoinNetwork
+			network: bitcoinNetwork,
+			minConfirmations: BTC_BALANCE_MIN_CONFIRMATIONS
 		});
 		const certifiedBalance = {
 			data: balance,


### PR DESCRIPTION
# Motivation

We want to show the latest balance.

In this PR, we change the requested balance to use only one confirmation.

# Changes

* Create a new constant `BTC_BALANCE_MIN_CONFIRMATIONS`.
* Use the new constat in the btc wallet scheduler when getting the balance.

# Tests

I deplyed the branch to test 2 and confirmed that the balance got updated when the transaction had 1 confirmation.
