### PR TITLE
chore(frontend): use postcss in BtcConvertReview

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertReview.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertReview.svelte
@@ -30,7 +30,7 @@
 	<slot name="cancel" slot="cancel" />
 </ConvertReview>
 
-<style lang="scss">
+<style lang="postcss">
 	:global(.btc-convert-review-fees > div.contents > div.header > button.collapsible-expand-icon) {
 		justify-content: flex-end;
 	}


### PR DESCRIPTION
# Motivation

One of the warnings we are receiving is linked to the wrong language in a `<style>` element.
