### PR TITLE
fix(ci): fix dependabot issue

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   format:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
# Motivation

The dependabot workflows fail because of insufficient access rights. So we want to exclude the dependabot workflows.

# Changes

- added condition to exclude dependabot workflows
