### PR TITLE
style(frontend): buttons success and error

### DIFF
--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -26,7 +26,9 @@ a.as-button {
 
 	&.primary,
 	&.secondary,
-	&.tertiary {
+	&.tertiary,
+	&.success,
+	&.error {
 		justify-content: center;
 
 		padding: var(--button-padding);
@@ -43,7 +45,9 @@ a.as-button {
 
 	&.primary,
 	&.secondary,
-	&.tertiary {
+	&.tertiary,
+	&.success,
+	&.error {
 		font-weight: var(--font-weight-bold);
 
 		&[disabled],
@@ -126,6 +130,32 @@ a.as-button {
 			&:hover {
 				color: var(--color-secondary);
 			}
+		}
+	}
+
+	&.success {
+		background: var(--color-green-crayola);
+		color: var(--color-white);
+
+		&:hover {
+			background: var(--color-dartmouth-green);
+		}
+
+		&:active {
+			background: var(--color-british-racing-green);
+		}
+	}
+
+	&.error {
+		background: var(--color-rusty-red);
+		color: var(--color-white);
+
+		&:hover {
+			background: var(--color-upsdell-red);
+		}
+
+		&:active {
+			background: var(--color-chocolate-cosmos);
 		}
 	}
 


### PR DESCRIPTION
# Motivation

In the signer flow we need green and red buttons.

# Changes

- Add `.success` and `.error` button global classes

# Screenshot

<img width="688" alt="Capture d’écran 2024-10-16 à 09 32 41" src="https://github.com/user-attachments/assets/51a58324-9982-4cca-a7cd-43c871ce010a">

