### PR TITLE
feat(frontend): token grouping view prep

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -4,7 +4,7 @@
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let token: Token;
+	export let token: Pick<Token, 'icon', 'name', 'network'>;
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let showNetworkIcon = true;
 	export let networkIconBlackAndWhite = false;

--- a/src/frontend/src/lib/components/tokens/TokenName.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenName.svelte
@@ -3,7 +3,7 @@
 	import Tag from '$lib/components/ui/Tag.svelte';
 	import type { Token } from '$lib/types/token';
 
-	export let token: Token;
+	export let token: Pick<Token, 'name'>;
 
 	const ariaLabel = nonNullish(token.oisyName)
 		? `${token.oisyName.prefix ?? ''}${token.oisyName.oisyName}`

--- a/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
@@ -5,7 +5,7 @@
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let token: Token;
+	export let token: Pick<Token, 'symbol' | 'network'>;
 </script>
 
 <div class="flex flex-row items-center justify-between gap-2">

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
 	import { debounce } from '@dfinity/utils';
-	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
-	import { showZeroBalances } from '$lib/derived/settings.derived';
-	import type { Token, TokenUi } from '$lib/types/token';
+	import {
+		combinedDerivedFilteredNetworkTokensUi
+	} from '$lib/derived/network-tokens.derived';
+	import type { TokenUi } from '$lib/types/token';
 
 	// We start it as undefined to avoid showing an empty list before the first update.
-	export let tokens: Token[] | undefined = undefined;
+	export let tokens: TokenUi[] | undefined = undefined;
 
 	let sortedTokens: TokenUi[];
-	$: sortedTokens = $combinedDerivedSortedNetworkTokensUi.filter(
-		({ balance, usdBalance }) => Number(balance ?? 0n) || (usdBalance ?? 0) || $showZeroBalances
-	);
+	$: sortedTokens = $combinedDerivedFilteredNetworkTokensUi;
 
 	const updateTokensToDisplay = () => (tokens = [...sortedTokens]);
 

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -6,6 +6,7 @@ import type { Token, TokenUi } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
+import { showZeroBalances } from '$lib/derived/settings.derived';
 
 /**
  * All user-enabled tokens matching the selected network or chain fusion.
@@ -35,3 +36,16 @@ export const combinedDerivedSortedNetworkTokensUi: Readable<TokenUi[]> = derived
 			$exchanges
 		})
 );
+
+/**
+ * Filtered tokens based on user settings (e.g., hiding/showing zero balances).
+ */
+export const combinedDerivedFilteredNetworkTokensUi: Readable<TokenUi[]> = derived(
+	[combinedDerivedSortedNetworkTokensUi, showZeroBalances],
+	([$sortedTokens, $showZeroBalances]) =>
+		$sortedTokens.filter(
+			({ balance, usdBalance }) =>
+				Number(balance ?? 0n) !== 0 || (usdBalance ?? 0) !== 0 || $showZeroBalances
+		)
+);
+


### PR DESCRIPTION
# Motivation

Pr contains clean-up tasks that are needed to implement later token grouping views.

# Changes

- Reduce the component interface to picked properties (needed to dual use with group)
- Move filter away from display handler (needs to be wrapped again later)

# Tests

None
