### PR TITLE
feat(frontend): sort BTC transactions

### DIFF
--- a/src/frontend/src/btc/derived/btc-transactions.derived.ts
+++ b/src/frontend/src/btc/derived/btc-transactions.derived.ts
@@ -1,14 +1,17 @@
 import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 import type { BtcTransactionUi } from '$btc/types/btc';
+import { sortBtcTransactions } from '$btc/utils/btc-transactions.utils';
 import { tokenWithFallback } from '$lib/derived/token.derived';
 import type { TransactionsData } from '$lib/stores/transactions.store';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-// TODO: decide how BTC transactions should be sorted and apply it here
 export const sortedBtcTransactions: Readable<TransactionsData<BtcTransactionUi>> = derived(
 	[btcTransactionsStore, tokenWithFallback],
-	([$transactionsStore, $token]) => $transactionsStore?.[$token.id] ?? []
+	([$transactionsStore, $token]) =>
+		($transactionsStore?.[$token.id] ?? []).sort(({ data: transactionA }, { data: transactionB }) =>
+			sortBtcTransactions({ transactionA, transactionB })
+		)
 );
 
 export const btcTransactionsInitialized: Readable<boolean> = derived(

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -83,3 +83,38 @@ export const mapBtcTransaction = ({
 		confirmations
 	};
 };
+
+export const sortBtcTransactions = ({
+	transactionA: { status: statusA, timestamp: timestampA },
+	transactionB: { status: statusB, timestamp: timestampB }
+}: {
+	transactionA: BtcTransactionUi;
+	transactionB: BtcTransactionUi;
+}): number => {
+	const isPendingA = statusA === 'pending';
+	const isPendingB = statusB === 'pending';
+	const isUnconfirmedA = statusA === 'unconfirmed';
+	const isUnconfirmedB = statusB === 'unconfirmed';
+
+	if (isPendingA && !isPendingB) {
+		return -1;
+	}
+
+	if (isPendingB && !isPendingA) {
+		return 1;
+	}
+
+	if (isUnconfirmedA && !isUnconfirmedB) {
+		return -1;
+	}
+
+	if (isUnconfirmedB && !isUnconfirmedA) {
+		return 1;
+	}
+
+	if (nonNullish(timestampA) && nonNullish(timestampB)) {
+		return Number(timestampB - timestampA);
+	}
+
+	return nonNullish(timestampA) ? -1 : 1;
+};

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -2,10 +2,11 @@ import {
 	CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS,
 	UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 } from '$btc/constants/btc.constants';
-import { mapBtcTransaction } from '$btc/utils/btc-transactions.utils';
+import type { BtcTransactionStatus } from '$btc/types/btc';
+import { mapBtcTransaction, sortBtcTransactions } from '$btc/utils/btc-transactions.utils';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
 import { mockBtcAddress, mockBtcTransaction, mockBtcTransactionUi } from '$tests/mocks/btc.mock';
-import { expect } from 'vitest';
+import { describe, expect } from 'vitest';
 
 describe('mapBtcTransaction', () => {
 	const sendTransaction = {
@@ -143,5 +144,62 @@ describe('mapBtcTransaction', () => {
 		};
 
 		expect(result).toEqual(expectedResult);
+	});
+});
+
+describe('sortBtcTransactions', () => {
+	it('sorts transactions correctly', () => {
+		const pendingTransaction1 = {
+			...mockBtcTransactionUi,
+			timestamp: 1n,
+			status: 'pending' as BtcTransactionStatus
+		};
+		const pendingTransaction2 = {
+			...mockBtcTransactionUi,
+			timestamp: 2n,
+			status: 'pending' as BtcTransactionStatus
+		};
+		const unconfirmedTransaction1 = {
+			...mockBtcTransactionUi,
+			timestamp: 3n,
+			status: 'unconfirmed' as BtcTransactionStatus
+		};
+		const unconfirmedTransaction2 = {
+			...mockBtcTransactionUi,
+			timestamp: 4n,
+			status: 'unconfirmed' as BtcTransactionStatus
+		};
+		const confirmedTransaction1 = {
+			...mockBtcTransactionUi,
+			timestamp: 5n,
+			status: 'confirmed' as BtcTransactionStatus
+		};
+		const confirmedTransaction2 = {
+			...mockBtcTransactionUi,
+			timestamp: 6n,
+			status: 'confirmed' as BtcTransactionStatus
+		};
+		const transactionsToSort = [
+			confirmedTransaction2,
+			pendingTransaction1,
+			unconfirmedTransaction2,
+			pendingTransaction2,
+			confirmedTransaction1,
+			unconfirmedTransaction1
+		];
+		const expectedResult = [
+			pendingTransaction2,
+			pendingTransaction1,
+			unconfirmedTransaction2,
+			unconfirmedTransaction1,
+			confirmedTransaction2,
+			confirmedTransaction1
+		];
+
+		expect(
+			transactionsToSort.sort((transactionA, transactionB) =>
+				sortBtcTransactions({ transactionA, transactionB })
+			)
+		).toStrictEqual(expectedResult);
 	});
 });

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -148,6 +148,7 @@ describe('mapBtcTransaction', () => {
 });
 
 describe('sortBtcTransactions', () => {
+	// TODO: add more test cases
 	it('sorts transactions correctly', () => {
 		const pendingTransaction1 = {
 			...mockBtcTransactionUi,


### PR DESCRIPTION
# Motivation

Sort BTC transactions with the following logic:
1. Pending status + timestamp.
2. Unconfirmed status + timestamp.
3. Confirmed status + timestamp.
