### PR TITLE
feat(frontend): handle BTC in the Import modal

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -13,7 +13,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
-	import { isNetworkIdICP, isNetworkIdEthereum } from '$lib/utils/network.utils';
+	import {
+		isNetworkIdICP,
+		isNetworkIdEthereum,
+		isNetworkIdBitcoin
+	} from '$lib/utils/network.utils';
 
 	export let network: Network | undefined;
 	export let tokenData: Partial<AddTokenData>;
@@ -55,7 +59,10 @@
 	$: enabledNetworkSelector = isNullish($selectedNetwork);
 
 	let availableNetworks: Network[] = [];
-	$: availableNetworks = $selectedNetwork?.env === 'testnet' ? $networks : $networksMainnets;
+	// filter out BTC networks - they do not have custom tokens
+	$: availableNetworks = (
+		$selectedNetwork?.env === 'testnet' ? $networks : $networksMainnets
+	).filter(({ id }) => !isNetworkIdBitcoin(id));
 </script>
 
 {#if enabledNetworkSelector}
@@ -80,6 +87,8 @@
 		<IcAddTokenForm on:icBack bind:ledgerCanisterId bind:indexCanisterId />
 	{:else if isNetworkIdEthereum(network?.id)}
 		<AddTokenForm on:icBack bind:contractAddress={erc20ContractAddress} />
+	{:else}
+		<span class="mb-6">{$i18n.tokens.import.text.custom_tokens_not_supported}</span>
 	{/if}
 
 	<AddTokenByNetworkToolbar {invalid} on:icBack />

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -426,7 +426,8 @@
 				"add_the_token": "Add the token",
 				"info": "To display custom token information correctly, $oisy_name requires setting both a Ledger and Index canister ID. More details can be found on GitHub.",
 				"github_howto": "Read how ICRC token Integration works",
-				"open_github_howto": "Open information about ICRC token integration on GitHub"
+				"open_github_howto": "Open information about ICRC token integration on GitHub",
+				"custom_tokens_not_supported": "The selected network does not support custom tokens."
 			},
 			"error": {
 				"loading_metadata": "Error while loading the metadata of the token.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -388,6 +388,7 @@ interface I18nTokens {
 			info: string;
 			github_howto: string;
 			open_github_howto: string;
+			custom_tokens_not_supported: string;
 		};
 		error: {
 			loading_metadata: string;


### PR DESCRIPTION
# Motivation

In this PR, BTC networks are filtered out from the selector in the Import modal. Also, an additional message is added in case user opens the modal while having an active BTC network.

<img width="1562" alt="Screenshot 2024-10-29 at 10 30 39" src="https://github.com/user-attachments/assets/09fd585a-0195-4e23-a423-795a83f4e36d">

<img width="1556" alt="Screenshot 2024-10-29 at 10 28 46" src="https://github.com/user-attachments/assets/e1b4a67f-77d1-4798-a2c1-9993e5a82358">
