### PR TITLE
fix(test): renamed SignRequest type

### DIFF
--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,7 +1,7 @@
 import type {
 	EthAddressResponse,
+	EthSignTransactionRequest,
 	RejectionCode_1,
-	SignRequest,
 	_SERVICE as SignerService
 } from '$declarations/signer/signer.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
@@ -59,7 +59,7 @@ describe('signer.canister', () => {
 			max_fee_per_gas: 5n,
 			chain_id: 10n,
 			nonce: 10n
-		} as SignRequest
+		} as EthSignTransactionRequest
 	};
 	const personalSignParams = {
 		message: 'message'


### PR DESCRIPTION
# Motivation

The `SignerRequest` type has been renamed three weeks ago in #2910. The related import in the test `signer.canister.spec.ts` was not updated - i.e. is therefore incorrect.