### PR TITLE
fix(frontend): Logo is inverteed on light mode with dark system theme

### DIFF
--- a/src/frontend/src/lib/components/about/AboutFeatureItem.svelte
+++ b/src/frontend/src/lib/components/about/AboutFeatureItem.svelte
@@ -8,7 +8,7 @@
 
 <div>
 	<div class="gap-3 font-bold flex items-center text-primary">
-		<div class="dark:invert">
+		<div class="invert-on-dark-theme">
 			<slot name="icon" />
 		</div>
 		<Html text={replaceOisyPlaceholders(title)} />

--- a/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
+++ b/src/frontend/src/lib/components/icons/OisyWalletLogo.svelte
@@ -15,7 +15,7 @@
 	<IconAstronautHelmet />
 </div>
 
-<picture aria-label={ariaLabel} class="w-24 dark:invert">
+<picture aria-label={ariaLabel} class="w-24 invert-on-dark-theme">
 	<source srcset={oisyLogoSmall} media="(max-width: 639px)" />
 	<Img src={oisyLogoLarge} alt={ariaLabel} />
 </picture>

--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -21,7 +21,7 @@
 	}
 
 	:root[theme='dark'] {
-		.dark\:invert {
+		.invert-on-dark-theme {
 			filter: invert(1);
 		}
 	}


### PR DESCRIPTION
# Motivation

When dark system theme is selected but light mode in the app, tailwinds dark:* classes always go for the system setting. We made it a custom class to avoid unexpected results.

# Changes

Made a custom class for inverting logos on dark mode and switched the classes on the elements

# Tests
Before:
![image](https://github.com/user-attachments/assets/84d5e9bb-f166-4be3-a395-26b543e5130c)

After:
![image](https://github.com/user-attachments/assets/6381a735-c3fa-4e28-9e53-3b76262a7a82)
