### PR TITLE
fix(frontend): span cannot be a child of option

### DIFF
--- a/src/frontend/src/eth/components/send/SendNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendNetwork.svelte
@@ -78,7 +78,7 @@
 <div id="network" class="mb-4 mt-1 pt-0.5">
 	<Dropdown name="network" bind:selectedValue={networkName}>
 		<option disabled selected value={undefined} class="hidden"
-			><span class="description">{$i18n.send.placeholder.select_network}</span></option
+			>{$i18n.send.placeholder.select_network}</option
 		>
 		<DropdownItem value={ETHEREUM_NETWORK.name}>{ETHEREUM_NETWORK.name}</DropdownItem>
 

--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -80,8 +80,7 @@
 			<div id="network" class="network mt-1 pt-0.5">
 				<Dropdown name="network" bind:selectedValue={networkName}>
 					<option disabled selected value={undefined} class:hidden={nonNullish(networkName)}
-						><span class="description">{$i18n.tokens.manage.placeholder.select_network}</span
-						></option
+						>{$i18n.tokens.manage.placeholder.select_network}</option
 					>
 					{#each availableNetworks as network}
 						<DropdownItem value={network.name}>{network.name}</DropdownItem>


### PR DESCRIPTION
# Motivation

It's probably a warning currently but, following becomes an error when migrating to Svelte v5 in #3929:

> `<span>` cannot be a child of `<option>`. `<option>` only allows these children: `<#text>`. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.

# Changes

- Remove `span` in `option`.