### PR TITLE
style(frontend): Updated styles for large info boxes

### DIFF
--- a/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
+++ b/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
@@ -48,7 +48,7 @@
 		>
 	</h4>
 
-	<p class="mt-3 text-misty-rose">
+	<p class="mt-3 text-black opacity-50">
 		{replacePlaceholders(replaceOisyPlaceholders($i18n.info.ethereum.description), {
 			$token: twinToken.symbol,
 			$ckToken: ckTokenSymbol,
@@ -56,7 +56,7 @@
 		})}
 	</p>
 
-	<p class="mt-3 text-misty-rose">
+	<p class="mt-3 text-black opacity-50">
 		{replacePlaceholders(replaceOisyPlaceholders($i18n.info.ethereum.note), {
 			$token: twinToken.symbol,
 			$ckToken: ckTokenSymbol

--- a/src/frontend/src/lib/components/info/InfoBox.svelte
+++ b/src/frontend/src/lib/components/info/InfoBox.svelte
@@ -8,12 +8,9 @@
 </script>
 
 {#if !hideInfo}
-	<div
-		class="relative mb-12 rounded-lg bg-white px-6 py-4"
-		transition:slide={SLIDE_EASING}
-	>
-		<button class="text-tertiary absolute right-2 top-2" on:click aria-label={$i18n.core.text.close}
-			><IconClose/></button
+	<div class="relative mb-12 rounded-lg bg-white px-6 py-4" transition:slide={SLIDE_EASING}>
+		<button class="absolute right-2 top-2 text-tertiary" on:click aria-label={$i18n.core.text.close}
+			><IconClose /></button
 		>
 		<slot />
 	</div>

--- a/src/frontend/src/lib/components/info/InfoBox.svelte
+++ b/src/frontend/src/lib/components/info/InfoBox.svelte
@@ -9,13 +9,12 @@
 
 {#if !hideInfo}
 	<div
-		class="relative mb-12 rounded-lg border-2 border-dust bg-white px-6 py-4"
+		class="relative mb-12 rounded-lg bg-white px-6 py-4"
 		transition:slide={SLIDE_EASING}
 	>
-		<button class="text absolute right-2 top-2" on:click aria-label={$i18n.core.text.close}
-			><IconClose size="24px" /></button
+		<button class="text-tertiary absolute right-2 top-2" on:click aria-label={$i18n.core.text.close}
+			><IconClose/></button
 		>
-
 		<slot />
 	</div>
 {/if}


### PR DESCRIPTION
Replaced leagacy stylings and colors for the "Convert to ckXXX" token helper info boxes 

# Motivation
These boxes used old styles which are differrent from what we have now. 

# Changes

1. Removed border 
2. Smaller close button (same that we use for info boxes on Activity page)
3. Changed description text to match new colors 

# Tests

**Before**

<img width="651" alt="image" src="https://github.com/user-attachments/assets/fea9c056-ee01-4eab-9dec-ba304d65e74e" />



**After** 
<img width="617" alt="image" src="https://github.com/user-attachments/assets/0d064966-5a61-4769-ae97-6a9496374f52" />

<img width="681" alt="image" src="https://github.com/user-attachments/assets/8d926185-9fe2-4dee-bc8d-23d934be602e" />

<img width="694" alt="image" src="https://github.com/user-attachments/assets/722c84ac-9526-4ed2-af5a-03a0a1e32a4a" />

