### PR TITLE
style(frontend): wallet connect disconnect button

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectButton.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectButton.svelte
@@ -3,12 +3,17 @@
 	import { ethAddressNotLoaded } from '$lib/derived/address.derived';
 </script>
 
-<button
-	on:click
-	class="wallet-connect icon desktop-wide text-white"
-	disabled={$ethAddressNotLoaded}
-	class:opacity-0={$ethAddressNotLoaded}
->
+<button on:click class="tertiary text-primary h-10" disabled={$ethAddressNotLoaded}>
 	<IconWalletConnect size="24" />
-	<span class="font-bold"><slot /></span>
+	<slot />
 </button>
+
+<style lang="scss">
+	button {
+		border-radius: var(--border-radius-sm-1_5x);
+
+		&:hover {
+			color: inherit;
+		}
+	}
+</style>

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -144,45 +144,6 @@ a.as-button {
 		}
 	}
 
-	&.wallet-connect {
-		background: var(--color-wallet-connect);
-		border: 1px solid var(--color-wallet-connect);
-
-		padding: var(--button-padding);
-	}
-
-	&.wallet-connect {
-		&.icon {
-			padding: 0;
-			border-radius: 50%;
-
-			width: var(--padding-6x);
-			height: var(--padding-6x);
-
-			display: flex;
-			justify-content: center;
-			align-items: center;
-
-			span:not(.block) {
-				display: none;
-			}
-
-			@include media.min-width(medium) {
-				&.desktop-wide {
-					padding: var(--button-padding);
-					border-radius: var(--button-border-radius);
-
-					width: inherit;
-					height: inherit;
-
-					span {
-						display: block;
-					}
-				}
-			}
-		}
-	}
-
 	&.icon {
 		@include button.icon;
 	}


### PR DESCRIPTION
# Motivation

The style of the WalletConnect disconnect button didn't fits the new design aynmore.

# Changes

- Update style
- Remove custom button global style

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-14 à 07 23 57" src="https://github.com/user-attachments/assets/80fd66d7-b992-4143-bcd6-523400ab0d3e">

After:

<img width="1536" alt="Capture d’écran 2024-10-14 à 07 23 42" src="https://github.com/user-attachments/assets/395711c8-9312-48c3-92b2-bf44fb87ceb7">

