### PR TITLE
test(frontend): exclude folders from coverage analysis

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,7 +62,10 @@ export default defineConfig(
 			watch: false,
 			silent: false,
 			setupFiles: ['./vitest.setup.ts'],
-			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)']
+			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+			coverage: {
+				exclude: ['build', '.dfx', '**/.svelte-kit']
+			}
 		}
 	})
 );


### PR DESCRIPTION
# Motivation

We exclude some folders from the coverage analysis, since there is nothing we can do to improve those (those are not project folders).
