### PR TITLE
refactor(frontend): create Solana Fee context

### DIFF
--- a/src/frontend/src/sol/components/fee/SolFeeContext.svelte
+++ b/src/frontend/src/sol/components/fee/SolFeeContext.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { assertNonNullish } from '@dfinity/utils';
+	import { getContext, onDestroy } from 'svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { estimatePriorityFee } from '$sol/api/solana.api';
+	import {
+		MICROLAMPORTS_PER_LAMPORT,
+		SOLANA_TRANSACTION_FEE_IN_LAMPORTS
+	} from '$sol/constants/sol.constants';
+	import { SOL_FEE_CONTEXT_KEY, type FeeContext } from '$sol/stores/sol-fee.store';
+	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
+	import { isTokenSpl } from '$sol/utils/spl.utils';
+
+	export let observe: boolean;
+
+	const { feeStore, prioritizationFeeStore }: FeeContext =
+		getContext<FeeContext>(SOL_FEE_CONTEXT_KEY);
+
+	const { sendToken, sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const estimateFee = async () => {
+		// In case we are already sending, we don't want to update the fee
+		if (!observe) {
+			return;
+		}
+
+		const solNetwork = mapNetworkIdToNetwork($sendTokenNetworkId);
+
+		assertNonNullish(
+			solNetwork,
+			replacePlaceholders($i18n.init.error.no_solana_network, {
+				$network: $sendTokenNetworkId.description ?? ''
+			})
+		);
+
+		const addresses = isTokenSpl($sendToken) ? [$sendToken.address] : undefined;
+		const priorityFee = await estimatePriorityFee({ network: solNetwork, addresses });
+		const fee = SOLANA_TRANSACTION_FEE_IN_LAMPORTS + priorityFee / MICROLAMPORTS_PER_LAMPORT;
+		feeStore.setFee(fee);
+		prioritizationFeeStore.setFee(priorityFee);
+	};
+
+	const updateFee = async () => {
+		clearTimer();
+
+		await estimateFee();
+
+		timer = setInterval(estimateFee, 5000);
+	};
+
+	$: $sendTokenNetworkId, (async () => await updateFee())();
+
+	let timer: NodeJS.Timeout | undefined;
+
+	const clearTimer = () => clearInterval(timer);
+
+	onDestroy(clearTimer);
+</script>
+
+<slot />

--- a/src/frontend/src/sol/components/fee/SolFeeDisplay.svelte
+++ b/src/frontend/src/sol/components/fee/SolFeeDisplay.svelte
@@ -2,50 +2,23 @@
 	import { assertNonNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import type { Lamports } from '@solana/rpc-types';
-	import { getContext, onDestroy } from 'svelte';
+	import { getContext } from 'svelte';
 	import { slide } from 'svelte/transition';
-	import {
-		SOLANA_DEVNET_TOKEN,
-		SOLANA_LOCAL_TOKEN,
-		SOLANA_TESTNET_TOKEN,
-		SOLANA_TOKEN
-	} from '$env/tokens/tokens.sol.env';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { Token } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import {
-		isNetworkIdSOLDevnet,
-		isNetworkIdSOLLocal,
-		isNetworkIdSOLTestnet
-	} from '$lib/utils/network.utils';
-	import { estimatePriorityFee, getSolCreateAccountFee } from '$sol/api/solana.api';
-	import {
-		MICROLAMPORTS_PER_LAMPORT,
-		SOLANA_TRANSACTION_FEE_IN_LAMPORTS
-	} from '$sol/constants/sol.constants';
+	import { getSolCreateAccountFee } from '$sol/api/solana.api';
 	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
-	import { isTokenSpl } from '$sol/utils/spl.utils';
+	import { type FeeContext, SOL_FEE_CONTEXT_KEY } from '$sol/stores/sol-fee.store';
 
 	export let showAtaFee = false;
 
-	const { sendToken, sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	let solanaNativeToken: Token;
-	$: solanaNativeToken = isNetworkIdSOLTestnet($sendTokenNetworkId)
-		? SOLANA_TESTNET_TOKEN
-		: isNetworkIdSOLDevnet($sendTokenNetworkId)
-			? SOLANA_DEVNET_TOKEN
-			: isNetworkIdSOLLocal($sendTokenNetworkId)
-				? SOLANA_LOCAL_TOKEN
-				: SOLANA_TOKEN;
-
-	$: ({ decimals, symbol } = solanaNativeToken);
-
-	let fee = SOLANA_TRANSACTION_FEE_IN_LAMPORTS;
+	const { feeStore:fee, feeDecimalsStore: decimals, feeSymbolStore:symbol }: FeeContext = getContext<FeeContext>(SOL_FEE_CONTEXT_KEY);
 
 	let ataFee: Lamports | undefined = undefined;
 
@@ -68,49 +41,18 @@
 	};
 
 	$: showAtaFee, $sendTokenNetworkId, updateAtaFee();
-
-	const estimateFee = async () => {
-		const solNetwork = mapNetworkIdToNetwork($sendTokenNetworkId);
-
-		assertNonNullish(
-			solNetwork,
-			replacePlaceholders($i18n.init.error.no_solana_network, {
-				$network: $sendTokenNetworkId.description ?? ''
-			})
-		);
-
-		const addresses = isTokenSpl($sendToken) ? [$sendToken.address] : undefined;
-		const priorityFee = await estimatePriorityFee({ network: solNetwork, addresses });
-		fee = SOLANA_TRANSACTION_FEE_IN_LAMPORTS + priorityFee / MICROLAMPORTS_PER_LAMPORT;
-	};
-
-	const updateFee = async () => {
-		clearTimer();
-
-		await estimateFee();
-
-		timer = setInterval(estimateFee, 5000);
-	};
-
-	$: $sendTokenNetworkId, (async () => await updateFee())();
-
-	let timer: NodeJS.Timeout | undefined;
-
-	const clearTimer = () => clearInterval(timer);
-
-	onDestroy(clearTimer);
 </script>
 
 <Value ref="fee">
 	<svelte:fragment slot="label">{$i18n.fee.text.fee}</svelte:fragment>
 
-	{#if nonNullish(fee) && nonNullish(decimals) && nonNullish(symbol)}
+	{#if nonNullish($fee) && nonNullish($decimals) && nonNullish($symbol)}
 		{formatToken({
-			value: BigNumber.from(fee),
-			unitName: decimals,
-			displayDecimals: decimals
+			value: BigNumber.from($fee),
+			unitName: $decimals,
+			displayDecimals: $decimals
 		})}
-		{symbol}
+		{$symbol}
 	{/if}
 </Value>
 
@@ -119,13 +61,13 @@
 		<Value ref="ataFee">
 			<svelte:fragment slot="label">{$i18n.fee.text.ata_fee}</svelte:fragment>
 
-			{#if nonNullish(decimals) && nonNullish(symbol)}
+			{#if nonNullish($decimals) && nonNullish($symbol)}
 				{formatToken({
 					value: BigNumber.from(ataFee),
-					unitName: decimals,
-					displayDecimals: decimals
+					unitName: $decimals,
+					displayDecimals: $decimals
 				})}
-				{symbol}
+				{$symbol}
 			{/if}
 		</Value>
 	</div>

--- a/src/frontend/src/sol/components/fee/SolFeeDisplay.svelte
+++ b/src/frontend/src/sol/components/fee/SolFeeDisplay.svelte
@@ -11,14 +11,18 @@
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getSolCreateAccountFee } from '$sol/api/solana.api';
-	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 	import { type FeeContext, SOL_FEE_CONTEXT_KEY } from '$sol/stores/sol-fee.store';
+	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 
 	export let showAtaFee = false;
 
 	const { sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const { feeStore:fee, feeDecimalsStore: decimals, feeSymbolStore:symbol }: FeeContext = getContext<FeeContext>(SOL_FEE_CONTEXT_KEY);
+	const {
+		feeStore: fee,
+		feeDecimalsStore: decimals,
+		feeSymbolStore: symbol
+	}: FeeContext = getContext<FeeContext>(SOL_FEE_CONTEXT_KEY);
 
 	let ataFee: Lamports | undefined = undefined;
 

--- a/src/frontend/src/sol/stores/sol-fee.store.ts
+++ b/src/frontend/src/sol/stores/sol-fee.store.ts
@@ -1,0 +1,30 @@
+import { writable, type Readable, type Writable } from 'svelte/store';
+
+export type FeeStoreData = bigint | undefined;
+
+export interface FeeStore extends Readable<FeeStoreData> {
+	setFee: (data: bigint | undefined) => void;
+}
+
+export const initFeeStore = (): FeeStore => {
+	const { subscribe, set } = writable<FeeStoreData>(undefined);
+
+	return {
+		subscribe,
+
+		setFee(data: bigint | undefined) {
+			set(data);
+		}
+	};
+};
+
+export interface FeeContext {
+	feeStore: FeeStore;
+	prioritizationFeeStore: FeeStore;
+	feeSymbolStore: Writable<string | undefined>;
+	feeDecimalsStore: Writable<number | undefined>;
+}
+
+export const initFeeContext = (params: FeeContext): FeeContext => params;
+
+export const SOL_FEE_CONTEXT_KEY = Symbol('sol-fee');

--- a/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
@@ -3,12 +3,19 @@ import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
 import * as solanaApi from '$sol/api/solana.api';
 import SolSendForm from '$sol/components/send/SolSendForm.svelte';
+import { SOL_FEE_CONTEXT_KEY, initFeeContext, initFeeStore } from '$sol/stores/sol-fee.store';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import { lamports } from '@solana/rpc-types';
 import { render } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
 
 describe('SolSendForm', () => {
 	const mockContext = new Map([]);
+
+	const mockFeeStore = initFeeStore();
+	mockFeeStore.setFee(123n);
+	const mockPrioritizationFeeStore = initFeeStore();
+	mockPrioritizationFeeStore.setFee(3n);
 
 	const props = {
 		destination: mockSolAddress2,
@@ -28,6 +35,16 @@ describe('SolSendForm', () => {
 		vi.resetAllMocks();
 
 		vi.spyOn(solanaApi, 'estimatePriorityFee').mockResolvedValue(0n);
+
+		mockContext.set(
+			SOL_FEE_CONTEXT_KEY,
+			initFeeContext({
+				feeStore: mockFeeStore,
+				prioritizationFeeStore: mockPrioritizationFeeStore,
+				feeSymbolStore: writable(SOLANA_TOKEN.symbol),
+				feeDecimalsStore: writable(SOLANA_TOKEN.decimals)
+			})
+		);
 	});
 
 	it('should render all fields', () => {


### PR DESCRIPTION
# Motivation

We will need to have the Solana fee through a few other components, especially to freeze it when sending the transaction.

So, we move the fee calculation (with the prioritization fee), in a separate component that defines the context. It is very similar to what it is done with Ethereum.

# Changes

- Create fee store and fee context: this is basically a simplified version of the Ethereum one.
- Move `prioritizationFee` calculation to another component `SolFeeContext`.
- Modify the functions to update the context instead of local variables.
- Wrap the components in `SolSendTokenWizard`.
- Initialize the context in `SolSendTokenWizard`.
- Adapt `SolFeeDisplay` to call the context.

# Tests

No changes to the replica:

![Screenshot 2025-01-27 at 13 26 58](https://github.com/user-attachments/assets/0aa119a3-5afe-47ea-80be-05248f8bb70e)
