### PR TITLE
chore(frontend): bump oisy-wallet-signer to next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@dfinity/gix-components": "^5.0.0-next-2025-02-10.2",
 				"@dfinity/ledger-icp": "^2.6.8-next-2025-02-04",
 				"@dfinity/ledger-icrc": "^2.7.3-next-2025-02-04",
-				"@dfinity/oisy-wallet-signer": "^0.1.4",
+				"@dfinity/oisy-wallet-signer": "^0.1.5-next-2025-02-10.1",
 				"@dfinity/principal": "^2.1.2",
 				"@dfinity/utils": "^2.10.0-next-2025-02-04",
 				"@dfinity/verifiable-credentials": "^0.0.4",
@@ -465,21 +465,21 @@
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-0.1.4.tgz",
-			"integrity": "sha512-FdaPFIkzK06a1Wz/kC+KtUtTR8cFw1D5ZFHuFA3mLLwxmHMxlForvkrR14z+oOj3DCShTL2hWNuC2pdsaVMW3w==",
+			"version": "0.1.5-next-2025-02-10.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-0.1.5-next-2025-02-10.1.tgz",
+			"integrity": "sha512-13DV7nnVHoad8Apk0/A8A1v90e7E+12gQkkcowB8eO8bcElKBCFy3h5bJUzuFieXp5j+m+MQvr7Qp4u3MZnFoA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=22"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.1.3",
-				"@dfinity/candid": "^2.1.3",
-				"@dfinity/ledger-icp": "^2.6.7",
-				"@dfinity/ledger-icrc": "^2.7.2",
-				"@dfinity/principal": "^2.1.3",
-				"@dfinity/utils": "^2.9.0",
-				"@dfinity/zod-schemas": "^0.0.2",
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/ledger-icp": "*",
+				"@dfinity/ledger-icrc": "*",
+				"@dfinity/principal": "*",
+				"@dfinity/utils": "*",
+				"@dfinity/zod-schemas": "*",
 				"borc": "^2.1.1",
 				"simple-cbor": "^0.4.1",
 				"zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@dfinity/gix-components": "^5.0.0-next-2025-02-10.2",
 		"@dfinity/ledger-icp": "^2.6.8-next-2025-02-04",
 		"@dfinity/ledger-icrc": "^2.7.3-next-2025-02-04",
-		"@dfinity/oisy-wallet-signer": "^0.1.4",
+		"@dfinity/oisy-wallet-signer": "^0.1.5-next-2025-02-10.1",
 		"@dfinity/principal": "^2.1.2",
 		"@dfinity/utils": "^2.10.0-next-2025-02-04",
 		"@dfinity/verifiable-credentials": "^0.0.4",


### PR DESCRIPTION
# Motivation

Using the scripts provided in https://github.com/dfinity/oisy-wallet/pull/4653 , we bump `oisy-wallet-signer` to the `next` version. This will allow us to avoid conflicts with `ic-js` packages.


