### PR TITLE
test(frontend): extend test time for Solana balance

### DIFF
--- a/src/frontend/src/tests/sol/services/sol-balance.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-balance.services.spec.ts
@@ -19,5 +19,5 @@ describe('sol-balance.services', () => {
 				expect(get(balancesStore)?.[token.id]?.data.toNumber()).toBeGreaterThanOrEqual(0);
 			}
 		);
-	});
+	}, 60000);
 });


### PR DESCRIPTION
# Motivation

Since the TESTNET environment is using the public Solana RPC API, it may happen that we have slow responses for the tests. That is why we extend the test time for the balance.
