### PR TITLE
feat(devops): Commands to run before docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ bitcoin*.gz
 # rust and downloaded wasm|did files
 target/
 
+# files used by docker buildx
+in/
+
 # files created by docker buildx
 out/
 

--- a/scripts/commit-metadata
+++ b/scripts/commit-metadata
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+: The commit and any tags.
+
+mkdir -p in
+git rev-parse HEAD >in/commit
+git tag -l --contains HEAD >in/tags

--- a/scripts/docker-build.pre
+++ b/scripts/docker-build.pre
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Commands run before calling docker.
+# This is used both in command line docker builds and in CI docker builds (that are called in a different way)
+
+set -euxo pipefail
+scripts/commit-metadata


### PR DESCRIPTION
# Motivation
To add git commit & tags to docker builds, it is necessary to do this either outside docker because otherwise:

- The docker cache gets very big (from pulling the git tree into Docker)
- The docker cache is missed due to completely unrelated changes.

We could pull the git tree into a separate docker stage, which protects the cache of other stages, but docker will still try to cache that one huge stage.

# Changes
- Add a command (not used yet) that gets the git commit hash and tags before running docker.

# Tests
- Used locally in a branch, both standalone and with Docker.
- Going forward, this will be used in Docker builds, so will be tested because we will check that the Wasm contains commit & tag in the metadata.