### PR TITLE
feat(frontend): adjust Convert components for ETH fees case

### DIFF
--- a/src/frontend/src/eth/components/convert/EthConvertForm.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertForm.svelte
@@ -13,7 +13,7 @@
 
 	const { sourceTokenExchangeRate } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
-	const { maxGasFee }: FeeContext = getContext<FeeContext>(FEE_CONTEXT_KEY);
+	const { minGasFee, maxGasFee } = getContext<FeeContext>(FEE_CONTEXT_KEY);
 
 	let insufficientFunds: boolean;
 	let insufficientFundsForFee: boolean;
@@ -33,6 +33,7 @@
 	bind:insufficientFunds
 	bind:insufficientFundsForFee
 	totalFee={$maxGasFee?.toBigInt()}
+	minFee={$minGasFee?.toBigInt()}
 	disabled={invalid}
 >
 	<EthFeeDisplay exchangeRate={$sourceTokenExchangeRate} slot="fee" />

--- a/src/frontend/src/lib/components/convert/ConvertAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmount.svelte
@@ -8,6 +8,7 @@
 	export let sendAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
 	export let totalFee: bigint | undefined;
+	export let minFee: bigint | undefined = undefined;
 	export let insufficientFunds: boolean;
 	export let insufficientFundsForFee: boolean;
 	export let exchangeValueUnit: DisplayUnit = 'usd';
@@ -24,6 +25,7 @@
 		bind:exchangeValueUnit
 		{inputUnit}
 		{totalFee}
+		{minFee}
 	/>
 
 	<div

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -2,6 +2,7 @@
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { getContext } from 'svelte';
+	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
@@ -14,6 +15,7 @@
 
 	export let sendAmount: OptionAmount = undefined;
 	export let totalFee: bigint | undefined;
+	export let minFee: bigint | undefined = undefined;
 	export let insufficientFunds: boolean;
 	export let insufficientFundsForFee: boolean;
 	export let exchangeValueUnit: DisplayUnit = 'usd';
@@ -32,7 +34,9 @@
 			userAmount,
 			decimals: $sourceToken.decimals,
 			balance: $sourceTokenBalance,
-			totalFee
+			// If ETH, the balance should cover the user entered amount plus the min gas fee
+			// If other tokens - the balance plus total (max) fee
+			totalFee: isSupportedEthTokenId($sourceToken.id) ? minFee : totalFee
 		});
 
 	let isZeroBalance: boolean;

--- a/src/frontend/src/lib/components/convert/ConvertForm.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertForm.svelte
@@ -11,6 +11,7 @@
 	export let sendAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
 	export let totalFee: bigint | undefined;
+	export let minFee: bigint | undefined = undefined;
 	export let disabled: boolean;
 	export let insufficientFunds: boolean;
 	export let insufficientFundsForFee: boolean;
@@ -28,6 +29,7 @@
 		bind:insufficientFundsForFee
 		bind:exchangeValueUnit
 		{totalFee}
+		{minFee}
 	/>
 
 	<div class="mt-6">


### PR DESCRIPTION
# Motivation

In case of ETH -> ckETH conversion, we need to operate with total (max) and min gas fee: the total fee needs to be used for calculating max transaction amount and the min fee - for validating user input. For the reference, this is how it currently works in the old conversion flow (https://github.com/dfinity/oisy-wallet/blob/main/src/frontend/src/eth/components/send/EthSendAmount.svelte#L52).

