### PR TITLE
chore(frontend): clean up unused i18n strings

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -642,6 +642,11 @@
 			"status": "Status",
 			"confirmations": "Confirmations"
 		},
+		"status": {
+			"included": "Included",
+			"safe": "Safe",
+			"finalised": "Finalised"
+		},
 		"label": {
 			"reimbursement": "Reimbursement",
 			"twin_token_sent": "$twinToken sent",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -13,7 +13,6 @@
 			"decimals": "Decimals",
 			"amount": "Amount",
 			"max": "Max",
-			"more": "More",
 			"reject": "Reject",
 			"approve": "Approve",
 			"view": "View",
@@ -66,7 +65,6 @@
 			"advanced_cryptography": "100% onchain: peace of mind through advanced cryptography"
 		},
 		"alt": {
-			"sign_in": "Sign in with Internet Identity to start using $oisy_name.",
 			"preview": "Preview of $oisy_name once signed in, both on desktop and mobile"
 		},
 		"warning": {
@@ -154,7 +152,6 @@
 			"no_etherscan_rest_api": "No Etherscan Rest API for network $network",
 			"no_infura_provider": "No Infura provider for network $network",
 			"no_infura_cketh_provider": "No Infura CkETH provider for network $network",
-			"no_infura_ckerc20_provider": "No Infura CkErc20 provider for network $network",
 			"no_infura_erc20_provider": "No Infura ERC20 provider for network $network",
 			"no_infura_erc20_icp_provider": "No Infura ERC20 Icp provider for network $network",
 			"eth_address_unknown": "ETH address is unknown.",
@@ -205,8 +202,7 @@
 			"pouh_credential": "Humanity Credential",
 			"pouh_credential_description": "The Humanity Credential is a proof of humanity. It is issued by Decide AI.",
 			"present_pouh_credential": "Present",
-			"pouh_credential_verified": "Verified ✅",
-			"sign_in": "Sign in to start using $oisy_name."
+			"pouh_credential_verified": "Verified ✅"
 		},
 		"alt": {
 			"testnets_toggle": "Toggle to show or hide testnets",
@@ -219,7 +215,6 @@
 	"networks": {
 		"title": "Current network. Access to selection.",
 		"test_networks": "Test networks",
-		"show_testnets": "Show test networks",
 		"more": "More networks coming soon...",
 		"chain_fusion": "Chain Fusion (all networks)"
 	},
@@ -472,7 +467,6 @@
 				"unexpected_index_ledger": "Something went wrong while loading the Ledger ID related to the Index canister.",
 				"invalid_ledger_id": "The Ledger ID is not related to the Index canister.",
 				"missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
-				"missing_index_id": "The Index ID is missing. Did you provide a value?",
 				"missing_contract_address": "The contract address is missing. Did you provide a value?",
 				"no_network": "No network is selected. This is unexpected."
 			}
@@ -648,11 +642,6 @@
 			"status": "Status",
 			"confirmations": "Confirmations"
 		},
-		"status": {
-			"included": "Included",
-			"safe": "Safe",
-			"finalised": "Finalised"
-		},
 		"label": {
 			"reimbursement": "Reimbursement",
 			"twin_token_sent": "$twinToken sent",
@@ -698,9 +687,6 @@
 		}
 	},
 	"about": {
-		"text": {
-			"title": "About $oisy_name"
-		},
 		"why_oisy": {
 			"text": {
 				"label": "Why $oisy_short",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -16,7 +16,6 @@ interface I18nCore {
 		decimals: string;
 		amount: string;
 		max: string;
-		more: string;
 		reject: string;
 		approve: string;
 		view: string;
@@ -62,7 +61,7 @@ interface I18nAuth {
 		instant_and_private: string;
 		advanced_cryptography: string;
 	};
-	alt: { sign_in: string; preview: string };
+	alt: { preview: string };
 	warning: { not_signed_in: string; session_expired: string };
 	error: {
 		no_internet_identity: string;
@@ -132,7 +131,6 @@ interface I18nInit {
 		no_etherscan_rest_api: string;
 		no_infura_provider: string;
 		no_infura_cketh_provider: string;
-		no_infura_ckerc20_provider: string;
 		no_infura_erc20_provider: string;
 		no_infura_erc20_icp_provider: string;
 		eth_address_unknown: string;
@@ -186,7 +184,6 @@ interface I18nSettings {
 		pouh_credential_description: string;
 		present_pouh_credential: string;
 		pouh_credential_verified: string;
-		sign_in: string;
 	};
 	alt: { testnets_toggle: string; github_release: string };
 	error: { loading_profile: string };
@@ -195,7 +192,6 @@ interface I18nSettings {
 interface I18nNetworks {
 	title: string;
 	test_networks: string;
-	show_testnets: string;
 	more: string;
 	chain_fusion: string;
 }
@@ -426,7 +422,6 @@ interface I18nTokens {
 			unexpected_index_ledger: string;
 			invalid_ledger_id: string;
 			missing_ledger_id: string;
-			missing_index_id: string;
 			missing_contract_address: string;
 			no_network: string;
 		};
@@ -578,7 +573,6 @@ interface I18nTransaction {
 		status: string;
 		confirmations: string;
 	};
-	status: { included: string; safe: string; finalised: string };
 	label: {
 		reimbursement: string;
 		twin_token_sent: string;
@@ -626,7 +620,6 @@ interface I18nTransactions {
 }
 
 interface I18nAbout {
-	text: { title: string };
 	why_oisy: {
 		text: {
 			label: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -573,6 +573,7 @@ interface I18nTransaction {
 		status: string;
 		confirmations: string;
 	};
+	status: { included: string; safe: string; finalised: string };
 	label: {
 		reimbursement: string;
 		twin_token_sent: string;


### PR DESCRIPTION
# Motivation

A small clean up of unused strings, given by script `check.i18n.sh` :

```bash
Unused keys: [
  'core.text.more',
  'auth.alt.sign_in',
  'init.error.no_infura_ckerc20_provider',
  'settings.text.sign_in',
  'networks.show_testnets',
  'tokens.import.error.missing_index_id',
  'transaction.status.included',
  'transaction.status.safe',
  'transaction.status.finalised',
  'about.text.title'
]
```

# Note

The following are being flagged because they are used dynamically



```
'transaction.status.included',
'transaction.status.safe',
'transaction.status.finalised',
```


`<span in:fade>{$i18n.transaction.status[status]}</span>`



