### PR TITLE
feat(frontend): extend convert store

### DIFF
--- a/src/frontend/src/lib/stores/convert.store.ts
+++ b/src/frontend/src/lib/stores/convert.store.ts
@@ -1,6 +1,18 @@
+import { ethereumToken } from '$eth/derived/token.derived';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
+import { ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
+import { ckEthMinterInfoStore, type CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
+import { ethereumFeeTokenCkEth } from '$icp/derived/ethereum-fee.derived';
+import { ckBtcMinterInfoStore, type CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
+import {
+	isTokenCkBtcLedger,
+	isTokenCkErc20Ledger,
+	isTokenCkEthLedger
+} from '$icp/utils/ic-send.utils';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token } from '$lib/types/token';
+import type { Option } from '$lib/types/utils';
 import { BigNumber } from '@ethersproject/bignumber';
 import { derived, writable, type Readable } from 'svelte/store';
 
@@ -33,13 +45,41 @@ export const initConvertContext = (convertData: ConvertData): ConvertContext => 
 		([$exchanges, $destinationToken]) => $exchanges?.[$destinationToken.id]?.usd
 	);
 
+	const balanceForFee = derived(
+		[sourceToken, balancesStore, ethereumToken, ethereumFeeTokenCkEth, ckEthereumNativeToken],
+		([
+			$sourceToken,
+			$balancesStore,
+			$ethereumToken,
+			$ethereumFeeTokenCkEth,
+			$ckEthereumNativeToken
+		]) =>
+			isTokenErc20($sourceToken)
+				? $balancesStore?.[$ethereumToken.id]?.data
+				: isTokenCkErc20Ledger($sourceToken)
+					? $balancesStore?.[($ethereumFeeTokenCkEth ?? $ckEthereumNativeToken).id]?.data
+					: undefined
+	);
+
+	const minterInfo = derived(
+		[sourceToken, ckEthMinterInfoStore, ckBtcMinterInfoStore, ckEthereumNativeToken],
+		([$sourceToken, $ckEthMinterInfoStore, $ckBtcMinterInfoStore, $ckEthereumNativeToken]) =>
+			isTokenCkEthLedger($sourceToken)
+				? $ckEthMinterInfoStore?.[$ckEthereumNativeToken.id]
+				: isTokenCkBtcLedger($sourceToken)
+					? $ckBtcMinterInfoStore?.[$sourceToken.id]
+					: undefined
+	);
+
 	return {
 		sourceToken,
 		destinationToken,
 		sourceTokenBalance,
 		destinationTokenBalance,
 		sourceTokenExchangeRate,
-		destinationTokenExchangeRate
+		destinationTokenExchangeRate,
+		balanceForFee,
+		minterInfo
 	};
 };
 
@@ -48,8 +88,10 @@ export interface ConvertContext {
 	destinationToken: Readable<Token>;
 	sourceTokenBalance: Readable<BigNumber | undefined>;
 	destinationTokenBalance: Readable<BigNumber | undefined>;
+	balanceForFee: Readable<BigNumber | undefined>;
 	sourceTokenExchangeRate: Readable<number | undefined>;
 	destinationTokenExchangeRate: Readable<number | undefined>;
+	minterInfo: Readable<Option<CkBtcMinterInfoData | CkEthMinterInfoData>>;
 }
 
 export const CONVERT_CONTEXT_KEY = Symbol('convert');

--- a/src/frontend/src/tests/lib/stores/convert.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/convert.store.spec.ts
@@ -1,12 +1,26 @@
-import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import {
+	LOCAL_CKBTC_LEDGER_CANISTER_ID,
+	LOCAL_CKETH_LEDGER_CANISTER_ID,
+	LOCAL_CKUSDC_LEDGER_CANISTER_ID
+} from '$env/networks/networks.icrc.env';
+import { ETHEREUM_TOKEN, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
+import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
+import type { IcCkToken } from '$icp/types/ic-token';
 import * as exchanges from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { initConvertContext } from '$lib/stores/convert.store';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockCkBtcMinterInfo as mockCkBtcMinterInfoData } from '$tests/mocks/ckbtc.mock';
+import { createMockErc20Tokens } from '$tests/mocks/erc20-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
+import type { MinterInfo as CkEthMinterInfo } from '@dfinity/cketh';
 import { BigNumber } from 'alchemy-sdk';
 import { get, readable } from 'svelte/store';
+import { vi } from 'vitest';
 
 const ethExchangeValue = 1;
 const icpExchangeValue = 2;
@@ -39,7 +53,9 @@ describe('convertStore', () => {
 			sourceTokenExchangeRate,
 			destinationTokenExchangeRate,
 			destinationTokenBalance,
-			destinationToken
+			destinationToken,
+			balanceForFee,
+			minterInfo
 		} = initConvertContext({
 			destinationToken: ETHEREUM_TOKEN,
 			sourceToken: ICP_TOKEN
@@ -64,5 +80,80 @@ describe('convertStore', () => {
 
 		expect(get(sourceTokenExchangeRate)).toStrictEqual(icpExchangeValue);
 		expect(get(destinationTokenExchangeRate)).toStrictEqual(ethExchangeValue);
+
+		expect(get(balanceForFee)).toStrictEqual(undefined);
+		expect(get(minterInfo)).toStrictEqual(undefined);
+	});
+
+	it('should have balance for fee set if sourceToken is ERC20', () => {
+		const ethBalance = BigNumber.from(1n);
+		balancesStore.set({
+			tokenId: SEPOLIA_TOKEN_ID,
+			data: { data: ethBalance, certified: true }
+		});
+
+		const { balanceForFee } = initConvertContext({
+			destinationToken: ETHEREUM_TOKEN,
+			sourceToken: createMockErc20Tokens({ n: 1, networkEnv: 'testnet' })[0]
+		});
+
+		expect(get(balanceForFee)).toStrictEqual(ethBalance);
+	});
+
+	it('should have balance for fee set if sourceToken is ckERC20', () => {
+		const ckEthBalance = BigNumber.from(1n);
+		balancesStore.set({
+			tokenId: parseTokenId('ckETH'),
+			data: { data: ckEthBalance, certified: true }
+		});
+
+		const { balanceForFee } = initConvertContext({
+			destinationToken: ETHEREUM_TOKEN,
+			sourceToken: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKUSDC_LEDGER_CANISTER_ID
+			} as IcCkToken
+		});
+
+		expect(get(balanceForFee)).toStrictEqual(ckEthBalance);
+	});
+
+	it('should have minter info fee set if sourceToken is ckETH', () => {
+		const mockCkEthMinterInfo = {
+			data: { minimum_withdrawal_amount: [500n] } as CkEthMinterInfo,
+			certified: true
+		};
+		ckEthMinterInfoStore.set({
+			tokenId: SEPOLIA_TOKEN_ID,
+			data: mockCkEthMinterInfo
+		});
+
+		const { minterInfo } = initConvertContext({
+			destinationToken: ETHEREUM_TOKEN,
+			sourceToken: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKETH_LEDGER_CANISTER_ID
+			} as IcCkToken
+		});
+
+		expect(get(minterInfo)).toStrictEqual(mockCkEthMinterInfo);
+	});
+
+	it('should have minter info fee set if sourceToken is ckBTC', () => {
+		const mockCkBtcMinterInfo = { data: mockCkBtcMinterInfoData, certified: true };
+		ckBtcMinterInfoStore.set({
+			tokenId: mockValidToken.id,
+			data: mockCkBtcMinterInfo
+		});
+
+		const { minterInfo } = initConvertContext({
+			destinationToken: ETHEREUM_TOKEN,
+			sourceToken: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKBTC_LEDGER_CANISTER_ID
+			} as IcCkToken
+		});
+
+		expect(get(minterInfo)).toStrictEqual(mockCkBtcMinterInfo);
 	});
 });


### PR DESCRIPTION
# Motivation

In this PR, I'm extending the Convert store with some data needed for ckERC/ckBTC/ckETH conversions.

# Changes

1. Add `balanceForFee` to the store.
2. Add `minterInfo` to the store.

# Tests

Tests are updated.
