### PR TITLE
feat(frontend): remove swap LP and gas fees from calculations

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -9,45 +9,13 @@
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { SWAP_TOTAL_FEE_THRESHOLD } from '$lib/constants/swap.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import {
-		SWAP_AMOUNTS_CONTEXT_KEY,
-		type SwapAmountsContext
-	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
-	import type { OptionAmount } from '$lib/types/send';
 	import { formatTokenBigintToNumber, formatUSD } from '$lib/utils/format.utils';
 
-	export let swapAmount: OptionAmount;
-
-	const {
-		destinationToken,
-		destinationTokenExchangeRate,
-		sourceToken,
-		sourceTokenExchangeRate,
-		isSourceTokenIcrc2
-	} = getContext<SwapContext>(SWAP_CONTEXT_KEY);
-
-	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
+	const { destinationToken, sourceToken, sourceTokenExchangeRate, isSourceTokenIcrc2 } =
+		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
-
-	let liquidityProvidersFee: number;
-	$: liquidityProvidersFee = nonNullish($destinationToken)
-		? formatTokenBigintToNumber({
-				value: $swapAmountsStore?.swapAmounts?.liquidityProvidersFee ?? 0n,
-				displayDecimals: $destinationToken.decimals,
-				unitName: $destinationToken.decimals
-			})
-		: 0;
-
-	let gasFee: number;
-	$: gasFee = nonNullish($destinationToken)
-		? formatTokenBigintToNumber({
-				value: $swapAmountsStore?.swapAmounts?.gasFee ?? 0n,
-				displayDecimals: $destinationToken.decimals,
-				unitName: $destinationToken.decimals
-			})
-		: 0;
 
 	let sourceTokenTransferFee: number;
 	$: sourceTokenTransferFee =
@@ -62,46 +30,37 @@
 	let sourceTokenApproveFee: number;
 	$: sourceTokenApproveFee = isSourceTokenIcrc2 ? sourceTokenTransferFee : 0;
 
-	let destinationTokenTotalFeeUSD: number;
-	$: destinationTokenTotalFeeUSD = nonNullish($destinationTokenExchangeRate)
-		? (liquidityProvidersFee + gasFee) * $destinationTokenExchangeRate
-		: 0;
-
 	let sourceTokenTotalFeeUSD: number;
 	$: sourceTokenTotalFeeUSD = nonNullish($sourceTokenExchangeRate)
 		? (sourceTokenTransferFee + sourceTokenApproveFee) * $sourceTokenExchangeRate
 		: 0;
 </script>
 
-{#if nonNullish($destinationToken) && nonNullish($sourceToken) && nonNullish(swapAmount) && $swapAmountsStore?.swapAmounts !== null}
+{#if nonNullish($destinationToken) && nonNullish($sourceToken)}
 	<ModalExpandableValues>
 		<ModalValue slot="list-header">
 			<svelte:fragment slot="label">{$i18n.swap.text.total_fee}</svelte:fragment>
 
 			<svelte:fragment slot="main-value">
-				{#if isNullish($swapAmountsStore?.swapAmounts?.receiveAmount)}
+				{#if isNullish($icTokenFeeStore?.[$sourceToken.symbol])}
 					<div class="w-14 sm:w-16">
 						<SkeletonText />
 					</div>
-				{:else if destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
+				{:else if isNullish($sourceTokenExchangeRate)}
+					{sourceTokenTransferFee + sourceTokenApproveFee} {$sourceToken.symbol}
+				{:else if sourceTokenTotalFeeUSD < SWAP_TOTAL_FEE_THRESHOLD}
 					{`< ${formatUSD({
 						value: SWAP_TOTAL_FEE_THRESHOLD
 					})}`}
 				{:else}
 					{formatUSD({
-						value: destinationTokenTotalFeeUSD + sourceTokenTotalFeeUSD
+						value: sourceTokenTotalFeeUSD
 					})}
 				{/if}
 			</svelte:fragment>
 		</ModalValue>
 
 		<svelte:fragment slot="list-items">
-			<SwapFee
-				fee={sourceTokenTransferFee}
-				symbol={$sourceToken.symbol}
-				label={$i18n.swap.text.token_fee}
-			/>
-
 			{#if $isSourceTokenIcrc2 && sourceTokenApproveFee !== 0}
 				<SwapFee
 					fee={sourceTokenApproveFee}
@@ -110,12 +69,10 @@
 				/>
 			{/if}
 
-			<SwapFee fee={gasFee} symbol={$destinationToken.symbol} label={$i18n.swap.text.gas_fee} />
-
 			<SwapFee
-				fee={liquidityProvidersFee}
-				symbol={$destinationToken.symbol}
-				label={$i18n.swap.text.lp_fee}
+				fee={sourceTokenTransferFee}
+				symbol={$sourceToken.symbol}
+				label={$i18n.swap.text.token_fee}
 			/>
 		</svelte:fragment>
 	</ModalExpandableValues>

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -72,7 +72,7 @@
 			<SwapFee
 				fee={sourceTokenTransferFee}
 				symbol={$sourceToken.symbol}
-				label={$i18n.swap.text.token_fee}
+				label={$i18n.swap.text.network_fee}
 			/>
 		</svelte:fragment>
 	</ModalExpandableValues>

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -202,7 +202,7 @@
 
 			<div class="gap-3 flex flex-col">
 				<SwapProvider />
-				<SwapFees {swapAmount} />
+				<SwapFees />
 			</div>
 		{/if}
 	</div>

--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -52,7 +52,7 @@
 			</svelte:fragment>
 		</ModalValue>
 
-		<SwapFees {swapAmount} />
+		<SwapFees />
 	</div>
 
 	<ButtonGroup slot="toolbar">

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -473,7 +473,7 @@
 			"not_available": "n/a",
 			"value_difference": "Value difference",
 			"total_fee": "Total estimated fee",
-			"token_fee": "Token fee",
+			"token_fee": "Network fee",
 			"approval_fee": "Approval fee",
 			"gas_fee": "Gas fee",
 			"lp_fee": "LP fee",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -473,7 +473,7 @@
 			"not_available": "n/a",
 			"value_difference": "Value difference",
 			"total_fee": "Total estimated fee",
-			"token_fee": "Network fee",
+			"network_fee": "Network fee",
 			"approval_fee": "Approval fee",
 			"gas_fee": "Gas fee",
 			"lp_fee": "LP fee",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -437,7 +437,7 @@ interface I18nSwap {
 		not_available: string;
 		value_difference: string;
 		total_fee: string;
-		token_fee: string;
+		network_fee: string;
 		approval_fee: string;
 		gas_fee: string;
 		lp_fee: string;


### PR DESCRIPTION
# Motivation

The next iteration of SwapFee changes - we remove the LP and gas fees from being displayed and assumed while calculating the total fee amount as they are both already included into a swap deal. In the next step, we will start showing them again but we'll update UI the way it's clear those fees are not to be paid once again.

<img width="602" alt="Screenshot 2025-02-17 at 12 26 32" src="https://github.com/user-attachments/assets/3d515ea6-932c-4b96-ab6b-2f591d42adf6" />

