### PR TITLE
feat(frontend): modal to sign Solana requests from WalletConnect

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { assertNonNullish } from '@dfinity/utils';
+	import type { Web3WalletTypes } from '@walletconnect/web3wallet';
+	import { onMount } from 'svelte';
+	import {
+		SOLANA_DEVNET_TOKEN,
+		SOLANA_LOCAL_TOKEN,
+		SOLANA_TESTNET_TOKEN,
+		SOLANA_TOKEN
+	} from '$env/tokens/tokens.sol.env';
+	import WalletConnectModalTitle from '$lib/components/wallet-connect/WalletConnectModalTitle.svelte';
+	import {
+		solAddressDevnet,
+		solAddressLocal,
+		solAddressMainnet,
+		solAddressTestnet
+	} from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { ProgressStepsSign } from '$lib/enums/progress-steps';
+	import { WizardStepsSign } from '$lib/enums/wizard-steps';
+	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionSolAddress } from '$lib/types/address';
+	import type { NetworkId } from '$lib/types/network';
+	import type { Token } from '$lib/types/token';
+	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
+	import {
+		isNetworkIdSOLDevnet,
+		isNetworkIdSOLLocal,
+		isNetworkIdSOLTestnet
+	} from '$lib/utils/network.utils';
+	import SolSendProgress from '$sol/components/send/SolSendProgress.svelte';
+	import SolWalletConnectSendReview from '$sol/components/wallet-connect/SolWalletConnectSendReview.svelte';
+	import {
+		sign as signService,
+		decode as decodeService
+	} from '$sol/services/wallet-connect.services';
+	import type { SolanaNetwork } from '$sol/types/network';
+
+	export let request: Web3WalletTypes.SessionRequest;
+	export let network: SolanaNetwork;
+
+	/**
+	 * Transaction
+	 */
+
+	let networkId: NetworkId;
+	$: ({ id: networkId } = network);
+
+	let address: OptionSolAddress;
+	let token: Token;
+	$: [address, token] = isNetworkIdSOLTestnet(networkId)
+		? [$solAddressTestnet, SOLANA_TESTNET_TOKEN]
+		: isNetworkIdSOLDevnet(networkId)
+			? [$solAddressDevnet, SOLANA_DEVNET_TOKEN]
+			: isNetworkIdSOLLocal(networkId)
+				? [$solAddressLocal, SOLANA_LOCAL_TOKEN]
+				: [$solAddressMainnet, SOLANA_TOKEN];
+
+	let data: string;
+	let amount: bigint | undefined;
+	let destination: OptionSolAddress;
+
+	onMount(async () => {
+		data = request.params.request.params.transaction;
+
+		({ amount, destination } = await decodeService({
+			base64EncodedTransactionMessage: data,
+			networkId
+		}));
+	});
+
+	/**
+	 * Modal
+	 */
+
+	const steps: WizardSteps = [
+		{
+			name: WizardStepsSign.REVIEW,
+			title: $i18n.send.text.review
+		},
+		{
+			name: WizardStepsSign.SIGNING,
+			title: $i18n.send.text.signing
+		}
+	];
+
+	let currentStep: WizardStep | undefined;
+	let modal: WizardModal;
+
+	const close = () => modalStore.close();
+
+	/**
+	 * WalletConnect
+	 */
+
+	export let listener: OptionWalletConnectListener;
+
+	/**
+	 * Reject a transaction
+	 */
+
+	const reject = async () => {
+		await rejectServices({ listener, request });
+
+		close();
+	};
+
+	/**
+	 * Send and approve
+	 */
+
+	let sendProgressStep: string = ProgressStepsSign.INITIALIZATION;
+
+	const send = async () => {
+		const { success } = await signService({
+			request,
+			listener,
+			address,
+			modalNext: modal.next,
+			token,
+			progress: (step: ProgressStepsSign) => (sendProgressStep = step),
+			identity: $authIdentity
+		});
+
+		setTimeout(() => close(), success ? 750 : 0);
+	};
+</script>
+
+<WizardModal {steps} bind:currentStep bind:this={modal} on:nnsClose={reject}>
+	<WalletConnectModalTitle slot="title"
+	>{$i18n.wallet_connect.text.sign_message}</WalletConnectModalTitle
+	>
+
+	{#if currentStep?.name === WizardStepsSign.SIGNING}
+		<SolSendProgress bind:sendProgressStep />
+	{:else}
+		<SolWalletConnectSendReview
+			amount={amount ?? 0n}
+			destination={destination ?? ''}
+			{data}
+			{token}
+			on:icApprove={send}
+			on:icReject={reject}
+		/>
+	{/if}
+</WizardModal>


### PR DESCRIPTION
# Motivation

Similar to Ethereum, we create a modal that will be used in case the WalletConnect listener receives a Solana sign request.
![Screenshot 2025-01-20 at 11 32 45](https://github.com/user-attachments/assets/34d7d83c-bbc2-4a5e-b9d8-a440b000ad76)

