### PR TITLE
feat(frontend): fallback of token address for mapping Solana instructions

### DIFF
--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -67,7 +67,7 @@ export interface MappedSolTransaction {
 }
 
 export interface SolMappedTransaction {
-	value: bigint | undefined;
+	value: bigint;
 	from: SolAddress;
 	to: SolAddress;
 	tokenAddress?: SplTokenAddress;

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -129,20 +129,26 @@ const mapTokenParsedInstruction = async ({
 			encoding: 'jsonParsed'
 		}).send();
 
-		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
-			const {
-				data: {
-					parsed: { info: sourceAccoutInfo }
-				}
-			} = sourceResult;
+		const { value: destinationResult } = await getAccountInfo(address(to), {
+			encoding: 'jsonParsed'
+		}).send();
 
-			const { mint: tokenAddress } = sourceAccoutInfo as {
-				mint: SplTokenAddress;
-				owner: SolAddress;
-			};
+		const { mint: tokenAddress } = (
+			nonNullish(sourceResult)
+				? 'parsed' in sourceResult.data
+					? sourceResult.data.parsed.info
+					: {}
+				: nonNullish(destinationResult)
+					? 'parsed' in destinationResult.data
+						? destinationResult.data.parsed.info
+						: {}
+					: {}
+		) as {
+			mint: SplTokenAddress;
+			owner: SolAddress;
+		};
 
-			return { value: BigInt(value), from, to, tokenAddress };
-		}
+		return { value: BigInt(value), from, to, tokenAddress };
 	}
 
 	if (type === 'transferChecked') {
@@ -206,20 +212,26 @@ const mapToken2022ParsedInstruction = async ({
 			encoding: 'jsonParsed'
 		}).send();
 
-		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
-			const {
-				data: {
-					parsed: { info: sourceAccoutInfo }
-				}
-			} = sourceResult;
+		const { value: destinationResult } = await getAccountInfo(address(to), {
+			encoding: 'jsonParsed'
+		}).send();
 
-			const { mint: tokenAddress } = sourceAccoutInfo as {
-				mint: SplTokenAddress;
-				owner: SolAddress;
-			};
+		const { mint: tokenAddress } = (
+			nonNullish(sourceResult)
+				? 'parsed' in sourceResult.data
+					? sourceResult.data.parsed.info
+					: {}
+				: nonNullish(destinationResult)
+					? 'parsed' in destinationResult.data
+						? destinationResult.data.parsed.info
+						: {}
+					: {}
+		) as {
+			mint: SplTokenAddress;
+			owner: SolAddress;
+		};
 
-			return { value: BigInt(value), from, to, tokenAddress };
-		}
+		return { value: BigInt(value), from, to, tokenAddress };
 	}
 
 	if (type === 'transferChecked') {

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -132,11 +132,11 @@ const mapTokenParsedInstruction = async ({
 		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
 			const {
 				data: {
-					parsed: { info }
+					parsed: { info: sourceInfo }
 				}
 			} = sourceResult;
 
-			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+			const { mint: tokenAddress } = sourceInfo as { mint: SplTokenAddress };
 
 			return { value: BigInt(value), from, to, tokenAddress };
 		}
@@ -148,11 +148,11 @@ const mapTokenParsedInstruction = async ({
 		if (nonNullish(destinationResult) && 'parsed' in destinationResult.data) {
 			const {
 				data: {
-					parsed: { info }
+					parsed: { info: destinationInfo }
 				}
 			} = destinationResult;
 
-			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+			const { mint: tokenAddress } = destinationInfo as { mint: SplTokenAddress };
 
 			return { value: BigInt(value), from, to, tokenAddress };
 		}
@@ -222,11 +222,11 @@ const mapToken2022ParsedInstruction = async ({
 		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
 			const {
 				data: {
-					parsed: { info }
+					parsed: { info: sourceInfo }
 				}
 			} = sourceResult;
 
-			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+			const { mint: tokenAddress } = sourceInfo as { mint: SplTokenAddress };
 
 			return { value: BigInt(value), from, to, tokenAddress };
 		}
@@ -238,11 +238,11 @@ const mapToken2022ParsedInstruction = async ({
 		if (nonNullish(destinationResult) && 'parsed' in destinationResult.data) {
 			const {
 				data: {
-					parsed: { info }
+					parsed: { info: destinationInfo }
 				}
 			} = destinationResult;
 
-			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+			const { mint: tokenAddress } = destinationInfo as { mint: SplTokenAddress };
 
 			return { value: BigInt(value), from, to, tokenAddress };
 		}

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -129,26 +129,33 @@ const mapTokenParsedInstruction = async ({
 			encoding: 'jsonParsed'
 		}).send();
 
+		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
+			const {
+				data: {
+					parsed: { info }
+				}
+			} = sourceResult;
+
+			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+
+			return { value: BigInt(value), from, to, tokenAddress };
+		}
+
 		const { value: destinationResult } = await getAccountInfo(address(to), {
 			encoding: 'jsonParsed'
 		}).send();
 
-		const { mint: tokenAddress } = (
-			nonNullish(sourceResult)
-				? 'parsed' in sourceResult.data
-					? sourceResult.data.parsed.info
-					: {}
-				: nonNullish(destinationResult)
-					? 'parsed' in destinationResult.data
-						? destinationResult.data.parsed.info
-						: {}
-					: {}
-		) as {
-			mint: SplTokenAddress;
-			owner: SolAddress;
-		};
+		if (nonNullish(destinationResult) && 'parsed' in destinationResult.data) {
+			const {
+				data: {
+					parsed: { info }
+				}
+			} = destinationResult;
 
-		return { value: BigInt(value), from, to, tokenAddress };
+			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+
+			return { value: BigInt(value), from, to, tokenAddress };
+		}
 	}
 
 	if (type === 'transferChecked') {
@@ -212,26 +219,33 @@ const mapToken2022ParsedInstruction = async ({
 			encoding: 'jsonParsed'
 		}).send();
 
+		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
+			const {
+				data: {
+					parsed: { info }
+				}
+			} = sourceResult;
+
+			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+
+			return { value: BigInt(value), from, to, tokenAddress };
+		}
+
 		const { value: destinationResult } = await getAccountInfo(address(to), {
 			encoding: 'jsonParsed'
 		}).send();
 
-		const { mint: tokenAddress } = (
-			nonNullish(sourceResult)
-				? 'parsed' in sourceResult.data
-					? sourceResult.data.parsed.info
-					: {}
-				: nonNullish(destinationResult)
-					? 'parsed' in destinationResult.data
-						? destinationResult.data.parsed.info
-						: {}
-					: {}
-		) as {
-			mint: SplTokenAddress;
-			owner: SolAddress;
-		};
+		if (nonNullish(destinationResult) && 'parsed' in destinationResult.data) {
+			const {
+				data: {
+					parsed: { info }
+				}
+			} = destinationResult;
 
-		return { value: BigInt(value), from, to, tokenAddress };
+			const { mint: tokenAddress } = info as { mint: SplTokenAddress };
+
+			return { value: BigInt(value), from, to, tokenAddress };
+		}
 	}
 
 	if (type === 'transferChecked') {


### PR DESCRIPTION
# Motivation

It is useful to have a fallback for the token address when mapping a Token program instruction. So we use the `destination` mint info as fallback, in the same way we use the `source` one.