### PR TITLE
feat(frontend): updates airdrop end date

### DIFF
--- a/src/frontend/src/env/airdrop-campaigns.json
+++ b/src/frontend/src/env/airdrop-campaigns.json
@@ -15,6 +15,6 @@
 		"jackpotHref": "https://x.com/intent/post?text=Just%20received%20%2450%20in%20tokens%20from%20%40OISY%20Wallet%E2%80%99s%20rewards%20initiative%20%F0%9F%8C%9F%0A%0AAnd%20I%E2%80%99m%20eligible%20again%20tomorrow...and%20the%20day%20after%20that...and%20the%20day%20after%20that...and%2C%20you%20get%20the%20idea%0A%0ASign%20up%20at%20OISY.com%E2%80%9450%20rewards%20a%20day%2C%20every%20day%20%F0%9F%A4%91",
 		"airdropHref": "https://x.com/intent/post?text=Just%20got%20my%20rewards%20from%20%40OISY%20Wallet.%0A%0AI%E2%80%99m%20eligible%20for%2050%20rewards%20every%20day%2C%20and%20I%E2%80%99m%20ready%20for%20more%21%20%F0%9F%AA%82%0A%0AIf%20you%E2%80%99re%20not%20on%20OISY.com%2C%20you%E2%80%99re%20NGMI",
 		"startDate": "2025-02-05T14:28:02.288Z",
-		"endDate": "2025-03-04T00:00:00.000Z"
+		"endDate": "2025-03-23T00:00:00.000Z"
 	}
 ]


### PR DESCRIPTION
# Motivation

The shown end date of the first campaign was not correct.

# Tests

before:
![image](https://github.com/user-attachments/assets/43a48c1a-559a-4621-88a5-b729aff712c9)

after:
![image](https://github.com/user-attachments/assets/a3a7eabb-0165-47da-baf7-8461f70d28a0)

