### PR TITLE
feat(frontend): add json import for additional icrc env tokens

### DIFF
--- a/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { envTokenSymbol } from '$env/types/env-token-common';
 import { EnvIcTokenSchema } from '$env/schema/env-icrc-token.schema';
+import { EnvTokenSymbolSchema } from '$env/schema/env-token-common.schema';
 
 // TODO, extract the union into it's own schema
 export const EnvAdditionalIcrcTokensSchema = z.record(
-	envTokenSymbol,
+	EnvTokenSymbolSchema,
 	z.union([z.undefined(), EnvIcTokenSchema])
 );
 

--- a/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
@@ -1,6 +1,6 @@
-import { z } from 'zod';
 import { EnvIcTokenSchema } from '$env/schema/env-icrc-token.schema';
 import { EnvTokenSymbolSchema } from '$env/schema/env-token-common.schema';
+import { z } from 'zod';
 
 // TODO, extract the union into it's own schema
 export const EnvAdditionalIcrcTokensSchema = z.record(

--- a/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { envTokenSymbol } from '$env/types/env-token-common';
+import { EnvIcTokenSchema } from '$env/schema/env-icrc-token.schema';
+
+// TODO, extract the union into it's own schema
+export const EnvAdditionalIcrcTokensSchema = z.record(
+	envTokenSymbol,
+	z.union([z.undefined(), EnvIcTokenSchema])
+);
+
+export const EnvTokensAdditionalIcrcSchema = z.object({
+	production: EnvAdditionalIcrcTokensSchema,
+	staging: EnvAdditionalIcrcTokensSchema
+});

--- a/src/frontend/src/env/tokens.icrc.env.ts
+++ b/src/frontend/src/env/tokens.icrc.env.ts
@@ -1,0 +1,8 @@
+import icrcTokens from '$env/tokens.icrc.json';
+import { envTokensAdditionalIcrc } from '$env/types/env-icrc-token';
+
+const additionalIcrcTokens = envTokensAdditionalIcrc.safeParse(icrcTokens);
+
+export const { production: additionalIcrcTokensProduction, staging: additionalIcrcTokensStaging } = additionalIcrcTokens.success
+	? additionalIcrcTokens.data
+	: { production: {}, staging: {} };

--- a/src/frontend/src/env/tokens.icrc.env.ts
+++ b/src/frontend/src/env/tokens.icrc.env.ts
@@ -1,5 +1,5 @@
-import icrcTokens from '$env/tokens.icrc.json';
 import { EnvTokensAdditionalIcrcSchema } from '$env/schema/env-additional-icrc-token.schema';
+import icrcTokens from '$env/tokens.icrc.json';
 
 const additionalIcrcTokens = EnvTokensAdditionalIcrcSchema.safeParse(icrcTokens);
 

--- a/src/frontend/src/env/tokens.icrc.env.ts
+++ b/src/frontend/src/env/tokens.icrc.env.ts
@@ -1,7 +1,7 @@
 import icrcTokens from '$env/tokens.icrc.json';
-import { envTokensAdditionalIcrc } from '$env/types/env-icrc-token';
+import { EnvTokensAdditionalIcrcSchema } from '$env/schema/env-additional-icrc-token.schema';
 
-const additionalIcrcTokens = envTokensAdditionalIcrc.safeParse(icrcTokens);
+const additionalIcrcTokens = EnvTokensAdditionalIcrcSchema.safeParse(icrcTokens);
 
 export const { production: additionalIcrcTokensProduction, staging: additionalIcrcTokensStaging } =
 	additionalIcrcTokens.success ? additionalIcrcTokens.data : { production: {}, staging: {} };

--- a/src/frontend/src/env/tokens.icrc.env.ts
+++ b/src/frontend/src/env/tokens.icrc.env.ts
@@ -3,6 +3,5 @@ import { envTokensAdditionalIcrc } from '$env/types/env-icrc-token';
 
 const additionalIcrcTokens = envTokensAdditionalIcrc.safeParse(icrcTokens);
 
-export const { production: additionalIcrcTokensProduction, staging: additionalIcrcTokensStaging } = additionalIcrcTokens.success
-	? additionalIcrcTokens.data
-	: { production: {}, staging: {} };
+export const { production: additionalIcrcTokensProduction, staging: additionalIcrcTokensStaging } =
+	additionalIcrcTokens.success ? additionalIcrcTokens.data : { production: {}, staging: {} };

--- a/src/frontend/src/env/tokens.icrc.json
+++ b/src/frontend/src/env/tokens.icrc.json
@@ -1,0 +1,4 @@
+{
+  "production": {},
+  "staging": {}
+}

--- a/src/frontend/src/env/tokens.icrc.json
+++ b/src/frontend/src/env/tokens.icrc.json
@@ -1,4 +1,4 @@
 {
-  "production": {},
-  "staging": {}
+	"production": {},
+	"staging": {}
 }

--- a/src/frontend/src/env/types/env-icrc-additional-token.ts
+++ b/src/frontend/src/env/types/env-icrc-additional-token.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
 import { EnvTokensAdditionalIcrcSchema } from '$env/schema/env-additional-icrc-token.schema';
+import { z } from 'zod';
 
 export type EnvAdditionalIcrcTokens = z.infer<typeof EnvTokensAdditionalIcrcSchema>;

--- a/src/frontend/src/env/types/env-icrc-additional-token.ts
+++ b/src/frontend/src/env/types/env-icrc-additional-token.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+import { EnvTokensAdditionalIcrcSchema } from '$env/schema/env-additional-icrc-token.schema';
+
+export type EnvAdditionalIcrcTokens = z.infer<typeof EnvTokensAdditionalIcrcSchema>;

--- a/src/frontend/src/env/types/env-icrc-token.ts
+++ b/src/frontend/src/env/types/env-icrc-token.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
 import { envTokenSymbol } from '$env/types/env-token-common';
+import { z } from 'zod';
 
 export const envIcrcTokenMetadata = z.object({
 	decimals: z.number(),

--- a/src/frontend/src/env/types/env-icrc-token.ts
+++ b/src/frontend/src/env/types/env-icrc-token.ts
@@ -31,6 +31,7 @@ export type EnvIcrcToken = z.infer<typeof envIcrcToken>;
 
 export type EnvIcrcTokens = z.infer<typeof envIcrcTokens>;
 
+// TODO, extract the union into it's own schema
 const envAdditionalIcrcTokens = z.record(envTokenSymbol, z.union([z.undefined(), envIcToken]));
 
 export type EnvAdditionalIcrcTokens = z.infer<typeof envAdditionalIcrcTokens>;

--- a/src/frontend/src/env/types/env-icrc-token.ts
+++ b/src/frontend/src/env/types/env-icrc-token.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { envTokenSymbol } from '$env/types/env-token-common';
 
 export const envIcrcTokenMetadata = z.object({
 	decimals: z.number(),
@@ -29,3 +30,12 @@ export type EnvIcrcTokenMetadata = z.infer<typeof envIcrcTokenMetadata>;
 export type EnvIcrcToken = z.infer<typeof envIcrcToken>;
 
 export type EnvIcrcTokens = z.infer<typeof envIcrcTokens>;
+
+const envAdditionalIcrcTokens = z.record(envTokenSymbol, z.union([z.undefined(), envIcToken]));
+
+export type EnvAdditionalIcrcTokens = z.infer<typeof envAdditionalIcrcTokens>;
+
+export const envTokensAdditionalIcrc = z.object({
+	production: envAdditionalIcrcTokens,
+	staging: envAdditionalIcrcTokens
+});


### PR DESCRIPTION
# Motivation

We want to load a selection of additional icrc tokens. This prepares the json data structure with zod parsing and typing.

# Changes

- Add types with zod
- Add parsing
- add empty json structure
