### PR TITLE
fix(frontend): Onramper widget is scrollable now

### DIFF
--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -11,9 +11,15 @@
 		>{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}</svelte:fragment
 	>
 
-	<div class="stretch flex overflow-hidden" style="padding-bottom: var(--padding-3x);">
+	<div class="stretch flex overflow-hidden">
 		<div class="w-full overflow-auto">
 			<OnramperWidget />
 		</div>
 	</div>
 </Modal>
+
+<style lang="scss">
+	.stretch {
+		--stretch-padding-bottom: var(--padding-3x);
+	}
+</style>

--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -11,7 +11,9 @@
 		>{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}</svelte:fragment
 	>
 
-	<div class="stretch">
-		<OnramperWidget />
+	<div class="stretch flex overflow-hidden" style="padding-bottom: var(--padding-3x);">
+		<div class="w-full overflow-auto">
+			<OnramperWidget />
+		</div>
 	</div>
 </Modal>

--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -11,7 +11,7 @@
 		>{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}</svelte:fragment
 	>
 
-	<div class="stretch overflow-hidden">
+	<div class="stretch">
 		<OnramperWidget />
 	</div>
 </Modal>

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -67,7 +67,7 @@
 <iframe
 	{src}
 	title={$i18n.buy.onramper.title}
-	height="660px"
+	height="680px"
 	width="100%"
 	allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
 	sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -179,6 +179,8 @@ div.modal {
 		flex-direction: column;
 		min-height: 100%;
 
+		--stretch-padding-bottom: 0;
+
 		&.min-h-auto {
 			min-height: auto;
 		}
@@ -188,7 +190,7 @@ div.modal {
 
 			@include modal.content;
 
-			padding: var(--padding-3x) var(--padding-2_5x) 0;
+			padding: var(--padding-3x) var(--padding-2_5x) var(--stretch-padding-bottom);
 
 			margin: 0 0 var(--padding-0_5x);
 


### PR DESCRIPTION
# Motivation

The Onramper widget was not scrollable for smaller screens, impeding the user to click the Buy button.


https://github.com/user-attachments/assets/ef40b4c9-cae5-4305-9dbb-239bf824c72c

