### PR TITLE
feat(frontend): Implement token groups in tokens list

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -2,17 +2,21 @@
 	import { debounce } from '@dfinity/utils';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { showZeroBalances } from '$lib/derived/settings.derived';
-	import type { Token, TokenUi } from '$lib/types/token';
+	import type { Token, TokenUi, TokenUiOrGroupUi } from '$lib/types/token';
+	import { groupTokensByTwin } from '$lib/utils/token.utils';
 
 	// We start it as undefined to avoid showing an empty list before the first update.
-	export let tokens: Token[] | undefined = undefined;
+	export let tokens: TokenUiOrGroupUi[] | undefined = undefined;
 
 	let sortedTokens: TokenUi[];
 	$: sortedTokens = $combinedDerivedSortedNetworkTokensUi.filter(
 		({ balance, usdBalance }) => Number(balance ?? 0n) || (usdBalance ?? 0) || $showZeroBalances
 	);
 
-	const updateTokensToDisplay = () => (tokens = [...sortedTokens]);
+	let groupedTokens: TokenUiOrGroupUi[];
+	$: groupedTokens = groupTokensByTwin(sortedTokens);
+
+	const updateTokensToDisplay = () => (tokens = [...groupedTokens]);
 
 	const debounceUpdateTokensToDisplay = debounce(updateTokensToDisplay, 500);
 

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -2,7 +2,7 @@
 	import { debounce } from '@dfinity/utils';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { showZeroBalances } from '$lib/derived/settings.derived';
-	import type { Token, TokenUi, TokenUiOrGroupUi } from '$lib/types/token';
+	import type { TokenUi, TokenUiOrGroupUi } from '$lib/types/token';
 	import { groupTokensByTwin } from '$lib/utils/token.utils';
 
 	// We start it as undefined to avoid showing an empty list before the first update.

--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -11,9 +11,11 @@
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import { modalManageTokens } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { TokenUi } from '$lib/types/token';
+	import type { TokenUiOrGroupUi } from '$lib/types/token';
+	import { isTokenUiGroup } from '$lib/utils/token.utils';
+	import TokenGroupCard from '$lib/components/tokens/TokenGroupCard.svelte';
 
-	let tokens: TokenUi[] | undefined;
+	let tokens: TokenUiOrGroupUi[] | undefined;
 
 	let animating = false;
 
@@ -48,11 +50,15 @@
 					on:animationend={handleAnimationEnd}
 					class:pointer-events-none={animating}
 				>
-					<Listener {token}>
-						<TokenCardWithUrl {token}>
-							<TokenCardContent data={token} />
-						</TokenCardWithUrl>
-					</Listener>
+					{#if isTokenUiGroup(token)}
+						<TokenGroupCard tokenGroup={token} />
+					{:else}
+						<Listener {token}>
+							<TokenCardWithUrl {token}>
+								<TokenCardContent data={token} />
+							</TokenCardWithUrl>
+						</Listener>
+					{/if}
 				</div>
 			{/each}
 		</div>

--- a/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSignedIn.svelte
@@ -7,13 +7,13 @@
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
 	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 	import TokenCardWithUrl from '$lib/components/tokens/TokenCardWithUrl.svelte';
+	import TokenGroupCard from '$lib/components/tokens/TokenGroupCard.svelte';
 	import TokensDisplayHandler from '$lib/components/tokens/TokensDisplayHandler.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
 	import { modalManageTokens } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenUiOrGroupUi } from '$lib/types/token';
 	import { isTokenUiGroup } from '$lib/utils/token.utils';
-	import TokenGroupCard from '$lib/components/tokens/TokenGroupCard.svelte';
 
 	let tokens: TokenUiOrGroupUi[] | undefined;
 

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -74,8 +74,11 @@ export type TokenUi = Token & TokenFinancialData;
 
 export type OptionTokenUi = Option<TokenUi>;
 
+//todo: separate typing from token id
+export type GroupId = TokenId;
+
 export type TokenUiGroup = {
-	id: TokenId;
+	id: GroupId;
 	nativeToken: TokenUi;
 	tokens: TokenUi[];
 } & TokenFinancialData;

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -77,6 +77,7 @@ export type OptionTokenUi = Option<TokenUi>;
 // TODO: remove header and nativeNetwork, since we added nativeToken that has all their data, and they became redundant
 export type TokenUiGroup = {
 	header: TokenMetadata;
+	id: TokenId;
 	nativeToken: TokenUi;
 	nativeNetwork: Network;
 	tokens: TokenUi[];

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -222,6 +222,7 @@ const createTokenGroup = ({
 		decimals: nativeToken.decimals,
 		icon: nativeToken.icon
 	},
+	id: nativeToken.id,
 	nativeToken,
 	nativeNetwork: nativeToken.network,
 	tokens: [nativeToken, twinToken],

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -214,7 +214,7 @@ const createTokenGroup = ({
 	nativeToken: TokenUi;
 	twinToken: TokenUi;
 }): TokenUiGroup => ({
-	id: nativeToken.id,
+	id: Symbol(`GRP-${nativeToken.symbol}`),
 	nativeToken,
 	tokens: [nativeToken, twinToken],
 	balance: sumTokenBalances([nativeToken, twinToken]),

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -195,9 +195,7 @@ export const isTokenUiGroup = (
 	tokenUiOrGroupUi: TokenUiOrGroupUi
 ): tokenUiOrGroupUi is TokenUiGroup =>
 	typeof tokenUiOrGroupUi === 'object' &&
-	nonNullish(tokenUiOrGroupUi) &&
-	'header' in tokenUiOrGroupUi &&
-	typeof tokenUiOrGroupUi.header === 'object' &&
+	'nativeToken' in tokenUiOrGroupUi &&
 	'tokens' in tokenUiOrGroupUi;
 
 /**


### PR DESCRIPTION
# Motivation

We want to start grouping tokens that refers to the same underlying. For example `BTC` and `ckBTC`, or `ETH` and `ckETH`. Basically twin tokens, where the "native token" definition falls on the most mainstream one of the group (BTC, ETH, etc)

To do that we first group the sorted tokens and then we show single-tokens differently from the token groups (we use the `TokenCardGroup` component introduced recently).


# Changes

- Modify function `isTokenUiGroup` to recognize the correct group type instead of the token type.
- Add an ID for the token group: this will be the same of the native token so that the animation can recognize it as the same element.
- Group tokens with function `groupTokensByTwin` in `TokenDisplayHandler`.
- In the token list, differentiate how we show a group from how we show a single-token card.

# Tests

I deployed the current branch in a test environment (otherwise there were no tokens to be grouped...):


https://github.com/user-attachments/assets/46f4abbc-e661-4e1b-aadf-18e973da1d97


