### PR TITLE
style(frontend): set better disabled colors for tertiary button

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -53,10 +53,9 @@ a.as-button {
 			opacity: 1;
 			cursor: not-allowed;
 
-			&:hover,
-			&:active {
-				background: var(--color-grey);
-				color: var(--color-white);
+			&.tertiary {
+				background: var(--color-white);
+				color: var(--color-grey);
 			}
 		}
 
@@ -83,7 +82,7 @@ a.as-button {
 		}
 	}
 
-	&.primary {
+	&.primary:not([disabled]):not(.disabled) {
 		background: var(--color-blue-ribbon);
 		color: var(--color-white);
 
@@ -96,7 +95,7 @@ a.as-button {
 		}
 	}
 
-	&.secondary {
+	&.secondary:not([disabled]):not(.disabled) {
 		background: var(--color-zumthor);
 		color: var(--color-primary);
 
@@ -109,7 +108,7 @@ a.as-button {
 		}
 	}
 
-	&.tertiary {
+	&.tertiary:not([disabled]):not(.disabled) {
 		background: var(--color-white);
 
 		&:hover {


### PR DESCRIPTION
# Motivation

We adjust the colors of the `tertiary` button class to be consistent with the other classes.

### Before

<img width="676" alt="Screenshot 2024-10-14 at 11 57 54" src="https://github.com/user-attachments/assets/152c67ac-61aa-4d29-9883-0eb1b5166718">

### After

<img width="675" alt="Screenshot 2024-10-14 at 11 55 31" src="https://github.com/user-attachments/assets/9f211371-604b-4ce0-9dcd-800368d4dca0">

### The rest is unchanged

<img width="610" alt="Screenshot 2024-10-14 at 11 55 35" src="https://github.com/user-attachments/assets/32bf34a1-7595-4af5-a21d-070e6ee12ef2">


