### PR TITLE
feat(frontend): reset network param when turning testnets off

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -3,11 +3,25 @@
 	import { testnetsEnabled } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnetsStore } from '$lib/stores/settings.store';
+	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
+	import { goto } from '$app/navigation';
+
+	// TODO: create tests for this component once we have testId from GIX-CMP
+	// PR: https://github.com/dfinity/gix-components/pull/531
+
 
 	let checked: boolean;
 	$: checked = $testnetsEnabled;
 
-	const toggleTestnets = () => testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
+	const toggleTestnets = async () => {
+		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
+		// Reset network param, since the network is selectable only when testnets are enabled
+		if (checked) {
+			const url = new URL(window.location.href);
+			url.searchParams.delete(NETWORK_PARAM);
+			await goto(url, { replaceState: true, noScroll: true });
+		}
+	};
 </script>
 
 <Toggle ariaLabel={$i18n.settings.alt.testnets_toggle} bind:checked on:nnsToggle={toggleTestnets} />

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -15,6 +15,7 @@
 
 	const toggleTestnets = async () => {
 		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
+
 		// Reset network param, since the network is selectable only when testnets are enabled
 		if (checked) {
 			const url = new URL(window.location.href);

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import { Toggle } from '@dfinity/gix-components';
+	import { goto } from '$app/navigation';
+	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
 	import { testnetsEnabled } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnetsStore } from '$lib/stores/settings.store';
-	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
-	import { goto } from '$app/navigation';
 
 	// TODO: create tests for this component once we have testId from GIX-CMP
 	// PR: https://github.com/dfinity/gix-components/pull/531
-
 
 	let checked: boolean;
 	$: checked = $testnetsEnabled;

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -13,14 +13,16 @@
 	$: checked = $testnetsEnabled;
 
 	const toggleTestnets = async () => {
-		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
-
 		// Reset network param, since the network is selectable only when testnets are enabled
 		if (checked) {
 			const url = new URL(window.location.href);
 			url.searchParams.delete(NETWORK_PARAM);
 			await goto(url, { replaceState: true, noScroll: true });
 		}
+
+		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
+
+
 	};
 </script>
 

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -21,8 +21,6 @@
 		}
 
 		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
-
-
 	};
 </script>
 

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { Toggle } from '@dfinity/gix-components';
-	import { nonNullish } from '@dfinity/utils';
 	import { goto } from '$app/navigation';
 	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
 	import { testnetsEnabled } from '$lib/derived/settings.derived';

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -18,9 +18,10 @@
 
 		// Reset network param, since the network is selectable only when testnets are enabled
 		if (checked) {
-			const url = URL.parse(window.location.href);
+			const href = window.location.href;
 
-			if (nonNullish(url)) {
+			if (URL.canParse(href)) {
+				const url = new URL(href);
 				url.searchParams.delete(NETWORK_PARAM);
 				await goto(url, { replaceState: true, noScroll: true });
 			}

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { Toggle } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import { goto } from '$app/navigation';
 	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
 	import { testnetsEnabled } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnetsStore } from '$lib/stores/settings.store';
-	import { nonNullish } from '@dfinity/utils';
-	import { goto } from '$app/navigation';
 
 	// TODO: create tests for this component once we have testId from GIX-CMP
 	// PR: https://github.com/dfinity/gix-components/pull/531

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -5,6 +5,7 @@
 	import { testnetsEnabled } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnetsStore } from '$lib/stores/settings.store';
+	import { UrlSchema } from '$lib/validation/url.validation';
 
 	// TODO: create tests for this component once we have testId from GIX-CMP
 	// PR: https://github.com/dfinity/gix-components/pull/531
@@ -13,14 +14,18 @@
 	$: checked = $testnetsEnabled;
 
 	const toggleTestnets = async () => {
+		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
+
 		// Reset network param, since the network is selectable only when testnets are enabled
 		if (checked) {
-			const url = new URL(window.location.href);
-			url.searchParams.delete(NETWORK_PARAM);
-			await goto(url, { replaceState: true, noScroll: true });
-		}
+			const parsedUrl = UrlSchema.safeParse(window.location.href);
 
-		testnetsStore.set({ key: 'testnets', value: { enabled: !checked } });
+			if (parsedUrl.success) {
+				const url = new URL(parsedUrl.data);
+				url.searchParams.delete(NETWORK_PARAM);
+				await goto(url, { replaceState: true, noScroll: true });
+			}
+		}
 	};
 </script>
 

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { Toggle } from '@dfinity/gix-components';
-	import { goto } from '$app/navigation';
 	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
 	import { testnetsEnabled } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { testnetsStore } from '$lib/stores/settings.store';
-	import { UrlSchema } from '$lib/validation/url.validation';
+	import { nonNullish } from '@dfinity/utils';
+	import { goto } from '$app/navigation';
 
 	// TODO: create tests for this component once we have testId from GIX-CMP
 	// PR: https://github.com/dfinity/gix-components/pull/531
@@ -18,10 +18,9 @@
 
 		// Reset network param, since the network is selectable only when testnets are enabled
 		if (checked) {
-			const parsedUrl = UrlSchema.safeParse(window.location.href);
+			const url = URL.parse(window.location.href);
 
-			if (parsedUrl.success) {
-				const url = new URL(parsedUrl.data);
+			if (nonNullish(url)) {
 				url.searchParams.delete(NETWORK_PARAM);
 				await goto(url, { replaceState: true, noScroll: true });
 			}


### PR DESCRIPTION
# Motivation

Since ,with PR #3734, we want to persist the selected network during navigation, it makes sense to reset the network param when the network selector is disabled. That means, when the testnets are disabled.

# Changes

- Delete NETWORK_PARAM when toggle is turned off.
- Replace state.
- Add TODO for future tests.

# Tests


https://github.com/user-attachments/assets/5ad53784-3c69-4e49-9dba-f6bf3639cdcd


