### PR TITLE
feat(frontend): Show warning and disable send if no utxos

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import type { Readable } from 'svelte/store';
-	import BtcSendHasPendingTransactions from './BtcSendHasPendingTransactions.svelte';
+	import BtcSendWarnings from './BtcSendWarnings.svelte';
 	import BtcUtxosFee from '$btc/components/send/BtcUtxosFee.svelte';
 	import {
 		BtcPendingSentTransactionsStatus,
@@ -29,6 +29,7 @@
 	$: disableSend =
 		$hasPendingTransactionsStore !== BtcPendingSentTransactionsStatus.NONE ||
 		isNullish(utxosFee) ||
+		utxosFee.utxos.length === 0 ||
 		invalid;
 
 	// Should never happen given that the same checks are performed on previous wizard step
@@ -43,8 +44,9 @@
 <SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
 	<BtcUtxosFee slot="fee" bind:utxosFee {progress} {networkId} {amount} />
 
-	<BtcSendHasPendingTransactions
+	<BtcSendWarnings
 		slot="info"
+		{utxosFee}
 		pendingTransactionsStatus={$hasPendingTransactionsStore}
 	/>
 </SendReview>

--- a/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import { BtcPendingSentTransactionsStatus } from '$btc/derived/btc-pending-sent-transactions-status.derived';
+	import type { UtxosFee } from '$btc/types/btc-send';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { UtxosFee } from '$btc/types/btc-send';
 
 	export let pendingTransactionsStatus: BtcPendingSentTransactionsStatus;
 	export let utxosFee: UtxosFee | undefined = undefined;

--- a/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
@@ -3,8 +3,10 @@
 	import { BtcPendingSentTransactionsStatus } from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { UtxosFee } from '$btc/types/btc-send';
 
 	export let pendingTransactionsStatus: BtcPendingSentTransactionsStatus;
+	export let utxosFee: UtxosFee | undefined = undefined;
 </script>
 
 {#if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.SOME}
@@ -14,5 +16,11 @@
 {:else if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.ERROR}
 	<div in:fade>
 		<WarningBanner>{$i18n.send.error.no_pending_bitcoin_transaction}</WarningBanner>
+	</div>
+{/if}
+
+{#if utxosFee?.utxos.length === 0}
+	<div in:fade>
+		<WarningBanner>{$i18n.send.info.no_available_utxos}</WarningBanner>
 	</div>
 {/if}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -286,7 +286,8 @@
 		"info": {
 			"ckbtc_certified": "Please wait until the ckBTC parameters have been certified.",
 			"cketh_certified": "Please wait until the ckETH parameters have been certified.",
-			"pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete."
+			"pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete.",
+			"no_available_utxos": "You won't have available utxos to perform this transaction."
 		},
 		"assertion": {
 			"invalid_destination_address": "Invalid destination address",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -248,7 +248,12 @@ interface I18nSend {
 		enter_wallet_address: string;
 		select_network: string;
 	};
-	info: { ckbtc_certified: string; cketh_certified: string; pending_bitcoin_transaction: string };
+	info: {
+		ckbtc_certified: string;
+		cketh_certified: string;
+		pending_bitcoin_transaction: string;
+		no_available_utxos: string;
+	};
 	assertion: {
 		invalid_destination_address: string;
 		insufficient_funds: string;


### PR DESCRIPTION
# Motivation

User can't send tokens if there are not available utxos.

Show a warning if the endpoint to select utxos and the fee returns no utxos.

# Changes

* Rename `BtcSendHasPendingTransactions` to `BtcSendWarnings`.
* Add prop `utxosFee` to `BtcSendWarnings` and use it to add a warning.
* Add new i18n key.

# Tests

Tested locally.
