### PR TITLE
feat(frontend): integrate signer idle

### DIFF
--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { onDestroy, setContext } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import SignerAccounts from '$lib/components/signer/SignerAccounts.svelte';
 	import SignerConsentMessage from '$lib/components/signer/SignerConsentMessage.svelte';
+	import SignerIdle from '$lib/components/signer/SignerIdle.svelte';
 	import SignerSignIn from '$lib/components/signer/SignerSignIn.svelte';
 	import { authNotSignedIn, authIdentity } from '$lib/derived/auth.derived';
 	import { initSignerContext, SIGNER_CONTEXT_KEY } from '$lib/stores/signer.store';
@@ -34,9 +36,13 @@
 	{:else}
 		<SignerAccounts>
 			{#if $idle}
-				<p>Work in progress. Click the OISY Wallet logo above to go back to wallet.</p>
+				<div in:fade={{ delay: 150, duration: 250 }}>
+					<SignerIdle />
+				</div>
 			{:else}
 				<SignerConsentMessage />
+
+				<p>Work in progress. Click the OISY Wallet logo above to go back to wallet.</p>
 			{/if}
 		</SignerAccounts>
 	{/if}


### PR DESCRIPTION
# Motivation

Not sure if I did not integrated it in a previous PR or if it was discarded in a merge conflicts but, the idle animation for the signer should be integrated in the `/sign` route.

# Changes

- User `SignerIdle` in `+page` route `/sign`
