### PR TITLE
fix(frontend): remove circular reference in tokens env file

### DIFF
--- a/src/frontend/src/env/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens.btc.env.ts
@@ -1,4 +1,3 @@
-import { BTC_MAINNET_ENABLED } from '$env/networks.btc.env';
 import { BTC_MAINNET_NETWORK, BTC_REGTEST_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks.env';
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
@@ -52,11 +51,3 @@ export const BTC_REGTEST_TOKEN: Token = {
 	decimals: BTC_DECIMALS,
 	icon: bitcoinTestnet
 };
-
-// The following tokens are used as fallback for any Bitcoin token defined in the token store.
-// That means that the order of the tokens in the array is important, to have a correct fallback chain.
-export const SUPPORTED_BITCOIN_TOKENS: [...Token[], Token] = [
-	...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
-	BTC_TESTNET_TOKEN,
-	BTC_REGTEST_TOKEN
-];

--- a/src/frontend/src/lib/constants/tokens.constants.ts
+++ b/src/frontend/src/lib/constants/tokens.constants.ts
@@ -1,6 +1,16 @@
-import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens.btc.env';
+import { BTC_MAINNET_ENABLED } from '$env/networks.btc.env';
+import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens.btc.env';
 import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens.env';
+import type { Token } from '$lib/types/token';
 
 export const [DEFAULT_ETHEREUM_TOKEN, _rest] = SUPPORTED_ETHEREUM_TOKENS;
+
+// The following tokens are used as fallback for any Bitcoin token defined in the token store.
+// That means that the order of the tokens in the array is important, to have a correct fallback chain.
+export const SUPPORTED_BITCOIN_TOKENS: [...Token[], Token] = [
+	...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
+	BTC_TESTNET_TOKEN,
+	BTC_REGTEST_TOKEN
+];
 
 export const [DEFAULT_BITCOIN_TOKEN, _] = SUPPORTED_BITCOIN_TOKENS;


### PR DESCRIPTION
# Motivation

We move `SUPPORTED_BITCOIN_TOKENS` since it was giving circular reference on initiation.
