### PR TITLE
feat(frontend): add price for twin tokens on Solana

### DIFF
--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -67,6 +67,17 @@ export const exchanges: Readable<ExchangesData> = derived(
 					}),
 					{}
 				),
+			...$splTokens
+				.filter(({ twinToken }) => nonNullish(twinToken))
+				.reduce((acc, { id, twinToken }) => {
+					const { address } = (twinToken as Partial<Erc20Token>) ?? { address: undefined };
+					const price = nonNullish(address) ? $exchangeStore?.[address.toLowerCase()] : undefined;
+
+					return {
+						...acc,
+						[id]: price
+					};
+				}, {}),
 			...$icrcTokens.reduce((acc, token) => {
 				const { id, ledgerCanisterId, exchangeCoinId } = token;
 

--- a/src/frontend/src/sol/types/spl.ts
+++ b/src/frontend/src/sol/types/spl.ts
@@ -3,6 +3,6 @@ import type { RequiredToken, Token } from '$lib/types/token';
 
 export type SplTokenAddress = SolAddress;
 
-export type SplToken = Token & { address: SplTokenAddress };
+export type SplToken = Token & { address: SplTokenAddress; twinToken?: Token };
 
 export type RequiredSplToken = RequiredToken<SplToken> & { twinToken?: Token };


### PR DESCRIPTION
# Motivation

For consistency, we use the twin token prices for the SPL tokens of Solana that have such a token.
