### PR TITLE
refactor(build): use ledger instead of root to identify deprecated SNS

### DIFF
--- a/scripts/build.tokens.sns.ts
+++ b/scripts/build.tokens.sns.ts
@@ -91,8 +91,8 @@ const saveLogos = async (logos: Logo[]) => {
 		);
 	};
 
-	const activeSnsLogos = logos.filter(({ rootCanisterId }) =>
-		isNullish(DEPRECATED_SNES[rootCanisterId])
+	const activeSnsLogos = logos.filter(({ ledgerCanisterId }) =>
+		isNullish(DEPRECATED_SNES[ledgerCanisterId])
 	);
 
 	await Promise.all(activeSnsLogos.map(writeLogo));
@@ -179,8 +179,8 @@ const filterNonNullishMetadata = (
 	token: SnsTokenWithOptionalMetadata
 ): token is EnvSnsTokenWithIcon => nonNullish(token.metadata);
 
-const DEPRECATED_SNES: Record<string, Partial<EnvIcrcTokenMetadataWithIcon>> = {
-	['ibahq-taaaa-aaaaq-aadna-cai']: {
+const DEPRECATED_SNES: Record<CanisterIdText, Partial<EnvIcrcTokenMetadataWithIcon>> = {
+	['itgqj-7qaaa-aaaaq-aadoa-cai']: {
 		name: '---- (formerly CYCLES-TRANSFER-STATION)',
 		symbol: '--- (CTS)',
 		alternativeName: undefined,
@@ -191,14 +191,14 @@ const DEPRECATED_SNES: Record<string, Partial<EnvIcrcTokenMetadataWithIcon>> = {
 
 const mapDeprecatedSnsMetadata = ({
 	metadata,
-	rootCanisterId,
+	ledgerCanisterId,
 	...rest
 }: EnvSnsTokenWithIcon): EnvSnsTokenWithIcon => ({
 	metadata: {
 		...metadata,
-		...(nonNullish(DEPRECATED_SNES[rootCanisterId]) && DEPRECATED_SNES[rootCanisterId])
+		...(nonNullish(DEPRECATED_SNES[ledgerCanisterId]) && DEPRECATED_SNES[ledgerCanisterId])
 	},
-	rootCanisterId,
+	ledgerCanisterId,
 	...rest
 });
 


### PR DESCRIPTION
# Motivation

We want to use the deprecated SNS list in our frontend codebase too. However, we do not use the root canister ID when we parse the SNS tokens. The information that is passed on and that can be used as identifier is the Ledger canister ID.
