### PR TITLE
refactor(frontend): unify Sol-get-transactions params

### DIFF
--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -1,10 +1,8 @@
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
-import type { SolAddress } from '$lib/types/address';
 import { fetchSignatures } from '$sol/api/solana.api';
 import { fetchSolTransactionsForSignature } from '$sol/services/sol-transactions.services';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
-import type { SplTokenAddress } from '$sol/types/spl';
 import { nonNullish } from '@dfinity/utils';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import { assertIsAddress, address as solAddress } from '@solana/addresses';
@@ -20,10 +18,7 @@ export const getSolTransactions = async ({
 	tokenOwnerAddress,
 	before,
 	limit = Number(WALLET_PAGINATION)
-}: GetSolTransactionsParams & {
-	tokenAddress?: SplTokenAddress;
-	tokenOwnerAddress?: SolAddress;
-}): Promise<SolTransactionUi[]> => {
+}: GetSolTransactionsParams): Promise<SolTransactionUi[]> => {
 	if (nonNullish(tokenAddress)) {
 		assertIsAddress(tokenAddress);
 	}

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -138,18 +138,10 @@ export const fetchSolTransactionsForSignature = async ({
 };
 
 export const loadNextSolTransactions = async ({
-	address,
-	network,
-	before,
-	limit,
-	signalEnd
+	signalEnd,
+	...rest
 }: LoadNextSolTransactionsParams): Promise<SolCertifiedTransaction[]> => {
-	const transactions = await loadSolTransactions({
-		address,
-		network,
-		before,
-		limit
-	});
+	const transactions = await loadSolTransactions(rest);
 
 	if (transactions.length === 0) {
 		signalEnd();
@@ -167,19 +159,15 @@ const networkToSolTokenIdMap = {
 };
 
 const loadSolTransactions = async ({
-	address,
 	network,
-	before,
-	limit
+	...rest
 }: GetSolTransactionsParams): Promise<SolCertifiedTransaction[]> => {
 	const solTokenIdForNetwork = networkToSolTokenIdMap[network];
 
 	try {
 		const transactions = await getSolTransactions({
-			address,
 			network,
-			before,
-			limit
+			...rest
 		});
 
 		const certifiedTransactions = transactions.map((transaction) => ({

--- a/src/frontend/src/sol/types/sol-api.ts
+++ b/src/frontend/src/sol/types/sol-api.ts
@@ -1,13 +1,12 @@
 import type { SolAddress } from '$lib/types/address';
 import type { SolanaNetworkType } from '$sol/types/network';
+import type { SplTokenAddress } from '$sol/types/spl';
 
 export interface GetSolTransactionsParams {
 	address: SolAddress;
 	network: SolanaNetworkType;
+	tokenAddress?: SplTokenAddress;
+	tokenOwnerAddress?: SolAddress;
 	before?: string;
 	limit?: number;
-}
-
-export interface GetSplTransactionsParams extends GetSolTransactionsParams {
-	tokenAddress: SolAddress;
 }


### PR DESCRIPTION
# Motivation

To avoid repetition of code we unify the params passed to get Solana transactions, that basically mean adding `tokenAddress` and `tokenOwnerAddress` (as options) to `GetSolTransactionsParams`.


UNRELATED: remove unused type `GetSplTransactionsParams`