### PR TITLE
feat(frontend): initiate new /sign route

### DIFF
--- a/src/frontend/src/routes/(sign)/sign/+layout.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+layout.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import Modals from '$lib/components/core/Modals.svelte';
+	import OisyWalletLogoLink from '$lib/components/core/OisyWalletLogoLink.svelte';
+	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
+</script>
+
+<main class="mx-auto flex flex-col gap-y-6 px-5 pt-10 sm:w-sm">
+	<div class="flex justify-center"><OisyWalletLogoLink /></div>
+
+	<WarningBanner>
+		This feature is unreviewed. DO NOT USE until it has undergone proper code and security
+		assessment!
+	</WarningBanner>
+
+	<slot />
+</main>
+
+<Modals />

--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -1,0 +1,3 @@
+<article class="mb-10 flex min-h-96 flex-col rounded-lg border border-water bg-white px-5 py-6">
+	<p>Work in progress. Click the OISY Wallet logo above to go back to wallet.</p>
+</article>

--- a/src/frontend/src/routes/(sign)/sign/+page.ts
+++ b/src/frontend/src/routes/(sign)/sign/+page.ts
@@ -1,0 +1,10 @@
+import type { RouteParams } from '$lib/utils/nav.utils';
+import type { LoadEvent } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+// We reset the data because the "sign" route operates without a network or token selected.
+export const load: PageLoad = (_$event: LoadEvent): RouteParams => ({
+	token: null,
+	network: null,
+	uri: null
+});


### PR DESCRIPTION
## Motivation

The signer feature of OISY will be available under a sub-route `/sign`, e.g., `https://oisy.com/sign`. This URL was decided by the product and design teams (Mary and Artem). This PR aims to initiate this route without any specific capabilities.

## Notes

These features do not require any of the core OISY Wallet functionalities, such as fetching USD, Ethereum, or Bitcoin transactions from third-party Web2 APIs. Similarly, they do not need ETH or BTC keys derived from the Crosschain Signer canister. The reason behind this is that the signer acts primarily as a proxy for messages. It receives requests, asserts and prompts the user for interaction, and propagates those requests if approved—nothing more, nothing less.

For this reason, this PR creates a new group in the routing, `(sign)`, which does not use the `LoadersGuard`.

It also does not use the `AuthGuard` because it is still custom and contains another call to action for sign-in.

## Security Notes

Since a few points are still being discussed with the security team and the library is not yet open source, the UI will include a warning banner to inform users about the ongoing work. I will keep track of this and provide a PR to remove the banner once everything is resolved.

# Changes

- Init new route `src/frontend/src/routes(sign)` with placeholders

# Screenshot

<img width="1536" alt="Capture d’écran 2024-10-16 à 13 41 32" src="https://github.com/user-attachments/assets/e7a9610c-c7ef-420f-9dfd-b3af54e06862">

