### PR TITLE
refactor(devops): Delete duplicate specified-id

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -321,12 +321,24 @@
 		"ckusdc_ledger": {
 			"type": "custom",
 			"candid": "target/ic/cketh_ledger.did",
-			"wasm": "target/ic/cketh_ledger.wasm"
+			"wasm": "target/ic/cketh_ledger.wasm",
+			"specified_id": "ycvkf-paaaa-aaaar-qaelq-cai",
+			"remote": {
+				"id": {
+					"ic": "xevnm-gaaaa-aaaar-qafnq-cai"
+				}
+			}
 		},
 		"ckusdc_index": {
 			"type": "custom",
 			"candid": "target/ic/cketh_index.did",
-			"wasm": "target/ic/cketh_index.wasm"
+			"wasm": "target/ic/cketh_index.wasm",
+			"specified_id": "ycvkf-paaaa-aaaar-qaelq-cai",
+			"remote": {
+				"id": {
+					"ic": "xrs4b-hiaaa-aaaar-qafoa-cai"
+				}
+			}
 		},
 		"rewards": {
 			"type": "custom",

--- a/scripts/deploy.ckbtc.sh
+++ b/scripts/deploy.ckbtc.sh
@@ -6,9 +6,9 @@
 DFX_NETWORK=local
 
 echo "Step 1: create canisters..."
-dfx canister create ckbtc_ledger --specified-id mc6ru-gyaaa-aaaar-qaaaq-cai --network "$DFX_NETWORK"
-dfx canister create ckbtc_minter --specified-id ml52i-qqaaa-aaaar-qaaba-cai --network "$DFX_NETWORK"
-dfx canister create ckbtc_kyt --specified-id pvm5g-xaaaa-aaaar-qaaia-cai --network "$DFX_NETWORK"
+dfx canister create ckbtc_ledger --network "$DFX_NETWORK"
+dfx canister create ckbtc_minter --network "$DFX_NETWORK"
+dfx canister create ckbtc_kyt --network "$DFX_NETWORK"
 
 MINTERID="$(dfx canister id ckbtc_minter --network "$DFX_NETWORK")"
 echo "$MINTERID"
@@ -18,7 +18,7 @@ KYTID="$(dfx canister id ckbtc_kyt --network "$DFX_NETWORK")"
 echo "$KYTID"
 
 echo "Step 2: deploy minter canister..."
-dfx deploy ckbtc_minter --specified-id ml52i-qqaaa-aaaar-qaaba-cai --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_minter --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
        btc_network = variant { Regtest };
        ledger_id = principal \"$LEDGERID\";
@@ -34,7 +34,7 @@ dfx deploy ckbtc_minter --specified-id ml52i-qqaaa-aaaar-qaaba-cai --network "$D
 
 echo "Step 3: deploy ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"
-dfx deploy ckbtc_ledger --specified-id mc6ru-gyaaa-aaaar-qaaaq-cai --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_ledger --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckBTC\";
      token_name = \"Chain key local Bitcoin\";
@@ -55,7 +55,7 @@ dfx deploy ckbtc_ledger --specified-id mc6ru-gyaaa-aaaar-qaaaq-cai --network "$D
 })"
 
 echo "Step 4: deploy kyt canister..."
-dfx deploy ckbtc_kyt --specified-id pvm5g-xaaaa-aaaar-qaaia-cai --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy ckbtc_kyt --network "$DFX_NETWORK" --argument "(variant {
   InitArg = record {
     minter_id = principal \"$MINTERID\";
     maintainers = vec {};
@@ -64,7 +64,7 @@ dfx deploy ckbtc_kyt --specified-id pvm5g-xaaaa-aaaar-qaaia-cai --network "$DFX_
 })"
 
 echo "Step 5: deploy index canister..."
-dfx deploy ckbtc_index --specified-id mm444-5iaaa-aaaar-qaabq-cai --network "$DFX_NETWORK" --argument "(opt variant {
+dfx deploy ckbtc_index --network "$DFX_NETWORK" --argument "(opt variant {
   Init = record {
     ledger_id = principal \"$LEDGERID\";
    }

--- a/scripts/deploy.cketh.sh
+++ b/scripts/deploy.cketh.sh
@@ -3,8 +3,8 @@
 DFX_NETWORK=local
 
 echo "Step 1: create canisters..."
-dfx canister create cketh_ledger --specified-id apia6-jaaaa-aaaar-qabma-cai --network "$DFX_NETWORK"
-dfx canister create cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$DFX_NETWORK"
+dfx canister create cketh_ledger --network "$DFX_NETWORK"
+dfx canister create cketh_minter --network "$DFX_NETWORK"
 
 MINTERID="$(dfx canister id cketh_minter --network "$DFX_NETWORK")"
 echo "$MINTERID"
@@ -16,7 +16,7 @@ echo "Step 2: deploy minter canister..."
 # ckETH minter deployed on using the smart contract address on Sepolia used by testnet.
 # We can alternatively also deploy our own contract.
 
-dfx deploy cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy cketh_minter --network "$DFX_NETWORK" --argument "(variant {
   InitArg = record {
        ethereum_network = variant {Sepolia};
        ecdsa_key_name = \"dfx_test_key\";
@@ -31,7 +31,7 @@ dfx deploy cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$D
 
 echo "Step 3: deploy ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"
-dfx deploy cketh_ledger --specified-id apia6-jaaaa-aaaar-qabma-cai --network "$DFX_NETWORK" --argument "(variant {
+dfx deploy cketh_ledger --network "$DFX_NETWORK" --argument "(variant {
   Init = record {
      token_symbol = \"ckSepoliaETH\";
      token_name = \"Chain key local Sepolia Ethereum\";
@@ -54,7 +54,7 @@ dfx deploy cketh_ledger --specified-id apia6-jaaaa-aaaar-qabma-cai --network "$D
 })"
 
 echo "Step 4: deploy index canister..."
-dfx deploy cketh_index --specified-id sh5u2-cqaaa-aaaar-qacna-cai --network "$DFX_NETWORK" --argument "(opt variant {
+dfx deploy cketh_index --network "$DFX_NETWORK" --argument "(opt variant {
   Init = record {
     ledger_id = principal \"$LEDGERID\";
    }

--- a/scripts/deploy.icp_index.sh
+++ b/scripts/deploy.icp_index.sh
@@ -5,8 +5,8 @@
 
 LEDGER_ACCOUNT_ID=$(dfx canister id icp_ledger)
 
-dfx deploy icp_index --specified-id qhbym-qaaaa-aaaaa-aaafq-cai --argument '(record {ledger_id = principal"'${LEDGER_ACCOUNT_ID}'";})'
+dfx deploy icp_index --argument '(record {ledger_id = principal"'${LEDGER_ACCOUNT_ID}'";})'
 
-dfx canister call qhbym-qaaaa-aaaaa-aaafq-cai ledger_id '()'
+dfx canister call icp_index ledger_id '()'
 
-dfx canister call qhbym-qaaaa-aaaaa-aaafq-cai status '()'
+dfx canister call icp_index status '()'

--- a/scripts/deploy.icp_ledger.sh
+++ b/scripts/deploy.icp_ledger.sh
@@ -11,7 +11,7 @@ dfx identity use default
 
 LEDGER_ACCOUNT_ID=$(dfx ledger account-id)
 
-dfx deploy --specified-id ryjl3-tyaaa-aaaaa-aaaba-cai icp_ledger --argument "
+dfx deploy icp_ledger --argument "
   (variant {
     Init = record {
       minting_account = \"$MINTER_ACCOUNT_ID\";

--- a/scripts/deploy.kong_backend.sh
+++ b/scripts/deploy.kong_backend.sh
@@ -3,4 +3,4 @@
 DFX_NETWORK=local
 
 # TODO: update canister_e2e_ids.json with kong_backend after the e2e tests flow is unblocked
-KONG_BUILDENV="$DFX_NETWORK" dfx deploy kong_backend --network "$DFX_NETWORK" --specified-id l4lgk-raaaa-aaaar-qahpq-cai
+KONG_BUILDENV="$DFX_NETWORK" dfx deploy kong_backend --network "$DFX_NETWORK"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,8 +20,8 @@ mkdir -p ./target/ic
 
 ./scripts/deploy.kong_backend.sh
 
-dfx deploy internet_identity --specified-id rdmx6-jaaaa-aaaaa-aaadq-cai
-dfx deploy pouh_issuer --specified-id qbw6f-caaaa-aaaah-qdcwa-cai
+dfx deploy internet_identity
+dfx deploy pouh_issuer
 dfx deploy cycles_ledger
 dfx deploy cycles_depositor
 dfx deploy rewards


### PR DESCRIPTION
# Motivation
We would like to be able to deploy the local environment simply and reliably. Ideally with no more than `dfx deploy`.  To that end I am simplifying deploy commands one step at a time until they are trivial.

Specifically, for this PR:  The preferred way of specifying canister IDs is now in dfx.json, so passing `--specified-id` as a deploy argument is really only for overrides.  Most canister IDs are already specified in `dfx.json` so in most cases we can simply delete the flags.

# Changes
- Delete `--specified-id` almost everywhere.

# Tests
Existing CI should suffice.