### PR TITLE
refactor(frontend): Simplify props of Hero

### DIFF
--- a/src/frontend/src/lib/components/hero/Hero.svelte
+++ b/src/frontend/src/lib/components/hero/Hero.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import HeroContent from '$lib/components/hero/HeroContent.svelte';
+	import type { HeroRoute } from '$lib/types/route';
 
-	export let usdTotal = false;
-	export let summary = false;
+	export let route: HeroRoute;
 </script>
 
 <article class="relative flex flex-col items-center rounded-lg pb-6">
-	<HeroContent {usdTotal} {summary} />
+	<HeroContent {route} />
 </article>

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -16,11 +16,11 @@
 	import { networkBitcoin, networkEthereum, networkICP } from '$lib/derived/network.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
+	import type { HeroRoute } from '$lib/types/route';
 	import type { OptionTokenUi } from '$lib/types/token';
 	import { mapTokenUi } from '$lib/utils/token.utils';
 
-	export let usdTotal = false;
-	export let summary = false;
+	export let route: HeroRoute;
 
 	let pageTokenUi: OptionTokenUi;
 	$: pageTokenUi = nonNullish($pageToken)
@@ -42,7 +42,7 @@
 	class:via-united-nations-blue={$networkEthereum}
 	class:to-bright-lilac={$networkEthereum}
 >
-	{#if summary}
+	{#if route === 'transactions'}
 		<div in:slide={SLIDE_PARAMS} class="flex w-full flex-col gap-6">
 			<div class="grid w-full grid-cols-[1fr_auto_1fr] flex-row items-center justify-between">
 				<Back color="current" onlyArrow />
@@ -68,9 +68,7 @@
 
 			<Balance token={pageTokenUi} />
 		</div>
-	{/if}
-
-	{#if usdTotal}
+	{:else}
 		<div in:slide={SLIDE_PARAMS}>
 			<ExchangeBalance />
 		</div>

--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -7,6 +7,7 @@
 	import NavigationItem from '$lib/components/navigation/NavigationItem.svelte';
 	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { Route } from '$lib/types/route';
 	import {
 		isRouteDappExplorer,
 		isRouteSettings,
@@ -14,7 +15,7 @@
 		networkParam
 	} from '$lib/utils/nav.utils.js';
 
-	let route: 'transactions' | 'tokens' | 'settings' | 'explore' = 'tokens';
+	let route: Route = 'tokens';
 	$: route = isRouteSettings($page)
 		? 'settings'
 		: isRouteDappExplorer($page)

--- a/src/frontend/src/lib/types/route.ts
+++ b/src/frontend/src/lib/types/route.ts
@@ -1,0 +1,3 @@
+export type Route = 'transactions' | 'tokens' | 'settings' | 'explore';
+
+export type HeroRoute = Extract<Route, 'transactions' | 'tokens'>;

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -15,11 +15,12 @@
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
+	import type { Route } from '$lib/types/route';
 	import { isRouteDappExplorer, isRouteSettings, isRouteTransactions } from '$lib/utils/nav.utils';
 
 	// TODO: We should consider adding a description for the pages, as this block of code is now appearing in two places.
 	// Other areas, like the Menu, are also somewhat disorganized, with navigation logic spread across multiple locations.
-	let route: 'transactions' | 'tokens' | 'settings' | 'explore' = 'tokens';
+	let route: Route = 'tokens';
 	$: route = isRouteSettings($page)
 		? 'settings'
 		: isRouteDappExplorer($page)
@@ -67,8 +68,8 @@
 				{/if}
 			</NavigationMenu>
 
-			{#if route !== 'settings' && route !== 'explore'}
-				<Hero usdTotal={route === 'tokens'} summary={route === 'transactions'} />
+			{#if route === 'tokens' || route === 'transactions'}
+				<Hero {route} />
 			{/if}
 
 			<LoadersGuard>


### PR DESCRIPTION
# Motivation

The props given to `Hero` are somehow a bit confused. They were ok before, since the `Hero` was used in all routes. With the latest changes, the scope of the `Hero` was reduced to only the main page (tokens) and the transaction page.

To clean-up a bit we refactor the Hero to be a bit more obvious.

# Changes

- Create types for routes and for the routes for the `Hero`.
- Pass `route` prop to `Hero` related component.
- Use `route` to define the content of the Hero.
- Remove deprecated props `summary` and `usdTotal`.

# Tests

No changes in local replica.
