### PR TITLE
refactor(frontend): Rename dAppname to dAppName

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappCard.svelte
+++ b/src/frontend/src/lib/components/dapps/DappCard.svelte
@@ -10,14 +10,14 @@
 </script>
 
 <button
-	aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppname: name })}
+	aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: name })}
 	on:click
 	class="relative h-44 flex-1 rounded-lg bg-white p-4 pt-12 shadow md:h-60"
 >
 	<span class="absolute -top-5 left-4">
 		<Logo
 			src={logo}
-			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppname: name })}
+			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: name })}
 			size="xl"
 			ring
 			color="white"

--- a/src/frontend/src/lib/components/dapps/DappCard.svelte
+++ b/src/frontend/src/lib/components/dapps/DappCard.svelte
@@ -6,18 +6,18 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let dAppDescription: OisyDappDescription;
-	$: ({ name, logo, oneLiner, tags } = dAppDescription);
+	$: ({ name: dAppName, logo, oneLiner, tags } = dAppDescription);
 </script>
 
 <button
-	aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: name })}
+	aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: dAppName })}
 	on:click
 	class="relative h-44 flex-1 rounded-lg bg-white p-4 pt-12 shadow md:h-60"
 >
 	<span class="absolute -top-5 left-4">
 		<Logo
 			src={logo}
-			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: name })}
+			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: dAppName })}
 			size="xl"
 			ring
 			color="white"
@@ -25,7 +25,7 @@
 	</span>
 	<article class="flex h-full flex-col justify-between gap-y-4 md:gap-y-2">
 		<section>
-			<p class="m-0 text-start text-lg font-semibold">{name}</p>
+			<p class="m-0 text-start text-lg font-semibold">{dAppName}</p>
 			<p
 				title={oneLiner}
 				class="m-0 mt-2 line-clamp-2 text-ellipsis text-start text-xs text-misty-rose md:line-clamp-4"
@@ -34,7 +34,7 @@
 			</p>
 		</section>
 		<section>
-			<DappTags dAppName={name} {tags} />
+			<DappTags {dAppName} {tags} />
 		</section>
 	</article>
 </button>

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -22,7 +22,7 @@
 		twitter,
 		github,
 		tags,
-		name,
+		name: dAppName,
 		description,
 		logo,
 		callToAction,
@@ -42,7 +42,7 @@
 
 <Modal on:nnsClose={modalStore.close}>
 	<svelte:fragment slot="title">
-		<span class="text-center text-xl">{name}</span>
+		<span class="text-center text-xl">{dAppName}</span>
 	</svelte:fragment>
 
 	<div class="flex flex-col gap-4">
@@ -53,7 +53,7 @@
 					height="100%"
 					width="100%"
 					src={screenshots[0]}
-					alt={replacePlaceholders($i18n.dapps.alt.website, { $dAppname: name })}
+					alt={replacePlaceholders($i18n.dapps.alt.website, { $dAppName: dAppName })}
 				/>
 			</div>
 		{/if}
@@ -63,15 +63,15 @@
 				<Logo
 					size="md"
 					src={logo}
-					alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppname: name })}
+					alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: dAppName })}
 				/>
 				<div class="mr-auto">
-					<div class="text-lg font-bold">{name}</div>
+					<div class="text-lg font-bold">{dAppName}</div>
 					{#if nonNullish(websiteURL)}
 						<ExternalLink
 							iconVisible={false}
 							ariaLabel={replacePlaceholders($i18n.dapps.text.open_dapp, {
-								$dAppname: name
+								$dAppName: dAppName
 							})}
 							href={websiteURL.toString()}
 							styleClass="text-sm text-misty-rose">{websiteURL.hostname}</ExternalLink
@@ -83,7 +83,7 @@
 						<ExternalLinkIcon
 							href={telegram}
 							ariaLabel={replacePlaceholders($i18n.dapps.alt.open_telegram, {
-								$dAppname: name
+								$dAppName: dAppName
 							})}
 						>
 							<IconTelegram size="22" />
@@ -93,7 +93,7 @@
 						<ExternalLinkIcon
 							href={openChat}
 							ariaLabel={replacePlaceholders($i18n.dapps.alt.open_open_chat, {
-								$dAppname: name
+								$dAppName: dAppName
 							})}
 						>
 							<IconOpenChat size="22" />
@@ -103,7 +103,7 @@
 						<ExternalLinkIcon
 							href={twitter}
 							ariaLabel={replacePlaceholders($i18n.dapps.alt.open_twitter, {
-								$dAppname: name
+								$dAppName: dAppName
 							})}
 						>
 							<IconTwitter />
@@ -113,7 +113,7 @@
 						<ExternalLinkIcon
 							href={github}
 							ariaLabel={replacePlaceholders($i18n.dapps.alt.source_code_on_github, {
-								$dAppname: name
+								$dAppName: dAppName
 							})}
 						>
 							<IconGitHub size="22" />
@@ -125,20 +125,20 @@
 			<p class="m-0 my-5 text-sm [&_ul]:list-disc [&_ul]:pl-6">
 				<Html text={description} />
 			</p>
-			<DappTags dAppName={name} {tags} />
+			<DappTags {dAppName} {tags} />
 		</article>
 	</div>
 
 	{#if nonNullish(websiteURL)}
 		<ExternalLink
 			ariaLabel={replacePlaceholders($i18n.dapps.alt.open_dapp, {
-				$dAppname: name
+				$dAppName: dAppName
 			})}
 			styleClass="as-button primary padding-sm mt-auto flex flex-row-reverse"
 			href={websiteURL.toString()}
 			>{callToAction ??
 				replacePlaceholders($i18n.dapps.text.open_dapp, {
-					$dAppname: name
+					$dAppName: dAppName
 				})}</ExternalLink
 		>
 	{/if}

--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -17,7 +17,7 @@
 				width="100%"
 				styleClass="object-cover"
 				src={dAppDescription.screenshots[0]}
-				alt={replacePlaceholders($i18n.dapps.alt.website, { $dAppname: dAppDescription.name })}
+				alt={replacePlaceholders($i18n.dapps.alt.website, { $dAppName: dAppDescription.name })}
 			/>
 		</div>
 	{/if}
@@ -26,7 +26,7 @@
 			<div class="h-12 w-12 rounded-full">
 				<Img
 					src={dAppDescription.logo}
-					alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppname: dAppDescription.name })}
+					alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: dAppDescription.name })}
 				/>
 			</div>
 			<div class="flex-1">

--- a/src/frontend/src/lib/components/dapps/DappTags.svelte
+++ b/src/frontend/src/lib/components/dapps/DappTags.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <ul
-	aria-label={replacePlaceholders($i18n.dapps.alt.tags, { $dAppname: dAppName })}
+	aria-label={replacePlaceholders($i18n.dapps.alt.tags, { $dAppName: dAppName })}
 	class="flex list-none flex-wrap gap-2"
 >
 	{#each tags as tag}

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -20,7 +20,7 @@
 			width="64"
 			rounded
 			src={logo}
-			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppname: name })}
+			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: name })}
 		/>
 	</div>
 	<div>
@@ -29,7 +29,7 @@
 			on:click={() => {
 				modalStore.openDappDetails(dappsCarouselSlide);
 			}}
-			aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppname: name })}
+			aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: name })}
 			class="text-primary text-sm font-semibold"
 		>
 			{callToAction} →

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -9,7 +9,7 @@
 	$: ({
 		carousel: { text, callToAction },
 		logo,
-		name
+		name: dAppName
 	} = dappsCarouselSlide);
 </script>
 
@@ -20,7 +20,7 @@
 			width="64"
 			rounded
 			src={logo}
-			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: name })}
+			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: dAppName })}
 		/>
 	</div>
 	<div>
@@ -29,7 +29,7 @@
 			on:click={() => {
 				modalStore.openDappDetails(dappsCarouselSlide);
 			}}
-			aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: name })}
+			aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: dAppName })}
 			class="text-primary text-sm font-semibold"
 		>
 			{callToAction} →

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -90,22 +90,22 @@
 			"featured": "Featured",
 			"sign_in": "Sign-in to explore the ecosystem.",
 			"title": "Explore Web3 Ecosystem",
-			"open_dapp": "Open $dAppname",
+			"open_dapp": "Open $dAppName",
 			"submit_your_dapp": "Submit your dapp"
 		},
 		"alt": {
-			"learn_more": "Learn more about $dAppname",
-			"logo": "Logo of $dAppname",
+			"learn_more": "Learn more about $dAppName",
+			"logo": "Logo of $dAppName",
 			"show_all": "Show all decentralised applications",
 			"show_tag": "Show decentralised applications with the tag $tag",
-			"open_dapp": "Open the app $dAppname",
-			"open_telegram": "Open $dAppname on Telegram",
-			"open_open_chat": "Open $dAppname on OpenChat",
-			"open_twitter": "Open the $dAppname X/Twitter feed",
-			"source_code_on_github": "View source code of $dAppname on github",
+			"open_dapp": "Open the app $dAppName",
+			"open_telegram": "Open $dAppName on Telegram",
+			"open_open_chat": "Open $dAppName on OpenChat",
+			"open_twitter": "Open the $dAppName X/Twitter feed",
+			"source_code_on_github": "View source code of $dAppName on github",
 			"submit_your_dapp": "Submit your dapp to be shown in the dapp-explorer",
-			"tags": "Tags related to $dAppname",
-			"website": "Image of $dAppname"
+			"tags": "Tags related to $dAppName",
+			"website": "Image of $dAppName"
 		}
 	},
 	"footer": {


### PR DESCRIPTION
# Motivation

Small refactoring to change `dAppname` to `dAppName`, and to not use the `name` variable that it was giving a deprecation warning by the `dom`.

![Screenshot 2024-10-29 at 22 00 57](https://github.com/user-attachments/assets/d4b72129-495c-48c5-a0cb-57227f554ebd)


