### PR TITLE
chore(test): use scss modern-compiler for tests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { basename, dirname, resolve } from 'node:path';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
-import {CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds} from './vite.utils';
+import { CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds } from './vite.utils';
 
 // npm run dev = local
 // npm run build = local

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { basename, dirname, resolve } from 'node:path';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
-import { defineViteReplacements, readCanisterIds } from './vite.utils';
+import {CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds} from './vite.utils';
 
 // npm run dev = local
 // npm run build = local
@@ -19,13 +19,7 @@ const config: UserConfig = {
 			$declarations: resolve('./src/declarations')
 		}
 	},
-	css: {
-		preprocessorOptions: {
-			scss: {
-				api: 'modern-compiler'
-			}
-		}
-	},
+	...CSS_CONFIG_OPTIONS,
 	build: {
 		target: 'es2020',
 		rollupOptions: {

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { UserConfig } from 'vite';
 import { readCanisterIds as readIds } from './env.utils';
 
 /**
@@ -105,4 +106,14 @@ export const defineViteReplacements = (): {
 		VITE_APP_VERSION: JSON.stringify(version),
 		VITE_DFX_NETWORK: JSON.stringify(network)
 	};
+};
+
+export const CSS_CONFIG_OPTIONS: Pick<UserConfig, 'css'> = {
+	css: {
+		preprocessorOptions: {
+			scss: {
+				api: 'modern-compiler'
+			}
+		}
+	}
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { svelteTesting } from '@testing-library/svelte/vite';
 import { resolve } from 'path';
 import { type UserConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
-import { defineViteReplacements, readCanisterIds } from './vite.utils';
+import { CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds } from './vite.utils';
 
 process.env = {
 	...process.env,
@@ -13,6 +13,7 @@ process.env = {
 export default defineConfig(
 	(): UserConfig => ({
 		plugins: [sveltekit(), svelteTesting()],
+		...CSS_CONFIG_OPTIONS,
 		resolve: {
 			alias: [
 				{


### PR DESCRIPTION
# Motivation

To resolve the following tests warning we want to use the CSS `modern-compiler` for testing purpose as well:

> Deprecation Warning [user-authored]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
>
> More info: https://sass-lang.com/d/legacy-js-api

# Changes

- Extract vite CSS options to a constant utils
- Use constant for vitest config
