### PR TITLE
feat(frontend): special gradient for GLDT token Hero

### DIFF
--- a/src/frontend/src/icp-eth/utils/token.utils.ts
+++ b/src/frontend/src/icp-eth/utils/token.utils.ts
@@ -1,0 +1,4 @@
+import type { Token } from '$lib/types/token';
+
+export const isGLDTToken = (token: Token): boolean =>
+	token.standard === 'icrc' && token.symbol === 'GLDT';

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/stores';
 	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
 	import { isErc20Icp } from '$eth/utils/token.utils';
+	import { isGLDTToken as isGLDTTokenUtil } from '$icp-eth/utils/token.utils';
 	import Back from '$lib/components/core/Back.svelte';
 	import Erc20Icp from '$lib/components/core/Erc20Icp.svelte';
 	import ExchangeBalance from '$lib/components/exchange/ExchangeBalance.svelte';
@@ -63,6 +64,9 @@
 
 	let isTrumpToken = false;
 	$: isTrumpToken = nonNullish($pageToken) ? isTrumpTokenUtil($pageToken) : false;
+
+	let isGLDTToken = false;
+	$: isGLDTToken = nonNullish($pageToken) ? isGLDTTokenUtil($pageToken) : false;
 </script>
 
 <div
@@ -70,13 +74,15 @@
 	class:bg-pos-100={$networkICP || $networkBitcoin || $networkEthereum || $networkSolana}
 	class:bg-cover={isTrumpToken}
 	class:bg-size-200={!isTrumpToken}
-	class:via-interdimensional-blue={$networkICP}
-	class:to-chinese-purple={$networkICP}
+	class:via-interdimensional-blue={$networkICP && !isGLDTToken}
+	class:to-chinese-purple={$networkICP && !isGLDTToken}
+	class:via-bright-gold={isGLDTToken}
+	class:to-golden-sap={isGLDTToken}
 	class:via-beer={$networkBitcoin}
 	class:to-fulvous={$networkBitcoin}
 	class:via-united-nations-blue={$networkEthereum}
 	class:to-bright-lilac={$networkEthereum}
-	class:bg-gradient-to-r={$networkSolana && !isTrumpToken}
+	class:bg-gradient-to-r={($networkSolana && !isTrumpToken) || isGLDTToken}
 	class:via-lavander-indigo={$networkSolana && !isTrumpToken}
 	class:to-medium-spring-green={$networkSolana && !isTrumpToken}
 	class:bg-trump-token-hero-image={isTrumpToken}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,7 +50,9 @@ export default {
 			cobalt: '#004abe',
 			zumthor: '#e8f1ff',
 			beer: '#f7931a',
-			fulvous: '#de7900'
+			fulvous: '#de7900',
+			'bright-gold': '#cca055',
+			'golden-sap': '#ebd27f'
 		},
 		extend: {
 			backgroundColor: themeVariables.background,


### PR DESCRIPTION
# Motivation

We want to display a special gradient for GLDT token Hero.

# Changes

* new theme colors
* new `isGLDTToken` util
* set `via-bright-gold`,  `to-golden-sap` and `bg-gradient-to-r` for the HeroContent component if it's GLDT token page

<img width="635" alt="Screenshot 2025-02-05 at 10 36 02" src="https://github.com/user-attachments/assets/a79a160e-6c98-4b42-8163-470d9c0f4bde" />

