### PR TITLE
feat(frontend): ConvertInputAmount component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
@@ -39,7 +39,7 @@
 	const debounceValidate = debounce(validate, 300);
 
 	let errorState: boolean;
-	$: errorState = nonNullish(errorType) && errorType === 'insufficient-balance';
+	$: errorState = nonNullish(errorType) && errorType === 'insufficient-funds';
 
 	$: amount, token.decimals, debounceValidate();
 </script>

--- a/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
@@ -69,7 +69,7 @@
 	</InputCurrency>
 </div>
 
-<style lang="scss">
+<style lang="postcss">
 	:global(.convert-input-amount div.input-block) {
 		--padding: 0;
 	}

--- a/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { IconClose } from '@dfinity/gix-components';
-	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import { debounce, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
+	import { fade } from 'svelte/transition';
 	import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
 	export let token: Token;
 	export let amount: number | undefined = undefined;
+	export let name = 'convert-amount';
 	export let disabled: boolean | undefined = undefined;
 	export let customValidate: (userAmount: BigNumber | undefined) => void = () => {};
 	export let error: Error | undefined = undefined;
@@ -36,7 +39,8 @@
 
 <div class="convert-input-amount text-3xl font-bold" class:error={nonNullish(error)}>
 	<InputCurrency
-		name="convert-amount"
+		{name}
+		testId="convert-amount"
 		bind:value={amount}
 		decimals={token.decimals}
 		{placeholder}
@@ -45,9 +49,11 @@
 		<svelte:fragment slot="inner-end">
 			{#if nonNullish(amount) && !disabled}
 				<button
+					transition:fade={{ duration: 200 }}
+					data-tid="convert-amount-reset"
+					aria-label={$i18n.convert.text.input_reset_button}
 					on:click|preventDefault={onReset}
 					class={nonNullish(error) ? 'text-error' : 'text-aurometalsaurus'}
-					class:hidden={isNullish(amount) || disabled}
 				>
 					<IconClose />
 				</button>

--- a/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { IconClose } from '@dfinity/gix-components';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
+	import type { Token } from '$lib/types/token';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	export let token: Token;
+	export let amount: number | undefined = undefined;
+	export let disabled: boolean | undefined = undefined;
+	export let customValidate: (userAmount: BigNumber | undefined) => void = () => {};
+	export let error: Error | undefined = undefined;
+	export let placeholder = '0.00';
+
+	const onReset = () => {
+		amount = undefined;
+	};
+
+	const validate = () => {
+		const parsedValue = !invalidAmount(amount)
+			? parseToken({
+					value: `${amount}`,
+					unitName: token.decimals
+				})
+			: undefined;
+
+		customValidate(parsedValue);
+	};
+
+	const debounceValidate = debounce(validate, 300);
+
+	$: amount, token.decimals, debounceValidate();
+</script>
+
+<div class="convert-input-amount text-3xl font-bold" class:error={nonNullish(error)}>
+	<InputCurrency
+		name="convert-amount"
+		bind:value={amount}
+		decimals={token.decimals}
+		{placeholder}
+		{disabled}
+	>
+		<svelte:fragment slot="inner-end">
+			{#if nonNullish(amount) && !disabled}
+				<button
+					on:click|preventDefault={onReset}
+					class={nonNullish(error) ? 'text-error' : 'text-aurometalsaurus'}
+					class:hidden={isNullish(amount) || disabled}
+				>
+					<IconClose />
+				</button>
+			{/if}
+		</svelte:fragment>
+	</InputCurrency>
+</div>
+
+<style lang="postcss">
+	:global(.convert-input-amount) {
+		&.error {
+			& > .input-block > div.input-field {
+				& input[id],
+				& input[id]:focus {
+					border-color: var(--color-error-default);
+					color: var(--color-error-default);
+				}
+			}
+		}
+
+		& > .input-block {
+			--padding: 0;
+
+			& > div.input-field input[id] {
+				@apply h-14;
+
+				&:disabled {
+					--disable: var(--color-bright-gray);
+					--input-background: var(--color-ghost-white);
+				}
+			}
+		}
+	}
+</style>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -377,7 +377,8 @@
 			"set_amount": "Set amount for conversion",
 			"check_balance_for_fees": "Check $token balance for conversion fees",
 			"fees_explanation": "You need enough $token to cover the smart contract execution fees.",
-			"current_balance": "👉 Current balance:"
+			"current_balance": "👉 Current balance:",
+			"input_reset_button": "Reset input value"
 		},
 		"error": {
 			"loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized."

--- a/src/frontend/src/lib/types/convert.ts
+++ b/src/frontend/src/lib/types/convert.ts
@@ -1,0 +1,4 @@
+export type ConvertAmountErrorType =
+	| 'insufficient-balance'
+	| 'insufficient-balance-for-fee'
+	| undefined;

--- a/src/frontend/src/lib/types/convert.ts
+++ b/src/frontend/src/lib/types/convert.ts
@@ -1,4 +1,4 @@
 export type ConvertAmountErrorType =
-	| 'insufficient-balance'
-	| 'insufficient-balance-for-fee'
+	| 'insufficient-funds'
+	| 'insufficient-funds-for-fee'
 	| undefined;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -344,6 +344,7 @@ interface I18nConvert {
 		check_balance_for_fees: string;
 		fees_explanation: string;
 		current_balance: string;
+		input_reset_button: string;
 	};
 	error: { loading_cketh_helper: string };
 }

--- a/src/frontend/src/tests/lib/components/convert/ConvertInputAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertInputAmount.spec.ts
@@ -1,0 +1,84 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
+import ConvertInputAmount from '$lib/components/convert/ConvertInputAmount.svelte';
+import { parseToken } from '$lib/utils/parse.utils';
+import { assertNonNullish } from '@dfinity/utils';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+describe('ConvertInputAmount', () => {
+	const amount = 20.25;
+
+	const props = {
+		token: BTC_MAINNET_TOKEN,
+		amount
+	};
+
+	const inputSelector = 'input[data-tid="convert-amount"]';
+	const resetButtonSelector = 'button[data-tid="convert-amount-reset"]';
+
+	it('should render an input', () => {
+		const { container } = render(ConvertInputAmount, { props });
+
+		const input: HTMLInputElement | null = container.querySelector(inputSelector);
+		assertNonNullish(input, 'Input not found');
+
+		expect(input?.value).toBe(props.amount.toString());
+	});
+
+	it('should render the reset button if amount is provided', () => {
+		const { container } = render(ConvertInputAmount, { props: props });
+
+		const resetButton: HTMLButtonElement | null = container.querySelector(resetButtonSelector);
+		expect(resetButton).toBeInTheDocument();
+	});
+
+	it('should not render the reset button if amount is undefined', () => {
+		const { amount: _, ...newProps } = props;
+		const { container } = render(ConvertInputAmount, { props: newProps });
+
+		const resetButton: HTMLButtonElement | null = container.querySelector(resetButtonSelector);
+		expect(resetButton).not.toBeInTheDocument();
+	});
+
+	it('should not render the reset button if input is disabled', () => {
+		const newProps = { ...props, disabled: true };
+		const { container } = render(ConvertInputAmount, { props: newProps });
+
+		const resetButton: HTMLButtonElement | null = container.querySelector(resetButtonSelector);
+		expect(resetButton).not.toBeInTheDocument();
+	});
+
+	it('should reset input value', async () => {
+		const { container, component } = render(ConvertInputAmount, { props });
+
+		const resetButton: HTMLButtonElement | null = container.querySelector(resetButtonSelector);
+		assertNonNullish(resetButton, 'Reset button not found');
+
+		await fireEvent.click(resetButton);
+
+		const input: HTMLInputElement | null = container.querySelector(inputSelector);
+
+		expect(input?.value).toBe('');
+		expect(component.$$.ctx[component.$$.props['amount']]).toBeUndefined();
+	});
+
+	it('should trigger validation', async () => {
+		const customValidate = vi.fn();
+
+		render(ConvertInputAmount, {
+			props: {
+				...props,
+				customValidate
+			}
+		});
+
+		await waitFor(() => {
+			expect(customValidate).toHaveBeenCalledTimes(1);
+			expect(customValidate).toHaveBeenCalledWith(
+				parseToken({
+					value: `${amount}`,
+					unitName: BTC_MAINNET_TOKEN.decimals
+				})
+			);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

In this PR, `ConvertInputAmount` component is implemented. Note: unfortunately, I needed to "hack" some internal GIX Input styles in order to match the design from Figma. 

Empty state:
<img width="314" alt="Screenshot 2024-11-11 at 18 34 41" src="https://github.com/user-attachments/assets/745cb319-ed07-4dab-9d86-bb42fa4aea40">

Normal state:
<img width="321" alt="Screenshot 2024-11-11 at 18 40 21" src="https://github.com/user-attachments/assets/f21c0ff0-25c1-4c85-9568-c94f38119c1b">

Disabled state:
<img width="305" alt="Screenshot 2024-11-11 at 18 37 21" src="https://github.com/user-attachments/assets/39f31768-f387-4070-987e-297002ee8b8d">

Error state:
<img width="311" alt="Screenshot 2024-11-11 at 18 34 50" src="https://github.com/user-attachments/assets/03dda8a6-63fd-45cb-9eac-b33a8e56cac1">

