### PR TITLE
fix(frontend): ckBTC minter info loaded on ckETH (and the contrary)

### DIFF
--- a/src/frontend/src/icp/workers/ckbtc-minter-info.worker.ts
+++ b/src/frontend/src/icp/workers/ckbtc-minter-info.worker.ts
@@ -11,13 +11,13 @@ export const onCkBtcMinterInfoMessage = async ({
 	const { msg, data } = dataMsg;
 
 	switch (msg) {
-		case 'stopCkMinterInfoTimer':
+		case 'stopCkBtcMinterInfoTimer':
 			scheduler.stop();
 			return;
-		case 'startCkMinterInfoTimer':
+		case 'startCkBtcMinterInfoTimer':
 			await scheduler.start(data);
 			return;
-		case 'triggerCkMinterInfoTimer':
+		case 'triggerCkBtcMinterInfoTimer':
 			await scheduler.trigger(data);
 			return;
 	}

--- a/src/frontend/src/icp/workers/cketh-minter-info.worker.ts
+++ b/src/frontend/src/icp/workers/cketh-minter-info.worker.ts
@@ -11,13 +11,13 @@ export const onCkEthMinterInfoMessage = async ({
 	const { msg, data } = dataMsg;
 
 	switch (msg) {
-		case 'stopCkMinterInfoTimer':
+		case 'stopCkEthMinterInfoTimer':
 			scheduler.stop();
 			return;
-		case 'startCkMinterInfoTimer':
+		case 'startCkEthMinterInfoTimer':
 			await scheduler.start(data);
 			return;
-		case 'triggerCkMinterInfoTimer':
+		case 'triggerCkEthMinterInfoTimer':
 			await scheduler.trigger(data);
 			return;
 	}

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -44,9 +44,12 @@ export const PostMessageRequestSchema = z.enum([
 	'triggerBtcStatusesTimer',
 	'stopCkBTCUpdateBalanceTimer',
 	'startCkBTCUpdateBalanceTimer',
-	'stopCkMinterInfoTimer',
-	'startCkMinterInfoTimer',
-	'triggerCkMinterInfoTimer'
+	'stopCkEthMinterInfoTimer',
+	'startCkEthMinterInfoTimer',
+	'triggerCkEthMinterInfoTimer',
+	'stopCkBtcMinterInfoTimer',
+	'startCkBtcMinterInfoTimer',
+	'triggerCkBtcMinterInfoTimer'
 ]);
 
 export const PostMessageDataRequestSchema = z.never();

--- a/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
@@ -60,9 +60,12 @@ describe('post-message.schema', () => {
 			'triggerBtcStatusesTimer',
 			'stopCkBTCUpdateBalanceTimer',
 			'startCkBTCUpdateBalanceTimer',
-			'stopCkMinterInfoTimer',
-			'startCkMinterInfoTimer',
-			'triggerCkMinterInfoTimer'
+			'stopCkEthMinterInfoTimer',
+			'startCkEthMinterInfoTimer',
+			'triggerCkEthMinterInfoTimer',
+			'stopCkBtcMinterInfoTimer',
+			'startCkBtcMinterInfoTimer',
+			'triggerCkBtcMinterInfoTimer'
 		];
 
 		const invalidCases = [


### PR DESCRIPTION
# Motivation

We merged the workers into a single entry in #4180, which is great for performance reasons but implies that messages should be unique. It turns out this is not the case when loading the minter info—for example, the same messages were used for ckBTC and ckETH. As a result, when a user navigates to a ck token, the page attempts to load information for both ckETH and ckBTC. Given that their APIs are different, the responses cannot be decoded correctly for one or the other.

# Notes

There might be better solutions; this is just a quick fix.

# Changes

- Duplicated the messages to ensure uniqueness.
- Added a `postMessage` key to interact with the worker, as the UI-side code is shared.
- Moved the code to load the worker, making it more explicit that there is a single entry.

# Tests

No tests or debugging were performed.
