### PR TITLE
test(frontend): clean console noise in unittests

### DIFF
--- a/src/frontend/src/tests/btc/services/btc-listener.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-listener.services.spec.ts
@@ -40,7 +40,7 @@ describe('btc-listener', () => {
 	});
 
 	// mock console.warn to avoid unnecessary logs
-	const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+	const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -216,6 +216,7 @@ describe('btc-wallet.worker', () => {
 		});
 
 		it('should trigger postMessage with error', async () => {
+			vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 			const err = new Error('test');
 			signerCanisterMock.getBtcBalance.mockRejectedValue(err);
 

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -26,8 +26,8 @@ describe('eth-transactions.services', () => {
 		let spyToastsError: MockInstance;
 
 		// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
-		vi.spyOn(console, 'error').mockImplementation(() => undefined);
-		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		beforeEach(() => {
 			vi.resetAllMocks();

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -33,7 +33,7 @@ describe('custom-token.services', () => {
 	let spyToastsError: MockInstance;
 
 	// we mock console.error just to avoid unnecessary logs while running the tests
-	vi.spyOn(console, 'error').mockImplementation(() => undefined);
+	vi.spyOn(console, 'error').mockImplementation(() => {});
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/frontend/src/tests/icp/services/ic-transactions.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-transactions.services.spec.ts
@@ -18,8 +18,9 @@ describe('ic-transactions.services', () => {
 			certified: false
 		}));
 
-		// we mock console.warn just to avoid unnecessary logs while running the tests
-		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		// we mock console just to avoid unnecessary logs while running the tests
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		let spyToastsError: MockInstance;
 

--- a/src/frontend/src/tests/lib/actors/query.ic.spec.ts
+++ b/src/frontend/src/tests/lib/actors/query.ic.spec.ts
@@ -6,7 +6,7 @@ describe('query.ic', () => {
 	const identity = new AnonymousIdentity();
 
 	// we mock console.error just to avoid unnecessary logs while running the tests
-	vi.spyOn(console, 'error').mockImplementation(() => undefined);
+	vi.spyOn(console, 'error').mockImplementation(() => {});
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/frontend/src/tests/lib/services/rest.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/rest.services.spec.ts
@@ -10,8 +10,8 @@ describe('rest.services', () => {
 		const mockOnRetry = vi.fn();
 
 		// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
-		vi.spyOn(console, 'error').mockImplementation(() => undefined);
-		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		beforeEach(() => {
 			vi.clearAllMocks();

--- a/src/frontend/src/tests/lib/services/token.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/token.services.spec.ts
@@ -71,7 +71,7 @@ describe('token.services', () => {
 		let spyBusyStop: MockInstance;
 
 		// we mock console.error just to avoid unnecessary logs while running the tests
-		vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		vi.spyOn(console, 'error').mockImplementation(() => {});
 
 		beforeEach(() => {
 			mockAssertSendTokenData = vi.fn();

--- a/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
@@ -113,6 +113,7 @@ describe('sol-address.services', () => {
 		});
 
 		it('should handle errors during address loading', async () => {
+			vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 			const error = new Error('Failed to load address');
 			spyGetSchnorrPublicKey.mockRejectedValue(error);
 

--- a/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
@@ -68,6 +68,8 @@ describe('sol-listener', () => {
 	});
 
 	describe('syncWalletError', () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
 		it('should reset balanceStore on error', () => {
 			syncWallet({ data: mockPostMessage({}), tokenId });
 
@@ -90,7 +92,6 @@ describe('sol-listener', () => {
 		});
 
 		it('should log a warning if hideToast is true', () => {
-			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 			syncWalletError({ error: 'test error', tokenId, hideToast: true });
 
 			expect(consoleWarnSpy).toHaveBeenCalled();

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -91,6 +91,7 @@ describe('sol-transactions.services', () => {
 		});
 
 		it('should handle errors and reset store', async () => {
+			vi.spyOn(console, 'error').mockImplementationOnce(() => {});
 			const error = new Error('Failed to load transactions');
 			spyGetTransactions.mockRejectedValue(error);
 


### PR DESCRIPTION
# Motivation

The tests are providing too much noise as feedback. Once first thing to tackle is to remove the `console` feedback when we mock errors and warnings.

Furthermore, we normalize the way we mock them.