### PR TITLE
feat(backend): Add topping up API

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -160,6 +160,10 @@ type Result_4 = variant {
 type Result_5 = variant { Ok : UserProfile; Err : GetUserProfileError };
 type Result_6 = variant { Ok : MigrationReport; Err : text };
 type Result_7 = variant { Ok; Err : text };
+type Result_8 = variant {
+  Ok : TopUpCyclesLedgerResponse;
+  Err : TopUpCyclesLedgerError;
+};
 type SelectedUtxosFeeError = variant {
   PendingTransactions;
   InternalError : record { msg : text };
@@ -187,6 +191,19 @@ type SupportedCredential = record {
   credential_type : CredentialType;
 };
 type Token = variant { Icrc : IcrcToken };
+type TopUpCyclesLedgerError = variant {
+  CouldNotGetBalanceFromCyclesLedger;
+  CouldNotTopUpCyclesLedger : record { tried_to_send : nat; available : nat };
+};
+type TopUpCyclesLedgerRequest = record {
+  threshold : opt nat;
+  percentage : opt nat8;
+};
+type TopUpCyclesLedgerResponse = record {
+  backend_cycles : nat;
+  ledger_balance : nat;
+  topped_up : nat;
+};
 type UserCredential = record {
   issuer : text;
   verified_date_timestamp : opt nat64;
@@ -236,4 +253,5 @@ service : (Arg) -> {
   set_user_token : (UserToken) -> ();
   stats : () -> (Stats) query;
   step_migration : () -> ();
+  top_up_cycles_ledger : (opt TopUpCyclesLedgerRequest) -> (Result_8);
 }

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -27,6 +27,7 @@ use shared::types::bitcoin::{
     SelectedUtxosFeeError, SelectedUtxosFeeRequest, SelectedUtxosFeeResponse,
 };
 use shared::types::custom_token::{CustomToken, CustomTokenId};
+use shared::types::signer::topup::{TopUpCyclesLedgerRequest, TopUpCyclesLedgerResult};
 use shared::types::token::{UserToken, UserTokenId};
 use shared::types::user_profile::{
     AddUserCredentialError, AddUserCredentialRequest, GetUserProfileError, ListUsersRequest,
@@ -35,10 +36,7 @@ use shared::types::user_profile::{
 use shared::types::{
     Arg, Config, Guards, InitArg, Migration, MigrationProgress, MigrationReport, Stats,
 };
-use signer::{
-    btc_principal_to_p2wpkh_address, AllowSigningError, TopUpCyclesLedgerRequest,
-    TopUpCyclesLedgerResult,
-};
+use signer::{btc_principal_to_p2wpkh_address, AllowSigningError};
 use std::cell::RefCell;
 use std::time::Duration;
 use types::{
@@ -57,7 +55,7 @@ mod heap_state;
 mod impls;
 mod migrate;
 mod oisy_user;
-mod signer;
+pub mod signer;
 mod state;
 mod token;
 mod types;

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -35,7 +35,10 @@ use shared::types::user_profile::{
 use shared::types::{
     Arg, Config, Guards, InitArg, Migration, MigrationProgress, MigrationReport, Stats,
 };
-use signer::{btc_principal_to_p2wpkh_address, AllowSigningError};
+use signer::{
+    btc_principal_to_p2wpkh_address, AllowSigningError, TopUpCyclesLedgerRequest,
+    TopUpCyclesLedgerResult,
+};
 use std::cell::RefCell;
 use std::time::Duration;
 use types::{
@@ -177,6 +180,17 @@ pub fn post_upgrade(arg: Option<Arg>) {
 #[must_use]
 pub fn config() -> Config {
     read_config(std::clone::Clone::clone)
+}
+
+/// Adds cycles to the cycles ledger, if it is below a certain threshold.
+///
+/// # Errors
+/// Error conditions are enumerated by: `TopUpCyclesLedgerError`
+#[update(guard = "caller_is_allowed")]
+pub async fn top_up_cycles_ledger(
+    request: Option<TopUpCyclesLedgerRequest>,
+) -> TopUpCyclesLedgerResult {
+    signer::top_up_cycles_ledger(request.unwrap_or_default()).await
 }
 
 /// Processes external HTTP requests.

--- a/src/backend/src/signer.rs
+++ b/src/backend/src/signer.rs
@@ -139,3 +139,54 @@ pub async fn btc_principal_to_p2wpkh_address(
         Err("Error getting P2WPKH from public key".to_string())
     }
 }
+
+/// A request to top up the cycles ledger.
+#[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+pub struct TopUpCyclesLedgerRequest {
+    /// If the cycles ledger account balance is below this threshold, top it up.
+    pub threshold: Option<Nat>,
+    /// The percentage of the backend canister's own cycles to send to the cycles ledger.
+    pub percentage: Option<u8>,
+}
+impl TopUpCyclesLedgerRequest {
+    pub fn threshold(&self) -> Nat {
+        self.threshold
+            .clone()
+            .unwrap_or(Nat::from(DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD))
+    }
+    pub fn percentage(&self) -> u8 {
+        self.percentage
+            .unwrap_or(DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE)
+    }
+}
+/// The default cycles ledger top up threshold.  If the cycles ledger balance falls below this, it should be topped up.
+pub const DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD: u128 = 10_000_000_000_000; // 10T
+/// The proportion of the backend canitster's own cycles to send to the cycles ledger.
+pub const DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE: u8 = 50;
+
+/// Possible error conditions when topping up the cycles ledger.
+#[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub enum TopUpCyclesLedgerError {
+    CouldNotGetBalanceFromCyclesLedger,
+    CouldNotTopUpCyclesLedger { available: Nat, tried_to_send: Nat },
+}
+/// Possible successful responses when topping up the cycles ledger.
+#[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct TopUpCyclesLedgerResponse {
+    /// The ledger balance after topping up.
+    ledger_balance: Nat,
+    /// The backend canister cycles after topping up.
+    backend_cycles: Nat,
+    /// The amount topped up.
+    /// - Zero if the ledger balance was already sufficient.
+    /// - The requested amount otherwise.
+    topped_up: Nat,
+}
+
+pub type TopUpCyclesLedgerResult = Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>;
+
+/// Tops up the cycles ledger.
+#[allow(clippy::unused_async)] // TODO: Remove once the code is implemented
+pub async fn top_up_cycles_ledger(request: TopUpCyclesLedgerRequest) -> TopUpCyclesLedgerResult {
+    todo!("Add code that tops up the cycles ledger per this request: {request:?}")
+}

--- a/src/backend/src/signer.rs
+++ b/src/backend/src/signer.rs
@@ -49,6 +49,9 @@ const fn per_user_cycles_allowance() -> u64 {
 /// Enables the user to sign transactions.
 ///
 /// Signing costs cycles.  Managing that cycle payment can be painful so we take care of that.
+/// 
+/// # Errors
+/// Errors are enumerated by: `AllowSigningError`
 pub async fn allow_signing() -> Result<(), AllowSigningError> {
     let cycles_ledger: Principal = *CYCLES_LEDGER;
     let signer: Principal = *SIGNER;
@@ -129,6 +132,9 @@ fn transform_network(network: BitcoinNetwork) -> Network {
 }
 
 /// Converts a public key to a P2PKH address.
+/// 
+/// # Errors
+/// - It was not possible to get the P2WPKH from the public key.
 pub async fn btc_principal_to_p2wpkh_address(
     network: BitcoinNetwork,
     principal: &Principal,

--- a/src/backend/src/signer.rs
+++ b/src/backend/src/signer.rs
@@ -12,6 +12,7 @@ use ic_cdk::api::management_canister::{
 use ic_cycles_ledger_client::{Account, ApproveArgs, ApproveError, Service as CyclesLedgerService};
 use ic_ledger_types::Subaccount;
 use serde_bytes::ByteBuf;
+use shared::types::signer::topup::{TopUpCyclesLedgerRequest, TopUpCyclesLedgerResult};
 
 #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub enum AllowSigningError {
@@ -140,52 +141,10 @@ pub async fn btc_principal_to_p2wpkh_address(
     }
 }
 
-/// A request to top up the cycles ledger.
-#[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
-pub struct TopUpCyclesLedgerRequest {
-    /// If the cycles ledger account balance is below this threshold, top it up.
-    pub threshold: Option<Nat>,
-    /// The percentage of the backend canister's own cycles to send to the cycles ledger.
-    pub percentage: Option<u8>,
-}
-impl TopUpCyclesLedgerRequest {
-    pub fn threshold(&self) -> Nat {
-        self.threshold
-            .clone()
-            .unwrap_or(Nat::from(DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD))
-    }
-    pub fn percentage(&self) -> u8 {
-        self.percentage
-            .unwrap_or(DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE)
-    }
-}
-/// The default cycles ledger top up threshold.  If the cycles ledger balance falls below this, it should be topped up.
-pub const DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD: u128 = 10_000_000_000_000; // 10T
-/// The proportion of the backend canitster's own cycles to send to the cycles ledger.
-pub const DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE: u8 = 50;
-
-/// Possible error conditions when topping up the cycles ledger.
-#[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
-pub enum TopUpCyclesLedgerError {
-    CouldNotGetBalanceFromCyclesLedger,
-    CouldNotTopUpCyclesLedger { available: Nat, tried_to_send: Nat },
-}
-/// Possible successful responses when topping up the cycles ledger.
-#[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct TopUpCyclesLedgerResponse {
-    /// The ledger balance after topping up.
-    ledger_balance: Nat,
-    /// The backend canister cycles after topping up.
-    backend_cycles: Nat,
-    /// The amount topped up.
-    /// - Zero if the ledger balance was already sufficient.
-    /// - The requested amount otherwise.
-    topped_up: Nat,
-}
-
-pub type TopUpCyclesLedgerResult = Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>;
-
 /// Tops up the cycles ledger.
+/// 
+/// # Errors
+/// Errors are enumerated by: `TopUpCyclesLedgerError`
 #[allow(clippy::unused_async)] // TODO: Remove once the code is implemented
 pub async fn top_up_cycles_ledger(request: TopUpCyclesLedgerRequest) -> TopUpCyclesLedgerResult {
     todo!("Add code that tops up the cycles ledger per this request: {request:?}")

--- a/src/backend/src/signer.rs
+++ b/src/backend/src/signer.rs
@@ -49,7 +49,7 @@ const fn per_user_cycles_allowance() -> u64 {
 /// Enables the user to sign transactions.
 ///
 /// Signing costs cycles.  Managing that cycle payment can be painful so we take care of that.
-/// 
+///
 /// # Errors
 /// Errors are enumerated by: `AllowSigningError`
 pub async fn allow_signing() -> Result<(), AllowSigningError> {
@@ -132,7 +132,7 @@ fn transform_network(network: BitcoinNetwork) -> Network {
 }
 
 /// Converts a public key to a P2PKH address.
-/// 
+///
 /// # Errors
 /// - It was not possible to get the P2WPKH from the public key.
 pub async fn btc_principal_to_p2wpkh_address(
@@ -148,7 +148,7 @@ pub async fn btc_principal_to_p2wpkh_address(
 }
 
 /// Tops up the cycles ledger.
-/// 
+///
 /// # Errors
 /// Errors are enumerated by: `TopUpCyclesLedgerError`
 #[allow(clippy::unused_async)] // TODO: Remove once the code is implemented

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -4,6 +4,7 @@ mod custom_token;
 mod guard;
 mod list_users;
 mod migration;
+mod signer;
 mod stats;
 mod token;
 mod upgrade;

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -1,0 +1,18 @@
+//! Tests the ledger account logic.
+
+use crate::utils::pocketic::pic_canister::PicCanisterTrait;
+use crate::utils::{mock::VC_HOLDER, pocketic::setup};
+use candid::Principal;
+use shared::types::signer::topup::TopUpCyclesLedgerResponse;
+
+#[test]
+fn test_list_users_cannot_be_called_if_not_allowed() {
+    let pic_setup = setup();
+    // A random unauthorized user.
+    let caller = Principal::from_text(VC_HOLDER).unwrap();
+
+    let response =
+        pic_setup.update::<TopUpCyclesLedgerResponse>(caller, "top_up_cycles_ledger", ());
+
+    assert!(response.is_err(),);
+}

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -6,7 +6,7 @@ use candid::Principal;
 use shared::types::signer::topup::TopUpCyclesLedgerResponse;
 
 #[test]
-fn test_list_users_cannot_be_called_if_not_allowed() {
+fn test_topup_cannot_be_called_if_not_allowed() {
     let pic_setup = setup();
     // A random unauthorized user.
     let caller = Principal::from_text(VC_HOLDER).unwrap();

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -160,6 +160,10 @@ type Result_4 = variant {
 type Result_5 = variant { Ok : UserProfile; Err : GetUserProfileError };
 type Result_6 = variant { Ok : MigrationReport; Err : text };
 type Result_7 = variant { Ok; Err : text };
+type Result_8 = variant {
+  Ok : TopUpCyclesLedgerResponse;
+  Err : TopUpCyclesLedgerError;
+};
 type SelectedUtxosFeeError = variant {
   PendingTransactions;
   InternalError : record { msg : text };
@@ -187,6 +191,19 @@ type SupportedCredential = record {
   credential_type : CredentialType;
 };
 type Token = variant { Icrc : IcrcToken };
+type TopUpCyclesLedgerError = variant {
+  CouldNotGetBalanceFromCyclesLedger;
+  CouldNotTopUpCyclesLedger : record { tried_to_send : nat; available : nat };
+};
+type TopUpCyclesLedgerRequest = record {
+  threshold : opt nat;
+  percentage : opt nat8;
+};
+type TopUpCyclesLedgerResponse = record {
+  backend_cycles : nat;
+  ledger_balance : nat;
+  topped_up : nat;
+};
 type UserCredential = record {
   issuer : text;
   verified_date_timestamp : opt nat64;
@@ -236,4 +253,5 @@ service : (Arg) -> {
   set_user_token : (UserToken) -> ();
   stats : () -> (Stats) query;
   step_migration : () -> ();
+  top_up_cycles_ledger : (opt TopUpCyclesLedgerRequest) -> (Result_8);
 }

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -174,6 +174,7 @@ export type Result_4 = { Ok: SelectedUtxosFeeResponse } | { Err: SelectedUtxosFe
 export type Result_5 = { Ok: UserProfile } | { Err: GetUserProfileError };
 export type Result_6 = { Ok: MigrationReport } | { Err: string };
 export type Result_7 = { Ok: null } | { Err: string };
+export type Result_8 = { Ok: TopUpCyclesLedgerResponse } | { Err: TopUpCyclesLedgerError };
 export type SelectedUtxosFeeError =
 	| { PendingTransactions: null }
 	| { InternalError: { msg: string } };
@@ -200,6 +201,25 @@ export interface SupportedCredential {
 	credential_type: CredentialType;
 }
 export type Token = { Icrc: IcrcToken };
+export type TopUpCyclesLedgerError =
+	| {
+			CouldNotGetBalanceFromCyclesLedger: null;
+	  }
+	| {
+			CouldNotTopUpCyclesLedger: {
+				tried_to_send: bigint;
+				available: bigint;
+			};
+	  };
+export interface TopUpCyclesLedgerRequest {
+	threshold: [] | [bigint];
+	percentage: [] | [number];
+}
+export interface TopUpCyclesLedgerResponse {
+	backend_cycles: bigint;
+	ledger_balance: bigint;
+	topped_up: bigint;
+}
 export interface UserCredential {
 	issuer: string;
 	verified_date_timestamp: [] | [bigint];
@@ -254,6 +274,7 @@ export interface _SERVICE {
 	set_user_token: ActorMethod<[UserToken], undefined>;
 	stats: ActorMethod<[], Stats>;
 	step_migration: ActorMethod<[], undefined>;
+	top_up_cycles_ledger: ActorMethod<[[] | [TopUpCyclesLedgerRequest]], Result_8>;
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -256,6 +256,26 @@ export const idlFactory = ({ IDL }) => {
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
 	});
+	const TopUpCyclesLedgerRequest = IDL.Record({
+		threshold: IDL.Opt(IDL.Nat),
+		percentage: IDL.Opt(IDL.Nat8)
+	});
+	const TopUpCyclesLedgerResponse = IDL.Record({
+		backend_cycles: IDL.Nat,
+		ledger_balance: IDL.Nat,
+		topped_up: IDL.Nat
+	});
+	const TopUpCyclesLedgerError = IDL.Variant({
+		CouldNotGetBalanceFromCyclesLedger: IDL.Null,
+		CouldNotTopUpCyclesLedger: IDL.Record({
+			tried_to_send: IDL.Nat,
+			available: IDL.Nat
+		})
+	});
+	const Result_8 = IDL.Variant({
+		Ok: TopUpCyclesLedgerResponse,
+		Err: TopUpCyclesLedgerError
+	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
 		allow_signing: IDL.Func([], [Result_1], []),
@@ -281,7 +301,8 @@ export const idlFactory = ({ IDL }) => {
 		set_many_user_tokens: IDL.Func([IDL.Vec(UserToken)], [], []),
 		set_user_token: IDL.Func([UserToken], [], []),
 		stats: IDL.Func([], [Stats]),
-		step_migration: IDL.Func([], [], [])
+		step_migration: IDL.Func([], [], []),
+		top_up_cycles_ledger: IDL.Func([IDL.Opt(TopUpCyclesLedgerRequest)], [Result_8], [])
 	});
 };
 // @ts-ignore

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -256,6 +256,26 @@ export const idlFactory = ({ IDL }) => {
 		chain_id: IDL.Nat64,
 		contract_address: IDL.Text
 	});
+	const TopUpCyclesLedgerRequest = IDL.Record({
+		threshold: IDL.Opt(IDL.Nat),
+		percentage: IDL.Opt(IDL.Nat8)
+	});
+	const TopUpCyclesLedgerResponse = IDL.Record({
+		backend_cycles: IDL.Nat,
+		ledger_balance: IDL.Nat,
+		topped_up: IDL.Nat
+	});
+	const TopUpCyclesLedgerError = IDL.Variant({
+		CouldNotGetBalanceFromCyclesLedger: IDL.Null,
+		CouldNotTopUpCyclesLedger: IDL.Record({
+			tried_to_send: IDL.Nat,
+			available: IDL.Nat
+		})
+	});
+	const Result_8 = IDL.Variant({
+		Ok: TopUpCyclesLedgerResponse,
+		Err: TopUpCyclesLedgerError
+	});
 	return IDL.Service({
 		add_user_credential: IDL.Func([AddUserCredentialRequest], [Result], []),
 		allow_signing: IDL.Func([], [Result_1], []),
@@ -281,7 +301,8 @@ export const idlFactory = ({ IDL }) => {
 		set_many_user_tokens: IDL.Func([IDL.Vec(UserToken)], [], []),
 		set_user_token: IDL.Func([UserToken], [], []),
 		stats: IDL.Func([], [Stats], ['query']),
-		step_migration: IDL.Func([], [], [])
+		step_migration: IDL.Func([], [], []),
+		top_up_cycles_ledger: IDL.Func([IDL.Opt(TopUpCyclesLedgerRequest)], [Result_8], [])
 	});
 };
 // @ts-ignore


### PR DESCRIPTION
# Motivation
We need to automatically top up the oisy cycles ledger account.

We do this by having an API method on the backend canister that tops up the account.  The method can be called by canister controllers or automatically on a timer.

# Changes
- Define (but do not implement) an API method to  top up the ledger canister.
  - Implementation is omitted to keep the PRs small.
- Update the candid file and bindings.

# Tests
CI has an existing test to verify that the bindings are up to date.