### PR TITLE
chore(frontend): Set missing Typescript in components

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsExplorer.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorer.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import DappsExplorerSignedIn from '$lib/components/dapps/DappsExplorerSignedIn.svelte';
 	import DappsExplorerSignedOut from '$lib/components/dapps/DappsExplorerSignedOut.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';

--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import SettingsSignedIn from '$lib/components/settings/SettingsSignedIn.svelte';
 	import SettingsSignedOut from '$lib/components/settings/SettingsSignedOut.svelte';
 	import SettingsVersion from '$lib/components/settings/SettingsVersion.svelte';


### PR DESCRIPTION
# Motivation

Just a small re-ordering: two components were missing `lang="ts"`. Not that it was necessary, but just for consistency.
