### PR TITLE
refactor(frontend): move getSolTransactions to services

### DIFF
--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -6,7 +6,6 @@ import { solanaHttpRpc } from '$sol/providers/sol-rpc.providers';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolRpcTransaction, SolSignature } from '$sol/types/sol-transaction';
-import { getSolBalanceChange } from '$sol/utils/sol-transactions.utils';
 import { getSplBalanceChange } from '$sol/utils/spl-transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { address, assertIsAddress, address as solAddress, type Address } from '@solana/addresses';
@@ -72,40 +71,9 @@ export const loadSplTokenBalance = async ({
 };
 
 /**
- * Fetches transactions without an error for a given wallet address.
- */
-export const getSolTransactions = async ({
-	address,
-	network,
-	before,
-	limit = Number(WALLET_PAGINATION)
-}: GetSolTransactionsParams): Promise<SolRpcTransaction[]> => {
-	const wallet = solAddress(address);
-	const beforeSignature = nonNullish(before) ? signature(before) : undefined;
-	const signatures = await fetchSignatures({ network, wallet, before: beforeSignature, limit });
-
-	const transactions = await signatures.reduce(
-		async (accPromise, signature) => {
-			const acc = await accPromise;
-			const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
-			if (
-				nonNullish(transactionDetail) &&
-				getSolBalanceChange({ transaction: transactionDetail, address })
-			) {
-				acc.push(transactionDetail);
-			}
-			return acc;
-		},
-		Promise.resolve([] as SolRpcTransaction[])
-	);
-
-	return transactions.slice(0, limit);
-};
-
-/**
  * Fetches signatures without an error for a given wallet address.
  */
-const fetchSignatures = async ({
+export const fetchSignatures = async ({
 	network,
 	wallet,
 	before,

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -8,11 +8,11 @@ import type {
 import type { CertifiedData } from '$lib/types/store';
 import type { Option } from '$lib/types/utils';
 import {
-	getSolTransactions,
 	getSplTransactions,
 	loadSolLamportsBalance,
 	loadSplTokenBalance
 } from '$sol/api/solana.api';
+import { getSolTransactions } from '$sol/services/sol-transactions.services';
 import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolBalance } from '$sol/types/sol-balance';

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -12,7 +12,7 @@ import {
 	loadSolLamportsBalance,
 	loadSplTokenBalance
 } from '$sol/api/solana.api';
-import { getSolTransactions } from '$sol/services/sol-transactions.services';
+import { getSolTransactions } from '$sol/services/sol-signatures.services';
 import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolBalance } from '$sol/types/sol-balance';

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -1,0 +1,39 @@
+import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { fetchSignatures, fetchTransactionDetailForSignature } from '$sol/api/solana.api';
+import type { GetSolTransactionsParams } from '$sol/types/sol-api';
+import type { SolRpcTransaction } from '$sol/types/sol-transaction';
+import { getSolBalanceChange } from '$sol/utils/sol-transactions.utils';
+import { nonNullish } from '@dfinity/utils';
+import { address as solAddress } from '@solana/addresses';
+import { signature } from '@solana/keys';
+
+/**
+ * Fetches transactions without an error for a given wallet address.
+ */
+export const getSolTransactions = async ({
+	address,
+	network,
+	before,
+	limit = Number(WALLET_PAGINATION)
+}: GetSolTransactionsParams): Promise<SolRpcTransaction[]> => {
+	const wallet = solAddress(address);
+	const beforeSignature = nonNullish(before) ? signature(before) : undefined;
+	const signatures = await fetchSignatures({ network, wallet, before: beforeSignature, limit });
+
+	const transactions = await signatures.reduce(
+		async (accPromise, signature) => {
+			const acc = await accPromise;
+			const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
+			if (
+				nonNullish(transactionDetail) &&
+				getSolBalanceChange({ transaction: transactionDetail, address })
+			) {
+				acc.push(transactionDetail);
+			}
+			return acc;
+		},
+		Promise.resolve([] as SolRpcTransaction[])
+	);
+
+	return transactions.slice(0, limit);
+};

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -4,8 +4,9 @@ import {
 	SOLANA_TESTNET_TOKEN_ID,
 	SOLANA_TOKEN_ID
 } from '$env/tokens/tokens.sol.env';
+import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
-import { fetchTransactionDetailForSignature, getSolTransactions } from '$sol/api/solana.api';
+import { fetchSignatures, fetchTransactionDetailForSignature } from '$sol/api/solana.api';
 import {
 	solTransactionsStore,
 	type SolCertifiedTransaction
@@ -13,11 +14,13 @@ import {
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolRpcInstruction } from '$sol/types/sol-instructions';
-import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
+import type { SolRpcTransaction, SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
-import { mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
+import { getSolBalanceChange, mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { address as solAddress } from '@solana/addresses';
+import { signature } from '@solana/keys';
 
 interface LoadNextSolTransactionsParams extends GetSolTransactionsParams {
 	signalEnd: () => void;
@@ -132,6 +135,37 @@ const networkToSolTokenIdMap = {
 	[SolanaNetworks.testnet]: SOLANA_TESTNET_TOKEN_ID,
 	[SolanaNetworks.devnet]: SOLANA_DEVNET_TOKEN_ID,
 	[SolanaNetworks.local]: SOLANA_LOCAL_TOKEN_ID
+};
+
+/**
+ * Fetches transactions without an error for a given wallet address.
+ */
+export const getSolTransactions = async ({
+	address,
+	network,
+	before,
+	limit = Number(WALLET_PAGINATION)
+}: GetSolTransactionsParams): Promise<SolRpcTransaction[]> => {
+	const wallet = solAddress(address);
+	const beforeSignature = nonNullish(before) ? signature(before) : undefined;
+	const signatures = await fetchSignatures({ network, wallet, before: beforeSignature, limit });
+
+	const transactions = await signatures.reduce(
+		async (accPromise, signature) => {
+			const acc = await accPromise;
+			const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
+			if (
+				nonNullish(transactionDetail) &&
+				getSolBalanceChange({ transaction: transactionDetail, address })
+			) {
+				acc.push(transactionDetail);
+			}
+			return acc;
+		},
+		Promise.resolve([] as SolRpcTransaction[])
+	);
+
+	return transactions.slice(0, limit);
 };
 
 const loadSolTransactions = async ({

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -4,6 +4,7 @@ import type { PostMessageDataRequestSol } from '$lib/types/post-message';
 import * as authUtils from '$lib/utils/auth.utils';
 import * as solanaApi from '$sol/api/solana.api';
 import { SolWalletScheduler } from '$sol/schedulers/sol-wallet.scheduler';
+import * as solSignaturesServices from '$sol/services/sol-signatures.services';
 import { SolanaNetworks } from '$sol/types/network';
 import { mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -93,7 +94,7 @@ describe('sol-wallet.scheduler', () => {
 			.spyOn(solanaApi, 'loadSplTokenBalance')
 			.mockResolvedValue(mockSplBalance);
 		spyLoadSolTransactions = vi
-			.spyOn(solanaApi, 'getSolTransactions')
+			.spyOn(solSignaturesServices, 'getSolTransactions')
 			.mockResolvedValue(mockSolTransactions);
 		spyLoadSplTransactions = vi
 			.spyOn(solanaApi, 'getSplTransactions')

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -1,0 +1,131 @@
+import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
+import * as solanaApi from '$sol/api/solana.api';
+import { getSolTransactions } from '$sol/services/sol-signatures.services';
+import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
+import { SolanaNetworks } from '$sol/types/network';
+import { mockSolSignature, mockSolSignatureResponse } from '$tests/mocks/sol-signatures.mock';
+import { mockSolRpcSendTransaction } from '$tests/mocks/sol-transactions.mock';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+import { vi, type MockInstance } from 'vitest';
+
+describe('sol-transactions.services', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetAllMocks();
+		vi.restoreAllMocks();
+
+		solTransactionsStore.reset(SOLANA_TOKEN_ID);
+	});
+
+	describe('getSolTransactions', () => {
+		let spyFetchSignatures: MockInstance;
+		let spyFetchTransactionDetailForSignature: MockInstance;
+
+		const mockError = new Error('RPC Error');
+
+		beforeEach(() => {
+			spyFetchSignatures = vi.spyOn(solanaApi, 'fetchSignatures');
+			spyFetchSignatures.mockReturnValue([mockSolSignatureResponse(), mockSolSignatureResponse()]);
+
+			spyFetchTransactionDetailForSignature = vi.spyOn(
+				solanaApi,
+				'fetchTransactionDetailForSignature'
+			);
+			spyFetchTransactionDetailForSignature.mockResolvedValue(mockSolRpcSendTransaction);
+		});
+
+		it('should fetch transactions successfully', async () => {
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toHaveLength(2);
+			expect(spyFetchSignatures).toHaveBeenCalledTimes(1);
+			expect(spyFetchTransactionDetailForSignature).toHaveBeenCalledTimes(2);
+		});
+
+		it('should handle before parameter', async () => {
+			const signature = mockSolSignature();
+			await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				before: signature
+			});
+
+			expect(spyFetchSignatures).toHaveBeenCalledWith(
+				expect.objectContaining({
+					before: signature
+				})
+			);
+		});
+
+		it('should handle limit parameter', async () => {
+			await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				limit: 5
+			});
+
+			expect(spyFetchSignatures).toHaveBeenCalledWith(
+				expect.objectContaining({
+					limit: 5
+				})
+			);
+		});
+
+		it('should not return transactions that do not change SOL balance', async () => {
+			spyFetchTransactionDetailForSignature.mockReturnValue({
+				...mockSolRpcSendTransaction,
+				meta: {
+					...mockSolRpcSendTransaction.meta,
+					postBalances: mockSolRpcSendTransaction.meta?.postBalances,
+					preBalances: mockSolRpcSendTransaction.meta?.postBalances
+				}
+			});
+
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				limit: 5
+			});
+
+			expect(transactions).toHaveLength(0);
+		});
+
+		it('should handle empty signatures response', async () => {
+			spyFetchSignatures.mockReturnValue([]);
+
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toHaveLength(0);
+			expect(spyFetchTransactionDetailForSignature).not.toHaveBeenCalled();
+		});
+
+		it('should handle null transaction responses', async () => {
+			spyFetchSignatures.mockReturnValue([mockSolSignatureResponse()]);
+			spyFetchTransactionDetailForSignature.mockReturnValue(null);
+
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toHaveLength(0);
+		});
+
+		it('should handle RPC errors gracefully', async () => {
+			spyFetchSignatures.mockRejectedValue(mockError);
+
+			await expect(
+				getSolTransactions({
+					address: mockSolAddress,
+					network: SolanaNetworks.mainnet
+				})
+			).rejects.toThrow(mockError);
+		});
+	});
+});

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -13,6 +13,7 @@ import type {
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
 import * as solInstructionsUtils from '$sol/utils/sol-instructions.utils';
+import * as solTransactionsUtils from '$sol/utils/sol-transactions.utils';
 import { mockSolSignature, mockSolSignatureResponse } from '$tests/mocks/sol-signatures.mock';
 import {
 	mockSolCertifiedTransactions,
@@ -21,20 +22,23 @@ import {
 } from '$tests/mocks/sol-transactions.mock';
 import { mockSolAddress, mockSolAddress2, mockSplAddress } from '$tests/mocks/sol.mock';
 import { get } from 'svelte/store';
-import type { MockInstance } from 'vitest';
+import { vi, type MockInstance } from 'vitest';
+
+vi.mock(import('$sol/services/sol-transactions.services'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		getSolTransactions: vi.fn()
+	};
+});
 
 describe('sol-transactions.services', () => {
-	let spyGetTransactions: MockInstance;
-	const signalEnd = vi.fn();
-
-	const mockTransactions = [mockSolRpcReceiveTransaction, mockSolRpcSendTransaction];
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.resetAllMocks();
+		vi.restoreAllMocks();
 
 		solTransactionsStore.reset(SOLANA_TOKEN_ID);
-		spyGetTransactions = vi.spyOn(solanaApi, 'getSolTransactions');
 	});
 
 	describe('fetchSolTransactionsForSignature', () => {
@@ -196,8 +200,46 @@ describe('sol-transactions.services', () => {
 	});
 
 	describe('loadNextSolTransactions', () => {
+		let spyMapSolTransactionUi: MockInstance;
+		let spyFetchTransactionDetailForSignature: MockInstance;
+		let spyGetTransactions: MockInstance;
+
+		const signalEnd = vi.fn();
+
+		const mockTransactions = [mockSolRpcReceiveTransaction, mockSolRpcSendTransaction];
+
+		const mockSolTransactionUi: SolTransactionUi = {
+			id: mockSolRpcSendTransaction.signature,
+			signature: mockSolRpcSendTransaction.signature,
+			timestamp: mockSolRpcSendTransaction.blockTime ?? 0n,
+			value: 123n,
+			from: mockSolAddress,
+			to: mockSolAddress2,
+			type: 'send',
+			status: mockSolRpcSendTransaction.confirmationStatus
+		};
+
+		beforeEach(() => {
+			spyMapSolTransactionUi = vi
+				.spyOn(solTransactionsUtils, 'mapSolTransactionUi')
+				.mockResolvedValueOnce(mockSolTransactionUi)
+				.mockResolvedValueOnce({
+					...mockSolTransactionUi,
+					id: mockSolRpcReceiveTransaction.signature,
+					signature: mockSolRpcReceiveTransaction.signature,
+					value: 456n,
+					from: mockSolAddress2,
+					to: mockSolAddress,
+					type: 'receive'
+				});
+
+			// spyGetTransactions = vi
+			// 	.spyOn(solTransactionsServices, 'getSolTransactions')
+			// 	.mockResolvedValue(mockTransactions);
+		});
+
 		it('should load and return transactions successfully', async () => {
-			spyGetTransactions.mockResolvedValue(mockTransactions);
+			// spyGetTransactions.mockResolvedValue(mockTransactions);
 
 			const transactions = await loadNextSolTransactions({
 				address: mockSolAddress,
@@ -248,7 +290,7 @@ describe('sol-transactions.services', () => {
 		});
 
 		it('should append transactions to the store', async () => {
-			spyGetTransactions.mockResolvedValue(mockTransactions);
+			spyGetTransactions.mockReturnValue(mockTransactions);
 
 			await loadNextSolTransactions({
 				address: mockSolAddress,
@@ -289,6 +331,122 @@ describe('sol-transactions.services', () => {
 				address: mockSolAddress,
 				network: SolanaNetworks.devnet
 			});
+		});
+	});
+
+	describe('getSolTransactions', async () => {
+		const { getSolTransactions } = await vi.importActual<
+			typeof import('$sol/services/sol-transactions.services')
+		>('$sol/services/sol-transactions.services');
+
+		let spyFetchSignatures: MockInstance;
+		let spyFetchTransactionDetailForSignature: MockInstance;
+
+		const mockError = new Error('RPC Error');
+
+		beforeEach(() => {
+			spyFetchSignatures = vi.spyOn(solanaApi, 'fetchSignatures');
+			spyFetchSignatures.mockReturnValue([mockSolSignatureResponse(), mockSolSignatureResponse()]);
+
+			spyFetchTransactionDetailForSignature = vi.spyOn(
+				solanaApi,
+				'fetchTransactionDetailForSignature'
+			);
+			spyFetchTransactionDetailForSignature.mockResolvedValue(mockSolRpcSendTransaction);
+		});
+
+		it('should fetch transactions successfully', async () => {
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toHaveLength(2);
+			expect(spyFetchSignatures).toHaveBeenCalledTimes(1);
+			expect(spyFetchTransactionDetailForSignature).toHaveBeenCalledTimes(2);
+		});
+
+		it('should handle before parameter', async () => {
+			const signature = mockSolSignature();
+			await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				before: signature
+			});
+
+			expect(spyFetchSignatures).toHaveBeenCalledWith(
+				expect.objectContaining({
+					before: signature
+				})
+			);
+		});
+
+		it('should handle limit parameter', async () => {
+			await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				limit: 5
+			});
+
+			expect(spyFetchSignatures).toHaveBeenCalledWith(
+				expect.objectContaining({
+					limit: 5
+				})
+			);
+		});
+
+		it('should not return transactions that do not change SOL balance', async () => {
+			spyFetchTransactionDetailForSignature.mockReturnValue({
+				...mockSolRpcSendTransaction,
+				meta: {
+					...mockSolRpcSendTransaction.meta,
+					postBalances: mockSolRpcSendTransaction.meta?.postBalances,
+					preBalances: mockSolRpcSendTransaction.meta?.postBalances
+				}
+			});
+
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				limit: 5
+			});
+
+			expect(transactions).toHaveLength(0);
+		});
+
+		it('should handle empty signatures response', async () => {
+			spyFetchSignatures.mockReturnValue([]);
+
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toHaveLength(0);
+			expect(spyFetchTransactionDetailForSignature).not.toHaveBeenCalled();
+		});
+
+		it('should handle null transaction responses', async () => {
+			spyFetchSignatures.mockReturnValue([mockSolSignatureResponse()]);
+			spyFetchTransactionDetailForSignature.mockReturnValue(null);
+
+			const transactions = await getSolTransactions({
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toHaveLength(0);
+		});
+
+		it('should handle RPC errors gracefully', async () => {
+			spyFetchSignatures.mockRejectedValue(mockError);
+
+			await expect(
+				getSolTransactions({
+					address: mockSolAddress,
+					network: SolanaNetworks.mainnet
+				})
+			).rejects.toThrow(mockError);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

It makes more sense that the method `getSolTransactions` is a service instead of being inside the API module.