### PR TITLE
refactor(frontend): extract filter for snapshot transactions

### DIFF
--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -66,6 +66,10 @@ interface ToSnapshotParams<T extends Token> {
 
 const LAST_TRANSACTIONS_COUNT = 5;
 
+const filterTransactions = <T extends Transaction_Icrc | Transaction_Spl>(
+	transactions: (T | undefined)[]
+) => transactions.filter(nonNullish).slice(0, LAST_TRANSACTIONS_COUNT);
+
 const toTransactionType = (type: IcTransactionType): TransactionType =>
 	type === 'send' ? { Send: null } : { Receive: null };
 
@@ -165,15 +169,17 @@ const toIcrcSnapshot = ({
 
 	const address = identity.getPrincipal();
 
-	const lastTransactions = (get(icTransactionsStore)?.[id] ?? [])
-		.map(({ data: transaction }) => transaction)
-		.slice(0, LAST_TRANSACTIONS_COUNT);
+	const lastTransactions = (get(icTransactionsStore)?.[id] ?? []).map(
+		({ data: transaction }) => transaction
+	);
 
 	const snapshot: AccountSnapshot_Icrc = {
 		...toBaseSnapshot({ token, balance, exchangeRate, timestamp }),
 		account: address,
 		token_address: Principal.from(ledgerCanisterId),
-		last_transactions: lastTransactions.map((transaction) => toIcrcTransaction({ transaction }))
+		last_transactions: filterTransactions(
+			lastTransactions.map((transaction) => toIcrcTransaction({ transaction }))
+		)
 	};
 
 	return { Icrc: snapshot };
@@ -217,7 +223,7 @@ const toSplSnapshot = ({
 		minterInfo: get(ckEthMinterInfoStore)?.[SEPOLIA_TOKEN_ID],
 		networkId: SEPOLIA_NETWORK_ID
 	});
-	const lastTransactions = (
+	const lastTransactions =
 		isNetworkIdEthereum(networkId) || isNetworkIdSepolia(networkId)
 			? (get(ethTransactionsStore)?.[id] ?? []).map((transaction) =>
 					mapEthTransactionUi({
@@ -230,16 +236,15 @@ const toSplSnapshot = ({
 				)
 			: isNetworkIdBTCMainnet(networkId) || isNetworkIdBTCTestnet(networkId)
 				? (get(btcTransactionsStore)?.[id] ?? []).map(({ data: transaction }) => transaction)
-				: (get(solTransactionsStore)?.[id] ?? []).map(({ data: transaction }) => transaction)
-	).slice(0, LAST_TRANSACTIONS_COUNT);
+				: (get(solTransactionsStore)?.[id] ?? []).map(({ data: transaction }) => transaction);
 
 	const snapshot: AccountSnapshot_Spl = {
 		...toBaseSnapshot({ token, balance, exchangeRate, timestamp }),
 		account: address,
 		token_address: tokenAddress,
-		last_transactions: lastTransactions
-			.map((transaction) => toSplTransaction({ transaction, address, networkId }))
-			.filter(nonNullish)
+		last_transactions: filterTransactions(
+			lastTransactions.map((transaction) => toSplTransaction({ transaction, address, networkId }))
+		)
 	};
 
 	return isNetworkIdSOLDevnet(networkId) ? { SplDevnet: snapshot } : { SplMainnet: snapshot };


### PR DESCRIPTION
# Motivation

To avoid repetition of code, it makes sense to concentrate filtering and slicing of the transactions used in the snapshots.

# Changes

- Create internal function to remove nullish transaction and slice the array.
- Apply its usage to the mapper `toIcrcTransaction` and `toSplTransaction`.

# Tests

Current tests are sufficient.
