### PR TITLE
feat(frontend): removes colons

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -22,7 +22,7 @@
 	$: destination, networkId, isInvalidDestination, debounceValidate();
 </script>
 
-<label for="destination" class="font-bold">{$i18n.send.text.destination}:</label>
+<label for="destination" class="font-bold">{$i18n.send.text.destination}</label>
 <InputTextWithAction
 	name="destination"
 	bind:value={destination}

--- a/src/frontend/src/lib/components/ui/Value.svelte
+++ b/src/frontend/src/lib/components/ui/Value.svelte
@@ -3,5 +3,5 @@
 	export let element: 'p' | 'div' = 'p';
 </script>
 
-<label for={ref} class="font-bold"><slot name="label" />:</label>
+<label for={ref} class="font-bold"><slot name="label" /></label>
 <svelte:element this={element} id={ref} class="mb-4 break-all font-normal"><slot /></svelte:element>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -653,7 +653,7 @@
 			"estimated_btc": "Estimated BTC Network Fee",
 			"estimated_inter_network": "Estimated Inter-network Fee",
 			"estimated_eth": "Estimated Ethereum Fee",
-			"max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>:",
+			"max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>",
 			"convert_fee": "Conversion fee",
 			"convert_inter_network_fee": "Inter-network fee",
 			"convert_btc_network_fee": "Bitcoin network fee",


### PR DESCRIPTION
# Motivation

The titles on the send and review form are written with a trailing colon, which should be removed.

# Changes

- removes colons

# Tests

**before:**
<img width="440" alt="image" src="https://github.com/user-attachments/assets/a7c61fe5-5962-47ef-a2aa-ec1b44cc7f46" />

<img width="427" alt="image" src="https://github.com/user-attachments/assets/e5f2be6a-e64c-43f0-8aa3-7739d20452c2" />


**after:**
<img width="437" alt="image" src="https://github.com/user-attachments/assets/ac496bf6-87c9-472e-ab39-83e20d245aa2" />

<img width="431" alt="image" src="https://github.com/user-attachments/assets/a7e2cea3-08bb-4734-9d59-a316a777edbe" />
