### PR TITLE
feat(frontend): signer centered content component

### DIFF
--- a/src/frontend/src/lib/components/signer/SignerCenteredContent.svelte
+++ b/src/frontend/src/lib/components/signer/SignerCenteredContent.svelte
@@ -1,0 +1,3 @@
+<div class="flex min-h-full flex-1 flex-col items-center justify-center gap-3">
+	<slot />
+</div>

--- a/src/frontend/src/lib/components/signer/SignerLoading.svelte
+++ b/src/frontend/src/lib/components/signer/SignerLoading.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { Spinner } from '@dfinity/gix-components';
+	import SignerCenteredContent from '$lib/components/signer/SignerCenteredContent.svelte';
 </script>
 
-<div class="flex min-h-full flex-1 flex-col items-center justify-center gap-3">
+<SignerCenteredContent>
 	<div class="text-[var(--color-primary)]">
 		<Spinner inline />
 	</div>
 	<span><slot /></span>
-</div>
+</SignerCenteredContent>


### PR DESCRIPTION
# Motivation

I realized there is few screen that are all centered in the signer flow. Therefore I extracted a component from the "loading" component that places the content at the center of the signer article.

# Changes

- Extract `SignerCenteredContent` component.
