### PR TITLE
feat(frontend): don't deduct fee from receiveAmount on convert

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmount.svelte
@@ -24,4 +24,4 @@
 	</div>
 </div>
 
-<ConvertAmountDestination bind:receiveAmount {sendAmount} {totalFee} {insufficientFunds} />
+<ConvertAmountDestination bind:receiveAmount {sendAmount} {insufficientFunds} />

--- a/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
@@ -8,39 +8,16 @@
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
-	import { formatToken, formatTokenBigintToNumber, formatUSD } from '$lib/utils/format.utils';
-	import { parseToken } from '$lib/utils/parse.utils';
+	import { formatToken, formatUSD } from '$lib/utils/format.utils';
 
 	export let sendAmount: OptionAmount = undefined;
 	export let receiveAmount: number | undefined = undefined;
 	export let insufficientFunds: boolean;
-	export let totalFee: bigint | undefined = undefined;
 
 	const { destinationToken, destinationTokenBalance, destinationTokenExchangeRate } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
-	let sendAmountAfterFee: bigint | undefined;
-	$: sendAmountAfterFee =
-		nonNullish(totalFee) && nonNullish(sendAmount)
-			? parseToken({
-					value: `${sendAmount}`,
-					unitName: $destinationToken.decimals
-				}).toBigInt() - totalFee
-			: undefined;
-
-	let parsedSendAmountAfterFee: number | undefined;
-	$: parsedSendAmountAfterFee = nonNullish(sendAmountAfterFee)
-		? formatTokenBigintToNumber({
-				value: sendAmountAfterFee,
-				unitName: $destinationToken.decimals,
-				displayDecimals: $destinationToken.decimals
-			})
-		: undefined;
-
-	$: receiveAmount =
-		insufficientFunds || isNullish(parsedSendAmountAfterFee)
-			? undefined
-			: Math.max(parsedSendAmountAfterFee, 0);
+	$: receiveAmount = insufficientFunds || isNullish(sendAmount) ? undefined : Number(sendAmount);
 
 	let receiveAmountUSD: number;
 	$: receiveAmountUSD =

--- a/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
@@ -17,6 +17,7 @@
 	const { destinationToken, destinationTokenBalance, destinationTokenExchangeRate } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
+	// receiveAmount will always be equal to sendAmount unless there are some fees on the receiver end (future case)
 	$: receiveAmount = insufficientFunds || isNullish(sendAmount) ? undefined : Number(sendAmount);
 
 	let receiveAmountUSD: number;
@@ -35,7 +36,7 @@
 	</span>
 
 	<span slot="balance" data-tid="convert-amount-destination-balance">
-		{$i18n.convert.text.available_balance}:
+		{$i18n.send.text.balance}:
 		{formatToken({
 			value: $destinationTokenBalance ?? ZERO,
 			unitName: $destinationToken.decimals

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -384,7 +384,6 @@
 			"input_reset_button": "Reset input value",
 			"swap_to_token": "Convert $sourceToken → $destinationToken",
 			"review": "Review transaction",
-			"available_balance": "Balance",
 			"max_balance": "Max",
 			"review_tokens_info_title": "You're converting",
 			"amount_to_convert": "Amount to convert",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -384,7 +384,7 @@
 			"input_reset_button": "Reset input value",
 			"swap_to_token": "Convert $sourceToken → $destinationToken",
 			"review": "Review transaction",
-			"available_balance": "Available",
+			"available_balance": "Balance",
 			"max_balance": "Max",
 			"review_tokens_info_title": "You're converting",
 			"amount_to_convert": "Amount to convert",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -353,7 +353,6 @@ interface I18nConvert {
 		input_reset_button: string;
 		swap_to_token: string;
 		review: string;
-		available_balance: string;
 		max_balance: string;
 		review_tokens_info_title: string;
 		amount_to_convert: string;

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountDestination.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountDestination.spec.ts
@@ -7,16 +7,14 @@ import { readable } from 'svelte/store';
 
 describe('ConvertAmountDestination', () => {
 	const sendAmount = 20;
-	const totalFee = 10000n;
-	const receiveAmount = 19.9999;
+	const receiveAmount = sendAmount;
 	const exchangeRate = 0.01;
 	const balance = BigNumber.from(10000n);
 	const insufficientFunds = false;
 
 	const props = {
 		sendAmount,
-		insufficientFunds,
-		totalFee
+		insufficientFunds
 	};
 
 	const mockContext = new Map([
@@ -62,16 +60,6 @@ describe('ConvertAmountDestination', () => {
 		expect(component.$$.ctx[component.$$.props['receiveAmount']]).toBeUndefined();
 	});
 
-	it('should calculate receiveAmount correctly if totalFee is not provided', () => {
-		const { totalFee: _, ...newProps } = props;
-		const { component } = render(ConvertAmountDestination, {
-			props: newProps,
-			context: mockContext
-		});
-
-		expect(component.$$.ctx[component.$$.props['receiveAmount']]).toBeUndefined();
-	});
-
 	it('should calculate receiveAmount correctly if insufficientFunds is true', () => {
 		const { component } = render(ConvertAmountDestination, {
 			props: { ...props, insufficientFunds: true },
@@ -79,14 +67,5 @@ describe('ConvertAmountDestination', () => {
 		});
 
 		expect(component.$$.ctx[component.$$.props['receiveAmount']]).toBeUndefined();
-	});
-
-	it('should calculate receiveAmount correctly if parsedSendAmountAfterFee is less than zero', () => {
-		const { component } = render(ConvertAmountDestination, {
-			props: { ...props, sendAmount: 0.000001 },
-			context: mockContext
-		});
-
-		expect(component.$$.ctx[component.$$.props['receiveAmount']]).toBe(0);
 	});
 });


### PR DESCRIPTION
# Motivation

This PR updates the logic of how `receiveAmount` is calculated - it should be equal to `sendAmount` unless there are some fees that are gonna be payed by receiver (not the case for BTC -> ckBTC). Also, I updated a translation key related to that component.