### PR TITLE
feat(frontend): assert-amount utils

### DIFF
--- a/src/frontend/src/lib/types/convert.ts
+++ b/src/frontend/src/lib/types/convert.ts
@@ -1,4 +1,9 @@
+// TODO: rename the type as it will be reused in both convert and send flows
 export type ConvertAmountErrorType =
 	| 'insufficient-funds'
 	| 'insufficient-funds-for-fee'
+	| 'unknown-minimum-amount'
+	| 'minimum-amount-not-reached'
+	| 'amount-less-than-ledger-fee'
+	| 'minter-info-not-certified'
 	| undefined;

--- a/src/frontend/src/lib/utils/assert-amount.utils.ts
+++ b/src/frontend/src/lib/utils/assert-amount.utils.ts
@@ -71,7 +71,7 @@ export const assertErc20Amount = ({
 	fee
 }: CommonParamsWithBalanceForFee): ConvertAmountErrorType => {
 	const assertBalanceError = assertBalance({ userAmount, balance });
-	if (assertBalanceError) {
+	if (nonNullish(assertBalanceError)) {
 		return assertBalanceError;
 	}
 
@@ -85,22 +85,10 @@ export const assertCkBtcAmount = ({
 	balance,
 	minterInfo,
 	fee
-}: CommonParamsWithMinter) => {
-	const assertBalanceError = assertBalance({ userAmount, balance });
-	if (assertBalanceError) {
-		return assertBalanceError;
-	}
-
-	const assertMinterInfoError = assertMinterInfo({ minterInfo, userAmount });
-	if (assertMinterInfoError) {
-		return assertMinterInfoError;
-	}
-
-	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
-	if (assertUserAmountWithFeeError) {
-		return assertUserAmountWithFeeError;
-	}
-};
+}: CommonParamsWithMinter) =>
+	assertBalance({ userAmount, balance }) ??
+	assertMinterInfo({ minterInfo, userAmount }) ??
+	assertUserAmountWithFee({ userAmount, balance, fee });
 
 export const assertCkEthAmount = ({
 	userAmount,
@@ -109,12 +97,12 @@ export const assertCkEthAmount = ({
 	fee
 }: CommonParamsWithMinter): ConvertAmountErrorType => {
 	const assertBalanceError = assertBalance({ userAmount, balance });
-	if (assertBalanceError) {
+	if (nonNullish(assertBalanceError)) {
 		return assertBalanceError;
 	}
 
 	const assertMinterInfoError = assertMinterInfo({ minterInfo, userAmount });
-	if (assertMinterInfoError) {
+	if (nonNullish(assertMinterInfoError)) {
 		return assertMinterInfoError;
 	}
 
@@ -122,10 +110,7 @@ export const assertCkEthAmount = ({
 		return 'amount-less-than-ledger-fee';
 	}
 
-	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
-	if (assertUserAmountWithFeeError) {
-		return assertUserAmountWithFeeError;
-	}
+	return assertUserAmountWithFee({ userAmount, balance, fee });
 };
 
 export const assertCkErc20Amount = ({
@@ -136,7 +121,7 @@ export const assertCkErc20Amount = ({
 	ethereumEstimateFee
 }: CommonParamsWithBalanceForFee & { ethereumEstimateFee?: bigint }): ConvertAmountErrorType => {
 	const assertBalanceError = assertBalance({ userAmount, balance });
-	if (assertBalanceError) {
+	if (nonNullish(assertBalanceError)) {
 		return assertBalanceError;
 	}
 
@@ -148,24 +133,8 @@ export const assertCkErc20Amount = ({
 		return 'insufficient-funds-for-fee';
 	}
 
-	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
-	if (assertUserAmountWithFeeError) {
-		return assertUserAmountWithFeeError;
-	}
+	return assertUserAmountWithFee({ userAmount, balance, fee });
 };
 
-export const assertAmount = ({
-	userAmount,
-	balance,
-	fee
-}: CommonParams): ConvertAmountErrorType => {
-	const assertBalanceError = assertBalance({ userAmount, balance });
-	if (assertBalanceError) {
-		return assertBalanceError;
-	}
-
-	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
-	if (assertUserAmountWithFeeError) {
-		return assertUserAmountWithFeeError;
-	}
-};
+export const assertAmount = ({ userAmount, balance, fee }: CommonParams): ConvertAmountErrorType =>
+	assertBalance({ userAmount, balance }) ?? assertUserAmountWithFee({ userAmount, balance, fee });

--- a/src/frontend/src/lib/utils/assert-amount.utils.ts
+++ b/src/frontend/src/lib/utils/assert-amount.utils.ts
@@ -1,0 +1,171 @@
+import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
+import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
+import type { ConvertAmountErrorType } from '$lib/types/convert';
+import type { Option } from '$lib/types/utils';
+import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+import { BigNumber } from '@ethersproject/bignumber';
+
+interface CommonParams {
+	userAmount: BigNumber;
+	balance: BigNumber;
+	fee?: bigint;
+}
+
+interface CommonParamsWithMinter extends CommonParams {
+	minterInfo: Option<CkBtcMinterInfoData | CkEthMinterInfoData>;
+}
+
+interface CommonParamsWithBalanceForFee extends CommonParams {
+	balanceForFee: BigNumber;
+}
+
+const assertBalance = ({ userAmount, balance }: CommonParams): ConvertAmountErrorType => {
+	if (userAmount.gt(balance)) {
+		return 'insufficient-funds';
+	}
+};
+
+const assertUserAmountWithFee = ({
+	userAmount,
+	balance,
+	fee
+}: CommonParams): ConvertAmountErrorType => {
+	if (nonNullish(fee) && userAmount.add(fee).gt(balance)) {
+		return 'insufficient-funds-for-fee';
+	}
+};
+
+const assertMinterInfo = ({
+	minterInfo,
+	userAmount
+}: {
+	userAmount: BigNumber;
+	minterInfo: Option<CkBtcMinterInfoData | CkEthMinterInfoData>;
+}): ConvertAmountErrorType => {
+	if (isNullish(minterInfo)) {
+		return 'unknown-minimum-amount';
+	}
+
+	const { certified: infoCertified, data } = minterInfo;
+
+	const minimumAmount =
+		'retrieve_btc_min_amount' in data
+			? data.retrieve_btc_min_amount
+			: 'minimum_withdrawal_amount' in data
+				? (fromNullable(data.minimum_withdrawal_amount) ?? 0n)
+				: undefined;
+
+	if (nonNullish(minimumAmount) && userAmount.toBigInt() < minimumAmount) {
+		return 'minimum-amount-not-reached';
+	}
+
+	if (!infoCertified) {
+		return 'minter-info-not-certified';
+	}
+};
+
+export const assertErc20Amount = ({
+	userAmount,
+	balance,
+	balanceForFee,
+	fee
+}: CommonParamsWithBalanceForFee): ConvertAmountErrorType => {
+	const assertBalanceError = assertBalance({ userAmount, balance });
+	if (assertBalanceError) {
+		return assertBalanceError;
+	}
+
+	if (nonNullish(fee) && balanceForFee.lt(fee)) {
+		return 'insufficient-funds-for-fee';
+	}
+};
+
+export const assertCkBtcAmount = ({
+	userAmount,
+	balance,
+	minterInfo,
+	fee
+}: CommonParamsWithMinter) => {
+	const assertBalanceError = assertBalance({ userAmount, balance });
+	if (assertBalanceError) {
+		return assertBalanceError;
+	}
+
+	const assertMinterInfoError = assertMinterInfo({ minterInfo, userAmount });
+	if (assertMinterInfoError) {
+		return assertMinterInfoError;
+	}
+
+	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
+	if (assertUserAmountWithFeeError) {
+		return assertUserAmountWithFeeError;
+	}
+};
+
+export const assertCkEthAmount = ({
+	userAmount,
+	balance,
+	minterInfo,
+	fee
+}: CommonParamsWithMinter): ConvertAmountErrorType => {
+	const assertBalanceError = assertBalance({ userAmount, balance });
+	if (assertBalanceError) {
+		return assertBalanceError;
+	}
+
+	const assertMinterInfoError = assertMinterInfo({ minterInfo, userAmount });
+	if (assertMinterInfoError) {
+		return assertMinterInfoError;
+	}
+
+	if (nonNullish(fee) && userAmount.lt(fee)) {
+		return 'amount-less-than-ledger-fee';
+	}
+
+	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
+	if (assertUserAmountWithFeeError) {
+		return assertUserAmountWithFeeError;
+	}
+};
+
+export const assertCkErc20Amount = ({
+	userAmount,
+	balance,
+	balanceForFee,
+	fee,
+	ethereumEstimateFee
+}: CommonParamsWithBalanceForFee & { ethereumEstimateFee?: bigint }): ConvertAmountErrorType => {
+	const assertBalanceError = assertBalance({ userAmount, balance });
+	if (assertBalanceError) {
+		return assertBalanceError;
+	}
+
+	if (
+		nonNullish(balanceForFee) &&
+		nonNullish(ethereumEstimateFee) &&
+		balanceForFee.lt(ethereumEstimateFee)
+	) {
+		return 'insufficient-funds-for-fee';
+	}
+
+	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
+	if (assertUserAmountWithFeeError) {
+		return assertUserAmountWithFeeError;
+	}
+};
+
+export const assertAmount = ({
+	userAmount,
+	balance,
+	fee
+}: CommonParams): ConvertAmountErrorType => {
+	const assertBalanceError = assertBalance({ userAmount, balance });
+	if (assertBalanceError) {
+		return assertBalanceError;
+	}
+
+	const assertUserAmountWithFeeError = assertUserAmountWithFee({ userAmount, balance, fee });
+	if (assertUserAmountWithFeeError) {
+		return assertUserAmountWithFeeError;
+	}
+};

--- a/src/frontend/src/tests/lib/utils/assert-amount.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/assert-amount.utils.spec.ts
@@ -1,0 +1,261 @@
+import {
+	assertAmount,
+	assertCkBtcAmount,
+	assertCkErc20Amount,
+	assertCkEthAmount,
+	assertErc20Amount
+} from '$lib/utils/assert-amount.utils';
+import { mockCkBtcMinterInfo } from '$tests/mocks/ckbtc.mock';
+import type { MinterInfo as CkBtcMinterInfo } from '@dfinity/ckbtc';
+import type { MinterInfo as CkEthMinterInfo } from '@dfinity/cketh';
+import { BigNumber } from 'alchemy-sdk';
+
+describe('asserts-amount.utils', () => {
+	describe('assertAmount', () => {
+		const params = {
+			userAmount: BigNumber.from(1000n),
+			balance: BigNumber.from(2000n),
+			fee: 100n
+		};
+
+		it('should return balance error', () => {
+			expect(
+				assertAmount({
+					...params,
+					balance: BigNumber.from(900n)
+				})
+			).toBe('insufficient-funds');
+		});
+
+		it('should return funds for fee error', () => {
+			expect(
+				assertAmount({
+					...params,
+					balance: BigNumber.from(1050n)
+				})
+			).toBe('insufficient-funds-for-fee');
+		});
+
+		it('should return undefined', () => {
+			expect(assertAmount(params)).toBeUndefined();
+		});
+	});
+
+	describe('assertErc20Amount', () => {
+		const params = {
+			userAmount: BigNumber.from(1000n),
+			balance: BigNumber.from(2000n),
+			balanceForFee: BigNumber.from(1000n),
+			fee: 100n
+		};
+
+		it('should return balance error', () => {
+			expect(
+				assertErc20Amount({
+					...params,
+					balance: BigNumber.from(900n)
+				})
+			).toBe('insufficient-funds');
+		});
+
+		it('should return funds for fee error', () => {
+			expect(
+				assertErc20Amount({
+					...params,
+					balanceForFee: BigNumber.from(50n)
+				})
+			).toBe('insufficient-funds-for-fee');
+		});
+
+		it('should return undefined', () => {
+			expect(assertErc20Amount(params)).toBeUndefined();
+		});
+	});
+
+	describe('assertCkBtcAmount', () => {
+		const params = {
+			userAmount: BigNumber.from(1000n),
+			balance: BigNumber.from(2000n),
+			fee: 100n,
+			minterInfo: { data: mockCkBtcMinterInfo, certified: true }
+		};
+
+		it('should return balance error', () => {
+			expect(
+				assertCkBtcAmount({
+					...params,
+					balance: BigNumber.from(900n)
+				})
+			).toBe('insufficient-funds');
+		});
+
+		it('should return funds for fee error', () => {
+			expect(
+				assertCkBtcAmount({
+					...params,
+					balance: BigNumber.from(1050n)
+				})
+			).toBe('insufficient-funds-for-fee');
+		});
+
+		it('should return unknown minimum amount error', () => {
+			expect(
+				assertCkBtcAmount({
+					...params,
+					minterInfo: undefined
+				})
+			).toBe('unknown-minimum-amount');
+		});
+
+		it('should return minimum amount not reached error', () => {
+			expect(
+				assertCkBtcAmount({
+					...params,
+					minterInfo: {
+						...params.minterInfo,
+						data: {
+							...params.minterInfo.data,
+							retrieve_btc_min_amount: 5000n
+						} as CkBtcMinterInfo
+					}
+				})
+			).toBe('minimum-amount-not-reached');
+		});
+
+		it('should return minter info not certified error', () => {
+			expect(
+				assertCkBtcAmount({
+					...params,
+					minterInfo: {
+						...params.minterInfo,
+						certified: false
+					}
+				})
+			).toBe('minter-info-not-certified');
+		});
+
+		it('should return undefined', () => {
+			expect(assertCkBtcAmount(params)).toBeUndefined();
+		});
+	});
+
+	describe('assertCkEthAmount', () => {
+		const params = {
+			userAmount: BigNumber.from(1000n),
+			balance: BigNumber.from(2000n),
+			fee: 100n,
+			minterInfo: {
+				data: { minimum_withdrawal_amount: [500n] } as CkEthMinterInfo,
+				certified: true
+			}
+		};
+
+		it('should return balance error', () => {
+			expect(
+				assertCkEthAmount({
+					...params,
+					balance: BigNumber.from(900n)
+				})
+			).toBe('insufficient-funds');
+		});
+
+		it('should return funds for fee error', () => {
+			expect(
+				assertCkEthAmount({
+					...params,
+					balance: BigNumber.from(1050n)
+				})
+			).toBe('insufficient-funds-for-fee');
+		});
+
+		it('should return user amount less than fee error', () => {
+			expect(
+				assertCkEthAmount({
+					...params,
+					userAmount: BigNumber.from(50n)
+				})
+			).toBe('minimum-amount-not-reached');
+		});
+
+		it('should return unknown minimum amount error', () => {
+			expect(
+				assertCkEthAmount({
+					...params,
+					minterInfo: undefined
+				})
+			).toBe('unknown-minimum-amount');
+		});
+
+		it('should return minimum amount not reached error', () => {
+			expect(
+				assertCkEthAmount({
+					...params,
+					minterInfo: {
+						...params.minterInfo,
+						data: {
+							...params.minterInfo.data,
+							minimum_withdrawal_amount: [5000n]
+						} as CkEthMinterInfo
+					}
+				})
+			).toBe('minimum-amount-not-reached');
+		});
+
+		it('should return minter info not certified error', () => {
+			expect(
+				assertCkBtcAmount({
+					...params,
+					minterInfo: {
+						...params.minterInfo,
+						certified: false
+					}
+				})
+			).toBe('minter-info-not-certified');
+		});
+
+		it('should return undefined', () => {
+			expect(assertCkBtcAmount(params)).toBeUndefined();
+		});
+	});
+
+	describe('assertCkErc20Amount', () => {
+		const params = {
+			userAmount: BigNumber.from(1000n),
+			balance: BigNumber.from(2000n),
+			balanceForFee: BigNumber.from(1000n),
+			ethereumEstimateFee: 500n,
+			fee: 100n
+		};
+
+		it('should return balance error', () => {
+			expect(
+				assertCkErc20Amount({
+					...params,
+					balance: BigNumber.from(900n)
+				})
+			).toBe('insufficient-funds');
+		});
+
+		it('should return funds for fee error if balance cannot cover IC token fee', () => {
+			expect(
+				assertCkErc20Amount({
+					...params,
+					balance: BigNumber.from(1050n)
+				})
+			).toBe('insufficient-funds-for-fee');
+		});
+
+		it('should return funds for fee error if balanceForFee cannot cover ethereumEstimateFee', () => {
+			expect(
+				assertCkErc20Amount({
+					...params,
+					ethereumEstimateFee: 4000n
+				})
+			).toBe('insufficient-funds-for-fee');
+		});
+
+		it('should return undefined', () => {
+			expect(assertCkErc20Amount(params)).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

The idea is to create utils for validating user amount that can be re-used in both convert and send flow. Some of the utils take into account tokens-specific conditions. The whole list of added functions:
* `assertAmount` - common for BTC and ETH
* `assertCkBtcAmount` - specific for ckBTC
* `assertCkErc20Amount` - specific for ckERC20 tokens
* `assertCkEthAmount` - specific for ckETH
* `assertErc20Amount` - specific for ERC20 tokens
