### PR TITLE
feat(frontend): create and use InsufficientFundsForFee component

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -2,7 +2,6 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import type { Readable } from 'svelte/store';
-	import { slide } from 'svelte/transition';
 	import BtcConvertFeeTotal from '$btc/components/convert/BtcConvertFeeTotal.svelte';
 	import BtcConvertFees from '$btc/components/convert/BtcConvertFees.svelte';
 	import BtcSendWarnings from '$btc/components/send/BtcSendWarnings.svelte';
@@ -12,10 +11,8 @@
 	} from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
+	import InsufficientFundsForFee from '$lib/components/fee/InsufficientFundsForFee.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
-	import MessageBox from '$lib/components/ui/MessageBox.svelte';
-	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
-	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
@@ -57,12 +54,7 @@
 >
 	<svelte:fragment slot="message">
 		{#if insufficientFundsForFee}
-			<div transition:slide={SLIDE_DURATION} data-tid="btc-convert-form-insufficient-funds-for-fee">
-				<MessageBox level="error"
-					><span class="text-error">{$i18n.convert.assertion.insufficient_funds_for_fee}</span
-					></MessageBox
-				>
-			</div>
+			<InsufficientFundsForFee testId="btc-convert-form-insufficient-funds-for-fee" />
 		{:else if nonNullish($hasPendingTransactionsStore)}
 			<div class="mb-4" data-tid="btc-convert-form-send-warnings">
 				<BtcSendWarnings

--- a/src/frontend/src/lib/components/fee/InsufficientFundsForFee.svelte
+++ b/src/frontend/src/lib/components/fee/InsufficientFundsForFee.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { slide } from 'svelte/transition';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { SLIDE_DURATION } from '$lib/constants/transition.constants.js';
+	import { i18n } from '$lib/stores/i18n.store.js';
+
+	export let testId: string | undefined = undefined;
+</script>
+
+<div transition:slide={SLIDE_DURATION} data-tid={testId}>
+	<MessageBox level="error"
+		><span class="text-error">{$i18n.fee.assertion.insufficient_funds_for_fee}</span></MessageBox
+	>
+</div>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -397,8 +397,7 @@
 			"unsupported_token_conversion": "Conversion for the selected token is not supported."
 		},
 		"assertion": {
-			"insufficient_funds": "Insufficient balance",
-			"insufficient_funds_for_fee": "Insufficient balance to cover the fees"
+			"insufficient_funds": "Insufficient balance"
 		},
 		"error": {
 			"loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized.",
@@ -539,6 +538,9 @@
 			"convert_btc_network_fee": "Bitcoin network fee",
 			"zero_fee": "Free",
 			"total_fee": "Total fee"
+		},
+		"assertion": {
+			"insufficient_funds_for_fee": "Insufficient balance to cover the fees."
 		},
 		"error": {
 			"cannot_fetch_gas_fee": "Cannot fetch gas fee."

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -365,7 +365,7 @@ interface I18nConvert {
 		refreshing_ui: string;
 		unsupported_token_conversion: string;
 	};
-	assertion: { insufficient_funds: string; insufficient_funds_for_fee: string };
+	assertion: { insufficient_funds: string };
 	error: { loading_cketh_helper: string; unexpected: string; unexpected_missing_data: string };
 }
 
@@ -478,6 +478,7 @@ interface I18nFee {
 		zero_fee: string;
 		total_fee: string;
 	};
+	assertion: { insufficient_funds_for_fee: string };
 	error: { cannot_fetch_gas_fee: string };
 }
 

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
@@ -137,7 +137,7 @@ describe('BtcConvertForm', () => {
 
 		await waitFor(() => {
 			expect(getByTestId(insufficientFundsForFeeTestId)).toHaveTextContent(
-				en.convert.assertion.insufficient_funds_for_fee
+				en.fee.assertion.insufficient_funds_for_fee
 			);
 		});
 	});


### PR DESCRIPTION
# Motivation

The same UI component can be re-used in both convert and send flow. In this PR, I'm extracting the code as well as using the new component in BtcConvertForm.
