### PR TITLE
style(frontend): body background

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -58,6 +58,10 @@
 		<!-- ROUTE_STYLE -->
 
 		<style>
+			body {
+				background: #e8f1ff;
+			}
+
 			#app-spinner {
 				--spinner-size: 30px;
 
@@ -189,8 +193,6 @@
 				z-index: -1;
 
 				overflow: hidden;
-
-				background: #e8f1ff;
 			}
 
 			#app-background {

--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -58,7 +58,7 @@
 		<!-- ROUTE_STYLE -->
 
 		<style>
-			body {
+			:root {
 				background: #e8f1ff;
 			}
 

--- a/src/frontend/src/lib/styles/global/body.scss
+++ b/src/frontend/src/lib/styles/global/body.scss
@@ -1,8 +1,3 @@
-:root {
-	background: var(--color-transparent);
-	color: var(--color-secondary);
-}
-
 body {
 	width: 100vw;
 	height: 100svh;


### PR DESCRIPTION
# Motivation

There should be no glitch given that the background is embeded in the html file but, just had this idea that we can maybe actually set the background color on the `:root` element.

# Changes

- Move background color from background container to root.
- Remove `:root` specified as transparent background and black color. The first will be specifically set in the HTML page, the second is the default.

# Screenshots

Before if I delete the background image:

<img width="1536" alt="Capture d’écran 2024-10-16 à 11 35 14" src="https://github.com/user-attachments/assets/d82b3d3f-07f5-478a-92aa-cb3abd9d4afc">

After if I remove the bg image:

<img width="1536" alt="Capture d’écran 2024-10-16 à 11 35 01" src="https://github.com/user-attachments/assets/b4d82a11-d00b-4265-bbda-5cc0e6cb71ea">
