### PR TITLE
refactor(backend): Move the maximum symbol length

### DIFF
--- a/src/backend/src/assertions.rs
+++ b/src/backend/src/assertions.rs
@@ -1,5 +1,5 @@
-use crate::MAX_SYMBOL_LENGTH;
 use shared::types::token::UserToken;
+use shared::types::MAX_SYMBOL_LENGTH;
 
 pub fn assert_token_symbol_length(token: &UserToken) -> Result<(), String> {
     if let Some(symbol) = token.symbol.as_ref() {

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -70,8 +70,6 @@ const USER_CUSTOM_TOKEN_MEMORY_ID: MemoryId = MemoryId::new(2);
 const USER_PROFILE_MEMORY_ID: MemoryId = MemoryId::new(3);
 const USER_PROFILE_UPDATED_MEMORY_ID: MemoryId = MemoryId::new(4);
 
-const MAX_SYMBOL_LENGTH: usize = 20;
-
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
         MemoryManager::init(DefaultMemoryImpl::default())

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -138,6 +138,9 @@ pub mod token {
     }
 }
 
+/// The default maximum length of a token symbol.
+pub const MAX_SYMBOL_LENGTH: usize = 20;
+
 /// Extendable custom user defined tokens
 pub mod custom_token {
     use crate::types::Version;


### PR DESCRIPTION
# Motivation
It would be useful to have the max symbol length available in the shared crate.  Technically, the maximum symbol length is also part of the public interface, so the shared crate is a more appropriate location anyway.

# Changes
- Move the definition of `MAX_SYMBOL_LENGTH` to the shared crate.

# Tests
Existing CI should suffice.