### PR TITLE
style(frontend): Fix transparent toasts

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -349,11 +349,11 @@ div.select {
 
 // TOASTS
 div.error .toast {
-	--overlay-background: var(--color-background-error-subtle-20);
+	--overlay-background: var(--color-background-error-secondary);
 }
 div.success .toast {
-	--overlay-background: var(--color-background-success-subtle-20);
+	--overlay-background: var(--color-background-success-secondary);
 }
 div.warn .toast {
-	--overlay-background: var(--color-background-warning-subtle-20);
+	--overlay-background: var(--color-background-warning-secondary);
 }


### PR DESCRIPTION
# Motivation

Since we styled toasts like alerts and alerts use alpha background colors, it can be very hard to see the text in some cases. After checking with Dan, we switch to using error/warning/success-secondary background color for toasts.

# Changes

Changed colors for toast bg

# Tests
Before:
![image](https://github.com/user-attachments/assets/a4643179-769f-43a7-9723-e1e200abd121)

After:
![image](https://github.com/user-attachments/assets/89569698-7ce9-4904-87b2-cabecddaf9e1)

