### PR TITLE
feat(frontend): fetch and display UTXOs fee on BTC send review step

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -9,6 +9,7 @@
 	} from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import SendReview from '$lib/components/send/SendReview.svelte';
+	import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
@@ -18,12 +19,13 @@
 	export let networkId: NetworkId | undefined = undefined;
 	export let source: string;
 	export let utxosFee: UtxosFee | undefined = undefined;
+	export let progress: (step: ProgressStepsSendBtc) => void;
 
 	let hasPendingTransactionsStore: Readable<BtcPendingSentTransactionsStatus>;
 	$: hasPendingTransactionsStore = initPendingSentTransactionsStatus(source);
 
 	let disableSend: boolean;
-	// We want to disable send if pending transactions or UTXOs fee are loading, there was an error or there are pending transactions.
+	// We want to disable send if pending transactions or UTXOs fee isn't available yet, there was an error or there are pending transactions.
 	$: disableSend =
 		$hasPendingTransactionsStore !== BtcPendingSentTransactionsStatus.NONE ||
 		isNullish(utxosFee) ||
@@ -39,7 +41,7 @@
 </script>
 
 <SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
-	<BtcUtxosFee slot="fee" on:icSelectUtxosFee {utxosFee} />
+	<BtcUtxosFee slot="fee" bind:utxosFee {progress} {networkId} {amount} />
 
 	<BtcSendHasPendingTransactions
 		slot="info"

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
-	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import BtcSendForm from '$btc/components/send/BtcSendForm.svelte';
 	import BtcSendProgress from '$btc/components/send/BtcSendProgress.svelte';
 	import BtcSendReview from '$btc/components/send/BtcSendReview.svelte';
-	import { selectUtxosFee as selectUtxosFeeApi } from '$btc/services/btc-send.services';
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendQrCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
@@ -16,17 +14,10 @@
 		btcAddressRegtest,
 		btcAddressTestnet
 	} from '$lib/derived/address.derived';
-	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
-	import { i18n } from '$lib/stores/i18n.store';
-	import { toastsError } from '$lib/stores/toasts.store';
 	import type { NetworkId } from '$lib/types/network';
-	import {
-		isNetworkIdBTCRegtest,
-		isNetworkIdBTCTestnet,
-		mapNetworkIdToBitcoinNetwork
-	} from '$lib/utils/network.utils';
+	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
 	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 
 	export let currentStep: WizardStep | undefined;
@@ -59,39 +50,14 @@
 
 	// TODO: implement send function when related services are ready
 	const send = () => {};
-
-	const selectUtxosFee = async () => {
-		try {
-			// all required params should be already defined at this stage
-			if (nonNullish(amount) && nonNullish(networkId) && nonNullish($authIdentity)) {
-				const network = mapNetworkIdToBitcoinNetwork(networkId);
-
-				utxosFee = nonNullish(network)
-					? await selectUtxosFeeApi({
-							amount,
-							network,
-							progress,
-							identity: $authIdentity
-						})
-					: undefined;
-			}
-		} catch (err: unknown) {
-			toastsError({
-				msg: { text: $i18n.send.error.unexpected_utxos_fee },
-				err
-			});
-
-			dispatch('icBack');
-		}
-	};
 </script>
 
 {#if currentStep?.name === WizardStepsSend.REVIEW}
 	<BtcSendReview
 		on:icBack
 		on:icSend={send}
-		on:icSelectUtxosFee={selectUtxosFee}
-		{utxosFee}
+		bind:utxosFee
+		{progress}
 		{destination}
 		{amount}
 		{networkId}

--- a/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
@@ -1,21 +1,59 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
+	import { selectUtxosFee as selectUtxosFeeApi } from '$btc/services/btc-send.services';
 	import type { UtxosFee } from '$btc/types/btc-send';
-	import { BTC_DECIMALS } from '$env/tokens.btc.env';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { NetworkId } from '$lib/types/network';
 	import { formatToken } from '$lib/utils/format.utils';
+	import { mapNetworkIdToBitcoinNetwork } from '$lib/utils/network.utils';
 
 	export let utxosFee: UtxosFee | undefined = undefined;
+	export let amount: number | undefined = undefined;
+	export let networkId: NetworkId | undefined = undefined;
+	export let progress: (step: ProgressStepsSendBtc) => void;
+
+	const { sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
-	onMount(() => {
+	const selectUtxosFee = async () => {
+		try {
+			// all required params should be already defined at this stage
+			if (isNullish(amount) || isNullish(networkId) || isNullish($authIdentity)) {
+				return;
+			}
+
+			const network = mapNetworkIdToBitcoinNetwork(networkId);
+
+			utxosFee = nonNullish(network)
+				? await selectUtxosFeeApi({
+						amount,
+						network,
+						progress,
+						identity: $authIdentity
+					})
+				: undefined;
+		} catch (err: unknown) {
+			toastsError({
+				msg: { text: $i18n.send.error.unexpected_utxos_fee },
+				err
+			});
+
+			dispatch('icBack');
+		}
+	};
+
+	onMount(async () => {
 		if (isNullish(utxosFee)) {
-			dispatch('icSelectUtxosFee');
+			await selectUtxosFee();
 		}
 	});
 </script>
@@ -28,8 +66,8 @@
 	{:else}
 		{formatToken({
 			value: BigNumber.from(utxosFee.feeSatoshis),
-			unitName: BTC_DECIMALS,
-			displayDecimals: BTC_DECIMALS
+			unitName: $sendTokenDecimals,
+			displayDecimals: $sendTokenDecimals
 		})}
 		BTC
 	{/if}

--- a/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import { createEventDispatcher, onMount } from 'svelte';
+	import type { UtxosFee } from '$btc/types/btc-send';
+	import { BTC_DECIMALS } from '$env/tokens.btc.env';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { formatToken } from '$lib/utils/format.utils';
+
+	export let utxosFee: UtxosFee | undefined = undefined;
+
+	const dispatch = createEventDispatcher();
+
+	onMount(() => {
+		if (isNullish(utxosFee)) {
+			dispatch('icSelectUtxosFee');
+		}
+	});
+</script>
+
+<Value ref="utxos-fee" element="div">
+	<svelte:fragment slot="label">{$i18n.fee.text.fee}</svelte:fragment>
+
+	{#if isNullish(utxosFee)}
+		<span class="mt-2 block w-full max-w-[140px]"><SkeletonText /></span>
+	{:else}
+		{formatToken({
+			value: BigNumber.from(utxosFee.feeSatoshis),
+			unitName: BTC_DECIMALS,
+			displayDecimals: BTC_DECIMALS
+		})}
+		BTC
+	{/if}
+</Value>

--- a/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { createEventDispatcher, getContext, onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import { selectUtxosFee as selectUtxosFeeApi } from '$btc/services/btc-send.services';
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
@@ -64,11 +65,13 @@
 	{#if isNullish(utxosFee)}
 		<span class="mt-2 block w-full max-w-[140px]"><SkeletonText /></span>
 	{:else}
-		{formatToken({
-			value: BigNumber.from(utxosFee.feeSatoshis),
-			unitName: $sendTokenDecimals,
-			displayDecimals: $sendTokenDecimals
-		})}
+		<span in:fade>
+			{formatToken({
+				value: BigNumber.from(utxosFee.feeSatoshis),
+				unitName: $sendTokenDecimals,
+				displayDecimals: $sendTokenDecimals
+			})}
+		</span>
 		BTC
 	{/if}
 </Value>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -319,7 +319,8 @@
 			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
 			"incompatible_token": "The token is incompatible. Please try again with a compatible token.",
 			"no_btc_network_id": "Current network ($networkId) is not a bitcoin network.",
-			"no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later."
+			"no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later.",
+			"unexpected_utxos_fee": "Something went wrong while calculating transaction fee."
 		}
 	},
 	"convert": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -281,6 +281,7 @@ interface I18nSend {
 		incompatible_token: string;
 		no_btc_network_id: string;
 		no_pending_bitcoin_transaction: string;
+		unexpected_utxos_fee: string;
 	};
 }
 


### PR DESCRIPTION
# Motivation

The goal of this PR is to use the btc-send service to get UTXOs fee and to display it on the review step. The PR could have been split into few pieces, but I think in this particular case it's useful to see the whole picture.

Loading state:
<img width="611" alt="Screenshot 2024-10-11 at 11 42 31" src="https://github.com/user-attachments/assets/084b1f8e-5bfa-4fb9-9a3f-8a9a4934444c">

UTXOs fee has been fetched:
<img width="580" alt="Screenshot 2024-10-11 at 11 42 36" src="https://github.com/user-attachments/assets/971858d1-9313-4b4c-916d-b9ce319d434b">

