### PR TITLE
feat(frontend): "unconfirmed" BTC transaction UI

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -17,6 +17,9 @@
 
 	let pending: boolean;
 	$: pending = status === 'pending';
+
+	let unconfirmed: boolean;
+	$: unconfirmed = status === 'unconfirmed';
 </script>
 
 <Transaction
@@ -25,4 +28,5 @@
 	{type}
 	{timestamp}
 	{pending}
+	{unconfirmed}
 />

--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -14,12 +14,6 @@
 	let type: TransactionType;
 
 	$: ({ type, status, value, timestamp } = transaction);
-
-	let pending: boolean;
-	$: pending = status === 'pending';
-
-	let unconfirmed: boolean;
-	$: unconfirmed = status === 'unconfirmed';
 </script>
 
 <Transaction
@@ -27,6 +21,5 @@
 	value={nonNullish(value) ? BigNumber.from(value) : undefined}
 	{type}
 	{timestamp}
-	{pending}
-	{unconfirmed}
+	{status}
 />

--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -1,6 +1,10 @@
-import type { TransactionType, TransactionUiCommon } from '$lib/types/transaction';
+import type {
+	TransactionStatus,
+	TransactionType,
+	TransactionUiCommon
+} from '$lib/types/transaction';
 
-export type BtcTransactionStatus = 'confirmed' | 'pending' | 'unconfirmed';
+export type BtcTransactionStatus = TransactionStatus;
 
 export interface BtcTransactionUi extends TransactionUiCommon {
 	id: string;

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -4,18 +4,17 @@
 	import type { ComponentType } from 'svelte';
 	import IconReceive from '$lib/components/icons/IconReceive.svelte';
 	import IconSend from '$lib/components/icons/IconSend.svelte';
-	import TransactionStatus from '$lib/components/transactions/TransactionStatus.svelte';
+	import TransactionStatusComponent from '$lib/components/transactions/TransactionStatus.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import RoundedIcon from '$lib/components/ui/RoundedIcon.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { TransactionType } from '$lib/types/transaction';
+	import type { TransactionType, TransactionStatus } from '$lib/types/transaction';
 	import { formatSecondsToDate } from '$lib/utils/format.utils.js';
 
 	export let value: BigNumber | undefined;
 	export let type: TransactionType;
-	export let pending: boolean;
-	export let unconfirmed: boolean | undefined;
+	export let status: TransactionStatus;
 	export let timestamp: bigint | undefined;
 
 	let label: string;
@@ -23,13 +22,16 @@
 
 	let icon: ComponentType;
 	$: icon = type === 'send' ? IconSend : IconReceive;
+
+	let iconWithOpacity: boolean;
+	$: iconWithOpacity = status === 'pending' || status === 'unconfirmed';
 </script>
 
 <button class="contents" on:click>
 	<Card>
 		<span class="inline-block first-letter:capitalize">{label}</span>
 
-		<RoundedIcon slot="icon" {icon} iconStyleClass={pending || unconfirmed ? 'opacity-10' : ''} />
+		<RoundedIcon slot="icon" {icon} iconStyleClass={iconWithOpacity ? 'opacity-10' : ''} />
 
 		<svelte:fragment slot="amount">
 			{#if nonNullish(value)}
@@ -42,7 +44,7 @@
 				{formatSecondsToDate(Number(timestamp))}
 			{/if}
 
-			<TransactionStatus {pending} {unconfirmed} />
+			<TransactionStatusComponent {status} />
 		</svelte:fragment>
 	</Card>
 </button>

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -4,7 +4,7 @@
 	import type { ComponentType } from 'svelte';
 	import IconReceive from '$lib/components/icons/IconReceive.svelte';
 	import IconSend from '$lib/components/icons/IconSend.svelte';
-	import TransactionPending from '$lib/components/transactions/TransactionPending.svelte';
+	import TransactionStatus from '$lib/components/transactions/TransactionStatus.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import RoundedIcon from '$lib/components/ui/RoundedIcon.svelte';
@@ -15,6 +15,7 @@
 	export let value: BigNumber | undefined;
 	export let type: TransactionType;
 	export let pending: boolean;
+	export let unconfirmed: boolean | undefined;
 	export let timestamp: bigint | undefined;
 
 	let label: string;
@@ -28,7 +29,7 @@
 	<Card>
 		<span class="inline-block first-letter:capitalize">{label}</span>
 
-		<RoundedIcon slot="icon" {icon} iconStyleClass={pending ? 'opacity-10' : ''} />
+		<RoundedIcon slot="icon" {icon} iconStyleClass={pending || unconfirmed ? 'opacity-10' : ''} />
 
 		<svelte:fragment slot="amount">
 			{#if nonNullish(value)}
@@ -41,7 +42,7 @@
 				{formatSecondsToDate(Number(timestamp))}
 			{/if}
 
-			<TransactionPending {pending} />
+			<TransactionStatus {pending} {unconfirmed} />
 		</svelte:fragment>
 	</Card>
 </button>

--- a/src/frontend/src/lib/components/transactions/TransactionPending.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionPending.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	// TODO: delete this component and use TransactionStatus instead
+
 	import { i18n } from '$lib/stores/i18n.store';
 
 	export let pending = false;

--- a/src/frontend/src/lib/components/transactions/TransactionStatus.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionStatus.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { fade } from 'svelte/transition';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TransactionStatus } from '$lib/types/transaction';
 
@@ -12,7 +13,7 @@
 </script>
 
 {#if pending || unconfirmed}
-	<span class="ml-2 text-goldenrod">
+	<span class="ml-2 text-goldenrod" in:fade>
 		{pending ? $i18n.transaction.text.pending : $i18n.transaction.text.unconfirmed}
 	</span>
 {/if}

--- a/src/frontend/src/lib/components/transactions/TransactionStatus.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionStatus.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { i18n } from '$lib/stores/i18n.store';
+
+	export let pending = false;
+	export let unconfirmed = false;
+</script>
+
+{#if pending || unconfirmed}
+	<span class="ml-2 text-goldenrod">
+		{pending ? $i18n.transaction.text.pending : $i18n.transaction.text.unconfirmed}
+	</span>
+{/if}

--- a/src/frontend/src/lib/components/transactions/TransactionStatus.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionStatus.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { TransactionStatus } from '$lib/types/transaction';
 
-	export let pending = false;
-	export let unconfirmed = false;
+	export let status: TransactionStatus;
+
+	let pending: boolean;
+	$: pending = status === 'pending';
+
+	let unconfirmed: boolean;
+	$: unconfirmed = status === 'unconfirmed';
 </script>
 
 {#if pending || unconfirmed}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -568,6 +568,7 @@
 			"block": "Block",
 			"interacted_with": "Interacted With (To)",
 			"pending": "Pending...",
+			"unconfirmed": "Unconfirmed",
 			"status": "Status"
 		},
 		"status": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -508,6 +508,7 @@ interface I18nTransaction {
 		block: string;
 		interacted_with: string;
 		pending: string;
+		unconfirmed: string;
 		status: string;
 	};
 	status: { included: string; safe: string; finalised: string };

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -15,6 +15,8 @@ export type TransactionFeeData = Pick<FeeData, 'maxFeePerGas' | 'maxPriorityFeeP
 
 export type TransactionType = 'send' | 'receive';
 
+export type TransactionStatus = 'confirmed' | 'pending' | 'unconfirmed';
+
 export type TransactionUiCommon = Pick<Transaction, 'blockNumber' | 'from' | 'to'> & {
 	timestamp?: bigint;
 	txExplorerUrl?: string;


### PR DESCRIPTION
# Motivation

In this PR, "unconfirmed" transaction label is added to the `Transaction` component. The intermediate design as shown on the screenshot was agreed with Artem. 

Note: after ETH and IC Transaction components are refactored to use `lib/Transaction`, `TransactionPending` can be deleted in favour of `TransactionStatus`.

<img width="631" alt="Screenshot 2024-10-15 at 13 46 50" src="https://github.com/user-attachments/assets/eff6f822-de8e-4283-83a6-ddde25771aeb">
