### PR TITLE
refactor(devops): Move release notes code into an action

### DIFF
--- a/.github/actions/release-notes/action.yml
+++ b/.github/actions/release-notes/action.yml
@@ -10,21 +10,21 @@ inputs:
 runs:
   using: composite
   steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+    - name: Create GitHub App Token
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+        private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
 
-      - name: Publish Release Notes
-        id: publish_release
-        uses: release-drafter/release-drafter@v6
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        with:
-          version: ${{ inputs.tag }}
-          tag: ${{ inputs.tag }}
-          name: ${{ inputs.tag }}
-          latest: true
-          publish: true
+    - name: Publish Release Notes
+      id: publish_release
+      uses: release-drafter/release-drafter@v6
+      env:
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      with:
+        version: ${{ inputs.tag }}
+        tag: ${{ inputs.tag }}
+        name: ${{ inputs.tag }}
+        latest: true
+        publish: true

--- a/.github/actions/release-notes/action.yml
+++ b/.github/actions/release-notes/action.yml
@@ -1,0 +1,30 @@
+name: Release Notes
+
+description: Publishes release notes
+
+inputs:
+  tag:
+    description: Name of the tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Publish Release Notes
+        id: publish_release
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          version: ${{ inputs.tag }}
+          tag: ${{ inputs.tag }}
+          name: ${{ inputs.tag }}
+          latest: true
+          publish: true

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   release_notes:
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-24.04
 
     steps:
@@ -17,7 +18,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish Release Notes
-        if: { { github.ref_type == 'tag' } }
-        uses: .github/actions/release-notes
+        uses: ./.github/actions/release-notes
         with:
           tag: github.ref_name

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,34 +6,18 @@ on:
   push:
     tags:
       - v*
-  workflow_run:
-    workflows: ['Tag on Merge from Release Branch']
-    types:
-      - completed
+  workflow_dispatch:
 
 jobs:
   release_notes:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Publish Release Notes
-        id: publish_release
-        uses: release-drafter/release-drafter@v6
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        if: {{ github.ref_type == 'tag' }}
+        uses: .github/actions/release-notes
         with:
-          version: ${{ github.ref_name }}
-          tag: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          latest: true
-          publish: true
+          tag: github.ref_name

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish Release Notes
-        if: {{ github.ref_type == 'tag' }}
+        if: { { github.ref_type == 'tag' } }
         uses: .github/actions/release-notes
         with:
           tag: github.ref_name

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,6 +32,6 @@ jobs:
           git push origin "v${{ steps.get_version.outputs.version }}"
 
       - name: Publish Release Notes
-        uses: .github/actions/release-notes
+        uses: ./.github/actions/release-notes
         with:
           tag: 'v${{ steps.get_version.outputs.version }}'

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Publish Release Notes
         uses: .github/actions/release-notes
         with:
-          tag: "v${{ steps.get_version.outputs.version }}"
+          tag: 'v${{ steps.get_version.outputs.version }}'

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -30,3 +30,8 @@ jobs:
         run: |
           git tag "v${{ steps.get_version.outputs.version }}"
           git push origin "v${{ steps.get_version.outputs.version }}"
+
+      - name: Publish Release Notes
+        uses: .github/actions/release-notes
+        with:
+          tag: "v${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
# Motivation
Chaining workflows is flaky and hard to test.  It looks as if we have our first casualty in the form of `main` tags being created due to the `ref_name` in the downstream workflow being unexpected. Time to pay down the technical debt and do this properly....

# Changes
- Move the release notes code into an action.
- Call the action directly from the release workflow.
- Call the action from "release notes on tag"

# Tests
Expected behaviours & tests:

## Release notes action is only ever run on tags

The action is called in two places.  We will cover each separately.

### In the Release Notes workflow
Here we use `ref_name` as the release tag, but check that the `ref_type` is tag.

To demonstrate, we will run the workflow explicitly on a branch:
```
gh workflow run --ref refs/heads/release-notes-action release-notes.yml
```
The workflow is skipped: https://github.com/dfinity/oisy-wallet/actions/runs/13126966742

And again, giving the just the branch name:
```
gh workflow run --ref release-notes-action release-notes.yml
```
Skipped again: https://github.com/dfinity/oisy-wallet/actions/runs/13126925891

But if we create a tag on this branch, we can run against that tag:
```
git tag test123 ; git push origin refs/tags/test123
gh workflow run --ref refs/tags/test123 release-notes.yml
```
Run succeeds: https://github.com/dfinity/oisy-wallet/actions/runs/13127143960

Arguments are as expected:
```
Run ./.github/actions/release-notes
  with:
    tag: test123
    app-id: 1063231
    private-key: ***
```

(although note that the third party release-drafter action emits warnings)
```
Run release-drafter/release-drafter@v6
Warning: "pull_request_target.opened" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
Warning: "pull_request_target.reopened" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
Warning: "pull_request_target.synchronize" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
Warning: "pull_request_target.edited" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
```
The release is created, with notes: https://github.com/dfinity/oisy-wallet/releases/tag/test123

### In the Tag Release workflow
Here the ref name is `main` but the workflow creates a tag and we use that tag name.

But we cannot test this properly without merging into main.