### PR TITLE
test(frontend): Tests for certified store init

### DIFF
--- a/src/frontend/src/tests/lib/stores/certified-setter.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/certified-setter.store.spec.ts
@@ -1,0 +1,49 @@
+import { SEPOLIA_TOKEN_ID } from '$env/tokens.env';
+import {
+	initCertifiedSetterStore,
+	type CertifiedSetterStoreStore
+} from '$lib/stores/certified-setter.store';
+import type { WritableUpdateStore } from '$lib/stores/certified.store';
+import { get } from 'svelte/store';
+
+describe('initCertifiedSetterStore', () => {
+	interface MockData {
+		name: string;
+		values: number[];
+	}
+	const data: MockData = { name: 'Test Item', values: [1, 2, 3] };
+	let mockStore: CertifiedSetterStoreStore<MockData> & WritableUpdateStore<MockData>;
+
+	beforeEach(() => {
+		mockStore = initCertifiedSetterStore<MockData>();
+	});
+
+	it('initialises with undefined state', () => {
+		expect(get(mockStore)).toBeUndefined();
+	});
+
+	describe('set', () => {
+		it('should set data for a specific tokenId', () => {
+			mockStore.set({ tokenId: SEPOLIA_TOKEN_ID, data });
+
+			const state = get(mockStore);
+
+			expect(state?.[SEPOLIA_TOKEN_ID]).toEqual(data);
+		});
+
+		it('should update data for a specific tokenId', () => {
+			const updatedData: MockData = { name: 'Updated Item', values: [4, 5, 6] };
+
+			mockStore.set({ tokenId: SEPOLIA_TOKEN_ID, data });
+			mockStore.set({ tokenId: SEPOLIA_TOKEN_ID, data: updatedData });
+
+			const state = get(mockStore);
+
+			expect(state?.[SEPOLIA_TOKEN_ID]).toEqual(updatedData);
+		});
+
+		it('should not throw an error when setting an unknown tokenId', () => {
+			expect(() => mockStore.set({ tokenId: SEPOLIA_TOKEN_ID, data })).not.toThrow();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/stores/certified.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/certified.store.spec.ts
@@ -1,0 +1,61 @@
+import { BTC_REGTEST_TOKEN_ID } from '$env/tokens.btc.env';
+import { SEPOLIA_TOKEN_ID } from '$env/tokens.env';
+import {
+	initCertifiedStore,
+	type CertifiedStore,
+	type WritableUpdateStore
+} from '$lib/stores/certified.store';
+import { get } from 'svelte/store';
+
+describe('initCertifiedStore', () => {
+	interface MockData {
+		name: string;
+		values: number[];
+	}
+	const data: MockData = { name: 'Test Item', values: [1, 2, 3] };
+	let mockStore: CertifiedStore<MockData> & WritableUpdateStore<MockData>;
+
+	beforeEach(() => {
+		mockStore = initCertifiedStore<MockData>();
+	});
+
+	it('initialises with undefined state', () => {
+		expect(get(mockStore)).toBeUndefined();
+	});
+
+	describe('reset', () => {
+		it('should reset a specific tokenId to null', () => {
+			mockStore.update((current) => ({
+				...current,
+				[SEPOLIA_TOKEN_ID]: data
+			}));
+
+			mockStore.reset(SEPOLIA_TOKEN_ID);
+
+			const state = get(mockStore);
+
+			expect(state?.[SEPOLIA_TOKEN_ID]).toBeNull();
+		});
+
+		it('should keep other records unchanged when resetting a specific tokenId', () => {
+			const otherData: MockData = { name: 'Other Item', values: [4, 5, 6] };
+
+			mockStore.update((current) => ({
+				...current,
+				[SEPOLIA_TOKEN_ID]: data,
+				[BTC_REGTEST_TOKEN_ID]: otherData
+			}));
+
+			mockStore.reset(SEPOLIA_TOKEN_ID);
+
+			const state = get(mockStore);
+
+			expect(state?.[SEPOLIA_TOKEN_ID]).toBeNull();
+			expect(state?.[BTC_REGTEST_TOKEN_ID]).toEqual(otherData);
+		});
+
+		it('should not throw an error when resetting an unknown tokenId', () => {
+			expect(() => mockStore.reset(SEPOLIA_TOKEN_ID)).not.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We create some base tests for `initCertifiedStore` and `initCertifiedSetterStore`

Note that we are not creating tests for the `update` function since it is replicated as it is from `writable` constructor of `svelte`.
