### PR TITLE
refactor(frontend): extract type for list of ProgressStep

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendProgress.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendProgress.svelte
@@ -3,10 +3,11 @@
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	export let sendProgressStep: string = ProgressStepsSendBtc.INITIALIZATION;
 
-	let steps: [ProgressStep, ...ProgressStep[]];
+	let steps: ProgressStepList;
 	$: steps = [
 		{
 			step: ProgressStepsSendBtc.INITIALIZATION,

--- a/src/frontend/src/eth/constants/steps.constants.ts
+++ b/src/frontend/src/eth/constants/steps.constants.ts
@@ -1,4 +1,5 @@
 import { ProgressStepsSend, ProgressStepsSign } from '$lib/enums/progress-steps';
+import type { ProgressStepList } from '$lib/types/progress-steps';
 import type { ProgressStep } from '@dfinity/gix-components';
 
 export const sendSteps = ({
@@ -7,7 +8,7 @@ export const sendSteps = ({
 }: {
 	i18n: I18n;
 	sendWithApproval: boolean;
-}): [ProgressStep, ...ProgressStep[]] => [
+}): ProgressStepList => [
 	{
 		step: ProgressStepsSend.INITIALIZATION,
 		text: i18n.send.text.initializing_transaction,
@@ -45,7 +46,7 @@ export const walletConnectSendSteps = ({
 }: {
 	i18n: I18n;
 	sendWithApproval: boolean;
-}): [ProgressStep, ...ProgressStep[]] => [
+}): ProgressStepList => [
 	...sendSteps({
 		i18n,
 		...rest
@@ -57,7 +58,7 @@ export const walletConnectSendSteps = ({
 	}
 ];
 
-export const walletConnectSignSteps = (i18n: I18n): [ProgressStep, ...ProgressStep[]] => [
+export const walletConnectSignSteps = (i18n: I18n): ProgressStepList => [
 	{
 		step: ProgressStepsSign.INITIALIZATION,
 		text: i18n.send.text.initializing,

--- a/src/frontend/src/icp/components/send/IcSendProgress.svelte
+++ b/src/frontend/src/icp/components/send/IcSendProgress.svelte
@@ -7,11 +7,12 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	export let sendProgressStep: string = ProgressStepsSendIc.INITIALIZATION;
 	export let networkId: NetworkId | undefined = undefined;
 
-	let steps: [ProgressStep, ...ProgressStep[]];
+	let steps: ProgressStepList;
 	$: steps = [
 		{
 			step: ProgressStepsSendIc.INITIALIZATION,

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusProgress.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusProgress.svelte
@@ -3,10 +3,11 @@
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { ProgressStepsUpdateBalanceCkBtc } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	export let receiveProgressStep: string = ProgressStepsUpdateBalanceCkBtc.INITIALIZATION;
 
-	let steps: [ProgressStep, ...ProgressStep[]];
+	let steps: ProgressStepList;
 	$: steps = [
 		{
 			step: ProgressStepsUpdateBalanceCkBtc.INITIALIZATION,

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -25,10 +25,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { loading } from '$lib/stores/loader.store';
 	import { emit } from '$lib/utils/events.utils';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	let progressStep: string = ProgressStepsLoader.ADDRESSES;
 
-	let steps: [ProgressStep, ...ProgressStep[]];
+	let steps: ProgressStepList;
 	$: steps = [
 		{
 			step: ProgressStepsLoader.INITIALIZATION,

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -17,6 +17,7 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { gotoReplaceRoot } from '$lib/utils/nav.utils';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	export let assertHide: () => { valid: boolean };
 	export let hideToken: (params: { identity: Identity }) => Promise<void>;
@@ -83,7 +84,7 @@
 		}
 	];
 
-	const HIDE_TOKEN_STEPS: [ProgressStep, ...ProgressStep[]] = [
+	const HIDE_TOKEN_STEPS:ProgressStepList = [
 		{
 			step: ProgressStepsHideToken.INITIALIZATION,
 			text: $i18n.tokens.text.initializing,

--- a/src/frontend/src/lib/components/ui/InProgress.svelte
+++ b/src/frontend/src/lib/components/ui/InProgress.svelte
@@ -3,6 +3,7 @@
 	import type { ComponentType } from 'svelte';
 	import StaticSteps from '$lib/components/ui/StaticSteps.svelte';
 	import type { StaticStep } from '$lib/types/steps';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	export let progressStep: string;
 	export let steps: [ProgressStep | StaticStep, ...(ProgressStep | StaticStep)[]];
@@ -26,7 +27,7 @@
 						...step,
 						state: index < progressIndex || progressStep === 'done' ? 'completed' : 'next'
 					}
-		) as [ProgressStep, ...ProgressStep[]];
+		) as ProgressStepList;
 	};
 
 	$: progressStep, updateSteps();

--- a/src/frontend/src/lib/components/ui/InProgressWizard.svelte
+++ b/src/frontend/src/lib/components/ui/InProgressWizard.svelte
@@ -8,9 +8,10 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { confirmToCloseBrowser } from '$lib/utils/before-unload.utils';
+	import type { ProgressStepList } from '$lib/types/progress-steps';
 
 	export let progressStep: string = ProgressStepsSend.INITIALIZATION;
-	export let steps: [ProgressStep, ...ProgressStep[]];
+	export let steps: ProgressStepList;
 
 	onMount(() => confirmToCloseBrowser(true));
 	onDestroy(() => confirmToCloseBrowser(false));

--- a/src/frontend/src/lib/constants/steps.constants.ts
+++ b/src/frontend/src/lib/constants/steps.constants.ts
@@ -1,7 +1,8 @@
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import type { ProgressStepList } from '$lib/types/progress-steps';
 import type { ProgressStep } from '@dfinity/gix-components';
 
-export const addTokenSteps = (i18n: I18n): [ProgressStep, ...ProgressStep[]] => [
+export const addTokenSteps = (i18n: I18n): ProgressStepList => [
 	{
 		step: ProgressStepsAddToken.INITIALIZATION,
 		text: i18n.tokens.text.initializing,

--- a/src/frontend/src/lib/types/progress-steps.ts
+++ b/src/frontend/src/lib/types/progress-steps.ts
@@ -1,0 +1,3 @@
+import type { ProgressStep } from '@dfinity/gix-components';
+
+export type ProgressStepList = [ProgressStep, ...ProgressStep[]];


### PR DESCRIPTION
# Motivation

We extract the type `[ProgressStep, ...ProgressStep[]]` to a generic one for reusability.

# Note

I didn't call the new type `ProgressSteps` because it could go in conflict with the component of the same name from GIX components. If any stronger opinion to have it as `ProgressSteps`, we can easily change the import of the GIX component when needed:

`import { ProgressSteps as ProgressStepsCmp } from '@dfinity/gix-components';`
