### PR TITLE
feat(frontend): Disable "Max" when sending btc

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -14,6 +14,8 @@
 
 	const { sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
+	// TODO: Enable Max button by passing the `calculateMax` prop - https://dfinity.atlassian.net/browse/GIX-3114
+
 	$: customValidate = (userAmount: BigNumber): Error | undefined => {
 		// calculate-UTXOs-fee endpoint only accepts "userAmount > 0"
 		if (invalidAmount(userAmount.toNumber()) || userAmount.isZero()) {

--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import type { BigNumber } from 'alchemy-sdk';
 	import { getContext } from 'svelte';
 	import { BtcAmountAssertionError } from '$btc/types/btc-send';
@@ -8,22 +8,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { invalidAmount } from '$lib/utils/input.utils';
-	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 
 	export let amount: number | undefined = undefined;
 	export let amountError: BtcAmountAssertionError | undefined;
 
-	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
-
-	$: calculateMax = (): number | undefined =>
-		isNullish($sendToken)
-			? undefined
-			: // TODO: Add fee to the calculation
-				getMaxTransactionAmount({
-					balance: $sendBalance ?? undefined,
-					tokenDecimals: $sendToken.decimals,
-					tokenStandard: $sendToken.standard
-				});
+	const { sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	$: customValidate = (userAmount: BigNumber): Error | undefined => {
 		// calculate-UTXOs-fee endpoint only accepts "userAmount > 0"
@@ -41,6 +30,5 @@
 	bind:amount
 	tokenDecimals={$tokenDecimals}
 	bind:error={amountError}
-	{calculateMax}
 	{customValidate}
 />


### PR DESCRIPTION
# Motivation

Calculating the maximum amount to send for a bitcoin wallet takes some calculation.

For the MVP, we disable the max button that will be enabled once the calculation is added to the endpoint to select utxos and fee.

# Changes

* Remove the function to calculate the bitcoin max amount which was anyway incorrect and that disables the Max button.

# Tests

Tested locally.
