### PR TITLE
feat(frontend): use new Solana transaction service

### DIFF
--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -1,15 +1,12 @@
-import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import type { OptionSolAddress, SolAddress } from '$lib/types/address';
 import { last } from '$lib/utils/array.utils';
 import { ATA_SIZE } from '$sol/constants/ata.constants';
 import { solanaHttpRpc } from '$sol/providers/sol-rpc.providers';
 import type { SolanaNetworkType } from '$sol/types/network';
-import type { GetSolTransactionsParams } from '$sol/types/sol-api';
-import type { SolRpcTransaction, SolSignature } from '$sol/types/sol-transaction';
-import { getSplBalanceChange } from '$sol/utils/spl-transactions.utils';
+import type { SolSignature } from '$sol/types/sol-transaction';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import { address, assertIsAddress, address as solAddress, type Address } from '@solana/addresses';
-import { signature, type Signature } from '@solana/keys';
+import { address, address as solAddress, type Address } from '@solana/addresses';
+import { type Signature } from '@solana/keys';
 import type { Lamports } from '@solana/rpc-types';
 import type { Writeable } from 'zod';
 
@@ -168,75 +165,6 @@ export const loadTokenAccount = async ({
 	const { pubkey: accountAddress } = response.value[0];
 
 	return accountAddress;
-};
-
-/**
- * Fetches SPL token transactions for a given wallet address and token mint.
- */
-//TODO add unit tests
-export const getSplTransactions = async ({
-	address,
-	network,
-	tokenAddress,
-	before,
-	limit = Number(WALLET_PAGINATION)
-}: GetSolTransactionsParams & {
-	tokenAddress: SolAddress;
-}): Promise<SolRpcTransaction[]> => {
-	assertIsAddress(tokenAddress);
-
-	const { getTokenAccountsByOwner } = solanaHttpRpc(network);
-	const relevantTokenAddress = solAddress(tokenAddress);
-	const wallet = solAddress(address);
-
-	const beforeSignature = nonNullish(before) ? signature(before) : undefined;
-
-	const tokenAccounts = await getTokenAccountsByOwner(
-		wallet,
-		{
-			mint: relevantTokenAddress
-		},
-		{ encoding: 'jsonParsed' }
-	).send();
-
-	const signatures = (
-		await Promise.all(
-			tokenAccounts.value.map(({ pubkey }) =>
-				fetchSignatures({
-					network,
-					wallet: solAddress(pubkey),
-					before: beforeSignature,
-					limit
-				})
-			)
-		)
-	).flat();
-
-	const transactions = await signatures.reduce(
-		async (accPromise, sig) => {
-			const acc = await accPromise;
-			const transactionDetail = await fetchTransactionDetailForSignature({
-				signature: sig,
-				network
-			});
-
-			if (
-				nonNullish(transactionDetail) &&
-				//TODO handle self sending
-				getSplBalanceChange({
-					transaction: transactionDetail,
-					tokenAddress,
-					address
-				}) > 0
-			) {
-				acc.push(transactionDetail);
-			}
-			return acc;
-		},
-		Promise.resolve([] as SolRpcTransaction[])
-	);
-
-	return transactions.slice(0, limit);
 };
 
 /**

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -7,18 +7,12 @@ import type {
 } from '$lib/types/post-message';
 import type { CertifiedData } from '$lib/types/store';
 import type { Option } from '$lib/types/utils';
-import {
-	getSplTransactions,
-	loadSolLamportsBalance,
-	loadSplTokenBalance
-} from '$sol/api/solana.api';
-import { getSolTransactions } from '$sol/services/sol-signatures.services';
+import { loadSolLamportsBalance, loadSplTokenBalance } from '$sol/api/solana.api';
+import { getSolTransactions, getSplTransactions } from '$sol/services/sol-signatures.services';
 import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolBalance } from '$sol/types/sol-balance';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
-import { mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
-import { mapSplTransactionUi } from '$sol/utils/spl-transactions.utils';
 import { assertNonNullish, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 
 interface LoadSolWalletParams {
@@ -90,13 +84,7 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 			: await getSolTransactions({ network: solanaNetwork, address });
 
 		const transactionsUi = transactions.map((transaction) => ({
-			data: nonNullish(tokenAddress)
-				? mapSplTransactionUi({
-						transaction,
-						tokenAddress,
-						address
-					})
-				: mapSolTransactionUi({ transaction, address }),
+			data: transaction,
 			certified: false
 		}));
 

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -1,10 +1,11 @@
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
-import { fetchSignatures, fetchTransactionDetailForSignature } from '$sol/api/solana.api';
+import type { SolAddress } from '$lib/types/address';
+import { fetchSignatures } from '$sol/api/solana.api';
+import { fetchSolTransactionsForSignature } from '$sol/services/sol-transactions.services';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
-import type { SolRpcTransaction } from '$sol/types/sol-transaction';
-import { getSolBalanceChange } from '$sol/utils/sol-transactions.utils';
+import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import { nonNullish } from '@dfinity/utils';
-import { address as solAddress } from '@solana/addresses';
+import { assertIsAddress, address as solAddress } from '@solana/addresses';
 import { signature } from '@solana/keys';
 
 /**
@@ -15,7 +16,7 @@ export const getSolTransactions = async ({
 	network,
 	before,
 	limit = Number(WALLET_PAGINATION)
-}: GetSolTransactionsParams): Promise<SolRpcTransaction[]> => {
+}: GetSolTransactionsParams): Promise<SolTransactionUi[]> => {
 	const wallet = solAddress(address);
 	const beforeSignature = nonNullish(before) ? signature(before) : undefined;
 	const signatures = await fetchSignatures({ network, wallet, before: beforeSignature, limit });
@@ -23,16 +24,54 @@ export const getSolTransactions = async ({
 	const transactions = await signatures.reduce(
 		async (accPromise, signature) => {
 			const acc = await accPromise;
-			const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
-			if (
-				nonNullish(transactionDetail) &&
-				getSolBalanceChange({ transaction: transactionDetail, address })
-			) {
-				acc.push(transactionDetail);
-			}
-			return acc;
+			const parsedTransactions = await fetchSolTransactionsForSignature({
+				signature,
+				network,
+				address
+			});
+
+			return [...acc, ...parsedTransactions];
 		},
-		Promise.resolve([] as SolRpcTransaction[])
+		Promise.resolve([] as SolTransactionUi[])
+	);
+
+	return transactions.slice(0, limit);
+};
+
+/**
+ * Fetches SPL token transactions for a given wallet address and token mint.
+ */
+//TODO add unit tests
+export const getSplTransactions = async ({
+	address,
+	network,
+	tokenAddress,
+	before,
+	limit = Number(WALLET_PAGINATION)
+}: GetSolTransactionsParams & {
+	tokenAddress: SolAddress;
+}): Promise<SolTransactionUi[]> => {
+	assertIsAddress(tokenAddress);
+
+	const wallet = solAddress(address);
+
+	const beforeSignature = nonNullish(before) ? signature(before) : undefined;
+
+	const signatures = await fetchSignatures({ network, wallet, before: beforeSignature, limit });
+
+	const transactions = await signatures.reduce(
+		async (accPromise, signature) => {
+			const acc = await accPromise;
+			const parsedTransactions = await fetchSolTransactionsForSignature({
+				signature,
+				network,
+				address,
+				tokenAddress
+			});
+
+			return [...acc, ...parsedTransactions];
+		},
+		Promise.resolve([] as SolTransactionUi[])
 	);
 
 	return transactions.slice(0, limit);

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -17,7 +17,6 @@ import type { SolRpcInstruction } from '$sol/types/sol-instructions';
 import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
-import { mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
 interface LoadNextSolTransactionsParams extends GetSolTransactionsParams {
@@ -152,7 +151,7 @@ const loadSolTransactions = async ({
 		});
 
 		const certifiedTransactions = transactions.map((transaction) => ({
-			data: mapSolTransactionUi({ transaction, address }),
+			data: transaction,
 			certified: false
 		}));
 

--- a/src/frontend/src/sol/services/spl-transactions.services.ts
+++ b/src/frontend/src/sol/services/spl-transactions.services.ts
@@ -1,11 +1,10 @@
 import { parseTokenId } from '$lib/validation/token.validation';
-import { getSplTransactions } from '$sol/api/solana.api';
+import { getSplTransactions } from '$sol/services/sol-signatures.services';
 import {
 	solTransactionsStore,
 	type SolCertifiedTransaction
 } from '$sol/stores/sol-transactions.store';
 import type { GetSplTransactionsParams } from '$sol/types/sol-api';
-import { mapSplTransactionUi } from '$sol/utils/spl-transactions.utils';
 
 interface LoadNextSolTransactionsParams extends GetSplTransactionsParams {
 	signalEnd: () => void;
@@ -54,7 +53,7 @@ const loadSplTransactions = async ({
 		});
 
 		const certifiedTransactions = transactions.map((transaction) => ({
-			data: mapSplTransactionUi({ transaction, address, tokenAddress }),
+			data: transaction,
 			certified: false
 		}));
 

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -6,9 +6,8 @@ import * as solanaApi from '$sol/api/solana.api';
 import { SolWalletScheduler } from '$sol/schedulers/sol-wallet.scheduler';
 import * as solSignaturesServices from '$sol/services/sol-signatures.services';
 import { SolanaNetworks } from '$sol/types/network';
-import { mapSolTransactionUi } from '$sol/utils/sol-transactions.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { mockSolRpcReceiveTransaction } from '$tests/mocks/sol-transactions.mock';
+import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 import { lamports } from '@solana/rpc-types';
@@ -24,13 +23,10 @@ describe('sol-wallet.scheduler', () => {
 
 	const mockSolBalance = lamports(100n);
 	const mockSplBalance = BigInt(123);
-	const mockSolTransactions = [mockSolRpcReceiveTransaction, mockSolRpcReceiveTransaction];
+	const mockSolTransactions = createMockSolTransactionsUi(2);
 
 	const expectedSoLTransactions = mockSolTransactions.map((transaction) => ({
-		data: mapSolTransactionUi({
-			transaction,
-			address: mockSolAddress
-		}),
+		data: transaction,
 		certified: false
 	}));
 
@@ -97,7 +93,7 @@ describe('sol-wallet.scheduler', () => {
 			.spyOn(solSignaturesServices, 'getSolTransactions')
 			.mockResolvedValue(mockSolTransactions);
 		spyLoadSplTransactions = vi
-			.spyOn(solanaApi, 'getSplTransactions')
+			.spyOn(solSignaturesServices, 'getSplTransactions')
 			//TODO add spl mock txns
 			.mockResolvedValue([]);
 


### PR DESCRIPTION
# Motivation

We can use the service `fetchSolTransactionsForSignature` introduced in https://github.com/dfinity/oisy-wallet/pull/4572 , to correctly fetch and parse instructions into transactions.

# Changes

- Move service `getSplTransactions` in the same module as `getSolTransactions`.
- For both of them use fetchSolTransactionsForSignature instead of the old method.
- The step above will provide a return of types `SolTransactionUi` directly, so we adapt the types. 

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
