### PR TITLE
feat(frontend): add Max button for Solana

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -40,7 +40,7 @@ export const getMaxTransactionAmount = ({
 	tokenDecimals: number;
 	tokenStandard: TokenStandard;
 }): number => {
-	const value = balance.sub(tokenStandard !== 'erc20' ? fee : 0n);
+	const value = balance.sub(tokenStandard !== 'erc20' && tokenStandard !== 'spl' ? fee : 0n);
 
 	return Number(
 		value.isNegative()

--- a/src/frontend/src/sol/components/send/SolSendAmount.svelte
+++ b/src/frontend/src/sol/components/send/SolSendAmount.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
-	import type { BigNumber } from 'alchemy-sdk';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { BigNumber } from 'alchemy-sdk';
 	import { getContext } from 'svelte';
 	import SendInputAmount from '$lib/components/send/SendInputAmount.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
+	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
+	import { SOLANA_TRANSACTION_FEE_IN_LAMPORTS } from '$sol/constants/sol.constants';
 	import { SolAmountAssertionError } from '$sol/types/sol-send';
 
 	export let amount: OptionAmount = undefined;
 	export let amountError: SolAmountAssertionError | undefined;
 
-	const { sendBalance, sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendToken, sendBalance, sendTokenDecimals, sendTokenStandard } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	$: customValidate = (userAmount: BigNumber): Error | undefined => {
 		if (invalidAmount(userAmount.toNumber()) || userAmount.isZero()) {
@@ -26,12 +30,21 @@
 		// TODO: add check for fee, when we will calculate the fees
 	};
 
-	// TODO: Enable Max button by passing the `calculateMax` prop
+	$: calculateMax = (): number | undefined =>
+		isNullish($sendToken)
+			? undefined
+			: getMaxTransactionAmount({
+					balance: $sendBalance ?? ZERO,
+					fee: BigNumber.from(SOLANA_TRANSACTION_FEE_IN_LAMPORTS),
+					tokenDecimals: $sendTokenDecimals,
+					tokenStandard: $sendTokenStandard
+				});
 </script>
 
 <SendInputAmount
 	bind:amount
 	tokenDecimals={$sendTokenDecimals}
 	{customValidate}
+	{calculateMax}
 	bind:error={amountError}
 />

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -105,6 +105,16 @@ describe('getMaxTransactionAmount', () => {
 		});
 		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 	});
+
+	it('should return the untouched amount if the token is SPL', () => {
+		const result = getMaxTransactionAmount({
+			balance: BigNumber.from(balance),
+			fee: BigNumber.from(fee),
+			tokenDecimals: tokenDecimals,
+			tokenStandard: 'spl'
+		});
+		expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
+	});
 });
 
 describe('calculateTokenUsdBalance', () => {


### PR DESCRIPTION
# Motivation

Similar to the other networks, we enable the Max button using the `calculateMax` function.


![Screenshot 2025-01-13 at 16 59 59](https://github.com/user-attachments/assets/30fb373c-e3d8-421e-a445-9e83d2b9e33f)
![Screenshot 2025-01-13 at 17 02 10](https://github.com/user-attachments/assets/1575b510-dc35-45e6-a67f-64886b594ee0)

