### PR TITLE
fix(build): Fix code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -94,7 +94,7 @@ const injectLinkPreloader = (indexHtml) => {
 const extractStartScript = (htmlFile) => {
 	const indexHtml = readFileSync(htmlFile, 'utf8');
 
-	const svelteKitStartScript = /(<script>)([\s\S]*?)(<\/script>)/gm;
+	const svelteKitStartScript = /(<script>)([\s\S]*?)(<\/script>)/gim;
 
 	// 1. extract SvelteKit start script to a separate main.js file
 	const [_script, _scriptStartTag, content, _scriptEndTag] = svelteKitStartScript.exec(indexHtml);


### PR DESCRIPTION
Fixes [https://github.com/dfinity/oisy-wallet/security/code-scanning/1](https://github.com/dfinity/oisy-wallet/security/code-scanning/1)

To fix the problem, we need to modify the regular expression to be case-insensitive. This can be achieved by adding the `i` flag to the regular expression. This change ensures that the regular expression will match `<script>`, `<SCRIPT>`, `<Script>`, and other case variations.

The best way to fix the problem without changing existing functionality is to update the regular expression on line 97 to include the `i` flag. This change will ensure that the regular expression matches script tags regardless of their case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
