### PR TITLE
feat(frontend): New public routes

### DIFF
--- a/src/frontend/src/routes/(public)/+layout.svelte
+++ b/src/frontend/src/routes/(public)/+layout.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <header
-	class="z-1 1.5lg:fixed 1.5lg:inset-x-0 1.5lg:top-0 1.5lg:z-10 pointer-events-none relative flex w-full max-w-screen-2.5xl items-center justify-between px-4 pt-6 md:px-8"
+	class="z-1 pointer-events-none relative flex w-full max-w-screen-2.5xl items-center justify-between px-4 pt-6 md:px-8 1.5lg:fixed 1.5lg:inset-x-0 1.5lg:top-0 1.5lg:z-10"
 >
 	<div class="pointer-events-auto">
 		<OisyWalletLogoLink />
@@ -11,7 +11,7 @@
 </header>
 
 <main
-	class="lg:w-md 1.5lg:mt-28 mx-0 mt-10 flex flex-col items-center justify-center px-8 pb-10 lg:mx-auto lg:px-0"
+	class="mx-0 mt-10 flex flex-col items-center justify-center px-8 pb-10 lg:mx-auto lg:w-md lg:px-0 1.5lg:mt-28"
 >
 	<slot />
 </main>

--- a/src/frontend/src/routes/(public)/+layout.svelte
+++ b/src/frontend/src/routes/(public)/+layout.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import OisyWalletLogoLink from '$lib/components/core/OisyWalletLogoLink.svelte';
+</script>
+
+<header
+	class="z-1 1.5lg:fixed 1.5lg:inset-x-0 1.5lg:top-0 1.5lg:z-10 pointer-events-none relative flex w-full max-w-screen-2.5xl items-center justify-between px-4 pt-6 md:px-8"
+>
+	<div class="pointer-events-auto">
+		<OisyWalletLogoLink />
+	</div>
+</header>
+
+<main
+	class="lg:w-md 1.5lg:mt-28 mx-0 mt-10 flex flex-col items-center justify-center px-8 pb-10 lg:mx-auto lg:px-0"
+>
+	<slot />
+</main>

--- a/src/frontend/src/routes/(public)/terms-and-conditions/+page.svelte
+++ b/src/frontend/src/routes/(public)/terms-and-conditions/+page.svelte
@@ -1,0 +1,2 @@
+<!--TODO: Add Terms and Conditions content here-->
+<slot />

--- a/src/frontend/src/routes/(public)/terms-and-conditions/+page.ts
+++ b/src/frontend/src/routes/(public)/terms-and-conditions/+page.ts
@@ -1,0 +1,10 @@
+import type { RouteParams } from '$lib/utils/nav.utils';
+import type { LoadEvent } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+// We reset the data because a public route operates without a network or token selected.
+export const load: PageLoad = (_$event: LoadEvent): RouteParams => ({
+	token: null,
+	network: null,
+	uri: null
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,10 +63,12 @@ export default {
 				'pos-100': '100% 100%'
 			},
 			width: {
-				sm: '576px'
+				sm: '576px',
+				md: '768px'
 			},
 			screens: {
 				'1.5md': '896px',
+				'1.5lg': '1152px',
 				'2.5xl': '1728px',
 				'h-md': { raw: '(max-height: 1090px)' }
 			}


### PR DESCRIPTION
# Motivation

We would like to have "public" routes in OISY, for example for Terms and Conditions. So, we set an independent page, agnostic to signed in or not.


![Screenshot 2024-10-25 at 12 48 55](https://github.com/user-attachments/assets/32a01b21-8c10-49ee-896c-d0b2e4323499)

