### PR TITLE
test(e2e): increase ledger cycles amount

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,4 +24,4 @@ dfx deploy pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
 dfx deploy cycles_ledger
 dfx deploy cycles_depositor
 
-scripts/top-up-cycles-ledger-account.sh --cycles 10T
+scripts/top-up-cycles-ledger-account.sh --cycles 50T


### PR DESCRIPTION
# Motivation

An attempt to fix `InsufficientAllowance` error while fetching BTC addresses in the E2E environment.
