### PR TITLE
fix(frontend): btc wallet error hideToast option

### DIFF
--- a/src/frontend/src/btc/services/btc-listener.services.ts
+++ b/src/frontend/src/btc/services/btc-listener.services.ts
@@ -56,7 +56,7 @@ export const syncWalletError = ({
 	// Currently, the certified error can only happen while fetching balance, but we still want to reset transactions to avoid displaying incorrect data
 	btcTransactionsStore.reset(tokenId);
 
-	if (!hideToast) {
+	if (hideToast) {
 		console.warn(`${errorText}:`, err);
 		return;
 	}


### PR DESCRIPTION
# Motivation

Fix for incorrect `hideToast` param handling in `btc-listener.services`.