### PR TITLE
feat(frontend): listener templating

### DIFF
--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -11,11 +11,19 @@
 </script>
 
 {#if isNullish(token) || $authNotSignedIn}
-	<NoListener />
+	<NoListener>
+		<slot />
+	</NoListener>
 {:else if isNetworkIdICP(token.network.id)}
-	<NoListener />
+	<NoListener>
+		<slot />
+	</NoListener>
 {:else if isNetworkIdBitcoin(token.network.id)}
-	<BitcoinListener />
+	<BitcoinListener>
+		<slot />
+	</BitcoinListener>
 {:else}
-	<EthListener {token} />
+	<EthListener {token}>
+		<slot />
+	</EthListener>
 {/if}

--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
-	import type { ComponentType } from 'svelte';
 	import BitcoinListener from '$btc/components/core/BitcoinListener.svelte';
 	import EthListener from '$eth/components/core/EthListener.svelte';
 	import NoListener from '$lib/components/core/NoListener.svelte';
@@ -9,18 +8,14 @@
 	import { isNetworkIdBitcoin, isNetworkIdICP } from '$lib/utils/network.utils';
 
 	export let token: OptionToken;
-
-	let cmp: ComponentType;
-	$: cmp =
-		isNullish(token) || $authNotSignedIn
-			? NoListener
-			: isNetworkIdICP(token.network.id)
-				? NoListener
-				: isNetworkIdBitcoin(token.network.id)
-					? BitcoinListener
-					: EthListener;
 </script>
 
-<svelte:component this={cmp} {token}>
-	<slot />
-</svelte:component>
+{#if isNullish(token) || $authNotSignedIn}
+	<NoListener />
+{:else if isNetworkIdICP(token.network.id)}
+	<NoListener />
+{:else if isNetworkIdBitcoin(token.network.id)}
+	<BitcoinListener />
+{:else}
+	<EthListener {token} />
+{/if}

--- a/src/frontend/src/lib/components/core/NoListener.svelte
+++ b/src/frontend/src/lib/components/core/NoListener.svelte
@@ -1,7 +1,1 @@
-<script lang="ts">
-	import type { OptionToken } from '$lib/types/token';
-
-	export const token: OptionToken = undefined;
-</script>
-
 <slot />


### PR DESCRIPTION
# Motivation

Migration to Svelte v5 (#3929) involves replacing the ComponentType. While updating the Listener, a minor TypeScript issue was identified. We use a `svelte:component` that maps a token property, which may or may not be present, and can sometimes be set or unset. This approach works because the component is assigned to a state variable, but it is not fully TypeScript-compliant. To address this, we can leverage the template to correctly mount the listener.

