### PR TITLE
build(frontend): bump gix-cmp v5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@dfinity/candid": "^2.3.0",
 				"@dfinity/ckbtc": "^3.1.8",
 				"@dfinity/cketh": "^3.4.5",
-				"@dfinity/gix-components": "^5.0.0-next-2025-02-12.1",
+				"@dfinity/gix-components": "^5.1.0",
 				"@dfinity/ledger-icp": "^2.6.9",
 				"@dfinity/ledger-icrc": "^2.7.4",
 				"@dfinity/oisy-wallet-signer": "^0.1.6-next-2025-02-17",
@@ -373,12 +373,12 @@
 			}
 		},
 		"node_modules/@dfinity/gix-components": {
-			"version": "5.0.0-next-2025-02-12.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.0.0-next-2025-02-12.1.tgz",
-			"integrity": "sha512-0sBqBggqFXx9AGNZQ5sYx4fEt1acHBqD19aaUFozvo6rWg2uW31XcoZwaZXzv8s7QU0O/xzHMXQusZ9c+baheA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-5.1.0.tgz",
+			"integrity": "sha512-BsmgfDyecJFBI70PslMDcFwjxHyuMdcVN5Z0qbZRNhTCVYUPYzwjFjoPKxbPsSgdJLOB0Ex55zntSdIIgmrrJQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"dompurify": "^3.1.6",
+				"dompurify": "^3.2.4",
 				"html5-qrcode": "^2.3.8",
 				"marked": "^9.1.0",
 				"qr-creator": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"@dfinity/candid": "^2.3.0",
 		"@dfinity/ckbtc": "^3.1.8",
 		"@dfinity/cketh": "^3.4.5",
-		"@dfinity/gix-components": "^5.0.0-next-2025-02-12.1",
+		"@dfinity/gix-components": "^5.1.0",
 		"@dfinity/ledger-icp": "^2.6.9",
 		"@dfinity/ledger-icrc": "^2.7.4",
 		"@dfinity/oisy-wallet-signer": "^0.1.6-next-2025-02-17",


### PR DESCRIPTION
# Motivation

We want to embed the latest version of gix-cmp which contains a patch in dompurify.

# Changes

- Bump [v5.1.0](https://github.com/dfinity/gix-components/releases/tag/v5.1.0)
