### PR TITLE
style(frontend): changes flex direction on viewport lg instead of md

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonHero.svelte
@@ -8,9 +8,9 @@
 </script>
 
 <Button on:click {ariaLabel} {disabled} {loading} {testId} colorStyle="tertiary" link paddingSmall>
-	<div class="flex flex-col items-center justify-center gap-2 md:flex-row">
+	<div class="flex flex-col items-center justify-center gap-2 lg:flex-row">
 		<slot name="icon" />
-		<div class="min-w-12 max-w-[72px] break-words text-sm md:text-base">
+		<div class="min-w-12 max-w-[72px] break-words text-sm lg:text-base">
 			<slot />
 		</div>
 	</div>


### PR DESCRIPTION
# Motivation

The action buttons moved out of the parents hero element which does not look nice.


# Changes

- change style class


# Tests

before:
![image](https://github.com/user-attachments/assets/e2f296f6-4330-4d83-b85c-4d0268f99126)


after:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/0c60c013-9cab-4c87-a0dd-8749725c2bd2">


