### PR TITLE
feat(frontend): derived store for user settings

### DIFF
--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -1,0 +1,10 @@
+import type { Settings } from '$declarations/backend/backend.did';
+import { userProfileStore } from '$lib/stores/user-profile.store';
+import { fromNullable, nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const userSettings: Readable<Settings | undefined> = derived(
+	[userProfileStore],
+	([$userProfile]) =>
+		nonNullish($userProfile) ? fromNullable($userProfile.profile.settings) : undefined
+);

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -1,0 +1,26 @@
+import { userSettings } from '$lib/derived/user-profile.derived';
+import { userProfileStore } from '$lib/stores/user-profile.store';
+import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
+import { get } from 'svelte/store';
+
+describe('user-profile.derived', () => {
+	describe('userSettings', () => {
+		it('should return undefined when user profile is not set', () => {
+			userProfileStore.reset();
+
+			expect(get(userSettings)).toBeUndefined();
+		});
+
+		it('should return user settings if they are not nullish', () => {
+			userProfileStore.set({ certified: true, profile: mockUserProfile });
+
+			expect(get(userSettings)).toEqual(mockUserSettings);
+		});
+
+		it('should return undefined if user settings are nullish', () => {
+			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
+
+			expect(get(userSettings)).toBeUndefined();
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/user-profile.mock.ts
+++ b/src/frontend/src/tests/mocks/user-profile.mock.ts
@@ -1,10 +1,12 @@
 import type { UserProfile } from '$declarations/backend/backend.did';
 import { toNullable } from '@dfinity/utils';
 
+export const mockUserSettings = { dapp: { dapp_carousel: { hidden_dapp_ids: [] } } };
+
 export const mockUserProfile: UserProfile = {
 	credentials: [],
 	version: [],
-	settings: toNullable({ dapp: { dapp_carousel: { hidden_dapp_ids: [] } } }),
+	settings: toNullable(mockUserSettings),
 	created_timestamp: 1234n,
 	updated_timestamp: 1234n
 };


### PR DESCRIPTION
# Motivation

We create a derived store for the user settings, so that we can handle eventual `nullable` values.
