### PR TITLE
chore(frontend): fix no-unused-vars

### DIFF
--- a/scripts/add.tokens.erc20.mjs
+++ b/scripts/add.tokens.erc20.mjs
@@ -112,7 +112,7 @@ const fetchTokenDetails = async ({ contractAddress, isTestnet }) => {
 const loadFileContentOrEmpty = (filePath) => {
 	try {
 		return readFileSync(filePath, 'utf8');
-	} catch (err) {
+	} catch (_err) {
 		console.log(`File ${filePath} does not exist, it will be created.`);
 		return '';
 	}

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -223,7 +223,7 @@ export const signMessage = ({
 							identity,
 							nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 						});
-					} catch (err: unknown) {
+					} catch (_err: unknown) {
 						// If the above failed, it's because JSON.parse throw an exception.
 						// We are assuming that it did so because it tried to parse a string that does not represent an object.
 						// Therefore, we continue with a message as hex string.

--- a/src/frontend/src/icp/components/fee/IcTokenFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/IcTokenFeeContext.svelte
@@ -30,7 +30,7 @@
 					ledgerCanisterId: token.ledgerCanisterId
 				})
 			});
-		} catch (e: unknown) {
+		} catch (_err: unknown) {
 			// as a fallback, we use the icToken fee prop
 			store.setIcTokenFee({
 				tokenSymbol: token.symbol,

--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -83,7 +83,7 @@ export const loadAndAssertAddCustomToken = async ({
 		}
 
 		return { result: 'success', data: { token, balance } };
-	} catch (err: unknown) {
+	} catch (_err: unknown) {
 		return { result: 'error' };
 	}
 };

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -37,8 +37,9 @@
 	let websiteURL: Option<URL>;
 	$: {
 		try {
+			// TODO: use URL.parse
 			websiteURL = new URL(website);
-		} catch (e) {
+		} catch (_err: unknown) {
 			websiteURL = null;
 		}
 	}

--- a/src/frontend/src/lib/components/send/SendDataAmount.svelte
+++ b/src/frontend/src/lib/components/send/SendDataAmount.svelte
@@ -21,7 +21,7 @@
 				unitName: token.decimals,
 				displayDecimals: token.decimals
 			});
-		} catch (err: unknown) {
+		} catch (_err: unknown) {
 			// Infinite amount e.g. 1.157920892373162e+59 will fail parsing
 			amountDisplay = `${amount ?? 0}`;
 		}

--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -64,7 +64,7 @@
 				},
 				amountForSwap: parsedAmount
 			});
-		} catch (e) {
+		} catch (_err: unknown) {
 			// if kongSwapAmounts fails, it means no pool is currently available for the provided tokens
 			store.setSwapAmounts({
 				swapAmounts: null,

--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -14,6 +14,7 @@
 	let kongSwapDApp: OisyDappDescription | undefined;
 	$: kongSwapDApp = dAppDescriptions.find(({ id }) => id === 'kongswap');
 
+	// TODO: this state - websiteURL - isn't one and should become a local variable
 	let websiteURL: Option<URL>;
 	let displayURL: OptionString;
 	$: {
@@ -29,7 +30,7 @@
 						? websiteURL.hostname.substring(4)
 						: websiteURL.hostname;
 				}
-			} catch (e: unknown) {
+			} catch (_err: unknown) {
 				websiteURL = null;
 				displayURL = null;
 			}

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -109,7 +109,7 @@ export const loadIdbTokenAddress = async <T extends Address>({
 		addressStore.set({ data: address, certified: false });
 
 		await updateIdbAddressLastUsage(identity.getPrincipal());
-	} catch (err: unknown) {
+	} catch (_err: unknown) {
 		// We silence the error as the dapp will proceed with a standard lookup of the address.
 		console.error(
 			`Error encountered while searching for locally stored ${tokenId.description} public address in the browser.`
@@ -155,7 +155,7 @@ export const certifyAddress = async <T extends Address>({
 		addressStore.set({ data: address, certified: true });
 
 		await updateIdbAddressLastUsage(identity.getPrincipal());
-	} catch (err: unknown) {
+	} catch (_err: unknown) {
 		addressStore.reset();
 
 		return { success: false, err: `Error while loading the ${tokenId.description} address.` };

--- a/src/frontend/src/lib/services/loader.services.ts
+++ b/src/frontend/src/lib/services/loader.services.ts
@@ -26,7 +26,7 @@ export const initSignerAllowance = async (): Promise<ResultSuccess> => {
 		const { identity } = get(authStore);
 
 		await allowSigning({ identity });
-	} catch (err: unknown) {
+	} catch (_err: unknown) {
 		// In the event of any error, we sign the user out, as we assume that the Oisy Wallet cannot function without ETH or Bitcoin addresses.
 		await errorSignOut(get(i18n).init.error.allow_signing);
 


### PR DESCRIPTION
# Motivation

Few unused errors were not prefixed with `_`.

I also added two TODOs. Unrelated to the change but close to it and easy to resolve.
