### PR TITLE
refactor(frontend): Extract sub-functions to sum balances

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -15,23 +15,11 @@ import type {
 	TokenUiOrGroupUi
 } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
-import type { Option } from '$lib/types/utils';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { BigNumber } from '@ethersproject/bignumber';
-
-export const isToken = (token: Option<unknown>): token is Token =>
-	nonNullish(token) &&
-	typeof token === 'object' &&
-	'id' in token &&
-	'network' in token &&
-	'standard' in token &&
-	'category' in token &&
-	'name' in token &&
-	'symbol' in token &&
-	'decimals' in token;
 
 /**
  * Calculates the maximum amount for a transaction.

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -162,24 +162,21 @@ const sumBalances = ([balance1, balance2]: [
 export const sumTokenBalances = ([token1, token2]: [TokenUi, TokenUi]): TokenUi['balance'] =>
 	token1.decimals === token2.decimals ? sumBalances([token1.balance, token2.balance]) : null;
 
-const sumUsdBalances = ([usdBalance1, usdBalance2]: [
+/** Function to sum the USD balances of two tokens.
+ *
+ * If one of the balances is nullish, the function returns the other balance.
+ *
+ * @param usdBalance1
+ * @param usdBalance2
+ * @returns The sum of the USD balances or nullish value.
+ */
+export const sumUsdBalances = ([usdBalance1, usdBalance2]: [
 	TokenUi['usdBalance'],
 	TokenUi['usdBalance']
 ]): TokenUi['usdBalance'] =>
 	nonNullish(usdBalance1) || nonNullish(usdBalance2)
 		? (usdBalance1 ?? 0) + (usdBalance2 ?? 0)
 		: undefined;
-
-/** Function to sum the USD balances of two tokens.
- *
- * If one of the balances is nullish, the function returns the other balance.
- *
- * @param token1
- * @param token2
- * @returns The sum of the USD balances or nullish value.
- */
-export const sumTokenUsdBalances = ([token1, token2]: [TokenUi, TokenUi]): TokenUi['usdBalance'] =>
-	sumUsdBalances([token1.usdBalance, token2.usdBalance]);
 
 /**
  * Type guard to check if a token is of type RequiredTokenWithLinkedData.
@@ -224,7 +221,7 @@ const createTokenGroup = ({
 	nativeToken,
 	tokens: [nativeToken, twinToken],
 	balance: sumTokenBalances([nativeToken, twinToken]),
-	usdBalance: sumTokenUsdBalances([nativeToken, twinToken])
+	usdBalance: sumUsdBalances([nativeToken.usdBalance, twinToken.usdBalance])
 });
 
 /**

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -9,7 +9,7 @@ import {
 	groupTokensByTwin,
 	mapTokenUi,
 	sumTokenBalances,
-	sumTokenUsdBalances
+	sumUsdBalances
 } from '$lib/utils/token.utils';
 import { $balances, bn1, bn2, bn3 } from '$tests/mocks/balances.mock';
 import { $exchanges } from '$tests/mocks/exchanges.mock';
@@ -329,32 +329,23 @@ describe('sumTokenBalances', () => {
 	});
 });
 
-describe('sumTokenUsdBalances', () => {
-	// We mock ETH to be a twin of ICP
-	const token1: TokenUi = { ...ICP_TOKEN, usdBalance: 100 };
-	const token2: TokenUi = { ...ETHEREUM_TOKEN, usdBalance: 200 };
-
+describe('sumUsdBalances', () => {
 	it('should sum token balances when both balances are non-null', () => {
-		const result = sumTokenUsdBalances([token1, token2]);
+		const result = sumUsdBalances([100, 200]);
 
 		expect(result).toEqual(300);
 	});
 
 	it('should return the first balance when the second balance is nullish', () => {
-		expect(sumTokenUsdBalances([token1, { ...token2, usdBalance: undefined }])).toBe(100);
+		expect(sumUsdBalances([100, undefined])).toBe(100);
 	});
 
 	it('should return the second balance when the first balance is nullish', () => {
-		expect(sumTokenUsdBalances([{ ...token1, usdBalance: undefined }, token2])).toBe(200);
+		expect(sumUsdBalances([undefined, 200])).toBe(200);
 	});
 
 	it('should return undefined when both balances are nullish', () => {
-		expect(
-			sumTokenUsdBalances([
-				{ ...token1, usdBalance: undefined },
-				{ ...token2, usdBalance: undefined }
-			])
-		).toBeUndefined();
+		expect(sumUsdBalances([undefined, undefined])).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
# Motivation

We need to re-use the sub-functions of `sumTokenBalances` and `sumTokenUsdBalances`, specifically to provide only the balances instead of the entire token object.
