### PR TITLE
style(frontend): Reduce padding of Hero

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <article
-	class="relative flex flex-col items-center rounded-lg py-6"
+	class="relative flex flex-col items-center rounded-lg pb-6"
 	transition:slide={SLIDE_PARAMS}
 >
 	<HeroContent {usdTotal} {summary} />

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,5 +1,5 @@
 <main
-	class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto lg:pt-6"
+	class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto"
 >
 	<div
 		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:my-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,5 +1,5 @@
 <main
-	class="relative mx-auto max-w-screen-2.5xl pt-8 md:flex md:w-full md:flex-row lg:w-auto lg:pt-0"
+	class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto lg:pt-6"
 >
 	<div
 		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:my-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,6 +1,4 @@
-<main
-	class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto"
->
+<main class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto">
 	<div
 		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:my-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"
 	>


### PR DESCRIPTION
# Motivation

To make it less dispersive, we reduce the padding on top of Hero, for the different brakpoints.


https://github.com/user-attachments/assets/5da80529-c68c-49f5-9c57-c8b57b53cc1e


