### PR TITLE
feat(frontend): save SPL custom tokens to backend

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -173,7 +173,6 @@
 			identity: $authIdentity
 		});
 
-	// TODO: implement this function in the backend
 	const saveSpl = (tokens: SaveSplUserToken[]): Promise<void> =>
 		saveSplUserTokens({
 			tokens,


### PR DESCRIPTION
# Motivation

Since we can now save SPL tokens in the backend, we use the common service `setManyCustomTokens` to set SPL Custom tokens.

