### PR TITLE
feat(frontend): send btc txId to BE after transaction send has succeeded

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -112,6 +112,7 @@
 				utxosFee,
 				progress,
 				network,
+				source,
 				identity: $authIdentity
 			});
 

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -106,7 +106,6 @@
 		dispatch('icNext');
 
 		try {
-			// TODO: add tracking
 			await sendBtc({
 				destination,
 				amount,

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -106,6 +106,7 @@
 		dispatch('icNext');
 
 		try {
+			// TODO: add tracking
 			await sendBtc({
 				destination,
 				amount,

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -59,6 +59,8 @@ export const sendBtc = async ({
 	// TODO: use txid returned by this method to register it as a pending transaction in BE
 	const { txid } = await send({ progress, utxosFee, network, identity, ...rest });
 
+	progress(ProgressStepsSendBtc.RELOAD);
+
 	await addPendingBtcTransaction({
 		identity,
 		network: mapToSignerBitcoinNetwork({ network }),
@@ -66,8 +68,6 @@ export const sendBtc = async ({
 		txId: hexStringToUint8Array(txid),
 		utxos: utxosFee.utxos
 	});
-
-	progress(ProgressStepsSendBtc.RELOAD);
 
 	await waitAndTriggerWallet();
 };

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -1,7 +1,7 @@
 import type { UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import type { SendBtcResponse } from '$declarations/signer/signer.did';
-import { selectUserUtxosFee } from '$lib/api/backend.api';
+import { addPendingBtcTransaction, selectUserUtxosFee } from '$lib/api/backend.api';
 import { sendBtc as sendBtcApi } from '$lib/api/signer.api';
 import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 import type { BtcAddress } from '$lib/types/address';
@@ -10,6 +10,7 @@ import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import type { Identity } from '@dfinity/agent';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import { toNullable } from '@dfinity/utils';
+import { hexStringToUint8Array } from '@dfinity/utils/dist/types/utils/arrays.utils';
 
 const DEFAULT_MIN_CONFIRMATIONS = 6;
 
@@ -22,6 +23,7 @@ interface BtcSendServiceParams {
 
 type SendBtcParams = BtcSendServiceParams & {
 	destination: BtcAddress;
+	source: BtcAddress;
 	utxosFee: UtxosFee;
 };
 
@@ -46,9 +48,24 @@ export const selectUtxosFee = async ({
 	};
 };
 
-export const sendBtc = async ({ progress, ...rest }: SendBtcParams): Promise<void> => {
+export const sendBtc = async ({
+	progress,
+	utxosFee,
+	network,
+	source,
+	identity,
+	...rest
+}: SendBtcParams): Promise<void> => {
 	// TODO: use txid returned by this method to register it as a pending transaction in BE
-	await send({ progress, ...rest });
+	const { txid } = await send({ progress, utxosFee, network, identity, ...rest });
+
+	await addPendingBtcTransaction({
+		identity,
+		network: mapToSignerBitcoinNetwork({ network }),
+		address: source,
+		txId: hexStringToUint8Array(txid),
+		utxos: utxosFee.utxos
+	});
 
 	progress(ProgressStepsSendBtc.RELOAD);
 
@@ -62,7 +79,7 @@ const send = async ({
 	amount,
 	utxosFee,
 	progress
-}: SendBtcParams): Promise<SendBtcResponse> => {
+}: Omit<SendBtcParams, 'source'>): Promise<SendBtcResponse> => {
 	const satoshisAmount = convertNumberToSatoshis({ amount });
 	const signerBitcoinNetwork = mapToSignerBitcoinNetwork({ network });
 


### PR DESCRIPTION
# Motivation

We need to send btc txId to BE after transaction send has succeeded.
