### PR TITLE
fix(frontend): self-closing HTML tags for non-void elements are ambiguous

### DIFF
--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -71,4 +71,4 @@
 	width="100%"
 	allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
 	sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
-/>
+></iframe>

--- a/src/frontend/src/lib/components/ui/StaticSteps.svelte
+++ b/src/frontend/src/lib/components/ui/StaticSteps.svelte
@@ -19,7 +19,7 @@
 
 		<h3 class={`${state}`}>{text}</h3>
 
-		<div class:line={!last} />
+		<div class:line={!last} ></div>
 
 		{#if nonNullish(progressLabel) && state === 'in_progress'}
 			<span class="state">{progressLabel}</span>


### PR DESCRIPTION
# Motivation

Following is a warning but becomes an error when upgrading the dependencies for Svelte v5 in https://github.com/dfinity/oisy-wallet/pull/3929:

> ...src/lib/components/ui/StaticSteps.svelte
  22:3  error  Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
https://svelte.dev/e/element_invalid_self_closing_tag(element_invalid_self_closing_tag)  svelte/valid-compile

# Changes

- Update self closing iframe and div
