### PR TITLE
feat(frontend): onSend callbacks in btc-send.services

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -113,8 +113,13 @@
 				network,
 				source,
 				identity: $authIdentity,
-				onSendStarted: () => progress(ProgressStepsSendBtc.SEND),
-				onSendCompleted: () => progress(ProgressStepsSendBtc.DONE)
+				onProgress: () => {
+					if (sendProgressStep === ProgressStepsSendBtc.INITIALIZATION) {
+						progress(ProgressStepsSendBtc.SEND);
+					} else if (sendProgressStep === ProgressStepsSendBtc.SEND) {
+						progress(ProgressStepsSendBtc.DONE);
+					}
+				}
 			});
 
 			sendProgressStep = ProgressStepsSendBtc.DONE;

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -110,10 +110,11 @@
 				destination,
 				amount,
 				utxosFee,
-				progress,
 				network,
 				source,
-				identity: $authIdentity
+				identity: $authIdentity,
+				onSendStarted: () => progress(ProgressStepsSendBtc.SEND),
+				onSendCompleted: () => progress(ProgressStepsSendBtc.DONE)
 			});
 
 			sendProgressStep = ProgressStepsSendBtc.DONE;

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -22,8 +22,7 @@ export type SendBtcParams = BtcSendServiceParams & {
 	destination: BtcAddress;
 	source: BtcAddress;
 	utxosFee: UtxosFee;
-	onSendStarted?: () => void;
-	onSendCompleted?: () => void;
+	onProgress?: () => void;
 };
 
 export const selectUtxosFee = async ({
@@ -52,13 +51,13 @@ export const sendBtc = async ({
 	network,
 	source,
 	identity,
-	onSendStarted,
-	onSendCompleted,
+	onProgress,
 	...rest
 }: SendBtcParams): Promise<void> => {
-	const { txid } = await send({ onSendStarted, utxosFee, network, identity, ...rest });
+	// TODO: use txid returned by this method to register it as a pending transaction in BE
+	const { txid } = await send({ onProgress, utxosFee, network, identity, ...rest });
 
-	onSendCompleted?.();
+	onProgress?.();
 
 	await addPendingBtcTransaction({
 		identity,
@@ -77,12 +76,12 @@ const send = async ({
 	network,
 	amount,
 	utxosFee,
-	onSendStarted
+	onProgress
 }: Omit<SendBtcParams, 'source'>): Promise<SendBtcResponse> => {
 	const satoshisAmount = convertNumberToSatoshis({ amount });
 	const signerBitcoinNetwork = mapToSignerBitcoinNetwork({ network });
 
-	onSendStarted?.();
+	onProgress?.();
 
 	return await sendBtcApi({
 		identity,

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -3,7 +3,6 @@ import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import type { SendBtcResponse } from '$declarations/signer/signer.did';
 import { addPendingBtcTransaction, selectUserUtxosFee } from '$lib/api/backend.api';
 import { sendBtc as sendBtcApi } from '$lib/api/signer.api';
-import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 import type { BtcAddress } from '$lib/types/address';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
@@ -17,13 +16,14 @@ interface BtcSendServiceParams {
 	identity: Identity;
 	network: BitcoinNetwork;
 	amount: number;
-	progress: (step: ProgressStepsSendBtc) => void;
 }
 
 export type SendBtcParams = BtcSendServiceParams & {
 	destination: BtcAddress;
 	source: BtcAddress;
 	utxosFee: UtxosFee;
+	onSendStarted?: () => void;
+	onSendCompleted?: () => void;
 };
 
 export const selectUtxosFee = async ({
@@ -48,16 +48,17 @@ export const selectUtxosFee = async ({
 };
 
 export const sendBtc = async ({
-	progress,
 	utxosFee,
 	network,
 	source,
 	identity,
+	onSendStarted,
+	onSendCompleted,
 	...rest
 }: SendBtcParams): Promise<void> => {
-	const { txid } = await send({ progress, utxosFee, network, identity, ...rest });
+	const { txid } = await send({ onSendStarted, utxosFee, network, identity, ...rest });
 
-	progress(ProgressStepsSendBtc.RELOAD);
+	onSendCompleted?.();
 
 	await addPendingBtcTransaction({
 		identity,
@@ -76,12 +77,12 @@ const send = async ({
 	network,
 	amount,
 	utxosFee,
-	progress
+	onSendStarted
 }: Omit<SendBtcParams, 'source'>): Promise<SendBtcResponse> => {
 	const satoshisAmount = convertNumberToSatoshis({ amount });
 	const signerBitcoinNetwork = mapToSignerBitcoinNetwork({ network });
 
-	progress(ProgressStepsSendBtc.SEND);
+	onSendStarted?.();
 
 	return await sendBtcApi({
 		identity,

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -2,7 +2,6 @@ import { sendBtc, type SendBtcParams } from '$btc/services/btc-send.services';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import * as backendAPI from '$lib/api/backend.api';
 import * as signerAPI from '$lib/api/signer.api';
-import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { mockUtxosFee } from '$tests/mocks/btc.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -10,7 +9,7 @@ import { hexStringToUint8Array, toNullable } from '@dfinity/utils';
 
 describe('btc-send.services', () => {
 	const defaultParams = {
-		progress: () => {},
+		onProgress: () => {},
 		utxosFee: mockUtxosFee,
 		network: 'mainnet',
 		source: 'address',
@@ -29,11 +28,11 @@ describe('btc-send.services', () => {
 				.spyOn(backendAPI, 'addPendingBtcTransaction')
 				.mockResolvedValue(true);
 			const sendBtcApiSpy = vi.spyOn(signerAPI, 'sendBtc').mockResolvedValue({ txid });
-			const progressSpy = vi.spyOn(defaultParams, 'progress');
+			const onProgressSpy = vi.spyOn(defaultParams, 'onProgress');
 
 			await sendBtc(defaultParams);
 
-			expect(progressSpy).toHaveBeenCalledWith(ProgressStepsSendBtc.SEND);
+			expect(onProgressSpy).toHaveBeenCalled();
 
 			expect(sendBtcApiSpy).toHaveBeenCalledOnce();
 			expect(sendBtcApiSpy).toHaveBeenCalledWith({
@@ -49,7 +48,7 @@ describe('btc-send.services', () => {
 				]
 			});
 
-			expect(progressSpy).toHaveBeenCalledWith(ProgressStepsSendBtc.RELOAD);
+			expect(onProgressSpy).toHaveBeenCalled();
 
 			expect(addPendingBtcTransactionSpy).toHaveBeenCalledOnce();
 			expect(addPendingBtcTransactionSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
# Motivation

The idea is to decouple btc-send.services from the send flow so the service can be re-used by the conversion wizard too.
