### PR TITLE
refactor(frontend): correct imports in safeParse

### DIFF
--- a/src/frontend/src/lib/validation/utils.validation.ts
+++ b/src/frontend/src/lib/validation/utils.validation.ts
@@ -1,4 +1,4 @@
-import { ZodType, type ZodTypeDef } from 'zod';
+import type { ZodType, ZodTypeDef } from 'zod';
 
 interface SafeParseParams<T, Fallback> {
 	schema: ZodType<T, ZodTypeDef, unknown>;


### PR DESCRIPTION
# Motivation

It slipped through my fingers that both imports from `zod` should be types. It changes nothing for the code, but it is the "correct" import consistency,