### PR TITLE
feat(frontend): add initialSearch and slot to ManageTokens/ManageTokensModal

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -52,6 +52,8 @@
 	// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
 	let icrcEnvTokens: IcrcCustomToken[] = [];
 
+	export let initialSearch: string | undefined = undefined
+
 	// To avoid strange behavior when the exchange data changes (for example, the tokens may shift
 	// since some of them are sorted by market cap), we store the exchange data in a variable during
 	// the life of the component.
@@ -116,11 +118,11 @@
 			)
 		: [];
 
-	let filterTokens = '';
+	let filterTokens = initialSearch ?? '';
 	const updateFilter = () => (filterTokens = filter);
 	const debounceUpdateFilter = debounce(updateFilter);
 
-	let filter = '';
+	let filter = initialSearch ?? '';
 	$: filter, debounceUpdateFilter();
 
 	const matchingToken = (token: Token): boolean =>
@@ -222,6 +224,8 @@
 		})}
 	</p>
 {/if}
+
+<slot name="info-element"/>
 
 {#if noTokensMatch}
 	<button

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -48,6 +48,10 @@
 		}
 	];
 
+
+	export let initialSearch: string | undefined = undefined;
+	export let disablePointerEvents = false;
+	
 	let saveProgressStep: ProgressStepsAddToken = ProgressStepsAddToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
@@ -160,7 +164,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === 'Saving'}
+	disablePointerEvents={disablePointerEvents || currentStep?.name === 'Saving'}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
@@ -190,6 +194,10 @@
 	{:else if currentStep?.name === 'Import'}
 		<AddTokenByNetwork on:icBack={modal.back} on:icNext={modal.next} bind:network bind:tokenData />
 	{:else}
-		<ManageTokens on:icClose={close} on:icAddToken={modal.next} on:icSave={saveTokens} />
+		<ManageTokens on:icClose={close} on:icAddToken={modal.next} on:icSave={saveTokens} initialSearch={initialSearch} >
+			<svelte:fragment slot="info-element">
+				<slot name="info-element"/>
+			</svelte:fragment>
+		</ManageTokens>
 	{/if}
 </WizardModal>

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -50,8 +50,7 @@
 
 
 	export let initialSearch: string | undefined = undefined;
-	export let disablePointerEvents = false;
-	
+
 	let saveProgressStep: ProgressStepsAddToken = ProgressStepsAddToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
@@ -164,7 +163,7 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={disablePointerEvents || currentStep?.name === 'Saving'}
+	disablePointerEvents={currentStep?.name === 'Saving'}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -49,6 +49,7 @@
 	];
 
 	export let initialSearch: string | undefined = undefined;
+	export let onClose: () => void = () => {};
 	let saveProgressStep: ProgressStepsAddToken = ProgressStepsAddToken.INITIALIZATION;
 
 	let currentStep: WizardStep | undefined;
@@ -141,6 +142,7 @@
 		modalStore.close();
 
 		saveProgressStep = ProgressStepsAddToken.INITIALIZATION;
+		onClose();
 	};
 
 	let ledgerCanisterId: string | undefined;


### PR DESCRIPTION
# Motivation

To achieve https://github.com/dfinity/oisy-wallet/pull/3964 we need to prefill the search of the Managetokens modal. Additionally we want to display an additional InfoElement and have an onClose handler.

# Changes

- add slot for infoElement
- add prop initialSearch
- add onClose

# Tests

Example usage: 

![image](https://github.com/user-attachments/assets/516e6ad6-329b-4bde-b378-c44735eb3eed)


Component still works as usual:


https://github.com/user-attachments/assets/22388995-f536-47aa-a2e0-886be106e3b4


