### PR TITLE
feat(frontend): adapt Solana transaciton loader to Token-2022

### DIFF
--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -97,7 +97,8 @@ export const PostMessageDataRequestSolSchema = z.object({
 	// TODO: generate zod schema for CertifiedData
 	address: z.custom<CertifiedData<SolAddress>>(),
 	solanaNetwork: z.custom<SolanaNetworkType>(),
-	tokenAddress: z.custom<SolAddress>().optional()
+	tokenAddress: z.custom<SplTokenAddress>().optional(),
+	tokenOwnerAddress: z.custom<SolAddress>().optional()
 });
 
 export const PostMessageResponseStatusSchema = z.enum([

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -13,12 +13,14 @@ import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolBalance } from '$sol/types/sol-balance';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
+import type { SplTokenAddress } from '$sol/types/spl';
 import { assertNonNullish, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 
 interface LoadSolWalletParams {
 	solanaNetwork: SolanaNetworkType;
 	address: SolAddress;
-	tokenAddress?: SolAddress;
+	tokenAddress?: SplTokenAddress;
+	tokenOwnerAddress?: SolAddress;
 }
 
 interface SolWalletStore {
@@ -73,12 +75,14 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 	private loadTransactions = async ({
 		address,
 		solanaNetwork,
-		tokenAddress
+		tokenAddress,
+		tokenOwnerAddress
 	}: LoadSolWalletParams): Promise<SolCertifiedTransaction[]> => {
 		const transactions = await getSolTransactions({
 			network: solanaNetwork,
 			address,
-			tokenAddress
+			tokenAddress,
+			tokenOwnerAddress
 		});
 
 		const transactionsUi = transactions.map((transaction) => ({
@@ -96,7 +100,8 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 			const {
 				address: { data: address },
 				solanaNetwork,
-				tokenAddress
+				tokenAddress,
+				tokenOwnerAddress
 			} = data;
 
 			const [balance, transactions] = await Promise.all([
@@ -108,7 +113,8 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 				this.loadTransactions({
 					address,
 					solanaNetwork,
-					tokenAddress
+					tokenAddress,
+					tokenOwnerAddress
 				})
 			]);
 

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -1,10 +1,10 @@
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import { fetchSignatures } from '$sol/api/solana.api';
-import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import { fetchSolTransactionsForSignature } from '$sol/services/sol-transactions.services';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
+import type { SplTokenAddress } from '$sol/types/spl';
 import { nonNullish } from '@dfinity/utils';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import { assertIsAddress, address as solAddress } from '@solana/addresses';
@@ -17,22 +17,25 @@ export const getSolTransactions = async ({
 	address,
 	network,
 	tokenAddress,
+	tokenOwnerAddress,
 	before,
 	limit = Number(WALLET_PAGINATION)
 }: GetSolTransactionsParams & {
-	tokenAddress?: SolAddress;
+	tokenAddress?: SplTokenAddress;
+	tokenOwnerAddress?: SolAddress;
 }): Promise<SolTransactionUi[]> => {
 	if (nonNullish(tokenAddress)) {
 		assertIsAddress(tokenAddress);
 	}
 
-	const [relevantAddress] = nonNullish(tokenAddress)
-		? await findAssociatedTokenPda({
-				owner: solAddress(address),
-				tokenProgram: solAddress(TOKEN_PROGRAM_ADDRESS),
-				mint: solAddress(tokenAddress)
-			})
-		: [address];
+	const [relevantAddress] =
+		nonNullish(tokenAddress) && nonNullish(tokenOwnerAddress)
+			? await findAssociatedTokenPda({
+					owner: solAddress(address),
+					tokenProgram: solAddress(tokenOwnerAddress),
+					mint: solAddress(tokenAddress)
+				})
+			: [address];
 
 	const wallet = solAddress(relevantAddress);
 

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -28,6 +28,10 @@ export const getSolTransactions = async ({
 		assertIsAddress(tokenAddress);
 	}
 
+	if (nonNullish(tokenOwnerAddress)) {
+		assertIsAddress(tokenOwnerAddress);
+	}
+
 	const [relevantAddress] =
 		nonNullish(tokenAddress) && nonNullish(tokenOwnerAddress)
 			? await findAssociatedTokenPda({
@@ -55,7 +59,8 @@ export const getSolTransactions = async ({
 				signature,
 				network,
 				address,
-				tokenAddress
+				tokenAddress,
+				tokenOwnerAddress
 			});
 
 			return [...acc, ...parsedTransactions];

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -6,7 +6,6 @@ import {
 } from '$env/tokens/tokens.sol.env';
 import type { SolAddress } from '$lib/types/address';
 import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
-import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import { getSolTransactions } from '$sol/services/sol-signatures.services';
 import {
 	solTransactionsStore,
@@ -30,12 +29,14 @@ export const fetchSolTransactionsForSignature = async ({
 	signature,
 	network,
 	address,
-	tokenAddress
+	tokenAddress,
+	tokenOwnerAddress
 }: {
 	signature: SolSignature;
 	network: SolanaNetworkType;
 	address: SolAddress;
 	tokenAddress?: SplTokenAddress;
+	tokenOwnerAddress?: SolAddress;
 }): Promise<SolTransactionUi[]> => {
 	const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
 
@@ -61,13 +62,14 @@ export const fetchSolTransactionsForSignature = async ({
 		...putativeInnerInstructions.flatMap(({ instructions }) => instructions)
 	];
 
-	const [ataAddress] = nonNullish(tokenAddress)
-		? await findAssociatedTokenPda({
-				owner: solAddress(address),
-				tokenProgram: solAddress(TOKEN_PROGRAM_ADDRESS),
-				mint: solAddress(tokenAddress)
-			})
-		: [undefined];
+	const [ataAddress] =
+		nonNullish(tokenAddress) && nonNullish(tokenOwnerAddress)
+			? await findAssociatedTokenPda({
+					owner: solAddress(address),
+					tokenProgram: solAddress(tokenOwnerAddress),
+					mint: solAddress(tokenAddress)
+				})
+			: [undefined];
 
 	// The instructions are received in the order they were executed, meaning the first instruction
 	// in the list was executed first, and the last instruction was executed last.

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -71,7 +71,8 @@ describe('sol-transactions.services', () => {
 			await getSolTransactions({
 				address: mockSolAddress,
 				network: SolanaNetworks.mainnet,
-				tokenAddress: mockSplAddress
+				tokenAddress: mockSplAddress,
+				tokenOwnerAddress: TOKEN_PROGRAM_ADDRESS
 			});
 
 			expect(spyFindAssociatedTokenPda).toHaveBeenCalledWith({

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -1,5 +1,6 @@
 import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
 import * as solanaApi from '$sol/api/solana.api';
+import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import * as solSignaturesServices from '$sol/services/sol-signatures.services';
 import {
 	fetchSolTransactionsForSignature,
@@ -196,7 +197,11 @@ describe('sol-transactions.services', () => {
 			});
 
 			await expect(
-				fetchSolTransactionsForSignature({ ...mockParams, tokenAddress: mockSplAddress })
+				fetchSolTransactionsForSignature({
+					...mockParams,
+					tokenAddress: mockSplAddress,
+					tokenOwnerAddress: TOKEN_PROGRAM_ADDRESS
+				})
 			).resolves.toEqual([]);
 			expect(spyFindAssociatedTokenPda).toHaveBeenCalledOnce();
 		});


### PR DESCRIPTION
# Motivation

We need to use the token's owner address to fetch Solana transactions, since now we have Token-2022 that use different Token Program address.
