### PR TITLE
feat(frontend): BtcConvertProgress component

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertProgress.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertProgress.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { ProgressStep } from '@dfinity/gix-components';
+	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
+	import { ProgressStepsConvert } from '$lib/enums/progress-steps';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	export let convertProgressStep: string = ProgressStepsConvert.INITIALIZATION;
+
+	let steps: [ProgressStep, ...ProgressStep[]];
+	$: steps = [
+		{
+			step: ProgressStepsConvert.INITIALIZATION,
+			text: $i18n.convert.text.initializing,
+			state: 'in_progress'
+		},
+		{
+			step: ProgressStepsConvert.CONVERT,
+			text: $i18n.convert.text.converting,
+			state: 'next'
+		},
+		{
+			step: ProgressStepsConvert.UPDATE_UI,
+			text: $i18n.convert.text.refreshing_ui,
+			state: 'next'
+		}
+	];
+</script>
+
+<InProgressWizard progressStep={convertProgressStep} {steps} />

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -11,6 +11,13 @@ export enum ProgressStepsSend {
 	DONE = 'done'
 }
 
+export enum ProgressStepsConvert {
+	INITIALIZATION = 'initialization',
+	CONVERT = 'convert',
+	UPDATE_UI = 'update_ui',
+	DONE = 'done'
+}
+
 export enum ProgressStepsSign {
 	INITIALIZATION = 'initialization',
 	SIGN = 'sign',


### PR DESCRIPTION
# Motivation

This PR contains a basic version of the BtcConvertProgress component. There is already a new, much fancier designs in Figma for this modal, therefore I kept it simple in the first iteration.

<img width="597" alt="Screenshot 2024-11-19 at 12 24 50" src="https://github.com/user-attachments/assets/89320d60-b267-41d5-ac79-ffefe6540071">
