### PR TITLE
fix(frontend): incorrect "value" type in InputCurrency

### DIFF
--- a/src/frontend/src/lib/components/ui/InputCurrency.svelte
+++ b/src/frontend/src/lib/components/ui/InputCurrency.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { Input } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import { createEventDispatcher } from 'svelte';
 
 	export let value: number | undefined = undefined;
 	export let disabled: boolean | undefined = undefined;
@@ -8,20 +10,34 @@
 	export let required = true;
 	export let decimals: number | undefined = undefined;
 	export let testId: string | undefined = undefined;
+
+	const dispatch = createEventDispatcher();
+
+	let inputValue: string | undefined;
+	// Convert value to string if it comes from parent (e.g. initial state or set-to-max button)
+	$: inputValue = nonNullish(value) ? `${value}` : undefined;
+
+	const onInput = () => {
+		// Convert inputValue to number before updating parent's value
+		value = nonNullish(inputValue) ? Number(inputValue) : undefined;
+
+		// Bubble nnsInput as consumers might require the event as well
+		dispatch('nnsInput');
+	};
 </script>
 
 <Input
 	{name}
 	inputType="currency"
 	{required}
-	bind:value
+	bind:value={inputValue}
 	{decimals}
 	{placeholder}
 	spellcheck={false}
 	autocomplete="off"
 	{testId}
 	{disabled}
-	on:nnsInput
+	on:nnsInput={onInput}
 >
 	<slot name="inner-end" slot="inner-end" />
 </Input>

--- a/src/frontend/src/tests/lib/components/ui/InputCurrency.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/InputCurrency.spec.ts
@@ -1,0 +1,54 @@
+import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
+import { assertNonNullish } from '@dfinity/utils';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('ConvertAmountExchange', () => {
+	const inputTestId = 'input-currency';
+	const props = {
+		name: 'input',
+		placeholder: 'placeholder',
+		testId: inputTestId
+	};
+
+	const inputSelector = `input[data-tid=${inputTestId}]`;
+
+	it('should be empty if no value is provided', () => {
+		const { container, component } = render(InputCurrency, { props });
+
+		const input: HTMLInputElement | null = container.querySelector(inputSelector);
+		assertNonNullish(input, 'Input not found');
+
+		expect(input?.value).toBe('');
+		expect(component.$$.ctx[component.$$.props['value']]).toBeUndefined();
+	});
+
+	it('should display correct value if it is provided', () => {
+		const { container, component } = render(InputCurrency, {
+			props: {
+				...props,
+				value: 10
+			}
+		});
+
+		const input: HTMLInputElement | null = container.querySelector(inputSelector);
+		assertNonNullish(input, 'Input not found');
+
+		expect(input?.value).toBe('10');
+		expect(component.$$.ctx[component.$$.props['value']]).toBe(10);
+	});
+
+	it('should display and update value prop on input correctly', async () => {
+		const { container, component } = render(InputCurrency, props);
+
+		const input: HTMLInputElement | null = container.querySelector(inputSelector);
+		assertNonNullish(input, 'Input not found');
+
+		await fireEvent.input(input, { target: { value: '10' } });
+		expect(input?.value).toBe('10');
+		expect(component.$$.ctx[component.$$.props['value']]).toBe(10);
+
+		await fireEvent.input(input, { target: { value: '' } });
+		expect(input?.value).toBe('');
+		expect(component.$$.ctx[component.$$.props['value']]).toBe(undefined);
+	});
+});


### PR DESCRIPTION
# Motivation

While working on the conversion flow, I noticed one suspicious thing: the `value` prop that is controlled by `InputCurrency` is actually a `string` and not a `number` as it is expected to be according to the types in our codebase. It means that we incorrectly assume across the whole `send` flow that `amount` is `number | undefined` when it's in reality `string | undefined`. The same applies to the convert flow: `sourceAmount` was never a number. 

After reading [the GIX Input docs](https://gix.design/components/input), I found this paragraph: 
```
If the inputType is set to icp, the value bind by the component is a number. On the contrary, if bind to currency, the value is a string. This to avoid issue with scientific notation enforced by JavaScript. It is then up to you to parse the currency according your need, for example to bigint or BigNumber.
```

Having said that, we have quite an error-prompt situation: I noticed this issue while debugging one of the conversion services - `sendAmount === 0` was always giving me `false` after typing 0, even though TS-wise the statement looks correct. Since in the code all `send` components also expect it to be a `number`, this may lead to the same issue. 

Solution 1 (implemented in this PR): as suggested by GIX, I added an internal `inputValue` to the `InputCurrency` component which has `string | undefined` type, and on `nnsInput` I convert it to `number` before notifying parent. Also, provided some tests to test this behaviour. 

Solution 2: update `amount` type everywhere where it's used. Would require a lot of changes. 