### PR TITLE
feat(frontend): disable Swap button if new quote is loading

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -57,9 +57,8 @@
 				})
 			: undefined;
 
-	let newSwapAmount = false;
-	// if it's true, it means we are currently fetching a new "swapAmounts" value
-	$: newSwapAmount =
+	let swapAmountsLoading = false;
+	$: swapAmountsLoading =
 		nonNullish(swapAmount) && nonNullish($swapAmountsStore?.amountForSwap)
 			? Number(swapAmount) !== Number($swapAmountsStore.amountForSwap)
 			: false;
@@ -72,7 +71,7 @@
 		isNullish(swapAmount) ||
 		Number(swapAmount) <= 0 ||
 		isNullish(receiveAmount) ||
-		newSwapAmount ||
+		swapAmountsLoading ||
 		Number(slippageValue) >= SWAP_SLIPPAGE_INVALID_VALUE;
 
 	const onTokensSwitch = () => {
@@ -131,7 +130,7 @@
 			<SwapSelectToken
 				token={$destinationToken}
 				amount={receiveAmount}
-				loading={newSwapAmount}
+				loading={swapAmountsLoading}
 				disabled={true}
 				on:click={() => {
 					dispatch('icShowTokensList', 'destination');

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -57,6 +57,13 @@
 				})
 			: undefined;
 
+	let newSwapAmount = false;
+	// if it's true, it means we are currently fetching a new "swapAmounts" value
+	$: newSwapAmount =
+		nonNullish(swapAmount) && nonNullish($swapAmountsStore?.amountForSwap)
+			? Number(swapAmount) !== Number($swapAmountsStore.amountForSwap)
+			: false;
+
 	const dispatch = createEventDispatcher();
 
 	let invalid: boolean;
@@ -65,6 +72,7 @@
 		isNullish(swapAmount) ||
 		Number(swapAmount) <= 0 ||
 		isNullish(receiveAmount) ||
+		newSwapAmount ||
 		Number(slippageValue) >= SWAP_SLIPPAGE_INVALID_VALUE;
 
 	const onTokensSwitch = () => {
@@ -123,6 +131,7 @@
 			<SwapSelectToken
 				token={$destinationToken}
 				amount={receiveAmount}
+				loading={newSwapAmount}
 				disabled={true}
 				on:click={() => {
 					dispatch('icShowTokensList', 'destination');

--- a/src/frontend/src/lib/components/swap/SwapInputCurrency.svelte
+++ b/src/frontend/src/lib/components/swap/SwapInputCurrency.svelte
@@ -12,9 +12,9 @@
 </script>
 
 <div
-	class:animate-pulse={loading}
 	class="swap-input-currency h-full w-full font-bold"
 	class:text-error={error}
+	class:animate-pulse={loading}
 >
 	<InputCurrency bind:value {name} {placeholder} {disabled} {decimals} on:focus on:blur>
 		<slot name="inner-end" slot="inner-end" />

--- a/src/frontend/src/lib/components/swap/SwapInputCurrency.svelte
+++ b/src/frontend/src/lib/components/swap/SwapInputCurrency.svelte
@@ -8,9 +8,14 @@
 	export let disabled = false;
 	export let placeholder = '0';
 	export let error = false;
+	export let loading = false;
 </script>
 
-<div class="swap-input-currency h-full w-full font-bold" class:text-error={error}>
+<div
+	class:animate-pulse={loading}
+	class="swap-input-currency h-full w-full font-bold"
+	class:text-error={error}
+>
 	<InputCurrency bind:value {name} {placeholder} {disabled} {decimals} on:focus on:blur>
 		<slot name="inner-end" slot="inner-end" />
 	</InputCurrency>

--- a/src/frontend/src/lib/components/swap/SwapSelectToken.svelte
+++ b/src/frontend/src/lib/components/swap/SwapSelectToken.svelte
@@ -22,6 +22,7 @@
 	export let placeholder = '0';
 	export let errorType: ConvertAmountErrorType = undefined;
 	export let amountSetToMax = false;
+	export let loading = false;
 	export let customValidate: (userAmount: BigNumber) => ConvertAmountErrorType = () => undefined;
 
 	const dispatch = createEventDispatcher();
@@ -70,6 +71,7 @@
 					{name}
 					{placeholder}
 					{disabled}
+					{loading}
 					decimals={token.decimals}
 					error={nonNullish(errorType)}
 					on:focus={onFocus}


### PR DESCRIPTION
# Motivation

One of the feature feedbacks was that we need to disable Swap button if a new quote is loading (e.g. when user typed a new swapAmount). This PR implements this suggestion. Also, I added a small pulse effect to the receive input to highlight that there is an ongoing loading.
