### PR TITLE
style(frontend): update Refresh button to current pallete

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -86,7 +86,7 @@
 		</div>{:else}
 		<button
 			in:blur
-			class="text flex gap-2 border-0 text-brand-primary"
+			class="text flex gap-2 border-0 text-brand-primary hover:text-brand-secondary active:text-brand-secondary"
 			on:click={async () => await receive()}
 			><IconReimbursed size="24" /> {$i18n.core.text.refresh}</button
 		>
@@ -102,12 +102,3 @@
 		</div>
 	</Modal>
 {/if}
-
-<style lang="scss">
-	button {
-		&:hover,
-		&:active {
-			color: var(--color-dark-blue);
-		}
-	}
-</style>


### PR DESCRIPTION
# Motivation

We adapt the refresh button to use the `brand-secondary` color for `hover` and `active`, as defined by the Design.
