### PR TITLE
feat(frontend): Extract Setter store from Certified store

### DIFF
--- a/src/frontend/src/lib/stores/certified-setter.store.ts
+++ b/src/frontend/src/lib/stores/certified-setter.store.ts
@@ -1,27 +1,7 @@
-import {
-	initCertifiedStore,
-	type CertifiedStore,
-	type WritableUpdateStore
-} from '$lib/stores/certified.store';
-import type { TokenId } from '$lib/types/token';
-import { nonNullish } from '@dfinity/utils';
+import { initSetterStore, type SetterStoreStore } from '$lib/stores/setter.store';
+import type { CertifiedData } from '$lib/types/store';
 
-export interface CertifiedSetterStoreStore<T> extends CertifiedStore<T> {
-	set: (params: { tokenId: TokenId; data: T }) => void;
-}
+export type CertifiedSetterStoreStore<T> = SetterStoreStore<CertifiedData<T>>;
 
-export const initCertifiedSetterStore = <T>(): CertifiedSetterStoreStore<T> &
-	WritableUpdateStore<T> => {
-	const { subscribe, update, reset } = initCertifiedStore<T>();
-
-	return {
-		set: ({ tokenId, data }: { tokenId: TokenId; data: T }) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: data
-			})),
-		update,
-		reset,
-		subscribe
-	};
-};
+export const initCertifiedSetterStore = <T>(): CertifiedSetterStoreStore<T> =>
+	initSetterStore<CertifiedData<T>>();

--- a/src/frontend/src/lib/stores/certified.store.ts
+++ b/src/frontend/src/lib/stores/certified.store.ts
@@ -1,25 +1,17 @@
-import type { TokenId } from '$lib/types/token';
-import { nonNullish } from '@dfinity/utils';
-import { writable, type Readable, type Writable } from 'svelte/store';
+import type { CertifiedSetterStoreStore } from '$lib/stores/certified-setter.store';
+import { initSetterStore, type SetterStoreData } from '$lib/stores/setter.store';
+import type { CertifiedData } from '$lib/types/store';
 
-export type WritableUpdateStore<T> = Pick<Writable<CertifiedStoreData<T>>, 'update'>;
+export type CertifiedStoreData<T> = SetterStoreData<CertifiedData<T>>;
 
-export type CertifiedStoreData<T> = Record<TokenId, T | null> | undefined;
+export type CertifiedStore<T> = Omit<CertifiedSetterStoreStore<T>, 'set'>;
 
-export interface CertifiedStore<T> extends Readable<CertifiedStoreData<T>> {
-	reset: (tokenId: TokenId) => void;
-}
-
-export const initCertifiedStore = <T>(): CertifiedStore<T> & WritableUpdateStore<T> => {
-	const { update, subscribe } = writable<CertifiedStoreData<T>>(undefined);
+export const initCertifiedStore = <T>(): CertifiedStore<T> => {
+	const { update, subscribe, reset } = initSetterStore<CertifiedData<T>>();
 
 	return {
 		update,
 		subscribe,
-		reset: (tokenId: TokenId) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: null
-			}))
+		reset
 	};
 };

--- a/src/frontend/src/lib/stores/setter.store.ts
+++ b/src/frontend/src/lib/stores/setter.store.ts
@@ -1,0 +1,31 @@
+import type { TokenId } from '$lib/types/token';
+import { nonNullish } from '@dfinity/utils';
+import { writable, type Readable, type Writable } from 'svelte/store';
+
+export type WritableUpdateStore<T> = Pick<Writable<SetterStoreData<T>>, 'update'>;
+
+export type SetterStoreData<T> = Record<TokenId, T | null> | undefined;
+
+export interface SetterStoreStore<T> extends Readable<SetterStoreData<T>>, WritableUpdateStore<T> {
+	reset: (tokenId: TokenId) => void;
+	set: (params: { tokenId: TokenId; data: T }) => void;
+}
+
+export const initSetterStore = <T>(): SetterStoreStore<T> & WritableUpdateStore<T> => {
+	const { subscribe, update } = writable<SetterStoreData<T>>(undefined);
+
+	return {
+		set: ({ tokenId, data }: { tokenId: TokenId; data: T }) =>
+			update((state) => ({
+				...(nonNullish(state) && state),
+				[tokenId]: data
+			})),
+		reset: (tokenId: TokenId) =>
+			update((state) => ({
+				...(nonNullish(state) && state),
+				[tokenId]: null
+			})),
+		update,
+		subscribe
+	};
+};


### PR DESCRIPTION
# Motivation

It is useful to have a setter store that is not strictly related to certified data (`certified` flag).
