### PR TITLE
feat(frontend): increase exchange refresh to 2 minutes

### DIFF
--- a/src/frontend/src/lib/constants/exchange.constants.ts
+++ b/src/frontend/src/lib/constants/exchange.constants.ts
@@ -5,6 +5,6 @@ import { SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
  * The CoinGecko Public API imposes a rate limit of 5 to 15 calls per minute, depending on global usage conditions.
  *
  * While the limitations of Coingecko appeared suitable for our initial use case involving two calls (ETH and ERC20), in practice, we've observed that Coingecko frequently generates errors.
- * As a result, we've restricted synchronization to a once-per-minute refresh.
+ * As a result, we've restricted synchronization to refresh every certain amount of time.
  */
 export const SYNC_EXCHANGE_TIMER_INTERVAL = SECONDS_IN_MINUTE * 1000 * 2; // 2 minute

--- a/src/frontend/src/lib/constants/exchange.constants.ts
+++ b/src/frontend/src/lib/constants/exchange.constants.ts
@@ -7,4 +7,4 @@ import { SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
  * While the limitations of Coingecko appeared suitable for our initial use case involving two calls (ETH and ERC20), in practice, we've observed that Coingecko frequently generates errors.
  * As a result, we've restricted synchronization to a once-per-minute refresh.
  */
-export const SYNC_EXCHANGE_TIMER_INTERVAL = SECONDS_IN_MINUTE * 1000; // 1 minute
+export const SYNC_EXCHANGE_TIMER_INTERVAL = SECONDS_IN_MINUTE * 1000 * 2; // 2 minute


### PR DESCRIPTION
# Motivation

To cope with the limits of our Coingecko subscription, and with the expansion of the user base, it was requested that we increase the exchange worker interval to refresh the exchange rates.
