### PR TITLE
feat(frontend): how to convert back btn full width

### DIFF
--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -9,6 +9,7 @@
 	} from '$icp-eth/derived/cketh.derived';
 	import ReceiveAddress from '$lib/components/receive/ReceiveAddress.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
@@ -151,13 +152,11 @@
 		</div>
 	</div>
 
-	<div slot="toolbar">
+	<svelte:fragment slot="toolbar">
 		{#if formCancelAction === 'back'}
-			<Button fullWidth type="button" on:click={() => dispatch('icBack')}
-				>{$i18n.core.text.back}</Button
-			>
+			<ButtonBack fullWidth on:click={() => dispatch('icBack')} />
 		{:else}
 			<ButtonDone on:click={modalStore.close} />
 		{/if}
-	</div>
+	</svelte:fragment>
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/ui/ButtonBack.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonBack.svelte
@@ -3,8 +3,9 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	export let disabled = false;
+	export let fullWidth = false;
 </script>
 
-<Button colorStyle="secondary" type="button" {disabled} on:click>
+<Button colorStyle="secondary" type="button" {disabled} {fullWidth} on:click>
 	{$i18n.core.text.back}
 </Button>


### PR DESCRIPTION
# Motivation

The "Back" button on the "How to convert..." modal does no inherits the secondary style of back button and is not fullwidth.

# Changes

- Add `fullWidth` to `ButtonBack`
- Correct slot, style and width for the back button on the modal

# Screenshots

Before:

<img width="1532" alt="Capture d’écran 2024-10-28 à 09 13 05" src="https://github.com/user-attachments/assets/b7e46298-9252-4ada-8883-08bff2bcec53">

After:

<img width="1532" alt="Capture d’écran 2024-10-28 à 09 13 41" src="https://github.com/user-attachments/assets/2cb184b0-6c00-4f60-93fe-7758e7b98d1f">