### PR TITLE
style(frontend): Remove legacy blue color

### DIFF
--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -7,7 +7,6 @@
 	--color-grey: theme(colors.grey);
 	--color-light-grey: theme(colors.light-grey);
 	--color-dust: theme(colors.dust);
-	--color-blue: theme(colors.blue);
 	--color-dark-blue: theme(colors.dark-blue);
 	--color-misty-rose: theme(colors.misty-rose);
 

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -8,7 +8,7 @@
 
 	--negative-emphasis: var(--color-cyclamen);
 
-	--primary: var(--color-blue);
+	--primary: var(--color-blue-ribbon);
 	--primary-contrast: var(--color-white);
 	--tertiary: var(--color-secondary);
 
@@ -202,7 +202,7 @@ div.toggle {
 	--card-background: var(--color-white);
 
 	&:has(input[type='checkbox']:checked) {
-		--card-background-contrast: var(--color-blue);
+		--card-background-contrast: var(--color-blue-ribbon);
 	}
 }
 

--- a/src/frontend/src/lib/styles/global/theme.scss
+++ b/src/frontend/src/lib/styles/global/theme.scss
@@ -60,7 +60,7 @@ a {
 }
 a:active,
 a:hover {
-	color: var(--color-blue);
+	color: var(--color-blue-ribbon);
 }
 a:hover,
 a:focus {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,6 @@ export default {
 			grey: '#c0bbc4',
 			'light-grey': '#ced4da',
 			'light-blue': '#e8f1ff',
-			blue: '#3b00b9',
 			'blue-ribbon-rgb': '0, 102, 255',
 			'blue-ribbon': '#0066ff',
 			'dark-blue': '#321469',


### PR DESCRIPTION
# Motivation

Alas, the legacy color defined as `blue` (but more on the purple side) was being used still. This PR removes its references in favor of the new blue decided for the pallet.