### PR TITLE
feat(backend): add types for user dApp

### DIFF
--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -1,16 +1,19 @@
 use crate::types::custom_token::{CustomToken, CustomTokenId, Token};
+use crate::types::dapp::Dapp;
 use crate::types::token::UserToken;
 use crate::types::user_profile::{
     AddUserCredentialError, OisyUser, StoredUserProfile, UserCredential, UserProfile,
 };
-use crate::types::{ApiEnabled, Config, CredentialType, DappVersion, InitArg, Migration, MigrationProgress, MigrationReport, Timestamp, TokenVersion, Version};
+use crate::types::{
+    ApiEnabled, Config, CredentialType, DappVersion, InitArg, Migration, MigrationProgress,
+    MigrationReport, Timestamp, TokenVersion, Version,
+};
 use candid::Principal;
 use ic_canister_sig_creation::{extract_raw_root_pk_from_der, IC_ROOT_PK_DER};
 use std::collections::BTreeMap;
 use std::fmt;
 #[cfg(test)]
 use strum::IntoEnumIterator;
-use crate::types::dapp::Dapp;
 
 impl DappVersion for Dapp {
     fn get_version(&self) -> Option<Version> {

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -3,16 +3,32 @@ use crate::types::token::UserToken;
 use crate::types::user_profile::{
     AddUserCredentialError, OisyUser, StoredUserProfile, UserCredential, UserProfile,
 };
-use crate::types::{
-    ApiEnabled, Config, CredentialType, InitArg, Migration, MigrationProgress, MigrationReport,
-    Timestamp, TokenVersion, Version,
-};
+use crate::types::{ApiEnabled, Config, CredentialType, DappVersion, InitArg, Migration, MigrationProgress, MigrationReport, Timestamp, TokenVersion, Version};
 use candid::Principal;
 use ic_canister_sig_creation::{extract_raw_root_pk_from_der, IC_ROOT_PK_DER};
 use std::collections::BTreeMap;
 use std::fmt;
 #[cfg(test)]
 use strum::IntoEnumIterator;
+use crate::types::dapp::Dapp;
+
+impl DappVersion for Dapp {
+    fn get_version(&self) -> Option<Version> {
+        self.version
+    }
+
+    fn clone_with_incremented_version(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned
+    }
+
+    fn clone_with_initial_version(&self) -> Self {
+        let mut cloned = self.clone();
+        cloned.version = Some(1);
+        cloned
+    }
+}
 
 impl From<&Token> for CustomTokenId {
     fn from(token: &Token) -> Self {

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -183,13 +183,11 @@ pub trait DappVersion: Debug {
         Self: Sized + Clone;
 }
 
-
 /// Dapp
 pub mod dapp {
     use crate::types::Version;
     use candid::{CandidType, Deserialize};
     use serde::Serialize;
-
 
     #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
     pub struct Dapp {
@@ -203,7 +201,6 @@ pub mod dapp {
         pub id: String,
     }
 }
-
 
 pub mod bitcoin {
     use candid::CandidType;

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -170,6 +170,41 @@ pub mod custom_token {
     }
 }
 
+pub trait DappVersion: Debug {
+    #[must_use]
+    fn get_version(&self) -> Option<Version>;
+    #[must_use]
+    fn clone_with_incremented_version(&self) -> Self
+    where
+        Self: Sized + Clone;
+    #[must_use]
+    fn clone_with_initial_version(&self) -> Self
+    where
+        Self: Sized + Clone;
+}
+
+
+/// Dapp
+pub mod dapp {
+    use crate::types::Version;
+    use candid::{CandidType, Deserialize};
+    use serde::Serialize;
+
+
+    #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+    pub struct Dapp {
+        pub id: String,
+        pub version: Option<Version>,
+        pub hide_carousel: Option<bool>,
+    }
+
+    #[derive(CandidType, Deserialize, Clone)]
+    pub struct DappId {
+        pub id: String,
+    }
+}
+
+
 pub mod bitcoin {
     use candid::CandidType;
     use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};


### PR DESCRIPTION
# Motivation

We want to save in the backend some configurations for the dApps specific to each user. So that it is persisted throughout the accesses. The first one is the fact that the user would not want to see the dApp in the carousel anymore.

# Changes

We replicate the structure of the user tokens, but I am not sure if it is overkill or not.

- Create version class
- Create dApp classes

# Tests

No test needed for now.
