### PR TITLE
fix(frontend): wrong WebSocket address for Solana Mainnet

### DIFF
--- a/src/frontend/src/env/networks/networks.sol.env.ts
+++ b/src/frontend/src/env/networks/networks.sol.env.ts
@@ -28,7 +28,7 @@ export const SOLANA_RPC_HTTP_URL_LOCAL = 'http://localhost:8899';
 // TODO: Once per year at least, check when Alchemy will support WebSocket for Solana RPC, so that we use just one service instead of two
 // TODO: Last time checked Alchemy: 2025-01-22
 // TODO: https://dashboard.alchemy.com/services/smart-websockets
-export const SOLANA_RPC_WS_URL_MAINNET = `wss://burned-little-dinghy.solana-devnet.quiknode.pro/${QUICKNODE_API_KEY}`;
+export const SOLANA_RPC_WS_URL_MAINNET = `wss://burned-little-dinghy.solana-mainnet.quiknode.pro/${QUICKNODE_API_KEY}`;
 export const SOLANA_RPC_WS_URL_TESTNET = 'wss://api.testnet.solana.com/';
 export const SOLANA_RPC_WS_URL_DEVNET = 'wss://api.devnet.solana.com/';
 export const SOLANA_RPC_WS_URL_LOCAL = 'ws://localhost:8900';


### PR DESCRIPTION
# Motivation

The websocket URL for Solana mainet was wrong: it was pointing at devnet. It is now fixed. 
