### PR TITLE
fix(frontend): Hide social media icons and beta badge on mobile on "secondary" pages

### DIFF
--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { IconGitHub } from '@dfinity/gix-components';
+	import { page } from '$app/stores';
 	import IconDfinity from '$lib/components/icons/IconDfinity.svelte';
 	import IconHeart from '$lib/components/icons/IconHeart.svelte';
 	import IconTwitter from '$lib/components/icons/IconTwitter.svelte';
@@ -10,7 +11,6 @@
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
-	import { page } from '$app/stores';
 	$: isHomePage = $page.url.pathname === '/';
 </script>
 
@@ -29,7 +29,9 @@
 		class:sm:flex-row={$authNotSignedIn}
 		class:sm:gap-4={$authNotSignedIn}
 	>
-		<div class={`pointer-events-auto flex flex-row items-center gap-4 ${isHomePage ? '' : 'hidden md:flex'}`}>
+		<div
+			class={`pointer-events-auto flex flex-row items-center gap-4 ${isHomePage ? '' : 'hidden md:flex'}`}
+		>
 			<ExternalLinkIcon
 				href={OISY_TWITTER_URL}
 				ariaLabel={replaceOisyPlaceholders($i18n.navigation.alt.open_twitter)}

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -10,6 +10,8 @@
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { page } from '$app/stores';
+	$: isHomePage = $page.url.pathname === '/';
 </script>
 
 <footer
@@ -27,7 +29,7 @@
 		class:sm:flex-row={$authNotSignedIn}
 		class:sm:gap-4={$authNotSignedIn}
 	>
-		<div class="pointer-events-auto flex flex-row items-center gap-4">
+		<div class={`pointer-events-auto flex flex-row items-center gap-4 ${isHomePage ? '' : 'hidden md:flex'}`}>
 			<ExternalLinkIcon
 				href={OISY_TWITTER_URL}
 				ariaLabel={replaceOisyPlaceholders($i18n.navigation.alt.open_twitter)}

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -11,7 +11,9 @@
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
-	$: isHomePage = $page.url.pathname === '/';
+	import { isRouteTokens } from '$lib/utils/nav.utils';
+
+	$: isHomePage = isRouteTokens($page);
 </script>
 
 <footer


### PR DESCRIPTION
# Motivation

On mobile – OISY footer is a bit cluttered, especially on secondary pages when they are empty. We'd like to hide social icons and beta badge on all pages on mobile except the "home screen" (footer is not that visible and located below the tokens) 

# Changes

Hiding block with buttons in <Footer.svelte> for all screens where sidebar is not visible. 

# Tests

Home screen: 
<img width="862" alt="image" src="https://github.com/user-attachments/assets/381497a0-0327-4b3b-8440-6da68e57dad4" />
<img width="1567" alt="image" src="https://github.com/user-attachments/assets/d1f103f5-3f15-4cf1-8c89-284331727f72" />


Token screen: 
<img width="612" alt="image" src="https://github.com/user-attachments/assets/957b3628-a7e5-4f44-abe1-4189e76318cd" />

<img width="1567" alt="image" src="https://github.com/user-attachments/assets/cff6e9f9-f119-4e4b-8066-913c6ab57fdb" />

