### PR TITLE
refactor(frontend): rename prop of IcTransaction

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -25,13 +25,7 @@
 	let timestamp: bigint | undefined;
 	let incoming: boolean | undefined;
 
-	$: ({
-		type,
-		typeLabel: transactionTypeLabel,
-		value,
-		timestamp,
-		incoming
-	} = transaction);
+	$: ({ type, typeLabel: transactionTypeLabel, value, timestamp, incoming } = transaction);
 
 	let pending = false;
 	$: pending = transaction?.status === 'pending';

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -19,14 +19,14 @@
 
 	export let transaction: IcTransactionUi;
 
-	let transactionType: IcTransactionType;
+	let type: IcTransactionType;
 	let transactionTypeLabel: string | undefined;
 	let value: bigint | undefined;
 	let timestamp: bigint | undefined;
 	let incoming: boolean | undefined;
 
 	$: ({
-		type: transactionType,
+		type,
 		typeLabel: transactionTypeLabel,
 		value,
 		timestamp,
@@ -41,13 +41,13 @@
 
 	let icon: ComponentType;
 	$: icon =
-		['burn', 'approve', 'mint'].includes(transactionType) && pending
+		['burn', 'approve', 'mint'].includes(type) && pending
 			? IconConvert
-			: ['burn', 'approve'].includes(transactionType)
+			: ['burn', 'approve'].includes(type)
 				? IconConvertTo
-				: transactionType === 'mint'
+				: type === 'mint'
 					? IconConvertFrom
-					: incoming === false
+					: type === 'send'
 						? IconSend
 						: IconReceive;
 
@@ -58,7 +58,7 @@
 <button on:click={() => modalStore.openIcTransaction(transaction)} class="block w-full border-0">
 	<Card>
 		<span class="inline-block first-letter:capitalize"
-			><IcTransactionLabel label={transactionTypeLabel} fallback={transactionType} /></span
+			><IcTransactionLabel label={transactionTypeLabel} fallback={type} /></span
 		>
 
 		<RoundedIcon slot="icon" {icon} />


### PR DESCRIPTION
# Motivation

We rename the prop `transactionType` to `type`, for consistency.

Furthermore, elsewhere in the code, in the util `mapIcrcTransaction`, the type is defined as

```typescript
const type: IcTransactionType = nonNullish(fromNullable(approve))
  ? 'approve'
  : nonNullish(fromNullable(burn))
    ? 'burn'
    : isMint
      ? 'mint'
      : source.incoming === false
        ? 'send'
        : 'receive';
```


Meaning that we can simply use `type === 'send'` in the same way that we use `incoming === false`

