### PR TITLE
fix(frontend): modal styling issue

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertReview.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertReview.svelte
@@ -15,7 +15,7 @@
 	const dispatch = createEventDispatcher();
 </script>
 
-<ContentWithToolbar>
+<ContentWithToolbar styleClass="flex flex-col">
 	<ConvertReviewTokens />
 
 	<div slot="outer-content" class="my-4 flex-1">

--- a/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQRCode.svelte
@@ -20,7 +20,7 @@
 	const dispatch = createEventDispatcher();
 </script>
 
-<ContentWithToolbar minHeight="50vh">
+<ContentWithToolbar styleClass="min-h-50vh">
 	<ReceiveAddressQRCodeContent
 		{address}
 		{addressLabel}

--- a/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
+++ b/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
-
-	export let minHeight: string | undefined = undefined;
+	export let styleClass: string | undefined = undefined;
 </script>
 
-<div class={`stretch flex flex-col ${nonNullish(minHeight) ? `min-h-[${minHeight}]` : ''}`}>
+<div class={`stretch ${styleClass ?? ''}`}>
 	<slot />
 </div>
 


### PR DESCRIPTION
# Motivation

Adding `flex` to `ContentWithToolbar` introduced in some particular cases some unwanted spacings between elements. Solution - make the component accept `styleClass` to allow consumers adjust the styling as needed. Having both `styleClass` and `minHeight` doesn't make too much sense, therefore I removed the latter.

![Capture d’écran 2024-11-20 à 10 17 26](https://github.com/user-attachments/assets/893328b5-4afa-4f2f-af49-d306af415d19)

![Capture d’écran 2024-11-20 à 10 21 28](https://github.com/user-attachments/assets/5ab93f3e-fe15-4ca1-958c-60ba00972f41)
