### PR TITLE
refactor(frontend): bg-dust --> bg-disabled

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
@@ -33,7 +33,7 @@
 
 	<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.message}:</p>
 	{#if nonNullish(json)}
-		<div class="mt-4 rounded-xs p-4 bg-dust">
+		<div class="mt-4 rounded-xs p-4 bg-disabled">
 			<Json {json} _collapsed={true} />
 		</div>
 	{:else}

--- a/src/frontend/src/lib/components/carousel/Indicator.svelte
+++ b/src/frontend/src/lib/components/carousel/Indicator.svelte
@@ -23,6 +23,6 @@
 	on:click
 	aria-label={replacePlaceholders($i18n.carousel.text.indicator, { $index: `${index + 1}` })}
 	data-tid={`${CAROUSEL_SLIDE_NAVIGATION}${index + 1}`}
-	class="{`${isActive ? 'w-7 bg-black' : 'w-4 bg-dust'} mr-1 h-1.5 last:mr-0 transition-all duration-300 ease-linear`}}"
+	class="{`${isActive ? 'w-7 bg-black' : 'w-4 bg-disabled'} mr-1 h-1.5 last:mr-0 transition-all duration-300 ease-linear`}}"
 	out:fade
 ></button>

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -2,7 +2,7 @@
 	export let styleClass: string | undefined = undefined;
 
 	const variantClassNames = {
-		default: 'border border-tertiary bg-dust/30',
+		default: 'bg-secondary border border-tertiary',
 		info: 'bg-brand-subtle text-brand-primary',
 		error: 'bg-error-subtle text-error',
 		warning: 'bg-warning-subtle text-warning',

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectReview.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectReview.svelte
@@ -72,7 +72,7 @@
 						})}:
 					</p>
 
-					<article class="mt-4 rounded-xs p-4 bg-dust">
+					<article class="mt-4 rounded-xs p-4 bg-disabled">
 						<p class="font-bold">{$i18n.wallet_connect.text.methods}:</p>
 
 						<p>{allMethods.length ? allMethods.join(', ') : '-'}</p>


### PR DESCRIPTION
# Motivation

It makes more sense that we use `bg-disabled` instead of `bg-dust` in all its usages. Apart from `bg-dust/30` that is `bg-secondary`.
