### PR TITLE
feat(backend): REVERT: remove Antonio's principal from the allowed callers

### DIFF
--- a/scripts/build.backend.args.ic.did
+++ b/scripts/build.backend.args.ic.did
@@ -1,7 +1,7 @@
 (variant {
     Init = record {
          ecdsa_key_name = "key_1";
-         allowed_callers = vec{ principal "nynz6-haaaa-aaaan-qzqda-cai"; principal "bzhxb-2565m-do3pw-yqhb3-jon2m-phepr-lccqh-zv7qq-q52q2-ognw4-yqe"; };
+         allowed_callers = vec{ principal "nynz6-haaaa-aaaan-qzqda-cai" };
          cfs_canister_id = opt principal "grghe-syaaa-aaaar-qabyq-cai";
          derivation_origin = opt "https://oisy.com";
          supported_credentials = opt vec {

--- a/scripts/build.backend.args.sh
+++ b/scripts/build.backend.args.sh
@@ -61,11 +61,10 @@ case "$DFX_NETWORK" in
 esac
 
 # If the rewards canister is known, it may perform privileged actions such as find which users are eligible for rewards.
-# Furthermore, we include some OISY team's users in the allowed_callers list, so that they can fetch statistics data.
 if [[ "${CANISTER_ID_REWARDS:-}" == "" ]]; then
   ALLOWED_CALLERS="vec {}"
 else
-  ALLOWED_CALLERS="vec{ principal \"$CANISTER_ID_REWARDS\"; principal \"bzhxb-2565m-do3pw-yqhb3-jon2m-phepr-lccqh-zv7qq-q52q2-ognw4-yqe\";  }"
+  ALLOWED_CALLERS="vec{ principal \"$CANISTER_ID_REWARDS\" }"
 fi
 
 # URL used by II-issuer in the id_alias-verifiable credentials (hard-coded in II)


### PR DESCRIPTION
# Motivation

This PR reverts https://github.com/dfinity/oisy-wallet/pull/4971/ where we included @AntonioVentilii principal among the allowed users, to retrieve statistics data.