### PR TITLE
feat(frontend): IcCanistersStrict type and validation

### DIFF
--- a/src/frontend/src/icp/types/ic-token.ts
+++ b/src/frontend/src/icp/types/ic-token.ts
@@ -1,6 +1,7 @@
 import {
 	IcAppMetadataSchema,
 	IcCanistersSchema,
+	IcCanistersStrictSchema,
 	IcCkInterfaceSchema,
 	IcCkLinkedAssetsSchema,
 	IcCkMetadataSchema,
@@ -18,6 +19,8 @@ export type IcFee = z.infer<typeof IcFeeSchema>;
 export type IcAppMetadata = z.infer<typeof IcAppMetadataSchema>;
 
 export type IcCanisters = z.infer<typeof IcCanistersSchema>;
+
+export type IcCanistersStrict = z.infer<typeof IcCanistersStrictSchema>;
 
 export type IcCkLinkedAssets = z.infer<typeof IcCkLinkedAssetsSchema>;
 

--- a/src/frontend/src/icp/validation/ic-token.validation.ts
+++ b/src/frontend/src/icp/validation/ic-token.validation.ts
@@ -16,6 +16,11 @@ export const IcAppMetadataSchema = z.object({
 
 export const IcCanistersSchema = z.object({
 	ledgerCanisterId: CanisterIdTextSchema,
+	// TODO: Make canister .optional()
+	indexCanisterId: CanisterIdTextSchema
+});
+
+export const IcCanistersStrictSchema = IcCanistersSchema.extend({
 	indexCanisterId: CanisterIdTextSchema
 });
 

--- a/src/frontend/src/tests/icp/validation/ic-token.validation.spec.ts
+++ b/src/frontend/src/tests/icp/validation/ic-token.validation.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
 	IcAppMetadataSchema,
 	IcCanistersSchema,
+	IcCanistersStrictSchema,
 	IcCkInterfaceSchema,
 	IcCkLinkedAssetsSchema,
 	IcCkMetadataSchema,
@@ -98,6 +99,14 @@ describe('Schema Validation Tests', () => {
 			expect(IcCanistersSchema.parse(validData)).toEqual(validData);
 		});
 
+		// TODO: uncomment when Index canister becomes optional
+		// it('should validate with ledger canister only', () => {
+		// 	const validData = {
+		// 		ledgerCanisterId: mockCanisters.ledgerCanisterId
+		// 	};
+		// 	expect(IcCanistersSchema.parse(validData)).toEqual(validData);
+		// });
+
 		it('should fail with invalid ledger canister id', () => {
 			const invalidData = {
 				...validData,
@@ -120,12 +129,39 @@ describe('Schema Validation Tests', () => {
 			};
 			expect(() => IcCanistersSchema.parse(invalidData)).toThrow();
 		});
+	});
+
+	describe('IcCanistersStrictSchema', () => {
+		const validToken = {
+			...mockToken,
+			...mockFee,
+			...mockCanisters,
+			...mockApp
+		};
+
+		it('should validate with correct data', () => {
+			const validData = {
+				ledgerCanisterId: mockCanisters.ledgerCanisterId,
+				indexCanisterId: mockCanisters.ledgerCanisterId
+			};
+
+			expect(IcCanistersSchema.parse(validData)).toEqual(validData);
+		});
+
+		it('should validate a token with index canister correct data', () => {
+			expect(() => IcCanistersStrictSchema.parse(validToken)).not.toThrow();
+		});
 
 		it('should fail with missing index canister field', () => {
 			const invalidData = {
 				ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID
 			};
-			expect(() => IcCanistersSchema.parse(invalidData)).toThrow();
+			expect(() => IcCanistersStrictSchema.parse(invalidData)).toThrow();
+		});
+
+		it('should fail for token with missing index canister field', () => {
+			const { indexCanisterId: _, ...tokenWithoutIndexCanisterId } = validToken;
+			expect(() => IcCanistersStrictSchema.parse(tokenWithoutIndexCanisterId)).toThrow();
 		});
 	});
 
@@ -182,6 +218,12 @@ describe('Schema Validation Tests', () => {
 		it('should validate with correct data', () => {
 			expect(IcInterfaceSchema.parse(validData)).toEqual(validData);
 		});
+
+		// TODO: uncomment when Index canister becomes optional
+		// it('should validate without Index canister', () => {
+		// 	const { indexCanisterId: _, ...restValidData } = validData;
+		// 	expect(IcInterfaceSchema.parse(restValidData)).toEqual(restValidData);
+		// });
 
 		it('should fail with incorrect IcCanisters data', () => {
 			const invalidData = {


### PR DESCRIPTION
# Motivation

This might not suffise but, it's a first step, type wise, to defined the "Index Canister" as optional.

# Notes

I add to include comments because we cannot just set the index as optional. On the other side, I also need this new validation becase otherwise I cannot split PR  #3334 in smaller PRs.

# Changes

- Provide validation and types `IcCanistersStrictSchema`
- Add TODO for making the Index Canister optional typewise
