### PR TITLE
chore(download): update renamed ledger and index did source paths

### DIFF
--- a/HOW-TO.md
+++ b/HOW-TO.md
@@ -30,7 +30,7 @@ Custom tokens seeking compatibility with OISY Wallet can choose one of the follo
 
 ### Index-ng
 
-The source code of the Index-ng canister can be found in the Internet Computer main [repository](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/icrc1/index-ng) and can be downloaded using the following script:
+The source code of the Index-ng canister can be found in the Internet Computer main [repository](https://github.com/dfinity/ic/tree/master/rs/ledger_suite/icrc1/index-ng) and can be downloaded using the following script:
 
 ```bash
 #!/bin/bash
@@ -40,7 +40,7 @@ IC_COMMIT="43f31c0a1b0d9f9ecbc4e2e5f142c56c7d9b0c7b"
 curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index-ng.wasm.gz -o "$DIR"/ckbtc_index.wasm.gz
 gunzip "$DIR"/ckbtc_index.wasm.gz
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/index-ng/index-ng.did -o "$DIR"/ckbtc_index.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did -o "$DIR"/ckbtc_index.did
 ```
 
 > Tips: You can follow this [guide](https://internetcomputer.org/docs/current/developer-docs/defi/icrc-1/icrc1-index-setup) to deploy an ICRC-1 index canister locally.
@@ -69,4 +69,4 @@ This function allows querying of balance and transactions for a specific account
 get_account_transactions : (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
 ```
 
-Find more information in the Index-ng [Candid file definition](https://github.com/dfinity/ic/blob/master/rs/rosetta-api/icrc1/index/index.did).
+Find more information in the Index-ng [Candid file definition](https://github.com/dfinity/ic/blob/master/rs/ledger_suite/icrc1/index-ng/index-ng.did).

--- a/scripts/download.ckbtc.sh
+++ b/scripts/download.ckbtc.sh
@@ -24,8 +24,8 @@ gunzip "$DIR"/ckbtc_kyt.wasm.gz
 
 curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/minter/ckbtc_minter.did -o "$DIR"/ckbtc_minter.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/ledger/ledger.did -o "$DIR"/ckbtc_ledger.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/ledger/ledger.did -o "$DIR"/ckbtc_ledger.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/index-ng/index-ng.did -o "$DIR"/ckbtc_index.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did -o "$DIR"/ckbtc_index.did
 
 curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/kyt/kyt.did -o "$DIR"/ckbtc_kyt.did

--- a/scripts/download.cketh.sh
+++ b/scripts/download.cketh.sh
@@ -22,6 +22,6 @@ gunzip "$DIR"/cketh_index.wasm.gz
 
 curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ethereum/cketh/minter/cketh_minter.did -o "$DIR"/cketh_minter.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/ledger/ledger.did -o "$DIR"/cketh_ledger.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/ledger/ledger.did -o "$DIR"/cketh_ledger.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/rosetta-api/icrc1/index-ng/index-ng.did -o "$DIR"/cketh_index.did
+curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did -o "$DIR"/cketh_index.did

--- a/scripts/download.icp.sh
+++ b/scripts/download.icp.sh
@@ -12,8 +12,8 @@ IC_VERSION=b0ade55f7e8999e2842fe3f49df163ba224b71a2
 
 curl -o "$DIR"/icp_index.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ic-icp-index-canister.wasm.gz"
 gunzip "$DIR"/icp_index.wasm.gz
-curl -o "$DIR"/icp_index.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/rosetta-api/icp_ledger/index/index.did"
+curl -o "$DIR"/icp_index.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/index/index.did"
 
 curl -o "$DIR"/icp_ledger.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister.wasm.gz"
 gunzip "$DIR"/icp_ledger.wasm.gz
-curl -o "$DIR"/icp_ledger.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/rosetta-api/icp_ledger/ledger.did"
+curl -o "$DIR"/icp_ledger.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/ledger/ledger.did"


### PR DESCRIPTION
# Motivation

The `rosetta-api` path was renamed and restructured to `ledger_suite` in the IC main repo. Therefore we have to update the paths to download the ICP and ICRC ledger and index did files.

# Notes

Detected in ic-js and fixed in PR https://github.com/dfinity/ic-js/pull/736

# Changes

- Update path as in [https://github.com/dfinity/ic/tree/master/rs/ledger_suite](https://github.com/dfinity/ic/tree/master/rs/ledger_suite)
