### PR TITLE
refactor(frontend): Rename entries in BtcPendingSentTransactionsStatus

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendHasPendingTransactions.svelte
@@ -7,7 +7,7 @@
 	export let pendingTransactionsStatus: BtcPendingSentTransactionsStatus;
 </script>
 
-{#if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.PRESENT}
+{#if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.SOME}
 	<div in:fade>
 		<WarningBanner>{$i18n.send.info.pending_bitcoin_transaction}</WarningBanner>
 	</div>

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -38,3 +38,4 @@
 		pendingTransactionsStatus={$hasPendingTransactionsStore}
 	/>
 </SendReview>
+NONE

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -21,7 +21,7 @@
 	let disableSend: boolean;
 	// We want to disable send if pending transactions are loading, there was an error or there are pending transactions.
 	$: disableSend =
-		$hasPendingTransactionsStore !== BtcPendingSentTransactionsStatus.EMPTY || invalid;
+		$hasPendingTransactionsStore !== BtcPendingSentTransactionsStatus.NONE || invalid;
 
 	// Should never happen given that the same checks are performed on previous wizard step
 	let invalid = true;
@@ -38,4 +38,3 @@
 		pendingTransactionsStatus={$hasPendingTransactionsStore}
 	/>
 </SendReview>
-NONE

--- a/src/frontend/src/btc/derived/btc-pending-sent-transactions-status.derived.ts
+++ b/src/frontend/src/btc/derived/btc-pending-sent-transactions-status.derived.ts
@@ -10,8 +10,8 @@ import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export enum BtcPendingSentTransactionsStatus {
-	PRESENT = 'has-pending-transactions',
-	EMPTY = 'empty-pending-transactions',
+	SOME = 'has-pending-transactions',
+	NONE = 'empty-pending-transactions',
 	LOADING = 'loading',
 	ERROR = 'error'
 }
@@ -40,14 +40,14 @@ export const initPendingSentTransactionsStatus = (
 				return pendingTransactionsData.data === null
 					? BtcPendingSentTransactionsStatus.ERROR
 					: pendingTransactionsData.data.length > 0
-						? BtcPendingSentTransactionsStatus.PRESENT
-						: BtcPendingSentTransactionsStatus.EMPTY;
+						? BtcPendingSentTransactionsStatus.SOME
+						: BtcPendingSentTransactionsStatus.NONE;
 			}
 
 			if (!$testnets) {
 				if (nonNullish($btcAddressMainnet) && $btcAddressMainnet !== address) {
 					// If the address is not a bitcoin address, there are no pending transactions.
-					return BtcPendingSentTransactionsStatus.EMPTY;
+					return BtcPendingSentTransactionsStatus.NONE;
 				}
 
 				// Return loading while we don't have btc addresses and we can't tell
@@ -62,7 +62,7 @@ export const initPendingSentTransactionsStatus = (
 			const isRegtestEnabled = LOCAL;
 			if (isNotMainnet && isNotTestnet && (isNotRegtest || !isRegtestEnabled)) {
 				// If the address is not a bitcoin address, there are no pending transactions.
-				return BtcPendingSentTransactionsStatus.EMPTY;
+				return BtcPendingSentTransactionsStatus.NONE;
 			}
 
 			// If we reach here is because either addresses nor pending transactions are loaded

--- a/src/frontend/src/tests/btc/derived/btc-pending-sent-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/btc-pending-sent-transactions.derived.spec.ts
@@ -60,30 +60,30 @@ describe('initPendingSentTransactionsStatus', () => {
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.ERROR);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.EMPTY" if address is not the mainnet bitcoin address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.NONE" if address is not the mainnet bitcoin address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			const store = initPendingSentTransactionsStatus('another-address');
-			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.EMPTY);
+			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.NONE);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.PRESENT" if there are pending transactions for the address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.SOME" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
-			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.PRESENT);
+			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.SOME);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.EMPTY" if there are no pending transactions for the address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.NONE" if there are no pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: []
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
-			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.EMPTY);
+			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.NONE);
 		});
 	});
 
@@ -142,53 +142,53 @@ describe('initPendingSentTransactionsStatus', () => {
 			);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.EMPTY" if address is not a bitcoin address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.NONE" if address is not a bitcoin address', () => {
 			loadAllAddresses();
 			expect(get(initPendingSentTransactionsStatus('another-address'))).toBe(
-				BtcPendingSentTransactionsStatus.EMPTY
+				BtcPendingSentTransactionsStatus.NONE
 			);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.PRESENT" if there are pending transactions for the address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.SOME" if there are pending transactions for the address', () => {
 			loadAllAddresses();
 			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressTestnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
-				BtcPendingSentTransactionsStatus.PRESENT
+				BtcPendingSentTransactionsStatus.SOME
 			);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.EMPTY" if pending transactions are present and empty', () => {
+		it('should return "BtcPendingSentTransactionsStatus.NONE" if pending transactions are present and empty', () => {
 			loadAllAddresses();
 			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressTestnet,
 				pendingTransactions: []
 			});
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
-				BtcPendingSentTransactionsStatus.EMPTY
+				BtcPendingSentTransactionsStatus.NONE
 			);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.PRESENT" if there are pending transactions for the address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.SOME" if there are pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
-			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.PRESENT);
+			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.SOME);
 		});
 
-		it('should return "BtcPendingSentTransactionsStatus.EMPTY" if there is empty pending transactions for the address', () => {
+		it('should return "BtcPendingSentTransactionsStatus.NONE" if there is empty pending transactions for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			btcPendingSentTransactionsStore.setPendingTransactions({
 				address: mockAddressMainnet,
 				pendingTransactions: []
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
-			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.EMPTY);
+			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.NONE);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Rename entries for `BtcPendingSentTransactionsStatus` as suggested [here](https://github.com/dfinity/oisy-wallet/pull/2788#discussion_r1795448373) for readability purposes.

# Changes

* Rename `PRESENT` to `SOME` and `EMPTY` to `NONE` in `BtcPendingSentTransactionsStatus` enum.

# Tests

Everything still works.
