### PR TITLE
revert(frontend): #4599 - Prepare Stores, Enums and Constants for Color Mode Selection

### DIFF
--- a/src/frontend/src/lib/components/settings/ThemeSelector.svelte
+++ b/src/frontend/src/lib/components/settings/ThemeSelector.svelte
@@ -1,21 +1,32 @@
 <script lang="ts">
 	import ThemeSelectorCard from '$lib/components/settings/ThemeSelectorCard.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
-	import { THEME_VALUES } from '$lib/constants/app.constants';
-	import { selectedTheme } from '$lib/derived/settings.derived';
-	import { Themes } from '$lib/enums/themes';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { themeStore } from '$lib/stores/settings.store';
-	const selectTheme = (name: Themes) => {
-		themeStore.set({ key: 'theme', value: { name } });
+
+	// TODO: replace with @dfinity/gix-components Theme.Light and Theme.Dark
+	enum Themes {
+		LIGHT = 'light',
+		DARK = 'dark',
+		SYSTEM = 'system'
+	}
+
+	const THEME_VALUES = Object.values(Themes);
+
+	// TODO: rename _name with theme
+	const selectTheme = (_name: Themes) => {
+		// TODO: use themeStore from @dfinity/gix-components
+		// themeStore.set({ key: 'theme', value: { name } });
 	};
+
+	// TODO: implement selected using $themeStore from @dfinity/gix-components
+	// selected={$selectedTheme === theme}
 </script>
 
 <div class="flex flex-row">
 	{#each THEME_VALUES as theme}
 		<ThemeSelectorCard
 			label={$i18n.settings.text[`appearance_${theme}`]}
-			selected={$selectedTheme === theme}
+			selected={false}
 			on:click={() => selectTheme(theme)}
 			on:keydown={() => selectTheme(theme)}
 			tabindex={THEME_VALUES.indexOf(theme)}

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -1,4 +1,3 @@
-import { Themes } from '$lib/enums/themes';
 import { Principal } from '@dfinity/principal';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -122,7 +121,3 @@ export const WALLET_PAGINATION = 10n;
 
 // VIP
 export const VIP_CODE_REGENERATE_INTERVAL_IN_SECONDS = 45;
-
-// THEMES
-export const DEFAULT_THEME_NAME = Themes.SYSTEM;
-export const THEME_VALUES = Object.values(Themes);

--- a/src/frontend/src/lib/derived/settings.derived.ts
+++ b/src/frontend/src/lib/derived/settings.derived.ts
@@ -1,6 +1,4 @@
-import { DEFAULT_THEME_NAME } from '$lib/constants/app.constants';
-import type { Themes } from '$lib/enums/themes';
-import { hideZeroBalancesStore, testnetsStore, themeStore } from '$lib/stores/settings.store';
+import { hideZeroBalancesStore, testnetsStore } from '$lib/stores/settings.store';
 import { derived, type Readable } from 'svelte/store';
 
 export const testnetsEnabled: Readable<boolean> = derived(
@@ -16,9 +14,4 @@ export const hideZeroBalances: Readable<boolean> = derived(
 export const showZeroBalances: Readable<boolean> = derived(
 	[hideZeroBalances],
 	([$hideZeroBalances]) => !$hideZeroBalances
-);
-
-export const selectedTheme: Readable<Themes> = derived(
-	[themeStore],
-	([$selectedTheme]) => $selectedTheme?.name ?? DEFAULT_THEME_NAME
 );

--- a/src/frontend/src/lib/enums/themes.ts
+++ b/src/frontend/src/lib/enums/themes.ts
@@ -1,5 +1,0 @@
-export enum Themes {
-	LIGHT = 'light',
-	DARK = 'dark',
-	SYSTEM = 'system'
-}

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -1,14 +1,8 @@
-import type { Themes } from '$lib/enums/themes';
 import { initStorageStore } from '$lib/stores/storage.store';
 
 export interface SettingsData {
 	enabled: boolean;
 }
 
-export interface SettingsThemeData {
-	name: Themes;
-}
-
 export const testnetsStore = initStorageStore<SettingsData>({ key: 'testnets' });
 export const hideZeroBalancesStore = initStorageStore<SettingsData>({ key: 'hide-zero-balances' });
-export const themeStore = initStorageStore<SettingsThemeData>({ key: 'theme' });


### PR DESCRIPTION
# Motivation

We don't strictly use only the design system; we also use Gix components as a UI library, which supports theming. While it is technically possible to duplicate theming stores in OISY and set the root attribute on the <html /> element using the same keyword, this carries a risk of desynchronization—where OISY uses theme X, which happens to be unsupported by Gix components.

It also feels somewhat hacky that two different layers of presentation potentially rely on separate stores for the same information, leading to possible inconsistencies. That’s why I find it somewhat inelegant and, to some extent, a bit hacky to duplicate this information.

I agree that Gix components currently do not support the concept of a System. However, given that decisions related to OISY are generally made with the motto "fast iteration," I would suggest dropping this notion for now. If it is truly necessary, it should be implemented within the UI kit while ensuring that no breaking changes are introduced.

Long story short, I believe it’s easier, faster, and cleaner to revert the logical components introduced last week and simply use Gix components.

# Notes

- If this PR gets merged, PR #4625 should be closed and deleted
- Gix components PR #578 will be necessary to resolve the TODO added in this PR

# Changes

- Revert #4599
- Add comments and TODOs in theme toggler

# Tests

No tests provided given there is no tests in place currently for those features.
