### PR TITLE
feat(frontend): merge Solana wallet signatures with ATA signatures

### DIFF
--- a/src/frontend/src/tests/mocks/sol-signatures.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-signatures.mock.ts
@@ -24,3 +24,6 @@ export const mockSolSignatureWithErrorResponse = () => ({
 	err: 'Some error',
 	confirmationStatus: 'finalized'
 });
+
+export const mockSolSignatureResponses = (n: number): SolSignature[] =>
+	Array.from({ length: n }, () => mockSolSignatureResponse());


### PR DESCRIPTION
# Motivation

In Solana, some signatures may be associated ONLY to the main wallet address, some others to ONLY the ATA address, and ultimately some with both. To include them all in our view, we merge them removing the duplicates one.
