### PR TITLE
refactor(frontend): use correct Ck token validation util

### DIFF
--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -1,9 +1,9 @@
-import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks.env';
+import { ICP_NETWORK } from '$env/networks.env';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
-import type { IcCkInterface, IcCkToken, IcFee, IcInterface, IcToken } from '$icp/types/ic-token';
+import type { IcCkInterface, IcFee, IcInterface, IcToken } from '$icp/types/ic-token';
 import type { IcTokenWithoutIdExtended, IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { CanisterIdText } from '$lib/types/canister';
-import type { Token, TokenCategory, TokenMetadata } from '$lib/types/token';
+import type { TokenCategory, TokenMetadata } from '$lib/types/token';
 import {
 	IcrcMetadataResponseEntries,
 	type IcrcTokenMetadataResponse,
@@ -150,6 +150,3 @@ export const mapTokenOisyName = (token: IcInterface): IcInterface => ({
 			}
 		: {})
 });
-
-export const isIcCkToken = (token: Token): token is IcCkToken =>
-	'minterCanisterId' in token && token.network?.id === ICP_NETWORK_ID;

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -1,5 +1,5 @@
 import type { IcCkToken } from '$icp/types/ic-token';
-import { isIcCkToken } from '$icp/utils/icrc.utils';
+import { isIcCkToken } from '$icp/validation/ic-token.validation';
 import { ZERO } from '$lib/constants/app.constants';
 import type { TokenUi } from '$lib/types/token';
 import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-group';

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -11,6 +11,7 @@ import {
 	updateTokenGroup
 } from '$lib/utils/token-group.utils';
 import { bn1, bn2, bn3 } from '$tests/mocks/balances.mock';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { BigNumber } from 'alchemy-sdk';
 
 const tokens = [
@@ -20,6 +21,7 @@ const tokens = [
 		usdBalance: 50000
 	},
 	{
+		...mockValidIcCkToken,
 		symbol: 'ckBTC',
 		network: ICP_NETWORK,
 		balance: BigNumber.from(2),
@@ -36,6 +38,7 @@ const tokens = [
 		usdBalance: 20000
 	},
 	{
+		...mockValidIcCkToken,
 		symbol: 'ckETH',
 		network: ICP_NETWORK,
 		balance: BigNumber.from(5),
@@ -56,6 +59,7 @@ const tokens = [
 const tokensWithMismatchedDecimals = [
 	...tokens,
 	{
+		...mockValidIcCkToken,
 		symbol: 'FOO',
 		network: {
 			id: Symbol('FOO'),
@@ -73,6 +77,7 @@ const tokensWithMismatchedDecimals = [
 		name: 'Foo Token'
 	},
 	{
+		...mockValidIcCkToken,
 		symbol: 'ckFOO',
 		network: ICP_NETWORK,
 		balance: BigNumber.from(200),


### PR DESCRIPTION
# Motivation

There was a duplicated `isIcCkToken` function that not really fits the correct validation. So we replace with the correct one that uses zod.