### PR TITLE
style(frontend): center ButtonAuthenticate for medium screens

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -8,7 +8,7 @@
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
 </script>
 
-<div class="flex w-full flex-col">
+<div class="flex w-full flex-col items-center md:items-start">
 	<ButtonAuthenticate on:click={async () => await signIn({})} {fullWidth} />
 
 	<span


### PR DESCRIPTION
# Motivation

Button ButtonAuthenticate was not centered in small-medium screens.

### Before

![Screenshot 2024-11-19 at 11 29 50](https://github.com/user-attachments/assets/ae48e229-1731-4138-bcf5-4386b65a8e8a)


### After

 
![Screenshot 2024-11-19 at 11 29 40](https://github.com/user-attachments/assets/3d010e56-b6cd-42b3-92c0-16dac46cdf50)

