### PR TITLE
refactor(frontend): simplify component RoundedIcon

### DIFF
--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -6,6 +6,6 @@
 </script>
 
 <div class="relative">
-	<div class="rounded-full bg-brand-subtle-alt" style={`width: 2.9rem; aspect-ratio: 1/1;`} />
+	<div class="aspect-square w-12 rounded-full bg-brand-subtle-alt" />
 	<svelte:component this={icon} styleClass={`inset-center ${iconStyleClass}`} />
 </div>

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -2,16 +2,13 @@
 	import type { ComponentType } from 'svelte';
 
 	export let icon: ComponentType;
-	export let iconSize = '2.9rem';
-	export let backgroundStyleClass = 'bg-brand-subtle-alt';
 	export let iconStyleClass = '';
-	export let additionalStyleClass = '';
 </script>
 
 <div class="relative">
 	<div
-		class={`rounded-full ${backgroundStyleClass}`}
-		style={`width: ${iconSize}; aspect-ratio: 1/1; ${additionalStyleClass}`}
+		class="rounded-full bg-brand-subtle-alt"
+		style={`width: 2.9rem; aspect-ratio: 1/1;`}
 	/>
 	<svelte:component this={icon} styleClass={`inset-center ${iconStyleClass}`} />
 </div>

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -6,9 +6,6 @@
 </script>
 
 <div class="relative">
-	<div
-		class="rounded-full bg-brand-subtle-alt"
-		style={`width: 2.9rem; aspect-ratio: 1/1;`}
-	/>
+	<div class="rounded-full bg-brand-subtle-alt" style={`width: 2.9rem; aspect-ratio: 1/1;`} />
 	<svelte:component this={icon} styleClass={`inset-center ${iconStyleClass}`} />
 </div>


### PR DESCRIPTION
# Motivation

Maybe this PR is not required, but I wanted to check if there are any objections when removing some props from `RoundedIcon`. 

Being a UI component, maybe it is good to have customizable props, but they are really not used for now.

Additionally, we replace `style` with Tailwind classes.
