### PR TITLE
refactor(frontend): commot props for transaction UI

### DIFF
--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -3,8 +3,7 @@ import type { TransactionStatus, TransactionUiCommon } from '$lib/types/transact
 
 export type BtcTransactionStatus = TransactionStatus;
 
-export interface BtcTransactionUi extends TransactionUiCommon {
-	id: string;
+export type BtcTransactionUi = TransactionUiCommon & {
 	type: BtcTransactionType;
 	status: BtcTransactionStatus;
 	value?: bigint;
@@ -14,4 +13,4 @@ export interface BtcTransactionUi extends TransactionUiCommon {
 	 1. Use https://blockchain.info/latestblock to get info about the latest block height.
 	 2. Calculate confirmations: confirmations = currentBlockHeight - transactionBlockHeight + 1
 	 */
-}
+};

--- a/src/frontend/src/eth/types/eth-transaction.ts
+++ b/src/frontend/src/eth/types/eth-transaction.ts
@@ -1,12 +1,9 @@
 import { ethTransactionTypes } from '$lib/schema/transaction.schema';
-import type { Transaction, TransactionType } from '$lib/types/transaction';
+import type { Transaction, TransactionType, TransactionUiCommon } from '$lib/types/transaction';
 
 export type EthTransactionType = Extract<
 	TransactionType,
 	(typeof ethTransactionTypes.options)[number]
 >;
 
-export interface EthTransactionUi extends Transaction {
-	id: string | undefined;
-	uiType: EthTransactionType;
-}
+export type EthTransactionUi = Transaction & TransactionUiCommon & { uiType: EthTransactionType };

--- a/src/frontend/src/icp/types/ic-transaction.ts
+++ b/src/frontend/src/icp/types/ic-transaction.ts
@@ -1,5 +1,5 @@
 import { icpTransactionTypes } from '$lib/schema/transaction.schema';
-import type { TransactionType } from '$lib/types/transaction';
+import type { TransactionType, TransactionUiCommon } from '$lib/types/transaction';
 import type { Transaction, TransactionWithId } from '@dfinity/ledger-icp';
 import type {
 	IcrcTransaction as IcrcTransactionCandid,
@@ -29,22 +29,15 @@ export type IcTransactionIdText = string;
 
 export type IcTransactionStatus = 'executed' | 'pending' | 'reimbursed' | 'failed';
 
-export interface IcTransactionUi {
-	id: bigint | string;
+export type IcTransactionUi = TransactionUiCommon & {
 	type: IcTransactionType;
 	// e.g. BTC Received
 	typeLabel?: string;
-	from?: string;
 	// e.g. From: BTC Network
 	fromLabel?: string;
-	fromExplorerUrl?: string;
-	to?: string;
 	// e.g. To: BTC Network
 	toLabel?: string;
-	toExplorerUrl?: string;
 	incoming?: boolean;
 	value?: bigint;
-	timestamp?: bigint;
 	status: IcTransactionStatus;
-	txExplorerUrl?: string;
-}
+};

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -27,6 +27,7 @@ export type TransactionType = z.infer<typeof TransactionTypeSchema>;
 export type TransactionStatus = z.infer<typeof TransactionStatusSchema>;
 
 export type TransactionUiCommon = Pick<Transaction, 'blockNumber' | 'from' | 'to'> & {
+	id: bigint | string;
 	timestamp?: bigint;
 	txExplorerUrl?: string;
 	toExplorerUrl?: string;

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -27,7 +27,7 @@ export type TransactionType = z.infer<typeof TransactionTypeSchema>;
 export type TransactionStatus = z.infer<typeof TransactionStatusSchema>;
 
 export type TransactionUiCommon = Pick<Transaction, 'blockNumber' | 'from' | 'to'> & {
-	id: bigint | string;
+	id: bigint | string | undefined;
 	timestamp?: bigint;
 	txExplorerUrl?: string;
 	toExplorerUrl?: string;

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -26,7 +26,7 @@ export type TransactionType = z.infer<typeof TransactionTypeSchema>;
 
 export type TransactionStatus = z.infer<typeof TransactionStatusSchema>;
 
-export type TransactionUiCommon = Pick<Transaction, 'blockNumber' | 'from' | 'to'> & {
+export type TransactionUiCommon = Partial<Pick<Transaction, 'blockNumber' | 'from' | 'to'>> & {
 	id: bigint | string | undefined;
 	timestamp?: bigint;
 	txExplorerUrl?: string;


### PR DESCRIPTION
# Motivation

A few props are in common with all the transaction UI. So we use `TransactionUiCommon`.

# Tests

Unfortunately, the Transaction type is derived from an external type: meaning that ZOD will not correctly test correct parsing. But I accept any kind of suggestion
