### PR TITLE
feat(frontend): Add padding prop to Button component

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -34,7 +34,7 @@
 				<h4 class="text-white">{dAppDescription.name}</h4>
 			</div>
 
-			<Button padding="md" styleClass="flex-grow-0 text-sm" colorStyle="secondary" on:click>
+			<Button padding="sm" styleClass="flex-grow-0 text-sm" colorStyle="secondary" on:click>
 				{$i18n.core.text.view}
 			</Button>
 		</div>

--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -34,7 +34,7 @@
 				<h4 class="text-white">{dAppDescription.name}</h4>
 			</div>
 
-			<Button paddingSmall styleClass="flex-grow-0 text-sm" colorStyle="secondary" on:click>
+			<Button padding="md" styleClass="flex-grow-0 text-sm" colorStyle="secondary" on:click>
 				{$i18n.core.text.view}
 			</Button>
 		</div>

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -52,7 +52,7 @@
 
 <div class="flex flex-wrap gap-4">
 	<Button
-		paddingSmall
+		padding="md"
 		ariaLabel={$i18n.dapps.alt.show_all}
 		on:click={() => (selectedTag = undefined)}
 		styleClass="text-nowrap max-w-fit text-sm"
@@ -61,7 +61,7 @@
 	>
 	{#each uniqueTags as tag}
 		<Button
-			paddingSmall
+			padding="md"
 			ariaLabel={replacePlaceholders($i18n.dapps.alt.show_tag, { $tag: tag })}
 			on:click={() => (selectedTag = tag)}
 			styleClass="text-nowrap max-w-fit text-sm"

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -52,7 +52,7 @@
 
 <div class="flex flex-wrap gap-4">
 	<Button
-		padding="md"
+		padding="sm"
 		ariaLabel={$i18n.dapps.alt.show_all}
 		on:click={() => (selectedTag = undefined)}
 		styleClass="text-nowrap max-w-fit text-sm"
@@ -61,7 +61,7 @@
 	>
 	{#each uniqueTags as tag}
 		<Button
-			padding="md"
+			padding="sm"
 			ariaLabel={replacePlaceholders($i18n.dapps.alt.show_tag, { $tag: tag })}
 			on:click={() => (selectedTag = tag)}
 			styleClass="text-nowrap max-w-fit text-sm"

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -1,27 +1,26 @@
 <script lang="ts">
-	import type { ButtonColorStyle } from '$lib/types/style';
 	import type { PaddingSize } from '$lib/types/components';
+	import type { ButtonColorStyle } from '$lib/types/style';
 
 	export let colorStyle: ButtonColorStyle = 'primary';
 	export let type: 'submit' | 'reset' | 'button' = 'submit';
 	export let disabled = false;
 	export let fullWidth = false;
 	export let link = false;
-	export let padding: PaddingSize= 'lg';
+	export let padding: PaddingSize = 'lg';
 	export let testId: string | undefined = undefined;
 	export let ariaLabel: string | undefined = undefined;
 	export let styleClass = '';
 
-	const paddings:Record<PaddingSize, string> = {
+	const paddings: Record<PaddingSize, string> = {
 		xs: 'p-1',
 		sm: 'px-3 py-2',
 		md: 'px-4 py-3',
 		lg: 'px-5 py-4',
 		xl: 'p-5',
-		none: 'p-0',
+		none: 'p-0'
 	};
-	let paddingStyle = paddings[padding]
-
+	let paddingStyle = paddings[padding];
 </script>
 
 <button

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -1,20 +1,31 @@
 <script lang="ts">
 	import type { ButtonColorStyle } from '$lib/types/style';
+	import type { PaddingSize } from '$lib/types/components';
 
 	export let colorStyle: ButtonColorStyle = 'primary';
 	export let type: 'submit' | 'reset' | 'button' = 'submit';
 	export let disabled = false;
 	export let fullWidth = false;
 	export let link = false;
-	export let paddingSmall = false;
+	export let padding: PaddingSize= 'lg';
 	export let testId: string | undefined = undefined;
 	export let ariaLabel: string | undefined = undefined;
 	export let styleClass = '';
+
+	const paddings:Record<PaddingSize, string> = {
+		xs: 'p-1',
+		sm: 'px-3 py-2',
+		md: 'px-4 py-3',
+		lg: 'px-5 py-4',
+		xl: 'p-5',
+		none: 'p-0',
+	};
+	let paddingStyle = paddings[padding]
+
 </script>
 
 <button
-	class={`${colorStyle} flex flex-1 text-center ${styleClass}`}
-	class:padding-sm={paddingSmall}
+	class={`${colorStyle} flex flex-1 text-center ${paddingStyle} ${styleClass}`}
 	class:w-full={fullWidth}
 	class:link
 	{type}

--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -6,7 +6,7 @@
 	export let ariaLabel: string;
 </script>
 
-<Button on:click {ariaLabel} {disabled} {testId} colorStyle="tertiary" link padding="md">
+<Button on:click {ariaLabel} {disabled} {testId} colorStyle="tertiary" link padding="sm">
 	<div class="flex flex-col items-center justify-center gap-2 md:flex-row">
 		<slot name="icon" />
 		<div class="min-w-12 max-w-[72px] break-words text-sm md:text-base">

--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -6,7 +6,7 @@
 	export let ariaLabel: string;
 </script>
 
-<Button on:click {ariaLabel} {disabled} {testId} colorStyle="tertiary" link paddingSmall>
+<Button on:click {ariaLabel} {disabled} {testId} colorStyle="tertiary" link padding="md">
 	<div class="flex flex-col items-center justify-center gap-2 md:flex-row">
 		<slot name="icon" />
 		<div class="min-w-12 max-w-[72px] break-words text-sm md:text-base">

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -31,8 +31,6 @@ a.as-button {
 	&.error {
 		justify-content: center;
 
-		padding: var(--button-padding);
-
 		&.icon {
 			--button-border-radius: var(--border-radius-sm-1_5x);
 			--button-padding: var(--padding);

--- a/src/frontend/src/lib/types/components.ts
+++ b/src/frontend/src/lib/types/components.ts
@@ -1,0 +1,3 @@
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export type PaddingSize = Size | 'none';


### PR DESCRIPTION
# Motivation

To align more with the Design structure and to be more re-usable, we add an optional parameter to component Button, that is padding size, mapped as such it reflects the Design team plan:

```typescript
const paddings:Record<PaddingSize, string> = {
  xs: 'p-1',
  sm: 'px-3 py-2',
  md: 'px-4 py-3',
  lg: 'px-5 py-4',
  xl: 'p-5',
  none: 'p-0',
};
```

It will default to `lg` that is more or less the current default value defined in CSS.

- CSS --> `padding-x = 21.6px ; padding-y = 14.4px`
- new one --> `padding-x = 20px ; padding-y = 16px`

Note that the previous definition of `paddingSmall` is now defined as padding `sm`.


# Changes

- Create new type for padding size.
- Define padding size map in Button component.
- Replace `paddingSmall` usage with `padding='sm'`
- Remove `paddingSmall` prop.

# Tests

Small visual change in the buttons

### Before

![Screenshot 2024-10-23 at 11 03 33](https://github.com/user-attachments/assets/1c9a0600-16d2-4f82-94c2-3cfb2a6de9a3)

### After

![Screenshot 2024-10-23 at 11 03 57](https://github.com/user-attachments/assets/dde32011-78a2-4733-a4d2-ee3c32fe80c4)


