### PR TITLE
feat(frontend): Prepare Stores, Enums and Constants for Color Mode Selection 

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -1,3 +1,4 @@
+import { Themes } from '$lib/enums/themes';
 import { Principal } from '@dfinity/principal';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -122,3 +123,7 @@ export const WALLET_PAGINATION = 10n;
 
 // VIP
 export const VIP_CODE_REGENERATE_INTERVAL_IN_SECONDS = 45;
+
+// THEMES
+export const DEFAULT_THEME_NAME = Themes.SYSTEM;
+export const THEME_VALUES = Object.values(Themes);

--- a/src/frontend/src/lib/derived/settings.derived.ts
+++ b/src/frontend/src/lib/derived/settings.derived.ts
@@ -1,5 +1,7 @@
-import { hideZeroBalancesStore, testnetsStore } from '$lib/stores/settings.store';
+import type { Themes } from '$lib/enums/themes';
+import { hideZeroBalancesStore, testnetsStore, themeStore } from '$lib/stores/settings.store';
 import { derived, type Readable } from 'svelte/store';
+import { DEFAULT_THEME_NAME } from '$lib/constants/app.constants';
 
 export const testnetsEnabled: Readable<boolean> = derived(
 	[testnetsStore],
@@ -14,4 +16,9 @@ export const hideZeroBalances: Readable<boolean> = derived(
 export const showZeroBalances: Readable<boolean> = derived(
 	[hideZeroBalances],
 	([$hideZeroBalances]) => !$hideZeroBalances
+);
+
+export const selectedTheme: Readable<Themes> = derived(
+	[themeStore],
+	([$selectedTheme]) => $selectedTheme?.name ?? DEFAULT_THEME_NAME
 );

--- a/src/frontend/src/lib/enums/themes.ts
+++ b/src/frontend/src/lib/enums/themes.ts
@@ -1,0 +1,5 @@
+export enum Themes {
+	LIGHT = 'light',
+	DARK = 'dark',
+	SYSTEM = 'system'
+}

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -1,8 +1,14 @@
+import type { Themes } from '$lib/enums/themes';
 import { initStorageStore } from '$lib/stores/storage.store';
 
 export interface SettingsData {
 	enabled: boolean;
 }
 
+export interface SettingsThemeData {
+	name: Themes;
+}
+
 export const testnetsStore = initStorageStore<SettingsData>({ key: 'testnets' });
 export const hideZeroBalancesStore = initStorageStore<SettingsData>({ key: 'hide-zero-balances' });
+export const themeStore = initStorageStore<SettingsThemeData>({ key: 'theme' });


### PR DESCRIPTION
# Motivation
This [comment](https://github.com/dfinity/oisy-wallet/pull/4594#pullrequestreview-2595783559) in PR #4594.

# Changes

- Added theme store to persist selected color mode
- Added derived theme store to get selected color mode
- Added enum for available themes
- Added constants for default color mode and the enums values

# Tests
Working screenshot in PR #4594.