### PR TITLE
fix(frontend): login banner spacing

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -130,7 +130,7 @@
 			<Modal testId={LOADER_MODAL}>
 				<div class="stretch">
 					<div class="relative mb-8 block md:h-40">
-						<ImgBanner src={banner} styleClass="md:absolute" />
+						<ImgBanner src={banner} styleClass="h-full md:absolute aspect-auto" />
 					</div>
 
 					<h3 class="my-3">{$i18n.init.text.initializing_wallet}</h3>

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -129,7 +129,9 @@
 		<div in:fade={{ delay: 0, duration: 250 }}>
 			<Modal testId={LOADER_MODAL}>
 				<div class="stretch">
-					<ImgBanner src={banner} />
+					<div class="relative mb-8 block md:h-40">
+						<ImgBanner src={banner} styleClass="md:absolute" />
+					</div>
 
 					<h3 class="my-3">{$i18n.init.text.initializing_wallet}</h3>
 


### PR DESCRIPTION
# Motivation

#3240 broke the spacing around the banner displayed in the login modal.

# Changes

- Redo div around banner and absolute image

# Notes

Note against better idea.

# Screenshots

Issue:

<img width="1536" alt="Capture d’écran 2024-11-20 à 18 08 19" src="https://github.com/user-attachments/assets/b84f3f90-1ad5-4e31-afc9-782c3b98a716">
<img width="751" alt="Capture d’écran 2024-11-20 à 18 08 15" src="https://github.com/user-attachments/assets/96d66ca4-54a0-4eb8-8d62-51affc9f7d3e">
<img width="1536" alt="Capture d’écran 2024-11-20 à 18 08 11" src="https://github.com/user-attachments/assets/e6e8e1c2-cc25-4c03-a40a-2b192f9710cc">


Fix:

<img width="1536" alt="Capture d’écran 2024-11-20 à 18 06 26" src="https://github.com/user-attachments/assets/ad2de8b0-07ff-4580-af9d-41895cecf867">
<img width="838" alt="Capture d’écran 2024-11-20 à 18 06 20" src="https://github.com/user-attachments/assets/b01a92bc-1073-427e-9b90-289523898ebd">
<img width="1491" alt="Capture d’écran 2024-11-20 à 18 06 17" src="https://github.com/user-attachments/assets/88d9f0d2-42a9-44c6-8cfe-b4b3c1bc1ee2">


