### PR TITLE
style(frontend): Increase breakpoint for mobile view

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthGuard.svelte
+++ b/src/frontend/src/lib/components/auth/AuthGuard.svelte
@@ -7,7 +7,7 @@
 {#if $authNotSignedIn}
 	<LandingPage />
 {:else}
-	<div in:fade class="sm:block sm:overflow-y-auto">
+	<div in:fade class="md:block md:overflow-y-auto">
 		<slot />
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -19,12 +19,14 @@
 	class:md:h-md:grid={$authNotSignedIn}
 	class:md:h-md:grid-cols-2={$authNotSignedIn}
 	class:md:h-md:pr-0={$authNotSignedIn}
-	class:sm:fixed={$authSignedIn}
-	class:sm:inset-x-0={$authSignedIn}
-	class:sm:bottom-0={$authSignedIn}
+	class:md:fixed={$authSignedIn}
+	class:md:inset-x-0={$authSignedIn}
+	class:md:bottom-0={$authSignedIn}
 >
 	<div
-		class="pointer-events-none flex w-full flex-col items-center justify-between sm:flex-row sm:gap-4"
+		class="pointer-events-none flex w-full flex-col items-center justify-between md:flex-row md:gap-4"
+		class:sm:flex-row={$authNotSignedIn}
+		class:sm:gap-4={$authNotSignedIn}
 	>
 		<div class="pointer-events-auto flex flex-row items-center gap-4">
 			<ExternalLinkIcon
@@ -43,13 +45,16 @@
 		</div>
 
 		<div
-			class="item pointer-events-auto flex flex-row items-center justify-end gap-2 text-sm transition-all duration-200 ease-in-out lg:max-w-48 xl:max-w-none"
+			class="item pointer-events-auto flex flex-row items-center justify-end gap-2 text-sm lg:max-w-48 xl:max-w-none"
 			class:sm:max-w-none={$authNotSignedIn}
 			class:lg:max-w-none={$authNotSignedIn}
 			class:md:h-md:pr-4={$authNotSignedIn}
-			class:sm:invisible={$authSignedIn}
+			class:md:transition-all={$authSignedIn}
+			class:md:duration-200={$authSignedIn}
+			class:md:ease-in-out={$authSignedIn}
+			class:md:invisible={$authSignedIn}
 			class:1.5md:visible={$authSignedIn}
-			class:sm:translate-x-full={$authSignedIn}
+			class:md:translate-x-full={$authSignedIn}
 			class:1.5md:translate-x-0={$authSignedIn}
 		>
 			<ExternalLink
@@ -60,7 +65,7 @@
 				<div class="flex flex-row items-center gap-2">
 					<IconDfinity />
 					<span
-						class:sm:hidden={$authSignedIn}
+						class:md:hidden={$authSignedIn}
 						class:xl:flex={$authSignedIn}
 						class:md:h-md:hidden={$authNotSignedIn}
 						class:1.5md:h-md:flex={$authNotSignedIn}

--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -12,13 +12,14 @@
 </script>
 
 <header
-	class="z-1 pointer-events-none relative flex w-full max-w-screen-2.5xl items-center justify-between gap-y-5 px-4 pt-6 sm:px-8"
+	class="z-1 pointer-events-none relative flex w-full max-w-screen-2.5xl items-center justify-between gap-y-5 px-4 pt-6 md:px-8"
 	class:lg:fixed={$authSignedIn}
 	class:lg:top-0={$authSignedIn}
 	class:lg:inset-x-0={$authSignedIn}
 	class:lg:z-10={$authSignedIn}
 	class:grid={$authNotSignedIn}
 	class:grid-cols-2={$authNotSignedIn}
+	class:sm:px-8={$authNotSignedIn}
 	class:xl:grid={$authNotSignedIn}
 	class:xl:grid-cols-[1fr_auto_1fr]={$authNotSignedIn}
 >

--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -24,7 +24,7 @@
 				: 'tokens';
 </script>
 
-<div class="box-content flex h-full w-full flex-col justify-between py-3 pl-4 sm:pl-8">
+<div class="box-content flex h-full w-full flex-col justify-between py-3 pl-4 md:pl-8">
 	<div class="flex flex-col gap-3">
 		<NavigationItem
 			href="/"

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,14 +1,14 @@
 <main
-	class="relative mx-auto max-w-screen-2.5xl pt-8 sm:flex sm:w-full sm:flex-row lg:w-auto lg:pt-0"
+	class="relative mx-auto max-w-screen-2.5xl pt-8 md:flex md:w-full md:flex-row lg:w-auto lg:pt-0"
 >
 	<div
-		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out sm:visible sm:fixed sm:inset-y-0 sm:my-24 sm:block sm:min-w-36 sm:translate-x-0 md:transition-none lg:min-w-44 xl:min-w-72"
+		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:my-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:min-w-72"
 	>
 		<slot name="menu" />
 	</div>
 
 	<div
-		class="mx-auto px-5 transition-all duration-500 ease-linear sm:ml-64 sm:box-content sm:w-sm xl:ml-auto"
+		class="mx-auto max-w-xl px-5 transition-all duration-500 ease-linear md:ml-64 md:box-content md:w-sm md:max-w-none xl:ml-auto"
 	>
 		<slot />
 	</div>


### PR DESCRIPTION
# Motivation

As a recent feedback, we are increasing the breakpoint for the "mobile" view to be on `md` instead of `sm` (just for logged in).


https://github.com/user-attachments/assets/562c5f21-9f17-4bab-885d-6f122fcb3625



