### PR TITLE
feat(frontend): DappsCarousel usage (all screen sizes)

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -24,7 +24,7 @@
 				: 'tokens';
 </script>
 
-<div class="box-content flex h-full w-full flex-col justify-between py-3 pl-4 md:pl-8">
+<div class="flex h-full w-full flex-col justify-between py-3 pl-4 md:pl-8">
 	<div class="flex flex-col gap-3">
 		<NavigationItem
 			href="/"
@@ -52,6 +52,10 @@
 			<IconlySettings />
 			{$i18n.navigation.text.settings}
 		</NavigationItem>
+	</div>
+
+	<div class="my-4 flex h-full flex-col justify-center">
+		<slot />
 	</div>
 
 	<InfoMenu />

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -8,7 +8,7 @@
 	</div>
 
 	<div
-		class="mx-auto max-w-xl px-5 transition-all duration-500 ease-linear md:ml-64 md:box-content md:w-sm md:max-w-none xl:ml-auto"
+		class="mx-auto max-w-xl overflow-hidden px-5 transition-all duration-500 ease-linear md:ml-64 md:box-content md:w-sm md:max-w-none xl:ml-auto"
 	>
 		<slot />
 	</div>

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -4,6 +4,7 @@
 	import Footer from '$lib/components/core/Footer.svelte';
 	import LoadersGuard from '$lib/components/core/LoadersGuard.svelte';
 	import Modals from '$lib/components/core/Modals.svelte';
+	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Header from '$lib/components/hero/Header.svelte';
 	import Hero from '$lib/components/hero/Hero.svelte';
 	import NavigationMenu from '$lib/components/navigation/NavigationMenu.svelte';
@@ -41,7 +42,11 @@
 
 	<AuthGuard>
 		<SplitPane>
-			<NavigationMenu slot="menu" />
+			<NavigationMenu slot="menu">
+				{#if route === 'tokens'}
+					<DappsCarousel styleClass="w-80 xl:block hidden" />
+				{/if}
+			</NavigationMenu>
 
 			{#if route !== 'settings' && route !== 'explore'}
 				<Hero usdTotal={route === 'tokens'} summary={route === 'transactions'} />

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
+	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Tokens from '$lib/components/tokens/Tokens.svelte';
 </script>
+
+<div class="mb-6 flex justify-center xl:hidden">
+	<DappsCarousel styleClass="w-full" />
+</div>
 
 <Tokens />


### PR DESCRIPTION
# Motivation

In this PR, DappsCarousel have been added to NavigationMenu (displayed on xl screens) and Tokens page layout (displayed on >= lg screens). For now, the carousel should be rendered only on the Tokens page. All the aspects (breakpoints, where to render) were agreed with Artem.

Desktop:
<img width="1527" alt="desktop" src="https://github.com/user-attachments/assets/ac359d31-a035-4445-ba43-238edfed6a40">

Tablet:
<img width="977" alt="tablet" src="https://github.com/user-attachments/assets/ff4b774c-28c1-4e61-a595-55820759d65c">

Mobile:
<img width="498" alt="mobile" src="https://github.com/user-attachments/assets/3d514ec7-c1f2-4b6e-a93a-173691010c01">


