### PR TITLE
feat(ci): include test files among bot policies

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -12,3 +12,4 @@ src/frontend/src/env/tokens/tokens.*.json
 src/frontend/src/env/tokens/tokens-erc20/
 src/frontend/static/icons/sns/*
 src/frontend/src/**/*.svelte
+src/frontend/src/tests/**/*.spec.ts


### PR DESCRIPTION
# Motivation

Same as with Svelte components, we need to allow bot to remove .spec.ts files.
