### PR TITLE
feat(frontend): findTwinToken util

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { fade } from 'svelte/transition';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import { formatUSD } from '$lib/utils/format.utils';
+	export let amount: number | undefined = undefined;
+	export let exchangeRate: number | undefined = undefined;
+	let usdValue: string | undefined;
+	$: usdValue =
+		nonNullish(amount) && nonNullish(exchangeRate)
+			? formatUSD({
+					value: amount * exchangeRate
+				})
+			: undefined;
+</script>
+
+{#if nonNullish(usdValue)}
+	<div in:fade>
+		{`${nonNullish(amount) && amount === 0 ? '' : '~'}`}{usdValue}
+	</div>
+{:else}
+	<div class="w-10 sm:w-8">
+		<SkeletonText />
+	</div>
+{/if}

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -4,6 +4,8 @@ import {
 } from '$env/networks.icrc.env';
 import { ERC20_SUGGESTED_TOKENS } from '$env/tokens.erc20.env';
 import type { ContractAddressText } from '$eth/types/address';
+import type { IcCkToken } from '$icp/types/ic-token';
+import { isIcCkToken } from '$icp/utils/icrc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -207,3 +209,22 @@ export const sumUsdBalances = ([usdBalance1, usdBalance2]: [
  */
 export const isRequiredTokenWithLinkedData = (token: Token): token is RequiredTokenWithLinkedData =>
 	'twinTokenSymbol' in token && typeof token.twinTokenSymbol === 'string';
+
+/** Find in the provided tokens list a twin IC token by symbol.
+ *
+ * @param tokenToPair - token to find a twin for.
+ * @param tokens - The list of tokens.
+ * @returns IcCkToken or undefined if no twin token found.
+ * */
+export const findTwinToken = ({
+	tokenToPair,
+	tokens
+}: {
+	tokenToPair: Token;
+	tokens: Token[];
+}): IcCkToken | undefined =>
+	isRequiredTokenWithLinkedData(tokenToPair)
+		? (tokens.find(
+				(token) => token.symbol === tokenToPair.twinTokenSymbol && isIcCkToken(token)
+			) as IcCkToken | undefined)
+		: undefined;

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -5,7 +5,7 @@ import {
 import { ERC20_SUGGESTED_TOKENS } from '$env/tokens.erc20.env';
 import type { ContractAddressText } from '$eth/types/address';
 import type { IcCkToken } from '$icp/types/ic-token';
-import { isIcCkToken } from '$icp/utils/icrc.utils';
+import { isIcCkToken } from '$icp/validation/ic-token.validation';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -3,12 +3,15 @@ import { IC_CKBTC_LEDGER_CANISTER_ID, IC_CKETH_LEDGER_CANISTER_ID } from '$env/n
 import { LINK_TOKEN } from '$env/tokens-erc20/tokens.link.env';
 import { USDC_TOKEN } from '$env/tokens-erc20/tokens.usdc.env';
 import { USDT_TOKEN } from '$env/tokens-erc20/tokens.usdt.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ckErc20Production } from '$env/tokens.ckerc20.env';
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import type { IcCkToken } from '$icp/types/ic-token';
 import type { TokenStandard, TokenUi } from '$lib/types/token';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
 	calculateTokenUsdBalance,
+	findTwinToken,
 	getMaxTransactionAmount,
 	mapDefaultTokenToToggleable,
 	mapTokenUi,
@@ -17,7 +20,8 @@ import {
 } from '$lib/utils/token.utils';
 import { bn1, bn2, bn3, mockBalances } from '$tests/mocks/balances.mock';
 import { mockExchanges } from '$tests/mocks/exchanges.mock';
-import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockTokens } from '$tests/mocks/tokens.mock';
 import { BigNumber } from 'alchemy-sdk';
 import { describe, type MockedFunction } from 'vitest';
 
@@ -281,6 +285,42 @@ describe('sumUsdBalances', () => {
 
 	it('should return undefined when both balances are nullish', () => {
 		expect(sumUsdBalances([undefined, undefined])).toBeUndefined();
+	});
+});
+
+describe('findTwinToken', () => {
+	it('should return correct twin token', () => {
+		const ckBtcToken = {
+			...mockValidIcCkToken,
+			symbol: BTC_MAINNET_TOKEN.twinTokenSymbol
+		} as IcCkToken;
+
+		const result = findTwinToken({
+			tokens: [...mockTokens, ckBtcToken],
+			tokenToPair: BTC_MAINNET_TOKEN
+		});
+
+		expect(result).toBe(ckBtcToken);
+	});
+
+	it('should return undefined if no twin token found', () => {
+		const result = findTwinToken({
+			tokens: mockTokens,
+			tokenToPair: ETHEREUM_TOKEN
+		});
+
+		expect(result).toBe(undefined);
+	});
+
+	it('should return undefined if tokenToPair does not contain twinTokenSymbol', () => {
+		const { twinTokenSymbol: _, ...tokenWithoutTwinTokenSymbol } = BTC_MAINNET_TOKEN;
+
+		const result = findTwinToken({
+			tokens: mockTokens,
+			tokenToPair: tokenWithoutTwinTokenSymbol
+		});
+
+		expect(result).toBe(undefined);
 	});
 });
 

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -289,12 +289,12 @@ describe('sumUsdBalances', () => {
 });
 
 describe('findTwinToken', () => {
-	it('should return correct twin token', () => {
-		const ckBtcToken = {
-			...mockValidIcCkToken,
-			symbol: BTC_MAINNET_TOKEN.twinTokenSymbol
-		} as IcCkToken;
+	const ckBtcToken = {
+		...mockValidIcCkToken,
+		symbol: BTC_MAINNET_TOKEN.twinTokenSymbol
+	} as IcCkToken;
 
+	it('should return correct twin token', () => {
 		const result = findTwinToken({
 			tokens: [...mockTokens, ckBtcToken],
 			tokenToPair: BTC_MAINNET_TOKEN
@@ -305,7 +305,7 @@ describe('findTwinToken', () => {
 
 	it('should return undefined if no twin token found', () => {
 		const result = findTwinToken({
-			tokens: mockTokens,
+			tokens: [...mockTokens, ckBtcToken],
 			tokenToPair: ETHEREUM_TOKEN
 		});
 
@@ -316,7 +316,7 @@ describe('findTwinToken', () => {
 		const { twinTokenSymbol: _, ...tokenWithoutTwinTokenSymbol } = BTC_MAINNET_TOKEN;
 
 		const result = findTwinToken({
-			tokens: mockTokens,
+			tokens: [...mockTokens, ckBtcToken],
 			tokenToPair: tokenWithoutTwinTokenSymbol
 		});
 


### PR DESCRIPTION
# Motivation

The goal is to create a util for finding a twin token that can be reused in token-grouping.util as well as in the upcoming `convert.store`.
