### PR TITLE
fix(frontend): adjust BTC tx confirmations calculation

### DIFF
--- a/src/frontend/src/btc/constants/btc.constants.ts
+++ b/src/frontend/src/btc/constants/btc.constants.ts
@@ -4,7 +4,7 @@
 // because the bitcoin canister doesn't know about the mempool and unconfirmed transactions.
 export const BTC_BALANCE_MIN_CONFIRMATIONS = 1;
 
-// no confirmations - transaction status "pending"
+// block_index (and hence confirmations value) is undefined - transaction status "pending"
 // 1 - 5 confirmations - transaction status "unconfirmed"
 // 6 and more confirmations - transaction status "confirmed"
 export const UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS = 1;

--- a/src/frontend/src/btc/constants/btc.constants.ts
+++ b/src/frontend/src/btc/constants/btc.constants.ts
@@ -4,9 +4,8 @@
 // because the bitcoin canister doesn't know about the mempool and unconfirmed transactions.
 export const BTC_BALANCE_MIN_CONFIRMATIONS = 1;
 
-// 0 confirmations (or undefined) - transaction status "pending"
+// no confirmations - transaction status "pending"
 // 1 - 5 confirmations - transaction status "unconfirmed"
 // 6 and more confirmations - transaction status "confirmed"
-export const PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS = 0;
 export const UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS = 1;
 export const CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS = 6;

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -64,7 +64,7 @@ export const mapBtcTransaction = ({
 	const utxosFee = totalInputValue - totalOutputValue;
 
 	const confirmations = nonNullish(block_index)
-		? latestBitcoinBlockHeight - block_index
+		? latestBitcoinBlockHeight - block_index + 1
 		: undefined;
 
 	const status =

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -1,7 +1,4 @@
-import {
-	CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS,
-	PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS
-} from '$btc/constants/btc.constants';
+import { CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { BtcAddress } from '$lib/types/address';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
@@ -63,16 +60,16 @@ export const mapBtcTransaction = ({
 
 	const utxosFee = totalInputValue - totalOutputValue;
 
+	// +1 is needed to account for the block where the transaction was first included
 	const confirmations = nonNullish(block_index)
 		? latestBitcoinBlockHeight - block_index + 1
 		: undefined;
 
-	const status =
-		isNullish(confirmations) || confirmations <= PENDING_BTC_TRANSACTION_MIN_CONFIRMATIONS
-			? 'pending'
-			: confirmations >= CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
-				? 'confirmed'
-				: 'unconfirmed';
+	const status = isNullish(confirmations)
+		? 'pending'
+		: confirmations >= CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			? 'confirmed'
+			: 'unconfirmed';
 
 	return {
 		id: hash,

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -31,6 +31,7 @@ describe('mapBtcTransaction', () => {
 		const expectedResult = {
 			...mockBtcTransactionUi,
 			blockNumber: undefined,
+			confirmations: undefined,
 			status: 'pending'
 		};
 
@@ -42,7 +43,6 @@ describe('mapBtcTransaction', () => {
 			...mockBtcTransaction,
 			block_index: mockBtcTransactionUi.blockNumber
 		} as BitcoinTransaction;
-
 		const result = mapBtcTransaction({
 			transaction,
 			btcAddress: mockBtcAddress,
@@ -52,7 +52,7 @@ describe('mapBtcTransaction', () => {
 		const expectedResult = {
 			...mockBtcTransactionUi,
 			status: 'unconfirmed',
-			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
 		};
 
 		expect(result).toEqual(expectedResult);
@@ -63,7 +63,6 @@ describe('mapBtcTransaction', () => {
 			...mockBtcTransaction,
 			block_index: mockBtcTransactionUi.blockNumber
 		} as BitcoinTransaction;
-
 		const result = mapBtcTransaction({
 			transaction,
 			btcAddress: mockBtcAddress,
@@ -73,7 +72,7 @@ describe('mapBtcTransaction', () => {
 
 		const expectedResult = {
 			...mockBtcTransactionUi,
-			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
 		};
 
 		expect(result).toEqual(expectedResult);
@@ -92,6 +91,7 @@ describe('mapBtcTransaction', () => {
 			value: sendTransactionValue,
 			type: 'send',
 			blockNumber: undefined,
+			confirmations: undefined,
 			status: 'pending'
 		};
 
@@ -116,7 +116,7 @@ describe('mapBtcTransaction', () => {
 			to: mockBtcTransaction.out[0].addr,
 			value: sendTransactionValue,
 			type: 'send',
-			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
 		};
 
 		expect(result).toEqual(expectedResult);
@@ -139,7 +139,7 @@ describe('mapBtcTransaction', () => {
 			to: mockBtcTransaction.out[0].addr,
 			value: sendTransactionValue,
 			type: 'send',
-			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
 		};
 
 		expect(result).toEqual(expectedResult);

--- a/src/frontend/src/tests/mocks/btc.mock.ts
+++ b/src/frontend/src/tests/mocks/btc.mock.ts
@@ -11,7 +11,8 @@ export const mockBtcTransactionUi: BtcTransactionUi = {
 	timestamp: 1727175987n,
 	to: 'bc1qt0nkp96r7p95xfacyp98pww2eu64yzuf78l4a2wy0sttt83hux4q6u2nl7',
 	type: 'receive',
-	value: 126527n
+	value: 126527n,
+	confirmations: 1
 };
 
 export const mockBtcTransaction: BitcoinTransaction = {


### PR DESCRIPTION
# Motivation

I realised I used incomplete formula to calculate BTC tx confirmations, it should be `confirmations = currentBlockHeight - transactionBlockHeight + 1`. Without adding +1, we didn't account for the block where the transaction was first included, which resulted in 0 confirmations immediately after the block is mined, which isn't correct.