### PR TITLE
feat(frontend): remove Networks switcher [GIX-3087]

### DIFF
--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -6,11 +6,12 @@
 	import TokensSignedOut from '$lib/components/tokens/TokensSignedOut.svelte';
 	import Header from '$lib/components/ui/Header.svelte';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
+	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
 <div class:pointer-events-none={$authNotSignedIn} class:blur-[1.5px]={$authNotSignedIn}>
 	<Header>
-		<h2 class="text-base">Tokens</h2>
+		<h2 class="text-base">{$i18n.tokens.text.title}</h2>
 
 		<TokensMenu slot="end" />
 	</Header>

--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
-	import NetworksSwitcher from '$lib/components/networks/NetworksSwitcher.svelte';
 	import ManageTokensButton from '$lib/components/tokens/ManageTokensButton.svelte';
 	import TokensMenu from '$lib/components/tokens/TokensMenu.svelte';
 	import TokensSignedIn from '$lib/components/tokens/TokensSignedIn.svelte';
@@ -11,7 +10,7 @@
 
 <div class:pointer-events-none={$authNotSignedIn} class:blur-[1.5px]={$authNotSignedIn}>
 	<Header>
-		<NetworksSwitcher disabled={$authNotSignedIn} />
+		<h2 class="text-base">Tokens</h2>
 
 		<TokensMenu slot="end" />
 	</Header>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -355,6 +355,7 @@
 	},
 	"tokens": {
 		"text": {
+			"title": "Tokens",
 			"contract_address": "Contract address",
 			"balance": "Balance",
 			"hide_zero_balances": "Hide zero balances",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -312,6 +312,7 @@ interface I18nBuy {
 
 interface I18nTokens {
 	text: {
+		title: string;
 		contract_address: string;
 		balance: string;
 		hide_zero_balances: string;


### PR DESCRIPTION
# Motivation

Time has arrived to remove the Networks switcher.

Since OISY is a multi-chain wallet by it's nature, we can remove the network selector from the home screen. It may be added a possible filter in the future, but not so bluntly, because the user should be driven to have all the tokens from multiple chains in one place.

### Note

The toggle for Testnet networks will be available only in Settings after this PR

# Results

<img width="950" alt="Screenshot 2024-10-10 at 18 00 10" src="https://github.com/user-attachments/assets/91e45a9a-0a21-403b-a9de-6212ac3668af">
<img width="378" alt="Screenshot 2024-10-10 at 18 00 24" src="https://github.com/user-attachments/assets/060c8410-3155-48b1-a072-8d9b7c23b0e5">
