### PR TITLE
feat(frontend): service to fetch Solana transaction and map them

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -4,18 +4,106 @@ import {
 	SOLANA_TESTNET_TOKEN_ID,
 	SOLANA_TOKEN_ID
 } from '$env/tokens/tokens.sol.env';
-import { getSolTransactions } from '$sol/api/solana.api';
+import type { SolAddress } from '$lib/types/address';
+import { fetchTransactionDetailForSignature, getSolTransactions } from '$sol/api/solana.api';
 import {
 	solTransactionsStore,
 	type SolCertifiedTransaction
 } from '$sol/stores/sol-transactions.store';
-import { SolanaNetworks } from '$sol/types/network';
+import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
+import type { SolRpcInstruction } from '$sol/types/sol-instructions';
+import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
+import type { SplTokenAddress } from '$sol/types/spl';
+import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
 import { mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 interface LoadNextSolTransactionsParams extends GetSolTransactionsParams {
 	signalEnd: () => void;
 }
+
+export const fetchSolTransactionsForSignature = async ({
+	signature,
+	network,
+	address,
+	tokenAddress
+}: {
+	signature: SolSignature;
+	network: SolanaNetworkType;
+	address: SolAddress;
+	tokenAddress?: SplTokenAddress;
+}): Promise<SolTransactionUi[]> => {
+	const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
+
+	if (isNullish(transactionDetail)) {
+		return [];
+	}
+
+	const {
+		blockTime,
+		confirmationStatus: status,
+		transaction: {
+			message: { instructions }
+		},
+		meta
+	} = transactionDetail;
+
+	return await instructions.reduce(
+		async (acc, instruction, idx) => {
+			const innerInstructionsRaw =
+				meta?.innerInstructions?.find(({ index }) => index === idx)?.instructions ?? [];
+
+			const innerInstructions: SolRpcInstruction[] = innerInstructionsRaw.map(
+				(innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				})
+			);
+
+			const mappedTransaction = await mapSolParsedInstruction({
+				instruction: {
+					...instruction,
+					programAddress: instruction.programId
+				},
+				innerInstructions,
+				network
+			});
+
+			if (nonNullish(mappedTransaction) && mappedTransaction.tokenAddress === tokenAddress) {
+				const { value, from, to } = mappedTransaction;
+
+				const newTransaction: SolTransactionUi = {
+					id: `${signature.signature}-${instruction.programId}`,
+					signature: signature.signature,
+					timestamp: blockTime ?? 0n,
+					value,
+					type: address === from ? 'send' : 'receive',
+					from,
+					to,
+					status
+				};
+
+				return [
+					...(await acc),
+					newTransaction,
+					...(from === to
+						? [
+								{
+									...newTransaction,
+									id: `${newTransaction.id}-self`,
+									type: newTransaction.type === 'send' ? 'receive' : 'send'
+								} as SolTransactionUi
+							]
+						: [])
+				];
+			}
+
+			return acc;
+		},
+		Promise.resolve([] as SolTransactionUi[])
+	);
+};
 
 export const loadNextSolTransactions = async ({
 	address,

--- a/src/frontend/src/tests/mocks/sol-signatures.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-signatures.mock.ts
@@ -1,5 +1,7 @@
+import type { SolSignature } from '$sol/types/sol-transaction';
 import { getBase58Decoder } from '@solana/codecs';
 import { signature } from '@solana/keys';
+import type { UnixTimestamp } from '@solana/rpc-types';
 
 export const mockSolSignature = () => {
 	const randomBytes = new Uint8Array(64);
@@ -8,10 +10,13 @@ export const mockSolSignature = () => {
 	return signature(base58);
 };
 
-export const mockSolSignatureResponse = () => ({
+export const mockSolSignatureResponse = (): SolSignature => ({
 	signature: mockSolSignature(),
 	err: null,
-	confirmationStatus: 'finalized'
+	confirmationStatus: 'finalized',
+	blockTime: 1234567890n as UnixTimestamp,
+	slot: 1234567890n,
+	memo: 'Some memo'
 });
 
 export const mockSolSignatureWithErrorResponse = () => ({

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -1,15 +1,25 @@
 import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
 import * as solanaApi from '$sol/api/solana.api';
-import { loadNextSolTransactions } from '$sol/services/sol-transactions.services';
+import {
+	fetchSolTransactionsForSignature,
+	loadNextSolTransactions
+} from '$sol/services/sol-transactions.services';
 import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
-import { SolanaNetworks } from '$sol/types/network';
-import { mockSolSignature } from '$tests/mocks/sol-signatures.mock';
+import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
+import type {
+	SolMappedTransaction,
+	SolRpcTransactionRaw,
+	SolSignature,
+	SolTransactionUi
+} from '$sol/types/sol-transaction';
+import * as solInstructionsUtils from '$sol/utils/sol-instructions.utils';
+import { mockSolSignature, mockSolSignatureResponse } from '$tests/mocks/sol-signatures.mock';
 import {
 	mockSolCertifiedTransactions,
 	mockSolRpcReceiveTransaction,
 	mockSolRpcSendTransaction
 } from '$tests/mocks/sol-transactions.mock';
-import { mockSolAddress } from '$tests/mocks/sol.mock';
+import { mockSolAddress, mockSolAddress2, mockSplAddress } from '$tests/mocks/sol.mock';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
@@ -21,8 +31,168 @@ describe('sol-transactions.services', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.resetAllMocks();
+
 		solTransactionsStore.reset(SOLANA_TOKEN_ID);
 		spyGetTransactions = vi.spyOn(solanaApi, 'getSolTransactions');
+	});
+
+	describe('fetchSolTransactionsForSignature', () => {
+		const network: SolanaNetworkType = 'mainnet';
+		const mockSignature: SolSignature = mockSolSignatureResponse();
+		const mockParams = {
+			signature: mockSignature,
+			network,
+			address: mockSolAddress
+		};
+
+		const mockTransactionDetail: SolRpcTransactionRaw = mockSolRpcSendTransaction;
+
+		const mockMappedTransaction: SolMappedTransaction = {
+			value: 123n,
+			from: mockSolAddress,
+			to: mockSolAddress2
+		};
+
+		const mockInstructions = mockTransactionDetail.transaction.message.instructions;
+
+		const expected: SolTransactionUi = {
+			id: mockSignature.signature,
+			signature: mockSignature.signature,
+			timestamp: mockTransactionDetail.blockTime ?? 0n,
+			value: mockMappedTransaction.value,
+			from: mockSolAddress,
+			to: mockSolAddress2,
+			type: 'send',
+			status: mockTransactionDetail.confirmationStatus
+		};
+
+		const expectedResults = [
+			{ ...expected, id: `${expected.id}-${mockInstructions[0].programId}` },
+			{ ...expected, id: `${expected.id}-${mockInstructions[1].programId}` },
+			{ ...expected, id: `${expected.id}-${mockInstructions[2].programId}` }
+		];
+
+		let spyFetchTransactionDetailForSignature: MockInstance;
+		let spyMapSolParsedInstruction: MockInstance;
+
+		beforeEach(() => {
+			spyFetchTransactionDetailForSignature = vi.spyOn(
+				solanaApi,
+				'fetchTransactionDetailForSignature'
+			);
+			spyFetchTransactionDetailForSignature.mockResolvedValue(mockTransactionDetail);
+
+			spyMapSolParsedInstruction = vi
+				.spyOn(solInstructionsUtils, 'mapSolParsedInstruction')
+				.mockResolvedValue(mockMappedTransaction);
+		});
+
+		it('should return an empty array if transaction detail is nullish', async () => {
+			spyFetchTransactionDetailForSignature.mockResolvedValueOnce(null);
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([]);
+
+			spyFetchTransactionDetailForSignature.mockResolvedValueOnce(undefined);
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([]);
+		});
+
+		it('should return an empty array if there are no instructions', async () => {
+			spyFetchTransactionDetailForSignature.mockResolvedValueOnce({
+				...mockTransactionDetail,
+				transaction: { message: { instructions: [] } }
+			});
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([]);
+		});
+
+		it('should process instructions and return transactions', async () => {
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(expectedResults);
+
+			expect(spyMapSolParsedInstruction).toHaveBeenCalledWith({
+				instruction: { ...mockInstructions[0], programAddress: mockInstructions[0].programId },
+				innerInstructions: [],
+				network
+			});
+		});
+
+		it('should use inner instructions if presents and required', async () => {
+			const innerInstructions = [
+				{ index: 0, instructions: [mockInstructions[0]] },
+				{ index: 1, instructions: [mockInstructions[1]] },
+				{ index: 2, instructions: [mockInstructions[2]] }
+			];
+
+			spyFetchTransactionDetailForSignature.mockResolvedValue({
+				...mockTransactionDetail,
+				meta: { innerInstructions }
+			});
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(expectedResults);
+
+			expect(spyMapSolParsedInstruction).toHaveBeenCalledWith({
+				instruction: { ...mockInstructions[0], programAddress: mockInstructions[0].programId },
+				innerInstructions: innerInstructions[0].instructions.map((innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				})),
+				network
+			});
+		});
+
+		it('should return an empty array if mapped transactions is nullish', async () => {
+			spyMapSolParsedInstruction.mockResolvedValue(null);
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([]);
+
+			spyMapSolParsedInstruction.mockResolvedValue(undefined);
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([]);
+		});
+
+		it('should return only transactions that have mapped transactions non-nullish', async () => {
+			const expected = expectedResults.slice(1);
+
+			spyMapSolParsedInstruction.mockResolvedValueOnce(null);
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(expected);
+
+			spyMapSolParsedInstruction.mockResolvedValueOnce(undefined);
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(expected);
+		});
+
+		it('should return an empty array if no mapped transactions match tokenAddress', async () => {
+			spyMapSolParsedInstruction.mockResolvedValue({
+				...mockMappedTransaction,
+				tokenAddress: 'other-token-address'
+			});
+
+			await expect(
+				fetchSolTransactionsForSignature({ ...mockParams, tokenAddress: mockSplAddress })
+			).resolves.toEqual([]);
+		});
+
+		it('should create a duplicate transaction for self-transfers with opposite type', async () => {
+			spyMapSolParsedInstruction.mockResolvedValueOnce({
+				...mockMappedTransaction,
+				from: mockSolAddress,
+				to: mockSolAddress
+			});
+
+			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([
+				{ ...expectedResults[0], from: mockSolAddress, to: mockSolAddress },
+				{
+					...expected,
+					id: `${expected.id}-${mockInstructions[0].programId}-self`,
+					type: 'receive',
+					from: mockSolAddress,
+					to: mockSolAddress
+				},
+				...expectedResults.slice(1)
+			]);
+		});
 	});
 
 	describe('loadNextSolTransactions', () => {


### PR DESCRIPTION
# Motivation

After PR https://github.com/dfinity/oisy-wallet/pull/4565 , we can create a service to fetch the transactions related to a specific signature and map them to `SolTransactionUi` type.

# Changes

- Create service `fetchSolTransactionsForSignature` that first fetches the transaction details to a signature.
- Break down the details into instructions and parse them back to transaction list.

# Tests

Included tests.
