### PR TITLE
refactor(frontend): re-use ExpandableValues between swap and convert

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import { Collapsible } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { fade } from 'svelte/transition';
+	import ModalExpandableValues from '$lib/components/ui/ModalExpandableValues.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { SWAP_TOTAL_FEE_THRESHOLD } from '$lib/constants/swap.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -58,27 +57,26 @@
 </script>
 
 {#if nonNullish($destinationToken) && nonNullish($sourceToken)}
-	<div in:fade class="swap-fees">
-		<Collapsible>
-			<!-- The width of the item below should be 100% - collapsible expand button width (1.5rem) -->
-			<div class="flex w-[calc(100%-1.5rem)] items-center" slot="header">
-				<ModalValue>
-					<svelte:fragment slot="label">{$i18n.swap.text.total_fee}</svelte:fragment>
+	<ModalExpandableValues>
+		<svelte:fragment slot="list-header">
+			<ModalValue>
+				<svelte:fragment slot="label">{$i18n.swap.text.total_fee}</svelte:fragment>
 
-					<svelte:fragment slot="main-value">
-						{#if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
-							{`< ${formatUSD({
-								value: SWAP_TOTAL_FEE_THRESHOLD
-							})}`}
-						{:else}
-							{formatUSD({
-								value: destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD
-							})}
-						{/if}
-					</svelte:fragment>
-				</ModalValue>
-			</div>
+				<svelte:fragment slot="main-value">
+					{#if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
+						{`< ${formatUSD({
+							value: SWAP_TOTAL_FEE_THRESHOLD
+						})}`}
+					{:else}
+						{formatUSD({
+							value: destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD
+						})}
+					{/if}
+				</svelte:fragment>
+			</ModalValue>
+		</svelte:fragment>
 
+		<svelte:fragment slot="list-items">
 			{#if nonNullish(sourceTokenFee)}
 				<ModalValue>
 					<svelte:fragment slot="label">{$i18n.swap.text.token_fee}</svelte:fragment>
@@ -107,12 +105,6 @@
 					{$destinationToken.symbol}
 				</svelte:fragment>
 			</ModalValue>
-		</Collapsible>
-	</div>
+		</svelte:fragment>
+	</ModalExpandableValues>
 {/if}
-
-<style lang="scss">
-	:global(.swap-fees > div.contents > div.header > button.collapsible-expand-icon) {
-		justify-content: flex-end;
-	}
-</style>

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -58,23 +58,21 @@
 
 {#if nonNullish($destinationToken) && nonNullish($sourceToken)}
 	<ModalExpandableValues>
-		<svelte:fragment slot="list-header">
-			<ModalValue>
-				<svelte:fragment slot="label">{$i18n.swap.text.total_fee}</svelte:fragment>
+		<ModalValue slot="list-header">
+			<svelte:fragment slot="label">{$i18n.swap.text.total_fee}</svelte:fragment>
 
-				<svelte:fragment slot="main-value">
-					{#if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
-						{`< ${formatUSD({
-							value: SWAP_TOTAL_FEE_THRESHOLD
-						})}`}
-					{:else}
-						{formatUSD({
-							value: destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD
-						})}
-					{/if}
-				</svelte:fragment>
-			</ModalValue>
-		</svelte:fragment>
+			<svelte:fragment slot="main-value">
+				{#if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
+					{`< ${formatUSD({
+						value: SWAP_TOTAL_FEE_THRESHOLD
+					})}`}
+				{:else}
+					{formatUSD({
+						value: destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD
+					})}
+				{/if}
+			</svelte:fragment>
+		</ModalValue>
 
 		<svelte:fragment slot="list-items">
 			{#if nonNullish(sourceTokenFee)}

--- a/src/frontend/src/lib/components/ui/ModalExpandableValues.svelte
+++ b/src/frontend/src/lib/components/ui/ModalExpandableValues.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Collapsible } from '@dfinity/gix-components';
+	import { fade } from 'svelte/transition';
+</script>
+
+<div in:fade class="modal-expandable-values">
+	<Collapsible>
+		<!-- The width of the item below should be 100% - collapsible expand button width (1.5rem) -->
+		<div class="flex w-[calc(100%-1.5rem)] items-center" slot="header">
+			<slot name="list-header" />
+		</div>
+
+		<slot name="list-items" />
+	</Collapsible>
+</div>
+
+<style lang="scss">
+	:global(.modal-expandable-values > div.contents > div.header > button.collapsible-expand-icon) {
+		justify-content: flex-end;
+	}
+</style>


### PR DESCRIPTION
# Motivation

The next step of aligning Convert and Swap flow is to extract ModalExpandableValues into a separate component. The convert form usage will be added in the following PR.
