### PR TITLE
feat(frontend): derived store userProfileLoaded

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -4,7 +4,7 @@
 	import Carousel from '$lib/components/carousel/Carousel.svelte';
 	import DappsCarouselSlide from '$lib/components/dapps/DappsCarouselSlide.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { userSettings } from '$lib/derived/user-profile.derived';
+	import { userProfileLoaded, userSettings } from '$lib/derived/user-profile.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
 	import {
@@ -57,7 +57,7 @@
 	};
 </script>
 
-{#if $userSettings !== undefined && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
+{#if $userProfileLoaded && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
 	<Carousel
 		bind:this={carousel}

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -4,7 +4,7 @@
 	import Carousel from '$lib/components/carousel/Carousel.svelte';
 	import DappsCarouselSlide from '$lib/components/dapps/DappsCarouselSlide.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { userProfileLoaded, userSettings } from '$lib/derived/user-profile.derived';
+	import { userSettings, userSettingsLoaded } from '$lib/derived/user-profile.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
 	import {
@@ -57,7 +57,7 @@
 	};
 </script>
 
-{#if $userProfileLoaded && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
+{#if $userSettingsLoaded && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
 	<Carousel
 		bind:this={carousel}

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -4,7 +4,7 @@
 	import Carousel from '$lib/components/carousel/Carousel.svelte';
 	import DappsCarouselSlide from '$lib/components/dapps/DappsCarouselSlide.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { userSettings, userSettingsLoaded } from '$lib/derived/user-profile.derived';
+	import { userProfileLoaded, userSettings } from '$lib/derived/user-profile.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
 	import {
@@ -57,7 +57,7 @@
 	};
 </script>
 
-{#if $userSettingsLoaded && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
+{#if $userProfileLoaded && nonNullish(dappsCarouselSlides) && dappsCarouselSlides.length > 0}
 	<!-- To align controls section with slide text - 100% - logo width (4rem) - margin logo-text (1rem) -->
 	<Carousel
 		bind:this={carousel}

--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -4,11 +4,12 @@ import type { Option } from '$lib/types/utils';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
+export const userProfileLoaded: Readable<boolean> = derived([userProfileStore], ([$userProfile]) =>
+	nonNullish($userProfile)
+);
+
 export const userSettings: Readable<Option<Settings>> = derived(
 	[userProfileStore],
 	([$userProfile]) =>
-		// The user profile may or may not have the settings field.
-		// To distinguish between user profile not loaded and missing settings,
-		// we use `undefined` for the former and `null` for the latter.
-		nonNullish($userProfile) ? (fromNullable($userProfile.profile.settings) ?? null) : undefined
+		nonNullish($userProfile) ? fromNullable($userProfile.profile.settings) : undefined
 );

--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -1,18 +1,15 @@
 import type { Settings } from '$declarations/backend/backend.did';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { Option } from '$lib/types/utils';
-import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+import { fromNullable, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
+
+export const userProfileLoaded: Readable<boolean> = derived([userProfileStore], ([$userProfile]) =>
+	nonNullish($userProfile)
+);
 
 export const userSettings: Readable<Option<Settings>> = derived(
 	[userProfileStore],
 	([$userProfile]) =>
 		nonNullish($userProfile) ? fromNullable($userProfile.profile.settings) : undefined
-);
-
-export const userSettingsLoaded: Readable<boolean> = derived(
-	[userProfileStore, userSettings],
-	([$userProfile, $userSettings]) =>
-		nonNullish($userSettings) ||
-		(nonNullish($userProfile) && isNullish(fromNullable($userProfile.profile.settings)))
 );

--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -1,15 +1,18 @@
 import type { Settings } from '$declarations/backend/backend.did';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { Option } from '$lib/types/utils';
-import { fromNullable, nonNullish } from '@dfinity/utils';
+import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
-
-export const userProfileLoaded: Readable<boolean> = derived([userProfileStore], ([$userProfile]) =>
-	nonNullish($userProfile)
-);
 
 export const userSettings: Readable<Option<Settings>> = derived(
 	[userProfileStore],
 	([$userProfile]) =>
 		nonNullish($userProfile) ? fromNullable($userProfile.profile.settings) : undefined
+);
+
+export const userSettingsLoaded: Readable<boolean> = derived(
+	[userProfileStore, userSettings],
+	([$userProfile, $userSettings]) =>
+		nonNullish($userSettings) ||
+		(nonNullish($userProfile) && isNullish(fromNullable($userProfile.profile.settings)))
 );

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -1,26 +1,35 @@
-import { userSettings } from '$lib/derived/user-profile.derived';
+import { userProfileLoaded, userSettings } from '$lib/derived/user-profile.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
 import { get } from 'svelte/store';
 
 describe('user-profile.derived', () => {
+	describe('userProfileLoaded', () => {
+		it('should return false when user profile is not set', () => {
+			userProfileStore.reset();
+			expect(get(userProfileLoaded)).toBe(false);
+		});
+
+		it('should return true when user profile is set', () => {
+			userProfileStore.set({ certified: true, profile: mockUserProfile });
+			expect(get(userProfileLoaded)).toBe(true);
+		});
+	});
+
 	describe('userSettings', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
-
 			expect(get(userSettings)).toBeUndefined();
 		});
 
 		it('should return user settings if they are not nullish', () => {
 			userProfileStore.set({ certified: true, profile: mockUserProfile });
-
 			expect(get(userSettings)).toEqual(mockUserSettings);
 		});
 
-		it('should return null if user settings are nullish', () => {
+		it('should return undefined if user settings are nullish', () => {
 			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
-
-			expect(get(userSettings)).toBeNull();
+			expect(get(userSettings)).toBeUndefined();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -1,21 +1,9 @@
-import { userProfileLoaded, userSettings } from '$lib/derived/user-profile.derived';
+import { userSettings, userSettingsLoaded } from '$lib/derived/user-profile.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
 import { get } from 'svelte/store';
 
 describe('user-profile.derived', () => {
-	describe('userProfileLoaded', () => {
-		it('should return false when user profile is not set', () => {
-			userProfileStore.reset();
-			expect(get(userProfileLoaded)).toBe(false);
-		});
-
-		it('should return true when user profile is set', () => {
-			userProfileStore.set({ certified: true, profile: mockUserProfile });
-			expect(get(userProfileLoaded)).toBe(true);
-		});
-	});
-
 	describe('userSettings', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
@@ -30,6 +18,23 @@ describe('user-profile.derived', () => {
 		it('should return undefined if user settings are nullish', () => {
 			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
 			expect(get(userSettings)).toBeUndefined();
+		});
+	});
+
+	describe('userSettingsLoaded', () => {
+		it('should return false when user profile is not set', () => {
+			userProfileStore.reset();
+			expect(get(userSettingsLoaded)).toBe(false);
+		});
+
+		it('should return true when user settings are not nullish', () => {
+			userProfileStore.set({ certified: true, profile: mockUserProfile });
+			expect(get(userSettingsLoaded)).toBe(true);
+		});
+
+		it('should return true when user settings are nullish but user profile is set', () => {
+			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
+			expect(get(userSettingsLoaded)).toBe(true);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -1,9 +1,21 @@
-import { userSettings, userSettingsLoaded } from '$lib/derived/user-profile.derived';
+import { userProfileLoaded, userSettings } from '$lib/derived/user-profile.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
 import { get } from 'svelte/store';
 
 describe('user-profile.derived', () => {
+	describe('userProfileLoaded', () => {
+		it('should return false when user profile is not set', () => {
+			userProfileStore.reset();
+			expect(get(userProfileLoaded)).toBe(false);
+		});
+
+		it('should return true when user profile is set', () => {
+			userProfileStore.set({ certified: true, profile: mockUserProfile });
+			expect(get(userProfileLoaded)).toBe(true);
+		});
+	});
+
 	describe('userSettings', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
@@ -18,23 +30,6 @@ describe('user-profile.derived', () => {
 		it('should return undefined if user settings are nullish', () => {
 			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
 			expect(get(userSettings)).toBeUndefined();
-		});
-	});
-
-	describe('userSettingsLoaded', () => {
-		it('should return false when user profile is not set', () => {
-			userProfileStore.reset();
-			expect(get(userSettingsLoaded)).toBe(false);
-		});
-
-		it('should return true when user settings are not nullish', () => {
-			userProfileStore.set({ certified: true, profile: mockUserProfile });
-			expect(get(userSettingsLoaded)).toBe(true);
-		});
-
-		it('should return true when user settings are nullish but user profile is set', () => {
-			userProfileStore.set({ certified: true, profile: { ...mockUserProfile, settings: [] } });
-			expect(get(userSettingsLoaded)).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

According to @peterpeterparker 's suggestion in https://github.com/dfinity/oisy-wallet/pull/3893#pullrequestreview-2486419830 , we find a better way to distinguish if the user settings are not available because the user profile is not loaded, or if they are missing (old accounts for example).

The base difference is simply if the user profile is not `nullish`: if it is not `nullish` and the settings are nullish, we are sure that the `settings` are missing.

# Changes

- Create derived store `userProfileLoaded`.
- Use new store in `DappsCarousel`.

# Tests

Test created and adjusted.
