### PR TITLE
feat(frontend): pass last signature to Sol wallet worker

### DIFF
--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -94,6 +94,7 @@ export const PostMessageDataRequestSolSchema = z.object({
 	// TODO: generate zod schema for CertifiedData
 	address: z.custom<CertifiedData<SolAddress>>(),
 	solanaNetwork: z.custom<SolanaNetworkType>(),
+	beforeSignature: z.string().optional(),
 	tokenAddress: z.custom<SplTokenAddress>().optional(),
 	tokenOwnerAddress: z.custom<SolAddress>().optional()
 });

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -12,6 +12,7 @@ import { getSolTransactions } from '$sol/services/sol-signatures.services';
 import { loadSplTokenBalance } from '$sol/services/spl-accounts.services';
 import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store';
 import type { SolanaNetworkType } from '$sol/types/network';
+import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolBalance } from '$sol/types/sol-balance';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
 import type { SplTokenAddress } from '$sol/types/spl';
@@ -82,7 +83,9 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 	private loadTransactions = async ({
 		solanaNetwork: network,
 		...rest
-	}: LoadSolWalletParams): Promise<SolCertifiedTransaction[]> => {
+	}: LoadSolWalletParams & Pick<GetSolTransactionsParams, 'before'>): Promise<
+		SolCertifiedTransaction[]
+	> => {
 		const transactions = await getSolTransactions({
 			network,
 			...rest
@@ -102,6 +105,7 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 		try {
 			const {
 				address: { data: address },
+				beforeSignature,
 				...rest
 			} = data;
 
@@ -112,6 +116,7 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 				}),
 				this.loadTransactions({
 					address,
+					before: beforeSignature,
 					...rest
 				})
 			]);

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -89,9 +89,9 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 	const data: PostMessageDataRequestSol = {
 		address,
 		solanaNetwork: network,
+		beforeSignature,
 		tokenAddress,
-		tokenOwnerAddress,
-		beforeSignature
+		tokenOwnerAddress
 	};
 
 	return {


### PR DESCRIPTION
# Motivation

Each Solana signature requires quite a lot of calls to the RPC to be parsed. To avoid too many unnecessary calls, we pass the last signature fetched to the worker, so that it can keep loading from there.

# Changes

- Get last signature imperatively from the Solana transaction store.
- Pass it to the worker as data.

# Tests

Current tests are sufficient.
