### PR TITLE
refactor(frontend): move Alpha warning inside the Hero when signed in

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -16,7 +16,6 @@
 
 <header
 	class="z-1 relative grid w-full max-w-screen-2.5xl grid-cols-2 items-center gap-y-5 px-4 pt-6 sm:px-8"
-	class:sm:grid-cols-[1fr_auto_1fr]={$authSignedIn}
 	class:xl:grid-cols-[1fr_auto_1fr]={$authNotSignedIn}
 >
 	{#if back}
@@ -25,19 +24,13 @@
 		<OisyWalletLogoLink />
 	{/if}
 
-	<div
-		class="col-span-3 col-start-1 row-start-2 flex"
-		class:sm:col-span-1={$authSignedIn}
-		class:xl:col-span-1={$authNotSignedIn}
-		class:sm:col-start-2={$authSignedIn}
-		class:xl:col-start-2={$authNotSignedIn}
-		class:sm:row-start-1={$authSignedIn}
-		class:xl:row-start-1={$authNotSignedIn}
-		class:sm:w-fit={$authSignedIn}
-		class:xl:w-fit={$authNotSignedIn}
-	>
-		<Alpha />
-	</div>
+	{#if $authNotSignedIn}
+		<div
+			class="col-span-3 col-start-1 row-start-2 flex xl:col-span-1 xl:col-start-2 xl:row-start-1 xl:w-fit"
+		>
+			<Alpha />
+		</div>
+	{/if}
 
 	<div class="flex justify-end gap-4">
 		{#if $authSignedIn}

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
+	import Alpha from '$lib/components/core/Alpha.svelte';
 	import HeroContent from '$lib/components/hero/HeroContent.svelte';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 
@@ -12,5 +13,8 @@
 	class="relative flex flex-col items-center rounded-lg pb-6"
 	transition:slide={SLIDE_PARAMS}
 >
+	<div class="py-4">
+		<Alpha />
+	</div>
 	<HeroContent {usdTotal} {summary} {back} />
 </article>


### PR DESCRIPTION
# Motivation

Since we are going to change the general layout of the elements when signed in, we need to move the Alpha warning to a place where it will not be affected by that.


<img width="1819" alt="Screenshot 2024-10-14 at 16 31 03" src="https://github.com/user-attachments/assets/173f7f58-e85e-41ea-9982-7597cb8def71">
<img width="885" alt="Screenshot 2024-10-14 at 16 31 15" src="https://github.com/user-attachments/assets/53dfc77d-b506-4c85-8de1-b8ef740e85b7">
<img width="544" alt="Screenshot 2024-10-14 at 16 31 22" src="https://github.com/user-attachments/assets/c82c72f9-9892-490f-9431-d7d81f3d38d3">
