### PR TITLE
refactor(frontend): re-use existing Env ICRC types for SNS script

### DIFF
--- a/src/frontend/src/env/schema/env-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-icrc-token.schema.ts
@@ -9,6 +9,10 @@ export const EnvIcrcTokenMetadataSchema = z.object({
 	url: z.optional(z.string().url())
 });
 
+export const EnvIcrcTokenIconSchema = z.object({
+	icon: z.string().optional()
+});
+
 export const EnvIcTokenSchema = z.object({
 	ledgerCanisterId: z.string(),
 	indexCanisterId: z.string()

--- a/src/frontend/src/env/tokens/tokens.sns.json
+++ b/src/frontend/src/env/tokens/tokens.sns.json
@@ -17,7 +17,17 @@
 	{
 		"ledgerCanisterId": "2ouva-viaaa-aaaaq-aaamq-cai",
 		"rootCanisterId": "3e3x2-xyaaa-aaaaq-aaalq-cai",
-		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai"
+		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai",
+		"metadata": {
+			"decimals": 8,
+			"name": "CHAT",
+			"symbol": "CHAT",
+			"fee": {
+				"__bigint__": "100000"
+			},
+			"alternativeName": "OpenChat",
+			"url": "https://oc.app"
+		}
 	},
 	{
 		"ledgerCanisterId": "73mez-iiaaa-aaaaq-aaasq-cai",
@@ -126,6 +136,8 @@
 	},
 	{
 		"ledgerCanisterId": "rxdbk-dyaaa-aaaaq-aabtq-cai",
+		"rootCanisterId": "rzbmc-yiaaa-aaaaq-aabsq-cai",
+		"indexCanisterId": "q5mdq-biaaa-aaaaq-aabuq-cai",
 		"metadata": {
 			"decimals": 8,
 			"name": "Nuance",
@@ -247,7 +259,7 @@
 		"rootCanisterId": "gyito-zyaaa-aaaaq-aacpq-cai",
 		"indexCanisterId": "dnqcx-eyaaa-aaaaq-aacrq-cai",
 		"metadata": {
-			"decimals": 123456,
+			"decimals": 8,
 			"name": "OpenFPL",
 			"symbol": "FPL",
 			"fee": {
@@ -383,6 +395,7 @@
 		"indexCanisterId": "i5e5b-eaaaa-aaaaq-aadpa-cai",
 		"metadata": {
 			"decimals": 8,
+			"name": "---- (formerly CYCLES-TRANSFER-STATION)",
 			"symbol": "--- (CTS)",
 			"fee": {
 				"__bigint__": "1000000000000000000"

--- a/src/frontend/src/env/tokens/tokens.sns.json
+++ b/src/frontend/src/env/tokens/tokens.sns.json
@@ -17,7 +17,7 @@
 	{
 		"ledgerCanisterId": "2ouva-viaaa-aaaaq-aaamq-cai",
 		"rootCanisterId": "3e3x2-xyaaa-aaaaq-aaalq-cai",
-		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai",
+		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai"
 	},
 	{
 		"ledgerCanisterId": "73mez-iiaaa-aaaaq-aaasq-cai",

--- a/src/frontend/src/env/tokens/tokens.sns.json
+++ b/src/frontend/src/env/tokens/tokens.sns.json
@@ -18,16 +18,6 @@
 		"ledgerCanisterId": "2ouva-viaaa-aaaaq-aaamq-cai",
 		"rootCanisterId": "3e3x2-xyaaa-aaaaq-aaalq-cai",
 		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai",
-		"metadata": {
-			"decimals": 8,
-			"name": "CHAT",
-			"symbol": "CHAT",
-			"fee": {
-				"__bigint__": "100000"
-			},
-			"alternativeName": "OpenChat",
-			"url": "https://oc.app"
-		}
 	},
 	{
 		"ledgerCanisterId": "73mez-iiaaa-aaaaq-aaasq-cai",
@@ -136,8 +126,6 @@
 	},
 	{
 		"ledgerCanisterId": "rxdbk-dyaaa-aaaaq-aabtq-cai",
-		"rootCanisterId": "rzbmc-yiaaa-aaaaq-aabsq-cai",
-		"indexCanisterId": "q5mdq-biaaa-aaaaq-aabuq-cai",
 		"metadata": {
 			"decimals": 8,
 			"name": "Nuance",
@@ -259,7 +247,7 @@
 		"rootCanisterId": "gyito-zyaaa-aaaaq-aacpq-cai",
 		"indexCanisterId": "dnqcx-eyaaa-aaaaq-aacrq-cai",
 		"metadata": {
-			"decimals": 8,
+			"decimals": 123456,
 			"name": "OpenFPL",
 			"symbol": "FPL",
 			"fee": {
@@ -395,7 +383,6 @@
 		"indexCanisterId": "i5e5b-eaaaa-aaaaq-aadpa-cai",
 		"metadata": {
 			"decimals": 8,
-			"name": "---- (formerly CYCLES-TRANSFER-STATION)",
 			"symbol": "--- (CTS)",
 			"fee": {
 				"__bigint__": "1000000000000000000"

--- a/src/frontend/src/env/types/env-icrc-token.ts
+++ b/src/frontend/src/env/types/env-icrc-token.ts
@@ -1,4 +1,11 @@
-import { EnvIcrcTokenMetadataSchema } from '$env/schema/env-icrc-token.schema';
+import {
+	EnvIcrcTokenIconSchema,
+	EnvIcrcTokenMetadataSchema
+} from '$env/schema/env-icrc-token.schema';
 import * as z from 'zod';
 
 export type EnvIcrcTokenMetadata = z.infer<typeof EnvIcrcTokenMetadataSchema>;
+
+export type EnvIcrcTokenIcon = z.infer<typeof EnvIcrcTokenIconSchema>;
+
+export type EnvIcrcTokenMetadataWithIcon = EnvIcrcTokenMetadata & EnvIcrcTokenIcon;

--- a/src/frontend/src/env/types/env-sns-token.ts
+++ b/src/frontend/src/env/types/env-sns-token.ts
@@ -1,6 +1,9 @@
-import { EnvSnsTokenSchema, EnvSnsTokensSchema } from '$env/schema/env-sns-token.schema';
+import { EnvSnsTokenSchema } from '$env/schema/env-sns-token.schema';
+import type { EnvIcrcTokenMetadataWithIcon } from '$env/types/env-icrc-token';
 import * as z from 'zod';
 
 export type EnvSnsToken = z.infer<typeof EnvSnsTokenSchema>;
 
-export type EnvSnsTokens = z.infer<typeof EnvSnsTokensSchema>;
+export type EnvSnsTokenWithIcon = Omit<EnvSnsToken, 'metadata'> & {
+	metadata: EnvIcrcTokenMetadataWithIcon;
+};


### PR DESCRIPTION
# Motivation

In script `build.tokens.sns` there are a few redundancies with the types: we can use some that already exists in folder $`env`, or a derived version of them.

# Changes

- Create type `EnvIcrcTokenIcon` that is just the optional `icon` prop used in the script.
- Create type `EnvIcrcTokenMetadataWithIcon` as union of `EnvIcrcTokenMetadata` and `EnvIcrcTokenIcon`.
- Replace `SnsMetadata` with `EnvIcrcTokenMetadataWithIcon`, and `OptionalSnsMetadata` with a `Partial` version of it.
- Created type `EnvSnsTokenWithIcon` that add the `icon` prop to `metadata` in `EnvSnsToken`.
- Replace `SnsToken` with `EnvSnsTokenWithIcon`.
- Adjusted `SnsTokenWithOptionalMetadata` to use be `EnvSnsTokenWithIcon` but with optional `metadata`.
- Remove unused `EnvSnsTokens` type.

# Tests

I injected a missing SNS token in this PR and ran the script, and it worked correctly.
