### PR TITLE
chore(backend): Add b58 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3228,7 @@ dependencies = [
 name = "shared"
 version = "0.0.2"
 dependencies = [
+ "bs58",
  "candid",
  "getrandom",
  "ic-canister-sig-creation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+bs58 = "0.5.1"
 ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.9.0"

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.2"
 edition = "2021"
 
 [dependencies]
+bs58 = { workspace = true }
 candid = { workspace = true }
 getrandom = { workspace = true }
 ic-canister-sig-creation = { workspace = true }


### PR DESCRIPTION
# Motivation
We wish to validate Solana addresses.  These are base58 encoded.

# Changes
- Add bs58 as a dependency.

# Tests
Dependency sanity checking:

There are [several base58 implementations](https://lib.rs/search?q=base58).  I chose this one as it is ranked top, has an acceptable license and has a bit more evidence of auditing than base58.