### PR TITLE
feat(frontend): add tracking for kong swap

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -6,9 +6,14 @@
 	import SwapForm from '$lib/components/swap/SwapForm.svelte';
 	import SwapProgress from '$lib/components/swap/SwapProgress.svelte';
 	import SwapReview from '$lib/components/swap/SwapReview.svelte';
+	import {
+		TRACK_COUNT_SWAP_ERROR,
+		TRACK_COUNT_SWAP_SUCCESS
+	} from '$lib/constants/analytics.contants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
+	import { trackEvent } from '$lib/services/analytics.services';
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { swap as swapService } from '$lib/services/swap.services';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -73,11 +78,29 @@
 
 			progress(ProgressStepsSwap.DONE);
 
+			await trackEvent({
+				name: TRACK_COUNT_SWAP_SUCCESS,
+				metadata: {
+					sourceToken: $sourceToken.symbol,
+					destinationToken: $destinationToken.symbol,
+					dApp: 'KONG'
+				}
+			});
+
 			setTimeout(() => close(), 750);
 		} catch (err: unknown) {
 			toastsError({
 				msg: { text: $i18n.swap.error.unexpected },
 				err
+			});
+
+			await trackEvent({
+				name: TRACK_COUNT_SWAP_ERROR,
+				metadata: {
+					sourceToken: $sourceToken.symbol,
+					destinationToken: $destinationToken.symbol,
+					dApp: 'KONG'
+				}
 			});
 
 			back();

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -41,3 +41,7 @@ export const TRACK_COUNT_CAROUSEL_NEXT = 'carousel_next_count';
 export const TRACK_COUNT_CAROUSEL_PREVIOUS = 'carousel_previous_count';
 export const TRACK_COUNT_CAROUSEL_CLOSE = 'carousel_close_count';
 export const TRACK_COUNT_CAROUSEL_OPEN = 'carousel_open_count';
+
+// Swap
+export const TRACK_COUNT_SWAP_SUCCESS = 'swap_success_count';
+export const TRACK_COUNT_SWAP_ERROR = 'swap_error_count';


### PR DESCRIPTION
# Motivation

Add missing tracking for the swap feature.
