### PR TITLE
feat(frontend): use common ID type for IcTransactionUi

### DIFF
--- a/src/frontend/src/icp/types/ic-transaction.ts
+++ b/src/frontend/src/icp/types/ic-transaction.ts
@@ -1,5 +1,5 @@
 import { icpTransactionTypes } from '$lib/schema/transaction.schema';
-import type { TransactionType } from '$lib/types/transaction';
+import type { TransactionId, TransactionType } from '$lib/types/transaction';
 import type { Transaction, TransactionWithId } from '@dfinity/ledger-icp';
 import type {
 	IcrcTransaction as IcrcTransactionCandid,
@@ -30,7 +30,7 @@ export type IcTransactionIdText = string;
 export type IcTransactionStatus = 'executed' | 'pending' | 'reimbursed' | 'failed';
 
 export interface IcTransactionUi {
-	id: bigint | string;
+	id: TransactionId;
 	type: IcTransactionType;
 	// e.g. BTC Received
 	typeLabel?: string;

--- a/src/frontend/src/icp/utils/icp-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icp-transactions.utils.ts
@@ -59,7 +59,7 @@ export const mapIcpTransaction = ({
 	const { operation, timestamp, transferToSelf } = transaction;
 
 	const tx: Pick<IcTransactionUi, 'timestamp' | 'id' | 'status' | 'txExplorerUrl'> = {
-		id,
+		id: id.toString(),
 		timestamp: fromNullable(timestamp)?.timestamp_nanos,
 		status: 'executed',
 		txExplorerUrl: `${ICP_EXPLORER_URL}/transaction/${id}`

--- a/src/frontend/src/icp/utils/icrc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icrc-transactions.utils.ts
@@ -126,7 +126,7 @@ export const mapIcrcTransaction = ({
 			: undefined;
 
 	return {
-		id,
+		id: id.toString(),
 		type,
 		...source,
 		to:


### PR DESCRIPTION
# Motivation

As further step to standardize the UI transactions (and their store), we use common type `TransactionId` for `IcTransactionUi`.

# Changes

- Adjust `IcTransactionUi`.
- Adjust utils.

# Tests

Current tests are sufficient.
