### PR TITLE
feat(frontend): append can duplicate and not in transactions store

### DIFF
--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -65,7 +65,7 @@ export const loadNextTransactions = ({
 				return;
 			}
 
-			icTransactionsStore.append({
+			icTransactionsStore.appendDuplicating({
 				tokenId: token.id,
 				transactions: transactions.map((transaction) => ({
 					data: mapIcTransaction({

--- a/src/frontend/src/lib/stores/transactions.store.ts
+++ b/src/frontend/src/lib/stores/transactions.store.ts
@@ -1,6 +1,6 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
-import { type CertifiedStore, initCertifiedStore } from '$lib/stores/certified.store';
+import { initCertifiedStore, type CertifiedStore } from '$lib/stores/certified.store';
 import type { CertifiedData } from '$lib/types/store';
 import type { TokenId } from '$lib/types/token';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';


### PR DESCRIPTION
# Motivation

By default, the `append` method of a transaction store should remove the duplicated IDs (one never know). However the IC transactions store was behaving ok with (possibly) duplicating the transactions. So we keep that behaviour too, creating method `appendDuplicating`.

The changed `append` method will be useful for the Solana transactions store: mapping signatures to transactions in Solana is quite non-trivial. So, to add a further layer of "insurance", we guarantee that there are no duplicates transactions in the list, since the ID is unique.

# Changes

- Create sub-function to update the transaction list with a prop to remove duplicates or not.
- Change `append` method to remove duplicated ID.
- Create method `appendDuplicating` identical to append but with allowing duplicates.

# Tests

Current tests are adapted.
