### PR TITLE
chore(ci): add list of Bot approved files

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,7 @@
+# List of approved files that can be changed by a bot via an automated PR
+# This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
+
+package.json
+package-lock.json
+e2e/**/*.png
+declarations/**/*

--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -5,3 +5,5 @@ package.json
 package-lock.json
 e2e/**/*.png
 declarations/**/*
+src/frontend/src/env/tokens/tokens.*.json
+src/frontend/src/env/tokens/tokens-erc20/


### PR DESCRIPTION
# Motivation

According to recent changes in the DFINITY repo policies, we require to add a list of files that can be changed by the a bot, for security reasons.
