### PR TITLE
feat(frontend): use a single web worker

### DIFF
--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -26,7 +26,7 @@ export const initBtcWalletWorker = async ({
 	token: Token;
 	minterCanisterId?: OptionCanisterIdText;
 }): Promise<WalletWorker> => {
-	const WalletWorker = await import('$btc/workers/btc-wallet.worker?worker');
+	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
 	const isTestnetNetwork = isNetworkIdBTCTestnet(networkId);

--- a/src/frontend/src/btc/workers/btc-wallet.worker.ts
+++ b/src/frontend/src/btc/workers/btc-wallet.worker.ts
@@ -3,7 +3,9 @@ import type { PostMessage, PostMessageDataRequestBtc } from '$lib/types/post-mes
 
 const scheduler: BtcWalletScheduler = new BtcWalletScheduler();
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestBtc>>) => {
+export const onBtcWalletMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequestBtc>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/icp/services/worker.btc-statuses.services.ts
+++ b/src/frontend/src/icp/services/worker.btc-statuses.services.ts
@@ -11,7 +11,7 @@ export const initBtcStatusesWorker: IcCkWorker = async ({
 	minterCanisterId,
 	token: { id: tokenId }
 }: IcCkWorkerParams): Promise<IcCkWorkerInitResult> => {
-	const BtcStatusesWorker = await import('$icp/workers/btc-statuses.worker?worker');
+	const BtcStatusesWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new BtcStatusesWorker.default();
 
 	worker.onmessage = ({

--- a/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
+++ b/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
@@ -22,7 +22,7 @@ import type { SyncState } from '$lib/types/sync';
 export const initCkBTCMinterInfoWorker: IcCkWorker = async (
 	params
 ): Promise<IcCkWorkerInitResult> => {
-	const CkBTCMinterInfoWorker = await import('$icp/workers/ckbtc-minter-info.worker?worker');
+	const CkBTCMinterInfoWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new CkBTCMinterInfoWorker.default();
 
 	return initCkMinterInfoWorker({
@@ -37,7 +37,7 @@ export const initCkBTCMinterInfoWorker: IcCkWorker = async (
 export const initCkETHMinterInfoWorker: IcCkWorker = async (
 	params
 ): Promise<IcCkWorkerInitResult> => {
-	const CkETHMinterInfoWorker = await import('$icp/workers/cketh-minter-info.worker?worker');
+	const CkETHMinterInfoWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new CkETHMinterInfoWorker.default();
 
 	return initCkMinterInfoWorker({

--- a/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
+++ b/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
@@ -20,7 +20,7 @@ export const initCkBTCUpdateBalanceWorker: IcCkWorker = async ({
 	token: { id: tokenId },
 	twinToken
 }: IcCkWorkerParams): Promise<IcCkWorkerInitResult> => {
-	const CkBTCUpdateBalanceWorker = await import('$icp/workers/ckbtc-update-balance.worker?worker');
+	const CkBTCUpdateBalanceWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new CkBTCUpdateBalanceWorker.default();
 
 	worker.onmessage = async ({

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -13,7 +13,7 @@ import type {
 } from '$lib/types/post-message';
 
 export const initIcpWalletWorker = async (): Promise<WalletWorker> => {
-	const WalletWorker = await import('$icp/workers/icp-wallet.worker?worker');
+	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
 	worker.onmessage = ({

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -18,7 +18,7 @@ export const initIcrcWalletWorker = async ({
 	id: tokenId,
 	network: { env }
 }: IcToken): Promise<WalletWorker> => {
-	const WalletWorker = await import('$icp/workers/icrc-wallet.worker?worker');
+	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
 	const restartWorkerWithLedgerOnly = () =>

--- a/src/frontend/src/icp/workers/btc-statuses.worker.ts
+++ b/src/frontend/src/icp/workers/btc-statuses.worker.ts
@@ -3,7 +3,9 @@ import type { PostMessage, PostMessageDataRequestIcCk } from '$lib/types/post-me
 
 const scheduler = new BtcStatusesScheduler();
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestIcCk>>) => {
+export const onBtcStatusesMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequestIcCk>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/icp/workers/ckbtc-minter-info.worker.ts
+++ b/src/frontend/src/icp/workers/ckbtc-minter-info.worker.ts
@@ -5,7 +5,9 @@ import type { PostMessage, PostMessageDataRequestIcCk } from '$lib/types/post-me
 
 const scheduler = new CkMinterInfoScheduler(CKBTC_MINTER_INFO_TIMER, minterInfo);
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestIcCk>>) => {
+export const onCkBtcMinterInfoMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequestIcCk>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/icp/workers/ckbtc-update-balance.worker.ts
+++ b/src/frontend/src/icp/workers/ckbtc-update-balance.worker.ts
@@ -6,7 +6,7 @@ import type {
 
 const scheduler = new CkBTCUpdateBalanceScheduler();
 
-onmessage = async ({
+export const onCkBtcUpdateBalanceMessage = async ({
 	data: dataMsg
 }: MessageEvent<PostMessage<PostMessageDataRequestIcCkBTCUpdateBalance>>) => {
 	const { msg, data } = dataMsg;

--- a/src/frontend/src/icp/workers/cketh-minter-info.worker.ts
+++ b/src/frontend/src/icp/workers/cketh-minter-info.worker.ts
@@ -5,7 +5,9 @@ import type { PostMessage, PostMessageDataRequestIcCk } from '$lib/types/post-me
 
 const scheduler = new CkMinterInfoScheduler(CKETH_MINTER_INFO_TIMER, minterInfo);
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestIcCk>>) => {
+export const onCkEthMinterInfoMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequestIcCk>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -53,7 +53,9 @@ export const initIcpWalletScheduler = (
 
 let scheduler: IcWalletScheduler<PostMessageDataRequest> | undefined;
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onIcpWalletMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/icp/workers/icrc-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icrc-wallet.worker.ts
@@ -109,7 +109,9 @@ export const initIcrcWalletScheduler = (
 
 let scheduler: IcWalletScheduler<PostMessageDataRequestIcrc> | undefined;
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestIcrc>>) => {
+export const onIcrcWalletMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequestIcrc>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/lib/services/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/worker.auth.services.ts
@@ -3,7 +3,7 @@ import { authRemainingTimeStore, type AuthStoreData } from '$lib/stores/auth.sto
 import type { PostMessage, PostMessageDataResponseAuth } from '$lib/types/post-message';
 
 export const initAuthWorker = async () => {
-	const AuthWorker = await import('$lib/workers/auth.worker?worker');
+	const AuthWorker = await import('$lib/workers/workers?worker');
 	const authWorker: Worker = new AuthWorker.default();
 
 	authWorker.onmessage = async ({

--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -17,7 +17,7 @@ export interface ExchangeWorker {
 let errorMessages: { msg: string; timestamp: number }[] = [];
 
 export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
-	const ExchangeWorker = await import('$lib/workers/exchange.worker?worker');
+	const ExchangeWorker = await import('$lib/workers/workers?worker');
 	const exchangeWorker: Worker = new ExchangeWorker.default();
 
 	exchangeWorker.onmessage = ({

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -4,7 +4,10 @@ import { createAuthClient } from '$lib/utils/auth.utils';
 import { IdbStorage, KEY_STORAGE_DELEGATION, type AuthClient } from '@dfinity/auth-client';
 import { DelegationChain, isDelegationValid } from '@dfinity/identity';
 
-onmessage = ({ data }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onAuthMessage = async ({
+	data
+	// eslint-disable-next-line require-await
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg } = data;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -13,7 +13,9 @@ import type { PostMessage, PostMessageDataRequestExchangeTimer } from '$lib/type
 import { errorDetailToString } from '$lib/utils/error.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
-onmessage = async ({ data }: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>>) => {
+export const onExchangeMessage = async ({
+	data
+}: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>>) => {
 	const { msg, data: payload } = data;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/workers.ts
+++ b/src/frontend/src/lib/workers/workers.ts
@@ -1,0 +1,26 @@
+import { onBtcWalletMessage } from '$btc/workers/btc-wallet.worker';
+import { onBtcStatusesMessage } from '$icp/workers/btc-statuses.worker';
+import { onCkBtcMinterInfoMessage } from '$icp/workers/ckbtc-minter-info.worker';
+import { onCkBtcUpdateBalanceMessage } from '$icp/workers/ckbtc-update-balance.worker';
+import { onCkEthMinterInfoMessage } from '$icp/workers/cketh-minter-info.worker';
+import { onIcpWalletMessage } from '$icp/workers/icp-wallet.worker';
+import { onIcrcWalletMessage } from '$icp/workers/icrc-wallet.worker';
+import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
+import { onAuthMessage } from '$lib/workers/auth.worker';
+import { onExchangeMessage } from '$lib/workers/exchange.worker';
+import { onSolWalletMessage } from '$sol/workers/sol-wallet.worker';
+
+onmessage = async (msg: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+	await Promise.allSettled([
+		onAuthMessage(msg),
+		onExchangeMessage(msg),
+		onBtcWalletMessage(msg),
+		onBtcStatusesMessage(msg),
+		onCkBtcMinterInfoMessage(msg),
+		onCkBtcUpdateBalanceMessage(msg),
+		onCkEthMinterInfoMessage(msg),
+		onIcpWalletMessage(msg),
+		onIcrcWalletMessage(msg),
+		onSolWalletMessage(msg)
+	]);
+};

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -28,7 +28,7 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 		network: { id: networkId }
 	} = token;
 
-	const WalletWorker = await import('$sol/workers/sol-wallet.worker?worker');
+	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
 	const isTestnetNetwork = isNetworkIdSOLTestnet(networkId);

--- a/src/frontend/src/sol/workers/sol-wallet.worker.ts
+++ b/src/frontend/src/sol/workers/sol-wallet.worker.ts
@@ -3,7 +3,9 @@ import { SolWalletScheduler } from '$sol/schedulers/sol-wallet.scheduler';
 
 const scheduler: SolWalletScheduler = new SolWalletScheduler();
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequestSol>>) => {
+export const onSolWalletMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequestSol>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {


### PR DESCRIPTION
# Credits

Copied from @peterpeterparker 's PR https://github.com/junobuild/juno/pull/1035 . The motivation below is the same as the Juno's PR, written by @peterpeterparker .

# Motivation

I don't know why I didn't realize this earlier, but each worker in our setup is bundled by vite and rollup into a standalone chunk without reusing chunks across workers. As a result, we are shipping quite a bit of redundant code since almost every worker includes both Buffer, agent-js and other inherited stuffs.

I couldn't find any non-hacky bundling option to improve this. However, I did come up with a potential solution: using a single worker entry point.

Since we are already splitting each worker into different modules, we can easily integrate a single worker entry point that dispatches messages to the appropriate modules. Furthermore, because the context is created at usage, even with a single entry point, we still maintain separate contexts for each worker.

# Results

### Before

![Screenshot 2025-01-11 at 10 20 28](https://github.com/user-attachments/assets/98d176f6-67bb-4368-9ce6-adf015f4d0d2)

### After

![Screenshot 2025-01-11 at 10 21 16](https://github.com/user-attachments/assets/a410b8be-a686-48b8-b471-da3f02d9ead1)
