### PR TITLE
chore(test): build test before execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"test": "vitest",
+		"test": "tsc --project tsconfig.spec.json --noEmit && vitest",
 		"cargo:test": "./scripts/test.backend.sh",
 		"clippy": "./scripts/lint.rust.sh",
 		"lint": "prettier --check './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}' && eslint .",


### PR DESCRIPTION
# Motivation

Few tests were not building because the declarations of the signer changed, see  #3328. This happens because the tests are actually not build. This PR aims to fix the issue by prepending the build of the tests before running those.

