### PR TITLE
feat(frontend): receive address copy button

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveCopy.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveCopy.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import IconCopy from '$lib/components/icons/IconCopy.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard.utils';
+
+	export let address: string;
+	export let copyAriaLabel: string;
+</script>
+
+<ButtonIcon
+	ariaLabel={copyAriaLabel}
+	on:click={async () => await copyToClipboard({ value: address, text: copyAriaLabel })}
+>
+	<IconCopy size="24" slot="icon" />
+</ButtonIcon>


### PR DESCRIPTION
# Motivation

For #3013 we need a new "Copy address" button. As explained in PR #3014, for now it just gonna be dedicated to the address and uses the existing function that was extracted in this related PR.

# Changes

- Create a "Copy receive address" button component.
