### PR TITLE
feat(frontend): include ID in Ethereum transactions UI

### DIFF
--- a/src/frontend/src/eth/types/eth-transaction.ts
+++ b/src/frontend/src/eth/types/eth-transaction.ts
@@ -7,5 +7,6 @@ export type EthTransactionType = Extract<
 >;
 
 export interface EthTransactionUi extends Transaction {
+	id: string | undefined;
 	uiType: EthTransactionType;
 }

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -37,6 +37,7 @@ export const mapEthTransactionUi = ({
 
 	return {
 		...transaction,
+		id: transaction.hash,
 		uiType: ckMinterInfoAddresses.includes(from.toLowerCase())
 			? 'withdraw'
 			: ckMinterInfoAddresses.includes(to?.toLowerCase())

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -82,4 +82,20 @@ describe('mapEthTransactionUi', () => {
 		expect(result.uiType).not.toBe('withdraw');
 		expect(result.uiType).not.toBe('deposit');
 	});
+
+	it('should map an ID to the transaction hash if it exists', () => {
+		const result = mapEthTransactionUi({
+			transaction: { ...transaction, hash: '0x1234' },
+			ckMinterInfoAddresses,
+			$ethAddress
+		});
+
+		expect(result.id).toBe('0x1234');
+	});
+
+	it('should map an ID to undefined if the transaction hash does not exist', () => {
+		const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+
+		expect(result.id).toBeUndefined;
+	});
 });


### PR DESCRIPTION
# Motivation

To normalize all transactions we first include an optional ID in the Ethereum transactions for UI.


