### PR TITLE
feat(frontend): integrate group store

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -6,13 +6,18 @@
 	import TokenCardWithUrl from '$lib/components/tokens/TokenCardWithUrl.svelte';
 	import { TOKEN_GROUP } from '$lib/constants/test-ids.constants';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
+	import { tokenGroupStore } from '$lib/stores/token-group.store';
 	import type { TokenUiGroup } from '$lib/types/token';
 	import type { CardData } from '$lib/types/token-card';
 	import { mapHeaderData } from '$lib/utils/token-card.utils';
 
 	export let tokenGroup: TokenUiGroup;
 
-	let isExpanded = false;
+	$: groups = $tokenGroupStore ?? {};
+	$: isExpanded = groups[tokenGroup.id]?.expanded ?? false;
+
+	const toggleIsExpand = (toggle: boolean) =>
+		tokenGroupStore.set({ tokenId: tokenGroup.id, data: { isExpanded: toggle } });
 
 	let headerData: CardData;
 	$: headerData = mapHeaderData(tokenGroup);
@@ -21,7 +26,7 @@
 <div class="flex flex-col">
 	<!-- TODO: Add listeners for all tokens in group -->
 	<TokenCardWithOnClick
-		on:click={() => (isExpanded = !isExpanded)}
+		on:click={() => toggleIsExpand(!isExpanded)}
 		styleClass="rounded-xl px-3 py-2 hover:bg-white active:bg-white {isExpanded
 			? 'bg-white rounded-b-none'
 			: ''}"

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -13,8 +13,8 @@
 
 	export let tokenGroup: TokenUiGroup;
 
-	$: groups = $tokenGroupStore ?? {};
-	$: isExpanded = groups[tokenGroup.id]?.isExpanded ?? false;
+	let isExpanded: boolean;
+	$: isExpanded = ($tokenGroupStore ?? {})[tokenGroup.id]?.isExpanded ?? false;
 
 	let headerData: CardData;
 	$: headerData = mapHeaderData(tokenGroup);

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -19,14 +19,14 @@
 	let headerData: CardData;
 	$: headerData = mapHeaderData(tokenGroup);
 
-	const toggleIsExpand = (toggle: boolean) =>
+	const toggleIsExpanded = (toggle: boolean) =>
 		tokenGroupStore.set({ tokenId: tokenGroup.id, data: { isExpanded: toggle } });
 </script>
 
 <div class="flex flex-col">
 	<MultipleListeners tokens={tokenGroup.tokens}>
 		<TokenCardWithOnClick
-			on:click={() => toggleIsExpand(!isExpanded)}
+			on:click={() => toggleIsExpanded(!isExpanded)}
 			styleClass="rounded-xl px-3 py-2 hover:bg-white active:bg-white {isExpanded
 				? 'bg-white rounded-b-none'
 				: ''}"

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -14,13 +14,14 @@
 	export let tokenGroup: TokenUiGroup;
 
 	$: groups = $tokenGroupStore ?? {};
-	$: isExpanded = groups[tokenGroup.id]?.expanded ?? false;
+	$: isExpanded = groups[tokenGroup.id]?.isExpanded ?? false;
+
+	let headerData: CardData;
+	$: headerData = mapHeaderData(tokenGroup);
 
 	const toggleIsExpand = (toggle: boolean) =>
 		tokenGroupStore.set({ tokenId: tokenGroup.id, data: { isExpanded: toggle } });
 
-	let headerData: CardData;
-	$: headerData = mapHeaderData(tokenGroup);
 </script>
 
 <div class="flex flex-col">

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -21,7 +21,6 @@
 
 	const toggleIsExpand = (toggle: boolean) =>
 		tokenGroupStore.set({ tokenId: tokenGroup.id, data: { isExpanded: toggle } });
-
 </script>
 
 <div class="flex flex-col">

--- a/src/frontend/src/lib/stores/token-group.store.ts
+++ b/src/frontend/src/lib/stores/token-group.store.ts
@@ -1,7 +1,7 @@
 import { initCertifiedSetterStore } from '$lib/stores/certified-setter.store';
 
 export interface TokenGroupData {
-	expanded: boolean;
+	isExpanded: boolean;
 }
 
 export const tokenGroupStore = initCertifiedSetterStore<TokenGroupData>();

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -214,7 +214,7 @@ const createTokenGroup = ({
 	nativeToken: TokenUi;
 	twinToken: TokenUi;
 }): TokenUiGroup => ({
-	id: Symbol(`GRP-${nativeToken.symbol}`),
+	id: Symbol.for(`GRP-${nativeToken.symbol}`),
 	nativeToken,
 	tokens: [nativeToken, twinToken],
 	balance: sumTokenBalances([nativeToken, twinToken]),

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -217,7 +217,9 @@ const createTokenGroup = ({
 	nativeToken: TokenUi;
 	twinToken: TokenUi;
 }): TokenUiGroup => ({
-	id: Symbol.for(`GRP-${nativeToken.symbol}`),
+	// Setting the same ID of the native token to ensure the Group Card component is treated as the same component of the Native Token Card.
+	// This allows Svelte transitions/animations to handle the two cards as the same component, giving a smoother user experience.
+	id: nativeToken.id,
 	nativeToken,
 	tokens: [nativeToken, twinToken],
 	balance: sumTokenBalances([nativeToken, twinToken]),


### PR DESCRIPTION
# Motivation

Integrate group store with token group card to enable storing the isExpanded state of the card.

# Changes

- Rename expanded to isExpanded for consistency
- use Symbol.for on group creation to prevent mismatch of logically same group
- Glue store and component

# Tests
