### PR TITLE
chore(frontend): remove deprecated custom CSS classes for buttons

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -41,10 +41,6 @@ a.as-button {
 		}
 	}
 
-	&.user {
-		border: 1px solid var(--color-blue);
-	}
-
 	&.primary,
 	&.secondary,
 	&.tertiary {
@@ -132,17 +128,6 @@ a.as-button {
 				color: var(--color-secondary);
 			}
 		}
-	}
-
-	&.hero {
-		justify-content: center;
-
-		background: var(--color-off-white);
-		color: var(--color-blue);
-
-		padding: var(--padding-1_5x) var(--padding-3x);
-
-		font-weight: var(--font-weight-bold);
 	}
 
 	&.primary,


### PR DESCRIPTION
# Motivation

Custom CSS classes `user` and `hero` for `button` are deprecated.