### PR TITLE
feat(frontend): remove unnecessary param from the utxos service

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -10,7 +10,6 @@
 	} from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import SendReview from '$lib/components/send/SendReview.svelte';
-	import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 	import type { NetworkId } from '$lib/types/network';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
@@ -20,7 +19,6 @@
 	export let networkId: NetworkId | undefined = undefined;
 	export let source: string;
 	export let utxosFee: UtxosFee | undefined = undefined;
-	export let progress: (step: ProgressStepsSendBtc) => void;
 
 	let hasPendingTransactionsStore: Readable<BtcPendingSentTransactionsStatus>;
 	$: hasPendingTransactionsStore = initPendingSentTransactionsStatus(source);
@@ -45,7 +43,7 @@
 <SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
 	<BtcReviewNetwork {networkId} slot="network" />
 
-	<BtcUtxosFee slot="fee" bind:utxosFee {progress} {networkId} {amount} />
+	<BtcUtxosFee slot="fee" bind:utxosFee {networkId} {amount} />
 
 	<BtcSendWarnings
 		slot="info"

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -135,7 +135,6 @@
 		on:icBack
 		on:icSend={send}
 		bind:utxosFee
-		{progress}
 		{destination}
 		{amount}
 		{networkId}

--- a/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
@@ -8,7 +8,6 @@
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { toastsError } from '$lib/stores/toasts.store';
@@ -19,7 +18,6 @@
 	export let utxosFee: UtxosFee | undefined = undefined;
 	export let amount: number | undefined = undefined;
 	export let networkId: NetworkId | undefined = undefined;
-	export let progress: (step: ProgressStepsSendBtc) => void;
 
 	const { sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
@@ -38,7 +36,6 @@
 				? await selectUtxosFeeApi({
 						amount,
 						network,
-						progress,
 						identity: $authIdentity
 					})
 				: undefined;

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -30,7 +30,7 @@ export const selectUtxosFee = async ({
 	identity,
 	network,
 	amount
-}: BtcSendServiceParams): Promise<UtxosFee> => {
+}: Omit<BtcSendServiceParams, 'progress'>): Promise<UtxosFee> => {
 	const satoshisAmount = convertNumberToSatoshis({ amount });
 	const signerBitcoinNetwork = mapToSignerBitcoinNetwork({ network });
 


### PR DESCRIPTION
# Motivation

"progress" was required but never used in that service. This popped up when I started reusing this method in the conversion flow.
