### PR TITLE
refactor(frontend): move ConvertETH component to convert folder

### DIFF
--- a/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
@@ -5,7 +5,7 @@
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { ethereumTokenId } from '$eth/derived/token.derived';
 	import type { OptionErc20Token } from '$eth/types/erc20';
-	import ConvertETH from '$icp-eth/components/send/ConvertETH.svelte';
+	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import { ckErc20HelperContractAddress } from '$icp-eth/derived/cketh.derived';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';

--- a/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
@@ -4,7 +4,7 @@
 	import EthSendTokenModal from '$eth/components/send/EthSendTokenModal.svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
-	import ConvertETH from '$icp-eth/components/send/ConvertETH.svelte';
+	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import { ckEthHelperContractAddress } from '$icp-eth/derived/cketh.derived';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';

--- a/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
@@ -40,7 +40,7 @@
 		) ||
 		($networkICP && isNullish($ckEthMinterInfoStore?.[nativeTokenId]));
 
-	const openSend = async () => {
+	const openConvert = async () => {
 		if (isDisabled()) {
 			const status = await waitWalletReady(isDisabled);
 
@@ -80,7 +80,7 @@
 
 <CkEthLoader {nativeTokenId}>
 	<ButtonHero
-		on:click={async () => await openSend()}
+		on:click={async () => await openConvert()}
 		disabled={$isBusy || $outflowActionsDisabled}
 		{ariaLabel}
 	>

--- a/src/frontend/src/icp/components/convert/ConvertToEthereum.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToEthereum.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import IcSendModal from '$icp/components/send/IcSendModal.svelte';
-	import ConvertETH from '$icp-eth/components/send/ConvertETH.svelte';
+	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import {
 		ckEthereumTwinTokenNetworkId,
 		ckEthereumTwinToken,


### PR DESCRIPTION
# Motivation

The idea is to move ConvertETH component to `.../convert/` folder since we now distinguish between send and convert flows, and therefore this component belongs to the convert folder.
