### PR TITLE
feat(frontend): save cached SPL tokens to backend

### DIFF
--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -1,6 +1,8 @@
+import type { CustomToken } from '$declarations/backend/backend.did';
 import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import { queryAndUpdate } from '$lib/actors/query.ic';
+import { listCustomTokens, setManyCustomTokens } from '$lib/api/backend.api';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -8,6 +10,7 @@ import type { SolAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenMetadata } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
+import { toCustomToken } from '$lib/utils/custom-token.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { get as getStorage } from '$lib/utils/storage.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -23,6 +26,7 @@ import type { SolanaNetworkType } from '$sol/types/network';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type { SplUserToken } from '$sol/types/spl-user-token';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
+import type { Identity } from '@dfinity/agent';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -63,22 +67,98 @@ export const loadSplUserTokens = ({ identity }: { identity: OptionIdentity }): P
 		strategy: 'query'
 	});
 
+// This function is a temporary solution: save the user tokens that we were caching in the browser into the backend.
+// This is done to avoid any disruptions to the user experience, as the user tokens are not yet stored in the backend.
+// However, it is acceptable to remove it after a certain amount of time, since we expect that most of the users
+// that consider this part relevant will log in before that time.
+// So, as timeline, we define a period of 1 month, more or less, to remove this function and its usage.
+// That is enough time for the users to log in and have their tokens saved in the backend.
+// The release before this change was v0.22.0, as reference.
+// TODO: remove this function and its usage starting from the 1st of March 2025
+const saveCachedUserTokensToBackend = async ({
+	identity,
+	savedTokens
+}: {
+	identity: Identity;
+	savedTokens: CustomToken[];
+}): Promise<SplTokenAddress[]> => {
+	const savedTokenAddresses = savedTokens.reduce<SplTokenAddress[]>(
+		(acc, { token }) => [
+			...acc,
+			...('SplMainnet' in token ? [token.SplMainnet.token_address] : [])
+		],
+		[]
+	);
+
+	const contractsMap: SplAddressMap = getStorage<SplAddressMap>({ key: SPL_USER_TOKENS_KEY }) ?? {};
+	const principal = identity.getPrincipal().toString();
+	const contracts = nonNullish(principal) ? (contractsMap[principal] ?? []) : [];
+
+	const tokens = [];
+
+	// We are using a for loop instead of a functional approach to avoid the async/await issue due to the limit  of the Quicknode API calls.
+	// This is acceptable since this is just a temporary solution that shall be removed soon.
+	for (const address of contracts.filter((address) => !savedTokenAddresses.includes(address))) {
+		const network = SOLANA_MAINNET_NETWORK;
+		const solNetwork = mapNetworkIdToNetwork(network.id);
+
+		assertNonNullish(
+			solNetwork,
+			replacePlaceholders(get(i18n).init.error.no_solana_network, {
+				$network: network.id.description ?? ''
+			})
+		);
+
+		const metadata = await getSplMetadata({ address, network: solNetwork });
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+
+		tokens.push({
+			address,
+			enabled: true,
+			...metadata
+		});
+	}
+
+	await setManyCustomTokens({
+		identity,
+		tokens: tokens.map((token) => toCustomToken({ ...token, networkKey: 'SplMainnet' })),
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	});
+
+	return contracts;
+};
+
+const loadSplCustomTokens = async (params: {
+	identity: OptionIdentity;
+	certified: boolean;
+}): Promise<CustomToken[]> => {
+	const tokens = await listCustomTokens({
+		...params,
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	});
+
+	// We filter the custom tokens that are Spl (the backend "Custom Token" potentially supports other types).
+	return tokens.filter(({ token }) => 'SplMainnet' in token);
+};
+
 export const loadUserTokens = async ({
 	identity
 }: {
 	identity: OptionIdentity;
 }): Promise<SplUserToken[]> => {
-	// TODO: use the backend method when we add the SPL tokens to the backend, similar to ERC20
 	const loadUserContracts = async (): Promise<SplUserToken[]> => {
 		if (isNullish(identity)) {
 			await nullishSignOut();
 			return [];
 		}
 
-		const contractsMap: SplAddressMap =
-			getStorage<SplAddressMap>({ key: SPL_USER_TOKENS_KEY }) ?? {};
-		const principal = identity.getPrincipal().toString();
-		const contracts = nonNullish(principal) ? (contractsMap[principal] ?? []) : [];
+		const splCustomTokens = await loadSplCustomTokens({ identity, certified: true });
+
+		const contracts = await saveCachedUserTokensToBackend({
+			identity,
+			savedTokens: splCustomTokens
+		});
 
 		const [existingTokens, userTokenAddresses] = contracts.reduce<
 			[SplUserToken[], SplTokenAddress[]]


### PR DESCRIPTION
# Motivation

Before starting to use the SPL Custom tokens backed, we first need to save the current browser-cached SPL tokens to the backend, to avoid any any disruptions to the user experience, as the user tokens are not yet stored in the backend.
However, it is acceptable to remove it after a certain amount of time, since we expect that most of the users that consider this part relevant will log in before that time.
So, as timeline, we define a period of 1 month, more or less, to remove this function and its usage. That is enough time for the users to log in and have their tokens saved in the backend.

# Changes

- Create temporary util to load the SPL cached in the browser (this part of code was already there, just moved) and upload them to the backend (this is a copy of how we do for ICRC Custom tokens).
- Note: we are using a for loop instead of a functional approach to avoid the async/await issue due to the limit of the Quicknode API calls. This is acceptable since this is just a temporary solution that shall be removed soon.
- Adapt service `loadUserTokens`.

# Tests

Current tests worked well.
