### PR TITLE
feat(frontend): add types for spl tokens

### DIFF
--- a/src/frontend/src/sol/types/spl-token-toggleable.ts
+++ b/src/frontend/src/sol/types/spl-token-toggleable.ts
@@ -1,0 +1,4 @@
+import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { SplToken } from '$sol/types/spl';
+
+export type SplTokenToggleable = TokenToggleable<SplToken>;

--- a/src/frontend/src/sol/types/spl-user-token.ts
+++ b/src/frontend/src/sol/types/spl-user-token.ts
@@ -1,0 +1,7 @@
+import type { Erc20Token } from '$eth/types/erc20';
+import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
+
+export type SplUserToken = SplTokenToggleable;
+
+export type SolanaUserToken = Omit<SplUserToken, 'address' | 'exchange'> &
+	Partial<Pick<Erc20Token, 'address' | 'exchange'>>;

--- a/src/frontend/src/sol/types/spl.ts
+++ b/src/frontend/src/sol/types/spl.ts
@@ -1,0 +1,8 @@
+import type { ContractAddress } from '$eth/types/address';
+import type { Exchange } from '$lib/types/exchange';
+import type { Token } from '$lib/types/token';
+
+export type SplToken = SplContract & Token;
+
+export type SplContractAddress = ContractAddress;
+export type SplContract = SplContractAddress & { exchange: Exchange };


### PR DESCRIPTION
# Motivation

SPL Tokens are what ERC20 is in Ethereum. Ultimately the goal is to not only handle SOL native tokens, but also SPL tokens. To handle them in the application, we add typing as we did for ERC20 Tokens.

https://spl.solana.com/#:~:text=The%20Solana%20Program%20Library%20(SPL,and%20deployed%20to%20its%20mainnet.

# Changes

- Add types for spl and user tokens
