### PR TITLE
feat(frontend): convert logo size to breakpoint prefix

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -61,7 +61,7 @@
 						src={token.token.icon}
 						slot="icon"
 						alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.token.name })}
-						size="medium"
+						size="md"
 						color="white"
 					/>
 

--- a/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
@@ -27,7 +27,7 @@
 					color="white"
 					src={token.network.icon}
 					alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.network.name })}
-					size="medium"
+					size="md"
 				/>
 			{/if}
 		</div>

--- a/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
@@ -18,7 +18,7 @@
 	<div class="icon flex flex-col items-center gap-3">
 		<Logo
 			src={$token?.icon}
-			size="big"
+			size="lg"
 			alt={replacePlaceholders($i18n.core.alt.logo, { $name: $token?.name ?? '' })}
 			color="off-white"
 		/>

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -21,7 +21,7 @@
 	<Logo
 		src={icon}
 		alt={replacePlaceholders($i18n.core.alt.logo, { $name: name })}
-		size="medium"
+		size="md"
 		{color}
 		{ring}
 	/>

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -5,16 +5,15 @@
 
 	export let src: string | undefined;
 	export let alt = '';
-	// TODO: rename into xs | sm | md | lg
-	export let size: 'small' | 'smallish' | 'medium' | 'big' = 'small';
+	export let size: 'xs' | 'sm' | 'md' | 'lg' = 'xs';
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let ring = false;
 
 	const sizes = {
-		small: '22px',
-		smallish: '36px',
-		medium: '52px',
-		big: '64px'
+		xs: '22px',
+		sm: '36px',
+		md: '52px',
+		lg: '64px'
 	};
 	let sizePx = sizes[size];
 


### PR DESCRIPTION
# Motivation

Follow-up of #3015 in which we decided to adopt breakpoint prefix to describe the various sizes of the logo

# Changes

- Replace `small | smallish | medium | big` by `xs | sm | md | lg`
