### PR TITLE
feat(frontend): updates reward campaign twitter links

### DIFF
--- a/src/frontend/src/env/airdrop-campaigns.json
+++ b/src/frontend/src/env/airdrop-campaigns.json
@@ -11,7 +11,7 @@
 			"Hold $20 worth of tokens at the time of issuance"
 		],
 		"logo": "/images/airdrops/oisy-airdrop-logo.svg",
-		"campaignHref": "https://x.com/intent/post?text=Sprinkles%20from%20%40OISY%20Wallet%20just%20went%20live%0A%0A50%20token%20reward%20opportunities%2C%20EVERY%20Day%0A%0ATry%20OISY.com%20and%20stack%20some%20rewards%20fam%20%F0%9F%9A%80",
+		"campaignHref": "2https://x.com/intent/post?text=Sprinkles%20from%20%40OISY%20Wallet%20just%20went%20live%0A%0A50%20token%20reward%20opportunities%2C%20EVERY%20Day%0A%0ATry%20OISY.com%20and%20stack%20some%20rewards%20fam%20%F0%9F%9A%80",
 		"jackpotHref": "https://x.com/intent/post?text=Just%20received%20%2450%20in%20tokens%20from%20%40OISY%20Wallet%E2%80%99s%20%E2%80%98Sprinkles%E2%80%99%20initiative%20%F0%9F%AA%82%0A%0AAnd%20I%E2%80%99m%20eligible%20again%20tomorrow%20...%20and%20the%20day%20after%20that%20...%20and%20the%20day%20after%20that%20...%20and%2C%20you%20get%20the%20idea%0A%0ASign%20up%20at%20OISY.com%20%E2%80%94%2050%20drops%20a%20day%2C%20every%20day%20%F0%9F%A4%91",
 		"airdropHref": "https://x.com/intent/post?text=Just%20got%20my%20sprinkles%20from%20%40OISY%20Wallet.%0A%0AI%E2%80%99m%20eligible%20for%2050%20drops%20every%20day%2C%20and%20I%E2%80%99m%20ready%20for%20more%21%20%F0%9F%AA%82%0A%0AIf%20you%E2%80%99re%20not%20on%20OISY.com%2C%20you%E2%80%99re%20NGMI",
 		"learnMoreHref": "https://docs.oisy.com/rewards/oisy-sprinkles",


### PR DESCRIPTION
# Motivation

The twitter links for the reward feature needs to be updated.

# Tests

**before:**

info:
<img width="451" alt="image" src="https://github.com/user-attachments/assets/708947ff-b4f0-4d0d-8328-b0d8e18a2a99" />


reward:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/d435f7bb-bc87-464d-9a38-3c90ce8048b8" />


jackpot:
<img width="451" alt="image" src="https://github.com/user-attachments/assets/e3de2819-b70f-40b3-a331-87e188ecf3c1" />


**after:**

info:

reward:

jackpot: