### PR TITLE
chore(frontend): solve SASS warning

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -143,14 +143,14 @@ div.modal {
 		--padding-3x: 0.5rem;
 		--padding: 1rem;
 
+		--color-grey: rgba(0, 0, 0, 0.05);
+
 		@screen sm {
 			--dialog-padding-y: 1.5rem;
 			--padding-3x: 1rem;
 		}
 
 		@apply border-b border-secondary items-center;
-
-		--color-grey: rgba(0, 0, 0, 0.05);
 
 		h2 {
 			font-size: var(--font-size-h3);


### PR DESCRIPTION
# Motivation

Removing SASS warning:

```bash
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
148 │ ┌         @screen sm {
149 │ │             --dialog-padding-y: 1.5rem;
150 │ │             --padding-3x: 1rem;
151 │ │         }
    │ └─── nested rule
... │
153 │           --color-grey: rgba(0, 0, 0, 0.05);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/frontend/src/lib/styles/global/gix.scss 153:3  load-css()
    src/frontend/src/lib/styles/global.scss 16:1       root stylesheet
```
