### PR TITLE
refactor(frontend): rename fn to initIcpWalletTransactionsScheduler

### DIFF
--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -33,7 +33,7 @@ const mapTransaction = ({
 }): IcTransactionUi => mapIcpTransaction({ transaction, identity });
 
 // Exposed for test purposes
-export const initIcpWalletScheduler = (): IcWalletTransactionsScheduler<
+export const initIcpWalletTransactionsScheduler = (): IcWalletTransactionsScheduler<
 	Transaction,
 	TransactionWithId,
 	PostMessageDataRequest
@@ -45,7 +45,7 @@ export const initIcpWalletScheduler = (): IcWalletTransactionsScheduler<
 		'syncIcpWallet'
 	);
 
-const scheduler = initIcpWalletScheduler();
+const scheduler = initIcpWalletTransactionsScheduler();
 
 onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;

--- a/src/frontend/src/tests/icp/workers/ic-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet.worker.spec.ts
@@ -2,7 +2,7 @@ import type { IcWalletTransactionsScheduler } from '$icp/schedulers/ic-wallet-tr
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { mapIcpTransaction } from '$icp/utils/icp-transactions.utils';
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
-import { initIcpWalletScheduler } from '$icp/workers/icp-wallet.worker';
+import { initIcpWalletTransactionsScheduler } from '$icp/workers/icp-wallet.worker';
 import { initIcrcWalletScheduler } from '$icp/workers/icrc-wallet.worker';
 import * as agent from '$lib/actors/agents.ic';
 import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
@@ -313,7 +313,7 @@ describe('ic-wallet.worker', () => {
 			const err = new Error('test');
 			initErrorMock(err);
 
-			const scheduler = initIcpWalletScheduler();
+			const scheduler = initIcpWalletTransactionsScheduler();
 			await scheduler.start(undefined);
 
 			// idle and in_progress
@@ -371,7 +371,7 @@ describe('ic-wallet.worker', () => {
 
 			initWithTransactions({
 				msg: 'syncIcpWallet',
-				initScheduler: initIcpWalletScheduler,
+				initScheduler: initIcpWalletTransactionsScheduler,
 				transaction: mockMappedTransaction
 			});
 		});
@@ -385,7 +385,7 @@ describe('ic-wallet.worker', () => {
 				});
 			});
 
-			initWithoutTransactions({ msg: 'syncIcpWallet', initScheduler: initIcpWalletScheduler });
+			initWithoutTransactions({ msg: 'syncIcpWallet', initScheduler: initIcpWalletTransactionsScheduler });
 		});
 
 		describe('other scenarios', () => {
@@ -411,7 +411,7 @@ describe('ic-wallet.worker', () => {
 				indexCanisterMock.getTransactions.mockRejectedValue(err);
 
 			initOtherScenarios({
-				initScheduler: initIcpWalletScheduler,
+				initScheduler: initIcpWalletTransactionsScheduler,
 				initCleanupMock,
 				initErrorMock,
 				msg: 'syncIcpWallet'

--- a/src/frontend/src/tests/icp/workers/ic-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet.worker.spec.ts
@@ -385,7 +385,10 @@ describe('ic-wallet.worker', () => {
 				});
 			});
 
-			initWithoutTransactions({ msg: 'syncIcpWallet', initScheduler: initIcpWalletTransactionsScheduler });
+			initWithoutTransactions({
+				msg: 'syncIcpWallet',
+				initScheduler: initIcpWalletTransactionsScheduler
+			});
 		});
 
 		describe('other scenarios', () => {


### PR DESCRIPTION
# Motivation

Even though we won't support "balance" only for ICP, let's rename the init scheduler with "transactions" anyway.
