### PR TITLE
fix(frontend): do not format usd

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapInputCurrencyUsd.svelte
+++ b/src/frontend/src/lib/components/swap/SwapInputCurrencyUsd.svelte
@@ -6,7 +6,6 @@
 		SWAP_INPUT_CURRENCY_USD_SYMBOL
 	} from '$lib/constants/test-ids.constants';
 	import type { OptionAmount } from '$lib/types/send';
-	import { formatUSD } from '$lib/utils/format.utils';
 
 	export let tokenAmount: OptionAmount;
 	export let tokenDecimals: number;
@@ -28,7 +27,7 @@
 	const syncDisplayValueWithTokenAmount = () => {
 		const newDisplayValue =
 			nonNullish(exchangeRate) && nonNullish(tokenAmount)
-				? formatUSD({ value: Number(tokenAmount) * exchangeRate, options: { symbol: false } })
+				? (Number(tokenAmount) * exchangeRate).toFixed(2)
 				: undefined;
 
 		if (Number(newDisplayValue) !== Number(displayValue)) {

--- a/src/frontend/src/tests/lib/components/swap/SwapInputCurrencyUsd.test.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapInputCurrencyUsd.test.ts
@@ -44,6 +44,14 @@ describe('SwapInputCurrencyUsd', () => {
 		expect(input).toHaveValue('');
 	});
 
+	it.each(['10000', '1000', '100'])('does not format usd value %s', async (value) => {
+		const { getByTestId } = render(SwapInputCurrencyUsd, defaultProps);
+		const input = getByTestId(SWAP_INPUT_CURRENCY_USD);
+
+		await fireEvent.input(input, { target: { value } });
+		expect(input).toHaveValue(value);
+	});
+
 	it('updates display value when tokenAmount changes', async () => {
 		const props = {
 			...defaultProps,


### PR DESCRIPTION
# Motivation

The USD input field in the swap formats values unexpectedly and breaks the usage.

# Changes

Replace formatUSD with toFixed(2)

# Tests

Unit tests added

Additionally

https://github.com/user-attachments/assets/4c32a2c8-f2af-461a-bc11-b857d644c1bf

