### PR TITLE
feat(frontend): expose sendIcp and sendIcrc methods

### DIFF
--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -93,13 +93,15 @@ const send = async ({
 	});
 };
 
-const sendIcrc = ({
+export const sendIcrc = ({
 	to,
 	amount,
 	identity,
 	ledgerCanisterId,
 	progress
-}: IcTransferParams & Pick<IcToken, 'ledgerCanisterId'>): Promise<IcrcBlockIndex> => {
+}: Omit<IcTransferParams, 'progress'> &
+	Partial<Pick<IcTransferParams, 'progress'>> &
+	Pick<IcToken, 'ledgerCanisterId'>): Promise<IcrcBlockIndex> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 
 	// UI validates addresses and disable form if not compliant. Therefore, this issue should unlikely happen.
@@ -107,7 +109,7 @@ const sendIcrc = ({
 		throw new Error(get(i18n).send.error.invalid_destination);
 	}
 
-	progress(ProgressStepsSendIc.SEND);
+	progress?.(ProgressStepsSendIc.SEND);
 
 	return transferIcrc({
 		identity,
@@ -117,7 +119,13 @@ const sendIcrc = ({
 	});
 };
 
-const sendIcp = ({ to, amount, identity, progress }: IcTransferParams): Promise<BlockHeight> => {
+export const sendIcp = ({
+	to,
+	amount,
+	identity,
+	progress
+}: Omit<IcTransferParams, 'progress'> &
+	Partial<Pick<IcTransferParams, 'progress'>>): Promise<BlockHeight> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 	const validIcpAddress = !invalidIcpAddress(to);
 
@@ -126,7 +134,7 @@ const sendIcp = ({ to, amount, identity, progress }: IcTransferParams): Promise<
 		throw new Error(get(i18n).send.error.invalid_destination);
 	}
 
-	progress(ProgressStepsSendIc.SEND);
+	progress?.(ProgressStepsSendIc.SEND);
 
 	return validIcrcAddress
 		? icrc1TransferIcp({

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -18,6 +18,7 @@ import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
+import type { PartialSpecific } from '$lib/types/utils';
 import { invalidIcpAddress } from '$lib/utils/account.utils';
 import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
@@ -99,8 +100,7 @@ export const sendIcrc = ({
 	identity,
 	ledgerCanisterId,
 	progress
-}: Omit<IcTransferParams, 'progress'> &
-	Partial<Pick<IcTransferParams, 'progress'>> &
+}: PartialSpecific<IcTransferParams, 'progress'> &
 	Pick<IcToken, 'ledgerCanisterId'>): Promise<IcrcBlockIndex> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 
@@ -124,8 +124,7 @@ export const sendIcp = ({
 	amount,
 	identity,
 	progress
-}: Omit<IcTransferParams, 'progress'> &
-	Partial<Pick<IcTransferParams, 'progress'>>): Promise<BlockHeight> => {
+}: PartialSpecific<IcTransferParams, 'progress'>): Promise<BlockHeight> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 	const validIcpAddress = !invalidIcpAddress(to);
 

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -13,3 +13,5 @@ export type Option<T> = T | null | undefined;
 
 export type AtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
 	{ [K in Keys]-?: Required<Pick<T, K>> & Partial<Omit<T, K>> }[Keys];
+
+export type PartialSpecific<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;


### PR DESCRIPTION
# Motivation

We need to expose sendIcp and sendIcrc methods in order to initiate transactions and get their block indexes before calling the swap API method of kong_backend.
