### PR TITLE
style(frontend): add 1px height to DappTag section in DappCard

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappCard.svelte
+++ b/src/frontend/src/lib/components/dapps/DappCard.svelte
@@ -30,7 +30,7 @@
 				{oneLiner}
 			</p>
 		</section>
-		<section class="absolute bottom-4 left-4 right-4 max-h-6 min-h-6 overflow-hidden md:max-h-14">
+		<section class="absolute bottom-4 left-4 right-4 max-h-6 min-h-6 overflow-hidden md:max-h-[calc(3.5rem+1px)]">
 			<DappTags {dAppName} {tags} />
 		</section>
 	</article>

--- a/src/frontend/src/lib/components/dapps/DappCard.svelte
+++ b/src/frontend/src/lib/components/dapps/DappCard.svelte
@@ -30,7 +30,9 @@
 				{oneLiner}
 			</p>
 		</section>
-		<section class="absolute bottom-4 left-4 right-4 max-h-6 min-h-6 overflow-hidden md:max-h-[calc(3.5rem+1px)]">
+		<section
+			class="absolute bottom-4 left-4 right-4 max-h-6 min-h-6 overflow-hidden md:max-h-[calc(3.5rem+1px)]"
+		>
 			<DappTags {dAppName} {tags} />
 		</section>
 	</article>


### PR DESCRIPTION
# Motivation

On MacOS + Chrome, there is a slight issue with not visible borders in the DappCard (Looked fine on Windows..)

# Changes

- add 1px height

# Tests

before: 

<img width="208" alt="image" src="https://github.com/user-attachments/assets/bd3fa5de-522a-413c-ac2b-9f46cd2f19ee">


after
<img width="228" alt="image" src="https://github.com/user-attachments/assets/3ddd057c-8e40-4df6-9520-b6933143f503">

