### PR TITLE
fix(frontend): typo util -> until

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -533,7 +533,7 @@
 				"no_network": "No network is selected. This is unexpected."
 			},
 			"warning": {
-				"do_not_close_manage": "$oisy_name is preparing and securing the new tokens. Please don't close this tab util it's completed."
+				"do_not_close_manage": "$oisy_name is preparing and securing the new tokens. Please don't close this tab until it's completed."
 			}
 		},
 		"manage": {


### PR DESCRIPTION
# Motivation

Someone spotted a typo and reported it on [X/Twitter](https://x.com/dhemingwayicp/status/1882837061151109187?mx=2).

# Changes

- Please don't close this tab **util** it's completed. -> **until**