### PR TITLE
feat(frontend): update ETH txs and erc20 tokens error messages

### DIFF
--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -14,7 +14,7 @@ import { mapErc20Token, mapErc20UserToken } from '$eth/utils/erc20.utils';
 import { queryAndUpdate } from '$lib/actors/query.ic';
 import { listUserTokens } from '$lib/api/backend.api';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsError } from '$lib/stores/toasts.store';
+import { toastsErrorGeneric } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { UserTokenState } from '$lib/types/token-toggleable';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -51,7 +51,7 @@ const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 	} catch (err: unknown) {
 		erc20DefaultTokensStore.reset();
 
-		toastsError({
+		toastsErrorGeneric({
 			msg: { text: get(i18n).init.error.erc20_contracts },
 			err
 		});
@@ -69,7 +69,7 @@ export const loadErc20UserTokens = ({ identity }: { identity: OptionIdentity }):
 		onCertifiedError: ({ error: err }) => {
 			erc20UserTokensStore.resetAll();
 
-			toastsError({
+			toastsErrorGeneric({
 				msg: { text: get(i18n).init.error.erc20_user_tokens },
 				err
 			});

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -14,7 +14,7 @@ import { mapErc20Token, mapErc20UserToken } from '$eth/utils/erc20.utils';
 import { queryAndUpdate } from '$lib/actors/query.ic';
 import { listUserTokens } from '$lib/api/backend.api';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsErrorGeneric } from '$lib/stores/toasts.store';
+import { toastsErrorNoTrace } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { UserTokenState } from '$lib/types/token-toggleable';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -51,7 +51,7 @@ const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 	} catch (err: unknown) {
 		erc20DefaultTokensStore.reset();
 
-		toastsErrorGeneric({
+		toastsErrorNoTrace({
 			msg: { text: get(i18n).init.error.erc20_contracts },
 			err
 		});
@@ -69,7 +69,7 @@ export const loadErc20UserTokens = ({ identity }: { identity: OptionIdentity }):
 		onCertifiedError: ({ error: err }) => {
 			erc20UserTokensStore.resetAll();
 
-			toastsErrorGeneric({
+			toastsErrorNoTrace({
 				msg: { text: get(i18n).init.error.erc20_user_tokens },
 				err
 			});

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -6,7 +6,7 @@ import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { retry } from '$lib/services/rest.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsError, toastsErrorGeneric } from '$lib/stores/toasts.store';
+import { toastsError, toastsErrorNoTrace } from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -65,7 +65,7 @@ const loadEthTransactions = async ({
 			}
 		} = get(i18n);
 
-		toastsErrorGeneric({
+		toastsErrorNoTrace({
 			msg: { text: loading_transactions },
 			err
 		});
@@ -131,7 +131,7 @@ const loadErc20Transactions = async ({
 			}
 		} = get(i18n);
 
-		toastsErrorGeneric({
+		toastsErrorNoTrace({
 			msg: {
 				text: replacePlaceholders(loading_transactions_symbol, {
 					$symbol: token.symbol

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -65,9 +65,10 @@ const loadEthTransactions = async ({
 			}
 		} = get(i18n);
 
+		console.error(`${loading_transactions}:`, err);
+
 		toastsError({
-			msg: { text: loading_transactions },
-			err
+			msg: { text: loading_transactions }
 		});
 		return { success: false };
 	}
@@ -130,14 +131,16 @@ const loadErc20Transactions = async ({
 				error: { loading_transactions_symbol }
 			}
 		} = get(i18n);
+		const errorMsg = replacePlaceholders(loading_transactions_symbol, {
+			$symbol: token.symbol
+		});
+
+		console.error(`${errorMsg}:`, err);
 
 		toastsError({
 			msg: {
-				text: replacePlaceholders(loading_transactions_symbol, {
-					$symbol: token.symbol
-				})
-			},
-			err
+				text: errorMsg
+			}
 		});
 		return { success: false };
 	}

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -6,7 +6,7 @@ import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { retry } from '$lib/services/rest.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsError } from '$lib/stores/toasts.store';
+import { toastsError, toastsErrorGeneric } from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -65,10 +65,9 @@ const loadEthTransactions = async ({
 			}
 		} = get(i18n);
 
-		console.error(`${loading_transactions}:`, err);
-
-		toastsError({
-			msg: { text: loading_transactions }
+		toastsErrorGeneric({
+			msg: { text: loading_transactions },
+			err
 		});
 		return { success: false };
 	}
@@ -131,16 +130,14 @@ const loadErc20Transactions = async ({
 				error: { loading_transactions_symbol }
 			}
 		} = get(i18n);
-		const errorMsg = replacePlaceholders(loading_transactions_symbol, {
-			$symbol: token.symbol
-		});
 
-		console.error(`${errorMsg}:`, err);
-
-		toastsError({
+		toastsErrorGeneric({
 			msg: {
-				text: errorMsg
-			}
+				text: replacePlaceholders(loading_transactions_symbol, {
+					$symbol: token.symbol
+				})
+			},
+			err
 		});
 		return { success: false };
 	}

--- a/src/frontend/src/lib/stores/toasts.store.ts
+++ b/src/frontend/src/lib/stores/toasts.store.ts
@@ -5,13 +5,11 @@ import { nonNullish } from '@dfinity/utils';
 
 export const toastsShow = (msg: ToastMsg): symbol => toastsStore.show(msg);
 
-export const toastsError = ({
-	msg: { text, ...rest },
-	err
-}: {
+interface ToastsErrorParams {
 	msg: Omit<ToastMsg, 'level'>;
 	err?: unknown;
-}): symbol => {
+}
+export const toastsError = ({ msg: { text, ...rest }, err }: ToastsErrorParams): symbol => {
 	if (nonNullish(err)) {
 		console.error(err);
 	}
@@ -20,6 +18,14 @@ export const toastsError = ({
 		text: `${text}${nonNullish(err) ? ` / ${errorDetailToString(err)}` : ''}`,
 		...rest,
 		level: 'error'
+	});
+};
+
+export const toastsErrorGeneric = ({ msg, err }: ToastsErrorParams) => {
+	console.error(`${msg.text}:`, err);
+
+	return toastsError({
+		msg
 	});
 };
 

--- a/src/frontend/src/lib/stores/toasts.store.ts
+++ b/src/frontend/src/lib/stores/toasts.store.ts
@@ -21,7 +21,7 @@ export const toastsError = ({ msg: { text, ...rest }, err }: ToastsErrorParams):
 	});
 };
 
-export const toastsErrorGeneric = ({ msg, err }: ToastsErrorParams) => {
+export const toastsErrorNoTrace = ({ msg, err }: ToastsErrorParams) => {
 	console.error(`${msg.text}:`, err);
 
 	return toastsError({

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -23,12 +23,12 @@ vi.mock('$eth/rest/etherscan.rest', () => ({
 
 describe('eth-transactions.services', () => {
 	describe('loadEthereumTransactions', () => {
-		let spyToastsErrorGeneric: MockInstance;
+		let spyToastsErrorNoTrace: MockInstance;
 
 		beforeEach(() => {
 			vi.resetAllMocks();
 
-			spyToastsErrorGeneric = vi.spyOn(toastsStore, 'toastsErrorGeneric');
+			spyToastsErrorNoTrace = vi.spyOn(toastsStore, 'toastsErrorNoTrace');
 
 			// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
 			vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -69,7 +69,7 @@ describe('eth-transactions.services', () => {
 					tokenId: mockTokenId
 				});
 
-				expect(spyToastsErrorGeneric).toHaveBeenCalledWith({
+				expect(spyToastsErrorNoTrace).toHaveBeenCalledWith({
 					msg: { text: en.init.error.eth_address_unknown }
 				});
 				expect(result).toEqual({ success: false });
@@ -81,7 +81,7 @@ describe('eth-transactions.services', () => {
 					tokenId: USDT_TOKEN_ID
 				});
 
-				expect(spyToastsErrorGeneric).toHaveBeenCalledWith({
+				expect(spyToastsErrorNoTrace).toHaveBeenCalledWith({
 					msg: { text: en.transactions.error.no_token_loading_transaction }
 				});
 				expect(result).toEqual({ success: false });
@@ -128,7 +128,7 @@ describe('eth-transactions.services', () => {
 
 				expect(result).toEqual({ success: false });
 				expect(get(ethTransactionsStore)).toEqual({ [mockTokenId]: null });
-				expect(spyToastsErrorGeneric).toHaveBeenCalledWith({
+				expect(spyToastsErrorNoTrace).toHaveBeenCalledWith({
 					err: mockError,
 					msg: {
 						text: replacePlaceholders(en.transactions.error.loading_transactions_symbol, {

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -23,12 +23,12 @@ vi.mock('$eth/rest/etherscan.rest', () => ({
 
 describe('eth-transactions.services', () => {
 	describe('loadEthereumTransactions', () => {
-		let spyToastsError: MockInstance;
+		let spyToastsErrorGeneric: MockInstance;
 
 		beforeEach(() => {
 			vi.resetAllMocks();
 
-			spyToastsError = vi.spyOn(toastsStore, 'toastsError');
+			spyToastsErrorGeneric = vi.spyOn(toastsStore, 'toastsErrorGeneric');
 
 			// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
 			vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -69,7 +69,7 @@ describe('eth-transactions.services', () => {
 					tokenId: mockTokenId
 				});
 
-				expect(spyToastsError).toHaveBeenCalledWith({
+				expect(spyToastsErrorGeneric).toHaveBeenCalledWith({
 					msg: { text: en.init.error.eth_address_unknown }
 				});
 				expect(result).toEqual({ success: false });
@@ -81,7 +81,7 @@ describe('eth-transactions.services', () => {
 					tokenId: USDT_TOKEN_ID
 				});
 
-				expect(spyToastsError).toHaveBeenCalledWith({
+				expect(spyToastsErrorGeneric).toHaveBeenCalledWith({
 					msg: { text: en.transactions.error.no_token_loading_transaction }
 				});
 				expect(result).toEqual({ success: false });
@@ -128,7 +128,7 @@ describe('eth-transactions.services', () => {
 
 				expect(result).toEqual({ success: false });
 				expect(get(ethTransactionsStore)).toEqual({ [mockTokenId]: null });
-				expect(spyToastsError).toHaveBeenCalledWith({
+				expect(spyToastsErrorGeneric).toHaveBeenCalledWith({
 					err: mockError,
 					msg: {
 						text: replacePlaceholders(en.transactions.error.loading_transactions_symbol, {

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -23,11 +23,13 @@ vi.mock('$eth/rest/etherscan.rest', () => ({
 
 describe('eth-transactions.services', () => {
 	describe('loadEthereumTransactions', () => {
+		let spyToastsError: MockInstance;
 		let spyToastsErrorNoTrace: MockInstance;
 
 		beforeEach(() => {
 			vi.resetAllMocks();
 
+			spyToastsError = vi.spyOn(toastsStore, 'toastsError');
 			spyToastsErrorNoTrace = vi.spyOn(toastsStore, 'toastsErrorNoTrace');
 
 			// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
@@ -69,7 +71,7 @@ describe('eth-transactions.services', () => {
 					tokenId: mockTokenId
 				});
 
-				expect(spyToastsErrorNoTrace).toHaveBeenCalledWith({
+				expect(spyToastsError).toHaveBeenCalledWith({
 					msg: { text: en.init.error.eth_address_unknown }
 				});
 				expect(result).toEqual({ success: false });
@@ -81,7 +83,7 @@ describe('eth-transactions.services', () => {
 					tokenId: USDT_TOKEN_ID
 				});
 
-				expect(spyToastsErrorNoTrace).toHaveBeenCalledWith({
+				expect(spyToastsError).toHaveBeenCalledWith({
 					msg: { text: en.transactions.error.no_token_loading_transaction }
 				});
 				expect(result).toEqual({ success: false });


### PR DESCRIPTION
# Motivation

The idea is to make ETH txs and erc20 tokens error messages user-friendlier by removing the "err" part from the error toasts. The `err` object will be logged in the console instead.

![a6575c24-a073-4cde-9728-98eb472ce5ab](https://github.com/user-attachments/assets/a25fed68-a7c3-478c-b940-0ee9e6f03c13)
