### PR TITLE
style(frontend): adjust header logout for small mobiles

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -32,7 +32,7 @@
 		{#if $authSignedIn}
 			<Menu />
 		{:else}
-			<div class="mr-2 flex justify-end gap-5 md:mr-0">
+			<div class="mr-2 flex justify-end  gap-3 sm:gap-5 md:mr-0">
 				<AboutWhyOisy />
 				<DocumentationLink shortTextOnMobile />
 				<ThemeSwitchButton />


### PR DESCRIPTION
# Motivation

Reducing the gap of the logged out header to fit the smaller mobiles.

### Before

![Screenshot 2025-02-26 at 20 10 11](https://github.com/user-attachments/assets/89bd2449-5a4a-4575-bd10-4ce084c82e92)

### After

![Screenshot 2025-02-26 at 20 09 16](https://github.com/user-attachments/assets/61a889fd-4fff-4507-aee4-d4b4752f0f7c)

