### PR TITLE
feat(frontend): add menu for dapp explorer

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -17,7 +17,8 @@
 	import { NAVIGATION_MENU_BUTTON, NAVIGATION_MENU } from '$lib/constants/test-ids.constants';
 	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { isRouteSettings, networkParam } from '$lib/utils/nav.utils';
+	import { isRouteDappExplorer, isRouteSettings, networkParam } from '$lib/utils/nav.utils';
+	import IconlyUfo from '$lib/components/icons/iconly/IconlyUfo.svelte';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -28,9 +29,16 @@
 		hidePopover();
 		await goto(`/settings?${networkParam($networkId)}`);
 	};
+	const goToDappExplorer = async () => {
+		hidePopover();
+		await goto(`/explore`);
+	};
 
 	let settingsRoute = false;
 	$: settingsRoute = isRouteSettings($page);
+
+	let dAppExplorerRoute = false;
+	$: dAppExplorerRoute = isRouteDappExplorer($page);
 
 	let walletOptions = true;
 	$: walletOptions = !settingsRoute;
@@ -50,6 +58,13 @@
 	<div class="flex flex-col gap-4" data-tid={NAVIGATION_MENU}>
 		{#if walletOptions}
 			<MenuWallet on:icMenuClick={hidePopover} />
+		{/if}
+
+		{#if !dAppExplorerRoute && !settingsRoute}
+			<ButtonMenu ariaLabel={$i18n.navigation.alt.dapp_explorer} on:click={goToDappExplorer}>
+				<IconlyUfo size="20" />
+				{$i18n.navigation.text.dapp_explorer}
+			</ButtonMenu>
 		{/if}
 
 		{#if !settingsRoute}


### PR DESCRIPTION
# Motivation

The Dapp explorer is missing in the mobile navigation.

# Changes

Add menu item in mobile nav.

Implemented the following visiblity but open for comments:

route: /

![image](https://github.com/user-attachments/assets/9f6024b5-8f60-4463-afb4-53ac46a460d9)

route: /settings

![image](https://github.com/user-attachments/assets/bc9bf096-c52e-4164-816a-a16b299ecf58)

route: /explore

![image](https://github.com/user-attachments/assets/6aa55328-ecc9-4ba4-a46d-ecdaabf677b4)

