### PR TITLE
fix(ci): Use workflow name rather than filename

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - v*
   workflow_run:
-    workflows: ['tag-release.yml']
+    workflows: ['Tag on Merge from Release Branch']
     types:
       - completed
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - v*
   workflow_run:
-    workflows: ['tag-release.yml']
+    workflows: ['Tag on Merge from Release Branch']
     types:
       - completed
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,4 +1,4 @@
-name: Tag and Release on Merge from Release Branch
+name: Tag on Merge from Release Branch
 
 on:
   pull_request:


### PR DESCRIPTION
# Motivation
Triggering releases on tag did not work.  Presumably that is because the workflow filename name was used instead of the human readable name.

# Changes
- Make the name more accurate - the triggering workflow tags but does not create a release.
- In the triggered workflows, use the name not the filename.

# Tests
Can only be tested properly in main.