### PR TITLE
refactor(frontend): split manage tokens services in respective networks

### DIFF
--- a/src/frontend/src/eth/services/manage-tokens.services.ts
+++ b/src/frontend/src/eth/services/manage-tokens.services.ts
@@ -1,0 +1,15 @@
+import { saveUserTokens, type SaveUserToken } from '$eth/services/erc20-user-tokens-services';
+import { saveTokens, type ManageTokensSaveParams } from '$lib/services/manage-tokens.services';
+
+export const saveErc20UserTokens = async ({
+	tokens,
+	...rest
+}: {
+	tokens: SaveUserToken[];
+} & ManageTokensSaveParams) => {
+	await saveTokens({
+		...rest,
+		tokens,
+		save: saveUserTokens
+	});
+};

--- a/src/frontend/src/icp/services/manage-tokens.services.ts
+++ b/src/frontend/src/icp/services/manage-tokens.services.ts
@@ -1,20 +1,6 @@
-import { saveUserTokens, type SaveUserToken } from '$eth/services/erc20-user-tokens-services';
 import { saveCustomTokens } from '$icp/services/ic-custom-tokens.services';
 import { saveTokens, type ManageTokensSaveParams } from '$lib/services/manage-tokens.services';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
-
-export const saveErc20UserTokens = async ({
-	tokens,
-	...rest
-}: {
-	tokens: SaveUserToken[];
-} & ManageTokensSaveParams) => {
-	await saveTokens({
-		...rest,
-		tokens,
-		save: saveUserTokens
-	});
-};
 
 export const saveIcrcCustomTokens = async ({
 	tokens,

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -9,10 +9,6 @@
 	import type { EthereumNetwork } from '$eth/types/network';
 	import IcAddTokenReview from '$icp/components/tokens/IcAddTokenReview.svelte';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-	import {
-		saveErc20UserTokens,
-		saveIcrcCustomTokens
-	} from '$icp-eth/services/manage-tokens.services';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import AddTokenByNetwork from '$lib/components/manage/AddTokenByNetwork.svelte';
 	import ManageTokens from '$lib/components/manage/ManageTokens.svelte';
@@ -35,6 +31,8 @@
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
 	import type { SaveSplUserToken } from '$sol/types/spl-user-token';
+	import { saveIcrcCustomTokens } from '$icp/services/manage-tokens.services';
+	import { saveErc20UserTokens } from '$eth/services/manage-tokens.services';
 
 	const steps: WizardSteps = [
 		{


### PR DESCRIPTION
# Motivation

To easy manageability and to prepare for more networks, we assign each manage-tokens service to each network folder.