### PR TITLE
refactor(frontend): make list for ReceiveAddressModal

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import {
 		BTC_MAINNET_NETWORK,
@@ -38,167 +39,137 @@
 	import { testnets } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
+	import type { Network } from '$lib/types/network';
 	import type { ReceiveQRCode } from '$lib/types/receive';
+	import type { Token } from '$lib/types/token';
 
 	const dispatch = createEventDispatcher();
 
 	const displayQRCode = (details: Omit<Required<ReceiveQRCode>, 'qrCodeAriaLabel'>) =>
 		dispatch('icQRCode', details);
+
+	interface ReceiveAddress {
+		labelRef: string;
+		address: OptionBtcAddress | OptionEthAddress;
+		network: Network;
+		token: Token;
+		testId: string;
+		title: string;
+		label: string;
+		copyAriaLabel: string;
+		qrCodeAriaLabel: string;
+		text?: string;
+		condition?: boolean;
+	}
+
+	let receiveAddressList: ReceiveAddress[];
+	$: receiveAddressList = [
+		{
+			labelRef: 'btcAddressMainnet',
+			address: $btcAddressMainnet,
+			network: BTC_MAINNET_NETWORK,
+			token: BTC_MAINNET_TOKEN,
+			testId: RECEIVE_TOKENS_MODAL_BTC_MAINNET_SECTION,
+			title: $i18n.receive.bitcoin.text.bitcoin_address,
+			label: $i18n.receive.bitcoin.text.bitcoin_address,
+			copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied,
+			qrCodeAriaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr
+		},
+		{
+			labelRef: 'btcAddressTestnet',
+			address: $btcAddressTestnet,
+			network: BTC_TESTNET_NETWORK,
+			token: BTC_TESTNET_TOKEN,
+			testId: RECEIVE_TOKENS_MODAL_BTC_TESTNET_SECTION,
+			title: $i18n.receive.bitcoin.text.bitcoin_testnet_address,
+			label: $i18n.receive.bitcoin.text.bitcoin_testnet_address,
+			copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied,
+			qrCodeAriaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr,
+			condition: $testnets
+		},
+		{
+			labelRef: 'btcAddressRegtest',
+			address: $btcAddressRegtest,
+			network: BTC_REGTEST_NETWORK,
+			token: BTC_REGTEST_TOKEN,
+			testId: RECEIVE_TOKENS_MODAL_BTC_REGTEST_SECTION,
+			title: $i18n.receive.bitcoin.text.bitcoin_regtest_address,
+			label: $i18n.receive.bitcoin.text.bitcoin_regtest_address,
+			copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied,
+			qrCodeAriaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr,
+			condition: $testnets && LOCAL
+		},
+		{
+			labelRef: 'ethAddress',
+			address: $ethAddress,
+			network: ETHEREUM_NETWORK,
+			token: ETHEREUM_TOKEN,
+			testId: RECEIVE_TOKENS_MODAL_ETH_SECTION,
+			title: $i18n.receive.ethereum.text.ethereum,
+			label: $i18n.receive.ethereum.text.ethereum_address,
+			copyAriaLabel: $i18n.receive.ethereum.text.ethereum_address_copied,
+			qrCodeAriaLabel: $i18n.receive.ethereum.text.display_ethereum_address_qr,
+			text: $i18n.receive.icp.text.your_private_eth_address
+		},
+		{
+			labelRef: 'icrcTokenAddress',
+			address: $icrcAccountIdentifierText,
+			network: ICP_NETWORK,
+			token: ICP_TOKEN,
+			testId: RECEIVE_TOKENS_MODAL_ICRC_SECTION,
+			title: $i18n.receive.icp.text.principal,
+			label: $i18n.receive.icp.text.principal,
+			copyAriaLabel: $i18n.receive.icp.text.internet_computer_principal_copied,
+			qrCodeAriaLabel: $i18n.receive.icp.text.display_internet_computer_principal_qr,
+			text: $i18n.receive.icp.text.use_for_icrc_deposit
+		},
+		{
+			labelRef: 'icpTokenAddress',
+			address: $icpAccountIdentifierText,
+			network: ICP_NETWORK,
+			token: ICP_TOKEN,
+			testId: RECEIVE_TOKENS_MODAL_ICP_SECTION,
+			title: $i18n.receive.icp.text.icp_account,
+			label: $i18n.receive.icp.text.icp_account,
+			copyAriaLabel: $i18n.receive.icp.text.icp_account_copied,
+			qrCodeAriaLabel: $i18n.receive.icp.text.display_icp_account_qr
+		}
+	];
 </script>
 
 <ContentWithToolbar>
 	<div class="flex flex-col gap-2">
-		<ReceiveAddress
-			labelRef="btcAddressMainnet"
-			on:click={() =>
-				displayQRCode({
-					address: $btcAddressMainnet ?? '',
-					addressLabel: $i18n.receive.bitcoin.text.bitcoin_address,
-					addressToken: BTC_MAINNET_TOKEN,
-					copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied
-				})}
-			address={$btcAddressMainnet}
-			network={BTC_MAINNET_NETWORK}
-			qrCodeAction={{
-				enabled: true,
-
-				testId: RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-				ariaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr
-			}}
-			copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
-			testId={RECEIVE_TOKENS_MODAL_BTC_MAINNET_SECTION}
-		>
-			<svelte:fragment slot="title">{$i18n.receive.bitcoin.text.bitcoin_address}</svelte:fragment>
-		</ReceiveAddress>
-
-		{#if $testnets}
-			<ReceiveAddress
-				labelRef="btcAddressTestnet"
-				on:click={() =>
-					displayQRCode({
-						address: $btcAddressTestnet ?? '',
-						addressLabel: $i18n.receive.bitcoin.text.bitcoin_testnet_address,
-						addressToken: BTC_TESTNET_TOKEN,
-						copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied
-					})}
-				address={$btcAddressTestnet}
-				network={BTC_TESTNET_NETWORK}
-				qrCodeAction={{
-					enabled: true,
-
-					testId: RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-					ariaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr
-				}}
-				copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
-				testId={RECEIVE_TOKENS_MODAL_BTC_TESTNET_SECTION}
-			>
-				<svelte:fragment slot="title"
-					>{$i18n.receive.bitcoin.text.bitcoin_testnet_address}</svelte:fragment
-				>
-			</ReceiveAddress>
-
-			{#if LOCAL}
-				<!-- Same address for Regtest and for Testnet are used. -->
+		{#each receiveAddressList as { labelRef, address, network, token: addressToken, testId, title, label: addressLabel, copyAriaLabel, qrCodeAriaLabel, text, condition } (labelRef)}
+			{#if condition !== false}
 				<ReceiveAddress
-					labelRef="btcAddressRegtest"
+					{labelRef}
 					on:click={() =>
 						displayQRCode({
-							address: $btcAddressRegtest ?? '',
-							addressLabel: $i18n.receive.bitcoin.text.bitcoin_regtest_address,
-							addressToken: BTC_REGTEST_TOKEN,
-							copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied
+							address: address ?? '',
+							addressLabel,
+							addressToken,
+							copyAriaLabel
 						})}
-					address={$btcAddressRegtest}
-					network={BTC_REGTEST_NETWORK}
+					{address}
+					{network}
 					qrCodeAction={{
 						enabled: true,
 						testId: RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-						ariaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr
+						ariaLabel: qrCodeAriaLabel
 					}}
-					copyAriaLabel={$i18n.receive.bitcoin.text.bitcoin_address_copied}
-					testId={RECEIVE_TOKENS_MODAL_BTC_REGTEST_SECTION}
+					{copyAriaLabel}
+					{testId}
 				>
-					<svelte:fragment slot="title"
-						>{$i18n.receive.bitcoin.text.bitcoin_regtest_address}</svelte:fragment
-					>
+					<svelte:fragment slot="title">{title}</svelte:fragment>
+					<svelte:fragment slot="text">
+						{#if nonNullish(text)}
+							<span class="text-sm text-black">{text}</span>
+						{/if}
+					</svelte:fragment>
 				</ReceiveAddress>
 			{/if}
-		{/if}
-
-		<ReceiveAddress
-			labelRef="ethAddress"
-			on:click={() =>
-				displayQRCode({
-					address: $ethAddress ?? '',
-					addressLabel: $i18n.receive.ethereum.text.ethereum_address,
-					addressToken: ETHEREUM_TOKEN,
-					copyAriaLabel: $i18n.receive.ethereum.text.ethereum_address_copied
-				})}
-			address={$ethAddress}
-			network={ETHEREUM_NETWORK}
-			qrCodeAction={{
-				enabled: true,
-				testId: RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-				ariaLabel: $i18n.receive.ethereum.text.display_ethereum_address_qr
-			}}
-			copyAriaLabel={$i18n.receive.ethereum.text.ethereum_address_copied}
-			testId={RECEIVE_TOKENS_MODAL_ETH_SECTION}
-		>
-			<svelte:fragment slot="title">{$i18n.receive.ethereum.text.ethereum}</svelte:fragment>
-
-			<span slot="text" class="text-sm text-black"
-				>{$i18n.receive.icp.text.your_private_eth_address}</span
-			>
-		</ReceiveAddress>
-
-		<ReceiveAddress
-			labelRef="icrcTokenAddress"
-			on:click={() =>
-				displayQRCode({
-					address: $icrcAccountIdentifierText ?? '',
-					addressLabel: $i18n.receive.icp.text.principal,
-					addressToken: ICP_TOKEN,
-					copyAriaLabel: $i18n.receive.icp.text.internet_computer_principal_copied
-				})}
-			address={$icrcAccountIdentifierText}
-			network={ICP_NETWORK}
-			qrCodeAction={{
-				enabled: true,
-				testId: RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-				ariaLabel: $i18n.receive.icp.text.display_internet_computer_principal_qr
-			}}
-			copyAriaLabel={$i18n.receive.icp.text.internet_computer_principal_copied}
-			testId={RECEIVE_TOKENS_MODAL_ICRC_SECTION}
-		>
-			<svelte:fragment slot="title">{$i18n.receive.icp.text.principal}</svelte:fragment>
-
-			<span slot="text" class="text-sm text-black"
-				>{$i18n.receive.icp.text.use_for_icrc_deposit}</span
-			>
-		</ReceiveAddress>
-
-		<ReceiveAddress
-			labelRef="icpTokenAddress"
-			on:click={() =>
-				displayQRCode({
-					address: $icpAccountIdentifierText ?? '',
-					addressLabel: $i18n.receive.icp.text.icp_account,
-					addressToken: ICP_TOKEN,
-					copyAriaLabel: $i18n.receive.icp.text.icp_account_copied
-				})}
-			address={$icpAccountIdentifierText}
-			network={ICP_NETWORK}
-			qrCodeAction={{
-				enabled: true,
-
-				testId: RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-				ariaLabel: $i18n.receive.icp.text.display_icp_account_qr
-			}}
-			copyAriaLabel={$i18n.receive.icp.text.icp_account_copied}
-			testId={RECEIVE_TOKENS_MODAL_ICP_SECTION}
-		>
-			<svelte:fragment slot="title">{$i18n.receive.icp.text.icp_account}</svelte:fragment>
-		</ReceiveAddress>
+		{/each}
 	</div>
 
 	<ButtonDone


### PR DESCRIPTION
# Motivation

Maybe opinionated, but since we are going to add more Networks, it feels more manageable to create a list of `addresses` and their configs, to pass it to a loop inside `ReceiveAddressModal` to be shown.

# Changes

- Create interface of address configs.
- Create list of configs given by the existing components.
- Create loop.

# Tests

No changes.

### Before

![Screenshot 2024-12-10 at 05 19 27](https://github.com/user-attachments/assets/7d0a65a8-f979-4a90-a6c6-52ab5bb82b24)
![Screenshot 2024-12-10 at 05 19 33](https://github.com/user-attachments/assets/ea7c8162-078d-472f-abbd-9a2a2c5b357e)

### After

![Screenshot 2024-12-10 at 05 30 57](https://github.com/user-attachments/assets/ed2f1ea2-262b-48d7-a481-6c58b2c5b018)
![Screenshot 2024-12-10 at 05 31 02](https://github.com/user-attachments/assets/d2711152-1880-49fd-8189-a6f12ff3e5c1)



