### PR TITLE
feat(frontend): use utility isEmptyString

### DIFF
--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fromNullable, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+	import { fromNullable, isNullish, nonNullish, isEmptyString } from '@dfinity/utils';
 	import type { TransactionResponse } from '@ethersproject/abstract-provider';
 	import { onDestroy } from 'svelte';
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
@@ -85,7 +85,7 @@
 	}) => {
 		await listener?.disconnect();
 
-		if (isNullish(toAddress) || !notEmptyString(toAddress)) {
+		if (isNullish(toAddress) || isEmptyString(toAddress)) {
 			return;
 		}
 


### PR DESCRIPTION
# Motivation

There is a new utility `isEmptyString` in `@dfinity/utils` which can be use instead of `!notEmptyString`. So this PR replace the one occurence of such code we have in our code base.

# Changes

- Replace function usage
