### PR TITLE
style(frontend): Fix minor styling issue on an error alert

### DIFF
--- a/src/frontend/src/lib/components/fee/InsufficientFundsForFee.svelte
+++ b/src/frontend/src/lib/components/fee/InsufficientFundsForFee.svelte
@@ -8,8 +8,5 @@
 </script>
 
 <div transition:slide={SLIDE_DURATION} data-tid={testId}>
-	<MessageBox level="error"
-		><span class="text-error-primary">{$i18n.fee.assertion.insufficient_funds_for_fee}</span
-		></MessageBox
-	>
+	<MessageBox level="error">{$i18n.fee.assertion.insufficient_funds_for_fee}</MessageBox>
 </div>


### PR DESCRIPTION
# Motivation

On Send Review the error alert displays if insufficient funds for fees displays with wrong text color.

# Changes

Removed span with wrong text color and let the text inherit MessageBox text class

# Tests

Before:
![image](https://github.com/user-attachments/assets/6f0d5c08-761f-439b-bac6-31fcb7a1d734)

After:
![image](https://github.com/user-attachments/assets/01877edb-3b9e-4b19-830b-7461cbbfa95d)

