### PR TITLE
chore(frontend): explicitly overrides elliptic v6.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
 	"type": "module",
 	"overrides": {
 		"ws": "^7.5.10",
-		"elliptic": "^6.5.7",
+		"elliptic": "^6.6.1",
 		"cookie": "^0.7.0"
 	},
 	"engines": {


### PR DESCRIPTION
# Motivation

We already use `elliptic` version `v6.1.1` (see [package-lock.json](https://github.com/dfinity/oisy-wallet/blob/2879a6d2599a34c046ac08c84d4d9f2f3258a661/package-lock.json#L6712)) since November 2024, therefore we are safe. However, given that three days ago a critival CVE rated 9/10 was published ([GHSA-vjh7-7g9h-fjfh](https://github.com/indutny/elliptic/security/advisories/GHSA-vjh7-7g9h-fjfh)) I was thinking it's probably best if we also align the reference in `package.json` instead of a less strict reference than `^6.5.7`.

# Changes

- Set `"elliptic": "^6.6.1"` in `package.json`
