### PR TITLE
feat(frontend): use theme colors for conversion inputs

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
@@ -84,8 +84,8 @@
 		@apply h-14;
 
 		&:disabled {
-			--disable: var(--color-bright-gray);
-			--input-background: var(--color-ghost-white);
+			--disable: var(--colors-neutrals-200);
+			--input-background: var(--colors-neutrals-100);
 		}
 	}
 </style>

--- a/src/frontend/src/lib/components/convert/ConvertInputsContainer.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputsContainer.svelte
@@ -1,6 +1,6 @@
 <div class="flex flex-col items-start justify-between md:flex-row">
 	<div
-		class="mb-3 flex h-14 w-full items-center rounded-lg border border-tertiary bg-secondary px-3 md:mb-0 md:w-[35%]"
+		class="mb-3 flex h-14 w-full items-center rounded-lg border border-disabled bg-secondary px-3 md:mb-0 md:w-[35%]"
 	>
 		<slot name="token-info" />
 	</div>


### PR DESCRIPTION
# Motivation

To align colors, we need to update some of the conversion input values. Visually, nothing has changed after the update.

<img width="498" alt="Screenshot 2024-11-21 at 11 10 17" src="https://github.com/user-attachments/assets/a5051a54-8e64-40d8-8b82-7d2baf4f2700">
