### PR TITLE
feat(frontend): increase exchange load interval to 5 minutes

### DIFF
--- a/src/frontend/src/lib/constants/exchange.constants.ts
+++ b/src/frontend/src/lib/constants/exchange.constants.ts
@@ -7,6 +7,6 @@ import { SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
  * While the limitations of Coingecko appeared suitable for our initial use case involving two calls (ETH and ERC20), in practice, we've observed that Coingecko frequently generates errors.
  * As a result, we've restricted synchronization to refresh every certain amount of time.
  */
-export const SYNC_EXCHANGE_TIMER_INTERVAL = SECONDS_IN_MINUTE * 1000 * 2; // 2 minute
+export const SYNC_EXCHANGE_TIMER_INTERVAL = SECONDS_IN_MINUTE * 1000 * 5; // 5 minute
 
 export const EXCHANGE_USD_AMOUNT_THRESHOLD = 0.01;


### PR DESCRIPTION
# Motivation

To reduce the number of calls to CoinGecko, we increase the interval of requesting exchange rates to 5 minutes. It is not so necessary for the user to have a very frequent rate.