### PR TITLE
feat(devops): Add audit to the list of networks

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -23,6 +23,7 @@ on:
           - test_fe_3
           - test_fe_4
           - test_be_1
+          - audit
       canister:
         required: true
         type: choice


### PR DESCRIPTION
# Motivation
There is a new network called "audit".  This PR adds it to the list of networks that can be deployed with CI.

# Changes
- Add audit to the list of networks in `deploy-to-environment.yml`

# Tests
