### PR TITLE
ci(e2e): added config to handle carousel

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -7,7 +7,12 @@ test('should display homepage in logged out state', async ({ page }) => {
 
 	await homepageLoggedOut.waitForReady();
 
-	await expect(page).toHaveScreenshot({ fullPage: true });
+	await page.waitForLoadState('networkidle');
+
+	await expect(page).toHaveScreenshot({ 
+		fullPage: true,
+		animations: 'disabled'
+	});
 });
 
 testWithII('should display homepage in logged in state', async ({ page, iiPage }) => {
@@ -15,5 +20,16 @@ testWithII('should display homepage in logged in state', async ({ page, iiPage }
 
 	await homepageLoggedIn.waitForReady();
 
-	await expect(page).toHaveScreenshot({ fullPage: true });
+	await page.waitForLoadState('networkidle');
+
+	const numberOfSlides = await homepageLoggedIn.getNumberOfSlides();
+	
+	for (let i = 1; i <= numberOfSlides; i++) {
+		await homepageLoggedIn.navigateToSlide(i);
+	}
+
+	await expect(page).toHaveScreenshot({ 
+		fullPage: true,
+		animations: 'disabled'
+	});
 });

--- a/e2e/utils/promotion-carousel.component.ts
+++ b/e2e/utils/promotion-carousel.component.ts
@@ -1,0 +1,17 @@
+import { Locator, Page } from '@playwright/test';
+import { 
+	CAROUSEL_CONTAINER,
+	CAROUSEL_SLIDE_NAVIGATION
+} from '$lib/constants/test-ids.constants';
+
+export class PromotionCarousel {
+	private page: Page;
+	private carouselContainer: Locator;
+	private carouselSlideNavigation: Locator;
+
+	constructor(page: Page) {
+    this.page = page;
+    this.carouselContainer = this.page.locator(`[data-tid="${CAROUSEL_CONTAINER}"]:visible`);
+    this.carouselSlideNavigation = this.page.locator(`[data-tid="${CAROUSEL_SLIDE_NAVIGATION}"]:visible`);
+	}
+}

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -4,6 +4,7 @@
 	import Controls from '$lib/components/carousel/Controls.svelte';
 	import Indicators from '$lib/components/carousel/Indicators.svelte';
 	import { moveSlider, extendCarouselSliderFrame } from '$lib/utils/carousel.utils';
+	import { CAROUSEL_CONTAINER } from '$lib/constants/test-ids.constants';
 
 	export let autoplay = 5000;
 	export let duration = 300;
@@ -245,7 +246,7 @@
 <svelte:window on:resize={onResize} />
 
 <div
-	class={`${styleClass ?? ''} relative overflow-hidden rounded-3xl bg-white px-3 pb-10 pt-3 shadow`}
+data-tid={CAROUSEL_CONTAINER} class={`${styleClass ?? ''} relative overflow-hidden rounded-3xl bg-white px-3 pb-10 pt-3 shadow`}
 >
 	<div class="w-full overflow-hidden" bind:this={container}>
 		<div class="flex" bind:this={sliderFrame}>

--- a/src/frontend/src/lib/components/carousel/Indicator.svelte
+++ b/src/frontend/src/lib/components/carousel/Indicator.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { CAROUSEL_SLIDE_NAVIGATION } from '$lib/constants/test-ids.constants';
 
 	export let currentSlide: number;
 	export let index: number;
@@ -20,5 +21,6 @@
 <button
 	on:click
 	aria-label={replacePlaceholders($i18n.carousel.text.indicator, { $index: `${index + 1}` })}
+	data-tid={`${CAROUSEL_SLIDE_NAVIGATION}${index + 1}`}
 	class="{`${isActive ? 'w-7 bg-black' : 'w-4 bg-dust'} mr-1 h-1.5 transition-all duration-300 ease-linear last:mr-0`}}"
 ></button>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -44,3 +44,6 @@ export const NAVIGATION_ITEM_TOKENS = 'navigation-item-tokens';
 export const NAVIGATION_ITEM_ACTIVITY = 'navigation-item-activity';
 export const NAVIGATION_ITEM_EXPLORER = 'navigation-item-explore';
 export const NAVIGATION_ITEM_SETTINGS = 'navigation-item-settings';
+
+export const CAROUSEL_CONTAINER = 'carousel-container'
+export const CAROUSEL_SLIDE_NAVIGATION = 'carousel-slide-navigation-'


### PR DESCRIPTION
# Motivation

Since the implementation of the Dapps Carousel, the e2e tests were inconsistent. Due to the carousel automatically switching slides there was a possibility for screenshot 1 to be on slide x and screenshot 2 to be on slide y. For a consistent and useful test this needs to be changed.

# Changes

- added config that whenever the test for the homepage is run, it will check the carousel slides and always take the screenshot on the last slide

# Tests

tested multiple times on local instance.
