### PR TITLE
feat(frontend): add code to calculate a Solana closeAccount redeemed value

### DIFF
--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -208,12 +208,36 @@ describe('sol-instructions.utils', () => {
 					}
 				};
 
-				const result = await mapSolParsedInstruction({
-					instruction: mockCloseAccountInstruction,
-					network
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockCloseAccountInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 0n,
+					from: mockSolAddress,
+					to: mockSolAddress2
 				});
 
-				expect(result).toEqual({
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockCloseAccountInstruction,
+						network,
+						cumulativeBalances: { [mockSolAddress]: 100n }
+					})
+				).resolves.toEqual({
+					value: 100n,
+					from: mockSolAddress,
+					to: mockSolAddress2
+				});
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockCloseAccountInstruction,
+						network,
+						cumulativeBalances: { [mockSolAddress2]: 100n }
+					})
+				).resolves.toEqual({
 					value: 0n,
 					from: mockSolAddress,
 					to: mockSolAddress2


### PR DESCRIPTION
# Motivation

The redeemed value of a SOlana closeAccount transaction is not explicitly indicated in the transaction data. So it must be inferred/calculated from the latest balance of the ATA that is being closed.

# Changes

- Provide new prop cumulativeBalances to the mapper of Solana Token program transactions.
- The map will be a list of addresses with their cumulative balance up until that point.
- Use the cumulated balance of the ATA address as value for the mapper.

# Tests

Adapted tests.
