### PR TITLE
refactor(frontend): move isSourceTokenIcrc2 to context

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapForm from '$lib/components/swap/SwapForm.svelte';
@@ -17,7 +17,6 @@
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { swap as swapService } from '$lib/services/swap.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 	import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import { toastsError } from '$lib/stores/toasts.store';
@@ -29,16 +28,10 @@
 	export let swapProgressStep: string;
 	export let currentStep: WizardStep | undefined;
 
-	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
+	const { sourceToken, destinationToken, isSourceTokenIcrc2 } =
+		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
-
-	let isSourceTokenIcrc2: boolean;
-	$: isSourceTokenIcrc2 =
-		nonNullish($sourceToken) &&
-		nonNullish($kongSwapTokensStore) &&
-		nonNullish($kongSwapTokensStore[$sourceToken.symbol]) &&
-		$kongSwapTokensStore[$sourceToken.symbol].icrc2;
 
 	const progress = (step: ProgressStepsSwap) => (swapProgressStep = step);
 
@@ -74,7 +67,7 @@
 				swapAmount,
 				receiveAmount: $swapAmountsStore.swapAmounts.receiveAmount,
 				slippageValue,
-				isSourceTokenIcrc2
+				isSourceTokenIcrc2: $isSourceTokenIcrc2
 			});
 
 			progress(ProgressStepsSwap.DONE);

--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -1,6 +1,7 @@
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
+import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { derived, writable, type Readable } from 'svelte/store';
@@ -37,6 +38,15 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 			nonNullish($destinationToken) ? $exchanges?.[$destinationToken.id]?.usd : undefined
 	);
 
+	const isSourceTokenIcrc2 = derived(
+		[kongSwapTokensStore, sourceToken],
+		([$kongSwapTokensStore, $sourceToken]) =>
+			nonNullish($sourceToken) &&
+			nonNullish($kongSwapTokensStore) &&
+			nonNullish($kongSwapTokensStore[$sourceToken.symbol]) &&
+			$kongSwapTokensStore[$sourceToken.symbol].icrc2
+	);
+
 	return {
 		sourceToken,
 		destinationToken,
@@ -44,6 +54,7 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		destinationTokenBalance,
 		sourceTokenExchangeRate,
 		destinationTokenExchangeRate,
+		isSourceTokenIcrc2,
 		setSourceToken: (token: IcTokenToggleable) =>
 			update((state) => ({
 				...state,
@@ -69,6 +80,7 @@ export interface SwapContext {
 	destinationTokenBalance: Readable<BigNumber | undefined>;
 	sourceTokenExchangeRate: Readable<number | undefined>;
 	destinationTokenExchangeRate: Readable<number | undefined>;
+	isSourceTokenIcrc2: Readable<boolean>;
 	setSourceToken: (token: IcTokenToggleable) => void;
 	setDestinationToken: (token: IcTokenToggleable) => void;
 	switchTokens: () => void;


### PR DESCRIPTION
# Motivation

In order to re-use the `isSourceTokenIcrc2` const, we need to move it up to the Swap context.
