### PR TITLE
fix(frontend): remove asserts from toIcrcTransaction method

### DIFF
--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -62,21 +62,15 @@ const toBaseTransaction = ({
 });
 
 const toIcrcTransaction = ({
-	transaction: { type, value, timestamp, from, to }
+	transaction: { type, value, timestamp }
 }: {
 	transaction: IcTransactionUi;
-}): Transaction_Icrc => {
-	// This does not happen, but we need it to be type-safe.
-	assertNonNullish(from);
-	assertNonNullish(to);
-
-	return {
-		...toBaseTransaction({ type, value, timestamp }),
-		timestamp: timestamp ?? 0n,
-		// TODO: use correct value when the Rewards canister is updated to accept account identifiers
-		counterparty: Principal.anonymous()
-	};
-};
+}): Transaction_Icrc => ({
+	...toBaseTransaction({ type, value, timestamp }),
+	timestamp: timestamp ?? 0n,
+	// TODO: use correct value when the Rewards canister is updated to accept account identifiers
+	counterparty: Principal.anonymous()
+});
 
 const toSplTransaction = ({
 	transaction: { type, value, timestamp, from, to },


### PR DESCRIPTION
# Motivation

I noticed that for accounts with ckBTC txs the register snapshot function throws an error. Most likely, it was related to some leftovers from the previous implementations where we were asserting `to` and `from` addresses for icrc txs. 
