### PR TITLE
refactor(frontend): Move gap among token cards in the list

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -25,11 +25,13 @@
 
 <ContentWithToolbar>
 	<TokensSkeletons {loading}>
-		{#each tokens as token (token.id)}
-			<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
-				<TokenCardContent {token} />
-			</TokenCardWithOnClick>
-		{/each}
+		<div class="flex flex-col gap-6">
+			{#each tokens as token (token.id)}
+				<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
+					<TokenCardContent {token} />
+				</TokenCardWithOnClick>
+			{/each}
+		</div>
 
 		{#if tokens.length === 0}
 			<p class="text-secondary mb-6 mt-4 opacity-50">

--- a/src/frontend/src/lib/components/tokens/TokenCardWithOnClick.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithOnClick.svelte
@@ -1,4 +1,4 @@
-<div class="mb-6 flex gap-3 sm:gap-8">
+<div class="flex gap-3 sm:gap-8">
 	<button class="flex-1" on:click>
 		<div class="w-full">
 			<slot />

--- a/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
@@ -11,7 +11,7 @@
 	$: url = transactionsUrl({ token });
 </script>
 
-<div class="group mb-3 flex gap-3 rounded-xl px-3 py-2 hover:bg-white active:bg-white sm:gap-8">
+<div class="group flex gap-3 rounded-xl px-3 py-2 hover:bg-white active:bg-white sm:gap-8">
 	<a
 		class="flex-1 no-underline"
 		href={url}

--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { debounce, isNullish } from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { flip } from 'svelte/animate';
 	import { fade } from 'svelte/transition';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
@@ -39,7 +39,7 @@
 
 <TokensDisplayHandler bind:tokens>
 	<TokensSkeletons {loading}>
-		<div class="flex flex-col">
+		<div class="flex flex-col gap-3">
 			{#each tokens ?? [] as token (token.id)}
 				<div
 					transition:fade

--- a/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedOut.svelte
@@ -8,8 +8,10 @@
 	onMount(unsafeLoadDefaultPublicIcrcTokens);
 </script>
 
-{#each $combinedDerivedSortedNetworkTokens as token (token.id)}
-	<TokenCardWithUrl {token} disableTabSelector>
-		<TokenCardSignedOut {token} />
-	</TokenCardWithUrl>
-{/each}
+<div class="flex flex-col gap-3">
+	{#each $combinedDerivedSortedNetworkTokens as token (token.id)}
+		<TokenCardWithUrl {token} disableTabSelector>
+			<TokenCardSignedOut {token} />
+		</TokenCardWithUrl>
+	{/each}
+</div>


### PR DESCRIPTION
# Motivation

To make TokenCards more re-usable, it would be better to put the spacing among themselves outside the components per-se. So, in this PR we keep that spacing but we move it in the lists that uses the Token Cards components.

Nothing changes visually:


### Before

![Screenshot 2024-10-23 at 15 30 30](https://github.com/user-attachments/assets/ee2c7635-0fce-45a8-95f6-f3da0fd059b7)
![Screenshot 2024-10-23 at 15 30 26](https://github.com/user-attachments/assets/01cea941-7859-4c07-9959-2e6222345444)
![Screenshot 2024-10-23 at 15 30 19](https://github.com/user-attachments/assets/2bf90622-3ff8-4e0a-a64b-1f1607fe29a9)

### After

![Screenshot 2024-10-23 at 15 29 52](https://github.com/user-attachments/assets/ebb30969-ca42-4248-8eca-5509618ea84a)
![Screenshot 2024-10-23 at 15 29 59](https://github.com/user-attachments/assets/3b040a01-2ac2-4b14-892b-c12c0b55f2ba)
![Screenshot 2024-10-23 at 15 30 08](https://github.com/user-attachments/assets/d5da0fa9-a21c-4eea-a362-7e705ec1b453)


