### PR TITLE
feat(frontend): remove recursive usage of inner instructions

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -8,12 +8,11 @@ import type { SolAddress } from '$lib/types/address';
 import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
 import { getSolTransactions } from '$sol/services/sol-signatures.services';
 import {
-	solTransactionsStore,
-	type SolCertifiedTransaction
+	type SolCertifiedTransaction,
+	solTransactionsStore
 } from '$sol/stores/sol-transactions.store';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
-import type { SolRpcInstruction } from '$sol/types/sol-instructions';
 import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
@@ -80,16 +79,6 @@ export const fetchSolTransactionsForSignature = async ({
 		}>
 	>(
 		async (acc, instruction, idx) => {
-			const innerInstructionsRaw =
-				putativeInnerInstructions.find(({ index }) => index === idx)?.instructions ?? [];
-
-			const innerInstructions: SolRpcInstruction[] = innerInstructionsRaw.map(
-				(innerInstruction) => ({
-					...innerInstruction,
-					programAddress: innerInstruction.programId
-				})
-			);
-
 			const { parsedTransactions } = await acc;
 
 			const mappedTransaction = await mapSolParsedInstruction({
@@ -97,7 +86,6 @@ export const fetchSolTransactionsForSignature = async ({
 					...instruction,
 					programAddress: instruction.programId
 				},
-				innerInstructions,
 				network
 			});
 
@@ -119,7 +107,7 @@ export const fetchSolTransactionsForSignature = async ({
 			}
 
 			const newTransaction: SolTransactionUi = {
-				id: `${signature.signature}-${instruction.programId}`,
+				id: `${signature.signature}-${idx}-${instruction.programId}`,
 				signature: signature.signature,
 				timestamp: blockTime ?? 0n,
 				value,

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -14,8 +14,6 @@ import {
 } from '$sol/stores/sol-transactions.store';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
-import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
-import type { SolRpcInstruction } from '$sol/types/sol-instructions';
 import type {
 	SolMappedTransaction,
 	SolSignature,

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -8,8 +8,8 @@ import type { SolAddress } from '$lib/types/address';
 import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
 import { getSolTransactions } from '$sol/services/sol-signatures.services';
 import {
-	type SolCertifiedTransaction,
-	solTransactionsStore
+	solTransactionsStore,
+	type SolCertifiedTransaction
 } from '$sol/stores/sol-transactions.store';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -84,6 +84,21 @@ const mapSystemParsedInstruction = ({
 	type: string;
 	info: object;
 }): SolMappedTransaction | undefined => {
+	if (type === 'createAccount') {
+		// We need to cast the type since it is not implied
+		const {
+			source: from,
+			newAccount: to,
+			lamports: value
+		} = info as {
+			source: SolAddress;
+			newAccount: SolAddress;
+			lamports: bigint;
+		};
+
+		return { value, from, to };
+	}
+
 	if (type === 'transfer') {
 		// We need to cast the type since it is not implied
 		const {
@@ -243,49 +258,23 @@ const mapToken2022ParsedInstruction = async ({
 };
 
 const mapAssociatedTokenAccountInstruction = ({
-	type,
-	innerInstructions
+	type
 }: {
 	type: string;
-	innerInstructions?: SolRpcInstruction[];
 }): SolMappedTransaction | undefined => {
 	if (type === 'create' || type === 'createIdempotent') {
-		if (isNullish(innerInstructions) || innerInstructions.length < 0) {
-			return;
-		}
-
-		const valueInnerInstruction = innerInstructions.find(
-			(instruction) => 'parsed' in instruction && instruction.parsed.type === 'createAccount'
-		);
-
-		if (isNullish(valueInnerInstruction) || !('parsed' in valueInnerInstruction)) {
-			return;
-		}
-
-		// We need to cast the type since it is not implied
-		const {
-			source: from,
-			newAccount: to,
-			lamports: value
-		} = valueInnerInstruction.parsed.info as {
-			source: SolAddress;
-			newAccount: SolAddress;
-			lamports: bigint;
-		};
-
-		return { value, from, to };
+		// We don't need to map the instruction since it is not relevant for the user
+		return;
 	}
 };
 
 export const mapSolParsedInstruction = async ({
 	instruction,
 	network,
-	innerInstructions,
 	cumulativeBalances
 }: {
 	instruction: SolRpcInstruction;
 	network: SolanaNetworkType;
-	innerInstructions?: SolRpcInstruction[];
 	cumulativeBalances?: Record<SolAddress, SolMappedTransaction['value']>;
 }): Promise<SolMappedTransaction | undefined> => {
 	if (!('parsed' in instruction)) {
@@ -314,7 +303,7 @@ export const mapSolParsedInstruction = async ({
 	}
 
 	if (programAddress === ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS) {
-		return mapAssociatedTokenAccountInstruction({ type, innerInstructions });
+		return mapAssociatedTokenAccountInstruction({ type });
 	}
 
 	// It is useful to receive feedback when we are not able to map an instruction

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -374,51 +374,7 @@ describe('sol-instructions.utils', () => {
 				parsed: { type: 'create', info: {} }
 			};
 
-			const mockInnerInstruction: SolRpcInstruction = {
-				parsed: {
-					type: 'createAccount',
-					info: {
-						source: mockSolAddress,
-						newAccount: mockSolAddress2,
-						lamports: 200n
-					}
-				},
-				program: 'mock-program',
-				programId: address(SYSTEM_PROGRAM_ADDRESS),
-				programAddress: address(SYSTEM_PROGRAM_ADDRESS)
-			};
-
-			const mockInnerInstructions: SolRpcInstruction[] = [mockInnerInstruction];
-
 			it('should map a valid `create` instruction with inner instructions', async () => {
-				const result = await mapSolParsedInstruction({
-					instruction: mockAtaInstruction,
-					network,
-					innerInstructions: mockInnerInstructions
-				});
-
-				expect(result).toEqual({
-					value: 200n,
-					from: mockSolAddress,
-					to: mockSolAddress2
-				});
-			});
-
-			it('should map a valid `createIdempotent` instruction with inner instructions', async () => {
-				const result = await mapSolParsedInstruction({
-					instruction: { ...mockAtaInstruction, parsed: { type: 'createIdempotent', info: {} } },
-					network,
-					innerInstructions: mockInnerInstructions
-				});
-
-				expect(result).toEqual({
-					value: 200n,
-					from: mockSolAddress,
-					to: mockSolAddress2
-				});
-			});
-
-			it('should return undefined if inner instructions are undefined', async () => {
 				const result = await mapSolParsedInstruction({
 					instruction: mockAtaInstruction,
 					network
@@ -427,38 +383,10 @@ describe('sol-instructions.utils', () => {
 				expect(result).toBeUndefined();
 			});
 
-			it('should return undefined if there are no inner instructions', async () => {
+			it('should map a valid `createIdempotent` instruction with inner instructions', async () => {
 				const result = await mapSolParsedInstruction({
-					instruction: mockAtaInstruction,
-					network,
-					innerInstructions: []
-				});
-
-				expect(result).toBeUndefined();
-			});
-
-			it('should return undefined if there is no `createAccount` in the inner instructions', async () => {
-				const result = await mapSolParsedInstruction({
-					instruction: mockAtaInstruction,
-					network,
-					innerInstructions: [{ ...mockInnerInstruction, parsed: { type: 'other-type', info: {} } }]
-				});
-
-				expect(result).toBeUndefined();
-			});
-
-			it('should return undefined if the `createAccount` inner instruction is not parsed', async () => {
-				const innerInstruction: SolRpcInstruction = {
-					data: 'mock-data' as Base58EncodedBytes,
-					programId: address(SYSTEM_PROGRAM_ADDRESS),
-					programAddress: address(SYSTEM_PROGRAM_ADDRESS),
-					accounts: [address(mockSolAddress), address(mockSolAddress2)]
-				};
-
-				const result = await mapSolParsedInstruction({
-					instruction: mockAtaInstruction,
-					network,
-					innerInstructions: [innerInstruction]
+					instruction: { ...mockAtaInstruction, parsed: { type: 'createIdempotent', info: {} } },
+					network
 				});
 
 				expect(result).toBeUndefined();


### PR DESCRIPTION
# Motivation

The inner instructions are being already treated as the other instructions, since we merge them together and pass to the mapper.

So we remove them from the usage as additional parsable transaction.
