### PR TITLE
fix(frontend): correct IconSchema

### DIFF
--- a/src/frontend/src/lib/schema/network.schema.ts
+++ b/src/frontend/src/lib/schema/network.schema.ts
@@ -19,7 +19,9 @@ export const NetworkAppMetadataSchema = z.object({
 
 const IconSchema = z
 	.string()
-	.refine((value) => value.endsWith('.svg'), { message: 'Must be an SVG file' });
+	.refine((value) => value.endsWith('.svg') || value.startsWith('data:image/svg+xml'), {
+		message: 'Must be an SVG file'
+	});
 
 export const NetworkSchema = z.object({
 	id: NetworkIdSchema,

--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -1,3 +1,4 @@
+import icpBW from '$lib/assets/networks/icp-bw.svg';
 import {
 	NetworkAppMetadataSchema,
 	NetworkBuySchema,
@@ -87,7 +88,7 @@ describe('network.schema', () => {
 		const validNetwork = {
 			...validNetworkWithRequiredFields,
 			icon: 'https://example.com/icon.svg',
-			iconBW: 'https://example.com/icon-bw.svg',
+			iconBW: icpBW,
 			buy: { onramperId: 'icp' }
 		};
 


### PR DESCRIPTION
# Motivation

In PR #3875 , I introduced the IconSchema, considering only the environments where the local files were passed as string path. However, in production, staging, and in general in any non-local deployed environment, the element is the SVG file content.

That is why we fix the schema here.