### PR TITLE
refactor(frontend): Introduce new size for Logo component

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -61,7 +61,7 @@
 						src={token.token.icon}
 						slot="icon"
 						alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.token.name })}
-						size="md"
+						size="lg"
 						color="white"
 					/>
 

--- a/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressWithLogo.svelte
@@ -27,7 +27,7 @@
 					color="white"
 					src={token.network.icon}
 					alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.network.name })}
-					size="md"
+					size="lg"
 				/>
 			{/if}
 		</div>

--- a/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
@@ -18,7 +18,7 @@
 	<div class="icon flex flex-col items-center gap-3">
 		<Logo
 			src={$token?.icon}
-			size="lg"
+			size="xl"
 			alt={replacePlaceholders($i18n.core.alt.logo, { $name: $token?.name ?? '' })}
 			color="off-white"
 		/>

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -21,7 +21,7 @@
 	<Logo
 		src={icon}
 		alt={replacePlaceholders($i18n.core.alt.logo, { $name: name })}
-		size="md"
+		size="lg"
 		{color}
 		{ring}
 	/>

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -5,15 +5,16 @@
 
 	export let src: string | undefined;
 	export let alt = '';
-	export let size: 'xs' | 'sm' | 'md' | 'lg' = 'xs';
+	export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'xs';
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let ring = false;
 
 	const sizes = {
 		xs: '22px',
 		sm: '36px',
-		md: '52px',
-		lg: '64px'
+		md: '42px',
+		lg: '52px',
+		xl: '64px'
 	};
 	let sizePx = sizes[size];
 


### PR DESCRIPTION
# Motivation

In PR #3028 we are going to use an additional size for Logo, that is `42px`.

So, we "shift" all the sizes so that the new mapping is

```typescript
const sizes = {
  xs: '22px',
  sm: '36px',
  md: '42px',
  lg: '52px',
  xl: '64px'
};
```