### PR TITLE
feat(frontend): update BtcConvertFees component

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertFees.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertFees.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { BTC_CONVERT_FEE } from '$btc/constants/btc.constants';
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
 	import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 	import ConvertFee from '$lib/components/convert/ConvertFee.svelte';
+	import ConvertFeeTotal from '$lib/components/convert/ConvertFeeTotal.svelte';
+	import ModalExpandableValues from '$lib/components/ui/ModalExpandableValues.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	export let totalFee: bigint | undefined = undefined;
 
 	const { sourceToken, sourceTokenExchangeRate, destinationToken } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
@@ -17,32 +22,48 @@
 
 	let satoshisFee: bigint | undefined;
 	$: satoshisFee = $storeUtxosFeeData?.utxosFee?.feeSatoshis;
+
+	$: totalFee =
+		nonNullish(kytFee) && nonNullish(satoshisFee)
+			? BTC_CONVERT_FEE + kytFee + satoshisFee
+			: undefined;
 </script>
 
-<ConvertFee
-	feeAmount={BTC_CONVERT_FEE}
-	decimals={$sourceToken.decimals}
-	exchangeRate={$sourceTokenExchangeRate}
-	symbol={$sourceToken.symbol}
-	zeroAmountLabel={$i18n.fee.text.zero_fee}
->
-	<svelte:fragment slot="label">{$i18n.fee.text.convert_fee}</svelte:fragment>
-</ConvertFee>
+<ModalExpandableValues>
+	<ConvertFeeTotal
+		slot="list-header"
+		feeAmount={totalFee}
+		decimals={$sourceToken.decimals}
+		exchangeRate={$sourceTokenExchangeRate}
+	/>
 
-<ConvertFee
-	feeAmount={kytFee}
-	decimals={$sourceToken.decimals}
-	exchangeRate={$sourceTokenExchangeRate}
-	symbol={$sourceToken.symbol}
->
-	<svelte:fragment slot="label">{$i18n.fee.text.convert_inter_network_fee}</svelte:fragment>
-</ConvertFee>
+	<svelte:fragment slot="list-items">
+		<ConvertFee
+			feeAmount={BTC_CONVERT_FEE}
+			decimals={$sourceToken.decimals}
+			exchangeRate={$sourceTokenExchangeRate}
+			symbol={$sourceToken.symbol}
+			zeroAmountLabel={$i18n.fee.text.zero_fee}
+		>
+			<svelte:fragment slot="label">{$i18n.fee.text.convert_fee}</svelte:fragment>
+		</ConvertFee>
 
-<ConvertFee
-	feeAmount={satoshisFee}
-	decimals={$sourceToken.decimals}
-	exchangeRate={$sourceTokenExchangeRate}
-	symbol={$sourceToken.symbol}
->
-	<svelte:fragment slot="label">{$i18n.fee.text.convert_btc_network_fee}</svelte:fragment>
-</ConvertFee>
+		<ConvertFee
+			feeAmount={kytFee}
+			decimals={$sourceToken.decimals}
+			exchangeRate={$sourceTokenExchangeRate}
+			symbol={$sourceToken.symbol}
+		>
+			<svelte:fragment slot="label">{$i18n.fee.text.convert_inter_network_fee}</svelte:fragment>
+		</ConvertFee>
+
+		<ConvertFee
+			feeAmount={satoshisFee}
+			decimals={$sourceToken.decimals}
+			exchangeRate={$sourceTokenExchangeRate}
+			symbol={$sourceToken.symbol}
+		>
+			<svelte:fragment slot="label">{$i18n.fee.text.convert_btc_network_fee}</svelte:fragment>
+		</ConvertFee>
+	</svelte:fragment>
+</ModalExpandableValues>

--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -2,7 +2,6 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import type { Readable } from 'svelte/store';
-	import BtcConvertFeeTotal from '$btc/components/convert/BtcConvertFeeTotal.svelte';
 	import BtcConvertFees from '$btc/components/convert/BtcConvertFees.svelte';
 	import BtcSendWarnings from '$btc/components/send/BtcSendWarnings.svelte';
 	import {
@@ -13,7 +12,6 @@
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
 	import InsufficientFundsForFee from '$lib/components/fee/InsufficientFundsForFee.svelte';
-	import Hr from '$lib/components/ui/Hr.svelte';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
@@ -66,13 +64,7 @@
 		{/if}
 	</svelte:fragment>
 
-	<svelte:fragment slot="fee">
-		<BtcConvertFees />
-
-		<Hr spacing="md" />
-
-		<BtcConvertFeeTotal bind:totalFee />
-	</svelte:fragment>
+	<BtcConvertFees bind:totalFee slot="fee" />
 
 	<slot name="cancel" slot="cancel" />
 </ConvertForm>

--- a/src/frontend/src/btc/components/convert/BtcConvertReview.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertReview.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { Collapsible } from '@dfinity/gix-components';
-	import BtcConvertFeeTotal from '$btc/components/convert/BtcConvertFeeTotal.svelte';
 	import BtcConvertFees from '$btc/components/convert/BtcConvertFees.svelte';
 	import ConvertReview from '$lib/components/convert/ConvertReview.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
@@ -12,16 +10,7 @@
 </script>
 
 <ConvertReview on:icConvert on:icBack {sendAmount} {receiveAmount}>
-	<div class="btc-convert-review-fees" slot="fee">
-		<Collapsible>
-			<!-- The width of the item below should be 100% - collapsible expand button width (1.5rem) -->
-			<div class="flex w-[calc(100%-1.5rem)] items-center" slot="header">
-				<BtcConvertFeeTotal />
-			</div>
-
-			<BtcConvertFees />
-		</Collapsible>
-	</div>
+	<BtcConvertFees slot="fee" />
 
 	<div slot="info-message" class="mt-4">
 		<MessageBox>{$i18n.convert.text.conversion_may_take}</MessageBox>
@@ -29,9 +18,3 @@
 
 	<slot name="cancel" slot="cancel" />
 </ConvertReview>
-
-<style lang="scss">
-	:global(.btc-convert-review-fees > div.contents > div.header > button.collapsible-expand-icon) {
-		justify-content: flex-end;
-	}
-</style>


### PR DESCRIPTION
# Motivation

In this PR, I'm updating the BtcConvertFees component to be aligned with SwapFees.

<img width="583" alt="Screenshot 2025-01-30 at 13 49 39" src="https://github.com/user-attachments/assets/ba949ea1-79c5-4d87-8555-2599614935d9" />
