### PR TITLE
style(frontend): use paddingSmall for ButtonCloseModal

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonCloseModal.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonCloseModal.svelte
@@ -7,6 +7,6 @@
 	export let colorStyle: ButtonColorStyle = 'secondary';
 </script>
 
-<Button {colorStyle} type="button" fullWidth on:click={modalStore.close}>
+<Button paddingSmall {colorStyle} type="button" fullWidth on:click={modalStore.close}>
 	{$i18n.core.text.close}
 </Button>


### PR DESCRIPTION
# Motivation

Use the paddingSmall prop for ButtonCloseModal

# Changes

- add paddingSmall

# Tests

before:

<img width="610" alt="image" src="https://github.com/user-attachments/assets/7352c104-a709-48d5-bc0a-6bea8274ffd7">


after:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/a7df0f77-1a38-47b3-99e0-9f9728265c3e">

