### PR TITLE
feat(frontend): align testnets behaviour between envs

### DIFF
--- a/src/frontend/src/lib/derived/testnets.derived.ts
+++ b/src/frontend/src/lib/derived/testnets.derived.ts
@@ -1,8 +1,7 @@
-import { LOCAL } from '$lib/constants/app.constants';
 import { testnetsStore } from '$lib/stores/settings.store';
 import { derived, type Readable } from 'svelte/store';
 
 export const testnets: Readable<boolean> = derived(
 	[testnetsStore],
-	([$testnetsStore]) => $testnetsStore?.enabled ?? LOCAL
+	([$testnetsStore]) => $testnetsStore?.enabled ?? false
 );

--- a/src/frontend/src/tests/btc/components/tokens/BtcTokenMenu.spec.ts
+++ b/src/frontend/src/tests/btc/components/tokens/BtcTokenMenu.spec.ts
@@ -22,6 +22,7 @@ import {
 	btcAddressRegtestStore,
 	btcAddressTestnetStore
 } from '$lib/stores/address.store';
+import { testnetsStore } from '$lib/stores/settings.store';
 import { token } from '$lib/stores/token.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render, waitFor } from '@testing-library/svelte';
@@ -33,6 +34,10 @@ describe('BtcTokenMenu', () => {
 
 	const tokenMenuButtonSelector = `button[data-tid="${TOKEN_MENU_BTC_BUTTON}"]`;
 	const explorerLinkSelector = 'a[data-tid="btc-explorer-link"]';
+
+	beforeAll(() => {
+		testnetsStore.set({ key: 'testnets', value: { enabled: true } });
+	});
 
 	beforeEach(() => {
 		mockPage.reset();

--- a/src/frontend/src/tests/eth/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/tokens.derived.spec.ts
@@ -39,11 +39,5 @@ describe('tokens.derived', () => {
 
 			expect(get(enabledEthereumTokens)).toEqual([ETHEREUM_TOKEN, SEPOLIA_TOKEN]);
 		});
-
-		it('should return ETH and Sepolia ETH when in local env', () => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementationOnce(() => true);
-
-			expect(get(enabledEthereumTokens)).toEqual([ETHEREUM_TOKEN, SEPOLIA_TOKEN]);
-		});
 	});
 });

--- a/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
@@ -3,6 +3,7 @@ import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { EthereumNetwork } from '$eth/types/network';
 import { decodeQrCode } from '$eth/utils/qr-code.utils';
+import { testnetsStore } from '$lib/stores/settings.store';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { get } from 'svelte/store';
 import type { MockedFunction } from 'vitest';
@@ -17,6 +18,7 @@ describe('decodeQrCode', () => {
 	const amount = 1.23;
 	const urn = 'some-urn';
 
+	testnetsStore.set({ key: 'testnets', value: { enabled: true } });
 	const otherProps = {
 		expectedToken: token,
 		ethereumTokens: get(enabledEthereumTokens),

--- a/src/frontend/src/tests/lib/components/hero/ContextMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/ContextMenu.spec.ts
@@ -6,6 +6,7 @@ import {
 	TOKEN_MENU_ETH_BUTTON,
 	TOKEN_MENU_IC_BUTTON
 } from '$lib/constants/test-ids.constants';
+import { testnetsStore } from '$lib/stores/settings.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
 
@@ -13,6 +14,10 @@ describe('ContextMenu', () => {
 	const icTokenMenuButtonSelector = `button[data-tid="${TOKEN_MENU_IC_BUTTON}"]`;
 	const ethTokenMenuButtonSelector = `button[data-tid="${TOKEN_MENU_ETH_BUTTON}"]`;
 	const btcTokenMenuButtonSelector = `button[data-tid="${TOKEN_MENU_BTC_BUTTON}"]`;
+
+	beforeAll(() => {
+		testnetsStore.set({ key: 'testnets', value: { enabled: true } });
+	});
 
 	beforeEach(() => {
 		mockPage.reset();


### PR DESCRIPTION
# Motivation

Currently, we force `testnets` store to be always on locally. On one hand, it's kinda convenient to have it always enabled there, but on the other hand, it's a bit confusing that the related toggle has absolutely no effect locally. Since `LOCAL` is also `true` in the e2e environment, it also affects the tests and makes it impossible to validate the setting toggle functionality. 
