### PR TITLE
feat(frontend): adjust convert utils for ERC20 case

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -2,9 +2,12 @@
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { getContext } from 'svelte';
+	import { ethereumToken } from '$eth/derived/token.derived';
 	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { balancesStore } from '$lib/stores/balances.store';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ConvertAmountErrorType } from '$lib/types/convert';
@@ -32,11 +35,12 @@
 	$: customValidate = (userAmount: BigNumber): ConvertAmountErrorType =>
 		validateConvertAmount({
 			userAmount,
-			decimals: $sourceToken.decimals,
+			token: $sourceToken,
 			balance: $sourceTokenBalance,
+			ethBalance: $balancesStore?.[$ethereumToken.id]?.data ?? ZERO,
 			// If ETH, the balance should cover the user entered amount plus the min gas fee
 			// If other tokens - the balance plus total (max) fee
-			totalFee: isSupportedEthTokenId($sourceToken.id) ? minFee : totalFee
+			fee: isSupportedEthTokenId($sourceToken.id) ? minFee : totalFee
 		});
 
 	let isZeroBalance: boolean;

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -112,9 +112,9 @@
 		nonNullish($sourceToken)
 			? validateConvertAmount({
 					userAmount,
-					decimals: $sourceToken.decimals,
+					token: $sourceToken,
 					balance: $sourceTokenBalance,
-					totalFee
+					fee: totalFee
 				})
 			: undefined;
 </script>

--- a/src/frontend/src/lib/utils/convert.utils.ts
+++ b/src/frontend/src/lib/utils/convert.utils.ts
@@ -1,5 +1,7 @@
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { ConvertAmountErrorType } from '$lib/types/convert';
+import type { Token } from '$lib/types/token';
 import { formatToken } from '$lib/utils/format.utils';
 import { nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -8,32 +10,45 @@ import { Utils } from 'alchemy-sdk';
 // TODO: standardise and re-use this util between Send and Convert flows
 export const validateConvertAmount = ({
 	userAmount,
-	decimals,
+	token,
 	balance,
-	totalFee
+	fee,
+	ethBalance
 }: {
 	userAmount: BigNumber;
-	decimals: number;
+	token: Token;
 	balance?: BigNumber;
-	totalFee?: bigint;
+	ethBalance?: BigNumber;
+	fee?: bigint;
 }): ConvertAmountErrorType => {
 	// We should align balance and userAmount to avoid issues caused by comparing formatted and unformatted BN
 	const parsedSendBalance = nonNullish(balance)
 		? Utils.parseUnits(
 				formatToken({
 					value: balance,
-					unitName: decimals,
-					displayDecimals: decimals
+					unitName: token.decimals,
+					displayDecimals: token.decimals
 				}),
-				decimals
+				token.decimals
 			)
 		: ZERO;
 
+	// Balance should cover the entered amount for all type of tokens
 	if (userAmount.gt(parsedSendBalance)) {
 		return 'insufficient-funds';
 	}
 
-	if (nonNullish(totalFee) && userAmount.add(totalFee).gt(parsedSendBalance)) {
+	// If ERC20, the ETH balance should be less or greater than the total (max gas) fee
+	if (isTokenErc20(token)) {
+		if (nonNullish(ethBalance) && nonNullish(fee) && ethBalance.lt(fee)) {
+			return 'insufficient-funds-for-fee';
+		}
+
+		return;
+	}
+
+	// If other tokens, the balance should cover the user entered amount plus total fee
+	if (nonNullish(fee) && userAmount.add(fee).gt(parsedSendBalance)) {
 		return 'insufficient-funds-for-fee';
 	}
 };

--- a/src/frontend/src/tests/lib/utils/convert.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/convert.utils.spec.ts
@@ -1,19 +1,23 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ZERO } from '$lib/constants/app.constants';
 import { validateConvertAmount } from '$lib/utils/convert.utils';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { BigNumber } from 'alchemy-sdk';
 
 describe('validateConvertAmount', () => {
 	const userAmount = BigNumber.from(200000n);
-	const decimals = 8;
+	const token = ETHEREUM_TOKEN;
 	const balance = BigNumber.from(9000000n);
-	const totalFee = 10000n;
+	const fee = 10000n;
 
 	it('should return undefined if all data satisfies the conditions', () => {
 		expect(
 			validateConvertAmount({
 				userAmount,
-				decimals,
+				token,
 				balance,
-				totalFee
+				fee
 			})
 		).toBeUndefined();
 	});
@@ -22,20 +26,43 @@ describe('validateConvertAmount', () => {
 		expect(
 			validateConvertAmount({
 				userAmount: balance.add(userAmount),
-				decimals,
+				token,
 				balance,
-				totalFee
+				fee
 			})
 		).toBe('insufficient-funds');
 	});
 
-	it('should return insufficient funds for fee error', () => {
+	it('should return insufficient funds for fee error for an ETH token', () => {
 		expect(
 			validateConvertAmount({
-				userAmount: balance.sub(BigNumber.from(totalFee).div(2)),
-				decimals,
+				userAmount: balance.sub(BigNumber.from(fee).div(2)),
+				token: SEPOLIA_TOKEN,
 				balance,
-				totalFee
+				fee
+			})
+		).toBe('insufficient-funds-for-fee');
+	});
+
+	it('should return insufficient funds for fee error for a ERC20 token', () => {
+		expect(
+			validateConvertAmount({
+				userAmount,
+				token: mockValidErc20Token,
+				balance,
+				ethBalance: ZERO,
+				fee
+			})
+		).toBe('insufficient-funds-for-fee');
+	});
+
+	it('should return insufficient funds for fee error for a BTC token', () => {
+		expect(
+			validateConvertAmount({
+				userAmount: balance.sub(BigNumber.from(fee).div(2)),
+				token: BTC_MAINNET_TOKEN,
+				balance,
+				fee
 			})
 		).toBe('insufficient-funds-for-fee');
 	});
@@ -43,8 +70,8 @@ describe('validateConvertAmount', () => {
 	it('should not return insufficient funds for fee error if totalFee is undefined', () => {
 		expect(
 			validateConvertAmount({
-				userAmount: balance.sub(BigNumber.from(totalFee).div(2)),
-				decimals,
+				userAmount: balance.sub(BigNumber.from(fee).div(2)),
+				token,
 				balance
 			})
 		).toBeUndefined();


### PR DESCRIPTION
# Motivation

This is the first step of preparing EthConvertTokenWizard to handle ERC20 conversions - convert utils should be updated to tackle ERC20 case where the fee is always paid in ETH.
