### PR TITLE
feat(frontend): remove token store from IcTransactionModal

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -43,7 +43,7 @@
 </script>
 
 <Transaction
-	on:click={() => modalStore.openIcTransaction(transaction)}
+	on:click={() => modalStore.openIcTransaction({ transaction, token })}
 	styleClass="block w-full border-0"
 	amount={BigNumber.from(amount)}
 	{type}

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -11,10 +11,11 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { token } from '$lib/stores/token.store';
+	import type { OptionToken } from '$lib/types/token';
 	import { formatNanosecondsToDate, formatToken } from '$lib/utils/format.utils';
 
 	export let transaction: IcTransactionUi;
+	export let token: OptionToken;
 
 	let id: bigint | string;
 	let from: string | undefined;
@@ -136,14 +137,14 @@
 		{#if nonNullish(value)}
 			<Value ref="amount">
 				<svelte:fragment slot="label">{$i18n.core.text.amount}</svelte:fragment>
-				{#if nonNullish($token)}
+				{#if nonNullish(token)}
 					<output>
 						{formatToken({
 							value: BigNumber.from(value),
-							unitName: $token.decimals,
-							displayDecimals: $token.decimals
+							unitName: token.decimals,
+							displayDecimals: token.decimals
 						})}
-						{$token.symbol}
+						{token.symbol}
 					</output>
 				{:else}
 					&ZeroWidthSpace;

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -39,7 +39,6 @@
 	import { last } from '$lib/utils/array.utils';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
-
 	let ckEthereum: boolean;
 	$: ckEthereum = $tokenCkEthLedger || $tokenCkErc20Ledger;
 
@@ -94,10 +93,11 @@
 
 	let selectedTransaction: IcTransactionUi | undefined;
 	let selectedToken: OptionToken;
-	$: ({ transaction: selectedTransaction, token: selectedToken } =mapTransactionModalData<IcTransactionUi>({
-		$modalOpen: $modalIcTransaction,
-		$modalStore: $modalStore
-	}));
+	$: ({ transaction: selectedTransaction, token: selectedToken } =
+		mapTransactionModalData<IcTransactionUi>({
+			$modalOpen: $modalIcTransaction,
+			$modalStore: $modalStore
+		}));
 
 	let noTransactions = false;
 	$: noTransactions = nonNullish($token) && $icTransactionsStore?.[$token.id] === null;

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -35,7 +35,10 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { token } from '$lib/stores/token.store';
+	import type { OptionToken } from '$lib/types/token';
 	import { last } from '$lib/utils/array.utils';
+	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
+
 
 	let ckEthereum: boolean;
 	$: ckEthereum = $tokenCkEthLedger || $tokenCkErc20Ledger;
@@ -90,9 +93,11 @@
 	};
 
 	let selectedTransaction: IcTransactionUi | undefined;
-	$: selectedTransaction = $modalIcTransaction
-		? ($modalStore?.data as IcTransactionUi | undefined)
-		: undefined;
+	let selectedToken: OptionToken;
+	$: ({ transaction: selectedTransaction, token: selectedToken } =mapTransactionModalData<IcTransactionUi>({
+		$modalOpen: $modalIcTransaction,
+		$modalStore: $modalStore
+	}));
 
 	let noTransactions = false;
 	$: noTransactions = nonNullish($token) && $icTransactionsStore?.[$token.id] === null;
@@ -133,7 +138,7 @@
 </IcTransactionsSkeletons>
 
 {#if $modalIcTransaction && nonNullish(selectedTransaction)}
-	<IcTransactionModal transaction={selectedTransaction} />
+	<IcTransactionModal transaction={selectedTransaction} token={selectedToken} />
 {:else if $modalIcToken}
 	<IcTokenModal />
 {/if}

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -59,10 +59,11 @@
 
 	let selectedIcTransaction: IcTransactionUi | undefined;
 	let selectedIcToken: OptionToken;
-	$: ({ transaction: selectedIcTransaction, token: selectedIcToken } =mapTransactionModalData<IcTransactionUi>({
-		$modalOpen: $modalIcTransaction,
-		$modalStore: $modalStore
-	}));
+	$: ({ transaction: selectedIcTransaction, token: selectedIcToken } =
+		mapTransactionModalData<IcTransactionUi>({
+			$modalOpen: $modalIcTransaction,
+			$modalStore: $modalStore
+		}));
 </script>
 
 <!--TODO: include skeleton for loading transactions and remove nullish checks-->

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -21,8 +21,9 @@
 	} from '$lib/derived/modal.derived';
 	import { enabledTokens } from '$lib/derived/tokens.derived';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionToken } from '$lib/types/token';
 	import type { AllTransactionUi, TransactionsUiDateGroup } from '$lib/types/transaction';
-	import { groupTransactionsByDate } from '$lib/utils/transaction.utils';
+	import { groupTransactionsByDate, mapTransactionModalData } from '$lib/utils/transaction.utils';
 	import { mapAllTransactionsUi, sortTransactions } from '$lib/utils/transactions.utils';
 
 	let transactions: AllTransactionUi[];
@@ -57,9 +58,11 @@
 		: undefined;
 
 	let selectedIcTransaction: IcTransactionUi | undefined;
-	$: selectedIcTransaction = $modalIcTransaction
-		? ($modalStore?.data as IcTransactionUi | undefined)
-		: undefined;
+	let selectedIcToken: OptionToken;
+	$: ({ transaction: selectedIcTransaction, token: selectedIcToken } =mapTransactionModalData<IcTransactionUi>({
+		$modalOpen: $modalIcTransaction,
+		$modalStore: $modalStore
+	}));
 </script>
 
 <!--TODO: include skeleton for loading transactions and remove nullish checks-->
@@ -78,5 +81,5 @@
 {:else if $modalEthTransaction && nonNullish(selectedEthTransaction)}
 	<EthTransactionModal transaction={selectedEthTransaction} />
 {:else if $modalIcTransaction && nonNullish(selectedIcTransaction)}
-	<IcTransactionModal transaction={selectedIcTransaction} />
+	<IcTransactionModal transaction={selectedIcTransaction} token={selectedIcToken} />
 {/if}

--- a/src/frontend/src/lib/utils/transaction.utils.ts
+++ b/src/frontend/src/lib/utils/transaction.utils.ts
@@ -4,6 +4,8 @@ import IconConvertFrom from '$lib/components/icons/IconConvertFrom.svelte';
 import IconConvertTo from '$lib/components/icons/IconConvertTo.svelte';
 import IconReceive from '$lib/components/icons/IconReceive.svelte';
 import IconSend from '$lib/components/icons/IconSend.svelte';
+import type { ModalData } from '$lib/stores/modal.store';
+import type { OptionToken } from '$lib/types/token';
 import type {
 	AnyTransactionUi,
 	TransactionStatus,
@@ -11,7 +13,7 @@ import type {
 	TransactionType
 } from '$lib/types/transaction';
 import { formatSecondsToNormalizedDate } from '$lib/utils/format.utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import type { ComponentType } from 'svelte';
 
 export const mapTransactionIcon = ({
@@ -66,3 +68,14 @@ export const groupTransactionsByDate = <T extends AnyTransactionUi>(
 		return { ...acc, [date]: [...(acc[date] ?? []), transaction] };
 	}, {});
 };
+
+export const mapTransactionModalData = <T extends AnyTransactionUi>({
+	$modalOpen,
+	$modalStore
+}: {
+	$modalOpen: boolean;
+	$modalStore: ModalData<unknown>;
+}): { transaction: T | undefined; token: OptionToken } =>
+	$modalOpen && nonNullish($modalStore?.data)
+		? ($modalStore.data as { transaction: T; token: OptionToken })
+		: { transaction: undefined, token: undefined };


### PR DESCRIPTION
# Motivation

The component `IcTransactionModal` was using the token store to define the token to which the transaction refers too.

That means that in the unified transaction list, we will have an issue when opening the modal, specifically, the amount is not calculated.

We remove this dependency making it a prop.

# Note

An alternative could be to create a context for the transaction modal.


# Changes

- Add prop token to `IcTransactionModal`.
- Make the `modalStore` call pass not only the transaction but the token too.
- Create function to "extract" the transaction data from the modal store. Plus tests.
- Adapt both `IcTransactions` and `AllTransactionsList`.

# Tests

![Screenshot 2024-11-19 at 15 11 27](https://github.com/user-attachments/assets/d57c7c46-7065-4d5c-96ea-1d7624342638)
