### PR TITLE
Fix/glitchy navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"@sveltejs/vite-plugin-svelte": "^3.1.2",
 				"@testing-library/jest-dom": "^6.6.2",
 				"@testing-library/svelte": "^5.2.3",
+				"@types/dom-view-transitions": "^1.0.5",
 				"@types/node": "^20.14.9",
 				"autoprefixer": "^10.4.20",
 				"dotenv": "^16.4.5",
@@ -3428,6 +3429,13 @@
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"dev": true
+		},
+		"node_modules/@types/dom-view-transitions": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/dom-view-transitions/-/dom-view-transitions-1.0.5.tgz",
+			"integrity": "sha512-N2sILR7fxSMnaFaAPwGj4DtHCXjIyQTHt+xJyf9jATpzUsTkMNM0DWtqZB6W7f501B/Y0tq3uqat/VlbjuTpMA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
 		"@testing-library/jest-dom": "^6.6.2",
 		"@testing-library/svelte": "^5.2.3",
+		"@types/dom-view-transitions": "^1.0.5",
 		"@types/node": "^20.14.9",
 		"autoprefixer": "^10.4.20",
 		"dotenv": "^16.4.5",

--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
-	import { slide } from 'svelte/transition';
 	import HeroContent from '$lib/components/hero/HeroContent.svelte';
-	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 
 	export let usdTotal = false;
 	export let summary = false;
 </script>
 
-<article
-	class="relative flex flex-col items-center rounded-lg pb-6"
-	transition:slide={SLIDE_PARAMS}
->
+<article class="relative flex flex-col items-center rounded-lg pb-6">
 	<HeroContent {usdTotal} {summary} />
 </article>

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -43,7 +43,7 @@
 	class:to-bright-lilac={$networkEthereum}
 >
 	{#if summary}
-		<div transition:slide={SLIDE_PARAMS} class="flex w-full flex-col gap-6">
+		<div in:slide={SLIDE_PARAMS} class="flex w-full flex-col gap-6">
 			<div class="grid w-full grid-cols-[1fr_auto_1fr] flex-row items-center justify-between">
 				<Back color="current" onlyArrow />
 
@@ -71,12 +71,12 @@
 	{/if}
 
 	{#if usdTotal}
-		<div transition:slide={SLIDE_PARAMS}>
+		<div in:slide={SLIDE_PARAMS}>
 			<ExchangeBalance />
 		</div>
 	{/if}
 
-	<div transition:slide|local={SLIDE_PARAMS} class="flex w-full justify-center text-left">
+	<div in:slide|local={SLIDE_PARAMS} class="flex w-full justify-center text-left">
 		<Actions />
 	</div>
 

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import { onNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
@@ -31,7 +32,7 @@
 
 	// Source: https://svelte.dev/blog/view-transitions
 	onNavigate((navigation) => {
-		if (!document.startViewTransition) {
+		if (isNullish(document.startViewTransition)) {
 			return;
 		}
 

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
+	import { onNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
 	import AuthGuard from '$lib/components/auth/AuthGuard.svelte';
 	import Footer from '$lib/components/core/Footer.svelte';
@@ -27,6 +28,20 @@
 				: 'tokens';
 
 	$: token.set($pageToken);
+
+	// Source: https://svelte.dev/blog/view-transitions
+	onNavigate((navigation) => {
+		if (!document.startViewTransition) {
+			return;
+		}
+
+		return new Promise((resolve) => {
+			document.startViewTransition(async () => {
+				resolve();
+				await navigation.complete;
+			});
+		});
+	});
 </script>
 
 <div

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
 	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Tokens from '$lib/components/tokens/Tokens.svelte';
 </script>
 
-<div transition:fade class="mb-6 flex justify-center xl:hidden">
+<div class="mb-6 flex justify-center xl:hidden">
 	<DappsCarousel />
 </div>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"types": ["node"]
+		"types": ["node", "@types/dom-view-transitions"]
 	},
 	"exclude": ["src/frontend/src/tests/**/*"]
 }


### PR DESCRIPTION
# Motivation

The navigation has become noticeably glitchy. The root causes are:

- The slide effect in the hero section has slowed down due to the increased data and components.
- The addition of the dApp explorer carousel, which uses transitions on certain pages, causes content to linger too long. This results in double content being displayed briefly, leading to layout shifts.

# Solution

- Remove the slide effect in the hero section.
- Implement the web API `startViewTransition` with its default values to smooth the transition between pages.

# Changes

- Remove slide effects in hero components.
- Add a `startViewTransition` snippet (copied from its usage on https://proposals.network).
- Add type support with `@types/dom-view-transitions`.
- Configure `tsconfig` to include these types.

# Screenshots

Before:

![issue](https://github.com/user-attachments/assets/220baf1b-f95d-4e37-b63f-f460b92b385a)

After:

![fix](https://github.com/user-attachments/assets/bbeb2367-f631-445c-98eb-b8995f6cc6a8)
