### PR TITLE
chore(e2e): do not ignore mac screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,4 @@ backend-v*.wasm.gz
 /playwright/.cache/
 pocket-ic
 
-e2e/*-snapshots/*-darwin.png
-
 coverage/


### PR DESCRIPTION
# Motivation

We started doing E2E Playwright tests for MacOS too, so we shouldn't ignore the `*-darwin` screenshots anymore.
