### PR TITLE
style(frontend): add styling classes for <ul> for DappModal

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -122,7 +122,7 @@
 				</div>
 			</div>
 
-			<p class="m-0 my-5 text-sm">
+			<p class="m-0 my-5 text-sm [&_ul]:pl-6 [&_ul]:list-disc">
 				<Html text={description} />
 			</p>
 			<DappTags dAppName={name} {tags} />


### PR DESCRIPTION
# Motivation

Some Dapp descriptions use lists. Without styling they do not look good.

# Changes

- add tw classes for <ul> in DappModal


# Tests

Before
<img width="451" alt="image" src="https://github.com/user-attachments/assets/5c0efcad-b94b-47ab-ad16-765791ad4f66">


After
<img width="441" alt="image" src="https://github.com/user-attachments/assets/0f9dccd7-c99b-4845-8ba1-5fd8f151a4c5">

