### PR TITLE
feat(build): treat audit ENV as staging

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Set Environment Variables Based on Network
         run: |
-          if [[ "$NETWORK" == "staging" ]] || [[ "$NETWORK" = test_* ]]; then
+          if [[ "$NETWORK" == "staging" ]] || [[ "$NETWORK" = test_* ]] || [[ "$NETWORK" = "audit" ]]; then
             echo "VITE_ETHERSCAN_API_KEY=${{ secrets.VITE_ETHERSCAN_API_KEY_STAGING }}" >> $GITHUB_ENV
             echo "VITE_INFURA_API_KEY=${{ secrets.VITE_INFURA_API_KEY_STAGING }}" >> $GITHUB_ENV
             echo "VITE_ALCHEMY_API_KEY=${{ secrets.VITE_ALCHEMY_API_KEY_STAGING }}" >> $GITHUB_ENV

--- a/scripts/build.utils.mjs
+++ b/scripts/build.utils.mjs
@@ -12,9 +12,11 @@ export const ENV =
 		? 'production'
 		: (REQUESTED_ENV ?? '').startsWith('test_fe_')
 			? 'staging'
-			: ['staging', 'beta'].includes(REQUESTED_ENV)
-				? REQUESTED_ENV
-				: 'development';
+			: REQUESTED_ENV === 'audit'
+				? 'staging'
+				: ['staging', 'beta'].includes(REQUESTED_ENV)
+					? REQUESTED_ENV
+					: 'development';
 
 const domain_for_dfx_network = (dfx_network) =>
 	OISY_DOMAINS.frontend[dfx_network] || `https://${dfx_network}.oisy.com`;

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -6,7 +6,7 @@ export const APP_VERSION = VITE_APP_VERSION;
 
 export const MODE = VITE_DFX_NETWORK;
 export const LOCAL = MODE === 'local';
-export const STAGING = MODE === 'staging' || MODE.startsWith('test_fe_');
+export const STAGING = MODE === 'staging' || MODE.startsWith('test_fe_') || MODE === 'audit';
 export const BETA = MODE === 'beta';
 export const PROD = MODE === 'ic';
 


### PR DESCRIPTION
# Motivation

The newly created `audit` environment should replicate the `staging` settings.