### PR TITLE
fix(frontend): Alpha is wrongly set when logged out

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -20,6 +20,8 @@
 	class:lg:top-0={$authSignedIn}
 	class:lg:inset-x-0={$authSignedIn}
 	class:lg:z-10={$authSignedIn}
+	class:grid={$authNotSignedIn}
+	class:grid-cols-2={$authNotSignedIn}
 	class:xl:grid={$authNotSignedIn}
 	class:xl:grid-cols-[1fr_auto_1fr]={$authNotSignedIn}
 >


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/2959 I forgot to wrap the Alpha layout for signed out page.

### Before

<img width="543" alt="Screenshot 2024-10-18 at 13 24 50" src="https://github.com/user-attachments/assets/a1d4f84b-5eb7-486c-8c18-13a35a4ab1ea">

### After

<img width="540" alt="Screenshot 2024-10-18 at 13 24 37" src="https://github.com/user-attachments/assets/077fb1c9-31ea-4ea0-a537-a8e092ea892f">
