### PR TITLE
refactor(frontend): clean up "swap" vars in tokens components

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -100,7 +100,8 @@
 					/>
 				{/if}
 			{:else}
-				<button on:click class="h-full w-full pl-3 text-base">{$i18n.swap.text.select_token}</button
+				<button on:click class="h-full w-full pl-3 text-base"
+					>{$i18n.tokens.text.select_token}</button
 				>
 			{/if}
 		</div>

--- a/src/frontend/src/lib/components/tokens/TokenInputAmountExchange.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputAmountExchange.svelte
@@ -49,7 +49,7 @@
 		>
 	{:else}
 		<span data-tid={TOKEN_INPUT_AMOUNT_EXCHANGE_UNAVAILABLE}
-			>{$i18n.swap.text.exchange_is_not_available}</span
+			>{$i18n.tokens.text.exchange_is_not_available}</span
 		>
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div
-	class={`swap-input-currency flex h-full w-full items-center font-bold ${styleClass}`}
+	class={`token-input-currency flex h-full w-full items-center font-bold ${styleClass}`}
 	class:text-error={error}
 	class:animate-pulse={loading}
 >
@@ -35,7 +35,7 @@
 </div>
 
 <style lang="scss">
-	:global(.swap-input-currency div.input-block) {
+	:global(.token-input-currency div.input-block) {
 		display: block;
 		height: 100%;
 		justify-content: center;
@@ -43,7 +43,7 @@
 		--input-width: 100%;
 	}
 
-	:global(.swap-input-currency div.input-field input[id]) {
+	:global(.token-input-currency div.input-field input[id]) {
 		height: 100%;
 		border: none;
 		border-radius: 0;

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
@@ -65,7 +65,7 @@
 </TokenInputCurrency>
 
 <style lang="scss">
-	:global(.swap-input-currency.no-padding div.input-field input[id]) {
+	:global(.token-input-currency.no-padding div.input-field input[id]) {
 		padding: 0;
 	}
 </style>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -440,7 +440,6 @@
 			"switch_tokens_button": "Switch tokens",
 			"review": "Review transaction",
 			"review_button": "Review swap",
-			"select_token": "Select token",
 			"max_slippage": "Max slippage",
 			"max_balance": "Max",
 			"not_available": "n/a",
@@ -454,7 +453,6 @@
 			"max_slippage_error": "Slippage tolerance cannot be 0% or exceed 50%",
 			"swap_button": "Swap now",
 			"swap_is_not_offered": "This swap is currently not offered.",
-			"exchange_is_not_available": "USD value is currently not available.",
 			"executing_transaction": "Executing transaction...",
 			"initializing": "Initializing transaction...",
 			"swapping": "Swapping...",
@@ -488,7 +486,9 @@
 			"initializing": "Initializing...",
 			"updating_ui": "Updating the UI...",
 			"show_token": "Show token",
-			"hide_token": "Hide token"
+			"hide_token": "Hide token",
+			"select_token": "Select token",
+			"exchange_is_not_available": "USD value is currently not available."
 		},
 		"details": {
 			"title": "Token details",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -402,7 +402,6 @@ interface I18nSwap {
 		switch_tokens_button: string;
 		review: string;
 		review_button: string;
-		select_token: string;
 		max_slippage: string;
 		max_balance: string;
 		not_available: string;
@@ -416,7 +415,6 @@ interface I18nSwap {
 		max_slippage_error: string;
 		swap_button: string;
 		swap_is_not_offered: string;
-		exchange_is_not_available: string;
 		executing_transaction: string;
 		initializing: string;
 		swapping: string;
@@ -445,6 +443,8 @@ interface I18nTokens {
 		updating_ui: string;
 		show_token: string;
 		hide_token: string;
+		select_token: string;
+		exchange_is_not_available: string;
 	};
 	details: {
 		title: string;


### PR DESCRIPTION
# Motivation

Refactoring PR to rename some "swap" leftovers after moving related components from `/swap/*` to `/tokens/*`.