### PR TITLE
chore(frontend): vitest is global - no import needed

### DIFF
--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -26,7 +26,7 @@ import { assertNonNullish, nonNullish, toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { BigNumber } from 'alchemy-sdk';
 import { get, readable, writable } from 'svelte/store';
-import { expect, type MockInstance } from 'vitest';
+import { type MockInstance } from 'vitest';
 
 vi.mock('$lib/services/auth.services', () => ({
 	nullishSignOut: vi.fn()

--- a/src/frontend/src/tests/lib/components/qr/VipQrCodeModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/qr/VipQrCodeModal.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '$lib/constants/test-ids.constants';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { render, waitFor } from '@testing-library/svelte';
-import { vi } from 'vitest';
 
 describe('VipQrCodeModal', () => {
 	const qrCodeSelector = `div[data-tid="qr-code"]`;

--- a/src/frontend/src/tests/lib/components/tokens/TokenInputAmountExchange.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenInputAmountExchange.spec.ts
@@ -8,7 +8,6 @@ import type { OptionAmount } from '$lib/types/send';
 import type { DisplayUnit } from '$lib/types/swap';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { fireEvent, render } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
 
 describe('TokenInputAmountExchange', () => {
 	const defaultProps = {

--- a/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyToken.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyToken.spec.ts
@@ -2,7 +2,6 @@ import TokenInputCurrencyToken from '$lib/components/tokens/TokenInputCurrencyTo
 import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
 import type { OptionAmount } from '$lib/types/send';
 import { fireEvent, render } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
 
 describe('TokenInputCurrencyToken', () => {
 	const defaultProps = {

--- a/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyUsd.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyUsd.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '$lib/constants/test-ids.constants';
 import type { OptionAmount } from '$lib/types/send';
 import { fireEvent, render } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
 
 describe('TokenInputCurrencyUsd', () => {
 	const defaultProps = {

--- a/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
@@ -4,7 +4,6 @@ import { balancesStore } from '$lib/stores/balances.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { BigNumber } from 'alchemy-sdk';
 import { get } from 'svelte/store';
-import { describe } from 'vitest';
 
 describe('swap.derived', () => {
 	describe('swappableTokens', () => {

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -26,7 +26,7 @@ import {
 import { mockSolAddress, mockSolAddress2, mockSplAddress } from '$tests/mocks/sol.mock';
 import { address } from '@solana/addresses';
 import { lamports } from '@solana/rpc-types';
-import { describe, type MockInstance } from 'vitest';
+import { type MockInstance } from 'vitest';
 
 vi.mock('$sol/providers/sol-rpc.providers');
 

--- a/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
@@ -18,7 +18,7 @@ import {
 	getComputeUnitEstimateForTransactionMessageFactory,
 	sendAndConfirmTransactionFactory
 } from '@solana/web3.js';
-import { expect, type MockInstance } from 'vitest';
+import { type MockInstance } from 'vitest';
 
 vi.mock('@solana/functional', () => ({
 	pipe: vi.fn()

--- a/src/frontend/src/tests/sol/utils/spl.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/spl.utils.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '$env/tokens/tokens.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import { isTokenSpl } from '$sol/utils/spl.utils';
-import { describe } from 'vitest';
 
 describe('spl.utils', () => {
 	describe('isTokenSpl', () => {


### PR DESCRIPTION
# Motivation

Just a bit of cleanup since most `vitest` imports can be spared as those are available globally.
