### PR TITLE
feat(frontend): changes swap slippage exceeded message

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -101,6 +101,7 @@
 			const errorDetail = errorDetailToString(err);
 
 			if (nonNullish(errorDetail) && errorDetail.startsWith('Slippage exceeded.')) {
+				// Expected slippage is currently not shown in the message anymore, but I'm leaving in its derivation in case it's needed again.
 				const expectedSlippageMatch = errorDetail.match(/(\d+(\.\d+)?)% slippage/);
 
 				const expectedSlippage = nonNullish(expectedSlippageMatch)
@@ -109,7 +110,6 @@
 
 				failedSwapError.set(
 					replacePlaceholders($i18n.swap.error.slippage_exceeded, {
-						$expectedSlippage: expectedSlippage,
 						$maxSlippage: slippageValue.toString()
 					})
 				);

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -101,13 +101,6 @@
 			const errorDetail = errorDetailToString(err);
 
 			if (nonNullish(errorDetail) && errorDetail.startsWith('Slippage exceeded.')) {
-				// Expected slippage is currently not shown in the message anymore, but I'm leaving in its derivation in case it's needed again.
-				const expectedSlippageMatch = errorDetail.match(/(\d+(\.\d+)?)% slippage/);
-
-				const expectedSlippage = nonNullish(expectedSlippageMatch)
-					? expectedSlippageMatch[1]
-					: 'N/A';
-
 				failedSwapError.set(
 					replacePlaceholders($i18n.swap.error.slippage_exceeded, {
 						$maxSlippage: slippageValue.toString()

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -493,7 +493,7 @@
 			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
 			"unexpected": "Something went wrong while swapping tokens.",
 			"unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
-			"slippage_exceeded": "The swap could not be executed because the expected slippage of $expectedSlippage% exceeded the maximum allowed value of $maxSlippage%.\nYou can change the allowed slippage in the previous form, but this can lead to more unfavorable trades."
+			"slippage_exceeded": "OISY protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again."
 		}
 	},
 	"buy": {


### PR DESCRIPTION
# Motivation

Pierre requested the message shown when an in-wallet fails due to exceeded slippage is more user frfiendly.

# Tests
before:
![image](https://github.com/user-attachments/assets/d1ba3734-1266-41ca-9dfa-ab90654bf8dd)

after:
![image](https://github.com/user-attachments/assets/2ca892f5-a3c1-4c31-9fc1-8a548a57e706)

