### PR TITLE
refactor(frontend): missing timestamps at the bottom of transactions list

### DIFF
--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -144,5 +144,5 @@ export const sortTransactions = ({
 		);
 	}
 
-	return nonNullish(timestampA) ? 1 : -1;
+	return nonNullish(timestampA) ? -1 : 1;
 };

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -316,11 +316,11 @@ describe('transactions.utils', () => {
 			expect(result).toEqual([transaction3, transaction2, transaction1]);
 		});
 
-		it('should sort transactions with nullish timestamps first', () => {
+		it('should sort transactions with nullish timestamps last', () => {
 			const result = [transaction1, transactionWithNullTimestamp, transaction2].sort((a, b) =>
 				sortTransactions({ transactionA: a, transactionB: b })
 			);
-			expect(result).toEqual([transactionWithNullTimestamp, transaction2, transaction1]);
+			expect(result).toEqual([transaction2, transaction1, transactionWithNullTimestamp]);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

For now, we will put the missing timestamps (local replica transctions for example) at the bottom of the unified transaction list.

