### PR TITLE
refactor(frontend): rename ETH transaction modal store

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -67,7 +67,7 @@
 </script>
 
 <Transaction
-	on:click={() => modalStore.openTransaction(transaction)}
+	on:click={() => modalStore.openEthTransaction(transaction)}
 	{amount}
 	{type}
 	timestamp={transactionDate}

--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -16,7 +16,7 @@
 	import Header from '$lib/components/ui/Header.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
-	import { modalToken, modalTransaction } from '$lib/derived/modal.derived';
+	import { modalToken, modalEthTransaction } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionEthAddress } from '$lib/types/address';
@@ -38,7 +38,7 @@
 	);
 
 	let selectedTransaction: TransactionType | undefined;
-	$: selectedTransaction = $modalTransaction
+	$: selectedTransaction = $modalEthTransaction
 		? ($modalStore?.data as TransactionType | undefined)
 		: undefined;
 </script>
@@ -59,7 +59,7 @@
 	</EthTransactionsSkeletons>
 </LoaderEthTransactions>
 
-{#if $modalTransaction && nonNullish(selectedTransaction)}
+{#if $modalEthTransaction && nonNullish(selectedTransaction)}
 	<EthTransactionModal transaction={selectedTransaction} />
 {:else if $modalToken}
 	<TokenModal />

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -9,6 +9,8 @@
 		isNetworkIdEthereum,
 		isNetworkIdICP
 	} from '$lib/utils/network.utils';
+	import { nonNullish } from '@dfinity/utils';
+	import BtcTransactionModal from '$btc/components/transactions/BtcTransactionModal.svelte';
 
 	let transactions: AllTransactionsUi;
 	// TODO: extract the function to a separate util

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -9,8 +9,6 @@
 		isNetworkIdEthereum,
 		isNetworkIdICP
 	} from '$lib/utils/network.utils';
-	import { nonNullish } from '@dfinity/utils';
-	import BtcTransactionModal from '$btc/components/transactions/BtcTransactionModal.svelte';
 
 	let transactions: AllTransactionsUi;
 	// TODO: extract the function to a separate util

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -69,9 +69,9 @@ export const modalWalletConnectSend: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'wallet-connect-send'
 );
-export const modalTransaction: Readable<boolean> = derived(
+export const modalEthTransaction: Readable<boolean> = derived(
 	modalStore,
-	($modalStore) => $modalStore?.type === 'transaction'
+	($modalStore) => $modalStore?.type === 'eth-transaction'
 );
 export const modalIcTransaction: Readable<boolean> = derived(
 	modalStore,

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -20,7 +20,7 @@ export interface Modal<T> {
 		| 'wallet-connect-auth'
 		| 'wallet-connect-sign'
 		| 'wallet-connect-send'
-		| 'transaction'
+		| 'eth-transaction'
 		| 'ic-transaction'
 		| 'manage-tokens'
 		| 'hide-token'
@@ -54,7 +54,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openWalletConnectAuth: () => void;
 	openWalletConnectSign: <D extends T>(data: D) => void;
 	openWalletConnectSend: <D extends T>(data: D) => void;
-	openTransaction: <D extends T>(data: D) => void;
+	openEthTransaction: <D extends T>(data: D) => void;
 	openIcTransaction: <D extends T>(data: D) => void;
 	openBtcTransaction: <D extends T>(data: D) => void;
 	openManageTokens: () => void;
@@ -89,7 +89,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openWalletConnectAuth: () => set({ type: 'wallet-connect-auth' }),
 		openWalletConnectSign: <D extends T>(data: D) => set({ type: 'wallet-connect-sign', data }),
 		openWalletConnectSend: <D extends T>(data: D) => set({ type: 'wallet-connect-send', data }),
-		openTransaction: <D extends T>(data: D) => set({ type: 'transaction', data }),
+		openEthTransaction: <D extends T>(data: D) => set({ type: 'eth-transaction', data }),
 		openIcTransaction: <D extends T>(data: D) => set({ type: 'ic-transaction', data }),
 		openBtcTransaction: <D extends T>(data: D) => set({ type: 'btc-transaction', data }),
 		openManageTokens: () => set({ type: 'manage-tokens' }),


### PR DESCRIPTION
# Motivation

For consistency, we rename all variables related to Ethereum transaction modal store.
