### PR TITLE
fix(frontend): issue with converting very low numbers to satoshis

### DIFF
--- a/src/frontend/src/btc/utils/btc-send.utils.ts
+++ b/src/frontend/src/btc/utils/btc-send.utils.ts
@@ -2,4 +2,7 @@ import { BTC_DECIMALS } from '$env/tokens/tokens.btc.env';
 import type { Amount } from '$lib/types/send';
 
 export const convertNumberToSatoshis = ({ amount }: { amount: Amount }): bigint =>
-	BigInt(Number(amount) * 10 ** BTC_DECIMALS);
+	// Numbers like 0.00004 can be stored internally by JS as 0.0000399999999...
+	// Therefore, when multiplied by 10 ** BTC_DECIMALS this can result in a float like 4000.0000000000005
+	// To avoid errors while converting to bigint, we need to ignore the floating part
+	BigInt((Number(amount) * 10 ** BTC_DECIMALS).toFixed(0));

--- a/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
@@ -6,5 +6,7 @@ describe('convertNumberToSatoshis', () => {
 		expect(convertNumberToSatoshis({ amount: 0.00005 })).toEqual(5000n);
 		expect(convertNumberToSatoshis({ amount: 0.25 })).toEqual(25000000n);
 		expect(convertNumberToSatoshis({ amount: 0 })).toEqual(0n);
+		expect(convertNumberToSatoshis({ amount: 0.00004 })).toEqual(4000n);
+		expect(convertNumberToSatoshis({ amount: 0.00000001 })).toEqual(1n);
 	});
 });

--- a/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
@@ -8,5 +8,6 @@ describe('convertNumberToSatoshis', () => {
 		expect(convertNumberToSatoshis({ amount: 0 })).toEqual(0n);
 		expect(convertNumberToSatoshis({ amount: 0.00004 })).toEqual(4000n);
 		expect(convertNumberToSatoshis({ amount: 0.00000001 })).toEqual(1n);
+		expect(convertNumberToSatoshis({ amount: 0.0000399999999999999 })).toEqual(4000n);
 	});
 });


### PR DESCRIPTION
# Motivation

I noticed that for some numbers the `convertNumberToSatoshis` was throwing `cannot be converted to a BigInt because it is not an integer` error. This PR fixes it as well as adds some explanations to the code.
