### PR TITLE
fix(frontend): show Tokens page when in WalletConnect link page

### DIFF
--- a/src/frontend/src/lib/constants/routes.constants.ts
+++ b/src/frontend/src/lib/constants/routes.constants.ts
@@ -3,7 +3,8 @@ export enum AppPath {
 	Explore = '/explore',
 	Settings = '/settings',
 	Transactions = '/transactions',
-	Activity = '/activity'
+	Activity = '/activity',
+	WalletConnect = '/wc'
 }
 
 // SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId. It also prefixes it with /.

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -29,7 +29,9 @@ export const isRouteDappExplorer = ({ route: { id } }: Page): boolean =>
 export const isRouteActivity = ({ route: { id } }: Page): boolean =>
 	id === `${ROUTE_ID_GROUP_APP}${AppPath.Activity}`;
 
-export const isRouteTokens = ({ route: { id } }: Page): boolean => id === ROUTE_ID_GROUP_APP;
+// The page of the link for WalletConnect is the same as the page where we show the Tokens list
+export const isRouteTokens = ({ route: { id } }: Page): boolean =>
+	id === ROUTE_ID_GROUP_APP || id === `${ROUTE_ID_GROUP_APP}${AppPath.WalletConnect}`;
 
 const tokenUrl = ({
 	token: {

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -317,6 +317,10 @@ describe('nav.utils', () => {
 				expect(isRouteTokens(mockPage(ROUTE_ID_GROUP_APP))).toBe(true);
 			});
 
+			it('should return true when route id matches Wallet Connect path', () => {
+				expect(isRouteTokens(mockPage(`${ROUTE_ID_GROUP_APP}${AppPath.WalletConnect}`))).toBe(true);
+			});
+
 			it('should return false when route id does not match ROUTE_ID_GROUP_APP exactly', () => {
 				expect(isRouteTokens(mockPage(`${ROUTE_ID_GROUP_APP}/wrongPath`))).toBe(false);
 


### PR DESCRIPTION
# Motivation

The route that opens when an user is redirected by WalletConnect should be the same of the main page (the Tokens List). However there are some checks that are managed by the util `isRouteTokens`, for example showing or not the `Hero`.

To make it the same for the two routes, we include the check for Wallet Connect route inside `isRouteTokens`.


