### PR TITLE
build(frontend): use @dfinity/utils next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@dfinity/ledger-icrc": "^2.6.0",
 				"@dfinity/oisy-wallet-signer": "^0.0.1",
 				"@dfinity/principal": "^2.1.2",
-				"@dfinity/utils": "^2.5.1",
+				"@dfinity/utils": "^2.5.2-next-2024-10-24",
 				"@dfinity/verifiable-credentials": "^0.0.4",
 				"@junobuild/analytics": "^0.0.28",
 				"@metamask/detect-provider": "^2.0.0",
@@ -432,14 +432,14 @@
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.5.2.tgz",
-			"integrity": "sha512-QSW7t8kcLj0s/gL4NbYqr+Pqr3e2QhFn2JriwcghuflhwrYet1y23ANyM4EwSUeDAUR/OQXR86e4MfWkGMttAg==",
+			"version": "2.5.2-next-2024-10-24",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.5.2-next-2024-10-24.tgz",
+			"integrity": "sha512-PST30j1H/GodpHHJCfEs1F40gqaxOidHL4psb9V3KwGSL4s1fY7XYqHBUUtP5D3GVro5VZT/AfVRKHwhtwqiMQ==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "^2.0.0",
-				"@dfinity/candid": "^2.0.0",
-				"@dfinity/principal": "^2.0.0"
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/principal": "*"
 			}
 		},
 		"node_modules/@dfinity/verifiable-credentials": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@dfinity/ledger-icrc": "^2.6.0",
 		"@dfinity/oisy-wallet-signer": "^0.0.1",
 		"@dfinity/principal": "^2.1.2",
-		"@dfinity/utils": "^2.5.1",
+		"@dfinity/utils": "^2.5.2-next-2024-10-24",
 		"@dfinity/verifiable-credentials": "^0.0.4",
 		"@junobuild/analytics": "^0.0.28",
 		"@metamask/detect-provider": "^2.0.0",


### PR DESCRIPTION
# Motivation

We want to use the the latest release (next) of @dfinity/utils because we want to use the recently-introduced class `AgentManager`.