### PR TITLE
feat(frontend): add Twin Tokens to Solana SPL

### DIFF
--- a/src/frontend/src/env/tokens/tokens-spl/tokens.eurc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.eurc.env.ts
@@ -1,4 +1,5 @@
 import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
+import { EURC_TOKEN as ETH_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import eurc from '$eth/assets/eurc.svg';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +20,8 @@ export const EURC_TOKEN: RequiredSplToken = {
 	symbol: EURC_SYMBOL,
 	decimals: EURC_DECIMALS,
 	icon: eurc,
-	address: 'HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr'
+	address: 'HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr',
+	twinToken: ETH_EURC_TOKEN
 };
 
 export const DEVNET_EURC_SYMBOL = 'DevnetEURC';

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.usdc.env.ts
@@ -1,4 +1,5 @@
 import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
+import { USDC_TOKEN as ETH_USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import usdc from '$eth/assets/usdc.svg';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +20,8 @@ export const USDC_TOKEN: RequiredSplToken = {
 	symbol: USDC_SYMBOL,
 	decimals: USDC_DECIMALS,
 	icon: usdc,
-	address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+	address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+	twinToken: ETH_USDC_TOKEN
 };
 
 export const DEVNET_USDC_SYMBOL = 'DevnetUSDC';

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.usdt.env.ts
@@ -1,4 +1,5 @@
 import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
+import { USDT_TOKEN as ETH_USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
 import usdt from '$eth/assets/usdt.svg';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,5 +20,6 @@ export const USDT_TOKEN: RequiredSplToken = {
 	symbol: USDT_SYMBOL,
 	decimals: USDT_DECIMALS,
 	icon: usdt,
-	address: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'
+	address: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+	twinToken: ETH_USDT_TOKEN
 };

--- a/src/frontend/src/sol/types/spl.ts
+++ b/src/frontend/src/sol/types/spl.ts
@@ -3,4 +3,4 @@ import type { RequiredToken, Token } from '$lib/types/token';
 
 export type SplToken = Token & { address: SolAddress };
 
-export type RequiredSplToken = RequiredToken<SplToken>;
+export type RequiredSplToken = RequiredToken<SplToken> & { twinToken?: Token };


### PR DESCRIPTION
# Motivation

Similar to CK Tokens, we add the `twinToken` property to SPL tokens, to group them together.
![Screenshot 2025-01-14 at 13 19 47](https://github.com/user-attachments/assets/ac42124a-af56-44dd-a510-c3519a0346cd)
![Screenshot 2025-01-14 at 13 19 55](https://github.com/user-attachments/assets/d5667cda-c99f-4aba-9aa1-837c1305f1c2)

