### PR TITLE
refactor(frontend): extract util to reset route params

### DIFF
--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -99,6 +99,12 @@ export const loadRouteParams = ($event: LoadEvent): RouteParams => {
 	};
 };
 
+export const resetRouteParams = (): RouteParams => ({
+	[TOKEN_PARAM]: null,
+	[NETWORK_PARAM]: null,
+	[URI_PARAM]: null
+});
+
 export const switchNetwork = async (networkId: Option<NetworkId>) => {
 	const url = new URL(window.location.href);
 

--- a/src/frontend/src/routes/(app)/activity/+page.ts
+++ b/src/frontend/src/routes/(app)/activity/+page.ts
@@ -1,10 +1,6 @@
-import { type RouteParams } from '$lib/utils/nav.utils';
+import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 // We reset the data because the "activity" route operates without a network or token selected.
-export const load: PageLoad = (_$event: LoadEvent): RouteParams => ({
-	token: null,
-	network: null,
-	uri: null
-});
+export const load: PageLoad = (_$event: LoadEvent): RouteParams => resetRouteParams();

--- a/src/frontend/src/routes/(public)/license-agreement/+page.ts
+++ b/src/frontend/src/routes/(public)/license-agreement/+page.ts
@@ -1,10 +1,6 @@
-import type { RouteParams } from '$lib/utils/nav.utils';
+import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 // We reset the data because a public route operates without a network or token selected.
-export const load: PageLoad = (_$event: LoadEvent): RouteParams => ({
-	token: null,
-	network: null,
-	uri: null
-});
+export const load: PageLoad = (_$event: LoadEvent): RouteParams => resetRouteParams();

--- a/src/frontend/src/routes/(sign)/sign/+page.ts
+++ b/src/frontend/src/routes/(sign)/sign/+page.ts
@@ -1,10 +1,6 @@
-import type { RouteParams } from '$lib/utils/nav.utils';
+import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 // We reset the data because the "sign" route operates without a network or token selected.
-export const load: PageLoad = (_$event: LoadEvent): RouteParams => ({
-	token: null,
-	network: null,
-	uri: null
-});
+export const load: PageLoad = (_$event: LoadEvent): RouteParams => resetRouteParams();

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -1,0 +1,11 @@
+import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
+
+describe('resetRouteParams', () => {
+	it('should return an object with all values set to null', () => {
+		const result = resetRouteParams();
+
+		Object.keys(result).forEach((key) => {
+			expect(result[key as keyof RouteParams]).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We extract an util to reset the Route parameters, to be reused in the code.
