### PR TITLE
test(frontend): mock utxos fee in BtcConvertTokenWizard

### DIFF
--- a/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
@@ -1,5 +1,6 @@
 import BtcConvertTokenWizard from '$btc/components/convert/BtcConvertTokenWizard.svelte';
 import * as btcPendingSentTransactionsStore from '$btc/services/btc-pending-sent-transactions.services';
+import * as btcSendApi from '$btc/services/btc-send.services';
 import * as utxosFeeStore from '$btc/stores/utxos-fee.store';
 import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import type { UtxosFee } from '$btc/types/btc-send';
@@ -58,6 +59,8 @@ describe('BtcConvertTokenWizard', () => {
 	};
 	const mockSignerApi = () =>
 		vi.spyOn(signerApi, 'sendBtc').mockResolvedValue({ txid: transactionId });
+	const mockSelectUtxosFeeApi = () =>
+		vi.spyOn(btcSendApi, 'selectUtxosFee').mockResolvedValue(mockUtxosFee);
 	const mockBackendApi = () =>
 		vi
 			.spyOn(backendApi, 'addPendingBtcTransaction')
@@ -96,6 +99,7 @@ describe('BtcConvertTokenWizard', () => {
 	beforeEach(() => {
 		mockPage.reset();
 		mockBtcPendingSentTransactionsStore();
+		mockSelectUtxosFeeApi();
 	});
 
 	it('should call sendBtc if all requirements are met', async () => {


### PR DESCRIPTION
# Motivation

When we run the tests for BtcConvertTokenWizard there is a warning:


> ```bash
> stderr | src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
> It looks like the agent is trying to make a request that should have been mocked at Error: 
>     at Object.transformRequest (/Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/tests/mocks/identity.mock.ts:11:3)
>     at HttpAgent.createReadStateRequest (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/agent/http/index.ts:1042:27)
>     at HttpAgent.readState (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/agent/http/index.ts:1048:21)
>     at /Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/canisterStatus/index.ts:152:12
>     at async Promise.all (index 0)
>     at Module.request (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/canisterStatus/index.ts:260:3)
>     at HttpAgent.syncTime (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/agent/http/index.ts:1124:8)
>     at async Promise.all (index 0)
>     at Function.create (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/lib/esm/agent/http/index.js:330:9)
>     at Module.Y (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/utils/dist/esm/index.js:4:2622)
>   Expected to find result for path time, but instead found nothing.
>   Error: Not implemented
>       at Object.transformRequest (/Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/tests/mocks/identity.mock.ts:13:8)
>       at HttpAgent.createReadStateRequest (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/agent/http/index.ts:1042:27)
>       at HttpAgent.readState (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/agent/http/index.ts:1048:21)
>       at /Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/canisterStatus/index.ts:152:12
>       at async Promise.all (index 0)
>       at Module.request (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/canisterStatus/index.ts:260:3)
>       at HttpAgent.syncTime (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/src/agent/http/index.ts:1124:8)
>       at async Promise.all (index 0)
>       at Function.create (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/agent/lib/esm/agent/http/index.js:330:9)
>       at Module.Y (/Users/antonio.ventilii/projects/oisy-wallet/node_modules/@dfinity/utils/dist/esm/index.js:4:2622)
> 
> ```


This happens because we didn't mock `selectUtxosFee` service.

