### PR TITLE
feat(devops): fix minter PEM issue

### DIFF
--- a/scripts/build.icp_ledger.args.sh
+++ b/scripts/build.icp_ledger.args.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 # Ensure that a minter id exists:
-dfx identity get-principal --identity minter 2>/dev/null || dfx identity new minter
+dfx identity get-principal --identity minter 2>/dev/null || dfx identity new minter --storage-mode=plaintext
 
 MINTER_ACCOUNT_ID=$(dfx ledger account-id --identity minter)
 CALLER_ACCOUNT_ID=$(dfx ledger account-id)


### PR DESCRIPTION
# Motivation

The recent changes in the backend deployment introduced an error with the PEM of the minter. 

# Changes

when creating the minter identity we use plaintext so it does not ask for an encrypted PEM
