### PR TITLE
refactor(frontend): remove custom class prop from RoundedIcon

### DIFF
--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -34,7 +34,7 @@
 			{#if nonNullish(token)}
 				<TokenLogo data={token} badge={{ type: 'icon', icon, ariaLabel: type }} />
 			{:else}
-				<RoundedIcon {icon} iconStyleClass={iconWithOpacity ? 'opacity-10' : ''} />
+				<RoundedIcon {icon} withOpacity={iconWithOpacity} />
 			{/if}
 		</div>
 

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -34,7 +34,7 @@
 			{#if nonNullish(token)}
 				<TokenLogo data={token} badge={{ type: 'icon', icon, ariaLabel: type }} />
 			{:else}
-				<RoundedIcon {icon} withOpacity={iconWithOpacity} />
+				<RoundedIcon {icon} opacity={iconWithOpacity} />
 			{/if}
 		</div>
 

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -8,7 +8,5 @@
 <div
 	class="relative flex items-center justify-center rounded-full bg-primary p-3 ring-2 ring-brand-subtle"
 >
-	<div class:opacity-10={withOpacity}>
-		<svelte:component this={icon}  />
-	</div>
+		<svelte:component this={icon}  styleClass={withOpacity ? 'opacity-10' : ''} />
 </div>

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -2,11 +2,11 @@
 	import type { ComponentType } from 'svelte';
 
 	export let icon: ComponentType;
-	export let withOpacity = false;
+	export let opacity = false;
 </script>
 
 <div
 	class="relative flex items-center justify-center rounded-full bg-primary p-3 ring-2 ring-brand-subtle"
 >
-	<svelte:component this={icon} styleClass={withOpacity ? 'opacity-10' : ''} />
+	<svelte:component this={icon} styleClass={opacity ? 'opacity-10' : ''} />
 </div>

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -8,5 +8,5 @@
 <div
 	class="relative flex items-center justify-center rounded-full bg-primary p-3 ring-2 ring-brand-subtle"
 >
-		<svelte:component this={icon}  styleClass={withOpacity ? 'opacity-10' : ''} />
+	<svelte:component this={icon} styleClass={withOpacity ? 'opacity-10' : ''} />
 </div>

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -2,11 +2,13 @@
 	import type { ComponentType } from 'svelte';
 
 	export let icon: ComponentType;
-	export let iconStyleClass = '';
+	export let withOpacity = false;
 </script>
 
 <div
 	class="relative flex items-center justify-center rounded-full bg-primary p-3 ring-2 ring-brand-subtle"
 >
-	<svelte:component this={icon} styleClass={iconStyleClass} />
+	<div class:opacity-10={withOpacity}>
+		<svelte:component this={icon}  />
+	</div>
 </div>

--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
@@ -14,7 +14,6 @@ import { mockPage } from '$tests/mocks/page.store.mock';
 import type { Identity } from '@dfinity/agent';
 import { render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
-import { expect } from 'vitest';
 
 describe('UtxosFeeContext', () => {
 	const amount = 10;

--- a/src/frontend/src/tests/btc/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/tokens.derived.spec.ts
@@ -4,7 +4,6 @@ import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/to
 import * as appContants from '$lib/constants/app.constants';
 import { testnetsStore } from '$lib/stores/settings.store';
 import { get } from 'svelte/store';
-import { expect } from 'vitest';
 
 describe('tokens.derived', () => {
 	describe('enabledBitcoinTokens', () => {

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -7,7 +7,7 @@ import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { token } from '$lib/stores/token.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render, waitFor } from '@testing-library/svelte';
-import { vi, type MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 vi.mock('$eth/services/transactions.services', () => ({
 	loadTransactions: vi.fn()

--- a/src/frontend/src/tests/eth/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/tokens.derived.spec.ts
@@ -4,7 +4,6 @@ import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import * as appContants from '$lib/constants/app.constants';
 import { testnetsStore } from '$lib/stores/settings.store';
 import { get } from 'svelte/store';
-import { expect } from 'vitest';
 
 describe('tokens.derived', () => {
 	describe('enabledEthereumTokens', () => {

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -20,7 +20,7 @@ import { IcrcLedgerCanister } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
 import { isNullish, toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import { expect, type MockInstance } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 describe('custom-token.services', () => {

--- a/src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts
@@ -4,7 +4,6 @@ import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { token } from '$lib/stores/token.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
-import { vi } from 'vitest';
 
 describe('IcTransactions', () => {
 	beforeEach(() => {

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -14,7 +14,7 @@ import { IcrcLedgerCanister } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import { expect, type MockInstance } from 'vitest';
+import { type MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 describe('icrc.services', () => {

--- a/src/frontend/src/tests/icp/utils/cketh-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/cketh-transactions.utils.spec.ts
@@ -6,7 +6,6 @@ import {
 import type { IcrcTransaction } from '$icp/types/ic-transaction';
 import { mapCkEthereumTransaction } from '$icp/utils/cketh-transactions.utils';
 import { Principal } from '@dfinity/principal';
-import { describe, expect, it } from 'vitest';
 
 describe('mapCkEthereumTransaction', () => {
 	const mockTransaction: IcrcTransaction = {

--- a/src/frontend/src/tests/lib/derived/exchange.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/exchange.derived.spec.ts
@@ -2,7 +2,6 @@ import * as exchangeEnv from '$env/exchange.env';
 import { exchangeInitialized } from '$lib/derived/exchange.derived';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import { get } from 'svelte/store';
-import { expect } from 'vitest';
 
 describe('exchange.derived', () => {
 	describe('exchangeInitialized', () => {

--- a/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -17,7 +17,6 @@ import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { get } from 'svelte/store';
-import { expect } from 'vitest';
 
 describe('tokens.derived', () => {
 	const mockErc20DefaultToken: Erc20Token = {

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -5,7 +5,6 @@ import {
 	formatTokenBigintToNumber
 } from '$lib/utils/format.utils';
 import { BigNumber } from 'ethers';
-import { describe } from 'vitest';
 
 describe('formatToken', () => {
 	const value = BigNumber.from('1000000000000000000');

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -9,7 +9,6 @@ import {
 	type RouteParams
 } from '$lib/utils/nav.utils';
 import type { Page } from '@sveltejs/kit';
-import { describe, expect } from 'vitest';
 
 describe('resetRouteParams', () => {
 	it('should return an object with all values set to null', () => {

--- a/src/frontend/src/tests/lib/utils/token-toggle.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-toggle.utils.spec.ts
@@ -7,7 +7,6 @@ import {
 	isEthereumTokenToggleDisabled,
 	isIcrcTokenToggleDisabled
 } from '$lib/utils/token-toggle.utils';
-import { describe, expect } from 'vitest';
 
 describe('isEthereumUserTokenDisabled', () => {
 	it('should check if default ethereum user token is disabled for token toggle', () => {

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -23,7 +23,7 @@ import { mockExchanges } from '$tests/mocks/exchanges.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockTokens } from '$tests/mocks/tokens.mock';
 import { BigNumber } from 'alchemy-sdk';
-import { describe, type MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 
 const tokenDecimals = 8;
 const tokenStandards: TokenStandard[] = ['ethereum', 'icp', 'icrc', 'bitcoin'];

--- a/src/frontend/src/tests/lib/validation/coingecko.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/coingecko.validation.spec.ts
@@ -1,5 +1,4 @@
 import { CoingeckoCoinsIdSchema } from '$lib/validation/coingecko.validation';
-import { describe, expect, it } from 'vitest';
 
 describe('CoingeckoCoinsIdSchema', () => {
 	it('should pass validation for "ethereum"', () => {

--- a/src/frontend/src/tests/lib/validation/token.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/token.validation.spec.ts
@@ -1,7 +1,6 @@
 import { isToken, parseTokenId } from '$lib/validation/token.validation';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
-import { describe, expect, it } from 'vitest';
 
 describe('token.validation', () => {
 	describe('parseTokenId', () => {


### PR DESCRIPTION
# Motivation

The prop iconStyleClass seemed unnecessary for just opacity. So we substitute with a direct boolean prop (reference https://github.com/dfinity/oisy-wallet/pull/3537#discussion_r1842195829).
