### PR TITLE
refactor(frontend): remove token derived stores from Amount component

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -6,10 +6,10 @@
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken } from '$lib/types/token';
+	import type { Token } from '$lib/types/token';
 
 	export let transaction: BtcTransactionUi;
-	export let token: OptionToken = undefined;
+	export let token: Token;
 
 	let value: bigint | undefined;
 	let timestamp: bigint | undefined;

--- a/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
@@ -13,6 +13,7 @@
 	import TransactionsSkeletons from '$lib/components/transactions/TransactionsSkeletons.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { modalBtcTransaction } from '$lib/derived/modal.derived';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 
 	let selectedTransaction: BtcTransactionUi | undefined;
@@ -26,7 +27,7 @@
 <TransactionsSkeletons loading={$btcTransactionsNotInitialized}>
 	{#each $sortedBtcTransactions as transaction (transaction.data.id)}
 		<div transition:slide={SLIDE_DURATION}>
-			<BtcTransaction transaction={transaction.data} />
+			<BtcTransaction transaction={transaction.data} token={$tokenWithFallback} />
 		</div>
 	{/each}
 

--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -7,12 +7,12 @@
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken } from '$lib/types/token';
+	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus } from '$lib/types/transaction';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let transaction: EthTransactionUi;
-	export let token: OptionToken = undefined;
+	export let token: Token;
 
 	let value: BigNumber;
 	let timestamp: number | undefined;

--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -17,9 +17,9 @@
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { modalToken, modalEthTransaction } from '$lib/derived/modal.derived';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { token } from '$lib/stores/token.store';
 	import type { OptionEthAddress } from '$lib/types/address';
 	import type { Transaction as TransactionType } from '$lib/types/transaction';
 
@@ -50,7 +50,7 @@
 	<EthTransactionsSkeletons>
 		{#each sortedTransactionsUi as transaction (transaction.hash)}
 			<div transition:slide={SLIDE_DURATION}>
-				<EthTransaction {transaction} token={$token} />
+				<EthTransaction {transaction} token={$tokenWithFallback} />
 			</div>
 		{/each}
 

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -6,9 +6,11 @@
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { NANO_SECONDS_IN_SECOND } from '$lib/constants/app.constants';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus } from '$lib/types/transaction';
 
 	export let transaction: IcTransactionUi;
+	export let token: Token;
 
 	let type: IcTransactionType;
 	let transactionTypeLabel: string | undefined;
@@ -46,6 +48,7 @@
 	{type}
 	{timestamp}
 	{status}
+	{token}
 >
 	<IcTransactionLabel label={transactionTypeLabel} fallback={type} />
 </Transaction>

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -30,6 +30,7 @@
 	import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalIcToken, modalIcTransaction } from '$lib/derived/modal.derived';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -117,7 +118,7 @@
 			<InfiniteScroll on:nnsIntersect={onIntersect} disabled={disableInfiniteScroll}>
 				{#each $icTransactions as transaction, index (`${transaction.data.id}-${index}`)}
 					<li in:slide={{ duration: transaction.data.status === 'pending' ? 250 : 0 }}>
-						<IcTransaction transaction={transaction.data} />
+						<IcTransaction transaction={transaction.data} token={$tokenWithFallback} />
 					</li>
 				{/each}
 			</InfiniteScroll>

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -16,7 +16,7 @@
 		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"
 	>
 		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !token.balance.isZero()}
-			<span><Amount amount={token.balance} /> {token.symbol}</span>
+			<span><Amount amount={token.balance} decimals={token.decimals} /> {token.symbol}</span>
 		{:else}
 			<span class:animate-pulse={$loading}>0.00</span>
 		{/if}

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -7,7 +7,7 @@
 	import Amount from '$lib/components/ui/Amount.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import RoundedIcon from '$lib/components/ui/RoundedIcon.svelte';
-	import type { OptionToken } from '$lib/types/token';
+	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus, TransactionType } from '$lib/types/transaction';
 	import { formatSecondsToDate } from '$lib/utils/format.utils.js';
 	import { mapTransactionIcon } from '$lib/utils/transaction.utils';
@@ -17,7 +17,7 @@
 	export let status: TransactionStatus;
 	export let timestamp: number | undefined;
 	export let styleClass: string | undefined = undefined;
-	export let token: OptionToken = undefined;
+	export let token: Token;
 
 	let icon: ComponentType;
 	$: icon = mapTransactionIcon({ type, status });
@@ -40,7 +40,7 @@
 
 		<svelte:fragment slot="amount">
 			{#if nonNullish(amount)}
-				<Amount {amount} />
+				<Amount {amount} decimals={token.decimals} />
 			{/if}
 		</svelte:fragment>
 

--- a/src/frontend/src/lib/components/ui/Amount.svelte
+++ b/src/frontend/src/lib/components/ui/Amount.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
 	import type { BigNumber } from '@ethersproject/bignumber';
 	import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { formatToken } from '$lib/utils/format.utils';
 
 	export let amount: BigNumber;
+	export let decimals: number;
 
 	let detailedValue: string;
 	$: detailedValue = formatToken({
 		value: amount,
-		unitName: $tokenWithFallback.decimals,
-		displayDecimals: $tokenWithFallback.decimals
+		unitName: decimals,
+		displayDecimals: decimals
 	});
 
 	let displayValue: string;
 	$: displayValue = formatToken({
 		value: amount,
-		unitName: $tokenWithFallback.decimals,
+		unitName: decimals,
 		displayDecimals: EIGHT_DECIMALS
 	});
 </script>


### PR DESCRIPTION
# Motivation

The component `Amount` was using a derived of `token` store. However, it is now used in a context where the token may change and it is not defined, for example, it is mounted on each transaction on the unified list.

So, I thought of giving the adequate properties instead of using the store. But that means that we need to propagate such properties.

I thought of creating a context too, but it will change for each Amount component mounted in the unified transaction list, so not a possible solution for now.

# Changes

- Add prop `decimals` to component `Amount`.
- Remove derived store dependency from `Amount`.
- Adapt component `Balance` that is using `Amount`.
- Adapt component `Transaction` that is using `Amount`.
- Adapt all transaction components for each network, providing at the highest level the token as token with fallback (that was what it was used before inside the `Amount` component, so no real change).
- We force the token to be non-optional for convenience, since in the future, we will be removing the `tokenWithFallback` store and we will need these components to have a defined token.

# Tests

No changes in local replica.
