### PR TITLE
refactor(frontend): add Sign step to Solana transaction flow

### DIFF
--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -71,6 +71,7 @@ export enum ProgressStepsSendBtc {
 
 export enum ProgressStepsSendSol {
 	INITIALIZATION = 'initialization',
+	SIGN = 'sign',
 	SEND = 'send',
 	RELOAD = 'reload',
 	DONE = 'done'

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -49,8 +49,6 @@
 
 	const { sendToken, sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const progress = (step: ProgressStepsSendSol) => (sendProgressStep = step);
-
 	let network: Network | undefined = undefined;
 	$: network = $sendToken.network;
 
@@ -109,27 +107,17 @@
 		dispatch('icNext');
 
 		try {
-			sendProgressStep = ProgressStepsSendSol.INITIALIZATION;
-
 			await sendSol({
 				identity: $authIdentity,
+				progress: (step: ProgressStepsSendSol) => (sendProgressStep = step),
 				token: $sendToken,
 				amount: parseToken({
 					value: `${amount}`,
 					unitName: $sendTokenDecimals
 				}),
 				destination,
-				source,
-				onProgress: () => {
-					if (sendProgressStep === ProgressStepsSendSol.INITIALIZATION) {
-						progress(ProgressStepsSendSol.SEND);
-					} else if (sendProgressStep === ProgressStepsSendSol.SEND) {
-						progress(ProgressStepsSendSol.DONE);
-					}
-				}
+				source
 			});
-
-			sendProgressStep = ProgressStepsSendSol.DONE;
 
 			await trackEvent({
 				name: TRACK_COUNT_SOL_SEND_SUCCESS,

--- a/src/frontend/src/sol/constants/steps.constants.ts
+++ b/src/frontend/src/sol/constants/steps.constants.ts
@@ -8,6 +8,11 @@ export const sendSteps = (i18n: I18n): ProgressSteps => [
 		state: 'in_progress'
 	},
 	{
+		step: ProgressStepsSendSol.SIGN,
+		text: i18n.send.text.signing_message,
+		state: 'next'
+	},
+	{
 		step: ProgressStepsSendSol.SEND,
 		text: i18n.send.text.sending,
 		state: 'next'

--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -1,3 +1,4 @@
+import { ProgressStepsSendSol } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { SolAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -210,19 +211,21 @@ export const sendSignedTransaction = ({
  */
 export const sendSol = async ({
 	identity,
+	progress,
 	token,
 	amount,
 	destination,
-	source,
-	onProgress
+	source
 }: {
 	identity: OptionIdentity;
+	progress: (step: ProgressStepsSendSol) => void;
 	token: Token;
 	amount: BigNumber;
 	destination: SolAddress;
 	source: SolAddress;
-	onProgress?: () => void;
 }): Promise<Signature> => {
+	progress(ProgressStepsSendSol.INITIALIZATION);
+
 	const {
 		network: { id: networkId }
 	} = token;
@@ -260,9 +263,11 @@ export const sendSol = async ({
 				network: solNetwork
 			});
 
-	onProgress?.();
+	progress(ProgressStepsSendSol.SIGN);
 
 	const { signedTransaction, signature } = await signTransaction(transactionMessage);
+
+	progress(ProgressStepsSendSol.SEND);
 
 	// Explicitly do not await to proceed in the background and allow the UI to continue
 	sendSignedTransaction({
@@ -271,7 +276,7 @@ export const sendSol = async ({
 		signedTransaction
 	});
 
-	onProgress?.();
+	progress(ProgressStepsSendSol.DONE);
 
 	return signature;
 };

--- a/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
@@ -101,7 +101,7 @@ describe('sol-send.services', () => {
 					amount: mockAmount,
 					destination: mockDestination,
 					source: mockSource,
-					onProgress: vi.fn()
+					progress: vi.fn()
 				})
 			).resolves.not.toThrow();
 
@@ -117,7 +117,7 @@ describe('sol-send.services', () => {
 					amount: mockAmount,
 					destination: mockDestination,
 					source: mockSource,
-					onProgress: vi.fn()
+					progress: vi.fn()
 				})
 			).resolves.not.toThrow();
 
@@ -133,7 +133,7 @@ describe('sol-send.services', () => {
 					amount: mockAmount,
 					destination: mockDestination,
 					source: mockSource,
-					onProgress: vi.fn()
+					progress: vi.fn()
 				})
 			).resolves.not.toThrow();
 
@@ -152,7 +152,7 @@ describe('sol-send.services', () => {
 					amount: mockAmount,
 					destination: mockDestination,
 					source: mockSource,
-					onProgress: vi.fn()
+					progress: vi.fn()
 				})
 			).rejects.toThrowError(
 				replacePlaceholders(en.init.error.no_solana_network, {
@@ -175,7 +175,7 @@ describe('sol-send.services', () => {
 					amount: mockAmount,
 					destination: mockDestination,
 					source: mockSource,
-					onProgress: vi.fn()
+					progress: vi.fn()
 				})
 			).rejects.toThrowError(
 				`Token account not found for wallet ${mockSource} and token ${DEVNET_USDC_TOKEN.address} on devnet network`


### PR DESCRIPTION
# Motivation

To provide a better feedback to the user, we add a step to the Solana send flow: `SIGN`.

![Screenshot 2025-01-24 at 10 42 51](https://github.com/user-attachments/assets/e82c3303-dc5d-4aa5-bb07-4bae68f59de0)

