### PR TITLE
refactor(devops): Install tools consistently

### DIFF
--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -71,11 +71,7 @@ jobs:
 
       - name: Install binstall
         if: steps.changes.outputs.src == 'true'
-        run: |
-          BINSTALL_VERSION="1.8.0"
-          curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf - cargo-binstall
-          ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"
-          rm cargo-binstall
+        run: scripts/setup cargo-binstall
 
       - name: Install candid-extractor
         if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install shfmt
-        run: sudo snap install --classic shfmt
+        run: scripts/setup shfmt
 
       - name: Install binstall
         run: scripts/setup cargo-binstall

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -49,11 +49,7 @@ jobs:
         run: sudo snap install --classic shfmt
 
       - name: Install binstall
-        run: |
-          BINSTALL_VERSION="1.8.0"
-          curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf - cargo-binstall
-          ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"
-          rm cargo-binstall
+        run: scripts/setup cargo-binstall
 
       - name: Install cargo dependency sorter
         run: cargo binstall --no-confirm cargo-sort@1.0.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -L https://github.com/mikefarah/yq/releases/download/v4.33.3/yq_linux_amd64 | install -m 755 /dev/stdin /bin/yq && yq --version | grep yq
-
 # Install node
 RUN curl --fail -sSf https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 ENV NVM_DIR=/root/.nvm
@@ -44,7 +42,7 @@ COPY ./rust-toolchain.toml ./rust-toolchain.toml
 COPY rust-toolchain.toml .
 COPY dev-tools.json .
 COPY scripts/setup scripts/setup-cargo-binstall scripts/setup-rust scripts/
-RUN scripts/setup rust cargo-binstall ic-wasm
+RUN scripts/setup rust cargo-binstall ic-wasm yq
 
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,12 @@ COPY ./rust-toolchain.toml ./rust-toolchain.toml
 COPY rust-toolchain.toml .
 COPY dev-tools.json .
 COPY scripts/setup scripts/setup-cargo-binstall scripts/setup-rust scripts/
-RUN scripts/setup rust cargo-binstall ic-wasm yq
+RUN scripts/setup rust
+RUN scripts/setup cargo-binstall
+RUN scripts/setup candid-extractor
+RUN scripts/setup ic-wasm
+RUN scripts/setup didc
+RUN scripts/setup yq
 
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,10 @@ COPY ./docker ./docker
 COPY ./rust-toolchain.toml ./rust-toolchain.toml
 
 # Setup toolchain and ic-wasm
-RUN ./docker/bootstrap
+COPY rust-toolchain.toml .
+COPY dev-tools.json .
+COPY scripts/setup scripts/setup-cargo-binstall scripts/setup-rust scripts/
+RUN scripts/setup rust cargo-binstall ic-wasm
 
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty

--- a/dev-tools.json
+++ b/dev-tools.json
@@ -20,9 +20,9 @@
 		"source": "mvdan.cc/sh/v3/cmd/shfmt"
 	},
 	"yq": {
-		"method": "go",
-		"version": "v4.33.3",
-		"source": "github.com/mikefarah/yq/v4"
+		"method": "curl",
+		"version": "4.33.3",
+		"url": "https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_amd64"
 	},
 	"cargo-binstall": {
 		"method": "sh",

--- a/dev-tools.json
+++ b/dev-tools.json
@@ -1,11 +1,55 @@
 {
+	"rustup": {
+		"method": "curl",
+		"version": "1.25.2",
+		"url": "https://raw.githubusercontent.com/rust-lang/rustup/${VERSION}/rustup-init.sh",
+		"pipe": [["sh"]]
+	},
+	"rust": {
+		"method": "sh",
+		"version": "See rust-toolchain.toml"
+	},
 	"didc": {
 		"method": "curl",
 		"version": "0.4.0",
 		"url": "https://github.com/dfinity/candid/releases/download/2024-07-29/didc-linux64"
 	},
+	"shfmt": {
+		"method": "go",
+		"version": "v3.5.1",
+		"source": "mvdan.cc/sh/v3/cmd/shfmt"
+	},
+	"yq": {
+		"method": "go",
+		"version": "v4.33.3",
+		"source": "github.com/mikefarah/yq/v4"
+	},
+	"cargo-binstall": {
+		"method": "sh",
+		"version": "1.7.4"
+	},
 	"solana": {
 		"method": "sh",
 		"version": "2.0.16"
+	},
+	"ic-wasm": {
+		"method": "cargo-binstall",
+		"version": "0.3.6"
+	},
+	"cargo-audit": {
+		"method": "cargo-binstall",
+		"version": "0.13.1"
+	},
+	"cargo-edit": {
+		"method": "cargo-binstall",
+		"version": "0.13.0"
+	},
+	"cargo-sort": {
+		"method": "cargo-binstall",
+		"version": "1.0.9"
+	},
+	"candid-extractor": {
+		"method": "cargo-binstall",
+		"version": "0.1.4"
 	}
 }

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -6,28 +6,4 @@ set -euo pipefail
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPTS_DIR/.."
 
-function run() {
-  echo 1>&2 "running $@"
-  rc=0 && "$@" || rc="$?"
-  if ! [ "$rc" -eq 0 ]; then
-    echo 1>&2 "Bootstrap command failed: $@"
-    exit "$rc"
-  fi
-}
-
-rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
-echo "using rust version '$rust_version'"
-
-# here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
-run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
-
-echo "looking for ic-wasm 0.3.6"
-if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.3.6" ]]; then
-  echo "installing ic-wasm 0.3.6"
-  run cargo install ic-wasm --version 0.3.6
-fi
-
-# make sure the packages are actually installed (rustup waits for the first invoke to lazyload)
-cargo --version
-cargo clippy --version
-cargo fmt --version
+scripts/setup rust ic-wasm

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# install build dependencies (rustup + ic-wasm)
-
-set -euo pipefail
-
-SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPTS_DIR/.."
-
-scripts/setup rust ic-wasm


### PR DESCRIPTION
# Motivation
Tools are currently installed inconsistently, making it easy for tool sets to get out of sync.

# Changes
- Add more tool sets to `dev-tools.json`
- Use the setup command to install these tools, consistently throughout the codebase. (With a few exceptions, that will be dealt with in another PR as those changes are a bit more complicated.)

# Tests
- See CI
- Additionally, as some of these changes affect the backend Docker build, I have run a docker build locally.