### PR TITLE
style(frontend): modal title font-size

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -139,6 +139,10 @@ div.modal {
 		margin-inline: calc(3 / 2 * var(--padding));
 
 		--color-grey: rgba(0, 0, 0, 0.05);
+
+		h2 {
+			font-size: var(--font-size-h3);
+		}
 	}
 
 	div.wrapper.dialog div.container-wrapper {


### PR DESCRIPTION
# Motivation

Change the font-size of the titles in the modals. We were requested 20px, I think it's sosolala h3 but, let me know if not.

# Changes

- Add global rule for title in modal

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-29 à 15 28 07" src="https://github.com/user-attachments/assets/c608959e-9a84-497e-a68e-e5660fbaf2d9">


After:

<img width="1536" alt="Capture d’écran 2024-10-29 à 15 28 00" src="https://github.com/user-attachments/assets/4f04cb4c-e76c-4d5b-bcc9-1cdcc3a6748a">

