### PR TITLE
refactor(frontend): keep caching only SPL mainnet tokens

### DIFF
--- a/src/frontend/src/sol/services/spl-user-tokens.services.ts
+++ b/src/frontend/src/sol/services/spl-user-tokens.services.ts
@@ -4,7 +4,7 @@ import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { TokenId } from '$lib/types/token';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
-import { isNetworkIdSOLDevnet } from '$lib/utils/network.utils';
+import { isNetworkIdSOLDevnet, isNetworkIdSOLMainnet } from '$lib/utils/network.utils';
 import { get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
 import { loadSplUserTokens, loadUserTokens } from '$sol/services/spl.services';
 import {
@@ -38,10 +38,13 @@ export const saveUserTokens = async ({
 	const [enabledNewAddresses, disabledNewAddresses] = tokens.reduce<
 		[SplTokenAddress[], SplTokenAddress[]]
 	>(
-		([accEnabled, accDisabled], { address, enabled }) => [
-			[...accEnabled, ...(enabled ? [address] : [])],
-			[...accDisabled, ...(!enabled ? [address] : [])]
-		],
+		([accEnabled, accDisabled], { address, enabled, network: { id: networkId } }) =>
+			isNetworkIdSOLMainnet(networkId)
+				? [
+						[...accEnabled, ...(enabled ? [address] : [])],
+						[...accDisabled, ...(!enabled ? [address] : [])]
+					]
+				: [accEnabled, accDisabled],
 		[[], []]
 	);
 

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -140,7 +140,7 @@ const loadSplCustomTokens = async (params: {
 	});
 
 	// We filter the custom tokens that are Spl (the backend "Custom Token" potentially supports other types).
-	return tokens.filter(({ token }) => 'SplMainnet' in token);
+	return tokens.filter(({ token }) => 'SplMainnet' in token || 'SplDevnet' in token);
 };
 
 export const loadUserTokens = async ({


### PR DESCRIPTION
# Motivation

Just to have a clean and smooth cache, we will be saving in the browser cache only SPL mainnet tokens, since the devnet and the testnet are not really relevant for the user experience, so they can be "lost" in the token list when the new version is released.
