### PR TITLE
fix(frontend): Deprecated input for TokenGroupCard

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -26,7 +26,7 @@
 			? 'bg-white rounded-b-none'
 			: ''}"
 	>
-		<TokenCard data={headerData} testIdPrefix={TOKEN_GROUP} tokenCount={tokenGroup.tokens.length} />
+		<TokenCard data={headerData} testIdPrefix={TOKEN_GROUP} />
 	</TokenCardWithOnClick>
 
 	{#if isExpanded}


### PR DESCRIPTION
# Motivation

Not really sure how, but a missing commit was lacking in PR #3054 and it was merged even if the CI checks didn't pass.

So fixing it here