### PR TITLE
style(frontend): metamask secondary button

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -31,7 +31,7 @@
 </script>
 
 {#if $metamaskAvailable && $networkEthereum && tokenStandardEth}
-	<Button fullWidth styleClass="my-4" on:click={receiveModal}>
+	<Button colorStyle="secondary" fullWidth styleClass="mt-8 mb-2" on:click={receiveModal}>
 		<IconMetamask />
 		<span class="text-dark-slate-blue font-bold">{$i18n.receive.ethereum.text.metamask}</span>
 	</Button>

--- a/src/frontend/src/lib/components/icons/IconMetamask.svelte
+++ b/src/frontend/src/lib/components/icons/IconMetamask.svelte
@@ -8,7 +8,7 @@
 	viewBox="0 0 204.8 192.4"
 	style="enable-background:new 0 0 204.8 192.4;"
 	xml:space="preserve"
-	height="32"
+	height="24"
 >
 	<style type="text/css">
 		.st0 {


### PR DESCRIPTION
# Motivation

The Metamask btn is currently displayed as a primary call to action which is incorrect.

# Notes

This PR does not exactly style the button as in the last iteration of Figma which modified again the secondary button. Therefore it just set the button to secondary that way, when we modify again the buttons, it will inherit the style.

# Changes

- Use secondary and reduce the size of the icon to make the button less big

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-22 à 07 02 25" src="https://github.com/user-attachments/assets/ba2691cc-2735-487f-98b8-d0b37083865b">

After:

<img width="1536" alt="Capture d’écran 2024-10-22 à 07 09 39" src="https://github.com/user-attachments/assets/d2743278-cc86-418b-b109-2b76d268bbb7">

