### PR TITLE
style(frontend): use btn close modal in sendTokensList

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -39,5 +39,5 @@
 		{/if}
 	</TokensSkeletons>
 
-	<ButtonCloseModal slot="toolbar"/>
+	<ButtonCloseModal slot="toolbar" />
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -4,12 +4,11 @@
 	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import type { TokenUi } from '$lib/types/token';
 
 	const dispatch = createEventDispatcher();
@@ -40,13 +39,5 @@
 		{/if}
 	</TokensSkeletons>
 
-	<Button
-		colorStyle="secondary"
-		fullWidth
-		styleClass="mb-2"
-		on:click={modalStore.close}
-		slot="toolbar"
-	>
-		{$i18n.core.text.close}
-	</Button>
+	<ButtonCloseModal slot="toolbar"/>
 </ContentWithToolbar>


### PR DESCRIPTION
# Motivation

Uniform layout of modals, use btn close modal in sendTokensList

# Changes

- replace btn with buttonCloseModal

# Tests

before:
![image](https://github.com/user-attachments/assets/ffb17055-a99b-4a1b-ac5d-9473b35f97c6)



after:
![image](https://github.com/user-attachments/assets/f53a8602-522c-402f-8090-73e695b8e8cc)


