### PR TITLE
refactor(frontend): rename tailwind border color classes

### DIFF
--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -90,7 +90,7 @@
 
 		<SignerOrigin payload={$payload} />
 
-		<div class="mb-6 rounded-lg p-6 border border-brand-subtle bg-brand-subtle-20">
+		<div class="mb-6 rounded-lg p-6 border border-brand-subtle-10 bg-brand-subtle-20">
 			<p class="font-bold break-normal">{$i18n.signer.permissions.text.requested_permissions}</p>
 
 			<ul class="mt-2.5 gap-1 flex list-none flex-col">

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -62,7 +62,7 @@
 <div
 	class="rounded-lg p-5 first:mb-2 border border-solid text-left transition"
 	class:bg-brand-subtle-30={focused}
-	class:border-brand-subtle-alt={focused}
+	class:border-brand-subtle-20={focused}
 	class:bg-secondary={!focused}
 	class:border-secondary={!focused}
 >

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <div
-	class="flex items-center justify-center overflow-hidden rounded-full ring-white"
+	class="flex items-center justify-center overflow-hidden rounded-full ring-primary"
 	class:bg-dust={color === 'dust' && !loaded}
 	class:bg-off-white={color === 'off-white' && !loaded}
 	class:bg-white={color === 'white' && !loaded}

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div
-	class="p-3 relative flex items-center justify-center rounded-full bg-primary ring-2 ring-brand-subtle"
+	class="p-3 relative flex items-center justify-center rounded-full bg-primary ring-2 ring-brand-subtle-10"
 >
 	<svelte:component this={icon} styleClass={opacity ? 'opacity-10' : ''} />
 </div>

--- a/src/frontend/src/lib/components/ui/WarningBanner.svelte
+++ b/src/frontend/src/lib/components/ui/WarningBanner.svelte
@@ -4,7 +4,7 @@
 
 <div
 	class="gap-2 rounded-lg px-6 py-2 text-xs font-bold sm:w-fit md:text-base inline-flex w-full items-center justify-center border border-warning-solid bg-warning-subtle-10 text-warning-primary"
-
+>
 	<IconWarning inline />
 	<span><slot /></span>
 </div>

--- a/src/frontend/src/lib/components/ui/WarningBanner.svelte
+++ b/src/frontend/src/lib/components/ui/WarningBanner.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div
-	class="gap-2 rounded-lg px-6 py-2 text-xs font-bold sm:w-fit md:text-base inline-flex w-full items-center justify-center border border-crayola-yellow bg-cornsilk text-warning-primary"
+	class="gap-2 rounded-lg px-6 py-2 text-xs font-bold sm:w-fit md:text-base inline-flex w-full items-center justify-center border border-warning-solid bg-cornsilk text-warning-primary"
 >
 	<IconWarning inline />
 	<span><slot /></span>

--- a/src/frontend/src/lib/styles/tailwind/theme-variables.ts
+++ b/src/frontend/src/lib/styles/tailwind/theme-variables.ts
@@ -49,29 +49,32 @@ export const themeVariables = {
 		'tertiary-inverted': 'var(--colors-neutrals-500)',
 		disabled: 'var(--colors-neutrals-200)',
 		brand: {
-			subtle: 'var(--color-brand-100)',
-			'subtle-alt': 'var(--color-brand-200)',
-			'subtle2-alt': 'var(--color-brand-300)',
+			'subtle-10': 'var(--color-brand-100)',
+			'subtle-20': 'var(--color-brand-200)',
+			'subtle-30': 'var(--color-brand-300)',
 			primary: 'var(--color-brand-base)',
 			secondary: 'var(--color-brand-500)',
 			tertiary: 'var(--color-brand-600)',
 			disabled: 'var(--color-brand-100)'
 		},
 		success: {
-			subtle: 'var(--color-success-lightest)',
-			'subtle-alt': 'var(--color-success-lighter)',
+			'subtle-10': 'var(--color-success-lightest)',
+			'subtle-20': 'var(--color-success-lighter)',
+			'subtle-30': 'var(--color-success-light)',
 			solid: 'var(--color-success-default)',
 			'solid-alt': 'var(--color-success-dark)'
 		},
 		warning: {
-			subtle: 'var(--color-warning-lightest)',
-			'subtle-alt': 'var(--color-warning-lighter)',
+			'subtle-10': 'var(--color-warning-lightest)',
+			'subtle-20': 'var(--color-warning-lighter)',
+			'subtle-30': 'var(--color-warning-light)',
 			solid: 'var(--color-warning-default)',
 			'solid-alt': 'var(--color-warning-dark)'
 		},
 		error: {
-			subtle: 'var(--color-error-lightest)',
-			'subtle-alt': 'var(--color-error-lighter)',
+			'subtle-10': 'var(--color-error-lightest)',
+			'subtle-20': 'var(--color-error-lighter)',
+			'subtle-30': 'var(--color-error-light)',
 			solid: 'var(--color-error-default)',
 			'solid-alt': 'var(--color-error-dark)'
 		}

--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <article
-	class="mb-10 min-h-96 rounded-lg px-5 py-6 flex flex-col border border-brand-subtle-alt bg-white"
+	class="mb-10 min-h-96 rounded-lg px-5 py-6 flex flex-col border border-brand-subtle-20 bg-white"
 >
 	{#if $authNotSignedIn}
 		<SignerSignIn />


### PR DESCRIPTION
# Motivation
As part of the new theme refactoring https://github.com/dfinity/oisy-wallet/pull/4686 , we rename a few bordr-* and ring-* (because ring classes reference border colors) colors that were hardcoded colors and map them to theme variables.