### PR TITLE
refactor(frontend): move WalletConnect generic constants to lib

### DIFF
--- a/src/frontend/src/eth/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/eth/constants/wallet-connect.constants.ts
@@ -1,23 +1,5 @@
-import { OISY_DESCRIPTION, OISY_ICON, OISY_NAME, OISY_URL } from '$lib/constants/oisy.constants';
-import type { AuthClientTypes } from '@walletconnect/auth-client';
-import type { ErrorResponse } from '@walletconnect/jsonrpc-utils';
-
-export const WALLET_CONNECT_METADATA: AuthClientTypes.Metadata = {
-	name: OISY_NAME,
-	description: OISY_DESCRIPTION,
-	url: OISY_URL,
-	icons: [OISY_ICON]
-};
-
 // Ethereum methods
 export const SESSION_REQUEST_ETH_SEND_TRANSACTION = 'eth_sendTransaction';
 export const SESSION_REQUEST_ETH_SIGN = 'eth_sign';
 export const SESSION_REQUEST_PERSONAL_SIGN = 'personal_sign';
 export const SESSION_REQUEST_ETH_SIGN_V4 = 'eth_signTypedData_v4';
-
-export const UNEXPECTED_ERROR: ErrorResponse = {
-	code: 20001,
-	message: 'Unexpected error.'
-};
-
-export const CONTEXT_VALIDATION_ISSCAM = 'ISSCAM';

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -1,4 +1,3 @@
-import { UNEXPECTED_ERROR } from '$eth/constants/wallet-connect.constants';
 import { send as executeSend } from '$eth/services/send.services';
 import type { FeeStoreData } from '$eth/stores/fee.store';
 import type { SendParams } from '$eth/types/send';
@@ -12,6 +11,7 @@ import {
 	TRACK_COUNT_WC_ETH_SEND_ERROR,
 	TRACK_COUNT_WC_ETH_SEND_SUCCESS
 } from '$lib/constants/analytics.contants';
+import { UNEXPECTED_ERROR } from '$lib/constants/wallet-connect.constants';
 import { ProgressStepsSend, ProgressStepsSign } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
 import {

--- a/src/frontend/src/eth/utils/wallet-connect.utils.ts
+++ b/src/frontend/src/eth/utils/wallet-connect.utils.ts
@@ -1,5 +1,5 @@
-import { CONTEXT_VALIDATION_ISSCAM } from '$eth/constants/wallet-connect.constants';
 import type { WalletConnectEthSignTypedDataV4 } from '$eth/types/wallet-connect';
+import { CONTEXT_VALIDATION_ISSCAM } from '$lib/constants/wallet-connect.constants';
 import { isEthAddress } from '$lib/utils/account.utils';
 import { isNullish } from '@dfinity/utils';
 import type { Verify } from '@walletconnect/types';

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectDomainVerification.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectDomainVerification.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { Verify } from '@walletconnect/types';
 	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
-	import { CONTEXT_VALIDATION_ISSCAM } from '$eth/constants/wallet-connect.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Option } from '$lib/types/utils';
+	import { CONTEXT_VALIDATION_ISSCAM } from '$lib/constants/wallet-connect.constants';
 
 	export let proposal: Option<Web3WalletTypes.SessionProposal>;
 

--- a/src/frontend/src/lib/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/lib/constants/wallet-connect.constants.ts
@@ -1,0 +1,17 @@
+import { OISY_DESCRIPTION, OISY_ICON, OISY_NAME, OISY_URL } from '$lib/constants/oisy.constants';
+import type { AuthClientTypes } from '@walletconnect/auth-client';
+import type { ErrorResponse } from '@walletconnect/jsonrpc-utils';
+
+export const WALLET_CONNECT_METADATA: AuthClientTypes.Metadata = {
+	name: OISY_NAME,
+	description: OISY_DESCRIPTION,
+	url: OISY_URL,
+	icons: [OISY_ICON]
+};
+
+export const UNEXPECTED_ERROR: ErrorResponse = {
+	code: 20001,
+	message: 'Unexpected error.'
+};
+
+export const CONTEXT_VALIDATION_ISSCAM = 'ISSCAM';

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -4,9 +4,9 @@ import {
 	SESSION_REQUEST_ETH_SEND_TRANSACTION,
 	SESSION_REQUEST_ETH_SIGN,
 	SESSION_REQUEST_ETH_SIGN_V4,
-	SESSION_REQUEST_PERSONAL_SIGN,
-	WALLET_CONNECT_METADATA
+	SESSION_REQUEST_PERSONAL_SIGN
 } from '$eth/constants/wallet-connect.constants';
+import { WALLET_CONNECT_METADATA } from '$lib/constants/wallet-connect.constants';
 import type { EthAddress, OptionSolAddress } from '$lib/types/address';
 import type { WalletConnectListener } from '$lib/types/wallet-connect';
 import { Core } from '@walletconnect/core';


### PR DESCRIPTION
# Motivation

Since they will be used for more network, we move some WalletConnect constants to `lib`.
