### PR TITLE
refactor(frontend): case of nullish balance in BtcSendAmount

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import type { BigNumber } from 'alchemy-sdk';
 	import { getContext } from 'svelte';
 	import { BtcAmountAssertionError } from '$btc/types/btc-send';
@@ -9,6 +8,7 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
+	import { ZERO } from '$lib/constants/app.constants';
 
 	export let amount: OptionAmount = undefined;
 	export let amountError: BtcAmountAssertionError | undefined;
@@ -23,7 +23,7 @@
 			return new BtcAmountAssertionError($i18n.send.assertion.amount_invalid);
 		}
 
-		if (nonNullish($sendBalance) && userAmount.gt($sendBalance)) {
+		if (userAmount.gt($sendBalance ?? ZERO)) {
 			return new BtcAmountAssertionError($i18n.send.assertion.insufficient_funds);
 		}
 	};


### PR DESCRIPTION
# Motivation

As @DenysKarmazynDFINITY pointed out in https://github.com/dfinity/oisy-wallet/pull/4215#discussion_r1914730201 , we should consider the case that `$sendBalance` can be nullish too.
