### PR TITLE
feat(frontend): do not show Utxos warning if no amount provided

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -10,6 +10,7 @@
 		initPendingSentTransactionsStatus
 	} from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
+	import type { UtxosFee } from '$btc/types/btc-send';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
 	import InsufficientFundsForFee from '$lib/components/fee/InsufficientFundsForFee.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
@@ -30,6 +31,9 @@
 
 	let hasPendingTransactionsStore: Readable<BtcPendingSentTransactionsStatus>;
 	$: hasPendingTransactionsStore = initPendingSentTransactionsStatus(source);
+
+	let utxosFee: UtxosFee | undefined;
+	$: utxosFee = nonNullish(sendAmount) ? $storeUtxosFeeData?.utxosFee : undefined;
 
 	let invalid: boolean;
 	$: invalid =
@@ -57,10 +61,7 @@
 			<InsufficientFundsForFee testId="btc-convert-form-insufficient-funds-for-fee" />
 		{:else if nonNullish($hasPendingTransactionsStore)}
 			<div class="mb-4" data-tid="btc-convert-form-send-warnings">
-				<BtcSendWarnings
-					utxosFee={nonNullish(sendAmount) ? $storeUtxosFeeData?.utxosFee : undefined}
-					pendingTransactionsStatus={$hasPendingTransactionsStore}
-				/>
+				<BtcSendWarnings {utxosFee} pendingTransactionsStatus={$hasPendingTransactionsStore} />
 			</div>
 		{/if}
 	</svelte:fragment>

--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -58,7 +58,7 @@
 		{:else if nonNullish($hasPendingTransactionsStore)}
 			<div class="mb-4" data-tid="btc-convert-form-send-warnings">
 				<BtcSendWarnings
-					utxosFee={$storeUtxosFeeData?.utxosFee}
+					utxosFee={nonNullish(sendAmount) ? $storeUtxosFeeData?.utxosFee : undefined}
 					pendingTransactionsStatus={$hasPendingTransactionsStore}
 				/>
 			</div>


### PR DESCRIPTION
# Motivation

We now fetch utxos even if no amount is provided by the user, so it's possible that the no-utxos warning message is shown before user actually types something. To avoid that, we add a small check. 

P.S.: pending-tx message will still be shown on `hasPendingTransactionsStore` availability.
