### PR TITLE
docs(frontend): Add description for submitting a dApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ What are the unique ICP technical building blocks enabling the creation of OISY?
 
 - (Upcoming) **HTTP outcalls:** for now, OISY calls centralized Ethereum endpoints, such as Infura or Alchemy, from the frontend. In the future, OISY might be improved to use [HTTP outcalls](https://internetcomputer.org/https-outcalls) to call these endpoints in a decentralized fashion. Check out the [HTTP outcalls sample code](https://internetcomputer.org/docs/current/developer-docs/integrations/https-outcalls/https-outcalls-how-to-use) to explore how to use Web 2.0 services on ICP.
 
+## Submit your dApp
+
+To file a request to have your dApp listed in the dApps explorer of OISY Wallet, please submit this [dApp Submission Request](https://github.com/dfinity/oisy-wallet/issues/new?assignees=&labels=&projects=&template=dapp_submission_request.md&title=Request+a+dApp+to+be+listed+on+the+OISY+Wallet+dApp+Explorer).
+
 ## Status
 
 Please note that this is a **beta version** of OISY Wallet which is still undergoing final testing before its official release.

--- a/src/frontend/src/lib/components/dapps/SubmitDappButton.svelte
+++ b/src/frontend/src/lib/components/dapps/SubmitDappButton.svelte
@@ -5,7 +5,7 @@
 
 <a
 	class="as-button tertiary padding-sm mx-auto my-10 w-fit text-sm no-underline"
-	href="https://github.com/dfinity/oisy-wallet/issues/new?assignees=&labels=&projects=&template=dapp_submission_request.md&title=Request+a+Dapp+to+be+listed+on+the+OISY+Wallet+Dapp+Explorer"
+	href="https://github.com/dfinity/oisy-wallet#submit-your-dapp"
 	rel="external noopener noreferrer"
 	target="_blank"
 	aria-label={$i18n.dapps.alt.submit_your_dapp}


### PR DESCRIPTION
# Motivation

When an user click to the "Submit your dApp" button it is redirected to the login page of Github, if it is not connected yet.

To avoid this disturbance, we redirect to a new section of the README file (that itself has the link to the submission form).
