### PR TITLE
style(frontend): adjust text elements to new color

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -10,7 +10,7 @@
 
 <p class="mb-2 mt-1 text-dark-blue">{replaceOisyPlaceholders($i18n.tokens.import.text.info)}</p>
 
-<p class="text-blue-ribbon mb-4 font-bold">
+<p class="mb-4 font-bold text-blue-ribbon">
 	<ExternalLink
 		href="https://github.com/dfinity/oisy-wallet/blob/main/HOW-TO.md#custom-icrc-token-integration"
 		ariaLabel={$i18n.tokens.import.text.open_github_howto}

--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -10,7 +10,7 @@
 
 <p class="mb-2 mt-1 text-dark-blue">{replaceOisyPlaceholders($i18n.tokens.import.text.info)}</p>
 
-<p class="mb-4 font-bold text-blue">
+<p class="text-blue-ribbon mb-4 font-bold">
 	<ExternalLink
 		href="https://github.com/dfinity/oisy-wallet/blob/main/HOW-TO.md#custom-icrc-token-integration"
 		ariaLabel={$i18n.tokens.import.text.open_github_howto}

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -86,7 +86,7 @@
 		</div>{:else}
 		<button
 			in:blur
-			class="text flex gap-2 border-0 text-blue"
+			class="text text-blue-ribbon flex gap-2 border-0"
 			on:click={async () => await receive()}
 			><IconReimbursed size="24" /> {$i18n.core.text.refresh}</button
 		>

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -86,7 +86,7 @@
 		</div>{:else}
 		<button
 			in:blur
-			class="text text-blue-ribbon flex gap-2 border-0"
+			class="text flex gap-2 border-0 text-blue-ribbon"
 			on:click={async () => await receive()}
 			><IconReimbursed size="24" /> {$i18n.core.text.refresh}</button
 		>

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -230,7 +230,7 @@
 	>
 		<span class="text-7xl">🤔</span>
 
-		<span class="py-4 text-center font-bold text-blue no-underline"
+		<span class="text-blue-ribbon py-4 text-center font-bold no-underline"
 			>+ {$i18n.tokens.manage.text.do_not_see_import}</span
 		>
 	</button>
@@ -262,7 +262,7 @@
 	<Hr />
 
 	<button
-		class="flex w-full justify-center pb-5 pt-4 text-center font-bold text-blue no-underline"
+		class="text-blue-ribbon flex w-full justify-center pb-5 pt-4 text-center font-bold no-underline"
 		on:click={() => dispatch('icAddToken')}>+ {$i18n.tokens.manage.text.do_not_see_import}</button
 	>
 

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -230,7 +230,7 @@
 	>
 		<span class="text-7xl">🤔</span>
 
-		<span class="text-blue-ribbon py-4 text-center font-bold no-underline"
+		<span class="py-4 text-center font-bold text-blue-ribbon no-underline"
 			>+ {$i18n.tokens.manage.text.do_not_see_import}</span
 		>
 	</button>
@@ -262,7 +262,7 @@
 	<Hr />
 
 	<button
-		class="text-blue-ribbon flex w-full justify-center pb-5 pt-4 text-center font-bold no-underline"
+		class="flex w-full justify-center pb-5 pt-4 text-center font-bold text-blue-ribbon no-underline"
 		on:click={() => dispatch('icAddToken')}>+ {$i18n.tokens.manage.text.do_not_see_import}</button
 	>
 

--- a/src/frontend/src/lib/components/tokens/TokensZeroBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensZeroBalance.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div class="content">
-	<span class="block text-sm text-blue">{$i18n.tokens.text.balance}</span>
+	<span class="block text-sm text-blue-ribbon">{$i18n.tokens.text.balance}</span>
 
 	<div class="flex items-center justify-between">
 		<span class="px-4.5">{$i18n.tokens.text.hide_zero_balances}</span>

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <button
-	class="hover:text-blue-ribbon active:text-blue-ribbon w-full text-left no-underline"
+	class="w-full text-left no-underline hover:text-blue-ribbon active:text-blue-ribbon"
 	aria-label={ariaLabel}
 	on:click
 	{disabled}

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <button
-	class="w-full text-left no-underline hover:text-blue active:text-blue"
+	class="hover:text-blue-ribbon active:text-blue-ribbon w-full text-left no-underline"
 	aria-label={ariaLabel}
 	on:click
 	{disabled}

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -155,7 +155,7 @@ a.as-button {
 	&.text {
 		&:hover,
 		&:active {
-			color: var(--color-blue);
+			color: var(--color-blue-ribbon);
 		}
 	}
 


### PR DESCRIPTION
# Motivation

Using new primary color for text that were still using the old one. A few of them had that color on hovering.


<img width="360" alt="Screenshot 2024-10-11 at 11 04 08" src="https://github.com/user-attachments/assets/cd5a15aa-15eb-456a-bd4f-bccccb61fa25">
<img width="342" alt="Screenshot 2024-10-11 at 11 04 17" src="https://github.com/user-attachments/assets/6894b6b7-3fe7-4da0-997a-98e6e51f09fe">
<img width="678" alt="Screenshot 2024-10-11 at 11 05 33" src="https://github.com/user-attachments/assets/2cb6bfe9-6e3e-4e9b-982b-9edbe6629136">
<img width="377" alt="Screenshot 2024-10-11 at 11 06 07" src="https://github.com/user-attachments/assets/fb28031d-e067-4948-8b53-a2690bdb55d1">



