### PR TITLE
style(frontend): Increase menu width for bigger screens [GIX-3045]

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -15,7 +15,7 @@
 			: 'tokens';
 </script>
 
-<div class=" flex w-full flex-col gap-3 py-3">
+<div class="box-content flex w-full flex-col gap-3 py-3 pl-4 sm:pl-8">
 	<NavigationItem
 		href="/"
 		ariaLabel={$i18n.navigation.alt.tokens}

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -2,7 +2,7 @@
 	class="relative mx-auto max-w-screen-2.5xl pt-8 sm:flex sm:w-full sm:flex-row lg:w-auto lg:pt-0"
 >
 	<div
-		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out sm:visible sm:fixed sm:top-0 sm:mt-24 sm:block sm:min-w-44 sm:translate-x-0 md:transition-none"
+		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out sm:visible sm:fixed sm:top-0 sm:mt-24 sm:block sm:min-w-36 sm:translate-x-0 md:transition-none lg:min-w-44 xl:min-w-72"
 	>
 		<slot name="menu" />
 	</div>

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -37,9 +37,7 @@
 
 	<AuthGuard>
 		<SplitPane>
-			<div class="pl-4 sm:pl-8" slot="menu">
-				<NavigationMenu />
-			</div>
+			<NavigationMenu slot="menu" />
 
 			{#if route !== 'settings'}
 				<Hero


### PR DESCRIPTION
# Motivation

More width when we are on larger screens. Since the menu is in an `absolute` position, we cannot use `flex`, but `min-w-`.


<img width="1900" alt="Screenshot 2024-10-15 at 11 35 11" src="https://github.com/user-attachments/assets/469afcef-2a43-456f-9b42-ae488f535512">
<img width="1184" alt="Screenshot 2024-10-15 at 11 35 22" src="https://github.com/user-attachments/assets/f60aa6c9-4e70-4c1b-93be-bc1efab1369d">
<img width="767" alt="Screenshot 2024-10-15 at 11 35 30" src="https://github.com/user-attachments/assets/785d4b95-2926-4634-89f5-27e78526d63a">
