### PR TITLE
feat(frontend): track carousel events

### DIFF
--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -7,6 +7,12 @@
 	import { CAROUSEL_CONTAINER } from '$lib/constants/test-ids.constants';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { moveSlider, extendCarouselSliderFrame } from '$lib/utils/carousel.utils';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import {
+		TRACK_COUNT_CAROUSEL_NEXT,
+		TRACK_COUNT_CAROUSEL_OPEN,
+		TRACK_COUNT_CAROUSEL_PREVIOUS
+	} from '$lib/constants/analytics.contants';
 
 	export let autoplay = 5000;
 	export let duration = 300;
@@ -178,7 +184,11 @@
 	/**
 	 * Reset the autoplay timer and call goToNextSlide
 	 */
-	const onNext = () => {
+	const onNext = async () => {
+		await trackEvent({
+			name: TRACK_COUNT_CAROUSEL_NEXT
+		});
+
 		// Do not do anything if last-to-first element transition is on
 		if (currentSlide > totalSlides + 1) {
 			return;
@@ -212,7 +222,11 @@
 	/**
 	 * Reset the autoplay timer and call goToPreviousSlide
 	 */
-	const onPrevious = () => {
+	const onPrevious = async () => {
+		await trackEvent({
+			name: TRACK_COUNT_CAROUSEL_PREVIOUS
+		});
+
 		// Do not do anything if first-to-last element transition is on
 		if (currentSlide < -1) {
 			return;

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -4,14 +4,14 @@
 	import { slide } from 'svelte/transition';
 	import Controls from '$lib/components/carousel/Controls.svelte';
 	import Indicators from '$lib/components/carousel/Indicators.svelte';
-	import { CAROUSEL_CONTAINER } from '$lib/constants/test-ids.constants';
-	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
-	import { moveSlider, extendCarouselSliderFrame } from '$lib/utils/carousel.utils';
-	import { trackEvent } from '$lib/services/analytics.services';
 	import {
 		TRACK_COUNT_CAROUSEL_NEXT,
 		TRACK_COUNT_CAROUSEL_PREVIOUS
 	} from '$lib/constants/analytics.contants';
+	import { CAROUSEL_CONTAINER } from '$lib/constants/test-ids.constants';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import { moveSlider, extendCarouselSliderFrame } from '$lib/utils/carousel.utils';
 
 	export let autoplay = 5000;
 	export let duration = 300;

--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -10,7 +10,6 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import {
 		TRACK_COUNT_CAROUSEL_NEXT,
-		TRACK_COUNT_CAROUSEL_OPEN,
 		TRACK_COUNT_CAROUSEL_PREVIOUS
 	} from '$lib/constants/analytics.contants';
 

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -6,6 +6,11 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { type CarouselSlideOisyDappDescription } from '$lib/types/dapp-description';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import {
+		TRACK_COUNT_CAROUSEL_CLOSE,
+		TRACK_COUNT_CAROUSEL_OPEN
+	} from '$lib/constants/analytics.contants';
 
 	export let dappsCarouselSlide: CarouselSlideOisyDappDescription;
 	$: ({
@@ -15,9 +20,27 @@
 		name: dAppName
 	} = dappsCarouselSlide);
 
+	const open = async () => {
+		await trackEvent({
+			name: TRACK_COUNT_CAROUSEL_OPEN,
+			metadata: {
+				dappId
+			}
+		});
+
+		modalStore.openDappDetails(dappsCarouselSlide);
+	};
+
 	const dispatch = createEventDispatcher();
 
-	const close = () => {
+	const close = async () => {
+		await trackEvent({
+			name: TRACK_COUNT_CAROUSEL_CLOSE,
+			metadata: {
+				dappId
+			}
+		});
+
 		dispatch('icCloseCarouselSlide', dappId);
 	};
 </script>
@@ -35,9 +58,7 @@
 	<div class="w-full justify-start">
 		<div class="mb-1">{text}</div>
 		<button
-			on:click={() => {
-				modalStore.openDappDetails(dappsCarouselSlide);
-			}}
+			on:click={open}
 			aria-label={replacePlaceholders($i18n.dapps.alt.learn_more, { $dAppName: dAppName })}
 			class="text-sm font-semibold text-brand-primary"
 		>

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -2,15 +2,15 @@
 	import { createEventDispatcher } from 'svelte';
 	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
-	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
-	import { type CarouselSlideOisyDappDescription } from '$lib/types/dapp-description';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { trackEvent } from '$lib/services/analytics.services';
 	import {
 		TRACK_COUNT_CAROUSEL_CLOSE,
 		TRACK_COUNT_CAROUSEL_OPEN
 	} from '$lib/constants/analytics.contants';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import { type CarouselSlideOisyDappDescription } from '$lib/types/dapp-description';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let dappsCarouselSlide: CarouselSlideOisyDappDescription;
 	$: ({

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -26,3 +26,9 @@ export const TRACK_COUNT_IC_SEND_ERROR = 'ic_send_error_count';
 export const TRACK_COUNT_WALLET_CONNECT_MENU_OPEN = 'wallet_connect_menu_open_count';
 export const TRACK_COUNT_WALLET_CONNECT_QR_CODE = 'wallet_connect_qr_code_count';
 export const TRACK_COUNT_WALLET_CONNECT = 'wallet_connect_count';
+
+// Carousel
+export const TRACK_COUNT_CAROUSEL_NEXT = 'carousel_next_count';
+export const TRACK_COUNT_CAROUSEL_PREVIOUS = 'carousel_previous_count';
+export const TRACK_COUNT_CAROUSEL_CLOSE = 'carousel_close_count';
+export const TRACK_COUNT_CAROUSEL_OPEN = 'carousel_open_count';


### PR DESCRIPTION
# Motivation

We would like to monitor the conversion rate of the carousel.

# Changes

- Add tracking constants.
- Add tracking events to `Carousel` control buttons.
- Add tracking event to close button.
- Create function to open the modal and track the event.

