### PR TITLE
style(frontend): Make ButtonHero loading synchronized with Balance bubbling loading prop

### DIFF
--- a/src/frontend/src/btc/components/convert/ConvertToCkBTC.svelte
+++ b/src/frontend/src/btc/components/convert/ConvertToCkBTC.svelte
@@ -4,9 +4,11 @@
 	import ButtonHero from '$lib/components/ui/ButtonHero.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	export let loading = true;
 </script>
 
-<ButtonHero disabled={$isBusy} ariaLabel={$i18n.convert.text.convert_to_ckbtc}>
+<ButtonHero disabled={$isBusy} ariaLabel={$i18n.convert.text.convert_to_ckbtc} {loading}>
 	<IconCkConvert size="28" slot="icon" />
 	<span>{BTC_MAINNET_TOKEN.twinTokenSymbol}</span>
 </ButtonHero>

--- a/src/frontend/src/btc/components/receive/BtcReceive.svelte
+++ b/src/frontend/src/btc/components/receive/BtcReceive.svelte
@@ -18,6 +18,8 @@
 	import type { Token } from '$lib/types/token';
 	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
 
+	export let loading = true;
+
 	let addressData: StorageAddressData<BtcAddress>;
 	$: addressData = isNetworkIdBTCTestnet($networkId)
 		? $btcAddressTestnetStore
@@ -47,7 +49,7 @@
 	};
 </script>
 
-<ReceiveButtonWithModal open={openReceive} isOpen={$modalBtcReceive}>
+<ReceiveButtonWithModal open={openReceive} isOpen={$modalBtcReceive} {loading}>
 	<ReceiveModal
 		slot="modal"
 		address={addressData?.data}

--- a/src/frontend/src/eth/components/receive/EthReceive.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceive.svelte
@@ -12,6 +12,7 @@
 	import type { Token } from '$lib/types/token';
 
 	export let token: Token;
+	export let loading = true;
 
 	const isDisabled = (): boolean => $ethAddressNotCertified || $metamaskNotInitialized;
 
@@ -28,7 +29,7 @@
 	};
 </script>
 
-<ReceiveButtonWithModal open={openReceive} isOpen={$modalEthReceive}>
+<ReceiveButtonWithModal open={openReceive} isOpen={$modalEthReceive} {loading}>
 	<ReceiveModal
 		slot="modal"
 		address={$networkAddress}

--- a/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
@@ -15,6 +15,8 @@
 	import { token } from '$lib/stores/token.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
+	export let loading = true;
+
 	/**
 	 * Send modal context store
 	 */
@@ -35,6 +37,7 @@
 	ariaLabel={replacePlaceholders($i18n.convert.text.convert_to_ckerc20, {
 		$ckErc20: convertToSymbol
 	})}
+	{loading}
 >
 	<IconCkConvert size="28" slot="icon" />
 	<span>{convertToSymbol}</span>

--- a/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
@@ -11,6 +11,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 
+	export let loading = true;
+
 	/**
 	 * Send modal context store
 	 */
@@ -26,6 +28,7 @@
 	nativeTokenId={$ethereumTokenId}
 	nativeNetworkId={$selectedEthereumNetwork.id}
 	ariaLabel={$i18n.convert.text.convert_to_cketh}
+	{loading}
 >
 	<IconCkConvert size="28" slot="icon" />
 	<span>{$ethereumToken.twinTokenSymbol ?? ''}</span>

--- a/src/frontend/src/icp-eth/components/send/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/send/ConvertETH.svelte
@@ -21,6 +21,7 @@
 
 	export let nativeTokenId: TokenId;
 	export let ariaLabel: string;
+	export let loading = true;
 	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	export let nativeNetworkId: NetworkId;
 
@@ -75,7 +76,7 @@
 </script>
 
 <CkEthLoader {nativeTokenId}>
-	<ButtonHero on:click={async () => await openSend()} disabled={$isBusy} {ariaLabel}>
+	<ButtonHero on:click={async () => await openSend()} disabled={$isBusy} {ariaLabel} {loading}>
 		<slot name="icon" slot="icon" />
 		<slot />
 	</ButtonHero>

--- a/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
@@ -16,6 +16,8 @@
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
 
+	export let loading = true;
+
 	const isDisabled = (): boolean =>
 		isNullish($tokenId) || isNullish($ckBtcMinterInfoStore?.[$tokenId]);
 
@@ -37,6 +39,7 @@
 	disabled={$isBusy}
 	on:click={async () => await openSend()}
 	ariaLabel={$i18n.convert.text.convert_to_btc}
+	{loading}
 >
 	<IconCkConvert size="28" slot="icon" />
 	{BTC_MAINNET_SYMBOL}

--- a/src/frontend/src/icp/components/convert/ConvertToEthereum.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToEthereum.svelte
@@ -12,6 +12,8 @@
 	import { modalConvertToTwinTokenEth } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	export let loading = true;
 </script>
 
 <ConvertETH
@@ -20,6 +22,7 @@
 	ariaLabel={replacePlaceholders($i18n.convert.text.convert_to_token, {
 		$token: $ckEthereumTwinToken.symbol
 	})}
+	{loading}
 >
 	<IconCkConvert size="28" slot="icon" />
 	<span>{$ckEthereumTwinToken.symbol}</span>

--- a/src/frontend/src/icp/components/receive/IcReceive.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceive.svelte
@@ -22,6 +22,7 @@
 	import type { Token } from '$lib/types/token';
 
 	export let token: Token;
+	export let loading = true;
 
 	let ckEthereum = false;
 	$: ckEthereum = isTokenCkEthLedger(token) || isTokenCkErc20Ledger(token);
@@ -55,11 +56,11 @@
 </script>
 
 {#if ckEthereum}
-	<IcReceiveCkEthereum />
+	<IcReceiveCkEthereum {loading} />
 {:else if ckBTC}
-	<IcReceiveCkBTC />
+	<IcReceiveCkBTC {loading} />
 {:else if icrc}
-	<IcReceiveIcrc />
+	<IcReceiveIcrc {loading} />
 {:else}
-	<IcReceiveIcp />
+	<IcReceiveIcp {loading} />
 {/if}

--- a/src/frontend/src/icp/components/receive/IcReceiveCkBTC.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkBTC.svelte
@@ -16,6 +16,8 @@
 	import { modalCkBTCReceive } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 
+	export let loading = true;
+
 	const { token, tokenId, ckEthereumTwinToken, open, close } =
 		getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
@@ -45,7 +47,7 @@
 
 <svelte:window on:oisyReceiveCkBTC={async () => await openModal(modalId)} />
 
-<ReceiveButtonWithModal open={openModal} isOpen={$modalCkBTCReceive} {modalId}>
+<ReceiveButtonWithModal open={openModal} isOpen={$modalCkBTCReceive} {modalId} {loading}>
 	<ReceiveAddressModal infoCmp={IcReceiveInfoCkBTC} on:nnsClose={close} slot="modal" />
 </ReceiveButtonWithModal>
 

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -14,6 +14,8 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 
+	export let loading = true;
+
 	const { ckEthereumTwinToken, open, close } =
 		getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
@@ -49,6 +51,6 @@
 	const openModal = async (modalId: symbol) => await open(async () => await openReceive(modalId));
 </script>
 
-<ReceiveButtonWithModal open={openModal} isOpen={$modalCkETHReceive}>
+<ReceiveButtonWithModal open={openModal} isOpen={$modalCkETHReceive} {loading}>
 	<IcReceiveCkEthereumModal on:nnsClose={close} slot="modal" />
 </ReceiveButtonWithModal>

--- a/src/frontend/src/icp/components/receive/IcReceiveICP.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveICP.svelte
@@ -12,6 +12,8 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { isRouteTokens } from '$lib/utils/nav.utils';
 
+	export let loading = true;
+
 	const { tokenStandard, open, close } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
 	const openReceive = (modalId: symbol) => {
@@ -26,6 +28,6 @@
 	const openModal = async (modalId: symbol) => await open(async () => await openReceive(modalId));
 </script>
 
-<ReceiveButtonWithModal open={openModal} isOpen={$modalIcpReceive}>
+<ReceiveButtonWithModal open={openModal} isOpen={$modalIcpReceive} {loading}>
 	<ReceiveAddressModal infoCmp={IcReceiveInfoICP} on:nnsClose={close} slot="modal" />
 </ReceiveButtonWithModal>

--- a/src/frontend/src/icp/components/receive/IcReceiveIcrc.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveIcrc.svelte
@@ -10,6 +10,8 @@
 	import { modalIcrcReceive } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 
+	export let loading = true;
+
 	const { open, close } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
 	const openReceive = (modalId: symbol) => {
@@ -19,6 +21,6 @@
 	const openModal = async (modalId: symbol) => await open(async () => await openReceive(modalId));
 </script>
 
-<ReceiveButtonWithModal open={openModal} isOpen={$modalIcrcReceive}>
+<ReceiveButtonWithModal open={openModal} isOpen={$modalIcrcReceive} {loading}>
 	<ReceiveAddressModal infoCmp={IcReceiveInfoIcrc} on:nnsClose={close} slot="modal" />
 </ReceiveButtonWithModal>

--- a/src/frontend/src/lib/components/buy/Buy.svelte
+++ b/src/frontend/src/lib/components/buy/Buy.svelte
@@ -4,10 +4,12 @@
 	import { modalBuy } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 
+	export let loading = true;
+
 	const modalId = Symbol();
 </script>
 
-<BuyButton on:click={() => modalStore.openBuy(modalId)} />
+<BuyButton on:click={() => modalStore.openBuy(modalId)} {loading} />
 
 {#if $modalBuy && $modalStore?.data === modalId}
 	<BuyModal />

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -5,12 +5,15 @@
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
+
+	export let loading = true;
 </script>
 
 <ButtonHero
 	on:click
 	disabled={$isBusy || isNullishOrEmpty(ONRAMPER_API_KEY)}
 	ariaLabel={$i18n.send.text.send}
+	{loading}
 >
 	<IconlyBuy size="28" slot="icon" />
 	{$i18n.buy.text.buy}

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -6,6 +6,8 @@
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { sumTokensUiUsdBalance } from '$lib/utils/tokens.utils';
 
+	export let loading = true;
+
 	let totalUsd: number;
 	$: totalUsd = sumTokensUiUsdBalance($combinedDerivedSortedNetworkTokensUi);
 </script>
@@ -14,7 +16,7 @@
 	<output
 		class={`break-all text-5xl font-bold ${totalUsd === 0 ? 'opacity-50' : 'opacity-100'} mt-8 inline-block`}
 	>
-		{#if $exchangeInitialized}
+		{#if !loading}
 			{formatUSD({ value: totalUsd })}
 		{:else}
 			<span class="animate-pulse">{formatUSD({ value: 0 })}</span>

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { anyBalanceNonZero } from '$lib/derived/balances.derived';
-	import { exchangeInitialized } from '$lib/derived/exchange.derived';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { formatUSD } from '$lib/utils/format.utils';

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -28,6 +28,8 @@
 	import { isRouteTransactions } from '$lib/utils/nav.utils';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 
+	export let loading = true;
+
 	let convertEth = false;
 	$: convertEth = $ethToCkETHEnabled && $erc20UserTokensInitialized;
 
@@ -50,45 +52,45 @@
 <div role="toolbar" class="flex w-full justify-center pt-10">
 	<HeroButtonGroup>
 		{#if $networkICP}
-			<IcReceive token={$tokenWithFallback} />
+			<IcReceive token={$tokenWithFallback} {loading} />
 		{:else if $networkEthereum}
-			<EthReceive token={$tokenWithFallback} />
+			<EthReceive token={$tokenWithFallback} {loading} />
 		{:else if $networkBitcoin}
-			<BtcReceive />
+			<BtcReceive {loading} />
 		{:else if $pseudoNetworkChainFusion}
-			<Receive />
+			<Receive {loading} />
 		{/if}
 
 		{#if sendAction}
-			<Send {isTransactionsPage} />
+			<Send {isTransactionsPage} {loading} />
 		{/if}
 
 		{#if isTransactionsPage}
 			{#if convertEth}
 				{#if $networkICP}
-					<ConvertToEthereum />
+					<ConvertToEthereum {loading} />
 				{:else}
-					<ConvertToCkETH />
+					<ConvertToCkETH {loading} />
 				{/if}
 			{/if}
 
 			{#if convertErc20}
 				{#if $networkICP}
-					<ConvertToEthereum />
+					<ConvertToEthereum {loading} />
 				{:else}
-					<ConvertToCkERC20 />
+					<ConvertToCkERC20 {loading} />
 				{/if}
 			{/if}
 
 			{#if convertCkBtc}
-				<ConvertToBTC />
+				<ConvertToBTC {loading} />
 			{/if}
 
 			{#if convertBtc}
-				<ConvertToCkBTC />
+				<ConvertToCkBTC {loading} />
 			{/if}
 		{/if}
 
-		<Buy />
+		<Buy {loading} />
 	</HeroButtonGroup>
 </div>

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
 	import type { OptionTokenUi } from '$lib/types/token';
 
 	export let token: OptionTokenUi;
+	export let loading = true;
 </script>
 
 <span class="flex flex-col gap-2">
@@ -14,7 +15,7 @@
 		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !token.balance.isZero()}
 			<span><Amount amount={token.balance} /> {token.symbol}</span>
 		{:else}
-			<span class:animate-pulse={isNullish(token?.balance)}>0.00</span>
+			<span class:animate-pulse={loading}>0.00</span>
 		{/if}
 	</output>
 

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -12,7 +12,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
-	import { exchanges } from '$lib/derived/exchange.derived';
+	import { exchangeInitialized, exchanges } from '$lib/derived/exchange.derived';
 	import { networkBitcoin, networkEthereum, networkICP } from '$lib/derived/network.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
@@ -30,6 +30,9 @@
 				$exchanges: $exchanges
 			})
 		: undefined;
+
+	let loading = true;
+	$: loading = !$exchangeInitialized;
 </script>
 
 <div
@@ -72,12 +75,12 @@
 
 	{#if usdTotal}
 		<div in:slide={SLIDE_PARAMS}>
-			<ExchangeBalance />
+			<ExchangeBalance {loading} />
 		</div>
 	{/if}
 
 	<div in:slide|local={SLIDE_PARAMS} class="flex w-full justify-center text-left">
-		<Actions />
+		<Actions {loading} />
 	</div>
 
 	{#if isErc20Icp($pageToken)}

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade, slide } from 'svelte/transition';
+	import { page } from '$app/stores';
 	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
 	import { isErc20Icp } from '$eth/utils/token.utils';
 	import Back from '$lib/components/core/Back.svelte';
@@ -17,6 +18,7 @@
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import type { OptionTokenUi } from '$lib/types/token';
+	import { isRouteTransactions } from '$lib/utils/nav.utils';
 	import { mapTokenUi } from '$lib/utils/token.utils';
 
 	export let usdTotal = false;
@@ -32,7 +34,7 @@
 		: undefined;
 
 	let loading = true;
-	$: loading = !$exchangeInitialized;
+	$: loading = isRouteTransactions($page) ? isNullish(pageTokenUi?.balance) : !$exchangeInitialized;
 </script>
 
 <div
@@ -69,7 +71,7 @@
 				<ContextMenu />
 			</div>
 
-			<Balance token={pageTokenUi} />
+			<Balance token={pageTokenUi} {loading} />
 		</div>
 	{/if}
 

--- a/src/frontend/src/lib/components/receive/Receive.svelte
+++ b/src/frontend/src/lib/components/receive/Receive.svelte
@@ -5,11 +5,13 @@
 	import { modalReceive } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 
+	export let loading = true;
+
 	const modalId = Symbol();
 </script>
 
 <svelte:window on:oisyReceive={() => modalStore.openReceive(modalId)} />
 
-<ReceiveButtonWithModal open={modalStore.openReceive} isOpen={$modalReceive} {modalId}>
+<ReceiveButtonWithModal open={modalStore.openReceive} isOpen={$modalReceive} {modalId} {loading}>
 	<ReceiveAddressModal infoCmp={ReceiveAddresses} on:nnsClose={modalStore.close} slot="modal" />
 </ReceiveButtonWithModal>

--- a/src/frontend/src/lib/components/receive/ReceiveButton.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveButton.svelte
@@ -4,6 +4,8 @@
 	import { RECEIVE_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	export let loading = true;
 </script>
 
 <ButtonHero
@@ -11,6 +13,7 @@
 	disabled={$isBusy}
 	ariaLabel={$i18n.receive.text.receive}
 	testId={RECEIVE_TOKENS_MODAL_OPEN_BUTTON}
+	{loading}
 >
 	<IconQr size="28" slot="icon" />
 	{$i18n.receive.text.receive}

--- a/src/frontend/src/lib/components/receive/ReceiveButtonWithModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveButtonWithModal.svelte
@@ -5,12 +5,13 @@
 	export let open: (modalId: symbol) => void | Promise<void>;
 	export let isOpen: boolean;
 	export let modalId: symbol | undefined = undefined;
+	export let loading = true;
 
 	let definedModalId: symbol;
 	$: definedModalId = modalId ?? Symbol();
 </script>
 
-<ReceiveButton on:click={async () => await open(definedModalId)} />
+<ReceiveButton on:click={async () => await open(definedModalId)} {loading} />
 
 {#if isOpen && $modalStore?.data === definedModalId}
 	<slot name="modal" />

--- a/src/frontend/src/lib/components/send/Send.svelte
+++ b/src/frontend/src/lib/components/send/Send.svelte
@@ -5,8 +5,9 @@
 	import { modalStore } from '$lib/stores/modal.store';
 
 	export let isTransactionsPage: boolean;
+	export let loading = true;
 </script>
 
-<SendButtonWithModal open={modalStore.openSend} isOpen={$modalSend}>
+<SendButtonWithModal open={modalStore.openSend} isOpen={$modalSend} {loading}>
 	<SendModal {isTransactionsPage} on:nnsClose slot="modal" />
 </SendButtonWithModal>

--- a/src/frontend/src/lib/components/send/SendButton.svelte
+++ b/src/frontend/src/lib/components/send/SendButton.svelte
@@ -4,6 +4,8 @@
 	import { SEND_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	export let loading = true;
 </script>
 
 <ButtonHero
@@ -11,6 +13,7 @@
 	disabled={$isBusy}
 	ariaLabel={$i18n.send.text.send}
 	testId={SEND_TOKENS_MODAL_OPEN_BUTTON}
+	{loading}
 >
 	<IconlySend size="28" slot="icon" />
 	{$i18n.send.text.send}

--- a/src/frontend/src/lib/components/send/SendButtonWithModal.svelte
+++ b/src/frontend/src/lib/components/send/SendButtonWithModal.svelte
@@ -4,11 +4,12 @@
 
 	export let open: (modalId: symbol) => void;
 	export let isOpen: boolean;
+	export let loading = true;
 
 	const modalId = Symbol();
 </script>
 
-<SendButton on:click={() => open(modalId)} />
+<SendButton on:click={() => open(modalId)} {loading} />
 
 {#if isOpen && $modalStore?.data === modalId}
 	<slot name="modal" />


### PR DESCRIPTION
# Motivation

We want to make the Buttons in the Hero in loading state, synchronized with the loading of the balance.

We have 2 situations:

- Main page --> `loading` is linked to exchange store initialized
- Transactions page --> `loading` is linked to the token balance being nullish

# Changes

<!-- List the changes that have been developed -->

# Tests


https://github.com/user-attachments/assets/2bdb9986-7edb-424c-a897-7b579136c6b7


