### PR TITLE
refactor(frontend): use isEmptyString from dfinity/utils

### DIFF
--- a/src/frontend/src/lib/utils/input.utils.ts
+++ b/src/frontend/src/lib/utils/input.utils.ts
@@ -1,9 +1,9 @@
 import type { OptionAmount } from '$lib/types/send';
 import type { OptionString } from '$lib/types/string';
-import { isNullish } from '@dfinity/utils';
+import { isEmptyString, isNullish } from '@dfinity/utils';
 
 export const isNullishOrEmpty = (value: OptionString): value is undefined | null =>
-	isNullish(value) || value === '';
+	isEmptyString(value);
 
 export const invalidAmount = (amount: OptionAmount): boolean =>
 	isNullish(amount) || Number(amount) < 0;


### PR DESCRIPTION
# Motivation

The logic of `isEmptyString` is the same as `isNullishOrEmpty` (it checks if it is nullish or empty string). The code can be checked here: https://github.com/dfinity/ic-js/blob/b744e3b0c799f5e3ee78a39a0dcd0b5dbf80a2d5/packages/utils/src/utils/nullish.utils.ts#L29


The only reason we don't replace completely the function is because `isNullishOrEmpty` provides a type hint definition too:

`value is undefined | null`

