### PR TITLE
style(frontend): fix onramper iframe overflow

### DIFF
--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -11,7 +11,7 @@
 		>{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}</svelte:fragment
 	>
 
-	<div class="stretch">
+	<div class="stretch overflow-hidden">
 		<OnramperWidget />
 	</div>
 </Modal>


### PR DESCRIPTION
# Motivation

The onramper iframe is just overflowding a bit due to the change of the modal design.

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-10-29 à 16 50 38" src="https://github.com/user-attachments/assets/85421ff1-eed8-433d-8d64-9ddc1aa357d8">

After:

<img width="1536" alt="Capture d’écran 2024-10-29 à 16 50 58" src="https://github.com/user-attachments/assets/552cded4-4094-4cf6-a680-5c5a22609dca">

