### PR TITLE
feat(frontend): abort opening Swap modal if kong_backend is down

### DIFF
--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -37,7 +37,7 @@
 		store: icTokenFeeStore
 	});
 
-	const isDisabled = () => isNullish($kongSwapTokensStore);
+	const isDisabled = (): boolean => isNullish($kongSwapTokensStore);
 
 	const loadKongSwapTokens = async (): Promise<'ready' | undefined> => {
 		if (isNullish($authIdentity)) {

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { setContext } from 'svelte';
-	import { get } from 'svelte/store';
 	import {
 		loadDisabledIcrcTokensBalances,
 		loadDisabledIcrcTokensExchanges
@@ -17,7 +16,7 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalSwap } from '$lib/derived/modal.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { loadKongSwapTokens } from '$lib/services/swap.services';
+	import { loadKongSwapTokens as loadKongSwapTokensService } from '$lib/services/swap.services';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
@@ -27,6 +26,8 @@
 		SWAP_AMOUNTS_CONTEXT_KEY,
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
+	import { toastsShow } from '$lib/stores/toasts.store';
+	import { waitReady } from '$lib/utils/timeout.utils';
 
 	setContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY, {
 		store: initSwapAmountsStore()
@@ -36,21 +37,57 @@
 		store: icTokenFeeStore
 	});
 
+	const isDisabled = () => isNullish($kongSwapTokensStore);
+
+	const loadKongSwapTokens = async (): Promise<'ready' | undefined> => {
+		if (isNullish($authIdentity)) {
+			await nullishSignOut();
+			return;
+		}
+
+		if (!isDisabled()) {
+			return 'ready';
+		}
+
+		try {
+			await loadKongSwapTokensService({
+				identity: $authIdentity
+			});
+
+			return 'ready';
+		} catch (_err: unknown) {
+			console.warn('Failed to load KongSwap tokens.');
+
+			return undefined;
+		}
+	};
+
 	const onOpenSwap = async (tokenId: symbol) => {
 		if (isNullish($authIdentity)) {
 			await nullishSignOut();
 			return;
 		}
 
-		// We only wait for the required data to be loaded, other requests can be finished after the modal is open
-		if (isNullish($kongSwapTokensStore)) {
-			busy.start({ msg: get(i18n).init.info.hold_loading });
+		busy.start({ msg: $i18n.init.info.hold_loading });
 
-			await loadKongSwapTokens({
-				identity: $authIdentity
+		// 1. If loadKongSwapTokens succeeds within 10s - show modal.
+		// 2. If loadKongSwapTokens does not succeed within 10s - show toast, do not show modal.
+		// 3. If loadKongSwapTokens throws - show toast, do not show modal.
+		const kongSwapTokensStatus = await Promise.any([
+			waitReady({ retries: 20, isDisabled }),
+			loadKongSwapTokens()
+		]);
+
+		busy.stop();
+
+		if (kongSwapTokensStatus !== 'ready') {
+			toastsShow({
+				text: $i18n.swap.error.kong_not_available,
+				level: 'info',
+				duration: 3000
 			});
 
-			busy.stop();
+			return;
 		}
 
 		modalStore.openSwap(tokenId);

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -490,6 +490,7 @@
 			"swap_provider": "Swap provider"
 		},
 		"error": {
+			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
 			"unexpected": "Something went wrong while swapping tokens.",
 			"unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
 			"slippage_exceeded": "The swap could not be executed because the expected slippage of $expectedSlippage% exceeded the maximum allowed value of $maxSlippage%.\nYou can change the allowed slippage in the previous form, but this can lead to more unfavorable trades."

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -457,7 +457,12 @@ interface I18nSwap {
 		refreshing_ui: string;
 		swap_provider: string;
 	};
-	error: { unexpected: string; unexpected_missing_data: string; slippage_exceeded: string };
+	error: {
+		kong_not_available: string;
+		unexpected: string;
+		unexpected_missing_data: string;
+		slippage_exceeded: string;
+	};
 }
 
 interface I18nBuy {


### PR DESCRIPTION
# Motivation

After recent incidents with kong_backend, we need to improve the swap modal opening behavior to avoid app being stuck if the dapp canister is not responsive.

The updated implementation of Swap component handles the following cases when user clicks the swap button:
1. If `loadKongSwapTokens` succeeds within 10s - show modal.
2. If `loadKongSwapTokens` does not succeed within 10s - show toast, do not show modal.
3. If `loadKongSwapTokens` throws - show toast, do not show modal.