### PR TITLE
fix(frontend): load Carousel when missing settings in user profile

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -57,7 +57,7 @@
 	};
 </script>
 
-{#if $userSettings!==undefined && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
+{#if $userSettings !== undefined && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
 	<Carousel
 		bind:this={carousel}

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -57,7 +57,7 @@
 	};
 </script>
 
-{#if nonNullish($userSettings) && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
+{#if $userSettings!==undefined && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
 	<Carousel
 		bind:this={carousel}

--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -1,10 +1,14 @@
 import type { Settings } from '$declarations/backend/backend.did';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import type { Option } from '$lib/types/utils';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const userSettings: Readable<Settings | undefined> = derived(
+export const userSettings: Readable<Option<Settings>> = derived(
 	[userProfileStore],
 	([$userProfile]) =>
-		nonNullish($userProfile) ? fromNullable($userProfile.profile.settings) : undefined
+		// The user profile may or may not have the settings field.
+		// To distinguish between user profile not loaded and missing settings,
+		// we use `undefined` for the former and `null` for the latter.
+		nonNullish($userProfile) ? (fromNullable($userProfile.profile.settings) ?? null) : undefined
 );

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -61,7 +61,7 @@ describe('DappsCarousel', () => {
 		expect(container.innerHTML).toBe('');
 	});
 
-	it('should render nothing if the user settings are nullish', () => {
+	it('should render the Carousel if the user settings are null', () => {
 		const userProfile: UserProfile = {
 			...mockUserProfile,
 			settings: []
@@ -69,8 +69,8 @@ describe('DappsCarousel', () => {
 
 		userProfileStore.set({ profile: userProfile, certified: false });
 
-		const { container } = render(DappsCarousel);
-		expect(container.innerHTML).toBe('');
+		const { getByTestId } = render(DappsCarousel);
+		expect(getByTestId(CAROUSEL_CONTAINER)).toBeInTheDocument();
 	});
 
 	it('should render the Carousel when data exist', () => {

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -17,10 +17,10 @@ describe('user-profile.derived', () => {
 			expect(get(userSettings)).toEqual(mockUserSettings);
 		});
 
-		it('should return undefined if user settings are nullish', () => {
+		it('should return null if user settings are nullish', () => {
 			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
 
-			expect(get(userSettings)).toBeUndefined();
+			expect(get(userSettings)).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The carousel was not being loaded for old accounts, because `userSettings` was always `undefined`.

However, we should distinguish between not having loaded the user profile (from which `userSettings` derives), and having a missing field `settings` in the user profile (it happens for old accounts, since we introduced the field recently).

# Changes

- Improve `userSettings` derived store to set `null` when the user profile exists but it is missing the `settings` field.
- Adapt tests.
- Adapt `DapsCarousel`.

# Tests

Provided.
