### PR TITLE
feat(frontend): ConvertNetwork component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertNetwork.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertNetwork.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import ConvertValue from '$lib/components/convert/ConvertValue.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import { i18n } from '$lib/stores/i18n.store.js';
+	import type { Token } from '$lib/types/token';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
+
+	export let token: Token;
+</script>
+
+<ConvertValue>
+	<slot slot="label" name="label" />
+
+	<div class="flex" slot="main-value">
+		<Logo
+			color="off-white"
+			src={token.network.iconBW}
+			alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.network.name })}
+		/><span class="ml-2">{token.network.name}</span>
+	</div>
+</ConvertValue>


### PR DESCRIPTION
# Motivation

`ConvertNetwork` component in action for both source and destination tokens:

<img width="192" alt="Screenshot 2024-11-12 at 18 36 19" src="https://github.com/user-attachments/assets/7b5dbfed-dcd4-4b51-98e5-4672f8c42b5d">
