### PR TITLE
Fix(frontend)/clickable header and footer when signed in

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthGuard.svelte
+++ b/src/frontend/src/lib/components/auth/AuthGuard.svelte
@@ -7,7 +7,7 @@
 {#if $authNotSignedIn}
 	<LandingPage />
 {:else}
-	<div in:fade class="sm:block sm:overflow-y-auto">
+	<div in:fade class="pointer-events-auto sm:block sm:overflow-y-auto">
 		<slot />
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <footer
-	class="z-1 mx-auto flex w-full max-w-screen-2.5xl flex-1 flex-col items-center justify-end px-4 pb-5 pt-12 sm:flex-1 sm:flex-grow sm:flex-row sm:items-end sm:justify-between sm:px-8 lg:fixed lg:inset-x-0 lg:bottom-0"
+	class="z-1 pointer-events-none mx-auto flex w-full max-w-screen-2.5xl flex-1 flex-col items-center justify-end px-4 pb-5 pt-12 sm:flex-1 sm:flex-grow sm:flex-row sm:items-end sm:justify-between sm:px-8 lg:fixed lg:inset-x-0 lg:bottom-0"
 	class:sm:sticky={$authNotSignedIn}
 	class:md:h-md:grid={$authNotSignedIn}
 	class:md:h-md:grid-cols-2={$authNotSignedIn}
@@ -23,8 +23,10 @@
 	class:sm:inset-x-0={$authSignedIn}
 	class:sm:bottom-0={$authSignedIn}
 >
-	<div class="flex w-full flex-col items-center justify-between sm:flex-row sm:gap-4">
-		<div class="flex flex-row items-center gap-4">
+	<div
+		class="pointer-events-none flex w-full flex-col items-center justify-between sm:flex-row sm:gap-4"
+	>
+		<div class="pointer-events-auto flex flex-row items-center gap-4">
 			<ExternalLinkIcon
 				href={OISY_REPO_URL}
 				ariaLabel={$i18n.navigation.text.source_code_on_github}
@@ -41,7 +43,7 @@
 		</div>
 
 		<div
-			class="item flex flex-row items-center justify-end gap-2 text-sm transition-all duration-200 ease-in-out lg:max-w-48 xl:max-w-none"
+			class="item pointer-events-auto flex flex-row items-center justify-end gap-2 text-sm transition-all duration-200 ease-in-out lg:max-w-48 xl:max-w-none"
 			class:sm:max-w-none={$authNotSignedIn}
 			class:lg:max-w-none={$authNotSignedIn}
 			class:md:h-md:pr-4={$authNotSignedIn}

--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -15,28 +15,31 @@
 </script>
 
 <header
-	class="z-1 relative grid w-full max-w-screen-2.5xl grid-cols-2 items-center gap-y-5 px-4 pt-6 sm:px-8"
+	class="z-1 pointer-events-none relative flex w-full max-w-screen-2.5xl items-center justify-between gap-y-5 px-4 pt-6 sm:px-8"
 	class:lg:fixed={$authSignedIn}
 	class:lg:top-0={$authSignedIn}
 	class:lg:inset-x-0={$authSignedIn}
 	class:lg:z-10={$authSignedIn}
+	class:xl:grid={$authNotSignedIn}
 	class:xl:grid-cols-[1fr_auto_1fr]={$authNotSignedIn}
 >
-	{#if back}
-		<Back />
-	{:else}
-		<OisyWalletLogoLink />
-	{/if}
+	<div class="pointer-events-auto">
+		{#if back}
+			<Back />
+		{:else}
+			<OisyWalletLogoLink />
+		{/if}
+	</div>
 
 	{#if $authNotSignedIn}
 		<div
-			class="col-span-3 col-start-1 row-start-2 flex xl:col-span-1 xl:col-start-2 xl:row-start-1 xl:w-fit"
+			class="pointer-events-auto col-span-3 col-start-1 row-start-2 flex xl:col-span-1 xl:col-start-2 xl:row-start-1 xl:w-fit"
 		>
 			<Alpha />
 		</div>
 	{/if}
 
-	<div class="flex justify-end gap-4">
+	<div class="pointer-events-auto flex justify-end gap-4">
 		{#if $authSignedIn}
 			<WalletConnect />
 		{/if}

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -8,7 +8,7 @@
 	</div>
 
 	<div
-		class="mx-auto px-5 transition-all duration-500 ease-linear sm:ml-52 sm:box-content sm:w-sm lg:ml-auto"
+		class="mx-auto px-5 transition-all duration-500 ease-linear sm:ml-64 sm:box-content sm:w-sm xl:ml-auto"
 	>
 		<slot />
 	</div>


### PR DESCRIPTION
# Motivation

When signed in and in large screens, a part of the token list is overlapped by the Header and the Footer. That means that those part are un-clickable (for example Alpha and Manage list).

To solve it, we make the entire Header and Footer with disabled pointer events, enabling it ONLY for the elements inside it.
