### PR TITLE
fix(frontend): fix hardcoded exchangecoinid

### DIFF
--- a/src/frontend/src/icp/utils/map-icrc-data.ts
+++ b/src/frontend/src/icp/utils/map-icrc-data.ts
@@ -17,7 +17,6 @@ export const mapIcrcData = (
 				nonNullish(value) && {
 					[key]: {
 						...value,
-						exchangeCoinId: 'internet-computer'
 					}
 				})
 		}),

--- a/src/frontend/src/icp/utils/map-icrc-data.ts
+++ b/src/frontend/src/icp/utils/map-icrc-data.ts
@@ -16,7 +16,7 @@ export const mapIcrcData = (
 			...(!LOCAL &&
 				nonNullish(value) && {
 					[key]: {
-						...value,
+						...value
 					}
 				})
 		}),

--- a/src/frontend/src/icp/utils/map-icrc-data.ts
+++ b/src/frontend/src/icp/utils/map-icrc-data.ts
@@ -15,9 +15,7 @@ export const mapIcrcData = (
 			...acc,
 			...(!LOCAL &&
 				nonNullish(value) && {
-					[key]: {
-						...value
-					}
+					[key]: value
 				})
 		}),
 		{}

--- a/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
+++ b/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
@@ -10,7 +10,7 @@ describe('mapIcrcData', () => {
 	};
 
 	const expected = {
-		TESTTOKEN: { ...token.TESTTOKEN}
+		TESTTOKEN: { ...token.TESTTOKEN }
 	};
 
 	const envs = [

--- a/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
+++ b/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
@@ -10,7 +10,7 @@ describe('mapIcrcData', () => {
 	};
 
 	const expected = {
-		TESTTOKEN: { ...token.TESTTOKEN, exchangeCoinId: 'internet-computer' }
+		TESTTOKEN: { ...token.TESTTOKEN}
 	};
 
 	const envs = [

--- a/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
+++ b/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
@@ -10,7 +10,7 @@ describe('mapIcrcData', () => {
 	};
 
 	const expected = {
-		TESTTOKEN: { ...token.TESTTOKEN }
+		TESTTOKEN: token.TESTTOKEN
 	};
 
 	const envs = [


### PR DESCRIPTION
# Motivation

IcrcData from the json is wrongly mapped with an exchangeCoinId hardcoded to internet-computer. This is wrong and causes the fallback logic of exchange balance to default to the ICP price.

# Changes

remove hardcoded value