### PR TITLE
fix(frontend): Show balance in Token Group Card

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -4,12 +4,14 @@
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
 	import type { LogoSize } from '$lib/types/components';
 	import type { CardData } from '$lib/types/token-card';
+	import { TOKEN_CARD, TOKEN_GROUP } from '$lib/constants/test-ids.constants';
 
 	export let data: CardData;
 	export let logoSize: LogoSize = 'lg';
+	export let testIdPrefix: typeof TOKEN_CARD | typeof TOKEN_GROUP = TOKEN_CARD;
 </script>
 
-<TokenCard {data} {logoSize}>
+<TokenCard {data} {logoSize} {testIdPrefix}>
 	<TokenBalance {data} slot="balance" />
 
 	<ExchangeTokenValue {data} slot="exchange" />

--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -2,9 +2,9 @@
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
 	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
+	import { TOKEN_CARD, TOKEN_GROUP } from '$lib/constants/test-ids.constants';
 	import type { LogoSize } from '$lib/types/components';
 	import type { CardData } from '$lib/types/token-card';
-	import { TOKEN_CARD, TOKEN_GROUP } from '$lib/constants/test-ids.constants';
 
 	export let data: CardData;
 	export let logoSize: LogoSize = 'lg';

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -26,7 +26,7 @@
 			? 'bg-white rounded-b-none'
 			: ''}"
 	>
-		<TokenCard data={headerData} testIdPrefix={TOKEN_GROUP} />
+		<TokenCardContent data={headerData} testIdPrefix={TOKEN_GROUP} />
 	</TokenCardWithOnClick>
 
 	{#if isExpanded}

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
-	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
 	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
 	import TokenCardWithUrl from '$lib/components/tokens/TokenCardWithUrl.svelte';


### PR DESCRIPTION
# Motivation

To show the balance (and USD balance) of the summary of the token group, we need to use `TokenCardContent` instead of `TokenCard`.