### PR TITLE
feat(frontend): updates TokenInput.svelte

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -72,9 +72,9 @@
 	<div class="mb-2 text-sm font-bold"><slot name="title" /></div>
 
 	<TokenInputContainer
-			{focused}
-			styleClass="h-14 text-3xl"
-			error={nonNullish(errorType) || nonNullish(error)}
+		{focused}
+		styleClass="h-14 text-3xl"
+		error={nonNullish(errorType) || nonNullish(error)}
 	>
 		<div class="flex h-full w-full items-center">
 			{#if token}

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -25,10 +25,12 @@
 	export let disabled = false;
 	export let placeholder = '0';
 	export let errorType: ConvertAmountErrorType = undefined;
+	export let error: Error | undefined = undefined;
 	export let amountSetToMax = false;
 	export let loading = false;
 	export let isSelectable = true;
 	export let customValidate: (userAmount: BigNumber) => ConvertAmountErrorType = () => undefined;
+	export let customErrorValidate: (userAmount: BigNumber) => Error | undefined = () => undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -53,6 +55,7 @@
 		});
 
 		errorType = customValidate(parsedValue);
+		error = customErrorValidate(parsedValue);
 	};
 
 	const debounceValidate = debounce(validate, 300);
@@ -68,7 +71,11 @@
 >
 	<div class="mb-2 text-sm font-bold"><slot name="title" /></div>
 
-	<TokenInputContainer {focused} styleClass="h-14 text-3xl" error={nonNullish(errorType)}>
+	<TokenInputContainer
+			{focused}
+			styleClass="h-14 text-3xl"
+			error={nonNullish(errorType) || nonNullish(error)}
+	>
 		<div class="flex h-full w-full items-center">
 			{#if token}
 				{#if displayUnit === 'token'}

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -25,6 +25,7 @@
 	export let disabled = false;
 	export let placeholder = '0';
 	export let errorType: ConvertAmountErrorType = undefined;
+	// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
 	export let error: Error | undefined = undefined;
 	export let amountSetToMax = false;
 	export let loading = false;


### PR DESCRIPTION
# Motivation

The `TokenInput` field should also be used in the `SendForms`. Since the custom validation for the `SendAmount` components works with `errors` instead of `errorTypes`, the `TokenInput` should support this as well.

# Changes

- adds support for errors

