### PR TITLE
fix(frontend): WalletConnect sign progression steps

### DIFF
--- a/src/frontend/src/eth/constants/steps.constants.ts
+++ b/src/frontend/src/eth/constants/steps.constants.ts
@@ -1,4 +1,4 @@
-import { ProgressStepsSend } from '$lib/enums/progress-steps';
+import { ProgressStepsSend, ProgressStepsSign } from '$lib/enums/progress-steps';
 import type { ProgressStep } from '@dfinity/gix-components';
 
 export const sendSteps = ({
@@ -59,17 +59,17 @@ export const walletConnectSendSteps = ({
 
 export const walletConnectSignSteps = (i18n: I18n): [ProgressStep, ...ProgressStep[]] => [
 	{
-		step: ProgressStepsSend.INITIALIZATION,
+		step: ProgressStepsSign.INITIALIZATION,
 		text: i18n.send.text.initializing,
 		state: 'in_progress'
 	} as ProgressStep,
 	{
-		step: ProgressStepsSend.SIGN_TRANSFER,
+		step: ProgressStepsSign.SIGN,
 		text: i18n.send.text.signing_message,
 		state: 'next'
 	} as ProgressStep,
 	{
-		step: ProgressStepsSend.TRANSFER,
+		step: ProgressStepsSign.APPROVE,
 		text: i18n.send.text.approving,
 		state: 'next'
 	} as ProgressStep


### PR DESCRIPTION
# Motivation

The progression steps of the WalletConnect signing process were set incorrectly. I have a feeling they've always been incorrect; I just noticed it today. As a result, the progression of the `signMessage` service was not displayed visually. Feature itself was and is fine.

# Changes

- Correct the enum value used to define the progression component

# Screenshots

Before:

<img width="1536" alt="Capture d’écran 2024-11-04 à 06 42 25" src="https://github.com/user-attachments/assets/6f0bf53c-c5dc-4aea-8a47-e894c5a43b87">

After:

<img width="1536" alt="Capture d’écran 2024-11-04 à 06 47 26" src="https://github.com/user-attachments/assets/a1721392-4b72-4072-9a7d-35c21fb83945">
