### PR TITLE
feat(frontend): convert store

### DIFF
--- a/src/frontend/src/lib/stores/convert.store.ts
+++ b/src/frontend/src/lib/stores/convert.store.ts
@@ -1,0 +1,75 @@
+import { exchanges } from '$lib/derived/exchange.derived';
+import { balancesStore } from '$lib/stores/balances.store';
+import type { Token } from '$lib/types/token';
+import { nonNullish } from '@dfinity/utils';
+import { BigNumber } from '@ethersproject/bignumber';
+import { derived, writable, type Readable } from 'svelte/store';
+
+export interface ConvertData {
+	sourceToken: Token;
+	destinationToken: Token;
+}
+
+export interface ConvertStore extends Readable<ConvertData> {
+	set: (data: ConvertData) => void;
+}
+
+export const initConvertStore = (data: ConvertData): ConvertStore => {
+	const { subscribe, set: setStore } = writable<ConvertData>(data);
+
+	return {
+		subscribe,
+
+		set(data: ConvertData) {
+			setStore(data);
+		}
+	};
+};
+
+export const initConvertContext = (convertData: ConvertData): ConvertContext => {
+	const convertStore = initConvertStore(convertData);
+
+	const sourceToken = derived([convertStore], ([{ sourceToken }]) => sourceToken);
+	const destinationToken = derived([convertStore], ([{ destinationToken }]) => destinationToken);
+
+	const sourceTokenBalance = derived(
+		[balancesStore, sourceToken],
+		([$balancesStore, $sourceToken]) =>
+			nonNullish($sourceToken) ? $balancesStore?.[$sourceToken.id]?.data : undefined
+	);
+	const destinationTokenBalance = derived(
+		[balancesStore, destinationToken],
+		([$balancesStore, $destinationToken]) =>
+			nonNullish($destinationToken) ? $balancesStore?.[$destinationToken.id]?.data : undefined
+	);
+
+	const sourceTokenExchangeRate = derived(
+		[exchanges, sourceToken],
+		([$exchanges, $sourceToken]) => $exchanges?.[$sourceToken.id]?.usd
+	);
+	const destinationTokenExchangeRate = derived(
+		[exchanges, destinationToken],
+		([$exchanges, $destinationToken]) =>
+			nonNullish($destinationToken) ? $exchanges?.[$destinationToken.id]?.usd : undefined
+	);
+
+	return {
+		sourceToken,
+		destinationToken,
+		sourceTokenBalance,
+		destinationTokenBalance,
+		sourceTokenExchangeRate,
+		destinationTokenExchangeRate
+	};
+};
+
+export interface ConvertContext {
+	sourceToken: Readable<Token>;
+	destinationToken: Readable<Token>;
+	sourceTokenBalance: Readable<BigNumber | undefined>;
+	destinationTokenBalance: Readable<BigNumber | undefined>;
+	sourceTokenExchangeRate: Readable<number | undefined>;
+	destinationTokenExchangeRate: Readable<number | undefined>;
+}
+
+export const CONVERT_CONTEXT_KEY = Symbol('convert');

--- a/src/frontend/src/lib/stores/convert.store.ts
+++ b/src/frontend/src/lib/stores/convert.store.ts
@@ -1,7 +1,6 @@
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token } from '$lib/types/token';
-import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { derived, writable, type Readable } from 'svelte/store';
 
@@ -10,37 +9,19 @@ export interface ConvertData {
 	destinationToken: Token;
 }
 
-export interface ConvertStore extends Readable<ConvertData> {
-	set: (data: ConvertData) => void;
-}
-
-export const initConvertStore = (data: ConvertData): ConvertStore => {
-	const { subscribe, set: setStore } = writable<ConvertData>(data);
-
-	return {
-		subscribe,
-
-		set(data: ConvertData) {
-			setStore(data);
-		}
-	};
-};
-
 export const initConvertContext = (convertData: ConvertData): ConvertContext => {
-	const convertStore = initConvertStore(convertData);
+	const data = writable<ConvertData>(convertData);
 
-	const sourceToken = derived([convertStore], ([{ sourceToken }]) => sourceToken);
-	const destinationToken = derived([convertStore], ([{ destinationToken }]) => destinationToken);
+	const sourceToken = derived([data], ([{ sourceToken }]) => sourceToken);
+	const destinationToken = derived([data], ([{ destinationToken }]) => destinationToken);
 
 	const sourceTokenBalance = derived(
 		[balancesStore, sourceToken],
-		([$balancesStore, $sourceToken]) =>
-			nonNullish($sourceToken) ? $balancesStore?.[$sourceToken.id]?.data : undefined
+		([$balancesStore, $sourceToken]) => $balancesStore?.[$sourceToken.id]?.data
 	);
 	const destinationTokenBalance = derived(
 		[balancesStore, destinationToken],
-		([$balancesStore, $destinationToken]) =>
-			nonNullish($destinationToken) ? $balancesStore?.[$destinationToken.id]?.data : undefined
+		([$balancesStore, $destinationToken]) => $balancesStore?.[$destinationToken.id]?.data
 	);
 
 	const sourceTokenExchangeRate = derived(
@@ -49,8 +30,7 @@ export const initConvertContext = (convertData: ConvertData): ConvertContext => 
 	);
 	const destinationTokenExchangeRate = derived(
 		[exchanges, destinationToken],
-		([$exchanges, $destinationToken]) =>
-			nonNullish($destinationToken) ? $exchanges?.[$destinationToken.id]?.usd : undefined
+		([$exchanges, $destinationToken]) => $exchanges?.[$destinationToken.id]?.usd
 	);
 
 	return {

--- a/src/frontend/src/tests/lib/stores/convert.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/convert.store.spec.ts
@@ -1,0 +1,19 @@
+import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import { initConvertStore } from '$lib/stores/convert.store';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.utils';
+
+describe('convertStore', () => {
+	beforeEach(() => {
+		mockPage.reset();
+	});
+
+	it('should ensure derived stores update at most once when the store changes', async () => {
+		await testDerivedUpdates(() =>
+			initConvertStore({
+				destinationToken: ETHEREUM_TOKEN,
+				sourceToken: ICP_TOKEN
+			})
+		);
+	});
+});

--- a/src/frontend/src/tests/lib/stores/convert.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/convert.store.spec.ts
@@ -1,12 +1,25 @@
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
+import * as exchanges from '$lib/derived/exchange.derived';
+import { balancesStore } from '$lib/stores/balances.store';
 import { initConvertContext } from '$lib/stores/convert.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
-import { expect } from 'vitest';
+import { BigNumber } from 'alchemy-sdk';
+import { get, readable } from 'svelte/store';
+
+const ethExchangeValue = 1;
+const icpExchangeValue = 2;
 
 describe('convertStore', () => {
 	beforeEach(() => {
 		mockPage.reset();
+
+		vi.spyOn(exchanges, 'exchanges', 'get').mockImplementation(() =>
+			readable({
+				[ETHEREUM_TOKEN.id]: { usd: ethExchangeValue },
+				[ICP_TOKEN.id]: { usd: icpExchangeValue }
+			})
+		);
 	});
 
 	it('should ensure derived stores update at most once when the store changes', async () => {
@@ -18,17 +31,37 @@ describe('convertStore', () => {
 		);
 	});
 
-	it('should have all expected properties', () => {
-		const store = initConvertContext({
+	it('should have all expected values', () => {
+		const {
+			sourceToken,
+			sourceTokenBalance,
+			sourceTokenExchangeRate,
+			destinationTokenExchangeRate,
+			destinationTokenBalance,
+			destinationToken
+		} = initConvertContext({
 			destinationToken: ETHEREUM_TOKEN,
 			sourceToken: ICP_TOKEN
 		});
+		const ethBalance = BigNumber.from(1n);
+		const icpBalance = BigNumber.from(2n);
 
-		expect(store).toHaveProperty('sourceToken');
-		expect(store).toHaveProperty('destinationToken');
-		expect(store).toHaveProperty('sourceTokenBalance');
-		expect(store).toHaveProperty('destinationTokenBalance');
-		expect(store).toHaveProperty('sourceTokenExchangeRate');
-		expect(store).toHaveProperty('destinationTokenExchangeRate');
+		balancesStore.set({
+			tokenId: ETHEREUM_TOKEN.id,
+			data: { data: ethBalance, certified: true }
+		});
+		balancesStore.set({
+			tokenId: ICP_TOKEN.id,
+			data: { data: icpBalance, certified: true }
+		});
+
+		expect(get(sourceToken)).toBe(ICP_TOKEN);
+		expect(get(destinationToken)).toBe(ETHEREUM_TOKEN);
+
+		expect(get(sourceTokenBalance)).toStrictEqual(icpBalance);
+		expect(get(destinationTokenBalance)).toStrictEqual(ethBalance);
+
+		expect(get(sourceTokenExchangeRate)).toStrictEqual(icpExchangeValue);
+		expect(get(destinationTokenExchangeRate)).toStrictEqual(ethExchangeValue);
 	});
 });

--- a/src/frontend/src/tests/lib/stores/convert.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/convert.store.spec.ts
@@ -1,7 +1,8 @@
 import { ETHEREUM_TOKEN, ICP_TOKEN } from '$env/tokens.env';
-import { initConvertStore } from '$lib/stores/convert.store';
+import { initConvertContext } from '$lib/stores/convert.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.utils';
+import { expect } from 'vitest';
 
 describe('convertStore', () => {
 	beforeEach(() => {
@@ -10,10 +11,24 @@ describe('convertStore', () => {
 
 	it('should ensure derived stores update at most once when the store changes', async () => {
 		await testDerivedUpdates(() =>
-			initConvertStore({
+			initConvertContext({
 				destinationToken: ETHEREUM_TOKEN,
 				sourceToken: ICP_TOKEN
 			})
 		);
+	});
+
+	it('should have all expected properties', () => {
+		const store = initConvertContext({
+			destinationToken: ETHEREUM_TOKEN,
+			sourceToken: ICP_TOKEN
+		});
+
+		expect(store).toHaveProperty('sourceToken');
+		expect(store).toHaveProperty('destinationToken');
+		expect(store).toHaveProperty('sourceTokenBalance');
+		expect(store).toHaveProperty('destinationTokenBalance');
+		expect(store).toHaveProperty('sourceTokenExchangeRate');
+		expect(store).toHaveProperty('destinationTokenExchangeRate');
 	});
 });


### PR DESCRIPTION
# Motivation

In this PR, a new store is created. It will be used across the conversion flow files. According to the new designs, we need to display data about both source and destination tokens, therefore the store contains the same set of info for both provided tokens.
