### PR TITLE
refactor(frontend): rename SESSION_REQUEST_ETH_SEND_TRANSACTION

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSession.svelte
@@ -9,7 +9,7 @@
 	import WalletConnectModalTitle from '$eth/components/wallet-connect/WalletConnectModalTitle.svelte';
 	import WalletConnectReview from '$eth/components/wallet-connect/WalletConnectReview.svelte';
 	import {
-		SESSION_REQUEST_SEND_TRANSACTION,
+		SESSION_REQUEST_ETH_SEND_TRANSACTION,
 		SESSION_REQUEST_PERSONAL_SIGN,
 		SESSION_REQUEST_ETH_SIGN,
 		SESSION_REQUEST_ETH_SIGN_V4
@@ -225,7 +225,7 @@
 					modalStore.openWalletConnectSign(sessionRequest);
 					return;
 				}
-				case SESSION_REQUEST_SEND_TRANSACTION: {
+				case SESSION_REQUEST_ETH_SEND_TRANSACTION: {
 					modalStore.openWalletConnectSend(sessionRequest);
 					return;
 				}

--- a/src/frontend/src/eth/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/eth/constants/wallet-connect.constants.ts
@@ -9,7 +9,8 @@ export const WALLET_CONNECT_METADATA: AuthClientTypes.Metadata = {
 	icons: [OISY_ICON]
 };
 
-export const SESSION_REQUEST_SEND_TRANSACTION = 'eth_sendTransaction';
+// Ethereum methods
+export const SESSION_REQUEST_ETH_SEND_TRANSACTION = 'eth_sendTransaction';
 export const SESSION_REQUEST_ETH_SIGN = 'eth_sign';
 export const SESSION_REQUEST_PERSONAL_SIGN = 'personal_sign';
 export const SESSION_REQUEST_ETH_SIGN_V4 = 'eth_signTypedData_v4';

--- a/src/frontend/src/eth/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/eth/providers/wallet-connect.providers.ts
@@ -1,9 +1,9 @@
 import { EIP155_CHAINS_KEYS } from '$env/eip155-chains.env';
 import {
+	SESSION_REQUEST_ETH_SEND_TRANSACTION,
 	SESSION_REQUEST_ETH_SIGN,
 	SESSION_REQUEST_ETH_SIGN_V4,
 	SESSION_REQUEST_PERSONAL_SIGN,
-	SESSION_REQUEST_SEND_TRANSACTION,
 	WALLET_CONNECT_METADATA
 } from '$eth/constants/wallet-connect.constants';
 import type { WalletConnectListener } from '$eth/types/wallet-connect';
@@ -82,7 +82,7 @@ export const initWalletConnect = async ({
 				eip155: {
 					chains: EIP155_CHAINS_KEYS,
 					methods: [
-						SESSION_REQUEST_SEND_TRANSACTION,
+						SESSION_REQUEST_ETH_SEND_TRANSACTION,
 						SESSION_REQUEST_ETH_SIGN,
 						SESSION_REQUEST_PERSONAL_SIGN,
 						SESSION_REQUEST_ETH_SIGN_V4


### PR DESCRIPTION
# Motivation

It seems coherent to rename `SESSION_REQUEST_SEND_TRANSACTION` to `SESSION_REQUEST_ETH_SEND_TRANSACTION`, since we will integrate Solana too.
