### PR TITLE
feat(frontend): introduce new Logo size

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertToken.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertToken.svelte
@@ -4,7 +4,7 @@
 	import type { Token } from '$lib/types/token';
 
 	export let token: Token;
-	export let size: Extract<LogoSize, 'md' | 'xs'> = 'xs';
+	export let size: Extract<LogoSize, 'md' | 'xxs'> = 'xxs';
 </script>
 
 <div class="flex items-center">

--- a/src/frontend/src/lib/components/networks/NetworkLogo.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkLogo.svelte
@@ -7,7 +7,7 @@
 
 	export let network: Network;
 	export let blackAndWhite = false;
-	export let size: LogoSize = 'xs';
+	export let size: LogoSize = 'xxs';
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let testId: string | undefined = undefined;
 </script>

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -2,23 +2,17 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import IconRandom from '$lib/components/icons/IconRandom.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
+	import { logoSizes } from '$lib/constants/components.constants';
 	import type { LogoSize } from '$lib/types/components';
 
 	export let src: string | undefined;
 	export let alt = '';
-	export let size: LogoSize = 'xs';
+	export let size: LogoSize = 'xxs';
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let ring = false;
 	export let testId: string | undefined = undefined;
 
-	const sizes = {
-		xs: '22px',
-		sm: '36px',
-		md: '42px',
-		lg: '52px',
-		xl: '64px'
-	};
-	let sizePx = sizes[size];
+	let sizePx = logoSizes[size];
 
 	let loaded = false;
 

--- a/src/frontend/src/lib/constants/components.constants.ts
+++ b/src/frontend/src/lib/constants/components.constants.ts
@@ -1,0 +1,8 @@
+export const logoSizes = {
+	xxs: '22px',
+	xs: '30px',
+	sm: '36px',
+	md: '42px',
+	lg: '52px',
+	xl: '64px'
+};

--- a/src/frontend/src/lib/types/components.ts
+++ b/src/frontend/src/lib/types/components.ts
@@ -1,3 +1,3 @@
-export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type Size = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export type LogoSize = Size;


### PR DESCRIPTION
# Motivation

In this PR, I'm introducing a new Logo size, which is an intermediate value between previous `sm` (36px) and `xs` (22px). 

Old values:
```
const logoSizes = {
	xs: '22px',
	sm: '36px',
	md: '42px',
	lg: '52px',
	xl: '64px'
};
```
New values:
```
const logoSizes = {
	xxs: '22px',
	xs: '30px',
	sm: '36px',
	md: '42px',
	lg: '52px',
	xl: '64px'
};
```

Also, moved the const to a separate file since the sizes are gonna be reused in the Swap components.