### PR TITLE
style(frontend): change color of info in IcAddTokenForm

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -8,7 +8,7 @@
 	export let indexCanisterId = '';
 </script>
 
-<p class="mb-2 mt-1 text-dark-blue">{replaceOisyPlaceholders($i18n.tokens.import.text.info)}</p>
+<p class="mb-2 mt-1">{replaceOisyPlaceholders($i18n.tokens.import.text.info)}</p>
 
 <p class="mb-4 font-bold text-brand-primary">
 	<ExternalLink


### PR DESCRIPTION
# Motivation

Correcting color of information in the token form review for IC tokens.

### Before

![Screenshot 2024-11-04 at 14 31 19](https://github.com/user-attachments/assets/da20ee93-bd4c-4630-8c92-bdf71805578d)


### After

![Screenshot 2024-11-04 at 14 30 53](https://github.com/user-attachments/assets/5aaeddef-d1c4-4fce-8da6-9d8ce9e52515)

