### PR TITLE
test(frontend): test modal store directly

### DIFF
--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -69,8 +69,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	close: () => void;
 }
 
-// Exposed for test purposes
-export const initModalStore = <T>(): ModalStore<T> => {
+const initModalStore = <T>(): ModalStore<T> => {
 	const { subscribe, set } = writable<ModalData<T>>(undefined);
 
 	const setType = (type: Modal<T>['type']) => () => set({ type });

--- a/src/frontend/src/tests/lib/stores/modal.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal.store.spec.ts
@@ -1,17 +1,7 @@
-import { initModalStore, type ModalStore } from '$lib/stores/modal.store';
+import { modalStore } from '$lib/stores/modal.store';
 import { get } from 'svelte/store';
 
 describe('modal.store', () => {
-	interface TestData {
-		value: number;
-	}
-
-	let modalStore: ModalStore<TestData>;
-
-	beforeEach(() => {
-		modalStore = initModalStore<TestData>();
-	});
-
 	it('should initialise with undefined', () => {
 		expect(get(modalStore)).toBeUndefined();
 	});


### PR DESCRIPTION
# Motivation

As discussed offline and in https://github.com/dfinity/oisy-wallet/pull/3608#discussion_r1845974057 , it does not make really sense to export `initModalStore` to test it, when we can test directly the initiated store modalStore.

In this PR we replace it.
