### PR TITLE
feat(frontend): update convert components

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmount.svelte
@@ -9,8 +9,13 @@
 	export let receiveAmount: number | undefined;
 	export let totalFee: bigint | undefined;
 	export let minFee: bigint | undefined = undefined;
+	export let ethereumEstimateFee: bigint | undefined = undefined;
 	export let insufficientFunds: boolean;
 	export let insufficientFundsForFee: boolean;
+	export let amountLessThanLedgerFee: boolean | undefined = undefined;
+	export let minimumAmountNotReached: boolean | undefined = undefined;
+	export let unknownMinimumAmount: boolean | undefined = undefined;
+	export let minterInfoNotCertified: boolean | undefined = undefined;
 	export let exchangeValueUnit: DisplayUnit = 'usd';
 
 	let inputUnit: DisplayUnit;
@@ -22,10 +27,15 @@
 		bind:sendAmount
 		bind:insufficientFunds
 		bind:insufficientFundsForFee
+		bind:amountLessThanLedgerFee
+		bind:minimumAmountNotReached
+		bind:unknownMinimumAmount
+		bind:minterInfoNotCertified
 		bind:exchangeValueUnit
 		{inputUnit}
 		{totalFee}
 		{minFee}
+		{ethereumEstimateFee}
 	/>
 
 	<div

--- a/src/frontend/src/lib/components/convert/ConvertForm.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertForm.svelte
@@ -12,9 +12,14 @@
 	export let receiveAmount: number | undefined;
 	export let totalFee: bigint | undefined;
 	export let minFee: bigint | undefined = undefined;
+	export let ethereumEstimateFee: bigint | undefined = undefined;
 	export let disabled: boolean;
 	export let insufficientFunds: boolean;
 	export let insufficientFundsForFee: boolean;
+	export let amountLessThanLedgerFee: boolean | undefined = undefined;
+	export let minimumAmountNotReached: boolean | undefined = undefined;
+	export let unknownMinimumAmount: boolean | undefined = undefined;
+	export let minterInfoNotCertified: boolean | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -27,9 +32,14 @@
 		bind:receiveAmount
 		bind:insufficientFunds
 		bind:insufficientFundsForFee
+		bind:amountLessThanLedgerFee
+		bind:minimumAmountNotReached
+		bind:unknownMinimumAmount
+		bind:minterInfoNotCertified
 		bind:exchangeValueUnit
 		{totalFee}
 		{minFee}
+		{ethereumEstimateFee}
 	/>
 
 	<div class="mt-6">


### PR DESCRIPTION
# Motivation

Following the previous PR, we now need to update the existing convert components accordingly. Mostly, it's about passing the props down (the ones, that cannot be put in the context).
