### PR TITLE
refactor(frontend): use new util groupTokens inside groupTokensByTwin

### DIFF
--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -1,14 +1,8 @@
-import type { IcCkToken } from '$icp/types/ic-token';
-import { isIcCkToken } from '$icp/validation/ic-token.validation';
 import { ZERO } from '$lib/constants/app.constants';
 import type { TokenId, TokenUi } from '$lib/types/token';
 import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-group';
-import {
-	isRequiredTokenWithLinkedData,
-	sumBalances,
-	sumTokenBalances,
-	sumUsdBalances
-} from '$lib/utils/token.utils';
+import { sumBalances, sumUsdBalances } from '$lib/utils/token.utils';
+import { isToken } from '$lib/validation/token.validation';
 import { nonNullish } from '@dfinity/utils';
 
 /**
@@ -25,31 +19,6 @@ export const isTokenUiGroup = (
 	'tokens' in tokenUiOrGroupUi;
 
 /**
- * Factory function to create a TokenUiGroup based on the provided tokens and network details.
- * This function creates a group header and adds both the native token and the twin token to the group's tokens array.
- *
- * @param nativeToken - The native token used for the group, typically the original token or the one from the selected network.
- * @param twinToken - The twin token to be grouped with the native token, usually representing the same asset on a different network.
- *
- * @returns A TokenUiGroup object that includes a header with network and symbol information and contains both the native and twin tokens.
- */
-const createTokenGroup = ({
-	nativeToken,
-	twinToken
-}: {
-	nativeToken: TokenUi;
-	twinToken: TokenUi;
-}): TokenUiGroup => ({
-	// Setting the same ID of the native token to ensure the Group Card component is treated as the same component of the Native Token Card.
-	// This allows Svelte transitions/animations to handle the two cards as the same component, giving a smoother user experience.
-	id: nativeToken.id,
-	nativeToken,
-	tokens: [nativeToken, twinToken],
-	balance: sumTokenBalances([nativeToken, twinToken]),
-	usdBalance: sumUsdBalances([nativeToken.usdBalance, twinToken.usdBalance])
-});
-
-/**
  * Function to create a list of TokenUiOrGroupUi by grouping tokens with matching twinTokenSymbol.
  * The group is placed in the position where the first token of the group was found.
  * Tokens with no twin remain as individual tokens in their original position.
@@ -62,30 +31,10 @@ const createTokenGroup = ({
  *          The group replaces the first token of the group in the list.
  */
 export const groupTokensByTwin = (tokens: TokenUi[]): TokenUiOrGroupUi[] => {
-	const groupedTokenTwins = new Set<string>();
-	const mappedTokensWithGroups: TokenUiOrGroupUi[] = tokens.map((token) => {
-		if (!isRequiredTokenWithLinkedData(token)) {
-			return token;
-		}
+	const tokenGroups = groupTokens(tokens);
 
-		const twinToken = tokens.find((t) => t.symbol === token.twinTokenSymbol && isIcCkToken(t)) as
-			| IcCkToken
-			| undefined;
-
-		if (twinToken && twinToken.decimals === token.decimals) {
-			groupedTokenTwins.add(twinToken.symbol);
-			groupedTokenTwins.add(token.symbol);
-			return createTokenGroup({
-				nativeToken: token,
-				twinToken: twinToken
-			});
-		}
-
-		return token;
-	});
-
-	return mappedTokensWithGroups
-		.filter((t) => isTokenUiGroup(t) || !groupedTokenTwins.has(t.symbol))
+	return tokenGroups
+		.map((group) => (group.tokens.length === 1 ? group.tokens[0] : group))
 		.sort(
 			(a, b) =>
 				(b.usdBalance ?? 0) - (a.usdBalance ?? 0) ||
@@ -189,8 +138,10 @@ export const groupTokens = (tokens: TokenUi[]): TokenUiGroup[] => {
 	}>(
 		(acc, token) => ({
 			...acc,
-			...(isIcCkToken(token) &&
+			...(isToken(token) &&
+			'twinToken' in token &&
 			nonNullish(token.twinToken) &&
+			isToken(token.twinToken) &&
 			// TODO: separate the check for decimals from the rest, since it seems important to the logic.
 			token.decimals === token.twinToken.decimals
 				? // If the token has a twinToken, and both have the same decimals, group them together.

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -16,6 +16,7 @@ import {
 	groupTokensByTwin,
 	updateTokenGroup
 } from '$lib/utils/token-group.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
 import { bn1, bn2, bn3 } from '$tests/mocks/balances.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { BigNumber } from 'alchemy-sdk';
@@ -34,9 +35,10 @@ const tokens = [
 		usdBalance: 100000,
 		standard: 'icrc',
 		category: 'default',
-		decimals: 8,
+		decimals: BTC_MAINNET_TOKEN.decimals,
 		name: 'Chain key Bitcoin',
-		minterCanisterId: 'mc6ru-gyaaa-aaaar-qaaaq-cai'
+		minterCanisterId: 'mc6ru-gyaaa-aaaar-qaaaq-cai',
+		twinToken: BTC_MAINNET_TOKEN
 	},
 	{
 		...ETHEREUM_TOKEN,
@@ -51,9 +53,10 @@ const tokens = [
 		usdBalance: 15000,
 		standard: 'icrc',
 		category: 'default',
-		decimals: 18,
+		decimals: ETHEREUM_TOKEN.decimals,
 		name: 'Chain key Ethereum',
-		minterCanisterId: 'apia6-jaaaa-aaaar-qabma-cai'
+		minterCanisterId: 'apia6-jaaaa-aaaar-qabma-cai',
+		twinToken: ETHEREUM_TOKEN
 	},
 	{
 		...ICP_TOKEN,
@@ -66,6 +69,7 @@ const tokensWithMismatchedDecimals = [
 	...tokens,
 	{
 		...mockValidIcCkToken,
+		id: parseTokenId('FOO'),
 		symbol: 'FOO',
 		network: {
 			id: Symbol('FOO'),
@@ -79,20 +83,23 @@ const tokensWithMismatchedDecimals = [
 		usdBalance: 1000,
 		standard: 'ethereum',
 		category: 'default',
-		decimals: 8,
-		name: 'Foo Token'
+		decimals: 1000,
+		name: 'Foo Token',
+		twinToken: ETHEREUM_TOKEN
 	},
 	{
 		...mockValidIcCkToken,
+		id: parseTokenId('ckFOO'),
 		symbol: 'ckFOO',
 		network: ICP_NETWORK,
 		balance: BigNumber.from(200),
 		usdBalance: 2000,
 		standard: 'icrc',
 		category: 'default',
-		decimals: 9, // Mismatched decimals
+		decimals: 5000,
 		name: 'Chain key Foo Token',
-		minterCanisterId: 'ckfoo-canister-id'
+		minterCanisterId: 'ckfoo-canister-id',
+		twinToken: ETHEREUM_TOKEN
 	}
 ];
 
@@ -104,817 +111,825 @@ const reorderedTokens = [
 	tokens[4] // ICP
 ];
 
-describe('groupTokensByTwin', () => {
-	it('should group tokens with matching twinTokenSymbol', () => {
-		const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
-		expect(groupedTokens).toHaveLength(3);
+describe('token-group.utils', () => {
+	describe('groupTokensByTwin', () => {
+		it('should group tokens with matching twinTokenSymbol', () => {
+			const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
 
-		const btcGroup = groupedTokens[0];
-		expect(btcGroup).toHaveProperty('tokens');
-		expect((btcGroup as TokenUiGroup).tokens).toHaveLength(2);
-		expect((btcGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('BTC');
-		expect((btcGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('ckBTC');
+			expect(groupedTokens).toHaveLength(3);
 
-		const icpToken = groupedTokens[2];
-		expect(icpToken).toHaveProperty('symbol', 'ICP');
-	});
+			const btcGroup = groupedTokens[0];
 
-	it('should handle tokens without twinTokenSymbol', () => {
-		const tokensWithoutTwins = [ICP_TOKEN];
-		const groupedTokens = groupTokensByTwin(tokensWithoutTwins);
+			expect(btcGroup).toHaveProperty('tokens');
+			expect((btcGroup as TokenUiGroup).tokens).toHaveLength(2);
+			expect((btcGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('BTC');
+			expect((btcGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('ckBTC');
 
-		expect(groupedTokens).toHaveLength(1);
-		expect(groupedTokens[0]).toHaveProperty('symbol', 'ICP');
-	});
+			const icpToken = groupedTokens[2];
 
-	it('should place the group in the position of the first token', () => {
-		const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
-		const firstGroup = groupedTokens[0];
-		expect(firstGroup).toHaveProperty('tokens');
-		expect((firstGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('BTC');
-		expect((firstGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('ckBTC');
-	});
+			expect(icpToken).toHaveProperty('symbol', 'ICP');
+		});
 
-	it('should not duplicate tokens in the result', () => {
-		const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
+		it('should handle tokens without twinTokenSymbol', () => {
+			const tokensWithoutTwins = [ICP_TOKEN];
+			const groupedTokens = groupTokensByTwin(tokensWithoutTwins);
 
-		const tokenSymbols = groupedTokens.flatMap((groupOrToken) =>
-			'tokens' in groupOrToken ? groupOrToken.tokens.map((t) => t.symbol) : [groupOrToken.symbol]
-		);
-		const uniqueSymbols = new Set(tokenSymbols);
-		expect(uniqueSymbols.size).toBe(tokenSymbols.length);
-	});
+			expect(groupedTokens).toHaveLength(1);
+			expect(groupedTokens[0]).toHaveProperty('symbol', 'ICP');
+		});
 
-	it('should not group tokens when their decimals are mismatched', () => {
-		const groupedTokens = groupTokensByTwin(tokensWithMismatchedDecimals as TokenUi[]);
-		expect(groupedTokens).toHaveLength(5);
+		it('should place the group in the position of the first token', () => {
+			const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
+			const firstGroup = groupedTokens[0];
 
-		const fooToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'FOO');
-		const ckFooToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'ckFOO');
+			expect(firstGroup).toHaveProperty('tokens');
+			expect((firstGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('BTC');
+			expect((firstGroup as TokenUiGroup).tokens.map((t) => t.symbol)).toContain('ckBTC');
+		});
 
-		expect(fooToken).toBeDefined();
-		expect(ckFooToken).toBeDefined();
+		it('should not duplicate tokens in the result', () => {
+			const groupedTokens = groupTokensByTwin(tokens as TokenUi[]);
 
-		expect(fooToken).not.toHaveProperty('tokens');
-		expect(ckFooToken).not.toHaveProperty('tokens');
-	});
+			const tokenSymbols = groupedTokens.flatMap((groupOrToken) =>
+				'tokens' in groupOrToken ? groupOrToken.tokens.map((t) => t.symbol) : [groupOrToken.symbol]
+			);
+			const uniqueSymbols = new Set(tokenSymbols);
 
-	it('should correctly group tokens even when the ckToken is declared before the native token', () => {
-		const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
+			expect(uniqueSymbols.size).toBe(tokenSymbols.length);
+		});
 
-		expect(groupedTokens).toHaveLength(3);
+		it('should not group tokens when their decimals are mismatched', () => {
+			const groupedTokens = groupTokensByTwin(tokensWithMismatchedDecimals as TokenUi[]);
+			console.log(groupedTokens);
+			expect(groupedTokens).toHaveLength(5);
 
-		const btcGroup = groupedTokens.find(
-			(groupOrToken) =>
-				'tokens' in groupOrToken && groupOrToken.tokens.some((t) => t.symbol === 'BTC')
-		) as TokenUiGroup;
+			const fooToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'FOO');
+			const ckFooToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'ckFOO');
 
-		expect(btcGroup).toBeDefined();
-		expect(btcGroup.tokens).toHaveLength(2);
-		expect(btcGroup.tokens.map((t) => t.symbol)).toContain('BTC');
-		expect(btcGroup.tokens.map((t) => t.symbol)).toContain('ckBTC');
+			expect(fooToken).toBeDefined();
+			expect(ckFooToken).toBeDefined();
 
-		const ethGroup = groupedTokens.find(
-			(groupOrToken) =>
-				'tokens' in groupOrToken && groupOrToken.tokens.some((t) => t.symbol === 'ETH')
-		) as TokenUiGroup;
+			expect(fooToken).not.toHaveProperty('tokens');
+			expect(ckFooToken).not.toHaveProperty('tokens');
+		});
 
-		expect(ethGroup).toBeDefined();
-		expect(ethGroup.tokens).toHaveLength(2);
-		expect(ethGroup.tokens.map((t) => t.symbol)).toContain('ETH');
-		expect(ethGroup.tokens.map((t) => t.symbol)).toContain('ckETH');
+		it('should correctly group tokens even when the ckToken is declared before the native token', () => {
+			const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
 
-		const icpToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'ICP');
+			expect(groupedTokens).toHaveLength(3);
 
-		expect(icpToken).toBeDefined();
-	});
+			const btcGroup = groupedTokens.find(
+				(groupOrToken) =>
+					'tokens' in groupOrToken && groupOrToken.tokens.some((t) => t.symbol === 'BTC')
+			) as TokenUiGroup;
 
-	it('should re-sort groups if their total USD balance made them out of order', () => {
-		const reorderedTokens = [
-			{ ...tokens[0], usdBalance: 5 }, // BTC
-			{ ...tokens[2], usdBalance: 4 }, // ETH
-			{ ...tokens[3], usdBalance: 3 }, // ckETH
-			{ ...tokens[4], usdBalance: 0 }, // ICP
-			{ ...tokens[1], usdBalance: 0 } // ckBTC
-		];
+			expect(btcGroup).toBeDefined();
+			expect(btcGroup.tokens).toHaveLength(2);
+			expect(btcGroup.tokens.map((t) => t.symbol)).toContain('BTC');
+			expect(btcGroup.tokens.map((t) => t.symbol)).toContain('ckBTC');
 
-		const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
+			const ethGroup = groupedTokens.find(
+				(groupOrToken) =>
+					'tokens' in groupOrToken && groupOrToken.tokens.some((t) => t.symbol === 'ETH')
+			) as TokenUiGroup;
 
-		expect(groupedTokens).toHaveLength(3);
+			expect(ethGroup).toBeDefined();
+			expect(ethGroup.tokens).toHaveLength(2);
+			expect(ethGroup.tokens.map((t) => t.symbol)).toContain('ETH');
+			expect(ethGroup.tokens.map((t) => t.symbol)).toContain('ckETH');
 
-		expect(groupedTokens[0]).toHaveProperty('nativeToken', reorderedTokens[1]);
-		expect(groupedTokens[1]).toHaveProperty('nativeToken', reorderedTokens[0]);
+			const icpToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'ICP');
 
-		expect(groupedTokens[0]).toHaveProperty('tokens', [reorderedTokens[1], reorderedTokens[2]]);
-		expect(groupedTokens[1]).toHaveProperty('tokens', [reorderedTokens[0], reorderedTokens[4]]);
-	});
+			expect(icpToken).toBeDefined();
+		});
 
-	it('should re-sort groups if their total balance made them out of order', () => {
-		const reorderedTokens = [
-			{ ...tokens[0], balance: bn2, usdBalance: 0 }, // BTC
-			{ ...tokens[2], balance: bn2, usdBalance: 0 }, // ETH
-			{ ...tokens[3], balance: bn1, usdBalance: 0 }, // ckETH
-			{ ...tokens[1], balance: ZERO, usdBalance: 0 } // ckBTC
-		];
+		it('should re-sort groups if their total USD balance made them out of order', () => {
+			const reorderedTokens = [
+				{ ...tokens[0], usdBalance: 5 }, // BTC
+				{ ...tokens[2], usdBalance: 4 }, // ETH
+				{ ...tokens[3], usdBalance: 3 }, // ckETH
+				{ ...tokens[4], usdBalance: 0 }, // ICP
+				{ ...tokens[1], usdBalance: 0 } // ckBTC
+			];
 
-		const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
+			const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
 
-		expect(groupedTokens).toHaveLength(2);
+			expect(groupedTokens).toHaveLength(3);
 
-		expect(groupedTokens[0]).toHaveProperty('nativeToken', reorderedTokens[1]);
-		expect(groupedTokens[1]).toHaveProperty('nativeToken', reorderedTokens[0]);
+			expect(groupedTokens[0]).toHaveProperty('nativeToken', reorderedTokens[1]);
+			expect(groupedTokens[1]).toHaveProperty('nativeToken', reorderedTokens[0]);
 
-		expect(groupedTokens[0]).toHaveProperty('tokens', [reorderedTokens[1], reorderedTokens[2]]);
-		expect(groupedTokens[1]).toHaveProperty('tokens', [reorderedTokens[0], reorderedTokens[3]]);
-	});
-});
+			expect(groupedTokens[0]).toHaveProperty('tokens', [reorderedTokens[1], reorderedTokens[2]]);
+			expect(groupedTokens[1]).toHaveProperty('tokens', [reorderedTokens[0], reorderedTokens[4]]);
+		});
 
-describe('updateTokenGroup', () => {
-	const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
-	const anotherToken = { ...SEPOLIA_TOKEN, balance: bn2, usdBalance: 200 };
+		it('should re-sort groups if their total balance made them out of order', () => {
+			const reorderedTokens = [
+				{ ...tokens[0], balance: bn2, usdBalance: 0 }, // BTC
+				{ ...tokens[2], balance: bn2, usdBalance: 0 }, // ETH
+				{ ...tokens[3], balance: bn1, usdBalance: 0 }, // ckETH
+				{ ...tokens[1], balance: ZERO, usdBalance: 0 } // ckBTC
+			];
 
-	const tokenGroup: TokenUiGroup = {
-		id: anotherToken.id,
-		nativeToken: anotherToken,
-		tokens: [anotherToken],
-		balance: anotherToken.balance,
-		usdBalance: anotherToken.usdBalance
-	};
+			const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
 
-	const expectedGroup: TokenUiGroup = {
-		...tokenGroup,
-		tokens: [anotherToken, token],
-		balance: anotherToken.balance.add(token.balance),
-		usdBalance: anotherToken.usdBalance + token.usdBalance
-	};
+			expect(groupedTokens).toHaveLength(2);
 
-	it('should add a token to a token group successfully', () => {
-		expect(updateTokenGroup({ token, tokenGroup })).toStrictEqual(expectedGroup);
-	});
+			expect(groupedTokens[0]).toHaveProperty('nativeToken', reorderedTokens[1]);
+			expect(groupedTokens[1]).toHaveProperty('nativeToken', reorderedTokens[0]);
 
-	it('should add a token to a token group with multiple tokens successfully', () => {
-		const thirdToken = { ...BTC_TESTNET_TOKEN, balance: bn3, usdBalance: 300 };
-
-		const initialGroup = updateTokenGroup({ token: thirdToken, tokenGroup });
-
-		const updatedGroup = updateTokenGroup({ token, tokenGroup: initialGroup });
-
-		expect(updatedGroup).toStrictEqual({
-			...tokenGroup,
-			tokens: [anotherToken, thirdToken, token],
-			balance: anotherToken.balance.add(thirdToken.balance).add(token.balance),
-			usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
+			expect(groupedTokens[0]).toHaveProperty('tokens', [reorderedTokens[1], reorderedTokens[2]]);
+			expect(groupedTokens[1]).toHaveProperty('tokens', [reorderedTokens[0], reorderedTokens[3]]);
 		});
 	});
 
-	it('should handle nullish balances in tokenGroup correctly', () => {
-		expect(
-			updateTokenGroup({
-				token,
-				tokenGroup: { ...tokenGroup, balance: undefined }
-			})
-		).toStrictEqual({ ...expectedGroup, balance: undefined });
+	describe('updateTokenGroup', () => {
+		const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
+		const anotherToken = { ...SEPOLIA_TOKEN, balance: bn2, usdBalance: 200 };
 
-		expect(
-			updateTokenGroup({
-				token,
-				tokenGroup: { ...tokenGroup, balance: null }
-			})
-		).toStrictEqual({ ...expectedGroup, balance: token.balance });
-
-		expect(
-			updateTokenGroup({
-				token,
-				tokenGroup: { ...tokenGroup, usdBalance: undefined }
-			})
-		).toStrictEqual({ ...expectedGroup, usdBalance: token.usdBalance });
-	});
-
-	it('should handle nullish balances in token correctly', () => {
-		expect(
-			updateTokenGroup({
-				token: { ...token, balance: undefined },
-				tokenGroup
-			})
-		).toStrictEqual({
-			...expectedGroup,
-			tokens: [anotherToken, { ...token, balance: undefined }],
-			balance: undefined
-		});
-
-		expect(
-			updateTokenGroup({
-				token: { ...token, balance: null },
-				tokenGroup
-			})
-		).toStrictEqual({
-			...expectedGroup,
-			tokens: [anotherToken, { ...token, balance: null }],
-			balance: tokenGroup.balance
-		});
-
-		expect(
-			updateTokenGroup({
-				token: { ...token, usdBalance: undefined },
-				tokenGroup
-			})
-		).toStrictEqual({
-			...expectedGroup,
-			tokens: [anotherToken, { ...token, usdBalance: undefined }],
-			usdBalance: tokenGroup.usdBalance
-		});
-	});
-});
-
-describe('groupMainToken', () => {
-	const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
-	const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
-
-	// We mock the tokens to have the same "main token"
-	const twinToken = {
-		...SEPOLIA_TOKEN,
-		balance: bn2,
-		usdBalance: 250,
-		twinToken: ICP_TOKEN,
-		decimals: ICP_TOKEN.decimals
-	};
-
-	it('should create a new group when no tokenGroup exists', () => {
-		expect(groupMainToken({ token, tokenGroup: undefined })).toEqual({
-			id: token.id,
-			nativeToken: token,
-			tokens: [token],
-			balance: token.balance,
-			usdBalance: token.usdBalance
-		});
-	});
-
-	it('should add token to existing group and update balances', () => {
 		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [twinToken],
-			balance: bn3,
-			usdBalance: 300
+			id: anotherToken.id,
+			nativeToken: anotherToken,
+			tokens: [anotherToken],
+			balance: anotherToken.balance,
+			usdBalance: anotherToken.usdBalance
 		};
 
-		expect(groupMainToken({ token, tokenGroup })).toEqual({
+		const expectedGroup: TokenUiGroup = {
 			...tokenGroup,
-			tokens: [...tokenGroup.tokens, token],
-			balance: tokenGroup.balance!.add(token.balance),
-			usdBalance: tokenGroup.usdBalance! + token.usdBalance
-		});
-	});
-
-	it('should add token to existing group with more than one token already', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [twinToken, anotherToken],
-			balance: bn3,
-			usdBalance: 300
+			tokens: [anotherToken, token],
+			balance: anotherToken.balance.add(token.balance),
+			usdBalance: anotherToken.usdBalance + token.usdBalance
 		};
 
-		expect(groupMainToken({ token, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, token],
-			balance: tokenGroup.balance!.add(token.balance),
-			usdBalance: tokenGroup.usdBalance! + token.usdBalance
+		it('should add a token to a token group successfully', () => {
+			expect(updateTokenGroup({ token, tokenGroup })).toStrictEqual(expectedGroup);
+		});
+
+		it('should add a token to a token group with multiple tokens successfully', () => {
+			const thirdToken = { ...BTC_TESTNET_TOKEN, balance: bn3, usdBalance: 300 };
+
+			const initialGroup = updateTokenGroup({ token: thirdToken, tokenGroup });
+
+			const updatedGroup = updateTokenGroup({ token, tokenGroup: initialGroup });
+
+			expect(updatedGroup).toStrictEqual({
+				...tokenGroup,
+				tokens: [anotherToken, thirdToken, token],
+				balance: anotherToken.balance.add(thirdToken.balance).add(token.balance),
+				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
+			});
+		});
+
+		it('should handle nullish balances in tokenGroup correctly', () => {
+			expect(
+				updateTokenGroup({
+					token,
+					tokenGroup: { ...tokenGroup, balance: undefined }
+				})
+			).toStrictEqual({ ...expectedGroup, balance: undefined });
+
+			expect(
+				updateTokenGroup({
+					token,
+					tokenGroup: { ...tokenGroup, balance: null }
+				})
+			).toStrictEqual({ ...expectedGroup, balance: token.balance });
+
+			expect(
+				updateTokenGroup({
+					token,
+					tokenGroup: { ...tokenGroup, usdBalance: undefined }
+				})
+			).toStrictEqual({ ...expectedGroup, usdBalance: token.usdBalance });
+		});
+
+		it('should handle nullish balances in token correctly', () => {
+			expect(
+				updateTokenGroup({
+					token: { ...token, balance: undefined },
+					tokenGroup
+				})
+			).toStrictEqual({
+				...expectedGroup,
+				tokens: [anotherToken, { ...token, balance: undefined }],
+				balance: undefined
+			});
+
+			expect(
+				updateTokenGroup({
+					token: { ...token, balance: null },
+					tokenGroup
+				})
+			).toStrictEqual({
+				...expectedGroup,
+				tokens: [anotherToken, { ...token, balance: null }],
+				balance: tokenGroup.balance
+			});
+
+			expect(
+				updateTokenGroup({
+					token: { ...token, usdBalance: undefined },
+					tokenGroup
+				})
+			).toStrictEqual({
+				...expectedGroup,
+				tokens: [anotherToken, { ...token, usdBalance: undefined }],
+				usdBalance: tokenGroup.usdBalance
+			});
 		});
 	});
 
-	it('should override the "main token" props if the group was created by a "secondary token"', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: twinToken.id,
-			nativeToken: twinToken,
-			tokens: [twinToken],
-			balance: bn3,
-			usdBalance: 300
-		};
+	describe('groupMainToken', () => {
+		const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
+		const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
 
-		expect(groupMainToken({ token, tokenGroup })).toEqual({
-			...tokenGroup,
-			id: token.id,
-			nativeToken: token,
-			tokens: [...tokenGroup.tokens, token],
-			balance: tokenGroup.balance!.add(token.balance),
-			usdBalance: tokenGroup.usdBalance! + token.usdBalance
-		});
-	});
-});
-
-describe('groupSecondaryToken', () => {
-	const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
-	const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
-
-	// We mock the tokens to have the same "main token"
-	const twinToken = {
-		...SEPOLIA_TOKEN,
-		balance: bn2,
-		usdBalance: 250,
-		twinToken: ICP_TOKEN,
-		decimals: ICP_TOKEN.decimals
-	};
-
-	it('should create a new group when no tokenGroup exists', () => {
-		expect(groupSecondaryToken({ token: twinToken, tokenGroup: undefined })).toEqual({
-			id: twinToken.id,
-			nativeToken: twinToken,
-			tokens: [twinToken],
-			balance: twinToken.balance,
-			usdBalance: twinToken.usdBalance
-		});
-	});
-
-	it('should add token to existing group and update balances', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [token],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, twinToken],
-			balance: tokenGroup.balance!.add(twinToken.balance),
-			usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
-		});
-	});
-
-	it('should add token to existing group with more than one token already', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [token, anotherToken],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, twinToken],
-			balance: tokenGroup.balance!.add(twinToken.balance),
-			usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
-		});
-	});
-});
-
-describe('updateTokenGroup', () => {
-	const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
-	const anotherToken = { ...SEPOLIA_TOKEN, balance: bn2, usdBalance: 200 };
-
-	const tokenGroup: TokenUiGroup = {
-		id: anotherToken.id,
-		nativeToken: anotherToken,
-		tokens: [anotherToken],
-		balance: anotherToken.balance,
-		usdBalance: anotherToken.usdBalance
-	};
-
-	const expectedGroup: TokenUiGroup = {
-		...tokenGroup,
-		tokens: [anotherToken, token],
-		balance: anotherToken.balance.add(token.balance),
-		usdBalance: anotherToken.usdBalance + token.usdBalance
-	};
-
-	it('should add a token to a token group successfully', () => {
-		expect(updateTokenGroup({ token, tokenGroup })).toStrictEqual(expectedGroup);
-	});
-
-	it('should add a token to a token group with multiple tokens successfully', () => {
-		const thirdToken = { ...BTC_TESTNET_TOKEN, balance: bn3, usdBalance: 300 };
-
-		const initialGroup = updateTokenGroup({ token: thirdToken, tokenGroup });
-
-		const updatedGroup = updateTokenGroup({ token, tokenGroup: initialGroup });
-
-		expect(updatedGroup).toStrictEqual({
-			...tokenGroup,
-			tokens: [anotherToken, thirdToken, token],
-			balance: anotherToken.balance.add(thirdToken.balance).add(token.balance),
-			usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
-		});
-	});
-
-	it('should handle nullish balances in tokenGroup correctly', () => {
-		expect(
-			updateTokenGroup({
-				token,
-				tokenGroup: { ...tokenGroup, balance: undefined }
-			})
-		).toStrictEqual({ ...expectedGroup, balance: undefined });
-
-		expect(
-			updateTokenGroup({
-				token,
-				tokenGroup: { ...tokenGroup, balance: null }
-			})
-		).toStrictEqual({ ...expectedGroup, balance: token.balance });
-
-		expect(
-			updateTokenGroup({
-				token,
-				tokenGroup: { ...tokenGroup, usdBalance: undefined }
-			})
-		).toStrictEqual({ ...expectedGroup, usdBalance: token.usdBalance });
-	});
-
-	it('should handle nullish balances in token correctly', () => {
-		expect(
-			updateTokenGroup({
-				token: { ...token, balance: undefined },
-				tokenGroup
-			})
-		).toStrictEqual({
-			...expectedGroup,
-			tokens: [anotherToken, { ...token, balance: undefined }],
-			balance: undefined
-		});
-
-		expect(
-			updateTokenGroup({
-				token: { ...token, balance: null },
-				tokenGroup
-			})
-		).toStrictEqual({
-			...expectedGroup,
-			tokens: [anotherToken, { ...token, balance: null }],
-			balance: tokenGroup.balance
-		});
-
-		expect(
-			updateTokenGroup({
-				token: { ...token, usdBalance: undefined },
-				tokenGroup
-			})
-		).toStrictEqual({
-			...expectedGroup,
-			tokens: [anotherToken, { ...token, usdBalance: undefined }],
-			usdBalance: tokenGroup.usdBalance
-		});
-	});
-});
-
-describe('groupMainToken', () => {
-	const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
-	const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
-
-	// We mock the tokens to have the same "main token"
-	const twinToken = {
-		...SEPOLIA_TOKEN,
-		balance: bn2,
-		usdBalance: 250,
-		twinToken: ICP_TOKEN,
-		decimals: ICP_TOKEN.decimals
-	};
-
-	it('should create a new group when no tokenGroup exists', () => {
-		expect(groupMainToken({ token, tokenGroup: undefined })).toEqual({
-			id: token.id,
-			nativeToken: token,
-			tokens: [token],
-			balance: token.balance,
-			usdBalance: token.usdBalance
-		});
-	});
-
-	it('should add token to existing group and update balances', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [twinToken],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupMainToken({ token, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, token],
-			balance: tokenGroup.balance!.add(token.balance),
-			usdBalance: tokenGroup.usdBalance! + token.usdBalance
-		});
-	});
-
-	it('should add token to existing group with more than one token already', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [twinToken, anotherToken],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupMainToken({ token, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, token],
-			balance: tokenGroup.balance!.add(token.balance),
-			usdBalance: tokenGroup.usdBalance! + token.usdBalance
-		});
-	});
-
-	it('should override the "main token" props if the group was created by a "secondary token"', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: twinToken.id,
-			nativeToken: twinToken,
-			tokens: [twinToken],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupMainToken({ token, tokenGroup })).toEqual({
-			...tokenGroup,
-			id: token.id,
-			nativeToken: token,
-			tokens: [...tokenGroup.tokens, token],
-			balance: tokenGroup.balance!.add(token.balance),
-			usdBalance: tokenGroup.usdBalance! + token.usdBalance
-		});
-	});
-});
-
-describe('groupSecondaryToken', () => {
-	const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
-	const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
-
-	// We mock the tokens to have the same "main token"
-	const twinToken = {
-		...SEPOLIA_TOKEN,
-		balance: bn2,
-		usdBalance: 250,
-		twinToken: ICP_TOKEN,
-		decimals: ICP_TOKEN.decimals
-	};
-
-	it('should create a new group when no tokenGroup exists', () => {
-		expect(groupSecondaryToken({ token: twinToken, tokenGroup: undefined })).toEqual({
-			id: twinToken.id,
-			nativeToken: twinToken,
-			tokens: [twinToken],
-			balance: twinToken.balance,
-			usdBalance: twinToken.usdBalance
-		});
-	});
-
-	it('should add token to existing group and update balances', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [token],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, twinToken],
-			balance: tokenGroup.balance!.add(twinToken.balance),
-			usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
-		});
-	});
-
-	it('should add token to existing group with more than one token already', () => {
-		const tokenGroup: TokenUiGroup = {
-			id: token.id,
-			nativeToken: token,
-			tokens: [token, anotherToken],
-			balance: bn3,
-			usdBalance: 300
-		};
-
-		expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
-			...tokenGroup,
-			tokens: [...tokenGroup.tokens, twinToken],
-			balance: tokenGroup.balance!.add(twinToken.balance),
-			usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
-		});
-	});
-});
-
-describe('groupTokens', () => {
-	const mockToken = { ...SEPOLIA_TOKEN, balance: bn1, usdBalance: 100 };
-	const mockSecondToken = { ...BTC_TESTNET_TOKEN, balance: bn3, usdBalance: 300 };
-	const mockThirdToken = { ...ICP_TOKEN, balance: bn2, usdBalance: 200 };
-
-	// We mock the tokens to have the same "main token"
-	const mockTwinToken1 = {
-		...mockValidIcToken,
-		balance: bn2,
-		usdBalance: 250,
-		twinToken: mockToken,
-		decimals: mockToken.decimals
-	};
-	const mockTwinToken2 = {
-		...mockValidIcToken,
-		balance: bn1,
-		usdBalance: 450,
-		twinToken: mockToken,
-		decimals: mockToken.decimals
-	};
-
-	it('should return an empty array if no tokens are provided', () => {
-		expect(groupTokens([]).length).toBe(0);
-	});
-
-	it('should create groups of single-element tokens if none of them have a "main token"', () => {
-		const tokens = [mockToken, mockSecondToken, mockThirdToken];
-
-		const result = groupTokens(tokens);
-
-		expect(result.length).toBe(3);
-
-		result.map((group) => {
-			expect(group.tokens.length).toBe(1);
-		});
-
-		expect(result[0].id).toBe(mockToken.id);
-		expect(result[1].id).toBe(mockSecondToken.id);
-		expect(result[2].id).toBe(mockThirdToken.id);
-
-		expect(result[0].nativeToken).toBe(mockToken);
-		expect(result[1].nativeToken).toBe(mockSecondToken);
-		expect(result[2].nativeToken).toBe(mockThirdToken);
-
-		expect(result[0].balance).toBe(mockToken.balance);
-		expect(result[1].balance).toBe(mockSecondToken.balance);
-		expect(result[2].balance).toBe(mockThirdToken.balance);
-
-		expect(result[0].usdBalance).toBe(mockToken.usdBalance);
-		expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
-		expect(result[2].usdBalance).toBe(mockThirdToken.usdBalance);
-
-		expect(result[0].tokens[0]).toBe(mockToken);
-		expect(result[1].tokens[0]).toBe(mockSecondToken);
-		expect(result[2].tokens[0]).toBe(mockThirdToken);
-	});
-
-	it('should group tokens with the same "main token" and same decimals', () => {
-		const tokens = [mockToken, mockTwinToken1, mockSecondToken, mockTwinToken2];
-
-		const result = groupTokens(tokens);
-
-		expect(result.length).toBe(2);
-
-		expect(result[0].tokens.length).toBe(3);
-		expect(result[1].tokens.length).toBe(1);
-
-		expect(result[0].id).toBe(mockToken.id);
-		expect(result[1].id).toBe(mockSecondToken.id);
-
-		expect(result[0].nativeToken).toBe(mockToken);
-		expect(result[1].nativeToken).toBe(mockSecondToken);
-
-		expect(result[0].balance).toStrictEqual(
-			mockToken.balance.add(mockTwinToken1.balance).add(mockTwinToken2.balance)
-		);
-		expect(result[1].balance).toBe(mockSecondToken.balance);
-
-		expect(result[0].usdBalance).toBe(
-			mockToken.usdBalance + mockTwinToken1.usdBalance + mockTwinToken2.usdBalance
-		);
-		expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
-
-		expect(result[0].tokens[0]).toBe(mockToken);
-		expect(result[0].tokens[1]).toBe(mockTwinToken1);
-		expect(result[0].tokens[2]).toBe(mockTwinToken2);
-	});
-
-	it('should group tokens with the same "main token" but not the ones with different decimals', () => {
-		const mockTwinToken = {
-			...mockTwinToken2,
-			decimals: mockTwinToken2.decimals + 1
-		};
-
-		const tokens = [mockToken, mockTwinToken1, mockSecondToken, mockTwinToken];
-
-		const result = groupTokens(tokens);
-
-		expect(result.length).toBe(3);
-
-		expect(result[0].tokens.length).toBe(2);
-		expect(result[1].tokens.length).toBe(1);
-		expect(result[2].tokens.length).toBe(1);
-
-		expect(result[0].id).toBe(mockToken.id);
-		expect(result[1].id).toBe(mockSecondToken.id);
-		expect(result[2].id).toBe(mockTwinToken.id);
-
-		expect(result[0].nativeToken).toBe(mockToken);
-		expect(result[1].nativeToken).toBe(mockSecondToken);
-		expect(result[2].nativeToken).toBe(mockTwinToken);
-
-		expect(result[0].balance).toStrictEqual(mockToken.balance.add(mockTwinToken1.balance));
-		expect(result[1].balance).toBe(mockSecondToken.balance);
-		expect(result[2].balance).toBe(mockTwinToken.balance);
-
-		expect(result[0].usdBalance).toBe(mockToken.usdBalance + mockTwinToken1.usdBalance);
-		expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
-		expect(result[2].usdBalance).toBe(mockTwinToken.usdBalance);
-
-		expect(result[0].tokens[0]).toBe(mockToken);
-		expect(result[0].tokens[1]).toBe(mockTwinToken1);
-	});
-
-	it('should group tokens with the same "main token" respecting the order they arrive in', () => {
-		const tokens = [mockTwinToken1, mockSecondToken, mockToken, mockTwinToken2];
-
-		const result = groupTokens(tokens);
-
-		expect(result.length).toBe(2);
-
-		expect(result[0].tokens.length).toBe(3);
-		expect(result[1].tokens.length).toBe(1);
-
-		expect(result[0].id).toBe(mockToken.id);
-		expect(result[1].id).toBe(mockSecondToken.id);
-
-		expect(result[0].nativeToken).toBe(mockToken);
-		expect(result[1].nativeToken).toBe(mockSecondToken);
-
-		expect(result[0].balance).toStrictEqual(
-			mockTwinToken1.balance.add(mockToken.balance).add(mockTwinToken2.balance)
-		);
-		expect(result[1].balance).toBe(mockSecondToken.balance);
-
-		expect(result[0].usdBalance).toBe(
-			mockTwinToken1.usdBalance + mockToken.usdBalance + mockTwinToken2.usdBalance
-		);
-		expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
-
-		expect(result[0].tokens[0]).toBe(mockTwinToken1);
-		expect(result[0].tokens[1]).toBe(mockToken);
-		expect(result[0].tokens[2]).toBe(mockTwinToken2);
-	});
-
-	it('should should create single-element group for the token with no "main token" in the list', () => {
-		const tokens = [mockTwinToken1, mockSecondToken];
-
-		const result = groupTokens(tokens);
-
-		expect(result.length).toBe(2);
-
-		result.map((group) => {
-			expect(group.tokens.length).toBe(1);
-		});
-
-		expect(result[0].id).toBe(mockTwinToken1.id);
-		expect(result[1].id).toBe(mockSecondToken.id);
-
-		expect(result[0].nativeToken).toBe(mockTwinToken1);
-		expect(result[1].nativeToken).toBe(mockSecondToken);
-
-		expect(result[0].balance).toBe(mockTwinToken1.balance);
-		expect(result[1].balance).toBe(mockSecondToken.balance);
-
-		expect(result[0].usdBalance).toBe(mockTwinToken1.usdBalance);
-		expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
-
-		expect(result[0].tokens[0]).toBe(mockTwinToken1);
-		expect(result[1].tokens[0]).toBe(mockSecondToken);
-	});
-
-	it('should not re-sort the groups even if the total balance of a group would put it in a higher position in the list', () => {
 		// We mock the tokens to have the same "main token"
-		const tokens = [mockSecondToken, mockToken, mockTwinToken1, mockTwinToken2];
-
-		const result = groupTokens(tokens);
-
-		expect(result.length).toBe(2);
-
-		expect(result[0].tokens.length).not.toBe(3);
-
-		expect(result[0].id).not.toBe(mockToken.id);
-
-		expect(result[0].nativeToken).not.toBe(mockToken);
-
-		expect(result[0].balance).not.toStrictEqual(
-			mockToken.balance.add(mockTwinToken1.balance).add(mockTwinToken2.balance)
-		);
-	});
-
-	it('should group with balance undefined if any of the tokens has balance undefined', () => {
-		const mockTwinToken = {
-			...mockTwinToken1,
-			balance: undefined,
-			usdBalance: undefined
+		const twinToken = {
+			...SEPOLIA_TOKEN,
+			balance: bn2,
+			usdBalance: 250,
+			twinToken: ICP_TOKEN,
+			decimals: ICP_TOKEN.decimals
 		};
 
-		const tokens = [mockToken, mockTwinToken, mockTwinToken2];
+		it('should create a new group when no tokenGroup exists', () => {
+			expect(groupMainToken({ token, tokenGroup: undefined })).toEqual({
+				id: token.id,
+				nativeToken: token,
+				tokens: [token],
+				balance: token.balance,
+				usdBalance: token.usdBalance
+			});
+		});
 
-		const result = groupTokens(tokens);
+		it('should add token to existing group and update balances', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [twinToken],
+				balance: bn3,
+				usdBalance: 300
+			};
 
-		expect(result.length).toBe(1);
+			expect(groupMainToken({ token, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, token],
+				balance: tokenGroup.balance!.add(token.balance),
+				usdBalance: tokenGroup.usdBalance! + token.usdBalance
+			});
+		});
 
-		expect(result[0].tokens.length).toBe(3);
+		it('should add token to existing group with more than one token already', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [twinToken, anotherToken],
+				balance: bn3,
+				usdBalance: 300
+			};
 
-		expect(result[0].id).toBe(mockToken.id);
+			expect(groupMainToken({ token, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, token],
+				balance: tokenGroup.balance!.add(token.balance),
+				usdBalance: tokenGroup.usdBalance! + token.usdBalance
+			});
+		});
 
-		expect(result[0].nativeToken).toBe(mockToken);
+		it('should override the "main token" props if the group was created by a "secondary token"', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: twinToken.id,
+				nativeToken: twinToken,
+				tokens: [twinToken],
+				balance: bn3,
+				usdBalance: 300
+			};
 
-		expect(result[0].balance).toBeUndefined();
+			expect(groupMainToken({ token, tokenGroup })).toEqual({
+				...tokenGroup,
+				id: token.id,
+				nativeToken: token,
+				tokens: [...tokenGroup.tokens, token],
+				balance: tokenGroup.balance!.add(token.balance),
+				usdBalance: tokenGroup.usdBalance! + token.usdBalance
+			});
+		});
+	});
 
-		expect(result[0].usdBalance).toBe(mockToken.usdBalance + mockTwinToken2.usdBalance);
+	describe('groupSecondaryToken', () => {
+		const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
+		const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
+
+		// We mock the tokens to have the same "main token"
+		const twinToken = {
+			...SEPOLIA_TOKEN,
+			balance: bn2,
+			usdBalance: 250,
+			twinToken: ICP_TOKEN,
+			decimals: ICP_TOKEN.decimals
+		};
+
+		it('should create a new group when no tokenGroup exists', () => {
+			expect(groupSecondaryToken({ token: twinToken, tokenGroup: undefined })).toEqual({
+				id: twinToken.id,
+				nativeToken: twinToken,
+				tokens: [twinToken],
+				balance: twinToken.balance,
+				usdBalance: twinToken.usdBalance
+			});
+		});
+
+		it('should add token to existing group and update balances', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [token],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, twinToken],
+				balance: tokenGroup.balance!.add(twinToken.balance),
+				usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
+			});
+		});
+
+		it('should add token to existing group with more than one token already', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [token, anotherToken],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, twinToken],
+				balance: tokenGroup.balance!.add(twinToken.balance),
+				usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
+			});
+		});
+	});
+
+	describe('updateTokenGroup', () => {
+		const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
+		const anotherToken = { ...SEPOLIA_TOKEN, balance: bn2, usdBalance: 200 };
+
+		const tokenGroup: TokenUiGroup = {
+			id: anotherToken.id,
+			nativeToken: anotherToken,
+			tokens: [anotherToken],
+			balance: anotherToken.balance,
+			usdBalance: anotherToken.usdBalance
+		};
+
+		const expectedGroup: TokenUiGroup = {
+			...tokenGroup,
+			tokens: [anotherToken, token],
+			balance: anotherToken.balance.add(token.balance),
+			usdBalance: anotherToken.usdBalance + token.usdBalance
+		};
+
+		it('should add a token to a token group successfully', () => {
+			expect(updateTokenGroup({ token, tokenGroup })).toStrictEqual(expectedGroup);
+		});
+
+		it('should add a token to a token group with multiple tokens successfully', () => {
+			const thirdToken = { ...BTC_TESTNET_TOKEN, balance: bn3, usdBalance: 300 };
+
+			const initialGroup = updateTokenGroup({ token: thirdToken, tokenGroup });
+
+			const updatedGroup = updateTokenGroup({ token, tokenGroup: initialGroup });
+
+			expect(updatedGroup).toStrictEqual({
+				...tokenGroup,
+				tokens: [anotherToken, thirdToken, token],
+				balance: anotherToken.balance.add(thirdToken.balance).add(token.balance),
+				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
+			});
+		});
+
+		it('should handle nullish balances in tokenGroup correctly', () => {
+			expect(
+				updateTokenGroup({
+					token,
+					tokenGroup: { ...tokenGroup, balance: undefined }
+				})
+			).toStrictEqual({ ...expectedGroup, balance: undefined });
+
+			expect(
+				updateTokenGroup({
+					token,
+					tokenGroup: { ...tokenGroup, balance: null }
+				})
+			).toStrictEqual({ ...expectedGroup, balance: token.balance });
+
+			expect(
+				updateTokenGroup({
+					token,
+					tokenGroup: { ...tokenGroup, usdBalance: undefined }
+				})
+			).toStrictEqual({ ...expectedGroup, usdBalance: token.usdBalance });
+		});
+
+		it('should handle nullish balances in token correctly', () => {
+			expect(
+				updateTokenGroup({
+					token: { ...token, balance: undefined },
+					tokenGroup
+				})
+			).toStrictEqual({
+				...expectedGroup,
+				tokens: [anotherToken, { ...token, balance: undefined }],
+				balance: undefined
+			});
+
+			expect(
+				updateTokenGroup({
+					token: { ...token, balance: null },
+					tokenGroup
+				})
+			).toStrictEqual({
+				...expectedGroup,
+				tokens: [anotherToken, { ...token, balance: null }],
+				balance: tokenGroup.balance
+			});
+
+			expect(
+				updateTokenGroup({
+					token: { ...token, usdBalance: undefined },
+					tokenGroup
+				})
+			).toStrictEqual({
+				...expectedGroup,
+				tokens: [anotherToken, { ...token, usdBalance: undefined }],
+				usdBalance: tokenGroup.usdBalance
+			});
+		});
+	});
+
+	describe('groupMainToken', () => {
+		const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
+		const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
+
+		// We mock the tokens to have the same "main token"
+		const twinToken = {
+			...SEPOLIA_TOKEN,
+			balance: bn2,
+			usdBalance: 250,
+			twinToken: ICP_TOKEN,
+			decimals: ICP_TOKEN.decimals
+		};
+
+		it('should create a new group when no tokenGroup exists', () => {
+			expect(groupMainToken({ token, tokenGroup: undefined })).toEqual({
+				id: token.id,
+				nativeToken: token,
+				tokens: [token],
+				balance: token.balance,
+				usdBalance: token.usdBalance
+			});
+		});
+
+		it('should add token to existing group and update balances', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [twinToken],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupMainToken({ token, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, token],
+				balance: tokenGroup.balance!.add(token.balance),
+				usdBalance: tokenGroup.usdBalance! + token.usdBalance
+			});
+		});
+
+		it('should add token to existing group with more than one token already', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [twinToken, anotherToken],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupMainToken({ token, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, token],
+				balance: tokenGroup.balance!.add(token.balance),
+				usdBalance: tokenGroup.usdBalance! + token.usdBalance
+			});
+		});
+
+		it('should override the "main token" props if the group was created by a "secondary token"', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: twinToken.id,
+				nativeToken: twinToken,
+				tokens: [twinToken],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupMainToken({ token, tokenGroup })).toEqual({
+				...tokenGroup,
+				id: token.id,
+				nativeToken: token,
+				tokens: [...tokenGroup.tokens, token],
+				balance: tokenGroup.balance!.add(token.balance),
+				usdBalance: tokenGroup.usdBalance! + token.usdBalance
+			});
+		});
+	});
+
+	describe('groupSecondaryToken', () => {
+		const token = { ...ICP_TOKEN, balance: bn1, usdBalance: 100 };
+		const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2, usdBalance: 200 };
+
+		// We mock the tokens to have the same "main token"
+		const twinToken = {
+			...SEPOLIA_TOKEN,
+			balance: bn2,
+			usdBalance: 250,
+			twinToken: ICP_TOKEN,
+			decimals: ICP_TOKEN.decimals
+		};
+
+		it('should create a new group when no tokenGroup exists', () => {
+			expect(groupSecondaryToken({ token: twinToken, tokenGroup: undefined })).toEqual({
+				id: twinToken.id,
+				nativeToken: twinToken,
+				tokens: [twinToken],
+				balance: twinToken.balance,
+				usdBalance: twinToken.usdBalance
+			});
+		});
+
+		it('should add token to existing group and update balances', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [token],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, twinToken],
+				balance: tokenGroup.balance!.add(twinToken.balance),
+				usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
+			});
+		});
+
+		it('should add token to existing group with more than one token already', () => {
+			const tokenGroup: TokenUiGroup = {
+				id: token.id,
+				nativeToken: token,
+				tokens: [token, anotherToken],
+				balance: bn3,
+				usdBalance: 300
+			};
+
+			expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, twinToken],
+				balance: tokenGroup.balance!.add(twinToken.balance),
+				usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
+			});
+		});
+	});
+
+	describe('groupTokens', () => {
+		const mockToken = { ...SEPOLIA_TOKEN, balance: bn1, usdBalance: 100 };
+		const mockSecondToken = { ...BTC_TESTNET_TOKEN, balance: bn3, usdBalance: 300 };
+		const mockThirdToken = { ...ICP_TOKEN, balance: bn2, usdBalance: 200 };
+
+		// We mock the tokens to have the same "main token"
+		const mockTwinToken1 = {
+			...mockValidIcToken,
+			balance: bn2,
+			usdBalance: 250,
+			twinToken: mockToken,
+			decimals: mockToken.decimals
+		};
+		const mockTwinToken2 = {
+			...mockValidIcToken,
+			balance: bn1,
+			usdBalance: 450,
+			twinToken: mockToken,
+			decimals: mockToken.decimals
+		};
+
+		it('should return an empty array if no tokens are provided', () => {
+			expect(groupTokens([]).length).toBe(0);
+		});
+
+		it('should create groups of single-element tokens if none of them have a "main token"', () => {
+			const tokens = [mockToken, mockSecondToken, mockThirdToken];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(3);
+
+			result.map((group) => {
+				expect(group.tokens.length).toBe(1);
+			});
+
+			expect(result[0].id).toBe(mockToken.id);
+			expect(result[1].id).toBe(mockSecondToken.id);
+			expect(result[2].id).toBe(mockThirdToken.id);
+
+			expect(result[0].nativeToken).toBe(mockToken);
+			expect(result[1].nativeToken).toBe(mockSecondToken);
+			expect(result[2].nativeToken).toBe(mockThirdToken);
+
+			expect(result[0].balance).toBe(mockToken.balance);
+			expect(result[1].balance).toBe(mockSecondToken.balance);
+			expect(result[2].balance).toBe(mockThirdToken.balance);
+
+			expect(result[0].usdBalance).toBe(mockToken.usdBalance);
+			expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
+			expect(result[2].usdBalance).toBe(mockThirdToken.usdBalance);
+
+			expect(result[0].tokens[0]).toBe(mockToken);
+			expect(result[1].tokens[0]).toBe(mockSecondToken);
+			expect(result[2].tokens[0]).toBe(mockThirdToken);
+		});
+
+		it('should group tokens with the same "main token" and same decimals', () => {
+			const tokens = [mockToken, mockTwinToken1, mockSecondToken, mockTwinToken2];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(2);
+
+			expect(result[0].tokens.length).toBe(3);
+			expect(result[1].tokens.length).toBe(1);
+
+			expect(result[0].id).toBe(mockToken.id);
+			expect(result[1].id).toBe(mockSecondToken.id);
+
+			expect(result[0].nativeToken).toBe(mockToken);
+			expect(result[1].nativeToken).toBe(mockSecondToken);
+
+			expect(result[0].balance).toStrictEqual(
+				mockToken.balance.add(mockTwinToken1.balance).add(mockTwinToken2.balance)
+			);
+			expect(result[1].balance).toBe(mockSecondToken.balance);
+
+			expect(result[0].usdBalance).toBe(
+				mockToken.usdBalance + mockTwinToken1.usdBalance + mockTwinToken2.usdBalance
+			);
+			expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
+
+			expect(result[0].tokens[0]).toBe(mockToken);
+			expect(result[0].tokens[1]).toBe(mockTwinToken1);
+			expect(result[0].tokens[2]).toBe(mockTwinToken2);
+		});
+
+		it('should group tokens with the same "main token" but not the ones with different decimals', () => {
+			const mockTwinToken = {
+				...mockTwinToken2,
+				decimals: mockTwinToken2.decimals + 1
+			};
+
+			const tokens = [mockToken, mockTwinToken1, mockSecondToken, mockTwinToken];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(3);
+
+			expect(result[0].tokens.length).toBe(2);
+			expect(result[1].tokens.length).toBe(1);
+			expect(result[2].tokens.length).toBe(1);
+
+			expect(result[0].id).toBe(mockToken.id);
+			expect(result[1].id).toBe(mockSecondToken.id);
+			expect(result[2].id).toBe(mockTwinToken.id);
+
+			expect(result[0].nativeToken).toBe(mockToken);
+			expect(result[1].nativeToken).toBe(mockSecondToken);
+			expect(result[2].nativeToken).toBe(mockTwinToken);
+
+			expect(result[0].balance).toStrictEqual(mockToken.balance.add(mockTwinToken1.balance));
+			expect(result[1].balance).toBe(mockSecondToken.balance);
+			expect(result[2].balance).toBe(mockTwinToken.balance);
+
+			expect(result[0].usdBalance).toBe(mockToken.usdBalance + mockTwinToken1.usdBalance);
+			expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
+			expect(result[2].usdBalance).toBe(mockTwinToken.usdBalance);
+
+			expect(result[0].tokens[0]).toBe(mockToken);
+			expect(result[0].tokens[1]).toBe(mockTwinToken1);
+		});
+
+		it('should group tokens with the same "main token" respecting the order they arrive in', () => {
+			const tokens = [mockTwinToken1, mockSecondToken, mockToken, mockTwinToken2];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(2);
+
+			expect(result[0].tokens.length).toBe(3);
+			expect(result[1].tokens.length).toBe(1);
+
+			expect(result[0].id).toBe(mockToken.id);
+			expect(result[1].id).toBe(mockSecondToken.id);
+
+			expect(result[0].nativeToken).toBe(mockToken);
+			expect(result[1].nativeToken).toBe(mockSecondToken);
+
+			expect(result[0].balance).toStrictEqual(
+				mockTwinToken1.balance.add(mockToken.balance).add(mockTwinToken2.balance)
+			);
+			expect(result[1].balance).toBe(mockSecondToken.balance);
+
+			expect(result[0].usdBalance).toBe(
+				mockTwinToken1.usdBalance + mockToken.usdBalance + mockTwinToken2.usdBalance
+			);
+			expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
+
+			expect(result[0].tokens[0]).toBe(mockTwinToken1);
+			expect(result[0].tokens[1]).toBe(mockToken);
+			expect(result[0].tokens[2]).toBe(mockTwinToken2);
+		});
+
+		it('should should create single-element group for the token with no "main token" in the list', () => {
+			const tokens = [mockTwinToken1, mockSecondToken];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(2);
+
+			result.map((group) => {
+				expect(group.tokens.length).toBe(1);
+			});
+
+			expect(result[0].id).toBe(mockTwinToken1.id);
+			expect(result[1].id).toBe(mockSecondToken.id);
+
+			expect(result[0].nativeToken).toBe(mockTwinToken1);
+			expect(result[1].nativeToken).toBe(mockSecondToken);
+
+			expect(result[0].balance).toBe(mockTwinToken1.balance);
+			expect(result[1].balance).toBe(mockSecondToken.balance);
+
+			expect(result[0].usdBalance).toBe(mockTwinToken1.usdBalance);
+			expect(result[1].usdBalance).toBe(mockSecondToken.usdBalance);
+
+			expect(result[0].tokens[0]).toBe(mockTwinToken1);
+			expect(result[1].tokens[0]).toBe(mockSecondToken);
+		});
+
+		it('should not re-sort the groups even if the total balance of a group would put it in a higher position in the list', () => {
+			// We mock the tokens to have the same "main token"
+			const tokens = [mockSecondToken, mockToken, mockTwinToken1, mockTwinToken2];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(2);
+
+			expect(result[0].tokens.length).not.toBe(3);
+
+			expect(result[0].id).not.toBe(mockToken.id);
+
+			expect(result[0].nativeToken).not.toBe(mockToken);
+
+			expect(result[0].balance).not.toStrictEqual(
+				mockToken.balance.add(mockTwinToken1.balance).add(mockTwinToken2.balance)
+			);
+		});
+
+		it('should group with balance undefined if any of the tokens has balance undefined', () => {
+			const mockTwinToken = {
+				...mockTwinToken1,
+				balance: undefined,
+				usdBalance: undefined
+			};
+
+			const tokens = [mockToken, mockTwinToken, mockTwinToken2];
+
+			const result = groupTokens(tokens);
+
+			expect(result.length).toBe(1);
+
+			expect(result[0].tokens.length).toBe(3);
+
+			expect(result[0].id).toBe(mockToken.id);
+
+			expect(result[0].nativeToken).toBe(mockToken);
+
+			expect(result[0].balance).toBeUndefined();
+
+			expect(result[0].usdBalance).toBe(mockToken.usdBalance + mockTwinToken2.usdBalance);
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -160,7 +160,7 @@ describe('token-group.utils', () => {
 
 		it('should not group tokens when their decimals are mismatched', () => {
 			const groupedTokens = groupTokensByTwin(tokensWithMismatchedDecimals as TokenUi[]);
-			console.log(groupedTokens);
+
 			expect(groupedTokens).toHaveLength(5);
 
 			const fooToken = groupedTokens.find((t) => 'symbol' in t && t.symbol === 'FOO');


### PR DESCRIPTION
# Motivation

We built the util `groupTokens` in the past, to group more than 2 tokens that are twins, and we finally use it for the main function `groupTokensByTwin`.



![Screenshot 2025-01-14 at 13 19 47](https://github.com/user-attachments/assets/2aeeb07f-9291-48ff-a808-0904e3937bbe)
![Screenshot 2025-01-14 at 13 19 55](https://github.com/user-attachments/assets/96170148-b3bd-45c8-81e5-7f6a11f77973)
