### PR TITLE
chore(frontend): Remove Alpha warning URL from metadata

### DIFF
--- a/src/frontend/src/env/oisy.metadata.json
+++ b/src/frontend/src/env/oisy.metadata.json
@@ -4,6 +4,6 @@
 	"OISY_ONELINER": "A multi-chain wallet powered by chainfusion",
 	"OISY_DESCRIPTION": "OISY Wallet provides a seamless on-chain experience to manage your Ethereum and ICP assets. By leveraging native web technologies and advanced cryptography, it eliminates the need for browser extensions or mobile apps. And accessing the wallet is easy using passkeys on a computer or mobile device.",
 	"OISY_REPO_URL": "https://github.com/dfinity/oisy-wallet",
-	"OISY_STATUS_URL": "https://github.com/dfinity/oisy-wallet#status"
+	"OISY_STATUS_URL": "https://github.com/dfinity/oisy-wallet#status",
 	"OISY_TWITTER_URL": "https://x.com/OISY_Wallet"
 }

--- a/src/frontend/src/env/oisy.metadata.json
+++ b/src/frontend/src/env/oisy.metadata.json
@@ -4,5 +4,5 @@
 	"OISY_ONELINER": "A multi-chain wallet powered by chainfusion",
 	"OISY_DESCRIPTION": "OISY Wallet provides a seamless on-chain experience to manage your Ethereum and ICP assets. By leveraging native web technologies and advanced cryptography, it eliminates the need for browser extensions or mobile apps. And accessing the wallet is easy using passkeys on a computer or mobile device.",
 	"OISY_REPO_URL": "https://github.com/dfinity/oisy-wallet",
-	"OISY_ALPHA_WARNING_URL": "https://github.com/dfinity/oisy-wallet#status"
+	"OISY_STATUS_URL": "https://github.com/dfinity/oisy-wallet#status"
 }

--- a/src/frontend/src/env/types/env-oisy-metadata.ts
+++ b/src/frontend/src/env/types/env-oisy-metadata.ts
@@ -6,6 +6,6 @@ export const oisyMetadata = z.object({
 	OISY_ONELINER: z.string(),
 	OISY_DESCRIPTION: z.string(),
 	OISY_REPO_URL: z.string().url(),
-	OISY_STATUS_URL: z.string().url()
+	OISY_STATUS_URL: z.string().url(),
 	OISY_TWITTER_URL: z.string().url()
 });

--- a/src/frontend/src/env/types/env-oisy-metadata.ts
+++ b/src/frontend/src/env/types/env-oisy-metadata.ts
@@ -6,5 +6,5 @@ export const oisyMetadata = z.object({
 	OISY_ONELINER: z.string(),
 	OISY_DESCRIPTION: z.string(),
 	OISY_REPO_URL: z.string().url(),
-	OISY_ALPHA_WARNING_URL: z.string().url()
+	OISY_STATUS_URL: z.string().url()
 });

--- a/src/frontend/src/lib/constants/oisy.constants.ts
+++ b/src/frontend/src/lib/constants/oisy.constants.ts
@@ -9,7 +9,7 @@ export const {
 	OISY_ONELINER,
 	OISY_DESCRIPTION,
 	OISY_REPO_URL,
-	OISY_ALPHA_WARNING_URL
+	OISY_STATUS_URL
 } = parsedMetadata.success
 	? parsedMetadata.data
 	: {
@@ -18,11 +18,8 @@ export const {
 			OISY_ONELINER: '',
 			OISY_DESCRIPTION: '',
 			OISY_REPO_URL: '',
-			OISY_ALPHA_WARNING_URL: ''
+			OISY_STATUS_URL: ''
 		};
 
 export const OISY_URL = import.meta.env.VITE_OISY_URL;
 export const OISY_ICON = `${OISY_URL}/favicons/icon-512x512.png`;
-
-// TODO: Adjust the URL when we remove the Alpha warning
-export const OISY_STATUS_URL = OISY_ALPHA_WARNING_URL;

--- a/src/frontend/src/lib/constants/oisy.constants.ts
+++ b/src/frontend/src/lib/constants/oisy.constants.ts
@@ -9,7 +9,7 @@ export const {
 	OISY_ONELINER,
 	OISY_DESCRIPTION,
 	OISY_REPO_URL,
-	OISY_STATUS_URL
+	OISY_STATUS_URL,
 	OISY_TWITTER_URL
 } = parsedMetadata.success
 	? parsedMetadata.data
@@ -19,7 +19,7 @@ export const {
 			OISY_ONELINER: '',
 			OISY_DESCRIPTION: '',
 			OISY_REPO_URL: '',
-			OISY_STATUS_URL: ''
+			OISY_STATUS_URL: '',
 			OISY_TWITTER_URL: ''
 		};
 

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -182,7 +182,6 @@
 	"hero": {
 		"text": {
 			"available_balance": "Available balance",
-			"use_with_caution": "This is an alpha version. Use with caution.",
 			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
 		}
 	},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -160,7 +160,7 @@ interface I18nInit {
 }
 
 interface I18nHero {
-	text: { available_balance: string; use_with_caution: string; learn_more_about_erc20_icp: string };
+	text: { available_balance: string; learn_more_about_erc20_icp: string };
 }
 
 interface I18nSettings {

--- a/src/frontend/src/lib/utils/i18n.utils.ts
+++ b/src/frontend/src/lib/utils/i18n.utils.ts
@@ -40,7 +40,7 @@ export const replaceOisyPlaceholders = (text: string): string =>
 		$oisy_description: OISY_DESCRIPTION,
 		$oisy_url: OISY_URL,
 		$oisy_repo_url: OISY_REPO_URL,
-		$oisy_status_url: OISY_STATUS_URL
+		$oisy_status_url: OISY_STATUS_URL,
 		$oisy_twitter_url: OISY_TWITTER_URL
 	});
 

--- a/src/frontend/src/lib/utils/i18n.utils.ts
+++ b/src/frontend/src/lib/utils/i18n.utils.ts
@@ -1,10 +1,10 @@
 import {
-	OISY_ALPHA_WARNING_URL,
 	OISY_DESCRIPTION,
 	OISY_NAME,
 	OISY_ONELINER,
 	OISY_REPO_URL,
 	OISY_SHORT,
+	OISY_STATUS_URL,
 	OISY_URL
 } from '$lib/constants/oisy.constants';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -39,7 +39,7 @@ export const replaceOisyPlaceholders = (text: string): string =>
 		$oisy_description: OISY_DESCRIPTION,
 		$oisy_url: OISY_URL,
 		$oisy_repo_url: OISY_REPO_URL,
-		$oisy_alpha_warning_url: OISY_ALPHA_WARNING_URL
+		$oisy_status_url: OISY_STATUS_URL
 	});
 
 interface MaybeI18n extends I18n {

--- a/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
@@ -1,9 +1,9 @@
 import {
-	OISY_ALPHA_WARNING_URL,
 	OISY_DESCRIPTION,
 	OISY_NAME,
 	OISY_ONELINER,
 	OISY_REPO_URL,
+	OISY_STATUS_URL,
 	OISY_URL
 } from '$lib/constants/oisy.constants';
 import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -52,11 +52,9 @@ describe('i18n-utils', () => {
 		it('should replace Oisy placeholders', () => {
 			expect(
 				replaceOisyPlaceholders(
-					'Lorem Ipsum! $oisy_name $oisy_oneliner $oisy_description $oisy_alpha_warning_url'
+					'Lorem Ipsum! $oisy_name $oisy_oneliner $oisy_description $oisy_status_url'
 				)
-			).toBe(
-				`Lorem Ipsum! ${OISY_NAME} ${OISY_ONELINER} ${OISY_DESCRIPTION} ${OISY_ALPHA_WARNING_URL}`
-			);
+			).toBe(`Lorem Ipsum! ${OISY_NAME} ${OISY_ONELINER} ${OISY_DESCRIPTION} ${OISY_STATUS_URL}`);
 
 			expect(replaceOisyPlaceholders('Url: $oisy_url')).toBe(`Url: ${OISY_URL}`);
 


### PR DESCRIPTION
# Motivation

We substitute the definition of the Alpha warning URL with the Repo status URL.
