### PR TITLE
chore(frontend): adapt to new SASS rules

### DIFF
--- a/src/frontend/src/lib/styles/global/links.scss
+++ b/src/frontend/src/lib/styles/global/links.scss
@@ -1,4 +1,4 @@
-@import '../theme/base-colors.scss';
+@use '../theme/base-colors.scss';
 
 a.no-underline {
 	&:hover,
@@ -8,5 +8,5 @@ a.no-underline {
 }
 
 a.blue-link {
-	color: #{$brandeis-blue};
+	color: #{base-colors.$brandeis-blue};
 }


### PR DESCRIPTION
# Motivation

There was a warning given by a Sass deprecation:

![Screenshot 2024-12-05 at 15 11 29](https://github.com/user-attachments/assets/86a4fe01-9363-4caf-9edf-707b28a30de6)


Fixed using `sass-migrator` as suggested by the [documentation](https://sass-lang.com/blog/import-is-deprecated/).
