### PR TITLE
style(frontend): smooth transition between group card and token card

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -217,7 +217,7 @@ const createTokenGroup = ({
 	nativeToken: TokenUi;
 	twinToken: TokenUi;
 }): TokenUiGroup => ({
-	id: Symbol(`GRP-${nativeToken.symbol}`),
+	id: nativeToken.id,
 	nativeToken,
 	tokens: [nativeToken, twinToken],
 	balance: sumTokenBalances([nativeToken, twinToken]),

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -217,6 +217,8 @@ const createTokenGroup = ({
 	nativeToken: TokenUi;
 	twinToken: TokenUi;
 }): TokenUiGroup => ({
+	// Setting the same ID of the native token to ensure the Group Card component is treated as the same component of the Native Token Card.
+	// This allows Svelte transitions/animations to handle the two cards as the same component, giving a smoother user experience.
 	id: nativeToken.id,
 	nativeToken,
 	tokens: [nativeToken, twinToken],


### PR DESCRIPTION
# Motivation

The svelte animation/transition bases itself on the "ID" given to  a specific component. For example, in the Tokens list, the "ID" in the `EACH` loop is given by the `token.id`:

``` svelte
{#each tokens ?? [] as token (token.id)}
```

That allows the `flip` animation, for example, to know exactly what is the component to "flip" even if it changes itself inside, or for the `fade` transition to "fade" always the same component.

So, if two components have the same ID, they will be treated as the same component for animation/transition.

However, for group cards, we have different IDs for the "native token" Token card and its Group card when one is created. Ideally, the transition between the two cards is none, meaning that a Native Token card becomes a group card if there are twin tokens.  

# Changes

Provide the same ID to the Group card as the one provided to the "native token" card.

# Tests

### Before


https://github.com/user-attachments/assets/df746327-9291-4857-9c23-4882293e01e2


### After


https://github.com/user-attachments/assets/88bb8904-c4a0-4642-9702-411bb6e43900


