### PR TITLE
feat(frontend): increase estimated max gas fee for RSC token

### DIFF
--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -56,11 +56,11 @@ export const getErc20FeeData = async ({
 		// Note that originally we added 25% but, after facing some issues with transferring Pepe on busy network, we decided to enhance the allowance further.
 		// Additionally, for some particular tokens (RSC), the returned estimated by infura fee is too low. Short-term solution: increase the fee manually for RSC by 150%.
 		// TODO: discuss the fee estimation issue with the cross-chain team and decide how can we properly calculate the max gas
-		const additionalAmount = BigNumber.from(
-			!isResearchCoin ? fee.toBigInt() / 2n : (fee.toBigInt() * 15n) / 10n
+		const feeBuffer = BigNumber.from(
+			isResearchCoin ? (fee.toBigInt() * 15n) / 10n : fee.toBigInt() / 2n
 		);
 
-		return fee.add(additionalAmount);
+		return fee.add(feeBuffer);
 	} catch (err: unknown) {
 		// We silence the error on purpose.
 		// The queries above often produce errors on mainnet, even when all parameters are correctly set.

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -4,7 +4,7 @@ import { ERC20_FALLBACK_FEE } from '$eth/constants/erc20.constants';
 import { ETH_BASE_FEE } from '$eth/constants/eth.constants';
 import { infuraErc20IcpProviders } from '$eth/providers/infura-erc20-icp.providers';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
-import type { Erc20ContractAddress } from '$eth/types/erc20';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import { isDestinationContractAddress } from '$eth/utils/send.utils';
 import type { EthAddress, OptionEthAddress } from '$lib/types/address';
@@ -33,9 +33,10 @@ export const getEthFeeData = ({
 export const getErc20FeeData = async ({
 	targetNetwork,
 	sourceNetwork: { id: sourceNetworkId },
+	contract,
 	...rest
 }: GetFeeData & {
-	contract: Erc20ContractAddress;
+	contract: Erc20Token;
 	amount: BigNumber;
 	sourceNetwork: EthereumNetwork;
 	targetNetwork: Network | undefined;
@@ -46,12 +47,18 @@ export const getErc20FeeData = async ({
 		const { getFeeData: fn } = isNetworkIdICP(targetNetworkId)
 			? infuraErc20IcpProviders(targetNetworkId as NetworkId)
 			: infuraErc20Providers(targetNetworkId ?? sourceNetworkId);
-		const fee = await fn(rest);
+		const fee = await fn({ ...rest, contract });
+
+		const isResearchCoin = contract.symbol === 'RSC' && contract.name === 'ResearchCoin';
 
 		// The cross-chain team recommended adding 10% to the fee to provide some buffer for when the transaction is effectively executed.
 		// However, according to our observations, we noticed that ERC20 transactions require even more fees. That is why we actually add 50%.
 		// Note that originally we added 25% but, after facing some issues with transferring Pepe on busy network, we decided to enhance the allowance further.
-		const additionalAmount = BigNumber.from(fee.toBigInt() / 2n);
+		// Additionally, for some particular tokens (RSC), the returned estimated by infura fee is too low. Short-term solution: increase the fee manually for RSC by 150%.
+		// TODO: discuss the fee estimation issue with the cross-chain team and decide how can we properly calculate the max gas
+		const additionalAmount = BigNumber.from(
+			!isResearchCoin ? fee.toBigInt() / 2n : (fee.toBigInt() * 15n) / 10n
+		);
 
 		return fee.add(additionalAmount);
 	} catch (err: unknown) {
@@ -69,7 +76,7 @@ export const getCkErc20FeeData = async ({
 	to,
 	...rest
 }: GetFeeData & {
-	contract: Erc20ContractAddress;
+	contract: Erc20Token;
 	amount: BigNumber;
 	sourceNetwork: EthereumNetwork;
 	erc20HelperContractAddress: OptionEthAddress;


### PR DESCRIPTION
# Motivation

A user complained that OISY fails to send one particular erc20 token - [ResearchCoin (RSC)](https://coinmarketcap.com/currencies/researchcoin/). Our internal tests confirmed it - [RSC transactions](https://etherscan.io/advanced-filter?tadd=0xD101dCC414F310268c37eEb4cD376CcFA507F571&qt=1&fadd=0x2Eb29A5553bBc0066bA3ce9Ad4e95C10ab040806) fail in 100% of cases because of the out of gas error. After comparing [a failed OISY tx](https://etherscan.io/tx/0xf9e308c90a93ed388a9cd1df484ee73b4b21ccfa38becf359a6c979a9052635a) and [some random successful RSC tx](https://etherscan.io/tx/0x1c40d707f63ae7b02f56e77cd75c673e545713a284b01921a8771c1e4196b408) on Etherscan (both were done almost at the same time), I can indeed see that OISY sets a low gas limit (82,434 gas, 100% of which is used), when all successful txs (currently and in the past) have higher values (e.g. 120,000 , 84.79% of which is used). I debugged the ethers erc20Contract.estimateGas method, it always returns ~50,000 gas (a bit more for a bigger amount), plus we add on top of that additional 50% which explains the values I saw set for the OISY txs.

### Short-term solution:
* Increate the max gas fee for RSC token only (50% -> 150%)


### Mid-term/long-term solution:
* Discuss the fee estimation issue with the cross-chain team.
* Find a solution for a more precise gas fee calculation (potentially, using another provider).