### PR TITLE
feat(frontend): add balance to icrc-ledger.api

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -1,4 +1,5 @@
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
+import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
 import { getAgent } from '$lib/actors/agents.ic';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -8,11 +9,24 @@ import {
 	type IcrcAccount,
 	type IcrcBlockIndex,
 	type IcrcSubaccount,
-	type IcrcTokenMetadataResponse
+	type IcrcTokenMetadataResponse,
+	type IcrcTokens
 } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish, toNullable, type QueryParams } from '@dfinity/utils';
 
+/**
+ * Retrieves metadata for the ICRC token.
+ *
+ * @param {Object} params - The parameters for fetching metadata.
+ * @param {boolean} [params.certified=true] - Whether the data should be certified.
+ * @param {OptionIdentity} params.identity - The identity to use for the request.
+ * @param {CanisterIdText} params.ledgerCanisterId - The ledger canister ID.
+ * @param {QueryParams} params.rest - Additional query parameters.
+ * @returns {Promise<IcrcTokenMetadataResponse>} The metadata response for the ICRC token.
+ *
+ * @todo Add missing test for this function.
+ */
 export const metadata = async ({
 	certified = true,
 	identity,
@@ -28,6 +42,47 @@ export const metadata = async ({
 	return metadata({ certified });
 };
 
+/**
+ * Retrieves the balance of ICRC tokens for a specified owner.
+ *
+ * @param {Object} params - The parameters for fetching the balance.
+ * @param {boolean} [params.certified=true] - Whether the balance data should be certified.
+ * @param {Principal} params.owner - The principal of the account owner.
+ * @param {OptionIdentity} params.identity - The identity to use for the request.
+ * @param {CanisterIdText} params.ledgerCanisterId - The ledger canister ID.
+ * @param {QueryParams} params.rest - Additional query parameters.
+ * @returns {Promise<IcrcTokens>} The balance of ICRC tokens.
+ */
+export const balance = async ({
+	certified = true,
+	owner,
+	identity,
+	...rest
+}: {
+	owner: Principal;
+	identity: OptionIdentity;
+	ledgerCanisterId: CanisterIdText;
+} & QueryParams): Promise<IcrcTokens> => {
+	assertNonNullish(identity);
+
+	const { balance } = await ledgerCanister({ identity, ...rest });
+
+	return balance({ certified, ...getIcrcAccount(owner) });
+};
+
+/**
+ * Executes a transfer of ICRC tokens.
+ *
+ * @param {Object} params - The parameters for the transfer.
+ * @param {OptionIdentity} params.identity - The identity to use for the transfer.
+ * @param {IcrcAccount} params.to - The recipient's account.
+ * @param {bigint} params.amount - The amount to transfer.
+ * @param {bigint} [params.createdAt] - Optional timestamp for when the transfer was created.
+ * @param {CanisterIdText} params.ledgerCanisterId - The ledger canister ID.
+ * @returns {Promise<IcrcBlockIndex>} The block index of the transfer.
+ *
+ * @todo Add missing test for this function.
+ */
 export const transfer = async ({
 	identity,
 	to,
@@ -52,6 +107,20 @@ export const transfer = async ({
 	});
 };
 
+/**
+ * Approves a spender for a specified amount of ICRC tokens.
+ *
+ * @param {Object} params - The parameters for the approval.
+ * @param {OptionIdentity} params.identity - The identity to use for the approval.
+ * @param {CanisterIdText} params.ledgerCanisterId - The ledger canister ID.
+ * @param {bigint} params.amount - The amount to approve.
+ * @param {IcrcAccount} params.spender - The account to approve as a spender.
+ * @param {bigint} params.expiresAt - The expiration timestamp for the approval.
+ * @param {bigint} [params.createdAt] - Optional timestamp for when the approval was created.
+ * @returns {Promise<IcrcBlockIndex>} The block index of the approval.
+ *
+ * @todo Add missing test for this function.
+ */
 export const approve = async ({
 	identity,
 	ledgerCanisterId,

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -1,0 +1,44 @@
+import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/networks.icrc.env';
+import { balance } from '$icp/api/icrc-ledger.api';
+import * as agent from '$lib/actors/agents.ic';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import type { HttpAgent } from '@dfinity/agent';
+import { IcrcLedgerCanister, type IcrcAccount } from '@dfinity/ledger-icrc';
+import { mock } from 'vitest-mock-extended';
+
+describe('icrc-ledger.api', () => {
+	const ledgerCanisterMock = mock<IcrcLedgerCanister>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(IcrcLedgerCanister, 'create').mockImplementation(() => ledgerCanisterMock);
+		vi.spyOn(agent, 'getAgent').mockResolvedValue(mock<HttpAgent>());
+	});
+
+	describe('balance', () => {
+		it('successfully calls balance endpoint', async () => {
+			const balanceE8s = 314_000_000n;
+			ledgerCanisterMock.balance.mockResolvedValue(balanceE8s);
+
+			const tokens = await balance({
+				certified: true,
+				owner: mockPrincipal,
+				ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+				identity: mockIdentity
+			});
+
+			expect(tokens).toEqual(balanceE8s);
+			expect(ledgerCanisterMock.balance).toBeCalledTimes(1);
+
+			const account: IcrcAccount = {
+				owner: mockPrincipal
+			};
+
+			expect(ledgerCanisterMock.balance).toBeCalledWith({
+				certified: true,
+				...account
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -40,5 +40,16 @@ describe('icrc-ledger.api', () => {
 				...account
 			});
 		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(
+				balance({
+					certified: true,
+					owner: mockPrincipal,
+					ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+					identity: undefined
+				})
+			).rejects.toThrow();
+		});
 	});
 });

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -17,26 +17,46 @@ describe('icrc-ledger.api', () => {
 	});
 
 	describe('balance', () => {
-		it('successfully calls balance endpoint', async () => {
-			const balanceE8s = 314_000_000n;
-			ledgerCanisterMock.balance.mockResolvedValue(balanceE8s);
+		const params = {
+			certified: true,
+			owner: mockPrincipal,
+			ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+			identity: mockIdentity
+		};
 
-			const tokens = await balance({
+		const balanceE8s = 314_000_000n;
+
+		const account: IcrcAccount = {
+			owner: mockPrincipal
+		};
+
+		beforeEach(() => {
+			ledgerCanisterMock.balance.mockResolvedValue(balanceE8s);
+		});
+
+		it('successfully calls balance endpoint', async () => {
+			const tokens = await balance(params);
+
+			expect(tokens).toEqual(balanceE8s);
+			expect(ledgerCanisterMock.balance).toBeCalledTimes(1);
+
+			expect(ledgerCanisterMock.balance).toBeCalledWith({
 				certified: true,
-				owner: mockPrincipal,
-				ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
-				identity: mockIdentity
+				...account
+			});
+		});
+
+		it('successfully calls balance endpoint as query', async () => {
+			const tokens = await balance({
+				...params,
+				certified: false
 			});
 
 			expect(tokens).toEqual(balanceE8s);
 			expect(ledgerCanisterMock.balance).toBeCalledTimes(1);
 
-			const account: IcrcAccount = {
-				owner: mockPrincipal
-			};
-
 			expect(ledgerCanisterMock.balance).toBeCalledWith({
-				certified: true,
+				certified: false,
 				...account
 			});
 		});


### PR DESCRIPTION
# Motivation

We aim to support tokens without an index canister. This means that we want to support tokens without transactions, but we still want to fetch balances. These balances can be queried directly from the ledger.

# Changes

- Add `balance` to `icrc-ledger.api`
- Comment and add todo for missing test to existing functions
