### PR TITLE
refactor(frontend): extract mock user profile

### DIFF
--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -4,6 +4,7 @@ import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { waitFor } from '@testing-library/svelte';
 import { beforeEach } from 'node:test';
 import { get } from 'svelte/store';
@@ -11,10 +12,8 @@ import { get } from 'svelte/store';
 vi.mock('$lib/api/backend.api');
 
 const mockProfile: UserProfile = {
-	credentials: [],
-	version: [1n],
-	created_timestamp: 1234n,
-	updated_timestamp: 1234n
+	...mockUserProfile,
+	version: [1n]
 };
 const nullishIdentityErrorMessage = en.auth.error.no_internet_identity;
 

--- a/src/frontend/src/tests/lib/services/request-pouh-credential.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/request-pouh-credential.services.spec.ts
@@ -6,6 +6,7 @@ import { POUH_CREDENTIAL_TYPE } from '$lib/constants/credentials.constants';
 import { requestPouhCredential } from '$lib/services/request-pouh-credential.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { toastsStore } from '@dfinity/gix-components';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { Principal } from '@dfinity/principal';
@@ -35,12 +36,7 @@ describe('request-pouh-credential.services', () => {
 
 		const identity = Ed25519KeyIdentity.generate();
 
-		const initialUserProfile: UserProfile = {
-			version: [],
-			created_timestamp: 1234n,
-			updated_timestamp: 1234n,
-			credentials: []
-		};
+		const initialUserProfile: UserProfile = { ...mockUserProfile };
 
 		beforeEach(() => {
 			vi.clearAllMocks();
@@ -55,9 +51,7 @@ describe('request-pouh-credential.services', () => {
 		it('should request credential validate it and store it', async () => {
 			addUserCredentialMock.mockResolvedValueOnce({ Ok: null });
 			const userProfileWithCredential: UserProfile = {
-				version: [],
-				created_timestamp: 1234n,
-				updated_timestamp: 1234n,
+				...mockUserProfile,
 				credentials: [
 					{
 						issuer: 'pouh',

--- a/src/frontend/src/tests/lib/utils/credentials.spec.ts
+++ b/src/frontend/src/tests/lib/utils/credentials.spec.ts
@@ -1,5 +1,6 @@
 import type { UserProfile } from '$declarations/backend/backend.did';
 import { hasPouhCredential } from '$lib/utils/credentials.utils';
+import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 
 describe('credentials utils', () => {
 	describe('hasPouhCredential', () => {
@@ -10,6 +11,7 @@ describe('credentials utils', () => {
 
 		it('should return true if the user has verified credential', () => {
 			const profile: UserProfile = {
+				...mockUserProfile,
 				credentials: [
 					{
 						issuer: 'test',
@@ -17,8 +19,6 @@ describe('credentials utils', () => {
 						verified_date_timestamp: [123456n]
 					}
 				],
-				created_timestamp: 123456n,
-				updated_timestamp: 123456n,
 				version: [0n]
 			};
 			expect(hasPouhCredential(profile)).toBe(true);
@@ -26,6 +26,7 @@ describe('credentials utils', () => {
 
 		it('should return false if the user has credential but not verified', () => {
 			const profile: UserProfile = {
+				...mockUserProfile,
 				credentials: [
 					{
 						issuer: 'test',
@@ -33,8 +34,6 @@ describe('credentials utils', () => {
 						verified_date_timestamp: []
 					}
 				],
-				created_timestamp: 123456n,
-				updated_timestamp: 123456n,
 				version: [0n]
 			};
 			expect(hasPouhCredential(profile)).toBe(false);
@@ -42,9 +41,7 @@ describe('credentials utils', () => {
 
 		it('should return false if the user has no credentials', () => {
 			const profile: UserProfile = {
-				credentials: [],
-				created_timestamp: 123456n,
-				updated_timestamp: 123456n,
+				...mockUserProfile,
 				version: [0n]
 			};
 			expect(hasPouhCredential(profile)).toBe(false);

--- a/src/frontend/src/tests/mocks/user-profile.mock.ts
+++ b/src/frontend/src/tests/mocks/user-profile.mock.ts
@@ -1,0 +1,8 @@
+import type { UserProfile } from '$declarations/backend/backend.did';
+
+export const mockUserProfile: UserProfile = {
+	credentials: [],
+	version: [],
+	created_timestamp: 1234n,
+	updated_timestamp: 1234n
+};


### PR DESCRIPTION
# Motivation

For reusability, we extract the user profile mock and we use it in the relevant tests.
