### PR TITLE
feat(frontend): util to create URL with network param

### DIFF
--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -12,7 +12,7 @@ import type { OptionString } from '$lib/types/string';
 import type { Token } from '$lib/types/token';
 import type { Option } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { LoadEvent, Page } from '@sveltejs/kit';
+import type { LoadEvent, NavigationTarget, Page } from '@sveltejs/kit';
 
 export const transactionsUrl = ({ token }: { token: Token }): string =>
 	tokenUrl({ path: AppPath.Transactions, token });
@@ -47,6 +47,25 @@ const tokenUrl = ({
 
 export const networkParam = (networkId: NetworkId | undefined): string =>
 	isNullish(networkId) ? '' : `${NETWORK_PARAM}=${networkId.description ?? ''}`;
+
+export const networkUrl = ({
+	path,
+	networkId,
+	isTransactionsRoute,
+	fromRoute
+}: {
+	path: AppPath;
+	networkId: Option<NetworkId>;
+	isTransactionsRoute: boolean;
+	fromRoute: NavigationTarget | null;
+}) =>
+	isTransactionsRoute
+		? nonNullish(fromRoute?.url.searchParams.get(NETWORK_PARAM))
+			? `${path}?${NETWORK_PARAM}=${fromRoute.url.searchParams.get(NETWORK_PARAM)}`
+			: path
+		: nonNullish(networkId)
+			? `${path}?${networkParam(networkId)}`
+			: path;
 
 export const back = async ({ pop }: { pop: boolean }) => {
 	if (pop) {

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -1,5 +1,5 @@
 import * as appNavigation from '$app/navigation';
-import { ICP_NETWORK_ID } from '$env/networks.env';
+import { ETHEREUM_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks.env';
 import {
 	AppPath,
 	NETWORK_PARAM,
@@ -17,10 +17,11 @@ import {
 	isRouteTransactions,
 	loadRouteParams,
 	networkParam,
+	networkUrl,
 	resetRouteParams,
 	type RouteParams
 } from '$lib/utils/nav.utils';
-import type { LoadEvent, Page } from '@sveltejs/kit';
+import type { LoadEvent, NavigationTarget, Page } from '@sveltejs/kit';
 import { describe, expect } from 'vitest';
 
 describe('nav.utils', () => {
@@ -39,6 +40,81 @@ describe('nav.utils', () => {
 
 		it('should return the formatted network parameter when networkId is provided', () => {
 			expect(networkParam(ICP_NETWORK_ID)).toBe(`${NETWORK_PARAM}=${ICP_NETWORK_ID.description}`);
+		});
+	});
+
+	describe('networkUrl', () => {
+		const mockPath = AppPath.Activity;
+		const mockNetworkId = ETHEREUM_NETWORK_ID;
+		const mockQueryParam = `${NETWORK_PARAM}=${mockNetworkId.description}`;
+		const mockFromRoute: NavigationTarget = {
+			url: new URL(`https://example.com/?${NETWORK_PARAM}=test-network`)
+		} as unknown as NavigationTarget;
+
+		it('should return the path without query params when networkId and fromRoute are undefined', () => {
+			expect(
+				networkUrl({
+					path: mockPath,
+					networkId: undefined,
+					isTransactionsRoute: false,
+					fromRoute: null
+				})
+			).toBe(mockPath);
+		});
+
+		it('should return the path with query params when networkId is defined and isTransactionsRoute is false', () => {
+			expect(
+				networkUrl({
+					path: mockPath,
+					networkId: mockNetworkId,
+					isTransactionsRoute: false,
+					fromRoute: null
+				})
+			).toBe(`${mockPath}?${mockQueryParam}`);
+		});
+
+		it('should return the path without query params when isTransactionsRoute is true but fromRoute is null', () => {
+			expect(
+				networkUrl({
+					path: mockPath,
+					networkId: mockNetworkId,
+					isTransactionsRoute: true,
+					fromRoute: null
+				})
+			).toBe(mockPath);
+		});
+
+		it('should return the path with query params from fromRoute when isTransactionsRoute is true and fromRoute is non-null', () => {
+			expect(
+				networkUrl({
+					path: mockPath,
+					networkId: undefined,
+					isTransactionsRoute: true,
+					fromRoute: mockFromRoute
+				})
+			).toBe(`${mockPath}?${NETWORK_PARAM}=test-network`);
+		});
+
+		it('should prioritize fromRoute query params when isTransactionsRoute is true and both networkId and fromRoute are provided', () => {
+			expect(
+				networkUrl({
+					path: mockPath,
+					networkId: mockNetworkId,
+					isTransactionsRoute: true,
+					fromRoute: mockFromRoute
+				})
+			).toBe(`${mockPath}?${NETWORK_PARAM}=test-network`);
+		});
+
+		it('should return the path without query params from fromRoute when isTransactionsRoute is true and ther is no network selected', () => {
+			expect(
+				networkUrl({
+					path: mockPath,
+					networkId: mockNetworkId,
+					isTransactionsRoute: true,
+					fromRoute: { url: new URL(`https://example.com/`) } as unknown as NavigationTarget
+				})
+			).toBe(mockPath);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Splitting PR #3734 into smaller parts, we use this one to create an util that defined the URL for a selected network.

We would like to persist the selected network network during navigation. So, if users enable testnets and select network A in the `Assets` page, when they move to `Activity`, they have the same network selected. But even moving around the site, the network should be persisted.

However, there is the edge case:

- user DOES not select a network in the `Assets` page;
- user clicks on a token;
- user clicks on on `Activity`;
- the token's network is persisted, and that is not what we want.

So for the `Transactions` page, we use the history instead of the selected network.

# Changes

- Create function to join a path with a selected network, given the history too in case of Transactions page.

# Tests

Provided some tests


