### PR TITLE
feat(frontend): button authenticate fullWith option

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import IconAstronautArrow from '$lib/components/icons/IconAstronautArrow.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	export let fullWidth = false;
 </script>
 
 <button
 	on:click
-	class="flex w-full items-center justify-center gap-4 rounded-2xl bg-[var(--color-primary)] py-3 text-lg font-bold leading-6 text-white sm:w-80 sm:px-12"
+	class="flex w-full items-center justify-center gap-4 rounded-2xl bg-[var(--color-primary)] py-3 text-lg font-bold leading-6 text-white sm:px-12"
+	class:sm:w-80={!fullWidth}
 	data-tid="login-button"
 >
 	{$i18n.auth.text.authenticate}


### PR DESCRIPTION
# Motivation

On the `/sign` route the `ButtonAuthenticate` requires to fit the full width according design.

# Changes

- Add a `fullWidth` option.

# Screenshot

<img width="688" alt="Capture d’écran 2024-10-16 à 16 26 38" src="https://github.com/user-attachments/assets/c06ebbb8-17f5-4dc0-9337-848f5c7cde93">

