### PR TITLE
feat(frontend): optional reload prop in loadUserProfile

### DIFF
--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -5,7 +5,7 @@ import { toastsError } from '$lib/stores/toasts.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { UserProfileNotFoundError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/identity';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 const queryProfile = async ({
@@ -60,10 +60,16 @@ export const loadCertifiedUserProfile = async ({
 };
 
 export const loadUserProfile = async ({
-	identity
+	identity,
+	reload = true
 }: {
 	identity: OptionIdentity;
+	reload?: boolean;
 }): Promise<void> => {
+	if (nonNullish(get(userProfileStore)) && !reload) {
+		return;
+	}
+
 	try {
 		let profile = await queryUnsafeProfile({ identity });
 		if (isNullish(profile)) {

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -66,6 +66,10 @@ export const loadUserProfile = async ({
 	identity: OptionIdentity;
 	reload?: boolean;
 }): Promise<void> => {
+	// We just want to verify that the store is empty, without being interested in the data.
+	// So we fetch it imperatively, instead of passing as parameter.
+	// If it is not empty, and we don't want to reload, we can return early.
+	// In any case, if `reload` is true, we will always fetch the profile.
 	if (nonNullish(get(userProfileStore)) && !reload) {
 		return;
 	}

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -23,7 +23,7 @@ describe('loadUserProfile', () => {
 		vi.clearAllMocks();
 	});
 
-	it("doesn't create a user profile if uncertified profile is found", async () => {
+	it('should not create a user profile if uncertified profile is found', async () => {
 		const getUserProfileSpy = vi
 			.spyOn(backendApi, 'getUserProfile')
 			.mockResolvedValue({ Ok: mockProfile });
@@ -40,7 +40,7 @@ describe('loadUserProfile', () => {
 		expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
 	});
 
-	it('creates a user profile if uncertified profile is not found', async () => {
+	it('should create a user profile if uncertified profile is not found', async () => {
 		const getUserProfileSpy = vi
 			.spyOn(backendApi, 'getUserProfile')
 			.mockResolvedValue({ Err: { NotFound: null } });
@@ -62,7 +62,7 @@ describe('loadUserProfile', () => {
 		expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile });
 	});
 
-	it('loads the store with certified data when uncertified profile is found', async () => {
+	it('should load the store with certified data when uncertified profile is found', async () => {
 		const getUserProfileSpy = vi
 			.spyOn(backendApi, 'getUserProfile')
 			.mockResolvedValue({ Ok: mockProfile });
@@ -82,5 +82,26 @@ describe('loadUserProfile', () => {
 		await waitFor(() =>
 			expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile })
 		);
+	});
+
+	it('should not load the user profile if reload is false and the store is not empty', async () => {
+		const anotherProfile: UserProfile = { ...mockProfile, version: [2n] };
+
+		userProfileStore.set({ certified: true, profile: anotherProfile });
+
+		const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile');
+
+		await loadUserProfile({ identity: mockIdentity, reload: false });
+
+		expect(getUserProfileSpy).not.toHaveBeenCalled();
+		expect(get(userProfileStore)).toEqual({ certified: true, profile: anotherProfile });
+	});
+
+	it('should load the user profile if reload is false but the store is nullish', async () => {
+		userProfileStore.reset();
+
+		await loadUserProfile({ identity: mockIdentity, reload: false });
+
+		expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
 	});
 });


### PR DESCRIPTION
# Motivation

We want to provide the choice of not reloading the user profile if not necessary.

# Changes

- Add optional prop `reload` to `loadUserProfile`
- Default to `true`, since it is the current behavior

# Tests

Included tests.
