### PR TITLE
chore(download): fix ic commit version for local deployement

### DIFF
--- a/scripts/download.ckbtc.sh
+++ b/scripts/download.ckbtc.sh
@@ -8,7 +8,7 @@ if [ ! -d "$DIR" ]; then
   mkdir "$DIR"
 fi
 
-IC_COMMIT="43f31c0a1b0d9f9ecbc4e2e5f142c56c7d9b0c7b"
+IC_COMMIT="03dd6ee6de80c2202f66948692c69c61eb6af54d"
 
 curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz -o "$DIR"/ckbtc_minter.wasm.gz
 gunzip "$DIR"/ckbtc_minter.wasm.gz

--- a/scripts/download.cketh.sh
+++ b/scripts/download.cketh.sh
@@ -8,7 +8,7 @@ if [ ! -d "$DIR" ]; then
   mkdir "$DIR"
 fi
 
-IC_COMMIT="83462faa39fe9b5c020edd6a3bf2b3660ad19fca"
+IC_COMMIT="03dd6ee6de80c2202f66948692c69c61eb6af54d"
 
 curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-cketh-minter.wasm.gz -o "$DIR"/cketh_minter.wasm.gz
 gunzip "$DIR"/cketh_minter.wasm.gz

--- a/scripts/download.icp.sh
+++ b/scripts/download.icp.sh
@@ -8,7 +8,7 @@ if [ ! -d "$DIR" ]; then
   mkdir "$DIR"
 fi
 
-IC_VERSION=b0ade55f7e8999e2842fe3f49df163ba224b71a2
+IC_VERSION=03dd6ee6de80c2202f66948692c69c61eb6af54d
 
 curl -o "$DIR"/icp_index.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ic-icp-index-canister.wasm.gz"
 gunzip "$DIR"/icp_index.wasm.gz


### PR DESCRIPTION
# Motivation

In #2996 I updated the new paths to match the IC main repo structure but, forgot to also update the commit version accordingly given that our scripts are pinned.

# Changes

- Update version to https://github.com/dfinity/ic/commit/03dd6ee6de80c2202f66948692c69c61eb6af54d which introduced the folder refactoring.
