### PR TITLE
feat(frontend): Theme refactoring preparations

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcTokenMenu.svelte
+++ b/src/frontend/src/icp/components/tokens/IcTokenMenu.svelte
@@ -19,6 +19,7 @@
 	{#if nonNullish(transactionsExplorerUrl)}
 		<div in:fade>
 			<ExternalLink
+				styleClass="nav-item"
 				fullWidth
 				href={transactionsExplorerUrl}
 				ariaLabel={$i18n.tokens.alt.open_dashboard}

--- a/src/frontend/src/lib/components/about/AboutItem.svelte
+++ b/src/frontend/src/lib/components/about/AboutItem.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	export let asMenuItem = false;
 	export let testId: string | undefined = undefined;
+	export let styleClass = '';
 </script>
 
 <button
-	class={asMenuItem ? 'text' : 'font-bold text-center whitespace-nowrap text-brand-primary'}
+	class={asMenuItem
+		? `text nav-item ${styleClass}`
+		: `font-bold text-center whitespace-nowrap text-brand-primary ${styleClass}`}
 	on:click
 	data-tid={testId}
 >

--- a/src/frontend/src/lib/components/about/AboutWhyOisy.svelte
+++ b/src/frontend/src/lib/components/about/AboutWhyOisy.svelte
@@ -8,6 +8,7 @@
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
 	export let asMenuItem = false;
+	export let styleClass = '';
 
 	const dispatch = createEventDispatcher();
 
@@ -17,7 +18,7 @@
 	};
 </script>
 
-<AboutItem {asMenuItem} on:click={openModal} testId={ABOUT_WHY_OISY_BUTTON}>
+<AboutItem {asMenuItem} on:click={openModal} testId={ABOUT_WHY_OISY_BUTTON} {styleClass}>
 	<IconInfo slot="icon" />
 	<span slot="label">{replaceOisyPlaceholders($i18n.about.why_oisy.text.label)}</span>
 </AboutItem>

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -200,7 +200,7 @@
 			href="mailto:support@oisy.com"
 			ariaLabel={$i18n.navigation.alt.support_email}
 			iconVisible={false}
-			class="nav-item nav-item-condensed"
+			styleClass="nav-item nav-item-condensed"
 		>
 			<IconHelp />
 			{$i18n.navigation.text.support_email}

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -192,14 +192,15 @@
 			</ButtonMenu>
 		{/if}
 
-		<AboutWhyOisy asMenuItem on:icOpenAboutModal={hidePopover} />
+		<AboutWhyOisy styleClass="nav-item-condensed" asMenuItem on:icOpenAboutModal={hidePopover} />
 
-		<ChangelogLink />
+		<ChangelogLink styleClass="nav-item-condensed" />
 
 		<ExternalLink
 			href="mailto:support@oisy.com"
 			ariaLabel={$i18n.navigation.alt.support_email}
 			iconVisible={false}
+			class="nav-item nav-item-condensed"
 		>
 			<IconHelp />
 			{$i18n.navigation.text.support_email}
@@ -211,7 +212,7 @@
 			href={OISY_REPO_URL}
 			rel="external noopener noreferrer"
 			target="_blank"
-			class="gap-2 flex items-center no-underline"
+			class="gap-2 nav-item nav-item-condensed flex items-center no-underline"
 			aria-label={$i18n.navigation.text.source_code_on_github}
 		>
 			<IconGitHub />

--- a/src/frontend/src/lib/components/core/SignOut.svelte
+++ b/src/frontend/src/lib/components/core/SignOut.svelte
@@ -13,7 +13,7 @@
 	};
 </script>
 
-<button on:click={logout} class="text gap-2" data-tid={LOGOUT_BUTTON}>
+<button on:click={logout} class="nav-item nav-item-condensed text gap-2" data-tid={LOGOUT_BUTTON}>
 	<IconLogout />
 	{$i18n.auth.text.logout}
 </button>

--- a/src/frontend/src/lib/components/core/WalletAddresses.svelte
+++ b/src/frontend/src/lib/components/core/WalletAddresses.svelte
@@ -12,7 +12,7 @@
 	};
 </script>
 
-<button on:click={openReceive} class="text gap-2">
+<button on:click={openReceive} class="text gap-2 nav-item nav-item-condensed">
 	<IconCopy />
 	{$i18n.wallet.text.your_addresses}
 </button>

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -140,6 +140,7 @@
 					ariaLabel={replacePlaceholders($i18n.dapps.alt.open_dapp, {
 						$dAppName: dAppName
 					})}
+					fullWidth
 					styleClass="as-button primary padding-sm flex-1 flex-row-reverse"
 					href={websiteURL.toString()}
 					trackEvent={{ name: TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK, metadata: { dappId } }}

--- a/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
+++ b/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
@@ -15,7 +15,7 @@
 	<IconAstronautHelmet />
 </div>
 
-<picture aria-label={ariaLabel} class="w-24">
+<picture aria-label={ariaLabel} id="oisy-wallet-logo" class="w-24">
 	<source srcset={oisyLogoSmall} media="(max-width: 639px)" />
 	<Img src={oisyLogoLarge} alt={ariaLabel} />
 </picture>

--- a/src/frontend/src/lib/components/navigation/ChangelogLink.svelte
+++ b/src/frontend/src/lib/components/navigation/ChangelogLink.svelte
@@ -3,12 +3,15 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+
+	export let styleClass = '';
 </script>
 
 <ExternalLink
 	href="https://github.com/dfinity/oisy-wallet/releases"
 	ariaLabel={replaceOisyPlaceholders($i18n.navigation.alt.changelog)}
 	iconVisible={false}
+	styleClass={`nav-item ${styleClass}`}
 >
 	<IconChangelog />
 	{replaceOisyPlaceholders($i18n.navigation.text.changelog)}

--- a/src/frontend/src/lib/components/navigation/NavigationItem.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationItem.svelte
@@ -7,7 +7,7 @@
 
 <a
 	{href}
-	class="gap-3 rounded-xl p-3 flex w-full flex-row text-left no-underline transition-colors duration-700 hover:text-brand-primary"
+	class="gap-3 rounded-xl p-3 nav-item flex w-full flex-row text-left no-underline transition-colors duration-700 hover:text-brand-primary"
 	class:text-brand-primary={selected}
 	class:bg-white={selected}
 	class:hover:bg-brand-subtle-alt={selected}

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -30,7 +30,12 @@
 	};
 </script>
 
-<button data-tid={testId} class="flex w-full items-start justify-between" on:click={onClick}>
+<button
+	data-tid={testId}
+	class="dropdown-item flex w-full items-start justify-between"
+	class:selected={id === $networkId}
+	on:click={onClick}
+>
 	<TextWithLogo
 		{name}
 		{icon}

--- a/src/frontend/src/lib/components/networks/NetworkLogo.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkLogo.svelte
@@ -18,4 +18,5 @@
 	{size}
 	{color}
 	{testId}
+	styleClass={blackAndWhite ? 'network-logo-bw' : ''}
 />

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -68,7 +68,7 @@
 
 		<ul class="gap-4 font-normal flex list-none flex-col">
 			<li class="flex items-center justify-between">
-				<div class="gap-2 flex items-center">
+				<div class="gap-2 dropdown-item disabled flex items-center">
 					<IconMorePlain />
 					<span class="text-grey">{$i18n.networks.more}</span>
 				</div>

--- a/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCardWithUrl.svelte
@@ -6,12 +6,15 @@
 
 	export let token: Token;
 	export let disableTabSelector = false;
+	export let styleClass = '';
 
 	let url: string;
 	$: url = transactionsUrl({ token });
 </script>
 
-<div class="group gap-3 rounded-xl px-3 py-2 sm:gap-8 flex hover:bg-white active:bg-white">
+<div
+	class={`group gap-3 rounded-xl px-3 py-2 sm:gap-8 flex hover:bg-white active:bg-white ${styleClass}`}
+>
 	<a
 		class="flex-1 no-underline"
 		href={url}

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <button
-	class="w-full text-left no-underline hover:text-brand-primary active:text-brand-primary"
+	class="nav-item nav-item-condensed w-full text-left no-underline hover:text-brand-primary active:text-brand-primary"
 	data-tid={testId}
 	aria-label={ariaLabel}
 	on:click

--- a/src/frontend/src/lib/components/ui/DropdownButton.svelte
+++ b/src/frontend/src/lib/components/ui/DropdownButton.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <button
-	class="min-w-72 gap-2 rounded-xl px-4 py-3 leading-5 font-medium justify-between border border-tertiary bg-white text-left text-black text-inherit hover:border-brand-primary"
+	class="min-w-72 gap-2 rounded-xl px-4 py-3 leading-5 font-medium dropdown-button justify-between border border-tertiary bg-white text-left text-black text-inherit hover:border-brand-primary"
 	bind:this={button}
 	on:click
 	aria-label={ariaLabel}

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -11,6 +11,7 @@
 	export let color: 'dust' | 'off-white' | 'white' = 'dust';
 	export let ring = false;
 	export let testId: string | undefined = undefined;
+	export let styleClass = '';
 
 	let sizePx = logoSizes[size];
 
@@ -30,7 +31,7 @@
 </script>
 
 <div
-	class="flex items-center justify-center overflow-hidden rounded-full ring-white"
+	class={`flex items-center justify-center overflow-hidden rounded-full ring-white ${styleClass}`}
 	class:bg-dust={color === 'dust' && !loaded}
 	class:bg-off-white={color === 'off-white' && !loaded}
 	class:bg-white={color === 'white' && !loaded}

--- a/src/frontend/src/lib/types/style.ts
+++ b/src/frontend/src/lib/types/style.ts
@@ -1,1 +1,7 @@
-export type ButtonColorStyle = 'primary' | 'secondary' | 'tertiary';
+export type ButtonColorStyle =
+	| 'primary'
+	| 'secondary'
+	| 'secondary-light'
+	| 'tertiary'
+	| 'tertiary-main-card'
+	| 'tertiary-alt';

--- a/src/frontend/src/sol/components/core/SolWalletAddress.svelte
+++ b/src/frontend/src/sol/components/core/SolWalletAddress.svelte
@@ -56,7 +56,11 @@
 </div>
 
 {#if nonNullish(explorerAddressUrl)}
-	<ExternalLink href={explorerAddressUrl} ariaLabel={$i18n.wallet.alt.open_solscan}>
+	<ExternalLink
+		styleClass="nav-item"
+		href={explorerAddressUrl}
+		ariaLabel={$i18n.wallet.alt.open_solscan}
+	>
 		{$i18n.navigation.text.view_on_explorer}
 	</ExternalLink>
 {/if}


### PR DESCRIPTION
# Motivation

In order to reduce the scope of the theme refactoring which is needed for the new dark mode, I split up the big PR in preperation to the full refactoring.

This step shouldnt change anything appearance wise, and just adds classes and prepares some heavily refactored components for the change.

# Changes

- Added styleClass prop to several components to accept classes from a parent
- Added nav-item, nav-item-condensed classes to navigational components to unify the nav components as they are in figma (these classes dont have any styling applied yet)
- Added dropdown-button and dropdown-item classes to dropdown buttons analogous to the nav items
- Added id to main oisy logo so it can be targeted by a selector (needed for inverting it in dark mode later)
- Added network-logo-bw class to network logo items if black and white (needed for inverting it in dark mode later)
- Added new button class types to style.ts so it matches the ones in figma

# Tests

None, there should be no visual or functional changes with this PR