### PR TITLE
fix(frontend): use signature instead of ID for Solana loader

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolTransactionsScroll.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionsScroll.svelte
@@ -34,9 +34,9 @@
 				: $solAddressMainnet;
 
 	const onIntersect = async () => {
-		const lastId = last($solTransactions)?.id;
+		const lastSignature = last($solTransactions)?.signature;
 
-		if (isNullish(lastId)) {
+		if (isNullish(lastSignature)) {
 			// No transactions, we do nothing here and wait for the worker to post the first transactions
 			return;
 		}
@@ -55,7 +55,7 @@
 		await loadNextSolTransactions({
 			network: network,
 			address: address,
-			before: lastId,
+			before: lastSignature,
 			signalEnd: () => (disableInfiniteScroll = true)
 		});
 	};


### PR DESCRIPTION
# Motivation

Since we changed the ID of a Solana transaction to be more complex, it is correct to use the `signature` to ask the loader for the next N transactions.
