### PR TITLE
feat(frontend): extract InputSearch component

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -11,7 +10,6 @@
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
-	import IconSearch from '$lib/components/icons/IconSearch.svelte';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TokenName from '$lib/components/tokens/TokenName.svelte';
@@ -19,7 +17,7 @@
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import Card from '$lib/components/ui/Card.svelte';
-	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
+	import InputSearch from '$lib/components/ui/InputSearch.svelte';
 	import { allTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
@@ -145,22 +143,11 @@
 </script>
 
 <div class="mb-4">
-	<InputTextWithAction
-		name="filter"
-		required={false}
-		bind:value={filter}
+	<InputSearch
+		bind:filter
+		noMatch={noTokensMatch}
 		placeholder={$i18n.tokens.placeholder.search_token}
-	>
-		<svelte:fragment slot="inner-end">
-			{#if noTokensMatch}
-				<button on:click={() => (filter = '')} aria-label={$i18n.tokens.manage.text.clear_filter}>
-					<IconClose />
-				</button>
-			{:else}
-				<IconSearch />
-			{/if}
-		</svelte:fragment>
-	</InputTextWithAction>
+	/>
 </div>
 
 {#if nonNullish($selectedNetwork)}

--- a/src/frontend/src/lib/components/ui/InputSearch.svelte
+++ b/src/frontend/src/lib/components/ui/InputSearch.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { IconClose } from '@dfinity/gix-components';
+	import IconSearch from '$lib/components/icons/IconSearch.svelte';
+	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	export let filter = '';
+	export let noMatch = false;
+	export let placeholder: string;
+</script>
+
+<InputTextWithAction name="filter" required={false} bind:value={filter} {placeholder}>
+	<svelte:fragment slot="inner-end">
+		{#if noMatch}
+			<button on:click={() => (filter = '')} aria-label={$i18n.core.text.clear_filter}>
+				<IconClose />
+			</button>
+		{:else}
+			<IconSearch />
+		{/if}
+	</svelte:fragment>
+</InputTextWithAction>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -16,7 +16,8 @@
 			"reject": "Reject",
 			"approve": "Approve",
 			"view": "View",
-			"copy": "Copy"
+			"copy": "Copy",
+			"clear_filter": "Clear filter"
 		},
 		"info": {
 			"test_banner": "For testing purposes only!"
@@ -498,7 +499,6 @@
 				"title": "Manage tokens",
 				"manage_list": "Manage list",
 				"do_not_see_import": "Don’t see your token? Import",
-				"clear_filter": "Clear filter",
 				"manage_for_network": "Managing tokens for $network",
 				"network": "Network",
 				"all_tokens_zero_balance": "All tokens have zero balance."

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -20,6 +20,7 @@ interface I18nCore {
 		approve: string;
 		view: string;
 		copy: string;
+		clear_filter: string;
 	};
 	info: { test_banner: string };
 	alt: { logo: string; go_to_home: string; back: string };
@@ -451,7 +452,6 @@ interface I18nTokens {
 			title: string;
 			manage_list: string;
 			do_not_see_import: string;
-			clear_filter: string;
 			manage_for_network: string;
 			network: string;
 			all_tokens_zero_balance: string;


### PR DESCRIPTION
# Motivation

Since Tokens list view is now gonna be available within the Swap feature, the idea is to re-use as match things from ManageTokens component as possible. One of such things - `InputSearch`.
