### PR TITLE
fix(frontend): remove reference to svelte in sol-rpc.providers.ts

### DIFF
--- a/src/frontend/src/sol/providers/sol-rpc.providers.ts
+++ b/src/frontend/src/sol/providers/sol-rpc.providers.ts
@@ -4,16 +4,12 @@ import {
 	SOLANA_RPC_HTTP_URL_MAINNET,
 	SOLANA_RPC_HTTP_URL_TESTNET
 } from '$env/networks/networks.sol.env';
-import { i18n } from '$lib/stores/i18n.store';
-import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import {
 	SolanaNetworks,
 	type SolRpcConnectionConfig,
 	type SolanaNetworkType
 } from '$sol/types/network';
-import { assertNonNullish } from '@dfinity/utils';
 import { createSolanaRpc } from '@solana/rpc';
-import { get } from 'svelte/store';
 
 const rpcs: Record<SolanaNetworkType, SolRpcConnectionConfig> = {
 	[SolanaNetworks.mainnet]: {
@@ -30,21 +26,8 @@ const rpcs: Record<SolanaNetworkType, SolRpcConnectionConfig> = {
 	}
 };
 
-const solanaRpcConfig = (network: SolanaNetworkType): SolRpcConnectionConfig => {
-	const solRpc = rpcs[network];
-
-	assertNonNullish(
-		solRpc,
-		replacePlaceholders(get(i18n).init.error.no_solana_rpc, {
-			$network: network.toString()
-		})
-	);
-
-	return solRpc;
-};
-
 export const solanaHttpRpc = (network: SolanaNetworkType): ReturnType<typeof createSolanaRpc> => {
-	const rpc = solanaRpcConfig(network);
+	const rpc = rpcs[network];
 
 	return createSolanaRpc(rpc.httpUrl);
 };

--- a/src/frontend/src/sol/providers/sol-rpc.providers.ts
+++ b/src/frontend/src/sol/providers/sol-rpc.providers.ts
@@ -6,8 +6,8 @@ import {
 } from '$env/networks/networks.sol.env';
 import {
 	SolanaNetworks,
-	type SolanaNetworkType,
-	type SolRpcConnectionConfig
+	type SolRpcConnectionConfig,
+	type SolanaNetworkType
 } from '$sol/types/network';
 import { createSolanaRpc } from '@solana/rpc';
 

--- a/src/frontend/src/sol/providers/sol-rpc.providers.ts
+++ b/src/frontend/src/sol/providers/sol-rpc.providers.ts
@@ -6,8 +6,8 @@ import {
 } from '$env/networks/networks.sol.env';
 import {
 	SolanaNetworks,
-	type SolRpcConnectionConfig,
-	type SolanaNetworkType
+	type SolanaNetworkType,
+	type SolRpcConnectionConfig
 } from '$sol/types/network';
 import { createSolanaRpc } from '@solana/rpc';
 
@@ -26,8 +26,12 @@ const rpcs: Record<SolanaNetworkType, SolRpcConnectionConfig> = {
 	}
 };
 
+const solanaRpcConfig = (network: SolanaNetworkType): SolRpcConnectionConfig => {
+	return rpcs[network];
+};
+
 export const solanaHttpRpc = (network: SolanaNetworkType): ReturnType<typeof createSolanaRpc> => {
-	const rpc = rpcs[network];
+	const rpc = solanaRpcConfig(network);
 
 	return createSolanaRpc(rpc.httpUrl);
 };

--- a/src/frontend/src/sol/providers/sol-rpc.providers.ts
+++ b/src/frontend/src/sol/providers/sol-rpc.providers.ts
@@ -26,9 +26,7 @@ const rpcs: Record<SolanaNetworkType, SolRpcConnectionConfig> = {
 	}
 };
 
-const solanaRpcConfig = (network: SolanaNetworkType): SolRpcConnectionConfig => {
-	return rpcs[network];
-};
+const solanaRpcConfig = (network: SolanaNetworkType): SolRpcConnectionConfig => rpcs[network];
 
 export const solanaHttpRpc = (network: SolanaNetworkType): ReturnType<typeof createSolanaRpc> => {
 	const rpc = solanaRpcConfig(network);


### PR DESCRIPTION
# Motivation

Via sol-wallet.worker.ts there was a reference to svelte. This broke the build via sol-wallet.worker.ts as sveltekit is not available there (see vite config).

# Changes

Remove assertion as it's unnecessary anyway, it's already secured via TS that there cannot be passed another network.

# Tests

<img width="965" alt="image" src="https://github.com/user-attachments/assets/377e436a-4269-47c1-92d7-00e6693c1a54" />