### PR TITLE
style(frontend): improves logout behaviour

### DIFF
--- a/src/frontend/src/lib/components/core/SignOut.svelte
+++ b/src/frontend/src/lib/components/core/SignOut.svelte
@@ -4,10 +4,12 @@
 	import { LOGOUT_BUTTON } from '$lib/constants/test-ids.constants';
 	import { signOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { replaceHistory } from '$lib/utils/route.utils';
 
 	const dispatch = createEventDispatcher();
 
 	const logout = async () => {
+		replaceHistory('/')
 		dispatch('icLogoutTriggered');
 		await signOut();
 	};


### PR DESCRIPTION
# Motivation

When i navigate on the activity page, logout and then login again, i should land on the home page instead of the activity page. 
When i use a link that brings me to the activity page and i then login i should land on the activity page.
When i get logged out automatically and the login again i should land on the page i was when i logged out.

# Changes

- changes url to '/' before logout

# Tests

**before:**

https://github.com/user-attachments/assets/c1116cde-7dc0-4875-882b-4e2c4a7ed234


**after:**

https://github.com/user-attachments/assets/b027b370-3310-481a-b797-5a2d7e48d370



