### PR TITLE
feat(frontend): ledger transactionFee

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -43,6 +43,31 @@ export const metadata = async ({
 };
 
 /**
+ * Retrieves ledger transaction fee for the ICRC token.
+ *
+ * @param {Object} params - The parameters for fetching transaction fee.
+ * @param {boolean} [params.certified=true] - Whether the data should be certified.
+ * @param {OptionIdentity} params.identity - The identity to use for the request.
+ * @param {CanisterIdText} params.ledgerCanisterId - The ledger canister ID.
+ * @param {QueryParams} params.rest - Additional query parameters.
+ * @returns {Promise<IcrcTokenMetadataResponse>} The metadata response for the ICRC token.
+ */
+export const transactionFee = async ({
+	certified = true,
+	identity,
+	...rest
+}: {
+	identity: OptionIdentity;
+	ledgerCanisterId: CanisterIdText;
+} & QueryParams): Promise<bigint> => {
+	assertNonNullish(identity);
+
+	const { transactionFee } = await ledgerCanister({ identity, ...rest });
+
+	return transactionFee({ certified });
+};
+
+/**
  * Retrieves the balance of ICRC tokens for a specified owner.
  *
  * @param {Object} params - The parameters for fetching the balance.

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -1,5 +1,5 @@
 import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
-import { balance } from '$icp/api/icrc-ledger.api';
+import { balance, transactionFee } from '$icp/api/icrc-ledger.api';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import { IcrcLedgerCanister, type IcrcAccount } from '@dfinity/ledger-icrc';
 import { mock } from 'vitest-mock-extended';
@@ -63,6 +63,55 @@ describe('icrc-ledger.api', () => {
 				balance({
 					certified: true,
 					owner: mockPrincipal,
+					ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+					identity: undefined
+				})
+			).rejects.toThrow();
+		});
+	});
+
+	describe('transactionFee', () => {
+		const params = {
+			certified: true,
+			ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+			identity: mockIdentity
+		};
+
+		const fee = 1_000n;
+
+		beforeEach(() => {
+			ledgerCanisterMock.transactionFee.mockResolvedValue(fee);
+		});
+
+		it('successfully calls transactionFee endpoint', async () => {
+			const result = await transactionFee(params);
+
+			expect(result).toEqual(fee);
+			expect(ledgerCanisterMock.transactionFee).toBeCalledTimes(1);
+
+			expect(ledgerCanisterMock.transactionFee).toBeCalledWith({
+				certified: true
+			});
+		});
+
+		it('successfully calls transactionFee endpoint as query', async () => {
+			const result = await transactionFee({
+				...params,
+				certified: false
+			});
+
+			expect(result).toEqual(fee);
+			expect(ledgerCanisterMock.transactionFee).toBeCalledTimes(1);
+
+			expect(ledgerCanisterMock.transactionFee).toBeCalledWith({
+				certified: false
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(
+				transactionFee({
+					certified: true,
 					ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
 					identity: undefined
 				})


### PR DESCRIPTION
# Motivation

To always use the latest icrc token fee, we are going to fetch this info from the ledgers in the Swap flow.