### PR TITLE
feat(frontend): ConvertFeeTotal component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertFeeTotal.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertFeeTotal.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { BigNumber } from '@ethersproject/bignumber';
+	import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
+	import ConvertValue from '$lib/components/convert/ConvertValue.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { formatToken } from '$lib/utils/format.utils';
+
+	export let feeAmount: bigint | undefined = undefined;
+	export let decimals: number;
+	export let exchangeRate: number | undefined = undefined;
+
+	let formattedAmount: number | undefined;
+	$: formattedAmount = nonNullish(feeAmount)
+		? Number(
+				formatToken({
+					value: BigNumber.from(feeAmount),
+					unitName: decimals,
+					displayDecimals: decimals
+				})
+			)
+		: undefined;
+</script>
+
+<ConvertValue>
+	<svelte:fragment slot="label">{$i18n.fee.text.total_fee}</svelte:fragment>
+
+	<svelte:fragment slot="main-value">
+		<ConvertAmountExchange amount={formattedAmount} {exchangeRate} />
+	</svelte:fragment>
+</ConvertValue>

--- a/src/frontend/src/lib/components/convert/ConvertFeeTotal.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertFeeTotal.svelte
@@ -12,7 +12,8 @@
 
 	let formattedAmount: number | undefined;
 	$: formattedAmount = nonNullish(feeAmount)
-		? Number(
+		? // TODO: create a util for formating and converting a bigint to number
+			Number(
 				formatToken({
 					value: BigNumber.from(feeAmount),
 					unitName: decimals,


### PR DESCRIPTION
# Motivation

A component for displaying total fee value. The difference with `ConvertFee` component is that total fee should only display a dollar value, and this value should be passed as `main-value` slot (in order to have `font-bold`).

P.S.: same as with `TotalFee`, I think this component is too simple to have its own unit tests. Let me know if you still want to have some tests.

<img width="489" alt="Screenshot 2024-11-14 at 14 50 38" src="https://github.com/user-attachments/assets/bbb697f5-6d38-4d39-84f7-2e11ada8c002">
