### PR TITLE
refactor(frontend): change variable name of networkUrl input

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -47,7 +47,7 @@
 
 	const navigateTo = async (path: AppPath) => {
 		hidePopover();
-		await goto(networkUrl({ path, networkId: $networkId, isTransactionsRoute, fromRoute }));
+		await goto(networkUrl({ path, networkId: $networkId, usePreviousRoute: isTransactionsRoute, fromRoute }));
 	};
 
 	const goToTokens = async () => await navigateTo(AppPath.Tokens);

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -47,7 +47,9 @@
 
 	const navigateTo = async (path: AppPath) => {
 		hidePopover();
-		await goto(networkUrl({ path, networkId: $networkId, usePreviousRoute: isTransactionsRoute, fromRoute }));
+		await goto(
+			networkUrl({ path, networkId: $networkId, usePreviousRoute: isTransactionsRoute, fromRoute })
+		);
 	};
 
 	const goToTokens = async () => await navigateTo(AppPath.Tokens);

--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -48,7 +48,7 @@
 			href={networkUrl({
 				path: AppPath.Tokens,
 				networkId: $networkId,
-				isTransactionsRoute,
+				usePreviousRoute:isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.tokens}
@@ -63,7 +63,7 @@
 			href={networkUrl({
 				path: AppPath.Activity,
 				networkId: $networkId,
-				isTransactionsRoute,
+				usePreviousRoute:isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.activity}
@@ -78,7 +78,7 @@
 			href={networkUrl({
 				path: AppPath.Explore,
 				networkId: $networkId,
-				isTransactionsRoute,
+				usePreviousRoute:isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.dapp_explorer}
@@ -93,7 +93,7 @@
 			href={networkUrl({
 				path: AppPath.Settings,
 				networkId: $networkId,
-				isTransactionsRoute,
+				usePreviousRoute:isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.settings}

--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -48,7 +48,7 @@
 			href={networkUrl({
 				path: AppPath.Tokens,
 				networkId: $networkId,
-				usePreviousRoute:isTransactionsRoute,
+				usePreviousRoute: isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.tokens}
@@ -63,7 +63,7 @@
 			href={networkUrl({
 				path: AppPath.Activity,
 				networkId: $networkId,
-				usePreviousRoute:isTransactionsRoute,
+				usePreviousRoute: isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.activity}
@@ -78,7 +78,7 @@
 			href={networkUrl({
 				path: AppPath.Explore,
 				networkId: $networkId,
-				usePreviousRoute:isTransactionsRoute,
+				usePreviousRoute: isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.dapp_explorer}
@@ -93,7 +93,7 @@
 			href={networkUrl({
 				path: AppPath.Settings,
 				networkId: $networkId,
-				usePreviousRoute:isTransactionsRoute,
+				usePreviousRoute: isTransactionsRoute,
 				fromRoute
 			})}
 			ariaLabel={$i18n.navigation.alt.settings}

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -51,15 +51,15 @@ export const networkParam = (networkId: NetworkId | undefined): string =>
 export const networkUrl = ({
 	path,
 	networkId,
-	isTransactionsRoute,
+	usePreviousRoute,
 	fromRoute
 }: {
 	path: AppPath;
 	networkId: Option<NetworkId>;
-	isTransactionsRoute: boolean;
+	usePreviousRoute: boolean;
 	fromRoute: NavigationTarget | null;
 }) =>
-	isTransactionsRoute
+	usePreviousRoute
 		? notEmptyString(fromRoute?.url.searchParams.get(NETWORK_PARAM))
 			? `${path}?${NETWORK_PARAM}=${fromRoute?.url.searchParams.get(NETWORK_PARAM)}`
 			: path

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -56,62 +56,62 @@ describe('nav.utils', () => {
 				networkUrl({
 					path: mockPath,
 					networkId: undefined,
-					isTransactionsRoute: false,
+					usePreviousRoute: false,
 					fromRoute: null
 				})
 			).toBe(mockPath);
 		});
 
-		it('should return the path with query params when networkId is defined and isTransactionsRoute is false', () => {
+		it('should return the path with query params when networkId is defined and usePreviousRoute is false', () => {
 			expect(
 				networkUrl({
 					path: mockPath,
 					networkId: mockNetworkId,
-					isTransactionsRoute: false,
+					usePreviousRoute: false,
 					fromRoute: null
 				})
 			).toBe(`${mockPath}?${mockQueryParam}`);
 		});
 
-		it('should return the path without query params when isTransactionsRoute is true but fromRoute is null', () => {
+		it('should return the path without query params when usePreviousRoute is true but fromRoute is null', () => {
 			expect(
 				networkUrl({
 					path: mockPath,
 					networkId: mockNetworkId,
-					isTransactionsRoute: true,
+					usePreviousRoute: true,
 					fromRoute: null
 				})
 			).toBe(mockPath);
 		});
 
-		it('should return the path with query params from fromRoute when isTransactionsRoute is true and fromRoute is non-null', () => {
+		it('should return the path with query params from fromRoute when usePreviousRoute is true and fromRoute is non-null', () => {
 			expect(
 				networkUrl({
 					path: mockPath,
 					networkId: undefined,
-					isTransactionsRoute: true,
+					usePreviousRoute: true,
 					fromRoute: mockFromRoute
 				})
 			).toBe(`${mockPath}?${NETWORK_PARAM}=test-network`);
 		});
 
-		it('should prioritize fromRoute query params when isTransactionsRoute is true and both networkId and fromRoute are provided', () => {
+		it('should prioritize fromRoute query params when usePreviousRoute is true and both networkId and fromRoute are provided', () => {
 			expect(
 				networkUrl({
 					path: mockPath,
 					networkId: mockNetworkId,
-					isTransactionsRoute: true,
+					usePreviousRoute: true,
 					fromRoute: mockFromRoute
 				})
 			).toBe(`${mockPath}?${NETWORK_PARAM}=test-network`);
 		});
 
-		it('should return the path without query params from fromRoute when isTransactionsRoute is true and ther is no network selected', () => {
+		it('should return the path without query params from fromRoute when usePreviousRoute is true and ther is no network selected', () => {
 			expect(
 				networkUrl({
 					path: mockPath,
 					networkId: mockNetworkId,
-					isTransactionsRoute: true,
+					usePreviousRoute: true,
 					fromRoute: { url: new URL(`https://example.com/`) } as unknown as NavigationTarget
 				})
 			).toBe(mockPath);


### PR DESCRIPTION
# Motivation

As suggested by @peterpeterparker  in https://github.com/dfinity/oisy-wallet/pull/3734#discussion_r1856973090 , we rename variable `isTransactionsRoute` in function `networkUrl`, to make it more generic.

