### PR TITLE
fix(e2e): added conditial device usage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,6 +49,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14]
+    env:
+      MATRIX_OS: ${{ matrix.os }}
     if: ${{ needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' }}
     needs: oisy-backend-wasm
     steps:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -39,6 +39,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-14]
+    env:
+      MATRIX_OS: ${{ matrix.os }}
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     
     steps:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,35 @@ dotenv.populate(
 
 const DEV = (process.env.NODE_ENV ?? 'production') === 'development';
 
+const MATRIX_OS = process.env.MATRIX_OS || '';
+const isMac = MATRIX_OS.includes('macos') || process.platform === 'darwin';
+
+const appleProjects = [
+	{
+		name: 'Safari',
+		use: devices['Desktop Safari'],
+	},
+	{
+		name: 'iPhone SE',
+		use: devices ['iPhone SE'],
+	},
+];
+
+const nonAppleProjects = [
+	{
+		name: 'Google Chrome',
+		use: devices['Desktop Chrome'],
+	},
+	{
+    name: 'Firefox',
+    use: devices['Desktop Firefox'],
+  },
+  {
+    name: 'Pixel 5',
+    use: devices['Pixel 5'],
+  },
+]
+
 const TIMEOUT = 5 * 60 * 1000;
 
 export default defineConfig({
@@ -37,10 +66,5 @@ export default defineConfig({
 		navigationTimeout: TIMEOUT,
 		...(DEV && { headless: false })
 	},
-	projects: [
-		{
-			name: 'Google Chrome',
-			use: { ...devices['Desktop Chrome'], channel: 'chrome' }
-		}
-	]
+	projects: isMac ? appleProjects : nonAppleProjects,
 });


### PR DESCRIPTION
# Motivation

We want to ensure that macOS runners are ONLY used for Apple devices and that everything else is being tested on ubuntu runners.

# Changes

adjusted the configuration for handling conditional device usage based on os.
