### PR TITLE
chore(frontend): deprecated button sub-class full

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -129,13 +129,6 @@ a.as-button {
 		}
 	}
 
-	&.primary,
-	&.secondary {
-		&.full {
-			width: 100%;
-		}
-	}
-
 	&.text {
 		&:hover,
 		&:active {


### PR DESCRIPTION
# Motivation

The sub-class `full` for buttons is deprecated, since it is now handled by tailwind into the `Button` component.
