### PR TITLE
refactor(frontend): replace text-secondary with black

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcNoIndexPlaceholder.svelte
+++ b/src/frontend/src/icp/components/transactions/IcNoIndexPlaceholder.svelte
@@ -17,7 +17,7 @@
 		<p class="m-0 text-center text-lg font-bold">
 			{$i18n.transactions.text.transaction_history_unavailable}
 		</p>
-		<p class="text-secondary m-0 text-center opacity-50">
+		<p class="text-black m-0 text-center opacity-50">
 			{replaceOisyPlaceholders(
 				placeholderType === 'not-working'
 					? $i18n.transactions.text.index_canister_not_working_explanation

--- a/src/frontend/src/icp/components/transactions/IcNoIndexPlaceholder.svelte
+++ b/src/frontend/src/icp/components/transactions/IcNoIndexPlaceholder.svelte
@@ -17,7 +17,7 @@
 		<p class="m-0 text-center text-lg font-bold">
 			{$i18n.transactions.text.transaction_history_unavailable}
 		</p>
-		<p class="text-black m-0 text-center opacity-50">
+		<p class="m-0 text-center text-black opacity-50">
 			{replaceOisyPlaceholders(
 				placeholderType === 'not-working'
 					? $i18n.transactions.text.index_canister_not_working_explanation

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedOut.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedOut.svelte
@@ -3,4 +3,4 @@
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 </script>
 
-<p class="text-secondary mt-4 opacity-50">{replaceOisyPlaceholders($i18n.dapps.text.sign_in)}</p>
+<p class="text-black mt-4 opacity-50">{replaceOisyPlaceholders($i18n.dapps.text.sign_in)}</p>

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedOut.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedOut.svelte
@@ -3,4 +3,4 @@
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 </script>
 
-<p class="text-black mt-4 opacity-50">{replaceOisyPlaceholders($i18n.dapps.text.sign_in)}</p>
+<p class="mt-4 text-black opacity-50">{replaceOisyPlaceholders($i18n.dapps.text.sign_in)}</p>

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -146,7 +146,7 @@
 		>
 			<svelte:fragment slot="title">{$i18n.receive.ethereum.text.ethereum}</svelte:fragment>
 
-			<span slot="text" class="text-black text-sm"
+			<span slot="text" class="text-sm text-black"
 				>{$i18n.receive.icp.text.your_private_eth_address}</span
 			>
 		</ReceiveAddress>
@@ -172,7 +172,7 @@
 		>
 			<svelte:fragment slot="title">{$i18n.receive.icp.text.principal}</svelte:fragment>
 
-			<span slot="text" class="text-black text-sm"
+			<span slot="text" class="text-sm text-black"
 				>{$i18n.receive.icp.text.use_for_icrc_deposit}</span
 			>
 		</ReceiveAddress>

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -146,7 +146,7 @@
 		>
 			<svelte:fragment slot="title">{$i18n.receive.ethereum.text.ethereum}</svelte:fragment>
 
-			<span slot="text" class="text-secondary text-sm"
+			<span slot="text" class="text-black text-sm"
 				>{$i18n.receive.icp.text.your_private_eth_address}</span
 			>
 		</ReceiveAddress>
@@ -172,7 +172,7 @@
 		>
 			<svelte:fragment slot="title">{$i18n.receive.icp.text.principal}</svelte:fragment>
 
-			<span slot="text" class="text-secondary text-sm"
+			<span slot="text" class="text-black text-sm"
 				>{$i18n.receive.icp.text.use_for_icrc_deposit}</span
 			>
 		</ReceiveAddress>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -34,7 +34,7 @@
 				{/each}
 			</div>
 		{:else}
-			<p class="text-secondary">
+			<p class="text-black">
 				{$i18n.tokens.manage.text.all_tokens_zero_balance}
 			</p>
 		{/if}

--- a/src/frontend/src/lib/components/settings/SettingsVersion.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsVersion.svelte
@@ -9,7 +9,7 @@
 	const releaseUrl = `${OISY_REPO_URL}/releases/tag/${version}`;
 </script>
 
-<p class="text-black mt-24 text-center text-xs opacity-50">
+<p class="mt-24 text-center text-xs text-black opacity-50">
 	{OISY_NAME}
 	<ExternalLink
 		href={releaseUrl}

--- a/src/frontend/src/lib/components/settings/SettingsVersion.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsVersion.svelte
@@ -9,7 +9,7 @@
 	const releaseUrl = `${OISY_REPO_URL}/releases/tag/${version}`;
 </script>
 
-<p class="text-secondary mt-24 text-center text-xs opacity-50">
+<p class="text-black mt-24 text-center text-xs opacity-50">
 	{OISY_NAME}
 	<ExternalLink
 		href={releaseUrl}

--- a/src/frontend/src/lib/components/tokens/NoTokensPlaceholder.svelte
+++ b/src/frontend/src/lib/components/tokens/NoTokensPlaceholder.svelte
@@ -21,6 +21,6 @@
 
 	<div class="space-y-4">
 		<p class="m-0 text-center text-lg font-bold">{$i18n.tokens.text.all_tokens_with_zero_hidden}</p>
-		<p class="text-secondary m-0 text-center opacity-50">{$i18n.tokens.text.buy_or_receive}</p>
+		<p class="text-black m-0 text-center opacity-50">{$i18n.tokens.text.buy_or_receive}</p>
 	</div>
 </div>

--- a/src/frontend/src/lib/components/tokens/NoTokensPlaceholder.svelte
+++ b/src/frontend/src/lib/components/tokens/NoTokensPlaceholder.svelte
@@ -21,6 +21,6 @@
 
 	<div class="space-y-4">
 		<p class="m-0 text-center text-lg font-bold">{$i18n.tokens.text.all_tokens_with_zero_hidden}</p>
-		<p class="text-black m-0 text-center opacity-50">{$i18n.tokens.text.buy_or_receive}</p>
+		<p class="m-0 text-center text-black opacity-50">{$i18n.tokens.text.buy_or_receive}</p>
 	</div>
 </div>

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -33,7 +33,7 @@
 	/>
 	{#if badge?.type === 'tokenCount' && badge.count > 0}
 		<span
-			class="absolute -right-2.5 bottom-0 flex h-6 w-6 items-center justify-center rounded-full border-[0.5px] border-tertiary bg-white text-sm font-semibold text-[var(--color-secondary)]"
+			class="absolute -right-2.5 bottom-0 flex h-6 w-6 items-center justify-center rounded-full border-[0.5px] border-tertiary bg-white text-sm font-semibold text-black"
 			aria-label={replacePlaceholders($i18n.tokens.alt.token_group_number, { $token: data.name })}
 			data-tid={`token-count-${badgeTestId}`}
 		>

--- a/src/frontend/src/lib/components/transactions/TransactionsPlaceholder.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsPlaceholder.svelte
@@ -25,7 +25,7 @@
 
 	<div class="space-y-4">
 		<p class="m-0 text-center text-lg font-bold">{$i18n.transactions.text.transaction_history}</p>
-		<p class="text-secondary m-0 text-center opacity-50">
+		<p class="text-black m-0 text-center opacity-50">
 			{$i18n.transactions.text.buy_or_receive}
 		</p>
 	</div>

--- a/src/frontend/src/lib/components/transactions/TransactionsPlaceholder.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsPlaceholder.svelte
@@ -25,7 +25,7 @@
 
 	<div class="space-y-4">
 		<p class="m-0 text-center text-lg font-bold">{$i18n.transactions.text.transaction_history}</p>
-		<p class="text-black m-0 text-center opacity-50">
+		<p class="m-0 text-center text-black opacity-50">
 			{$i18n.transactions.text.buy_or_receive}
 		</p>
 	</div>

--- a/src/frontend/src/lib/components/ui/DropdownButton.svelte
+++ b/src/frontend/src/lib/components/ui/DropdownButton.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <button
-	class="text-secondary min-w-72 justify-between gap-2 rounded-xl border border-tertiary bg-white px-4 py-3 text-left font-medium leading-5 text-inherit hover:border-brand-primary"
+	class="text-black min-w-72 justify-between gap-2 rounded-xl border border-tertiary bg-white px-4 py-3 text-left font-medium leading-5 text-inherit hover:border-brand-primary"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}

--- a/src/frontend/src/lib/components/ui/DropdownButton.svelte
+++ b/src/frontend/src/lib/components/ui/DropdownButton.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <button
-	class="text-black min-w-72 justify-between gap-2 rounded-xl border border-tertiary bg-white px-4 py-3 text-left font-medium leading-5 text-inherit hover:border-brand-primary"
+	class="min-w-72 justify-between gap-2 rounded-xl border border-tertiary bg-white px-4 py-3 text-left font-medium leading-5 text-black text-inherit hover:border-brand-primary"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}

--- a/src/frontend/src/lib/styles/global/colors.scss
+++ b/src/frontend/src/lib/styles/global/colors.scss
@@ -4,6 +4,7 @@
 	--color-white: theme(colors.white);
 	--color-white-rgb: theme(colors.white-rgb);
 	--color-black-rgb: theme(colors.black-rgb);
+	--color-black: rgb(var(--color-black-rgb));
 	--color-grey: theme(colors.grey);
 	--color-dust: theme(colors.dust);
 	--color-dark-blue: theme(colors.dark-blue);

--- a/src/frontend/src/lib/styles/global/text.scss
+++ b/src/frontend/src/lib/styles/global/text.scss
@@ -7,7 +7,3 @@
 .clamp-4 {
 	@include text.clamp(2);
 }
-
-.text-secondary {
-	color: var(--color-secondary);
-}


### PR DESCRIPTION
# Motivation

We need to introduce the real foreground color secondary. But before that we remove the custom class text-secondary that is really not necessary, and that is actually black.


