### PR TITLE
chore(frontend): specify type of tokens in swap context

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -2,6 +2,7 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
+	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
 	import SwapWizard from '$lib/components/swap/SwapWizard.svelte';
@@ -16,7 +17,6 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapSelectTokenType } from '$lib/types/swap';
 	import { closeModal } from '$lib/utils/modal.utils';
-	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 
 	const { setSourceToken, setDestinationToken } = setContext<SwapContext>(
 		SWAP_CONTEXT_KEY,

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -3,6 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import type { IcToken } from '$icp/types/ic-token';
+	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
 	import SwapWizard from '$lib/components/swap/SwapWizard.svelte';
@@ -17,7 +18,6 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapSelectTokenType } from '$lib/types/swap';
 	import { closeModal } from '$lib/utils/modal.utils';
-	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 
 	const { setSourceToken, setDestinationToken } = setContext<SwapContext>(
 		SWAP_CONTEXT_KEY,

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -17,6 +17,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapSelectTokenType } from '$lib/types/swap';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 
 	const { setSourceToken, setDestinationToken } = setContext<SwapContext>(
 		SWAP_CONTEXT_KEY,
@@ -49,7 +50,7 @@
 		selectTokenType = undefined;
 	};
 
-	const selectToken = ({ detail: token }: CustomEvent<IcToken>) => {
+	const selectToken = ({ detail: token }: CustomEvent<IcrcCustomToken>) => {
 		if (selectTokenType === 'source') {
 			setSourceToken(token);
 		} else if (selectTokenType === 'destination') {

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -2,8 +2,6 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
-	import type { IcToken } from '$icp/types/ic-token';
-	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
 	import SwapWizard from '$lib/components/swap/SwapWizard.svelte';
@@ -18,6 +16,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapSelectTokenType } from '$lib/types/swap';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 
 	const { setSourceToken, setDestinationToken } = setContext<SwapContext>(
 		SWAP_CONTEXT_KEY,
@@ -50,7 +49,7 @@
 		selectTokenType = undefined;
 	};
 
-	const selectToken = ({ detail: token }: CustomEvent<IcrcCustomToken>) => {
+	const selectToken = ({ detail: token }: CustomEvent<IcTokenToggleable>) => {
 		if (selectTokenType === 'source') {
 			setSourceToken(token);
 		} else if (selectTokenType === 'destination') {

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -15,11 +14,12 @@
 	import type { Token, TokenUi } from '$lib/types/token';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { filterTokens, pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
+	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 
 	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher<{
-		icSelectToken: IcrcCustomToken;
+		icSelectToken: IcTokenToggleable;
 		icCloseTokensList: void;
 	}>();
 
@@ -28,7 +28,7 @@
 	let noTokensMatch = false;
 	$: noTokensMatch = filteredTokens.length === 0;
 
-	let tokens: TokenUi<IcrcCustomToken>[];
+	let tokens: TokenUi<IcTokenToggleable>[];
 	$: tokens = pinTokensWithBalanceAtTop({
 		$tokens: [{ ...ICP_TOKEN, enabled: true }, ...$allKongSwapCompatibleIcrcTokens].filter(
 			(token: Token) => token.id !== $sourceToken?.id && token.id !== $destinationToken?.id
@@ -37,7 +37,7 @@
 		$balances: $balancesStore
 	});
 
-	let filteredTokens: TokenUi<IcrcCustomToken>[] = [];
+	let filteredTokens: TokenUi<IcTokenToggleable>[] = [];
 	$: filteredTokens = filterTokens({ tokens, filter });
 </script>
 

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -14,7 +15,6 @@
 	import type { Token, TokenUi } from '$lib/types/token';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { filterTokens, pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
-	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 
 	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 	import TokenCardContent from '$lib/components/tokens/TokenCardContent.svelte';
 	import TokenCardWithOnClick from '$lib/components/tokens/TokenCardWithOnClick.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -11,29 +12,32 @@
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
-	import type { Token } from '$lib/types/token';
+	import type { Token, TokenUi } from '$lib/types/token';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { filterTokens, pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
 
 	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher<{
+		icSelectToken: IcrcCustomToken;
+		icCloseTokensList: void;
+	}>();
 
 	let filter = '';
 
 	let noTokensMatch = false;
 	$: noTokensMatch = filteredTokens.length === 0;
 
-	let tokens: Token[];
+	let tokens: TokenUi<IcrcCustomToken>[];
 	$: tokens = pinTokensWithBalanceAtTop({
-		$tokens: [ICP_TOKEN, ...$allKongSwapCompatibleIcrcTokens].filter(
+		$tokens: [{ ...ICP_TOKEN, enabled: true }, ...$allKongSwapCompatibleIcrcTokens].filter(
 			(token: Token) => token.id !== $sourceToken?.id && token.id !== $destinationToken?.id
 		),
 		$exchanges: $exchanges,
 		$balances: $balancesStore
 	});
 
-	let filteredTokens: Token[] = [];
+	let filteredTokens: TokenUi<IcrcCustomToken>[] = [];
 	$: filteredTokens = filterTokens({ tokens, filter });
 </script>
 

--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -4,6 +4,7 @@ import { erc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
+import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
@@ -16,31 +17,34 @@ import { derived, type Readable } from 'svelte/store';
 // The entire list of ICRC tokens to display to the user:
 // This includes the default tokens (disabled or enabled), the custom tokens (disabled or enabled),
 // and the environment tokens that have never been used.
-export const allIcrcTokens: Readable<IcrcCustomToken[]> = derived([icrcTokens], ([$icrcTokens]) => {
-	// The list of ICRC tokens (SNSes) is defined as environment variables.
-	// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
-	const tokens = buildIcrcCustomTokens();
-	const icrcEnvTokens: IcrcCustomToken[] =
-		tokens?.map((token) => ({ ...token, id: parseTokenId(token.symbol), enabled: false })) ?? [];
+export const allIcrcTokens: Readable<IcTokenToggleable[]> = derived(
+	[icrcTokens],
+	([$icrcTokens]) => {
+		// The list of ICRC tokens (SNSes) is defined as environment variables.
+		// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
+		const tokens = buildIcrcCustomTokens();
+		const icrcEnvTokens: IcrcCustomToken[] =
+			tokens?.map((token) => ({ ...token, id: parseTokenId(token.symbol), enabled: false })) ?? [];
 
-	// All the Icrc ledger ids including the default tokens and the user custom tokens regardless if enabled or disabled.
-	const knownLedgerCanisterIds = $icrcTokens.map(({ ledgerCanisterId }) => ledgerCanisterId);
+		// All the Icrc ledger ids including the default tokens and the user custom tokens regardless if enabled or disabled.
+		const knownLedgerCanisterIds = $icrcTokens.map(({ ledgerCanisterId }) => ledgerCanisterId);
 
-	return [
-		...$icrcTokens,
-		...icrcEnvTokens.filter(
-			({ ledgerCanisterId }) => !knownLedgerCanisterIds.includes(ledgerCanisterId)
-		)
-	].sort(sortIcTokens);
-});
+		return [
+			...$icrcTokens,
+			...icrcEnvTokens.filter(
+				({ ledgerCanisterId }) => !knownLedgerCanisterIds.includes(ledgerCanisterId)
+			)
+		].sort(sortIcTokens);
+	}
+);
 
-export const allKongSwapCompatibleIcrcTokens: Readable<IcrcCustomToken[]> = derived(
+export const allKongSwapCompatibleIcrcTokens: Readable<IcTokenToggleable[]> = derived(
 	[allIcrcTokens, kongSwapTokensStore],
 	([$allIcrcTokens, $kongSwapTokensStore]) =>
 		$allIcrcTokens.filter(({ symbol }) => nonNullish($kongSwapTokensStore?.[symbol]))
 );
 
-export const allDisabledKongSwapCompatibleIcrcTokens: Readable<IcrcCustomToken[]> = derived(
+export const allDisabledKongSwapCompatibleIcrcTokens: Readable<IcTokenToggleable[]> = derived(
 	[allKongSwapCompatibleIcrcTokens, enabledIcrcTokens],
 	([allKongSwapCompatibleIcrcTokens, $enabledIcrcTokens]) => {
 		const enabledIcrcTokenIds = $enabledIcrcTokens.map(({ id }) => id);

--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -5,7 +5,6 @@ import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
-import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -23,7 +22,7 @@ export const allIcrcTokens: Readable<IcTokenToggleable[]> = derived(
 		// The list of ICRC tokens (SNSes) is defined as environment variables.
 		// These tokens are not necessarily loaded at boot time if the user has not added them to their list of custom tokens.
 		const tokens = buildIcrcCustomTokens();
-		const icrcEnvTokens: IcrcCustomToken[] =
+		const icrcEnvTokens: IcTokenToggleable[] =
 			tokens?.map((token) => ({ ...token, id: parseTokenId(token.symbol), enabled: false })) ?? [];
 
 		// All the Icrc ledger ids including the default tokens and the user custom tokens regardless if enabled or disabled.

--- a/src/frontend/src/lib/derived/swap.derived.ts
+++ b/src/frontend/src/lib/derived/swap.derived.ts
@@ -1,5 +1,5 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import type { IcToken } from '$icp/types/ic-token';
+import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import { allKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
 import { pageToken } from '$lib/derived/page-token.derived';
@@ -9,22 +9,26 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { derived, type Readable } from 'svelte/store';
 
 export interface SwappableTokens {
-	sourceToken: IcToken | undefined;
-	destinationToken: IcToken | undefined;
+	sourceToken: IcTokenToggleable | undefined;
+	destinationToken: IcTokenToggleable | undefined;
 }
 
-const selectedSwappableToken: Readable<IcToken | undefined> = derived(
+const selectedSwappableToken: Readable<IcTokenToggleable | undefined> = derived(
 	[pageToken, allKongSwapCompatibleIcrcTokens],
 	([$pageToken, $allKongSwapCompatibleIcrcTokens]) => {
 		if (nonNullish($pageToken) && isIcToken($pageToken)) {
 			const selectedToken = $pageToken;
 
-			const isSwapAvailable: boolean = [ICP_TOKEN, ...$allKongSwapCompatibleIcrcTokens].some(
-				(t) => t.id === selectedToken.id
-			);
+			const swappableToken: IcTokenToggleable | undefined = [
+				{ ...ICP_TOKEN, enabled: true },
+				...$allKongSwapCompatibleIcrcTokens
+			].find((t) => t.id === selectedToken.id);
 
-			if (isSwapAvailable) {
-				return selectedToken;
+			if (nonNullish(swappableToken)) {
+				return {
+					...selectedToken,
+					...swappableToken
+				};
 			}
 		}
 

--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -1,4 +1,4 @@
-import type { IcToken } from '$icp/types/ic-token';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { nonNullish } from '@dfinity/utils';
@@ -6,8 +6,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { derived, writable, type Readable } from 'svelte/store';
 
 export interface SwapData {
-	sourceToken?: IcToken;
-	destinationToken?: IcToken;
+	sourceToken?: IcrcCustomToken;
+	destinationToken?: IcrcCustomToken;
 }
 
 export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
@@ -44,12 +44,12 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		destinationTokenBalance,
 		sourceTokenExchangeRate,
 		destinationTokenExchangeRate,
-		setSourceToken: (token: IcToken) =>
+		setSourceToken: (token: IcrcCustomToken) =>
 			update((state) => ({
 				...state,
 				sourceToken: token
 			})),
-		setDestinationToken: (token: IcToken) =>
+		setDestinationToken: (token: IcrcCustomToken) =>
 			update((state) => ({
 				...state,
 				destinationToken: token
@@ -63,14 +63,14 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 };
 
 export interface SwapContext {
-	sourceToken: Readable<IcToken | undefined>;
-	destinationToken: Readable<IcToken | undefined>;
+	sourceToken: Readable<IcrcCustomToken | undefined>;
+	destinationToken: Readable<IcrcCustomToken | undefined>;
 	sourceTokenBalance: Readable<BigNumber | undefined>;
 	destinationTokenBalance: Readable<BigNumber | undefined>;
 	sourceTokenExchangeRate: Readable<number | undefined>;
 	destinationTokenExchangeRate: Readable<number | undefined>;
-	setSourceToken: (token: IcToken) => void;
-	setDestinationToken: (token: IcToken) => void;
+	setSourceToken: (token: IcrcCustomToken) => void;
+	setDestinationToken: (token: IcrcCustomToken) => void;
 	switchTokens: () => void;
 }
 

--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -1,4 +1,4 @@
-import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
+import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { nonNullish } from '@dfinity/utils';
@@ -6,8 +6,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { derived, writable, type Readable } from 'svelte/store';
 
 export interface SwapData {
-	sourceToken?: IcrcCustomToken;
-	destinationToken?: IcrcCustomToken;
+	sourceToken?: IcTokenToggleable;
+	destinationToken?: IcTokenToggleable;
 }
 
 export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
@@ -44,12 +44,12 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		destinationTokenBalance,
 		sourceTokenExchangeRate,
 		destinationTokenExchangeRate,
-		setSourceToken: (token: IcrcCustomToken) =>
+		setSourceToken: (token: IcTokenToggleable) =>
 			update((state) => ({
 				...state,
 				sourceToken: token
 			})),
-		setDestinationToken: (token: IcrcCustomToken) =>
+		setDestinationToken: (token: IcTokenToggleable) =>
 			update((state) => ({
 				...state,
 				destinationToken: token
@@ -63,14 +63,14 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 };
 
 export interface SwapContext {
-	sourceToken: Readable<IcrcCustomToken | undefined>;
-	destinationToken: Readable<IcrcCustomToken | undefined>;
+	sourceToken: Readable<IcTokenToggleable | undefined>;
+	destinationToken: Readable<IcTokenToggleable | undefined>;
 	sourceTokenBalance: Readable<BigNumber | undefined>;
 	destinationTokenBalance: Readable<BigNumber | undefined>;
 	sourceTokenExchangeRate: Readable<number | undefined>;
 	destinationTokenExchangeRate: Readable<number | undefined>;
-	setSourceToken: (token: IcrcCustomToken) => void;
-	setDestinationToken: (token: IcrcCustomToken) => void;
+	setSourceToken: (token: IcTokenToggleable) => void;
+	setDestinationToken: (token: IcTokenToggleable) => void;
 	switchTokens: () => void;
 }
 

--- a/src/frontend/src/tests/lib/components/swap/SwapForm.test.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapForm.test.ts
@@ -28,9 +28,11 @@ describe('SwapForm', () => {
 	};
 
 	beforeEach(() => {
+		const mockToken = { ...mockValidIcToken, enabled: true };
+
 		const originalContext = initSwapContext({
-			sourceToken: mockValidIcToken,
-			destinationToken: mockValidIcToken
+			sourceToken: mockToken,
+			destinationToken: mockToken
 		});
 
 		const mockSwapContext = {

--- a/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
@@ -24,7 +24,7 @@ describe('swap.derived', () => {
 			});
 
 			const tokens = get(swappableTokens);
-			expect(tokens.sourceToken).toBe(ICP_TOKEN);
+			expect(tokens.sourceToken).toEqual({ ...ICP_TOKEN, enabled: true });
 			expect(tokens.destinationToken).toBeUndefined();
 		});
 
@@ -39,7 +39,7 @@ describe('swap.derived', () => {
 
 			const tokens = get(swappableTokens);
 			expect(tokens.sourceToken).toBeUndefined();
-			expect(tokens.destinationToken).toBe(ICP_TOKEN);
+			expect(tokens.destinationToken).toEqual({ ...ICP_TOKEN, enabled: true });
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/stores/swap.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap.store.spec.ts
@@ -18,13 +18,16 @@ const ckBtcToken = {
 } as IcToken;
 
 describe('swapStore', () => {
+	const mockToken1 = { ...ckBtcToken, enabled: true };
+	const mockToken2 = { ...ICP_TOKEN, enabled: false };
+
 	beforeEach(() => {
 		mockPage.reset();
 
 		vi.spyOn(exchanges, 'exchanges', 'get').mockImplementation(() =>
 			readable({
-				[ckBtcToken.id]: { usd: ckBtcExchangeValue },
-				[ICP_TOKEN.id]: { usd: icpExchangeValue }
+				[mockToken1.id]: { usd: ckBtcExchangeValue },
+				[mockToken2.id]: { usd: icpExchangeValue }
 			})
 		);
 	});
@@ -32,8 +35,8 @@ describe('swapStore', () => {
 	it('should ensure derived stores update at most once when the store changes', async () => {
 		await testDerivedUpdates(() =>
 			initSwapContext({
-				destinationToken: ckBtcToken,
-				sourceToken: ICP_TOKEN
+				destinationToken: mockToken1,
+				sourceToken: mockToken2
 			})
 		);
 	});
@@ -47,23 +50,23 @@ describe('swapStore', () => {
 			destinationTokenBalance,
 			destinationToken
 		} = initSwapContext({
-			destinationToken: ckBtcToken,
-			sourceToken: ICP_TOKEN
+			destinationToken: mockToken1,
+			sourceToken: mockToken2
 		});
 		const ckBtcBalance = BigNumber.from(1n);
 		const icpBalance = BigNumber.from(2n);
 
 		balancesStore.set({
-			tokenId: ckBtcToken.id,
+			tokenId: mockToken1.id,
 			data: { data: ckBtcBalance, certified: true }
 		});
 		balancesStore.set({
-			tokenId: ICP_TOKEN.id,
+			tokenId: mockToken2.id,
 			data: { data: icpBalance, certified: true }
 		});
 
-		expect(get(sourceToken)).toBe(ICP_TOKEN);
-		expect(get(destinationToken)).toBe(ckBtcToken);
+		expect(get(sourceToken)).toBe(mockToken2);
+		expect(get(destinationToken)).toBe(mockToken1);
 
 		expect(get(sourceTokenBalance)).toStrictEqual(icpBalance);
 		expect(get(destinationTokenBalance)).toStrictEqual(ckBtcBalance);
@@ -74,32 +77,32 @@ describe('swapStore', () => {
 
 	it('should set tokens correctly', () => {
 		const { sourceToken, destinationToken, setSourceToken, setDestinationToken } = initSwapContext({
-			destinationToken: ckBtcToken,
-			sourceToken: ICP_TOKEN
+			destinationToken: mockToken1,
+			sourceToken: mockToken2
 		});
 
-		expect(get(sourceToken)).toBe(ICP_TOKEN);
-		expect(get(destinationToken)).toBe(ckBtcToken);
+		expect(get(sourceToken)).toBe(mockToken2);
+		expect(get(destinationToken)).toBe(mockToken1);
 
-		setSourceToken(ckBtcToken);
-		setDestinationToken(ICP_TOKEN);
+		setSourceToken(mockToken1);
+		setDestinationToken(mockToken2);
 
-		expect(get(sourceToken)).toBe(ckBtcToken);
-		expect(get(destinationToken)).toBe(ICP_TOKEN);
+		expect(get(sourceToken)).toBe(mockToken1);
+		expect(get(destinationToken)).toBe(mockToken2);
 	});
 
 	it('should switch tokens correctly', () => {
 		const { sourceToken, destinationToken, switchTokens } = initSwapContext({
-			destinationToken: ckBtcToken,
-			sourceToken: ICP_TOKEN
+			destinationToken: mockToken1,
+			sourceToken: mockToken2
 		});
 
-		expect(get(sourceToken)).toBe(ICP_TOKEN);
-		expect(get(destinationToken)).toBe(ckBtcToken);
+		expect(get(sourceToken)).toBe(mockToken2);
+		expect(get(destinationToken)).toBe(mockToken1);
 
 		switchTokens();
 
-		expect(get(sourceToken)).toBe(ckBtcToken);
-		expect(get(destinationToken)).toBe(ICP_TOKEN);
+		expect(get(sourceToken)).toBe(mockToken1);
+		expect(get(destinationToken)).toBe(mockToken2);
 	});
 });


### PR DESCRIPTION
# Motivation

In all the Swap components, the correct type for the destination tokens and the source token is `IcTokenToggleable`.