### PR TITLE
fix(frontend): rename kong_backend API param

### DIFF
--- a/src/frontend/src/lib/canisters/kong_backend.canister.ts
+++ b/src/frontend/src/lib/canisters/kong_backend.canister.ts
@@ -53,7 +53,7 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 		sendAmount,
 		referredBy,
 		receiveAmount,
-		destinationAddress,
+		receiveAddress,
 		sourceToken,
 		payTransactionId
 	}: KongSwapParams): Promise<bigint> => {
@@ -66,7 +66,7 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 			receive_token: destinationToken.symbol,
 			pay_amount: sendAmount,
 			max_slippage: toNullable(maxSlippage),
-			receive_address: toNullable(destinationAddress),
+			receive_address: toNullable(receiveAddress),
 			receive_amount: toNullable(receiveAmount),
 			pay_tx_id: toNullable(payTransactionId),
 			referred_by: toNullable(referredBy)

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -76,7 +76,7 @@ export interface KongSwapParams {
 	sendAmount: bigint;
 	referredBy?: string;
 	receiveAmount: bigint;
-	destinationAddress: Address;
+	receiveAddress: Address;
 	sourceToken: Token;
 	payTransactionId: TxId;
 }

--- a/src/frontend/src/tests/lib/canisters/kong_backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/kong_backend.canister.spec.ts
@@ -68,7 +68,7 @@ describe('kong_backend.canister', () => {
 		sendAmount: sourceAmount,
 		referredBy: 'referredBy',
 		receiveAmount: sourceAmount,
-		destinationAddress: 'destinationAddress',
+		receiveAddress: 'receiveAddress',
 		sourceToken,
 		payTransactionId: { TransactionId: '1' }
 	};
@@ -186,7 +186,7 @@ describe('kong_backend.canister', () => {
 				receive_token: swapParams.destinationToken.symbol,
 				pay_amount: swapParams.sendAmount,
 				max_slippage: toNullable(swapParams.maxSlippage),
-				receive_address: toNullable(swapParams.destinationAddress),
+				receive_address: toNullable(swapParams.receiveAddress),
 				receive_amount: toNullable(swapParams.receiveAmount),
 				pay_tx_id: toNullable(swapParams.payTransactionId),
 				referred_by: toNullable(swapParams.referredBy)


### PR DESCRIPTION
# Motivation

There was an incorrectly named kong_backend API param - it should have been `receiveAddress` instead of `destinationAddress`.
