### PR TITLE
fix(frontend): Remove conversion action when not in transaction page

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -50,24 +50,26 @@
 
 		<Send {isTransactionsPage} />
 
-		{#if convertEth}
-			{#if $networkICP}
-				<ConvertToEthereum />
-			{:else}
-				<ConvertToCkETH />
+		{#if isTransactionsPage}
+			{#if convertEth}
+				{#if $networkICP}
+					<ConvertToEthereum />
+				{:else}
+					<ConvertToCkETH />
+				{/if}
 			{/if}
-		{/if}
 
-		{#if convertErc20}
-			{#if $networkICP}
-				<ConvertToEthereum />
-			{:else}
-				<ConvertToCkERC20 />
+			{#if convertErc20}
+				{#if $networkICP}
+					<ConvertToEthereum />
+				{:else}
+					<ConvertToCkERC20 />
+				{/if}
 			{/if}
-		{/if}
 
-		{#if convertBtc}
-			<ConvertToBTC />
+			{#if convertBtc}
+				<ConvertToBTC />
+			{/if}
 		{/if}
 
 		<Buy />


### PR DESCRIPTION
# Motivation

There was a bug so that when we set the `token` store to a convertible one in the main page, the conversion button would appear (since it is linked to the `token` store and its possibility to be converted).

To quickly fix the visual aspect of the issue, we filter that button to appear ONLY in when the user already selected the token, meaning, when the user is in a transaction page. In that case, in fact, the `token` store is set to be the `pageToken`.

# NOTE

To re-iterate, this does not fixes the issue completely, it is just a visual fix. The correct long-term fix is to remove the deprecated `token` store and adapt the code.

# Tests

### Before

We notice that the conversion button appears and stays when we select a convertible token in the main page.

https://github.com/user-attachments/assets/4067543a-cdbe-4827-bee5-e66966598626

### After

https://github.com/user-attachments/assets/fdc2947f-8358-4ad6-9c78-e123aae89544





