### PR TITLE
feat(frontend): add custom token without index canister

### DIFF
--- a/src/frontend/src/icp-eth/types/add-token.ts
+++ b/src/frontend/src/icp-eth/types/add-token.ts
@@ -6,7 +6,7 @@ export interface Erc20AddTokenData {
 
 export interface IcAddTokenData {
 	ledgerCanisterId: string;
-	indexCanisterId: string;
+	indexCanisterId: string | undefined;
 }
 
 export type AddTokenData = Either<Erc20AddTokenData, IcAddTokenData>;

--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import InputText from '$lib/components/ui/InputText.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -8,20 +7,11 @@
 	export let indexCanisterId = '';
 </script>
 
-<p class="mb-2 mt-1">{replaceOisyPlaceholders($i18n.tokens.import.text.info)}</p>
-
-<p class="mb-4 font-bold text-brand-primary">
-	<ExternalLink
-		href="https://github.com/dfinity/oisy-wallet/blob/main/HOW-TO.md#custom-icrc-token-integration"
-		ariaLabel={$i18n.tokens.import.text.open_github_howto}
-	>
-		{$i18n.tokens.import.text.github_howto}
-	</ExternalLink>
-</p>
-
 <div class="stretch">
+	<p class="mb-6">{$i18n.tokens.import.text.info}</p>
+
 	<label for="ledgerCanisterId" class="px-4.5 font-bold"
-		>{$i18n.tokens.import.text.ledger_canister_id}:</label
+		>{$i18n.tokens.import.text.ledger_canister_id}: <span class="text-blue-ribbon">*</span></label
 	>
 	<InputText
 		name="ledgerCanisterId"
@@ -29,12 +19,15 @@
 		placeholder="_____-_____-_____-_____-cai"
 	/>
 
-	<label for="indexCanisterId" class="px-4.5 font-bold"
+	<label for="indexCanisterId" class="px-4.5 mt-6 block font-bold"
 		>{$i18n.tokens.import.text.index_canister_id}:</label
 	>
 	<InputText
 		name="indexCanisterId"
 		bind:value={indexCanisterId}
 		placeholder="_____-_____-_____-_____-cai"
+		required={false}
 	/>
+
+	<p class="mb-6">{replaceOisyPlaceholders($i18n.tokens.import.text.info_index)}</p>
 </div>

--- a/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenReview.svelte
@@ -86,10 +86,14 @@
 				{token.token.ledgerCanisterId}
 			</Value>
 
-			<Value ref="ledgerId" element="div">
-				<svelte:fragment slot="label">{$i18n.tokens.import.text.index_canister_id}</svelte:fragment>
-				{token.token.indexCanisterId}
-			</Value>
+			{#if nonNullish(indexCanisterId)}
+				<Value ref="indexId" element="div">
+					<svelte:fragment slot="label"
+						>{$i18n.tokens.import.text.index_canister_id}</svelte:fragment
+					>
+					{token.token.indexCanisterId}
+				</Value>
+			{/if}
 
 			<AddTokenWarning />
 		</div>

--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Dropdown, DropdownItem } from '@dfinity/gix-components';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import AddTokenForm from '$eth/components/tokens/AddTokenForm.svelte';
@@ -36,7 +36,13 @@
 	// only the data related to the selected network is passed.
 	$: {
 		if (isNetworkIdICP(network?.id)) {
-			tokenData = { ledgerCanisterId, indexCanisterId };
+			tokenData = {
+				ledgerCanisterId,
+				indexCanisterId:
+					nonNullish(indexCanisterId) && notEmptyString(indexCanisterId)
+						? indexCanisterId
+						: undefined
+			};
 		} else if (isNetworkIdEthereum(network?.id)) {
 			tokenData = { contractAddress: erc20ContractAddress };
 		} else {
@@ -50,7 +56,7 @@
 	$: invalidErc20 = isNullishOrEmpty(erc20ContractAddress);
 
 	let invalidIc = true;
-	$: invalidIc = isNullishOrEmpty(ledgerCanisterId) || isNullishOrEmpty(indexCanisterId);
+	$: invalidIc = isNullishOrEmpty(ledgerCanisterId);
 
 	let invalid = true;
 	$: invalid = isNetworkIdEthereum(network?.id) ? invalidErc20 : invalidIc;

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -80,13 +80,6 @@
 			return;
 		}
 
-		if (isNullish(indexCanisterId)) {
-			toastsError({
-				msg: { text: get(i18n).tokens.import.error.missing_index_id }
-			});
-			return;
-		}
-
 		await saveIcrc([
 			{
 				enabled: true,

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -428,9 +428,8 @@
 				"minter_canister_id_copied": "Minter Canister ID copied to clipboard.",
 				"verifying": "Verifying token details...",
 				"add_the_token": "Add the token",
-				"info": "To display custom token information correctly, $oisy_name requires setting both a Ledger and Index canister ID. More details can be found on GitHub.",
-				"github_howto": "Read how ICRC token Integration works",
-				"open_github_howto": "Open information about ICRC token integration on GitHub",
+				"info": "Ledger and Index canister IDs are usually available on the project’s website. ",
+				"info_index": "The Index canister ID is optional, but without it, $oisy_short can’t display transaction history.",
 				"custom_tokens_not_supported": "The selected network does not support custom tokens."
 			},
 			"error": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -390,8 +390,7 @@ interface I18nTokens {
 			verifying: string;
 			add_the_token: string;
 			info: string;
-			github_howto: string;
-			open_github_howto: string;
+			info_index: string;
 			custom_tokens_not_supported: string;
 		};
 		error: {


### PR DESCRIPTION
# Motivation

Update the "Add custom IC token" wizard to support tokens without index canister.

# Changes

- Make index optional in required data
- Adapt UI/UX around it

# Screenshot

<img width="1536" alt="Capture d’écran 2024-11-13 à 09 54 42" src="https://github.com/user-attachments/assets/5f173165-60cb-406d-a9c1-0f5301e92bcb">
<img width="1536" alt="Capture d’écran 2024-11-13 à 09 54 36" src="https://github.com/user-attachments/assets/d075284a-1e8f-4ee1-b11f-75fab1d0d9bd">
<img width="1536" alt="Capture d’écran 2024-11-13 à 09 54 19" src="https://github.com/user-attachments/assets/72a0f862-01f9-4d8d-a00a-211146b407a1">

