### PR TITLE
chore(frontend): ic-mgmt dev dependency script

### DIFF
--- a/scripts/update-agent.sh
+++ b/scripts/update-agent.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/principal @dfinity/ckbtc @dfinity/cketh @dfinity/ic-management @dfinity/ledger-icp @dfinity/ledger-icrc @dfinity/utils
+npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/principal @dfinity/ckbtc @dfinity/cketh @dfinity/ledger-icp @dfinity/ledger-icrc @dfinity/utils
 
-npm rm @dfinity/identity-secp256k1 -D
+npm rm @dfinity/identity-secp256k1 @dfinity/ic-management -D
 
-npm i @dfinity/agent@1.4.0 @dfinity/auth-client@1.4.0 @dfinity/candid@1.4.0 @dfinity/principal@1.4.0 @dfinity/ckbtc@latest @dfinity/cketh@latest @dfinity/ic-management@latest @dfinity/ledger-icp@latest @dfinity/ledger-icrc@latest @dfinity/utils@latest
+npm i @dfinity/agent@1.4.0 @dfinity/auth-client@1.4.0 @dfinity/candid@1.4.0 @dfinity/principal@1.4.0 @dfinity/ckbtc@latest @dfinity/cketh@latest @dfinity/ledger-icp@latest @dfinity/ledger-icrc@latest @dfinity/utils@latest
 
-npm i @dfinity/identity-secp256k1@1.4.0 -D
+npm i @dfinity/identity-secp256k1@1.4.0 @dfinity/ic-management@latest -D


### PR DESCRIPTION
# Motivation

`ledger-icrc@next` cannot solely be bumped because the ic-js dependencies were released and we did not upgraded those. So this PR upgrade ic-js libraries to their most recent version.

It also set `ic-management` as dev dependency since we do not use it at runtime.
