### PR TITLE
style(frontend): add bg for loading phase of dapp promo banner

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -10,7 +10,7 @@
 
 <article class="relative flex h-64 items-end overflow-hidden rounded-2xl">
 	{#if dAppDescription.screenshots.length > 0}
-		<div class="absolute inset-0">
+		<div class="absolute inset-0 bg-light-grey">
 			<Img
 				fitHeight={true}
 				height="100%"

--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -21,7 +21,7 @@
 			/>
 		</div>
 	{/if}
-	<div class="flex-1 px-4 py-4 z-10 backdrop-blur-sm bg-black/30">
+	<div class="z-10 flex-1 bg-black/30 px-4 py-4 backdrop-blur-sm">
 		<div class="flex items-center gap-x-2">
 			<div class="h-12 w-12 rounded-full">
 				<Img

--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -10,7 +10,7 @@
 
 <article class="relative flex h-64 items-end overflow-hidden rounded-2xl">
 	{#if dAppDescription.screenshots.length > 0}
-		<div class="absolute inset-0 bg-light-grey">
+		<div class="absolute inset-0 bg-onahau">
 			<Img
 				fitHeight={true}
 				height="100%"

--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -21,7 +21,7 @@
 			/>
 		</div>
 	{/if}
-	<div class="flex-1 px-4 py-4 backdrop-blur-sm">
+	<div class="flex-1 px-4 py-4 z-10 backdrop-blur-sm bg-black/30">
 		<div class="flex items-center gap-x-2">
 			<div class="h-12 w-12 rounded-full">
 				<Img


### PR DESCRIPTION
# Motivation

The buttons and text of the DappPromoBanner are not visible during loading of the image. Design-team wants a simple background to provide contrast during loading time.

# Changes

- Add background
- improve backdrop

before: 
<img width="680" alt="image" src="https://github.com/user-attachments/assets/5e899c3d-6c3b-44e3-a520-bb8f1b2d1715">



after:
<img width="677" alt="image" src="https://github.com/user-attachments/assets/a40d33ac-4cd0-4b08-949b-cb888ae99b24">


