### PR TITLE
feat(frontend): avoid showing toast on errors with BTC testnet

### DIFF
--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -1,6 +1,5 @@
 import { syncWallet, syncWalletError } from '$btc/services/btc-listener.services';
 import type { BtcPostMessageDataResponseWallet } from '$btc/types/btc-post-message';
-import { LOCAL } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -48,8 +47,12 @@ export const initBtcWalletWorker = async ({
 				syncWalletError({
 					tokenId,
 					error: (data.data as PostMessageDataResponseError).error,
-					// TODO: do not launch worker locally if BTC canister is not deployed, and remove the below param afterwards
-					hideToast: isRegtestNetwork && LOCAL
+					/**
+					 * TODOs:
+					 * 1. Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
+					 * 2. Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
+					 * **/
+					hideToast: isRegtestNetwork || isTestnetNetwork
 				});
 				return;
 		}

--- a/src/frontend/src/tests/btc/services/btc-listener.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-listener.services.spec.ts
@@ -40,7 +40,7 @@ describe('btc-listener', () => {
 	});
 
 	// mock console.warn to avoid unnecessary logs
-	vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+	const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -103,6 +103,7 @@ describe('btc-listener', () => {
 			const balance = get(balancesStore);
 			const transactions = get(btcTransactionsStore);
 
+			expect(consoleWarnSpy).toHaveBeenCalledOnce();
 			expect(balance?.[tokenId]).toBeNull();
 			expect(transactions?.[tokenId]).toBeNull();
 		});


### PR DESCRIPTION
# Motivation

Since BTC testnet is not working at the moment, we want to avoid showing toast for all the users that have "testnet" setting on. We will remove it after it is fixed on the canister side. 
