### PR TITLE
fix(scripts): issue with generating certified candid

### DIFF
--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -105,7 +105,7 @@ const copyCertifiedFactory = async ({ dest = `./src/declarations` }) => {
 
 						const certifiedFactoryPath = join(dest, dir, `${dir}.factory.certified.did.js`);
 
-						await writeFile(certifiedFactoryPath, content.toString().replace(/\['query']/g, ''));
+						await writeFile(certifiedFactoryPath, content.toString().replace(/\['query'],?/g, ''));
 
 						resolve();
 					};


### PR DESCRIPTION
Currently, the certified candid generation script does not handle correctly the case when `['query'] parameter is placed on the new line. It wasn't noticed before since such a case only present in the frontend candid for which we do not generate a certified file.

This code
```
get_txs: IDL.Func(
	[IDL.Opt(IDL.Nat64), IDL.Opt(IDL.Nat64), IDL.Opt(IDL.Nat32), IDL.Opt(IDL.Nat16)],
	[TxsResult],
	['query']
),
```
is parsed into
```
'get_txs' : IDL.Func(
        [
          IDL.Opt(IDL.Nat64),
          IDL.Opt(IDL.Nat64),
          IDL.Opt(IDL.Nat32),
          IDL.Opt(IDL.Nat16),
        ],
        [TxsResult],
        ,
 ),
```

With this fix, that code will be correctly compiled into:
```
get_txs: IDL.Func(
	[IDL.Opt(IDL.Nat64), IDL.Opt(IDL.Nat64), IDL.Opt(IDL.Nat32), IDL.Opt(IDL.Nat16)],
	[TxsResult]
),
```