### PR TITLE
refactor(frontend): Use colors mapping instead of blue-ribbon

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <div
-	class="flex h-full w-full flex-col content-center items-center justify-center rounded-[40px] bg-background-brand-primary bg-gradient-to-b from-blue-ribbon via-absolute-blue bg-size-200 bg-pos-0 p-6 text-center text-white transition-all duration-500 ease-in-out"
+	class="flex h-full w-full flex-col content-center items-center justify-center rounded-[40px] bg-background-brand-primary bg-gradient-to-b from-background-brand-primary via-absolute-blue bg-size-200 bg-pos-0 p-6 text-center text-white transition-all duration-500 ease-in-out"
 	class:bg-pos-100={$networkICP || $networkBitcoin || $networkEthereum}
 	class:via-interdimensional-blue={$networkICP}
 	class:to-chinese-purple={$networkICP}

--- a/src/frontend/src/lib/components/signer/SignerAlert.svelte
+++ b/src/frontend/src/lib/components/signer/SignerAlert.svelte
@@ -13,7 +13,7 @@
 	<div
 		class="flex h-20 w-20 items-center justify-center rounded-full"
 		class:bg-cyclamen={alertType === 'error'}
-		class:bg-[var(--color-primary)]={alertType === 'ok'}
+		class:bg-background-brand-primary={alertType === 'ok'}
 	>
 		<svelte:component this={icon} />
 	</div>

--- a/src/frontend/src/lib/components/signer/SignerAnimatedAstronaut.svelte
+++ b/src/frontend/src/lib/components/signer/SignerAnimatedAstronaut.svelte
@@ -4,10 +4,10 @@
 
 <span class="relative flex aspect-square w-20">
 	<span
-		class="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--color-primary)] opacity-75"
+		class="absolute inline-flex h-full w-full animate-ping rounded-full bg-background-brand-primary opacity-75"
 	></span>
 	<span
-		class="relative inline-flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-primary)] text-[var(--color-primary)]"
+		class="relative inline-flex h-20 w-20 items-center justify-center rounded-full bg-background-brand-primary text-foreground-brand-primary"
 		><IconAstronautWithEyes /></span
 	>
 </span>

--- a/src/frontend/src/lib/components/signer/SignerLoading.svelte
+++ b/src/frontend/src/lib/components/signer/SignerLoading.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <SignerCenteredContent>
-	<div class="text-[var(--color-primary)]">
+	<div class="text-foreground-brand-primary">
 		<Spinner inline />
 	</div>
 	<span><slot /></span>

--- a/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
@@ -7,7 +7,7 @@
 
 <button
 	on:click
-	class="flex w-full items-center justify-center gap-4 rounded-2xl bg-[var(--color-primary)] py-3 text-lg font-bold leading-6 text-white sm:px-12"
+	class="flex w-full items-center justify-center gap-4 rounded-2xl bg-background-brand-primary py-3 text-lg font-bold leading-6 text-white sm:px-12"
 	class:sm:w-80={!fullWidth}
 	data-tid="login-button"
 >

--- a/src/frontend/src/lib/components/ui/Info.svelte
+++ b/src/frontend/src/lib/components/ui/Info.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="mb-4 flex items-center gap-4 rounded-xl bg-onahau px-4 py-3 text-sm sm:text-base">
-	<div class="min-w-5 text-blue-ribbon">
+	<div class="min-w-5 text-foreground-brand-primary">
 		<IconInfo />
 	</div>
 	<div>


### PR DESCRIPTION
# Motivation

Only for Tailwind, we want to replace the use of `blue-ribbon` (`primary`) with the new colors mapping.