### PR TITLE
ci(e2e): solve checkout error for pull request

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -37,7 +37,17 @@ jobs:
           exit 1
 
       - name: Checkout
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v4
+
+      - name: Checkout for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
+
 
       - name: Deploy the backend
         uses: ./.github/actions/deploy-backend


### PR DESCRIPTION
# Motivation

The CI workflow that updates the snapshots is giving the error of not being on a branch.

See https://github.com/dfinity/oisy-wallet/actions/runs/11929888449/job/33249595587?pr=3673

This is caused by the trigger on Pull request introduced in PR #3614 
We fix it here differentiating the checkouts.
