### PR TITLE
fix(frontend): show ATA addresses as destination and sources

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -103,18 +103,20 @@ const mapSystemParsedInstruction = ({
 const mapTokenParsedInstruction = async ({
 	type,
 	info,
-	network
+	network,
+	cumulativeBalances
 }: {
 	type: string;
 	info: object;
 	network: SolanaNetworkType;
+	cumulativeBalances?: Record<SolAddress, SolMappedTransaction['value']>;
 }): Promise<SolMappedTransaction | undefined> => {
 	if (type === 'transfer') {
 		// We need to cast the type since it is not implied
 		const {
-			destination,
+			destination: to,
 			amount: value,
-			source
+			source: from
 		} = info as {
 			destination: SolAddress;
 			amount: string;
@@ -123,38 +125,19 @@ const mapTokenParsedInstruction = async ({
 
 		const { getAccountInfo } = solanaHttpRpc(network);
 
-		const { value: sourceResult } = await getAccountInfo(address(source), {
+		const { value: sourceResult } = await getAccountInfo(address(to), {
 			encoding: 'jsonParsed'
 		}).send();
 
-		const { value: destinationResult } = await getAccountInfo(address(destination), {
-			encoding: 'jsonParsed'
-		}).send();
-
-		if (
-			nonNullish(sourceResult) &&
-			'parsed' in sourceResult.data &&
-			nonNullish(destinationResult) &&
-			'parsed' in destinationResult.data
-		) {
+		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
 			const {
 				data: {
 					parsed: { info: sourceAccoutInfo }
 				}
 			} = sourceResult;
 
-			const { mint: tokenAddress, owner: from } = sourceAccoutInfo as {
+			const { mint: tokenAddress } = sourceAccoutInfo as {
 				mint: SplTokenAddress;
-				owner: SolAddress;
-			};
-
-			const {
-				data: {
-					parsed: { info: destinationAccoutInfo }
-				}
-			} = destinationResult;
-
-			const { owner: to } = destinationAccoutInfo as {
 				owner: SolAddress;
 			};
 
@@ -242,9 +225,9 @@ const mapToken2022ParsedInstruction = async ({
 	if (type === 'transfer') {
 		// We need to cast the type since it is not implied
 		const {
-			destination,
+			destination: to,
 			amount: value,
-			source
+			source: from
 		} = info as {
 			destination: SolAddress;
 			amount: string;
@@ -253,38 +236,19 @@ const mapToken2022ParsedInstruction = async ({
 
 		const { getAccountInfo } = solanaHttpRpc(network);
 
-		const { value: sourceResult } = await getAccountInfo(address(source), {
+		const { value: sourceResult } = await getAccountInfo(address(from), {
 			encoding: 'jsonParsed'
 		}).send();
 
-		const { value: destinationResult } = await getAccountInfo(address(destination), {
-			encoding: 'jsonParsed'
-		}).send();
-
-		if (
-			nonNullish(sourceResult) &&
-			'parsed' in sourceResult.data &&
-			nonNullish(destinationResult) &&
-			'parsed' in destinationResult.data
-		) {
+		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
 			const {
 				data: {
 					parsed: { info: sourceAccoutInfo }
 				}
 			} = sourceResult;
 
-			const { mint: tokenAddress, owner: from } = sourceAccoutInfo as {
+			const { mint: tokenAddress } = sourceAccoutInfo as {
 				mint: SplTokenAddress;
-				owner: SolAddress;
-			};
-
-			const {
-				data: {
-					parsed: { info: destinationAccoutInfo }
-				}
-			} = destinationResult;
-
-			const { owner: to } = destinationAccoutInfo as {
 				owner: SolAddress;
 			};
 

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -103,13 +103,11 @@ const mapSystemParsedInstruction = ({
 const mapTokenParsedInstruction = async ({
 	type,
 	info,
-	network,
-	cumulativeBalances
+	network
 }: {
 	type: string;
 	info: object;
 	network: SolanaNetworkType;
-	cumulativeBalances?: Record<SolAddress, SolMappedTransaction['value']>;
 }): Promise<SolMappedTransaction | undefined> => {
 	if (type === 'transfer') {
 		// We need to cast the type since it is not implied

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -125,7 +125,7 @@ const mapTokenParsedInstruction = async ({
 
 		const { getAccountInfo } = solanaHttpRpc(network);
 
-		const { value: sourceResult } = await getAccountInfo(address(to), {
+		const { value: sourceResult } = await getAccountInfo(address(from), {
 			encoding: 'jsonParsed'
 		}).send();
 
@@ -148,9 +148,9 @@ const mapTokenParsedInstruction = async ({
 	if (type === 'transferChecked') {
 		// We need to cast the type since it is not implied
 		const {
-			destination,
+			destination: to,
 			tokenAmount: { amount: value },
-			source,
+			source: from,
 			mint: tokenAddress
 		} = info as {
 			destination: SolAddress;
@@ -161,44 +161,7 @@ const mapTokenParsedInstruction = async ({
 			mint: SplTokenAddress;
 		};
 
-		const { getAccountInfo } = solanaHttpRpc(network);
-
-		const { value: sourceResult } = await getAccountInfo(address(source), {
-			encoding: 'jsonParsed'
-		}).send();
-
-		const { value: destinationResult } = await getAccountInfo(address(destination), {
-			encoding: 'jsonParsed'
-		}).send();
-
-		if (
-			nonNullish(sourceResult) &&
-			'parsed' in sourceResult.data &&
-			nonNullish(destinationResult) &&
-			'parsed' in destinationResult.data
-		) {
-			const {
-				data: {
-					parsed: { info: sourceAccoutInfo }
-				}
-			} = sourceResult;
-
-			const { owner: from } = sourceAccoutInfo as {
-				owner: SolAddress;
-			};
-
-			const {
-				data: {
-					parsed: { info: destinationAccoutInfo }
-				}
-			} = destinationResult;
-
-			const { owner: to } = destinationAccoutInfo as {
-				owner: SolAddress;
-			};
-
-			return { value: BigInt(value), from, to, tokenAddress };
-		}
+		return { value: BigInt(value), from, to, tokenAddress };
 	}
 
 	if (type === 'closeAccount') {
@@ -259,9 +222,9 @@ const mapToken2022ParsedInstruction = async ({
 	if (type === 'transferChecked') {
 		// We need to cast the type since it is not implied
 		const {
-			destination,
+			destination: to,
 			tokenAmount: { amount: value },
-			source,
+			source: from,
 			mint: tokenAddress
 		} = info as {
 			destination: SolAddress;
@@ -272,44 +235,7 @@ const mapToken2022ParsedInstruction = async ({
 			mint: SplTokenAddress;
 		};
 
-		const { getAccountInfo } = solanaHttpRpc(network);
-
-		const { value: sourceResult } = await getAccountInfo(address(source), {
-			encoding: 'jsonParsed'
-		}).send();
-
-		const { value: destinationResult } = await getAccountInfo(address(destination), {
-			encoding: 'jsonParsed'
-		}).send();
-
-		if (
-			nonNullish(sourceResult) &&
-			'parsed' in sourceResult.data &&
-			nonNullish(destinationResult) &&
-			'parsed' in destinationResult.data
-		) {
-			const {
-				data: {
-					parsed: { info: sourceAccoutInfo }
-				}
-			} = sourceResult;
-
-			const { owner: from } = sourceAccoutInfo as {
-				owner: SolAddress;
-			};
-
-			const {
-				data: {
-					parsed: { info: destinationAccoutInfo }
-				}
-			} = destinationResult;
-
-			const { owner: to } = destinationAccoutInfo as {
-				owner: SolAddress;
-			};
-
-			return { value: BigInt(value), from, to, tokenAddress };
-		}
+		return { value: BigInt(value), from, to, tokenAddress };
 	}
 };
 

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -141,10 +141,10 @@ describe('sol-instructions.utils', () => {
 
 			beforeEach(() => {
 				const mockRpc = {
-					getAccountInfo: vi.fn((address) => ({
+					getAccountInfo: vi.fn(() => ({
 						send: vi.fn(() => ({
 							value: {
-								data: { parsed: { info: { mint: mockTokenAddress, owner: `${address}-owner` } } }
+								data: { parsed: { info: { mint: mockTokenAddress } } }
 							}
 						}))
 					}))
@@ -161,8 +161,8 @@ describe('sol-instructions.utils', () => {
 
 				expect(result).toEqual({
 					value: 50n,
-					from: `${mockSolAddress}-owner`,
-					to: `${mockSolAddress2}-owner`,
+					from: mockSolAddress,
+					to: mockSolAddress2,
 					tokenAddress: mockTokenAddress
 				});
 			});
@@ -190,8 +190,8 @@ describe('sol-instructions.utils', () => {
 
 				expect(result).toEqual({
 					value: 50n,
-					from: `${mockSolAddress}-owner`,
-					to: `${mockSolAddress2}-owner`,
+					from: mockSolAddress,
+					to: mockSolAddress2,
 					tokenAddress: mockTokenAddress
 				});
 			});
@@ -248,10 +248,10 @@ describe('sol-instructions.utils', () => {
 
 			beforeEach(() => {
 				const mockRpc = {
-					getAccountInfo: vi.fn((address) => ({
+					getAccountInfo: vi.fn(() => ({
 						send: vi.fn(() => ({
 							value: {
-								data: { parsed: { info: { mint: mockTokenAddress, owner: `${address}-owner` } } }
+								data: { parsed: { info: { mint: mockTokenAddress } } }
 							}
 						}))
 					}))
@@ -268,8 +268,8 @@ describe('sol-instructions.utils', () => {
 
 				expect(result).toEqual({
 					value: 50n,
-					from: `${mockSolAddress}-owner`,
-					to: `${mockSolAddress2}-owner`,
+					from: mockSolAddress,
+					to: mockSolAddress2,
 					tokenAddress: mockTokenAddress
 				});
 			});
@@ -297,8 +297,8 @@ describe('sol-instructions.utils', () => {
 
 				expect(result).toEqual({
 					value: 50n,
-					from: `${mockSolAddress}-owner`,
-					to: `${mockSolAddress2}-owner`,
+					from: mockSolAddress,
+					to: mockSolAddress2,
 					tokenAddress: mockTokenAddress
 				});
 			});


### PR DESCRIPTION
# Motivation

Under PRODSEC suggestion: we will show the original addresses of a Solana transaction instead of their owner when we are parsing transactions
