### PR TITLE
chore(frontend): add type parameter to pinTokensWithBalanceAtTop

### DIFF
--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -51,6 +51,6 @@ export interface TokenFinancialData {
 	usdBalance?: number;
 }
 
-export type TokenUi = Token & TokenFinancialData;
+export type TokenUi<T extends Token = Token> = T & TokenFinancialData;
 
 export type OptionTokenUi = Option<TokenUi>;

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -137,15 +137,15 @@ export const calculateTokenUsdBalance = ({
  * @param $exchanges - The exchange rates data for the tokens.
  * @returns The token UI.
  */
-export const mapTokenUi = ({
+export const mapTokenUi = <T extends Token>({
 	token,
 	$balances,
 	$exchanges
 }: {
-	token: Token;
+	token: T;
 	$balances: CertifiedStoreData<BalancesData>;
 	$exchanges: ExchangesData;
-}): TokenUi => ({
+}): TokenUi<T> => ({
 	...token,
 	// There is a difference between undefined and null for the balance.
 	// The balance is undefined if the balance store is not initiated or the specific balance loader for the token is not initiated.

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -79,23 +79,23 @@ export const sortTokens = <T extends Token>({
  * @returns The sorted list of tokens.
  *
  */
-export const pinTokensWithBalanceAtTop = ({
+export const pinTokensWithBalanceAtTop = <T extends Token>({
 	$tokens,
 	$balances,
 	$exchanges
 }: {
-	$tokens: Token[];
+	$tokens: T[];
 	$balances: CertifiedStoreData<BalancesData>;
 	$exchanges: ExchangesData;
-}): TokenUi[] => {
+}): TokenUi<T>[] => {
 	// If balances data are nullish, there is no need to sort.
 	if (isNullish($balances)) {
 		return $tokens.map((token) => mapTokenUi({ token, $balances, $exchanges }));
 	}
 
-	const [positiveBalances, nonPositiveBalances] = $tokens.reduce<[TokenUi[], TokenUi[]]>(
+	const [positiveBalances, nonPositiveBalances] = $tokens.reduce<[TokenUi<T>[], TokenUi<T>[]]>(
 		(acc, token) => {
-			const tokenUI: TokenUi = mapTokenUi({
+			const tokenUI: TokenUi<T> = mapTokenUi<T>({
 				token,
 				$balances,
 				$exchanges


### PR DESCRIPTION
# Motivation

Since util `pinTokensWithBalanceAtTop` is being used with lists of specific types of Tokens, it is useful to make the type of such object parametrizable, especially for the return.
