### PR TITLE
fix(build): search for unused svelte files in TS modules too

### DIFF
--- a/scripts/check.unused.mjs
+++ b/scripts/check.unused.mjs
@@ -15,6 +15,8 @@ const REMOVE_FILES = process.argv.includes('--remove-files');
 
 const findSvelteFiles = (dir) => findFiles({ dir, extensions: ['.svelte'] });
 
+const findSearchFiles = (dir) => findFiles({ dir, extensions: ['.svelte', '.ts'] });
+
 const noUnusedFiles = () => {
 	console.log(`${GREEN}No unused components found.${NC}`);
 	process.exit(0);
@@ -24,10 +26,13 @@ const main = async () => {
 	console.log(`${NC}Scanning ${DATA_DIR} folder to find all .svelte files\n`);
 
 	const allSvelteFiles = findSvelteFiles(DATA_DIR_PATH);
+	const allSearchFiles = findSearchFiles(DATA_DIR_PATH).filter(
+		(file) => !file.includes('.spec.ts')
+	);
 
 	let potentialUnusedFiles = allSvelteFiles.filter((file) => !dirname(file).includes('routes'));
 
-	allSvelteFiles.forEach((file) => {
+	allSearchFiles.forEach((file) => {
 		const content = readFileSync(file, 'utf-8');
 
 		potentialUnusedFiles = potentialUnusedFiles.filter((potentialUnusedFile) => {


### PR DESCRIPTION
# Motivation

The script `check.unused.mjs` was mistakenly pointing out some components that were actually used inside an util. For example, the icons used by `mapTransactionIcon`:


```bash
antonio.ventilii@Antonio-Ventilii-W0LHX2LX6V oisy-wallet % ./scripts/check.unused.sh
Scanning src/frontend/src folder to find all .svelte files

Found 5 unused component(s).
Unused Svelte file: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/btc/components/convert/BtcConvertTokenWizard.svelte
Unused Svelte file: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/components/icons/IconConvert.svelte
Unused Svelte file: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/components/icons/IconConvertFrom.svelte
Unused Svelte file: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/components/icons/IconConvertTo.svelte
Unused Svelte file: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/components/icons/IconSend.svelte
```

# Changes

- Change the script to search all .svelte and .ts files (excluded tests).

# Tests

I ran the script and the result was

```bash
antonio.ventilii@Antonio-Ventilii-W0LHX2LX6V oisy-wallet % ./scripts/check.unused.sh
Scanning src/frontend/src folder to find all .svelte files

Found 1 unused component(s).
Unused Svelte file: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/btc/components/convert/BtcConvertTokenWizard.svelte
```
