### PR TITLE
chore(frontend): SPL contracts --> SPL tokens

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -167,7 +167,7 @@
 			"loading_balance": "Error while loading the ETH balance.",
 			"loading_balance_symbol": "Error while loading $symbol balance.",
 			"erc20_contracts": "Error while loading the ERC20 contracts.",
-			"spl_contract": "Error while loading the SPL contract.",
+			"spl_tokens": "Error while loading the SPL tokens.",
 			"minter_ckbtc_btc": "A configured minter is required to convert ckBTC to BTC.",
 			"minter_cketh_eth": "A configured minter is required to convert ckETH to ETH.",
 			"minter_ckerc20_erc20": "A configured minter is required to convert ckERC20 to Erc20.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -144,7 +144,7 @@ interface I18nInit {
 		loading_balance: string;
 		loading_balance_symbol: string;
 		erc20_contracts: string;
-		spl_contract: string;
+		spl_tokens: string;
 		minter_ckbtc_btc: string;
 		minter_cketh_eth: string;
 		minter_ckerc20_erc20: string;

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -28,7 +28,7 @@ const loadDefaultSplTokens = (): ResultSuccess => {
 		splDefaultTokensStore.reset();
 
 		toastsError({
-			msg: { text: get(i18n).init.error.spl_contract },
+			msg: { text: get(i18n).init.error.spl_tokens },
 			err
 		});
 


### PR DESCRIPTION
# Motivation

It is more consistent to call the SPL contracts as SPL tokens.
