### PR TITLE
feat(frontend): nullify ic transactions store on post message

### DIFF
--- a/src/frontend/src/icp/services/ic-listener.services.ts
+++ b/src/frontend/src/icp/services/ic-listener.services.ts
@@ -2,7 +2,7 @@ import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { PostMessageDataResponseWallet } from '$lib/types/post-message';
 import type { TokenId } from '$lib/types/token';
-import { jsonReviver } from '@dfinity/utils';
+import { isNullish, jsonReviver } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export const syncWallet = ({
@@ -27,9 +27,13 @@ export const syncWallet = ({
 		}
 	});
 
-	// TODO(OISY-296): set nullish if newTransactions is null
+	if (isNullish(newTransactions)) {
+		icTransactionsStore.nullify(tokenId);
+		return;
+	}
+
 	icTransactionsStore.prepend({
 		tokenId,
-		transactions: JSON.parse(newTransactions ?? '[]', jsonReviver)
+		transactions: JSON.parse(newTransactions, jsonReviver)
 	});
 };

--- a/src/frontend/src/tests/icp/services/ic-listener.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-listener.services.spec.ts
@@ -1,0 +1,128 @@
+import { syncWallet } from '$icp/services/ic-listener.services';
+import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
+import { balancesStore } from '$lib/stores/balances.store';
+import type { PostMessageDataResponseWallet } from '$lib/types/post-message';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { createCertifiedIcTransactionUiMock } from '$tests/utils/transactions-stores.test-utils';
+import { jsonReplacer } from '@dfinity/utils';
+import { BigNumber } from 'alchemy-sdk';
+import { get } from 'svelte/store';
+
+describe('ic-listener', () => {
+	const tokenId: TokenId = parseTokenId('test');
+
+	const mockBalance = 1256n;
+
+	const mockTransactions = [
+		createCertifiedIcTransactionUiMock('tx1'),
+		createCertifiedIcTransactionUiMock('tx2')
+	];
+
+	const mockCertifiedTransactions = mockTransactions.map((data, i) => ({
+		data,
+		certified: i % 2 === 0
+	}));
+
+	const mockPostMessage: PostMessageDataResponseWallet = {
+		wallet: {
+			balance: {
+				certified: true,
+				data: mockBalance
+			},
+			newTransactions: JSON.stringify(mockCertifiedTransactions, jsonReplacer)
+		}
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		balancesStore.reset(tokenId);
+		icTransactionsStore.reset(tokenId);
+	});
+
+	it('should set the balance in balancesStore', () => {
+		syncWallet({ data: mockPostMessage, tokenId });
+
+		const balance = get(balancesStore);
+
+		expect(balance?.[tokenId]).toEqual({
+			data: BigNumber.from(mockBalance),
+			certified: true
+		});
+	});
+
+	it('should set the transactions in icTransactionsStore', () => {
+		syncWallet({ data: mockPostMessage, tokenId });
+
+		const transactions = get(icTransactionsStore);
+
+		expect(transactions?.[tokenId]).toEqual(mockCertifiedTransactions);
+	});
+
+	it('should prepend the transactions in icTransactionsStore', () => {
+		syncWallet({ data: mockPostMessage, tokenId });
+
+		const mockMoreCertifiedTransactions = mockTransactions.map((data, i) => ({
+			data: {
+				...data,
+				id: `more-tx${i}`
+			},
+			certified: i % 2 === 0
+		}));
+
+		const mockMorePostMessage: PostMessageDataResponseWallet = {
+			wallet: {
+				balance: {
+					certified: true,
+					data: mockBalance
+				},
+				newTransactions: JSON.stringify(mockMoreCertifiedTransactions, jsonReplacer)
+			}
+		};
+
+		syncWallet({ data: mockMorePostMessage, tokenId });
+
+		const transactions = get(icTransactionsStore);
+
+		expect(transactions?.[tokenId]).toEqual([
+			...mockMoreCertifiedTransactions,
+			...mockCertifiedTransactions
+		]);
+	});
+
+	it('should nullify the transactions of icTransactionsStore if newTransactions undefined', () => {
+		const mockPostMessage: PostMessageDataResponseWallet = {
+			wallet: {
+				balance: {
+					certified: true,
+					data: mockBalance
+				},
+				newTransactions: undefined
+			}
+		};
+
+		syncWallet({ data: mockPostMessage, tokenId });
+
+		const transactions = get(icTransactionsStore);
+
+		expect(transactions?.[tokenId]).toBeNull();
+	});
+
+	it('should nullify the transactions of icTransactionsStore if newTransactions is not provided', () => {
+		const mockPostMessage: PostMessageDataResponseWallet = {
+			wallet: {
+				balance: {
+					certified: true,
+					data: mockBalance
+				}
+			}
+		};
+
+		syncWallet({ data: mockPostMessage, tokenId });
+
+		const transactions = get(icTransactionsStore);
+
+		expect(transactions?.[tokenId]).toBeNull();
+	});
+});


### PR DESCRIPTION
# Motivation

When the IC web worker scheduler runs without index canister to solely fetch the balance from the ledger, the related ic transactions store entry for the token should be nullified.

# Changes

- `nullify` ic transactions store if undefined transactions is received (no matter what - i.e. regardless if there were transactions in memory)
