### PR TITLE
feat(frontend): explicit filter out IC approve transactions in snapshot

### DIFF
--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -87,12 +87,18 @@ const toIcrcTransaction = ({
 	transaction: { type, value, timestamp }
 }: {
 	transaction: IcTransactionUi;
-}): Transaction_Icrc => ({
-	...toBaseTransaction({ type, value, timestamp }),
-	timestamp: timestamp ?? 0n,
-	// TODO: use correct value when the Rewards canister is updated to accept account identifiers
-	counterparty: Principal.anonymous()
-});
+}): Transaction_Icrc | undefined => {
+	if (type === 'approve') {
+		return undefined;
+	}
+
+	return {
+		...toBaseTransaction({ type, value, timestamp }),
+		timestamp: timestamp ?? 0n,
+		// TODO: use correct value when the Rewards canister is updated to accept account identifiers
+		counterparty: Principal.anonymous()
+	};
+};
 
 const toSplTransaction = ({
 	transaction: { type, value, timestamp, from, to, ...rest },
@@ -173,7 +179,9 @@ const toIcrcSnapshot = ({
 		...toBaseSnapshot({ token, balance, exchangeRate, timestamp }),
 		account: address,
 		token_address: Principal.from(ledgerCanisterId),
-		last_transactions: lastTransactions.map((transaction) => toIcrcTransaction({ transaction }))
+		last_transactions: lastTransactions
+			.map((transaction) => toIcrcTransaction({ transaction }))
+			.filter(nonNullish)
 	};
 
 	return { Icrc: snapshot };


### PR DESCRIPTION
# Motivation

The IC `approve` transactions are already filtered out by the `from` and `to` props. However, we explicitly filter them out for clarity.
