### PR TITLE
refactor(frontend): extract functions to sign and send Solana transactions

### DIFF
--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -2,6 +2,10 @@ import { solTransactionTypes } from '$lib/schema/transaction.schema';
 import type { TransactionType, TransactionUiCommon } from '$lib/types/transaction';
 import type { GetSignaturesForAddressApi, GetTransactionApi } from '@solana/rpc';
 import type { Commitment } from '@solana/rpc-types';
+import type {
+	FullySignedTransaction,
+	TransactionWithBlockhashLifetime
+} from '@solana/transactions';
 
 export type SolTransactionType = Extract<
 	TransactionType,
@@ -24,3 +28,5 @@ export type SolRpcTransaction = NonNullable<ReturnType<GetTransactionApi['getTra
 export type SolSignature = ReturnType<
 	GetSignaturesForAddressApi['getSignaturesForAddress']
 >[number];
+
+export type SolSignedTransaction = FullySignedTransaction & TransactionWithBlockhashLifetime;

--- a/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
@@ -24,6 +24,11 @@ vi.mock('@solana/signers', () => ({
 	signTransactionMessageWithSigners: vi.fn()
 }));
 
+vi.mock('@solana/transactions', () => ({
+	assertTransactionIsFullySigned: vi.fn(),
+	getSignatureFromTransaction: vi.fn()
+}));
+
 vi.mock('@solana/transaction-messages', () => ({
 	createTransactionMessage: vi.fn(),
 	setTransactionMessageFeePayer: vi.fn(),


### PR DESCRIPTION
# Motivation

To make the code more manageable, we create two functions: one that signs a Solana transactions and one that sends a Solana signed transaction.
