### PR TITLE
feat(frontend): adapt deprecated meta-tag apple-mobile-web-app-capable

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -38,7 +38,7 @@
 		<link rel="shortcut icon" href="%sveltekit.assets%/favicon.ico" />
 
 		<!-- iOS meta tags & icons -->
-		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<meta name="mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="#016DFC" />
 		<meta name="apple-mobile-web-app-title" content="{{OISY_NAME}}" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/favicons/apple-touch-icon.png" />


### PR DESCRIPTION
# Motivation

Chrome is warning about the deprecation of `apple-mobile-web-app-capable` which should be replaced by `mobile-web-app-capable`.

> [!WARNING]  
> meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes"

# Notes

A similar change was applied in Flutter. See https://github.com/flutter/flutter/issues/154596.

# Resources

- https://web.dev/learn/pwa/web-app-manifest#designing_your_pwa_experience

> [!CAUTION]
> Warning: Before the web app manifest spec was defined, several browsers, including Safari on iOS/iPadOS and Chrome on Android, supported custom <meta> elements to describe the application experience, such as apple-mobile-web-app-capable. Do not use these <meta> elements today; it's no longer recommended, and may harm the installation experience when the browser can't load the manifest properly; the experience you get as a fallback may be different and unexpected

- https://web.dev/learn/pwa/enhancements#installation_reliability

> [!CAUTION]
> Warning: If the browser can't load the manifest, it will fall back to check if your PWA has some deprecated meta tags, such as apple-mobile-web-app-capable. You shouldn't use these metatags. They provide a home screen app experience without essential attributes for your PWA, such as honoring the start_url or the scope attributes, making a terrible app experience. 

# Changes

- Rename `apple-mobile-web-app-capable` to `mobile-web-app-capable`

# Screenshot

<img width="1536" alt="Capture d’écran 2024-10-21 à 07 45 47" src="https://github.com/user-attachments/assets/7763e34f-98f0-439d-811f-dd7b69b15d73">

