### PR TITLE
feat(backend): Add derivation_origin to backend config

### DIFF
--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -53,7 +53,7 @@ if [ -n "${ENV+1}" ]; then
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
          cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
-         derivation_origin = \"$DERIVATION_ORIGIN\";
+         derivation_origin = opt \"$DERIVATION_ORIGIN\";
          supported_credentials = opt vec {
             record {
               credential_type = variant { ProofOfUniqueness };
@@ -73,7 +73,7 @@ else
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
          cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
-         derivation_origin = \"$DERIVATION_ORIGIN\";
+         derivation_origin = opt \"$DERIVATION_ORIGIN\";
          supported_credentials = opt vec {
             record {
               credential_type = variant { ProofOfUniqueness };

--- a/scripts/deploy.backend.sh
+++ b/scripts/deploy.backend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
+BACKEND_CANISTER_ID="$(dfx canister id backend --network "${ENV:-local}")"
 POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
 SIGNER_CANISTER_ID="$(dfx canister id signer --network "${ENV:-local}")"
 
@@ -12,6 +13,7 @@ case $ENV in
   # URL used by issuer in the issued verifiable credentials (typically hard-coded)
   # Represents more an ID than a URL
   POUH_ISSUER_VC_URL="https://${POUH_ISSUER_CANISTER_ID}.icp0.io/"
+  DERIVATION_ORIGIN="https://tewsx-xaaaa-aaaad-aadia-cai.icp0.io"
   ;;
 "ic")
   ECDSA_KEY_NAME="key_1"
@@ -20,6 +22,7 @@ case $ENV in
   # URL used by issuer in the issued verifiable credentials (tipically hard-coded)
   # Represents more an ID than a URL
   POUH_ISSUER_VC_URL="https://id.decideai.xyz/"
+  DERIVATION_ORIGIN="https://oisy.com"
   ;;
 *)
   ECDSA_KEY_NAME="dfx_test_key"
@@ -34,6 +37,7 @@ case $ENV in
   # URL used by issuer in the issued verifiable credentials (tipically hard-coded)
   # We use the dummy issuer canister for local development
   POUH_ISSUER_VC_URL="https://dummy-issuer.vc/"
+  DERIVATION_ORIGIN="http://${BACKEND_CANISTER_ID}.localhost:4943"
   ;;
 esac
 
@@ -49,6 +53,7 @@ if [ -n "${ENV+1}" ]; then
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
          cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
+         derivation_origin = \"$DERIVATION_ORIGIN\";
          supported_credentials = opt vec {
             record {
               credential_type = variant { ProofOfUniqueness };
@@ -68,6 +73,7 @@ else
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = vec {};
          cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
+         derivation_origin = \"$DERIVATION_ORIGIN\";
          supported_credentials = opt vec {
             record {
               credential_type = variant { ProofOfUniqueness };

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -60,7 +60,7 @@ type CanisterStatusResultV2 = record {
 type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
   api : opt Guards;
-  derivation_origin : text;
+  derivation_origin : opt text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;
@@ -100,7 +100,7 @@ type HttpResponse = record {
 type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   api : opt Guards;
-  derivation_origin : text;
+  derivation_origin : opt text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -60,6 +60,7 @@ type CanisterStatusResultV2 = record {
 type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
   api : opt Guards;
+  derivation_origin : text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;
@@ -99,6 +100,7 @@ type HttpResponse = record {
 type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   api : opt Guards;
+  derivation_origin : text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -322,6 +322,7 @@ pub(crate) fn init_arg() -> Arg {
         cfs_canister_id: Some(
             Principal::from_text(SIGNER_CANISTER_ID.to_string()).expect("wrong cfs canister id"),
         ),
+        derivation_origin: "https://l7rua-raaaa-aaaap-ahh6a-cai.ic0.app".to_string(),
     })
 }
 

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -322,7 +322,7 @@ pub(crate) fn init_arg() -> Arg {
         cfs_canister_id: Some(
             Principal::from_text(SIGNER_CANISTER_ID.to_string()).expect("wrong cfs canister id"),
         ),
-        derivation_origin: "https://l7rua-raaaa-aaaap-ahh6a-cai.ic0.app".to_string(),
+        derivation_origin: Some("https://l7rua-raaaa-aaaap-ahh6a-cai.ic0.app".to_string()),
     })
 }
 

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -60,7 +60,7 @@ type CanisterStatusResultV2 = record {
 type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
   api : opt Guards;
-  derivation_origin : text;
+  derivation_origin : opt text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;
@@ -100,7 +100,7 @@ type HttpResponse = record {
 type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   api : opt Guards;
-  derivation_origin : text;
+  derivation_origin : opt text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -60,6 +60,7 @@ type CanisterStatusResultV2 = record {
 type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
   api : opt Guards;
+  derivation_origin : text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;
@@ -99,6 +100,7 @@ type HttpResponse = record {
 type IcrcToken = record { ledger_id : principal; index_id : opt principal };
 type InitArg = record {
   api : opt Guards;
+  derivation_origin : text;
   ecdsa_key_name : text;
   cfs_canister_id : opt principal;
   allowed_callers : vec principal;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -63,7 +63,7 @@ export interface CanisterStatusResultV2 {
 export type CanisterStatusType = { stopped: null } | { stopping: null } | { running: null };
 export interface Config {
 	api: [] | [Guards];
-	derivation_origin: string;
+	derivation_origin: [] | [string];
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
@@ -109,7 +109,7 @@ export interface IcrcToken {
 }
 export interface InitArg {
 	api: [] | [Guards];
-	derivation_origin: string;
+	derivation_origin: [] | [string];
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -63,6 +63,7 @@ export interface CanisterStatusResultV2 {
 export type CanisterStatusType = { stopped: null } | { stopping: null } | { running: null };
 export interface Config {
 	api: [] | [Guards];
+	derivation_origin: string;
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
@@ -108,6 +109,7 @@ export interface IcrcToken {
 }
 export interface InitArg {
 	api: [] | [Guards];
+	derivation_origin: string;
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -19,6 +19,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
+		derivation_origin: IDL.Text,
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -128,6 +129,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
+		derivation_origin: IDL.Text,
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -331,6 +333,7 @@ export const init = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
+		derivation_origin: IDL.Text,
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -19,7 +19,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
-		derivation_origin: IDL.Text,
+		derivation_origin: IDL.Opt(IDL.Text),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -129,7 +129,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
-		derivation_origin: IDL.Text,
+		derivation_origin: IDL.Opt(IDL.Text),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -333,7 +333,7 @@ export const init = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
-		derivation_origin: IDL.Text,
+		derivation_origin: IDL.Opt(IDL.Text),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -19,6 +19,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
+		derivation_origin: IDL.Text,
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -128,6 +129,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
+		derivation_origin: IDL.Text,
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -331,6 +333,7 @@ export const init = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
+		derivation_origin: IDL.Text,
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -19,7 +19,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
-		derivation_origin: IDL.Text,
+		derivation_origin: IDL.Opt(IDL.Text),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -129,7 +129,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Config = IDL.Record({
 		api: IDL.Opt(Guards),
-		derivation_origin: IDL.Text,
+		derivation_origin: IDL.Opt(IDL.Text),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -333,7 +333,7 @@ export const init = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		api: IDL.Opt(Guards),
-		derivation_origin: IDL.Text,
+		derivation_origin: IDL.Opt(IDL.Text),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -53,6 +53,7 @@ impl From<InitArg> for Config {
             ic_root_key_der,
             api,
             cfs_canister_id,
+            derivation_origin,
         } = arg;
         let ic_root_key_raw = match extract_raw_root_pk_from_der(
             &ic_root_key_der.unwrap_or_else(|| IC_ROOT_PK_DER.to_vec()),
@@ -67,6 +68,7 @@ impl From<InitArg> for Config {
             supported_credentials,
             ic_root_key_raw: Some(ic_root_key_raw),
             api,
+            derivation_origin,
         }
     }
 }

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -32,7 +32,7 @@ pub struct InitArg {
     pub cfs_canister_id: Option<Principal>,
     /// Derivation origins when logging in the dapp with Internet Identity.
     /// Used to validate the id alias credential which includes the derivation origin of the id alias.
-    pub derivation_origin: String,
+    pub derivation_origin: Option<String>,
 }
 
 #[derive(CandidType, Deserialize, Eq, PartialEq, Debug, Copy, Clone)]
@@ -79,7 +79,7 @@ pub struct Config {
     pub cfs_canister_id: Option<Principal>,
     /// Derivation origins when logging in the dapp with Internet Identity.
     /// Used to validate the id alias credential which includes the derivation origin of the id alias.
-    pub derivation_origin: String,
+    pub derivation_origin: Option<String>,
 }
 
 pub mod transaction {

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -30,6 +30,9 @@ pub struct InitArg {
     pub api: Option<Guards>,
     /// Chain Fusion Signer canister id. Used to derive the bitcoin address in `btc_select_user_utxos_fee`
     pub cfs_canister_id: Option<Principal>,
+    /// Derivation origins when logging in the dapp with Internet Identity.
+    /// Used to validate the id alias credential which includes the derivation origin of the id alias.
+    pub derivation_origin: String,
 }
 
 #[derive(CandidType, Deserialize, Eq, PartialEq, Debug, Copy, Clone)]
@@ -74,6 +77,9 @@ pub struct Config {
     pub api: Option<Guards>,
     /// Chain Fusion Signer canister id. Used to derive the bitcoin address in `btc_select_user_utxos_fee`
     pub cfs_canister_id: Option<Principal>,
+    /// Derivation origins when logging in the dapp with Internet Identity.
+    /// Used to validate the id alias credential which includes the derivation origin of the id alias.
+    pub derivation_origin: String,
 }
 
 pub mod transaction {


### PR DESCRIPTION
# Motivation

We want to validate the new field "derivationOrigin" in the id alias credential.

Before we can do that, the backend needs to know the derivation origin.

This PR, adds the derivation origin to the configuration parameter of the backend.

# Changes

## Manual Changes

* Add a new field `derivation_origin` in InitArg and Config struts.
* Add new field in `deploy.backend.sh` script.

## Automatic Changes

* `.did` and related file changes after running `npm run generate`.

# Tests

* Add a `derivation_origin` in the pocket ic init args of the backend canister.
