### PR TITLE
feat(frontend): ConvertValue component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertValue.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertValue.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 	export let ref: undefined | string = undefined;
+
+	let secondaryValue: boolean;
+	$: secondaryValue = $$slots['secondary-value'];
 </script>
 
 <div class="mb-2 flex w-full justify-between last:mb-0 md:items-center">
 	<label for={ref} class="mr-1 text-sm sm:mr-2 sm:text-base"><slot name="label" /></label>
 
 	<div class="flex flex-col items-end sm:flex-row sm:items-center">
-		<span
-			class={`mb-1 text-sm font-bold sm:mb-0 sm:text-base ${$$slots['secondary-value'] ? 'mr-0 sm:mr-3' : ''}`}
+		<span class={`mb-1 text-sm font-bold sm:mb-0 sm:text-base ${secondaryValue ? 'sm:mr-3' : ''}`}
 			><slot name="main-value" /></span
 		>
 
+		<!-- TODO: Update colors with values from theme-variables when they are available there -->
 		<span class="text-sm text-aurometalsaurus"><slot name="secondary-value" /></span>
 	</div>
 </div>

--- a/src/frontend/src/lib/components/convert/ConvertValue.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertValue.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	export let ref: undefined | string = undefined;
+</script>
+
+<div class="mb-2 flex w-full justify-between last:mb-0 md:items-center">
+	<label for={ref} class="mr-1 text-sm sm:mr-2 sm:text-base"><slot name="label" /></label>
+
+	<div class="flex flex-col items-end sm:flex-row sm:items-center">
+		<span
+			class={`mb-1 text-sm font-bold sm:mb-0 sm:text-base ${$$slots['secondary-value'] ? 'mr-0 sm:mr-3' : ''}`}
+			><slot name="main-value" /></span
+		>
+
+		<span class="text-sm text-aurometalsaurus"><slot name="secondary-value" /></span>
+	</div>
+</div>

--- a/src/frontend/src/lib/components/convert/ConvertValue.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertValue.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+
 	export let ref: undefined | string = undefined;
 
 	let secondaryValue: boolean;
-	$: secondaryValue = $$slots['secondary-value'];
+	$: secondaryValue = nonNullish($$slots['secondary-value']);
 </script>
 
 <div class="mb-2 flex w-full justify-between last:mb-0 md:items-center">


### PR DESCRIPTION
# Motivation

Desktop (1 row = 1 ConvertValue component):
<img width="498" alt="Screenshot 2024-11-11 at 21 33 19" src="https://github.com/user-attachments/assets/6ae5161f-c326-44da-a75f-030ae03f0832">

Mobile Desktop (1 row = 1 ConvertValue component):
<img width="419" alt="Screenshot 2024-11-11 at 21 33 27" src="https://github.com/user-attachments/assets/0cde65be-893c-4ed4-8d6a-9b11f5e7eb39">
