### PR TITLE
feat(frontend): display ReviewNetwork components for IC and BTC

### DIFF
--- a/src/frontend/src/btc/components/send/BtcReviewNetwork.svelte
+++ b/src/frontend/src/btc/components/send/BtcReviewNetwork.svelte
@@ -13,5 +13,4 @@
 		: isNetworkIdBTCRegtest(networkId)
 			? BTC_REGTEST_NETWORK
 			: BTC_MAINNET_NETWORK}
-	destinationNetworkId={networkId}
 />

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -2,6 +2,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import type { Readable } from 'svelte/store';
 	import BtcSendWarnings from './BtcSendWarnings.svelte';
+	import BtcReviewNetwork from '$btc/components/send/BtcReviewNetwork.svelte';
 	import BtcUtxosFee from '$btc/components/send/BtcUtxosFee.svelte';
 	import {
 		BtcPendingSentTransactionsStatus,
@@ -42,6 +43,8 @@
 </script>
 
 <SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
+	<BtcReviewNetwork {networkId} slot="network" />
+
 	<BtcUtxosFee slot="fee" bind:utxosFee {progress} {networkId} {amount} />
 
 	<BtcSendWarnings

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import IcReviewNetwork from '$icp/components/send/IcReviewNetwork.svelte';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import SendReview from '$lib/components/send/SendReview.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -26,4 +27,6 @@
 		invalidAmount(amount);
 </script>
 
-<SendReview on:icBack on:icSend {source} {amount} {destination} disabled={invalid} />
+<SendReview on:icBack on:icSend {source} {amount} {destination} disabled={invalid}>
+	<IcReviewNetwork {networkId} slot="network" />
+</SendReview>


### PR DESCRIPTION
# Motivation

The new NetworkReview components must be used in the send-review modals. Also, since BTC <-> ckBTC conversion is not implemented yet, we can remove `destinationNetworkId` from `BtcSendReview`.

BTC:

<img width="528" alt="Screenshot 2024-10-16 at 11 55 44" src="https://github.com/user-attachments/assets/42d37a59-1cce-4044-bce9-0e42b3357393">

IC:
<img width="516" alt="Screenshot 2024-10-16 at 11 55 22" src="https://github.com/user-attachments/assets/1b5378c3-c09e-46f4-8229-faa8f1c1ae56">

ck conversion:
<img width="513" alt="Screenshot 2024-10-16 at 12 27 13" src="https://github.com/user-attachments/assets/181bccb2-57e6-44d0-8fea-431858a7e601">

