### PR TITLE
feat(frontend): init and reset signer context on route sign

### DIFF
--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -1,7 +1,30 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { onDestroy, setContext } from 'svelte';
 	import SignerAccounts from '$lib/components/signer/SignerAccounts.svelte';
 	import SignerSignIn from '$lib/components/signer/SignerSignIn.svelte';
-	import { authNotSignedIn } from '$lib/derived/auth.derived';
+	import { authNotSignedIn, authIdentity } from '$lib/derived/auth.derived';
+	import { initSignerContext, SIGNER_CONTEXT_KEY } from '$lib/stores/signer.store';
+
+	const { idle, reset, ...context } = initSignerContext();
+	setContext(SIGNER_CONTEXT_KEY, {
+		...context,
+		idle,
+		reset
+	});
+
+	const init = () => {
+		if (isNullish($authIdentity)) {
+			reset();
+			return;
+		}
+
+		context.init({ owner: $authIdentity });
+	};
+
+	onDestroy(reset);
+
+	$: $authIdentity, init();
 </script>
 
 <article class="mb-10 flex min-h-96 flex-col rounded-lg border border-water bg-white px-5 py-6">


### PR DESCRIPTION
# Motivation

At the top of the `/sign` route we want to initialize and reset the signer context.

# Changes

- Subscribe to auth and destroy hook and init or reset the context.
