### PR TITLE
fix(e2e): correct the download path of the backend wasm

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backend.wasm.gz
+          path: out/
 
       - name: Prepare macOS
         if: runner.os == 'macOS'


### PR DESCRIPTION
# Motivation

There was an issue in the e2e test workflow, where the backend wasm was downloaded to the wrong location.

# Changes

Fixed the location path for the wasm download.
