### PR TITLE
refactor(frontend): rename icrc env tokens specific for sns

### DIFF
--- a/src/frontend/src/env/types/env-icrc-token.ts
+++ b/src/frontend/src/env/types/env-icrc-token.ts
@@ -9,23 +9,9 @@ export const envIcrcTokenMetadata = z.object({
 	url: z.optional(z.string().url())
 });
 
-const indexCanisterVersion = z.union([z.literal('up-to-date'), z.literal('outdated')]);
-
 export const envIcToken = z.object({
 	ledgerCanisterId: z.string(),
 	indexCanisterId: z.string()
 });
 
-export const envIcrcToken = envIcToken.extend({
-	rootCanisterId: z.string(),
-	metadata: envIcrcTokenMetadata,
-	indexCanisterVersion
-});
-
-export const envIcrcTokens = z.array(envIcrcToken);
-
 export type EnvIcrcTokenMetadata = z.infer<typeof envIcrcTokenMetadata>;
-
-export type EnvIcrcToken = z.infer<typeof envIcrcToken>;
-
-export type EnvIcrcTokens = z.infer<typeof envIcrcTokens>;

--- a/src/frontend/src/env/types/env-sns-token.ts
+++ b/src/frontend/src/env/types/env-sns-token.ts
@@ -1,0 +1,16 @@
+import { envIcrcTokenMetadata, envIcToken } from '$env/types/env-icrc-token';
+import { z } from 'zod';
+
+const IndexCanisterVersionSchema = z.union([z.literal('up-to-date'), z.literal('outdated')]);
+
+export const EnvSnsTokenSchema = envIcToken.extend({
+	rootCanisterId: z.string(),
+	metadata: envIcrcTokenMetadata,
+	indexCanisterVersion: IndexCanisterVersionSchema
+});
+
+export const EnvSnsTokensSchema = z.array(EnvSnsTokenSchema);
+
+export type EnvSnsToken = z.infer<typeof EnvSnsTokenSchema>;
+
+export type EnvSnsTokens = z.infer<typeof EnvSnsTokensSchema>;

--- a/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
@@ -1,7 +1,7 @@
 import { SNS_EXPLORER_URL } from '$env/explorers.env';
 import { ICP_NETWORK } from '$env/networks.env';
 import snsTokens from '$env/tokens.sns.json';
-import { envIcrcToken, envIcrcTokens, type EnvIcrcToken } from '$env/types/env-icrc-token';
+import { EnvSnsTokenSchema, EnvSnsTokensSchema, type EnvSnsToken } from '$env/types/env-sns-token';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcTokenWithoutIdExtended } from '$icp/types/icrc-custom-token';
 import { i18n } from '$lib/stores/i18n.store';
@@ -28,26 +28,24 @@ export const buildIndexedIcrcCustomTokens = (): Record<
  */
 export const buildIcrcCustomTokens = (): IcTokenWithoutIdExtended[] => {
 	try {
-		const tokens = envIcrcTokens
-			.parse(
-				snsTokens.map(
-					({
+		const tokens = EnvSnsTokensSchema.parse(
+			snsTokens.map(
+				({
+					metadata: {
+						fee: { __bigint__ },
+						...rest
+					},
+					...ids
+				}) =>
+					EnvSnsTokenSchema.parse({
+						...ids,
 						metadata: {
-							fee: { __bigint__ },
-							...rest
-						},
-						...ids
-					}) =>
-						envIcrcToken.parse({
-							...ids,
-							metadata: {
-								...rest,
-								fee: BigInt(__bigint__)
-							}
-						})
-				)
+							...rest,
+							fee: BigInt(__bigint__)
+						}
+					})
 			)
-			.map(mapIcrcCustomToken);
+		).map(mapIcrcCustomToken);
 
 		return tokens;
 	} catch (err: unknown) {
@@ -67,7 +65,7 @@ const mapIcrcCustomToken = ({
 	indexCanisterVersion,
 	rootCanisterId,
 	metadata: { name, decimals, symbol, fee, alternativeName }
-}: EnvIcrcToken): IcTokenWithoutIdExtended => ({
+}: EnvSnsToken): IcTokenWithoutIdExtended => ({
 	ledgerCanisterId,
 	indexCanisterId,
 	network: ICP_NETWORK,

--- a/src/frontend/src/icp/types/icrc-custom-token.ts
+++ b/src/frontend/src/icp/types/icrc-custom-token.ts
@@ -1,4 +1,5 @@
-import type { EnvIcrcTokenMetadata, EnvSnsToken } from '$env/types/env-icrc-token';
+import type { EnvIcrcTokenMetadata } from '$env/types/env-icrc-token';
+import type { EnvSnsToken } from '$env/types/env-sns-token';
 import type { IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
 import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 import type { Option } from '$lib/types/utils';

--- a/src/frontend/src/icp/types/icrc-custom-token.ts
+++ b/src/frontend/src/icp/types/icrc-custom-token.ts
@@ -1,10 +1,10 @@
-import type { EnvIcrcToken, EnvIcrcTokenMetadata } from '$env/types/env-icrc-token';
+import type { EnvIcrcTokenMetadata, EnvSnsToken } from '$env/types/env-icrc-token';
 import type { IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
 import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 import type { Option } from '$lib/types/utils';
 
 export type IcrcCustomTokenExtra = Pick<EnvIcrcTokenMetadata, 'alternativeName'> &
-	Partial<Pick<EnvIcrcToken, 'indexCanisterVersion'>>;
+	Partial<Pick<EnvSnsToken, 'indexCanisterVersion'>>;
 
 export type IcTokenWithoutIdExtended = IcTokenWithoutId & IcrcCustomTokenExtra;
 


### PR DESCRIPTION
# Motivation

On one hand, we will extend the environment with some "additional icrc tokens" #3506, on the other, existing "sns env tokens" are not solely "icrc tokens" because they contains addition information such as the root canister.

To clean up a bit the naming and data inconsistency, this PR move and rename the sns related env types to a particular module and also add the "Schema" suffix we have started to use for our zod schema.

# Tests

Skipped.
