### PR TITLE
refactor(frontend): rename types of Ethereum transactions store

### DIFF
--- a/src/frontend/src/eth/stores/eth-transactions.store.ts
+++ b/src/frontend/src/eth/stores/eth-transactions.store.ts
@@ -12,7 +12,7 @@ export interface EthTransactionsStore extends Readable<EthTransactionsData> {
 	reset: () => void;
 }
 
-const initTransactionsStore = (): EthTransactionsStore => {
+const initEthTransactionsStore = (): EthTransactionsStore => {
 	const INITIAL: EthTransactionsData = {} as Record<TokenId, Transaction[]>;
 
 	const { subscribe, update, set } = writable<EthTransactionsData>(INITIAL);
@@ -41,4 +41,4 @@ const initTransactionsStore = (): EthTransactionsStore => {
 	};
 };
 
-export const ethTransactionsStore = initTransactionsStore();
+export const ethTransactionsStore = initEthTransactionsStore();

--- a/src/frontend/src/eth/stores/eth-transactions.store.ts
+++ b/src/frontend/src/eth/stores/eth-transactions.store.ts
@@ -3,19 +3,19 @@ import type { Transaction } from '$lib/types/transaction';
 import { nonNullish } from '@dfinity/utils';
 import { writable, type Readable } from 'svelte/store';
 
-export type TransactionsData = Record<TokenId, Transaction[]>;
+export type EthTransactionsData = Record<TokenId, Transaction[]>;
 
-export interface TransactionsStore extends Readable<TransactionsData> {
+export interface EthTransactionsStore extends Readable<EthTransactionsData> {
 	set: (params: { tokenId: TokenId; transactions: Transaction[] }) => void;
 	add: (params: { tokenId: TokenId; transactions: Transaction[] }) => void;
 	update: (params: { tokenId: TokenId; transaction: Transaction }) => void;
 	reset: () => void;
 }
 
-const initTransactionsStore = (): TransactionsStore => {
-	const INITIAL: TransactionsData = {} as Record<TokenId, Transaction[]>;
+const initTransactionsStore = (): EthTransactionsStore => {
+	const INITIAL: EthTransactionsData = {} as Record<TokenId, Transaction[]>;
 
-	const { subscribe, update, set } = writable<TransactionsData>(INITIAL);
+	const { subscribe, update, set } = writable<EthTransactionsData>(INITIAL);
 
 	return {
 		set: ({ tokenId, transactions }: { tokenId: TokenId; transactions: Transaction[] }) =>


### PR DESCRIPTION
# Motivation

Renaming Ethereum transactions store types.
