### PR TITLE
feat(frontend)/remove-token-store-from-EthTransactionModal

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -11,7 +11,6 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { ethAddress } from '$lib/derived/address.derived';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Transaction } from '$lib/types/transaction';
@@ -21,8 +20,10 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import type { OptionToken } from '$lib/types/token';
 
 	export let transaction: Transaction;
+	export let token: OptionToken;
 
 	let from: string;
 	let to: string | undefined;
@@ -124,14 +125,16 @@
 
 		<Value ref="amount">
 			<svelte:fragment slot="label">{$i18n.core.text.amount}</svelte:fragment>
+			{#if nonNullish(token)}
 			<output>
 				{formatToken({
 					value,
-					unitName: $tokenWithFallback.decimals,
-					displayDecimals: $tokenWithFallback.decimals
+					unitName: token.decimals,
+					displayDecimals: token.decimals
 				})}
-				{$tokenWithFallback.symbol}
+				{token.symbol}
 			</output>
+				{/if}
 		</Value>
 
 		<ButtonCloseModal colorStyle="primary" slot="toolbar" />

--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -22,6 +22,9 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionEthAddress } from '$lib/types/address';
 	import type { Transaction as TransactionType } from '$lib/types/transaction';
+	import type { IcTransactionUi } from '$icp/types/ic-transaction';
+	import type { OptionToken } from '$lib/types/token';
+	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let ckMinterInfoAddresses: OptionEthAddress[] = [];
 	$: ckMinterInfoAddresses = toCkMinterInfoAddresses({
@@ -38,10 +41,15 @@
 		})
 	);
 
+
+
 	let selectedTransaction: TransactionType | undefined;
-	$: selectedTransaction = $modalEthTransaction
-		? ($modalStore?.data as TransactionType | undefined)
-		: undefined;
+	let selectedToken: OptionToken;
+	$: ({ transaction: selectedTransaction, token: selectedToken } =
+		mapTransactionModalData<TransactionType>({
+			$modalOpen: $modalEthTransaction,
+			$modalStore: $modalStore
+		}));
 </script>
 
 <Header>{$i18n.transactions.text.title}</Header>
@@ -61,7 +69,7 @@
 </LoaderEthTransactions>
 
 {#if $modalEthTransaction && nonNullish(selectedTransaction)}
-	<EthTransactionModal transaction={selectedTransaction} />
+	<EthTransactionModal transaction={selectedTransaction} token={selectedToken} />
 {:else if $modalToken}
 	<TokenModal />
 {/if}

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -53,9 +53,12 @@
 		: undefined;
 
 	let selectedEthTransaction: EthTransactionUi | undefined;
-	$: selectedEthTransaction = $modalEthTransaction
-		? ($modalStore?.data as EthTransactionUi | undefined)
-		: undefined;
+	let selectedEthToken: OptionToken;
+	$: ({ transaction: selectedEthTransaction, token: selectedEthToken } =
+		mapTransactionModalData<EthTransactionUi>({
+			$modalOpen: $modalEthTransaction,
+			$modalStore: $modalStore
+		}));
 
 	let selectedIcTransaction: IcTransactionUi | undefined;
 	let selectedIcToken: OptionToken;
@@ -80,7 +83,7 @@
 {#if $modalBtcTransaction && nonNullish(selectedBtcTransaction)}
 	<BtcTransactionModal transaction={selectedBtcTransaction} />
 {:else if $modalEthTransaction && nonNullish(selectedEthTransaction)}
-	<EthTransactionModal transaction={selectedEthTransaction} />
+	<EthTransactionModal transaction={selectedEthTransaction}  token={selectedEthToken} />
 {:else if $modalIcTransaction && nonNullish(selectedIcTransaction)}
 	<IcTransactionModal transaction={selectedIcTransaction} token={selectedIcToken} />
 {/if}


### PR DESCRIPTION
# Motivation

Similar to PR #3660 , the component `EthTransactionModal` was using the token store to define the token to which the transaction refers too.

That means that in the unified transaction list, we will have an issue when opening the modal, specifically, the amount is not calculated.

We remove this dependency making it a prop.

