### PR TITLE
refactor(frontend): extract filterTokens util

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -7,7 +7,6 @@
 	import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
 	import IcManageTokenToggle from '$icp/components/tokens/IcManageTokenToggle.svelte';
-	import type { IcCkToken } from '$icp/types/ic-token';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
@@ -27,9 +26,8 @@
 	import type { Token } from '$lib/types/token';
 	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
+	import { filterTokens, pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 	import SolManageTokenToggle from '$sol/components/tokens/SolManageTokenToggle.svelte';
 	import { isSolanaToken } from '$sol/utils/token.utils';
 
@@ -62,26 +60,14 @@
 			)
 		: [];
 
-	let filterTokens = '';
-	const updateFilter = () => (filterTokens = filter);
+	let tokensFilter = '';
+	const updateFilter = () => (tokensFilter = filter);
 	const debounceUpdateFilter = debounce(updateFilter);
 
 	let filter = '';
 	$: filter, debounceUpdateFilter();
 
-	const matchingToken = (token: Token): boolean =>
-		token.name.toLowerCase().includes(filterTokens.toLowerCase()) ||
-		token.symbol.toLowerCase().includes(filterTokens.toLowerCase()) ||
-		(icTokenIcrcCustomToken(token) &&
-			(token.alternativeName ?? '').toLowerCase().includes(filterTokens.toLowerCase()));
-
-	let filteredTokens: Token[] = [];
-	$: filteredTokens = isNullishOrEmpty(filterTokens)
-		? allTokensSorted
-		: allTokensSorted.filter((token) => {
-				const twinToken = (token as IcCkToken).twinToken;
-				return matchingToken(token) || (nonNullish(twinToken) && matchingToken(twinToken));
-			});
+	$: filteredTokens = filterTokens({ tokens: allTokensSorted, filter: tokensFilter });
 
 	let tokens: Token[] = [];
 	$: tokens = filteredTokens.map((token) => {

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -67,6 +67,7 @@
 	let filter = '';
 	$: filter, debounceUpdateFilter();
 
+	let filteredTokens: Token[] = [];
 	$: filteredTokens = filterTokens({ tokens: allTokensSorted, filter: tokensFilter });
 
 	let tokens: Token[] = [];

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -175,6 +175,7 @@ export const pinEnabledTokensAtTop = <T extends Token>(
  * @param filter - filter keyword.
  * @returns Filtered list of tokens.
  * */
+// TODO: add tests
 export const filterTokens = ({ tokens, filter }: { tokens: Token[]; filter: string }): Token[] => {
 	const matchingToken = (token: Token) =>
 		token.name.toLowerCase().includes(filter.toLowerCase()) ||

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -1,3 +1,5 @@
+import type { IcCkToken } from '$icp/types/ic-token';
+import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -5,6 +7,7 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import { isNullishOrEmpty } from '$lib/utils/input.utils';
 import { calculateTokenUsdBalance, mapTokenUi } from '$lib/utils/token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
@@ -165,3 +168,24 @@ export const filterEnabledTokens = ([$tokens]: [$tokens: Token[]]): Token[] =>
 export const pinEnabledTokensAtTop = <T extends Token>(
 	$tokens: TokenToggleable<T>[]
 ): TokenToggleable<T>[] => $tokens.sort(({ enabled: a }, { enabled: b }) => Number(b) - Number(a));
+
+/** Filters provided tokens list according to a filter keyword
+ *
+ * @param tokens - The list of tokens.
+ * @param filter - filter keyword.
+ * @returns Filtered list of tokens.
+ * */
+export const filterTokens = ({ tokens, filter }: { tokens: Token[]; filter: string }): Token[] => {
+	const matchingToken = (token: Token) =>
+		token.name.toLowerCase().includes(filter.toLowerCase()) ||
+		token.symbol.toLowerCase().includes(filter.toLowerCase()) ||
+		(icTokenIcrcCustomToken(token) &&
+			(token.alternativeName ?? '').toLowerCase().includes(filter.toLowerCase()));
+
+	return isNullishOrEmpty(filter)
+		? tokens
+		: tokens.filter((token) => {
+				const twinToken = (token as IcCkToken).twinToken;
+				return matchingToken(token) || (nonNullish(twinToken) && matchingToken(twinToken));
+			});
+};


### PR DESCRIPTION
# Motivation

The idea is to re-use the filterTokens functionality between ManageTokens and SwapTokensList.
