### PR TITLE
feat(frontend): ConvertAmountExchange component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
@@ -3,8 +3,10 @@
 	import { fade } from 'svelte/transition';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { formatUSD } from '$lib/utils/format.utils';
+
 	export let amount: number | undefined = undefined;
 	export let exchangeRate: number | undefined = undefined;
+
 	let usdValue: string | undefined;
 	$: usdValue =
 		nonNullish(amount) && nonNullish(exchangeRate)

--- a/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
@@ -17,11 +17,11 @@
 </script>
 
 {#if nonNullish(usdValue)}
-	<div in:fade>
+	<div in:fade data-tid="convert-amount-exchange">
 		{`${nonNullish(amount) && amount === 0 ? '' : '~'}`}{usdValue}
 	</div>
 {:else}
-	<div class="w-10 sm:w-8">
+	<div class="w-10 sm:w-8" data-tid="convert-amount-exchange-skeleton">
 		<SkeletonText />
 	</div>
 {/if}

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
@@ -1,6 +1,4 @@
 import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
-import { formatUSD } from '$lib/utils/format.utils';
-import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
 
 describe('ConvertAmountExchange', () => {
@@ -12,56 +10,34 @@ describe('ConvertAmountExchange', () => {
 		exchangeRate
 	};
 
-	const divSelector = 'div[data-tid="convert-amount-exchange"]';
-	const skeletonSelector = 'div[data-tid="convert-amount-exchange-skeleton"]';
+	const divTestId = 'convert-amount-exchange';
+	const skeletonTestId = 'convert-amount-exchange-skeleton';
 
-	it('should display value with tilde sign if amount is provided', () => {
-		const { container, getByText } = render(ConvertAmountExchange, { props });
+	it('should display correct value if amount is provided', () => {
+		const { getByTestId } = render(ConvertAmountExchange, { props });
 
-		const div: HTMLDivElement | null = container.querySelector(divSelector);
-		assertNonNullish(div, 'Div not found');
-
-		expect(
-			getByText(
-				`~${formatUSD({
-					value: amount * exchangeRate
-				})}`
-			)
-		).toBeInTheDocument();
+		expect(getByTestId(divTestId)).toHaveTextContent('~$0.20');
 	});
 
-	it('should display value without tilde sign if amount is zero', () => {
-		const { container, getByText } = render(ConvertAmountExchange, {
+	it('should display correct value if amount is zero', () => {
+		const { getByTestId } = render(ConvertAmountExchange, {
 			props: { ...props, amount: 0 }
 		});
 
-		const div: HTMLDivElement | null = container.querySelector(divSelector);
-		assertNonNullish(div, 'Div not found');
-
-		expect(
-			getByText(
-				formatUSD({
-					value: 0
-				})
-			)
-		).toBeInTheDocument();
+		expect(getByTestId(divTestId)).toHaveTextContent('$0.00');
 	});
 
 	it('should display skeleton if amount is not provided', () => {
 		const { amount: _, ...newProps } = props;
-		const { container } = render(ConvertAmountExchange, { props: newProps });
+		const { getByTestId } = render(ConvertAmountExchange, { props: newProps });
 
-		const skeleton: HTMLDivElement | null = container.querySelector(skeletonSelector);
-
-		expect(skeleton).toBeInTheDocument();
+		expect(getByTestId(skeletonTestId)).toBeInTheDocument();
 	});
 
 	it('should display skeleton if exchange rate is not provided', () => {
 		const { exchangeRate: _, ...newProps } = props;
-		const { container } = render(ConvertAmountExchange, { props: newProps });
+		const { getByTestId } = render(ConvertAmountExchange, { props: newProps });
 
-		const skeleton: HTMLDivElement | null = container.querySelector(skeletonSelector);
-
-		expect(skeleton).toBeInTheDocument();
+		expect(getByTestId(skeletonTestId)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
@@ -1,0 +1,67 @@
+import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
+import { formatUSD } from '$lib/utils/format.utils';
+import { assertNonNullish } from '@dfinity/utils';
+import { render } from '@testing-library/svelte';
+
+describe('ConvertAmountExchange', () => {
+	const amount = 20.25;
+	const exchangeRate = 0.01;
+
+	const props = {
+		amount,
+		exchangeRate
+	};
+
+	const divSelector = 'div[data-tid="convert-amount-exchange"]';
+	const skeletonSelector = 'div[data-tid="convert-amount-exchange-skeleton"]';
+
+	it('should display value with tilde sign if amount is provided', () => {
+		const { container, getByText } = render(ConvertAmountExchange, { props });
+
+		const div: HTMLDivElement | null = container.querySelector(divSelector);
+		assertNonNullish(div, 'Div not found');
+
+		expect(
+			getByText(
+				`~${formatUSD({
+					value: amount * exchangeRate
+				})}`
+			)
+		).toBeInTheDocument();
+	});
+
+	it('should display value without tilde sign if amount is zero', () => {
+		const { container, getByText } = render(ConvertAmountExchange, {
+			props: { ...props, amount: 0 }
+		});
+
+		const div: HTMLDivElement | null = container.querySelector(divSelector);
+		assertNonNullish(div, 'Div not found');
+
+		expect(
+			getByText(
+				formatUSD({
+					value: 0
+				})
+			)
+		).toBeInTheDocument();
+	});
+
+	it('should display skeleton if amount is not provided', () => {
+		const { amount: _, ...newProps } = props;
+		const { container } = render(ConvertAmountExchange, { props: newProps });
+
+		const skeleton: HTMLDivElement | null = container.querySelector(skeletonSelector);
+
+		expect(skeleton).toBeInTheDocument();
+	});
+
+	it('should display skeleton if exchange rate is not provided', () => {
+		const { exchangeRate: _, ...newProps } = props;
+		const { container } = render(ConvertAmountExchange, { props: newProps });
+
+		const skeleton: HTMLDivElement | null = container.querySelector(skeletonSelector);
+
+		expect(skeleton).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

`ConvertAmountExchange` component in action (when some of the values is undefined, just a regular skeleton will be shown):

<img width="78" alt="Screenshot 2024-11-12 at 18 40 11" src="https://github.com/user-attachments/assets/574afa51-f5da-4bd4-9e85-d3131829c1bd">
