### PR TITLE
feat(frontend): load Solana user tokens that were included manually

### DIFF
--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -1,3 +1,4 @@
+import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import { queryAndUpdate } from '$lib/actors/query.ic';
 import { nullishSignOut } from '$lib/services/auth.services';
@@ -7,7 +8,9 @@ import type { SolAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenMetadata } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { get as getStorage } from '$lib/utils/storage.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
 import { getTokenDecimals } from '$sol/api/solana.api';
 import { splMetadata } from '$sol/rest/quicknode.rest';
 import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
@@ -19,7 +22,8 @@ import {
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type { SplUserToken } from '$sol/types/spl-user-token';
-import { isNullish, nonNullish } from '@dfinity/utils';
+import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
+import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 export const loadSplTokens = async ({ identity }: { identity: OptionIdentity }): Promise<void> => {
@@ -65,10 +69,10 @@ export const loadUserTokens = async ({
 	identity: OptionIdentity;
 }): Promise<SplUserToken[]> => {
 	// TODO: use the backend method when we add the SPL tokens to the backend, similar to ERC20
-	const loadUserContracts = async (): Promise<SplTokenAddress[]> => {
+	const loadUserContracts = async (): Promise<SplUserToken[]> => {
 		if (isNullish(identity)) {
 			await nullishSignOut();
-			return await Promise.resolve([]);
+			return [];
 		}
 
 		const contractsMap: SplAddressMap =
@@ -76,14 +80,53 @@ export const loadUserTokens = async ({
 		const principal = identity.getPrincipal().toString();
 		const contracts = nonNullish(principal) ? (contractsMap[principal] ?? []) : [];
 
-		return await Promise.resolve(contracts);
+		const [existingTokens, userTokenAddresses] = contracts.reduce<
+			[SplUserToken[], SplTokenAddress[]]
+		>(
+			([accExisting, accUser], address) => {
+				const existingToken = SPL_TOKENS.find((token) => token.address === address);
+
+				return nonNullish(existingToken)
+					? [[...accExisting, { ...existingToken, enabled: true }], accUser]
+					: [accExisting, [...accUser, address]];
+			},
+			[[], []]
+		);
+
+		const userTokens = await Promise.all(
+			userTokenAddresses.map(async (address) => {
+				// TODO: add checks for the network, when we have the backend
+				const network = SOLANA_MAINNET_NETWORK;
+
+				const solNetwork = mapNetworkIdToNetwork(network.id);
+
+				assertNonNullish(
+					solNetwork,
+					replacePlaceholders(get(i18n).init.error.no_solana_network, {
+						$network: network.id.description ?? ''
+					})
+				);
+
+				const metadata = await getSplMetadata({ address, network: solNetwork });
+
+				return {
+					...{
+						id: parseTokenId(`user-token#${metadata.symbol}#${network.chainId}`),
+						network,
+						address,
+						standard: 'spl' as const,
+						category: 'custom' as const,
+						enabled: true
+					},
+					...metadata
+				};
+			})
+		);
+
+		return [...existingTokens, ...userTokens];
 	};
 
-	const contracts = await loadUserContracts();
-	return SPL_TOKENS.filter((token) => contracts.includes(token.address)).map((token) => ({
-		...token,
-		enabled: true
-	}));
+	return await loadUserContracts();
 };
 
 const loadUserTokenData = ({

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -110,14 +110,12 @@ export const loadUserTokens = async ({
 				const metadata = await getSplMetadata({ address, network: solNetwork });
 
 				return {
-					...{
-						id: parseTokenId(`user-token#${metadata.symbol}#${network.chainId}`),
-						network,
-						address,
-						standard: 'spl' as const,
-						category: 'custom' as const,
-						enabled: true
-					},
+					id: parseTokenId(`user-token#${metadata.symbol}#${network.chainId}`),
+					network,
+					address,
+					standard: 'spl' as const,
+					category: 'custom' as const,
+					enabled: true,
 					...metadata
 				};
 			})


### PR DESCRIPTION
# Motivation

Awaiting for the backend methods to be completed, to show better the SPL tokens that the user added manually, we can now split the loaded user tokens between the ones that we have hard-coded and the ones that require to load the metadata. 

# Changes

- Split loaded token addresses between existing tokens in the `SPL_TOKENS` list and addresses without matching token.
- Map the unmatched addresses using method `getSplMetadata`: this is very similar to how we map the ERC20 tokens.

# Tests


https://github.com/user-attachments/assets/82e913d0-9733-4268-b83a-07d8e08856e7


