### PR TITLE
refactor(frontend): use foreground color for blue link class

### DIFF
--- a/src/frontend/src/lib/styles/global/links.scss
+++ b/src/frontend/src/lib/styles/global/links.scss
@@ -8,7 +8,7 @@ a.no-underline {
 }
 
 a.blue-link {
-	color: var(--color-background-brand-primary);
+	color: var(--color-foreground-brand-primary);
 }
 
 // NAV ITEMS


### PR DESCRIPTION
# Motivation

It does not affect the color (since it is the same), but it seems more correct to use `--color-foreground-brand-primary` instead of the background one for the `blue-link` class of hyperlinks.
