### PR TITLE
feat(frontend): add badge component

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappTags.svelte
+++ b/src/frontend/src/lib/components/dapps/DappTags.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Badge from '$lib/components/ui/Badge.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
@@ -11,8 +12,8 @@
 	class="flex list-none flex-wrap gap-2"
 >
 	{#each tags as tag}
-		<li class="rounded border border-light-grey bg-dust/30 px-2 py-0.5 text-xs font-semibold">
+		<Badge>
 			{tag}
-		</li>
+		</Badge>
 	{/each}
 </ul>

--- a/src/frontend/src/lib/components/dapps/DappTags.svelte
+++ b/src/frontend/src/lib/components/dapps/DappTags.svelte
@@ -12,8 +12,10 @@
 	class="flex list-none flex-wrap gap-2"
 >
 	{#each tags as tag}
-		<Badge>
-			{tag}
-		</Badge>
+		<li>
+			<Badge>
+				{tag}
+			</Badge>
+		</li>
 	{/each}
 </ul>

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -12,10 +12,10 @@
 	};
 </script>
 
-<div
+<span
 	class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold {variantClassNames[
 		variant
 	]} {styleClass ?? ''}"
 >
 	<slot />
-</div>
+</span>

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	export let variant: 'default' | 'info' | 'error' | 'warning' | 'success' | 'outline' = 'default';
 	export let styleClass: string | undefined = undefined;
 
 	const variantClassNames = {
@@ -10,6 +9,8 @@
 		success: 'bg-green-crayola/20 text-green-crayola',
 		outline: 'border border-light-grey bg-off-white'
 	};
+
+	export let variant: keyof typeof variantClassNames = 'default';
 </script>
 
 <span

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-
 	export let variant: 'default' | 'info' | 'error' | 'warning' | 'success' | 'outline' = 'default';
+	export let styleClass: string | undefined = undefined;
 
 	const variantClassNames = {
 		default: 'border border-light-grey bg-dust/30',
@@ -10,10 +10,12 @@
 		success: 'bg-green-crayola/20 text-green-crayola',
 		outline: 'border border-light-grey bg-off-white'
 	};
-
 </script>
 
-
-<div class="inline-flex px-2 py-0.5 gap-1 items-center rounded  text-xs font-semibold {variantClassNames[variant]}">
+<div
+	class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold {variantClassNames[
+		variant
+	]} {styleClass ?? ''}"
+>
 	<slot />
 </div>

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+
+	export let variant: 'default' | 'info' | 'error' | 'warning' | 'success' | 'outline' = 'default';
+
+	const variantClassNames = {
+		default: 'border border-light-grey bg-dust/30',
+		info: 'bg-light-blue text-blue-ribbon',
+		error: 'bg-rusty-red/20 text-rusty-red',
+		warning: 'bg-american-orange/20 text-american-orange',
+		success: 'bg-green-crayola/20 text-green-crayola',
+		outline: 'border border-light-grey bg-off-white'
+	};
+
+</script>
+
+
+<div class="inline-flex px-2 py-0.5 gap-1 items-center rounded  text-xs font-semibold {variantClassNames[variant]}">
+	<slot />
+</div>


### PR DESCRIPTION
# Motivation

Implement the reusable component 'Badge' from figma.

![image](https://github.com/user-attachments/assets/c07642a2-5cd8-4b0f-8ea4-d05d7663fa9f)

# Changes

- Implement Badge
- Replace current concrete 'implementations' in DappTags with abstracted component


# Tests

Looks same same:

new: 
![image](https://github.com/user-attachments/assets/2a9a9145-b327-4203-a0f6-36c6631258fc)
![image](https://github.com/user-attachments/assets/f954b736-ea77-4f3a-8695-46d1c3228104)
