### PR TITLE
test(frontend): use .textContent instead of .innerHTML

### DIFF
--- a/src/frontend/src/tests/lib/components/core/Listener.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Listener.spec.ts
@@ -24,7 +24,7 @@ describe('Listener', () => {
 			props: { token: null }
 		});
 
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render nothing if user is not connected', () => {
@@ -34,7 +34,7 @@ describe('Listener', () => {
 			props: { token: ETHEREUM_TOKEN }
 		});
 
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render nothing if the token has an unknown network', () => {
@@ -46,7 +46,7 @@ describe('Listener', () => {
 			props: { token: ICP_TOKEN }
 		});
 
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render nothing if it is an IC token', () => {
@@ -54,7 +54,7 @@ describe('Listener', () => {
 			props: { token: ICP_TOKEN }
 		});
 
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	// TODO: add tests for rendered listeners, when it is possible to dynamically pass children to the components

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -19,7 +19,7 @@ describe('DappsCarousel', () => {
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValueOnce([]);
 
 		const { container } = render(DappsCarousel);
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render nothing if no dApps has the carousel prop', () => {
@@ -28,7 +28,7 @@ describe('DappsCarousel', () => {
 		);
 
 		const { container } = render(DappsCarousel);
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render nothing if all dApps were hidden', () => {
@@ -51,14 +51,14 @@ describe('DappsCarousel', () => {
 		userProfileStore.set({ profile: userProfile, certified: false });
 
 		const { container } = render(DappsCarousel);
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render nothing if the user profile is nullish', () => {
 		userProfileStore.reset();
 
 		const { container } = render(DappsCarousel);
-		expect(container.innerHTML).toBe('');
+		expect(container.textContent).toBe('');
 	});
 
 	it('should render the Carousel if the user settings are null', () => {


### PR DESCRIPTION
# Motivation

Svelte v5 #3929 wraps rendered elements with `<!----><!---->` around it. If we use `.innerHTML` for comparison purpose we would need to amend those comments or trim those, which isn't nice. Therefore, instead of it, we can use `.textContent` for comparison purposes.
