### PR TITLE
test(frontend): add tests for SolSendForm

### DIFF
--- a/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
@@ -56,6 +56,7 @@ describe('EthSendForm', () => {
 
 		const source: HTMLDivElement | null = container.querySelector(sourceSelector);
 		expect(source).not.toBeNull();
+
 		const balance: HTMLDivElement | null = container.querySelector(balanceSelector);
 		expect(balance).not.toBeNull();
 
@@ -70,6 +71,7 @@ describe('EthSendForm', () => {
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
 		expect(toolbar).not.toBeNull();
 	});
+
 	it('should not render source field', () => {
 		const { container } = render(EthSendForm, {
 			props: { ...props, simplifiedForm: true },
@@ -84,6 +86,7 @@ describe('EthSendForm', () => {
 
 		const source: HTMLDivElement | null = container.querySelector(sourceSelector);
 		expect(source).toBeNull();
+
 		const balance: HTMLDivElement | null = container.querySelector(balanceSelector);
 		expect(balance).not.toBeNull();
 

--- a/src/frontend/src/tests/icp/components/send/IcSendForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendForm.spec.ts
@@ -54,6 +54,7 @@ describe('IcSendForm', () => {
 
 		const source: HTMLDivElement | null = container.querySelector(sourceSelector);
 		expect(source).not.toBeNull();
+
 		const balance: HTMLDivElement | null = container.querySelector(balanceSelector);
 		expect(balance).not.toBeNull();
 
@@ -83,6 +84,7 @@ describe('IcSendForm', () => {
 
 		const source: HTMLDivElement | null = container.querySelector(sourceSelector);
 		expect(source).toBeNull();
+
 		const balance: HTMLDivElement | null = container.querySelector(balanceSelector);
 		expect(balance).not.toBeNull();
 

--- a/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
@@ -1,0 +1,54 @@
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import SolSendForm from '$sol/components/send/SolSendForm.svelte';
+import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SolSendForm', () => {
+	const mockContext = new Map([]);
+	mockContext.set(
+		SEND_CONTEXT_KEY,
+		initSendContext({
+			sendPurpose: 'send',
+			token: SOLANA_TOKEN
+		})
+	);
+
+	const props = {
+		destination: mockSolAddress2,
+		amount: 22_000_000,
+		source: mockSolAddress
+	};
+
+	const destinationSelector = 'input[data-tid="destination-input"]';
+	const amountSelector = 'input[data-tid="amount-input"]';
+	const sourceSelector = 'div[id="source"]';
+	const balanceSelector = 'div[id="balance"]';
+	const feeSelector = 'p[id="fee"]';
+	const toolbarSelector = 'div[data-tid="toolbar"]';
+
+	it('should render all fields', () => {
+		const { container } = render(SolSendForm, {
+			props,
+			context: mockContext
+		});
+
+		const destination: HTMLInputElement | null = container.querySelector(destinationSelector);
+		expect(destination).not.toBeNull();
+
+		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+		expect(amount).not.toBeNull();
+
+		const source: HTMLDivElement | null = container.querySelector(sourceSelector);
+		expect(source).not.toBeNull();
+
+		const balance: HTMLDivElement | null = container.querySelector(balanceSelector);
+		expect(balance).not.toBeNull();
+
+		const fee: HTMLParagraphElement | null = container.querySelector(feeSelector);
+		expect(fee).toBeNull();
+
+		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
+		expect(toolbar).not.toBeNull();
+	});
+});


### PR DESCRIPTION
# Motivation

Small unittest for `SolSendForm`, similar to other similar components for other networks. 
