### PR TITLE
feat(frontend): updates the rewards texts

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -129,9 +129,9 @@
 			"no_balance_title": "Start exploring",
 			"no_balance_description": "Check back later to see your rewards",
 			"open_wallet": "Take me to the wallet",
-			"state_modal_title": "Congratulations on winning today's reward!",
-			"state_modal_title_jackpot": "Congratulations on winning today's highest reward!",
-			"state_modal_content_text": "Share your victory on Twitter to qualify for another chance to win.",
+			"state_modal_title": "Congratulations on earning today's reward!",
+			"state_modal_title_jackpot": "Congratulations on earning today's highest reward!",
+			"state_modal_content_text": "Share your victory on Twitter to qualify for another chance to earn.",
 			"carousel_slide_title": "OISY Rewards Are Now Live!",
 			"carousel_slide_cta": "Learn more"
 		},


### PR DESCRIPTION
# Motivation

The text displayed on the `airdrop details modal` needs to be updated. It should congratulate users for `earning` rewards instead of `winning` rewards.


# Tests

**before:**

reward:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/3efdf44d-ba1b-47f5-9fbc-8f738cd960eb" />


jackpot:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/94d76cd8-795b-4fb4-ade7-c83b38240479" />



**after:**

reward:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/7575945f-4a89-4e90-91bf-37cd4bc70646" />

jackpot:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/5378d4dc-2890-46fd-bf02-d37c8c9e6a52" />
