### PR TITLE
feat(frontend): adjust Carousel initialisation function

### DIFF
--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -45,11 +45,9 @@
 	onMount(() => {
 		initializeSlides();
 		initializeCarousel();
-		initialiseAutoplayTimer();
 
 		return () => {
-			clearAutoplayTimer();
-			clearSlideTransformTimer();
+			clearTimers();
 		};
 	});
 
@@ -66,6 +64,14 @@
 	};
 
 	/**
+	 * Clear all timers
+	 */
+	const clearTimers = () => {
+		clearAutoplayTimer();
+		clearSlideTransformTimer();
+	};
+
+	/**
 	 * Build slider frame and set required variables
 	 */
 	const initializeCarousel = () => {
@@ -74,6 +80,12 @@
 		}
 
 		containerWidth = container.offsetWidth;
+
+		// Clear timers and stop further initialisation in case container is rendered but not visible (e.g. display: none)
+		if (containerWidth === 0) {
+			clearTimers();
+			return;
+		}
 
 		// Clean previous HTML if the frame is being re-built (e.g. in case of window resize)
 		sliderFrame.innerHTML = '';
@@ -88,6 +100,11 @@
 			goToSlide({
 				slide: currentSlide
 			});
+
+			// Start autoplay timer if it is not running
+			if (isNullish(autoplayTimer)) {
+				initialiseAutoplayTimer();
+			}
 		}
 	};
 


### PR DESCRIPTION
# Motivation

While implementing Carousel usages (2 instances rendered on the token page to comply with the provided design, one for XL screens, another one for smaller ones), I noticed that the frame and timers are being initialised even if one of carousel is not actually visible (display: none). In this PR, I add a check to avoid that. The check works and stops all processes both on mount and on resize.
