### PR TITLE
chore(frontend): add types to derived stores of Kong swap ICRC tokens

### DIFF
--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -4,22 +4,23 @@ import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { splTokens } from '$sol/derived/spl.derived';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
 import { nonNullish } from '@dfinity/utils';
-import { derived } from 'svelte/store';
+import { derived, type Readable } from 'svelte/store';
 
 // The entire list of ICRC tokens to display to the user:
 // This includes the default tokens (disabled or enabled), the custom tokens (disabled or enabled),
 // and the environment tokens that have never been used.
-export const allIcrcTokens = derived([icrcTokens], ([$icrcTokens]) => {
+export const allIcrcTokens: Readable<IcrcCustomToken[]> = derived([icrcTokens], ([$icrcTokens]) => {
 	// The list of ICRC tokens (SNSes) is defined as environment variables.
 	// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
 	const tokens = buildIcrcCustomTokens();
-	const icrcEnvTokens =
+	const icrcEnvTokens: IcrcCustomToken[] =
 		tokens?.map((token) => ({ ...token, id: parseTokenId(token.symbol), enabled: false })) ?? [];
 
 	// All the Icrc ledger ids including the default tokens and the user custom tokens regardless if enabled or disabled.
@@ -33,13 +34,13 @@ export const allIcrcTokens = derived([icrcTokens], ([$icrcTokens]) => {
 	].sort(sortIcTokens);
 });
 
-export const allKongSwapCompatibleIcrcTokens = derived(
+export const allKongSwapCompatibleIcrcTokens: Readable<IcrcCustomToken[]> = derived(
 	[allIcrcTokens, kongSwapTokensStore],
 	([$allIcrcTokens, $kongSwapTokensStore]) =>
 		$allIcrcTokens.filter(({ symbol }) => nonNullish($kongSwapTokensStore?.[symbol]))
 );
 
-export const allDisabledKongSwapCompatibleIcrcTokens = derived(
+export const allDisabledKongSwapCompatibleIcrcTokens: Readable<IcrcCustomToken[]> = derived(
 	[allKongSwapCompatibleIcrcTokens, enabledIcrcTokens],
 	([allKongSwapCompatibleIcrcTokens, $enabledIcrcTokens]) => {
 		const enabledIcrcTokenIds = $enabledIcrcTokens.map(({ id }) => id);


### PR DESCRIPTION
# Motivation

Just to have more manageability, we explicitly set the types of a few derived stores on ICRC tokens that pertains to Kong swap
