### PR TITLE
refactor(frontend): rename Ethereum services for balance

### DIFF
--- a/src/frontend/src/eth/services/eth-balance.services.ts
+++ b/src/frontend/src/eth/services/eth-balance.services.ts
@@ -15,15 +15,15 @@ import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export const reloadBalance = (token: Token): Promise<ResultSuccess> => {
+export const reloadEthereumBalance = (token: Token): Promise<ResultSuccess> => {
 	if (isSupportedEthTokenId(token.id)) {
-		return loadBalance({ networkId: token.network.id, tokenId: token.id });
+		return loadEthBalance({ networkId: token.network.id, tokenId: token.id });
 	}
 
 	return loadErc20Balance({ token: token as Erc20Token });
 };
 
-export const loadBalance = async ({
+export const loadEthBalance = async ({
 	networkId,
 	tokenId
 }: {
@@ -110,10 +110,10 @@ const loadErc20Balance = async ({
 	return { success: true };
 };
 
-export const loadBalances = async (): Promise<ResultSuccess> => {
+export const loadEthBalances = async (): Promise<ResultSuccess> => {
 	const results = await Promise.all([
 		...SUPPORTED_ETHEREUM_TOKENS.map(({ network: { id: networkId }, id: tokenId }) =>
-			loadBalance({ networkId, tokenId })
+			loadEthBalance({ networkId, tokenId })
 		)
 	]);
 

--- a/src/frontend/src/eth/services/eth-listener.services.ts
+++ b/src/frontend/src/eth/services/eth-listener.services.ts
@@ -1,7 +1,10 @@
 import { alchemyErc20Providers } from '$eth/providers/alchemy-erc20.providers';
 import { initMinedTransactionsListener as initMinedTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
 import { initWalletConnect } from '$eth/providers/wallet-connect.providers';
-import { processErc20Transaction, processEthTransaction } from '$eth/services/transaction.services';
+import {
+	processErc20Transaction,
+	processEthTransaction
+} from '$eth/services/eth-transaction.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { WebSocketListener } from '$eth/types/listener';
 import type { WalletConnectListener } from '$eth/types/wallet-connect';

--- a/src/frontend/src/eth/services/eth-transaction.services.ts
+++ b/src/frontend/src/eth/services/eth-transaction.services.ts
@@ -1,5 +1,5 @@
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
-import { reloadBalance } from '$eth/services/balance.services';
+import { reloadEthereumBalance } from '$eth/services/eth-balance.services';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { decodeErc20AbiDataValue } from '$eth/utils/transactions.utils';
@@ -142,5 +142,5 @@ const processMinedTransaction = async ({
 	});
 
 	// Reload balance as a transaction has been mined
-	await reloadBalance(token);
+	await reloadEthereumBalance(token);
 };

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -5,7 +5,7 @@ import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
 import { infuraErc20IcpProviders } from '$eth/providers/infura-erc20-icp.providers';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
-import { processTransactionSent } from '$eth/services/transaction.services';
+import { processTransactionSent } from '$eth/services/eth-transaction.services';
 import type {
 	CkEthPopulateTransaction,
 	Erc20PopulateTransaction

--- a/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
+++ b/src/frontend/src/icp-eth/components/core/LoaderBalances.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { debounce } from '@dfinity/utils';
-	import { loadBalances, loadErc20Balances } from '$eth/services/balance.services';
+	import { loadEthBalances, loadErc20Balances } from '$eth/services/eth-balance.services';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
 
 	const load = async () => {
 		await Promise.allSettled([
 			// We might require Ethereum balance on IC network as well given that one can convert ckETH to ETH.
-			loadBalances(),
+			loadEthBalances(),
 			loadErc20Balances({
 				address: $ethAddress,
 				erc20Tokens: $enabledErc20Tokens


### PR DESCRIPTION
# Motivation

Renaming some Ethereum services for balance and transactions with the prefix `eth-`.
