### PR TITLE
feat(frontend): Swap fee logic update

### DIFF
--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -6,6 +6,11 @@
 		loadDisabledIcrcTokensBalances,
 		loadDisabledIcrcTokensExchanges
 	} from '$icp/services/icrc.services';
+	import {
+		IC_TOKEN_FEE_CONTEXT_KEY,
+		type IcTokenFeeContext,
+		icTokenFeeStore
+	} from '$icp/stores/ic-token-fee.store';
 	import SwapButtonWithModal from '$lib/components/swap/SwapButtonWithModal.svelte';
 	import SwapModal from '$lib/components/swap/SwapModal.svelte';
 	import { allDisabledKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
@@ -25,6 +30,10 @@
 
 	setContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY, {
 		store: initSwapAmountsStore()
+	});
+
+	setContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY, {
+		store: icTokenFeeStore
 	});
 
 	const onOpenSwap = async (tokenId: symbol) => {

--- a/src/frontend/src/lib/components/swap/SwapFee.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFee.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+
+	export let fee: number;
+	export let symbol: string;
+	export let label: string;
+</script>
+
+<ModalValue>
+	<svelte:fragment slot="label">{label}</svelte:fragment>
+
+	<svelte:fragment slot="main-value">
+		{fee}
+		{symbol}
+	</svelte:fragment>
+</ModalValue>

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -60,7 +60,7 @@
 			: 0;
 
 	let sourceTokenApproveFee: number;
-	$: sourceTokenApproveFee = sourceTokenTransferFee;
+	$: sourceTokenApproveFee = isSourceTokenIcrc2 ? sourceTokenTransferFee : 0;
 
 	let destinationTokenTotalFeeUSD: number;
 	$: destinationTokenTotalFeeUSD = nonNullish($destinationTokenExchangeRate)

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
+	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
+	import SwapFee from '$lib/components/swap/SwapFee.svelte';
 	import ModalExpandableValues from '$lib/components/ui/ModalExpandableValues.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { SWAP_TOTAL_FEE_THRESHOLD } from '$lib/constants/swap.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
@@ -10,12 +14,22 @@
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
+	import type { OptionAmount } from '$lib/types/send';
 	import { formatTokenBigintToNumber, formatUSD } from '$lib/utils/format.utils';
 
-	const { destinationToken, destinationTokenExchangeRate, sourceToken, sourceTokenExchangeRate } =
-		getContext<SwapContext>(SWAP_CONTEXT_KEY);
+	export let swapAmount: OptionAmount;
+
+	const {
+		destinationToken,
+		destinationTokenExchangeRate,
+		sourceToken,
+		sourceTokenExchangeRate,
+		isSourceTokenIcrc2
+	} = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
+
+	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
 
 	let liquidityProvidersFee: number;
 	$: liquidityProvidersFee = nonNullish($destinationToken)
@@ -35,15 +49,18 @@
 			})
 		: 0;
 
-	let sourceTokenFee: number;
-	$: sourceTokenFee =
-		nonNullish($sourceToken) && nonNullish($sourceToken.fee)
+	let sourceTokenTransferFee: number;
+	$: sourceTokenTransferFee =
+		nonNullish($sourceToken) && nonNullish($icTokenFeeStore?.[$sourceToken.symbol])
 			? formatTokenBigintToNumber({
-					value: $sourceToken.fee,
+					value: $icTokenFeeStore?.[$sourceToken.symbol],
 					displayDecimals: $sourceToken.decimals,
 					unitName: $sourceToken.decimals
 				})
 			: 0;
+
+	let sourceTokenApproveFee: number;
+	$: sourceTokenApproveFee = sourceTokenTransferFee;
 
 	let destinationTokenTotalFeeUSD: number;
 	$: destinationTokenTotalFeeUSD = nonNullish($destinationTokenExchangeRate)
@@ -52,17 +69,21 @@
 
 	let sourceTokenTotalFeeUSD: number;
 	$: sourceTokenTotalFeeUSD = nonNullish($sourceTokenExchangeRate)
-		? sourceTokenFee * $sourceTokenExchangeRate
+		? (sourceTokenTransferFee + sourceTokenApproveFee) * $sourceTokenExchangeRate
 		: 0;
 </script>
 
-{#if nonNullish($destinationToken) && nonNullish($sourceToken)}
+{#if nonNullish($destinationToken) && nonNullish($sourceToken) && nonNullish(swapAmount) && $swapAmountsStore?.swapAmounts !== null}
 	<ModalExpandableValues>
 		<ModalValue slot="list-header">
 			<svelte:fragment slot="label">{$i18n.swap.text.total_fee}</svelte:fragment>
 
 			<svelte:fragment slot="main-value">
-				{#if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
+				{#if isNullish($swapAmountsStore?.swapAmounts?.receiveAmount)}
+					<div class="w-14 sm:w-16">
+						<SkeletonText />
+					</div>
+				{:else if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
 					{`< ${formatUSD({
 						value: SWAP_TOTAL_FEE_THRESHOLD
 					})}`}
@@ -75,34 +96,27 @@
 		</ModalValue>
 
 		<svelte:fragment slot="list-items">
-			{#if nonNullish(sourceTokenFee)}
-				<ModalValue>
-					<svelte:fragment slot="label">{$i18n.swap.text.token_fee}</svelte:fragment>
+			<SwapFee
+				fee={sourceTokenTransferFee}
+				symbol={$sourceToken.symbol}
+				label={$i18n.swap.text.token_fee}
+			/>
 
-					<svelte:fragment slot="main-value">
-						{sourceTokenFee}
-						{$sourceToken.symbol}
-					</svelte:fragment>
-				</ModalValue>
+			{#if $isSourceTokenIcrc2 && sourceTokenApproveFee !== 0}
+				<SwapFee
+					fee={sourceTokenApproveFee}
+					symbol={$sourceToken.symbol}
+					label={$i18n.swap.text.approval_fee}
+				/>
 			{/if}
 
-			<ModalValue>
-				<svelte:fragment slot="label">{$i18n.swap.text.gas_fee}</svelte:fragment>
+			<SwapFee fee={gasFee} symbol={$destinationToken.symbol} label={$i18n.swap.text.gas_fee} />
 
-				<svelte:fragment slot="main-value">
-					{gasFee}
-					{$destinationToken.symbol}
-				</svelte:fragment>
-			</ModalValue>
-
-			<ModalValue>
-				<svelte:fragment slot="label">{$i18n.swap.text.lp_fee}</svelte:fragment>
-
-				<svelte:fragment slot="main-value">
-					{liquidityProvidersFee}
-					{$destinationToken.symbol}
-				</svelte:fragment>
-			</ModalValue>
+			<SwapFee
+				fee={liquidityProvidersFee}
+				symbol={$destinationToken.symbol}
+				label={$i18n.swap.text.lp_fee}
+			/>
 		</svelte:fragment>
 	</ModalExpandableValues>
 {/if}

--- a/src/frontend/src/lib/components/swap/SwapMaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/swap/SwapMaxBalanceButton.svelte
@@ -2,6 +2,8 @@
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { getContext } from 'svelte';
+	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
+	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { ConvertAmountErrorType } from '$lib/types/convert';
@@ -14,11 +16,15 @@
 
 	const { sourceTokenBalance, sourceToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	let isZeroBalance: boolean;
-	$: isZeroBalance = isNullish($sourceTokenBalance) || $sourceTokenBalance.isZero();
+	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
 
 	let sourceTokenFee: bigint | undefined;
-	$: sourceTokenFee = $sourceToken?.fee;
+	$: sourceTokenFee = nonNullish($sourceToken)
+		? $icTokenFeeStore?.[$sourceToken.symbol]
+		: undefined;
+
+	let isZeroBalance: boolean;
+	$: isZeroBalance = isNullish($sourceTokenBalance) || $sourceTokenBalance.isZero();
 
 	let maxAmount: number | undefined;
 	$: maxAmount = nonNullish($sourceToken)

--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -52,7 +52,7 @@
 			</svelte:fragment>
 		</ModalValue>
 
-		<SwapFees />
+		<SwapFees {swapAmount} />
 	</div>
 
 	<ButtonGroup slot="toolbar">

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
+	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
+	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapForm from '$lib/components/swap/SwapForm.svelte';
 	import SwapProgress from '$lib/components/swap/SwapProgress.svelte';
@@ -33,9 +35,16 @@
 
 	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
+	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
+
 	const progress = (step: ProgressStepsSwap) => (swapProgressStep = step);
 
 	const dispatch = createEventDispatcher();
+
+	let sourceTokenFee: bigint | undefined;
+	$: sourceTokenFee = nonNullish($sourceToken)
+		? $icTokenFeeStore?.[$sourceToken.symbol]
+		: undefined;
 
 	const swap = async () => {
 		if (isNullish($authIdentity)) {
@@ -67,6 +76,7 @@
 				swapAmount,
 				receiveAmount: $swapAmountsStore.swapAmounts.receiveAmount,
 				slippageValue,
+				sourceTokenFee,
 				isSourceTokenIcrc2: $isSourceTokenIcrc2
 			});
 
@@ -105,25 +115,27 @@
 	const back = () => dispatch('icBack');
 </script>
 
-<SwapAmountsContext
-	amount={swapAmount}
-	sourceToken={$sourceToken}
-	destinationToken={$destinationToken}
->
-	{#if currentStep?.name === WizardStepsSwap.SWAP}
-		<SwapForm
-			on:icClose
-			on:icNext
-			on:icShowTokensList
-			bind:swapAmount
-			bind:receiveAmount
-			bind:slippageValue
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.REVIEW}
-		<SwapReview on:icSwap={swap} on:icBack {slippageValue} {swapAmount} {receiveAmount} />
-	{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
-		<SwapProgress bind:swapProgressStep />
-	{:else}
-		<slot />
-	{/if}
-</SwapAmountsContext>
+<IcTokenFeeContext token={$sourceToken}>
+	<SwapAmountsContext
+		amount={swapAmount}
+		sourceToken={$sourceToken}
+		destinationToken={$destinationToken}
+	>
+		{#if currentStep?.name === WizardStepsSwap.SWAP}
+			<SwapForm
+				on:icClose
+				on:icNext
+				on:icShowTokensList
+				bind:swapAmount
+				bind:receiveAmount
+				bind:slippageValue
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.REVIEW}
+			<SwapReview on:icSwap={swap} on:icBack {slippageValue} {swapAmount} {receiveAmount} />
+		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
+			<SwapProgress bind:swapProgressStep />
+		{:else}
+			<slot />
+		{/if}
+	</SwapAmountsContext>
+</IcTokenFeeContext>

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -57,6 +57,7 @@
 			isNullish($destinationToken) ||
 			isNullish(slippageValue) ||
 			isNullish(swapAmount) ||
+			isNullish(sourceTokenFee) ||
 			isNullish($swapAmountsStore?.swapAmounts?.receiveAmount)
 		) {
 			toastsError({

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -456,6 +456,7 @@
 			"value_difference": "Value difference",
 			"total_fee": "Total estimated fee",
 			"token_fee": "Token fee",
+			"approval_fee": "Approval fee",
 			"gas_fee": "Gas fee",
 			"lp_fee": "LP fee",
 			"max_slippage_info": "Enter value between 0% and 50%",

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -30,6 +30,7 @@ export const swap = async ({
 	swapAmount,
 	receiveAmount,
 	slippageValue,
+	sourceTokenFee,
 	isSourceTokenIcrc2
 }: {
 	identity: OptionIdentity;
@@ -39,6 +40,7 @@ export const swap = async ({
 	swapAmount: Amount;
 	receiveAmount: bigint;
 	slippageValue: Amount;
+	sourceTokenFee: bigint | undefined;
 	isSourceTokenIcrc2: boolean;
 }) => {
 	progress(ProgressStepsSwap.SWAP);
@@ -68,7 +70,7 @@ export const swap = async ({
 		(await approve({
 			identity,
 			ledgerCanisterId,
-			amount: parsedSwapAmount.toBigInt() + (sourceToken.fee ?? 0n),
+			amount: parsedSwapAmount.toBigInt() + (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n),
 			expiresAt: nowInBigIntNanoSeconds() + 5n * NANO_SECONDS_IN_MINUTE,
 			spender: {
 				owner: Principal.from(KONG_BACKEND_CANISTER_ID)

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -40,7 +40,7 @@ export const swap = async ({
 	swapAmount: Amount;
 	receiveAmount: bigint;
 	slippageValue: Amount;
-	sourceTokenFee: bigint | undefined;
+	sourceTokenFee: bigint;
 	isSourceTokenIcrc2: boolean;
 }) => {
 	progress(ProgressStepsSwap.SWAP);
@@ -70,7 +70,8 @@ export const swap = async ({
 		(await approve({
 			identity,
 			ledgerCanisterId,
-			amount: parsedSwapAmount.toBigInt() + (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n),
+			// for icrc2 tokens, we need to double sourceTokenFee to cover "approve" and "transfer" fees
+			amount: parsedSwapAmount.toBigInt() + sourceTokenFee * 2n,
 			expiresAt: nowInBigIntNanoSeconds() + 5n * NANO_SECONDS_IN_MINUTE,
 			spender: {
 				owner: Principal.from(KONG_BACKEND_CANISTER_ID)

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -420,6 +420,7 @@ interface I18nSwap {
 		value_difference: string;
 		total_fee: string;
 		token_fee: string;
+		approval_fee: string;
 		gas_fee: string;
 		lp_fee: string;
 		max_slippage_info: string;

--- a/src/frontend/src/tests/lib/components/swap/SwapForm.test.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapForm.test.ts
@@ -1,3 +1,4 @@
+import { IC_TOKEN_FEE_CONTEXT_KEY, icTokenFeeStore } from '$icp/stores/ic-token-fee.store';
 import SwapForm from '$lib/components/swap/SwapForm.svelte';
 import {
 	SWAP_SWITCH_TOKENS_BUTTON,
@@ -52,6 +53,13 @@ describe('SwapForm', () => {
 		mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: swapAmountsStore });
 		return swapAmountsStore;
 	};
+	const setupIcTokenFeeStore = () => {
+		icTokenFeeStore.setIcTokenFee({
+			tokenSymbol: mockValidIcToken.symbol,
+			fee: 1000n
+		});
+		mockContext.set(IC_TOKEN_FEE_CONTEXT_KEY, { store: icTokenFeeStore });
+	};
 
 	describe('switch tokens button', () => {
 		it.each([
@@ -81,6 +89,7 @@ describe('SwapForm', () => {
 			}
 		])('should handle button state when $description', ({ swapAmounts, props, expected }) => {
 			setupSwapAmountsStore(swapAmounts as SwapAmountsStoreData);
+			setupIcTokenFeeStore();
 
 			const { getByTestId } = render(SwapForm, {
 				props: { ...props, slippageValue: undefined },
@@ -99,6 +108,7 @@ describe('SwapForm', () => {
 	describe('display values', () => {
 		beforeEach(() => {
 			setupSwapAmountsStore(mockSwapAmounts);
+			setupIcTokenFeeStore();
 		});
 
 		const renderSwapForm = () =>


### PR DESCRIPTION
# Motivation

In this PR, we start using the IcTokenFee store in the Swap flow, as well as update SwapFees component UI with the skeleton loading indicator and additional entry for the approval fee.
