### PR TITLE
fix(e2e): fixing e2e wasm failure

### DIFF
--- a/.github/actions/oisy-backend/action.yml
+++ b/.github/actions/oisy-backend/action.yml
@@ -19,7 +19,7 @@ runs:
       if: steps.backend-wasm-cache.outputs.cache-hit == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ runner.os == 'macOS' && 'backend.wasm.gz-macOS' || 'backend.wasm.gz' }}
+        name: backend.wasm.gz
         path: ./backend.wasm.gz
 
     - name: Build base docker image

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,10 +34,7 @@ jobs:
         continue-on-error: false
 
   oisy-backend-wasm:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, macos-14]
+    runs-on: ubuntu-24.04
     if: ${{ needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' }}
     needs: check-e2e-changes
     steps:
@@ -57,6 +54,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend.wasm.gz
 
       - name: Prepare macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -15,10 +15,7 @@ concurrency:
 jobs:
 
   oisy-backend-wasm:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, macos-14]
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     steps:
       - name: Checkout
@@ -32,17 +29,17 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GIX_CREATE_PR_PAT }}
-
+      
       - name: Build oisy-backend WASM
         uses: ./.github/actions/oisy-backend
 
   update_snapshots:
     runs-on: ${{ matrix.os }}
+    needs: oisy-backend-wasm
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14]
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
-    needs: oisy-backend-wasm
     
     steps:
 
@@ -70,6 +67,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend.wasm.gz
 
       - name: Prepare macOS
         if: runner.os == 'macOS'


### PR DESCRIPTION
# Motivation

Our E2E Tests are failing due to wasm not being built on macOS. This PR will fix this issue in a stable manner.

# Changes

adjusted workflows to build the wasm only on ubuntu but download it as artifact on macOS.

# Tests

ran on different branch with success
