### PR TITLE
refactor(e2e): make extendWaitForReady function abstract

### DIFF
--- a/e2e/utils/pages/activity.page.ts
+++ b/e2e/utils/pages/activity.page.ts
@@ -14,11 +14,8 @@ export class ActivityPage extends HomepageLoggedIn {
 		this.#page = page;
 	}
 
-	/**
-	 * @override
-	 */
 	// TODO: Implement this method clicking on the navigation item instead of using the URL, when the activity page is implemented
-	async extendWaitForReady(): Promise<void> {
+	override async extendWaitForReady(): Promise<void> {
 		await this.#page.goto(ACTIVITY_URL);
 	}
 }

--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -199,6 +199,8 @@ abstract class Homepage {
 		await expect(modal).toHaveScreenshot();
 	}
 
+	abstract extendWaitForReady(): Promise<void>;
+
 	abstract waitForReady(): Promise<void>;
 }
 
@@ -206,6 +208,11 @@ export class HomepageLoggedOut extends Homepage {
 	constructor(params: HomepageParams) {
 		super(params);
 	}
+
+	/**
+	 * @override
+	 */
+	async extendWaitForReady(): Promise<void> {}
 
 	/**
 	 * @override
@@ -277,6 +284,9 @@ export class HomepageLoggedIn extends Homepage {
 		await expect(qrCodeOutputLocator).toHaveText(qrCode ?? '');
 	}
 
+	/**
+	 * @override
+	 */
 	async extendWaitForReady(): Promise<void> {
 		// Extend the waitForReady method in a subclass
 	}

--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -209,10 +209,7 @@ export class HomepageLoggedOut extends Homepage {
 		super(params);
 	}
 
-	/**
-	 * @override
-	 */
-	async extendWaitForReady(): Promise<void> {}
+	override async extendWaitForReady(): Promise<void> {}
 
 	/**
 	 * @override
@@ -284,10 +281,7 @@ export class HomepageLoggedIn extends Homepage {
 		await expect(qrCodeOutputLocator).toHaveText(qrCode ?? '');
 	}
 
-	/**
-	 * @override
-	 */
-	async extendWaitForReady(): Promise<void> {
+	override async extendWaitForReady(): Promise<void> {
 		// Extend the waitForReady method in a subclass
 	}
 

--- a/e2e/utils/pages/transactions.page.ts
+++ b/e2e/utils/pages/transactions.page.ts
@@ -14,10 +14,7 @@ export class TransactionsPage extends HomepageLoggedIn {
 		this.#tokenSymbol = tokenSymbol;
 	}
 
-	/**
-	 * @override
-	 */
-	async extendWaitForReady(): Promise<void> {
+	override async extendWaitForReady(): Promise<void> {
 		await this.clickByTestId(`${TOKEN_CARD}-${this.#tokenSymbol}`);
 	}
 }


### PR DESCRIPTION
# Motivation

Following @peterpeterparker 's suggestion (https://github.com/dfinity/oisy-wallet/pull/3666#pullrequestreview-2447431986) , we make `extendWaitForReady` an `abstract` function.
