### PR TITLE
style(frontend): Center available balance label

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -13,7 +13,7 @@
 	$: totalUsd = sumTokensUiUsdBalance($combinedDerivedSortedNetworkTokensUi);
 </script>
 
-<span class="flex flex-col gap-2">
+<span class="flex flex-col items-center gap-2">
 	<output class={`mt-8 inline-block break-all text-5xl font-bold`}>
 		{#if $loaded}
 			{formatUSD({ value: totalUsd })}


### PR DESCRIPTION
# Motivation

For mobile version, the label "Available balance" in the `Hero` was not centered. Now it is.

### Before

![Screenshot 2025-01-22 at 14 13 00](https://github.com/user-attachments/assets/c1ef9e88-b71a-4b8d-ae27-1f1dddee5a1f)

### After

![Screenshot 2025-01-22 at 14 12 47](https://github.com/user-attachments/assets/d8deda57-2c2e-4ecc-9048-8da1d1675937)
