### PR TITLE
feat(backend): add Antonio's principal to the allowed callers

### DIFF
--- a/scripts/build.backend.args.ic.did
+++ b/scripts/build.backend.args.ic.did
@@ -1,7 +1,7 @@
 (variant {
     Init = record {
          ecdsa_key_name = "key_1";
-         allowed_callers = vec{ principal "nynz6-haaaa-aaaan-qzqda-cai" };
+         allowed_callers = vec{ principal "nynz6-haaaa-aaaan-qzqda-cai"; principal "bzhxb-2565m-do3pw-yqhb3-jon2m-phepr-lccqh-zv7qq-q52q2-ognw4-yqe"; };
          cfs_canister_id = opt principal "grghe-syaaa-aaaar-qabyq-cai";
          derivation_origin = opt "https://oisy.com";
          supported_credentials = opt vec {

--- a/scripts/build.backend.args.sh
+++ b/scripts/build.backend.args.sh
@@ -60,11 +60,12 @@ case "$DFX_NETWORK" in
   ;;
 esac
 
-# If the rewards canister is known, it may perform priviliged actions such as find which users are eligible for rewards.
+# If the rewards canister is known, it may perform privileged actions such as find which users are eligible for rewards.
+# Furthermore, we include some OISY team's users in the allowed_callers list, so that they can fetch statistics data.
 if [[ "${CANISTER_ID_REWARDS:-}" == "" ]]; then
   ALLOWED_CALLERS="vec {}"
 else
-  ALLOWED_CALLERS="vec{ principal \"$CANISTER_ID_REWARDS\" }"
+  ALLOWED_CALLERS="vec{ principal \"$CANISTER_ID_REWARDS\"; principal \"bzhxb-2565m-do3pw-yqhb3-jon2m-phepr-lccqh-zv7qq-q52q2-ognw4-yqe\";  }"
 fi
 
 # URL used by II-issuer in the id_alias-verifiable credentials (hard-coded in II)


### PR DESCRIPTION
# !!! IMPORTANT !!!

This change allows a specific user (in this case @AntonioVentilii ) to access some data and endpoint of the OISY backend. Specifically all the endpoints with guard `caller_is_allowed`, and among them the `update` endpoints are:
- `bulk_up`
- `migrate_user_data_to`
- `migration_stop_timer`
- `set_guards`
- `step_migration`
- `top_up_cycles_ledger`

# Motivation

As recent requirement, we would like to quickly check the user statistics of OISY, such as endpoint `stats`. The quickest way is to allow some user. In this case, we will allow me.

# Suggestion

We should have a different list of allowed users (or a different guard) for the less sensitive endpoints, that are useful to the OISY devs team.
