### PR TITLE
feat(frontend): extend dApps description schema with data for carousel

### DIFF
--- a/src/frontend/src/env/dapp-descriptions.json
+++ b/src/frontend/src/env/dapp-descriptions.json
@@ -16,8 +16,10 @@
 		"logo": "/images/dapps/kong-swap-logo.svg",
 		"screenshots": ["/images/dapps/kong-swap.webp"],
 		"featured": true,
-		"carouselSlideText": "Swap tokens on DEX",
-		"carouselSlideCallToAction": "Try KongSwap"
+		"carousel": {
+			"text": "Swap tokens on DEX",
+			"callToAction": "Try KongSwap"
+		}
 	},
 	{
 		"id": "openchat",
@@ -34,8 +36,10 @@
 		"stats": "80,000+ users",
 		"logo": "/images/dapps/open-chat-logo.svg",
 		"screenshots": ["/images/dapps/open-chat.webp"],
-		"carouselSlideText": "OpenChat - where web3 communicates",
-		"carouselSlideCallToAction": "Show more"
+		"carousel": {
+			"text": "OpenChat - where web3 communicates",
+			"callToAction": "Show more"
+		}
 	},
 	{
 		"id": "decideid",
@@ -51,7 +55,9 @@
 		"logo": "/images/dapps/decide-ai-logo.svg",
 		"github": "https://github.com/modclub-app",
 		"screenshots": ["/images/dapps/decide-ai.webp"],
-		"carouselSlideText": "Enjoy a privacy-first way to verify and engage online",
-		"carouselSlideCallToAction": "Interested?"
+		"carousel": {
+			"text": "Enjoy a privacy-first way to verify and engage online",
+			"callToAction": "Interested?"
+		}
 	}
 ]

--- a/src/frontend/src/env/dapp-descriptions.json
+++ b/src/frontend/src/env/dapp-descriptions.json
@@ -15,7 +15,9 @@
 		"stats": "",
 		"logo": "/images/dapps/kong-swap-logo.svg",
 		"screenshots": ["/images/dapps/kong-swap.webp"],
-		"featured": true
+		"featured": true,
+		"carouselSlideText": "Swap tokens on DEX",
+		"carouselSlideCallToAction": "Try KongSwap"
 	},
 	{
 		"id": "openchat",
@@ -31,7 +33,9 @@
 		"display": "Large",
 		"stats": "80,000+ users",
 		"logo": "/images/dapps/open-chat-logo.svg",
-		"screenshots": ["/images/dapps/open-chat.webp"]
+		"screenshots": ["/images/dapps/open-chat.webp"],
+		"carouselSlideText": "OpenChat - where web3 communicates",
+		"carouselSlideCallToAction": "Show more"
 	},
 	{
 		"id": "decideid",
@@ -46,6 +50,8 @@
 		"usesInternetIdentity": true,
 		"logo": "/images/dapps/decide-ai-logo.svg",
 		"github": "https://github.com/modclub-app",
-		"screenshots": ["/images/dapps/decide-ai.webp"]
+		"screenshots": ["/images/dapps/decide-ai.webp"],
+		"carouselSlideText": "Enjoy a privacy-first way to verify and engage online",
+		"carouselSlideCallToAction": "Interested?"
 	}
 ]

--- a/src/frontend/src/lib/types/oisyDappDescription.ts
+++ b/src/frontend/src/lib/types/oisyDappDescription.ts
@@ -30,18 +30,18 @@ const dAppDescriptionSchema = z.object({
 	submittableId: z.string().optional()
 });
 
-const carouselDappDescriptionSchema = {
+const carouselDappDescriptionSchema = z.object({
 	// TODO: check if text is not too long using logic from https://github.com/dfinity/portal/blob/34a0328ed4792f5a7f3943be73f13f5abaefb4b8/plugins/validate-showcase.js#L179
 	text: z.string(),
 	callToAction: z.string()
-};
+});
 
 const oisyDappDescriptionSchema = dAppDescriptionSchema.extend({
 	featured: z.boolean().optional(),
 	callToAction: z.string().optional(),
 	telegram: z.string().url().optional(),
 	openChat: z.string().url().optional(),
-	carousel: z.object(carouselDappDescriptionSchema).optional()
+	carousel: carouselDappDescriptionSchema.optional()
 });
 
 export type OisyDappDescription = z.infer<typeof oisyDappDescriptionSchema>;

--- a/src/frontend/src/lib/types/oisyDappDescription.ts
+++ b/src/frontend/src/lib/types/oisyDappDescription.ts
@@ -15,6 +15,10 @@ const dAppDescriptionSchema = z.object({
 	stats: z.string(),
 	logo: z.string(),
 
+	// TODO: check if text is not too long using logic from https://github.com/dfinity/portal/blob/34a0328ed4792f5a7f3943be73f13f5abaefb4b8/plugins/validate-showcase.js#L179
+	carouselSlideText: z.string().optional(),
+	carouselSlideCallToAction: z.string().optional(),
+
 	usesInternetIdentity: z.boolean(),
 	authOrigins: z.array(z.string()).optional(),
 
@@ -40,6 +44,11 @@ const oisyDappDescriptionSchema = dAppDescriptionSchema.extend({
 export type OisyDappDescription = z.infer<typeof oisyDappDescriptionSchema>;
 export type FeaturedOisyDappDescription = Omit<OisyDappDescription, 'screenshots'> &
 	Required<Pick<OisyDappDescription, 'screenshots'>>;
+export type CarouselCardOisyDappDescription = Omit<
+	OisyDappDescription,
+	'carouselSlideText' | 'carouselSlideCallToAction'
+> &
+	Required<Pick<OisyDappDescription, 'carouselSlideText' & 'carouselSlideCallToAction'>>;
 
 const parseResult = z.array(oisyDappDescriptionSchema).safeParse(dAppDescriptionsJson);
 export const dAppDescriptions: OisyDappDescription[] = parseResult.success ? parseResult.data : [];

--- a/src/frontend/src/lib/types/oisyDappDescription.ts
+++ b/src/frontend/src/lib/types/oisyDappDescription.ts
@@ -15,10 +15,6 @@ const dAppDescriptionSchema = z.object({
 	stats: z.string(),
 	logo: z.string(),
 
-	// TODO: check if text is not too long using logic from https://github.com/dfinity/portal/blob/34a0328ed4792f5a7f3943be73f13f5abaefb4b8/plugins/validate-showcase.js#L179
-	carouselSlideText: z.string().optional(),
-	carouselSlideCallToAction: z.string().optional(),
-
 	usesInternetIdentity: z.boolean(),
 	authOrigins: z.array(z.string()).optional(),
 
@@ -34,21 +30,24 @@ const dAppDescriptionSchema = z.object({
 	submittableId: z.string().optional()
 });
 
+const carouselDappDescriptionSchema = {
+	// TODO: check if text is not too long using logic from https://github.com/dfinity/portal/blob/34a0328ed4792f5a7f3943be73f13f5abaefb4b8/plugins/validate-showcase.js#L179
+	text: z.string(),
+	callToAction: z.string()
+};
+
 const oisyDappDescriptionSchema = dAppDescriptionSchema.extend({
 	featured: z.boolean().optional(),
 	callToAction: z.string().optional(),
 	telegram: z.string().url().optional(),
-	openChat: z.string().url().optional()
+	openChat: z.string().url().optional(),
+	carousel: z.object(carouselDappDescriptionSchema).optional()
 });
 
 export type OisyDappDescription = z.infer<typeof oisyDappDescriptionSchema>;
 export type FeaturedOisyDappDescription = Omit<OisyDappDescription, 'screenshots'> &
 	Required<Pick<OisyDappDescription, 'screenshots'>>;
-export type CarouselCardOisyDappDescription = Omit<
-	OisyDappDescription,
-	'carouselSlideText' | 'carouselSlideCallToAction'
-> &
-	Required<Pick<OisyDappDescription, 'carouselSlideText' & 'carouselSlideCallToAction'>>;
-
+export type CarouselSlideOisyDappDescription = Omit<OisyDappDescription, 'carousel'> &
+	Required<Pick<OisyDappDescription, 'carousel'>>;
 const parseResult = z.array(oisyDappDescriptionSchema).safeParse(dAppDescriptionsJson);
 export const dAppDescriptions: OisyDappDescription[] = parseResult.success ? parseResult.data : [];


### PR DESCRIPTION
# Motivation

We need to extend dApps description schema with data required for Carousel slides. Some fields (e.g. logo) is already present in the JSON, therefore I added only the missing ones. The fields are optional in case in the future not all dApps need to be showcased in the carousel. 

<img width="312" alt="Screenshot 2024-10-24 at 11 08 54" src="https://github.com/user-attachments/assets/186119ed-d28e-4a05-959c-22b1b1a3301d">
