### PR TITLE
chore(frontend): bump prettier-plugin-tailwindcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
 				"prettier": "^3.5.0",
 				"prettier-plugin-organize-imports": "^4.1.0",
 				"prettier-plugin-svelte": "^3.3.3",
-				"prettier-plugin-tailwindcss": "^0.6.10",
+				"prettier-plugin-tailwindcss": "^0.6.11",
 				"sass": "^1.83.4",
 				"svelte": "^4.2.19",
 				"svelte-check": "^4.1.4",
@@ -10711,10 +10711,11 @@
 			}
 		},
 		"node_modules/prettier-plugin-tailwindcss": {
-			"version": "0.6.10",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.10.tgz",
-			"integrity": "sha512-ndj2WLDaMzACnr1gAYZiZZLs5ZdOeBYgOsbBmHj3nvW/6q8h8PymsXiEnKvj/9qgCCAoHyvLOisoQdIcsDvIgw==",
+			"version": "0.6.11",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.11.tgz",
+			"integrity": "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.21.3"
 			},

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
 		"prettier": "^3.5.0",
 		"prettier-plugin-organize-imports": "^4.1.0",
 		"prettier-plugin-svelte": "^3.3.3",
-		"prettier-plugin-tailwindcss": "^0.6.10",
+		"prettier-plugin-tailwindcss": "^0.6.11",
 		"sass": "^1.83.4",
 		"svelte": "^4.2.19",
 		"svelte-check": "^4.1.4",


### PR DESCRIPTION
# Motivation

To try and reduce the file changed in https://github.com/dfinity/oisy-wallet/pull/4665 , we bump `prettier-plugin-tailwindcss` in a separate PR (plus the consequent changes in format).
