### PR TITLE
feat(frontend): search tokens by network too

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -191,7 +191,9 @@ export const filterTokens = ({ tokens, filter }: { tokens: Token[]; filter: stri
 		token.name.toLowerCase().includes(filter.toLowerCase()) ||
 		token.symbol.toLowerCase().includes(filter.toLowerCase()) ||
 		(icTokenIcrcCustomToken(token) &&
-			(token.alternativeName ?? '').toLowerCase().includes(filter.toLowerCase()));
+			(token.alternativeName ?? '').toLowerCase().includes(filter.toLowerCase())) ||
+		token.network.name.toLowerCase().includes(filter.toLowerCase()) ||
+		(token.network.id.description ?? '').toLowerCase().includes(filter.toLowerCase());
 
 	return isNullishOrEmpty(filter)
 		? tokens

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -3,6 +3,7 @@ import {
 	ETHEREUM_NETWORK_ID,
 	ICP_NETWORK_ID
 } from '$env/networks/networks.env';
+import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
@@ -438,5 +439,11 @@ describe('filterTokens', () => {
 
 	it('should filter tokens correctly when filter is not provided', () => {
 		expect(filterTokens({ tokens: mockTokens, filter: '' })).toStrictEqual(mockTokens);
+	});
+
+	it('should filter correctly by network', () => {
+		expect(filterTokens({ tokens: [...mockTokens, PEPE_TOKEN], filter: 'ethereum' })).toStrictEqual(
+			[ETHEREUM_TOKEN, PEPE_TOKEN]
+		);
 	});
 });


### PR DESCRIPTION
# Motivation

We would like to search the tokens not only by name, but by network too, so that all the tokens for example of Solana will appear if we write "solana".


![Screenshot 2025-01-22 at 12 44 57](https://github.com/user-attachments/assets/3fc0d9f7-75ce-4fb5-ba09-829c6c32f5c3)

