### PR TITLE
feat(frontend): take fees into account while calculating BTC tx value

### DIFF
--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -4,7 +4,7 @@ import {
 } from '$btc/constants/btc.constants';
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { BtcAddress } from '$lib/types/address';
-import type { BitcoinOutput, BitcoinTransaction } from '$lib/types/blockchain';
+import type { BitcoinTransaction } from '$lib/types/blockchain';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const mapBtcTransaction = ({
@@ -16,10 +16,50 @@ export const mapBtcTransaction = ({
 	btcAddress: BtcAddress;
 	latestBitcoinBlockHeight: number;
 }): BtcTransactionUi => {
-	const isTypeSend = inputs.some(({ prev_out }) => prev_out.addr === btcAddress);
-	const output: BitcoinOutput | undefined = out.find(({ addr }) =>
-		isTypeSend ? addr !== btcAddress : addr === btcAddress
+	const { totalInputValue, isTypeSend } = inputs.reduce<{
+		totalInputValue: number;
+		isTypeSend: boolean;
+	}>(
+		(acc, { prev_out: { value, addr } }) => ({
+			totalInputValue: acc.totalInputValue + value,
+			isTypeSend: !acc.isTypeSend ? addr === btcAddress : acc.isTypeSend
+		}),
+		{
+			totalInputValue: 0,
+			isTypeSend: false
+		}
 	);
+
+	const { totalOutputValue, value, to } = out.reduce<{
+		totalOutputValue: number;
+		value: number | undefined;
+		to: string | undefined;
+	}>(
+		(acc, { addr, value }) => {
+			const isValidOutput =
+				(isTypeSend && addr !== btcAddress) || (!isTypeSend && addr === btcAddress);
+
+			if (isNullish(acc.value) && isValidOutput) {
+				acc.value = (acc.value ?? 0) + value;
+			}
+
+			if (isNullish(acc.to) && isValidOutput) {
+				acc.to = addr;
+			}
+
+			return {
+				...acc,
+				totalOutputValue: acc.totalOutputValue + value
+			};
+		},
+		{
+			totalOutputValue: 0,
+			value: undefined,
+			to: undefined
+		}
+	);
+
+	const utxosFee = totalInputValue - totalOutputValue;
 
 	const confirmations = nonNullish(block_index)
 		? latestBitcoinBlockHeight - block_index
@@ -35,11 +75,11 @@ export const mapBtcTransaction = ({
 	return {
 		id: hash,
 		timestamp: BigInt(time),
-		value: nonNullish(output?.value) ? BigInt(output.value) : undefined,
+		value: nonNullish(value) ? BigInt(isTypeSend ? value + utxosFee : value) : undefined,
 		status,
 		blockNumber: block_index ?? undefined,
 		type: isTypeSend ? 'send' : 'receive',
 		from: isTypeSend ? btcAddress : inputs[0].prev_out.addr,
-		to: nonNullish(output) ? (isTypeSend ? output.addr : btcAddress) : undefined
+		to
 	};
 };

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -37,6 +37,7 @@ export const mapBtcTransaction = ({
 		to: string | undefined;
 	}>(
 		(acc, { addr, value }) => {
+			// TODO: test what happens when user sends to the current address (hence isValidOutput = false)
 			const isValidOutput =
 				(isTypeSend && addr !== btcAddress) || (!isTypeSend && addr === btcAddress);
 

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -7,6 +7,7 @@ import type { BtcAddress } from '$lib/types/address';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
+// TODO: Add docs/comments to the steps needed to parse a BTC tx
 export const mapBtcTransaction = ({
 	transaction: { inputs, block_index, out, hash, time },
 	btcAddress,
@@ -22,7 +23,7 @@ export const mapBtcTransaction = ({
 	}>(
 		(acc, { prev_out: { value, addr } }) => ({
 			totalInputValue: acc.totalInputValue + value,
-			isTypeSend: !acc.isTypeSend ? addr === btcAddress : acc.isTypeSend
+			isTypeSend: acc.isTypeSend ? acc.isTypeSend : addr === btcAddress
 		}),
 		{
 			totalInputValue: 0,


### PR DESCRIPTION
# Motivation

The previous implementation didn't take utxos fee into account while calculating a transaction value for "send" txs. In this PR, I update the implementation in order to get complete numbers. The mapper is implemented the way that it loops through `inputs` and `out` just once to get all required vars.

Previous values:
<img width="631" alt="Screenshot 2024-10-14 at 12 20 13" src="https://github.com/user-attachments/assets/d0257cca-49d1-4885-a4fe-8c0a863ef08b">

Updated values:
<img width="614" alt="Screenshot 2024-10-14 at 12 20 18" src="https://github.com/user-attachments/assets/4a4c7333-9d31-48c3-958a-23bfecbc8486">

Note: please ignore the UI, it will be tackled separately. 
