### PR TITLE
chore(frontend): remove unused env var VITE_AUTH_DERIVATION_ORIGIN

### DIFF
--- a/src/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -69,7 +69,6 @@ describe('auth utils', () => {
 			beforeEach(() => {
 				vi.resetModules();
 				vi.stubEnv('VITE_AUTH_ALTERNATIVE_ORIGINS', alternativeOrigins.join(','));
-				vi.stubEnv('VITE_AUTH_DERIVATION_ORIGIN', '');
 			});
 
 			afterEach(() => {


### PR DESCRIPTION
# Motivation

With https://github.com/dfinity/oisy-wallet/pull/4142 I forgot to remove the mocked `VITE_AUTH_DERIVATION_ORIGIN` from the tests.