### PR TITLE
chore(deps): bump @solana/web3.js to @solana/kit (v2.1.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@solana-program/compute-budget": "^0.6.1",
 				"@solana-program/system": "^0.6.2",
 				"@solana-program/token": "^0.4.1",
-				"@solana/web3.js": "^2.0.0",
+				"@solana/kit": "^2.1.0",
 				"@walletconnect/web3wallet": "1.14.0",
 				"alchemy-sdk": "3.4.1",
 				"buffer": "^6.0.3",
@@ -3243,6 +3243,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0.tgz",
 			"integrity": "sha512-1CE4P3QSDH5x+ZtSthMY2mn/ekROBnlT3/4f3CHDJicDvLQsgAq2yCvGHsYkK3ZA0mxhFLuhJVjuKASPnmG1rQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3263,6 +3264,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0.tgz",
 			"integrity": "sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/assertions": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3281,6 +3283,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0.tgz",
 			"integrity": "sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0"
 			},
@@ -3296,6 +3299,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
 			"integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/codecs-core": "2.0.0",
 				"@solana/codecs-data-structures": "2.0.0",
@@ -3315,6 +3319,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
 			"integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0"
 			},
@@ -3330,6 +3335,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
 			"integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/codecs-core": "2.0.0",
 				"@solana/codecs-numbers": "2.0.0",
@@ -3347,6 +3353,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
 			"integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/codecs-core": "2.0.0",
 				"@solana/errors": "2.0.0"
@@ -3363,6 +3370,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
 			"integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/codecs-core": "2.0.0",
 				"@solana/codecs-numbers": "2.0.0",
@@ -3381,6 +3389,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
 			"integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"chalk": "^5.3.0",
 				"commander": "^12.1.0"
@@ -3400,6 +3409,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
 			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -3412,6 +3422,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
 			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3421,6 +3432,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0.tgz",
 			"integrity": "sha512-EsIx9z+eoxOmC+FpzhEb+H67CCYTbs/omAqXD4EdEYnCHWrI1li1oYBV+NoKzfx8fKlX+nzNB7S/9kc4u7Etpw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.18.0"
 			},
@@ -3433,6 +3445,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0.tgz",
 			"integrity": "sha512-Sj+sLiUTimnMEyGnSLGt0lbih2xPDUhxhonnrIkPwA+hjQ3ULGHAxeevHU06nqiVEgENQYUJ5rCtHs4xhUFAkQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.18.0"
 			},
@@ -3445,6 +3458,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0.tgz",
 			"integrity": "sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0"
 			},
@@ -3460,6 +3474,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0.tgz",
 			"integrity": "sha512-SSLSX8BXRvfLKBqsmBghmlhMKpwHeWd5CHi5zXgTS1BRrtiU6lcrTVC9ie6B+WaNNq7oe3e6K5bdbhu3fFZ+0g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/assertions": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3473,11 +3488,684 @@
 				"typescript": ">=5"
 			}
 		},
+		"node_modules/@solana/kit": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.1.0.tgz",
+			"integrity": "sha512-vqaHROLKp89xdIbaKVG6BQ44uMN9E6/rSTeltkvquD2qdTObssafGDbAKVFjwZhlNO+sdzHDCLekGabn5VAL6A==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/accounts": "2.1.0",
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/instructions": "2.1.0",
+				"@solana/keys": "2.1.0",
+				"@solana/programs": "2.1.0",
+				"@solana/rpc": "2.1.0",
+				"@solana/rpc-parsed-types": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0",
+				"@solana/rpc-subscriptions": "2.1.0",
+				"@solana/rpc-types": "2.1.0",
+				"@solana/signers": "2.1.0",
+				"@solana/sysvars": "2.1.0",
+				"@solana/transaction-confirmation": "2.1.0",
+				"@solana/transaction-messages": "2.1.0",
+				"@solana/transactions": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/accounts": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.1.0.tgz",
+			"integrity": "sha512-1JOBiLFeIeHmGx7k1b23UWF9vM1HAh9GBMCzr5rBPrGSBs+QUgxBJ3+yrRg+UPEOSELubqo7qoOVFUKYsb1nXw==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/rpc-spec": "2.1.0",
+				"@solana/rpc-types": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/addresses": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.1.0.tgz",
+			"integrity": "sha512-IgiRuju2yLz14GnrysOPSNZbZQ8F+7jhx7FYZLrbKogf6NX4wy4ijLHxRsLFqP8o8aY69BZULkM9MwrSjsZi7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/assertions": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/assertions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.1.0.tgz",
+			"integrity": "sha512-KCYmxFRsg897Ec7yGdpc0rniOlqGD3NpicmIjWIV87uiXX5uFco4t+01sKyFlhsv4T4OgHxngMsxkfQ3AUkFVg==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/codecs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.1.0.tgz",
+			"integrity": "sha512-C0TnfrpbTg7zoIFYfM65ofeL2AWEz80OsD6mjVdcTKpb1Uj7XuBuNLss3dMnatPQaL7RagD9VLA5/WfYayyteQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-data-structures": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/options": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/codecs-core": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.1.0.tgz",
+			"integrity": "sha512-SR7pKtmJBg2mhmkel2NeHA1pz06QeQXdMv8WJoIR9m8F/hw80K/612uaYbwTt2nkK0jg/Qn/rNSd7EcJ4SBGjw==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/codecs-data-structures": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.1.0.tgz",
+			"integrity": "sha512-oDF5ek54kirqJ09q8k/qEpobBiWOhd3CkkGOTyfjsmTF/IGIigNbdYIakxV3+vudBeaNBw08y0XdBYI4JL/nqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/codecs-numbers": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.1.0.tgz",
+			"integrity": "sha512-XMu4yw5iCgQnMKsxSWPPOrGgtaohmupN3eyAtYv3K3C/MJEc5V90h74k5B1GUCiHvcrdUDO9RclNjD9lgbjFag==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/codecs-core": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/codecs-strings": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.1.0.tgz",
+			"integrity": "sha512-O/eJFLzFrHomcCR1Y5QbIqoPo7iaJaWNnIeskB4mVhVjLyjlJS4WtBP2NBRzM9uJXaXyOxxKroqqO9zFsHOpvQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"fastestsmallesttextencoderdecoder": "^1.0.22",
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/errors": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.1.0.tgz",
+			"integrity": "sha512-l+GxAv0Ar4d3c3PlZdA9G++wFYZREEbbRyAFP8+n8HSg0vudCuzogh/13io6hYuUhG/9Ve8ARZNamhV7UScKNw==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"commander": "^13.1.0"
+			},
+			"bin": {
+				"errors": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/fast-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-a8vR92qbe/VsvQ1BpN3PIEwnoHD2fTHEwCJh9GG58z3R15RIjk73gc0khjcdg4U1tZwTJqWkvk8SbDIgGdOgMA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/functional": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.1.0.tgz",
+			"integrity": "sha512-RVij8Av4F2uUOFcEC8n9lgD72e9gQMritmGHhMh+G91Xops4I6Few+oQ++XgSTiL2t3g3Cs0QZ13onZ0FL45FQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/instructions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.1.0.tgz",
+			"integrity": "sha512-wfn6e7Rgm0Sw/Th1v/pXsKTvloZvAAQI7j1yc9WcIk9ngqH5p6LhqMMkrwYPB2oTk8+MMr7SZ4E+2eK2gL6ODA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/codecs-core": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.1.0.tgz",
+			"integrity": "sha512-esY1+dlZjB18hZML5p+YPec29wi3HH0SzKx7RiqF//dI2cJ6vHfq3F+7ArbNnF6R2YCLFtl7DzS/tkqR2Xkxeg==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/assertions": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/options": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/options/-/options-2.1.0.tgz",
+			"integrity": "sha512-T/vJCr8qnwK6HxriOPXCrx31IpA9ZYecxuOzQ3G74kIayED4spmpXp6PLtRYR/fo2LZ6UcgHN0qSgONnvwEweg==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-data-structures": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/programs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.1.0.tgz",
+			"integrity": "sha512-9Y30/yUbTR99+QRN2ukNXQQTGY68oKmVrXnh/et6StM1JF5WHvAJqBigsHG5bt6KxTISoRuncBnH/IRnDqPxKg==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/promises": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.1.0.tgz",
+			"integrity": "sha512-eQJaQXA2kD4dVyifzhslV3wOvq27fwOJ4az89BQ4Cz83zPbR94xOeDShwcXrKBYqaUf6XqH5MzdEo14t4tKAFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.1.0.tgz",
+			"integrity": "sha512-myg9qAo6b2WKyHSMXURQykb+ZRnNEXBPLEcwRwkos8STzPPyRFg6ady2s0FCQQTtL/pVjanIU2bObZIzbMGugA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/fast-stable-stringify": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/rpc-api": "2.1.0",
+				"@solana/rpc-spec": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0",
+				"@solana/rpc-transformers": "2.1.0",
+				"@solana/rpc-transport-http": "2.1.0",
+				"@solana/rpc-types": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-api": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.1.0.tgz",
+			"integrity": "sha512-4yCnHYHFlz9VffivoY5q/HVeBjT59byB2gmg7UyC3ktxD28AlF9jjsE5tJKiapAKr2J3KWm0D/rH/QwW14cGeA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/keys": "2.1.0",
+				"@solana/rpc-parsed-types": "2.1.0",
+				"@solana/rpc-spec": "2.1.0",
+				"@solana/rpc-transformers": "2.1.0",
+				"@solana/rpc-types": "2.1.0",
+				"@solana/transaction-messages": "2.1.0",
+				"@solana/transactions": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-parsed-types": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.1.0.tgz",
+			"integrity": "sha512-mRzHemxlWDS9p1fPQNKwL+1vEOUMG8peSUJb0X/NbM12yjowDNdzM++fkOgIyCKDPddfkcoNmNrQmr2jwjdN1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-spec": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.1.0.tgz",
+			"integrity": "sha512-NPAIM5EY7Jke0mHnmoMpgCEb/nZKIo+bgVFK/u+z74gY0JnCNt0DfocStUUQtlhqSmTyoHamt3lfxp4GT2zXbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-spec-types": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.1.0.tgz",
+			"integrity": "sha512-NxcZ8piXMyCdbNUL6d36QJfL2UAQEN33StlGku0ltTVe1nrokZ5WRNjSPohU1fODlNaZzTvUFzvUkM1yGCkyzw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.1.0.tgz",
+			"integrity": "sha512-dTyI03VlueE3s7mA/OBlA5l6yKUUKHMJd31tpzxV3AFnqE/QPS5NVrF/WY6pPBobLJiCP0UFOe7eR/MKP9SUCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/fast-stable-stringify": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/promises": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0",
+				"@solana/rpc-subscriptions-api": "2.1.0",
+				"@solana/rpc-subscriptions-channel-websocket": "2.1.0",
+				"@solana/rpc-subscriptions-spec": "2.1.0",
+				"@solana/rpc-transformers": "2.1.0",
+				"@solana/rpc-types": "2.1.0",
+				"@solana/subscribable": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-api": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.1.0.tgz",
+			"integrity": "sha512-de1dBRSE2CUwoZHMXQ/0v7iC+/pG0+iYY8jLHGGNxtKrYbTnV08mXQbaAMrmv2Rk8ZFmfJWbqbYZ9dRWdO3P5g==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/keys": "2.1.0",
+				"@solana/rpc-subscriptions-spec": "2.1.0",
+				"@solana/rpc-transformers": "2.1.0",
+				"@solana/rpc-types": "2.1.0",
+				"@solana/transaction-messages": "2.1.0",
+				"@solana/transactions": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.1.0.tgz",
+			"integrity": "sha512-goJe9dv0cs967HJ382vSX8yapXgQzRHCmH323LsXrrpj/s3Eb3yUwJq7AcHgoh4gKIqyAfGybq/bE5Aa8Pcm9g==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/rpc-subscriptions-spec": "2.1.0",
+				"@solana/subscribable": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5",
+				"ws": "^8.18.0"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-spec": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.1.0.tgz",
+			"integrity": "sha512-Uqasfd3Tlr22lC/Vy5dToF0e68dMKPdnt4ks7FwXuPdEbNRM/TDGb0GqG+bt/d3IIrNOCA5Y8vsE0nQHGrWG/w==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/promises": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0",
+				"@solana/subscribable": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-transformers": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.1.0.tgz",
+			"integrity": "sha512-E2xPlaCu6tNO00v4HIJxJCYkoNwgVJYad5sxbIUZOQBWwXnWIcll2jUT4bWKpBGq5vFDYfkzRBr8Rco3DhfXqg==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0",
+				"@solana/rpc-types": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-transport-http": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.1.0.tgz",
+			"integrity": "sha512-E3UovTBid4/S8QDd9FkADVKfyG+v7CW5IqI4c27ZDKfazCsnDLLkqh98C6BvNCqi278HKBui4lI2GoFpCq89Pw==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0",
+				"@solana/rpc-spec": "2.1.0",
+				"@solana/rpc-spec-types": "2.1.0",
+				"undici-types": "^7.3.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/rpc-types": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.1.0.tgz",
+			"integrity": "sha512-1ODnhmpR1X/GjB7hs4gVR3mcCagfPQV0dzq/2DNuCiMjx2snn64KP5WoAHfBEyoC9/Rb36+JpNj/hLAOikipKA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/signers": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.1.0.tgz",
+			"integrity": "sha512-Yq0JdJnCecRsSBshNWy+OIRmAGeVfjwIh9Z+H1jv8u8p+dJCOreKakTWuxMt5tnj3q5K1mPcak9O2PqVPZ0teA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/instructions": "2.1.0",
+				"@solana/keys": "2.1.0",
+				"@solana/transaction-messages": "2.1.0",
+				"@solana/transactions": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/subscribable": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.1.0.tgz",
+			"integrity": "sha512-xi12Cm889+uT5sRKnIzr7nLnHAp3hiR3dqIzrT1P7z7iEGp8OnqUQIQCHlgozFHM2cPW+6685NQXk1l1ImuJIw==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/errors": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/sysvars": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.1.0.tgz",
+			"integrity": "sha512-GXu9yS0zIebmM1Unqw/XFpYuvug03m42w98ioOPV/yiHzECggGRGpHGD9RLVYnkyz0eL4NRbnJ5dAEu/fvGe0A==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/accounts": "2.1.0",
+				"@solana/codecs": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/rpc-types": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/transaction-confirmation": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.1.0.tgz",
+			"integrity": "sha512-VxOvtvs2e9h5u73PHyE2TptLAMO5x6dOXlOgvq1Nk6l3rKM2HAsd+KDpN7gjOo8/EgItMMmyEilXygWWRgpSIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/keys": "2.1.0",
+				"@solana/promises": "2.1.0",
+				"@solana/rpc": "2.1.0",
+				"@solana/rpc-subscriptions": "2.1.0",
+				"@solana/rpc-types": "2.1.0",
+				"@solana/transaction-messages": "2.1.0",
+				"@solana/transactions": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/transaction-messages": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.1.0.tgz",
+			"integrity": "sha512-+GPzZHLYNFbqHKoiL8mYALp7eAXtAbI6zLViZpIM3zUbVNU3q5+FCKGv6jCBnxs+3QCbeapu+W1OyfDa6BUtTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-data-structures": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/instructions": "2.1.0",
+				"@solana/rpc-types": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/@solana/transactions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.1.0.tgz",
+			"integrity": "sha512-QeM4sCItReeIy5LU7LhGkz7RPfMPTg/Qo8h0LSfhiJiPTOHOhElmh42vkLJmwPl83+MsKtisyPQNK6penM2nAw==",
+			"license": "MIT",
+			"dependencies": {
+				"@solana/addresses": "2.1.0",
+				"@solana/codecs-core": "2.1.0",
+				"@solana/codecs-data-structures": "2.1.0",
+				"@solana/codecs-numbers": "2.1.0",
+				"@solana/codecs-strings": "2.1.0",
+				"@solana/errors": "2.1.0",
+				"@solana/functional": "2.1.0",
+				"@solana/instructions": "2.1.0",
+				"@solana/keys": "2.1.0",
+				"@solana/rpc-types": "2.1.0",
+				"@solana/transaction-messages": "2.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/chalk": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+			"integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@solana/kit/node_modules/undici-types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.4.0.tgz",
+			"integrity": "sha512-4tv8DA1nBRW5kF2KBJZzEBjd66kDf3jArNVPoktdlv9Xsgw7EcIMu1bVbAXbX5IWuuZZ3YW3jIM2x85SPgMP6w==",
+			"license": "MIT"
+		},
 		"node_modules/@solana/options": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
 			"integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/codecs-core": "2.0.0",
 				"@solana/codecs-data-structures": "2.0.0",
@@ -3497,6 +4185,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0.tgz",
 			"integrity": "sha512-JPIKB61pWfODnsvEAaPALc6vR5rn7kmHLpFaviWhBtfUlEVgB8yVTR0MURe4+z+fJCPRV5wWss+svA4EeGDYzQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/errors": "2.0.0"
@@ -3513,6 +4202,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0.tgz",
 			"integrity": "sha512-4teQ52HDjK16ORrZe1zl+Q9WcZdQ+YEl0M1gk59XG7D0P9WqaVEQzeXGnKSCs+Y9bnB1u5xCJccwpUhHYWq6gg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.18.0"
 			},
@@ -3525,6 +4215,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0.tgz",
 			"integrity": "sha512-TumQ9DFRpib/RyaIqLVfr7UjqSo7ldfzpae0tgjM93YjbItB4Z0VcUXc3uAFvkeYw2/HIMb46Zg43mkUwozjDg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/fast-stable-stringify": "2.0.0",
@@ -3548,6 +4239,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0.tgz",
 			"integrity": "sha512-1FwitYxwADMF/6zKP2kNXg8ESxB6GhNBNW1c4f5dEmuXuBbeD/enLV3WMrpg8zJkIaaYarEFNbt7R7HyFzmURQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3573,6 +4265,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0.tgz",
 			"integrity": "sha512-VCeY/oKVEtBnp8EDOc5LSSiOeIOLFIgLndcxqU0ij/cZaQ01DOoHbhluvhZtU80Z3dUeicec8TiMgkFzed+WhQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.18.0"
 			},
@@ -3585,6 +4278,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0.tgz",
 			"integrity": "sha512-1uIDzj7vocCUqfOifjv1zAuxQ53ugiup/42edVFoQLOnJresoEZLL6WjnsJq4oCTccEAvGhUBI1WWKeZTGNxFQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/rpc-spec-types": "2.0.0"
@@ -3601,6 +4295,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0.tgz",
 			"integrity": "sha512-G2lmhFhgtxMQd/D6B04BHGE7bm5dMZdIPQNOqVGhzNAVjrmyapD3JN2hKAbmaYPe97wLfZERw0Ux1u4Y6q7TqA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.18.0"
 			},
@@ -3613,6 +4308,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0.tgz",
 			"integrity": "sha512-AdwMJHMrhlj7q1MPjZmVcKq3iLqMW3N0MT8kzIAP2vP+8o/d6Fn4aqGxoz2Hlfn3OYIZoYStN2VBtwzbcfEgMA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/fast-stable-stringify": "2.0.0",
@@ -3638,6 +4334,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0.tgz",
 			"integrity": "sha512-NAJQvSFXYIIf8zxsMFBCkSbZNZgT32pzPZ1V6ZAd+U2iDEjx3L+yFwoJgfOcHp8kAV+alsF2lIsGBlG4u+ehvw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/keys": "2.0.0",
@@ -3659,6 +4356,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.0.0.tgz",
 			"integrity": "sha512-hSQDZBmcp2t+gLZsSBqs/SqVw4RuNSC7njiP46azyzW7oGg8X2YPV36AHGsHD12KPsc0UpT1OAZ4+AN9meVKww==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/functional": "2.0.0",
@@ -3678,6 +4376,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0.tgz",
 			"integrity": "sha512-VXMiI3fYtU1PkVVTXL87pcY48ZY8aCi1N6FqtxSP2xg/GASL01j1qbwyIL1OvoCqGyRgIxdd/YfaByW9wmWBhA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/promises": "2.0.0",
@@ -3696,6 +4395,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0.tgz",
 			"integrity": "sha512-H6tN0qcqzUangowsLLQtYXKJsf1Roe3/qJ1Cy0gv9ojY9uEvNbJqpeEj+7blv0MUZfEe+rECAwBhxxRKPMhYGw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/functional": "2.0.0",
@@ -3714,6 +4414,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0.tgz",
 			"integrity": "sha512-UJLhKhhxDd1OPi8hb2AenHsDm1mofCBbhWn4bDCnH2Q3ulwYadUhcNqNbxjJPQ774VNhAf53SSI5A6PQo8IZSQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0",
 				"@solana/rpc-spec": "2.0.0",
@@ -3731,13 +4432,15 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@solana/rpc-types": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0.tgz",
 			"integrity": "sha512-o1ApB9PYR0A3XjVSOh//SOVWgjDcqMlR3UNmtqciuREIBmWqnvPirdOa5EJxD3iPhfA4gnNnhGzT+tMDeDW/Kw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3757,6 +4460,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0.tgz",
 			"integrity": "sha512-JEYJS3x/iKkqPV/3b1nLpX9lHib21wQKV3fOuu1aDLQqmX9OYKrnIIITYdnFDhmvGhpEpkkbPnqu7yVaFIBYsQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3778,6 +4482,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.0.0.tgz",
 			"integrity": "sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/errors": "2.0.0"
 			},
@@ -3793,6 +4498,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0.tgz",
 			"integrity": "sha512-8D4ajKcCYQsTG1p4k30lre2vjxLR6S5MftUGJnIaQObDCzGmaeA9GRti4Kk4gSPWVYFTBoj1ASx8EcEXaB3eIQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/accounts": "2.0.0",
 				"@solana/codecs": "2.0.0",
@@ -3811,6 +4517,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0.tgz",
 			"integrity": "sha512-JkTw5gXLiqQjf6xK0fpVcoJ/aMp2kagtFSD/BAOazdJ3UYzOzbzqvECt6uWa3ConcMswQ2vXalVtI7ZjmYuIeg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-strings": "2.0.0",
@@ -3835,6 +4542,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0.tgz",
 			"integrity": "sha512-Uc6Fw1EJLBrmgS1lH2ZfLAAKFvprWPQQzOVwZS78Pv8Whsk7tweYTK6S0Upv0nHr50rGpnORJfmdBrXE6OfNGg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3857,6 +4565,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0.tgz",
 			"integrity": "sha512-VfdTE+59WKvuBG//6iE9RPjAB+ZT2kLgY2CDHabaz6RkH6OjOkMez9fWPVa3Xtcus+YQWN1SnQoryjF/xSx04w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/addresses": "2.0.0",
 				"@solana/codecs-core": "2.0.0",
@@ -3882,6 +4591,7 @@
 			"resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
 			"integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@solana/accounts": "2.0.0",
 				"@solana/addresses": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"@solana-program/compute-budget": "^0.6.1",
 		"@solana-program/system": "^0.6.2",
 		"@solana-program/token": "^0.4.1",
-		"@solana/web3.js": "^2.0.0",
+		"@solana/kit": "^2.1.0",
 		"@walletconnect/web3wallet": "1.14.0",
 		"alchemy-sdk": "3.4.1",
 		"buffer": "^6.0.3",

--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -6,12 +6,7 @@ import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolSignature } from '$sol/types/sol-transaction';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import {
-	address as solAddress,
-	type Address,
-	type Lamports,
-	type Signature
-} from '@solana/web3.js';
+import { address as solAddress, type Address, type Lamports, type Signature } from '@solana/kit';
 import type { Writeable } from 'zod';
 
 //lamports are like satoshis: https://solana.com/docs/terminology#lamport

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
 	import { assertNonNullish, isNullish } from '@dfinity/utils';
-	import { isSolanaError, SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED } from '@solana/web3.js';
+	import { isSolanaError, SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED } from '@solana/kit';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 	import {

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import type { Commitment } from '@solana/web3.js';
+	import type { Commitment } from '@solana/kit';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import type { Commitment } from '@solana/web3.js';
+	import type { Commitment } from '@solana/kit';
 	import TransactionModal from '$lib/components/transactions/TransactionModal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/sol/providers/sol-rpc.providers.ts
+++ b/src/frontend/src/sol/providers/sol-rpc.providers.ts
@@ -20,7 +20,7 @@ import {
 	type RpcSubscriptions,
 	type SolanaRpcApi,
 	type SolanaRpcSubscriptionsApi
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 const rpcs: Record<SolanaNetworkType, SolRpcConnectionConfig> = {
 	[SolanaNetworks.mainnet]: {

--- a/src/frontend/src/sol/services/sol-address.services.ts
+++ b/src/frontend/src/sol/services/sol-address.services.ts
@@ -36,7 +36,7 @@ import type { TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
 import { SOLANA_DERIVATION_PATH_PREFIX } from '$sol/constants/sol.constants';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
-import { getAddressDecoder } from '@solana/web3.js';
+import { getAddressDecoder } from '@solana/kit';
 
 const getSolanaPublicKey = async (
 	params: CanisterApiFunctionParams<{ derivationPath: string[] }>

--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -47,7 +47,7 @@ import {
 	type TransactionPartialSigner,
 	type TransactionSigner,
 	type TransactionVersion
-} from '@solana/web3.js';
+} from '@solana/kit';
 import { get } from 'svelte/store';
 
 const setFeePayerToTransaction = ({

--- a/src/frontend/src/sol/services/sol-sign.services.ts
+++ b/src/frontend/src/sol/services/sol-sign.services.ts
@@ -4,7 +4,7 @@ import {
 	getSignatureFromTransaction,
 	signTransactionMessageWithSigners,
 	type Signature
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 export const signTransaction = async (
 	transactionMessage: SolTransactionMessage

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -5,7 +5,7 @@ import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
 import { nonNullish } from '@dfinity/utils';
 import { findAssociatedTokenPda } from '@solana-program/token';
-import { assertIsAddress, signature, address as solAddress } from '@solana/web3.js';
+import { assertIsAddress, signature, address as solAddress } from '@solana/kit';
 
 /**
  * Fetches transactions without an error for a given wallet address.

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -23,7 +23,7 @@ import type { SplTokenAddress } from '$sol/types/spl';
 import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { findAssociatedTokenPda } from '@solana-program/token';
-import { address as solAddress } from '@solana/web3.js';
+import { address as solAddress } from '@solana/kit';
 
 interface LoadNextSolTransactionsParams extends GetSolTransactionsParams {
 	signalEnd: () => void;

--- a/src/frontend/src/sol/services/spl-accounts.services.ts
+++ b/src/frontend/src/sol/services/spl-accounts.services.ts
@@ -8,7 +8,7 @@ import {
 	findAssociatedTokenPda,
 	getCreateAssociatedTokenInstructionAsync
 } from '@solana-program/token';
-import { address as solAddress, type TransactionSigner } from '@solana/web3.js';
+import { address as solAddress, type TransactionSigner } from '@solana/kit';
 
 export const calculateAssociatedTokenAddress = async ({
 	owner,

--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -40,7 +40,7 @@ import {
 	getBase64Decoder,
 	getTransactionEncoder,
 	type Base64EncodedWireTransaction
-} from '@solana/web3.js';
+} from '@solana/kit';
 import { get } from 'svelte/store';
 
 interface WalletConnectDecodeTransactionParams {

--- a/src/frontend/src/sol/types/sol-balance.ts
+++ b/src/frontend/src/sol/types/sol-balance.ts
@@ -1,3 +1,3 @@
-import type { Lamports } from '@solana/web3.js';
+import type { Lamports } from '@solana/kit';
 
 export type SolBalance = Lamports | bigint;

--- a/src/frontend/src/sol/types/sol-instructions.ts
+++ b/src/frontend/src/sol/types/sol-instructions.ts
@@ -3,7 +3,7 @@ import type { SolRpcTransactionRaw } from '$sol/types/sol-transaction';
 import type { ParsedComputeBudgetInstruction } from '@solana-program/compute-budget';
 import type { ParsedSystemInstruction } from '@solana-program/system';
 import type { ParsedTokenInstruction } from '@solana-program/token';
-import type { Address, CompilableTransactionMessage } from '@solana/web3.js';
+import type { Address, CompilableTransactionMessage } from '@solana/kit';
 
 export type SolParsedComputeBudgetInstruction = ParsedComputeBudgetInstruction<SolAddress>;
 export type SolParsedSystemInstruction = ParsedSystemInstruction<SolAddress>;

--- a/src/frontend/src/sol/types/sol-send.ts
+++ b/src/frontend/src/sol/types/sol-send.ts
@@ -4,7 +4,7 @@ import type {
 	TransactionMessage,
 	TransactionMessageWithBlockhashLifetime,
 	TransactionVersion
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 export class SolAmountAssertionError extends Error {}
 

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -10,7 +10,7 @@ import type {
 	GetSignaturesForAddressApi,
 	Signature,
 	TransactionWithBlockhashLifetime
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 export type SolTransactionType = Extract<
 	TransactionType,
@@ -31,7 +31,7 @@ type SolRpcTransactionRawWithBug = NonNullable<
 >;
 
 // This is a temporary type that we are using to cast the parsed account keys of an RPC Solana Transaction.
-// We need to do this, because in the current version of @solana/web3.js (v2.0.0) there is a bug: https://github.com/anza-xyz/solana-web3.js/issues/80
+// We need to do this, because in the current version of @solana/kit (v2.0.0) there is a bug: https://github.com/anza-xyz/solana-web3.js/issues/80
 // TODO: Remove this type and its usage when the bug is fixed and released.
 type ParsedAccounts = {
 	pubkey: Address;

--- a/src/frontend/src/sol/utils/sol-address.utils.ts
+++ b/src/frontend/src/sol/utils/sol-address.utils.ts
@@ -2,7 +2,7 @@ import type { SolAddress } from '$lib/types/address';
 import { getAccountOwner } from '$sol/api/solana.api';
 import type { SolanaNetworkType } from '$sol/types/network';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import { assertIsAddress } from '@solana/web3.js';
+import { assertIsAddress } from '@solana/kit';
 
 export const isSolAddress = (address: SolAddress | undefined): boolean => {
 	if (isNullish(address)) {

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -74,11 +74,7 @@ import {
 	parseTransferInstruction,
 	parseUiAmountToAmountInstruction
 } from '@solana-program/token';
-import {
-	address,
-	assertIsInstructionWithAccounts,
-	assertIsInstructionWithData
-} from '@solana/web3.js';
+import { address, assertIsInstructionWithAccounts, assertIsInstructionWithData } from '@solana/kit';
 
 const mapSystemParsedInstruction = ({
 	type,

--- a/src/frontend/src/sol/utils/sol-sign.utils.ts
+++ b/src/frontend/src/sol/utils/sol-sign.utils.ts
@@ -11,7 +11,7 @@ import {
 	type SignatureDictionary,
 	type Transaction,
 	type TransactionPartialSigner
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 interface CreateSignerParams {
 	identity: OptionIdentity;

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -12,7 +12,7 @@ import {
 	type SolanaRpcApi,
 	type Transaction,
 	type TransactionMessage
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 export const decodeTransactionMessage = (transactionMessage: string): Transaction => {
 	const transactionBytes = getBase64Encoder().encode(transactionMessage);

--- a/src/frontend/src/tests/mocks/sol-balance.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-balance.mock.ts
@@ -1,5 +1,5 @@
 import { DEVNET_EURC_TOKEN } from '$env/tokens/tokens-spl/tokens.eurc.env';
-import { lamports, type Address } from '@solana/web3.js';
+import { lamports, type Address } from '@solana/kit';
 import { mockSolAddress } from './sol.mock';
 
 export const mockTokenAccountResponse = {

--- a/src/frontend/src/tests/mocks/sol-signatures.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-signatures.mock.ts
@@ -1,5 +1,5 @@
 import type { SolSignature } from '$sol/types/sol-transaction';
-import { getBase58Decoder, signature, type UnixTimestamp } from '@solana/web3.js';
+import { getBase58Decoder, signature, type UnixTimestamp } from '@solana/kit';
 
 export const mockSolSignature = () => {
 	const randomBytes = new Uint8Array(64);

--- a/src/frontend/src/tests/mocks/sol-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-transactions.mock.ts
@@ -20,7 +20,7 @@ import {
 	type Blockhash,
 	type TransactionMessageBytes,
 	type UnixTimestamp
-} from '@solana/web3.js';
+} from '@solana/kit';
 
 const mockSignature =
 	'4UjEjyVYfPNkr5TzZ3oH8ZS8PiEzbHsBdhvRtrLiuBfk8pQMRNvY3UUxjHe4nSzxAnhd8JCSQ3YYmAj651ZWeArM';

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -26,7 +26,7 @@ import {
 	mockSolAddress2,
 	mockSplAddress
 } from '$tests/mocks/sol.mock';
-import { address, lamports } from '@solana/web3.js';
+import { address, lamports } from '@solana/kit';
 import { type MockInstance } from 'vitest';
 
 vi.mock('$sol/providers/sol-rpc.providers');

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -11,7 +11,7 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { jsonReplacer, nonNullish } from '@dfinity/utils';
-import { lamports } from '@solana/web3.js';
+import { lamports } from '@solana/kit';
 import { type MockInstance } from 'vitest';
 
 describe('sol-wallet.scheduler', () => {

--- a/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
@@ -28,11 +28,11 @@ import {
 import { SolanaNetworks } from '$sol/types/network';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { getAddressDecoder } from '@solana/web3.js';
+import { getAddressDecoder } from '@solana/kit';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
-vi.mock('@solana/web3.js', () => ({
+vi.mock('@solana/kit', () => ({
 	getAddressDecoder: vi.fn()
 }));
 

--- a/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
@@ -8,7 +8,7 @@ import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-messa
 import { mockSolCertifiedTransactions } from '$tests/mocks/sol-transactions.mock';
 import { jsonReplacer } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
-import { lamports } from '@solana/web3.js';
+import { lamports } from '@solana/kit';
 import { get } from 'svelte/store';
 
 describe('sol-listener.services', () => {

--- a/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
@@ -20,7 +20,7 @@ import {
 import { BigNumber } from '@ethersproject/bignumber';
 import { getTransferSolInstruction } from '@solana-program/system';
 import { getTransferInstruction } from '@solana-program/token';
-import * as solanaWeb3 from '@solana/web3.js';
+import * as solanaWeb3 from '@solana/kit';
 import {
 	appendTransactionMessageInstructions,
 	getComputeUnitEstimateForTransactionMessageFactory,
@@ -30,10 +30,10 @@ import {
 	type RpcSubscriptions,
 	type SolanaRpcApi,
 	type SolanaRpcSubscriptionsApi
-} from '@solana/web3.js';
+} from '@solana/kit';
 import { type MockInstance } from 'vitest';
 
-vi.mock(import('@solana/web3.js'), async (importOriginal) => {
+vi.mock(import('@solana/kit'), async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...actual,

--- a/src/frontend/src/tests/sol/services/sol-sign.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-sign.services.spec.ts
@@ -4,10 +4,10 @@ import {
 	mockSolSignedTransaction,
 	mockSolTransactionMessage
 } from '$tests/mocks/sol-transactions.mock';
-import * as solanaWeb3Pkg from '@solana/web3.js';
+import * as solanaWeb3Pkg from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
-vi.mock(import('@solana/web3.js'), async (importOriginal) => {
+vi.mock(import('@solana/kit'), async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...actual,

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -14,7 +14,7 @@ import {
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import { mockSolAddress, mockSplAddress } from '$tests/mocks/sol.mock';
 import * as solProgramToken from '@solana-program/token';
-import { address } from '@solana/web3.js';
+import { address } from '@solana/kit';
 import { type MockInstance } from 'vitest';
 
 vi.mock('@solana-program/token', () => ({

--- a/src/frontend/src/tests/sol/services/spl-accounts.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/spl-accounts.services.spec.ts
@@ -5,7 +5,7 @@ import { SolanaNetworks } from '$sol/types/network';
 import * as solAddressUtils from '$sol/utils/sol-address.utils';
 import { mockAtaAddress, mockAtaAddress2, mockSolAddress } from '$tests/mocks/sol.mock';
 import * as solProgramToken from '@solana-program/token';
-import { address, type ProgramDerivedAddressBump } from '@solana/web3.js';
+import { address, type ProgramDerivedAddressBump } from '@solana/kit';
 import { type MockInstance } from 'vitest';
 
 vi.mock('@solana-program/token', () => ({

--- a/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
@@ -7,7 +7,7 @@ import {
 	mapSolTransactionMessage,
 	parseSolBase64TransactionMessage
 } from '$sol/utils/sol-transactions.utils';
-import type { CompilableTransactionMessage } from '@solana/web3.js';
+import type { CompilableTransactionMessage } from '@solana/kit';
 
 describe('wallet-connect.services', () => {
 	describe('decode', () => {

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -11,7 +11,7 @@ import type { SolRpcInstruction } from '$sol/types/sol-instructions';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
-import { address, type Base58EncodedBytes, type Rpc, type SolanaRpcApi } from '@solana/web3.js';
+import { address, type Base58EncodedBytes, type Rpc, type SolanaRpcApi } from '@solana/kit';
 
 vi.mock('$sol/providers/sol-rpc.providers', () => ({
 	solanaHttpRpc: vi.fn(),

--- a/src/frontend/src/tests/sol/utils/sol-sign.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-sign.utils.spec.ts
@@ -5,7 +5,7 @@ import type { SolanaNetworkType } from '$sol/types/network';
 import { createSigner } from '$sol/utils/sol-sign.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
-import type { Transaction } from '@solana/web3.js';
+import type { Transaction } from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
 describe('sol-sign.utils', () => {


### PR DESCRIPTION
# Motivation

We bump `@solana/web3.js` to version `2.1.0` , however there was a change in name too: it is now `@solana/kit` (see https://github.com/anza-xyz/kit/releases/tag/v2.1.0)
