### PR TITLE
fix(frontend): glitchy navigation between pages

### DIFF
--- a/src/frontend/src/lib/components/tokens/Tokens.svelte
+++ b/src/frontend/src/lib/components/tokens/Tokens.svelte
@@ -22,7 +22,7 @@
 
 	<TokensList />
 
-	<div transition:fade class="mb-4 mt-12 flex w-full justify-center sm:w-auto">
+	<div in:fade class="mb-4 mt-12 flex w-full justify-center sm:w-auto">
 		<ManageTokensButton />
 	</div>
 </div>


### PR DESCRIPTION
# Motivation

Not sure exactly why but the navigation between pages from assets to other pages become glitchy again.

# Changes

- Use an animation to display the "Manage tokens" button only on enter

# Screenshots

Before:

![demo 18 06 12](https://github.com/user-attachments/assets/b71450b4-f063-40df-a8e5-c4c9361a46b6)

After:

![after](https://github.com/user-attachments/assets/4f3098fc-a658-48c7-a654-d57fdbc87a79)

