### PR TITLE
feat(frontend): convert wizard steps

### DIFF
--- a/src/frontend/src/lib/config/convert.config.ts
+++ b/src/frontend/src/lib/config/convert.config.ts
@@ -1,0 +1,31 @@
+import { WizardStepsConvert } from '$lib/enums/wizard-steps';
+import type { WizardStepsParams } from '$lib/types/steps';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import type { WizardSteps } from '@dfinity/gix-components';
+
+interface ConvertWizardStepsParams extends WizardStepsParams {
+	sourceToken: string;
+	destinationToken: string;
+}
+
+export const convertWizardSteps = ({
+	i18n,
+	sourceToken,
+	destinationToken
+}: ConvertWizardStepsParams): WizardSteps => [
+	{
+		name: WizardStepsConvert.CONVERT,
+		title: replacePlaceholders(i18n.convert.text.swap_to_token, {
+			$sourceToken: sourceToken,
+			$destinationToken: destinationToken
+		})
+	},
+	{
+		name: WizardStepsConvert.REVIEW,
+		title: i18n.convert.text.review
+	},
+	{
+		name: WizardStepsConvert.CONVERTING,
+		title: i18n.convert.text.executing_transaction
+	}
+];

--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -1,8 +1,8 @@
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
+import type { WizardStepsParams } from '$lib/types/steps';
 import type { WizardSteps } from '@dfinity/gix-components';
 
-interface SendWizardStepsParams {
-	i18n: I18n;
+interface SendWizardStepsParams extends WizardStepsParams {
 	converting?: boolean;
 }
 

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -5,3 +5,9 @@ export enum WizardStepsSend {
 	SENDING = 'Sending',
 	QR_CODE_SCAN = 'QR Code Scan'
 }
+
+export enum WizardStepsConvert {
+	CONVERT = 'Convert',
+	REVIEW = 'Review',
+	CONVERTING = 'Converting'
+}

--- a/src/frontend/src/lib/types/steps.ts
+++ b/src/frontend/src/lib/types/steps.ts
@@ -4,3 +4,7 @@ export interface StaticStep extends Omit<ProgressStep, 'state'> {
 	progressLabel?: string;
 	state: ProgressStepState | 'skipped';
 }
+
+export interface WizardStepsParams {
+	i18n: I18n;
+}


### PR DESCRIPTION
# Motivation

This PR includes convert wizard steps for the swap flow. It also shares a common interface `WizardStepsParams` between send and convert flows.
