### PR TITLE
feat(backend): use wrapping_add to increment version

### DIFF
--- a/src/backend/tests/it/upgrade/impls.rs
+++ b/src/backend/tests/it/upgrade/impls.rs
@@ -8,7 +8,7 @@ impl TokenVersion for UserTokenV0_0_19 {
 
     fn clone_with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
-        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -43,7 +43,7 @@ impl TokenVersion for UserToken {
 
     fn clone_with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
-        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 
@@ -94,7 +94,7 @@ impl TokenVersion for CustomToken {
 
     fn clone_with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
-        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 
@@ -120,7 +120,7 @@ impl TokenVersion for StoredUserProfile {
 
     fn clone_with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
-        cloned.version = Some(cloned.version.unwrap_or_default() + 1);
+        cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 


### PR DESCRIPTION
# Motivation

We would like to rotate the version increment in the unlikely events - an absolute edge case as it would consumes zillion of cycles to get there - of the number - used to prevent overwrite - reached `u64::MAX`.

# Changes

- Replace plus one with `wrapping_add` as discussed offline.

# Tests

No particular tests given the above motivation.
