### PR TITLE
chore(frontend): remove unused function mapOnramperWallets

### DIFF
--- a/src/frontend/src/lib/utils/onramper.utils.ts
+++ b/src/frontend/src/lib/utils/onramper.utils.ts
@@ -9,7 +9,6 @@ import type {
 	OnramperNetworkWallet,
 	OnramperWalletAddress
 } from '$lib/types/onramper';
-import type { Token, TokenStandard } from '$lib/types/token';
 import type { Option } from '$lib/types/utils';
 import { nonNullish } from '@dfinity/utils';
 
@@ -77,39 +76,6 @@ export const buildOnramperLink = ({
 
 	return `${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}&${toQueryString(params)}${walletsParam}${networkWalletsParam}`;
 };
-
-/** Map a list of tokens to a list of Onramper wallets.
- *
- * The Onramper widget requires a list of wallet addresses that are a combination of a token ID and a wallet address, to which send the tokens.
- * For example: `btc:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa` or `eth:0x0000000123456789abcdef0123456789abcdef0123`.
- * The documentation can be found here: https://docs.onramper.com/docs/supported-widget-parameters#wallets
- *
- * So we map each token to a wallet address, based on the token standard, and create a list of objects with the token ID and the wallet address.
- *
- * @param tokens - The list of tokens to map.
- * @param walletMap - The map of token standards to wallet addresses.
- */
-export const mapOnramperWallets = ({
-	tokens,
-	walletMap
-}: {
-	tokens: Token[];
-	walletMap: { [key in TokenStandard]: Option<OnramperWalletAddress> };
-}): OnramperCryptoWallet[] =>
-	tokens.reduce<OnramperCryptoWallet[]>((acc, { buy, standard }) => {
-		const { onramperId: cryptoId } = buy ?? {};
-		const wallet = walletMap[standard];
-
-		return nonNullish(cryptoId) && nonNullish(wallet)
-			? [
-					...acc,
-					{
-						cryptoId,
-						wallet
-					}
-				]
-			: acc;
-	}, []);
 
 /** Map a list of networks to a list of Onramper wallets.
  *

--- a/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
@@ -7,263 +7,210 @@ import {
 	SEPOLIA_NETWORK
 } from '$env/networks.env';
 import { ONRAMPER_API_KEY, ONRAMPER_BASE_URL } from '$env/rest/onramper.env';
-import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
-import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import type {
-	OnramperCryptoWallet,
-	OnramperNetworkWallet,
-	OnramperWalletAddress
-} from '$lib/types/onramper';
-import type { TokenStandard } from '$lib/types/token';
+import type { OnramperNetworkWallet, OnramperWalletAddress } from '$lib/types/onramper';
 import type { Option } from '$lib/types/utils';
 import {
 	buildOnramperLink,
 	mapOnramperNetworkWallets,
-	mapOnramperWallets,
 	type BuildOnramperLinkParams
 } from '$lib/utils/onramper.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
-import { mockAccountIdentifierText, mockPrincipalText } from '$tests/mocks/identity.mock';
+import { mockAccountIdentifierText } from '$tests/mocks/identity.mock';
+import { describe } from 'vitest';
 
-describe('buildOnramperLink', () => {
-	it('should build the correct URL with all parameters', () => {
-		const params: BuildOnramperLinkParams = {
-			mode: 'buy',
-			defaultFiat: 'usd',
-			defaultCrypto: 'icp',
-			onlyCryptos: ['btc', 'eth', 'icp'],
-			onlyCryptoNetworks: ['bitcoin', 'ethereum'],
-			wallets: [
-				{ cryptoId: 'btc', wallet: mockBtcAddress },
-				{ cryptoId: 'icp', wallet: mockAccountIdentifierText }
-			],
-			networkWallets: [
-				{ networkId: 'bitcoin', wallet: mockBtcAddress },
-				{ networkId: 'icp', wallet: mockAccountIdentifierText }
-			],
-			supportRecurringPayments: true,
-			enableCountrySelector: false
-		};
+describe('onramper.utils', () => {
+	describe('buildOnramperLink', () => {
+		it('should build the correct URL with all parameters', () => {
+			const params: BuildOnramperLinkParams = {
+				mode: 'buy',
+				defaultFiat: 'usd',
+				defaultCrypto: 'icp',
+				onlyCryptos: ['btc', 'eth', 'icp'],
+				onlyCryptoNetworks: ['bitcoin', 'ethereum'],
+				wallets: [
+					{ cryptoId: 'btc', wallet: mockBtcAddress },
+					{ cryptoId: 'icp', wallet: mockAccountIdentifierText }
+				],
+				networkWallets: [
+					{ networkId: 'bitcoin', wallet: mockBtcAddress },
+					{ networkId: 'icp', wallet: mockAccountIdentifierText }
+				],
+				supportRecurringPayments: true,
+				enableCountrySelector: false
+			};
 
-		const expectedUrl =
-			`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
-			`&mode=buy&defaultFiat=usd&defaultCrypto=icp` +
-			`&onlyCryptos=btc,eth,icp&onlyCryptoNetworks=bitcoin,ethereum` +
-			`&supportRecurringPayments=true&enableCountrySelector=false` +
-			`&wallets=btc:${mockBtcAddress},icp:${mockAccountIdentifierText}` +
-			`&networkWallets=bitcoin:${mockBtcAddress},icp:${mockAccountIdentifierText}`;
+			const expectedUrl =
+				`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
+				`&mode=buy&defaultFiat=usd&defaultCrypto=icp` +
+				`&onlyCryptos=btc,eth,icp&onlyCryptoNetworks=bitcoin,ethereum` +
+				`&supportRecurringPayments=true&enableCountrySelector=false` +
+				`&wallets=btc:${mockBtcAddress},icp:${mockAccountIdentifierText}` +
+				`&networkWallets=bitcoin:${mockBtcAddress},icp:${mockAccountIdentifierText}`;
 
-		const result = buildOnramperLink(params);
-		expect(result).toBe(expectedUrl);
+			const result = buildOnramperLink(params);
+			expect(result).toBe(expectedUrl);
+		});
+
+		it('should build the correct URL with only required parameters', () => {
+			const params: BuildOnramperLinkParams = {
+				mode: 'buy',
+				defaultFiat: 'eur',
+				onlyCryptos: ['btc'],
+				onlyCryptoNetworks: ['bitcoin'],
+				wallets: [{ cryptoId: 'btc', wallet: mockBtcAddress }],
+				networkWallets: [{ networkId: 'bitcoin', wallet: mockBtcAddress }],
+				supportRecurringPayments: false,
+				enableCountrySelector: true
+			};
+
+			const expectedUrl =
+				`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
+				`&mode=buy&defaultFiat=eur` +
+				`&onlyCryptos=btc&onlyCryptoNetworks=bitcoin` +
+				`&supportRecurringPayments=false&enableCountrySelector=true` +
+				`&wallets=btc:${mockBtcAddress}` +
+				`&networkWallets=bitcoin:${mockBtcAddress}`;
+
+			const result = buildOnramperLink(params);
+			expect(result).toBe(expectedUrl);
+		});
+
+		it('should handle empty wallets array', () => {
+			const params: BuildOnramperLinkParams = {
+				mode: 'buy',
+				defaultFiat: 'eur',
+				onlyCryptos: ['btc', 'eth'],
+				onlyCryptoNetworks: ['bitcoin', 'ethereum'],
+				wallets: [],
+				networkWallets: [],
+				supportRecurringPayments: false,
+				enableCountrySelector: true
+			};
+
+			const expectedUrl =
+				`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
+				`&mode=buy&defaultFiat=eur` +
+				`&onlyCryptos=btc,eth&onlyCryptoNetworks=bitcoin,ethereum` +
+				`&supportRecurringPayments=false&enableCountrySelector=true`;
+
+			const result = buildOnramperLink(params);
+
+			expect(result).toBe(expectedUrl);
+		});
+
+		it('should handle only crypto wallets array', () => {
+			const params: BuildOnramperLinkParams = {
+				mode: 'buy',
+				defaultFiat: 'eur',
+				onlyCryptos: ['btc', 'eth'],
+				onlyCryptoNetworks: ['bitcoin', 'ethereum'],
+				wallets: [{ cryptoId: 'btc', wallet: mockBtcAddress }],
+				networkWallets: [],
+				supportRecurringPayments: false,
+				enableCountrySelector: true
+			};
+
+			const expectedUrl =
+				`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
+				`&mode=buy&defaultFiat=eur` +
+				`&onlyCryptos=btc,eth&onlyCryptoNetworks=bitcoin,ethereum` +
+				`&supportRecurringPayments=false&enableCountrySelector=true` +
+				`&wallets=btc:${mockBtcAddress}`;
+
+			const result = buildOnramperLink(params);
+
+			expect(result).toBe(expectedUrl);
+		});
+
+		it('should handle only network wallets array', () => {
+			const params: BuildOnramperLinkParams = {
+				mode: 'buy',
+				defaultFiat: 'eur',
+				onlyCryptos: ['btc', 'eth'],
+				onlyCryptoNetworks: ['bitcoin', 'ethereum'],
+				wallets: [],
+				networkWallets: [{ networkId: 'bitcoin', wallet: mockBtcAddress }],
+				supportRecurringPayments: false,
+				enableCountrySelector: true
+			};
+
+			const expectedUrl =
+				`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
+				`&mode=buy&defaultFiat=eur` +
+				`&onlyCryptos=btc,eth&onlyCryptoNetworks=bitcoin,ethereum` +
+				`&supportRecurringPayments=false&enableCountrySelector=true` +
+				`&networkWallets=bitcoin:${mockBtcAddress}`;
+
+			const result = buildOnramperLink(params);
+
+			expect(result).toBe(expectedUrl);
+		});
+
+		it('should handle empty onlyCryptos and onlyCryptoNetworks arrays', () => {
+			const params: BuildOnramperLinkParams = {
+				mode: 'buy',
+				defaultFiat: 'usd',
+				onlyCryptos: [],
+				onlyCryptoNetworks: [],
+				wallets: [{ cryptoId: 'btc', wallet: mockBtcAddress }],
+				networkWallets: [{ networkId: 'bitcoin', wallet: mockBtcAddress }],
+				supportRecurringPayments: false,
+				enableCountrySelector: true
+			};
+
+			const expectedUrl =
+				`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
+				`&mode=buy&defaultFiat=usd` +
+				`&supportRecurringPayments=false&enableCountrySelector=true&wallets=btc:${mockBtcAddress}&networkWallets=bitcoin:${mockBtcAddress}`;
+
+			const result = buildOnramperLink(params);
+
+			expect(result).toBe(expectedUrl);
+		});
 	});
 
-	it('should build the correct URL with only required parameters', () => {
-		const params: BuildOnramperLinkParams = {
-			mode: 'buy',
-			defaultFiat: 'eur',
-			onlyCryptos: ['btc'],
-			onlyCryptoNetworks: ['bitcoin'],
-			wallets: [{ cryptoId: 'btc', wallet: mockBtcAddress }],
-			networkWallets: [{ networkId: 'bitcoin', wallet: mockBtcAddress }],
-			supportRecurringPayments: false,
-			enableCountrySelector: true
-		};
+	describe('mapOnramperNetworkWallets', () => {
+		const walletMap: Map<symbol, Option<OnramperWalletAddress>> = new Map([
+			[BTC_MAINNET_NETWORK_ID, mockBtcAddress],
+			[ETHEREUM_NETWORK_ID, mockEthAddress],
+			[ICP_NETWORK_ID, mockAccountIdentifierText]
+		]);
 
-		const expectedUrl =
-			`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
-			`&mode=buy&defaultFiat=eur` +
-			`&onlyCryptos=btc&onlyCryptoNetworks=bitcoin` +
-			`&supportRecurringPayments=false&enableCountrySelector=true` +
-			`&wallets=btc:${mockBtcAddress}` +
-			`&networkWallets=bitcoin:${mockBtcAddress}`;
+		it('should return correct wallets when tokens have valid cryptoIds and wallets', () => {
+			const networks = [ICP_NETWORK, ETHEREUM_NETWORK, SEPOLIA_NETWORK];
 
-		const result = buildOnramperLink(params);
-		expect(result).toBe(expectedUrl);
-	});
+			const expectedWallets: OnramperNetworkWallet[] = [
+				{ networkId: ICP_NETWORK.buy?.onramperId ?? 'icp', wallet: mockAccountIdentifierText },
+				{ networkId: ETHEREUM_NETWORK.buy?.onramperId ?? 'icp', wallet: mockEthAddress }
+			];
 
-	it('should handle empty wallets array', () => {
-		const params: BuildOnramperLinkParams = {
-			mode: 'buy',
-			defaultFiat: 'eur',
-			onlyCryptos: ['btc', 'eth'],
-			onlyCryptoNetworks: ['bitcoin', 'ethereum'],
-			wallets: [],
-			networkWallets: [],
-			supportRecurringPayments: false,
-			enableCountrySelector: true
-		};
+			const result = mapOnramperNetworkWallets({ networks, walletMap });
 
-		const expectedUrl =
-			`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
-			`&mode=buy&defaultFiat=eur` +
-			`&onlyCryptos=btc,eth&onlyCryptoNetworks=bitcoin,ethereum` +
-			`&supportRecurringPayments=false&enableCountrySelector=true`;
+			expect(result).toEqual(expectedWallets);
+		});
 
-		const result = buildOnramperLink(params);
+		it('should return an empty array if no valid tokens are present', () => {
+			const networks = [SEPOLIA_NETWORK];
 
-		expect(result).toBe(expectedUrl);
-	});
+			const result = mapOnramperNetworkWallets({ networks, walletMap });
 
-	it('should handle only crypto wallets array', () => {
-		const params: BuildOnramperLinkParams = {
-			mode: 'buy',
-			defaultFiat: 'eur',
-			onlyCryptos: ['btc', 'eth'],
-			onlyCryptoNetworks: ['bitcoin', 'ethereum'],
-			wallets: [{ cryptoId: 'btc', wallet: mockBtcAddress }],
-			networkWallets: [],
-			supportRecurringPayments: false,
-			enableCountrySelector: true
-		};
+			expect(result).toEqual([]);
+		});
 
-		const expectedUrl =
-			`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
-			`&mode=buy&defaultFiat=eur` +
-			`&onlyCryptos=btc,eth&onlyCryptoNetworks=bitcoin,ethereum` +
-			`&supportRecurringPayments=false&enableCountrySelector=true` +
-			`&wallets=btc:${mockBtcAddress}`;
+		it('should handle cases where wallet addresses are null or undefined', () => {
+			const networks = [ICP_NETWORK, ETHEREUM_NETWORK];
 
-		const result = buildOnramperLink(params);
+			const newWalletMap: Map<symbol, Option<OnramperWalletAddress>> = new Map(walletMap);
+			newWalletMap.set(ETHEREUM_NETWORK_ID, undefined);
 
-		expect(result).toBe(expectedUrl);
-	});
+			const expectedWallets: OnramperNetworkWallet[] = [
+				{ networkId: ICP_NETWORK.buy?.onramperId ?? 'icp', wallet: mockAccountIdentifierText }
+			];
 
-	it('should handle only network wallets array', () => {
-		const params: BuildOnramperLinkParams = {
-			mode: 'buy',
-			defaultFiat: 'eur',
-			onlyCryptos: ['btc', 'eth'],
-			onlyCryptoNetworks: ['bitcoin', 'ethereum'],
-			wallets: [],
-			networkWallets: [{ networkId: 'bitcoin', wallet: mockBtcAddress }],
-			supportRecurringPayments: false,
-			enableCountrySelector: true
-		};
+			const result = mapOnramperNetworkWallets({ networks, walletMap: newWalletMap });
 
-		const expectedUrl =
-			`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
-			`&mode=buy&defaultFiat=eur` +
-			`&onlyCryptos=btc,eth&onlyCryptoNetworks=bitcoin,ethereum` +
-			`&supportRecurringPayments=false&enableCountrySelector=true` +
-			`&networkWallets=bitcoin:${mockBtcAddress}`;
-
-		const result = buildOnramperLink(params);
-
-		expect(result).toBe(expectedUrl);
-	});
-
-	it('should handle empty onlyCryptos and onlyCryptoNetworks arrays', () => {
-		const params: BuildOnramperLinkParams = {
-			mode: 'buy',
-			defaultFiat: 'usd',
-			onlyCryptos: [],
-			onlyCryptoNetworks: [],
-			wallets: [{ cryptoId: 'btc', wallet: mockBtcAddress }],
-			networkWallets: [{ networkId: 'bitcoin', wallet: mockBtcAddress }],
-			supportRecurringPayments: false,
-			enableCountrySelector: true
-		};
-
-		const expectedUrl =
-			`${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}` +
-			`&mode=buy&defaultFiat=usd` +
-			`&supportRecurringPayments=false&enableCountrySelector=true&wallets=btc:${mockBtcAddress}&networkWallets=bitcoin:${mockBtcAddress}`;
-
-		const result = buildOnramperLink(params);
-
-		expect(result).toBe(expectedUrl);
-	});
-});
-
-describe('mapOnramperWallets', () => {
-	const walletMap: { [key in TokenStandard]: Option<OnramperWalletAddress> } = {
-		bitcoin: mockBtcAddress,
-		ethereum: mockEthAddress,
-		erc20: mockEthAddress,
-		icrc: mockPrincipalText,
-		icp: mockAccountIdentifierText
-	};
-
-	it('should return correct wallets when tokens have valid cryptoIds and wallets', () => {
-		const tokens = [ICP_TOKEN, ETHEREUM_TOKEN, SEPOLIA_TOKEN];
-
-		const expectedWallets: OnramperCryptoWallet[] = [
-			{ cryptoId: ICP_TOKEN.buy?.onramperId ?? '', wallet: mockAccountIdentifierText },
-			{ cryptoId: ETHEREUM_TOKEN.buy?.onramperId ?? '', wallet: mockEthAddress }
-		];
-
-		const result = mapOnramperWallets({ tokens, walletMap });
-
-		expect(result).toEqual(expectedWallets);
-	});
-
-	it('should return an empty array if no valid tokens are present', () => {
-		const tokens = [SEPOLIA_TOKEN];
-
-		const result = mapOnramperWallets({ tokens, walletMap });
-
-		expect(result).toEqual([]);
-	});
-
-	it('should handle cases where wallet addresses are null or undefined', () => {
-		const tokens = [ICP_TOKEN, ETHEREUM_TOKEN];
-
-		const newWalletMap: { [key in TokenStandard]: Option<OnramperWalletAddress> } = {
-			...walletMap,
-			ethereum: undefined
-		};
-
-		const expectedWallets: OnramperCryptoWallet[] = [
-			{ cryptoId: ICP_TOKEN.buy?.onramperId ?? '', wallet: mockAccountIdentifierText }
-		];
-
-		const result = mapOnramperWallets({ tokens, walletMap: newWalletMap });
-
-		expect(result).toEqual(expectedWallets);
-	});
-});
-
-describe('mapOnramperNetworkWallets', () => {
-	const walletMap: Map<symbol, Option<OnramperWalletAddress>> = new Map([
-		[BTC_MAINNET_NETWORK_ID, mockBtcAddress],
-		[ETHEREUM_NETWORK_ID, mockEthAddress],
-		[ICP_NETWORK_ID, mockAccountIdentifierText]
-	]);
-
-	it('should return correct wallets when tokens have valid cryptoIds and wallets', () => {
-		const networks = [ICP_NETWORK, ETHEREUM_NETWORK, SEPOLIA_NETWORK];
-
-		const expectedWallets: OnramperNetworkWallet[] = [
-			{ networkId: ICP_NETWORK.buy?.onramperId ?? 'icp', wallet: mockAccountIdentifierText },
-			{ networkId: ETHEREUM_NETWORK.buy?.onramperId ?? 'icp', wallet: mockEthAddress }
-		];
-
-		const result = mapOnramperNetworkWallets({ networks, walletMap });
-
-		expect(result).toEqual(expectedWallets);
-	});
-
-	it('should return an empty array if no valid tokens are present', () => {
-		const networks = [SEPOLIA_NETWORK];
-
-		const result = mapOnramperNetworkWallets({ networks, walletMap });
-
-		expect(result).toEqual([]);
-	});
-
-	it('should handle cases where wallet addresses are null or undefined', () => {
-		const networks = [ICP_NETWORK, ETHEREUM_NETWORK];
-
-		const newWalletMap: Map<symbol, Option<OnramperWalletAddress>> = new Map(walletMap);
-		newWalletMap.set(ETHEREUM_NETWORK_ID, undefined);
-
-		const expectedWallets: OnramperNetworkWallet[] = [
-			{ networkId: ICP_NETWORK.buy?.onramperId ?? 'icp', wallet: mockAccountIdentifierText }
-		];
-
-		const result = mapOnramperNetworkWallets({ networks, walletMap: newWalletMap });
-
-		expect(result).toEqual(expectedWallets);
+			expect(result).toEqual(expectedWallets);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The function `mapOnramperWallets` was deprecated in the past, but never ultimately removed.
