### PR TITLE
feat(frontend): use saveSplUserTokens in ManageTokensModal

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -29,7 +29,6 @@
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 	import { saveSplUserTokens } from '$sol/services/manage-tokens.services';
-	import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
 
 	const steps: WizardSteps = [

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -30,6 +30,7 @@
 	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
 	import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
+	import { saveSplUserTokens } from '$sol/services/manage-tokens.services';
 
 	const steps: WizardSteps = [
 		{
@@ -145,12 +146,14 @@
 
 	// TODO: implement this function in the backend
 	const saveSpl = (tokens: SplTokenToggleable[]): void => {
-		modal.set(3);
-		progress(ProgressStepsAddToken.SAVE);
-		splDefaultTokensStore.set(tokens);
-		progress(ProgressStepsAddToken.UPDATE_UI);
-		progress(ProgressStepsAddToken.DONE);
-		setTimeout(() => close(), 750);
+		saveSplUserTokens({
+			tokens,
+			progress,
+			modalNext: () => modal.set(3),
+			onSuccess: close,
+			onError: () => modal.set(0),
+			identity: $authIdentity
+		});
 	};
 
 	const close = () => {

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -28,9 +28,9 @@
 	import type { Network } from '$lib/types/network';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isNetworkIdEthereum, isNetworkIdICP } from '$lib/utils/network.utils';
+	import { saveSplUserTokens } from '$sol/services/manage-tokens.services';
 	import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
-	import { saveSplUserTokens } from '$sol/services/manage-tokens.services';
 
 	const steps: WizardSteps = [
 		{


### PR DESCRIPTION
# Motivation

We can now use the `saveSplUserTokens` service in `ManageTokensModal`.
