### PR TITLE
build(scripts): include the script folder for the aliases

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -35,6 +35,7 @@
 		"./tests/**/*.ts",
 		"./tests/**/*.svelte",
 		"./vitest.config.ts",
-		"./vitest.setup.ts"
+		"./vitest.setup.ts",
+		"./scripts/*.ts",
 	]
 }


### PR DESCRIPTION
# Motivation

It is useful that the IDE recognize the aliases for the Typescript scripts. So we include those scripts in the tsconfig for the aliases.
