### PR TITLE
chore(devops): Simplify signer deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 dfx canister create --all
 dfx deploy backend
-./scripts/deploy.signer.sh
+dfx deploy signer
 
 mkdir -p ./target/ic
 

--- a/scripts/deploy.signer.sh
+++ b/scripts/deploy.signer.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-dfx deploy signer --network "${ENV:-local}"


### PR DESCRIPTION
# Motivation
The signer is deployed with a script when `dfx deploy signer` will suffice.  Indeed, that is all the script does.

# Changes
- Delete the deploy script & call `dfx deploy` instead.

# Tests
CI should suffice, as this is called in the e2e tests.