### PR TITLE
feat(ci): include config result in may-merge status check

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -104,7 +104,7 @@ jobs:
 
   may-merge:
     if: always()
-    needs: [ 'format', 'lint', 'check', 'test', 'config' ]
+    needs: ['format', 'lint', 'check', 'test', 'config']
     runs-on: ubuntu-24.04
     steps:
       - name: Cleared for merging

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -104,12 +104,12 @@ jobs:
 
   may-merge:
     if: always()
-    needs: ['format', 'lint', 'check', 'test', 'config']
+    needs: [ 'format', 'lint', 'check', 'test', 'config' ]
     runs-on: ubuntu-24.04
     steps:
       - name: Cleared for merging
         run: |
-          if [ "${{ needs.format.result }}" == "success" ] && [ "${{ needs.lint.result }}" == "success" ] && [ "${{ needs.check.result }}" == "success" ] && [ "${{ needs.test.result }}" == "success" ]; then
+          if [ "${{ needs.format.result }}" == "success" ] && [ "${{ needs.lint.result }}" == "success" ] && [ "${{ needs.check.result }}" == "success" ] && [ "${{ needs.test.result }}" == "success" ] && [ "${{ needs.config.result }}" == "success" ]; then
             echo "This PR is cleared for merging"
           else
             echo "This PR is not cleared for merging"


### PR DESCRIPTION
# Motivation

The `config` step was missing int the `may-merge` status check.
