### PR TITLE
refactor(frontend): move WalletConnect reject function to lib

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -9,9 +9,7 @@
 	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
-	import {
-		send as sendServices
-	} from '$eth/services/wallet-connect.services';
+	import { send as sendServices } from '$eth/services/wallet-connect.services';
 	import {
 		FEE_CONTEXT_KEY,
 		type FeeContext as FeeContextType,
@@ -32,13 +30,13 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network } from '$lib/types/network';
 	import type { TokenId } from '$lib/types/token';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
-	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 
 	export let request: Web3WalletTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -10,8 +10,7 @@
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
 	import {
-		send as sendServices,
-		reject as rejectServices
+		send as sendServices
 	} from '$eth/services/wallet-connect.services';
 	import {
 		FEE_CONTEXT_KEY,
@@ -39,6 +38,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { TokenId } from '$lib/types/token';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
+	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 
 	export let request: Web3WalletTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
@@ -3,13 +3,14 @@
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
 	import WalletConnectSignReview from '$eth/components/wallet-connect/WalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$eth/constants/steps.constants';
-	import { signMessage, reject as rejectServices } from '$eth/services/wallet-connect.services';
+	import { signMessage } from '$eth/services/wallet-connect.services';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import WalletConnectModalTitle from '$lib/components/wallet-connect/WalletConnectModalTitle.svelte';
 	import { ProgressStepsSign } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
+	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 
 	export let listener: OptionWalletConnectListener;
 	export let request: Web3WalletTypes.SessionRequest;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignModal.svelte
@@ -7,10 +7,10 @@
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import WalletConnectModalTitle from '$lib/components/wallet-connect/WalletConnectModalTitle.svelte';
 	import { ProgressStepsSign } from '$lib/enums/progress-steps';
+	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
-	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 
 	export let listener: OptionWalletConnectListener;
 	export let request: Web3WalletTypes.SessionRequest;

--- a/src/frontend/src/lib/services/wallet-connect.services.ts
+++ b/src/frontend/src/lib/services/wallet-connect.services.ts
@@ -1,0 +1,92 @@
+import { busy } from '$lib/stores/busy.store';
+import { i18n } from '$lib/stores/i18n.store';
+import { toastsError, toastsShow } from '$lib/stores/toasts.store';
+import type { ResultSuccess } from '$lib/types/utils';
+import type { OptionWalletConnectListener, WalletConnectListener } from '$lib/types/wallet-connect';
+import { isNullish } from '@dfinity/utils';
+import { getSdkError } from '@walletconnect/utils';
+import type { Web3WalletTypes } from '@walletconnect/web3wallet';
+import { get } from 'svelte/store';
+
+export interface WalletConnectCallBackParams {
+	request: Web3WalletTypes.SessionRequest;
+	listener: WalletConnectListener;
+}
+
+export type WalletConnectExecuteParams = Pick<WalletConnectCallBackParams, 'request'> & {
+	listener: OptionWalletConnectListener;
+};
+
+export const execute = async ({
+	params: { request, listener },
+	callback,
+	toastMsg
+}: {
+	params: WalletConnectExecuteParams;
+	callback: (params: WalletConnectCallBackParams) => Promise<ResultSuccess>;
+	toastMsg: string;
+}): Promise<ResultSuccess> => {
+	const {
+		wallet_connect: {
+			error: { no_connection_opened, request_not_defined, unexpected_processing_request }
+		}
+	} = get(i18n);
+
+	if (isNullish(listener)) {
+		toastsError({
+			msg: { text: no_connection_opened }
+		});
+		return { success: false };
+	}
+
+	if (isNullish(request)) {
+		toastsError({
+			msg: { text: request_not_defined }
+		});
+		return { success: false };
+	}
+
+	try {
+		const { success, err } = await callback({ request, listener });
+
+		if (!success) {
+			return { success, err };
+		}
+
+		toastsShow({
+			text: toastMsg,
+			level: 'info',
+			duration: 2000
+		});
+	} catch (err: unknown) {
+		toastsError({
+			msg: { text: unexpected_processing_request },
+			err
+		});
+		return { success: false, err };
+	}
+
+	return { success: true };
+};
+
+export const reject = (params: WalletConnectExecuteParams): Promise<ResultSuccess> =>
+	execute({
+		params,
+		callback: async ({
+			request,
+			listener
+		}: WalletConnectCallBackParams): Promise<ResultSuccess> => {
+			busy.start();
+
+			const { id, topic } = request;
+
+			try {
+				await listener.rejectRequest({ topic, id, error: getSdkError('USER_REJECTED') });
+
+				return { success: true };
+			} finally {
+				busy.stop();
+			}
+		},
+		toastMsg: get(i18n).wallet_connect.error.request_rejected
+	});


### PR DESCRIPTION
# Motivation

The `reject` function and its sub-function `execute` will be used for more networks than Ethereum, so we move them to `lib`.