### PR TITLE
feat(frontend): adapt SPL derived stores to user tokens

### DIFF
--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -5,7 +5,7 @@ import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import { routeNetwork, routeToken } from '$lib/derived/nav.derived';
 import type { OptionToken } from '$lib/types/token';
-import { splTokens } from '$sol/derived/spl.derived';
+import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -21,7 +21,7 @@ export const pageToken: Readable<OptionToken> = derived(
 		enabledSolanaTokens,
 		enabledErc20Tokens,
 		enabledIcrcTokens,
-		splTokens
+		enabledSplTokens
 	],
 	([
 		$routeToken,

--- a/src/frontend/src/sol/derived/spl.derived.ts
+++ b/src/frontend/src/sol/derived/spl.derived.ts
@@ -1,7 +1,11 @@
+import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { enabledSolanaNetworksIds } from '$sol/derived/networks.derived';
 import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
+import { splUserTokensStore } from '$sol/stores/spl-user-tokens.store';
+import type { SolanaNetwork } from '$sol/types/network';
 import type { SplToken, SplTokenAddress } from '$sol/types/spl';
 import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
+import type { SplUserToken } from '$sol/types/spl-user-token';
 import { derived, type Readable } from 'svelte/store';
 
 const splDefaultTokens: Readable<SplToken[]> = derived(
@@ -12,27 +16,82 @@ const splDefaultTokens: Readable<SplToken[]> = derived(
 		)
 );
 
-const splDefaultTokensToggleable: Readable<SplTokenToggleable[]> = derived(
+const splDefaultTokensAddresses: Readable<SplTokenAddress[]> = derived(
 	[splDefaultTokens],
-	([$splDefaultTokens]) => $splDefaultTokens.map((token) => ({ ...token, enabled: true }))
+	([$splDefaultTokens]) => $splDefaultTokens.map(({ address }) => address.toLowerCase())
 );
 
+/**
+ * The list of SPL tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
+ * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "user token" in the backend.
+ */
+const splUserTokens: Readable<SplUserToken[]> = derived(
+	[splUserTokensStore],
+	([$splUserTokensStore]) => $splUserTokensStore?.map(({ data: token }) => token) ?? []
+);
+
+const splDefaultTokensToggleable: Readable<SplTokenToggleable[]> = derived(
+	[splDefaultTokens, splUserTokens],
+	([$splDefaultTokens, $splUserTokens]) =>
+		$splDefaultTokens.map(({ address, network, ...rest }) => {
+			const userToken = $splUserTokens.find(
+				({ address: contractAddress, network: contractNetwork }) =>
+					contractAddress === address &&
+					(network as SolanaNetwork).chainId === (contractNetwork as SolanaNetwork).chainId
+			);
+
+			return mapDefaultTokenToToggleable({
+				defaultToken: {
+					address,
+					network,
+					...rest
+				},
+				userToken
+			});
+		})
+);
+
+/**
+ * The list of default tokens that are enabled - i.e. the list of default SPL tokens minus those disabled by the user.
+ */
 const enabledSplDefaultTokens: Readable<SplTokenToggleable[]> = derived(
 	[splDefaultTokensToggleable],
 	([$splDefaultTokensToggleable]) => $splDefaultTokensToggleable.filter(({ enabled }) => enabled)
+);
+
+const splUserTokensToggleable: Readable<SplUserToken[]> = derived(
+	[splUserTokens, splDefaultTokensAddresses],
+	([$splUserTokens, $splDefaultTokensAddresses]) =>
+		$splUserTokens.filter(
+			({ address }) => !$splDefaultTokensAddresses.includes(address.toLowerCase())
+		)
+);
+
+const enabledSplUserTokens: Readable<SplUserToken[]> = derived(
+	[splUserTokens],
+	([$splUserTokens]) => $splUserTokens.filter(({ enabled }) => enabled)
 );
 
 /**
  * The list of all SPL tokens.
  */
 export const splTokens: Readable<SplTokenToggleable[]> = derived(
-	[splDefaultTokensToggleable],
-	([$splDefaultTokensToggleable]) => [...$splDefaultTokensToggleable]
+	[splDefaultTokensToggleable, splUserTokensToggleable],
+	([$splDefaultTokensToggleable, $splUserTokensToggleable]) => [
+		...$splDefaultTokensToggleable,
+		...$splUserTokensToggleable
+	]
 );
 
-export const enabledSplTokens: Readable<SplToken[]> = derived(
-	[enabledSplDefaultTokens],
-	([$splTokens]) => [...$splTokens]
+/**
+ * The list of SPL tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
+ */
+export const enabledSplTokens: Readable<SplTokenToggleable[]> = derived(
+	[enabledSplDefaultTokens, enabledSplUserTokens],
+	([$enabledSplDefaultTokens, $enabledSplUserTokens]) => [
+		...$enabledSplDefaultTokens,
+		...$enabledSplUserTokens
+	]
 );
 
 export const enabledSplTokenAddresses: Readable<SplTokenAddress[]> = derived(

--- a/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
@@ -8,7 +8,7 @@ import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { pageToken } from '$lib/derived/page-token.derived';
-import { splTokens } from '$sol/derived/spl.derived';
+import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -21,7 +21,7 @@ describe('page-token.derived', () => {
 		vi.spyOn(btcEnv, 'BTC_MAINNET_ENABLED', 'get').mockImplementation(() => true);
 		vi.spyOn(solEnv, 'SOLANA_NETWORK_ENABLED', 'get').mockImplementation(() => true);
 
-		vi.spyOn(splTokens, 'subscribe').mockImplementation((fn) => {
+		vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
 			fn([{ ...JUP_TOKEN, enabled: true }]);
 			return () => {};
 		});


### PR DESCRIPTION
# Motivation

Since we now have the same structure of default tokens and user tokens for SPL tokens, as we have in ERC20, we adapt the derived stores to avoid duplicates, and to have all of them, in preparation for the backend to be able to save them too.

It is basically a copy of the module `erc20.derived` (removing the unused ones).
