### PR TITLE
feat(frontend): hide error toasts on BTC balance update

### DIFF
--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -1,5 +1,6 @@
 import { syncWallet, syncWalletError } from '$btc/services/btc-listener.services';
 import type { BtcPostMessageDataResponseWallet } from '$btc/types/btc-post-message';
+import { STAGING } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -31,6 +32,7 @@ export const initBtcWalletWorker = async ({
 
 	const isTestnetNetwork = isNetworkIdBTCTestnet(networkId);
 	const isRegtestNetwork = isNetworkIdBTCRegtest(networkId);
+	const isMainnetNetwork = isNetworkIdBTCMainnet(networkId);
 
 	worker.onmessage = ({ data }: MessageEvent<PostMessage<BtcPostMessageDataResponseWallet>>) => {
 		const { msg } = data;
@@ -51,8 +53,9 @@ export const initBtcWalletWorker = async ({
 					 * TODOs:
 					 * 1. Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
 					 * 2. Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
+					 * 3. Investigate why update balance call sometimes throws "ingress_expire" error and remove "isMainnetNetwork" afterwards.
 					 * **/
-					hideToast: isRegtestNetwork || isTestnetNetwork
+					hideToast: isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !STAGING)
 				});
 				return;
 		}

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -1,6 +1,6 @@
 import { syncWallet, syncWalletError } from '$btc/services/btc-listener.services';
 import type { BtcPostMessageDataResponseWallet } from '$btc/types/btc-post-message';
-import { STAGING } from '$lib/constants/app.constants';
+import { LOCAL, STAGING } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -53,9 +53,10 @@ export const initBtcWalletWorker = async ({
 					 * TODOs:
 					 * 1. Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
 					 * 2. Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
-					 * 3. Investigate why update balance call sometimes throws "ingress_expire" error and remove "isMainnetNetwork" afterwards.
+					 * 3. After the "ingress_expiry" error caused by the overloaded networks is fixed, remove "isMainnetNetwork".
 					 * **/
-					hideToast: isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !STAGING)
+					hideToast:
+						isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !(STAGING || LOCAL))
 				});
 				return;
 		}

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -50,10 +50,9 @@ export const initBtcWalletWorker = async ({
 					tokenId,
 					error: (data.data as PostMessageDataResponseError).error,
 					/**
-					 * TODOs:
-					 * 1. Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
-					 * 2. Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
-					 * 3. Investigate the "ingress_expiry" error that is sometimes thrown by update BTC balance call, and remove "isMainnetNetwork" afterwards.
+					 * TODO: Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
+					 * TODO: Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
+					 * TODO: Investigate the "ingress_expiry" error that is sometimes thrown by update BTC balance call, and remove "isMainnetNetwork" afterwards.
 					 * **/
 					hideToast: isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !STAGING)
 				});

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -53,7 +53,7 @@ export const initBtcWalletWorker = async ({
 					 * TODOs:
 					 * 1. Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
 					 * 2. Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
-					 * 3. After the "ingress_expiry" error caused by the overloaded networks is fixed, remove "isMainnetNetwork".
+					 * 3. Investigate the "ingress_expiry" error that is sometimes thrown by update BTC balance call, and remove "isMainnetNetwork" afterwards.
 					 * **/
 					hideToast: isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !STAGING)
 				});

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -1,6 +1,6 @@
 import { syncWallet, syncWalletError } from '$btc/services/btc-listener.services';
 import type { BtcPostMessageDataResponseWallet } from '$btc/types/btc-post-message';
-import { LOCAL, STAGING } from '$lib/constants/app.constants';
+import { STAGING } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -55,8 +55,7 @@ export const initBtcWalletWorker = async ({
 					 * 2. Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.
 					 * 3. After the "ingress_expiry" error caused by the overloaded networks is fixed, remove "isMainnetNetwork".
 					 * **/
-					hideToast:
-						isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !(STAGING || LOCAL))
+					hideToast: isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !STAGING)
 				});
 				return;
 		}


### PR DESCRIPTION
# Motivation

Update BTC balance still sometimes throws "ingress_expiry" issue. Previously, there was a problem with busy subnets (https://forum.dfinity.org/t/subnets-with-heavy-compute-load-what-can-you-do-now-next-steps/35762/19), but it is supposed to be fixed some time ago. 

For the time being, we were asked to hide related error toasts (same as in the Solana wallet worker). I added a TODO comment to remove this change after a proper investigation is completed and the error is fixed. For the debugging purposes, we will still show toast in staging env.
