### PR TITLE
refactor(frontend): create approve step for WalletConnect

### DIFF
--- a/src/frontend/src/eth/constants/steps.constants.ts
+++ b/src/frontend/src/eth/constants/steps.constants.ts
@@ -1,6 +1,5 @@
 import { ProgressStepsSend, ProgressStepsSign } from '$lib/enums/progress-steps';
 import type { ProgressSteps } from '$lib/types/progress-steps';
-import type { ProgressStep } from '@dfinity/gix-components';
 
 export const sendSteps = ({
 	i18n,
@@ -13,31 +12,31 @@ export const sendSteps = ({
 		step: ProgressStepsSend.INITIALIZATION,
 		text: i18n.send.text.initializing_transaction,
 		state: 'in_progress'
-	} as ProgressStep,
+	},
 	...(sendWithApproval
-		? [
+		? ([
 				{
 					step: ProgressStepsSend.SIGN_APPROVE,
 					text: i18n.send.text.signing_approval,
 					state: 'next'
-				} as ProgressStep,
+				},
 				{
 					step: ProgressStepsSend.APPROVE,
 					text: i18n.send.text.approving,
 					state: 'next'
-				} as ProgressStep
-			]
+				}
+			] as ProgressSteps)
 		: []),
 	{
 		step: ProgressStepsSend.SIGN_TRANSFER,
 		text: i18n.send.text.signing_transaction,
 		state: 'next'
-	} as ProgressStep,
+	},
 	{
 		step: ProgressStepsSend.TRANSFER,
 		text: i18n.send.text.sending,
 		state: 'next'
-	} as ProgressStep
+	}
 ];
 
 export const walletConnectSendSteps = ({
@@ -63,15 +62,15 @@ export const walletConnectSignSteps = (i18n: I18n): ProgressSteps => [
 		step: ProgressStepsSign.INITIALIZATION,
 		text: i18n.send.text.initializing,
 		state: 'in_progress'
-	} as ProgressStep,
+	},
 	{
 		step: ProgressStepsSign.SIGN,
 		text: i18n.send.text.signing_message,
 		state: 'next'
-	} as ProgressStep,
+	},
 	{
-		step: ProgressStepsSign.APPROVE,
-		text: i18n.send.text.approving,
+		step: ProgressStepsSign.APPROVE_WALLET_CONNECT,
+		text: i18n.send.text.approving_wallet_connect,
 		state: 'next'
-	} as ProgressStep
+	}
 ];

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -238,7 +238,7 @@ export const signMessage = ({
 
 				const signedMessage = await sign(params);
 
-				progress(ProgressStepsSign.APPROVE);
+				progress(ProgressStepsSign.APPROVE_WALLET_CONNECT);
 
 				await listener.approveRequest({ topic, id, message: signedMessage });
 

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -29,6 +29,7 @@ export enum ProgressStepsSign {
 	INITIALIZATION = 'initialization',
 	SIGN = 'sign',
 	APPROVE = 'approve',
+	APPROVE_WALLET_CONNECT = 'approve_wallet_connect',
 	DONE = 'done'
 }
 


### PR DESCRIPTION
# Motivation

For consistency, we add the `APPROVE_WALLET_CONNECT` to the steps of signing a WalletConnect transaction.
