### PR TITLE
feat(frontend): remove todo and explicit undefined return

### DIFF
--- a/src/frontend/src/lib/services/reward-code.services.ts
+++ b/src/frontend/src/lib/services/reward-code.services.ts
@@ -91,9 +91,8 @@ export const getNewReward = async (identity: Identity): Promise<VipReward | unde
 			msg: { text: vip.reward.error.loading_reward },
 			err
 		});
+		return undefined;
 	}
-
-	// TODO: should return a ResultSuccess
 };
 
 const updateVipReward = async ({


### PR DESCRIPTION
# Motivation

Alessandro noticed that we can actually not use `ResultSuccess<VipReward>` because that would be a misuage of `ResultSuccess`. Something I mislead the type and thought about ` {result: T, err?: Err} ` or `{result: T, err?: Err}` but, we do not have those patterns. So, for pragamatical reason, we decided to remove the TODO.

As a nipick, since I removed the TODO, I added an explicit `return undefined` for the function.
