### PR TITLE
feat(frontend): convert max button format

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -89,7 +89,8 @@
 		{$i18n.convert.text.max_balance}:
 		{formatToken({
 			value: $sourceTokenBalance ?? ZERO,
-			unitName: $sourceToken.decimals
+			unitName: $sourceToken.decimals,
+			displayDecimals: $sourceToken.decimals
 		})}
 		{$sourceToken.symbol}
 	</button>

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountSource.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountSource.spec.ts
@@ -100,4 +100,13 @@ describe('ConvertAmountSource', () => {
 
 		expect(component.$$.ctx[component.$$.props['sendAmount']]).toBe(props.sendAmount);
 	});
+
+	it('should display max button value in a correct format', () => {
+		const { getByTestId } = render(ConvertAmountSource, {
+			props,
+			context: mockContext(BigNumber.from(50000438709n))
+		});
+
+		expect(getByTestId(balanceTestId)).toHaveTextContent('Max: 500.00438709 BTC');
+	});
 });


### PR DESCRIPTION
# Motivation

The convert max button format was using only 4 decimals which doesn't match with value format we display in `sendAmount` input.
