### PR TITLE
feat(frontend): updates the rewards texts

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -129,8 +129,8 @@
 			"no_balance_title": "Start exploring",
 			"no_balance_description": "Check back later to see your rewards",
 			"open_wallet": "Take me to the wallet",
-			"state_modal_title": "Congratulations on winning today's airdrop!",
-			"state_modal_title_jackpot": "Congratulations on winning today's highest airdrop!",
+			"state_modal_title": "Congratulations on winning today's reward!",
+			"state_modal_title_jackpot": "Congratulations on winning today's highest reward!",
 			"state_modal_content_text": "Share your victory on Twitter to qualify for another chance to win.",
 			"carousel_slide_title": "OISY Rewards Are Now Live!",
 			"carousel_slide_cta": "Learn more"


### PR DESCRIPTION
# Motivation

The text on the `reward received modal` still refers to `airdrops`, but it should say `rewards` instead.


# Tests

**before:**

reward:
<img width="429" alt="image" src="https://github.com/user-attachments/assets/42350bb8-c998-4e21-bbc2-449b89b457b4" />

jackpot:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/79a6d268-a01f-4cd0-8d20-4afbf3bc4607" />


**after:**

reward:
<img width="437" alt="image" src="https://github.com/user-attachments/assets/8e4c533c-f528-4d3b-b175-eb9dcc7489fa" />


jackpot:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/8ba9cce8-63a9-40df-89b0-3831abbd71c8" />

