### PR TITLE
chore(download): fix icp ledger did path

### DIFF
--- a/scripts/download.icp.sh
+++ b/scripts/download.icp.sh
@@ -16,4 +16,4 @@ curl -o "$DIR"/icp_index.did "https://raw.githubusercontent.com/dfinity/ic/$IC_V
 
 curl -o "$DIR"/icp_ledger.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister.wasm.gz"
 gunzip "$DIR"/icp_ledger.wasm.gz
-curl -o "$DIR"/icp_ledger.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/ledger/ledger.did"
+curl -o "$DIR"/icp_ledger.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/ledger.did"


### PR DESCRIPTION
# Motivation

In #2996 I updated the new paths to match the IC main repo structure but, turns out the IC main repo is organized differently for the ledger and index ICP. The first is at the root of `ledger_suite` while the second is in a subfolder.

# Changes

- Correct `ledger.did` path for ICP
