### PR TITLE
test(frontend): cleanup mocks prefix

### DIFF
--- a/src/frontend/src/tests/icp/validation/ic-token.validation.spec.ts
+++ b/src/frontend/src/tests/icp/validation/ic-token.validation.spec.ts
@@ -5,34 +5,34 @@ import {
 	isNotIcToken,
 	isNotIcTokenCanistersStrict
 } from '$icp/validation/ic-token.validation';
-import { validIcToken } from '$tests/mocks/ic-tokens.mock';
-import { validToken } from '$tests/mocks/tokens.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
 import { describe, expect, it } from 'vitest';
 
 describe('ic-token.validation', () => {
 	describe('isIcToken', () => {
 		it('should return true for a valid IcToken', () => {
-			expect(isIcToken(validIcToken)).toBe(true);
+			expect(isIcToken(mockValidIcToken)).toBe(true);
 		});
 
 		it('should return false for an invalid IcToken', () => {
-			expect(isIcToken(validToken)).toBe(false);
+			expect(isIcToken(mockValidToken)).toBe(false);
 		});
 	});
 
 	describe('isNotIcToken', () => {
 		it('should return false for a valid IcToken', () => {
-			expect(isNotIcToken(validIcToken)).toBe(false);
+			expect(isNotIcToken(mockValidIcToken)).toBe(false);
 		});
 
 		it('should return true for an invalid IcToken', () => {
-			expect(isNotIcToken(validToken)).toBe(true);
+			expect(isNotIcToken(mockValidToken)).toBe(true);
 		});
 	});
 
 	describe('isIcTokenCanistersStrict', () => {
 		it('should return true for a valid IcToken with IcCanistersStrict', () => {
-			expect(isIcTokenCanistersStrict(validIcToken)).toBe(true);
+			expect(isIcTokenCanistersStrict(mockValidIcToken)).toBe(true);
 		});
 
 		// TODO: test missing indexCanisterId when it becomes optional
@@ -41,13 +41,13 @@ describe('ic-token.validation', () => {
 		// });
 
 		it('should return false for a token type casted to IcToken', () => {
-			expect(isIcTokenCanistersStrict(validToken as IcToken)).toBe(false);
+			expect(isIcTokenCanistersStrict(mockValidToken as IcToken)).toBe(false);
 		});
 	});
 
 	describe('isNotIcTokenCanistersStrict', () => {
 		it('should return false for a valid IcToken with IcCanistersStrict', () => {
-			expect(isNotIcTokenCanistersStrict(validIcToken)).toBe(false);
+			expect(isNotIcTokenCanistersStrict(mockValidIcToken)).toBe(false);
 		});
 
 		// TODO: test missing indexCanisterId when it becomes optional
@@ -56,7 +56,7 @@ describe('ic-token.validation', () => {
 		// });
 
 		it('should return true for a token type casted to IcToken', () => {
-			expect(isNotIcTokenCanistersStrict(validToken as IcToken)).toBe(true);
+			expect(isNotIcTokenCanistersStrict(mockValidToken as IcToken)).toBe(true);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -8,8 +8,8 @@ import {
 	sumTokenBalances,
 	sumUsdBalances
 } from '$lib/utils/token.utils';
-import { $balances, bn1, bn2, bn3 } from '$tests/mocks/balances.mock';
-import { $exchanges } from '$tests/mocks/exchanges.mock';
+import { bn1, bn2, bn3, mockBalances } from '$tests/mocks/balances.mock';
+import { mockExchanges } from '$tests/mocks/exchanges.mock';
 import { BigNumber } from 'alchemy-sdk';
 import type { MockedFunction } from 'vitest';
 
@@ -103,17 +103,29 @@ describe('calculateTokenUsdBalance', () => {
 	});
 
 	it('should correctly calculate USD balance for the token', () => {
-		const result = calculateTokenUsdBalance({ token: ETHEREUM_TOKEN, $balances, $exchanges });
+		const result = calculateTokenUsdBalance({
+			token: ETHEREUM_TOKEN,
+			$balances: mockBalances,
+			$exchanges: mockExchanges
+		});
 		expect(result).toEqual(bn3.toNumber());
 	});
 
 	it('should return undefined if exchange rate is not available', () => {
-		const result = calculateTokenUsdBalance({ token: ICP_TOKEN, $balances, $exchanges: {} });
+		const result = calculateTokenUsdBalance({
+			token: ICP_TOKEN,
+			$balances: mockBalances,
+			$exchanges: {}
+		});
 		expect(result).toEqual(undefined);
 	});
 
 	it('should return 0 if balances store is not available', () => {
-		const result = calculateTokenUsdBalance({ token: ETHEREUM_TOKEN, $balances: {}, $exchanges });
+		const result = calculateTokenUsdBalance({
+			token: ETHEREUM_TOKEN,
+			$balances: {},
+			$exchanges: mockExchanges
+		});
 		expect(result).toEqual(0);
 	});
 
@@ -121,7 +133,7 @@ describe('calculateTokenUsdBalance', () => {
 		const result = calculateTokenUsdBalance({
 			token: ETHEREUM_TOKEN,
 			$balances: undefined,
-			$exchanges
+			$exchanges: mockExchanges
 		});
 		expect(result).toEqual(0);
 	});
@@ -139,7 +151,11 @@ describe('mapTokenUi', () => {
 	});
 
 	it('should return an object TokenUi with the correct values', () => {
-		const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances, $exchanges });
+		const result = mapTokenUi({
+			token: ETHEREUM_TOKEN,
+			$balances: mockBalances,
+			$exchanges: mockExchanges
+		});
 		expect(result).toEqual({
 			...ETHEREUM_TOKEN,
 			balance: bn3,
@@ -148,7 +164,7 @@ describe('mapTokenUi', () => {
 	});
 
 	it('should return an object TokenUi with undefined usdBalance if exchange rate is not available', () => {
-		const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances, $exchanges: {} });
+		const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances: mockBalances, $exchanges: {} });
 		expect(result).toEqual({
 			...ETHEREUM_TOKEN,
 			balance: bn3,
@@ -157,7 +173,11 @@ describe('mapTokenUi', () => {
 	});
 
 	it('should return an object TokenUi with undefined balance if balances store is not initiated', () => {
-		const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances: undefined, $exchanges });
+		const result = mapTokenUi({
+			token: ETHEREUM_TOKEN,
+			$balances: undefined,
+			$exchanges: mockExchanges
+		});
 		expect(result).toEqual({
 			...ETHEREUM_TOKEN,
 			balance: undefined,
@@ -166,7 +186,7 @@ describe('mapTokenUi', () => {
 	});
 
 	it('should return an object TokenUi with undefined balance if balances store is not available', () => {
-		const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances: {}, $exchanges });
+		const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances: {}, $exchanges: mockExchanges });
 		expect(result).toEqual({
 			...ETHEREUM_TOKEN,
 			balance: undefined,
@@ -178,7 +198,7 @@ describe('mapTokenUi', () => {
 		const result = mapTokenUi({
 			token: ETHEREUM_TOKEN,
 			$balances: { [ETHEREUM_TOKEN.id]: null },
-			$exchanges
+			$exchanges: mockExchanges
 		});
 		expect(result).toEqual({
 			...ETHEREUM_TOKEN,

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -16,9 +16,9 @@ import {
 	sumMainnetTokensUsdBalancesPerNetwork,
 	sumTokensUiUsdBalance
 } from '$lib/utils/tokens.utils';
-import { $balances, bn1, bn2, bn3, certified } from '$tests/mocks/balances.mock';
-import { $exchanges, usd } from '$tests/mocks/exchanges.mock';
-import { $tokens } from '$tests/mocks/tokens.mock';
+import { bn1, bn2, bn3, certified, mockBalances } from '$tests/mocks/balances.mock';
+import { mockExchanges, mockOneUsd } from '$tests/mocks/exchanges.mock';
+import { mockTokens } from '$tests/mocks/tokens.mock';
 import type { MockedFunction } from 'vitest';
 
 vi.mock('$lib/utils/exchange.utils', () => ({
@@ -28,40 +28,40 @@ vi.mock('$lib/utils/exchange.utils', () => ({
 describe('sortTokens', () => {
 	it('should sort tokens by market cap, then by name, and finally by network name', () => {
 		const $exchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
-			[BTC_MAINNET_TOKEN.id]: { usd },
-			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd }
+			[ICP_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd },
+			[BTC_MAINNET_TOKEN.id]: { usd: mockOneUsd },
+			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd: mockOneUsd }
 		};
-		const sortedTokens = sortTokens({ $tokens, $exchanges, $tokensToPin: [] });
+		const sortedTokens = sortTokens({ $tokens: mockTokens, $exchanges, $tokensToPin: [] });
 		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, ICP_TOKEN, BTC_MAINNET_TOKEN]);
 	});
 
 	it('should sort tokens with same market cap by name', () => {
 		const $exchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
-			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
-			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd }
+			[ICP_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd },
+			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd },
+			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd }
 		};
-		const sortedTokens = sortTokens({ $tokens, $exchanges, $tokensToPin: [] });
+		const sortedTokens = sortTokens({ $tokens: mockTokens, $exchanges, $tokensToPin: [] });
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
 	it('should sort tokens by name if market cap is not provided', () => {
 		const $exchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd },
-			[BTC_MAINNET_TOKEN.id]: { usd },
-			[ETHEREUM_TOKEN.id]: { usd }
+			[ICP_TOKEN.id]: { usd: mockOneUsd },
+			[BTC_MAINNET_TOKEN.id]: { usd: mockOneUsd },
+			[ETHEREUM_TOKEN.id]: { usd: mockOneUsd }
 		};
-		const sortedTokens = sortTokens({ $tokens, $exchanges, $tokensToPin: [] });
+		const sortedTokens = sortTokens({ $tokens: mockTokens, $exchanges, $tokensToPin: [] });
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
 	it('should sort tokens with same market cap and name by network name', () => {
-		const newTokens: Token[] = $tokens.map((token) => ({ ...token, name: 'Test Token' }));
+		const newTokens: Token[] = mockTokens.map((token) => ({ ...token, name: 'Test Token' }));
 		const $exchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
-			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd },
-			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd }
+			[ICP_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd },
+			[BTC_MAINNET_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd },
+			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd }
 		};
 		const sortedTokens = sortTokens({
 			$tokens: newTokens,
@@ -77,11 +77,11 @@ describe('sortTokens', () => {
 	});
 
 	it('should sort tokens with same name by network name if market cap is not provided', () => {
-		const newTokens: Token[] = $tokens.map((token) => ({ ...token, name: 'Test Token' }));
+		const newTokens: Token[] = mockTokens.map((token) => ({ ...token, name: 'Test Token' }));
 		const $exchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd },
-			[BTC_MAINNET_TOKEN.id]: { usd },
-			[ETHEREUM_TOKEN.id]: { usd }
+			[ICP_TOKEN.id]: { usd: mockOneUsd },
+			[BTC_MAINNET_TOKEN.id]: { usd: mockOneUsd },
+			[ETHEREUM_TOKEN.id]: { usd: mockOneUsd }
 		};
 		const sortedTokens = sortTokens({
 			$tokens: newTokens,
@@ -98,13 +98,13 @@ describe('sortTokens', () => {
 
 	it('should pin tokens at the top of the list', () => {
 		const $exchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd_market_cap: 200, usd },
-			[BTC_MAINNET_TOKEN.id]: { usd },
-			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd }
+			[ICP_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd },
+			[BTC_MAINNET_TOKEN.id]: { usd: mockOneUsd },
+			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd: mockOneUsd }
 		};
 		const tokensToPin: TokenToPin[] = [ETHEREUM_TOKEN, BTC_MAINNET_TOKEN];
 		const sortedTokens = sortTokens({
-			$tokens,
+			$tokens: mockTokens,
 			$exchanges,
 			$tokensToPin: tokensToPin
 		});
@@ -130,7 +130,11 @@ describe('pinTokensWithBalanceAtTop', () => {
 			[ETHEREUM_TOKEN.id]: { data: bn3, certified }
 		};
 
-		const result = pinTokensWithBalanceAtTop({ $tokens, $balances: newBalances, $exchanges });
+		const result = pinTokensWithBalanceAtTop({
+			$tokens: mockTokens,
+			$balances: newBalances,
+			$exchanges: mockExchanges
+		});
 
 		expect(result.map((token) => token.id)).toEqual([
 			ETHEREUM_TOKEN.id,
@@ -141,10 +145,14 @@ describe('pinTokensWithBalanceAtTop', () => {
 
 	it('should put tokens with no usd balance after the ones with and sort them by balance', () => {
 		const newExchanges: ExchangesData = {
-			[ICP_TOKEN.id]: { usd }
+			[ICP_TOKEN.id]: { usd: mockOneUsd }
 		};
 
-		const result = pinTokensWithBalanceAtTop({ $tokens, $balances, $exchanges: newExchanges });
+		const result = pinTokensWithBalanceAtTop({
+			$tokens: mockTokens,
+			$balances: mockBalances,
+			$exchanges: newExchanges
+		});
 
 		expect(result.map((token) => token.id)).toEqual([
 			ICP_TOKEN.id,
@@ -160,7 +168,11 @@ describe('pinTokensWithBalanceAtTop', () => {
 			[ETHEREUM_TOKEN.id]: { data: ZERO, certified }
 		};
 
-		const result = pinTokensWithBalanceAtTop({ $tokens, $balances: newBalances, $exchanges });
+		const result = pinTokensWithBalanceAtTop({
+			$tokens: mockTokens,
+			$balances: newBalances,
+			$exchanges: mockExchanges
+		});
 
 		expect(result.map((token) => token.id)).toEqual([
 			ICP_TOKEN.id,
@@ -176,7 +188,11 @@ describe('pinTokensWithBalanceAtTop', () => {
 			[ETHEREUM_TOKEN.id]: { data: ZERO, certified }
 		};
 
-		const result = pinTokensWithBalanceAtTop({ $tokens, $balances: newBalances, $exchanges });
+		const result = pinTokensWithBalanceAtTop({
+			$tokens: mockTokens,
+			$balances: newBalances,
+			$exchanges: mockExchanges
+		});
 
 		expect(result.map((token) => token.id)).toEqual([
 			BTC_MAINNET_TOKEN.id,
@@ -191,7 +207,11 @@ describe('pinTokensWithBalanceAtTop', () => {
 			[ETHEREUM_TOKEN.id]: { data: bn3, certified }
 		};
 
-		const result = pinTokensWithBalanceAtTop({ $tokens, $balances: newBalances, $exchanges });
+		const result = pinTokensWithBalanceAtTop({
+			$tokens: mockTokens,
+			$balances: newBalances,
+			$exchanges: mockExchanges
+		});
 
 		expect(result.map((token) => token.id)).toEqual([
 			ETHEREUM_TOKEN.id,
@@ -273,15 +293,15 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 
 	it('should return a dictionary with correct balances for the list of mainnet and testnet tokens', () => {
 		const balances = {
-			...$balances,
+			...mockBalances,
 			[BTC_TESTNET_TOKEN.id]: { data: bn3, certified }
 		};
-		const tokens = [...$tokens, BTC_TESTNET_TOKEN];
+		const tokens = [...mockTokens, BTC_TESTNET_TOKEN];
 
 		const result = sumMainnetTokensUsdBalancesPerNetwork({
 			$tokens: tokens,
 			$balances: balances,
-			$exchanges
+			$exchanges: mockExchanges
 		});
 		expect(result).toEqual({
 			[BTC_MAINNET_NETWORK_ID]: bn2.toNumber(),
@@ -297,12 +317,12 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			[ETHEREUM_TOKEN.id]: { data: ZERO, certified },
 			[BTC_TESTNET_TOKEN.id]: { data: ZERO, certified }
 		};
-		const tokens = [...$tokens, BTC_TESTNET_TOKEN];
+		const tokens = [...mockTokens, BTC_TESTNET_TOKEN];
 
 		const result = sumMainnetTokensUsdBalancesPerNetwork({
 			$tokens: tokens,
 			$balances: balances,
-			$exchanges
+			$exchanges: mockExchanges
 		});
 		expect(result).toEqual({
 			[BTC_MAINNET_NETWORK_ID]: ZERO.toNumber(),
@@ -313,7 +333,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 
 	it('should return an empty dictionary if no mainnet tokens are in the list', () => {
 		const balances = {
-			...$balances,
+			...mockBalances,
 			[BTC_TESTNET_TOKEN.id]: { data: bn2, certified }
 		};
 		const tokens = [BTC_TESTNET_TOKEN];
@@ -321,7 +341,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 		const result = sumMainnetTokensUsdBalancesPerNetwork({
 			$tokens: tokens,
 			$balances: balances,
-			$exchanges
+			$exchanges: mockExchanges
 		});
 		expect(result).toEqual({});
 	});
@@ -329,8 +349,8 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 	it('should return an empty dictionary if no tokens are provided', () => {
 		const result = sumMainnetTokensUsdBalancesPerNetwork({
 			$tokens: [],
-			$balances,
-			$exchanges
+			$balances: mockBalances,
+			$exchanges: mockExchanges
 		});
 		expect(result).toEqual({});
 	});
@@ -354,7 +374,7 @@ describe('pinEnabledTokensAtTop', () => {
 	});
 
 	it('should return the same array when all tokens are enabled', () => {
-		const tokens: TokenToggleable<Token>[] = $tokens.map((t) => ({ ...t, enabled: true }));
+		const tokens: TokenToggleable<Token>[] = mockTokens.map((t) => ({ ...t, enabled: true }));
 
 		const result = pinEnabledTokensAtTop(tokens);
 
@@ -362,7 +382,7 @@ describe('pinEnabledTokensAtTop', () => {
 	});
 
 	it('should return the same array when all tokens are disabled', () => {
-		const tokens: TokenToggleable<Token>[] = $tokens.map((t) => ({ ...t, enabled: false }));
+		const tokens: TokenToggleable<Token>[] = mockTokens.map((t) => ({ ...t, enabled: false }));
 
 		const result = pinEnabledTokensAtTop(tokens);
 

--- a/src/frontend/src/tests/lib/validation/token.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/token.validation.spec.ts
@@ -1,6 +1,6 @@
 import { isToken, parseTokenId } from '$lib/validation/token.validation';
-import { validIcToken } from '$tests/mocks/ic-tokens.mock';
-import { validToken } from '$tests/mocks/tokens.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
 import { describe, expect, it } from 'vitest';
 
 describe('token.validation', () => {
@@ -18,25 +18,25 @@ describe('token.validation', () => {
 
 	describe('isToken', () => {
 		it('should return true for a valid Token', () => {
-			expect(isToken(validToken)).toBe(true);
+			expect(isToken(mockValidToken)).toBe(true);
 		});
 
 		it('should return true for a valid Token with expansion', () => {
-			expect(isToken(validIcToken)).toBe(true);
+			expect(isToken(mockValidIcToken)).toBe(true);
 		});
 
 		it('should return false for an invalid Token', () => {
-			const { id: _, ...invalidToken } = validToken;
+			const { id: _, ...invalidToken } = mockValidToken;
 
 			expect(isToken(invalidToken)).toBe(false);
 
-			expect(isToken({ ...validToken, id: 'invalid-id' })).toBe(false);
+			expect(isToken({ ...mockValidToken, id: 'invalid-id' })).toBe(false);
 
-			expect(isToken({ ...validToken, network: 'invalid-network' })).toBe(false);
+			expect(isToken({ ...mockValidToken, network: 'invalid-network' })).toBe(false);
 
-			expect(isToken({ ...validToken, standard: 'invalid-standard' })).toBe(false);
+			expect(isToken({ ...mockValidToken, standard: 'invalid-standard' })).toBe(false);
 
-			expect(isToken({ ...validToken, category: 'invalid-category' })).toBe(false);
+			expect(isToken({ ...mockValidToken, category: 'invalid-category' })).toBe(false);
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/balances.mock.ts
+++ b/src/frontend/src/tests/mocks/balances.mock.ts
@@ -10,7 +10,7 @@ export const bn1 = BigNumber.from(1n);
 export const bn2 = BigNumber.from(2n);
 export const bn3 = BigNumber.from(3n);
 
-export const $balances: CertifiedStoreData<BalancesData> = {
+export const mockBalances: CertifiedStoreData<BalancesData> = {
 	[ICP_TOKEN.id]: { data: bn1, certified },
 	[BTC_MAINNET_TOKEN.id]: { data: bn2, certified },
 	[ETHEREUM_TOKEN.id]: { data: bn3, certified }

--- a/src/frontend/src/tests/mocks/exchanges.mock.ts
+++ b/src/frontend/src/tests/mocks/exchanges.mock.ts
@@ -1,9 +1,9 @@
 import type { ExchangesData } from '$lib/types/exchange';
-import { $tokens } from './tokens.mock';
+import { mockTokens } from './tokens.mock';
 
-export const usd = 1;
+export const mockOneUsd = 1;
 
-export const $exchanges: ExchangesData = $tokens.reduce<ExchangesData>((acc, token) => {
-	acc[token.id] = { usd };
+export const mockExchanges: ExchangesData = mockTokens.reduce<ExchangesData>((acc, token) => {
+	acc[token.id] = { usd: mockOneUsd };
 	return acc;
 }, {});

--- a/src/frontend/src/tests/mocks/ic-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/ic-tokens.mock.ts
@@ -1,16 +1,16 @@
 import { IC_CKBTC_INDEX_CANISTER_ID, IC_CKBTC_LEDGER_CANISTER_ID } from '$env/networks.icrc.env';
 import type { IcCanisters, IcToken } from '$icp/types/ic-token';
-import { validToken } from '$tests/mocks/tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
 
-export const validIcCanisters: IcCanisters = {
+export const mockValidIcCanisters: IcCanisters = {
 	ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
 	// TODO: to be removed when indexCanisterId becomes optional
 	indexCanisterId: IC_CKBTC_INDEX_CANISTER_ID
 };
 
-export const validIcToken: IcToken = {
-	...validToken,
-	...validIcCanisters,
+export const mockValidIcToken: IcToken = {
+	...mockValidToken,
+	...mockValidIcCanisters,
 	fee: 123n,
 	position: 1
 };

--- a/src/frontend/src/tests/mocks/tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/tokens.mock.ts
@@ -4,9 +4,9 @@ import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
 import type { Token } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
 
-export const $tokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
+export const mockTokens: Token[] = [ICP_TOKEN, BTC_MAINNET_TOKEN, ETHEREUM_TOKEN];
 
-export const validToken: Token = {
+export const mockValidToken: Token = {
 	id: parseTokenId('TokenId'),
 	network: ICP_NETWORK,
 	standard: 'icp',


### PR DESCRIPTION
# Motivation

It's cleaner to prefix all mock values with `mock` to warn the developer that a value imported might comes from the tests.