### PR TITLE
feat(frontend): change airdrops route to rewards

### DIFF
--- a/src/frontend/src/lib/constants/routes.constants.ts
+++ b/src/frontend/src/lib/constants/routes.constants.ts
@@ -5,7 +5,7 @@ export enum AppPath {
 	Transactions = '/transactions',
 	Activity = '/activity',
 	WalletConnect = '/wc',
-	Airdrops = '/airdrops'
+	Airdrops = '/rewards'
 }
 
 // SvelteKit uses the group defined in src/routes/(app)/ as part of the routeId. It also prefixes it with /.


### PR DESCRIPTION
# Motivation

We should not use the term airdrops and changed the **Airdrops** page and navigation element to read **Rewards**.
Ideally, we should also adjust the route to this page

**Note:**
I don't know where else this needs a change (yet). This PR is a draft and should be picked up by a proper Dev.
I just intended to give a start here :)

# Changes

- changed the route from /airdrops to /rewards

# Tests

-