### PR TITLE
build(frontend): bump oisy-wallet-signer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@dfinity/gix-components": "^5.0.0-next-2025-02-12.1",
 				"@dfinity/ledger-icp": "^2.6.8-next-2025-02-10",
 				"@dfinity/ledger-icrc": "^2.7.3-next-2025-02-10",
-				"@dfinity/oisy-wallet-signer": "^0.1.5-next-2025-02-10.1",
+				"@dfinity/oisy-wallet-signer": "^0.1.6-next-2025-02-17",
 				"@dfinity/principal": "^2.3.0",
 				"@dfinity/utils": "^2.10.0-next-2025-02-10",
 				"@dfinity/verifiable-credentials": "^0.0.4",
@@ -465,9 +465,9 @@
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer": {
-			"version": "0.1.5-next-2025-02-10.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-0.1.5-next-2025-02-10.1.tgz",
-			"integrity": "sha512-13DV7nnVHoad8Apk0/A8A1v90e7E+12gQkkcowB8eO8bcElKBCFy3h5bJUzuFieXp5j+m+MQvr7Qp4u3MZnFoA==",
+			"version": "0.1.6-next-2025-02-17",
+			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-0.1.6-next-2025-02-17.tgz",
+			"integrity": "sha512-+779T//rSnrRNUGQYlEE9Ddjap3Y+Zj63NCu74Q+dt6Q4JyuLaODZgv0lSwQNJVykfXbbfE90h5D+K1o4SufMA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=22"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"@dfinity/gix-components": "^5.0.0-next-2025-02-12.1",
 		"@dfinity/ledger-icp": "^2.6.8-next-2025-02-10",
 		"@dfinity/ledger-icrc": "^2.7.3-next-2025-02-10",
-		"@dfinity/oisy-wallet-signer": "^0.1.5-next-2025-02-10.1",
+		"@dfinity/oisy-wallet-signer": "^0.1.6-next-2025-02-17",
 		"@dfinity/principal": "^2.3.0",
 		"@dfinity/utils": "^2.10.0-next-2025-02-10",
 		"@dfinity/verifiable-credentials": "^0.0.4",


### PR DESCRIPTION
# Motivation

Version compatible with Agent-js v2.3.0 which was bumped in #4756.

# Changes

- Bump oisy-wallet-signer next build at the top of https://github.com/dfinity/oisy-wallet-signer/releases/tag/v0.1.6. Next because we use ic-js next.
