### PR TITLE
refactor(frontend): invert icons in landing page bullet points [GIX-3044]

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -11,11 +11,11 @@
 	$: infoList = [
 		{
 			label: $i18n.auth.text.safe_access,
-			icon: IconGlasses
+			icon: IconShieldAlert
 		},
 		{
 			label: $i18n.auth.text.privacy_and_security,
-			icon: IconShieldAlert
+			icon: IconGlasses
 		},
 		{
 			label: $i18n.auth.text.powered_by_chain_fusion,


### PR DESCRIPTION
# Motivation

The icons in the landing page bullet points were mixed up.

<img width="640" alt="Screenshot 2024-10-11 at 14 41 44" src="https://github.com/user-attachments/assets/45967c37-0d5f-42a2-9c03-04304afb77f1">
