### PR TITLE
test(frontend): create global mock for page store

### DIFF
--- a/src/frontend/src/tests/lib/stores/balances.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/balances.store.spec.ts
@@ -1,12 +1,14 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { balancesStore } from '$lib/stores/balances.store';
-import { mockPageStore } from '$tests/mocks/page.store.mock';
+import { page } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
 import { BigNumber } from 'alchemy-sdk';
 
-mockPageStore();
-
 describe('balancesStore', () => {
+	beforeEach(() => {
+		page.reset();
+	});
+
 	it('should ensure derived stores update at most once when the store changes', async () => {
 		await testDerivedUpdates(() =>
 			balancesStore.set({

--- a/src/frontend/src/tests/lib/stores/balances.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/balances.store.spec.ts
@@ -1,12 +1,12 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { balancesStore } from '$lib/stores/balances.store';
-import { page } from '$tests/mocks/page.store.mock';
+import { mockPage } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
 import { BigNumber } from 'alchemy-sdk';
 
 describe('balancesStore', () => {
 	beforeEach(() => {
-		page.reset();
+		mockPage.reset();
 	});
 
 	it('should ensure derived stores update at most once when the store changes', async () => {

--- a/src/frontend/src/tests/lib/stores/token.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/token.store.spec.ts
@@ -1,11 +1,11 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { token } from '$lib/stores/token.store';
-import { page } from '$tests/mocks/page.store.mock';
+import { mockPage } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
 
 describe('token store', () => {
 	beforeEach(() => {
-		page.reset();
+		mockPage.reset();
 	});
 
 	it('should ensure derived stores update at most once when the store changes', async () => {

--- a/src/frontend/src/tests/lib/stores/token.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/token.store.spec.ts
@@ -1,11 +1,13 @@
 import { ICP_TOKEN } from '$env/tokens.env';
 import { token } from '$lib/stores/token.store';
-import { mockPageStore } from '$tests/mocks/page.store.mock';
+import { page } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
 
-mockPageStore();
-
 describe('token store', () => {
+	beforeEach(() => {
+		page.reset();
+	});
+
 	it('should ensure derived stores update at most once when the store changes', async () => {
 		await testDerivedUpdates(() => token.set(ICP_TOKEN));
 	});

--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -14,9 +14,9 @@ const initPageStoreMock = () => {
 
 	return {
 		subscribe,
-		mock: (params: Partial<RouteParams>) =>
+		mock: (data: Partial<RouteParams>) =>
 			set({
-				data: params
+				data
 			}),
 
 		reset: () => set(initialStoreValue)

--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -1,13 +1,26 @@
+import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
+import type { Page } from '@sveltejs/kit';
 import { writable } from 'svelte/store';
 
-export const mockPageStore = () => {
-	vi.mock('$app/stores', () => ({
-		page: writable({
-			params: {},
-			route: {},
-			status: 200,
-			error: null,
-			data: {}
-		})
-	}));
+const initialStoreValue = {
+	data: resetRouteParams(),
+	route: {
+		id: null
+	}
 };
+
+const initPageStoreMock = () => {
+	const { subscribe, set } = writable<Partial<Page>>(initialStoreValue);
+
+	return {
+		subscribe,
+		mock: (params: Partial<RouteParams>) =>
+			set({
+				data: params
+			}),
+
+		reset: () => set(initialStoreValue)
+	};
+};
+
+export const page = initPageStoreMock();

--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -23,4 +23,4 @@ const initPageStoreMock = () => {
 	};
 };
 
-export const page = initPageStoreMock();
+export const mockPage = initPageStoreMock();

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
 import 'fake-indexeddb/auto';
 import { vi } from 'vitest';
-import { page } from './src/frontend/src/tests/mocks/page.store.mock';
+import { mockPage } from './src/frontend/src/tests/mocks/page.store.mock';
 
 vi.mock('$app/stores', () => ({
-	page
+	page: mockPage
 }));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,8 @@
 import '@testing-library/jest-dom';
 import 'fake-indexeddb/auto';
+import { vi } from 'vitest';
+import { page } from './src/frontend/src/tests/mocks/page.store.mock';
+
+vi.mock('$app/stores', () => ({
+	page
+}));


### PR DESCRIPTION
# Motivation

Inspired by [NNS Dapp codebase](https://github.com/dfinity/nns-dapp/blob/95d58213187190f606cffe7b43e6fc857d50528d/frontend/__mocks__/%24app/stores.ts#L40), we create a mock for the `page` store at the base of the vitest configs.

# Changes

- Create `page` store mock similar to NNS Dapp.
- Include it in `vitest.setup`.
- Adapt the tests. 

# Tests

All tests still works.
