### PR TITLE
fix(frontend): updated toast warning color in the dark theme

### DIFF
--- a/src/frontend/src/lib/styles/theme/base-colors.scss
+++ b/src/frontend/src/lib/styles/theme/base-colors.scss
@@ -46,6 +46,7 @@ $dusk-900: #0a182f;
 $dusk-950: #070f1c;
 $salmon-600: #ee3850;
 $yellow-900: #713b12;
+$yellow-950: #352213;
 $a-white-0: #ffffff00;
 $a-white-5: #ffffff0d;
 $a-white-10: #ffffff1a;

--- a/src/frontend/src/lib/styles/theme/base-colors.scss
+++ b/src/frontend/src/lib/styles/theme/base-colors.scss
@@ -46,7 +46,6 @@ $dusk-900: #0a182f;
 $dusk-950: #070f1c;
 $salmon-600: #ee3850;
 $yellow-900: #713b12;
-$yellow-950: #542C0D;
 $a-white-0: #ffffff00;
 $a-white-5: #ffffff0d;
 $a-white-10: #ffffff1a;

--- a/src/frontend/src/lib/styles/theme/base-colors.scss
+++ b/src/frontend/src/lib/styles/theme/base-colors.scss
@@ -45,7 +45,6 @@ $dusk-800: #131e3c;
 $dusk-900: #0a182f;
 $dusk-950: #070f1c;
 $salmon-600: #ee3850;
-$yellow-900: #713b12;
 $yellow-950: #352213;
 $a-white-0: #ffffff00;
 $a-white-5: #ffffff0d;

--- a/src/frontend/src/lib/styles/theme/base-colors.scss
+++ b/src/frontend/src/lib/styles/theme/base-colors.scss
@@ -46,6 +46,7 @@ $dusk-900: #0a182f;
 $dusk-950: #070f1c;
 $salmon-600: #ee3850;
 $yellow-900: #713b12;
+$yellow-950: #542C0D;
 $a-white-0: #ffffff00;
 $a-white-5: #ffffff0d;
 $a-white-10: #ffffff1a;

--- a/src/frontend/src/lib/styles/theme/dark-theme.scss
+++ b/src/frontend/src/lib/styles/theme/dark-theme.scss
@@ -58,7 +58,7 @@
 	--color-background-warning-subtle-10: #{$a-sunset-10};
 	--color-background-warning-subtle-20: #{$a-sunset-20};
 	--color-background-warning-subtle-30: #{$a-sunset-30};
-	--color-background-warning-light: #{$yellow-900};
+	--color-background-warning-light: #{$yellow-950};
 	--color-background-error-primary: #{$salmon-600};
 	--color-background-error-secondary: #{$salmon-900};
 	--color-background-error-tertiary: #{$salmon-950};

--- a/src/frontend/src/lib/styles/theme/dark-theme.scss
+++ b/src/frontend/src/lib/styles/theme/dark-theme.scss
@@ -58,7 +58,7 @@
 	--color-background-warning-subtle-10: #{$a-sunset-10};
 	--color-background-warning-subtle-20: #{$a-sunset-20};
 	--color-background-warning-subtle-30: #{$a-sunset-30};
-	--color-background-warning-light: #{$yellow-950};
+	--color-background-warning-light: #{$yellow-900};
 	--color-background-error-primary: #{$salmon-600};
 	--color-background-error-secondary: #{$salmon-900};
 	--color-background-error-tertiary: #{$salmon-950};


### PR DESCRIPTION
# Motivation

Current yellow warning color in the dark theme is too active - suggestion is to dim it down a little bit

# Changes

<!-- List the changes that have been developed -->

# Tests
Before: 
<img width="757" alt="image" src="https://github.com/user-attachments/assets/32afa6ed-3dd9-42a0-89cc-b762577cdb3d" />

After: 
<img width="773" alt="image" src="https://github.com/user-attachments/assets/d4413d4d-4789-4f56-a954-4d7c386e1a13" />

<!-- Please provide any information or screenshots about the tests that have been done -->
