### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/agent": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {


### PR DESCRIPTION
# Motivation

This PR prepares the release of version v1.2.1. It is a patch to include `nICP` token.
