### PR TITLE
feat(frontend): create Storage Setter store

### DIFF
--- a/src/frontend/src/lib/stores/storage-setter.store.ts
+++ b/src/frontend/src/lib/stores/storage-setter.store.ts
@@ -6,12 +6,13 @@ import { type Readable } from 'svelte/store';
 export type StorageSetterStoreData<T> = Option<Record<TokenId, T | null>>;
 
 export interface StorageSetterStore<T> extends Readable<StorageSetterStoreData<T>> {
-	reset: (tokenId: TokenId) => void;
 	set: (params: { tokenId: TokenId; data: T }) => void;
+	reset: (tokenId: TokenId) => void;
+	resetAll: (params: { key: string }) => void;
 }
 
 export const initStorageSetterStore = <T>({ key }: { key: string }): StorageSetterStore<T> => {
-	const { set, subscribe, update } = initStorageStore<StorageSetterStoreData<T>>({ key });
+	const { set, subscribe, update, reset } = initStorageStore<StorageSetterStoreData<T>>({ key });
 
 	return {
 		set: ({ tokenId, data }: { tokenId: TokenId; data: T }) =>
@@ -36,6 +37,7 @@ export const initStorageSetterStore = <T>({ key }: { key: string }): StorageSett
 
 				return newState;
 			}),
+		resetAll: reset,
 		subscribe
 	};
 };

--- a/src/frontend/src/lib/stores/storage-setter.store.ts
+++ b/src/frontend/src/lib/stores/storage-setter.store.ts
@@ -1,0 +1,41 @@
+import { initStorageStore } from '$lib/stores/storage.store';
+import type { TokenId } from '$lib/types/token';
+import type { Option } from '$lib/types/utils';
+import { type Readable } from 'svelte/store';
+
+export type StorageSetterStoreData<T> = Option<Record<TokenId, T | null>>;
+
+export interface StorageSetterStore<T> extends Readable<StorageSetterStoreData<T>> {
+	reset: (tokenId: TokenId) => void;
+	set: (params: { tokenId: TokenId; data: T }) => void;
+}
+
+export const initStorageSetterStore = <T>({ key }: { key: string }): StorageSetterStore<T> => {
+	const { set, subscribe, update } = initStorageStore<StorageSetterStoreData<T>>({ key });
+
+	return {
+		set: ({ tokenId, data }: { tokenId: TokenId; data: T }) =>
+			update((state) => {
+				const newState: StorageSetterStoreData<T> = {
+					...state,
+					[tokenId]: data
+				};
+
+				set({ key, value: newState });
+
+				return newState;
+			}),
+		reset: (tokenId: TokenId) =>
+			update((state) => {
+				const newState = {
+					...state,
+					[tokenId]: null
+				};
+
+				set({ key, value: newState });
+
+				return newState;
+			}),
+		subscribe
+	};
+};

--- a/src/frontend/src/lib/stores/storage.store.ts
+++ b/src/frontend/src/lib/stores/storage.store.ts
@@ -1,10 +1,12 @@
 import { del, get, set as setStorage } from '$icp/utils/storage.utils';
 import type { Option } from '$lib/types/utils';
-import { writable, type Readable } from 'svelte/store';
+import { writable, type Readable, type Writable } from 'svelte/store';
 
 export type StorageStoreData<T> = Option<T>;
 
-export interface StorageStore<T> extends Readable<StorageStoreData<T>> {
+export interface StorageStore<T>
+	extends Readable<StorageStoreData<T>>,
+		Pick<Writable<StorageStoreData<T>>, 'update'> {
 	set: (params: { key: string; value: T }) => void;
 	reset: (params: { key: string }) => void;
 }
@@ -12,13 +14,14 @@ export interface StorageStore<T> extends Readable<StorageStoreData<T>> {
 export const initStorageStore = <T>({ key }: { key: string }): StorageStore<T> => {
 	const initialValue = get<T>({ key });
 
-	const { set, subscribe } = writable<StorageStoreData<T>>(initialValue);
+	const { set, subscribe, update } = writable<StorageStoreData<T>>(initialValue);
 
 	return {
 		set: ({ key, value }) => {
 			setStorage({ key, value });
 			set(value);
 		},
+		update,
 		subscribe,
 		reset: (params) => {
 			del(params);

--- a/src/frontend/src/lib/stores/token-group.store.ts
+++ b/src/frontend/src/lib/stores/token-group.store.ts
@@ -1,7 +1,7 @@
-import { initCertifiedSetterStore } from '$lib/stores/certified-setter.store';
+import { initStorageSetterStore } from '$lib/stores/storage-setter.store';
 
 export interface TokenGroupData {
 	expanded: boolean;
 }
 
-export const tokenGroupStore = initCertifiedSetterStore<TokenGroupData>();
+export const tokenGroupStore = initStorageSetterStore<TokenGroupData>({ key: 'group-tokens' });


### PR DESCRIPTION
# Motivation

For the token group store, we need a mix between the `Storage` store and the map provided by the `Certified` store. Meaning that we want saved in local storage some thing that is

```typescript
{
  id1: data1,
  id2: data2,
  ...
}
```

In this PR we create a new type of `Storage` store that resembles the mapping provided by the `Certified` store.

