### PR TITLE
refactor(frontend): remove prefix from new colors

### DIFF
--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -46,7 +46,7 @@
 	</div>
 
 	{#if ckErc20}
-		<div class="mb-4 mt-2 rounded-lg bg-background-brand-subtle p-4">
+		<div class="mb-4 mt-2 rounded-lg bg-brand-subtle p-4">
 			<p class="break-normal font-bold">
 				{replacePlaceholders($i18n.convert.text.check_balance_for_fees, {
 					$token: $ckEthereumNativeToken.symbol

--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -10,7 +10,7 @@
 
 <p class="mb-2 mt-1 text-dark-blue">{replaceOisyPlaceholders($i18n.tokens.import.text.info)}</p>
 
-<p class="mb-4 font-bold text-foreground-brand-primary">
+<p class="mb-4 font-bold text-brand-primary">
 	<ExternalLink
 		href="https://github.com/dfinity/oisy-wallet/blob/main/HOW-TO.md#custom-icrc-token-integration"
 		ariaLabel={$i18n.tokens.import.text.open_github_howto}

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -49,7 +49,7 @@
 </script>
 
 <div class="stretch min-h-[20vh]">
-	<div class="mb-4 rounded-lg bg-background-brand-subtle p-4">
+	<div class="mb-4 rounded-lg bg-brand-subtle p-4">
 		{#if isNullish(token)}
 			<SkeletonCardWithoutAmount>{$i18n.tokens.import.text.verifying}</SkeletonCardWithoutAmount>
 		{:else}

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -86,7 +86,7 @@
 		</div>{:else}
 		<button
 			in:blur
-			class="text flex gap-2 border-0 text-foreground-brand-primary"
+			class="text flex gap-2 border-0 text-brand-primary"
 			on:click={async () => await receive()}
 			><IconReimbursed size="24" /> {$i18n.core.text.refresh}</button
 		>

--- a/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
+++ b/src/frontend/src/lib/components/dapps/DappPromoBanner.svelte
@@ -10,7 +10,7 @@
 
 <article class="relative flex h-64 items-end overflow-hidden rounded-2xl">
 	{#if dAppDescription.screenshots.length > 0}
-		<div class="absolute inset-0 bg-background-brand-subtle-alt">
+		<div class="absolute inset-0 bg-brand-subtle-alt">
 			<Img
 				fitHeight={true}
 				height="100%"

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -23,7 +23,7 @@
 			<span class="animate-pulse">{formatUSD({ value: 0 })}</span>
 		{/if}
 	</output>
-	<span class="max-w-48 text-xl font-medium text-foreground-brand-secondary-alt sm:max-w-none">
+	<span class="max-w-48 text-xl font-medium text-brand-secondary-alt sm:max-w-none">
 		{$anyBalanceNonZero ? $i18n.hero.text.available_balance : $i18n.hero.text.top_up}
 	</span>
 </span>

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -45,7 +45,7 @@
 </script>
 
 <div
-	class="flex h-full w-full flex-col content-center items-center justify-center rounded-[40px] bg-background-brand-primary bg-gradient-to-b from-background-brand-primary via-absolute-blue bg-size-200 bg-pos-0 p-6 text-center text-white transition-all duration-500 ease-in-out"
+	class="flex h-full w-full flex-col content-center items-center justify-center rounded-[40px] bg-brand-primary bg-gradient-to-b from-brand-primary via-absolute-blue bg-size-200 bg-pos-0 p-6 text-center text-white transition-all duration-500 ease-in-out"
 	class:bg-pos-100={$networkICP || $networkBitcoin || $networkEthereum}
 	class:via-interdimensional-blue={$networkICP}
 	class:to-chinese-purple={$networkICP}

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -231,7 +231,7 @@
 	>
 		<span class="text-7xl">🤔</span>
 
-		<span class="py-4 text-center font-bold text-foreground-brand-primary no-underline"
+		<span class="py-4 text-center font-bold text-brand-primary no-underline"
 			>+ {$i18n.tokens.manage.text.do_not_see_import}</span
 		>
 	</button>
@@ -263,7 +263,7 @@
 	</div>
 
 	<button
-		class="mb-4 flex w-full justify-center pt-4 text-center font-bold text-foreground-brand-primary no-underline"
+		class="mb-4 flex w-full justify-center pt-4 text-center font-bold text-brand-primary no-underline"
 		on:click={() => dispatch('icAddToken')}>+ {$i18n.tokens.manage.text.do_not_see_import}</button
 	>
 

--- a/src/frontend/src/lib/components/navigation/NavigationItem.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationItem.svelte
@@ -6,10 +6,10 @@
 
 <a
 	{href}
-	class="flex w-full flex-row gap-3 rounded-xl p-3 text-left no-underline transition-colors duration-700 hover:text-foreground-brand-primary"
-	class:text-foreground-brand-primary={selected}
+	class="flex w-full flex-row gap-3 rounded-xl p-3 text-left no-underline transition-colors duration-700 hover:text-brand-primary"
+	class:text-brand-primary={selected}
 	class:bg-white={selected}
-	class:hover:bg-background-brand-subtle-alt={selected}
+	class:hover:bg-brand-subtle-alt={selected}
 	aria-label={ariaLabel}
 >
 	<slot />

--- a/src/frontend/src/lib/components/receive/ReceiveAddress.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddress.svelte
@@ -36,7 +36,7 @@
 		{/if}
 
 		<div
-			class="flex items-center justify-between gap-4 rounded-lg bg-background-brand-subtle px-3 py-2"
+			class="flex items-center justify-between gap-4 rounded-lg bg-brand-subtle px-3 py-2"
 			class:mt-3={!text}
 			data-tid={testId}
 		>

--- a/src/frontend/src/lib/components/signer/SignerAlert.svelte
+++ b/src/frontend/src/lib/components/signer/SignerAlert.svelte
@@ -13,7 +13,7 @@
 	<div
 		class="flex h-20 w-20 items-center justify-center rounded-full"
 		class:bg-cyclamen={alertType === 'error'}
-		class:bg-background-brand-primary={alertType === 'ok'}
+		class:bg-brand-primary={alertType === 'ok'}
 	>
 		<svelte:component this={icon} />
 	</div>

--- a/src/frontend/src/lib/components/signer/SignerAnimatedAstronaut.svelte
+++ b/src/frontend/src/lib/components/signer/SignerAnimatedAstronaut.svelte
@@ -4,10 +4,10 @@
 
 <span class="relative flex aspect-square w-20">
 	<span
-		class="absolute inline-flex h-full w-full animate-ping rounded-full bg-background-brand-primary opacity-75"
+		class="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand-primary opacity-75"
 	></span>
 	<span
-		class="relative inline-flex h-20 w-20 items-center justify-center rounded-full bg-background-brand-primary text-foreground-brand-primary"
+		class="relative inline-flex h-20 w-20 items-center justify-center rounded-full bg-brand-primary text-brand-primary"
 		><IconAstronautWithEyes /></span
 	>
 </span>

--- a/src/frontend/src/lib/components/signer/SignerLoading.svelte
+++ b/src/frontend/src/lib/components/signer/SignerLoading.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <SignerCenteredContent>
-	<div class="text-foreground-brand-primary">
+	<div class="text-brand-primary">
 		<Spinner inline />
 	</div>
 	<span><slot /></span>

--- a/src/frontend/src/lib/components/signer/SignerOrigin.svelte
+++ b/src/frontend/src/lib/components/signer/SignerOrigin.svelte
@@ -34,7 +34,7 @@
 {#if nonNullish(origin)}
 	<p class="mb-6 break-normal text-center">
 		{$i18n.signer.origin.text.request_from}
-		{#if nonNullish(host)}<span class="font-bold text-foreground-brand-primary"
+		{#if nonNullish(host)}<span class="font-bold text-brand-primary"
 				><ExternalLink
 					ariaLabel={$i18n.signer.origin.alt.link_to_dapp}
 					href={origin}

--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -90,7 +90,7 @@
 
 		<SignerOrigin payload={$payload} />
 
-		<div class="mb-6 rounded-lg border border-border-brand-subtle bg-background-brand-subtle p-6">
+		<div class="mb-6 rounded-lg border border-brand-subtle bg-brand-subtle p-6">
 			<p class="break-normal font-bold">{$i18n.signer.permissions.text.requested_permissions}</p>
 
 			<ul class="mt-2.5 flex list-none flex-col gap-1">

--- a/src/frontend/src/lib/components/tokens/TokensZeroBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensZeroBalance.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div class="content">
-	<span class="block text-sm text-foreground-brand-primary">{$i18n.tokens.text.balance}</span>
+	<span class="block text-sm text-brand-primary">{$i18n.tokens.text.balance}</span>
 
 	<div class="flex items-center justify-between">
 		<span class="px-4.5">{$i18n.tokens.text.hide_zero_balances}</span>

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -3,10 +3,10 @@
 
 	const variantClassNames = {
 		default: 'border border-light-grey bg-dust/30',
-		info: 'bg-background-brand-subtle text-foreground-brand-primary',
-		error: 'bg-background-error-subtle text-foreground-error',
-		warning: 'bg-background-warning-subtle text-foreground-warning',
-		success: 'bg-background-success-subtle text-foreground-success',
+		info: 'bg-brand-subtle text-brand-primary',
+		error: 'bg-error-subtle text-error',
+		warning: 'bg-warning-subtle text-warning',
+		success: 'bg-success-subtle text-success',
 		outline: 'border border-light-grey bg-off-white'
 	};
 

--- a/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonAuthenticate.svelte
@@ -7,7 +7,7 @@
 
 <button
 	on:click
-	class="flex w-full items-center justify-center gap-4 rounded-2xl bg-background-brand-primary py-3 text-lg font-bold leading-6 text-white sm:px-12"
+	class="flex w-full items-center justify-center gap-4 rounded-2xl bg-brand-primary py-3 text-lg font-bold leading-6 text-white sm:px-12"
 	class:sm:w-80={!fullWidth}
 	data-tid="login-button"
 >

--- a/src/frontend/src/lib/components/ui/ButtonControl.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonControl.svelte
@@ -5,7 +5,7 @@
 
 <button
 	aria-label={ariaLabel}
-	class={`${styleClass ?? ''} h-7 w-7 rounded-md bg-white p-1 shadow transition-colors duration-700 hover:text-foreground-brand-primary active:text-foreground-brand-primary`}
+	class={`${styleClass ?? ''} h-7 w-7 rounded-md bg-white p-1 shadow transition-colors duration-700 hover:text-brand-primary active:text-brand-primary`}
 	on:click
 >
 	<slot />

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <button
-	class="w-full text-left no-underline hover:text-foreground-brand-primary active:text-foreground-brand-primary"
+	class="w-full text-left no-underline hover:text-brand-primary active:text-brand-primary"
 	aria-label={ariaLabel}
 	on:click
 	{disabled}

--- a/src/frontend/src/lib/components/ui/DropdownButton.svelte
+++ b/src/frontend/src/lib/components/ui/DropdownButton.svelte
@@ -8,13 +8,13 @@
 </script>
 
 <button
-	class="text-secondary min-w-72 justify-between gap-2 rounded-xl border border-light-grey bg-white px-4 py-3 text-left font-medium leading-5 text-inherit hover:border-border-brand-primary"
+	class="text-secondary min-w-72 justify-between gap-2 rounded-xl border border-light-grey bg-white px-4 py-3 text-left font-medium leading-5 text-inherit hover:border-brand-primary"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}
 	{disabled}
 	class:opacity-50={disabled}
-	class:border-border-brand-primary={opened}
+	class:border-brand-primary={opened}
 >
 	<slot />
 	<div class="transform transition-transform duration-300 ease-in-out" class:-scale-y-100={opened}>

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -21,8 +21,8 @@
 	class:text-primary={color === 'blue'}
 	class:hover:text-inherit={color === 'blue'}
 	class:active:text-inherit={color === 'blue'}
-	class:hover:text-foreground-brand-primary={color === 'inherit'}
-	class:active:text-foreground-brand-primary={color === 'inherit'}
+	class:hover:text-brand-primary={color === 'inherit'}
+	class:active:text-brand-primary={color === 'inherit'}
 	class:w-full={fullWidth}
 >
 	{#if iconVisible}

--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -6,13 +6,13 @@
 
 <div
 	class="mb-4 flex items-start gap-4 rounded-xl px-4 py-3 text-sm font-medium sm:text-base"
-	class:bg-background-brand-subtle-alt={level === 'info'}
-	class:bg-background-warning-subtle={level === 'light-warning'}
+	class:bg-brand-subtle-alt={level === 'info'}
+	class:bg-warning-subtle={level === 'light-warning'}
 >
 	<div
 		class="min-w-5 py-0 sm:py-0.5"
-		class:text-foreground-brand-primary={level === 'info'}
-		class:text-foreground-warning={level === 'light-warning'}
+		class:text-brand-primary={level === 'info'}
+		class:text-warning={level === 'light-warning'}
 	>
 		<IconInfo />
 	</div>

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -3,7 +3,7 @@
 
 	export let icon: ComponentType;
 	export let iconSize = '2.9rem';
-	export let backgroundStyleClass = 'bg-background-brand-subtle-alt';
+	export let backgroundStyleClass = 'bg-brand-subtle-alt';
 	export let iconStyleClass = '';
 	export let additionalStyleClass = '';
 </script>

--- a/src/frontend/src/lib/components/ui/WarningBanner.svelte
+++ b/src/frontend/src/lib/components/ui/WarningBanner.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div
-	class="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-crayola-yellow bg-cornsilk px-6 py-2 text-xs font-bold text-foreground-warning sm:w-fit md:text-base"
+	class="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-crayola-yellow bg-cornsilk px-6 py-2 text-xs font-bold text-warning sm:w-fit md:text-base"
 >
 	<IconWarning inline />
 	<span><slot /></span>

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -91,27 +91,27 @@ a.as-button {
 	}
 
 	&.primary:not([disabled]):not(.disabled):not(.loading) {
-		@apply bg-background-brand-primary;
+		@apply bg-brand-primary;
 		color: var(--color-white);
 
 		&:hover {
-			@apply bg-background-brand-secondary;
+			@apply bg-brand-secondary;
 		}
 
 		&:active {
-			@apply bg-background-brand-tertiary;
+			@apply bg-brand-tertiary;
 		}
 	}
 
 	&.secondary:not([disabled]):not(.disabled):not(.loading) {
-		@apply text-foreground-brand-primary bg-background-brand-subtle;
+		@apply text-brand-primary bg-brand-subtle;
 
 		&:hover {
-			@apply bg-background-brand-subtle-alt;
+			@apply bg-brand-subtle-alt;
 		}
 
 		&:active {
-			@apply bg-background-brand-subtle2-alt;
+			@apply bg-brand-subtle2-alt;
 		}
 	}
 
@@ -119,23 +119,23 @@ a.as-button {
 		background: var(--color-white);
 
 		&:hover {
-			@apply text-foreground-brand-primary;
+			@apply text-brand-primary;
 		}
 
 		&:active {
-			@apply bg-background-brand-subtle-alt;
+			@apply bg-brand-subtle-alt;
 			color: currentColor;
 		}
 
 		&.link {
-			@apply text-foreground-brand-primary;
+			@apply text-brand-primary;
 
 			&:hover {
-				@apply text-foreground-brand-secondary;
+				@apply text-brand-secondary;
 			}
 
 			&:active {
-				@apply text-foreground-brand-secondary;
+				@apply text-brand-secondary;
 			}
 		}
 	}
@@ -169,7 +169,7 @@ a.as-button {
 	&.text {
 		&:hover,
 		&:active {
-			@apply text-foreground-brand-primary;
+			@apply text-brand-primary;
 		}
 	}
 

--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <article
-	class="mb-10 flex min-h-96 flex-col rounded-lg border border-border-brand-subtle-alt bg-white px-5 py-6"
+	class="mb-10 flex min-h-96 flex-col rounded-lg border border-brand-subtle-alt bg-white px-5 py-6"
 >
 	{#if $authNotSignedIn}
 		<SignerSignIn />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -48,10 +48,14 @@ export default {
 			cobalt: '#004abe',
 			zumthor: '#e8f1ff',
 			beer: '#f7931a',
-			fulvous: '#de7900',
-			...themeVariables
+			fulvous: '#de7900'
 		},
 		extend: {
+			backgroundColor: themeVariables.background,
+			gradientColorStops: themeVariables.background,
+			borderColor: themeVariables.border,
+			ringColor: themeVariables.border,
+			textColor: themeVariables.foreground,
 			backgroundSize: {
 				'size-200': '200% 200%'
 			},


### PR DESCRIPTION
# Motivation

It is too verbose to have bg-background- or border-border- for the new color mapping. So, we simplify it extending the colors of specific scopes with the correct mapping:

1. Background: `bg-` and `gradient-`
2. Border: `border-` and `ring-`
3. Foreground: `text-`

Thanks @peterpeterparker for the suggestion!