### PR TITLE
feat(frontend): SwapInputCurrency component

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapInputCurrency.svelte
+++ b/src/frontend/src/lib/components/swap/SwapInputCurrency.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
+	import type { OptionAmount } from '$lib/types/send';
+	export let value: OptionAmount;
+	export let decimals: number;
+	export let name = 'swap-amount';
+	export let disabled = false;
+	export let placeholder = '0';
+	export let error = false;
+</script>
+
+<div class="swap-input-currency h-full w-full font-bold" class:text-error={error}>
+	<InputCurrency bind:value {name} {placeholder} {disabled} {decimals} on:focus on:blur>
+		<slot name="inner-end" slot="inner-end" />
+	</InputCurrency>
+</div>
+
+<style lang="postcss">
+	:global(.swap-input-currency div.input-block) {
+		display: block;
+		height: 100%;
+		justify-content: center;
+		--padding: 0;
+		--input-width: 100%;
+	}
+	:global(.swap-input-currency div.input-field input[id]) {
+		height: 100%;
+		border: none;
+		border-radius: 0;
+		padding: 0 0 0 0.75rem;
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/InputCurrency.svelte
+++ b/src/frontend/src/lib/components/ui/InputCurrency.svelte
@@ -22,6 +22,8 @@
 	{testId}
 	{disabled}
 	on:nnsInput
+	on:blur
+	on:focus
 >
 	<slot name="inner-end" slot="inner-end" />
 </Input>


### PR DESCRIPTION
# Motivation

SwapInputCurrency - a small wrapper around existing InputCurrency, adds styling according to the design specs.

<img width="529" alt="Screenshot 2025-01-14 at 09 24 30" src="https://github.com/user-attachments/assets/5ebe4d3e-17b3-4fa2-b32b-3635b4abfc49" />
