### PR TITLE
chore(release): next version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "0.0.43",
+	"version": "0.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "0.0.43",
+			"version": "0.9.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/agent": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "0.0.43",
+	"version": "0.9.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {


### PR DESCRIPTION
# Motivation

We bump to the first `beta` version of OISY that is `v0.9.0`
