### PR TITLE
feat(frontend): input text with action

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -26,7 +26,7 @@
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
-	import InputText from '$lib/components/ui/InputText.svelte';
+	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import {
 		networkEthereum,
@@ -195,7 +195,7 @@
 </script>
 
 <div class="mb-4">
-	<InputText
+	<InputTextWithAction
 		name="filter"
 		required={false}
 		bind:value={filter}
@@ -210,7 +210,7 @@
 				<IconSearch />
 			{/if}
 		</svelte:fragment>
-	</InputText>
+	</InputTextWithAction>
 </div>
 
 {#if nonNullish($selectedNetwork)}

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -2,7 +2,7 @@
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import QRButton from '$lib/components/common/QRButton.svelte';
-	import InputText from '$lib/components/ui/InputText.svelte';
+	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
@@ -22,13 +22,18 @@
 </script>
 
 <label for="destination" class="px-4.5 font-bold">{$i18n.send.text.destination}:</label>
-<InputText name="destination" bind:value={destination} placeholder={inputPlaceholder} on:nnsInput>
+<InputTextWithAction
+	name="destination"
+	bind:value={destination}
+	placeholder={inputPlaceholder}
+	on:nnsInput
+>
 	<svelte:fragment slot="inner-end">
 		{#if nonNullish(onQRButtonClick)}
 			<QRButton on:click={onQRButtonClick} />
 		{/if}
 	</svelte:fragment>
-</InputText>
+</InputTextWithAction>
 
 {#if invalidDestination}
 	<p transition:slide={SLIDE_DURATION} class="pb-3 text-cyclamen">

--- a/src/frontend/src/lib/components/ui/InputTextWithAction.svelte
+++ b/src/frontend/src/lib/components/ui/InputTextWithAction.svelte
@@ -15,4 +15,7 @@
 	{placeholder}
 	spellcheck={false}
 	autocomplete="off"
-/>
+	on:nnsInput
+>
+	<slot name="inner-end" slot="inner-end" />
+</Input>


### PR DESCRIPTION
# Motivation

I've been bothered for quite some time by input fields that lack a call to action yet don't use the full width for the input. The root cause of the issue is that the slot must be declared at the top, even if it's not used, which causes gix-cmp to assume that a slot is always in use.

To resolve this, I created a new component, `InputTextWithAction`. This allows us to choose either a simple input or an input with an action, as needed.

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-29 à 13 37 29" src="https://github.com/user-attachments/assets/4a16bd0f-66df-43ad-be93-30b5aee0a4e8">
<img width="1536" alt="Capture d’écran 2024-10-29 à 13 37 35" src="https://github.com/user-attachments/assets/089597f0-669d-4468-b1bc-10f15a17e345">
<img width="1536" alt="Capture d’écran 2024-10-29 à 13 37 38" src="https://github.com/user-attachments/assets/a49a56a6-b249-4634-ab4c-d815ccbe56ce">

After:

<img width="1536" alt="Capture d’écran 2024-10-29 à 13 36 58" src="https://github.com/user-attachments/assets/de795f0d-56d7-4923-8a4f-a16ea8d1a8ba">
<img width="1536" alt="Capture d’écran 2024-10-29 à 13 36 53" src="https://github.com/user-attachments/assets/786fe49f-3bac-4060-a495-bbdf8d222bc5">
<img width="1536" alt="Capture d’écran 2024-10-29 à 13 36 49" src="https://github.com/user-attachments/assets/6994f6b9-f4cb-4bd1-af2b-b66d293633d4">
