### PR TITLE
feat(frontend): make DappModal accessible across all routes

### DIFF
--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import HideTokenModal from '$eth/components/tokens/HideTokenModal.svelte';
 	import IcHideTokenModal from '$icp/components/tokens/IcHideTokenModal.svelte';
+	import DappModalDetails from '$lib/components/dapps/DappModalDetails.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
-	import { modalHideToken, modalIcHideToken } from '$lib/derived/modal.derived';
+	import { modalDAppDetails, modalHideToken, modalIcHideToken } from '$lib/derived/modal.derived';
 
 	/**
 	 * Modals that must be declared at the root of the layout if they are used across routes - available on navigation.
@@ -14,5 +15,7 @@
 		<HideTokenModal />
 	{:else if $modalIcHideToken}
 		<IcHideTokenModal />
+	{:else if $modalDAppDetails}
+		<DappModalDetails />
 	{/if}
 {/if}

--- a/src/frontend/src/lib/components/dapps/DappModalDetails.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModalDetails.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import DappModal from '$lib/components/dapps/DappModal.svelte';
+	import { modalDAppDetails } from '$lib/derived/modal.derived';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { OisyDappDescription } from '$lib/types/oisyDappDescription';
+
+	let selectedDapp: OisyDappDescription | undefined = undefined;
+	$: selectedDapp = $modalDAppDetails
+		? ($modalStore?.data as OisyDappDescription | undefined)
+		: undefined;
+</script>
+
+{#if nonNullish(selectedDapp)}
+	<DappModal dAppDescription={selectedDapp} />
+{/if}

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -2,15 +2,12 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import DappCard from '$lib/components/dapps/DappCard.svelte';
-	import DappModal from '$lib/components/dapps/DappModal.svelte';
 	import DappPromoBanner from '$lib/components/dapps/DappPromoBanner.svelte';
 	import SubmitDappButton from '$lib/components/dapps/SubmitDappButton.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import { modalDAppDetails } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import {
-		type OisyDappDescription,
 		dAppDescriptions,
 		type FeaturedOisyDappDescription
 	} from '$lib/types/oisyDappDescription';
@@ -32,11 +29,6 @@
 	$: filteredDapps = dAppDescriptions.filter(
 		({ tags }) => isNullish(selectedTag) || tags.includes(selectedTag)
 	);
-
-	let selectedDapp: OisyDappDescription | undefined = undefined;
-	$: selectedDapp = $modalDAppDetails
-		? ($modalStore?.data as OisyDappDescription | undefined)
-		: undefined;
 </script>
 
 <h1 class="mb-5 mt-6">{$i18n.dapps.text.title}</h1>
@@ -84,7 +76,3 @@
 </ul>
 
 <SubmitDappButton />
-
-{#if $modalDAppDetails && nonNullish(selectedDapp)}
-	<DappModal dAppDescription={selectedDapp} />
-{/if}


### PR DESCRIPTION
# Motivation

This PR is about moving `DappModal` from `DappsExplorerSignedIn` to global `Modals` so the modal can be opened from different places (e.g. list item on the explorer page, carousel slides on the token page). Also, to avoid having `selectedDapp` retrieval logic in the global component (`Modals`), I created `DappModalDetails` where all the checks will be placed.