### PR TITLE
feat(frontend): track dApp modal clicks

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -11,6 +11,7 @@
 	import ExternalLinkIcon from '$lib/components/ui/ExternalLinkIcon.svelte';
 	import ImgBanner from '$lib/components/ui/ImgBanner.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
+	import { TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK } from '$lib/constants/analytics.contants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OisyDappDescription } from '$lib/types/dapp-description';
@@ -140,6 +141,7 @@
 					})}
 					styleClass="as-button primary padding-sm flex-1 flex-row-reverse"
 					href={websiteURL.toString()}
+					trackEventName={TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK}
 					>{callToAction ??
 						replacePlaceholders($i18n.dapps.text.open_dapp, {
 							$dAppName: dAppName

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -142,7 +142,7 @@
 					})}
 					styleClass="as-button primary padding-sm flex-1 flex-row-reverse"
 					href={websiteURL.toString()}
-					trackEventParams={{ name: TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK, metadata: { dappId } }}
+					trackEvent={{ name: TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK, metadata: { dappId } }}
 					>{callToAction ??
 						replacePlaceholders($i18n.dapps.text.open_dapp, {
 							$dAppName: dAppName

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -20,6 +20,7 @@
 
 	export let dAppDescription: OisyDappDescription;
 	$: ({
+		id: dappId,
 		website,
 		screenshots,
 		twitter,
@@ -141,7 +142,7 @@
 					})}
 					styleClass="as-button primary padding-sm flex-1 flex-row-reverse"
 					href={websiteURL.toString()}
-					trackEventName={TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK}
+					trackEventParams={{ name: TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK, metadata: { dappId } }}
 					>{callToAction ??
 						replacePlaceholders($i18n.dapps.text.open_dapp, {
 							$dAppName: dAppName

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
-	import { trackEvent } from '$lib/services/analytics.services';
+	import { trackEvent as trackEventServices } from '$lib/services/analytics.services';
 	import type { TrackEventParams } from '$lib/types/analytics';
 
 	export let href: string;
@@ -12,14 +12,14 @@
 	export let color: 'blue' | 'inherit' = 'inherit';
 	export let fullWidth = false;
 	export let styleClass = '';
-	export let trackEventParams: TrackEventParams | undefined = undefined;
+	export let trackEvent: TrackEventParams | undefined = undefined;
 
 	const onClick = async () => {
-		if (isNullish(trackEventParams)) {
+		if (isNullish(trackEvent)) {
 			return;
 		}
 
-		await trackEvent(trackEventParams);
+		await trackEventServices(trackEvent);
 	};
 </script>
 

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -2,6 +2,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import type { TrackEventParams } from '$lib/types/analytics';
 
 	export let href: string;
 	export let ariaLabel: string;
@@ -11,14 +12,14 @@
 	export let color: 'blue' | 'inherit' = 'inherit';
 	export let fullWidth = false;
 	export let styleClass = '';
-	export let trackEventName: string | undefined = undefined;
+	export let trackEventParams: TrackEventParams | undefined = undefined;
 
 	const onClick = async () => {
-		if (isNullish(trackEventName)) {
+		if (isNullish(trackEventParams)) {
 			return;
 		}
 
-		await trackEvent({ name: trackEventName, metadata: { url: href } });
+		await trackEvent(trackEventParams);
 	};
 </script>
 

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
 	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
+	import { trackEvent } from '$lib/services/analytics.services';
 
 	export let href: string;
 	export let ariaLabel: string;
@@ -9,6 +11,15 @@
 	export let color: 'blue' | 'inherit' = 'inherit';
 	export let fullWidth = false;
 	export let styleClass = '';
+	export let trackEventName: string | undefined = undefined;
+
+	const onClick = async () => {
+		if (isNullish(trackEventName)) {
+			return;
+		}
+
+		await trackEvent({ name: trackEventName, metadata: { url: href } });
+	};
 </script>
 
 <a
@@ -24,6 +35,7 @@
 	class:hover:text-brand-primary={color === 'inherit'}
 	class:active:text-brand-primary={color === 'inherit'}
 	class:w-full={fullWidth}
+	on:click={onClick}
 >
 	{#if iconVisible}
 		<IconExternalLink size={iconSize} />

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -26,3 +26,6 @@ export const TRACK_COUNT_IC_SEND_ERROR = 'ic_send_error_count';
 export const TRACK_COUNT_WALLET_CONNECT_MENU_OPEN = 'wallet_connect_menu_open_count';
 export const TRACK_COUNT_WALLET_CONNECT_QR_CODE = 'wallet_connect_qr_code_count';
 export const TRACK_COUNT_WALLET_CONNECT = 'wallet_connect_count';
+
+// dApps
+export const TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK = 'dapp_modal_open_hyperlink_count';

--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -1,4 +1,5 @@
 import { PROD } from '$lib/constants/app.constants';
+import type { TrackEventParams } from '$lib/types/analytics';
 import { isNullish } from '@dfinity/utils';
 import { initOrbiter, trackEvent as trackEventOrbiter } from '@junobuild/analytics';
 
@@ -26,13 +27,7 @@ export const initAnalytics = async () => {
 	});
 };
 
-export const trackEvent = async ({
-	name,
-	metadata
-}: {
-	name: string;
-	metadata?: Record<string, string>;
-}) => {
+export const trackEvent = async ({ name, metadata }: TrackEventParams) => {
 	if (!PROD) {
 		return;
 	}

--- a/src/frontend/src/lib/types/analytics.ts
+++ b/src/frontend/src/lib/types/analytics.ts
@@ -1,0 +1,4 @@
+export interface TrackEventParams {
+	name: string;
+	metadata?: Record<string, string>;
+}


### PR DESCRIPTION
# Motivation

We start tracking the click on the hyperlink of the dApp modal.

# Changes

- Add tracking constants.
- Add `on:click` event in `ExternalLink` that uses a new prop `trackEventParams`.
- Add `trackEventParams` in `DappModal`.
