### PR TITLE
fix(frontend): missing SPL token owner address in worker message data

### DIFF
--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -75,11 +75,18 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 	const network = mapNetworkIdToNetwork(token.network.id);
 	assertNonNullish(network, 'No Solana network provided to start Solana wallet worker.');
 
-	// If the token is an SPL token, we need to pass the token address to the worker.
+	// If the token is an SPL token, we need to pass the token address and the owner address to the worker.
 	// Otherwise, we pass undefined, which will be considered as the native SOLANA token.
-	const tokenAddress = isTokenSpl(token) ? token.address : undefined;
+	const { address: tokenAddress, owner: tokenOwnerAddress } = isTokenSpl(token)
+		? token
+		: { address: undefined, owner: undefined };
 
-	const data: PostMessageDataRequestSol = { address, solanaNetwork: network, tokenAddress };
+	const data: PostMessageDataRequestSol = {
+		address,
+		solanaNetwork: network,
+		tokenAddress,
+		tokenOwnerAddress
+	};
 
 	return {
 		start: () => {


### PR DESCRIPTION
# Motivation

When I included the token owner address to the SPL tokens, I forgot to add it in the POST messages sent by the worker.