### PR TITLE
style(frontend): modify string for missing date of date group

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -664,7 +664,8 @@
 			"sending_twin_token_failed": "Sending $twinToken failed",
 			"converting_twin_token": "Converting $twinToken to $ckToken",
 			"converting_ck_token": "Converting $ckToken to $twinToken",
-			"twin_network": "$twinNetwork network"
+			"twin_network": "$twinNetwork network",
+			"no_date_available": "No Date Available"
 		},
 		"alt": {
 			"open_block_explorer": "Open this transaction on a block explorer",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -591,6 +591,7 @@ interface I18nTransaction {
 		converting_twin_token: string;
 		converting_ck_token: string;
 		twin_network: string;
+		no_date_available: string;
 	};
 	alt: {
 		open_block_explorer: string;

--- a/src/frontend/src/lib/utils/transaction.utils.ts
+++ b/src/frontend/src/lib/utils/transaction.utils.ts
@@ -4,6 +4,7 @@ import IconConvertFrom from '$lib/components/icons/IconConvertFrom.svelte';
 import IconConvertTo from '$lib/components/icons/IconConvertTo.svelte';
 import IconReceive from '$lib/components/icons/IconReceive.svelte';
 import IconSend from '$lib/components/icons/IconSend.svelte';
+import { i18n } from '$lib/stores/i18n.store';
 import type { ModalData } from '$lib/stores/modal.store';
 import type { OptionToken } from '$lib/types/token';
 import type {
@@ -16,6 +17,7 @@ import type {
 import { formatSecondsToNormalizedDate } from '$lib/utils/format.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { ComponentType } from 'svelte';
+import { get } from 'svelte/store';
 
 export const mapTransactionIcon = ({
 	type,
@@ -55,10 +57,11 @@ export const groupTransactionsByDate = <T extends AnyTransactionUi>(
 	transactions: T[]
 ): TransactionsUiDateGroup<T> => {
 	const currentDate = new Date();
+	const undefinedKey = get(i18n).transaction.label.no_date_available;
 
 	return transactions.reduce<TransactionsUiDateGroup<T>>((acc, transaction) => {
 		if (isNullish(transaction.timestamp)) {
-			return { ...acc, undefined: [...(acc['undefined'] ?? []), transaction] };
+			return { ...acc, [undefinedKey]: [...(acc['undefined'] ?? []), transaction] };
 		}
 
 		const date = formatSecondsToNormalizedDate({

--- a/src/frontend/src/tests/lib/utils/transaction.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transaction.utils.spec.ts
@@ -14,6 +14,7 @@ import {
 	mapTransactionIcon,
 	mapTransactionModalData
 } from '$lib/utils/transaction.utils';
+import en from '$tests/mocks/i18n.mock';
 import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
 import { createTransactionsUi } from '$tests/mocks/transactions.mock';
 
@@ -119,11 +120,12 @@ describe('transaction.utils', () => {
 		});
 
 		it('should handle transactions without timestamps', () => {
+			const undefinedKey = en.transaction.label.no_date_available;
 			const transactions = [mockTransactions[0], { ...mockTransactions[1], timestamp: undefined }];
 
 			expect(groupTransactionsByDate(transactions)).toEqual({
 				'1': [transactions[0]],
-				undefined: [transactions[1]]
+				[undefinedKey]: [transactions[1]]
 			});
 		});
 


### PR DESCRIPTION
# Motivation

Instead of showing `Undefined` for missing timestamps, we show `No Date Available`.

![Screenshot 2024-11-20 at 14 34 12](https://github.com/user-attachments/assets/7d5852b5-c0f7-4c5c-bbc0-b54ba4ab44a7)
![Screenshot 2024-11-20 at 14 34 27](https://github.com/user-attachments/assets/dccc35ab-92cb-4379-8a44-3d39bc66bda7)
