### PR TITLE
refactor(frontend): Use Zod for NetworkId

### DIFF
--- a/src/frontend/src/env/networks.env.ts
+++ b/src/frontend/src/env/networks.env.ts
@@ -18,14 +18,15 @@ import ethereumBW from '$lib/assets/networks/ethereum-bw.svg';
 import icpBW from '$lib/assets/networks/icp-bw.svg';
 import sepoliaBW from '$lib/assets/networks/sepolia-bw.svg';
 import { LOCAL } from '$lib/constants/app.constants';
-import type { Network } from '$lib/types/network';
+import type { Network, NetworkId } from '$lib/types/network';
+import { parseNetworkId } from '$lib/validation/network.validation';
 
 /**
  * Ethereum
  */
 export const ETHEREUM_NETWORK_SYMBOL = 'ETH';
 
-export const ETHEREUM_NETWORK_ID: unique symbol = Symbol(ETHEREUM_NETWORK_SYMBOL);
+export const ETHEREUM_NETWORK_ID: NetworkId = parseNetworkId(ETHEREUM_NETWORK_SYMBOL);
 
 export const ETHEREUM_NETWORK: EthereumNetwork = {
 	id: ETHEREUM_NETWORK_ID,
@@ -42,7 +43,7 @@ export const { chainId: ETHEREUM_NETWORK_CHAIN_ID } = ETHEREUM_NETWORK;
 
 export const SEPOLIA_NETWORK_SYMBOL = 'SepoliaETH';
 
-export const SEPOLIA_NETWORK_ID: unique symbol = Symbol(SEPOLIA_NETWORK_SYMBOL);
+export const SEPOLIA_NETWORK_ID: NetworkId = parseNetworkId(SEPOLIA_NETWORK_SYMBOL);
 
 export const SEPOLIA_NETWORK: EthereumNetwork = {
 	id: SEPOLIA_NETWORK_ID,
@@ -78,7 +79,7 @@ export const SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS: EthereumChainId[] =
  */
 export const ICP_NETWORK_SYMBOL = 'ICP';
 
-export const ICP_NETWORK_ID = Symbol(ICP_NETWORK_SYMBOL);
+export const ICP_NETWORK_ID: NetworkId = parseNetworkId(ICP_NETWORK_SYMBOL);
 
 export const ICP_NETWORK: Network = {
 	id: ICP_NETWORK_ID,
@@ -94,7 +95,7 @@ export const ICP_NETWORK: Network = {
  */
 export const BTC_MAINNET_NETWORK_SYMBOL = 'BTC';
 
-export const BTC_MAINNET_NETWORK_ID = Symbol(BTC_MAINNET_NETWORK_SYMBOL);
+export const BTC_MAINNET_NETWORK_ID: NetworkId = parseNetworkId(BTC_MAINNET_NETWORK_SYMBOL);
 
 export const BTC_MAINNET_NETWORK: BitcoinNetwork = {
 	id: BTC_MAINNET_NETWORK_ID,
@@ -108,7 +109,7 @@ export const BTC_MAINNET_NETWORK: BitcoinNetwork = {
 
 export const BTC_TESTNET_NETWORK_SYMBOL = 'BTC (Testnet)';
 
-export const BTC_TESTNET_NETWORK_ID = Symbol(BTC_TESTNET_NETWORK_SYMBOL);
+export const BTC_TESTNET_NETWORK_ID: NetworkId = parseNetworkId(BTC_TESTNET_NETWORK_SYMBOL);
 
 export const BTC_TESTNET_NETWORK: BitcoinNetwork = {
 	id: BTC_TESTNET_NETWORK_ID,
@@ -121,7 +122,7 @@ export const BTC_TESTNET_NETWORK: BitcoinNetwork = {
 
 export const BTC_REGTEST_NETWORK_SYMBOL = 'BTC (Regtest)';
 
-export const BTC_REGTEST_NETWORK_ID = Symbol(BTC_REGTEST_NETWORK_SYMBOL);
+export const BTC_REGTEST_NETWORK_ID: NetworkId = parseNetworkId(BTC_REGTEST_NETWORK_SYMBOL);
 
 export const BTC_REGTEST_NETWORK: BitcoinNetwork = {
 	id: BTC_REGTEST_NETWORK_ID,

--- a/src/frontend/src/lib/types/network.ts
+++ b/src/frontend/src/lib/types/network.ts
@@ -1,7 +1,10 @@
 import type { OnramperNetworkId } from '$lib/types/onramper';
 import type { AtLeastOne } from '$lib/types/utils';
+import { z } from 'zod';
 
-export type NetworkId = symbol;
+export const NetworkIdSchema = z.symbol().brand<'NetworkId'>();
+
+export type NetworkId = z.infer<typeof NetworkIdSchema>;
 
 export type NetworkEnvironment = 'mainnet' | 'testnet';
 

--- a/src/frontend/src/lib/validation/network.validation.ts
+++ b/src/frontend/src/lib/validation/network.validation.ts
@@ -1,0 +1,4 @@
+import { NetworkIdSchema, type NetworkId } from '$lib/types/network';
+
+export const parseNetworkId = (networkIdString: string): NetworkId =>
+	NetworkIdSchema.parse(Symbol(networkIdString));


### PR DESCRIPTION
# Motivation

We want to use Zod to safe parse the types of `Token`. Its interface uses the type `Network` too. So, we change type `NetworkId`, branding it specifically for NetworkId. This is similar to PR #3189 

# Changes

- Create schema for `NetworkId`.
- Use it to define `NetworkId` type.
- Create util to parse `NetworkId` type.
- Adapt the code in each usage of `NetworkId`.

# Tests

I didn't create a test for the util because I am not sure how to make it throw errors, but open to suggestions.