### PR TITLE
feat(frontend): query calls to kong_backend token and swap_amount

### DIFF
--- a/src/frontend/src/lib/canisters/kong_backend.canister.ts
+++ b/src/frontend/src/lib/canisters/kong_backend.canister.ts
@@ -36,7 +36,7 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 		sourceAmount
 	}: KongSwapAmountsParams): Promise<SwapAmountsReply> => {
 		const { swap_amounts } = this.caller({
-			certified: true
+			certified: false
 		});
 
 		const response = await swap_amounts(sourceToken.symbol, sourceAmount, destinationToken.symbol);
@@ -82,7 +82,7 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 
 	tokens = async (): Promise<TokenReply[]> => {
 		const { tokens } = this.caller({
-			certified: true
+			certified: false
 		});
 
 		const response = await tokens(toNullable());


### PR DESCRIPTION
# Motivation

After the recent changes in kong_backend code, the update calls to their `token` and `swap_amount` endpoints are protected with a guard. The solution is to query them instead.
