### PR TITLE
feat(frontend): remove token store from IcTransactionLabel

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionLabel.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionLabel.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import type { OptionIcCkToken } from '$icp/types/ic-token';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { token } from '$lib/stores/token.store';
-	import type { Token } from '$lib/types/token';
+	import type { OptionToken, Token } from '$lib/types/token';
 	import { replacePlaceholders, resolveText } from '$lib/utils/i18n.utils';
 
 	export let label: string | undefined;
 	export let fallback = '';
+	export let token: OptionToken;
 
 	let twinToken: Token | undefined;
-	$: twinToken = ($token as OptionIcCkToken)?.twinToken;
+	$: twinToken = (token as OptionIcCkToken)?.twinToken;
 </script>
 
 {replacePlaceholders(resolveText({ i18n: $i18n, path: label }) ?? fallback, {

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -83,7 +83,7 @@
 				<svelte:fragment slot="label">{$i18n.transaction.text.from}</svelte:fragment>
 
 				{#if nonNullish(fromLabel)}
-					<p class="mb-0.5 first-letter:capitalize"><IcTransactionLabel label={fromLabel} /></p>
+					<p class="mb-0.5 first-letter:capitalize"><IcTransactionLabel label={fromLabel} {token}/></p>
 				{/if}
 
 				{#if nonNullish(from)}


### PR DESCRIPTION
# Motivation

Component `IcTransactionLabel` was using the `token` store. We remove it and pass it via prop.
