### PR TITLE
feat(frontend): disable Carousel slide animation on init

### DIFF
--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -99,7 +99,8 @@
 
 		if (nonNullish(sliderFrame.children)) {
 			goToSlide({
-				slide: currentSlide
+				slide: currentSlide,
+				withTransition: false
 			});
 
 			// Start autoplay timer if it is not running

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -45,7 +45,7 @@
 		<SplitPane>
 			<NavigationMenu slot="menu">
 				{#if route === 'tokens'}
-					<div in:fade class="hidden xl:block">
+					<div in:fade out:fade class="hidden xl:block">
 						<DappsCarousel />
 					</div>
 				{/if}

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -45,7 +45,7 @@
 		<SplitPane>
 			<NavigationMenu slot="menu">
 				{#if route === 'tokens'}
-					<div in:fade out:fade class="hidden xl:block">
+					<div transition:fade class="hidden xl:block">
 						<DappsCarousel />
 					</div>
 				{/if}

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -4,7 +4,7 @@
 	import Tokens from '$lib/components/tokens/Tokens.svelte';
 </script>
 
-<div in:fade class="mb-6 flex justify-center xl:hidden">
+<div in:fade out:fade class="mb-6 flex justify-center xl:hidden">
 	<DappsCarousel />
 </div>
 

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -4,7 +4,7 @@
 	import Tokens from '$lib/components/tokens/Tokens.svelte';
 </script>
 
-<div in:fade out:fade class="mb-6 flex justify-center xl:hidden">
+<div transition:fade class="mb-6 flex justify-center xl:hidden">
 	<DappsCarousel />
 </div>
 


### PR DESCRIPTION
# Motivation

The idea is to disable Carousel slide animation on init (on back/load). Also, I added `out` animation to dapps carousel containers, similar as we had them for `in`.
