### PR TITLE
fix(frontend): separate ckBTC update balance listener from other loaders

### DIFF
--- a/src/frontend/src/icp/components/core/CkBTCUpdateBalanceListener.svelte
+++ b/src/frontend/src/icp/components/core/CkBTCUpdateBalanceListener.svelte
@@ -19,7 +19,5 @@
 		initFn={initCkBTCUpdateBalanceWorker}
 		token={ckBtcToken}
 		twinToken={ckBtcToken.twinToken}
-	>
-		<slot />
-	</IcCkListener>
+	/>
 {/if}

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -15,17 +15,18 @@
 		<RewardGuard>
 			<LoaderEthBalances>
 				<LoaderWallets>
-					<CkBTCUpdateBalanceListener>
-						<ExchangeWorker>
-							<LoaderMetamask
-								><LoaderUserProfile>
-									<slot />
-								</LoaderUserProfile>
-							</LoaderMetamask>
-						</ExchangeWorker>
-					</CkBTCUpdateBalanceListener>
+					<ExchangeWorker>
+						<LoaderMetamask
+							><LoaderUserProfile>
+								<slot />
+							</LoaderUserProfile>
+						</LoaderMetamask>
+					</ExchangeWorker>
 				</LoaderWallets>
 			</LoaderEthBalances>
 		</RewardGuard>
 	</Loader>
 </AddressGuard>
+
+<!-- This listener is kept outside of the Loaders tree to prevent slow page loading on localhost/e2e -->
+<CkBTCUpdateBalanceListener />


### PR DESCRIPTION
# Motivation

The idea is to separate ckBTC update balance listener from other loaders to prevent very slow page loading on localhost/e2e.
