### PR TITLE
chore(backend): Better test error messages

### DIFF
--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -54,12 +54,11 @@ fn test_add_custom_token(user_token: &CustomToken) {
 
     let before_set = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
-    assert!(before_set.is_ok());
-    assert_eq!(before_set.unwrap().len(), 0);
+    assert_eq!(before_set, Ok(Vec::new()));
 
     let result = pic_setup.update::<()>(caller, "set_custom_token", user_token.clone());
 
-    assert!(result.is_ok());
+    assert_eq!(result, Ok(()));
 
     let after_set = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 


### PR DESCRIPTION
# Motivation
When tests assert that something `.is_ok()` the error message gives no information about what went wrong.

# Changes
- Use `assert_eq` instead of `assert!(x.is_ok())`, as this displays the error.

# Tests
This is part of a test.  The change has been useful locally.