### PR TITLE
style(frontend): calculates amount for btc transactions correctly

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -22,7 +22,7 @@
 	let label: string;
 	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
 
-	let amount: BigNumber;
+	let amount: BigInt | undefined;
 	$: amount = nonNullish(value) ? (type === 'send' ? value * BigInt(-1) : value) : undefined;
 </script>
 

--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -23,7 +23,7 @@
 	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
 
 	let amount: BigNumber;
-	$: amount = nonNullish(value) ? type === 'send' ? value * BigInt(-1) : value : undefined;
+	$: amount = nonNullish(value) ? (type === 'send' ? value * BigInt(-1) : value) : undefined;
 </script>
 
 <Transaction

--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -21,11 +21,14 @@
 
 	let label: string;
 	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
+
+	let amount: BigNumber;
+	$: amount = nonNullish(value) ? type === 'send' ? value * BigInt(-1) : value : undefined;
 </script>
 
 <Transaction
 	on:click={() => modalStore.openBtcTransaction({ transaction, token })}
-	amount={nonNullish(value) ? BigNumber.from(value) : undefined}
+	amount={nonNullish(amount) ? BigNumber.from(amount) : undefined}
 	{type}
 	timestamp={Number(timestamp)}
 	{status}

--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -22,7 +22,7 @@
 	let label: string;
 	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
 
-	let amount: BigInt | undefined;
+	let amount: bigint | undefined;
 	$: amount = nonNullish(value) ? (type === 'send' ? value * BigInt(-1) : value) : undefined;
 </script>
 

--- a/src/frontend/src/tests/btc/components/transactions/BtcTransaction.spec.ts
+++ b/src/frontend/src/tests/btc/components/transactions/BtcTransaction.spec.ts
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/svelte';
 import BtcTransaction from '$btc/components/transactions/BtcTransaction.svelte';
 import type { BtcTransactionUi } from '$btc/types/btc';
 import { DEFAULT_BITCOIN_TOKEN } from '$lib/constants/tokens.constants';
+import { render } from '@testing-library/svelte';
 
 describe('BtcTransaction', () => {
 	const mockTransaction: BtcTransactionUi = {
@@ -17,22 +17,22 @@ describe('BtcTransaction', () => {
 		const props = {
 			transaction: mockTransaction,
 			token: DEFAULT_BITCOIN_TOKEN
-		}
+		};
 
-		const { getByText } = render(BtcTransaction, {props});
+		const { getByText } = render(BtcTransaction, { props });
 
 		expect(getByText('Send')).toBeInTheDocument();
 		expect(getByText('-0.00040827')).toBeInTheDocument();
 	});
 	it('should calculate amount for receive transaction correctly', () => {
-		const btcTransaction: BtcTransactionUi = {...mockTransaction, type: 'receive'};
+		const btcTransaction: BtcTransactionUi = { ...mockTransaction, type: 'receive' };
 
 		const props = {
 			transaction: btcTransaction,
 			token: DEFAULT_BITCOIN_TOKEN
-		}
+		};
 
-		const { getByText } = render(BtcTransaction, {props});
+		const { getByText } = render(BtcTransaction, { props });
 
 		expect(getByText('Receive')).toBeInTheDocument();
 		expect(getByText('+0.00040827')).toBeInTheDocument();

--- a/src/frontend/src/tests/btc/components/transactions/BtcTransaction.spec.ts
+++ b/src/frontend/src/tests/btc/components/transactions/BtcTransaction.spec.ts
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/svelte';
+import BtcTransaction from '$btc/components/transactions/BtcTransaction.svelte';
+import type { BtcTransactionUi } from '$btc/types/btc';
+import { DEFAULT_BITCOIN_TOKEN } from '$lib/constants/tokens.constants';
+
+describe('BtcTransaction', () => {
+	const mockTransaction: BtcTransactionUi = {
+		id: 'test',
+		type: 'send',
+		status: 'confirmed',
+		value: BigInt(40827),
+		confirmations: 88822,
+		from: '0xD379F3d4578DE7aC47a5928811B3407Ef03F7C49'
+	};
+
+	it('should calculate amount for send transaction correctly', () => {
+		const props = {
+			transaction: mockTransaction,
+			token: DEFAULT_BITCOIN_TOKEN
+		}
+
+		const { getByText } = render(BtcTransaction, {props});
+
+		expect(getByText('Send')).toBeInTheDocument();
+		expect(getByText('-0.00040827')).toBeInTheDocument();
+	});
+	it('should calculate amount for receive transaction correctly', () => {
+		const btcTransaction: BtcTransactionUi = {...mockTransaction, type: 'receive'};
+
+		const props = {
+			transaction: btcTransaction,
+			token: DEFAULT_BITCOIN_TOKEN
+		}
+
+		const { getByText } = render(BtcTransaction, {props});
+
+		expect(getByText('Receive')).toBeInTheDocument();
+		expect(getByText('+0.00040827')).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/btc/components/transactions/BtcTransaction.spec.ts
+++ b/src/frontend/src/tests/btc/components/transactions/BtcTransaction.spec.ts
@@ -24,6 +24,7 @@ describe('BtcTransaction', () => {
 		expect(getByText('Send')).toBeInTheDocument();
 		expect(getByText('-0.00040827')).toBeInTheDocument();
 	});
+
 	it('should calculate amount for receive transaction correctly', () => {
 		const btcTransaction: BtcTransactionUi = { ...mockTransaction, type: 'receive' };
 


### PR DESCRIPTION
# Motivation

On the transactions page the BTC send transactions are displayed as if the user is receiving tokens instead of sending them. The amount of a `send` transaction should be displayed with a leading `-` (minus) and the text should be black.

# Changes

- fixes calculation

# Tests

**before:**
![image](https://github.com/user-attachments/assets/8b56855f-f69c-4f8b-b1f6-32aacd8fd8a1)


**after:**
![image](https://github.com/user-attachments/assets/44671b83-b7b1-45fc-8fc9-774689a02782)

