### PR TITLE
fix(devops): Deploy only frontend in frontend step

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Deploy Frontend to Environment
         run: |
           if [ "$CANISTER" == "frontend" ] || [ "${{ github.event_name }}" == "push" ]; then
-            dfx deploy $CANISTER --network $NETWORK
+            dfx deploy frontend --network $NETWORK
           fi
 
       - name: Deploy Backend to Environment


### PR DESCRIPTION
# Motivation
The step "Deploy Frontend to Environment" deploys `$CANISTER` but it looks as if it may be possible for that not to be the frontend.  This is _probably_ not intentional, and if it is, it should be documented.

# Changes
- Deploy `frontend` instead of `$CANISTER` in the "Deploy Frontend to Environment" step.

# Tests
