### PR TITLE
refactor(frontend): rename AllTransactionsUi type

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
-	import type { AllTransactionsUi } from '$lib/types/transaction';
+	import type { AllTransactionUiNonEmptyList } from '$lib/types/transaction';
 
 	export let date: string;
-	export let transactions: AllTransactionsUi;
+	export let transactions: AllTransactionUiNonEmptyList;
 </script>
 
 {#if transactions.length > 0}

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -41,6 +41,6 @@ export type AllTransactionUi = AnyTransactionUi & {
 	component: ComponentType;
 };
 
-export type AllTransactionsUi = [AllTransactionUi, ...AllTransactionUi[]];
+export type AllTransactionUiNonEmptyList = [AllTransactionUi, ...AllTransactionUi[]];
 
 export type TransactionsUiDateGroup<T extends AnyTransactionUi> = Record<string, [T, ...T[]]>;

--- a/src/frontend/src/tests/lib/components/transactions/TransactionsDateGroup.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/TransactionsDateGroup.spec.ts
@@ -3,7 +3,7 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens.env';
 import EthTransaction from '$eth/components/transactions/EthTransaction.svelte';
 import TransactionsDateGroup from '$lib/components/transactions/TransactionsDateGroup.svelte';
-import type { AllTransactionsUi, AllTransactionUi } from '$lib/types/transaction';
+import type { AllTransactionUi, AllTransactionUiNonEmptyList } from '$lib/types/transaction';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc-transactions.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
 import { render } from '@testing-library/svelte';
@@ -37,7 +37,7 @@ describe('TransactionsDateGroup', () => {
 	const mockTransactions = [
 		...mockBtcTransactionsUi,
 		...mockEthTransactionsUi
-	] as AllTransactionsUi;
+	] as AllTransactionUiNonEmptyList;
 
 	it('should render the date', () => {
 		const { getByText } = render(TransactionsDateGroup, {


### PR DESCRIPTION
# Motivation

As suggested in https://github.com/dfinity/oisy-wallet/pull/3601#pullrequestreview-2440325251 , we rename type`AllTransactionsUi` for readability reasons.
