### PR TITLE
feat(frontend): use prod kong_backend in all envs

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -33,12 +33,12 @@
 				"id": {
 					"ic": "2ipq2-uqaaa-aaaar-qailq-cai",
 					"beta": "2ipq2-uqaaa-aaaar-qailq-cai",
-					"test_be_1": "l4lgk-raaaa-aaaar-qahpq-cai",
-					"test_fe_1": "l4lgk-raaaa-aaaar-qahpq-cai",
-					"test_fe_2": "l4lgk-raaaa-aaaar-qahpq-cai",
-					"test_fe_3": "l4lgk-raaaa-aaaar-qahpq-cai",
-					"test_fe_4": "l4lgk-raaaa-aaaar-qahpq-cai",
-					"staging": "l4lgk-raaaa-aaaar-qahpq-cai"
+					"test_be_1": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"test_fe_1": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"test_fe_2": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"test_fe_3": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"test_fe_4": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"staging": "2ipq2-uqaaa-aaaar-qailq-cai"
 				}
 			}
 		},


### PR DESCRIPTION
# Motivation

The staging kong_backend canister is not very stable, has very limited amount of pools and some broken endpoints (e.g. `tokens`). Therefore, it makes sense for us to use the prod canister in all testing and staging envs (same as we do with II). Beta and prod already use the correct one.
