### PR TITLE
feat(frontend): remove unused service from blockchain.rest

### DIFF
--- a/src/frontend/src/lib/rest/blockchain.rest.ts
+++ b/src/frontend/src/lib/rest/blockchain.rest.ts
@@ -1,8 +1,4 @@
-import type {
-	BitcoinAddressData,
-	BitcoinBlock,
-	BlockchainBtcAddressDataParams
-} from '$lib/types/blockchain';
+import type { BitcoinAddressData, BlockchainBtcAddressDataParams } from '$lib/types/blockchain';
 
 const API_URL = import.meta.env.VITE_BLOCKCHAIN_API_URL;
 
@@ -18,18 +14,6 @@ export const btcAddressData = ({
 }: BlockchainBtcAddressDataParams): Promise<BitcoinAddressData> =>
 	fetchBlockchainApi<BitcoinAddressData>({
 		endpointPath: `rawaddr/${btcAddress}`
-	});
-
-/**
- * Get latest mined BTC block. Used for calculating the number of confirmations for a BTC transaction.
- *
- * Documentation:
- * - https://www.blockchain.com/explorer/api/blockchain_api
- *
- */
-export const btcLatestBlock = (): Promise<BitcoinBlock> =>
-	fetchBlockchainApi<BitcoinBlock>({
-		endpointPath: `latestblock`
 	});
 
 const fetchBlockchainApi = async <T>({ endpointPath }: { endpointPath: string }): Promise<T> => {

--- a/src/frontend/src/lib/types/blockchain.ts
+++ b/src/frontend/src/lib/types/blockchain.ts
@@ -67,14 +67,6 @@ export interface BitcoinAddressData {
 	txs: BitcoinTransaction[];
 }
 
-export interface BitcoinBlock {
-	hash: string;
-	time: number;
-	block_index: number;
-	height: number;
-	txIndexes: number[];
-}
-
 export interface BlockchainBtcAddressDataParams {
 	btcAddress: BtcAddress;
 }


### PR DESCRIPTION
# Motivation

Since we switched to Blockstream API, we can clean up `blockchain.rest` and related types.
