### PR TITLE
refactor(frontend): oisy metadata schema

### DIFF
--- a/src/frontend/src/env/schema/env-oisy-metadata.schema.ts
+++ b/src/frontend/src/env/schema/env-oisy-metadata.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const oisyMetadata = z.object({
+export const OisyMetadataSchema = z.object({
 	OISY_SHORT: z.string(),
 	OISY_NAME: z.string(),
 	OISY_ONELINER: z.string(),

--- a/src/frontend/src/lib/constants/oisy.constants.ts
+++ b/src/frontend/src/lib/constants/oisy.constants.ts
@@ -1,5 +1,5 @@
 import metadata from '$env/oisy.metadata.json';
-import { oisyMetadata } from '$env/types/env-oisy-metadata';
+import { OisyMetadataSchema } from '$env/schema/env-oisy-metadata.schema';
 import { safeParse } from '$lib/validation/utils.validation';
 
 export const {
@@ -11,7 +11,7 @@ export const {
 	OISY_STATUS_URL,
 	OISY_TWITTER_URL
 } = safeParse({
-	schema: oisyMetadata,
+	schema: OisyMetadataSchema,
 	value: metadata,
 	fallback: {
 		OISY_SHORT: '',


### PR DESCRIPTION
# Motivation

Use our naming and structure convention for `OisyMetadataSchema`.

# Tests

Skipped.
