### PR TITLE
refactor(scripts): build ckErc20 tokens to Typescript

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -132,7 +132,7 @@ This last step will generate the screenshots for the CI and add them to your PR.
 
 ## Integrate ckERC20 Tokens
 
-While the weekly GitHub Action that runs the job [./scripts/build.tokens.ckerc20.mjs] helps discover new ckERC20 tokens deployed on the IC mainnet for testnet purposes or through proposals for effective production usage, some manual steps are still required to integrate them within OISY.
+While the weekly GitHub Action that runs the job [./scripts/build.tokens.ckerc20.ts] helps discover new ckERC20 tokens deployed on the IC mainnet for testnet purposes or through proposals for effective production usage, some manual steps are still required to integrate them within OISY.
 
 The steps are as follows:
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"build:copy-workers": "node ./scripts/build.copy-workers.mjs",
 		"build:post-process": "npm run build:style && npm run build:metadata && npm run build:ic-domains && npm run build:ii-alternative-origins && npm run build:csp && npm run build:copy-workers && npm run build:compress",
 		"build:tokens-sns": "vite-node scripts/build.tokens.sns.ts && npm run format",
-		"build:tokens-ckerc20": "node scripts/build.tokens.ckerc20.mjs && npm run format",
+		"build:tokens-ckerc20": "vite-node scripts/build.tokens.ckerc20.ts && npm run format",
 		"dev": "vite dev",
 		"build": "tsc --noEmit && vite build && npm run build:post-process",
 		"prepare": "svelte-kit sync",

--- a/scripts/build.tokens.ckerc20.ts
+++ b/scripts/build.tokens.ckerc20.ts
@@ -116,8 +116,8 @@ const buildOrchestratorInfo = async (orchestratorId: Principal): Promise<EnvCkEr
 	);
 };
 
-const ORCHESTRATOR_STAGING_ID = Principal.fromText('2s5qh-7aaaa-aaaar-qadya-cai');
-const ORCHESTRATOR_PRODUCTION_ID = Principal.fromText('vxkom-oyaaa-aaaar-qafda-cai');
+const ORCHESTRATOR_STAGING_ID: Principal = Principal.fromText('2s5qh-7aaaa-aaaar-qadya-cai');
+const ORCHESTRATOR_PRODUCTION_ID: Principal = Principal.fromText('vxkom-oyaaa-aaaar-qafda-cai');
 
 const LOGO_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'icp-eth', 'assets');
 
@@ -177,7 +177,7 @@ const findCkErc20 = async () => {
 			...tokens.staging
 		})
 			.filter(
-				([_, token]) =>
+				([, token]) =>
 					nonNullish(token) && !SKIP_CANISTER_IDS_LOGOS.includes(token.ledgerCanisterId)
 			)
 			.map(

--- a/scripts/build.tokens.ckerc20.ts
+++ b/scripts/build.tokens.ckerc20.ts
@@ -183,7 +183,7 @@ const findCkErc20 = async () => {
 			.map(
 				([name, token]) =>
 					nonNullish(token?.ledgerCanisterId) &&
-					saveTokenLogo({ canisterId: token.ledgerCanisterId, name })
+					saveTokenLogo({ canisterId: Principal.from(token.ledgerCanisterId), name })
 			)
 	);
 };

--- a/scripts/build.tokens.ckerc20.ts
+++ b/scripts/build.tokens.ckerc20.ts
@@ -1,21 +1,33 @@
 #!/usr/bin/env node
 
-import { AnonymousIdentity } from '@dfinity/agent';
-import { CkETHOrchestratorCanister } from '@dfinity/cketh';
+import type {
+	EnvCkErc20TokenData,
+	EnvCkErc20Tokens,
+	EnvCkErc20TokensRaw,
+	EnvTokensCkErc20
+} from '$env/types/env-token-ckerc20';
+import type { EnvTokenSymbol } from '$env/types/env-token-common';
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import { AnonymousIdentity, HttpAgent } from '@dfinity/agent';
+import {
+	CkETHOrchestratorCanister,
+	type ManagedCanisters,
+	type OrchestratorInfo
+} from '@dfinity/cketh';
 import { IcrcLedgerCanister } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
-import { createAgent, fromNullable, isNullish, jsonReplacer } from '@dfinity/utils';
+import { createAgent, fromNullable, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { CK_ERC20_JSON_FILE } from './constants.mjs';
 
-const agent = await createAgent({
+const agent: HttpAgent = await createAgent({
 	identity: new AnonymousIdentity(),
 	host: 'https://icp-api.io'
 });
 
 // Tokens for which the ERC20 and ckERC20 logos are different—i.e., tokens that are presented with their original ERC20 logos but have a custom logo for ckERC20.
-const SKIP_CANISTER_IDS_LOGOS = [
+const SKIP_CANISTER_IDS_LOGOS: LedgerCanisterIdText[] = [
 	// ckUSDC
 	'xevnm-gaaaa-aaaar-qafnq-cai',
 	// ckUSDT
@@ -28,7 +40,11 @@ const SKIP_CANISTER_IDS_LOGOS = [
 	'nza5v-qaaaa-aaaar-qahzq-cai'
 ];
 
-const orchestratorInfo = async ({ orchestratorId: canisterId }) => {
+const orchestratorInfo = async ({
+	orchestratorId: canisterId
+}: {
+	orchestratorId: Principal;
+}): Promise<OrchestratorInfo> => {
 	const { getOrchestratorInfo } = CkETHOrchestratorCanister.create({
 		agent,
 		canisterId
@@ -37,14 +53,19 @@ const orchestratorInfo = async ({ orchestratorId: canisterId }) => {
 	return await getOrchestratorInfo({ certified: true });
 };
 
-const buildOrchestratorInfo = async (orchestratorId) => {
+const buildOrchestratorInfo = async (orchestratorId: Principal): Promise<EnvCkErc20Tokens> => {
 	const { managed_canisters } = await orchestratorInfo({ orchestratorId });
 
 	// eslint-disable-next-line local-rules/prefer-object-params -- This is a destructuring assignment
 	const mapManagedCanisters = (
-		acc,
-		{ ledger, index, ckerc20_token_symbol, erc20_contract: { address: erc20ContractAddress } }
-	) => {
+		acc: EnvCkErc20TokensRaw,
+		{
+			ledger,
+			index,
+			ckerc20_token_symbol,
+			erc20_contract: { address: erc20ContractAddress }
+		}: ManagedCanisters
+	): EnvCkErc20TokensRaw => {
 		const ledgerCanister = fromNullable(ledger);
 		const indexCanister = fromNullable(index);
 
@@ -71,9 +92,14 @@ const buildOrchestratorInfo = async (orchestratorId) => {
 		};
 	};
 
-	const tokens = managed_canisters.reduce(mapManagedCanisters, {});
+	const tokens: EnvCkErc20TokensRaw = managed_canisters.reduce<EnvCkErc20TokensRaw>(
+		mapManagedCanisters,
+		{}
+	);
 
-	const assertUniqueTokenSymbol = Object.values(tokens).find((value) => value.length > 1);
+	const assertUniqueTokenSymbol: EnvCkErc20TokenData[] | undefined = Object.values(tokens).find(
+		(value) => value.length > 1
+	);
 
 	if (assertUniqueTokenSymbol !== undefined) {
 		throw new Error(
@@ -95,7 +121,13 @@ const ORCHESTRATOR_PRODUCTION_ID = Principal.fromText('vxkom-oyaaa-aaaar-qafda-c
 
 const LOGO_FOLDER = join(process.cwd(), 'src', 'frontend', 'src', 'icp-eth', 'assets');
 
-const saveTokenLogo = async ({ canisterId, name }) => {
+const saveTokenLogo = async ({
+	canisterId,
+	name
+}: {
+	canisterId: Principal;
+	name: EnvTokenSymbol;
+}) => {
 	const logoName = name.toLowerCase().replace('ck', '').replace('sepolia', '');
 	const file = join(LOGO_FOLDER, `${logoName}.svg`);
 
@@ -112,7 +144,7 @@ const saveTokenLogo = async ({ canisterId, name }) => {
 
 	const logoItem = data.find((item) => item[0] === 'icrc1:logo');
 
-	if (isNullish(logoItem)) {
+	if (isNullish(logoItem) || !('Text' in logoItem[1])) {
 		const error = new Error(`No 'icrc1:logo' data found for ${name}`);
 		console.warn(error.stack);
 		return;
@@ -122,17 +154,17 @@ const saveTokenLogo = async ({ canisterId, name }) => {
 
 	const [encoding, encodedStr] = logoData.split(';')[1].split(',');
 
-	const svgContent = Buffer.from(encodedStr, encoding).toString('utf-8');
+	const svgContent = Buffer.from(encodedStr, encoding as BufferEncoding).toString('utf-8');
 
 	writeFileSync(file, svgContent, 'utf-8');
 };
 
 const findCkErc20 = async () => {
-	const [staging, production] = await Promise.all(
+	const [staging, production]: EnvCkErc20Tokens[] = await Promise.all(
 		[ORCHESTRATOR_STAGING_ID, ORCHESTRATOR_PRODUCTION_ID].map(buildOrchestratorInfo)
 	);
 
-	const tokens = {
+	const tokens: EnvTokensCkErc20 = {
 		production,
 		staging
 	};
@@ -144,8 +176,15 @@ const findCkErc20 = async () => {
 			...tokens.production,
 			...tokens.staging
 		})
-			.filter(([_, { ledgerCanisterId }]) => !SKIP_CANISTER_IDS_LOGOS.includes(ledgerCanisterId))
-			.map(([name, { ledgerCanisterId }]) => saveTokenLogo({ canisterId: ledgerCanisterId, name }))
+			.filter(
+				([_, token]) =>
+					nonNullish(token) && !SKIP_CANISTER_IDS_LOGOS.includes(token.ledgerCanisterId)
+			)
+			.map(
+				([name, token]) =>
+					nonNullish(token?.ledgerCanisterId) &&
+					saveTokenLogo({ canisterId: token.ledgerCanisterId, name })
+			)
 	);
 };
 

--- a/src/frontend/src/env/schema/env-token-ckerc20.schema.ts
+++ b/src/frontend/src/env/schema/env-token-ckerc20.schema.ts
@@ -8,9 +8,14 @@ const EnvErc20ContractAddressSchema = z.custom<string>(
 	'Invalid ERC20 Contract Address'
 );
 
-const EnvCkErc20TokenDataSchema = EnvIcTokenSchema.extend({
+export const EnvCkErc20TokenDataSchema = EnvIcTokenSchema.extend({
 	erc20ContractAddress: EnvErc20ContractAddressSchema
 });
+
+export const EnvCkErc20TokensRawSchema = z.record(
+	EnvTokenSymbolSchema,
+	z.array(EnvCkErc20TokenDataSchema)
+);
 
 export const EnvCkErc20TokensSchema = z.record(
 	EnvTokenSymbolSchema,

--- a/src/frontend/src/env/tokens/tokens.ckerc20.json
+++ b/src/frontend/src/env/tokens/tokens.ckerc20.json
@@ -25,7 +25,7 @@
 			"erc20ContractAddress": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
 		},
 		"ckSHIB": {
-			"ledgerCanisterId": "fxffn-xiaaa-aaaar-qagoa-cai",
+			"ledgerCanisterId": "fxffn-xiaaa-aaaar-qagoa-cai"
 		},
 		"ckUSDC": {
 			"ledgerCanisterId": "xevnm-gaaaa-aaaar-qafnq-cai",

--- a/src/frontend/src/env/tokens/tokens.ckerc20.json
+++ b/src/frontend/src/env/tokens/tokens.ckerc20.json
@@ -12,6 +12,7 @@
 		},
 		"ckWBTC": {
 			"ledgerCanisterId": "bptq2-faaaa-aaaar-qagxq-cai",
+			"indexCanisterId": "dso6s-wiaaa-aaaar-qagya-cai",
 			"erc20ContractAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
 		},
 		"ckLINK": {
@@ -19,13 +20,25 @@
 			"indexCanisterId": "gvqys-hyaaa-aaaar-qagfa-cai",
 			"erc20ContractAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
 		},
+		"ckXAUT": {
+			"ledgerCanisterId": "nza5v-qaaaa-aaaar-qahzq-cai",
+			"indexCanisterId": "nmhmy-riaaa-aaaar-qah2a-cai",
+			"erc20ContractAddress": "0x68749665FF8D2d112Fa859AA293F07A622782F38"
+		},
+		"ckPEPE": {
+			"ledgerCanisterId": "etik7-oiaaa-aaaar-qagia-cai",
+			"indexCanisterId": "eujml-dqaaa-aaaar-qagiq-cai",
+			"erc20ContractAddress": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
+		},
 		"ckWSTETH": {
 			"ledgerCanisterId": "j2tuh-yqaaa-aaaar-qahcq-cai",
 			"indexCanisterId": "jtq73-oyaaa-aaaar-qahda-cai",
 			"erc20ContractAddress": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
 		},
 		"ckSHIB": {
-			"ledgerCanisterId": "fxffn-xiaaa-aaaar-qagoa-cai"
+			"ledgerCanisterId": "fxffn-xiaaa-aaaar-qagoa-cai",
+			"indexCanisterId": "fqedz-2qaaa-aaaar-qagoq-cai",
+			"erc20ContractAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
 		},
 		"ckUSDC": {
 			"ledgerCanisterId": "xevnm-gaaaa-aaaar-qafnq-cai",

--- a/src/frontend/src/env/tokens/tokens.ckerc20.json
+++ b/src/frontend/src/env/tokens/tokens.ckerc20.json
@@ -12,23 +12,12 @@
 		},
 		"ckWBTC": {
 			"ledgerCanisterId": "bptq2-faaaa-aaaar-qagxq-cai",
-			"indexCanisterId": "dso6s-wiaaa-aaaar-qagya-cai",
 			"erc20ContractAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
 		},
 		"ckLINK": {
 			"ledgerCanisterId": "g4tto-rqaaa-aaaar-qageq-cai",
 			"indexCanisterId": "gvqys-hyaaa-aaaar-qagfa-cai",
 			"erc20ContractAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
-		},
-		"ckXAUT": {
-			"ledgerCanisterId": "nza5v-qaaaa-aaaar-qahzq-cai",
-			"indexCanisterId": "nmhmy-riaaa-aaaar-qah2a-cai",
-			"erc20ContractAddress": "0x68749665FF8D2d112Fa859AA293F07A622782F38"
-		},
-		"ckPEPE": {
-			"ledgerCanisterId": "etik7-oiaaa-aaaar-qagia-cai",
-			"indexCanisterId": "eujml-dqaaa-aaaar-qagiq-cai",
-			"erc20ContractAddress": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
 		},
 		"ckWSTETH": {
 			"ledgerCanisterId": "j2tuh-yqaaa-aaaar-qahcq-cai",
@@ -37,8 +26,6 @@
 		},
 		"ckSHIB": {
 			"ledgerCanisterId": "fxffn-xiaaa-aaaar-qagoa-cai",
-			"indexCanisterId": "fqedz-2qaaa-aaaar-qagoq-cai",
-			"erc20ContractAddress": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
 		},
 		"ckUSDC": {
 			"ledgerCanisterId": "xevnm-gaaaa-aaaar-qafnq-cai",

--- a/src/frontend/src/env/types/env-token-ckerc20.ts
+++ b/src/frontend/src/env/types/env-token-ckerc20.ts
@@ -1,4 +1,15 @@
-import { EnvCkErc20TokensSchema } from '$env/schema/env-token-ckerc20.schema';
+import {
+	EnvCkErc20TokenDataSchema,
+	EnvCkErc20TokensRawSchema,
+	EnvCkErc20TokensSchema,
+	EnvTokensCkErc20Schema
+} from '$env/schema/env-token-ckerc20.schema';
 import * as z from 'zod';
 
+export type EnvCkErc20TokenData = z.infer<typeof EnvCkErc20TokenDataSchema>;
+
+export type EnvCkErc20TokensRaw = z.infer<typeof EnvCkErc20TokensRawSchema>;
+
 export type EnvCkErc20Tokens = z.infer<typeof EnvCkErc20TokensSchema>;
+
+export type EnvTokensCkErc20 = z.infer<typeof EnvTokensCkErc20Schema>;


### PR DESCRIPTION
# Motivation

To be consistent we transform the `build.tokens.ckerc20` script in Typescript.

# Changes

- Add more schemas and types for the script.
- Rename the script to `.ts`
- Apply typing throughout the script.

# Tests

I removed some ckERC2 tokens from the JSON file and modified others. Then I ran the script and it was reverted. Both commits are included in this PR.
