### PR TITLE
fix(frontend): improve the naming and fix the content of ICRC Tokens ledger canister id

### DIFF
--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -458,7 +458,7 @@ const ICRC_CK_TOKENS: IcInterface[] = [
 	...(nonNullish(CKUNI_IC_DATA) ? [CKUNI_IC_DATA] : []),
 	...(nonNullish(CKEURC_IC_DATA) ? [CKEURC_IC_DATA] : []),
 	...(nonNullish(CKXAUT_IC_DATA) ? [CKXAUT_IC_DATA] : [])
-]
+];
 
 const ADDITIONAL_ICRC_TOKENS: IcInterface[] = [...(nonNullish(BURN_IC_DATA) ? [BURN_IC_DATA] : [])];
 
@@ -466,12 +466,11 @@ export const ICRC_TOKENS: IcInterface[] = [
 	...PUBLIC_ICRC_TOKENS,
 	...ADDITIONAL_ICRC_TOKENS,
 	...ICRC_CK_TOKENS
-
 ];
 
-export const ICRC_CK_TOKENS_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = ICRC_CK_TOKENS.concat(PUBLIC_ICRC_TOKENS).map(
-	({ ledgerCanisterId }) => ledgerCanisterId
-);
+export const ICRC_CK_TOKENS_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = ICRC_CK_TOKENS.concat(
+	PUBLIC_ICRC_TOKENS
+).map(({ ledgerCanisterId }) => ledgerCanisterId);
 
 export const ICRC_LEDGER_CANISTER_TESTNET_IDS = [
 	...CKBTC_LEDGER_CANISTER_TESTNET_IDS,

--- a/src/frontend/src/env/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks.icrc.env.ts
@@ -439,11 +439,7 @@ export const PUBLIC_ICRC_TOKENS: IcInterface[] = [
 	...(nonNullish(CKUSDC_IC_DATA) ? [CKUSDC_IC_DATA] : [])
 ];
 
-const ADDITIONAL_ICRC_TOKENS: IcInterface[] = [...(nonNullish(BURN_IC_DATA) ? [BURN_IC_DATA] : [])];
-
-export const ICRC_TOKENS: IcInterface[] = [
-	...PUBLIC_ICRC_TOKENS,
-	...ADDITIONAL_ICRC_TOKENS,
+const ICRC_CK_TOKENS: IcInterface[] = [
 	...(nonNullish(CKBTC_LOCAL_DATA) ? [CKBTC_LOCAL_DATA] : []),
 	...(nonNullish(CKBTC_STAGING_DATA) ? [CKBTC_STAGING_DATA] : []),
 	...(nonNullish(CKETH_LOCAL_DATA) ? [CKETH_LOCAL_DATA] : []),
@@ -462,9 +458,18 @@ export const ICRC_TOKENS: IcInterface[] = [
 	...(nonNullish(CKUNI_IC_DATA) ? [CKUNI_IC_DATA] : []),
 	...(nonNullish(CKEURC_IC_DATA) ? [CKEURC_IC_DATA] : []),
 	...(nonNullish(CKXAUT_IC_DATA) ? [CKXAUT_IC_DATA] : [])
+]
+
+const ADDITIONAL_ICRC_TOKENS: IcInterface[] = [...(nonNullish(BURN_IC_DATA) ? [BURN_IC_DATA] : [])];
+
+export const ICRC_TOKENS: IcInterface[] = [
+	...PUBLIC_ICRC_TOKENS,
+	...ADDITIONAL_ICRC_TOKENS,
+	...ICRC_CK_TOKENS
+
 ];
 
-export const ICRC_TOKENS_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = ICRC_TOKENS.map(
+export const ICRC_CK_TOKENS_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = ICRC_CK_TOKENS.concat(PUBLIC_ICRC_TOKENS).map(
 	({ ledgerCanisterId }) => ledgerCanisterId
 );
 

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -1,6 +1,6 @@
 import {
 	ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS,
-	ICRC_TOKENS_LEDGER_CANISTER_IDS
+	ICRC_CK_TOKENS_LEDGER_CANISTER_IDS
 } from '$env/networks.icrc.env';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
@@ -139,7 +139,7 @@ const enabledIcrcTokensNoCk: Readable<IcToken[]> = derived(
 	[enabledIcrcTokens],
 	([$enabledIcrcTokens]) =>
 		$enabledIcrcTokens.filter(
-			({ ledgerCanisterId }) => !ICRC_TOKENS_LEDGER_CANISTER_IDS.includes(ledgerCanisterId)
+			({ ledgerCanisterId }) => !ICRC_CK_TOKENS_LEDGER_CANISTER_IDS.includes(ledgerCanisterId)
 		)
 );
 


### PR DESCRIPTION
# Motivation

The original intention of the list ICRC_TOKENS_LEDGER_CANISTER_IDS implied by its only usage in enabledIcrcTokensNoCk was to filter out Ck canister ids. By adding additional ICRC tokens to ICRC_TOKENS and the following mapping of the canister ids to the list, causes a bug:
There will be no usd exchange rates for these tokens as they are not included in the enabledIcrcTokensNoCk store.
This bug, combined with the wrong fallback logic corrected in https://github.com/dfinity/oisy-wallet/pull/3740 led to a false usd value of additional ICRC tokens.
# Changes

Rename the variable ICRC_TOKENS_LEDGER_CANISTER_IDS to reflect its only usage of holding CK token ledger canister ids
Fix the content of this list to include CK tokens.

# Tests

![image](https://github.com/user-attachments/assets/d29ba59a-ecb7-4f98-b483-0d7596866348)
