### PR TITLE
refactor(frontend): split env sns tokens schema and types

### DIFF
--- a/src/frontend/src/env/schema/env-sns-token.schema.ts
+++ b/src/frontend/src/env/schema/env-sns-token.schema.ts
@@ -1,0 +1,15 @@
+import { EnvIcrcTokenMetadataSchema, EnvIcTokenSchema } from '$env/schema/env-icrc-token.schema';
+import { EnvSnsTokensSchema } from '$env/types/env-sns-token';
+import { z } from 'zod';
+
+const IndexCanisterVersionSchema = z.union([z.literal('up-to-date'), z.literal('outdated')]);
+
+export const EnvSnsTokenSchema = EnvIcTokenSchema.extend({
+	rootCanisterId: z.string(),
+	metadata: EnvIcrcTokenMetadataSchema,
+	indexCanisterVersion: IndexCanisterVersionSchema
+});
+
+export type EnvSnsToken = z.infer<typeof EnvSnsTokenSchema>;
+
+export type EnvSnsTokens = z.infer<typeof EnvSnsTokensSchema>;

--- a/src/frontend/src/env/types/env-sns-token.ts
+++ b/src/frontend/src/env/types/env-sns-token.ts
@@ -1,16 +1,4 @@
-import { EnvIcrcTokenMetadataSchema, EnvIcTokenSchema } from '$env/schema/env-icrc-token.schema';
+import { EnvSnsTokenSchema } from '$env/schema/env-sns-token.schema';
 import { z } from 'zod';
 
-const IndexCanisterVersionSchema = z.union([z.literal('up-to-date'), z.literal('outdated')]);
-
-export const EnvSnsTokenSchema = EnvIcTokenSchema.extend({
-	rootCanisterId: z.string(),
-	metadata: EnvIcrcTokenMetadataSchema,
-	indexCanisterVersion: IndexCanisterVersionSchema
-});
-
 export const EnvSnsTokensSchema = z.array(EnvSnsTokenSchema);
-
-export type EnvSnsToken = z.infer<typeof EnvSnsTokenSchema>;
-
-export type EnvSnsTokens = z.infer<typeof EnvSnsTokensSchema>;

--- a/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
@@ -1,7 +1,8 @@
 import { SNS_EXPLORER_URL } from '$env/explorers.env';
 import { ICP_NETWORK } from '$env/networks.env';
+import { EnvSnsTokenSchema, type EnvSnsToken } from '$env/schema/env-sns-token.schema';
 import snsTokens from '$env/tokens.sns.json';
-import { EnvSnsTokenSchema, EnvSnsTokensSchema, type EnvSnsToken } from '$env/types/env-sns-token';
+import { EnvSnsTokensSchema } from '$env/types/env-sns-token';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcTokenWithoutIdExtended } from '$icp/types/icrc-custom-token';
 import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/icp/types/icrc-custom-token.ts
+++ b/src/frontend/src/icp/types/icrc-custom-token.ts
@@ -1,5 +1,5 @@
+import type { EnvSnsToken } from '$env/schema/env-sns-token.schema';
 import type { EnvIcrcTokenMetadata } from '$env/types/env-icrc-token';
-import type { EnvSnsToken } from '$env/types/env-sns-token';
 import type { IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
 import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 import type { Option } from '$lib/types/utils';


### PR DESCRIPTION
# Motivation

Similar to #3516, let's split schema and types for consistency in the env sns tokens.

# Tests

Skipped.
