### PR TITLE
feat(frontend): add Assets button to the Menu

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -9,6 +9,7 @@
 	import IconActivity from '$lib/components/icons/iconly/IconActivity.svelte';
 	import IconlySettings from '$lib/components/icons/iconly/IconlySettings.svelte';
 	import IconlyUfo from '$lib/components/icons/iconly/IconlyUfo.svelte';
+	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
 	import LicenseLink from '$lib/components/license-agreement/LicenseLink.svelte';
 	import ChangelogLink from '$lib/components/navigation/ChangelogLink.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
@@ -24,6 +25,7 @@
 		isRouteActivity,
 		isRouteDappExplorer,
 		isRouteSettings,
+		isRouteTokens,
 		networkParam
 	} from '$lib/utils/nav.utils';
 
@@ -31,6 +33,11 @@
 	let button: HTMLButtonElement | undefined;
 
 	const hidePopover = () => (visible = false);
+
+	const goToTokens = async () => {
+		hidePopover();
+		await goto(AppPath.Tokens);
+	};
 
 	const gotoSettings = async () => {
 		hidePopover();
@@ -46,6 +53,9 @@
 		hidePopover();
 		await goto(AppPath.Activity);
 	};
+
+	let assetsRoute = false;
+	$: assetsRoute = isRouteTokens($page);
 
 	let settingsRoute = false;
 	$: settingsRoute = isRouteSettings($page);
@@ -74,6 +84,13 @@
 	<div class="flex flex-col gap-4" data-tid={NAVIGATION_MENU}>
 		{#if addressesOption}
 			<MenuAddresses on:icMenuClick={hidePopover} />
+		{/if}
+
+		{#if !assetsRoute && !settingsRoute}
+			<ButtonMenu ariaLabel={$i18n.navigation.alt.tokens} on:click={goToTokens}>
+				<IconWallet size="20" />
+				{$i18n.navigation.text.tokens}
+			</ButtonMenu>
 		{/if}
 
 		{#if !activityRoute && !settingsRoute}

--- a/src/frontend/src/lib/components/icons/lucide/IconWallet.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconWallet.svelte
@@ -1,8 +1,12 @@
 <!-- source: ISC Lucide - please visit https://lucide.dev/license -->
+<script lang="ts">
+	export let size = '24';
+</script>
+
 <svg
+	width={size}
+	height={size}
 	xmlns="http://www.w3.org/2000/svg"
-	width="24"
-	height="24"
 	viewBox="0 0 24 24"
 	fill="none"
 	stroke="currentColor"

--- a/src/frontend/src/lib/constants/routes.constants.ts
+++ b/src/frontend/src/lib/constants/routes.constants.ts
@@ -1,4 +1,5 @@
 export enum AppPath {
+	Tokens = '/',
 	Explore = '/explore',
 	Settings = '/settings',
 	Transactions = '/transactions',


### PR DESCRIPTION
# Motivation

We include the Asset button to the Menu to navigate back to the homepage.

# Changes

- Add Assets/Tokens path to `AppPath` enum.
- Change `IconWallet` to accept `size` prop.
- Add logic for tokens page in `Menu`.
- Add component in `Menu` to navigate to Assets.

# Tests

![Screenshot 2024-11-20 at 10 44 55](https://github.com/user-attachments/assets/6740f67f-af26-444a-8505-03a91824d5ca)
![Screenshot 2024-11-20 at 10 45 08](https://github.com/user-attachments/assets/50f752de-e5c9-4e7b-b861-e48253c6ef63)
![Screenshot 2024-11-20 at 10 45 19](https://github.com/user-attachments/assets/b7f80f41-5f6f-4d78-88e9-0194466e6f1c)

