### PR TITLE
feat(frontend): smallish logo size

### DIFF
--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -5,12 +5,13 @@
 
 	export let src: string | undefined;
 	export let alt = '';
-	export let size: 'small' | 'medium' | 'big' = 'small';
+	export let size: 'small' | 'smallish' | 'medium' | 'big' = 'small';
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let ring = false;
 
 	const sizes = {
 		small: '22px',
+		smallish: '36px',
 		medium: '52px',
 		big: '64px'
 	};

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -5,6 +5,7 @@
 
 	export let src: string | undefined;
 	export let alt = '';
+	// TODO: rename into xs | sm | md | lg
 	export let size: 'small' | 'smallish' | 'medium' | 'big' = 'small';
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let ring = false;


### PR DESCRIPTION
# Motivation

In #3013 we need a new logo size between "small" and "medium". I was not sure how to called it, so I named it "smallish". Open to better idea!

# Changes

- Add `smallish` option to `Logo` for an icon of `36px`.
