### PR TITLE
feat(frontend): reverse Solana transactions only after mapping

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -97,6 +97,7 @@ export const fetchSolTransactionsForSignature = async ({
 
 		const { value, from, to, tokenAddress: mappedTokenAddress } = mappedTransaction;
 
+		// Ignoring the instruction if the transaction is not related to the address or its associated token account.
 		if (from !== address && to !== address && from !== ataAddress && to !== ataAddress) {
 			return acc;
 		}

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -113,6 +113,7 @@ export const fetchSolTransactionsForSignature = async ({
 
 					return [
 						...(await acc),
+						newTransaction,
 						...(from === to
 							? [
 									{
@@ -121,8 +122,7 @@ export const fetchSolTransactionsForSignature = async ({
 										type: newTransaction.type === 'send' ? 'receive' : 'send'
 									} as SolTransactionUi
 								]
-							: []),
-						newTransaction
+							: [])
 					];
 				}
 

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -93,40 +93,44 @@ export const fetchSolTransactionsForSignature = async ({
 					network
 				});
 
-				if (nonNullish(mappedTransaction) && mappedTransaction.tokenAddress === tokenAddress) {
-					const { value, from, to } = mappedTransaction;
-
-					if (from !== address && to !== address && from !== ataAddress && to !== ataAddress) {
-						return acc;
-					}
-
-					const newTransaction: SolTransactionUi = {
-						id: `${signature.signature}-${instruction.programId}`,
-						signature: signature.signature,
-						timestamp: blockTime ?? 0n,
-						value,
-						type: address === from ? 'send' : 'receive',
-						from,
-						to,
-						status
-					};
-
-					return [
-						...(await acc),
-						newTransaction,
-						...(from === to
-							? [
-									{
-										...newTransaction,
-										id: `${newTransaction.id}-self`,
-										type: newTransaction.type === 'send' ? 'receive' : 'send'
-									} as SolTransactionUi
-								]
-							: [])
-					];
+				if (isNullish(mappedTransaction)) {
+					return acc;
 				}
 
-				return acc;
+				if (mappedTransaction.tokenAddress !== tokenAddress) {
+					return acc;
+				}
+
+				const { value, from, to } = mappedTransaction;
+
+				if (from !== address && to !== address && from !== ataAddress && to !== ataAddress) {
+					return acc;
+				}
+
+				const newTransaction: SolTransactionUi = {
+					id: `${signature.signature}-${instruction.programId}`,
+					signature: signature.signature,
+					timestamp: blockTime ?? 0n,
+					value,
+					type: address === from ? 'send' : 'receive',
+					from,
+					to,
+					status
+				};
+
+				return [
+					...(await acc),
+					newTransaction,
+					...(from === to
+						? [
+								{
+									...newTransaction,
+									id: `${newTransaction.id}-self`,
+									type: newTransaction.type === 'send' ? 'receive' : 'send'
+								} as SolTransactionUi
+							]
+						: [])
+				];
 			}, Promise.resolve([]))
 		)
 			// The instructions are received in the order they were executed, meaning the first instruction

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -157,8 +157,8 @@ describe('sol-transactions.services', () => {
 
 			expect(spyMapSolParsedInstruction).toHaveBeenCalledWith({
 				instruction: {
-					...mockInstructions[mockInstructions.length - 1],
-					programAddress: mockInstructions[mockInstructions.length - 1].programId
+					...mockInstructions[0],
+					programAddress: mockInstructions[0].programId
 				},
 				innerInstructions: innerInstructions[0].instructions.map((innerInstruction) => ({
 					...innerInstruction,
@@ -179,7 +179,7 @@ describe('sol-transactions.services', () => {
 		});
 
 		it('should return only transactions that have mapped transactions non-nullish', async () => {
-			const expected = expectedResults.slice(1);
+			const expected = expectedResults.slice(0, -1);
 
 			spyMapSolParsedInstruction.mockResolvedValueOnce(null);
 
@@ -214,15 +214,15 @@ describe('sol-transactions.services', () => {
 			});
 
 			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([
+				...expectedResults.slice(0, -1),
 				{
 					...expected,
-					id: `${expected.id}-${mockInstructions[mockInstructions.length - 1].programId}-self`,
+					id: `${expected.id}-${mockInstructions[0].programId}-self`,
 					type: 'receive',
 					from: mockSolAddress,
 					to: mockSolAddress
 				},
-				{ ...expectedResults[0], from: mockSolAddress, to: mockSolAddress },
-				...expectedResults.slice(1)
+				{ ...expectedResults[expectedResults.length - 1], from: mockSolAddress, to: mockSolAddress }
 			]);
 		});
 
@@ -234,7 +234,7 @@ describe('sol-transactions.services', () => {
 			});
 
 			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(
-				expectedResults.slice(1)
+				expectedResults.slice(0, -1)
 			);
 		});
 	});


### PR DESCRIPTION
# Motivation

As pointed out by PRODSEC, we should reverse the list of mapped transactions ONLY after the mapping, to avoid mixing the indexes that match the inner instructions.
