### PR TITLE
feat(frontend): update BTC transaction modal

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -59,12 +59,14 @@
 	sendToLabel={$i18n.transaction.text.to}
 	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
 >
-	{#if nonNullish(confirmations)}
-		<Value ref="confirmations" slot="transaction-confirmations">
-			<svelte:fragment slot="label">{$i18n.transaction.text.confirmations}</svelte:fragment>
-			{confirmations}
-		</Value>
-	{/if}
+	<svelte:fragment slot="transaction-confirmations">
+		{#if nonNullish(confirmations)}
+			<Value ref="confirmations">
+				<svelte:fragment slot="label">{$i18n.transaction.text.confirmations}</svelte:fragment>
+				{confirmations}
+			</Value>
+		{/if}
+	</svelte:fragment>
 
 	<Value ref="status" slot="transaction-status">
 		<svelte:fragment slot="label">{$i18n.transaction.text.status}</svelte:fragment>

--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -19,6 +19,7 @@
 	let timestamp: bigint | undefined;
 	let id: string;
 	let blockNumber: number | undefined;
+	let confirmations: number | undefined;
 	let status: BtcTransactionStatus;
 
 	let explorerUrl: string | undefined;
@@ -30,7 +31,7 @@
 				: BTC_MAINNET_EXPLORER_URL;
 	}
 
-	$: ({ from, value, timestamp, id, blockNumber, to, type, status } = transaction);
+	$: ({ from, value, timestamp, id, blockNumber, to, type, status, confirmations } = transaction);
 
 	let txExplorerUrl: string | undefined;
 	$: txExplorerUrl = nonNullish(explorerUrl) ? `${explorerUrl}/tx/${id}` : undefined;
@@ -58,9 +59,21 @@
 	sendToLabel={$i18n.transaction.text.to}
 	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
 >
-	<!--	TODO: Implement BtcTransactionStatus component	-->
+	{#if nonNullish(confirmations)}
+		<Value ref="confirmations" slot="confirmations">
+			<svelte:fragment slot="label">{$i18n.transaction.text.confirmations}</svelte:fragment>
+			{confirmations}
+		</Value>
+	{/if}
+
 	<Value ref="status" slot="transaction-status">
 		<svelte:fragment slot="label">{$i18n.transaction.text.status}</svelte:fragment>
-		{`${status === 'pending' ? $i18n.transaction.text.pending : 'Confirmed'}`}
+		{`${
+			status === 'pending'
+				? $i18n.transaction.text.pending
+				: status === 'unconfirmed'
+					? $i18n.transaction.text.unconfirmed
+					: $i18n.transaction.text.confirmed
+		}`}
 	</Value>
 </TransactionModal>

--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -60,7 +60,7 @@
 	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
 >
 	{#if nonNullish(confirmations)}
-		<Value ref="confirmations" slot="confirmations">
+		<Value ref="confirmations" slot="transaction-confirmations">
 			<svelte:fragment slot="label">{$i18n.transaction.text.confirmations}</svelte:fragment>
 			{confirmations}
 		</Value>

--- a/src/frontend/src/lib/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionModal.svelte
@@ -67,7 +67,7 @@
 
 		<slot name="transaction-status" />
 
-		<slot name="confirmations" />
+		<slot name="transaction-confirmations" />
 
 		{#if nonNullish(timestamp)}
 			<Value ref="timestamp">

--- a/src/frontend/src/lib/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionModal.svelte
@@ -67,6 +67,8 @@
 
 		<slot name="transaction-status" />
 
+		<slot name="confirmations" />
+
 		{#if nonNullish(timestamp)}
 			<Value ref="timestamp">
 				<svelte:fragment slot="label">{$i18n.transaction.text.timestamp}</svelte:fragment>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -569,7 +569,9 @@
 			"interacted_with": "Interacted With (To)",
 			"pending": "Pending...",
 			"unconfirmed": "Unconfirmed",
-			"status": "Status"
+			"confirmed": "Confirmed",
+			"status": "Status",
+			"confirmations": "Confirmations"
 		},
 		"status": {
 			"included": "Included",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -509,7 +509,9 @@ interface I18nTransaction {
 		interacted_with: string;
 		pending: string;
 		unconfirmed: string;
+		confirmed: string;
 		status: string;
+		confirmations: string;
 	};
 	status: { included: string; safe: string; finalised: string };
 	label: {


### PR DESCRIPTION
# Motivation

The goal of this PR is to update BTC transaction modal with the following data:
1. Properly parse and display BTC tx status (previously, "unconfirmed" was missing).
2. Display number of confirmations if it's available.

<img width="506" alt="Screenshot 2024-10-15 at 18 01 35" src="https://github.com/user-attachments/assets/d86460a4-80d6-4733-bfae-7c803cd24879">
