### PR TITLE
feat(frontend): try and fetch SPL icon in metadata

### DIFF
--- a/src/frontend/src/sol/rest/quicknode.rest.ts
+++ b/src/frontend/src/sol/rest/quicknode.rest.ts
@@ -1,11 +1,16 @@
 import { QUICKNODE_API_KEY, QUICKNODE_API_URL } from '$env/rest/quicknode.env';
 import type { TokenMetadata } from '$lib/types/token';
+import type { UrlSchema } from '$lib/validation/url.validation';
 import type { SplTokenAddress } from '$sol/types/spl';
+import { z } from 'zod';
 
 interface SplMetadataResponse {
 	result: {
 		content: {
 			metadata: TokenMetadata;
+			links: {
+				image: z.infer<typeof UrlSchema>;
+			};
 		};
 	};
 }

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -148,7 +148,10 @@ export const getSplMetadata = async ({
 
 	const {
 		result: {
-			content: { metadata }
+			content: {
+				metadata,
+				links: { image: icon }
+			}
 		}
 	} = await splMetadata({ tokenAddress: address });
 
@@ -157,6 +160,7 @@ export const getSplMetadata = async ({
 	return {
 		decimals,
 		name,
-		symbol
+		symbol,
+		icon
 	};
 };


### PR DESCRIPTION
# Motivation

Some tokens provide an image URL to the icon in their metadata.

# Changes

- Adapt type of response of Quicknode metadata.
- Adapt service that fetches metadata.

# Tests

I manually added PENGU:

![Screenshot 2025-01-29 at 09 23 24](https://github.com/user-attachments/assets/8dd79a0f-80e0-49c6-ab20-9e8ae5b14119)



