### PR TITLE
feat(frontend): add SPL balance in wallet worker and service

### DIFF
--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -88,7 +88,8 @@ export const PostMessageDataRequestBtcSchema = z.object({
 export const PostMessageDataRequestSolSchema = z.object({
 	// TODO: generate zod schema for CertifiedData
 	address: z.custom<CertifiedData<SolAddress>>(),
-	solanaNetwork: z.custom<SolanaNetworkType>()
+	solanaNetwork: z.custom<SolanaNetworkType>(),
+	tokenAddress: z.custom<SolAddress>().optional()
 });
 
 export const PostMessageResponseStatusSchema = z.enum([

--- a/src/frontend/src/sol/schema/sol-post-message.schema.ts
+++ b/src/frontend/src/sol/schema/sol-post-message.schema.ts
@@ -3,11 +3,11 @@ import {
 	PostMessageDataResponseSchema
 } from '$lib/schema/post-message.schema';
 import type { CertifiedData } from '$lib/types/store';
-import type { Lamports } from '@solana/rpc-types';
+import type { SolBalance } from '$sol/types/sol-balance';
 import { z } from 'zod';
 
 const SolPostMessageWalletDataSchema = z.object({
-	balance: z.custom<CertifiedData<Lamports | null>>(),
+	balance: z.custom<CertifiedData<SolBalance | null>>(),
 	newTransactions: JsonTransactionsTextSchema
 });
 

--- a/src/frontend/src/sol/services/sol-balance.services.ts
+++ b/src/frontend/src/sol/services/sol-balance.services.ts
@@ -4,12 +4,14 @@ import type { SolAddress } from '$lib/types/address';
 import type { Token } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
-import { loadSolLamportsBalance } from '$sol/api/solana.api';
+import { loadSolLamportsBalance, loadSplTokenBalance } from '$sol/api/solana.api';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
+import { isTokenSpl } from '$sol/utils/spl.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { get } from 'svelte/store';
 
+// TODO: check if this function is used in the app or not
 export const loadSolBalance = async ({
 	address,
 	token
@@ -32,7 +34,9 @@ export const loadSolBalance = async ({
 	);
 
 	try {
-		const balance = await loadSolLamportsBalance({ address, network: solNetwork });
+		const balance = isTokenSpl(token)
+			? await loadSplTokenBalance({ address, network: solNetwork, tokenAddress: token.address })
+			: await loadSolLamportsBalance({ address, network: solNetwork });
 
 		balancesStore.set({ tokenId, data: { data: BigNumber.from(balance), certified: false } });
 

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -19,6 +19,7 @@ import {
 import { syncWallet, syncWalletError } from '$sol/services/sol-listener.services';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
+import { isTokenSpl } from '$sol/utils/spl.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -71,7 +72,11 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 	const network = mapNetworkIdToNetwork(token.network.id);
 	assertNonNullish(network, 'No Solana network provided to start Solana wallet worker.');
 
-	const data: PostMessageDataRequestSol = { address, solanaNetwork: network };
+	// If the token is an SPL token, we need to pass the token address to the worker.
+	// Otherwise, we pass undefined, which will be considered as the native SOLANA token.
+	const tokenAddress = isTokenSpl(token) ? token.address : undefined;
+
+	const data: PostMessageDataRequestSol = { address, solanaNetwork: network, tokenAddress };
 
 	return {
 		start: () => {

--- a/src/frontend/src/sol/types/sol-balance.ts
+++ b/src/frontend/src/sol/types/sol-balance.ts
@@ -1,0 +1,3 @@
+import type { Lamports } from '@solana/rpc-types';
+
+export type SolBalance = Lamports | bigint;

--- a/src/frontend/src/sol/utils/spl.utils.ts
+++ b/src/frontend/src/sol/utils/spl.utils.ts
@@ -1,0 +1,4 @@
+import type { Token } from '$lib/types/token';
+import type { SplToken } from '$sol/types/spl';
+
+export const isTokenSpl = (token: Token): token is SplToken => token.standard === 'spl';

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -51,7 +51,7 @@ describe('solana.api', () => {
 		vi.mocked(solRpcProviders.solanaHttpRpc).mockImplementation(mockSolanaHttpRpc);
 	});
 
-	describe('loadSolBalance', () => {
+	describe('loadSolLamportsBalance', () => {
 		it('should load balance successfully', async () => {
 			const balance = await loadSolLamportsBalance({
 				address: mockSolAddress,

--- a/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
@@ -3,11 +3,12 @@ import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { syncWallet, syncWalletError } from '$sol/services/sol-listener.services';
 import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
+import type { SolBalance } from '$sol/types/sol-balance';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
 import { mockSolCertifiedTransactions } from '$tests/mocks/sol-transactions.mock';
 import { jsonReplacer } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
-import { lamports, type Lamports } from '@solana/rpc-types';
+import { lamports } from '@solana/rpc-types';
 import { get } from 'svelte/store';
 
 describe('sol-listener', () => {
@@ -18,7 +19,7 @@ describe('sol-listener', () => {
 		balance = mockBalance,
 		newTransactions = JSON.stringify(mockSolCertifiedTransactions, jsonReplacer)
 	}: {
-		balance?: Lamports | null;
+		balance?: SolBalance | null;
 		newTransactions?: string;
 	}): SolPostMessageDataResponseWallet => ({
 		wallet: {

--- a/src/frontend/src/tests/sol/utils/spl.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/spl.utils.spec.ts
@@ -1,0 +1,36 @@
+import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import {
+	SOLANA_DEVNET_TOKEN,
+	SOLANA_LOCAL_TOKEN,
+	SOLANA_TESTNET_TOKEN,
+	SOLANA_TOKEN
+} from '$env/tokens/tokens.sol.env';
+import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
+import { isTokenSpl } from '$sol/utils/spl.utils';
+import { describe } from 'vitest';
+
+describe('spl.utils', () => {
+	describe('isTokenSpl', () => {
+		it.each(SPL_TOKENS)('should return true for SPL token $id', (token) => {
+			expect(isTokenSpl(token)).toBe(true);
+		});
+
+		it.each([SOLANA_TOKEN, SOLANA_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN])(
+			'should return false for SOLANA token $id',
+			(token) => {
+				expect(isTokenSpl(token)).toBe(false);
+			}
+		);
+
+		it.each([ETHEREUM_TOKEN, SEPOLIA_TOKEN, ICP_TOKEN, BTC_MAINNET_TOKEN, USDC_TOKEN, PEPE_TOKEN])(
+			'should return false for non-SPL token $id',
+			(token) => {
+				expect(isTokenSpl(token)).toBe(false);
+			}
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

We include the SPL balance service in the wallet workers. To do so, we pass the SPL token address to the workers IF the Solana token is an SPL token and not a native one.

# Changes

- Adapt worker balance to be either `Lamports` (for native SOL tokens) or `bigint` (for SPL tokens).
- Add `tokenAddress` as an optional parameter to the data passed to the worker.
- Create util to check if it is a SPL token (plus tests).
- Use the util to decide if passing the token address or `undefined`.
- Adapt the worker to use `loadSplTokenBalance` if there is `tokenAddress` provided.

# Tests

Test adapted and results below:

![Screenshot 2025-01-11 at 12 34 24](https://github.com/user-attachments/assets/7e444a13-6f46-40fa-a702-c593cd3147b0)

