### PR TITLE
feat(frontend): query and update BTC wallet

### DIFF
--- a/src/frontend/src/btc/components/core/BtcLoaderWallets.svelte
+++ b/src/frontend/src/btc/components/core/BtcLoaderWallets.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { initBtcWalletWorker } from '$btc/services/worker.btc-wallet.services';
+	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+	import type { IcCkToken } from '$icp/types/ic-token';
 	import WalletWorkers from '$lib/components/core/WalletWorkers.svelte';
 	import { LOCAL } from '$lib/constants/app.constants';
 	import {
@@ -8,7 +10,7 @@
 		btcAddressRegtest,
 		btcAddressTestnet
 	} from '$lib/derived/address.derived';
-	import { enabledBtcTokens } from '$lib/derived/tokens.derived';
+	import { enabledBtcTokens, tokens } from '$lib/derived/tokens.derived';
 	import type { InitWalletWorkerFn } from '$lib/types/listener';
 	import type { Token } from '$lib/types/token';
 	import {
@@ -16,21 +18,36 @@
 		isNetworkIdBTCRegtest,
 		isNetworkIdBTCTestnet
 	} from '$lib/utils/network.utils';
+	import { findTwinToken } from '$lib/utils/token.utils';
 
-	let tokens: Token[];
+	let ckBtcToken: IcCkToken | undefined;
+	$: ckBtcToken = findTwinToken({
+		tokenToPair: BTC_MAINNET_TOKEN,
+		tokens: $tokens
+	});
 
+	let walletWorkerTokens: Token[];
 	// Locally, only the Regtest worker has to be launched, in all other envs - testnet and mainnet
-	$: tokens = $enabledBtcTokens.filter(({ network: { id: networkId } }) =>
+	$: walletWorkerTokens = $enabledBtcTokens.filter(({ network: { id: networkId } }) =>
 		LOCAL
 			? isNetworkIdBTCRegtest(networkId) && nonNullish($btcAddressRegtest)
 			: !isNetworkIdBTCRegtest(networkId) &&
 				((isNetworkIdBTCTestnet(networkId) && nonNullish($btcAddressTestnet)) ||
-					(isNetworkIdBTCMainnet(networkId) && nonNullish($btcAddressMainnet)))
+					// To query mainnet BTC balance, we need to wait for ckBtcToken.minterCanisterId to be available
+					(nonNullish(ckBtcToken) &&
+						isNetworkIdBTCMainnet(networkId) &&
+						nonNullish($btcAddressMainnet)))
 	);
 
-	const initWalletWorker: InitWalletWorkerFn = ({ token }) => initBtcWalletWorker(token);
+	const initWalletWorker: InitWalletWorkerFn = ({ token }) =>
+		initBtcWalletWorker({
+			token,
+			...(isNetworkIdBTCMainnet(token.network.id) && {
+				minterCanisterId: ckBtcToken?.minterCanisterId
+			})
+		});
 </script>
 
-<WalletWorkers {tokens} {initWalletWorker}>
+<WalletWorkers tokens={walletWorkerTokens} {initWalletWorker}>
 	<slot />
 </WalletWorkers>

--- a/src/frontend/src/btc/components/core/BtcLoaderWallets.svelte
+++ b/src/frontend/src/btc/components/core/BtcLoaderWallets.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { initBtcWalletWorker } from '$btc/services/worker.btc-wallet.services';
-	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
-	import type { IcCkToken } from '$icp/types/ic-token';
 	import WalletWorkers from '$lib/components/core/WalletWorkers.svelte';
 	import { LOCAL } from '$lib/constants/app.constants';
 	import {
@@ -10,7 +8,7 @@
 		btcAddressRegtest,
 		btcAddressTestnet
 	} from '$lib/derived/address.derived';
-	import { enabledBtcTokens, tokens } from '$lib/derived/tokens.derived';
+	import { enabledBtcTokens } from '$lib/derived/tokens.derived';
 	import type { InitWalletWorkerFn } from '$lib/types/listener';
 	import type { Token } from '$lib/types/token';
 	import {
@@ -18,36 +16,21 @@
 		isNetworkIdBTCRegtest,
 		isNetworkIdBTCTestnet
 	} from '$lib/utils/network.utils';
-	import { findTwinToken } from '$lib/utils/token.utils';
 
-	let ckBtcToken: IcCkToken | undefined;
-	$: ckBtcToken = findTwinToken({
-		tokenToPair: BTC_MAINNET_TOKEN,
-		tokens: $tokens
-	});
+	let tokens: Token[];
 
-	let walletWorkerTokens: Token[];
 	// Locally, only the Regtest worker has to be launched, in all other envs - testnet and mainnet
-	$: walletWorkerTokens = $enabledBtcTokens.filter(({ network: { id: networkId } }) =>
+	$: tokens = $enabledBtcTokens.filter(({ network: { id: networkId } }) =>
 		LOCAL
 			? isNetworkIdBTCRegtest(networkId) && nonNullish($btcAddressRegtest)
 			: !isNetworkIdBTCRegtest(networkId) &&
 				((isNetworkIdBTCTestnet(networkId) && nonNullish($btcAddressTestnet)) ||
-					// To query mainnet BTC balance, we need to wait for ckBtcToken.minterCanisterId to be available
-					(nonNullish(ckBtcToken) &&
-						isNetworkIdBTCMainnet(networkId) &&
-						nonNullish($btcAddressMainnet)))
+					(isNetworkIdBTCMainnet(networkId) && nonNullish($btcAddressMainnet)))
 	);
 
-	const initWalletWorker: InitWalletWorkerFn = ({ token }) =>
-		initBtcWalletWorker({
-			token,
-			...(isNetworkIdBTCMainnet(token.network.id) && {
-				minterCanisterId: ckBtcToken?.minterCanisterId
-			})
-		});
+	const initWalletWorker: InitWalletWorkerFn = ({ token }) => initBtcWalletWorker(token);
 </script>
 
-<WalletWorkers tokens={walletWorkerTokens} {initWalletWorker}>
+<WalletWorkers {tokens} {initWalletWorker}>
 	<slot />
 </WalletWorkers>

--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -170,7 +170,7 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 					shouldFetchTransactions: data?.shouldFetchTransactions,
 					minterCanisterId: data?.minterCanisterId
 				}),
-			onLoad: ({ certified: _, ...rest }) => this.syncWalletData({ ...rest }),
+			onLoad: ({ certified: _, ...rest }) => this.syncWalletData(rest),
 			identity,
 			resolution: 'all_settled'
 		});

--- a/src/frontend/src/btc/schema/btc-post-message.schema.ts
+++ b/src/frontend/src/btc/schema/btc-post-message.schema.ts
@@ -1,10 +1,12 @@
 import {
 	JsonTransactionsTextSchema,
-	PostMessageDataResponseSchema,
-	PostMessageWalletDataSchema
+	PostMessageDataResponseSchema
 } from '$lib/schema/post-message.schema';
+import type { CertifiedData } from '$lib/types/store';
+import { z } from 'zod';
 
-const BtcPostMessageWalletDataSchema = PostMessageWalletDataSchema.extend({
+const BtcPostMessageWalletDataSchema = z.object({
+	balance: z.custom<CertifiedData<bigint | null>>(),
 	newTransactions: JsonTransactionsTextSchema
 });
 

--- a/src/frontend/src/btc/services/btc-listener.services.ts
+++ b/src/frontend/src/btc/services/btc-listener.services.ts
@@ -2,7 +2,7 @@ import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 import type { BtcPostMessageDataResponseWallet } from '$btc/types/btc-post-message';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { TokenId } from '$lib/types/token';
-import { jsonReviver } from '@dfinity/utils';
+import { jsonReviver, nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 
 export const syncWallet = ({
@@ -19,13 +19,15 @@ export const syncWallet = ({
 		}
 	} = data;
 
-	balancesStore.set({
-		tokenId,
-		data: {
-			data: BigNumber.from(balance),
-			certified
-		}
-	});
+	if (nonNullish(balance)) {
+		balancesStore.set({
+			tokenId,
+			data: {
+				data: BigNumber.from(balance),
+				certified
+			}
+		});
+	}
 
 	btcTransactionsStore.prepend({
 		tokenId,

--- a/src/frontend/src/btc/services/btc-listener.services.ts
+++ b/src/frontend/src/btc/services/btc-listener.services.ts
@@ -27,6 +27,8 @@ export const syncWallet = ({
 				certified
 			}
 		});
+	} else {
+		balancesStore.reset(tokenId);
 	}
 
 	btcTransactionsStore.prepend({

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -5,21 +5,27 @@ import {
 	btcAddressRegtestStore,
 	btcAddressTestnetStore
 } from '$lib/stores/address.store';
+import type { OptionCanisterIdText } from '$lib/types/canister';
 import type { WalletWorker } from '$lib/types/listener';
 import type { PostMessage } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
 import {
 	isNetworkIdBTCMainnet,
 	isNetworkIdBTCRegtest,
-	isNetworkIdBTCTestnet,
-	mapToSignerBitcoinNetwork
+	isNetworkIdBTCTestnet
 } from '$lib/utils/network.utils';
 import { get } from 'svelte/store';
 
 export const initBtcWalletWorker = async ({
-	id: tokenId,
-	network: { id: networkId }
-}: Token): Promise<WalletWorker> => {
+	token: {
+		id: tokenId,
+		network: { id: networkId }
+	},
+	minterCanisterId
+}: {
+	token: Token;
+	minterCanisterId?: OptionCanisterIdText;
+}): Promise<WalletWorker> => {
 	const WalletWorker = await import('$btc/workers/btc-wallet.worker?worker');
 	const worker: Worker = new WalletWorker.default();
 
@@ -48,11 +54,10 @@ export const initBtcWalletWorker = async ({
 					? btcAddressRegtestStore
 					: btcAddressMainnetStore
 		),
-		bitcoinNetwork: mapToSignerBitcoinNetwork({
-			network: isTestnetNetwork ? 'testnet' : isRegtestNetwork ? 'regtest' : 'mainnet'
-		}),
+		bitcoinNetwork: isTestnetNetwork ? 'testnet' : isRegtestNetwork ? 'regtest' : 'mainnet',
 		// only mainnet transactions can be fetched via Blockchain API
-		shouldFetchTransactions: isNetworkIdBTCMainnet(networkId)
+		shouldFetchTransactions: isNetworkIdBTCMainnet(networkId),
+		minterCanisterId
 	};
 
 	return {

--- a/src/frontend/src/icp/api/bitcoin.api.ts
+++ b/src/frontend/src/icp/api/bitcoin.api.ts
@@ -33,15 +33,19 @@ export const getBalanceQuery = async ({
 	identity,
 	address,
 	network,
-	bitcoinCanisterId
-}: BitcoinCanisterParams): Promise<bigint> => {
+	bitcoinCanisterId,
+	minConfirmations
+}: BitcoinCanisterParams & {
+	minConfirmations?: number;
+}): Promise<bigint> => {
 	assertNonNullish(identity);
 
 	const { getBalanceQuery } = await bitcoinCanister({ identity, bitcoinCanisterId });
 
 	return getBalanceQuery({
 		address,
-		network
+		network,
+		minConfirmations
 	});
 };
 

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -1,4 +1,3 @@
-import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import {
 	IcCanistersSchema,
@@ -10,7 +9,7 @@ import type { JsonText } from '$icp/types/btc.post-message';
 import { NetworkSchema } from '$lib/schema/network.schema';
 import { SyncStateSchema } from '$lib/schema/sync.schema';
 import type { BtcAddress } from '$lib/types/address';
-import { CanisterIdTextSchema } from '$lib/types/canister';
+import { CanisterIdTextSchema, type OptionCanisterIdText } from '$lib/types/canister';
 import type {
 	CoingeckoSimplePriceResponse,
 	CoingeckoSimpleTokenPriceResponse
@@ -78,7 +77,8 @@ export const PostMessageDataRequestBtcSchema = z.object({
 	btcAddress: z.custom<CertifiedData<BtcAddress>>(),
 	shouldFetchTransactions: z.boolean(),
 	// TODO: can we implement a generic way to convert Candid types to Zod?
-	bitcoinNetwork: z.custom<SignerBitcoinNetwork>()
+	bitcoinNetwork: z.custom<BitcoinNetwork>(),
+	minterCanisterId: z.custom<OptionCanisterIdText>().optional()
 });
 
 export const PostMessageResponseStatusSchema = z.enum([

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -199,14 +199,12 @@ describe('btc-wallet.worker', () => {
 
 			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
 
-			// query call should be skipped as we already have certified balance
-			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(2);
 			expect(spyGetCertifiedBalance).toHaveBeenCalledTimes(2);
 
 			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
 
-			// query call should be skipped as we already have certified balance
-			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(3);
 			expect(spyGetCertifiedBalance).toHaveBeenCalledTimes(3);
 		});
 

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -11,12 +11,18 @@ import { mockBtcTransaction } from '$tests/mocks/btc-transactions.mock';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { HttpAgent } from '@dfinity/agent';
+import { BitcoinCanister, type BitcoinNetwork } from '@dfinity/ckbtc';
 import { jsonReplacer } from '@dfinity/utils';
-import { beforeAll, type MockInstance } from 'vitest';
+import { waitFor } from '@testing-library/svelte';
+import { type MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 describe('btc-wallet.worker', () => {
-	let spyGetBalance: MockInstance;
+	let spyGetCertifiedBalance: MockInstance;
+	let spyGetUncertifiedBalance: MockInstance;
+
+	const signerCanisterMock = mock<SignerCanister>();
+	const bitcoinCanisterMock = mock<BitcoinCanister>();
 
 	let originalPostmessage: unknown;
 
@@ -104,6 +110,15 @@ describe('btc-wallet.worker', () => {
 			n_unredeemed: 100,
 			total_sent: 100
 		});
+
+		vi.spyOn(SignerCanister, 'create').mockResolvedValue(signerCanisterMock);
+		vi.spyOn(BitcoinCanister, 'create').mockReturnValue(bitcoinCanisterMock);
+
+		spyGetUncertifiedBalance = bitcoinCanisterMock.getBalanceQuery.mockResolvedValue(mockBalance);
+		spyGetCertifiedBalance = signerCanisterMock.getBtcBalance.mockImplementation(async () => {
+			await waitFor(() => Promise.resolve(), { timeout: 1000 });
+			return mockBalance;
+		});
 	});
 
 	afterEach(() => {
@@ -115,19 +130,47 @@ describe('btc-wallet.worker', () => {
 	}: {
 		startData?: PostMessageDataRequestBtc | undefined;
 	}) => {
-		let scheduler: BtcWalletScheduler = new BtcWalletScheduler();
+		const scheduler: BtcWalletScheduler = new BtcWalletScheduler();
 
-		const mockPostMessageCertifiedWithTransactions = mockPostMessage({
-			certified: true,
-			withTransactions: startData?.shouldFetchTransactions ?? false
+		const mockPostMessageUncertified = mockPostMessage({
+			certified: false,
+			withTransactions: true
 		});
-		const mockPostMessageCertifiedWithoutTransactions = mockPostMessage({
+		const mockPostMessageCertified = mockPostMessage({
 			certified: true,
 			withTransactions: false
 		});
 
 		afterEach(() => {
+			// reset internal store with transactions
+			scheduler['store'] = {
+				transactions: {},
+				balance: undefined
+			};
+
 			scheduler.stop();
+		});
+
+		it('should trigger postMessage with correct data', async () => {
+			await scheduler.start(startData);
+
+			expect(postMessageMock).toHaveBeenCalledTimes(4);
+			expect(postMessageMock).toHaveBeenNthCalledWith(1, mockPostMessageStatusInProgress);
+			expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageUncertified);
+			expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageCertified);
+			expect(postMessageMock).toHaveBeenNthCalledWith(4, mockPostMessageStatusIdle);
+
+			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+			expect(postMessageMock).toHaveBeenCalledTimes(6);
+			expect(postMessageMock).toHaveBeenNthCalledWith(5, mockPostMessageStatusInProgress);
+			expect(postMessageMock).toHaveBeenNthCalledWith(6, mockPostMessageStatusIdle);
+
+			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+			expect(postMessageMock).toHaveBeenCalledTimes(8);
+			expect(postMessageMock).toHaveBeenNthCalledWith(7, mockPostMessageStatusInProgress);
+			expect(postMessageMock).toHaveBeenNthCalledWith(8, mockPostMessageStatusIdle);
 		});
 
 		it('should start the scheduler with an interval', async () => {
@@ -139,8 +182,8 @@ describe('btc-wallet.worker', () => {
 		it('should trigger the scheduler manually', async () => {
 			await scheduler.trigger(startData);
 
-			// update call only = 1
-			expect(spyGetBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetCertifiedBalance).toHaveBeenCalledTimes(1);
 		});
 
 		it('should stop the scheduler', () => {
@@ -148,54 +191,23 @@ describe('btc-wallet.worker', () => {
 			expect(scheduler['timer']['timer']).toBeUndefined();
 		});
 
-		// TODO: update this test after "queryAndUpdate" approach is introduced in the following PR
 		it('should trigger syncWallet periodically', async () => {
 			await scheduler.start(startData);
 
-			expect(spyGetBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetCertifiedBalance).toHaveBeenCalledTimes(1);
 
 			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
 
-			expect(spyGetBalance).toHaveBeenCalledTimes(2);
+			// query call should be skipped as we already have certified balance
+			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetCertifiedBalance).toHaveBeenCalledTimes(2);
 
 			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
 
-			expect(spyGetBalance).toHaveBeenCalledTimes(3);
-		});
-
-		// TODO: right now, postMessage is triggered even on changes (it is fixed in the following PR and the test will be updated accordingly)
-		it('should trigger postMessage with correct data', async () => {
-			// create a new wallet instance to reset internal store with transactions
-			scheduler = new BtcWalletScheduler();
-
-			await scheduler.start(startData);
-
-			expect(postMessageMock).toHaveBeenCalledTimes(3);
-			expect(postMessageMock).toHaveBeenNthCalledWith(1, mockPostMessageStatusInProgress);
-			expect(postMessageMock).toHaveBeenNthCalledWith(2, mockPostMessageCertifiedWithTransactions);
-			expect(postMessageMock).toHaveBeenNthCalledWith(3, mockPostMessageStatusIdle);
-
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
-
-			expect(postMessageMock).toHaveBeenCalledTimes(6);
-			expect(postMessageMock).toHaveBeenNthCalledWith(4, mockPostMessageStatusInProgress);
-			// mocked transaction is already cached at this point so the next postMessage should not have it
-			expect(postMessageMock).toHaveBeenNthCalledWith(
-				5,
-				mockPostMessageCertifiedWithoutTransactions
-			);
-			expect(postMessageMock).toHaveBeenNthCalledWith(6, mockPostMessageStatusIdle);
-
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
-
-			expect(postMessageMock).toHaveBeenCalledTimes(9);
-			expect(postMessageMock).toHaveBeenNthCalledWith(7, mockPostMessageStatusInProgress);
-			// mocked transaction is already cached at this point so the next postMessage should not have it
-			expect(postMessageMock).toHaveBeenNthCalledWith(
-				8,
-				mockPostMessageCertifiedWithoutTransactions
-			);
-			expect(postMessageMock).toHaveBeenNthCalledWith(9, mockPostMessageStatusIdle);
+			// query call should be skipped as we already have certified balance
+			expect(spyGetUncertifiedBalance).toHaveBeenCalledTimes(1);
+			expect(spyGetCertifiedBalance).toHaveBeenCalledTimes(3);
 		});
 
 		it('should postMessage with status of the worker', async () => {
@@ -207,38 +219,16 @@ describe('btc-wallet.worker', () => {
 	};
 
 	describe('btc-wallet worker should work', () => {
-		const signerCanisterMock = mock<SignerCanister>();
-
 		const startData = {
 			btcAddress: {
 				certified: true,
 				data: mockBtcAddress
 			},
-			bitcoinNetwork: { mainnet: null }
+			shouldFetchTransactions: true,
+			bitcoinNetwork: 'mainnet' as BitcoinNetwork,
+			minterCanisterId: 'mqygn-kiaaa-aaaar-qaadq-cai'
 		};
 
-		beforeEach(() => {
-			vi.spyOn(SignerCanister, 'create').mockResolvedValue(signerCanisterMock);
-
-			spyGetBalance = signerCanisterMock.getBtcBalance.mockResolvedValue(mockBalance);
-		});
-
-		describe('with balance only', () => {
-			testWorker({
-				startData: {
-					...startData,
-					shouldFetchTransactions: false
-				}
-			});
-		});
-
-		describe('with balance and transactions', () => {
-			testWorker({
-				startData: {
-					...startData,
-					shouldFetchTransactions: true
-				}
-			});
-		});
+		testWorker({ startData });
 	});
 });


### PR DESCRIPTION
# Motivation

In this PR, the "query and update" strategy is implemented in the BTC wallet worker. Important notes:
* "Querying" balance only available for BTC mainnet
* At the moment, we don't have a way of certifying BTC transactions, therefore they are fetched only on `query`

P.S: the UI part of the feature can be found here - https://github.com/dfinity/oisy-wallet/pull/3806
