### PR TITLE
build(frontend): bump vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"@testing-library/svelte": "^5.2.4",
 				"@types/dom-view-transitions": "^1.0.5",
 				"@types/node": "^20.14.9",
-				"@vitest/coverage-v8": "^2.1.7",
+				"@vitest/coverage-v8": "^2.1.8",
 				"autoprefixer": "^10.4.20",
 				"dotenv": "^16.4.5",
 				"fake-indexeddb": "^6.0.0",
@@ -65,7 +65,7 @@
 				"typescript": "^5.4.5",
 				"vite": "^5.4.10",
 				"vite-node": "^2.1.5",
-				"vitest": "^2.1.4",
+				"vitest": "^2.1.8",
 				"vitest-mock-extended": "^2.0.2"
 			},
 			"engines": {
@@ -3945,9 +3945,9 @@
 			"peer": true
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.7.tgz",
-			"integrity": "sha512-deQ4J+yu6nEjmEfcBndbgrRM95IZoRpV1dDVRbZhjUcgYVZz/Wc4YaLiDDt9Sy5qcikrJUZMlrUxDy7dBojebg==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.8.tgz",
+			"integrity": "sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3968,8 +3968,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "2.1.7",
-				"vitest": "2.1.7"
+				"@vitest/browser": "2.1.8",
+				"vitest": "2.1.8"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -4003,14 +4003,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.7.tgz",
-			"integrity": "sha512-folWk4qQDEedgUyvaZw94LIJuNLoDtY+rhKhhNy0csdwifn/pQz8EWVRnyrW3j0wMpy+xwJT8WiwiYxk+i+s7w==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+			"integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.7",
-				"@vitest/utils": "2.1.7",
+				"@vitest/spy": "2.1.8",
+				"@vitest/utils": "2.1.8",
 				"chai": "^5.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -4019,13 +4019,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.7.tgz",
-			"integrity": "sha512-nKMTnuJrarFH+7llWxeLmYRldIwTY3OM1DzdytHj0f2+fah6Cyk4XbswhjOiTCnAvXsZAEoo1OaD6rneSSU+3Q==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+			"integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.7",
+				"@vitest/spy": "2.1.8",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.12"
 			},
@@ -4046,9 +4046,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.7.tgz",
-			"integrity": "sha512-HoqRIyfQlXPrRDB43h0lC8eHPUDPwFweMaD6t+psOvwClCC+oZZim6wPMjuoMnRdiFxXqbybg/QbuewgTwK1vA==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+			"integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4059,13 +4059,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.7.tgz",
-			"integrity": "sha512-MrDNpXUIXksR57qipYh068SOX4N1hVw6oVILlTlfeTyA1rp0asuljyp15IZwKqhjpWLObFj+tiNrOM4R8UnSqg==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+			"integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "2.1.7",
+				"@vitest/utils": "2.1.8",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -4073,13 +4073,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.7.tgz",
-			"integrity": "sha512-OioIxV/xS393DKdlkRNhmtY0K37qVdCv8w1M2SlLTBSX+fNK6zgcd01VlT1nXdbKVDaB8Zb6BOfQYYoGeGTEGg==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+			"integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.7",
+				"@vitest/pretty-format": "2.1.8",
 				"magic-string": "^0.30.12",
 				"pathe": "^1.1.2"
 			},
@@ -4088,9 +4088,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.7.tgz",
-			"integrity": "sha512-e5pzIaIC0LBrb/j1FaF7HXlPJLGtltiAkwXTMqNEHALJc7USSLEwziJ+aIWTmjsWNg89zazg37h7oZITnublsQ==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+			"integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4101,13 +4101,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.7.tgz",
-			"integrity": "sha512-7gUdvIzCCuIrMZu0WHTvDJo8C1NsUtOqmwmcS3bRHUcfHemj29wmkzLVNuWQD7WHoBD/+I7WIgrnzt7kxR54ow==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+			"integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.7",
+				"@vitest/pretty-format": "2.1.8",
 				"loupe": "^3.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -12365,9 +12365,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.7.tgz",
-			"integrity": "sha512-b/5MxSWd0ftWt1B1LHfzCw0ASzaxHztUwP0rcsBhkDSGy9ZDEDieSIjFG3I78nI9dUN0eSeD6LtuKPZGjwwpZQ==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+			"integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12381,7 +12381,7 @@
 				"vite-node": "vite-node.mjs"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -12427,19 +12427,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.7.tgz",
-			"integrity": "sha512-wzJ7Wri44ufkzTZbI1lHsdHfiGdFRmnJ9qIudDQ6tknjJeHhF5QgNSSjk7KRZUU535qEiEXFJ7tSHqyzyIv0jQ==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+			"integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "2.1.7",
-				"@vitest/mocker": "2.1.7",
-				"@vitest/pretty-format": "^2.1.7",
-				"@vitest/runner": "2.1.7",
-				"@vitest/snapshot": "2.1.7",
-				"@vitest/spy": "2.1.7",
-				"@vitest/utils": "2.1.7",
+				"@vitest/expect": "2.1.8",
+				"@vitest/mocker": "2.1.8",
+				"@vitest/pretty-format": "^2.1.8",
+				"@vitest/runner": "2.1.8",
+				"@vitest/snapshot": "2.1.8",
+				"@vitest/spy": "2.1.8",
+				"@vitest/utils": "2.1.8",
 				"chai": "^5.1.2",
 				"debug": "^4.3.7",
 				"expect-type": "^1.1.0",
@@ -12451,23 +12451,23 @@
 				"tinypool": "^1.0.1",
 				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "2.1.7",
+				"vite-node": "2.1.8",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^18.0.0 || >=20.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "2.1.7",
-				"@vitest/ui": "2.1.7",
+				"@types/node": "^18.0.0 || >=20.0.0",
+				"@vitest/browser": "2.1.8",
+				"@vitest/ui": "2.1.8",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"@testing-library/svelte": "^5.2.4",
 		"@types/dom-view-transitions": "^1.0.5",
 		"@types/node": "^20.14.9",
-		"@vitest/coverage-v8": "^2.1.7",
+		"@vitest/coverage-v8": "^2.1.8",
 		"autoprefixer": "^10.4.20",
 		"dotenv": "^16.4.5",
 		"fake-indexeddb": "^6.0.0",
@@ -106,7 +106,7 @@
 		"typescript": "^5.4.5",
 		"vite": "^5.4.10",
 		"vite-node": "^2.1.5",
-		"vitest": "^2.1.4",
+		"vitest": "^2.1.8",
 		"vitest-mock-extended": "^2.0.2"
 	},
 	"type": "module",


### PR DESCRIPTION
# Motivation

vitest cannot be bumped automatically by bot PR #3814 because it requires the vitest coverage library to be bumped as well.

# Changes

- `npm rm vitest @vitest/coverage-v8 && npm i vitest @vitest/coverage-v8 -D`