### PR TITLE
chore(frontend): Remove SASS deprecation warning for imports

### DIFF
--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @use './global/font-faces';
 @use './global/fonts';
 @use './global/theme';
@@ -15,3 +11,7 @@
 @use './global/position';
 @use './global/links';
 @use './global/border';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -2,16 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
-@import './global/font-faces';
-@import './global/fonts';
-@import './global/theme';
-@import './global/variables';
-@import './global/colors';
-@import './global/layout';
-@import './global/body';
-@import './global/button';
-@import './global/text';
-@import './global/gix';
-@import './global/position';
-@import './global/links';
-@import './global/border';
+@use './global/font-faces';
+@use './global/fonts';
+@use './global/theme';
+@use './global/variables';
+@use './global/colors';
+@use './global/layout';
+@use './global/body';
+@use './global/button';
+@use './global/text';
+@use './global/gix';
+@use './global/position';
+@use './global/links';
+@use './global/border';
+

--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -15,4 +15,3 @@
 @use './global/position';
 @use './global/links';
 @use './global/border';
-

--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -1,4 +1,4 @@
-@use "sass:meta";
+@use 'sass:meta';
 
 @tailwind base;
 @tailwind components;

--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -1,17 +1,19 @@
-@use './global/font-faces';
-@use './global/fonts';
-@use './global/theme';
-@use './global/variables';
-@use './global/colors';
-@use './global/layout';
-@use './global/body';
-@use './global/button';
-@use './global/text';
-@use './global/gix';
-@use './global/position';
-@use './global/links';
-@use './global/border';
+@use "sass:meta";
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@include meta.load-css('global/font-faces');
+@include meta.load-css('global/fonts');
+@include meta.load-css('global/theme');
+@include meta.load-css('global/variables');
+@include meta.load-css('global/colors');
+@include meta.load-css('global/layout');
+@include meta.load-css('global/body');
+@include meta.load-css('global/button');
+@include meta.load-css('global/text');
+@include meta.load-css('global/gix');
+@include meta.load-css('global/position');
+@include meta.load-css('global/links');
+@include meta.load-css('global/border');


### PR DESCRIPTION
# Motivation

The syntax `@import` was deprecated in favor of `@use` and `@forward` (see [announcement](https://sass-lang.com/blog/import-is-deprecated/)). As per the latest versions of SASS, we are receiving deprecation warnings about it, for example:

```bash
Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
6 │ @import './global/fonts';
  │         ^^^^^^^^^^^^^^^^
  ╵
    src/frontend/src/lib/styles/global.scss 6:9  root stylesheet
```

So we adjust the only usages of `@import` left.

To do that I used directly the command suggested in the article:

`sass-migrator module --migrate-deps ./global.scss`
