### PR TITLE
feat(frontend): expose kong_backend API to FE

### DIFF
--- a/src/frontend/src/lib/api/kong_backend.api.ts
+++ b/src/frontend/src/lib/api/kong_backend.api.ts
@@ -1,0 +1,52 @@
+import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
+import { KongBackendCanister } from '$lib/canisters/kong_backend.canister';
+import { KONG_BACKEND_CANISTER_ID } from '$lib/constants/app.constants';
+import type { KongSwapAmountsParams, KongSwapParams } from '$lib/types/api';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
+import { Principal } from '@dfinity/principal';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
+
+let canister: KongBackendCanister | undefined = undefined;
+
+export const kongSwapAmounts = async ({
+	identity,
+	canisterId,
+	nullishIdentityErrorMessage,
+	...restParams
+}: CanisterApiFunctionParams<KongSwapAmountsParams>): Promise<SwapAmountsReply> => {
+	const { swapAmounts } = await kongBackendCanister({
+		identity,
+		canisterId,
+		nullishIdentityErrorMessage
+	});
+
+	return swapAmounts(restParams);
+};
+
+export const kongSwap = async ({
+	identity,
+	canisterId,
+	nullishIdentityErrorMessage,
+	...restParams
+}: CanisterApiFunctionParams<KongSwapParams>): Promise<bigint> => {
+	const { swap } = await kongBackendCanister({ identity, canisterId, nullishIdentityErrorMessage });
+
+	return swap(restParams);
+};
+
+const kongBackendCanister = async ({
+	identity,
+	nullishIdentityErrorMessage,
+	canisterId = KONG_BACKEND_CANISTER_ID
+}: CanisterApiFunctionParams): Promise<KongBackendCanister> => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	if (isNullish(canister)) {
+		canister = await KongBackendCanister.create({
+			identity,
+			canisterId: Principal.fromText(canisterId)
+		});
+	}
+
+	return canister;
+};

--- a/src/frontend/src/lib/canisters/kong_backend.canister.ts
+++ b/src/frontend/src/lib/canisters/kong_backend.canister.ts
@@ -1,0 +1,81 @@
+import type {
+	_SERVICE as KongBackendService,
+	SwapAmountsReply
+} from '$declarations/kong_backend/kong_backend.did';
+import { idlFactory as idlCertifiedFactoryKongBackend } from '$declarations/kong_backend/kong_backend.factory.certified.did';
+import { idlFactory as idlFactoryKongBackend } from '$declarations/kong_backend/kong_backend.factory.did';
+import { getAgent } from '$lib/actors/agents.ic';
+import { mapKongBackendCanisterError } from '$lib/canisters/kong_backend.errors';
+import type { KongSwapAmountsParams, KongSwapParams } from '$lib/types/api';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { Canister, createServices, toNullable } from '@dfinity/utils';
+
+export class KongBackendCanister extends Canister<KongBackendService> {
+	static async create({
+		identity,
+		...options
+	}: CreateCanisterOptions<KongBackendService>): Promise<KongBackendCanister> {
+		const agent = await getAgent({ identity });
+
+		const { service, certifiedService, canisterId } = createServices<KongBackendService>({
+			options: {
+				...options,
+				agent
+			},
+			idlFactory: idlFactoryKongBackend,
+			certifiedIdlFactory: idlCertifiedFactoryKongBackend
+		});
+
+		return new KongBackendCanister(canisterId, service, certifiedService);
+	}
+
+	swapAmounts = async ({
+		sourceToken,
+		destinationToken,
+		sourceAmount
+	}: KongSwapAmountsParams): Promise<SwapAmountsReply> => {
+		const { swap_amounts } = this.caller({
+			certified: true
+		});
+
+		const response = await swap_amounts(sourceToken.symbol, sourceAmount, destinationToken.symbol);
+
+		if ('Ok' in response) {
+			return response.Ok;
+		}
+
+		throw mapKongBackendCanisterError(response.Err);
+	};
+
+	swap = async ({
+		destinationToken,
+		maxSlippage,
+		sendAmount,
+		referredBy,
+		receiveAmount,
+		destinationAddress,
+		sourceToken,
+		payTransactionId
+	}: KongSwapParams): Promise<bigint> => {
+		const { swap_async } = this.caller({
+			certified: true
+		});
+
+		const response = await swap_async({
+			pay_token: sourceToken.symbol,
+			receive_token: destinationToken.symbol,
+			pay_amount: sendAmount,
+			max_slippage: toNullable(maxSlippage),
+			receive_address: toNullable(destinationAddress),
+			receive_amount: toNullable(receiveAmount),
+			pay_tx_id: toNullable(payTransactionId),
+			referred_by: toNullable(referredBy)
+		});
+
+		if ('Ok' in response) {
+			return response.Ok;
+		}
+
+		throw mapKongBackendCanisterError(response.Err);
+	};
+}

--- a/src/frontend/src/lib/canisters/kong_backend.errors.ts
+++ b/src/frontend/src/lib/canisters/kong_backend.errors.ts
@@ -1,0 +1,4 @@
+import { CanisterInternalError } from '$lib/canisters/errors';
+
+export const mapKongBackendCanisterError = (err: string): CanisterInternalError =>
+	new CanisterInternalError(err);

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -63,6 +63,12 @@ export const SIGNER_CANISTER_ID = LOCAL
 		? import.meta.env.VITE_STAGING_SIGNER_CANISTER_ID
 		: import.meta.env.VITE_IC_SIGNER_CANISTER_ID;
 
+export const KONG_BACKEND_CANISTER_ID = LOCAL
+	? import.meta.env.VITE_LOCAL_KONG_BACKEND_CANISTER_ID
+	: STAGING
+		? import.meta.env.VITE_STAGING_KONG_BACKEND_CANISTER_ID
+		: import.meta.env.VITE_IC_KONG_BACKEND_CANISTER_ID;
+
 // How long the delegation identity should remain valid?
 // e.g. BigInt(60 * 60 * 1000 * 1000 * 1000) = 1 hour in nanoseconds
 export const AUTH_MAX_TIME_TO_LIVE = BigInt(60 * 60 * 1000 * 1000 * 1000);

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -6,12 +6,14 @@ import type {
 	UserProfile,
 	Utxo
 } from '$declarations/backend/backend.did';
+import type { TxId } from '$declarations/kong_backend/kong_backend.did';
 import type {
 	BtcTxOutput,
 	BitcoinNetwork as SignerBitcoinNetwork,
 	Utxo as SignerUtxo
 } from '$declarations/signer/signer.did';
-import type { BtcAddress } from '$lib/types/address';
+import type { Address, BtcAddress } from '$lib/types/address';
+import type { Token } from '$lib/types/token';
 import { Principal } from '@dfinity/principal';
 
 export interface AddUserCredentialParams {
@@ -50,4 +52,21 @@ export interface SendBtcParams {
 export interface AddUserHiddenDappIdParams {
 	dappId: string;
 	currentUserVersion?: bigint;
+}
+
+export interface KongSwapAmountsParams {
+	sourceToken: Token;
+	destinationToken: Token;
+	sourceAmount: bigint;
+}
+
+export interface KongSwapParams {
+	destinationToken: Token;
+	maxSlippage: number;
+	sendAmount: bigint;
+	referredBy?: string;
+	receiveAmount: bigint;
+	destinationAddress: Address;
+	sourceToken: Token;
+	payTransactionId: TxId;
 }

--- a/src/frontend/src/tests/lib/canisters/kong_backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/kong_backend.canister.spec.ts
@@ -1,0 +1,235 @@
+import type { _SERVICE as KongBackendService } from '$declarations/kong_backend/kong_backend.did';
+import {
+	IC_CKETH_INDEX_CANISTER_ID,
+	IC_CKETH_LEDGER_CANISTER_ID,
+	IC_CKETH_MINTER_CANISTER_ID
+} from '$env/networks/networks.icrc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import type { IcCkToken } from '$icp/types/ic-token';
+import { CanisterInternalError } from '$lib/canisters/errors';
+import { KongBackendCanister } from '$lib/canisters/kong_backend.canister';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { HttpAgent, type ActorSubclass } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+import { toNullable } from '@dfinity/utils';
+import { mock } from 'vitest-mock-extended';
+
+vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		LOCAL: false
+	};
+});
+
+vi.mock(import('$lib/actors/agents.ic'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		// eslint-disable-next-line require-await
+		getAgent: async () => mock<HttpAgent>()
+	};
+});
+
+describe('kong_backend.canister', () => {
+	const createKongBackendCanister = ({
+		serviceOverride
+	}: Pick<
+		CreateCanisterOptions<KongBackendService>,
+		'serviceOverride'
+	>): Promise<KongBackendCanister> =>
+		KongBackendCanister.create({
+			canisterId: Principal.fromText('l4lgk-raaaa-aaaar-qahpq-cai'),
+			identity: mockIdentity,
+			certifiedServiceOverride: serviceOverride,
+			serviceOverride
+		});
+	const service = mock<ActorSubclass<KongBackendService>>();
+	const mockResponseError = new Error('Test response error');
+
+	const sourceAmount = 1000000n;
+	const sourceToken = ICP_TOKEN;
+	const destinationToken = {
+		...ICP_TOKEN,
+		standard: 'icrc',
+		ledgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID,
+		indexCanisterId: IC_CKETH_INDEX_CANISTER_ID,
+		minterCanisterId: IC_CKETH_MINTER_CANISTER_ID
+	} as IcCkToken;
+	const swapAmountsParams = {
+		sourceAmount,
+		sourceToken,
+		destinationToken
+	};
+	const swapParams = {
+		destinationToken,
+		maxSlippage: 1,
+		sendAmount: sourceAmount,
+		referredBy: 'referredBy',
+		receiveAmount: sourceAmount,
+		destinationAddress: 'destinationAddress',
+		sourceToken,
+		payTransactionId: { TransactionId: '1' }
+	};
+	const errorResponse = { Err: 'Test error' };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('kongSwapAmounts', () => {
+		it('returns correct swap amounts', async () => {
+			const response = {
+				Ok: {
+					txs: [
+						{
+							gas_fee: 10000n,
+							lp_fee: 112499994n,
+							pay_address: 'nppha-riaaa-aaaal-ajf2q-cai',
+							pay_amount: 10000000000000000000n,
+							pay_chain: 'IC',
+							pay_symbol: 'ICP',
+							pool_symbol: 'ICP_ckUSDT',
+							price: 0.00000373875,
+							receive_address: 'zdzgz-siaaa-aaaar-qaiba-cai',
+							receive_amount: 37387488131n,
+							receive_chain: 'IC',
+							receive_symbol: 'ckUSDT'
+						}
+					],
+					mid_price: 7.5,
+					pay_address: 'nppha-riaaa-aaaal-ajf2q-cai',
+					pay_amount: 10000000000000000000n,
+					pay_chain: 'IC',
+					pay_symbol: 'ICP',
+					price: 0.000000373875,
+					receive_address: 'zdzgz-siaaa-aaaar-qaiba-cai',
+					receive_amount: 37387488131n,
+					receive_chain: 'IC',
+					receive_symbol: 'ckUSDT',
+					slippage: 100
+				}
+			};
+			service.swap_amounts.mockResolvedValue(response);
+
+			const { swapAmounts } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await swapAmounts(swapAmountsParams);
+
+			expect(res).toEqual(response.Ok);
+			expect(service.swap_amounts).toHaveBeenCalledWith(
+				sourceToken.symbol,
+				sourceAmount,
+				destinationToken.symbol
+			);
+		});
+
+		it('should throw an error if swap_amounts returns an error', async () => {
+			service.swap_amounts.mockResolvedValue(errorResponse);
+
+			const { swapAmounts } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = swapAmounts(swapAmountsParams);
+
+			await expect(res).rejects.toThrow(new CanisterInternalError(errorResponse.Err));
+		});
+
+		it('should throw an error if swap_amounts throws', async () => {
+			service.swap_amounts.mockImplementation(() => {
+				throw mockResponseError;
+			});
+
+			const { swapAmounts } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = swapAmounts(swapAmountsParams);
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+
+		it('should throw an error if swap_amounts returns an unexpected response', async () => {
+			// @ts-expect-error we test this in purposes
+			service.swap_amounts.mockResolvedValue({ test: 'unexpected' });
+
+			const { swapAmounts } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = swapAmounts(swapAmountsParams);
+
+			await expect(res).rejects.toThrow();
+		});
+	});
+
+	describe('kongSwap', () => {
+		it('returns correct swap request id', async () => {
+			const response = {
+				Ok: 1000n
+			};
+			service.swap_async.mockResolvedValue(response);
+
+			const { swap } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await swap(swapParams);
+
+			expect(res).toEqual(response.Ok);
+			expect(service.swap_async).toHaveBeenCalledWith({
+				pay_token: swapParams.sourceToken.symbol,
+				receive_token: swapParams.destinationToken.symbol,
+				pay_amount: swapParams.sendAmount,
+				max_slippage: toNullable(swapParams.maxSlippage),
+				receive_address: toNullable(swapParams.destinationAddress),
+				receive_amount: toNullable(swapParams.receiveAmount),
+				pay_tx_id: toNullable(swapParams.payTransactionId),
+				referred_by: toNullable(swapParams.referredBy)
+			});
+		});
+
+		it('should throw an error if swap_async returns an error', async () => {
+			service.swap_async.mockResolvedValue(errorResponse);
+
+			const { swap } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = swap(swapParams);
+
+			await expect(res).rejects.toThrow(new CanisterInternalError(errorResponse.Err));
+		});
+
+		it('should throw an error if swap_async throws', async () => {
+			service.swap_async.mockImplementation(() => {
+				throw mockResponseError;
+			});
+
+			const { swap } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = swap(swapParams);
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+
+		it('should throw an error if swap_async returns an unexpected response', async () => {
+			// @ts-expect-error we test this in purposes
+			service.swap_async.mockResolvedValue({ test: 'unexpected' });
+
+			const { swap } = await createKongBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = swap(swapParams);
+
+			await expect(res).rejects.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

In this PR, we are exposing to frontend required for the Swap functionality kong_backend services: `swap_amounts` and `swap_async`. The PR includes:

1. `kong_backend` canister class and related tests.
2. `KONG_BACKEND_CANISTER_ID` app constant.
3. `kong_backend` API methods.