### PR TITLE
feat(frontend): Disable if amount higher than balance

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import type { BtcAmountAssertionError } from '$btc/types/btc-send';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 	import { tokenDecimals } from '$lib/derived/token.derived';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
+	import type { BigNumber } from 'alchemy-sdk';
+	import { IcAmountAssertionError } from '$icp/types/ic-send';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	export let amount: number | undefined = undefined;
 	export let amountError: BtcAmountAssertionError | undefined;
@@ -21,6 +24,12 @@
 					tokenDecimals: $sendToken.decimals,
 					tokenStandard: $sendToken.standard
 				});
+
+	$: customValidate = (userAmount: BigNumber): Error | undefined => {
+		if (nonNullish($sendBalance) && userAmount.gt($sendBalance)) {
+			return new IcAmountAssertionError($i18n.send.assertion.insufficient_funds);
+		}
+	};
 </script>
 
 <SendInputAmount
@@ -28,4 +37,5 @@
 	tokenDecimals={$tokenDecimals}
 	bind:error={amountError}
 	{calculateMax}
+	{customValidate}
 />

--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -2,8 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { BigNumber } from 'alchemy-sdk';
 	import { getContext } from 'svelte';
-	import type { BtcAmountAssertionError } from '$btc/types/btc-send';
-	import { IcAmountAssertionError } from '$icp/types/ic-send';
+	import { BtcAmountAssertionError } from '$btc/types/btc-send';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 	import { tokenDecimals } from '$lib/derived/token.derived';
@@ -27,7 +26,7 @@
 
 	$: customValidate = (userAmount: BigNumber): Error | undefined => {
 		if (nonNullish($sendBalance) && userAmount.gt($sendBalance)) {
-			return new IcAmountAssertionError($i18n.send.assertion.insufficient_funds);
+			return new BtcAmountAssertionError($i18n.send.assertion.insufficient_funds);
 		}
 	};
 </script>

--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { BigNumber } from 'alchemy-sdk';
 	import { getContext } from 'svelte';
 	import type { BtcAmountAssertionError } from '$btc/types/btc-send';
+	import { IcAmountAssertionError } from '$icp/types/ic-send';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$icp-eth/stores/send.store';
 	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 	import { tokenDecimals } from '$lib/derived/token.derived';
-	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
-	import type { BigNumber } from 'alchemy-sdk';
-	import { IcAmountAssertionError } from '$icp/types/ic-send';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 
 	export let amount: number | undefined = undefined;
 	export let amountError: BtcAmountAssertionError | undefined;


### PR DESCRIPTION
# Motivation

We want to give fast feedback to the user if a transaction can't be made.

In this PR, compare the amount that the user wants to send to the current balance and show an error is the amount is larger.

This doesn't consider the fee because the fee is calculated based on the amount, the utxos and the current fee of the network in the backend.

# Changes

* Introduce a `customValidate` in `BtcSendAmount`.

# Tests

Tested locally.
