### PR TITLE
fix(frontend): avoid concurrency of calls in Loader Transactions

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -9,16 +9,18 @@
 	// TODO: make it more functional
 	let tokensLoaded: TokenId[] = [];
 
-
 	const load = async () => {
 		if ($erc20UserTokensNotInitialized) {
 			return;
 		}
 
-		const tokens:Token[]=[...$enabledEthereumTokens, ...$enabledErc20Tokens];
+		const tokens: Token[] = [...$enabledEthereumTokens, ...$enabledErc20Tokens];
 
 		for (let i = 0; i < tokens.length; i++) {
-			const { network: { id: networkId }, id: tokenId } = tokens[i];
+			const {
+				network: { id: networkId },
+				id: tokenId
+			} = tokens[i];
 			if (!tokensLoaded.includes(tokenId)) {
 				await loadTransactions({ tokenId, networkId });
 				tokensLoaded.push(tokenId);

--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -1,31 +1,29 @@
 <script lang="ts">
+	import pLimit from 'p-limit';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import { loadTransactions } from '$eth/services/transactions.services';
 	import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
-	import type { TokenId } from '$lib/types/token';
+	import type { Token, TokenId } from '$lib/types/token';
 
 	// TODO: make it more functional
 	let tokensLoaded: TokenId[] = [];
+
 
 	const load = async () => {
 		if ($erc20UserTokensNotInitialized) {
 			return;
 		}
 
-		await Promise.allSettled(
-			[...$enabledEthereumTokens, ...$enabledErc20Tokens].map(
-				async ({ network: { id: networkId }, id: tokenId }) => {
-					if (tokensLoaded.includes(tokenId)) {
-						return;
-					}
+		const tokens:Token[]=[...$enabledEthereumTokens, ...$enabledErc20Tokens];
 
-					await loadTransactions({ tokenId, networkId });
-
-					tokensLoaded.push(tokenId);
-				}
-			)
-		);
+		for (let i = 0; i < tokens.length; i++) {
+			const { network: { id: networkId }, id: tokenId } = tokens[i];
+			if (!tokensLoaded.includes(tokenId)) {
+				await loadTransactions({ tokenId, networkId });
+				tokensLoaded.push(tokenId);
+			}
+		}
 	};
 
 	$: $enabledEthereumTokens, $enabledErc20Tokens, $erc20UserTokensNotInitialized, load();


### PR DESCRIPTION
# Motivation

Etherscan API has a limit of calls per seconds, depending on which plan we use. With the unified transaction we query all the tokens

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
