### PR TITLE
fix(frontend): event bubbling in TokenInput

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputCurrencyToken.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrencyToken.svelte
@@ -23,6 +23,7 @@
 	on:focus
 	on:blur
 	testId={TOKEN_INPUT_CURRENCY_TOKEN}
+	on:nnsInput
 >
 	<slot name="inner-end" slot="inner-end" />
 </TokenInputCurrency>

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { createEventDispatcher } from 'svelte';
 	import TokenInputCurrency from '$lib/components/tokens/TokenInputCurrency.svelte';
 	import {
 		TOKEN_INPUT_CURRENCY_USD,
@@ -18,11 +19,16 @@
 
 	let displayValue: OptionAmount;
 
-	const handleInput = () =>
-		(tokenAmount =
+	const dispatch = createEventDispatcher();
+
+	const handleInput = () => {
+		tokenAmount =
 			nonNullish(exchangeRate) && nonNullish(displayValue)
 				? (Number(displayValue) / exchangeRate).toFixed(tokenDecimals)
-				: undefined);
+				: undefined;
+
+		dispatch('nnsInput');
+	};
 
 	const syncDisplayValueWithTokenAmount = () => {
 		const newDisplayValue =


### PR DESCRIPTION
# Motivation

While working on the conversion flows, I noticed that `nnsInput` event bubbling was not properly working after the latest changes in TokenInput components.  
