### PR TITLE
fix(frontend): global GIX styles

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -130,7 +130,7 @@ div.modal {
 		padding-inline: var(--padding);
 	}
 
-	div.wrapper.dialog div.header {
+	div.wrapper.dialog > div.header {
 		// TODO: Improve padding definition when the Modal of GIX Components has an updated way of setting it and not being hard-coded (https://github.com/dfinity/gix-components/blob/1c4ab390f9cab1d0e3ec73a23384e045679eb6b8/src/lib/components/Modal.svelte#L195)
 		--padding-3x: 0;
 		--padding: var(--padding-2x);
@@ -145,13 +145,13 @@ div.modal {
 		}
 	}
 
-	div.wrapper.dialog div.container-wrapper {
+	div.wrapper.dialog > div.container-wrapper {
 		margin: 0;
 
-		div.container {
+		& > div.container {
 			border-radius: 0;
 
-			div.content {
+			& > div.content {
 				padding-inline: var(--padding-1_5x);
 
 				@include media.min-width(medium) {
@@ -164,7 +164,7 @@ div.modal {
 	div.container {
 		max-width: 100%;
 
-		div.content {
+		& > div.content {
 			border-radius: var(--padding-0_75x);
 
 			overscroll-behavior: contain;


### PR DESCRIPTION
# Motivation

Since most of the GIX UI components use the same CSS classes namings (.content, .header, .container, .etc), the styles, that were supposed to be applied to the Modal component, affect all other GIX components inside a modal (e.g. in case token conversion flow I use `Collapsible`). This PR fixes it by applying the global styles from gix.scss only to direct children of the specified selectors.