### PR TITLE
refactor(frontend): use authNotSignedIn in Listener

### DIFF
--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -4,7 +4,7 @@
 	import BitcoinListener from '$btc/components/core/BitcoinListener.svelte';
 	import EthListener from '$eth/components/core/EthListener.svelte';
 	import NoListener from '$lib/components/core/NoListener.svelte';
-	import { authSignedIn } from '$lib/derived/auth.derived';
+	import { authNotSignedIn } from '$lib/derived/auth.derived';
 	import type { OptionToken } from '$lib/types/token';
 	import { isNetworkIdBitcoin, isNetworkIdICP } from '$lib/utils/network.utils';
 
@@ -12,7 +12,7 @@
 
 	let cmp: ComponentType;
 	$: cmp =
-		isNullish(token) || !$authSignedIn
+		isNullish(token) || $authNotSignedIn
 			? NoListener
 			: isNetworkIdICP(token.network.id)
 				? NoListener


### PR DESCRIPTION
# Motivation

It seems cleaner to use `authNotSignedIn` instead of negating `authSignedIn`.
