### PR TITLE
feat(frontend): include Solana testnet tokens in user tokens

### DIFF
--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -84,10 +84,15 @@ export const loadUserTokens = async ({
 			[SplUserToken[], SplTokenAddress[]]
 		>(
 			([accExisting, accUser], address) => {
-				const existingToken = SPL_TOKENS.find((token) => token.address === address);
+				const existingTokens = SPL_TOKENS.filter((token) => contracts.includes(token.address)).map(
+					(token) => ({
+						...token,
+						enabled: true
+					})
+				);
 
-				return nonNullish(existingToken)
-					? [[...accExisting, { ...existingToken, enabled: true }], accUser]
+				return existingTokens.length > 0
+					? [[...accExisting, ...existingTokens], accUser]
 					: [accExisting, [...accUser, address]];
 			},
 			[[], []]


### PR DESCRIPTION
# Motivation

Since we are filtering only by contract, it makes sense to get all the SPL tokens with the same contract saved (including the testnet ones).
