### PR TITLE
fix(frontend): limit the symbol length for SPL tokens

### DIFF
--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -261,7 +261,8 @@ export const getSplMetadata = async ({
 		return {
 			decimals,
 			name: address,
-			symbol: address
+			// In the backend there is a limitation on the number of characters for the symbol.
+			symbol: address.slice(0, 6)
 		};
 	}
 


### PR DESCRIPTION
# Motivation

The backend limits any symbol to max 20 characters. Since we use the address of a token as fallback in case of missing metadata, we limit the symbol there too, to a fair number of unique first characters.
