### PR TITLE
feat(frontend): remove fallback from ckETH Helper Contract address

### DIFF
--- a/src/frontend/src/env/networks/networks.cketh.env.ts
+++ b/src/frontend/src/env/networks/networks.cketh.env.ts
@@ -5,6 +5,3 @@ export const CKETH_HELPER_CONTRACT_SIGNATURE =
 // ckErc20 helper event signature. Same for all Erc20 helpers. Immutable. Similar on Mainnet and Sepolia.
 export const CKERC20_HELPER_CONTRACT_SIGNATURE =
 	'0x4d69d0bd4287b7f66c548f90154dc81bc98f65a1b362775df5ae171a2ccd262b';
-
-// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
-export const CKETH_HELPER_CONTRACT_ADDRESS_MAINNET = '0x7574eB42cA208A4f6960ECCAfDF186D627dCC175';

--- a/src/frontend/src/icp-eth/utils/cketh.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh.utils.ts
@@ -1,21 +1,14 @@
-import { CKETH_HELPER_CONTRACT_ADDRESS_MAINNET } from '$env/networks/networks.cketh.env';
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.env';
 import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { fromNullishNullable, nonNullish } from '@dfinity/utils';
 
 export const toCkEthHelperContractAddress = ({
-	minterInfo,
-	networkId
+	minterInfo
 }: {
 	minterInfo: OptionCertifiedMinterInfo;
-	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
 	networkId: NetworkId;
-}): OptionEthAddress =>
-	fromNullishNullable(minterInfo?.data.eth_helper_contract_address) ??
-	// TODO: to be removed once minterInfo breaking changes have been executed on mainnet
-	(networkId === ETHEREUM_NETWORK_ID ? CKETH_HELPER_CONTRACT_ADDRESS_MAINNET : undefined);
+}): OptionEthAddress => fromNullishNullable(minterInfo?.data.eth_helper_contract_address);
 
 export const toCkErc20HelperContractAddress = (
 	minterInfo: OptionCertifiedMinterInfo


### PR DESCRIPTION
# Motivation

It seems that the fallback for the ckETH helper contract is not needed anymore. It was introduced in PR https://github.com/dfinity/oisy-wallet/pull/1231 as safe measure. But currently both ckETH minters ([prod](https://dashboard.internetcomputer.org/canister/sv3dd-oaaaa-aaaar-qacoa-cai#get_minter_info) and [staging](https://dashboard.internetcomputer.org/canister/jzenf-aiaaa-aaaar-qaa7q-cai#get_minter_info)) provide the `eth_helper_contract_address`.


![Screenshot 2025-03-04 at 11 29 35](https://github.com/user-attachments/assets/06d28a23-6235-4626-8a68-7698691bbe2a)


![Screenshot 2025-03-04 at 11 29 25](https://github.com/user-attachments/assets/21da4d0e-de4b-4aa6-baed-4e68863f3e1c)
