### PR TITLE
feat(frontend): add resetAll to initTransactionsStore

### DIFF
--- a/src/frontend/src/lib/stores/transactions.store.ts
+++ b/src/frontend/src/lib/stores/transactions.store.ts
@@ -16,6 +16,7 @@ export interface TransactionsStore<T> extends CertifiedStore<TransactionsData<T>
 	append: (params: { tokenId: TokenId; transactions: CertifiedTransaction<T>[] }) => void;
 	cleanUp: (params: { tokenId: TokenId; transactionIds: string[] }) => void;
 	nullify: (tokenId: TokenId) => void;
+	resetAll: () => void;
 }
 
 export const initTransactionsStore = <
@@ -64,6 +65,7 @@ export const initTransactionsStore = <
 				[tokenId]: null
 			})),
 		reset,
+		resetAll: () => update(() => ({})),
 		subscribe
 	};
 };

--- a/src/frontend/src/tests/lib/stores/transactions.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/transactions.store.spec.ts
@@ -227,4 +227,21 @@ describe('transactions.store', () => {
 				})();
 			}));
 	});
+
+	describe('resetAll', () => {
+		it('should clear all transactions and keys', () =>
+			new Promise<void>((done) => {
+				const store = initTransactionsStore<IcTransactionUi>();
+
+				const transactions = [createCertifiedIcTransactionUiMock('tx1')];
+				store.append({ tokenId, transactions });
+				store.resetAll();
+
+				store.subscribe((state) => {
+					expect(state).toEqual({});
+
+					done();
+				})();
+			}));
+	});
 });


### PR DESCRIPTION
# Motivation

Mostly for testing purposes, it is useful to have a way of "resetting" the entire transaction store.
