### PR TITLE
style(frontend): use scss instead of postcss

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsPlaceholder.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsPlaceholder.svelte
@@ -30,7 +30,7 @@
 	</div>
 </div>
 
-<style lang="postcss">
+<style lang="scss">
 	.transaction-action-icon {
 		@apply flex items-center justify-center rounded-full bg-brand-subtle-alt p-3.5 ring-2 ring-brand-subtle;
 	}


### PR DESCRIPTION
# Motivation

We are using `scss` as CSS processor. In PR https://github.com/dfinity/oisy-wallet/pull/3451#discussion_r1837930148 we discussed `postcss` and noticed similar Tailwind imports can be resolved with our standard approach, therefore this PR removes an inconsistency.
