### PR TITLE
fix(frontend): Wrong flex for buttons in modal

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonGroup.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonGroup.svelte
@@ -1,3 +1,3 @@
-<div class="mb-2 flex gap-3">
+<div class="mb-2 flex w-full gap-3">
 	<slot />
 </div>

--- a/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
+++ b/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
@@ -2,4 +2,6 @@
 	<slot />
 </div>
 
-<slot name="toolbar" />
+<div class="flex w-full">
+	<slot name="toolbar" />
+</div>


### PR DESCRIPTION
# Motivation

For mobiles, the buttons in the modal were stretching too much, because the were not wrapped into a `flex`.

### Before

<img width="392" alt="Screenshot 2024-10-15 at 17 35 51" src="https://github.com/user-attachments/assets/6dea8f3b-1620-4997-b18f-64daf44606cf">

### After

<img width="391" alt="Screenshot 2024-10-15 at 17 36 09" src="https://github.com/user-attachments/assets/6c4ae13e-cc04-4fa1-8367-ca53f7a77079">
