### PR TITLE
refactor(frontend): simplify utils filterTokensForSelectedNetwork

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -101,8 +101,7 @@
 			...(manageEthereumTokens ? allErc20Tokens : []),
 			...(manageIcTokens ? allIcrcTokens : [])
 		],
-		$selectedNetwork,
-		$pseudoNetworkChainFusion
+		$selectedNetwork
 	]);
 
 	let allTokensSorted: Token[] = [];

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,5 +1,5 @@
 import { exchanges } from '$lib/derived/exchange.derived';
-import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
+import { selectedNetwork } from '$lib/derived/network.derived';
 import { enabledTokens, tokensToPin } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenUi } from '$lib/types/token';
@@ -10,8 +10,8 @@ import { derived, type Readable } from 'svelte/store';
 /**
  * All user-enabled tokens matching the selected network or chain fusion.
  */
-const enabledNetworkTokens: Readable<Token[]> = derived(
-	[enabledTokens, selectedNetwork, pseudoNetworkChainFusion],
+export const enabledNetworkTokens: Readable<Token[]> = derived(
+	[enabledTokens, selectedNetwork],
 	filterTokensForSelectedNetwork
 );
 

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -11,7 +11,7 @@ import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const isNetworkICP = (network: Network | undefined): boolean => isNetworkIdICP(network?.id);
 
@@ -45,18 +45,17 @@ export const mapNetworkIdToBitcoinNetwork = (networkId: NetworkId): BitcoinNetwo
 /**
  * Filter the tokens that either lives on the selected network or, if no network is provided, pseud Chain Fusion, then those that are not testnets.
  */
-export const filterTokensForSelectedNetwork = <T extends Token>([
-	$tokens,
-	$selectedNetwork,
-	$pseudoNetworkChainFusion
-]: [T[], Network | undefined, boolean]): T[] =>
+export const filterTokensForSelectedNetwork = <T extends Token>([$tokens, $selectedNetwork]: [
+	T[],
+	Network | undefined
+]): T[] =>
 	$tokens.filter((token) => {
 		const {
 			network: { id: networkId, env }
 		} = token;
 
 		return (
-			($pseudoNetworkChainFusion && !isTokenIcrcTestnet(token) && env !== 'testnet') ||
+			(isNullish($selectedNetwork) && !isTokenIcrcTestnet(token) && env !== 'testnet') ||
 			$selectedNetwork?.id === networkId
 		);
 	});

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -1,25 +1,68 @@
 import {
+	BTC_MAINNET_NETWORK,
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID,
 	ETHEREUM_NETWORK_ID,
 	ICP_NETWORK_ID,
+	SEPOLIA_NETWORK,
 	SEPOLIA_NETWORK_ID
 } from '$env/networks.env';
-import { mapNetworkIdToBitcoinNetwork } from '$lib/utils/network.utils';
+import { SEPOLIA_PEPE_TOKEN } from '$env/tokens-erc20/tokens.pepe.env';
+import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN } from '$env/tokens.btc.env';
+import { ICP_TOKEN, SEPOLIA_TOKEN } from '$env/tokens.env';
+import type { Token } from '$lib/types/token';
+import {
+	filterTokensForSelectedNetwork,
+	mapNetworkIdToBitcoinNetwork
+} from '$lib/utils/network.utils';
 
-describe('network utils', () => {
-	describe('mapNetworkIdToBitcoinNetwork', () => {
-		it('should map network id to bitcoin network', () => {
-			expect(mapNetworkIdToBitcoinNetwork(BTC_MAINNET_NETWORK_ID)).toBe('mainnet');
-			expect(mapNetworkIdToBitcoinNetwork(BTC_TESTNET_NETWORK_ID)).toBe('testnet');
-			expect(mapNetworkIdToBitcoinNetwork(BTC_REGTEST_NETWORK_ID)).toBe('regtest');
-		});
+describe('mapNetworkIdToBitcoinNetwork', () => {
+	it('should map network id to bitcoin network', () => {
+		expect(mapNetworkIdToBitcoinNetwork(BTC_MAINNET_NETWORK_ID)).toBe('mainnet');
+		expect(mapNetworkIdToBitcoinNetwork(BTC_TESTNET_NETWORK_ID)).toBe('testnet');
+		expect(mapNetworkIdToBitcoinNetwork(BTC_REGTEST_NETWORK_ID)).toBe('regtest');
+	});
 
-		it('should return `undefined` with non bitcoin network', () => {
-			expect(mapNetworkIdToBitcoinNetwork(ETHEREUM_NETWORK_ID)).toBeUndefined();
-			expect(mapNetworkIdToBitcoinNetwork(SEPOLIA_NETWORK_ID)).toBeUndefined();
-			expect(mapNetworkIdToBitcoinNetwork(ICP_NETWORK_ID)).toBeUndefined();
-		});
+	it('should return `undefined` with non bitcoin network', () => {
+		expect(mapNetworkIdToBitcoinNetwork(ETHEREUM_NETWORK_ID)).toBeUndefined();
+		expect(mapNetworkIdToBitcoinNetwork(SEPOLIA_NETWORK_ID)).toBeUndefined();
+		expect(mapNetworkIdToBitcoinNetwork(ICP_NETWORK_ID)).toBeUndefined();
+	});
+});
+
+describe('filterTokensForSelectedNetwork', () => {
+	const tokens: Token[] = [
+		ICP_TOKEN,
+		SEPOLIA_TOKEN,
+		SEPOLIA_PEPE_TOKEN,
+		BTC_REGTEST_TOKEN,
+		BTC_MAINNET_TOKEN
+	];
+
+	it('should return an empty array when no tokens are provided', () => {
+		expect(filterTokensForSelectedNetwork([[], undefined])).toEqual([]);
+
+		expect(filterTokensForSelectedNetwork([[], BTC_MAINNET_NETWORK])).toEqual([]);
+
+		expect(filterTokensForSelectedNetwork([[], SEPOLIA_NETWORK])).toEqual([]);
+	});
+
+	it('should filter tokens on the selected network when it is provided', () => {
+		expect(filterTokensForSelectedNetwork([tokens, BTC_MAINNET_NETWORK])).toEqual([
+			BTC_MAINNET_TOKEN
+		]);
+
+		expect(filterTokensForSelectedNetwork([tokens, SEPOLIA_NETWORK])).toEqual([
+			SEPOLIA_TOKEN,
+			SEPOLIA_PEPE_TOKEN
+		]);
+	});
+
+	it('should filter tokens without testnets when no network is provided and Chain Fusion is true', () => {
+		expect(filterTokensForSelectedNetwork([tokens, undefined])).toEqual([
+			ICP_TOKEN,
+			BTC_MAINNET_TOKEN
+		]);
 	});
 });


### PR DESCRIPTION
# Motivation

Util function `filterTokensForSelectedNetwork` was using `pseudoNetworkChainFusion` derived, that however is by itself a simple derived of `selectedNetwork` (another dependency that `filterTokensForSelectedNetwork` is already using).

So, we simplify it, removing `pseudoNetworkChainFusion` dependency and substituting with its logic.

# Changes

- Replace `pseudoNetworkChainFusion` dependency from filterTokensForSelectedNetwork with `isNullish(selectedNetwork)`
- Remove deprecated `pseudoNetworkChainFusion` dependency.
- Adapt the code.
- Create tests.

# Tests

Furthermore, we create some tests for `filterTokensForSelectedNetwork`, that were missing.