### PR TITLE
test(frontend): skip ETH transactions page test

### DIFF
--- a/e2e/transactions-page.spec.ts
+++ b/e2e/transactions-page.spec.ts
@@ -10,7 +10,8 @@ testWithII('should display BTC transactions page', async ({ page, iiPage }) => {
 	await expect(page).toHaveScreenshot({ fullPage: true });
 });
 
-testWithII('should display ETH transactions page', async ({ page, iiPage }) => {
+// TODO: resolve the below test flakiness
+testWithII.skip('should display ETH transactions page', async ({ page, iiPage }) => {
 	const transactionsPage = new TransactionsPage({ page, iiPage, tokenSymbol: 'ETH' });
 
 	await transactionsPage.waitForReady();


### PR DESCRIPTION
# Motivation

The test that we decided to skip for now seems to be flaky (fails in ~50% of times).
