### PR TITLE
feat(frontend): add close button to carousel slides

### DIFF
--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -279,7 +279,7 @@
 	{#if nonNullish(slides) && slides.length > 1}
 		<div
 			class={`absolute bottom-2 right-0 flex justify-between px-3 ${controlsWidthStyleClass ?? 'w-full'}`}
-			transition:slide={SLIDE_PARAMS}
+			out:slide={SLIDE_PARAMS}
 		>
 			<Indicators {onIndicatorClick} {totalSlides} {currentSlide} />
 			<Controls {onNext} {onPrevious} />

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -269,7 +269,7 @@
 	data-tid={CAROUSEL_CONTAINER}
 	class={`${styleClass ?? ''} relative overflow-hidden rounded-3xl bg-white px-3 pb-10 pt-3 shadow`}
 	class:pb-3={nonNullish(slides) && slides.length <= 1}
-	out:slide={SLIDE_PARAMS}
+	transition:slide={SLIDE_PARAMS}
 >
 	<div class="w-full overflow-hidden" bind:this={container}>
 		<div data-tid="carousel-slide" class="flex" bind:this={sliderFrame}>

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -269,7 +269,7 @@
 	data-tid={CAROUSEL_CONTAINER}
 	class={`${styleClass ?? ''} relative overflow-hidden rounded-3xl bg-white px-3 pb-10 pt-3 shadow`}
 	class:pb-3={nonNullish(slides) && slides.length <= 1}
-	transition:slide={SLIDE_PARAMS}
+	out:slide={SLIDE_PARAMS}
 >
 	<div class="w-full overflow-hidden" bind:this={container}>
 		<div data-tid="carousel-slide" class="flex" bind:this={sliderFrame}>

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -269,6 +269,7 @@
 	data-tid={CAROUSEL_CONTAINER}
 	class={`${styleClass ?? ''} relative overflow-hidden rounded-3xl bg-white px-3 pb-10 pt-3 shadow`}
 	class:pb-3={nonNullish(slides) && slides.length <= 1}
+	out:slide={SLIDE_PARAMS}
 >
 	<div class="w-full overflow-hidden" bind:this={container}>
 		<div data-tid="carousel-slide" class="flex" bind:this={sliderFrame}>

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -250,9 +250,13 @@
 	export const removeSlide = (idx: number) => {
 		slides = slides.filter((_, i) => i !== idx);
 
+		totalSlides = slides.length;
+
 		initializeCarousel();
 
-		if (slides.length === 1) {
+		goToNextSlide();
+
+		if (slides.length <= 1) {
 			clearAutoplayTimer();
 		}
 	};

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -256,7 +256,7 @@
 
 		goToNextSlide();
 
-		if (slides.length <= 1) {
+		if (totalSlides <= 1) {
 			clearAutoplayTimer();
 		}
 	};

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -17,13 +17,19 @@
 
 	let dappsCarouselSlides: CarouselSlideOisyDappDescription[];
 	$: dappsCarouselSlides = filterCarouselDapps({ dAppDescriptions, hiddenDappsIds });
+
+	const closeSlide = async ({
+		detail: dappId
+	}: CustomEvent<CarouselSlideOisyDappDescription['id']>) => {
+		hiddenDappsIds = [...hiddenDappsIds, dappId];
+	};
 </script>
 
 {#if nonNullish($userSettings) && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
 	<Carousel controlsWidthStyleClass="w-[calc(100%-5rem)]" styleClass={`w-full ${styleClass ?? ''}`}>
 		{#each dappsCarouselSlides as dappsCarouselSlide}
-			<DappsCarouselSlide {dappsCarouselSlide} />
+			<DappsCarouselSlide {dappsCarouselSlide} on:icCloseCarouselSlide={closeSlide} />
 		{/each}
 	</Carousel>
 {/if}

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -20,10 +20,12 @@
 
 	let carousel: Carousel;
 
-	const closeSlide = async ({
-		detail: dappId
-	}: CustomEvent<CarouselSlideOisyDappDescription['id']>) => {
+	const closeSlide = ({ detail: dappId }: CustomEvent<CarouselSlideOisyDappDescription['id']>) => {
 		const idx = dappsCarouselSlides.findIndex(({ id }) => id === dappId);
+
+		hiddenDappsIds = [...hiddenDappsIds, dappId];
+
+		dappsCarouselSlides = filterCarouselDapps({ dAppDescriptions, hiddenDappsIds });
 
 		if (idx !== -1) {
 			carousel.removeSlide(idx);
@@ -38,7 +40,7 @@
 		controlsWidthStyleClass="w-[calc(100%-5rem)]"
 		styleClass={`w-full ${styleClass ?? ''}`}
 	>
-		{#each dappsCarouselSlides as dappsCarouselSlide}
+		{#each dappsCarouselSlides as dappsCarouselSlide (dappsCarouselSlide.id)}
 			<DappsCarouselSlide {dappsCarouselSlide} on:icCloseCarouselSlide={closeSlide} />
 		{/each}
 	</Carousel>

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -18,16 +18,26 @@
 	let dappsCarouselSlides: CarouselSlideOisyDappDescription[];
 	$: dappsCarouselSlides = filterCarouselDapps({ dAppDescriptions, hiddenDappsIds });
 
+	let carousel: Carousel;
+
 	const closeSlide = async ({
 		detail: dappId
 	}: CustomEvent<CarouselSlideOisyDappDescription['id']>) => {
-		hiddenDappsIds = [...hiddenDappsIds, dappId];
+		const idx = dappsCarouselSlides.findIndex(({ id }) => id === dappId);
+
+		if (idx !== -1) {
+			carousel.removeSlide(idx);
+		}
 	};
 </script>
 
 {#if nonNullish($userSettings) && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
-	<Carousel controlsWidthStyleClass="w-[calc(100%-5rem)]" styleClass={`w-full ${styleClass ?? ''}`}>
+	<Carousel
+		bind:this={carousel}
+		controlsWidthStyleClass="w-[calc(100%-5rem)]"
+		styleClass={`w-full ${styleClass ?? ''}`}
+	>
 		{#each dappsCarouselSlides as dappsCarouselSlide}
 			<DappsCarouselSlide {dappsCarouselSlide} on:icCloseCarouselSlide={closeSlide} />
 		{/each}

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -7,13 +9,20 @@
 
 	export let dappsCarouselSlide: CarouselSlideOisyDappDescription;
 	$: ({
+		id: dappId,
 		carousel: { text, callToAction },
 		logo,
 		name: dAppName
 	} = dappsCarouselSlide);
+
+	const dispatch = createEventDispatcher();
+
+	const close = () => {
+		dispatch('icCloseCarouselSlide', dappId);
+	};
 </script>
 
-<div class="flex h-full items-center">
+<div class="flex h-full items-center justify-between">
 	<div class="mr-4 shrink-0">
 		<Img
 			height="64"
@@ -23,7 +32,7 @@
 			alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: dAppName })}
 		/>
 	</div>
-	<div>
+	<div class="w-full justify-start">
 		<div class="mb-1">{text}</div>
 		<button
 			on:click={() => {
@@ -35,4 +44,11 @@
 			{callToAction} →
 		</button>
 	</div>
+	<button
+		class="h-full items-start p-1 text-tertiary"
+		on:click={close}
+		aria-label={$i18n.core.text.close}
+	>
+		<IconClose size="20" />
+	</button>
 </div>

--- a/src/frontend/src/lib/components/icons/lucide/IconClose.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconClose.svelte
@@ -1,5 +1,9 @@
 <!-- source: ISC Lucide - please visit https://lucide.dev/license -->
-<svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<script lang="ts">
+	export let size = '18';
+</script>
+
+<svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path
 		fill-rule="evenodd"
 		clip-rule="evenodd"


### PR DESCRIPTION
# Motivation

We add a close button to the carousel slides to hide them.

# Note

This affects only current navigation. Persisting that will be applied in another PR, using the backend method `add_hidden_dapp_id` introduced with PR #3777  

# Changes

- Add button close to component `DappsCarouselSlide`.
- Bubble event `icCloseCarouselSlide` that provides the dApp that is being closed.
- Create function in `DappsCarousel` to manage the event and remove the correspondent slide.
- Adjust `Carousel` function removeSlide to refresh all needed variables.
- Add transitions.

# Tests


https://github.com/user-attachments/assets/873fa742-5307-48a2-b81a-2276e54afdc7


