### PR TITLE
refactor(frontend): use deconstruction of token data in AddTokenByNetwork

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -40,10 +40,7 @@
 	let isSolanaNetwork = false;
 	$: isSolanaNetwork = isNetworkIdSolana(network?.id);
 
-	let ledgerCanisterId = tokenData?.ledgerCanisterId ?? '';
-	let indexCanisterId = tokenData?.indexCanisterId ?? '';
-	let erc20ContractAddress = tokenData?.erc20ContractAddress ?? '';
-	let splTokenAddress = tokenData?.splTokenAddress ?? '';
+	let { ledgerCanisterId, indexCanisterId, erc20ContractAddress, splTokenAddress } = tokenData;
 
 	// Since we persist the values of relevant variables when switching networks, this ensures that
 	// only the data related to the selected network is passed.


### PR DESCRIPTION
# Motivation

Small refactoring that it will come in handy when we will brand the type of addresses. Note that we remove the fallback to empty string that it was not really necessary