### PR TITLE
ci(build): add rust and cargo to bot approved files

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -3,6 +3,8 @@
 
 package.json
 package-lock.json
+cargo.toml
+rust-toolchain.toml
 e2e/**/*.png
 declarations/**/*
 src/frontend/src/env/tokens/tokens.*.json


### PR DESCRIPTION
# Motivation

Missing files from the approved for the Bots: cargo and rust files.
