### PR TITLE
style(frontend): Increase hero buttons text size for mobile [OISY-62]

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -9,7 +9,7 @@
 <Button on:click {ariaLabel} {disabled} {testId} colorStyle="tertiary" link paddingSmall>
 	<div class="flex flex-col items-center justify-center gap-2 md:flex-row">
 		<slot name="icon" />
-		<div class="min-w-12 max-w-[72px] text-xs md:text-base">
+		<div class="min-w-12 max-w-[72px] text-sm md:text-base">
 			<slot />
 		</div>
 	</div>


### PR DESCRIPTION
# Motivation

Slightly increase mobile text dimension for the buttons in `Hero`.


### Before

<img width="416" alt="Screenshot 2024-10-16 at 10 49 47" src="https://github.com/user-attachments/assets/3dbc711e-efdd-4ef1-8ab9-7c08aded5ad6">

### After

<img width="415" alt="Screenshot 2024-10-16 at 10 49 39" src="https://github.com/user-attachments/assets/47fd1ef0-7f3c-4c23-b1e0-c64cd261ad38">
