### PR TITLE
feat(frontend): create common type for transaction ID

### DIFF
--- a/src/frontend/src/lib/schema/transaction.schema.ts
+++ b/src/frontend/src/lib/schema/transaction.schema.ts
@@ -19,3 +19,5 @@ export const solTransactionTypes = z.enum(commonTypes);
 export const TransactionTypeSchema = z.enum(allTypes);
 
 export const TransactionStatusSchema = z.enum(['confirmed', 'pending', 'unconfirmed']);
+
+export const TransactionIdSchema = z.string();

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -1,9 +1,10 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { EthTransactionUi } from '$eth/types/eth-transaction';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
-import type {
-	TransactionStatusSchema,
-	TransactionTypeSchema
+import {
+	TransactionIdSchema,
+	type TransactionStatusSchema,
+	type TransactionTypeSchema
 } from '$lib/schema/transaction.schema';
 import type { Token } from '$lib/types/token';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
@@ -12,6 +13,8 @@ import type { BigNumber } from '@ethersproject/bignumber';
 import type { FeeData } from '@ethersproject/providers';
 import type { Transaction as EthTransaction } from '@ethersproject/transactions';
 import * as z from 'zod';
+
+export type TransactionId = z.infer<typeof TransactionIdSchema>;
 
 export type Transaction = Omit<EthTransaction, 'data'> &
 	Pick<TransactionResponse, 'blockNumber' | 'from' | 'to' | 'timestamp'> & {


### PR DESCRIPTION
# Motivation

We want to unify the transactions types, as much as possible. One of the first step is to have the same type of ID, in this case, a `string`.