### PR TITLE
fix(frontend): Navigation consistency

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -129,14 +129,14 @@
 			<MenuAddresses on:icMenuClick={hidePopover} />
 		{/if}
 
-		{#if !assetsRoute && !settingsRoute}
+		{#if !assetsRoute}
 			<ButtonMenu ariaLabel={$i18n.navigation.alt.tokens} on:click={goToTokens}>
 				<IconWallet size="20" />
 				{$i18n.navigation.text.tokens}
 			</ButtonMenu>
 		{/if}
 
-		{#if !activityRoute && !settingsRoute}
+		{#if !activityRoute}
 			<ButtonMenu
 				testId={NAVIGATION_ITEM_ACTIVITY}
 				ariaLabel={$i18n.navigation.alt.activity}
@@ -147,18 +147,7 @@
 			</ButtonMenu>
 		{/if}
 
-		{#if !dAppExplorerRoute && !settingsRoute}
-			<ButtonMenu
-				testId={NAVIGATION_ITEM_EXPLORER}
-				ariaLabel={$i18n.navigation.alt.dapp_explorer}
-				on:click={goToDappExplorer}
-			>
-				<IconlyUfo size="20" />
-				{$i18n.navigation.text.dapp_explorer}
-			</ButtonMenu>
-		{/if}
-
-		{#if AIRDROPS_ENABLED && !airdropsRoute && !settingsRoute}
+		{#if AIRDROPS_ENABLED && !airdropsRoute}
 			<ButtonMenu
 				testId={NAVIGATION_ITEM_AIRDROPS}
 				ariaLabel={$i18n.navigation.alt.airdrops}
@@ -166,6 +155,17 @@
 			>
 				<IconGift size="20" />
 				{$i18n.navigation.text.airdrops}
+			</ButtonMenu>
+		{/if}
+
+		{#if !dAppExplorerRoute}
+			<ButtonMenu
+				testId={NAVIGATION_ITEM_EXPLORER}
+				ariaLabel={$i18n.navigation.alt.dapp_explorer}
+				on:click={goToDappExplorer}
+			>
+				<IconlyUfo size="20" />
+				{$i18n.navigation.text.dapp_explorer}
 			</ButtonMenu>
 		{/if}
 
@@ -178,9 +178,9 @@
 				<IconlySettings size="20" />
 				{$i18n.settings.text.title}
 			</ButtonMenu>
-
-			<Hr />
 		{/if}
+
+		<Hr />
 
 		{#if isVip}
 			<ButtonMenu


### PR DESCRIPTION
# Motivation

On settings page, the main page links disappear which is a problem on mobile, since the main navigation to the left disappears. Theres then no way for a mobile user to navigate away from the settings page except clicking on the logo, which might not be clear for all users.

# Changes

Removed conditions that hide the links if youre on the settings page.

Also changed the order of Airdrops menu item and explore dapps menu item so it is the same as on the desktop only navigation to the left.

# Tests
![image](https://github.com/user-attachments/assets/ceb3f1f4-8597-4634-8e11-d69f17af7878)
