### PR TITLE
feat(frontend): back and logo transition

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { quintOut } from 'svelte/easing';
+	import { slide, type SlideParams } from 'svelte/transition';
 	import WalletConnect from '$eth/components/wallet-connect/WalletConnect.svelte';
 	import SignIn from '$lib/components/auth/SignIn.svelte';
 	import Alpha from '$lib/components/core/Alpha.svelte';
@@ -12,6 +14,8 @@
 	import { modalAboutHow, modalAboutWhat } from '$lib/derived/modal.derived';
 
 	export let back = false;
+
+	const backAndLogoTransition: SlideParams = { axis: 'x', easing: quintOut, duration: 150 };
 </script>
 
 <header
@@ -27,9 +31,13 @@
 >
 	<div class="pointer-events-auto">
 		{#if back}
-			<Back />
+			<div in:slide={backAndLogoTransition}>
+				<Back />
+			</div>
 		{:else}
-			<OisyWalletLogoLink />
+			<div in:slide={backAndLogoTransition}>
+				<OisyWalletLogoLink />
+			</div>
 		{/if}
 	</div>
 


### PR DESCRIPTION
# Motivation

I find the transition between "OISY logo" and "Back" in the header a bit rough. Therefore I proposed to add an small slide animation between the two states.

# Changes

- Use an `in:slide` on `x` axis when components are displayed

# Screenshots

![Google Chrome](https://github.com/user-attachments/assets/3d8836d0-21e3-4439-94d3-1ba23add6033)

