### PR TITLE
test(frontend): mocks multiple times and restore

### DIFF
--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -11,19 +11,20 @@ import { render } from '@testing-library/svelte';
 describe('DappsCarousel', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.restoreAllMocks();
 
 		userProfileStore.set({ profile: mockUserProfile, certified: false });
 	});
 
 	it('should render nothing if there is no dApps', () => {
-		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValueOnce([]);
+		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue([]);
 
 		const { container } = render(DappsCarousel);
 		expect(container.innerHTML).toBe('');
 	});
 
 	it('should render nothing if no dApps has the carousel prop', () => {
-		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValueOnce(
+		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue(
 			mockDappsDescriptions.map((dapp) => ({ ...dapp, carousel: undefined }))
 		);
 


### PR DESCRIPTION
# Motivation

In the Svelte v5 branch the tests aren't working because the dApps data are mocked only once, I assume Svelte v5 reads the data constant more than once, and also because the mocks are not restored once a test is over.