### PR TITLE
feat(frontend): always show Send button

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -16,7 +16,6 @@
 	import Receive from '$lib/components/receive/Receive.svelte';
 	import Send from '$lib/components/send/Send.svelte';
 	import HeroButtonGroup from '$lib/components/ui/HeroButtonGroup.svelte';
-	import { allBalancesZero } from '$lib/derived/balances.derived';
 	import {
 		networkEthereum,
 		networkICP,
@@ -42,9 +41,6 @@
 
 	let isTransactionsPage = false;
 	$: isTransactionsPage = isRouteTransactions($page);
-
-	let sendAction = true;
-	$: sendAction = !$allBalancesZero || isTransactionsPage;
 </script>
 
 <div role="toolbar" class="flex w-full justify-center pt-10">
@@ -59,9 +55,7 @@
 			<Receive />
 		{/if}
 
-		{#if sendAction}
-			<Send {isTransactionsPage} />
-		{/if}
+		<Send {isTransactionsPage} />
 
 		{#if isTransactionsPage}
 			{#if convertEth}


### PR DESCRIPTION
# Motivation

As a part of Swap feature, we need to make some adjustments to the Actions component - "Send" as well as future "Swap" buttons will always be visible and enabled on the tokens page. 

Message that is shown to a user with zero balance:
<img width="595" alt="Screenshot 2024-12-09 at 13 41 15" src="https://github.com/user-attachments/assets/1c03ce7b-4d13-4e17-8d2c-bfcb256a673f">
