### PR TITLE
feat(devops): Support prerelease version bumps for testing

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version_bump:
-        description: 'Version bump type (major, minor, patch)'
+        description: 'Version bump type (major, minor, patch, prerelease)'
         required: true
         default: 'patch'
         type: choice
@@ -12,6 +12,7 @@ on:
           - major
           - minor
           - patch
+          - prerelease
       release_description:
         description: 'Short description of the release (motivation, changes, tests)'
         required: true


### PR DESCRIPTION
# Motivation
We have workflows for tagging.  We would like to test that without having to affect production release numbers.

# Changes
- Support pre-release version bumps.  So we get e.g. 1.2.3-4 .  See: https://docs.npmjs.com/cli/v8/commands/npm-version

# Tests
