### PR TITLE
feat(frontend): settings page title

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -9,6 +9,7 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { dAppDescriptions, type FeaturedOisyDappDescription } from '$lib/types/dapp-description';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 
 	// For the moment only the first featured dapp is highlighted
 	const selectFirstFeaturedDapp = (): FeaturedOisyDappDescription | undefined =>
@@ -28,7 +29,7 @@
 	);
 </script>
 
-<h1 class="mb-5 mt-6">{$i18n.dapps.text.title}</h1>
+<PageTitle>{$i18n.dapps.text.title}</PageTitle>
 
 {#if nonNullish(featuredDapp) && nonNullish(featuredDapp.screenshots)}
 	<div class="mb-10">

--- a/src/frontend/src/lib/components/ui/PageTitle.svelte
+++ b/src/frontend/src/lib/components/ui/PageTitle.svelte
@@ -1,0 +1,1 @@
+<h1 class="mb-5 mt-6"><slot /></h1>

--- a/src/frontend/src/routes/(app)/settings/+page.svelte
+++ b/src/frontend/src/routes/(app)/settings/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import Settings from '$lib/components/settings/Settings.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 </script>
 
-<h2 class="mb-6 pb-1 text-base lg:mt-20">{$i18n.settings.text.title}</h2>
+<PageTitle>{$i18n.settings.text.title}</PageTitle>
 
 <Settings />


### PR DESCRIPTION
# Motivation

Use the same title style for "Settings" page as dapp explorer for consistency reason.

# Changes

- New `PageTitle` cmp
- Use component in dapp explorer and settings

# Screenshots

<img width="1536" alt="Capture d’écran 2024-10-29 à 14 32 12" src="https://github.com/user-attachments/assets/e547ad8b-d11a-479e-904f-cb80335f88da">
<img width="1536" alt="Capture d’écran 2024-10-29 à 14 32 13" src="https://github.com/user-attachments/assets/2477e6de-41a3-4e39-9357-1010279540f8">
anto
