### PR TITLE
fix(frontend): Svelte routing trailing slash never

### DIFF
--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -46,7 +46,7 @@ const tokenUrl = ({
 	token: Token;
 	path: AppPath.Transactions | undefined;
 }): string =>
-	`${path ?? ''}/?${TOKEN_PARAM}=${encodeURIComponent(
+	`${path ?? ''}?${TOKEN_PARAM}=${encodeURIComponent(
 		name.replace(/\p{Emoji}/gu, (m, _idx) => `\\u${m.codePointAt(0)?.toString(16)}`)
 	)}${nonNullish(networkId.description) ? `&${networkParam(networkId)}` : ''}`;
 

--- a/src/frontend/src/routes/+layout.ts
+++ b/src/frontend/src/routes/+layout.ts
@@ -1,6 +1,6 @@
 export const prerender = true;
 export const ssr = false;
-export const trailingSlash = 'always';
+export const trailingSlash = 'never';
 
 // ⚠️ For production build the polyfill needs to be injected with Rollup (see vite.config.ts) because the page might be loaded before the _layout.js which will contains this polyfill.
 // The / in buffer/ is mandatory here.


### PR DESCRIPTION
# Motivation

Currently its defined that svelte always forces trailing slashes to routes. This was never a problem it seems but this leads to unexpected behaviours when navigating without passing trailing slashes on mobile (or mobile emulation through chrome dev tools!).

Example: 
Click nav `Assets` (`/`), path in browser is `oisy.com`
Click nav `Rewards` (`/rewards`), path in browser is now `oisy.com/rewards/` as the trailing slash is forced
When now clicking on `Rewards` again, the app recognizes it as a link to a different page because all routes are defined without trailing slash.

Note: to reproduce, select responsive mode in chrome dev tools!

For some reason, most browsers dont have a problem with that and the behavior is as expected. Some mobile devices however recognize this change in the routing and some routing mechanisms such as checking which route you are on (to check which menu item is highlighted for example) return inconsistent values or it just redirects to root route (`/`).

# Changes

- Set trailingSlashes to `never` so no trailing slashes are forced
- Adjust how link for token pages are build (removed slash being added)

Since all routes are defined without trailing slash in `routes.constants.ts`, this change would also be in line and consistent with never having/forcing trailing slashes.