### PR TITLE
chore(test): fix missing issuer mock data

### DIFF
--- a/src/frontend/src/tests/lib/utils/credentials.spec.ts
+++ b/src/frontend/src/tests/lib/utils/credentials.spec.ts
@@ -12,6 +12,7 @@ describe('credentials utils', () => {
 			const profile: UserProfile = {
 				credentials: [
 					{
+						issuer: "test",
 						credential_type: { ProofOfUniqueness: null },
 						verified_date_timestamp: [123456n]
 					}
@@ -27,6 +28,7 @@ describe('credentials utils', () => {
 			const profile: UserProfile = {
 				credentials: [
 					{
+						issuer: "test",
 						credential_type: { ProofOfUniqueness: null },
 						verified_date_timestamp: []
 					}

--- a/src/frontend/src/tests/lib/utils/credentials.spec.ts
+++ b/src/frontend/src/tests/lib/utils/credentials.spec.ts
@@ -12,7 +12,7 @@ describe('credentials utils', () => {
 			const profile: UserProfile = {
 				credentials: [
 					{
-						issuer: "test",
+						issuer: 'test',
 						credential_type: { ProofOfUniqueness: null },
 						verified_date_timestamp: [123456n]
 					}
@@ -28,7 +28,7 @@ describe('credentials utils', () => {
 			const profile: UserProfile = {
 				credentials: [
 					{
-						issuer: "test",
+						issuer: 'test',
 						credential_type: { ProofOfUniqueness: null },
 						verified_date_timestamp: []
 					}


### PR DESCRIPTION
# Motivation

Spotted mock data that were incomplete.

```
src/frontend/src/tests/lib/utils/credentials.spec.ts:14:6 - error TS2741: Property 'issuer' is missing in type '{ credential_type: { ProofOfUniqueness: null; }; verified_date_timestamp: [bigint]; }' but required in type 'UserCredential'.

14      {
        ~
15       credential_type: { ProofOfUniqueness: null },
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
16       verified_date_timestamp: [123456n]
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
17      }
   ~~~~~~

  src/declarations/backend/backend.did.d.ts:204:2
    204  issuer: string;
         ~~~~~~
    'issuer' is declared here.
```
