### PR TITLE
feat(devops): Manually deploy breaking changes via CI

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -25,11 +25,6 @@ on:
         type: boolean
         description: 'Force backend deployment even if no changes are detected.'
         default: false
-      backend-yes:
-        required: false
-        type: boolean
-        description: 'Allow breaking changes and other blockers to backend deployment'
-        default: false
 
 run-name: >-
   ${{ 
@@ -160,7 +155,7 @@ jobs:
       - name: Deploy Backend to Environment
         run: |
           DFX_DEPLOY_FLAGS=() # Arguments to be added to the dfx deploy command.
-          [[ "${{ github.event.inputs.backend-yes }}" != "true" ]] || DFX_DEPLOY_FLAGS+=('--yes') # Corresponds to: dfx deploy --yes
+          [[ "${{ github.event.inputs.force-backend }}" != "true" ]] || DFX_DEPLOY_FLAGS+=('--yes' '--upgrade-unchanged') # Corresponds to: dfx deploy --yes --upgrade-unchanged
 
           if [ "$CANISTER" == "backend" ] || [ "${{ github.event_name }}" == "push" ]; then
             if git diff --quiet HEAD~1 HEAD -- Cargo.toml Cargo.lock rust-toolchain.toml src/backend/**/* src/shared/**/*; then

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -25,6 +25,11 @@ on:
         type: boolean
         description: 'Force backend deployment even if no changes are detected.'
         default: false
+      backend-yes:
+        required: false
+        type: boolean
+        description: 'Allow breaking changes and other blockers to backend deployment'
+        default: false
 
 run-name: >-
   ${{ 
@@ -154,14 +159,17 @@ jobs:
 
       - name: Deploy Backend to Environment
         run: |
+          DFX_DEPLOY_FLAGS=() # Arguments to be added to the dfx deploy command.
+          [[ "${{ github.event.inputs.backend-yes }}" != "true" ]] || DFX_DEPLOY_FLAGS+=('--yes') # Corresponds to: dfx deploy --yes
+
           if [ "$CANISTER" == "backend" ] || [ "${{ github.event_name }}" == "push" ]; then
             if git diff --quiet HEAD~1 HEAD -- Cargo.toml Cargo.lock rust-toolchain.toml src/backend/**/* src/shared/**/*; then
               if [ "${{ github.event.inputs.force-backend }}" == "false" ]; then
                 echo "No changes in specified files/folders detected, skipping backend deployment."
               else
-                ENV=$NETWORK ./scripts/deploy.backend.sh
+                ENV=$NETWORK ./scripts/deploy.backend.sh "${DFX_DEPLOY_FLAGS[@]}"
               fi
             else            
-              ENV=$NETWORK ./scripts/deploy.backend.sh
+              ENV=$NETWORK ./scripts/deploy.backend.sh "${DFX_DEPLOY_FLAGS[@]}"
             fi
           fi

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           echo "This workflow can only be manually triggered with workflow_dispatch on the main branch"
-          exit 1
+          # exit 1
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           echo "This workflow can only be manually triggered with workflow_dispatch on the main branch"
-          # exit 1
+          exit 1
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -60,7 +60,7 @@ if [ -n "${ENV+1}" ]; then
          };
          ic_root_key_der = $ic_root_key_der;
      }
-  })" --network "$ENV"
+  })" --network "$ENV" "${@}"
 else
   DEFAULT_CANISTER_ID="$(dfx canister id --network staging backend)"
   dfx deploy backend --argument "(variant {
@@ -79,5 +79,5 @@ else
          };
          ic_root_key_der = $ic_root_key_der;
      }
-  })" --specified-id "$DEFAULT_CANISTER_ID"
+  })" --specified-id "$DEFAULT_CANISTER_ID" "${@}"
 fi


### PR DESCRIPTION
# Motivation
If an API changes, dfx will typically ask the user whether they really want to deploy.  In CI, we need a way of saying "yes", but probably don't want this to be the default.

There is an existing checkbox for forcing the backend deployment to take place, no matter what.  It seems reasonable to use `--yes` when that is selected, so we do not need a new input.

# Changes
- If `force-backend` is selected in the CI deployment task, deploy with `--yes` and `--upgrade-unchanged`.

# Tests
Executed the action by:
- Disabling the check that allows deploying only from main.
- Running the action with: `gh workflow run deploy-to-environment.yml --ref "yes" --field network=staging --field canister=backend --field force-backend=true`
- Re-enabling the main check.
