### PR TITLE
feat(frontend): add SPL parser to Custom Token parser

### DIFF
--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -25,7 +25,9 @@ export const saveCustomTokens = async ({
 
 	// Hide tokens that have been disabled
 	const disabledTokens = tokens.filter(({ enabled }) => !enabled);
-	disabledTokens.forEach(({ ledgerCanisterId }) => icrcCustomTokensStore.reset(ledgerCanisterId));
+	disabledTokens.forEach((token) =>
+		token.networkKey === 'Icrc' ? icrcCustomTokensStore.reset(token.ledgerCanisterId) : null
+	);
 
 	// Reload all custom tokens for simplicity reason.
 	await loadCustomTokens({ identity });

--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -1,13 +1,22 @@
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { UserTokenState } from '$lib/types/token-toggleable';
+import type { SplToken } from '$sol/types/spl';
 
-export type CustomTokenNetworkKeys = 'Icrc';
+export type CustomTokenNetworkKeys = 'Icrc' | 'SplMainnet' | 'SplDevnet';
 
 export type IcrcSaveCustomToken = Pick<IcrcCustomToken, 'ledgerCanisterId' | 'indexCanisterId'>;
 
-export type SaveCustomToken = UserTokenState & IcrcSaveCustomToken;
+export type SplSaveCustomToken = Pick<SplToken, 'address' | 'decimals' | 'symbol'>;
+
+export type SaveCustomToken = UserTokenState & (IcrcSaveCustomToken | SplSaveCustomToken);
+
+type IcrcSaveCustomTokenWithKey = IcrcSaveCustomToken & {
+	networkKey: Extract<CustomTokenNetworkKeys, 'Icrc'>;
+};
+
+type SplSaveCustomTokenWithKey = SplSaveCustomToken & {
+	networkKey: Extract<CustomTokenNetworkKeys, 'SplMainnet' | 'SplDevnet'>;
+};
 
 export type SaveCustomTokenWithKey = UserTokenState &
-	(IcrcSaveCustomToken & {
-		networkKey: Extract<CustomTokenNetworkKeys, 'Icrc'>;
-	});
+	(IcrcSaveCustomTokenWithKey | SplSaveCustomTokenWithKey);

--- a/src/frontend/src/lib/utils/custom-token.utils.ts
+++ b/src/frontend/src/lib/utils/custom-token.utils.ts
@@ -1,5 +1,9 @@
-import type { CustomToken, IcrcToken } from '$declarations/backend/backend.did';
-import type { IcrcSaveCustomToken, SaveCustomTokenWithKey } from '$lib/types/custom-token';
+import type { CustomToken, IcrcToken, SplToken } from '$declarations/backend/backend.did';
+import type {
+	IcrcSaveCustomToken,
+	SaveCustomTokenWithKey,
+	SplSaveCustomToken
+} from '$lib/types/custom-token';
 import { Principal } from '@dfinity/principal';
 import { nonNullish, toNullable } from '@dfinity/utils';
 
@@ -13,12 +17,28 @@ const toIcrcCustomToken = ({
 	)
 });
 
+const toSplCustomToken = ({
+	address: token_address,
+	decimals,
+	symbol
+}: SplSaveCustomToken): SplToken => ({
+	token_address,
+	decimals: toNullable(decimals),
+	symbol: toNullable(symbol)
+});
+
 export const toCustomToken = ({
 	enabled,
 	version,
+	networkKey,
 	...rest
 }: SaveCustomTokenWithKey): CustomToken => ({
 	enabled,
 	version: toNullable(version),
-	token: { Icrc: toIcrcCustomToken(rest as IcrcSaveCustomToken) }
+	token:
+		networkKey === 'Icrc'
+			? { Icrc: toIcrcCustomToken(rest as IcrcSaveCustomToken) }
+			: networkKey === 'SplMainnet'
+				? { SplMainnet: toSplCustomToken(rest as SplSaveCustomToken) }
+				: { SplDevnet: toSplCustomToken(rest as SplSaveCustomToken) }
 });

--- a/src/frontend/src/tests/lib/utils/custom-token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/custom-token.utils.spec.ts
@@ -14,6 +14,27 @@ describe('custom-token.utils', () => {
 			version: [1n]
 		};
 
+		it('should convert to CustomToken with nullish version', () => {
+			expect(
+				toCustomToken({
+					...mockParams,
+					version: undefined,
+					networkKey: 'Icrc',
+					ledgerCanisterId: mockLedgerCanisterId,
+					indexCanisterId: mockIndexCanisterId
+				})
+			).toEqual({
+				...partialExpected,
+				version: [],
+				token: {
+					Icrc: {
+						ledger_id: Principal.fromText(mockLedgerCanisterId),
+						index_id: [Principal.fromText(mockIndexCanisterId)]
+					}
+				}
+			});
+		});
+
 		it('should return correct type for Icrc network', () => {
 			const networkKey = 'Icrc';
 
@@ -51,22 +72,43 @@ describe('custom-token.utils', () => {
 			});
 		});
 
-		it('should convert to CustomToken with nullish version', () => {
+		it('should return correct type for SplMainnet network', () => {
 			expect(
 				toCustomToken({
 					...mockParams,
-					version: undefined,
-					networkKey: 'Icrc',
-					ledgerCanisterId: mockLedgerCanisterId,
-					indexCanisterId: mockIndexCanisterId
+					networkKey: 'SplMainnet',
+					address: 'mock-token-address',
+					decimals: 8,
+					symbol: 'mock-symbol'
 				})
 			).toEqual({
 				...partialExpected,
-				version: [],
 				token: {
-					Icrc: {
-						ledger_id: Principal.fromText(mockLedgerCanisterId),
-						index_id: [Principal.fromText(mockIndexCanisterId)]
+					SplMainnet: {
+						token_address: 'mock-token-address',
+						decimals: [8],
+						symbol: ['mock-symbol']
+					}
+				}
+			});
+		});
+
+		it('should return correct type for SplDevnet network', () => {
+			expect(
+				toCustomToken({
+					...mockParams,
+					networkKey: 'SplDevnet',
+					address: 'mock-token-address',
+					decimals: 8,
+					symbol: 'mock-symbol'
+				})
+			).toEqual({
+				...partialExpected,
+				token: {
+					SplDevnet: {
+						token_address: 'mock-token-address',
+						decimals: [8],
+						symbol: ['mock-symbol']
 					}
 				}
 			});

--- a/src/frontend/src/tests/mocks/ic-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/ic-tokens.mock.ts
@@ -1,12 +1,15 @@
-import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import {
+	IC_CKBTC_INDEX_CANISTER_ID,
+	IC_CKBTC_LEDGER_CANISTER_ID
+} from '$env/networks/networks.icrc.env';
 import type { IcCanisters, IcCkToken, IcToken } from '$icp/types/ic-token';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
 
 export const mockLedgerCanisterId = IC_CKBTC_LEDGER_CANISTER_ID;
-export const mockIndexCanisterId = IC_CKBTC_LEDGER_CANISTER_ID;
+export const mockIndexCanisterId = IC_CKBTC_INDEX_CANISTER_ID;
 
 export const mockValidIcCanisters: IcCanisters = {
-	ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID
+	ledgerCanisterId: mockLedgerCanisterId
 };
 
 export const mockValidIcToken: IcToken = {


### PR DESCRIPTION
# Motivation

Including the SPL parser for util `toCustomToken`.

# Changes

- Create types and interfaces for the SPL custom tokens, similar to ICRC.
- Create sub-util to parse.

# Tests

Added tests.
