### PR TITLE
feat(frontend): move and test token validation

### DIFF
--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,55 +1,16 @@
 import type { OptionBalance } from '$lib/types/balance';
-import { NetworkSchema } from '$lib/types/network';
-import type { OnramperId } from '$lib/types/onramper';
-import type { AtLeastOne, Option, RequiredExcept } from '$lib/types/utils';
+import type { Option, RequiredExcept } from '$lib/types/utils';
+import {
+	TokenAppearanceSchema,
+	TokenBuySchema,
+	TokenBuyableSchema,
+	TokenCategorySchema,
+	TokenMetadataSchema,
+	TokenSchema,
+	TokenStandardSchema,
+	type TokenIdSchema
+} from '$lib/validation/token.validation';
 import { z } from 'zod';
-
-export const TokenIdSchema = z.symbol().brand<'TokenId'>();
-
-const TokenStandardSchema = z.enum(['ethereum', 'erc20', 'icp', 'icrc', 'bitcoin']);
-
-const TokenCategorySchema = z.enum(['default', 'custom']);
-
-const TokenMetadataSchema = z.object({
-	name: z.string(),
-	symbol: z.string(),
-	decimals: z.number(),
-	icon: z.string().optional()
-});
-
-const TokenOisySymbolSchema = z.object({
-	oisySymbol: z.string()
-});
-
-const TokenOisyNameSchema = z.object({
-	prefix: z.string().optional(),
-	oisyName: z.string()
-});
-
-const TokenAppearanceSchema = z.object({
-	oisySymbol: TokenOisySymbolSchema.optional(),
-	oisyName: TokenOisyNameSchema.optional()
-});
-
-// TODO: use Zod to validate the OnramperId
-const TokenBuySchema = z.object({
-	onramperId: z.custom<OnramperId>().optional()
-});
-
-const TokenBuyableSchema = z.object({
-	buy: z.custom<AtLeastOne<TokenBuy>>().optional()
-});
-
-const TokenSchema = z
-	.object({
-		id: TokenIdSchema,
-		network: NetworkSchema,
-		standard: TokenStandardSchema,
-		category: TokenCategorySchema
-	})
-	.merge(TokenMetadataSchema)
-	.merge(TokenAppearanceSchema)
-	.merge(TokenBuyableSchema);
 
 export type TokenId = z.infer<typeof TokenIdSchema>;
 

--- a/src/frontend/src/lib/validation/token.validation.ts
+++ b/src/frontend/src/lib/validation/token.validation.ts
@@ -1,4 +1,62 @@
-import { TokenIdSchema, type TokenId } from '$lib/types/token';
+import { NetworkSchema } from '$lib/types/network';
+import type { OnramperId } from '$lib/types/onramper';
+import type { TokenBuy } from '$lib/types/token';
+import type { AtLeastOne } from '$lib/types/utils';
+import { z } from 'zod';
 
-export const parseTokenId = (tokenIdString: string): TokenId =>
-	TokenIdSchema.parse(Symbol(tokenIdString));
+export const TokenIdSchema = z.symbol().brand<'TokenId'>();
+
+const TokenIdStringSchema = z.string();
+
+// We are not using the Token type as return value to avoid recursive imports
+export const parseTokenId = (
+	tokenIdString: z.infer<typeof TokenIdStringSchema>
+): z.infer<typeof TokenIdSchema> => {
+	const validString = TokenIdStringSchema.parse(tokenIdString);
+	return TokenIdSchema.parse(Symbol(validString));
+};
+
+export const TokenStandardSchema = z.enum(['ethereum', 'erc20', 'icp', 'icrc', 'bitcoin']);
+
+export const TokenCategorySchema = z.enum(['default', 'custom']);
+
+export const TokenMetadataSchema = z.object({
+	name: z.string(),
+	symbol: z.string(),
+	decimals: z.number(),
+	icon: z.string().optional()
+});
+
+const TokenOisySymbolSchema = z.object({
+	oisySymbol: z.string()
+});
+
+const TokenOisyNameSchema = z.object({
+	prefix: z.string().optional(),
+	oisyName: z.string()
+});
+
+export const TokenAppearanceSchema = z.object({
+	oisySymbol: TokenOisySymbolSchema.optional(),
+	oisyName: TokenOisyNameSchema.optional()
+});
+
+// TODO: use Zod to validate the OnramperId
+export const TokenBuySchema = z.object({
+	onramperId: z.custom<OnramperId>().optional()
+});
+
+export const TokenBuyableSchema = z.object({
+	buy: z.custom<AtLeastOne<TokenBuy>>().optional()
+});
+
+export const TokenSchema = z
+	.object({
+		id: TokenIdSchema,
+		network: NetworkSchema,
+		standard: TokenStandardSchema,
+		category: TokenCategorySchema
+	})
+	.merge(TokenMetadataSchema)
+	.merge(TokenAppearanceSchema)
+	.merge(TokenBuyableSchema);

--- a/src/frontend/src/tests/lib/validation/token.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/token.validation.spec.ts
@@ -1,0 +1,261 @@
+import { SEPOLIA_NETWORK } from '$env/networks.env';
+import {
+	parseTokenId,
+	TokenAppearanceSchema,
+	TokenBuyableSchema,
+	TokenBuySchema,
+	TokenCategorySchema,
+	TokenIdSchema,
+	TokenMetadataSchema,
+	TokenSchema,
+	TokenStandardSchema
+} from '$lib/validation/token.validation';
+
+describe('Token Schema Validation Tests', () => {
+	describe('TokenIdSchema', () => {
+		it('should validate with a symbol as TokenId', () => {
+			const tokenId = Symbol('TokenId');
+			expect(TokenIdSchema.parse(tokenId)).toEqual(tokenId);
+		});
+
+		it('should fail validation with a string instead of a symbol', () => {
+			const invalidTokenId = 'TokenId';
+			expect(() => TokenIdSchema.parse(invalidTokenId)).toThrow();
+		});
+	});
+
+	describe('parseTokenId', () => {
+		it('should correctly parse a string into a symbol TokenId', () => {
+			const tokenId = parseTokenId('testTokenId');
+			expect(typeof tokenId).toBe('symbol');
+		});
+
+		it('should fail to parse non-string input', () => {
+			const invalidInput = 123;
+			expect(() => parseTokenId(invalidInput as unknown as string)).toThrow();
+		});
+	});
+
+	describe('TokenStandardSchema', () => {
+		it('should validate "ethereum" as a supported token standard', () => {
+			const validStandard = 'ethereum';
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
+		it('should validate "erc20" as a supported token standard', () => {
+			const validStandard = 'erc20';
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
+		it('should validate "icp" as a supported token standard', () => {
+			const validStandard = 'icp';
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
+		it('should validate "icrc" as a supported token standard', () => {
+			const validStandard = 'icrc';
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
+		it('should validate "bitcoin" as a supported token standard', () => {
+			const validStandard = 'bitcoin';
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
+		it('should fail validation with an unsupported token standard', () => {
+			const invalidStandard = 'unsupported-standard';
+			expect(() => TokenStandardSchema.parse(invalidStandard)).toThrow();
+		});
+	});
+
+	describe('TokenCategorySchema', () => {
+		it('should validate "default" as a supported token category', () => {
+			const validCategory = 'default';
+			expect(TokenCategorySchema.parse(validCategory)).toEqual(validCategory);
+		});
+
+		it('should validate "custom" as a supported token category', () => {
+			const validCategory = 'custom';
+			expect(TokenCategorySchema.parse(validCategory)).toEqual(validCategory);
+		});
+
+		it('should fail validation with an unsupported token category', () => {
+			const invalidCategory = 'unsupported-category';
+			expect(() => TokenCategorySchema.parse(invalidCategory)).toThrow();
+		});
+	});
+
+	describe('TokenMetadataSchema', () => {
+		it('should validate complete metadata with a URL icon', () => {
+			const validMetadata = {
+				name: 'SampleToken',
+				symbol: 'STK',
+				decimals: 8,
+				icon: 'https://example.com/icon.png'
+			};
+			expect(TokenMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
+		});
+
+		it('should validate complete metadata with a base64 icon', () => {
+			const validMetadata = {
+				name: 'SampleToken',
+				symbol: 'STK',
+				decimals: 8,
+				icon: 'data:image/png;base64,iVBORw0KGgo=' // Very short base64 string
+			};
+			expect(TokenMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
+		});
+
+		it('should validate metadata without an optional icon', () => {
+			const validMetadata = {
+				name: 'SampleToken',
+				symbol: 'STK',
+				decimals: 8
+			};
+			expect(TokenMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
+		});
+
+		it('should fail validation with an invalid decimals type', () => {
+			const invalidMetadata = {
+				name: 'SampleToken',
+				symbol: 'STK',
+				decimals: 'eight', // Should be a number
+				icon: 'https://example.com/icon.png'
+			};
+			expect(() => TokenMetadataSchema.parse(invalidMetadata)).toThrow();
+		});
+
+		it('should fail validation with missing name', () => {
+			const invalidMetadata = {
+				symbol: 'STK',
+				decimals: 8,
+				icon: 'https://example.com/icon.png'
+			};
+			expect(() => TokenMetadataSchema.parse(invalidMetadata)).toThrow();
+		});
+
+		it('should fail validation with missing symbol', () => {
+			const invalidMetadata = {
+				name: 'SampleToken',
+				decimals: 8,
+				icon: 'https://example.com/icon.png'
+			};
+			expect(() => TokenMetadataSchema.parse(invalidMetadata)).toThrow();
+		});
+	});
+
+	describe('TokenAppearanceSchema', () => {
+		it('should validate with oisySymbol and oisyName', () => {
+			const validAppearance = {
+				oisySymbol: { oisySymbol: 'OSYM' },
+				oisyName: { prefix: 'OS', oisyName: 'OisyToken' }
+			};
+			expect(TokenAppearanceSchema.parse(validAppearance)).toEqual(validAppearance);
+		});
+
+		it('should validate with only oisySymbol', () => {
+			const validAppearance = {
+				oisySymbol: { oisySymbol: 'OSYM' }
+			};
+			expect(TokenAppearanceSchema.parse(validAppearance)).toEqual(validAppearance);
+		});
+
+		it('should fail validation with invalid oisySymbol type', () => {
+			const invalidAppearance = {
+				oisySymbol: { oisySymbol: 123 }
+			};
+			expect(() => TokenAppearanceSchema.parse(invalidAppearance)).toThrow();
+		});
+	});
+
+	describe('TokenBuySchema', () => {
+		it('should validate with an optional onramperId', () => {
+			const validBuy = { onramperId: 'valid-id' };
+			expect(TokenBuySchema.parse(validBuy)).toEqual(validBuy);
+		});
+
+		it('should validate with an empty object (onramperId optional)', () => {
+			const validBuy = {};
+			expect(TokenBuySchema.parse(validBuy)).toEqual(validBuy);
+		});
+	});
+
+	describe('TokenBuyableSchema', () => {
+		it('should validate with a buy object', () => {
+			const validBuyable = {
+				buy: { onramperId: 'valid-id' }
+			};
+			expect(TokenBuyableSchema.parse(validBuyable)).toEqual(validBuyable);
+		});
+
+		it('should validate with an empty object (buy optional)', () => {
+			const validBuyable = {};
+			expect(TokenBuyableSchema.parse(validBuyable)).toEqual(validBuyable);
+		});
+	});
+
+	describe('TokenSchema', () => {
+		const { chainId: _, explorerUrl: __, ...mockNetwork } = SEPOLIA_NETWORK;
+
+		const validTokenWithRequiredFields = {
+			id: parseTokenId('TokenId'),
+			network: mockNetwork,
+			standard: 'ethereum',
+			category: 'default',
+			name: 'SampleToken',
+			symbol: 'STK',
+			decimals: 8
+		};
+
+		const validToken = {
+			...validTokenWithRequiredFields,
+			icon: 'https://example.com/icon.png',
+			oisySymbol: { oisySymbol: 'OSYM' },
+			oisyName: { prefix: 'OS', oisyName: 'OisyToken' },
+			buy: { onramperId: 'valid-id' }
+		};
+
+		it('should validate a complete token', () => {
+			expect(TokenSchema.parse(validToken)).toEqual(validToken);
+		});
+
+		it('should validate a token with only required fields', () => {
+			expect(TokenSchema.parse(validTokenWithRequiredFields)).toEqual(validTokenWithRequiredFields);
+		});
+
+		it('should fail validation when id is missing', () => {
+			const { id: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+
+		it('should fail validation when network is missing', () => {
+			const { network: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+
+		it('should fail validation when standard is missing', () => {
+			const { standard: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+
+		it('should fail validation when category is missing', () => {
+			const { category: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+
+		it('should fail validation when name is missing', () => {
+			const { name: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+
+		it('should fail validation when symbol is missing', () => {
+			const { symbol: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+
+		it('should fail validation when decimals is missing', () => {
+			const { decimals: _, ...invalidToken } = validToken;
+			expect(() => TokenSchema.parse(invalidToken)).toThrow();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Extract the token zod schemas and add test.

# Changes

- Extract the `Token` zod from `types` to `validation`
- Add tests
- Comment about explicit type to avoid recursive import
- Add parameter validation in `parseTokenId`
