### PR TITLE
refactor(frontend): rename services for Ethereum transactions

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { tokenNotInitialized } from '$eth/derived/nav.derived';
-	import { loadTransactions } from '$eth/services/transactions.services';
+	import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import type { TokenId } from '$lib/types/token';
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
@@ -32,7 +32,7 @@
 
 		tokenIdLoaded = tokenId;
 
-		const { success } = await loadTransactions({ tokenId, networkId });
+		const { success } = await loadEthereumTransactions({ tokenId, networkId });
 
 		if (!success) {
 			tokenIdLoaded = undefined;

--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-	import { loadTransactions } from '$eth/services/transactions.services';
+	import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
 	import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
 	import type { TokenId } from '$lib/types/token';
 
@@ -20,7 +20,7 @@
 						return;
 					}
 
-					await loadTransactions({ tokenId, networkId });
+					await loadEthereumTransactions({ tokenId, networkId });
 
 					tokensLoaded.push(tokenId);
 				}

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -13,7 +13,7 @@ import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export const loadTransactions = ({
+export const loadEthereumTransactions = ({
 	networkId,
 	tokenId
 }: {

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -2,7 +2,7 @@ import { SEPOLIA_NETWORK_ID } from '$env/networks.env';
 import { SEPOLIA_PEPE_TOKEN } from '$env/tokens-erc20/tokens.pepe.env';
 import { ICP_TOKEN, SEPOLIA_TOKEN, SEPOLIA_TOKEN_ID } from '$env/tokens.env';
 import LoaderEthTransactions from '$eth/components/loaders/LoaderEthTransactions.svelte';
-import { loadTransactions } from '$eth/services/transactions.services';
+import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { token } from '$lib/stores/token.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -14,7 +14,9 @@ vi.mock('$eth/services/transactions.services', () => ({
 }));
 
 describe('LoaderEthTransactions', () => {
-	const mockLoadTransactions = loadTransactions as MockedFunction<typeof loadTransactions>;
+	const mockLoadTransactions = loadEthereumTransactions as MockedFunction<
+		typeof loadEthereumTransactions
+	>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -33,7 +35,7 @@ describe('LoaderEthTransactions', () => {
 		render(LoaderEthTransactions);
 
 		await waitFor(() => {
-			expect(loadTransactions).not.toHaveBeenCalled();
+			expect(loadEthereumTransactions).not.toHaveBeenCalled();
 		});
 	});
 
@@ -43,7 +45,7 @@ describe('LoaderEthTransactions', () => {
 		mockPage.mock({ token: ICP_TOKEN.name });
 
 		await waitFor(() => {
-			expect(loadTransactions).not.toHaveBeenCalled();
+			expect(loadEthereumTransactions).not.toHaveBeenCalled();
 		});
 	});
 
@@ -54,7 +56,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(ICP_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).not.toHaveBeenCalled();
+			expect(loadEthereumTransactions).not.toHaveBeenCalled();
 		});
 	});
 
@@ -65,7 +67,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledWith({
+			expect(loadEthereumTransactions).toHaveBeenCalledWith({
 				tokenId: SEPOLIA_TOKEN_ID,
 				networkId: SEPOLIA_NETWORK_ID
 			});
@@ -79,7 +81,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_PEPE_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledWith({
+			expect(loadEthereumTransactions).toHaveBeenCalledWith({
 				tokenId: SEPOLIA_PEPE_TOKEN.id,
 				networkId: SEPOLIA_PEPE_TOKEN.network.id
 			});
@@ -96,8 +98,8 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledOnce();
-			expect(loadTransactions).toHaveBeenCalledWith({
+			expect(loadEthereumTransactions).toHaveBeenCalledOnce();
+			expect(loadEthereumTransactions).toHaveBeenCalledWith({
 				tokenId: SEPOLIA_TOKEN_ID,
 				networkId: SEPOLIA_NETWORK_ID
 			});
@@ -111,7 +113,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledWith({
+			expect(loadEthereumTransactions).toHaveBeenCalledWith({
 				tokenId: SEPOLIA_TOKEN_ID,
 				networkId: SEPOLIA_NETWORK_ID
 			});
@@ -121,13 +123,13 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_PEPE_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledWith({
+			expect(loadEthereumTransactions).toHaveBeenCalledWith({
 				tokenId: SEPOLIA_PEPE_TOKEN.id,
 				networkId: SEPOLIA_PEPE_TOKEN.network.id
 			});
 		});
 
-		expect(loadTransactions).toHaveBeenCalledTimes(2);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(2);
 	});
 
 	it('should not call the load function everytime the token changes but it was already loaded before', async () => {
@@ -144,8 +146,8 @@ describe('LoaderEthTransactions', () => {
 		});
 
 		await waitFor(() => {
-			expect(loadTransactions).not.toHaveBeenCalledTimes(n);
-			expect(loadTransactions).toHaveBeenCalledOnce();
+			expect(loadEthereumTransactions).not.toHaveBeenCalledTimes(n);
+			expect(loadEthereumTransactions).toHaveBeenCalledOnce();
 		});
 	});
 
@@ -164,7 +166,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_PEPE_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledTimes(2);
+			expect(loadEthereumTransactions).toHaveBeenCalledTimes(2);
 		});
 	});
 
@@ -175,7 +177,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledOnce();
+			expect(loadEthereumTransactions).toHaveBeenCalledOnce();
 		});
 
 		render(LoaderEthTransactions);
@@ -187,7 +189,7 @@ describe('LoaderEthTransactions', () => {
 		token.set(SEPOLIA_TOKEN);
 
 		await waitFor(() => {
-			expect(loadTransactions).toHaveBeenCalledTimes(2);
+			expect(loadEthereumTransactions).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -9,8 +9,8 @@ import { mockPage } from '$tests/mocks/page.store.mock';
 import { render, waitFor } from '@testing-library/svelte';
 import type { MockedFunction } from 'vitest';
 
-vi.mock('$eth/services/transactions.services', () => ({
-	loadTransactions: vi.fn()
+vi.mock('$eth/services/eth-transactions.services', () => ({
+	loadEthereumTransactions: vi.fn()
 }));
 
 describe('LoaderEthTransactions', () => {

--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -9,8 +9,8 @@ import { testnetsStore } from '$lib/stores/settings.store';
 import { createMockErc20UserTokens } from '$tests/mocks/erc20-tokens.mock';
 import { render, waitFor } from '@testing-library/svelte';
 
-vi.mock('$eth/services/transactions.services', () => ({
-	loadTransactions: vi.fn()
+vi.mock('$eth/services/eth-transactions.services', () => ({
+	loadEthereumTransactions: vi.fn()
 }));
 
 describe('LoaderMultipleEthTransactions', () => {

--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -2,7 +2,7 @@ import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks.env';
 import * as ethEnv from '$env/networks.eth.env';
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens.env';
 import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
-import { loadTransactions } from '$eth/services/transactions.services';
+import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import * as appContants from '$lib/constants/app.constants';
 import { testnetsStore } from '$lib/stores/settings.store';
@@ -34,7 +34,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		render(LoaderMultipleEthTransactions);
 
 		await waitFor(() => {
-			expect(loadTransactions).not.toHaveBeenCalled();
+			expect(loadEthereumTransactions).not.toHaveBeenCalled();
 		});
 	});
 
@@ -51,7 +51,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// mockErc20UserTokens.length + both native tokens (Ethereum and Sepolia)
-				expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 2);
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 2);
 			});
 		});
 
@@ -60,21 +60,21 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// mockErc20UserTokens.length + Ethereum native token
-				expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
 			});
 
 			await new Promise((resolve) => setTimeout(resolve, 3000));
 
 			// same number of calls as before
-			expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
+			expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
 		});
 
 		it('should not load transactions for native Sepolia token when testnets flag is disabled', async () => {
 			render(LoaderMultipleEthTransactions);
 
 			await waitFor(() => {
-				expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
-				expect(loadTransactions).not.toHaveBeenCalledWith({
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
+				expect(loadEthereumTransactions).not.toHaveBeenCalledWith({
 					networkId: SEPOLIA_NETWORK_ID,
 					tokenId: SEPOLIA_TOKEN_ID
 				});
@@ -88,8 +88,8 @@ describe('LoaderMultipleEthTransactions', () => {
 			render(LoaderMultipleEthTransactions);
 
 			await waitFor(() => {
-				expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
-				expect(loadTransactions).not.toHaveBeenCalledWith({
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
+				expect(loadEthereumTransactions).not.toHaveBeenCalledWith({
 					networkId: ETHEREUM_NETWORK_ID,
 					tokenId: ETHEREUM_TOKEN_ID
 				});
@@ -107,7 +107,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// mockErc20UserTokens.length + Ethereum native token
-				expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
 			});
 
 			erc20UserTokensStore.resetAll();
@@ -115,10 +115,10 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// the number of calls as before + mockAdditionalTokens.length
-				expect(loadTransactions).toHaveBeenCalledTimes(
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(
 					mockErc20UserTokens.length + 1 + mockAdditionalTokens.length
 				);
-				expect(loadTransactions).not.toHaveBeenCalledTimes(
+				expect(loadEthereumTransactions).not.toHaveBeenCalledTimes(
 					2 * (mockErc20UserTokens.length + 1) + mockAdditionalTokens.length
 				);
 			});
@@ -135,7 +135,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// mockErc20UserTokens.length + Ethereum native token
-				expect(loadTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockErc20UserTokens.length + 1);
 			});
 
 			erc20UserTokensStore.resetAll();
@@ -143,7 +143,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// the number of calls as before + mockAdditionalTokens.length
-				expect(loadTransactions).toHaveBeenCalledTimes(
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(
 					mockErc20UserTokens.length + 1 + mockAdditionalTokens.length
 				);
 			});
@@ -152,7 +152,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 			await waitFor(() => {
 				// the number of calls of the first render + the number of additional tokens + Sepolia native token
-				expect(loadTransactions).toHaveBeenCalledTimes(
+				expect(loadEthereumTransactions).toHaveBeenCalledTimes(
 					mockErc20UserTokens.length + 1 + mockAdditionalTokens.length + 1
 				);
 			});


### PR DESCRIPTION
# Motivation

It seems more consistent to rename `loadTransactions` to `loadEthereumTransactions` (both ETH and ERC20). Note that `loadEthTransactions` already exists in the same module.
