### PR TITLE
feat(frontend): BTC transaction status based on current block height

### DIFF
--- a/src/frontend/src/btc/constants/btc.constants.ts
+++ b/src/frontend/src/btc/constants/btc.constants.ts
@@ -3,3 +3,10 @@
 // There is no difference between 0 and 1
 // because the bitcoin canister doesn't know about the mempool and unconfirmed transactions.
 export const BTC_BALANCE_MIN_CONFIRMATIONS = 1;
+
+// 0 confirmations (or undefined) - transaction status "pending"
+// 1 - 5 confirmations - transaction status "unconfirmed"
+// 6 and more confirmations - transaction status "confirmed"
+export const PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS = 0;
+export const UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS = 1;
+export const CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS = 6;

--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -3,7 +3,7 @@ import { mapBtcTransaction } from '$btc/utils/btc-transactions.utils';
 import type { BitcoinNetwork } from '$declarations/signer/signer.did';
 import { getBtcBalance } from '$lib/api/signer.api';
 import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
-import { btcAddressData } from '$lib/rest/blockchain.rest';
+import { btcAddressData, btcLatestBlock } from '$lib/rest/blockchain.rest';
 import { SchedulerTimer, type Scheduler, type SchedulerJobData } from '$lib/schedulers/scheduler';
 import type { BtcAddress } from '$lib/types/address';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
@@ -120,8 +120,9 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 			? await this.loadBtcTransactions({ btcAddress })
 			: [];
 
+		const { height } = await btcLatestBlock();
 		const uncertifiedTransactions = newTransactions.map((transaction) => ({
-			data: mapBtcTransaction({ transaction, btcAddress }),
+			data: mapBtcTransaction({ transaction, btcAddress, latestBitcoinBlockHeight: height }),
 			certified: false
 		}));
 

--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -1,6 +1,6 @@
 import type { TransactionType, TransactionUiCommon } from '$lib/types/transaction';
 
-export type BtcTransactionStatus = 'confirmed' | 'pending';
+export type BtcTransactionStatus = 'confirmed' | 'pending' | 'unconfirmed';
 
 export interface BtcTransactionUi extends TransactionUiCommon {
 	id: string;

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -26,7 +26,7 @@ export const mapBtcTransaction = ({
 		: undefined;
 
 	const status =
-		isNullish(confirmations) || confirmations === PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS
+		isNullish(confirmations) || confirmations <= PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS
 			? 'pending'
 			: confirmations >= CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 				? 'confirmed'

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -1,26 +1,41 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { BtcAddress } from '$lib/types/address';
 import type { BitcoinOutput, BitcoinTransaction } from '$lib/types/blockchain';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const mapBtcTransaction = ({
 	transaction: { inputs, block_index, out, hash, time },
-	btcAddress
+	btcAddress,
+	latestBitcoinBlockHeight
 }: {
 	transaction: BitcoinTransaction;
 	btcAddress: BtcAddress;
+	latestBitcoinBlockHeight: number;
 }): BtcTransactionUi => {
 	const isTypeSend = inputs.some(({ prev_out }) => prev_out.addr === btcAddress);
-	const blockIndexAvailable = nonNullish(block_index);
 	const output: BitcoinOutput | undefined = out.find(({ addr }) =>
 		isTypeSend ? addr !== btcAddress : addr === btcAddress
 	);
+
+	const confirmations = nonNullish(block_index)
+		? latestBitcoinBlockHeight - block_index
+		: undefined;
+
+	// 0 confirmations (or undefined) - status "pending"
+	// 1 - 5 confirmations - status "unconfirmed"
+	// 6 and more confirmations - status "confirmed"
+	const status =
+		isNullish(confirmations) || confirmations === 0
+			? 'pending'
+			: confirmations >= 6
+				? 'confirmed'
+				: 'unconfirmed';
 
 	return {
 		id: hash,
 		timestamp: BigInt(time),
 		value: nonNullish(output?.value) ? BigInt(output.value) : undefined,
-		status: blockIndexAvailable ? 'confirmed' : 'pending',
+		status,
 		blockNumber: block_index ?? undefined,
 		type: isTypeSend ? 'send' : 'receive',
 		from: isTypeSend ? btcAddress : inputs[0].prev_out.addr,

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -1,3 +1,7 @@
+import {
+	CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS,
+	PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS
+} from '$btc/constants/btc.constants';
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { BtcAddress } from '$lib/types/address';
 import type { BitcoinOutput, BitcoinTransaction } from '$lib/types/blockchain';
@@ -21,13 +25,10 @@ export const mapBtcTransaction = ({
 		? latestBitcoinBlockHeight - block_index
 		: undefined;
 
-	// 0 confirmations (or undefined) - status "pending"
-	// 1 - 5 confirmations - status "unconfirmed"
-	// 6 and more confirmations - status "confirmed"
 	const status =
-		isNullish(confirmations) || confirmations === 0
+		isNullish(confirmations) || confirmations === PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS
 			? 'pending'
-			: confirmations >= 6
+			: confirmations >= CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 				? 'confirmed'
 				: 'unconfirmed';
 

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -7,7 +7,8 @@ describe('mapBtcTransaction', () => {
 	it('should map correctly when receive transaction is pending', () => {
 		const result = mapBtcTransaction({
 			transaction: mockBtcTransaction,
-			btcAddress: mockBtcAddress
+			btcAddress: mockBtcAddress,
+			latestBitcoinBlockHeight: 1
 		});
 		const expectedResult = {
 			...mockBtcTransactionUi,
@@ -18,13 +19,33 @@ describe('mapBtcTransaction', () => {
 		expect(result).toEqual(expectedResult);
 	});
 
+	it('should map correctly when receive transaction is unconfirmed', () => {
+		const transaction = {
+			...mockBtcTransaction,
+			block_index: mockBtcTransactionUi.blockNumber
+		} as BitcoinTransaction;
+
+		const result = mapBtcTransaction({
+			transaction,
+			btcAddress: mockBtcAddress,
+			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 1
+		});
+		const expectedResult = { ...mockBtcTransactionUi, status: 'unconfirmed' };
+
+		expect(result).toEqual(expectedResult);
+	});
+
 	it('should map correctly when receive transaction is confirmed', () => {
 		const transaction = {
 			...mockBtcTransaction,
 			block_index: mockBtcTransactionUi.blockNumber
 		} as BitcoinTransaction;
 
-		const result = mapBtcTransaction({ transaction, btcAddress: mockBtcAddress });
+		const result = mapBtcTransaction({
+			transaction,
+			btcAddress: mockBtcAddress,
+			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 6
+		});
 
 		expect(result).toEqual(mockBtcTransactionUi);
 	});
@@ -34,7 +55,11 @@ describe('mapBtcTransaction', () => {
 			...mockBtcTransaction,
 			inputs: [...mockBtcTransaction.inputs, { prev_out: { addr: mockBtcAddress } }]
 		} as BitcoinTransaction;
-		const result = mapBtcTransaction({ transaction, btcAddress: mockBtcAddress });
+		const result = mapBtcTransaction({
+			transaction,
+			btcAddress: mockBtcAddress,
+			latestBitcoinBlockHeight: 1
+		});
 		const expectedResult = {
 			...mockBtcTransactionUi,
 			from: mockBtcAddress,
@@ -48,13 +73,40 @@ describe('mapBtcTransaction', () => {
 		expect(result).toEqual(expectedResult);
 	});
 
+	it('should map correctly when send transaction is unconfirmed', () => {
+		const transaction = {
+			...mockBtcTransaction,
+			block_index: mockBtcTransactionUi.blockNumber,
+			inputs: [...mockBtcTransaction.inputs, { prev_out: { addr: mockBtcAddress } }]
+		} as BitcoinTransaction;
+		const result = mapBtcTransaction({
+			transaction,
+			btcAddress: mockBtcAddress,
+			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 3
+		});
+		const expectedResult = {
+			...mockBtcTransactionUi,
+			status: 'unconfirmed',
+			from: mockBtcAddress,
+			to: mockBtcTransaction.out[0].addr,
+			value: BigInt(mockBtcTransaction.out[0].value),
+			type: 'send'
+		};
+
+		expect(result).toEqual(expectedResult);
+	});
+
 	it('should map correctly when send transaction is confirmed', () => {
 		const transaction = {
 			...mockBtcTransaction,
 			block_index: mockBtcTransactionUi.blockNumber,
 			inputs: [...mockBtcTransaction.inputs, { prev_out: { addr: mockBtcAddress } }]
 		} as BitcoinTransaction;
-		const result = mapBtcTransaction({ transaction, btcAddress: mockBtcAddress });
+		const result = mapBtcTransaction({
+			transaction,
+			btcAddress: mockBtcAddress,
+			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 10
+		});
 		const expectedResult = {
 			...mockBtcTransactionUi,
 			from: mockBtcAddress,

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -1,3 +1,7 @@
+import {
+	CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS,
+	UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+} from '$btc/constants/btc.constants';
 import { mapBtcTransaction } from '$btc/utils/btc-transactions.utils';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
 import { mockBtcAddress, mockBtcTransaction, mockBtcTransactionUi } from '$tests/mocks/btc.mock';
@@ -28,7 +32,8 @@ describe('mapBtcTransaction', () => {
 		const result = mapBtcTransaction({
 			transaction,
 			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 1
+			latestBitcoinBlockHeight:
+				(mockBtcTransactionUi.blockNumber ?? 0) + UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 		});
 		const expectedResult = { ...mockBtcTransactionUi, status: 'unconfirmed' };
 
@@ -44,7 +49,8 @@ describe('mapBtcTransaction', () => {
 		const result = mapBtcTransaction({
 			transaction,
 			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 6
+			latestBitcoinBlockHeight:
+				(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 		});
 
 		expect(result).toEqual(mockBtcTransactionUi);
@@ -82,7 +88,8 @@ describe('mapBtcTransaction', () => {
 		const result = mapBtcTransaction({
 			transaction,
 			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 3
+			latestBitcoinBlockHeight:
+				(mockBtcTransactionUi.blockNumber ?? 0) + UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 		});
 		const expectedResult = {
 			...mockBtcTransactionUi,
@@ -105,7 +112,8 @@ describe('mapBtcTransaction', () => {
 		const result = mapBtcTransaction({
 			transaction,
 			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight: (mockBtcTransactionUi.blockNumber ?? 0) + 10
+			latestBitcoinBlockHeight:
+				(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 		});
 		const expectedResult = {
 			...mockBtcTransactionUi,


### PR DESCRIPTION
# Motivation

In this PR, I fetch the current BTC block height to determine whether a transaction is confirmed, unconfirmed or pending. This will be used in:

1. Transaction list - an item will have a status displayed, plus pending txs will have "disabled" background.
2. The number of confirmations will be displayed in the tx detail view.

The UI PRs will be done separately.