### PR TITLE
refactor(frontend): add SVG schema to network schema

### DIFF
--- a/src/frontend/src/lib/schema/network.schema.ts
+++ b/src/frontend/src/lib/schema/network.schema.ts
@@ -2,7 +2,6 @@ import type { NetworkBuy } from '$lib/types/network';
 import type { OnramperNetworkId } from '$lib/types/onramper';
 import type { AtLeastOne } from '$lib/types/utils';
 import { UrlSchema } from '$lib/validation/url.validation';
-import { notEmptyString } from '@dfinity/utils';
 import { z } from 'zod';
 
 export const NetworkIdSchema = z.symbol().brand<'NetworkId'>();
@@ -20,8 +19,7 @@ export const NetworkAppMetadataSchema = z.object({
 
 const IconSchema = z
 	.string()
-	.refine((value) => notEmptyString(value), { message: 'Must not be empty' })
-	.refine((value) => /<svg[\s\S]*<\/svg>/i.test(value), { message: 'Must be a valid SVG string' });
+	.refine((value) => value.endsWith('.svg'), { message: 'Must be an SVG file' });
 
 export const NetworkSchema = z.object({
 	id: NetworkIdSchema,

--- a/src/frontend/src/lib/schema/network.schema.ts
+++ b/src/frontend/src/lib/schema/network.schema.ts
@@ -2,6 +2,7 @@ import type { NetworkBuy } from '$lib/types/network';
 import type { OnramperNetworkId } from '$lib/types/onramper';
 import type { AtLeastOne } from '$lib/types/utils';
 import { UrlSchema } from '$lib/validation/url.validation';
+import { notEmptyString } from '@dfinity/utils';
 import { z } from 'zod';
 
 export const NetworkIdSchema = z.symbol().brand<'NetworkId'>();
@@ -17,11 +18,16 @@ export const NetworkAppMetadataSchema = z.object({
 	explorerUrl: UrlSchema
 });
 
+const IconSchema = z
+	.string()
+	.refine((value) => notEmptyString(value), { message: 'Must not be empty' })
+	.refine((value) => /<svg[\s\S]*<\/svg>/i.test(value), { message: 'Must be a valid SVG string' });
+
 export const NetworkSchema = z.object({
 	id: NetworkIdSchema,
 	env: NetworkEnvironmentSchema,
 	name: z.string(),
-	icon: z.string().optional(),
-	iconBW: z.string().optional(),
+	icon: IconSchema.optional(),
+	iconBW: IconSchema.optional(),
 	buy: z.custom<AtLeastOne<NetworkBuy>>().optional()
 });

--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -86,8 +86,8 @@ describe('network.schema', () => {
 
 		const validNetwork = {
 			...validNetworkWithRequiredFields,
-			icon: '<svg></svg>',
-			iconBW: '<svg></svg>',
+			icon: 'https://example.com/icon.svg',
+			iconBW: 'https://example.com/icon-bw.svg',
 			buy: { onramperId: 'icp' }
 		};
 
@@ -119,7 +119,7 @@ describe('network.schema', () => {
 		it('should fail validation when icon is not a valid SVG string', () => {
 			const invalidNetwork = {
 				...validNetwork,
-				icon: 'invalid-icon'
+				icon: 'https://example.com/invalid-icon.png'
 			};
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
@@ -127,7 +127,7 @@ describe('network.schema', () => {
 		it('should fail validation when iconBW is not a valid SVG string', () => {
 			const invalidNetwork = {
 				...validNetwork,
-				iconBW: 'invalid-icon'
+				iconBW: 'https://example.com/invalid-icon-bw.png'
 			};
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});

--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -86,8 +86,8 @@ describe('network.schema', () => {
 
 		const validNetwork = {
 			...validNetworkWithRequiredFields,
-			icon: 'https://example.com/icon.png',
-			iconBW: 'https://example.com/icon-bw.png',
+			icon: '<svg></svg>',
+			iconBW: '<svg></svg>',
 			buy: { onramperId: 'icp' }
 		};
 
@@ -113,6 +113,22 @@ describe('network.schema', () => {
 
 		it('should fail validation when name is missing', () => {
 			const { name: _, ...invalidNetwork } = validNetwork;
+			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
+		});
+
+		it('should fail validation when icon is not a valid SVG string', () => {
+			const invalidNetwork = {
+				...validNetwork,
+				icon: 'invalid-icon'
+			};
+			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
+		});
+
+		it('should fail validation when iconBW is not a valid SVG string', () => {
+			const invalidNetwork = {
+				...validNetwork,
+				iconBW: 'invalid-icon'
+			};
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
 	});


### PR DESCRIPTION
# Motivation

As suggested in the past, we should refine the schema of network type to be more specific for the icons.
