### PR TITLE
feat(frontend): calculate cumulative balances when parsing Solana transactions

### DIFF
--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -45,6 +45,7 @@ describe('sol-transactions.services', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.resetAllMocks();
+		vi.resetAllMocks();
 
 		solTransactionsStore.reset(SOLANA_TOKEN_ID);
 		spyGetTransactions = vi.spyOn(solSignaturesServices, 'getSolTransactions');
@@ -63,8 +64,10 @@ describe('sol-transactions.services', () => {
 
 		const mockTransactionDetail: SolRpcTransactionRaw = mockSolRpcSendTransaction;
 
+		const mockValue = 123n;
+
 		const mockMappedTransaction: SolMappedTransaction = {
-			value: 123n,
+			value: mockValue,
 			from: mockSolAddress,
 			to: mockSolAddress2
 		};
@@ -92,6 +95,10 @@ describe('sol-transactions.services', () => {
 		let spyMapSolParsedInstruction: MockInstance;
 
 		beforeEach(() => {
+			vi.clearAllMocks();
+			vi.resetAllMocks();
+			vi.resetAllMocks();
+
 			spyFetchTransactionDetailForSignature = vi.spyOn(
 				solanaApi,
 				'fetchTransactionDetailForSignature'
@@ -125,10 +132,30 @@ describe('sol-transactions.services', () => {
 		it('should process instructions and return transactions', async () => {
 			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(expectedResults);
 
-			expect(spyMapSolParsedInstruction).toHaveBeenCalledWith({
+			expect(spyMapSolParsedInstruction).toHaveBeenCalledTimes(3);
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(1, {
 				instruction: { ...mockInstructions[0], programAddress: mockInstructions[0].programId },
 				innerInstructions: [],
-				network
+				network,
+				cumulativeBalances: {}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(2, {
+				instruction: { ...mockInstructions[1], programAddress: mockInstructions[1].programId },
+				innerInstructions: [],
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue,
+					[mockSolAddress2]: mockValue
+				}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(3, {
+				instruction: { ...mockInstructions[2], programAddress: mockInstructions[2].programId },
+				innerInstructions: [],
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue * 2n,
+					[mockSolAddress2]: mockValue * 2n
+				}
 			});
 		});
 
@@ -161,7 +188,8 @@ describe('sol-transactions.services', () => {
 				expectedInnerInstructions[1]
 			]);
 
-			expect(spyMapSolParsedInstruction).toHaveBeenCalledWith({
+			expect(spyMapSolParsedInstruction).toHaveBeenCalledTimes(6);
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(1, {
 				instruction: {
 					...mockInstructions[0],
 					programAddress: mockInstructions[0].programId
@@ -170,7 +198,74 @@ describe('sol-transactions.services', () => {
 					...innerInstruction,
 					programAddress: innerInstruction.programId
 				})),
-				network
+				network,
+				cumulativeBalances: {}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(2, {
+				instruction: innerInstructions[0].instructions.map((innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				}))[0],
+				innerInstructions: innerInstructions[1].instructions.map((innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				})),
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue,
+					[mockSolAddress2]: mockValue
+				}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(3, {
+				instruction: {
+					...mockInstructions[1],
+					programAddress: mockInstructions[1].programId
+				},
+				innerInstructions: innerInstructions[2].instructions.map((innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				})),
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue * 2n,
+					[mockSolAddress2]: mockValue * 2n
+				}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(4, {
+				instruction: innerInstructions[1].instructions.map((innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				}))[0],
+				innerInstructions: [],
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue * 3n,
+					[mockSolAddress2]: mockValue * 3n
+				}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(5, {
+				instruction: {
+					...mockInstructions[2],
+					programAddress: mockInstructions[2].programId
+				},
+				innerInstructions: [],
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue * 4n,
+					[mockSolAddress2]: mockValue * 4n
+				}
+			});
+			expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(6, {
+				instruction: innerInstructions[2].instructions.map((innerInstruction) => ({
+					...innerInstruction,
+					programAddress: innerInstruction.programId
+				}))[0],
+				innerInstructions: [],
+				network,
+				cumulativeBalances: {
+					[mockSolAddress]: -mockValue * 5n,
+					[mockSolAddress2]: mockValue * 5n
+				}
 			});
 		});
 


### PR DESCRIPTION
# Motivation

The redeemed SOL value of a Solana `closeAccount` transaction is not explicitly indicated in the transaction data. So it must be inferred/calculated from the latest SOL balance of the ATA that is being closed.

After PR https://github.com/dfinity/oisy-wallet/pull/5056 , we can provide the accumulated balances to the mapper.

To calculate them we keep a record in the `reduce` function: every instruction inside a generic transaction will affect the cumulative SOL balance of each address.

It is guaranteed to be progressive since the RPC returns the list of instructions in the correct internal chronological order. 

The redeemed SOL value is the latest total SOL balance of the closed Associated Token Account.

NOTE: We include WSOL in the calculation, because it is used to affect the SOL balance of the ATA.


# Changes

<!-- List the changes that have been developed -->

# Tests

Apart from expanding the current tests, we verified with a [practical transaction](https://solscan.io/tx/inspector?txhash=4E88TD8dpeivGbAn83DQcfQYyBcPF869Q9Nw9xfRvbZMDB46EMwC8FEqidJ5PoCZRSZVrBJJz486Ncju7duD3kwn) comparing our results with Solscan.

![Screenshot 2025-03-06 at 22 40 33](https://github.com/user-attachments/assets/15332bc9-9f50-46e4-af1a-8b7bd597c31f)
![Screenshot 2025-03-06 at 22 41 56](https://github.com/user-attachments/assets/284bdc86-13f4-4724-a18f-f0401f1a4968)

