### PR TITLE
feat(frontend): update ERC20 conversion flow

### DIFF
--- a/src/frontend/src/eth/components/convert/EthConvertReview.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertReview.svelte
@@ -1,23 +1,31 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
+	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import ConvertReview from '$lib/components/convert/ConvertReview.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	export let sendAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
 
-	const { sourceTokenExchangeRate } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
+	const { sourceToken, destinationToken } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 </script>
 
 <ConvertReview on:icConvert on:icBack {sendAmount} {receiveAmount}>
-	<EthFeeDisplay exchangeRate={$sourceTokenExchangeRate} slot="fee" />
+	<EthFeeDisplay slot="fee" />
 
 	<div slot="info-message" class="mt-4">
-		<MessageBox>{$i18n.convert.text.cketh_conversions_may_take}</MessageBox>
+		<MessageBox>
+			{isTokenErc20($sourceToken)
+				? replacePlaceholders($i18n.convert.text.ckerc20_conversions_may_take, {
+						$ckErc20: $destinationToken.symbol
+					})
+				: $i18n.convert.text.cketh_conversions_may_take}
+		</MessageBox>
 	</div>
 
 	<slot name="cancel" slot="cancel" />

--- a/src/frontend/src/eth/components/fee/EthFeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeDisplay.svelte
@@ -6,9 +6,7 @@
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	export let exchangeRate: number | undefined = undefined;
-
-	const { maxGasFee, feeSymbolStore, feeDecimalsStore }: FeeContext =
+	const { maxGasFee, feeSymbolStore, feeDecimalsStore, feeExchangeRateStore }: FeeContext =
 		getContext<FeeContext>(FEE_CONTEXT_KEY);
 
 	let fee: bigint | undefined = undefined;
@@ -45,7 +43,12 @@
 </script>
 
 {#if nonNullish($feeSymbolStore) && nonNullish($feeDecimalsStore)}
-	<FeeDisplay feeAmount={fee} decimals={$feeDecimalsStore} symbol={$feeSymbolStore} {exchangeRate}>
+	<FeeDisplay
+		feeAmount={fee}
+		decimals={$feeDecimalsStore}
+		symbol={$feeSymbolStore}
+		exchangeRate={$feeExchangeRateStore}
+	>
 		<Html slot="label" text={$i18n.fee.text.convert_fee} />
 	</FeeDisplay>
 {/if}

--- a/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
@@ -1,32 +1,33 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
-	import EthSendTokenModal from '$eth/components/send/EthSendTokenModal.svelte';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { ethereumTokenId } from '$eth/derived/token.derived';
 	import type { OptionErc20Token } from '$eth/types/erc20';
+	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
-	import { ckErc20HelperContractAddress } from '$icp-eth/derived/cketh.derived';
+	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { pageToken } from '$lib/derived/page-token.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import { token } from '$lib/stores/token.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-
-	/**
-	 * Send modal context store
-	 */
-
-	const context = initSendContext({
-		sendPurpose: 'convert-erc20-to-ckerc20',
-		token: $tokenWithFallback
-	});
-	setContext<SendContext>(SEND_CONTEXT_KEY, context);
+	import { findTwinToken } from '$lib/utils/token.utils';
 
 	let convertToSymbol: string;
-	$: convertToSymbol = ($token as OptionErc20Token)?.twinTokenSymbol ?? '';
+	$: convertToSymbol = ($pageToken as OptionErc20Token)?.twinTokenSymbol ?? '';
+
+	let ckToken: IcCkToken | undefined;
+	$: (() => {
+		if (nonNullish(ckToken) || isNullish($pageToken)) {
+			return;
+		}
+
+		ckToken = findTwinToken({
+			tokenToPair: $pageToken,
+			tokens: $tokens
+		});
+	})();
 </script>
 
 <ConvertETH
@@ -40,9 +41,6 @@
 	<span>{convertToSymbol}</span>
 </ConvertETH>
 
-{#if $modalConvertToTwinTokenCkEth}
-	<EthSendTokenModal
-		destination={$ckErc20HelperContractAddress ?? ''}
-		targetNetwork={ICP_NETWORK}
-	/>
+{#if $modalConvertToTwinTokenCkEth && nonNullish(ckToken) && nonNullish($pageToken)}
+	<ConvertModal sourceToken={$pageToken} destinationToken={ckToken} />
 {/if}

--- a/src/frontend/src/eth/stores/fee.store.ts
+++ b/src/frontend/src/eth/stores/fee.store.ts
@@ -30,6 +30,7 @@ export interface FeeContext {
 	feeDecimalsStore: Writable<number | undefined>;
 	maxGasFee: Readable<BigNumber | undefined>;
 	minGasFee: Readable<BigNumber | undefined>;
+	feeExchangeRateStore?: Writable<number | undefined>;
 	evaluateFee?: () => void;
 }
 

--- a/src/frontend/src/tests/eth/components/convert/EthConvertForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertForm.spec.ts
@@ -8,7 +8,6 @@ import {
 	type FeeContext,
 	type FeeStore
 } from '$eth/stores/fee.store';
-import * as ckEthDerived from '$icp-eth/derived/cketh.derived';
 import {
 	CONVERT_CONTEXT_KEY,
 	initConvertContext,
@@ -17,7 +16,7 @@ import {
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
 import { BigNumber } from 'alchemy-sdk';
-import { readable, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 
 describe('EthConvertForm', () => {
 	let store: FeeStore;
@@ -29,7 +28,8 @@ describe('EthConvertForm', () => {
 					feeStore,
 					feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals),
 					feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
-					feeTokenIdStore: writable(ETHEREUM_TOKEN.id)
+					feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
+					feeExchangeRateStore: writable(100)
 				})
 			],
 			[
@@ -41,14 +41,10 @@ describe('EthConvertForm', () => {
 			]
 		]);
 
-	const mockCkEthStore = (address?: string) =>
-		vi
-			.spyOn(ckEthDerived, 'ckEthHelperContractAddress', 'get')
-			.mockImplementation(() => readable(address));
-
 	const props = {
 		sendAmount: 0.001,
-		receiveAmount: 0.001
+		receiveAmount: 0.001,
+		destination: 'address'
 	};
 	const mockFeeStore = {
 		maxFeePerGas: BigNumber.from(1000n),
@@ -67,7 +63,6 @@ describe('EthConvertForm', () => {
 
 	it('should keep the next button clickable if all requirements are met', () => {
 		store.setFee(mockFeeStore);
-		mockCkEthStore('address');
 
 		const { getByTestId } = render(EthConvertForm, {
 			props,
@@ -79,7 +74,6 @@ describe('EthConvertForm', () => {
 
 	it('should keep the next button disabled if amount is undefined', () => {
 		store.setFee(mockFeeStore);
-		mockCkEthStore('address');
 
 		const { getByTestId } = render(EthConvertForm, {
 			props: {
@@ -94,7 +88,6 @@ describe('EthConvertForm', () => {
 
 	it('should keep the next button disabled if amount is invalid', () => {
 		store.setFee(mockFeeStore);
-		mockCkEthStore('address');
 
 		const { getByTestId } = render(EthConvertForm, {
 			props: {
@@ -107,12 +100,14 @@ describe('EthConvertForm', () => {
 		expect(getByTestId(buttonTestId)).toHaveAttribute('disabled');
 	});
 
-	it('should keep the next button disabled if ckEthHelperContractAddress is not available', () => {
+	it('should keep the next button disabled if destination is not provided', () => {
 		store.setFee(mockFeeStore);
-		mockCkEthStore(undefined);
 
 		const { getByTestId } = render(EthConvertForm, {
-			props,
+			props: {
+				...props,
+				destination: undefined
+			},
 			context: mockContext({ feeStore: store })
 		});
 


### PR DESCRIPTION
# Motivation

In this PR, the new conversion flow is enabled for the erc20 tokens. To do that, we needed to update EthConvertTokenForm to cover both ETH and ERC20 cases (similar as it was before with EthSendTokenForm).

<img width="638" alt="Screenshot 2025-02-26 at 14 08 24" src="https://github.com/user-attachments/assets/6c8caa92-5ea5-43d1-8884-d66899650970" />
