### PR TITLE
chore(frontend): vitest is global - no import needed

### DIFF
--- a/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
@@ -5,7 +5,6 @@ import { BTC_MAINNET_TOKEN, BTC_MAINNET_TOKEN_ID } from '$env/tokens.btc.env';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import { token } from '$lib/stores/token.store';
 import { get } from 'svelte/store';
-import { describe, expect, it } from 'vitest';
 
 describe('btc-transactions.derived', () => {
 	describe('sortedBtcTransactions', () => {

--- a/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
@@ -1,7 +1,6 @@
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import type { PendingTransaction } from '$declarations/backend/backend.did';
 import { get } from 'svelte/store';
-import { beforeEach, describe, expect, it } from 'vitest';
 
 const pendingTransactionMock1 = {
 	txid: new Uint8Array([1, 2, 3]),

--- a/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
@@ -1,5 +1,4 @@
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
-import { describe, expect } from 'vitest';
 
 describe('convertNumberToSatoshis', () => {
 	it('converts number to Satoshis correctly', () => {

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -6,7 +6,6 @@ import type { BtcTransactionStatus } from '$btc/types/btc';
 import { mapBtcTransaction, sortBtcTransactions } from '$btc/utils/btc-transactions.utils';
 import type { BitcoinTransaction } from '$lib/types/blockchain';
 import { mockBtcAddress, mockBtcTransaction, mockBtcTransactionUi } from '$tests/mocks/btc.mock';
-import { describe, expect } from 'vitest';
 
 describe('mapBtcTransaction', () => {
 	const sendTransaction = {

--- a/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
@@ -5,7 +5,7 @@ import type { EthereumNetwork } from '$eth/types/network';
 import { decodeQrCode } from '$eth/utils/qr-code.utils';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { get } from 'svelte/store';
-import { expect, type MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 vi.mock('$lib/utils/qr-code.utils', () => ({
 	decodeQrCodeUrn: vi.fn()

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -2,7 +2,6 @@ import { mapTransactionUi } from '$eth/utils/transactions.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { Transaction } from '$lib/types/transaction';
-import { expect } from 'vitest';
 
 const transaction: Transaction = {
 	blockNumber: 123456,

--- a/src/frontend/src/tests/icp/utils/cketh-memo.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/cketh-memo.utils.spec.ts
@@ -14,7 +14,6 @@ import {
 	hexStringToUint8Array,
 	uint8ArrayToHexString
 } from '@dfinity/utils';
-import { expect } from 'vitest';
 
 describe('cketh-memo.utils', () => {
 	describe('decode mint memo', () => {

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -17,7 +17,6 @@ import { type ActorSubclass } from '@dfinity/agent';
 import { mapIcrc2ApproveError } from '@dfinity/ledger-icp';
 import { Principal } from '@dfinity/principal';
 import { toNullable } from '@dfinity/utils';
-import { describe } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -15,7 +15,6 @@ import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
-import { describe } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {

--- a/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
@@ -11,7 +11,7 @@ import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { render } from '@testing-library/svelte';
-import { expect, type MockInstance } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 describe('AddressGuard', () => {
 	let apiMock: MockInstance;

--- a/src/frontend/src/tests/lib/components/send/SendInputAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendInputAmount.spec.ts
@@ -2,7 +2,6 @@ import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { expect } from 'vitest';
 
 describe('SendInputAmount', () => {
 	const amount = 10.25;

--- a/src/frontend/src/tests/lib/services/loader.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/loader.services.spec.ts
@@ -4,7 +4,7 @@ import * as authServices from '$lib/services/auth.services';
 import { initSignerAllowance } from '$lib/services/loader.services';
 import { authStore } from '$lib/stores/auth.store';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
-import { expect, type MockInstance } from 'vitest';
+import type { MockInstance } from 'vitest';
 
 describe('loader.services', () => {
 	describe('initSignerAllowance', () => {

--- a/src/frontend/src/tests/lib/stores/balances.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/balances.store.spec.ts
@@ -3,7 +3,6 @@ import { balancesStore } from '$lib/stores/balances.store';
 import { mockPageStore } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
 import { BigNumber } from 'alchemy-sdk';
-import { describe, it } from 'vitest';
 
 mockPageStore();
 

--- a/src/frontend/src/tests/lib/stores/signer.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/signer.store.spec.ts
@@ -3,7 +3,6 @@ import { initSignerContext } from '$lib/stores/signer.store';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { Signer } from '@dfinity/oisy-wallet-signer/signer';
 import { get } from 'svelte/store';
-import { describe, expect, it, vi } from 'vitest';
 
 describe('SignerContext', () => {
 	const identity = Ed25519KeyIdentity.generate();

--- a/src/frontend/src/tests/lib/stores/token.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/token.store.spec.ts
@@ -2,7 +2,6 @@ import { ICP_TOKEN } from '$env/tokens.env';
 import { token } from '$lib/stores/token.store';
 import { mockPageStore } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
-import { describe, it } from 'vitest';
 
 mockPageStore();
 

--- a/src/frontend/src/tests/lib/stores/transactions.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/transactions.store.spec.ts
@@ -2,7 +2,6 @@ import { ETHEREUM_TOKEN_ID, ICP_TOKEN_ID } from '$env/tokens.env';
 import type { IcTransactionUi } from '$icp/types/ic';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import { initTransactionsStore } from '$lib/stores/transactions.store';
-import { expect } from 'vitest';
 
 describe('transactions.store', () => {
 	const createMockTransaction = (id: string): IcTransactionUi => ({

--- a/src/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -1,5 +1,3 @@
-import { afterAll, describe } from 'vitest';
-
 describe('auth utils', () => {
 	describe('getOptionalDerivationOrigin', () => {
 		let originalWindowLocation: Location;

--- a/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
@@ -1,5 +1,4 @@
 import { buildCarouselSliderFrameItem, extendCarouselSliderFrame } from '$lib/utils/carousel.utils';
-import { describe, expect } from 'vitest';
 
 const slides = [
 	document.createTextNode('Slide 1.'),

--- a/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
@@ -24,7 +24,6 @@ import {
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { mockAccountIdentifierText, mockPrincipalText } from '$tests/mocks/identity.mock';
-import { describe, expect, it } from 'vitest';
 
 describe('buildOnramperLink', () => {
 	it('should build the correct URL with all parameters', () => {

--- a/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
@@ -4,7 +4,6 @@ import type { TokenUiGroup } from '$lib/types/token';
 import type { CardData } from '$lib/types/token-card';
 import { mapHeaderData } from '$lib/utils/token-card.utils';
 import { bn1 } from '$tests/mocks/balances.mock';
-import { describe, expect, it } from 'vitest';
 
 describe('mapHeaderData', () => {
 	// We mock the token group with a mix of data just to verify that the function works correctly

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -12,7 +12,6 @@ import {
 } from '$lib/utils/token-group.utils';
 import { bn1, bn2, bn3 } from '$tests/mocks/balances.mock';
 import { BigNumber } from 'alchemy-sdk';
-import { describe, expect, it } from 'vitest';
 
 const tokens = [
 	{

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -11,7 +11,7 @@ import {
 import { $balances, bn1, bn2, bn3 } from '$tests/mocks/balances.mock';
 import { $exchanges } from '$tests/mocks/exchanges.mock';
 import { BigNumber } from 'alchemy-sdk';
-import { describe, expect, it, type MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 const tokenDecimals = 8;
 const tokenStandards: TokenStandard[] = ['ethereum', 'icp', 'icrc', 'bitcoin'];

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -19,7 +19,7 @@ import {
 import { $balances, bn1, bn2, bn3, certified } from '$tests/mocks/balances.mock';
 import { $exchanges, usd } from '$tests/mocks/exchanges.mock';
 import { $tokens } from '$tests/mocks/tokens.mock';
-import { describe, expect, it, type MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 vi.mock('$lib/utils/exchange.utils', () => ({
 	usdValue: vi.fn()

--- a/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
@@ -1,7 +1,6 @@
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
 import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
 import { WizardModal, type WizardSteps } from '@dfinity/gix-components';
-import { describe, expect, it, vi } from 'vitest';
 
 const mockModal = {
 	set: vi.fn()


### PR DESCRIPTION
# Motivation

Just a bit of cleanup since most `vitest` imports can be spared as those are available globally.