### PR TITLE
feat(frontend): reduce the number of calls of the Solana wallet

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -118,6 +118,10 @@ export const ZERO = BigNumber.from(0n);
 // Wallets
 export const WALLET_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 2) * 1000; // 30 seconds in milliseconds
 export const WALLET_PAGINATION = 10n;
+// Solana wallets
+// Until we find a way to reduce the number of calls (that we pay proportionally) done to the Solana RPC, we delay them more than the other wallets.
+// TODO: Use the normal one when we have a better way to handle the Solana wallets, for example when we have the internal Solana RPC canister, or when we don't load again the transactions that are already loaded.
+export const SOL_WALLET_TIMER_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 1000; // 1 minute in milliseconds
 
 // VIP
 export const VIP_CODE_REGENERATE_INTERVAL_IN_SECONDS = 45;

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -1,4 +1,4 @@
-import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+import { SOL_WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { SchedulerTimer, type Scheduler, type SchedulerJobData } from '$lib/schedulers/scheduler';
 import type { SolAddress } from '$lib/types/address';
 import type {
@@ -48,7 +48,7 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 
 	async start(data: PostMessageDataRequestSol | undefined) {
 		await this.timer.start<PostMessageDataRequestSol>({
-			interval: WALLET_TIMER_INTERVAL_MILLIS,
+			interval: SOL_WALLET_TIMER_INTERVAL_MILLIS,
 			job: this.syncWallet,
 			data
 		});

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -1,5 +1,5 @@
 import { DEVNET_USDC_TOKEN } from '$env/tokens/tokens-spl/tokens.usdc.env';
-import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+import { SOL_WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import type { PostMessageDataRequestSol } from '$lib/types/post-message';
 import * as authUtils from '$lib/utils/auth.utils';
 import * as solanaApi from '$sol/api/solana.api';
@@ -133,13 +133,13 @@ describe('sol-wallet.scheduler', () => {
 			);
 			expect(postMessageMock).toHaveBeenNthCalledWith(3, mockPostMessageStatusIdle);
 
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+			await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
 
 			expect(postMessageMock).toHaveBeenCalledTimes(5);
 			expect(postMessageMock).toHaveBeenNthCalledWith(4, mockPostMessageStatusInProgress);
 			expect(postMessageMock).toHaveBeenNthCalledWith(5, mockPostMessageStatusIdle);
 
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+			await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
 
 			expect(postMessageMock).toHaveBeenCalledTimes(7);
 			expect(postMessageMock).toHaveBeenNthCalledWith(6, mockPostMessageStatusInProgress);
@@ -170,12 +170,12 @@ describe('sol-wallet.scheduler', () => {
 			expect(spyLoadBalance).toHaveBeenCalledTimes(1);
 			expect(spyLoadTransactions).toHaveBeenCalledTimes(1);
 
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+			await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
 
 			expect(spyLoadBalance).toHaveBeenCalledTimes(2);
 			expect(spyLoadTransactions).toHaveBeenCalledTimes(2);
 
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+			await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
 
 			expect(spyLoadBalance).toHaveBeenCalledTimes(3);
 			expect(spyLoadTransactions).toHaveBeenCalledTimes(3);
@@ -215,7 +215,7 @@ describe('sol-wallet.scheduler', () => {
 			spyLoadSolBalance.mockResolvedValue(mockSolBalance);
 			spyLoadSplBalance.mockResolvedValue(mockSplBalance);
 
-			await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+			await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
 
 			// Only status messages should be sent
 			expect(postMessageMock).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
# Motivation

We pay the calls of the Solana RPC provider, and they are proportional to the number. It is becoming too unscalable.

So, as a temporary measure, we delay the calls of the Solana wallet scheduler to one minute (double the other wallets).

# Future improvement

This solution should be removed when we have a better one. For example, if we have a Solana RPC canister (similar to the EVM one), or when we change the code to not re-load the same transactions twice but guarantee that the data are correct.
