### PR TITLE
fix(frontend): issues with ETH fees on send/convert

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/FeeDisplay.svelte
@@ -10,8 +10,13 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Option } from '$lib/types/utils';
 
-	const { maxGasFee, feeSymbolStore, feeTokenIdStore, feeDecimalsStore }: FeeContext =
-		getContext<FeeContext>(FEE_CONTEXT_KEY);
+	const {
+		maxGasFee,
+		feeSymbolStore,
+		feeTokenIdStore,
+		feeDecimalsStore,
+		feeExchangeRateStore
+	}: FeeContext = getContext<FeeContext>(FEE_CONTEXT_KEY);
 
 	let fee: Option<BigNumber> = undefined;
 
@@ -55,6 +60,7 @@
 			feeSymbol={$feeSymbolStore}
 			feeTokenId={$feeTokenIdStore}
 			feeDecimals={$feeDecimalsStore}
+			feeExchangeRate={$feeExchangeRateStore}
 		/>
 	{/if}
 </div>

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -34,6 +34,7 @@
 	} from '$lib/constants/analytics.contants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
@@ -97,6 +98,9 @@
 	let feeDecimalsStore = writable<number | undefined>(undefined);
 	$: feeDecimalsStore.set(nativeEthereumToken.decimals);
 
+	let feeExchangeRateStore = writable<number | undefined>(undefined);
+	$: feeExchangeRateStore.set($exchanges?.[nativeEthereumToken.id]?.usd);
+
 	let feeContext: FeeContext | undefined;
 	const evaluateFee = () => feeContext?.triggerUpdateFee();
 
@@ -107,6 +111,7 @@
 			feeSymbolStore,
 			feeTokenIdStore,
 			feeDecimalsStore,
+			feeExchangeRateStore,
 			evaluateFee
 		})
 	);

--- a/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
+++ b/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import { getContext } from 'svelte';
-	import { slide } from 'svelte/transition';
+	import { slide, fade } from 'svelte/transition';
 	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { OptionBalance } from '$lib/types/balance';
 	import type { TokenId } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
@@ -18,8 +16,7 @@
 	export let feeSymbol: string;
 	export let feeTokenId: TokenId;
 	export let feeDecimals: number;
-
-	const { sendTokenExchangeRate } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	export let feeExchangeRate: number | undefined = undefined;
 
 	let balance: Exclude<OptionBalance, null>;
 	$: balance = nonNullish($balancesStore) ? ($balancesStore[feeTokenId]?.data ?? ZERO) : undefined;
@@ -33,12 +30,15 @@
 	$: balance, fee, debounceCheckFeeFunds();
 </script>
 
-<ExchangeAmountDisplay
-	amount={fee}
-	decimals={feeDecimals}
-	symbol={feeSymbol}
-	exchangeRate={$sendTokenExchangeRate}
-/>
+<div transition:fade>
+	<ExchangeAmountDisplay
+		amount={fee}
+		decimals={feeDecimals}
+		symbol={feeSymbol}
+		exchangeRate={feeExchangeRate}
+	/>
+</div>
+
 {#if insufficientFeeFunds && nonNullish(balance)}
 	<p in:slide={SLIDE_DURATION} class="text-error-primary">
 		{replacePlaceholders($i18n.send.assertion.not_enough_tokens_for_gas, {

--- a/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
+++ b/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import { slide, fade } from 'svelte/transition';
+	import { slide } from 'svelte/transition';
 	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
@@ -30,14 +30,12 @@
 	$: balance, fee, debounceCheckFeeFunds();
 </script>
 
-<div transition:fade>
-	<ExchangeAmountDisplay
-		amount={fee}
-		decimals={feeDecimals}
-		symbol={feeSymbol}
-		exchangeRate={feeExchangeRate}
-	/>
-</div>
+<ExchangeAmountDisplay
+	amount={fee}
+	decimals={feeDecimals}
+	symbol={feeSymbol}
+	exchangeRate={feeExchangeRate}
+/>
 
 {#if insufficientFeeFunds && nonNullish(balance)}
 	<p in:slide={SLIDE_DURATION} class="text-error-primary">

--- a/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumEstimatedFee.svelte
@@ -12,6 +12,7 @@
 	import { ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import type { Option } from '$lib/types/utils';
@@ -23,6 +24,9 @@
 
 	let maxTransactionFee: Option<bigint> = undefined;
 	$: maxTransactionFee = $store?.maxTransactionFee;
+
+	let ethFeeExchangeRate: number | undefined;
+	$: ethFeeExchangeRate = $exchanges?.[feeToken.id]?.usd;
 </script>
 
 {#if nonNullish($store)}
@@ -37,6 +41,7 @@
 						feeSymbol={feeToken.symbol}
 						feeTokenId={feeToken.id}
 						feeDecimals={feeToken.decimals}
+						feeExchangeRate={ethFeeExchangeRate}
 					/>
 				{:else}
 					&ZeroWidthSpace;

--- a/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
@@ -24,7 +24,7 @@
 </script>
 
 {#if nonNullish(amount) && nonNullish(decimals) && nonNullish(symbol)}
-	<div transition:fade class="flex gap-4">
+	<div transition:fade|global class="flex gap-4">
 		{formatToken({
 			value: amount,
 			unitName: decimals,


### PR DESCRIPTION
# Motivation

This PR fixes a few related things:
1. ckERC20 tokens conversion forms (both send and review) are now properly calculating USD values using the ETH exchange rate. 
<img width="579" alt="Screenshot 2025-03-03 at 17 38 24" src="https://github.com/user-attachments/assets/2cd98bf8-7b2c-4b3d-a3b0-47b0fbe1920b" />

2. Same issue fixed for the ERC20 tokens send flow.
<img width="587" alt="Screenshot 2025-03-03 at 17 40 58" src="https://github.com/user-attachments/assets/6fd203a8-1bef-44ee-b5ad-f6351c13eb06" />

3. Added back the animation of the ETH fee value. 