### PR TITLE
fix(frontend): do not show token import text if no network selected

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -87,7 +87,7 @@
 		<IcAddTokenForm on:icBack bind:ledgerCanisterId bind:indexCanisterId />
 	{:else if isNetworkIdEthereum(network?.id)}
 		<AddTokenForm on:icBack bind:contractAddress={erc20ContractAddress} />
-	{:else}
+	{:else if nonNullish($selectedNetwork)}
 		<span class="mb-6">{$i18n.tokens.import.text.custom_tokens_not_supported}</span>
 	{/if}
 


### PR DESCRIPTION
The "custom_tokens_not_supported" should be shown only if unsupported network is selected. In case, no network selected at all, it must be hidden.

<img width="563" alt="Screenshot 2024-10-29 at 13 48 20" src="https://github.com/user-attachments/assets/66c201f5-0474-4bfa-8ea2-9967aa6d1599">
