### PR TITLE
refactor(frontend): Rename type for token groups

### DIFF
--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -75,11 +75,11 @@ export type TokenUi = Token & TokenFinancialData;
 export type OptionTokenUi = Option<TokenUi>;
 
 // TODO: remove header and nativeNetwork, since we added nativeToken that has all their data, and they became redundant
-export type TokenGroupUi = {
+export type TokenUiGroup = {
 	header: TokenMetadata;
 	nativeToken: TokenUi;
 	nativeNetwork: Network;
 	tokens: TokenUi[];
 } & TokenFinancialData;
 
-export type TokenUiOrGroupUi = TokenUi | TokenGroupUi;
+export type TokenUiOrGroupUi = TokenUi | TokenUiGroup;

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -9,9 +9,9 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type {
 	RequiredTokenWithLinkedData,
 	Token,
-	TokenGroupUi,
 	TokenStandard,
 	TokenUi,
+	TokenUiGroup,
 	TokenUiOrGroupUi
 } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
@@ -186,14 +186,14 @@ export const isRequiredTokenWithLinkedData = (token: Token): token is RequiredTo
 	'twinTokenSymbol' in token && typeof token.twinTokenSymbol === 'string';
 
 /**
- * Type guard to check if an object is of type TokenGroupUi.
+ * Type guard to check if an object is of type TokenUiGroup.
  *
  * @param tokenUiOrGroupUi - The object to check.
- * @returns A boolean indicating whether the object is a TokenGroupUi.
+ * @returns A boolean indicating whether the object is a TokenUiGroup.
  */
-export const isTokenGroupUi = (
+export const isTokenUiGroup = (
 	tokenUiOrGroupUi: TokenUiOrGroupUi
-): tokenUiOrGroupUi is TokenGroupUi =>
+): tokenUiOrGroupUi is TokenUiGroup =>
 	typeof tokenUiOrGroupUi === 'object' &&
 	nonNullish(tokenUiOrGroupUi) &&
 	'header' in tokenUiOrGroupUi &&
@@ -201,13 +201,13 @@ export const isTokenGroupUi = (
 	'tokens' in tokenUiOrGroupUi;
 
 /**
- * Factory function to create a TokenGroupUi based on the provided tokens and network details.
+ * Factory function to create a TokenUiGroup based on the provided tokens and network details.
  * This function creates a group header and adds both the native token and the twin token to the group's tokens array.
  *
  * @param nativeToken - The native token used for the group, typically the original token or the one from the selected network.
  * @param twinToken - The twin token to be grouped with the native token, usually representing the same asset on a different network.
  *
- * @returns A TokenGroupUi object that includes a header with network and symbol information and contains both the native and twin tokens.
+ * @returns A TokenUiGroup object that includes a header with network and symbol information and contains both the native and twin tokens.
  */
 const createTokenGroup = ({
 	nativeToken,
@@ -215,7 +215,7 @@ const createTokenGroup = ({
 }: {
 	nativeToken: TokenUi;
 	twinToken: TokenUi;
-}): TokenGroupUi => ({
+}): TokenUiGroup => ({
 	header: {
 		name: nativeToken.network.name,
 		symbol: `${nativeToken.symbol}, ${twinToken.symbol}`,
@@ -237,7 +237,7 @@ const createTokenGroup = ({
  * @param tokens - The list of TokenUi objects to group. Each token may or may not have a twinTokenSymbol.
  *                 Tokens with a twinTokenSymbol are grouped together.
  *
- * @returns A new list where tokens with twinTokenSymbols are grouped into a TokenGroupUi,
+ * @returns A new list where tokens with twinTokenSymbols are grouped into a TokenUiGroup,
  *          and tokens without twins remain in their original place.
  *          The group replaces the first token of the group in the list.
  */
@@ -265,6 +265,6 @@ export const groupTokensByTwin = (tokens: TokenUi[]): TokenUiOrGroupUi[] => {
 	});
 
 	return mappedTokensWithGroups.filter(
-		(t) => isTokenGroupUi(t) || !groupedTokenTwins.has(t.symbol)
+		(t) => isTokenUiGroup(t) || !groupedTokenTwins.has(t.symbol)
 	);
 };

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,7 +1,7 @@
 import { ICP_NETWORK } from '$env/networks.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
-import type { TokenGroupUi, TokenStandard, TokenUi } from '$lib/types/token';
+import type { TokenStandard, TokenUi, TokenUiGroup } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
 	calculateTokenUsdBalance,
@@ -366,9 +366,9 @@ describe('groupTokensByTwin', () => {
 		const btcGroup = groupedTokens[0];
 		expect(btcGroup).toHaveProperty('header');
 		expect(btcGroup).toHaveProperty('tokens');
-		expect((btcGroup as TokenGroupUi).tokens).toHaveLength(2);
-		expect((btcGroup as TokenGroupUi).tokens.map((t) => t.symbol)).toContain('BTC');
-		expect((btcGroup as TokenGroupUi).tokens.map((t) => t.symbol)).toContain('ckBTC');
+		expect((btcGroup as TokenUiGroup).tokens).toHaveLength(2);
+		expect((btcGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('BTC');
+		expect((btcGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('ckBTC');
 
 		const icpToken = groupedTokens[2];
 		expect(icpToken).toHaveProperty('symbol', 'ICP');
@@ -386,8 +386,8 @@ describe('groupTokensByTwin', () => {
 		const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
 		const firstGroup = groupedTokens[0];
 		expect(firstGroup).toHaveProperty('tokens');
-		expect((firstGroup as TokenGroupUi).tokens.map((t) => t.symbol)).toContain('BTC');
-		expect((firstGroup as TokenGroupUi).tokens.map((t) => t.symbol)).toContain('ckBTC');
+		expect((firstGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('BTC');
+		expect((firstGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('ckBTC');
 	});
 
 	it('should not duplicate tokens in the result', () => {
@@ -422,7 +422,7 @@ describe('groupTokensByTwin', () => {
 		const btcGroup = groupedTokens.find(
 			(groupOrToken) =>
 				'tokens' in groupOrToken && groupOrToken.tokens.some((t) => t.symbol === 'BTC')
-		) as TokenGroupUi;
+		) as TokenUiGroup;
 
 		expect(btcGroup).toBeDefined();
 		expect(btcGroup.tokens).toHaveLength(2);
@@ -432,7 +432,7 @@ describe('groupTokensByTwin', () => {
 		const ethGroup = groupedTokens.find(
 			(groupOrToken) =>
 				'tokens' in groupOrToken && groupOrToken.tokens.some((t) => t.symbol === 'ETH')
-		) as TokenGroupUi;
+		) as TokenUiGroup;
 
 		expect(ethGroup).toBeDefined();
 		expect(ethGroup.tokens).toHaveLength(2);


### PR DESCRIPTION
# Motivation

As discussed, the more obvious name for the variable should be `TokenUiGroup` since it represents a group of `TokenUi` types.