### PR TITLE
feat(devops): Add VITE_BLOCKCHAIN_API_URL to staging deploy

### DIFF
--- a/.github/workflows/frontend-deploy-staging.yml
+++ b/.github/workflows/frontend-deploy-staging.yml
@@ -9,7 +9,7 @@ on:
       network:
         required: true
         type: choice
-        description: "Select the network to deploy to."
+        description: 'Select the network to deploy to.'
         options:
           - staging
           - beta
@@ -17,7 +17,7 @@ on:
       canister:
         required: true
         type: choice
-        description: "Select the canister to deploy."
+        description: 'Select the canister to deploy.'
         options:
           - frontend
           - backend
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Fail if branch is not main
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
@@ -67,6 +66,7 @@ jobs:
             echo "VITE_AUTH_ALTERNATIVE_ORIGINS=${{ secrets.VITE_AUTH_ALTERNATIVE_ORIGINS_STAGING }}" >> $GITHUB_ENV
             echo "VITE_AUTH_DERIVATION_ORIGIN=${{ secrets.VITE_AUTH_DERIVATION_ORIGIN_STAGING }}" >> $GITHUB_ENV
             echo "VITE_NETWORK_BITCOIN_ENABLED=${{ secrets.VITE_NETWORK_BITCOIN_ENABLED_STAGING }}" >> $GITHUB_ENV
+            echo "VITE_BLOCKCHAIN_API_URL=https://blockchain.info" >> $GITHUB_ENV
             echo "VITE_ONRAMPER_API_KEY_DEV=${{ secrets.VITE_ONRAMPER_API_KEY_DEV_STAGING }}" >> $GITHUB_ENV
             echo "VITE_ONRAMPER_API_KEY_PROD=${{ secrets.VITE_ONRAMPER_API_KEY_PROD_STAGING }}" >> $GITHUB_ENV
             {
@@ -90,6 +90,7 @@ jobs:
             echo "VITE_AUTH_ALTERNATIVE_ORIGINS=${{ secrets.VITE_AUTH_ALTERNATIVE_ORIGINS_BETA }}" >> $GITHUB_ENV
             echo "VITE_AUTH_DERIVATION_ORIGIN=${{ secrets.VITE_AUTH_DERIVATION_ORIGIN_BETA }}" >> $GITHUB_ENV
             echo "VITE_NETWORK_BITCOIN_ENABLED=${{ secrets.VITE_NETWORK_BITCOIN_ENABLED_BETA }}" >> $GITHUB_ENV
+            echo "VITE_BLOCKCHAIN_API_URL=https://blockchain.info" >> $GITHUB_ENV
             echo "VITE_ONRAMPER_API_KEY_DEV=${{ secrets.VITE_ONRAMPER_API_KEY_DEV_BETA }}" >> $GITHUB_ENV
             echo "VITE_ONRAMPER_API_KEY_PROD=${{ secrets.VITE_ONRAMPER_API_KEY_PROD_BETA }}" >> $GITHUB_ENV
             {
@@ -113,6 +114,7 @@ jobs:
             echo "VITE_AUTH_ALTERNATIVE_ORIGINS=${{ secrets.VITE_AUTH_ALTERNATIVE_ORIGINS_PROD }}" >> $GITHUB_ENV
             echo "VITE_AUTH_DERIVATION_ORIGIN=${{ secrets.VITE_AUTH_DERIVATION_ORIGIN_PROD }}" >> $GITHUB_ENV
             echo "VITE_NETWORK_BITCOIN_ENABLED=${{ secrets.VITE_NETWORK_BITCOIN_ENABLED_PROD }}" >> $GITHUB_ENV
+            echo "VITE_BLOCKCHAIN_API_URL=https://blockchain.info" >> $GITHUB_ENV
             echo "VITE_ONRAMPER_API_KEY_DEV=${{ secrets.VITE_ONRAMPER_API_KEY_DEV_PROD }}" >> $GITHUB_ENV
             echo "VITE_ONRAMPER_API_KEY_PROD=${{ secrets.VITE_ONRAMPER_API_KEY_PROD_PROD }}" >> $GITHUB_ENV
             {


### PR DESCRIPTION
# Motivation

We want to enable bitcoin in Staging and other environments but bitcoin requires an extra env var apart from the flags that was missing in the current env vars: `VITE_BLOCKCHAIN_API_URL`.

# Changes

* Add `VITE_BLOCKCHAIN_API_URL` in the GH workflow that deploys the frontend.

# Tests

We will test when this PR is merged.
