### PR TITLE
feat(frontend): util to sort unified transaction list

### DIFF
--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -1,5 +1,6 @@
 import BtcTransaction from '$btc/components/transactions/BtcTransaction.svelte';
 import type { BtcTransactionUi } from '$btc/types/btc';
+import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { Token } from '$lib/types/token';
@@ -60,7 +61,10 @@ export const sortTransactions = ({
 	transactionB: AnyTransactionUi;
 }): number => {
 	if (nonNullish(timestampA) && nonNullish(timestampB)) {
-		return Number(timestampB) - Number(timestampA);
+		return (
+			Number(normalizeTimestampToSeconds(timestampB)) -
+			Number(normalizeTimestampToSeconds(timestampA))
+		);
 	}
 
 	return nonNullish(timestampA) ? 1 : -1;

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -3,13 +3,13 @@ import type { BtcTransactionUi } from '$btc/types/btc';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { Token } from '$lib/types/token';
-import type { AllTransactionsUi } from '$lib/types/transaction';
+import type { AllTransactionsUi, AnyTransactionUi } from '$lib/types/transaction';
 import {
 	isNetworkIdBTCMainnet,
 	isNetworkIdEthereum,
 	isNetworkIdICP
 } from '$lib/utils/network.utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 /**
  * Maps the transactions stores to a unified list of transactions with their respective components.
@@ -51,3 +51,17 @@ export const mapAllTransactionsUi = ({
 
 		return acc;
 	}, []);
+
+export const sortTransactions = ({
+	transactionA: { timestamp: timestampA },
+	transactionB: { timestamp: timestampB }
+}: {
+	transactionA: AnyTransactionUi;
+	transactionB: AnyTransactionUi;
+}): number => {
+	if (nonNullish(timestampA) && nonNullish(timestampB)) {
+		return Number(timestampB) - Number(timestampA);
+	}
+
+	return nonNullish(timestampA) ? 1 : -1;
+};

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -8,7 +8,8 @@ import {
 } from '$env/tokens.btc.env';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
-import { mapAllTransactionsUi } from '$lib/utils/transactions.utils';
+import type { AnyTransactionUi } from '$lib/types/transaction';
+import { mapAllTransactionsUi, sortTransactions } from '$lib/utils/transactions.utils';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc.mock';
 
 describe('transactions.utils', () => {
@@ -54,6 +55,27 @@ describe('transactions.utils', () => {
 
 				expect(result).toEqual([]);
 			});
+		});
+	});
+
+	describe('sortTransactions', () => {
+		const transaction1 = { timestamp: 1 } as AnyTransactionUi;
+		const transaction2 = { timestamp: 2 } as AnyTransactionUi;
+		const transaction3 = { timestamp: 3 } as AnyTransactionUi;
+		const transactionWithNullTimestamp = { timestamp: undefined } as AnyTransactionUi;
+
+		it('should sort transactions in descending order by timestamp', () => {
+			const result = [transaction2, transaction1, transaction3].sort((a, b) =>
+				sortTransactions({ transactionA: a, transactionB: b })
+			);
+			expect(result).toEqual([transaction3, transaction2, transaction1]);
+		});
+
+		it('should sort transactions with nullish timestamps first', () => {
+			const result = [transaction1, transactionWithNullTimestamp, transaction2].sort((a, b) =>
+				sortTransactions({ transactionA: a, transactionB: b })
+			);
+			expect(result).toEqual([transactionWithNullTimestamp, transaction2, transaction1]);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

I thought a lot about what would be the best way to reduce loops for the unified transaction list, but the only flow that I was able to reach and respect the requirements is:

- First loop --> unify the transactions looping the enabled tokens
- Second loop --> sort the transactions
- Third loop --> group by date (that gives automatically the correct sorting)

I verified if performance was better when the sorting would happen after, for dates and for each date group, but it was not better.

Furthermore there would be another method, but it would create the date groups directly when rendering inside the component. We yield the "latest date" and every-time it changes, we add a title with the new date, so we don't need to group anymore, just an if condition inside the component rendering. However, I think that is too much logic in the component.

So, for now we still create another util to sort the transactions, only by timestamp. The ones without timestamp will be put automatically on top (pending).

We will use it in the UI in another PR.

# Tests

Added tests.
