### PR TITLE
fix(ci): correct BOT policies wildcard

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -10,4 +10,4 @@ e2e/**/*.png
 declarations/**/*
 src/frontend/src/env/tokens/tokens.*.json
 src/frontend/src/env/tokens/tokens-erc20/
-src/frontend/static/icons/sns/
+src/frontend/static/icons/sns/*


### PR DESCRIPTION
# Motivation

The CIs for the BOT Repo Policies are failing at https://github.com/dfinity/oisy-wallet/pull/4361 most probably because we are missing a wildcard in the SNS icon folder path.
