### PR TITLE
refactor(frontend): extract function to save managed tokens

### DIFF
--- a/src/frontend/src/eth/services/erc20-user-tokens-services.ts
+++ b/src/frontend/src/eth/services/erc20-user-tokens-services.ts
@@ -4,9 +4,9 @@ import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import { toUserToken } from '$icp-eth/services/user-token.services';
 import { setManyUserTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import type { SaveUserTokensParams } from '$lib/services/manage-tokens.services';
 import { i18n } from '$lib/stores/i18n.store';
 import type { TokenId } from '$lib/types/token';
-import type { Identity } from '@dfinity/agent';
 import { nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -20,11 +20,7 @@ export const saveUserTokens = async ({
 	progress,
 	identity,
 	tokens
-}: {
-	progress: (step: ProgressStepsAddToken) => void;
-	identity: Identity;
-	tokens: SaveUserToken[];
-}) => {
+}: SaveUserTokensParams<SaveUserToken>) => {
 	progress(ProgressStepsAddToken.SAVE);
 
 	await setManyUserTokens({

--- a/src/frontend/src/icp-eth/services/manage-tokens.services.ts
+++ b/src/frontend/src/icp-eth/services/manage-tokens.services.ts
@@ -1,21 +1,6 @@
 import { saveUserTokens, type SaveUserToken } from '$eth/services/erc20-user-tokens-services';
 import { saveCustomTokens, type SaveCustomToken } from '$icp/services/ic-custom-tokens.services';
-import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
-import { nullishSignOut } from '$lib/services/auth.services';
-import { i18n } from '$lib/stores/i18n.store';
-import { toastsError } from '$lib/stores/toasts.store';
-import type { OptionIdentity } from '$lib/types/identity';
-import type { Identity } from '@dfinity/agent';
-import { isNullish } from '@dfinity/utils';
-import { get } from 'svelte/store';
-
-export interface ManageTokensSaveParams {
-	progress: (step: ProgressStepsAddToken) => void;
-	modalNext: () => void;
-	onSuccess: () => void;
-	onError: () => void;
-	identity: OptionIdentity;
-}
+import { saveTokens, type ManageTokensSaveParams } from '$lib/services/manage-tokens.services';
 
 export const saveErc20UserTokens = async ({
 	tokens,
@@ -23,16 +8,10 @@ export const saveErc20UserTokens = async ({
 }: {
 	tokens: SaveUserToken[];
 } & ManageTokensSaveParams) => {
-	const save = (params: {
-		progress: (step: ProgressStepsAddToken) => void;
-		identity: Identity;
-		tokens: [SaveUserToken, ...SaveUserToken[]];
-	}): Promise<void> => saveUserTokens(params);
-
 	await saveTokens({
 		...rest,
 		tokens,
-		save
+		save: saveUserTokens
 	});
 };
 
@@ -42,67 +21,9 @@ export const saveIcrcCustomTokens = async ({
 }: {
 	tokens: SaveCustomToken[];
 } & ManageTokensSaveParams) => {
-	const save = (params: {
-		progress: (step: ProgressStepsAddToken) => void;
-		identity: Identity;
-		tokens: [SaveCustomToken, ...SaveCustomToken[]];
-	}): Promise<void> => saveCustomTokens(params);
-
 	await saveTokens({
 		...rest,
 		tokens,
-		save
+		save: saveCustomTokens
 	});
-};
-
-const saveTokens = async <T>({
-	tokens,
-	save,
-	progress,
-	modalNext,
-	onSuccess,
-	onError,
-	identity
-}: {
-	tokens: T[];
-	save: (params: {
-		progress: (step: ProgressStepsAddToken) => void;
-		identity: Identity;
-		tokens: [T, ...T[]];
-	}) => Promise<void>;
-} & ManageTokensSaveParams) => {
-	const $i18n = get(i18n);
-
-	if (isNullish(identity)) {
-		await nullishSignOut();
-		return;
-	}
-
-	if (tokens.length === 0) {
-		toastsError({
-			msg: { text: $i18n.tokens.manage.error.empty }
-		});
-		return;
-	}
-
-	modalNext();
-
-	try {
-		await save({
-			progress,
-			identity,
-			tokens: tokens as [T, ...T[]]
-		});
-
-		progress(ProgressStepsAddToken.DONE);
-
-		setTimeout(() => onSuccess(), 750);
-	} catch (err: unknown) {
-		toastsError({
-			msg: { text: $i18n.tokens.error.unexpected },
-			err
-		});
-
-		onError();
-	}
 };

--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -4,8 +4,8 @@ import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { setManyCustomTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import type { SaveUserTokensParams } from '$lib/services/manage-tokens.services';
 import { i18n } from '$lib/stores/i18n.store';
-import type { Identity } from '@dfinity/agent';
 import { get } from 'svelte/store';
 
 export type SaveCustomToken = Pick<
@@ -17,11 +17,7 @@ export const saveCustomTokens = async ({
 	progress,
 	identity,
 	tokens
-}: {
-	progress: (step: ProgressStepsAddToken) => void;
-	identity: Identity;
-	tokens: SaveCustomToken[];
-}) => {
+}: SaveUserTokensParams<SaveCustomToken>) => {
 	progress(ProgressStepsAddToken.SAVE);
 
 	await setManyCustomTokens({

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -1,0 +1,70 @@
+import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import { nullishSignOut } from '$lib/services/auth.services';
+import { i18n } from '$lib/stores/i18n.store';
+import { toastsError } from '$lib/stores/toasts.store';
+import type { OptionIdentity } from '$lib/types/identity';
+import type { Identity } from '@dfinity/agent';
+import { isNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+export interface ManageTokensSaveParams {
+	progress: (step: ProgressStepsAddToken) => void;
+	modalNext: () => void;
+	onSuccess: () => void;
+	onError: () => void;
+	identity: OptionIdentity;
+}
+
+export interface SaveUserTokensParams<T> {
+	progress: (step: ProgressStepsAddToken) => void;
+	identity: Identity;
+	tokens: [T, ...T[]];
+}
+
+export const saveTokens = async <T>({
+	tokens,
+	save,
+	progress,
+	modalNext,
+	onSuccess,
+	onError,
+	identity
+}: {
+	tokens: T[];
+	save: (params: SaveUserTokensParams<T>) => Promise<void>;
+} & ManageTokensSaveParams) => {
+	const $i18n = get(i18n);
+
+	if (isNullish(identity)) {
+		await nullishSignOut();
+		return;
+	}
+
+	if (tokens.length === 0) {
+		toastsError({
+			msg: { text: $i18n.tokens.manage.error.empty }
+		});
+		return;
+	}
+
+	modalNext();
+
+	try {
+		await save({
+			progress,
+			identity,
+			tokens: tokens as [T, ...T[]]
+		});
+
+		progress(ProgressStepsAddToken.DONE);
+
+		setTimeout(() => onSuccess(), 750);
+	} catch (err: unknown) {
+		toastsError({
+			msg: { text: $i18n.tokens.error.unexpected },
+			err
+		});
+
+		onError();
+	}
+};

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -1,0 +1,87 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import { nullishSignOut } from '$lib/services/auth.services';
+import { saveTokens } from '$lib/services/manage-tokens.services';
+import { toastsError } from '$lib/stores/toasts.store';
+import en from '$tests/mocks/i18n.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+
+vi.mock('$lib/services/auth.services', () => ({
+	nullishSignOut: vi.fn()
+}));
+
+describe('manage-tokens.services', () => {
+	describe('saveTokens', () => {
+		const mockProgress = vi.fn();
+		const mockModalNext = vi.fn();
+		const mockOnSuccess = vi.fn();
+		const mockOnError = vi.fn();
+		const mockSave = vi.fn();
+
+		const tokens = [BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN, SOLANA_TOKEN];
+
+		const params = {
+			tokens,
+			save: mockSave,
+			progress: mockProgress,
+			modalNext: mockModalNext,
+			onSuccess: mockOnSuccess,
+			onError: mockOnError,
+			identity: mockIdentity
+		};
+
+		beforeEach(() => {
+			vi.resetAllMocks();
+		});
+
+		it('should call nullishSignOut if identity is nullish', async () => {
+			await saveTokens({ ...params, identity: null });
+
+			expect(nullishSignOut).toHaveBeenCalledOnce();
+			expect(mockSave).not.toHaveBeenCalled();
+		});
+
+		it('should show an error toast if tokens are empty', async () => {
+			await saveTokens({ ...params, tokens: [] });
+
+			expect(toastsError).toHaveBeenCalledWith({
+				msg: { text: en.tokens.manage.error.empty }
+			});
+			expect(mockSave).not.toHaveBeenCalled();
+		});
+
+		it('should call save and handle success', async () => {
+			mockSave.mockResolvedValueOnce(undefined);
+
+			await saveTokens(params);
+
+			expect(mockModalNext).toHaveBeenCalledOnce();
+			expect(mockSave).toHaveBeenCalledWith({
+				progress: mockProgress,
+				identity: mockIdentity,
+				tokens
+			});
+			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsAddToken.DONE);
+
+			await new Promise((resolve) => setTimeout(resolve, 750));
+			expect(mockOnSuccess).toHaveBeenCalledOnce();
+		});
+
+		it('should handle errors from save', async () => {
+			mockSave.mockRejectedValueOnce(new Error('Save failed'));
+
+			await saveTokens(params);
+
+			expect(mockModalNext).toHaveBeenCalledOnce();
+			expect(mockSave).toHaveBeenCalledOnce();
+			expect(toastsError).toHaveBeenCalledWith({
+				msg: { text: en.tokens.error.unexpected },
+				err: new Error('Save failed')
+			});
+			expect(mockOnError).toHaveBeenCalledOnce();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

The function `saveTokens` will not be anymore exclusive to ICP and Ethereum. So we move it to `lib` (Solana will use it too, and other networks).

# Changes

- Move function `saveTokens` to a module in `lib` (and its types).
- Create a new interface SaveTokensParams for the parameter that is given as the custom function that really saves the tokens (exclusive to each network).
- Simplify redundancy in the code for `saveErc20UserTokens` and `saveIcrcCustomTokens`: we were creating a sub-function save that is basically the same as providing directly the network save-funtion to `saveTokens`.

# Tests

Since we are here, we created some tests.
