### PR TITLE
docs(config): fix typo in Dockerfile comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY ./rust-toolchain.toml ./rust-toolchain.toml
 RUN ./docker/bootstrap
 
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
-# to build only the dependecies, we pretend that our project is a simple, empty
+# to build only the dependencies, we pretend that our project is a simple, empty
 # `lib.rs`. When we COPY the actual files we make sure to `touch` lib.rs so
 # that cargo knows to rebuild it with the new content.
 COPY Cargo.lock .


### PR DESCRIPTION
# Motivation

Fix a typo similar to the one spotted by @goodactive in a comment on the Dockerfile of  [Juno](https://github.com/junobuild/juno/pull/891).

# Changes

- `dependecies` -> `dependencies`
