### PR TITLE
feat(frontend): fixes share button styling

### DIFF
--- a/src/frontend/src/lib/components/ui/Share.svelte
+++ b/src/frontend/src/lib/components/ui/Share.svelte
@@ -13,7 +13,8 @@
 	{testId}
 	ariaLabel={text}
 	iconVisible={false}
-	styleClass={`${styleClass ?? ''} border border-disabled rounded-xl px-3 py-2`}
+	asButton
+	styleClass={`${styleClass ?? ''} border border-disabled rounded-xl px-3 py-2 tertiary`}
 >
 	{text}
 	<IconShare />


### PR DESCRIPTION
# Motivation

The text of the share button should be displayed in a bolder style.

# Tests

before:
<img width="428" alt="image" src="https://github.com/user-attachments/assets/bf466daa-da52-4db9-ba12-6aff4b17ec9d" />

after:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/3f4ebb05-45df-45cf-8872-b1a3cf49ee7e" />

