### PR TITLE
refactor(frontend): extract copy to clipboard to a module

### DIFF
--- a/src/frontend/src/lib/components/ui/Copy.svelte
+++ b/src/frontend/src/lib/components/ui/Copy.svelte
@@ -1,27 +1,16 @@
 <script lang="ts">
 	import IconCopy from '$lib/components/icons/IconCopy.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { toastsShow } from '$lib/stores/toasts.store';
-	import { copyText } from '$lib/utils/share.utils';
+	import { copyToClipboard } from '$lib/utils/clipboard.utils';
 
 	export let value: string;
 	export let text: string;
 	export let inline = false;
 	export let color: 'blue' | 'inherit' = 'blue';
-
-	const copyToClipboard = async () => {
-		await copyText(value);
-
-		toastsShow({
-			text,
-			level: 'success',
-			duration: 2000
-		});
-	};
 </script>
 
 <button
-	on:click|preventDefault|stopPropagation={copyToClipboard}
+	on:click|preventDefault|stopPropagation={async () => await copyToClipboard({ value, text })}
 	aria-label={`${$i18n.core.text.copy}: ${value}`}
 	class="pl-0.5"
 	class:py-2={!inline}

--- a/src/frontend/src/lib/utils/clipboard.utils.ts
+++ b/src/frontend/src/lib/utils/clipboard.utils.ts
@@ -1,0 +1,12 @@
+import { toastsShow } from '$lib/stores/toasts.store';
+import { copyText } from '$lib/utils/share.utils';
+
+export const copyToClipboard = async ({ value, text }: { value: string; text: string }) => {
+	await copyText(value);
+
+	toastsShow({
+		text: text,
+		level: 'success',
+		duration: 2000
+	});
+};


### PR DESCRIPTION
# Motivation

In #3013 we will need a specific copy button icon. I'm not sure if it will be use elsewhere, that's why instead of enhancing the existing `Copy` button, I rather like to create a specific "Receive related button". Also why it's handy to extract the "copy to clipboard" function to a module for reusability purposes.

# Changes

- Move existing copy to clipboard function to a utils.

# Tests

No particular tests.
