### PR TITLE
Revert "chore(devops): Bump dfx version (#4498)"

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-	"dfx": "0.24.3",
+	"dfx": "0.23.0",
 	"canisters": {
 		"signer": {
 			"type": "custom",


### PR DESCRIPTION
This reverts commit f86a5e147b8fee2e05484793256371053dfce612.

The asset canister deployment demands to update the asset canister.  This is unexpected.  It _may_ be fine but needs time to investigate. https://github.com/dfinity/oisy-wallet/actions/runs/13036151733/job/36366962202