### PR TITLE
fix(frontend): forgot to remove default icon of Support

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -176,7 +176,7 @@
 
 		<ChangelogLink />
 
-		<ExternalLink href="mailto:support@oisy.com" ariaLabel={$i18n.navigation.alt.support_email}>
+		<ExternalLink href="mailto:support@oisy.com" ariaLabel={$i18n.navigation.alt.support_email} iconVisible={false}>
 			<IconHelp />
 			{$i18n.navigation.text.support_email}
 		</ExternalLink>

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -176,7 +176,11 @@
 
 		<ChangelogLink />
 
-		<ExternalLink href="mailto:support@oisy.com" ariaLabel={$i18n.navigation.alt.support_email} iconVisible={false}>
+		<ExternalLink
+			href="mailto:support@oisy.com"
+			ariaLabel={$i18n.navigation.alt.support_email}
+			iconVisible={false}
+		>
 			<IconHelp />
 			{$i18n.navigation.text.support_email}
 		</ExternalLink>


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/oisy-wallet/pull/4280 I forgot to remove the existing icon of `ExternalLink` component.

### Before

![Screenshot 2025-01-15 at 14 09 28](https://github.com/user-attachments/assets/6c3f1f15-00b7-4061-b392-2628e544ea70)


### After

![Screenshot 2025-01-15 at 14 09 17](https://github.com/user-attachments/assets/0a9ccc4a-53ad-4ee4-ae56-88c86554b54f)
