### PR TITLE
feat(frontend): zero balance send message

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -33,9 +33,7 @@
 					</TokenCardWithOnClick>
 				{/each}
 			</div>
-		{/if}
-
-		{#if tokens.length === 0}
+		{:else}
 			<p class="text-secondary">
 				{$i18n.tokens.manage.text.all_tokens_zero_balance}
 			</p>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -25,16 +25,18 @@
 
 <ContentWithToolbar>
 	<TokensSkeletons {loading}>
-		<div class="mb-6 flex flex-col gap-6">
-			{#each tokens as token (token.id)}
-				<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
-					<TokenCardContent data={token} />
-				</TokenCardWithOnClick>
-			{/each}
-		</div>
+		{#if tokens.length > 0}
+			<div class="mb-6 flex flex-col gap-6">
+				{#each tokens as token (token.id)}
+					<TokenCardWithOnClick on:click={() => dispatch('icSendToken', token)}>
+						<TokenCardContent data={token} />
+					</TokenCardWithOnClick>
+				{/each}
+			</div>
+		{/if}
 
 		{#if tokens.length === 0}
-			<p class="text-secondary mb-6 mt-4 opacity-50">
+			<p class="text-secondary">
 				{$i18n.tokens.manage.text.all_tokens_zero_balance}
 			</p>
 		{/if}


### PR DESCRIPTION
# Motivation

The "zero balance no send" message style got a bit off.

# Changes

- Display list of tokens only if there are tokens
- Adapt padding

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-29 à 16 43 00" src="https://github.com/user-attachments/assets/b6591f94-949c-42ff-8123-cf84dcf4a1c9">

After:

<img width="1536" alt="Capture d’écran 2024-10-29 à 16 46 12" src="https://github.com/user-attachments/assets/71d25f65-1fdb-4031-83f2-89a72e127922">

