### PR TITLE
test(frontend): remove mockedAgent

### DIFF
--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -10,10 +10,9 @@ import { BackendCanister } from '$lib/canisters/backend.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import type { AddUserCredentialParams, BtcSelectUserUtxosFeeParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
-import { mockedAgent } from '$tests/mocks/agents.mock';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
-import { type ActorSubclass } from '@dfinity/agent';
+import { HttpAgent, type ActorSubclass } from '@dfinity/agent';
 import { mapIcrc2ApproveError } from '@dfinity/ledger-icp';
 import { Principal } from '@dfinity/principal';
 import { toNullable } from '@dfinity/utils';
@@ -32,7 +31,7 @@ vi.mock(import('$lib/actors/agents.ic'), async (importOriginal) => {
 	return {
 		...actual,
 		// eslint-disable-next-line require-await
-		getAgent: async () => mockedAgent
+		getAgent: async () => mock<HttpAgent>()
 	};
 });
 

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -10,10 +10,9 @@ import { P2WPKH, SIGNER_PAYMENT_TYPE } from '$lib/canisters/signer.constants';
 import { SignerCanisterPaymentError } from '$lib/canisters/signer.errors';
 import type { SendBtcParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
-import { mockedAgent } from '$tests/mocks/agents.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { type ActorSubclass } from '@dfinity/agent';
+import { HttpAgent, type ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { mock } from 'vitest-mock-extended';
 
@@ -30,7 +29,7 @@ vi.mock(import('$lib/actors/agents.ic'), async (importOriginal) => {
 	return {
 		...actual,
 		// eslint-disable-next-line require-await
-		getAgent: async () => mockedAgent
+		getAgent: async () => mock<HttpAgent>()
 	};
 });
 

--- a/src/frontend/src/tests/mocks/agents.mock.ts
+++ b/src/frontend/src/tests/mocks/agents.mock.ts
@@ -1,4 +1,0 @@
-import { HttpAgent } from '@dfinity/agent';
-import { mock } from 'vitest-mock-extended';
-
-export const mockedAgent = mock<HttpAgent>();


### PR DESCRIPTION
# Motivation

A bit opiniated but, I feel like it's cleaner to not have the `mock<HttpAgent>()` provided as a global mock module. Feel like it's particular to every test suite. Hence, removing the existing mock use in two tests.
