### PR TITLE
chore(docs): remove beta status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ To file a request to have your dApp listed in the dApps explorer of OISY Wallet,
 
 ## Status
 
-Please note that this is a **beta version** of OISY Wallet which is still undergoing final testing before its official release.
 The platform, its software and all content found on it are provided on an “as is” and “as available” basis.
 OISY Wallet does not give any warranties, whether express or implied, as to the suitability or usability of the application, its software or any of its content.
 


### PR DESCRIPTION
# Motivation

Removing the status `beta` from the README file for version 1.
