### PR TITLE
feat(frontend): updates SwapMaxBalanceButton.svelte

### DIFF
--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -5,7 +5,6 @@
 	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
 	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
@@ -32,7 +31,7 @@
 	let maxAmount: number | undefined;
 	$: maxAmount = nonNullish(token)
 		? getMaxTransactionAmount({
-				balance: $sourceTokenBalance,
+				balance: balance ?? undefined,
 				// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
 				fee: BigNumber.from((sourceTokenFee ?? 0n) * (isIcrc2Token ? 2n : 1n)),
 				tokenDecimals: token.decimals,

--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -1,29 +1,18 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import { getContext } from 'svelte';
-	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
-	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionBalance } from '$lib/types/balance';
-	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Token } from '$lib/types/token';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 
 	export let amount: OptionAmount;
 	export let amountSetToMax = false;
-	export let errorType: ConvertAmountErrorType = undefined;
-	// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
-	export let error: Error | undefined = undefined;
+	export let error: boolean = false;
 	export let balance: OptionBalance;
 	export let token: Token | undefined = undefined;
-	export let isIcrc2Token: boolean | undefined = undefined;
-
-	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
-
-	let sourceTokenFee: bigint | undefined;
-	$: sourceTokenFee = nonNullish(token) ? $icTokenFeeStore?.[token.symbol] : undefined;
+	export let fee: BigNumber | undefined = undefined;
 
 	let isZeroBalance: boolean;
 	$: isZeroBalance = isNullish(balance) || balance.isZero();
@@ -32,8 +21,7 @@
 	$: maxAmount = nonNullish(token)
 		? getMaxTransactionAmount({
 				balance: balance ?? undefined,
-				// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
-				fee: BigNumber.from((sourceTokenFee ?? 0n) * (isIcrc2Token ? 2n : 1n)),
+				fee,
 				tokenDecimals: token.decimals,
 				tokenStandard: token.standard
 			})
@@ -47,7 +35,7 @@
 	};
 
 	/**
-	 * Reevaluate max amount if user has used the "Max" button and sourceTokenFee is changing.
+	 * Reevaluate max amount if user has used the "Max" button and fee is changing.
 	 */
 	const debounceSetMax = () => {
 		if (!amountSetToMax) {
@@ -56,14 +44,14 @@
 		debounce(() => setMax(), 500)();
 	};
 
-	$: sourceTokenFee, debounceSetMax();
+	$: fee, debounceSetMax();
 </script>
 
 <button
 	class="font-semibold text-brand-primary transition-all"
 	on:click|preventDefault={setMax}
-	class:text-error-primary={isZeroBalance || nonNullish(errorType) || nonNullish(error)}
-	class:text-brand-primary={(!isZeroBalance && isNullish(errorType)) || isNullish(error)}
+	class:text-error-primary={isZeroBalance || error}
+	class:text-brand-primary={(!isZeroBalance && !error)}
 >
 	{$i18n.core.text.max}:
 	{nonNullish(maxAmount) && nonNullish(token)

--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -65,8 +65,8 @@
 	class:text-error-primary={isZeroBalance || nonNullish(errorType) || nonNullish(error)}
 	class:text-brand-primary={(!isZeroBalance && isNullish(errorType)) || isNullish(error)}
 >
-	{$i18n.swap.text.max_balance}:
+	{$i18n.core.text.max}:
 	{nonNullish(maxAmount) && nonNullish(token)
 		? `${maxAmount} ${token.symbol}`
-		: $i18n.swap.text.not_available}
+		: $i18n.core.text.not_available}
 </button>

--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -62,8 +62,8 @@
 <button
 	class="font-semibold text-brand-primary transition-all"
 	on:click|preventDefault={setMax}
-	class:text-error-primary={isZeroBalance || nonNullish(errorType) || nonNullish(errorType)}
-	class:text-brand-primary={!isZeroBalance && isNullish(errorType) || isNullish(errorType)}
+	class:text-error-primary={isZeroBalance || nonNullish(errorType) || nonNullish(error)}
+	class:text-brand-primary={!isZeroBalance && isNullish(errorType) || isNullish(error)}
 >
 	{$i18n.swap.text.max_balance}:
 	{nonNullish(maxAmount) && nonNullish(token)

--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -9,7 +9,7 @@
 
 	export let amount: OptionAmount;
 	export let amountSetToMax = false;
-	export let error: boolean = false;
+	export let error = false;
 	export let balance: OptionBalance;
 	export let token: Token | undefined = undefined;
 	export let fee: BigNumber | undefined = undefined;
@@ -51,7 +51,7 @@
 	class="font-semibold text-brand-primary transition-all"
 	on:click|preventDefault={setMax}
 	class:text-error-primary={isZeroBalance || error}
-	class:text-brand-primary={(!isZeroBalance && !error)}
+	class:text-brand-primary={!isZeroBalance && !error}
 >
 	{$i18n.core.text.max}:
 	{nonNullish(maxAmount) && nonNullish(token)

--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -5,11 +5,11 @@
 	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
 	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionBalance } from '$lib/types/balance';
 	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
+	import type { Token } from '$lib/types/token';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
-	import type {Token} from "$lib/types/token";
-	import type {OptionBalance} from "$lib/types/balance";
 
 	export let amount: OptionAmount;
 	export let amountSetToMax = false;
@@ -63,7 +63,7 @@
 	class="font-semibold text-brand-primary transition-all"
 	on:click|preventDefault={setMax}
 	class:text-error-primary={isZeroBalance || nonNullish(errorType) || nonNullish(error)}
-	class:text-brand-primary={!isZeroBalance && isNullish(errorType) || isNullish(error)}
+	class:text-brand-primary={(!isZeroBalance && isNullish(errorType)) || isNullish(error)}
 >
 	{$i18n.swap.text.max_balance}:
 	{nonNullish(maxAmount) && nonNullish(token)

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -72,6 +72,10 @@
 		? $icTokenFeeStore?.[$sourceToken.symbol]
 		: undefined;
 
+	let totalFee: bigint | undefined;
+	// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
+	$: totalFee = (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n)
+
 	let swapAmountsLoading = false;
 	$: swapAmountsLoading =
 		nonNullish(swapAmount) && nonNullish($swapAmountsStore?.amountForSwap)
@@ -111,7 +115,7 @@
 					decimals: $sourceToken.decimals,
 					balance: $sourceTokenBalance,
 					// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
-					totalFee: (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n)
+					totalFee
 				})
 			: undefined;
 </script>
@@ -151,10 +155,11 @@
 						<MaxBalanceButton
 							bind:amountSetToMax
 							bind:amount={swapAmount}
-							{errorType}
+							error={nonNullish(errorType)}
 							balance={$sourceTokenBalance}
 							token={$sourceToken}
 							isIcrc2Token={$isSourceTokenIcrc2}
+							fee={totalFee}
 						/>
 					{/if}
 				</svelte:fragment>

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -114,7 +114,6 @@
 					userAmount,
 					decimals: $sourceToken.decimals,
 					balance: $sourceTokenBalance,
-					// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
 					totalFee
 				})
 			: undefined;

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -74,7 +74,7 @@
 
 	let totalFee: bigint | undefined;
 	// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
-	$: totalFee = (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n)
+	$: totalFee = (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n);
 
 	let swapAmountsLoading = false;
 	$: swapAmountsLoading =

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -5,8 +5,8 @@
 	import { slide } from 'svelte/transition';
 	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
 	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
-	import SwapFees from '$lib/components/swap/SwapFees.svelte';
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
+	import SwapFees from '$lib/components/swap/SwapFees.svelte';
 	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
 	import SwapSlippage from '$lib/components/swap/SwapSlippage.svelte';
 	import SwapSwitchTokensButton from '$lib/components/swap/SwapSwitchTokensButton.svelte';
@@ -148,7 +148,14 @@
 
 				<svelte:fragment slot="balance">
 					{#if nonNullish($sourceToken)}
-						<MaxBalanceButton bind:amountSetToMax bind:amount={swapAmount} {errorType} balance={$sourceTokenBalance} token={$sourceToken} isIcrc2Token={$isSourceTokenIcrc2} />
+						<MaxBalanceButton
+							bind:amountSetToMax
+							bind:amount={swapAmount}
+							{errorType}
+							balance={$sourceTokenBalance}
+							token={$sourceToken}
+							isIcrc2Token={$isSourceTokenIcrc2}
+						/>
 					{/if}
 				</svelte:fragment>
 			</TokenInput>

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -159,7 +159,7 @@
 							balance={$sourceTokenBalance}
 							token={$sourceToken}
 							isIcrc2Token={$isSourceTokenIcrc2}
-							fee={totalFee}
+							fee={BigNumber.from(totalFee)}
 						/>
 					{/if}
 				</svelte:fragment>

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -158,7 +158,6 @@
 							error={nonNullish(errorType)}
 							balance={$sourceTokenBalance}
 							token={$sourceToken}
-							isIcrc2Token={$isSourceTokenIcrc2}
 							fee={BigNumber.from(totalFee)}
 						/>
 					{/if}

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -148,7 +148,7 @@
 
 				<svelte:fragment slot="balance">
 					{#if nonNullish($sourceToken)}
-						<MaxBalanceButton bind:amountSetToMax bind:swapAmount {errorType} balance={$sourceTokenBalance} token={$sourceToken} isIcrc2Token={$isSourceTokenIcrc2} />
+						<MaxBalanceButton bind:amountSetToMax bind:amount={swapAmount} {errorType} balance={$sourceTokenBalance} token={$sourceToken} isIcrc2Token={$isSourceTokenIcrc2} />
 					{/if}
 				</svelte:fragment>
 			</TokenInput>

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -6,7 +6,7 @@
 	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
 	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 	import SwapFees from '$lib/components/swap/SwapFees.svelte';
-	import SwapMaxBalanceButton from '$lib/components/swap/SwapMaxBalanceButton.svelte';
+	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
 	import SwapSlippage from '$lib/components/swap/SwapSlippage.svelte';
 	import SwapSwitchTokensButton from '$lib/components/swap/SwapSwitchTokensButton.svelte';
@@ -148,7 +148,7 @@
 
 				<svelte:fragment slot="balance">
 					{#if nonNullish($sourceToken)}
-						<SwapMaxBalanceButton bind:amountSetToMax bind:swapAmount {errorType} />
+						<MaxBalanceButton bind:amountSetToMax bind:swapAmount {errorType} balance={$sourceTokenBalance} token={$sourceToken} isIcrc2Token={$isSourceTokenIcrc2} />
 					{/if}
 				</svelte:fragment>
 			</TokenInput>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -17,7 +17,8 @@
 			"approve": "Approve",
 			"view": "View",
 			"copy": "Copy",
-			"clear_filter": "Clear filter"
+			"clear_filter": "Clear filter",
+			"not_available": "n/a"
 		},
 		"info": {
 			"test_banner": "For testing purposes only!"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -21,6 +21,7 @@ interface I18nCore {
 		view: string;
 		copy: string;
 		clear_filter: string;
+		not_available: string;
 	};
 	info: { test_banner: string };
 	alt: { logo: string; go_to_home: string; back: string };


### PR DESCRIPTION
# Motivation

The `SwapMaxBalanceButton` component should be more generic so that it can also be used in the `SendForms`. Since the custom validation for the `SendAmount` components works with `errors` instead of `errorTypes`, the `MaxBalanceButton` should support this as well.

# Changes

- renames SwapMaxBalanceButton to MaxBalanceButton
- makes component more generic

