### PR TITLE
feat(frontend): Carousel utils

### DIFF
--- a/src/frontend/src/lib/utils/carousel.utils.ts
+++ b/src/frontend/src/lib/utils/carousel.utils.ts
@@ -1,0 +1,96 @@
+import { isNullish } from '@dfinity/utils';
+
+interface CommonParams {
+	sliderFrame: HTMLElement | undefined;
+}
+
+/**
+ * A util for building carousel slider frame item.
+ */
+export const buildCarouselSliderFrameItem = ({
+	slide,
+	totalSlides
+}: {
+	slide: Node;
+	totalSlides: number;
+}): HTMLDivElement => {
+	// Create slider frame item and apply styling
+	const frameItem = document.createElement('div');
+	frameItem.style.width = `${100 / totalSlides}%`;
+
+	frameItem.appendChild(slide);
+
+	return frameItem;
+};
+
+/**
+ * A util for building carousel slider frame.
+ */
+export const buildCarouselSliderFrame = ({
+	slides,
+	slideWidth
+}: {
+	slides: Node[];
+	slideWidth: number;
+}): HTMLDivElement => {
+	// We add the last slide as the first element to properly animate last-to-first slide transition.
+	// The same applies to the last element - we use the first slide as the last item of the array.
+	const extendedSlides = [slides[slides.length - 1], ...slides, slides[0]];
+	const totalSlides = extendedSlides.length;
+
+	// Create slider frame and apply styling
+	const sliderFrame = document.createElement('div');
+	sliderFrame.style.width = `${slideWidth * totalSlides}px`;
+	sliderFrame.style.display = 'flex';
+
+	extendedSlides.forEach((slide) => {
+		sliderFrame.appendChild(
+			buildCarouselSliderFrameItem({
+				slide: slide.cloneNode(true),
+				totalSlides
+			})
+		);
+	});
+
+	return sliderFrame;
+};
+
+/**
+ * Disable transition for the provided slider frame.
+ */
+export const disableTransition = ({ sliderFrame }: CommonParams) => {
+	if (isNullish(sliderFrame)) {
+		return;
+	}
+
+	sliderFrame.style.transition = 'none';
+};
+
+/**
+ * Enable transition for the provided slider frame.
+ */
+export const enableTransition = ({
+	sliderFrame,
+	duration,
+	easing
+}: { duration: number; easing: string } & CommonParams) => {
+	if (isNullish(sliderFrame)) {
+		return;
+	}
+
+	sliderFrame.style.transition = `all ${duration}ms ${easing}`;
+};
+
+/**
+ * Update visible part of the provided slider frame.
+ */
+export const updateSliderFrameVisiblePart = ({
+	animateTo,
+	sliderFrame
+}: { animateTo: number } & CommonParams): void => {
+	if (isNullish(sliderFrame)) {
+		return;
+	}
+
+	sliderFrame.style.transform = `translate3d(${animateTo}px, 0, 0)`;
+};

--- a/src/frontend/src/lib/utils/carousel.utils.ts
+++ b/src/frontend/src/lib/utils/carousel.utils.ts
@@ -16,7 +16,10 @@ export const buildCarouselSliderFrameItem = ({
 }): HTMLDivElement => {
 	// Create slider frame item and apply styling
 	const frameItem = document.createElement('div');
-	frameItem.style.width = `${100 / totalSlides}%`;
+
+	if (totalSlides > 0) {
+		frameItem.style.width = `${100 / totalSlides}%`;
+	}
 
 	frameItem.appendChild(slide);
 
@@ -24,35 +27,40 @@ export const buildCarouselSliderFrameItem = ({
 };
 
 /**
- * A util for building carousel slider frame.
+ * A util for extending provided sliderFrame element with carousel items and width style..
  */
-export const buildCarouselSliderFrame = ({
+export const extendCarouselSliderFrame = ({
+	sliderFrame,
 	slides,
 	slideWidth
 }: {
 	slides: Node[];
 	slideWidth: number;
-}): HTMLDivElement => {
+} & CommonParams) => {
+	if (isNullish(sliderFrame)) {
+		return;
+	}
+
 	// We add the last slide as the first element to properly animate last-to-first slide transition.
 	// The same applies to the last element - we use the first slide as the last item of the array.
-	const extendedSlides = [slides[slides.length - 1], ...slides, slides[0]];
+	const extendedSlides = [
+		slides[slides.length - 1].cloneNode(true),
+		...slides,
+		slides[0].cloneNode(true)
+	];
 	const totalSlides = extendedSlides.length;
 
-	// Create slider frame and apply styling
-	const sliderFrame = document.createElement('div');
+	// Calculate and set width
 	sliderFrame.style.width = `${slideWidth * totalSlides}px`;
-	sliderFrame.style.display = 'flex';
 
-	extendedSlides.forEach((slide) => {
-		sliderFrame.appendChild(
+	sliderFrame.append(
+		...extendedSlides.map((slide) =>
 			buildCarouselSliderFrameItem({
-				slide: slide.cloneNode(true),
+				slide,
 				totalSlides
 			})
-		);
-	});
-
-	return sliderFrame;
+		)
+	);
 };
 
 /**

--- a/src/frontend/src/lib/utils/carousel.utils.ts
+++ b/src/frontend/src/lib/utils/carousel.utils.ts
@@ -15,6 +15,7 @@ export const buildCarouselSliderFrameItem = ({
 	totalSlides: number;
 }): HTMLDivElement => {
 	// Create slider frame item and apply styling
+	// TODO: check if slide is an HTMLElement and if so, only set width w/o creating a new div
 	const frameItem = document.createElement('div');
 
 	if (totalSlides > 0) {
@@ -41,6 +42,7 @@ export const extendCarouselSliderFrame = ({
 		return;
 	}
 
+	// TODO: use Svelte 5 and/or pure CSS in order to avoid the hacky solution
 	// We add the last slide as the first element to properly animate last-to-first slide transition.
 	// The same applies to the last element - we use the first slide as the last item of the array.
 	const extendedSlides = [
@@ -50,7 +52,7 @@ export const extendCarouselSliderFrame = ({
 	];
 	const totalSlides = extendedSlides.length;
 
-	// Calculate and set width
+	// Calculate and set width for CSS transform to work correctly
 	sliderFrame.style.width = `${slideWidth * totalSlides}px`;
 
 	sliderFrame.append(
@@ -92,7 +94,7 @@ export const enableTransition = ({
 /**
  * Update visible part of the provided slider frame.
  */
-export const updateSliderFrameVisiblePart = ({
+export const moveSlider = ({
 	animateTo,
 	sliderFrame
 }: { animateTo: number } & CommonParams): void => {

--- a/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
@@ -1,4 +1,4 @@
-import { buildCarouselSliderFrame, buildCarouselSliderFrameItem } from '$lib/utils/carousel.utils';
+import { buildCarouselSliderFrameItem, extendCarouselSliderFrame } from '$lib/utils/carousel.utils';
 import { describe, expect } from 'vitest';
 
 const slides = [
@@ -10,9 +10,11 @@ const slides = [
 const extendedSlides = [slides[slides.length - 1], ...slides, slides[0]];
 const slideWidth = 300;
 
-describe('buildCarouselSliderFrame', () => {
+describe('extendCarouselSliderFrame', () => {
 	it('puts correct amount of slides in the frame', () => {
-		const sliderFrame = buildCarouselSliderFrame({
+		const sliderFrame = document.createElement('div');
+		extendCarouselSliderFrame({
+			sliderFrame,
 			slides,
 			slideWidth
 		});
@@ -21,7 +23,9 @@ describe('buildCarouselSliderFrame', () => {
 	});
 
 	it('sets correct width to frame', () => {
-		const sliderFrame = buildCarouselSliderFrame({
+		const sliderFrame = document.createElement('div');
+		extendCarouselSliderFrame({
+			sliderFrame,
 			slides,
 			slideWidth
 		});

--- a/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
@@ -1,0 +1,42 @@
+import { buildCarouselSliderFrame, buildCarouselSliderFrameItem } from '$lib/utils/carousel.utils';
+import { describe, expect } from 'vitest';
+
+const slides = [
+	document.createTextNode('Slide 1.'),
+	document.createTextNode('Slide 2.'),
+	document.createTextNode('Slide 3.'),
+	document.createTextNode('Slide 4.')
+];
+const extendedSlides = [slides[slides.length - 1], ...slides, slides[0]];
+const slideWidth = 300;
+
+describe('buildCarouselSliderFrame', () => {
+	it('puts correct amount of slides in the frame', () => {
+		const sliderFrame = buildCarouselSliderFrame({
+			slides,
+			slideWidth
+		});
+
+		expect(sliderFrame.children.length).toEqual(extendedSlides.length);
+	});
+
+	it('sets correct width to frame', () => {
+		const sliderFrame = buildCarouselSliderFrame({
+			slides,
+			slideWidth
+		});
+
+		expect(sliderFrame.style.width).toEqual(`${slideWidth * extendedSlides.length}px`);
+	});
+});
+
+describe('buildCarouselSliderFrameItem', () => {
+	it('sets correct width to frame item', () => {
+		const frameItem = buildCarouselSliderFrameItem({
+			slide: extendedSlides[0],
+			totalSlides: extendedSlides.length
+		});
+
+		expect(frameItem.style.width).toEqual(`${100 / extendedSlides.length}%`);
+	});
+});


### PR DESCRIPTION
# Motivation

This PR includes utils needed for the Carousel component. The idea is to take provided to `Carousel` as children slides (can be any HTML elements, components, etc.) and to create a slider frame - a div that has `slidesNumber * slideWidth` width (only active slide is visible) and includes all slides with equal (percentage) size. The other 3 functions are small helpers to enable/disable (we need to disable animation when we do last-to-first and first-to-last switches) animation and to change a current slide by applying `transform` to the frame.   

Please let me know if you need more context to review this PR (e.g. you also want to include the UI component itself here).


https://github.com/user-attachments/assets/0cf5618b-1e26-45d2-8b9f-b2d1c3ce771c


