### PR TITLE
feat(frontend): Add allowance method to Send services

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -93,6 +93,19 @@ export class InfuraErc20Provider implements Erc20Provider {
 		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);
 		return erc20Contract.populateTransaction.approve(spender, amount);
 	};
+
+	allowance = ({
+		contract: { address: contractAddress },
+		owner,
+		spender
+	}: {
+		contract: Erc20ContractAddress;
+		owner: EthAddress;
+		spender: EthAddress;
+	}): Promise<BigNumber> => {
+		const erc20Contract = new ethers.Contract(contractAddress, ERC20_ABI, this.provider);
+		return erc20Contract.allowance(owner, spender);
+	};
 }
 
 const providers: Record<NetworkId, InfuraErc20Provider> = {

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -170,6 +170,28 @@ const ckErc20HelperContractPrepareTransaction = async ({
 };
 
 /**
+ * Get the current allowance of an Erc20 contract.
+ */
+const erc20ContractAllowance = async ({
+	token,
+	owner,
+	spender,
+	networkId
+}: {
+	networkId: NetworkId;
+	owner: EthAddress;
+	spender: EthAddress;
+} & Pick<SendParams, 'token'>): Promise<BigNumber> => {
+	const { allowance } = infuraErc20Providers(networkId);
+
+	return await allowance({
+		contract: token as Erc20Token,
+		owner,
+		spender
+	});
+};
+
+/**
  * Prepare an Erc20 contract to approve a transaction from another contract (address).
  * i.e. tell an Erc20 contract to approve a transaction from the ckErc20 helper.
  *

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -172,8 +172,9 @@ const ckErc20HelperContractPrepareTransaction = async ({
 /**
  * Get the current allowance of an Erc20 contract.
  */
-// TODO: this function is still not used in the codebase, so for now we export globally
-export const erc20ContractAllowance = async ({
+// TODO: this function is still not used in the codebase, so for now we put an ESLINT exception
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const erc20ContractAllowance = async ({
 	token,
 	owner,
 	spender,

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -172,7 +172,8 @@ const ckErc20HelperContractPrepareTransaction = async ({
 /**
  * Get the current allowance of an Erc20 contract.
  */
-const erc20ContractAllowance = async ({
+// TODO: this function is still not used in the codebase, so for now we export globally
+export const erc20ContractAllowance = async ({
 	token,
 	owner,
 	spender,


### PR DESCRIPTION
# Context

A partner encountered an issue not specific to Oisy, but somehow can be food for thought for improvement.

It may happen that after the approval transaction is done, the transfer transaction may fail for whatever reasons. In this case, the next approval transaction will be rejected, since there is already an approved amount. So, the next transfer transaction will work only if the amount is below the one already approved. Otherwise, the user is blocked until it consumes all the approved amount.

# Example

1. The user wants to convert 10 USDT to ckUSDT:
    1. `approve` transaction for 10 USDT --> _successful_
    2. `transfer_from` transaction for 10 USDT --> _failed_ (for whatever reason)
2. The user wants to convert 20 USDT to ckUSDT:
    1. `approve` transaction for 20 USDT --> _failed_ (the previous approved amount is still there)
    2. `transfer_from` transaction for 20 USDT --> _failed_ (not enough approved amount)
3. The user wants to convert 7 USDT to ckUSDT:
    1. `approve` transaction for 7 USDT --> _failed_ (the previous approved amount is still there)
    2. `transfer_from` transaction for 7 USDT --> _successful_ (remaining approved amount is 3 USDT)

# Practical example

We had a practical example with USDT. Please check the sender wallet transaction history backwards from this one: https://etherscan.io/tx/0x084432404a919c1ee720c906bb5c7a565b6e1fdcd5bb9da32049dddfa21ad23f

# Motivation

As first step to help the User with this: for the Send flow, it is useful to know the allowance of the ERC20 smart contract for the Helper smart contract. In this PR, we add the method in the provider and in the services.

Consequently, in another PR, we will use it.
