### PR TITLE
chore(backend): Increase the topping-up threshold to 50T

### DIFF
--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -271,7 +271,7 @@ pub mod signer {
             }
         }
         /// The default cycles ledger top up threshold.  If the cycles ledger balance falls below this, it should be topped up.
-        pub const DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD: u128 = 10_000_000_000_000; // 10T
+        pub const DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD: u128 = 50_000_000_000_000; // 50T
         /// The proportion of the backend canister's own cycles to send to the cycles ledger.
         pub const DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE: u8 = 50;
         /// The minimum sensible percentage to send to the cycles ledger.


### PR DESCRIPTION
# Motivation
The 10T cycles ledger balance has proven itself insufficient for usage spikes.

# Changes
- Increase the cycles ledger topping-up threshold to 50T.

# Tests
N/A