### PR TITLE
refactor(devops): dfx deploy cketh_minter works out of the box

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -287,8 +287,10 @@
 		},
 		"cketh_minter": {
 			"type": "custom",
+			"build": "scripts/build.cketh_minter.sh",
 			"candid": "target/ic/cketh_minter.did",
 			"wasm": "target/ic/cketh_minter.wasm",
+			"init_arg_file": "target/ic/cketh_minter.args.did",
 			"specified_id": "jzenf-aiaaa-aaaar-qaa7q-cai",
 			"remote": {
 				"id": {

--- a/scripts/build.cketh_minter.args.sh
+++ b/scripts/build.cketh_minter.args.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRINCIPAL="$(dfx identity get-principal)"
+ARG_FILE="$(jq -re .canisters.cketh_minter.init_arg_file dfx.json)"
+
+mkdir -p "$(dirname "$ARG_FILE")"
+
+cat <<EOF > "$ARG_FILE"
+(variant {
+  InitArg = record {
+       ethereum_network = variant {Sepolia};
+       ecdsa_key_name = "dfx_test_key";
+       ethereum_contract_address = opt "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34";
+       ledger_id = principal "$CANISTER_ID_CKETH_LEDGER";
+       ethereum_block_height = variant {Finalized};
+       minimum_withdrawal_amount = 10_000_000_000_000_000;
+       next_transaction_nonce = 209;
+       last_scraped_block_number = 5371702;
+   }
+})
+EOF

--- a/scripts/build.cketh_minter.args.sh
+++ b/scripts/build.cketh_minter.args.sh
@@ -6,7 +6,7 @@ ARG_FILE="$(jq -re .canisters.cketh_minter.init_arg_file dfx.json)"
 
 mkdir -p "$(dirname "$ARG_FILE")"
 
-cat <<EOF > "$ARG_FILE"
+cat <<EOF >"$ARG_FILE"
 (variant {
   InitArg = record {
        ethereum_network = variant {Sepolia};

--- a/scripts/build.cketh_minter.sh
+++ b/scripts/build.cketh_minter.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+scripts/download.cketh.sh
+scripts/build.cketh_minter.args.sh

--- a/scripts/deploy.cketh.sh
+++ b/scripts/deploy.cketh.sh
@@ -3,11 +3,9 @@
 DFX_NETWORK=local
 
 echo "Step 1: create canisters..."
-dfx canister create cketh_ledger --specified-id apia6-jaaaa-aaaar-qabma-cai --network "$DFX_NETWORK"
-dfx canister create cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$DFX_NETWORK"
+dfx canister create cketh_ledger --network "$DFX_NETWORK"
+dfx canister create cketh_minter --network "$DFX_NETWORK"
 
-MINTERID="$(dfx canister id cketh_minter --network "$DFX_NETWORK")"
-echo "$MINTERID"
 LEDGERID="$(dfx canister id cketh_ledger --network "$DFX_NETWORK")"
 echo "$LEDGERID"
 

--- a/scripts/deploy.cketh.sh
+++ b/scripts/deploy.cketh.sh
@@ -16,18 +16,7 @@ echo "Step 2: deploy minter canister..."
 # ckETH minter deployed on using the smart contract address on Sepolia used by testnet.
 # We can alternatively also deploy our own contract.
 
-dfx deploy cketh_minter --specified-id jzenf-aiaaa-aaaar-qaa7q-cai --network "$DFX_NETWORK" --argument "(variant {
-  InitArg = record {
-       ethereum_network = variant {Sepolia};
-       ecdsa_key_name = \"dfx_test_key\";
-       ethereum_contract_address = opt \"0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34\";
-       ledger_id = principal \"$LEDGERID\";
-       ethereum_block_height = variant {Finalized};
-       minimum_withdrawal_amount = 10_000_000_000_000_000;
-       next_transaction_nonce = 209;
-       last_scraped_block_number = 5371702;
-   }
-})"
+dfx deploy cketh_minter --network "$DFX_NETWORK"
 
 echo "Step 3: deploy ledger canister..."
 dfx deploy cketh_ledger --network "$DFX_NETWORK"


### PR DESCRIPTION
# Motivation
`dfx deploy X` should work out of the box for all canisters.  This implements that for `cketh_minter`.

# Changes
- Define a build command for `cketh_minter` that downloads the Wasm and generates the default arguments.
- Delete unneeded arguments and variables.

# Tests
Existing e2e tests should suffice.

Additionally, here is a manual test:

```
$ dfx start --clean --background
$ dfx canister create --all
$ dfx deploy cketh_minter
...
Installing code for canister cketh_minter, with canister ID jzenf-aiaaa-aaaar-qaa7q-cai
Deployed canisters.
```
Checking the arguments:
```
$ cat target/ic/cketh_minter.args.did 
(variant {
  InitArg = record {
       ethereum_network = variant {Sepolia};
       ecdsa_key_name = "dfx_test_key";
       ethereum_contract_address = opt "0xb44B5e756A894775FC32EDdf3314Bb1B1944dC34";
       ledger_id = principal "apia6-jaaaa-aaaar-qabma-cai";
       ethereum_block_height = variant {Finalized};
       minimum_withdrawal_amount = 10_000_000_000_000_000;
       next_transaction_nonce = 209;
       last_scraped_block_number = 5371702;
   }
})
```