### PR TITLE
refactor(frontend): Use Zod for base token types

### DIFF
--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -2,12 +2,19 @@ import type { OptionBalance } from '$lib/types/balance';
 import type { Network } from '$lib/types/network';
 import type { OnramperId } from '$lib/types/onramper';
 import type { AtLeastOne, Option, RequiredExcept } from '$lib/types/utils';
+import { z } from 'zod';
 
-export type TokenId = symbol;
+const TokenIdSchema = z.symbol().brand<'TokenId'>();
 
-export type TokenStandard = 'ethereum' | 'erc20' | 'icp' | 'icrc' | 'bitcoin';
+const TokenStandardSchema = z.enum(['ethereum', 'erc20', 'icp', 'icrc', 'bitcoin']);
 
-export type TokenCategory = 'default' | 'custom';
+const TokenCategorySchema = z.enum(['default', 'custom']);
+
+export type TokenId = z.infer<typeof TokenIdSchema>;
+
+export type TokenStandard = z.infer<typeof TokenStandardSchema>;
+
+export type TokenCategory = z.infer<typeof TokenCategorySchema>;
 
 export type Token = {
 	id: TokenId;


### PR DESCRIPTION
# Motivation

We want to refactor the type `Token` to use Zod. But we need to do it gradually, since it may require quite a lot of implementation.

So, as first PR, we use Zod for base token types like symbol, standard and category.
