### PR TITLE
style(frontend): center license in Sign screen

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -8,8 +8,9 @@
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
 </script>
 
-<div class="flex w-full flex-col items-center md:items-start"
-class:md:items-center={licenseAlignment === 'center'}
+<div
+	class="flex w-full flex-col items-center md:items-start"
+	class:md:items-center={licenseAlignment === 'center'}
 >
 	<ButtonAuthenticate on:click={async () => await signIn({})} {fullWidth} />
 

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -8,7 +8,9 @@
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
 </script>
 
-<div class="flex w-full flex-col items-center md:items-start">
+<div class="flex w-full flex-col items-center md:items-start"
+class:md:items-center={licenseAlignment === 'center'}
+>
 	<ButtonAuthenticate on:click={async () => await signIn({})} {fullWidth} />
 
 	<span


### PR DESCRIPTION
# Motivation

Centering the license agreement in the Sign page. No changes for the other screens.

### Before

![Screenshot 2024-12-06 at 07 49 22](https://github.com/user-attachments/assets/bb7ff83e-5c47-4bbe-8e0c-75500f1f57c3)


### After

![Screenshot 2024-12-06 at 07 48 41](https://github.com/user-attachments/assets/bc1c0e92-f71b-4750-95b3-59b24854c0e9)


