### PR TITLE
refactor(frontend): hide partially the footer DFINITY string [OISY-62]

### DIFF
--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -5,7 +5,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import ExternalLinkIcon from '$lib/components/ui/ExternalLinkIcon.svelte';
 	import { OISY_REPO_URL } from '$lib/constants/oisy.constants';
-	import { authNotSignedIn } from '$lib/derived/auth.derived';
+	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
@@ -19,6 +19,9 @@
 	class:md:h-md:grid={$authNotSignedIn}
 	class:md:h-md:grid-cols-4={$authNotSignedIn}
 	class:md:h-md:pr-0={$authNotSignedIn}
+	class:sm:fixed={$authSignedIn}
+	class:sm:inset-x-0={$authSignedIn}
+	class:sm:bottom-0={$authSignedIn}
 >
 	<div class="flex flex-row items-center gap-4">
 		<ExternalLinkIcon href={OISY_REPO_URL} ariaLabel={$i18n.navigation.text.source_code_on_github}>
@@ -34,20 +37,24 @@
 	</div>
 
 	<div
-		class="item flex flex-row items-center justify-end gap-2 text-sm lg:max-w-48 xl:max-w-none"
+		class="item flex flex-row items-center justify-end gap-2 text-sm transition-all duration-200 ease-in-out lg:max-w-48 xl:max-w-none"
 		class:sm:max-w-none={$authNotSignedIn}
+		class:sm:invisible={$authSignedIn}
+		class:1.5md:visible={$authSignedIn}
+		class:translate-x-full={$authSignedIn}
+		class:1.5md:translate-x-0={$authSignedIn}
 	>
-		<IconDfinity />
-		<span>
-			{replaceOisyPlaceholders($i18n.footer.text.developed_with)}
-			<ExternalLink
-				href="https://dfinity.org"
-				ariaLabel={replaceOisyPlaceholders($i18n.footer.alt.dfinity)}
-				color="blue"
-				iconVisible={false}
-			>
-				{replaceOisyPlaceholders($i18n.footer.text.dfinity)}
-			</ExternalLink>
-		</span>
+		<ExternalLink
+			href="https://dfinity.org"
+			ariaLabel={replaceOisyPlaceholders($i18n.footer.alt.dfinity)}
+			iconVisible={false}
+		>
+			<div class="flex flex-row items-center gap-2">
+				<IconDfinity />
+				<span class:sm:hidden={$authSignedIn} class:xl:flex={$authSignedIn}>
+					{replaceOisyPlaceholders($i18n.footer.text.developed_with)}
+				</span>
+			</div>
+		</ExternalLink>
 	</div>
 </footer>

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -8,7 +8,7 @@
 	</div>
 
 	<div
-		class="mx-auto px-5 transition-all duration-500 ease-linear sm:ml-44 sm:box-content sm:w-sm lg:ml-auto"
+		class="mx-auto px-5 transition-all duration-500 ease-linear sm:ml-52 sm:box-content sm:w-sm lg:ml-auto"
 	>
 		<slot />
 	</div>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -81,8 +81,7 @@
 	},
 	"footer": {
 		"text": {
-			"developed_with": "© 2024 Developed with ❤\uFE0F at ",
-			"dfinity": "DFINITY"
+			"developed_with": "© 2024 Developed with ❤\uFE0F at DFINITY"
 		},
 		"alt": {
 			"dfinity": "Go to DFINITY Foundation website"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -72,7 +72,7 @@ interface I18nAuth {
 }
 
 interface I18nFooter {
-	text: { developed_with: string; dfinity: string };
+	text: { developed_with: string };
 	alt: { dfinity: string };
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,7 @@ export default {
 				sm: '576px'
 			},
 			screens: {
+				'1.5md': '896px',
 				'2.5xl': '1728px',
 				'h-md': { raw: '(max-height: 1090px)' }
 			}


### PR DESCRIPTION
# Motivation

The idea is to hide the "Developed with..." string for middle screens, leaving just the DFINITY logo. However, for narrower middle screen, hide the logo too.

# Changes

- Make the entire string be an hyperlink.
- Modify the footer so that it is hidden on narrow middle screens, and only a logo on middle screens.
- The rest is unchanged.

# Tests


https://github.com/user-attachments/assets/72d9e1b8-65c0-41f8-a0fc-c75f8886d0b5




