### PR TITLE
fix(ci): frontend checks are not blocking merging

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -40,8 +40,15 @@ jobs:
         run: npm run test
 
   may-merge:
+    if: always()
     needs: ['lint', 'check', 'test']
     runs-on: ubuntu-24.04
     steps:
       - name: Cleared for merging
-        run: echo OK
+        run: |
+          if [ "${{ needs.lint.result }}" == "success" ] && [ "${{ needs.check.result }}" == "success" ] && [ "${{ needs.test.result }}" == "success" ]; then
+            echo "This PR is cleared for merging"
+          else
+            echo "This PR is not cleared for merging"
+            exit 1
+          fi

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -5,11 +5,11 @@
 	import { page } from '$app/stores';
 	import AuthGuard from '$lib/components/auth/AuthGuard.svelte';
 	import Footer from '$lib/components/core/Footer.svelte';
-	import Loaders from '$lib/components/core/Loaders.svelte';
 	import Modals from '$lib/components/core/Modals.svelte';
 	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Header from '$lib/components/hero/Header.svelte';
 	import Hero from '$lib/components/hero/Hero.svelte';
+	import Loaders from '$lib/components/loaders/Loaders.svelte';
 	import NavigationMenu from '$lib/components/navigation/NavigationMenu.svelte';
 	import SplitPane from '$lib/components/ui/SplitPane.svelte';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -5,11 +5,11 @@
 	import { page } from '$app/stores';
 	import AuthGuard from '$lib/components/auth/AuthGuard.svelte';
 	import Footer from '$lib/components/core/Footer.svelte';
+	import Loaders from '$lib/components/core/Loaders.svelte';
 	import Modals from '$lib/components/core/Modals.svelte';
 	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Header from '$lib/components/hero/Header.svelte';
 	import Hero from '$lib/components/hero/Hero.svelte';
-	import Loaders from '$lib/components/core/Loaders.svelte';
 	import NavigationMenu from '$lib/components/navigation/NavigationMenu.svelte';
 	import SplitPane from '$lib/components/ui/SplitPane.svelte';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -9,7 +9,7 @@
 	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Header from '$lib/components/hero/Header.svelte';
 	import Hero from '$lib/components/hero/Hero.svelte';
-	import Loaders from '$lib/components/loaders/Loaders.svelte';
+	import Loaders from '$lib/components/core/Loaders.svelte';
 	import NavigationMenu from '$lib/components/navigation/NavigationMenu.svelte';
 	import SplitPane from '$lib/components/ui/SplitPane.svelte';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';


### PR DESCRIPTION
# Motivation

As spotted by @loki344 , once again we were able to merge in `main` a PR that did not passed the frontend CI checks: latest example is PR #3410 at last commit https://github.com/dfinity/oisy-wallet/pull/3410/commits/090e14577f7f6730a02ab29a6eea79072bdaa0bf where [the frontend CI checks failed](https://github.com/dfinity/oisy-wallet/actions/runs/11738140030/job/32700102628).

The issue surges because, even if one the sub-steps of the check fail, the `may-merge` step is not marked as failed, but simply as "skipped". And that is considered by Github in the same way as "passed", or "ignored".

![Screenshot 2024-11-08 at 11 46 13](https://github.com/user-attachments/assets/c7a7026f-c3e8-4731-81d2-a5132979c00c)

This PR aims to have a more explicit "fail" status for the status check `may-merge`, that is present in `frontend-checks` workflow.

# Note

We tried to solve the issue with PR #3233 but it. did not solved the issue completely.


# Changes

We force the status check `may-merge` to have all the previous steps successful to be successful itself.

# Tests

We created a fake PR #3417 to verify that after being approved, even with failed CI checks, we could merge. We gave a rubber stamp just to test.

### Before

In commit https://github.com/dfinity/oisy-wallet/pull/3417/commits/866e462c9158cb38e820f3ef5bfe097aa175afa5 , even if the CI failed, I could have merged:

![Screenshot 2024-11-08 at 11 36 32](https://github.com/user-attachments/assets/07656baa-6dcf-42ac-ab71-d0bf5dd15c92)


### After

After the modification proposed, in commit https://github.com/dfinity/oisy-wallet/pull/3417/commits/b2f2e298af640596f6d1e50222b5c1518128780e , I was not able to merge after the CI failed. That is because `may-merge` failed too.

![Screenshot 2024-11-08 at 11 40 05](https://github.com/user-attachments/assets/1a55d8aa-5778-46cd-a702-e077adf40264)





