### PR TITLE
refactor(frontend): Limit data provided to token cards

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -2,8 +2,9 @@
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import TokenExchangeValueSkeleton from '$lib/components/tokens/TokenExchangeValueSkeleton.svelte';
 	import type { TokenUi } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: TokenUi;
+	export let token: CardData;
 
 	let balance: TokenUi['balance'];
 	let usdBalance: TokenUi['usdBalance'];

--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -4,14 +4,14 @@
 	import type { TokenUi } from '$lib/types/token';
 	import type { CardData } from '$lib/types/token-card';
 
-	export let token: CardData;
+	export let data: CardData;
 
 	let balance: TokenUi['balance'];
 	let usdBalance: TokenUi['usdBalance'];
 
-	$: ({ balance, usdBalance } = token);
+	$: ({ balance, usdBalance } = data);
 </script>
 
-<TokenExchangeValueSkeleton {token}>
+<TokenExchangeValueSkeleton {data}>
 	<TokenExchangeBalance {balance} {usdBalance} />
 </TokenExchangeValueSkeleton>

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -52,7 +52,7 @@
 						{#if $erc20UserTokensInitialized && nonNullish($pageToken)}
 							<div in:fade>
 								<TokenLogo
-									token={$pageToken}
+									data={$pageToken}
 									ring
 									subLogo={{ type: 'network', blackAndWhite: true }}
 								/>

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -238,9 +238,9 @@
 	<div class="container overflow-y-auto overscroll-contain pr-2 pt-1 md:max-h-[26rem]">
 		{#each tokens as token (`${token.network.id.description}-${token.id.description}`)}
 			<Card>
-				<TokenName {token} />
+				<TokenName data={token} />
 
-				<TokenLogo slot="icon" color="white" {token} subLogo={{ type: 'network' }} />
+				<TokenLogo slot="icon" color="white" data={token} subLogo={{ type: 'network' }} />
 
 				<span class="break-all" slot="description">
 					{token.symbol}

--- a/src/frontend/src/lib/components/receive/ReceiveQRCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveQRCode.svelte
@@ -38,7 +38,7 @@
 				<svelte:fragment slot="logo">
 					{#if nonNullish(addressToken)}
 						<div class="flex items-center justify-center rounded-lg bg-white p-2">
-							<TokenLogo token={addressToken} />
+							<TokenLogo data={addressToken} />
 						</div>
 					{/if}
 				</svelte:fragment>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -27,9 +27,9 @@
 	<TokensSkeletons {loading}>
 		<div class="mb-6 flex flex-col gap-6">
 			{#each tokens as token (token.id)}
-        <TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
-          <TokenCardContent data={token} />
-        </TokenCardWithOnClick>
+				<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
+					<TokenCardContent data={token} />
+				</TokenCardWithOnClick>
 			{/each}
 		</div>
 

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -27,7 +27,7 @@
 	<TokensSkeletons {loading}>
 		{#each tokens as token (token.id)}
 			<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
-				<TokenCardContent {token} />
+				<TokenCardContent data={token} />
 			</TokenCardWithOnClick>
 		{/each}
 

--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -3,10 +3,10 @@
 	import TokenBalanceSkeleton from '$lib/components/tokens/TokenBalanceSkeleton.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { TOKEN_BALANCE } from '$lib/constants/test-ids.constants';
-	import type { TokenUi } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 	import { formatToken } from '$lib/utils/format.utils';
 
-	export let token: TokenUi;
+	export let token: CardData;
 </script>
 
 <TokenBalanceSkeleton {token}>

--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -6,20 +6,20 @@
 	import type { CardData } from '$lib/types/token-card';
 	import { formatToken } from '$lib/utils/format.utils';
 
-	export let token: CardData;
+	export let data: CardData;
 </script>
 
-<TokenBalanceSkeleton {token}>
-	<output class="break-all" data-tid={`${TOKEN_BALANCE}-${token.symbol}`}>
-		{#if nonNullish(token.balance)}
+<TokenBalanceSkeleton {data}>
+	<output class="break-all" data-tid={`${TOKEN_BALANCE}-${data.symbol}`}>
+		{#if nonNullish(data.balance)}
 			{formatToken({
-				value: token.balance,
-				unitName: token.decimals
+				value: data.balance,
+				unitName: data.decimals
 			})}
 		{:else}
 			{formatToken({
 				value: ZERO,
-				unitName: token.decimals
+				unitName: data.decimals
 			}).replace('0', '-')}
 		{/if}
 	</output>

--- a/src/frontend/src/lib/components/tokens/TokenBalanceSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalanceSkeleton.svelte
@@ -2,10 +2,10 @@
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import type { CardData } from '$lib/types/token-card';
 
-	export let token: CardData;
+	export let data: CardData;
 </script>
 
-{#if token.balance === undefined}
+{#if data.balance === undefined}
 	<span class="mt-2 w-full max-w-[100px]"><SkeletonText /></span>
 {:else}
 	<slot />

--- a/src/frontend/src/lib/components/tokens/TokenBalanceSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalanceSkeleton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
-	import type { TokenUi } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: TokenUi;
+	export let token: CardData;
 </script>
 
 {#if token.balance === undefined}

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -6,16 +6,16 @@
 	import { TOKEN_CARD, TOKEN_GROUP } from '$lib/constants/test-ids.constants';
 	import type { CardData } from '$lib/types/token-card';
 
-	export let token: CardData;
+	export let data: CardData;
 	export let testIdPrefix: typeof TOKEN_CARD | typeof TOKEN_GROUP = TOKEN_CARD;
 </script>
 
-<Card noMargin testId={`${testIdPrefix}-${token.symbol}`}>
-	<TokenSymbol {token} />
+<Card noMargin testId={`${testIdPrefix}-${data.symbol}`}>
+	<TokenSymbol {data} />
 
-	<TokenName {token} slot="description" />
+	<TokenName {data} slot="description" />
 
-	<TokenLogo {token} slot="icon" color="white" />
+	<TokenLogo {data} slot="icon" color="white" />
 
 	<slot name="balance" slot="amount" />
 

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -4,9 +4,9 @@
 	import TokenSymbol from '$lib/components/tokens/TokenSymbol.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import { TOKEN_CARD, TOKEN_GROUP } from '$lib/constants/test-ids.constants';
-	import type { Token } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: Token;
+	export let token: CardData;
 	export let testIdPrefix: typeof TOKEN_CARD | typeof TOKEN_GROUP = TOKEN_CARD;
 </script>
 

--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -2,9 +2,9 @@
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
 	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
-	import type { TokenUi } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: TokenUi;
+	export let token: CardData;
 </script>
 
 <TokenCard {token}>

--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -2,9 +2,9 @@
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
 	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
-	import type { CardData } from '$lib/types/token-card';
+	import type { TokenUi } from '$lib/types/token.js';
 
-	export let token: CardData;
+	export let token: TokenUi;
 </script>
 
 <TokenCard {token}>

--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -2,13 +2,13 @@
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
 	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
-	import type { TokenUi } from '$lib/types/token.js';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: TokenUi;
+	export let data: CardData;
 </script>
 
-<TokenCard {token}>
-	<TokenBalance {token} slot="balance" />
+<TokenCard {data}>
+	<TokenBalance {data} slot="balance" />
 
-	<ExchangeTokenValue {token} slot="exchange" />
+	<ExchangeTokenValue {data} slot="exchange" />
 </TokenCard>

--- a/src/frontend/src/lib/components/tokens/TokenCardSignedOut.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardSignedOut.svelte
@@ -5,7 +5,7 @@
 	export let token: Token;
 </script>
 
-<TokenCard {token}>
+<TokenCard data={token}>
 	<span class="break-all" slot="balance">-/-</span>
 
 	<span slot="exchange" class="mr-[3px] font-bold">-/-</span>

--- a/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { exchangeInitialized } from '$lib/derived/exchange.derived';
-	import type { TokenUi } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: TokenUi;
+	export let data: CardData;
 </script>
 
-{#if token.balance === undefined || !$exchangeInitialized}
+{#if data.balance === undefined || !$exchangeInitialized}
 	<span class="w-full max-w-[50px]"><SkeletonText /></span>
 {:else}
 	<slot />

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -4,7 +4,7 @@
 	import type { CardData } from '$lib/types/token-card';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let token: CardData;
+	export let data: CardData;
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let subLogo:
 		| { type: 'network'; blackAndWhite?: boolean }
@@ -16,7 +16,7 @@
 		icon,
 		name,
 		network: { name: networkName, icon: networkIcon, iconBW: networkIconBW }
-	} = token;
+	} = data;
 </script>
 
 <div class="relative">
@@ -30,7 +30,7 @@
 	{#if subLogo?.type === 'tokenCount' && subLogo.count > 0}
 		<span
 			class="absolute -right-2.5 bottom-0 flex h-6 w-6 items-center justify-center rounded-full border-[0.5px] border-light-grey bg-white text-sm font-semibold text-[var(--color-secondary)]"
-			aria-label={replacePlaceholders($i18n.tokens.alt.token_group_number, { $token: token.name })}
+			aria-label={replacePlaceholders($i18n.tokens.alt.token_group_number, { $token: data.name })}
 		>
 			{subLogo.count}
 		</span>

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { Token } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let token: Token;
+	export let token: CardData;
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let subLogo:
 		| { type: 'network'; blackAndWhite?: boolean }

--- a/src/frontend/src/lib/components/tokens/TokenName.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenName.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import Tag from '$lib/components/ui/Tag.svelte';
-	import type { Token } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 
-	export let token: Token;
+	export let token: CardData;
 
 	const ariaLabel = nonNullish(token.oisyName)
 		? `${token.oisyName.prefix ?? ''}${token.oisyName.oisyName}`

--- a/src/frontend/src/lib/components/tokens/TokenName.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenName.svelte
@@ -3,16 +3,16 @@
 	import Tag from '$lib/components/ui/Tag.svelte';
 	import type { CardData } from '$lib/types/token-card';
 
-	export let token: CardData;
+	export let data: CardData;
 
-	const ariaLabel = nonNullish(token.oisyName)
-		? `${token.oisyName.prefix ?? ''}${token.oisyName.oisyName}`
-		: token.name;
+	const ariaLabel = nonNullish(data.oisyName)
+		? `${data.oisyName.prefix ?? ''}${data.oisyName.oisyName}`
+		: data.name;
 </script>
 
 <span aria-label={ariaLabel}>
-	{#if nonNullish(token.oisyName?.prefix)}
-		<Tag ariaHidden>{token.oisyName.prefix}</Tag>
+	{#if nonNullish(data.oisyName?.prefix)}
+		<Tag ariaHidden>{data.oisyName.prefix}</Tag>
 	{/if}
-	<span aria-hidden="true">{token.oisyName?.oisyName ?? token.name}</span>
+	<span aria-hidden="true">{data.oisyName?.oisyName ?? data.name}</span>
 </span>

--- a/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
@@ -2,10 +2,10 @@
 	import { nonNullish } from '@dfinity/utils';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { Token } from '$lib/types/token';
+	import type { CardData } from '$lib/types/token-card';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let token: Token;
+	export let token: CardData;
 </script>
 
 <div class="flex flex-row items-center justify-between gap-2">

--- a/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
@@ -5,16 +5,16 @@
 	import type { CardData } from '$lib/types/token-card';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let token: CardData;
+	export let data: CardData;
 </script>
 
 <div class="flex flex-row items-center justify-between gap-2">
-	{nonNullish(token.oisySymbol) ? token.oisySymbol.oisySymbol : token.symbol}
+	{nonNullish(data.oisySymbol) ? data.oisySymbol.oisySymbol : data.symbol}
 
-	{#if nonNullish(token.network.iconBW)}
+	{#if nonNullish(data.network.iconBW)}
 		<Logo
-			src={token.network.iconBW}
-			alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.network.name })}
+			src={data.network.iconBW}
+			alt={replacePlaceholders($i18n.core.alt.logo, { $name: data.network.name })}
 		/>
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -50,7 +50,7 @@
 				>
 					<Listener {token}>
 						<TokenCardWithUrl {token}>
-							<TokenCardContent {token} />
+							<TokenCardContent data={token} />
 						</TokenCardWithUrl>
 					</Listener>
 				</div>

--- a/src/frontend/src/lib/types/token-card.ts
+++ b/src/frontend/src/lib/types/token-card.ts
@@ -1,0 +1,14 @@
+import type { TokenUi } from '$lib/types/token';
+
+export type CardData = Pick<
+	TokenUi,
+	| 'name'
+	| 'symbol'
+	| 'decimals'
+	| 'icon'
+	| 'network'
+	| 'oisyName'
+	| 'oisySymbol'
+	| 'balance'
+	| 'usdBalance'
+>;


### PR DESCRIPTION
# Motivation

We want to re-use TokenCard and its related components for the token groups. However, to abstract the data provided, instead of Token, we create a set of data that are common/required in both cases: single token or token group.

This is just a refactoring PR.

# Changes

- Create type with common props required for the token card, called `CardData`
- Substitute the input types of all token card components from `Token`/`TokenUi` to `CardData`.
- Substitute the input name of all token card components from `token` to `data`.
