### PR TITLE
chore(frontend): remove leftover misty-rose class

### DIFF
--- a/src/frontend/src/lib/components/airdrops/AirdropCard.svelte
+++ b/src/frontend/src/lib/components/airdrops/AirdropCard.svelte
@@ -25,7 +25,7 @@
 	<article class="h-full">
 		<section>
 			<p class="m-0 text-lg font-semibold text-start">{airdrop.title}</p>
-			<p class="m-0 mt-2 text-xs text-tertiary text-start">
+			<p class="m-0 mt-2 text-xs text-start text-tertiary">
 				{airdrop.oneLiner}
 			</p>
 		</section>

--- a/src/frontend/src/lib/components/airdrops/AirdropCard.svelte
+++ b/src/frontend/src/lib/components/airdrops/AirdropCard.svelte
@@ -25,7 +25,7 @@
 	<article class="h-full">
 		<section>
 			<p class="m-0 text-lg font-semibold text-start">{airdrop.title}</p>
-			<p class="m-0 mt-2 text-xs text-misty-rose text-start">
+			<p class="m-0 mt-2 text-xs text-tertiary text-start">
 				{airdrop.oneLiner}
 			</p>
 		</section>

--- a/src/frontend/src/lib/schedulers/user-snapshot.scheduler.ts
+++ b/src/frontend/src/lib/schedulers/user-snapshot.scheduler.ts
@@ -1,12 +1,9 @@
 import { USER_SNAPSHOT_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { SchedulerTimer, type Scheduler } from '$lib/schedulers/scheduler';
 import { registerUserSnapshot } from '$lib/services/user-snapshot.services';
-import type {
-	PostMessageDataRequestBtc,
-	PostMessageDataResponseError
-} from '$lib/types/post-message';
+import type { PostMessageDataRequest, PostMessageDataResponseError } from '$lib/types/post-message';
 
-export class UserSnapshotScheduler implements Scheduler<PostMessageDataRequestBtc> {
+export class UserSnapshotScheduler implements Scheduler<PostMessageDataRequest> {
 	private timer = new SchedulerTimer('syncUserSnapshotStatus');
 
 	stop() {

--- a/src/frontend/src/lib/workers/workers.ts
+++ b/src/frontend/src/lib/workers/workers.ts
@@ -8,14 +8,12 @@ import { onIcrcWalletMessage } from '$icp/workers/icrc-wallet.worker';
 import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
 import { onAuthMessage } from '$lib/workers/auth.worker';
 import { onExchangeMessage } from '$lib/workers/exchange.worker';
-import { onUserSnapshotMessage } from '$lib/workers/user-snapshot.worker';
 import { onSolWalletMessage } from '$sol/workers/sol-wallet.worker';
 
 onmessage = async (msg: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	await Promise.allSettled([
 		onAuthMessage(msg),
 		onExchangeMessage(msg),
-		onUserSnapshotMessage(msg),
 		onBtcWalletMessage(msg),
 		onBtcStatusesMessage(msg),
 		onCkBtcMinterInfoMessage(msg),


### PR DESCRIPTION
# Motivation

We left a `text-misty-rose` class to be replaced by `text-tertiary`.
