### PR TITLE
refactor(frontend): extract qr code address content component

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
-	import ReceiveQRCode from '$lib/components/receive/ReceiveQRCode.svelte';
+	import ReceiveAddressQRCodeContent from '$lib/components/receive/ReceiveAddressQRCodeContent.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Copy from '$lib/components/ui/Copy.svelte';
-	import { RECEIVE_TOKENS_MODAL_QR_CODE_OUTPUT } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 
@@ -16,16 +14,7 @@
 </script>
 
 <ContentWithToolbar minHeight="50vh">
-	<p class="text-center font-bold">{addressLabel ?? $i18n.wallet.text.address}:</p>
-	<p class="mb-4 px-2 text-center font-normal">
-		<output class="break-all" data-tid={RECEIVE_TOKENS_MODAL_QR_CODE_OUTPUT}>{address}</output><Copy
-			inline
-			value={address ?? ''}
-			text={$i18n.wallet.text.address_copied}
-		/>
-	</p>
-
-	<ReceiveQRCode address={address ?? ''} {addressToken} />
+	<ReceiveAddressQRCodeContent {address} {addressLabel} {addressToken} />
 
 	<Button
 		colorStyle="secondary"

--- a/src/frontend/src/lib/components/receive/ReceiveAddressQRCodeContent.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQRCodeContent.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import ReceiveQRCode from '$lib/components/receive/ReceiveQRCode.svelte';
+	import Copy from '$lib/components/ui/Copy.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Address, OptionAddress } from '$lib/types/address';
+	import type { Token } from '$lib/types/token';
+
+	export let address: OptionAddress<Address>;
+	export let addressLabel: string | undefined = undefined;
+	export let addressToken: Token | undefined;
+	export let testId: string | undefined = undefined;
+</script>
+
+<p class="text-center font-bold">{addressLabel ?? $i18n.wallet.text.address}:</p>
+<p class="mb-4 px-2 text-center font-normal">
+	<output class="break-all" data-tid={testId}>{address}</output><Copy
+		inline
+		value={address ?? ''}
+		text={$i18n.wallet.text.address_copied}
+	/>
+</p>
+
+<ReceiveQRCode address={address ?? ''} {addressToken} />

--- a/src/frontend/src/lib/components/receive/ReceiveModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveModal.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
-	import ReceiveQRCode from '$lib/components/receive/ReceiveQRCode.svelte';
+	import ReceiveAddressQRCodeContent from '$lib/components/receive/ReceiveAddressQRCodeContent.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Copy from '$lib/components/ui/Copy.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionAddress, Address } from '$lib/types/address';
@@ -17,16 +16,7 @@
 	<svelte:fragment slot="title">{$i18n.receive.text.receive}</svelte:fragment>
 
 	<ContentWithToolbar>
-		<p class="text-center font-bold">Address:</p>
-		<p class="mx-auto mb-4 max-w-xs px-2 text-center font-normal">
-			<output class="break-all">{address ?? ''}</output><Copy
-				inline
-				value={address ?? ''}
-				text={$i18n.wallet.text.address_copied}
-			/>
-		</p>
-
-		<ReceiveQRCode address={address ?? ''} {addressToken} />
+		<ReceiveAddressQRCodeContent {address} {addressToken} />
 
 		<slot name="content" />
 


### PR DESCRIPTION
# Motivation

Two components that display a QR-code where using a similar content - a qr code, and address and a copy button. As we have to update their UI, it felt like the good time to extract a common component.

Plus, I spotted a missing i18n key usage.

# Changes

- Extract new component `ReceiveAddressQRCodeContent` to present the qr code and address
