### PR TITLE
feat(frontend): adjust day difference calculation

### DIFF
--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -107,7 +107,12 @@ export const formatSecondsToNormalizedDate = ({
 }): string => {
 	const date = new Date(seconds * 1000);
 	const today = currentDate ?? new Date();
-	const daysDifference = Math.ceil((date.getTime() - today.getTime()) / MILLISECONDS_IN_DAY);
+
+	const dateOnlyDate = new Date(date.setHours(0, 0, 0, 0));
+	const dateOnlyToday = new Date(today.setHours(0, 0, 0, 0));
+	const daysDifference = Math.ceil(
+		(dateOnlyDate.getTime() - dateOnlyToday.getTime()) / MILLISECONDS_IN_DAY
+	);
 
 	if (Math.abs(daysDifference) < 2) {
 		// TODO: When the method is called many times with the same arguments, it is better to create a Intl.DateTimeFormat object and use its format() method, because a DateTimeFormat object remembers the arguments passed to it and may decide to cache a slice of the database, so future format calls can search for localization strings within a more constrained context.

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -108,6 +108,7 @@ export const formatSecondsToNormalizedDate = ({
 	const date = new Date(seconds * 1000);
 	const today = currentDate ?? new Date();
 
+	// TODO: add additional test suite for the below calculations
 	const dateOnlyDate = new Date(date.setHours(0, 0, 0, 0));
 	const dateOnlyToday = new Date(today.setHours(0, 0, 0, 0));
 	const daysDifference = Math.ceil(


### PR DESCRIPTION
# Motivation

To properly decide whether "today" or "yesterday" label should be displayed, `daysDifference` needs to be calculated with vars in dates-only format.
