### PR TITLE
refactor(frontend): Create specific Checkbox component to be re-used

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensZeroBalanceCheckbox.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensZeroBalanceCheckbox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Checkbox } from '@dfinity/gix-components';
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import { hideZeroBalances } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { hideZeroBalancesStore } from '$lib/stores/settings.store';
@@ -11,8 +11,6 @@
 		hideZeroBalancesStore.set({ key: 'hide-zero-balances', value: { enabled: !checked } });
 </script>
 
-<div style="--checkbox-label-order: 1">
-	<Checkbox inputId="checkbox-zero-balance" {checked} on:nnsChange={toggleHide}>
-		{$i18n.tokens.text.hide_zeros}
-	</Checkbox>
-</div>
+<Checkbox bind:checked on:click={toggleHide}>
+	{$i18n.tokens.text.hide_zeros}
+</Checkbox>

--- a/src/frontend/src/lib/components/ui/Checkbox.svelte
+++ b/src/frontend/src/lib/components/ui/Checkbox.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { draw } from 'svelte/transition';
+
+	export let checked: boolean;
+	export let testId: string | undefined = undefined;
+</script>
+
+<label class="flex cursor-pointer items-center gap-3">
+	<div class="relative flex size-fit items-center">
+		<input
+			type="checkbox"
+			class="peer relative size-5 appearance-none rounded border border-light-grey bg-white checked:border-0 checked:bg-blue-ribbon hover:border-blue-ribbon checked:hover:bg-cobalt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-ribbon focus-visible:ring-offset-2"
+			bind:checked
+			on:click
+			data-tid={testId}
+		/>
+		{#if checked}
+			<svg
+				class="pointer-events-none absolute inset-0 m-0.5 hidden size-4 stroke-white outline-none peer-checked:block"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="3"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<polyline in:draw={{ duration: 800 }} points="4 12 9 17 19 7" />
+			</svg>
+		{/if}
+	</div>
+	<slot />
+</label>

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -52,9 +52,6 @@
 	// Segment
 	--segment-selected-background: var(--color-secondary);
 
-	// Checkbox
-	--checkbox-padding: 0;
-
 	// Modal
 
 	--alert-width: calc(100% - var(--padding-8x));
@@ -219,34 +216,5 @@ div.step.completed {
 
 	div.line {
 		--line-color: var(--color-primary);
-	}
-}
-
-div.checkbox {
-	input[type='checkbox'] {
-		--secondary: var(--color-primary);
-		--focus-background: var(--color-white);
-
-		&:focus {
-			--secondary: var(--color-primary);
-			--focus-background: var(--color-white);
-		}
-
-		&:checked {
-			--secondary: var(--color-primary);
-			--focus-background: var(--color-cobalt);
-			--input-custom-border-color: var(--color-primary);
-			--input-background: var(--color-primary);
-
-			&:focus {
-				--secondary: var(--color-cobalt);
-				--focus-background: var(--color-cobalt);
-				--input-custom-border-color: var(--color-cobalt);
-			}
-		}
-
-		&:checked:after {
-			--background-contrast: var(--color-white);
-		}
 	}
 }


### PR DESCRIPTION
# Motivation

With the aim of making it as much closer as the design as possible (but even improving the general estetic of it), we substitute the built-in Checkbox component with a new one with the same functionalities and smaller adaptations. For example, it will now have a central checkmark.

### Default

<img width="441" alt="Screenshot 2024-10-18 at 16 36 55" src="https://github.com/user-attachments/assets/270b79bd-ce2f-4352-808d-ae8eed1b4519">

### Hover

<img width="451" alt="Screenshot 2024-10-18 at 16 37 03" src="https://github.com/user-attachments/assets/8033c912-03e8-47cc-9a49-4686e9733d6f">

### Checked

<img width="461" alt="Screenshot 2024-10-18 at 16 36 50" src="https://github.com/user-attachments/assets/a2d59d03-5c92-4e22-b4d8-844f06028cd6">


### Checked and Hover

<img width="426" alt="Screenshot 2024-10-18 at 16 37 15" src="https://github.com/user-attachments/assets/2794fc4c-218f-415d-b3d3-1f1b639e333f">

### Video of usage

https://github.com/user-attachments/assets/b03ba38b-ea8b-4c26-a85b-96f07ab63d92

# Note

There is no easy way of modifying the an element `<input type="checkbox" ... />` that I know of. In fact, if one wants to customize part of it, it must first annul the previous CSS appearances (`appearance-none`) and then re-build the important things, like the checkmark.