### PR TITLE
feat(frontend): add signout when authIdentity is nullish

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -23,8 +23,6 @@
 	let dappsCarouselSlides: CarouselSlideOisyDappDescription[];
 	$: dappsCarouselSlides = filterCarouselDapps({ dAppDescriptions, hiddenDappsIds });
 
-	$: console.log('dappsCarouselSlides', $userSettings, hiddenDappsIds, dappsCarouselSlides);
-
 	let carousel: Carousel;
 
 	const closeSlide = async ({

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -23,6 +23,8 @@
 	let dappsCarouselSlides: CarouselSlideOisyDappDescription[];
 	$: dappsCarouselSlides = filterCarouselDapps({ dAppDescriptions, hiddenDappsIds });
 
+	$: console.log('dappsCarouselSlides', $userSettings, hiddenDappsIds, dappsCarouselSlides);
+
 	let carousel: Carousel;
 
 	const closeSlide = async ({

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -3,17 +3,20 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { loadUserProfile } from '$lib/services/load-user-profile.services';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
+	import { nullishSignOut } from '$lib/services/auth.services';
 
-	const load = ({ reload = false }: { reload?: boolean }) => {
+	const load =async ({ reload = false }: { reload?: boolean }) => {
 		if (isNullish($authIdentity)) {
 			userProfileStore.reset();
+			await nullishSignOut();
 			return;
 		}
 
-		loadUserProfile({ identity: $authIdentity, reload });
+		await loadUserProfile({ identity: $authIdentity, reload });
 	};
 
-	$: $authIdentity, load({});
+	$: $authIdentity, (async () => await load({}))();
+
 
 	const reload = () => {
 		load({ reload: true });

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -17,7 +17,7 @@
 
 	$: $authIdentity, (async () => await load({}))();
 
-	const reload =async () => {
+	const reload = async () => {
 		await load({ reload: true });
 	};
 </script>

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { nullishSignOut } from '$lib/services/auth.services';
 	import { loadUserProfile } from '$lib/services/load-user-profile.services';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
-	import { nullishSignOut } from '$lib/services/auth.services';
 
-	const load =async ({ reload = false }: { reload?: boolean }) => {
+	const load = async ({ reload = false }: { reload?: boolean }) => {
 		if (isNullish($authIdentity)) {
 			userProfileStore.reset();
 			await nullishSignOut();
@@ -16,7 +16,6 @@
 	};
 
 	$: $authIdentity, (async () => await load({}))();
-
 
 	const reload = () => {
 		load({ reload: true });

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -17,8 +17,8 @@
 
 	$: $authIdentity, (async () => await load({}))();
 
-	const reload = () => {
-		load({ reload: true });
+	const reload =async () => {
+		await load({ reload: true });
 	};
 </script>
 


### PR DESCRIPTION
# Motivation

As suggested by @DenysKarmazynDFINITY , we include function `nullishSignOut` in the check for `authIdentity` inside `LoaderUserProfile`.
