### PR TITLE
style(frontend): show Solana transactions in order of execution

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -58,7 +58,13 @@ export const fetchSolTransactionsForSignature = async ({
 		...putativeInnerInstructions.flatMap(({ instructions }) => instructions)
 	];
 
-	return await allInstructions.reduce(
+	// The instructions are received in the order they were executed, meaning the first instruction
+	// in the list was executed first, and the last instruction was executed last.
+	// However, since they all share the same timestamp, we want to display them in reverse
+	// order—from the last executed instruction to the first. This ensures that when shown,
+	// the most recently executed instruction appears first, maintaining a more intuitive,
+	// backward-looking view of execution history.
+	return await allInstructions.reverse().reduce(
 		async (acc, instruction, idx) => {
 			const innerInstructionsRaw =
 				putativeInnerInstructions.find(({ index }) => index === idx)?.instructions ?? [];


### PR DESCRIPTION
# Motivation

The Solana instructions are received in the order they were executed, meaning the first instruction in the list was executed first, and the last instruction was executed last.
However, since they all share the same timestamp, we want to display them in reverse order—from the last executed instruction to the first.
This ensures that when shown, the most recently executed instruction appears first, maintaining a more intuitive, backward-looking view of execution history.

### Before

![Screenshot 2025-02-10 at 16 19 17](https://github.com/user-attachments/assets/e0aa48d1-5066-4c78-9c9c-193418b1fd65)


### After

![Screenshot 2025-02-10 at 16 18 21](https://github.com/user-attachments/assets/4a977269-b159-4ca7-a870-70622b1c8c84)
