### PR TITLE
feat(frontend): Introduce OisySymbol prop for appearence interface

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div class="flex flex-row items-center justify-between gap-2">
-	{token.symbol}
+	{nonNullish(token.oisySymbol) ? token.oisySymbol.oisySymbol : token.symbol}
 
 	{#if nonNullish(token.network.iconBW)}
 		<Logo

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -26,11 +26,16 @@ export interface TokenMetadata {
 }
 
 export interface TokenAppearance {
+	oisySymbol?: TokenOisySymbol;
 	oisyName?: TokenOisyName;
 }
 
+export interface TokenOisySymbol {
+	oisySymbol: string;
+}
+
 export interface TokenOisyName {
-	prefix: string | undefined;
+	prefix?: string | undefined;
 	oisyName: string;
 }
 


### PR DESCRIPTION
# Motivation

For grouping tokens, we are going to re-use the `TokenCard` component that takes a few props of a given token, for example `name` and `symbol`. However, for the group, we will provide some different data to be shown, just for appearance sake.

For prop `name`, we already have `oisyName` substitute to show something different in place. But, for `symbol`, there is nothing.

So, similar to `oisyName`, we create an optional prop `oisySymbol` to be provided if we want to show some substitute to the usual `token.symbol`, just for different appearance.


