### PR TITLE
feat(frontend): allDisabledIcrcTokens derived

### DIFF
--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -2,7 +2,7 @@ import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-import { icrcTokens } from '$icp/derived/icrc.derived';
+import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -13,7 +13,7 @@ import { derived } from 'svelte/store';
 // The entire list of ICRC tokens to display to the user:
 // This includes the default tokens (disabled or enabled), the custom tokens (disabled or enabled),
 // and the environment tokens that have never been used.
-const allIcrcTokens = derived([icrcTokens], ([$icrcTokens]) => {
+export const allIcrcTokens = derived([icrcTokens], ([$icrcTokens]) => {
 	// The list of ICRC tokens (SNSes) is defined as environment variables.
 	// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
 	const tokens = buildIcrcCustomTokens();
@@ -30,6 +30,16 @@ const allIcrcTokens = derived([icrcTokens], ([$icrcTokens]) => {
 		)
 	].sort(sortIcTokens);
 });
+
+// TODO: add tests
+export const allDisabledIcrcTokens = derived(
+	[allIcrcTokens, enabledIcrcTokens],
+	([$allIcrcTokens, $enabledIcrcTokens]) => {
+		const enabledIcrcTokenIds = $enabledIcrcTokens.map(({ id }) => id);
+
+		return $allIcrcTokens.filter(({ id }) => !enabledIcrcTokenIds.includes(id));
+	}
+);
 
 export const allTokens = derived(
 	[


### PR DESCRIPTION
# Motivation

This PR includes:
1. Expose `allIcrcTokens` store to be used in SwapTokensList.
2. Create a new `allDisabledIcrcTokens` store in order to have all disabled icrc tokens for which we need to fetch balances and USD rates.
