### PR TITLE
fix(build): issue with processing files with Tailwind via Docker

### DIFF
--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -2,8 +2,9 @@
 
 // We explicitly need to import Tailwind with a plain CSS @import as described in their documentation.
 // Trying to import it with Sass — such as using @use — leads to reproducibility issues.
-@import 'tailwindcss';
-
+// Additionally, we need to explicitly set the base path in order to avoid issues with building the app via Docker.
+/* prettier-ignore */
+@import 'tailwindcss' source("../../../../../src");
 @config '../../../../../tailwind.config.ts';
 
 @layer base {


### PR DESCRIPTION
# Motivation

## Problem
After migrating to Tailwind 4, building OISY via Docker was no longer possible due to the issue on the screenshot below. Investigation showed that there was a problem with transforming files that contain tailwind classes. [The function that was throwing the error](https://github.com/tailwindlabs/tailwindcss/blob/main/crates/oxide/src/scanner/allowed_paths.rs#L111) implied that we somehow try to parse some unexpected by tailwind files. Also, there were [some complains](https://github.com/tailwindlabs/tailwindcss/issues/15987) on the exact same issue recently.

<img width="573" alt="Screenshot 2025-02-19 at 18 28 41" src="https://github.com/user-attachments/assets/b8be362a-3d52-44b8-ab4a-bfa3cdef2641" />

## Solution
Apparently, the previous way of specifying content for parsing in Tailwind.config file doesn't work in the 4th version. Instead, we need to set [the base path](https://tailwindcss.com/docs/detecting-classes-in-source-files#setting-your-base-path) when importing tailwindcss module. After adding the `source` directive, `npm run build` works in both local and Docker environment. Also, it explains why we suddenly started seeing CSS warning that were coming from `e2e` folder - Tailwind was trying to process files outside of `src`.
