### PR TITLE
feat(ci): Explicitly trigger tagging workflows

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - v*
     workflow_run:
-      workflows: ["bump-version.yml"]
+      workflows: ['bump-version.yml']
       types:
         - completed
 

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -6,10 +6,10 @@ on:
       - main
     tags:
       - v*
-    workflow_run:
-      workflows: ['bump-version.yml']
-      types:
-        - completed
+  workflow_run:
+    workflows: ['bump-version.yml']
+    types:
+      - completed
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -6,6 +6,11 @@ on:
       - main
     tags:
       - v*
+    workflow_run:
+      workflows: ["bump-version.yml"]
+      types:
+        - completed
+
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - v*
     workflow_run:
-      workflows: ["bump-version.yml"]
+      workflows: ['bump-version.yml']
       types:
         - completed
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,10 +6,10 @@ on:
   push:
     tags:
       - v*
-    workflow_run:
-      workflows: ['bump-version.yml']
-      types:
-        - completed
+  workflow_run:
+    workflows: ['bump-version.yml']
+    types:
+      - completed
 
 jobs:
   release_notes:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - v*
+    workflow_run:
+      workflows: ["bump-version.yml"]
+      types:
+        - completed
 
 jobs:
   release_notes:


### PR DESCRIPTION
# Motivation
Some workflows are meant to be triggered when a tag is pushed.

But GitHub has a policy of not letting workflows trigger workflows, except in a few very specific ways.

So we have a few options:

- Put code in actions
- Use the (limited)  explicit "trigger this workflow when that one has finished" functionality.

The latter a has strong limitations, but in this case the triggered events are simple and few, so as long as we don't add fancy chains this is probably the simpler option.

# Changes
- Trigger workflows when we create a tag in CI.

# Tests
Hard to test workflows triggering workflows when this is not in main.  But once merged, we can trigger some patch updates.  Note: Factoring code into actions is more testable, even in brances.

- Note: The tagging workflow has a very long name, so I have tried using the filename instead.  I'm not sure that this will work.  I'd recommend shortening that workflow name though so that (a) it's possible to read it in the sidebar and (b) it's easy to see whether there is a one-character difference between the workflow name and the name used elsewhere.