### PR TITLE
feat(frontend): do nothing if slides are empty in extendCarouselSliderFrame

### DIFF
--- a/src/frontend/src/lib/utils/carousel.utils.ts
+++ b/src/frontend/src/lib/utils/carousel.utils.ts
@@ -38,7 +38,7 @@ export const extendCarouselSliderFrame = ({
 	slides: Node[];
 	slideWidth: number;
 } & CommonParams) => {
-	if (isNullish(sliderFrame)) {
+	if (isNullish(sliderFrame) || slides.length === 0) {
 		return;
 	}
 

--- a/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/carousel.utils.spec.ts
@@ -10,6 +10,28 @@ const extendedSlides = [slides[slides.length - 1], ...slides, slides[0]];
 const slideWidth = 300;
 
 describe('extendCarouselSliderFrame', () => {
+	it('does nothing if sliderFrame is nullish', () => {
+		const sliderFrame = undefined;
+		extendCarouselSliderFrame({
+			sliderFrame,
+			slides,
+			slideWidth
+		});
+
+		expect(sliderFrame).toBeUndefined();
+	});
+
+	it('does nothing if slides array is empty', () => {
+		const sliderFrame = document.createElement('div');
+		extendCarouselSliderFrame({
+			sliderFrame,
+			slides: [],
+			slideWidth
+		});
+
+		expect(sliderFrame.children.length).toEqual(0);
+	});
+
 	it('puts correct amount of slides in the frame', () => {
 		const sliderFrame = document.createElement('div');
 		extendCarouselSliderFrame({


### PR DESCRIPTION
# Motivation

It makes sense to return immediately if the `slides` array is empty in `extendCarouselSliderFrame`.
