### PR TITLE
refactor(frontend): move icrc services from Swap component

### DIFF
--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -1,21 +1,16 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
+	import { isNullish } from '@dfinity/utils';
 	import { setContext } from 'svelte';
-	import { ICRC_CK_TOKENS_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
-	import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
-	import { balance } from '$icp/api/icrc-ledger.api';
-	import type { LedgerCanisterIdText } from '$icp/types/canister';
-	import type { IcCkToken } from '$icp/types/ic-token';
+	import {
+		loadDisabledIcrcTokensBalances,
+		loadDisabledIcrcTokensExchanges
+	} from '$icp/services/icrc.services';
 	import SwapButtonWithModal from '$lib/components/swap/SwapButtonWithModal.svelte';
 	import SwapModal from '$lib/components/swap/SwapModal.svelte';
 	import { allDisabledIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalSwap } from '$lib/derived/modal.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { exchangeRateERC20ToUsd, exchangeRateICRCToUsd } from '$lib/services/exchange.services';
-	import { balancesStore } from '$lib/stores/balances.store';
-	import { exchangeStore } from '$lib/stores/exchange.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import {
 		initSwapAmountsStore,
@@ -35,62 +30,13 @@
 
 		modalStore.openSwap(tokenId);
 
-		const loadDisabledIcrcTokensBalances = (): Promise<void[]> =>
-			Promise.all(
-				$allDisabledIcrcTokens.map(async ({ ledgerCanisterId, id }) => {
-					const icrcTokenBalance = await balance({
-						identity: $authIdentity,
-						owner: $authIdentity.getPrincipal(),
-						ledgerCanisterId
-					});
-
-					balancesStore.set({
-						tokenId: id,
-						data: {
-							data: BigNumber.from(icrcTokenBalance),
-							certified: true
-						}
-					});
-				})
-			);
-
-		const loadDisabledIcrcTokensExchanges = async (): Promise<void> => {
-			const [currentErc20Prices, currentIcrcPrices] = await Promise.all([
-				exchangeRateERC20ToUsd(
-					$allDisabledIcrcTokens.reduce<Erc20ContractAddress[]>((acc, token) => {
-						const twinTokenAddress = (
-							(token as Partial<IcCkToken>).twinToken as Erc20Token | undefined
-						)?.address;
-
-						return nonNullish(twinTokenAddress)
-							? [
-									...acc,
-									{
-										address: twinTokenAddress
-									}
-								]
-							: acc;
-					}, [])
-				),
-				exchangeRateICRCToUsd(
-					$allDisabledIcrcTokens.reduce<LedgerCanisterIdText[]>(
-						(acc, { ledgerCanisterId }) =>
-							!ICRC_CK_TOKENS_LEDGER_CANISTER_IDS.includes(ledgerCanisterId)
-								? [...acc, ledgerCanisterId]
-								: acc,
-						[]
-					)
-				)
-			]);
-
-			exchangeStore.set([
-				...(nonNullish(currentErc20Prices) ? [currentErc20Prices] : []),
-				...(nonNullish(currentIcrcPrices) ? [currentIcrcPrices] : [])
-			]);
-		};
-
-		await loadDisabledIcrcTokensBalances();
-		await loadDisabledIcrcTokensExchanges();
+		await loadDisabledIcrcTokensBalances({
+			identity: $authIdentity,
+			disabledIcrcTokens: $allDisabledIcrcTokens
+		});
+		await loadDisabledIcrcTokensExchanges({
+			disabledIcrcTokens: $allDisabledIcrcTokens
+		});
 	};
 </script>
 


### PR DESCRIPTION
# Motivation

This PR refactors the Swap component by moving icrc-related services into the dedicated to them file. Also, some unit tests have been added.
