### PR TITLE
test(frontend): add sendBtc tests

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -20,7 +20,7 @@ interface BtcSendServiceParams {
 	progress: (step: ProgressStepsSendBtc) => void;
 }
 
-type SendBtcParams = BtcSendServiceParams & {
+export type SendBtcParams = BtcSendServiceParams & {
 	destination: BtcAddress;
 	source: BtcAddress;
 	utxosFee: UtxosFee;
@@ -55,7 +55,6 @@ export const sendBtc = async ({
 	identity,
 	...rest
 }: SendBtcParams): Promise<void> => {
-	// TODO: use txid returned by this method to register it as a pending transaction in BE
 	const { txid } = await send({ progress, utxosFee, network, identity, ...rest });
 
 	progress(ProgressStepsSendBtc.RELOAD);

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -1,0 +1,71 @@
+import * as btcSendService from '$btc/services/btc-send.services';
+import { type SendBtcParams } from '$btc/services/btc-send.services';
+import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
+import * as backendAPI from '$lib/api/backend.api';
+import * as signerAPI from '$lib/api/signer.api';
+import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
+import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
+import * as walletUtils from '$lib/utils/wallet.utils';
+import { mockUtxosFee } from '$tests/mocks/btc.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { hexStringToUint8Array, toNullable } from '@dfinity/utils';
+
+describe('btc-send.services', () => {
+	const defaultParams = {
+		progress: () => {},
+		utxosFee: mockUtxosFee,
+		network: 'mainnet',
+		source: 'address',
+		destination: 'address',
+		identity: mockIdentity,
+		amount: 10
+	} as SendBtcParams;
+	const txid = 'txid;';
+
+	beforeEach(() => {
+		mockPage.reset();
+	});
+
+	describe('sendBtc', () => {
+		it('should call all required functions', async () => {
+			const addPendingBtcTransactionSpy = vi
+				.spyOn(backendAPI, 'addPendingBtcTransaction')
+				.mockResolvedValue(true);
+			const sendBtcApiSpy = vi.spyOn(signerAPI, 'sendBtc').mockResolvedValue({ txid });
+			const progressSpy = vi.spyOn(defaultParams, 'progress');
+			const waitAndTriggerWalletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
+
+			await btcSendService.sendBtc(defaultParams);
+
+			expect(progressSpy).toHaveBeenCalledWith(ProgressStepsSendBtc.SEND);
+
+			expect(sendBtcApiSpy).toHaveBeenCalledOnce();
+			expect(sendBtcApiSpy).toHaveBeenCalledWith({
+				identity: defaultParams.identity,
+				network: mapToSignerBitcoinNetwork({ network: defaultParams.network }),
+				feeSatoshis: toNullable(defaultParams.utxosFee.feeSatoshis),
+				utxosToSpend: defaultParams.utxosFee.utxos,
+				outputs: [
+					{
+						destination_address: defaultParams.destination,
+						sent_satoshis: convertNumberToSatoshis({ amount: defaultParams.amount })
+					}
+				]
+			});
+
+			expect(progressSpy).toHaveBeenCalledWith(ProgressStepsSendBtc.RELOAD);
+
+			expect(addPendingBtcTransactionSpy).toHaveBeenCalledOnce();
+			expect(addPendingBtcTransactionSpy).toHaveBeenCalledWith({
+				identity: defaultParams.identity,
+				network: mapToSignerBitcoinNetwork({ network: defaultParams.network }),
+				address: defaultParams.source,
+				txId: hexStringToUint8Array(txid),
+				utxos: defaultParams.utxosFee.utxos
+			});
+
+			expect(waitAndTriggerWalletSpy).toHaveBeenCalledOnce();
+		});
+	});
+});

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -4,7 +4,6 @@ import * as backendAPI from '$lib/api/backend.api';
 import * as signerAPI from '$lib/api/signer.api';
 import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
-import * as walletUtils from '$lib/utils/wallet.utils';
 import { mockUtxosFee } from '$tests/mocks/btc.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { hexStringToUint8Array, toNullable } from '@dfinity/utils';
@@ -31,7 +30,6 @@ describe('btc-send.services', () => {
 				.mockResolvedValue(true);
 			const sendBtcApiSpy = vi.spyOn(signerAPI, 'sendBtc').mockResolvedValue({ txid });
 			const progressSpy = vi.spyOn(defaultParams, 'progress');
-			const waitAndTriggerWalletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
 
 			await sendBtc(defaultParams);
 
@@ -61,8 +59,6 @@ describe('btc-send.services', () => {
 				txId: hexStringToUint8Array(txid),
 				utxos: defaultParams.utxosFee.utxos
 			});
-
-			expect(waitAndTriggerWalletSpy).toHaveBeenCalledOnce();
 		});
 
 		it('should throw if signer sendBtc throws', async () => {


### PR DESCRIPTION
# Motivation

As agreed, before adding changes to a function, I'm covering existing functionality with tests. In this case, it's about `sendBtc` of `btc-send.services`.
