### PR TITLE
refactor(frontend): put Sol inner instructions at the respective index

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -58,13 +58,12 @@ export const fetchSolTransactionsForSignature = async ({
 	// Inside the instructions there could be some that we are unable to decode, but that may have
 	// simpler (and decoded) inner instructions. We should try to map those as well.
 	// They are inserted in the instructions array in the order they refer to the main instruction.
-	const allInstructions = putativeInnerInstructions.reduce(
-		(acc, { index, instructions }, offset) => {
+	const allInstructions = [...putativeInnerInstructions]
+		.sort((a, b) => a.index - b.index)
+		.reduce((acc, { index, instructions }, offset) => {
 			const insertIndex = index + 1 + offset;
 			return [...acc.slice(0, insertIndex), ...instructions, ...acc.slice(insertIndex)];
-		},
-		instructions
-	);
+		}, instructions);
 
 	const [ataAddress] =
 		nonNullish(tokenAddress) && nonNullish(tokenOwnerAddress)

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -57,10 +57,14 @@ export const fetchSolTransactionsForSignature = async ({
 
 	// Inside the instructions there could be some that we are unable to decode, but that may have
 	// simpler (and decoded) inner instructions. We should try to map those as well.
-	const allInstructions = [
-		...instructions,
-		...putativeInnerInstructions.flatMap(({ instructions }) => instructions)
-	];
+	// They are inserted in the instructions array in the order they refer to the main instruction.
+	const allInstructions = putativeInnerInstructions.reduce(
+		(acc, { index, instructions }, offset) => {
+			const insertIndex = index + 1 + offset;
+			return [...acc.slice(0, insertIndex), ...instructions, ...acc.slice(insertIndex)];
+		},
+		instructions
+	);
 
 	const [ataAddress] =
 		nonNullish(tokenAddress) && nonNullish(tokenOwnerAddress)

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -139,20 +139,26 @@ describe('sol-transactions.services', () => {
 				{ index: 2, instructions: [mockInstructions[2]] }
 			];
 
+			const expectedInnerInstructions = innerInstructions
+				.flatMap(({ instructions }) => instructions)
+				.map((instruction) => ({
+					...expected,
+					id: `${expected.id}-${instruction.programId}`
+				}))
+				.reverse();
+
 			spyFetchTransactionDetailForSignature.mockResolvedValue({
 				...mockTransactionDetail,
 				meta: { innerInstructions }
 			});
 
 			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual([
-				...innerInstructions
-					.flatMap(({ instructions }) => instructions)
-					.map((instruction) => ({
-						...expected,
-						id: `${expected.id}-${instruction.programId}`
-					}))
-					.reverse(),
-				...expectedResults
+				expectedResults[0],
+				expectedInnerInstructions[0],
+				expectedResults[1],
+				expectedInnerInstructions[1],
+				expectedResults[2],
+				expectedInnerInstructions[1]
 			]);
 
 			expect(spyMapSolParsedInstruction).toHaveBeenCalledWith({


### PR DESCRIPTION
# Motivation

Just to be more correct, we put the inner instructions right after the instruction they refer to: this will allow to have a proper cumulative balance during the parsing.