### PR TITLE
feat(frontend): Hide network logo for Token group

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -11,10 +11,11 @@
 	export let data: CardData;
 	export let testIdPrefix: typeof TOKEN_CARD | typeof TOKEN_GROUP = TOKEN_CARD;
 	export let logoSize: LogoSize = 'lg';
+	export let hideNetworkLogo = false;
 </script>
 
 <Card noMargin testId={`${testIdPrefix}-${data.symbol}`}>
-	<TokenSymbol {data} />
+	<TokenSymbol {data} {hideNetworkLogo} />
 
 	<TokenName {data} slot="description" />
 

--- a/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardContent.svelte
@@ -8,10 +8,11 @@
 
 	export let data: CardData;
 	export let logoSize: LogoSize = 'lg';
+	export let hideNetworkLogo = false;
 	export let testIdPrefix: typeof TOKEN_CARD | typeof TOKEN_GROUP = TOKEN_CARD;
 </script>
 
-<TokenCard {data} {logoSize} {testIdPrefix}>
+<TokenCard {data} {logoSize} {hideNetworkLogo} {testIdPrefix}>
 	<TokenBalance {data} slot="balance" />
 
 	<ExchangeTokenValue {data} slot="exchange" />

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -31,7 +31,7 @@
 				? 'bg-white rounded-b-none'
 				: ''}"
 		>
-			<TokenCardContent data={headerData} testIdPrefix={TOKEN_GROUP} />
+			<TokenCardContent data={headerData} hideNetworkLogo testIdPrefix={TOKEN_GROUP} />
 		</TokenCardWithOnClick>
 	</MultipleListeners>
 

--- a/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenSymbol.svelte
@@ -6,12 +6,13 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let data: CardData;
+	export let hideNetworkLogo = false;
 </script>
 
 <div class="flex flex-row items-center justify-between gap-2">
 	{nonNullish(data.oisySymbol) ? data.oisySymbol.oisySymbol : data.symbol}
 
-	{#if nonNullish(data.network.iconBW)}
+	{#if nonNullish(data.network.iconBW) && !hideNetworkLogo}
 		<Logo
 			src={data.network.iconBW}
 			alt={replacePlaceholders($i18n.core.alt.logo, { $name: data.network.name })}


### PR DESCRIPTION
# Motivation

It was requested to hide the network logo for the Token Group card.