### PR TITLE
feat(frontend): user-amount utils

### DIFF
--- a/src/frontend/src/lib/utils/user-amount.utils.ts
+++ b/src/frontend/src/lib/utils/user-amount.utils.ts
@@ -1,0 +1,102 @@
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
+import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
+import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
+import {
+	isTokenCkBtcLedger,
+	isTokenCkErc20Ledger,
+	isTokenCkEthLedger
+} from '$icp/utils/ic-send.utils';
+import { ZERO } from '$lib/constants/app.constants';
+import type { ConvertAmountErrorType } from '$lib/types/convert';
+import type { Token } from '$lib/types/token';
+import type { Option } from '$lib/types/utils';
+import {
+	assertAmount,
+	assertCkBtcAmount,
+	assertCkErc20Amount,
+	assertCkEthAmount,
+	assertErc20Amount
+} from '$lib/utils/assert-amount.utils';
+import { formatToken } from '$lib/utils/format.utils';
+import { nonNullish } from '@dfinity/utils';
+import { BigNumber } from '@ethersproject/bignumber';
+import { Utils } from 'alchemy-sdk';
+
+export const validateUserAmount = ({
+	userAmount,
+	token,
+	balance,
+	fee,
+	balanceForFee,
+	ethereumEstimateFee,
+	minterInfo,
+	isSwapFlow = false
+}: {
+	userAmount: BigNumber;
+	token: Token;
+	balance?: BigNumber;
+	balanceForFee?: BigNumber;
+	fee?: bigint;
+	ethereumEstimateFee?: bigint;
+	minterInfo?: Option<CkBtcMinterInfoData | CkEthMinterInfoData>;
+	isSwapFlow?: boolean;
+}): ConvertAmountErrorType => {
+	// We should align balance and userAmount to avoid issues caused by comparing formatted and unformatted BN
+	const parsedSendBalance = nonNullish(balance)
+		? Utils.parseUnits(
+				formatToken({
+					value: balance,
+					unitName: token.decimals,
+					displayDecimals: token.decimals
+				}),
+				token.decimals
+			)
+		: ZERO;
+
+	// if the function called in the swap flow, we only need to check the basic assertAmount condition
+	// if convert or send - we identify token type and check some network-specific conditions
+	if (!isSwapFlow) {
+		if (isTokenErc20(token)) {
+			return assertErc20Amount({
+				userAmount,
+				balance: parsedSendBalance,
+				balanceForFee: balanceForFee ?? ZERO,
+				fee
+			});
+		}
+
+		if (isTokenCkBtcLedger(token)) {
+			return assertCkBtcAmount({
+				userAmount,
+				balance: parsedSendBalance,
+				minterInfo,
+				fee
+			});
+		}
+
+		if (isTokenCkEthLedger(token)) {
+			return assertCkEthAmount({
+				userAmount,
+				balance: parsedSendBalance,
+				minterInfo,
+				fee
+			});
+		}
+
+		if (isTokenCkErc20Ledger(token)) {
+			return assertCkErc20Amount({
+				userAmount,
+				balance: parsedSendBalance,
+				balanceForFee: balanceForFee ?? ZERO,
+				ethereumEstimateFee,
+				fee
+			});
+		}
+	}
+
+	return assertAmount({
+		userAmount,
+		balance: parsedSendBalance,
+		fee
+	});
+};

--- a/src/frontend/src/tests/lib/utils/user-amount.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/user-amount.utils.spec.ts
@@ -1,0 +1,181 @@
+import {
+	LOCAL_CKBTC_LEDGER_CANISTER_ID,
+	LOCAL_CKETH_LEDGER_CANISTER_ID,
+	LOCAL_CKUSDC_LEDGER_CANISTER_ID
+} from '$env/networks/networks.icrc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import type { IcCkToken } from '$icp/types/ic-token';
+import * as assertAmountUtils from '$lib/utils/assert-amount.utils';
+import { validateUserAmount } from '$lib/utils/user-amount.utils';
+import { mockCkBtcMinterInfo as mockCkBtcMinterInfoData } from '$tests/mocks/ckbtc.mock';
+import { createMockErc20Tokens } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
+import type { MinterInfo as CkEthMinterInfo } from '@dfinity/cketh/dist/candid/minter';
+import { BigNumber } from 'alchemy-sdk';
+import { vi, type MockInstance } from 'vitest';
+
+describe('validateUserAmount', () => {
+	const userAmount = BigNumber.from(200000n);
+	const balance = BigNumber.from(9000000n);
+	const fee = 10000n;
+	const mockCkEthMinterInfo = {
+		data: { minimum_withdrawal_amount: [500n] } as CkEthMinterInfo,
+		certified: true
+	};
+	const mockCkBtcMinterInfo = {
+		data: mockCkBtcMinterInfoData,
+		certified: true
+	};
+
+	let assertErc20AmountSpy: MockInstance;
+	let assertCkErc20AmountSpy: MockInstance;
+	let assertCkEthAmountSpy: MockInstance;
+	let assertCkBtcAmountSpy: MockInstance;
+	let assertAmountSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		assertErc20AmountSpy = vi.spyOn(assertAmountUtils, 'assertErc20Amount');
+		assertCkErc20AmountSpy = vi.spyOn(assertAmountUtils, 'assertCkErc20Amount');
+		assertCkEthAmountSpy = vi.spyOn(assertAmountUtils, 'assertCkEthAmount');
+		assertCkBtcAmountSpy = vi.spyOn(assertAmountUtils, 'assertCkBtcAmount');
+		assertAmountSpy = vi.spyOn(assertAmountUtils, 'assertAmount');
+	});
+
+	it('should call assertErc20Amount if token is erc20', () => {
+		validateUserAmount({
+			userAmount,
+			token: createMockErc20Tokens({ n: 1, networkEnv: 'testnet' })[0],
+			balance,
+			balanceForFee: balance,
+			fee
+		});
+
+		expect(assertErc20AmountSpy).toHaveBeenCalledOnce();
+		expect(assertErc20AmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			balanceForFee: balance,
+			fee
+		});
+	});
+
+	it('should call mockedAssertCkErc20Amount if token is ckErc20', () => {
+		validateUserAmount({
+			userAmount,
+			token: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKUSDC_LEDGER_CANISTER_ID
+			} as IcCkToken,
+			balance,
+			balanceForFee: balance,
+			fee,
+			ethereumEstimateFee: fee
+		});
+
+		expect(assertCkErc20AmountSpy).toHaveBeenCalledOnce();
+		expect(assertCkErc20AmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			balanceForFee: balance,
+			fee,
+			ethereumEstimateFee: fee
+		});
+	});
+
+	it('should call assertCkEthAmountSpy if token is ckETH', () => {
+		validateUserAmount({
+			userAmount,
+			token: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKETH_LEDGER_CANISTER_ID
+			} as IcCkToken,
+			balance,
+			fee,
+			minterInfo: mockCkEthMinterInfo
+		});
+
+		expect(assertCkEthAmountSpy).toHaveBeenCalledOnce();
+		expect(assertCkEthAmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			fee,
+			minterInfo: mockCkEthMinterInfo
+		});
+	});
+
+	it('should call assertCkBtcAmountSpy if token is ckETH', () => {
+		validateUserAmount({
+			userAmount,
+			token: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKBTC_LEDGER_CANISTER_ID
+			} as IcCkToken,
+			balance,
+			fee,
+			minterInfo: mockCkBtcMinterInfo
+		});
+
+		expect(assertCkBtcAmountSpy).toHaveBeenCalledOnce();
+		expect(assertCkBtcAmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			fee,
+			minterInfo: mockCkBtcMinterInfo
+		});
+	});
+
+	it('should call assertAmount if token is ETH', () => {
+		validateUserAmount({
+			userAmount,
+			token: ETHEREUM_TOKEN,
+			balance,
+			fee
+		});
+
+		expect(assertAmountSpy).toHaveBeenCalledOnce();
+		expect(assertAmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			fee
+		});
+	});
+
+	it('should call assertAmount if token is BTC', () => {
+		validateUserAmount({
+			userAmount,
+			token: BTC_MAINNET_TOKEN,
+			balance,
+			fee
+		});
+
+		expect(assertAmountSpy).toHaveBeenCalledOnce();
+		expect(assertAmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			fee
+		});
+	});
+
+	it('should call assertAmount if it is called from the swap flow', () => {
+		validateUserAmount({
+			userAmount,
+			token: {
+				...mockValidToken,
+				ledgerCanisterId: LOCAL_CKBTC_LEDGER_CANISTER_ID
+			} as IcCkToken,
+			balance,
+			fee,
+			isSwapFlow: true
+		});
+
+		expect(assertAmountSpy).toHaveBeenCalledOnce();
+		expect(assertAmountSpy).toBeCalledWith({
+			userAmount,
+			balance,
+			fee
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

In this PR, the user-amount utils are created. They are gonna replace the existing `convert.utils`. `validateUserAmount` is implemented the way that it can be used in swap, send and convert flow. 

In the next PR, I will remove the old file and update SwapForm and ConvertAmountSource to start using this method.

# Changes

New util is created.

# Tests

Provided.
