### PR TITLE
fix(frontend): outer-content slot appearance in ConvertReview modal

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertReview.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertReview.svelte
@@ -18,7 +18,7 @@
 <ContentWithToolbar styleClass="flex flex-col">
 	<ConvertReviewTokens />
 
-	<div slot="outer-content" class="my-4 flex-1">
+	<div slot="outer-content" class="mx-6 my-4 flex-1">
 		<ConvertReviewNetworks />
 
 		<ConvertReviewAmount {sendAmount} {receiveAmount} />


### PR DESCRIPTION
# Motivation

I just noticed in prod that after the recent changes in the Modals-related code the appearance of outer-content slot (ConvertReview modal) is a bit off. 

Before:
<img width="608" alt="Screenshot 2025-01-02 at 16 30 39" src="https://github.com/user-attachments/assets/169f4564-1442-4001-b808-a87549283633" />

After:
<img width="593" alt="Screenshot 2025-01-02 at 16 37 38" src="https://github.com/user-attachments/assets/98b0ddd5-5a32-416e-86f5-695749734e23" />

