### PR TITLE
fix(frontend): wrong token symbol and exchange in ckBTC convert

### DIFF
--- a/src/frontend/src/icp/components/fee/BitcoinEstimatedFee.svelte
+++ b/src/frontend/src/icp/components/fee/BitcoinEstimatedFee.svelte
@@ -3,34 +3,40 @@
 	import { BigNumber } from '@ethersproject/bignumber';
 	import { getContext } from 'svelte';
 	import { slide } from 'svelte/transition';
+	import {
+		BTC_DECIMALS,
+		BTC_MAINNET_SYMBOL,
+		BTC_MAINNET_TOKEN_ID
+	} from '$env/tokens/tokens.btc.env';
 	import { BITCOIN_FEE_CONTEXT_KEY, type BitcoinFeeContext } from '$icp/stores/bitcoin-fee.store';
 	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 
 	const { store: storeFeeData } = getContext<BitcoinFeeContext>(BITCOIN_FEE_CONTEXT_KEY);
-	const { sendTokenDecimals, sendTokenSymbol, sendTokenExchangeRate } =
-		getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let bitcoinEstimatedFee: bigint | undefined;
 	$: bitcoinEstimatedFee =
 		nonNullish($storeFeeData) && nonNullish($storeFeeData.bitcoinFee)
 			? $storeFeeData.bitcoinFee.bitcoin_fee + $storeFeeData.bitcoinFee.minter_fee
 			: undefined;
+
+	let btcFeeExchangeRate: number | undefined;
+	$: btcFeeExchangeRate = $exchanges?.[BTC_MAINNET_TOKEN_ID]?.usd;
 </script>
 
 {#if nonNullish(bitcoinEstimatedFee)}
 	<div transition:slide={SLIDE_DURATION}>
-		<Value ref="kyt-fee">
+		<Value ref="bitcoin-estimated-fee">
 			<svelte:fragment slot="label">{$i18n.fee.text.estimated_btc}</svelte:fragment>
 
 			<ExchangeAmountDisplay
 				amount={BigNumber.from(bitcoinEstimatedFee)}
-				decimals={$sendTokenDecimals}
-				symbol={$sendTokenSymbol}
-				exchangeRate={$sendTokenExchangeRate}
+				decimals={BTC_DECIMALS}
+				symbol={BTC_MAINNET_SYMBOL}
+				exchangeRate={btcFeeExchangeRate}
 			/>
 		</Value>
 	</div>


### PR DESCRIPTION
# Motivation

Instead ckBTC token data, the estimated Bitcoin network fee should use BTC symbol, decimals and exchange rate.
