### PR TITLE
feat(frontend): ConvertFee component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertFee.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertFee.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import ConvertAmountDisplay from '$lib/components/convert/ConvertAmountDisplay.svelte';
+	import { formatToken } from '$lib/utils/format.utils';
+
+	export let feeAmount: bigint | undefined = undefined;
+	export let symbol: string;
+	export let decimals: number;
+	export let exchangeRate: number | undefined = undefined;
+	export let zeroAmountLabel: string | undefined = undefined;
+
+	let formattedFeeAmount: number | undefined;
+	$: formattedFeeAmount = nonNullish(feeAmount)
+		? Number(
+				formatToken({
+					value: BigNumber.from(feeAmount),
+					unitName: decimals,
+					displayDecimals: decimals
+				})
+			)
+		: undefined;
+</script>
+
+<ConvertAmountDisplay amount={formattedFeeAmount} {exchangeRate} {symbol} {zeroAmountLabel}
+	><slot slot="label" name="label" />
+</ConvertAmountDisplay>

--- a/src/frontend/src/lib/components/convert/ConvertFee.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertFee.svelte
@@ -12,7 +12,8 @@
 
 	let formattedFeeAmount: number | undefined;
 	$: formattedFeeAmount = nonNullish(feeAmount)
-		? Number(
+		? // TODO: create a util for formating and converting a bigint to number
+			Number(
 				formatToken({
 					value: BigNumber.from(feeAmount),
 					unitName: decimals,


### PR DESCRIPTION
# Motivation

A small wrapper around `ConvertAmountDisplay` to display provided `feeAmount` (or `zeroAmountLabel` if fee is zero and the label is there).

Small heads up: total fee will have a separate component, since it should be displayed differently.

P.S.: I haven't added unit tests for this one as the child component as well as all used here utils are tested separately.

<img width="526" alt="Screenshot 2024-11-14 at 14 46 20" src="https://github.com/user-attachments/assets/068e1c48-a5f7-48c7-93ef-6046a780ee42">
