### PR TITLE
refactor(frontend): Remove token store from HeroContent

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -13,7 +13,7 @@
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { networkBitcoin, networkEthereum, networkICP } from '$lib/derived/network.derived';
-	import { token } from '$lib/stores/token.store';
+	import { pageToken } from '$lib/derived/page-token.derived';
 
 	export let usdTotal = false;
 	export let summary = false;
@@ -42,9 +42,9 @@
 
 				<div>
 					<div class="my-0.5 flex items-center justify-center">
-						{#if displayTokenSymbol && nonNullish($token)}
+						{#if displayTokenSymbol && nonNullish($pageToken)}
 							<div in:fade>
-								<TokenLogo token={$token} ring networkIconBlackAndWhite />
+								<TokenLogo token={$pageToken} ring networkIconBlackAndWhite />
 							</div>
 						{:else}
 							<SkeletonLogo size="small" />
@@ -69,7 +69,7 @@
 		<Actions />
 	</div>
 
-	{#if isErc20Icp($token)}
+	{#if isErc20Icp($pageToken)}
 		<Erc20Icp />
 	{/if}
 </div>


### PR DESCRIPTION
# Motivation

The `HeroContent` component is using the `token` store. However it is not needed for its scope since it could directly use the `pageToken` store.

In fact, in this context, the token store is set as  such: `token.set($pageToken)`. We are not removing this, we are just substituting the store used to provide the same value.

Some of its sub-components use the `token` store too, but this PR change will not affect them, since we are just reading values that are equals.
We will analyze them in other PRs.
