### PR TITLE
feat(frontend): map Solana transaction createAccount directly

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -84,6 +84,21 @@ const mapSystemParsedInstruction = ({
 	type: string;
 	info: object;
 }): SolMappedTransaction | undefined => {
+	if (type === 'createAccount') {
+		// We need to cast the type since it is not implied
+		const {
+			source: from,
+			newAccount: to,
+			lamports: value
+		} = info as {
+			source: SolAddress;
+			newAccount: SolAddress;
+			lamports: bigint;
+		};
+
+		return { value, from, to };
+	}
+
 	if (type === 'transfer') {
 		// We need to cast the type since it is not implied
 		const {

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -87,22 +87,48 @@ describe('sol-instructions.utils', () => {
 		});
 
 		describe('with a System parsed instruction', () => {
-			const mockSystemInstruction: SolRpcInstruction = {
-				...mockInstruction,
-				programAddress: address(SYSTEM_PROGRAM_ADDRESS),
-				parsed: {
-					type: 'transfer',
-					info: {
-						destination: 'toAddress',
-						lamports: 100n,
-						source: 'fromAddress'
+			it('should map a valid `createAccount` instruction', async () => {
+				const mockCreateAccountInstruction: SolRpcInstruction = {
+					...mockInstruction,
+					programAddress: address(SYSTEM_PROGRAM_ADDRESS),
+					parsed: {
+						type: 'createAccount',
+						info: {
+							newAccount: 'toAddress',
+							lamports: 100n,
+							source: 'fromAddress'
+						}
 					}
-				}
-			};
+				};
+
+				const result = await mapSolParsedInstruction({
+					instruction: mockCreateAccountInstruction,
+					network
+				});
+
+				expect(result).toEqual({
+					value: 100n,
+					from: 'fromAddress',
+					to: 'toAddress'
+				});
+			});
 
 			it('should map a valid `transfer` instruction', async () => {
+				const mockTransferInstruction: SolRpcInstruction = {
+					...mockInstruction,
+					programAddress: address(SYSTEM_PROGRAM_ADDRESS),
+					parsed: {
+						type: 'transfer',
+						info: {
+							destination: 'toAddress',
+							lamports: 100n,
+							source: 'fromAddress'
+						}
+					}
+				};
+
 				const result = await mapSolParsedInstruction({
-					instruction: mockSystemInstruction,
+					instruction: mockTransferInstruction,
 					network
 				});
 
@@ -115,7 +141,11 @@ describe('sol-instructions.utils', () => {
 
 			it('should return undefined for non-mapped instruction', async () => {
 				const result = await mapSolParsedInstruction({
-					instruction: { ...mockSystemInstruction, parsed: { type: 'other-type', info: {} } },
+					instruction: {
+						...mockInstruction,
+						programAddress: address(SYSTEM_PROGRAM_ADDRESS),
+						parsed: { type: 'other-type', info: {} }
+					},
 					network
 				});
 


### PR DESCRIPTION
# Motivation

We want to map directly the createAccount transaction from the Solana RPC.
