### PR TITLE
feat(frontend): convert max button update

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -61,14 +61,14 @@
 	/**
 	 * Reevaluate max amount if user has used the "Max" button and totalFee is changing.
 	 */
-	$: totalFee,
-		(() => {
-			if (!amountSetToMax) {
-				return;
-			}
+	const debounceSetMax = () => {
+		if (!amountSetToMax) {
+			return;
+		}
 
-			debounce(() => setMax(), 500)();
-		})();
+		debounce(() => setMax(), 500)();
+	};
+	$: totalFee, debounceSetMax();
 
 	let convertAmountUSD: number;
 	$: convertAmountUSD =

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -103,7 +103,7 @@
 
 	<button
 		slot="balance"
-		class={`rounded px-2 py-0.5 ${isZeroBalance ? 'bg-error-subtle-alt text-error' : isNullish(maxAmount) ? 'animate-pulse bg-disabled text-tertiary' : 'bg-brand-subtle text-brand-primary'}`}
+		class={`rounded px-2 py-0.5 transition-all ${isZeroBalance ? 'bg-error-subtle-alt text-error' : isNullish(maxAmount) ? 'animate-pulse bg-disabled text-tertiary' : 'bg-brand-subtle text-brand-primary'}`}
 		on:click|preventDefault={setMax}
 		data-tid="convert-amount-source-balance"
 	>

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { getContext } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import ConvertInputAmount from '$lib/components/convert/ConvertInputAmount.svelte';
 	import ConvertInputsContainer from '$lib/components/convert/ConvertInputsContainer.svelte';
 	import ConvertToken from '$lib/components/convert/ConvertToken.svelte';
-	import { ZERO } from '$lib/constants/app.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
 	import { validateConvertAmount } from '$lib/utils/convert.utils';
-	import { formatToken, formatUSD } from '$lib/utils/format.utils';
+	import { formatUSD } from '$lib/utils/format.utils';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 
 	export let sendAmount: OptionAmount = undefined;
@@ -40,15 +39,36 @@
 	let isZeroBalance: boolean;
 	$: isZeroBalance = isNullish($sourceTokenBalance) || $sourceTokenBalance.isZero();
 
-	const setMax = () => {
-		if (!isZeroBalance) {
-			sendAmount = getMaxTransactionAmount({
+	let maxAmount: number | undefined;
+	$: maxAmount = nonNullish(totalFee)
+		? getMaxTransactionAmount({
 				balance: $sourceTokenBalance,
+				fee: BigNumber.from(totalFee),
 				tokenDecimals: $sourceToken.decimals,
 				tokenStandard: $sourceToken.standard
-			});
+			})
+		: undefined;
+
+	let amountSetToMax = false;
+	const setMax = () => {
+		if (!isZeroBalance && nonNullish(maxAmount)) {
+			amountSetToMax = true;
+
+			sendAmount = maxAmount;
 		}
 	};
+
+	/**
+	 * Reevaluate max amount if user has used the "Max" button and totalFee is changing.
+	 */
+	$: totalFee,
+		(() => {
+			if (!amountSetToMax) {
+				return;
+			}
+
+			debounce(() => setMax(), 500)();
+		})();
 
 	let convertAmountUSD: number;
 	$: convertAmountUSD =
@@ -66,6 +86,7 @@
 		{customValidate}
 		disabled={isZeroBalance}
 		bind:errorType
+		bind:amountSetToMax
 	/>
 
 	<div slot="amount-info" data-tid="convert-amount-source-amount-info">
@@ -82,16 +103,13 @@
 
 	<button
 		slot="balance"
-		class={`rounded px-2 py-0.5 ${isZeroBalance ? 'bg-error-subtle-alt text-error' : 'bg-brand-subtle text-brand-primary'}`}
+		class={`rounded px-2 py-0.5 ${isZeroBalance ? 'bg-error-subtle-alt text-error' : isNullish(maxAmount) ? 'animate-pulse bg-disabled text-tertiary' : 'bg-brand-subtle text-brand-primary'}`}
 		on:click|preventDefault={setMax}
 		data-tid="convert-amount-source-balance"
 	>
 		{$i18n.convert.text.max_balance}:
-		{formatToken({
-			value: $sourceTokenBalance ?? ZERO,
-			unitName: $sourceToken.decimals,
-			displayDecimals: $sourceToken.decimals
-		})}
-		{$sourceToken.symbol}
+		{nonNullish(maxAmount)
+			? `${maxAmount} ${$sourceToken.symbol}`
+			: $i18n.convert.text.calculating_max_amount}
 	</button>
 </ConvertInputsContainer>

--- a/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertInputAmount.svelte
@@ -2,6 +2,7 @@
 	import { IconClose } from '@dfinity/gix-components';
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
+	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -13,13 +14,25 @@
 
 	export let token: Token;
 	export let amount: OptionAmount = undefined;
+	export let amountSetToMax = false;
 	export let name = 'convert-amount';
 	export let disabled: boolean | undefined = undefined;
 	export let customValidate: (userAmount: BigNumber) => ConvertAmountErrorType = () => undefined;
 	export let errorType: ConvertAmountErrorType = undefined;
 	export let placeholder = '0';
 
+	const dispatch = createEventDispatcher();
+
+	const onInput = () => {
+		amountSetToMax = false;
+
+		// Bubble nnsInput as consumers might require the event as well (which is the case in Oisy).
+		dispatch('nnsInput');
+	};
+
 	const onReset = () => {
+		amountSetToMax = false;
+
 		amount = undefined;
 	};
 
@@ -53,6 +66,7 @@
 		decimals={token.decimals}
 		{placeholder}
 		{disabled}
+		on:nnsInput={onInput}
 	>
 		<svelte:fragment slot="inner-end">
 			{#if nonNullish(amount) && !disabled}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -394,7 +394,8 @@
 			"executing_transaction": "Executing transaction...",
 			"initializing": "Initializing transaction...",
 			"refreshing_ui": "Refreshing UI",
-			"unsupported_token_conversion": "Conversion for the selected token is not supported."
+			"unsupported_token_conversion": "Conversion for the selected token is not supported.",
+			"calculating_max_amount": "Calculating..."
 		},
 		"assertion": {
 			"insufficient_funds": "Insufficient balance"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -364,6 +364,7 @@ interface I18nConvert {
 		initializing: string;
 		refreshing_ui: string;
 		unsupported_token_conversion: string;
+		calculating_max_amount: string;
 	};
 	assertion: { insufficient_funds: string };
 	error: { loading_cketh_helper: string; unexpected: string; unexpected_missing_data: string };


### PR DESCRIPTION
# Motivation

In this PR, I'm updating the max button behavior in the Conversion flow - it is now working similar to the ETH send flow, where it considers the fee and also updates input value automatically if fees got changed after the max button was clicked. Also, according the UX team suggestion, we need to display "Calculating..." label until all fees are known. The tests are updated accordingly.

Total fee is not available:
<img width="555" alt="Screenshot 2024-12-05 at 14 20 07" src="https://github.com/user-attachments/assets/90fd4726-7417-4558-8441-eacf41597f14">

Total fee is available:
<img width="581" alt="Screenshot 2024-12-05 at 14 20 55" src="https://github.com/user-attachments/assets/844e011d-6497-4a6a-9f54-23b3615df9a8">
