### PR TITLE
chore(frontend): remove unused theme constants

### DIFF
--- a/src/frontend/src/lib/constants/themes.constants.ts
+++ b/src/frontend/src/lib/constants/themes.constants.ts
@@ -1,7 +1,0 @@
-import { SystemTheme } from '$lib/enums/themes';
-import { Theme } from '@dfinity/gix-components';
-
-export const THEME_VALUES = [...Object.values(Theme), ...Object.values(SystemTheme)];
-
-// TODO: use variable exposed from gix-components when it will be exposed.
-export const THEME_KEY = 'nnsTheme';

--- a/src/frontend/src/lib/enums/themes.ts
+++ b/src/frontend/src/lib/enums/themes.ts
@@ -1,3 +1,0 @@
-export enum SystemTheme {
-	SYSTEM = 'system'
-}


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/oisy-wallet/pull/4669 I forgot to remove the unused variables once imported inside the component.
