### PR TITLE
style(frontend): wider modal width on desktop

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -65,7 +65,7 @@
 	--alert-padding-y: 0;
 	--alert-padding-x: 0;
 
-	--dialog-width: 464px;
+	--dialog-width: 560px;
 	--dialog-max-width: var(--alert-max-width);
 	--dialog-max-height: var(--alert-max-height);
 	--dialog-min-height: var(--alert-max-height);


### PR DESCRIPTION
# Motivation

Design inputs to have wider modals on desktop.

# Changes

- Set width to 560px

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-29 à 15 30 45" src="https://github.com/user-attachments/assets/63df0ab4-fcb1-466a-ace0-5308fa1b5bfa">


After:
<img width="1536" alt="Capture d’écran 2024-10-29 à 15 30 35" src="https://github.com/user-attachments/assets/7eb00cc0-537d-407e-8fd3-818ed78c5285">


