### PR TITLE
chore(frontend): npm ci in reproducibility test

### DIFF
--- a/scripts/test.frontend.reproducibility.sh
+++ b/scripts/test.frontend.reproducibility.sh
@@ -10,6 +10,12 @@ if [ ! -d "$DIR" ]; then
 fi
 
 for ((n = 0; n < 10; n++)); do
+  echo "*********** Round $n ***********"
+
+  # We clean the modules because some libraries might generate and reuse a cache saved under node_modules, which could result in different bundles.
+  rm -r node_modules
+  npm ci
+
   npm run build && find build -type f -exec sha256sum {} \; | awk '{print $2 " " $1}' | sort >"$DIR/sha256-batch${n}.txt"
 
   # Save results for manual comparison


### PR DESCRIPTION
# Motivation

Some libraries might generate and reuse a cache saved under `node_modules`, which could result in different bundles, so in the reproducibility script it's better to always reinstall the lib before building.