### PR TITLE
fix(frontend): Display correct sprinkle amount

### DIFF
--- a/src/frontend/src/lib/components/airdrops/AirdropEarnings.svelte
+++ b/src/frontend/src/lib/components/airdrops/AirdropEarnings.svelte
@@ -65,6 +65,9 @@
 	let totalRewardUsd: number;
 	$: totalRewardUsd = ckBtcRewardUsd + ckUsdcRewardUsd + icpRewardUsd;
 
+	let amountOfRewards: number;
+	$: amountOfRewards = 0;
+
 	let loading: boolean;
 	$: loading = true;
 
@@ -86,7 +89,7 @@
 			return;
 		}
 
-		({ ckBtcReward, ckUsdcReward, icpReward } = await getUserRewardsTokenAmounts({
+		({ ckBtcReward, ckUsdcReward, icpReward, amountOfRewards } = await getUserRewardsTokenAmounts({
 			ckBtcToken,
 			ckUsdcToken,
 			icpToken,
@@ -118,7 +121,7 @@
 			class:ease-in-out={loading}
 			class:animate-pulse={loading}
 			>{replacePlaceholders($i18n.airdrops.text.sprinkles_earned, {
-				$noOfSprinkles: '3',
+				$noOfSprinkles: amountOfRewards.toString(),
 				$amount: formatUSD({ value: totalRewardUsd })
 			})}
 		</div>

--- a/src/frontend/src/lib/services/reward-code.services.ts
+++ b/src/frontend/src/lib/services/reward-code.services.ts
@@ -238,11 +238,13 @@ export const getUserRewardsTokenAmounts = async ({
 	ckBtcReward: BigNumber;
 	ckUsdcReward: BigNumber;
 	icpReward: BigNumber;
+	amountOfRewards: number;
 }> => {
 	const initialRewards = {
 		ckBtcReward: ZERO,
 		ckUsdcReward: ZERO,
-		icpReward: ZERO
+		icpReward: ZERO,
+		amountOfRewards: 0
 	};
 
 	const { usage_awards } = await getUserInfo({ identity });
@@ -252,15 +254,18 @@ export const getUserRewardsTokenAmounts = async ({
 		return initialRewards;
 	}
 
-	return usageAwards.reduce((acc, { ledger, amount }) => {
-		const canisterId = ledger.toText();
+	return {
+		...usageAwards.reduce((acc, { ledger, amount }) => {
+			const canisterId = ledger.toText();
 
-		return ckBtcToken.ledgerCanisterId === canisterId
-			? { ...acc, ckBtcReward: acc.ckBtcReward.add(amount) }
-			: icpToken.ledgerCanisterId === canisterId
-				? { ...acc, icpReward: acc.icpReward.add(amount) }
-				: ckUsdcToken.ledgerCanisterId === canisterId
-					? { ...acc, ckUsdcReward: acc.ckUsdcReward.add(amount) }
-					: acc;
-	}, initialRewards);
+			return ckBtcToken.ledgerCanisterId === canisterId
+				? { ...acc, ckBtcReward: acc.ckBtcReward.add(amount) }
+				: icpToken.ledgerCanisterId === canisterId
+					? { ...acc, icpReward: acc.icpReward.add(amount) }
+					: ckUsdcToken.ledgerCanisterId === canisterId
+						? { ...acc, ckUsdcReward: acc.ckUsdcReward.add(amount) }
+						: acc;
+		}, initialRewards),
+		amountOfRewards: usageAwards.length
+	};
 };

--- a/src/frontend/src/lib/services/reward-code.services.ts
+++ b/src/frontend/src/lib/services/reward-code.services.ts
@@ -254,18 +254,23 @@ export const getUserRewardsTokenAmounts = async ({
 		return initialRewards;
 	}
 
-	return {
-		...usageAwards.reduce((acc, { ledger, amount }) => {
-			const canisterId = ledger.toText();
+	return usageAwards.reduce((acc, { ledger, amount }) => {
+		const canisterId = ledger.toText();
 
-			return ckBtcToken.ledgerCanisterId === canisterId
-				? { ...acc, ckBtcReward: acc.ckBtcReward.add(amount) }
-				: icpToken.ledgerCanisterId === canisterId
-					? { ...acc, icpReward: acc.icpReward.add(amount) }
-					: ckUsdcToken.ledgerCanisterId === canisterId
-						? { ...acc, ckUsdcReward: acc.ckUsdcReward.add(amount) }
-						: acc;
-		}, initialRewards),
-		amountOfRewards: usageAwards.length
-	};
+		return ckBtcToken.ledgerCanisterId === canisterId
+			? {
+					...acc,
+					ckBtcReward: acc.ckBtcReward.add(amount),
+					amountOfRewards: acc.amountOfRewards + 1
+				}
+			: icpToken.ledgerCanisterId === canisterId
+				? { ...acc, icpReward: acc.icpReward.add(amount), amountOfRewards: acc.amountOfRewards + 1 }
+				: ckUsdcToken.ledgerCanisterId === canisterId
+					? {
+							...acc,
+							ckUsdcReward: acc.ckUsdcReward.add(amount),
+							amountOfRewards: acc.amountOfRewards + 1
+						}
+					: acc;
+	}, initialRewards);
 };

--- a/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
@@ -447,7 +447,7 @@ describe('reward-code', () => {
 			expect(result.ckBtcReward.toString()).toEqual('1000');
 			expect(result.ckUsdcReward.toString()).toEqual('0');
 			expect(result.icpReward.toString()).toEqual('0');
-			expect(result.amountOfRewards.toString()).toEqual('4');
+			expect(result.amountOfRewards.toString()).toEqual('1');
 		});
 
 		it('should ignore invalid canister ids but still return values', async () => {
@@ -460,7 +460,7 @@ describe('reward-code', () => {
 			expect(result.ckBtcReward.toString()).toEqual('0');
 			expect(result.ckUsdcReward.toString()).toEqual('0');
 			expect(result.icpReward.toString()).toEqual('0');
-			expect(result.amountOfRewards.toString()).toEqual('6');
+			expect(result.amountOfRewards.toString()).toEqual('3');
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
@@ -434,6 +434,7 @@ describe('reward-code', () => {
 			expect(result.ckBtcReward.toString()).toEqual('3000');
 			expect(result.ckUsdcReward.toString()).toEqual('4000');
 			expect(result.icpReward.toString()).toEqual('3000');
+			expect(result.amountOfRewards.toString()).toEqual('6');
 		});
 
 		it('should ignore invalid canister ids', async () => {
@@ -446,6 +447,7 @@ describe('reward-code', () => {
 			expect(result.ckBtcReward.toString()).toEqual('1000');
 			expect(result.ckUsdcReward.toString()).toEqual('0');
 			expect(result.icpReward.toString()).toEqual('0');
+			expect(result.amountOfRewards.toString()).toEqual('4');
 		});
 
 		it('should ignore invalid canister ids but still return values', async () => {
@@ -458,6 +460,7 @@ describe('reward-code', () => {
 			expect(result.ckBtcReward.toString()).toEqual('0');
 			expect(result.ckUsdcReward.toString()).toEqual('0');
 			expect(result.icpReward.toString()).toEqual('0');
+			expect(result.amountOfRewards.toString()).toEqual('6');
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Currently we hardcoded to display 3 sprinkles in the `<AirdropEarnings/>` component. This PR implements displaying the correct amount of airdrops received.

# Changes

- Updated `getUserRewardsTokenAmounts` to return amount of airdrops
- Updated AirdropEarnings component to display amount of airdrops
- Updated tests

# Tests

Tests have been updated to also check for the amount of airdrops received