### PR TITLE
feat(frontend): use kong-swap-tokens store

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -6,7 +6,7 @@
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import InputSearch from '$lib/components/ui/InputSearch.svelte';
-	import { allIcrcTokens } from '$lib/derived/all-tokens.derived';
+	import { allKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -25,7 +25,7 @@
 
 	let tokens: Token[];
 	$: tokens = pinTokensWithBalanceAtTop({
-		$tokens: [ICP_TOKEN, ...$allIcrcTokens].filter(
+		$tokens: [ICP_TOKEN, ...$allKongSwapCompatibleIcrcTokens].filter(
 			(token: Token) => token.id !== $sourceToken?.id && token.id !== $destinationToken?.id
 		),
 		$exchanges: $exchanges,

--- a/src/frontend/src/tests/lib/derived/all-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/all-tokens.derived.spec.ts
@@ -16,11 +16,15 @@ import {
 } from '$env/tokens/tokens.sol.env';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
 import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
-import { icrcTokens } from '$icp/derived/icrc.derived';
+import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import * as icrcCustomTokensServices from '$icp/services/icrc-custom-tokens.services';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import * as appContants from '$lib/constants/app.constants';
-import { allTokens } from '$lib/derived/all-tokens.derived';
+import {
+	allDisabledKongSwapCompatibleIcrcTokens,
+	allKongSwapCompatibleIcrcTokens,
+	allTokens
+} from '$lib/derived/all-tokens.derived';
 import { testnetsStore } from '$lib/stores/settings.store';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { splTokens } from '$sol/derived/spl.derived';
@@ -191,6 +195,54 @@ describe('all-tokens.derived', () => {
 				SOLANA_DEVNET_TOKEN.id.description,
 				SOLANA_LOCAL_TOKEN.id.description
 			]);
+		});
+	});
+
+	describe('allDisabledKongSwapCompatibleIcrcTokens', () => {
+		beforeEach(() => {
+			vi.spyOn(allKongSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([]);
+				return () => {};
+			});
+			vi.spyOn(enabledIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([]);
+				return () => {};
+			});
+		});
+
+		it('correctly sets store if there are some disabled kong-compatible icrc tokens', () => {
+			vi.spyOn(allKongSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockIcrcToken, mockIcrcToken2]);
+				return () => {};
+			});
+			vi.spyOn(enabledIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockIcrcToken2]);
+				return () => {};
+			});
+
+			expect(get(allDisabledKongSwapCompatibleIcrcTokens)).toStrictEqual([mockIcrcToken]);
+		});
+
+		it('correctly sets store if all icrc tokens are enabled', () => {
+			vi.spyOn(allKongSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockIcrcToken, mockIcrcToken2]);
+				return () => {};
+			});
+			vi.spyOn(enabledIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockIcrcToken, mockIcrcToken2]);
+				return () => {};
+			});
+
+			expect(get(allDisabledKongSwapCompatibleIcrcTokens)).toStrictEqual([]);
+		});
+
+		it('correctly sets store if there are no kong-compatible tokens', () => {
+			vi.spyOn(enabledIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockIcrcToken, mockIcrcToken2]);
+				return () => {};
+			});
+
+			expect(get(allDisabledKongSwapCompatibleIcrcTokens)).toStrictEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

In this PR, instead of using the store with all disabled ICRC tokens, we filter all uncompatible with kong_backend entries to avoid fetching unnecessary balances and exchanges, as well as not to render them in the tokens list. Data for kong-swap-tokens store will be fetched only on the first open of the Swap modal.
