### PR TITLE
refactor(frontend): replace CSS class text primary with mapped colors

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectButton.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectButton.svelte
@@ -10,7 +10,7 @@
 	aria-label={ariaLabel}
 	on:click
 	in:fade
-	class="tertiary text-primary h-10"
+	class="tertiary h-10 text-brand-primary"
 	class:icon={!$$slots.default}
 	disabled={$ethAddressNotLoaded}
 >

--- a/src/frontend/src/lib/components/about/AboutItem.svelte
+++ b/src/frontend/src/lib/components/about/AboutItem.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <button
-	class={asMenuItem ? 'text' : 'text-primary whitespace-nowrap text-center font-bold'}
+	class={asMenuItem ? 'text' : 'whitespace-nowrap text-center font-bold text-brand-primary'}
 	on:click
 	data-tid={testId}
 >

--- a/src/frontend/src/lib/components/common/MaxButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxButton.svelte
@@ -9,7 +9,7 @@
 	data-tid={MAX_BUTTON}
 	type="button"
 	on:click|preventDefault
-	class="text-primary font-medium hover:text-inherit active:text-inherit"
+	class="font-medium text-brand-primary hover:text-inherit active:text-inherit"
 	{disabled}
 	class:opacity-50={disabled}
 >

--- a/src/frontend/src/lib/components/common/QRButton.svelte
+++ b/src/frontend/src/lib/components/common/QRButton.svelte
@@ -8,7 +8,7 @@
 	data-tid="qr-code-scanner-button"
 	on:click|preventDefault
 	aria-label={$i18n.send.text.open_qr_modal}
-	class="text-primary hover:text-inherit active:text-inherit"
+	class="text-brand-primary hover:text-inherit active:text-inherit"
 >
 	<IconQRCodeScanner />
 </button>

--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -18,7 +18,9 @@
 </script>
 
 <button
-	class={`text-${color} pointer-events-auto flex gap-0.5 font-bold`}
+	class="pointer-events-auto flex gap-0.5 font-bold"
+	class:text-current={color === 'current'}
+	class:text-brand-primary={color === 'primary'}
 	class:icon={onlyArrow}
 	on:click={() => back({ pop: nonNullish(fromRoute) })}
 	aria-label={$i18n.core.alt.back}

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -30,7 +30,7 @@
 				modalStore.openDappDetails(dappsCarouselSlide);
 			}}
 			aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: dAppName })}
-			class="text-primary text-sm font-semibold"
+			class="text-sm font-semibold text-brand-primary"
 		>
 			{callToAction} →
 		</button>

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -26,7 +26,7 @@
 <div class="flex flex-col items-center text-center md:items-start md:text-left">
 	<div class="mb-7 mt-5 pt-2">
 		<h1 class="text-4xl md:text-5xl md:leading-tight">
-			{$i18n.auth.text.title_part_1}<br /><span class="text-primary"
+			{$i18n.auth.text.title_part_1}<br /><span class="text-brand-primary"
 				>{$i18n.auth.text.title_part_2}</span
 			>
 		</h1>

--- a/src/frontend/src/lib/components/icons/IconAstronautHelmet.svelte
+++ b/src/frontend/src/lib/components/icons/IconAstronautHelmet.svelte
@@ -1,6 +1,6 @@
 <!-- source: DFINITY foundation -->
 <svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<g class="text-primary">
+	<g class="text-brand-primary">
 		<circle cx="22" cy="22" r="22" fill="currentColor" />
 	</g>
 	<path

--- a/src/frontend/src/lib/components/ui/Copy.svelte
+++ b/src/frontend/src/lib/components/ui/Copy.svelte
@@ -17,7 +17,7 @@
 	data-tid={testId}
 	class:py-2={!inline}
 	class:inline-block={inline}
-	class:text-primary={color === 'blue'}
+	class:text-brand-primary={color === 'blue'}
 	class:hover:text-inherit={color === 'blue'}
 	class:active:text-inherit={color === 'blue'}
 	style={`${inline ? 'vertical-align: sub;' : ''}`}

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -18,7 +18,7 @@
 	class="inline-flex items-center gap-2 no-underline {styleClass}"
 	aria-label={ariaLabel}
 	style={`${inline ? 'vertical-align: sub;' : ''}`}
-	class:text-primary={color === 'blue'}
+	class:text-brand-primary={color === 'blue'}
 	class:hover:text-inherit={color === 'blue'}
 	class:active:text-inherit={color === 'blue'}
 	class:hover:text-brand-primary={color === 'inherit'}

--- a/src/frontend/src/lib/styles/global/text.scss
+++ b/src/frontend/src/lib/styles/global/text.scss
@@ -8,10 +8,6 @@
 	@include text.clamp(2);
 }
 
-.text-primary {
-	color: var(--color-primary);
-}
-
 .text-secondary {
 	color: var(--color-secondary);
 }


### PR DESCRIPTION
# Motivation

The custom CSS class `text-primary` was still using the definition of primary color that was not the one according to new mapping colors. We replace it.
