### PR TITLE
feat(frontend): hide custom token without Index canister

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Identity } from '@dfinity/agent';
 	import { Principal } from '@dfinity/principal';
-	import { assertNonNullish, toNullable } from '@dfinity/utils';
+	import { assertNonNullish, nonNullish, toNullable } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { loadCustomTokens } from '$icp/services/icrc.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
@@ -35,19 +35,11 @@
 			return { valid: false };
 		}
 
-		if (isNullishOrEmpty(indexCanisterId)) {
-			toastsError({
-				msg: { text: $i18n.tokens.error.invalid_index }
-			});
-			return { valid: false };
-		}
-
 		return { valid: true };
 	};
 
 	const hideToken = async (params: { identity: Identity }) => {
 		assertNonNullish(ledgerCanisterId);
-		assertNonNullish(indexCanisterId);
 
 		await setCustomToken({
 			...params,
@@ -57,7 +49,9 @@
 				token: {
 					Icrc: {
 						ledger_id: Principal.fromText(ledgerCanisterId),
-						index_id: toNullable(Principal.fromText(indexCanisterId))
+						index_id: toNullable(
+							nonNullish(indexCanisterId) ? Principal.fromText(indexCanisterId) : undefined
+						)
 					}
 				}
 			},

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -491,7 +491,6 @@
 		"error": {
 			"invalid_contract_address": "Contract address is invalid.",
 			"invalid_ledger": "The selected token is not linked with an Icrc Ledger canister.",
-			"invalid_index": "The selected token is not linked with an Icrc Index canister.",
 			"no_metadata": "No metadata were fetched for the contract address.",
 			"unexpected": "Something went wrong while saving the token.",
 			"unexpected_hiding": "Something went wrong while hiding the token.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -433,7 +433,6 @@ interface I18nTokens {
 	error: {
 		invalid_contract_address: string;
 		invalid_ledger: string;
-		invalid_index: string;
 		no_metadata: string;
 		unexpected: string;
 		unexpected_hiding: string;


### PR DESCRIPTION
# Motivation

Now that we support custom tokens without an Index canister, it should also be possible to hide them. However, this is not yet the case, as the hide function currently requires an Index canister to be provided.

# Changes

- Handle nullable Index canister ID in "Hide" component.
- Remove unused label key.

# Tests

Manually tested.
