### PR TITLE
refactor(frontend): rename prop regarding ERC20 in Manage Tokens modal

### DIFF
--- a/src/frontend/src/icp-eth/types/add-token.ts
+++ b/src/frontend/src/icp-eth/types/add-token.ts
@@ -1,10 +1,10 @@
 import type { Either } from '$lib/utils/ts.utils';
 
-export interface Erc20AddTokenData {
-	contractAddress: string;
+interface Erc20AddTokenData {
+	erc20ContractAddress: string;
 }
 
-export interface IcAddTokenData {
+interface IcAddTokenData {
 	ledgerCanisterId: string;
 	indexCanisterId: string | undefined;
 }

--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -31,7 +31,7 @@
 
 	let ledgerCanisterId = tokenData?.ledgerCanisterId ?? '';
 	let indexCanisterId = tokenData?.indexCanisterId ?? '';
-	let erc20ContractAddress = tokenData?.contractAddress ?? '';
+	let erc20ContractAddress = tokenData?.erc20ContractAddress ?? '';
 
 	// Since we persist the values of relevant variables when switching networks, this ensures that
 	// only the data related to the selected network is passed.
@@ -45,7 +45,7 @@
 						: undefined
 			};
 		} else if (isNetworkIdEthereum(network?.id)) {
-			tokenData = { contractAddress: erc20ContractAddress };
+			tokenData = { erc20ContractAddress };
 		} else {
 			tokenData = {};
 		}

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -171,7 +171,7 @@
 	let tokenData: Partial<AddTokenData> = {};
 
 	$: tokenData,
-		({ ledgerCanisterId, indexCanisterId, contractAddress: erc20ContractAddress } = tokenData);
+		({ ledgerCanisterId, indexCanisterId, erc20ContractAddress } = tokenData);
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -170,8 +170,7 @@
 	let network: Network | undefined = $selectedNetwork;
 	let tokenData: Partial<AddTokenData> = {};
 
-	$: tokenData,
-		({ ledgerCanisterId, indexCanisterId, erc20ContractAddress } = tokenData);
+	$: tokenData, ({ ledgerCanisterId, indexCanisterId, erc20ContractAddress } = tokenData);
 </script>
 
 <WizardModal


### PR DESCRIPTION
# Motivation

For more clarity, we specify that the prop `contractAddress` is for ERC20, when adding a new token. It will be useful since Solana uses a similar nomenclature.
