### PR TITLE
feat(frontend): network icon black white for receive

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddress.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddress.svelte
@@ -30,7 +30,7 @@
 		<div class="flex items-center justify-between gap-6 rounded-lg bg-zumthor px-3 py-2">
 			<div class="h-8 w-8">
 				<Logo
-					src={network.icon}
+					src={network.iconBW}
 					alt={replacePlaceholders($i18n.core.alt.logo, { $name: network.name })}
 					color="white"
 					size="sm"


### PR DESCRIPTION
# Motivation

The network icon displayed in the receive modals should be black and white according Figma.
