### PR TITLE
style(frontend): add padding to single addresses in menu

### DIFF
--- a/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
+++ b/src/frontend/src/btc/components/core/BtcWalletAddress.svelte
@@ -17,7 +17,7 @@
 			: $btcAddressMainnet;
 </script>
 
-<div>
+<div class="p-3">
 	<label class="text-sm font-bold block" for="btc-wallet-address"
 		>{$i18n.wallet.text.wallet_address}:</label
 	>

--- a/src/frontend/src/eth/components/core/EthWalletAddress.svelte
+++ b/src/frontend/src/eth/components/core/EthWalletAddress.svelte
@@ -12,7 +12,7 @@
 		: undefined;
 </script>
 
-<div>
+<div class="p-3">
 	<label class="text-sm font-bold block" for="eth-wallet-address"
 		>{$i18n.wallet.text.wallet_address}:</label
 	>

--- a/src/frontend/src/icp/components/core/IcWalletAddress.svelte
+++ b/src/frontend/src/icp/components/core/IcWalletAddress.svelte
@@ -5,7 +5,7 @@
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 </script>
 
-<div>
+<div class="p-3">
 	<label class="text-sm font-bold block" for="ic-wallet-address"
 		>{$i18n.wallet.text.wallet_address}:</label
 	>

--- a/src/frontend/src/sol/components/core/SolWalletAddress.svelte
+++ b/src/frontend/src/sol/components/core/SolWalletAddress.svelte
@@ -45,7 +45,7 @@
 		: undefined;
 </script>
 
-<div>
+<div class="p-3">
 	<label class="text-sm font-bold block" for="eth-wallet-address"
 		>{$i18n.wallet.text.wallet_address}:</label
 	>


### PR DESCRIPTION
# Motivation

We want to put a bit more space in the address shown for the single network in the menu.

### Before

![Screenshot 2025-02-14 at 08 08 36](https://github.com/user-attachments/assets/b7459d0e-9503-4213-af07-eb1c7de3bd29)

### After

![Screenshot 2025-02-14 at 08 08 24](https://github.com/user-attachments/assets/1b482f08-5dd8-4712-aee1-13c6ffec7cd0)

