### PR TITLE
fix(ci): add SNS icons folder to BOT approved files

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -10,3 +10,4 @@ e2e/**/*.png
 declarations/**/*
 src/frontend/src/env/tokens/tokens.*.json
 src/frontend/src/env/tokens/tokens-erc20/
+src/frontend/static/icons/sns/


### PR DESCRIPTION
# Motivation

The CI that updates the SNS tokens requires to act on the icons folder too.