### PR TITLE
fix(frontend): avoid using "global" transition

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
@@ -23,8 +23,8 @@
 			: undefined;
 </script>
 
-{#if nonNullish(amount) && nonNullish(decimals) && nonNullish(symbol)}
-	<div transition:fade|global class="flex gap-4">
+<div transition:fade class="flex gap-4">
+	{#if nonNullish(amount) && nonNullish(decimals) && nonNullish(symbol)}
 		{formatToken({
 			value: amount,
 			unitName: decimals,
@@ -43,5 +43,5 @@
 				{/if}
 			</div>
 		{/if}
-	</div>
-{/if}
+	{/if}
+</div>

--- a/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
@@ -24,24 +24,22 @@
 </script>
 
 <div transition:fade class="flex gap-4">
-	{#if nonNullish(amount) && nonNullish(decimals) && nonNullish(symbol)}
-		{formatToken({
-			value: amount,
-			unitName: decimals,
-			displayDecimals: EIGHT_DECIMALS
-		})}
-		{symbol}
+	{formatToken({
+		value: amount,
+		unitName: decimals,
+		displayDecimals: EIGHT_DECIMALS
+	})}
+	{symbol}
 
-		{#if nonNullish(usdAmount)}
-			<div class="text-tertiary">
-				{#if usdAmount < EXCHANGE_USD_AMOUNT_THRESHOLD}
-					{`( < ${formatUSD({
-						value: EXCHANGE_USD_AMOUNT_THRESHOLD
-					})} )`}
-				{:else}
-					{`( ${formatUSD({ value: usdAmount })} )`}
-				{/if}
-			</div>
-		{/if}
+	{#if nonNullish(usdAmount)}
+		<div class="text-tertiary">
+			{#if usdAmount < EXCHANGE_USD_AMOUNT_THRESHOLD}
+				{`( < ${formatUSD({
+					value: EXCHANGE_USD_AMOUNT_THRESHOLD
+				})} )`}
+			{:else}
+				{`( ${formatUSD({ value: usdAmount })} )`}
+			{/if}
+		</div>
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
@@ -13,14 +13,13 @@
 	export let exchangeRate: number | undefined;
 
 	let usdAmount: number | undefined;
-	$: usdAmount =
-		nonNullish(decimals) && nonNullish(amount) && nonNullish(exchangeRate)
-			? usdValue({
-					decimals,
-					balance: amount,
-					exchangeRate
-				})
-			: undefined;
+	$: usdAmount = nonNullish(exchangeRate)
+		? usdValue({
+				decimals,
+				balance: amount,
+				exchangeRate
+			})
+		: undefined;
 </script>
 
 <div transition:fade class="flex gap-4">


### PR DESCRIPTION
# Motivation

We got an unexpected behaviour of the Send modal after adding `global` Svelte transition to the ETH fee component. It appeared that the `if` statement is not needed, which simplifies everything.
