### PR TITLE
refactor(build): centralize variables for tokens JSON files

### DIFF
--- a/scripts/add.tokens.erc20.mjs
+++ b/scripts/add.tokens.erc20.mjs
@@ -6,7 +6,6 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import path from 'path';
 import { ENV } from './build.utils.mjs';
-
 import { CK_ERC20_JSON_FILE } from './constants.mjs';
 
 dotenv.config({ path: `.env.${ENV}` });

--- a/scripts/add.tokens.erc20.mjs
+++ b/scripts/add.tokens.erc20.mjs
@@ -6,6 +6,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import path from 'path';
 import { ENV } from './build.utils.mjs';
+import { CK_ERC20_JSON_FILE } from './utils.mjs';
 
 dotenv.config({ path: `.env.${ENV}` });
 
@@ -313,7 +314,7 @@ const flattenEnvironmentData = (data) =>
 	);
 
 const readSupportedTokens = () => {
-	const jsonPath = resolve(DATA_DIR_PATH, 'tokens.ckerc20.json');
+	const jsonPath = resolve(CK_ERC20_JSON_FILE);
 	return JSON.parse(readFileSync(jsonPath, 'utf-8'));
 };
 

--- a/scripts/add.tokens.erc20.mjs
+++ b/scripts/add.tokens.erc20.mjs
@@ -6,7 +6,8 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import path from 'path';
 import { ENV } from './build.utils.mjs';
-import { CK_ERC20_JSON_FILE } from './utils.mjs';
+
+import { CK_ERC20_JSON_FILE } from './constants.mjs';
 
 dotenv.config({ path: `.env.${ENV}` });
 

--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -7,7 +7,8 @@ import { Principal } from '@dfinity/principal';
 import { createAgent, fromNullable, isNullish, jsonReplacer } from '@dfinity/utils';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CK_ERC20_JSON_FILE } from './utils.mjs';
+
+import { CK_ERC20_JSON_FILE } from './constants.mjs';
 
 const agent = await createAgent({
 	identity: new AnonymousIdentity(),

--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -7,7 +7,6 @@ import { Principal } from '@dfinity/principal';
 import { createAgent, fromNullable, isNullish, jsonReplacer } from '@dfinity/utils';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-
 import { CK_ERC20_JSON_FILE } from './constants.mjs';
 
 const agent = await createAgent({

--- a/scripts/build.tokens.ckerc20.mjs
+++ b/scripts/build.tokens.ckerc20.mjs
@@ -7,6 +7,7 @@ import { Principal } from '@dfinity/principal';
 import { createAgent, fromNullable, isNullish, jsonReplacer } from '@dfinity/utils';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { CK_ERC20_JSON_FILE } from './utils.mjs';
 
 const agent = await createAgent({
 	identity: new AnonymousIdentity(),
@@ -92,8 +93,6 @@ const buildOrchestratorInfo = async (orchestratorId) => {
 const ORCHESTRATOR_STAGING_ID = Principal.fromText('2s5qh-7aaaa-aaaar-qadya-cai');
 const ORCHESTRATOR_PRODUCTION_ID = Principal.fromText('vxkom-oyaaa-aaaar-qafda-cai');
 
-const DATA_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'env');
-
 const LOGO_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'icp-eth', 'assets');
 
 const saveTokenLogo = async ({ canisterId, name }) => {
@@ -138,7 +137,7 @@ const findCkErc20 = async () => {
 		staging
 	};
 
-	writeFileSync(join(DATA_FOLDER, 'tokens.ckerc20.json'), JSON.stringify(tokens, jsonReplacer, 8));
+	writeFileSync(CK_ERC20_JSON_FILE, JSON.stringify(tokens, jsonReplacer, 8));
 
 	await Promise.allSettled(
 		Object.entries({

--- a/scripts/build.tokens.sns.mjs
+++ b/scripts/build.tokens.sns.mjs
@@ -10,6 +10,7 @@ import {
 } from '@dfinity/utils';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { SNS_JSON_FILE } from './utils.mjs';
 
 const AGGREGATOR_PAGE_SIZE = 10;
 const SNS_AGGREGATOR_CANISTER_URL = 'https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io';
@@ -167,7 +168,7 @@ export const findSnses = async () => {
 			{ tokens: [], icons: [] }
 		);
 
-	writeFileSync(join(DATA_FOLDER, 'tokens.sns.json'), JSON.stringify(tokens, jsonReplacer, 8));
+	writeFileSync(SNS_JSON_FILE, JSON.stringify(tokens, jsonReplacer, 8));
 
 	await saveLogos(icons);
 };

--- a/scripts/build.tokens.sns.mjs
+++ b/scripts/build.tokens.sns.mjs
@@ -10,7 +10,8 @@ import {
 } from '@dfinity/utils';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { SNS_JSON_FILE } from './utils.mjs';
+
+import { SNS_JSON_FILE } from './constants.mjs';
 
 const AGGREGATOR_PAGE_SIZE = 10;
 const SNS_AGGREGATOR_CANISTER_URL = 'https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io';

--- a/scripts/build.tokens.sns.mjs
+++ b/scripts/build.tokens.sns.mjs
@@ -10,7 +10,6 @@ import {
 } from '@dfinity/utils';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-
 import { SNS_JSON_FILE } from './constants.mjs';
 
 const AGGREGATOR_PAGE_SIZE = 10;

--- a/scripts/check.tokens.erc20.ts
+++ b/scripts/check.tokens.erc20.ts
@@ -1,10 +1,10 @@
-import type { Erc20Contract } from '$eth/types/erc20';
 import {
 	ERC20_CONTRACTS_PRODUCTION,
 	ERC20_CONTRACTS_SEPOLIA,
 	ERC20_TWIN_TOKENS_MAINNET,
 	ERC20_TWIN_TOKENS_SEPOLIA
-} from '../src/frontend/src/env/tokens.erc20.env';
+} from '$env/tokens.erc20.env';
+import type { Erc20Contract } from '$eth/types/erc20';
 
 const getAddresses = (contracts: Erc20Contract[]): string[] =>
 	contracts.map((contract) => contract.address.toLowerCase());

--- a/scripts/constants.mjs
+++ b/scripts/constants.mjs
@@ -1,0 +1,7 @@
+import { join } from 'node:path';
+
+const DATA_DIR = join(process.cwd(), 'src', 'frontend', 'src', 'env');
+
+export const CK_ERC20_JSON_FILE = join(DATA_DIR, 'tokens.ckerc20.json');
+
+export const SNS_JSON_FILE = join(DATA_DIR, 'tokens.sns.json');

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -7,7 +7,11 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import pemfile from 'pem-file';
 
-const SNS_JSON_FILE = join(process.cwd(), 'src', 'frontend', 'src', 'env', 'tokens.sns.json');
+const DATA_DIR = join(process.cwd(), 'src', 'frontend', 'src', 'env');
+
+export const CK_ERC20_JSON_FILE = join(DATA_DIR, 'tokens.ckerc20.json');
+export const SNS_JSON_FILE = join(DATA_DIR, 'tokens.sns.json');
+
 export const SNSES = JSON.parse((await readFile(SNS_JSON_FILE)).toString(), jsonReviver);
 
 /**

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -4,13 +4,9 @@ import { Secp256k1KeyIdentity } from '@dfinity/identity-secp256k1';
 import { jsonReviver } from '@dfinity/utils';
 import { readdirSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import pemfile from 'pem-file';
-
-const DATA_DIR = join(process.cwd(), 'src', 'frontend', 'src', 'env');
-
-export const CK_ERC20_JSON_FILE = join(DATA_DIR, 'tokens.ckerc20.json');
-export const SNS_JSON_FILE = join(DATA_DIR, 'tokens.sns.json');
+import { SNS_JSON_FILE } from './constants.mjs';
 
 export const SNSES = JSON.parse((await readFile(SNS_JSON_FILE)).toString(), jsonReviver);
 


### PR DESCRIPTION
# Motivation

To have better control on them, we extract and centralize some variables that points to the tokens CkERC20 and SNS JSON files in a new file called `constants.mjs`


UNRELATED: there was a non-alias import in one of the scripts.