### PR TITLE
feat(frontend): remove the warning for non-ATA destination address

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1,988 +1,988 @@
 {
-  "core": {
-    "text": {
-      "cancel": "Cancel",
-      "next": "Next",
-      "save": "Save",
-      "back": "Back",
-      "done": "Done",
-      "close": "Close",
-      "refresh": "Refresh",
-      "name": "Name",
-      "symbol": "Symbol",
-      "decimals": "Decimals",
-      "amount": "Amount",
-      "max": "Max",
-      "reject": "Reject",
-      "approve": "Approve",
-      "view": "View",
-      "copy": "Copy",
-      "clear_filter": "Clear filter",
-      "not_available": "n/a",
-      "new": "New"
-    },
-    "info": {
-      "test_banner": "For testing purposes only!"
-    },
-    "alt": {
-      "logo": "$name logo",
-      "go_to_home": "Go to the $oisy_name home page",
-      "back": "Go back to the previous page"
-    },
-    "warning": {
-      "do_not_close": "Don't close this tab until the transaction is done"
-    }
-  },
-  "navigation": {
-    "text": {
-      "tokens": "Assets",
-      "settings": "Settings",
-      "dapp_explorer": "Explore",
-      "activity": "Activity",
-      "airdrops": "Rewards",
-      "source_code_on_github": "Source code on GitHub",
-      "view_on_explorer": "View on explorer",
-      "source_code": "Source code",
-      "changelog": "Changelog",
-      "documentation": "Documentation",
-      "support": "Support",
-      "confirm_navigate": "Are you sure you want to navigate away?",
-      "vip_qr_code": "VIP QR codes"
-    },
-    "alt": {
-      "tokens": "Go to the assets view",
-      "settings": "Open your settings",
-      "dapp_explorer": "Open dapp explorer",
-      "activity": "Open the activity view",
-      "airdrops": "Open the Rewards view",
-      "more_settings": "More settings",
-      "menu": "Your wallet address, settings, sign-out and external links",
-      "changelog": "Open the changelog of $oisy_name on GitHub to review the latest updates",
-      "documentation": "Open the $oisy_name documentation",
-      "support": "Open the Support section of the $oisy_name documentation",
-      "open_twitter": "Open the DFINITY X/Twitter feed",
-      "vip_qr_code": "Generate an invitation link"
-    },
-    "short": {
-      "documentation": "Docs"
-    }
-  },
-  "auth": {
-    "text": {
-      "title_part_1": "$oisy_name",
-      "title_part_2": "100% Decentralized",
-      "logout": "Logout",
-      "authenticate": "Open or Create",
-      "asset_types": "Bitcoin, Solana, Ethereum, ICP, and more",
-      "instant_and_private": "Instant and private access anywhere",
-      "advanced_cryptography": "100% onchain: peace of mind through advanced cryptography"
-    },
-    "alt": {
-      "preview": "Preview of $oisy_name once signed in, both on desktop and mobile"
-    },
-    "warning": {
-      "not_signed_in": "You are not signed in. Please sign in to continue.",
-      "session_expired": "You have been logged out because your session has expired."
-    },
-    "error": {
-      "no_internet_identity": "No internet identity.",
-      "invalid_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential. Please contact the issuer and request the credential again.",
-      "error_validating_pouh_credential_oisy": "Sorry, but there was an error while validating the Humanity Credential in $oisy_short: $error",
-      "error_validating_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential.",
-      "error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
-      "missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
-      "no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?",
-      "error_while_signing_in": "Something went wrong while sign-in.",
-      "unexpected_issue_with_syncing": "Unexpected issue while syncing the status of your authentication."
-    }
-  },
-  "dapps": {
-    "text": {
-      "all_dapps": "All dapps",
-      "featured": "Featured",
-      "sign_in": "Sign-in to explore the ecosystem.",
-      "title": "Explore Apps",
-      "open_dapp": "Open $dAppName",
-      "submit_your_dapp": "Submit your dapp"
-    },
-    "alt": {
-      "learn_more": "Learn more about $dAppName",
-      "logo": "Logo of $dAppName",
-      "show_all": "Show all decentralised applications",
-      "show_tag": "Show decentralised applications with the tag $tag",
-      "open_dapp": "Open the app $dAppName",
-      "open_telegram": "Open $dAppName on Telegram",
-      "open_open_chat": "Open $dAppName on OpenChat",
-      "open_twitter": "Open the $dAppName X/Twitter feed",
-      "source_code_on_github": "View source code of $dAppName on github",
-      "submit_your_dapp": "Submit your dapp to be shown in the dapp-explorer",
-      "tags": "Tags related to $dAppName",
-      "website": "Image of $dAppName"
-    }
-  },
-  "airdrops": {
-    "text": {
-      "title": "Rewards",
-      "active_campaigns": "Active Opportunities",
-      "upcoming_campaigns": "Upcoming Opportunities",
-      "active_date": "Due on",
-      "participate_title": "Participate and earn Sprinkles",
-      "share": "Share on X",
-      "learn_more": "Learn more",
-      "check_status": "Check Status & Eligibility",
-      "requirements_title": "Requirements",
-      "modal_button_text": "Got it",
-      "activity_button_text": "Check on Recent Activity",
-      "activity_button_text_short": "Check activity",
-      "no_balance_title": "Earn $oisy_short Sprinkles",
-      "no_balance_description": "Check back later to see your rewards",
-      "open_wallet": "Take me to the wallet",
-      "state_modal_title": "Congratulations on earning today’s $oisy_short Sprinkles!",
-      "state_modal_title_jackpot": "Congratulations on earning today’s largest $oisy_short Sprinkles!",
-      "state_modal_content_text": "Share your victory on Twitter to qualify for another chance to earn.",
-      "carousel_slide_title": "$oisy_short Sprinkles are now Live!",
-      "carousel_slide_cta": "Learn more",
-      "sprinkles_earned": "You've earned $noOfSprinkles sprinkles, totaling $amount! \uD83C\uDF89",
-      "youre_eligible": "You're eligible!"
-    },
-    "alt": {
-      "upcoming_campaigns": "Keep an eye out for upcoming token drops! Subscribe to $oisy_short on X and follow us to catch all the latest updates."
-    }
-  },
-  "footer": {
-    "text": {
-      "incubated_with": "Incubated with",
-      "by": "by",
-      "dfinity_foundation": "DFINITY Foundation",
-      "copyright": "© 2025"
-    },
-    "alt": {
-      "dfinity": "Go to DFINITY Foundation website"
-    }
-  },
-  "wallet": {
-    "text": {
-      "address": "Address",
-      "wallet_address": "Wallet address",
-      "your_addresses": "Your addresses",
-      "address_copied": "Address copied to clipboard.",
-      "wallet_address_copied": "Wallet address copied to clipboard.",
-      "display_wallet_address_qr": "Display wallet address as a QR code",
-      "icp_deposits": "Note: For ICP deposits, use the 'Receive' button in your ICP account to get the right address.",
-      "use_address_from_to": "Use this address to transfer $token to and from your wallet."
-    },
-    "alt": {
-      "open_etherscan": "Open your address on Etherscan",
-      "open_solscan": "Open your address on Solscan",
-      "qrcode_address": "Scan this QR code to copy the address to receive $token tokens"
-    }
-  },
-  "init": {
-    "text": {
-      "initializing_wallet": "Preparing your wallet...",
-      "securing_session": "Securing session with Internet Identity",
-      "retrieving_public_keys": "Retrieving your public keys for Bitcoin, Ethereum and Solana",
-      "done": "Enjoy $oisy_short"
-    },
-    "info": {
-      "hold_loading": "Hold tight, we are loading some information...",
-      "hold_loading_wallet": "Hold tight, we are loading some initial data for your wallet..."
-    },
-    "error": {
-      "no_alchemy_config": "No Alchemy config for network $network",
-      "no_alchemy_provider": "No Alchemy provider for network $network",
-      "no_alchemy_erc20_provider": "No Alchemy ERC20 provider for network $network",
-      "no_etherscan_provider": "No Etherscan provider for network $network",
-      "no_etherscan_rest_api": "No Etherscan Rest API for network $network",
-      "no_infura_provider": "No Infura provider for network $network",
-      "no_infura_cketh_provider": "No Infura CkETH provider for network $network",
-      "no_infura_erc20_provider": "No Infura ERC20 provider for network $network",
-      "no_infura_erc20_icp_provider": "No Infura ERC20 Icp provider for network $network",
-      "no_solana_rpc": "No Solana RPC for network $network",
-      "no_solana_network": "No Solana network for network $network",
-      "eth_address_unknown": "ETH address is unknown.",
-      "loading_address": "Error while loading the $symbol address.",
-      "loading_balance": "Error while loading the ETH balance.",
-      "loading_balance_symbol": "Error while loading $symbol balance.",
-      "erc20_contracts": "Error while loading the ERC20 contracts.",
-      "spl_tokens": "Error while loading the SPL tokens.",
-      "minter_ckbtc_btc": "A configured minter is required to convert ckBTC to BTC.",
-      "minter_cketh_eth": "A configured minter is required to convert ckETH to ETH.",
-      "minter_ckerc20_erc20": "A configured minter is required to convert ckERC20 to Erc20.",
-      "ledger_cketh_eth": "A configured ckETH ledger is required to convert ckErc20 to Erc20.",
-      "minter_btc": "A configured minter is required to retrieve BTC.",
-      "minter_ckbtc_info": "A configured minter is required to fetch the ckBTC info",
-      "minter_cketh_info": "A configured minter is required to fetch the ckETH info",
-      "minter_ckbtc_loading_info": "Error while loading the ckBTC minter information.",
-      "minter_cketh_loading_info": "Error while loading the ckETH minter information.",
-      "btc_fees_estimation": "Error while querying the estimation of the BTC fees.",
-      "btc_withdrawal_statuses": "Error while fetching the BTC withdrawal statuses.",
-      "transaction_price": "Error while loading the estimation of the price of a transaction.",
-      "icrc_canisters": "Error while loading the ICRC canisters.",
-      "erc20_user_tokens": "Error while loading the ERC20 user tokens.",
-      "spl_user_tokens": "Error while loading the SPL user tokens.",
-      "erc20_user_token": "Error while enabling the ERC20 twin token.",
-      "icrc_custom_token": "Error while loading the ICRC custom token.",
-      "loading_wallet_timeout": "Your wallet requires some initial data which has not been loaded yet. Please try again.",
-      "allow_signing": "An issue occurred while setting up your wallet for signing. You've been signed out. If the issue persists, contact support.",
-      "btc_wallet_error": "Error while loading BTC wallet information.",
-      "sol_wallet_error": "Error while loading SOL wallet information."
-    }
-  },
-  "hero": {
-    "text": {
-      "available_balance": "Available balance",
-      "unavailable_balance": "$ value is not available",
-      "top_up": "Top up your wallet to start using it!",
-      "learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
-    }
-  },
-  "settings": {
-    "text": {
-      "title": "Settings",
-      "principal": "Your Principal",
-      "principal_copied": "Principal copied to clipboard",
-      "principal_description": "Your ID for the $oisy_name. Created by your Internet Identity.",
-      "session": "Your session expires in",
-      "session_description": "All sessions last 1 hour. After 1 hour, you will need to authenticate again with Internet Identity.",
-      "testnets": "Show test networks",
-      "testnets_description": "Display the test networks (Sepolia) and twin tokens on testnets (ckTESTBTC and ckSepolia).",
-      "hide_zero_balances_description": "Enable this feature to declutter your wallet view by hiding all tokens with a zero balance.",
-      "credentials_title": "Credentials",
-      "pouh_credential": "Humanity Credential",
-      "pouh_credential_description": "The Humanity Credential is a proof of humanity. It is issued by Decide AI.",
-      "present_pouh_credential": "Present",
-      "pouh_credential_verified": "Verified ✅",
-      "appearance": "Appearance",
-      "appearance_light": "Light",
-      "appearance_dark": "Dark",
-      "appearance_system": "System"
-    },
-    "alt": {
-      "testnets_toggle": "Toggle to show or hide testnets",
-      "github_release": "$oisy_short release notes on GitHub",
-      "appearance_light": "Enables light mode",
-      "appearance_dark": "Enables dark mode",
-      "appearance_system": "Enables your operating systems color mode"
-    },
-    "error": {
-      "loading_profile": "Error while loading the profile. Please refresh the page to have the full experience."
-    }
-  },
-  "networks": {
-    "title": "Current network. Access to selection.",
-    "test_networks": "Test networks",
-    "more": "More networks coming soon...",
-    "chain_fusion": "Chain Fusion (all networks)",
-    "network": "Network"
-  },
-  "receive": {
-    "text": {
-      "receive": "Receive",
-      "address": "Receive address",
-      "receive_token": "Receive $token"
-    },
-    "icp": {
-      "text": {
-        "account_id": "ICP Account ID",
-        "use_for_all_tokens": "Use for all tokens when receiving from wallets, users, or other apps that support this address format.",
-        "use_for_icrc_deposit": "Use for receiving ICRC-1 tokens in the ICP network, such as SNS, ck tokens, etc.",
-        "use_for_icp_deposit": "Use for ICP deposits from exchanges or other wallets that only support Account IDs.",
-        "your_private_eth_address": "Your private address for all ERC20 tokens.",
-        "display_account_id_qr": "Display ICP Account ID as a QR code",
-        "account_id_copied": "ICP Account ID copied to clipboard.",
-        "principal": "ICP Principal",
-        "internet_computer_principal_copied": "Internet Computer Principal copied to clipboard.",
-        "display_internet_computer_principal_qr": "Display Internet Computer Principal as a QR code",
-        "icp_account": "ICP Account (for exchanges)",
-        "icp_account_copied": "ICP Account copied to clipboard.",
-        "display_icp_account_qr": "Display ICP Account as a QR code"
-      }
-    },
-    "ethereum": {
-      "text": {
-        "checking_status": "Checking $token status...",
-        "from_network": "Receive from $network Network",
-        "eth_to_cketh_description": "Converting $token into $ckToken requires a call to a smart contract on $network and passing your IC principal as argument – $oisy_name simplifies this procedure by enabling you to perform the conversion directly within the wallet.",
-        "learn_how_to_convert": "Learn how to convert $token to $ckToken",
-        "metamask": "Receive from Metamask",
-        "ethereum": "Ethereum",
-        "ethereum_address": "Address",
-        "ethereum_address_copied": "Ethereum address copied to clipboard.",
-        "display_ethereum_address_qr": "Display Ethereum address as a QR code"
-      },
-      "error": {
-        "no_metamask": "Metamask is not available."
-      }
-    },
-    "bitcoin": {
-      "text": {
-        "bitcoin": "Bitcoin",
-        "checking_status": "Checking BTC status...",
-        "refresh_status": "Refresh BTC status",
-        "initializing": "Initializing...",
-        "checking_incoming": "Checking for incoming BTC...",
-        "refreshing_wallet": "Refreshing wallet...",
-        "bitcoin_address": "Bitcoin",
-        "bitcoin_testnet_address": "Bitcoin (Testnet)",
-        "bitcoin_regtest_address": "Bitcoin (Regtest)",
-        "display_bitcoin_address_qr": "Display Bitcoin Address as a QR code",
-        "bitcoin_address_copied": "Bitcoin Address copied to clipboard.",
-        "from_network": "Transfer Bitcoin on the BTC network to this address to receive ckBTC.",
-        "fee_applied": "Please note that an estimated inter-network fee of $fee BTC will be applied."
-      },
-      "info": {
-        "no_new_btc": "No new confirmed BTC.",
-        "check_btc_progress": "Checking for incoming BTC already in progress."
-      },
-      "error": {
-        "unexpected_btc": "Something went wrong while checking for incoming BTC."
-      }
-    },
-    "solana": {
-      "text": {
-        "solana_address": "Solana Address",
-        "solana_testnet_address": "Solana Testnet Address",
-        "solana_devnet_address": "Solana Devnet Address",
-        "solana_local_address": "Solana Local Address",
-        "solana_address_copied": "Solana address copied to clipboard",
-        "display_solana_address_qr": "Display Solana address as QR code"
-      }
-    }
-  },
-  "send": {
-    "text": {
-      "send": "Send",
-      "destination": "Destination",
-      "source": "Source",
-      "balance": "Balance",
-      "review": "Review",
-      "signing_approval": "Signing approval...",
-      "approving": "Approving...",
-      "approving_fees": "Approving fees...",
-      "approving_transfer": "Approving transfer...",
-      "approving_wallet_connect": "Approving WalletConnect request...",
-      "refreshing_ui": "Refreshing UI",
-      "initializing": "Initializing transaction...",
-      "signing_transaction": "Signing transaction...",
-      "sending": "Sending...",
-      "signing": "Signing...",
-      "signing_message": "Signing message...",
-      "network": "Network",
-      "source_network": "Source network",
-      "destination_network": "Destination network",
-      "initializing_transaction": "Initializing transaction",
-      "convert_to_native_icp": "Convert to native ICP",
-      "open_qr_modal": "Start QR Code scan for transaction details",
-      "scan_qr": "Scan QR Code"
-    },
-    "placeholder": {
-      "enter_eth_address": "Enter public address (0x)",
-      "enter_recipient_address": "Enter recipient address",
-      "enter_wallet_address": "Enter wallet address",
-      "select_network": "Select network"
-    },
-    "info": {
-      "ckbtc_certified": "Please wait until the ckBTC parameters have been certified.",
-      "cketh_certified": "Please wait until the ckETH parameters have been certified.",
-      "pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete.",
-      "no_available_utxos": "You won't have available utxos to perform this transaction."
-    },
-    "assertion": {
-      "invalid_destination_address": "Invalid destination address",
-      "insufficient_funds": "Insufficient funds.",
-      "unknown_minimum_ckbtc_amount": "The minimum amount of ckBTC required for converting to BTC is unknown.",
-      "unknown_minimum_cketh_amount": "The minimum amount of ckETH required for converting to ETH is unknown.",
-      "unknown_minimum_amount": "The minimum amount of $sourceTokenSymbol required for converting to $destinationTokenSymbol is unknown.",
-      "minimum_ckbtc_amount": "The amount falls below the minimum of $amount ckBTC required for converting to BTC.",
-      "minimum_cketh_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
-      "minimum_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
-      "minimum_ledger_fees": "The amount falls below the ledger fees $symbol.",
-      "minimum_cketh_balance": "The $symbol balance falls below the estimated fee of $amount.",
-      "unknown_cketh": "The ckETH token cannot be retrieved.",
-      "destination_address_invalid": "Destination address is invalid.",
-      "amount_invalid": "Amount is invalid.",
-      "insufficient_funds_for_gas": "Insufficient funds for gas",
-      "insufficient_funds_for_amount": "Insufficient funds for amount",
-      "insufficient_ethereum_funds_to_cover_the_fees": "Insufficient Ethereum funds to cover the fees",
-      "insufficient_solana_funds_to_cover_the_fees": "Insufficient Solana funds to cover the fees",
-      "not_enough_tokens_for_gas": "Not enough $symbol for gas. Balance: $balance $symbol",
-      "gas_fees_not_defined": "Gas fees are not defined.",
-      "max_gas_fee_per_gas_undefined": "Max fee per gas or max priority fee per gas is undefined.",
-      "address_unknown": "Address is unknown.",
-      "minter_info_not_loaded": "Try again in a few seconds, a ckETH configuration parameter is not yet loaded.",
-      "minter_info_not_certified": "Try again in a few seconds, a ckETH configuration parameter has not been certified.",
-      "cketh_max_transaction_fee_missing": "The maximum transaction fee for ckETH is missing.",
-      "utxos_fee_missing": "UTXOs fee is missing."
-    },
-    "error": {
-      "unexpected": "Something went wrong while sending the transaction.",
-      "destination_address_unknown": "ETH destination address is unknown",
-      "metamask_connected": "Cannot get your accounts. Is your Metamask open and already connected?",
-      "metamask_no_accounts": "No Metamask accounts found.",
-      "metamask_switch_network": "Cannot request Metamask to switch to chain ID $chain_id. Is your Metamask using $network_name?",
-      "erc20_data_undefined": "Erc20 transaction Data cannot be undefined or null.",
-      "data_undefined": "Transaction Data cannot be undefined or null.",
-      "no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
-      "invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
-      "incompatible_token": "The token is incompatible. Please try again with a compatible token.",
-      "no_btc_network_id": "Current network ($networkId) is not a Bitcoin network.",
-      "no_solana_network_id": "Current network ($networkId) is not a Solana network.",
-      "no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later.",
-      "unexpected_utxos_fee": "Something went wrong while calculating transaction fee.",
-      "unable_to_retrieve_amount": "n/a (unable to retrieve)",
-      "solana_transaction_expired": "Your send transaction was not processed by the Solana network and expired, most likely because the provided priority fee was not sufficient. We updated it to the latest recommended amount, so please try sending it again."
-    }
-  },
-  "convert": {
-    "text": {
-      "converting": "Converting...",
-      "convert_to_btc": "Convert to BTC",
-      "convert_to_ckbtc": "Convert to ckBTC",
-      "convert_to_token": "Convert to $token",
-      "convert_to_cketh": "Convert to ckETH",
-      "convert_to_ckerc20": "Convert to $ckErc20",
-      "convert_eth_to_cketh": "Convert $token to $ckToken",
-      "cketh_conversions_may_take": "ckETH conversions may take up to 20 minutes",
-      "ckerc20_conversions_may_take": "$ckErc20 conversions may take up to 20 minutes",
-      "how_to_convert_eth_to_cketh": "Here is how to can convert $token to $ckToken on $oisy_name",
-      "send_eth": "Send $token to your $oisy_name address",
-      "wait_eth_current_balance": "Wait for $token to arrive. Current balance",
-      "set_amount": "Set amount for conversion",
-      "check_balance_for_fees": "Check $token balance for conversion fees",
-      "fees_explanation": "You need enough $token to cover the smart contract execution fees.",
-      "current_balance": "👉 Current balance:",
-      "review_button": "Review",
-      "convert_button": "Convert",
-      "input_reset_button": "Reset input value",
-      "swap_to_token": "Convert $sourceToken → $destinationToken",
-      "review": "Review transaction",
-      "max_balance": "Max",
-      "source_network": "Source network",
-      "destination_network": "Destination network",
-      "conversion_may_take": "Conversion may take up to 1 hour",
-      "executing_transaction": "Executing transaction...",
-      "initializing": "Initializing transaction...",
-      "refreshing_ui": "Refreshing UI",
-      "unsupported_token_conversion": "Conversion for the selected token is not supported.",
-      "calculating_max_amount": "Calculating..."
-    },
-    "assertion": {
-      "insufficient_funds": "Insufficient balance"
-    },
-    "error": {
-      "loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized.",
-      "unexpected": "Something went wrong while converting tokens.",
-      "unexpected_missing_data": "Something went wrong while initiating a convert transaction."
-    }
-  },
-  "swap": {
-    "text": {
-      "swap": "Swap",
-      "select_destination_token": "Select token to receive",
-      "select_source_token": "Select token to pay",
-      "switch_tokens_button": "Switch tokens",
-      "review": "Review transaction",
-      "review_button": "Review swap",
-      "max_slippage": "Max slippage",
-      "max_balance": "Max",
-      "not_available": "n/a",
-      "value_difference": "Value difference",
-      "total_fee": "Total estimated fee",
-      "network_fee": "Network fee",
-      "approval_fee": "Approval fee",
-      "gas_fee": "Gas fee",
-      "lp_fee": "LP fee",
-      "max_slippage_info": "Enter value between 0% and 50%",
-      "max_slippage_warning": "Risk warning: high slippage may lead to losses due to market volatility",
-      "max_slippage_error": "Slippage tolerance cannot be 0% or exceed 50%",
-      "swap_button": "Swap now",
-      "swap_is_not_offered": "This swap is currently not offered.",
-      "executing_transaction": "Executing transaction...",
-      "initializing": "Initializing transaction...",
-      "swapping": "Swapping...",
-      "refreshing_ui": "Refreshing UI",
-      "swap_provider": "Swap provider"
-    },
-    "error": {
-      "kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
-      "unexpected": "Something went wrong while swapping tokens.",
-      "unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
-      "slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again."
-    }
-  },
-  "buy": {
-    "text": {
-      "buy": "Buy",
-      "buy_dev": "Buy (Dev Environment)"
-    },
-    "onramper": {
-      "title": "Buy through Onramper"
-    }
-  },
-  "tokens": {
-    "text": {
-      "title": "Tokens",
-      "contract_address": "Contract address",
-      "token_address": "Token address",
-      "balance": "Balance",
-      "hide_zero_balances": "Hide zero balances",
-      "hide_zeros": "Hide zeros",
-      "all_tokens_with_zero_hidden": "All assets with zero balance are currently hidden",
-      "buy_or_receive": "Buy or receive your first tokens now to see them in the list",
-      "initializing": "Initializing...",
-      "updating_ui": "Updating the UI...",
-      "show_token": "Show token",
-      "hide_token": "Hide token",
-      "select_token": "Select token",
-      "exchange_is_not_available": "USD value is currently not available.",
-      "source_token_title": "You pay",
-      "destination_token_title": "You receive"
-    },
-    "details": {
-      "title": "Token details",
-      "token": "Token",
-      "network": "Network",
-      "contract_address_copied": "Contract address copied to clipboard.",
-      "token_address_copied": "Token address copied to clipboard.",
-      "twin_token": "Twin token",
-      "standard": "Standard"
-    },
-    "balance": {
-      "error": {
-        "not_applicable": "n/a"
-      }
-    },
-    "import": {
-      "text": {
-        "title": "Import token",
-        "review": "Review",
-        "saving": "Saving...",
-        "updating": "Updating token list",
-        "ledger_canister_id": "Ledger Canister ID",
-        "index_canister_id": "Index Canister ID",
-        "minter_canister_id": "Minter Canister ID",
-        "ledger_canister_id_copied": "Ledger Canister ID copied to clipboard.",
-        "index_canister_id_copied": "Index Canister ID copied to clipboard.",
-        "minter_canister_id_copied": "Minter Canister ID copied to clipboard.",
-        "verifying": "Verifying token details...",
-        "add_the_token": "Add the token",
-        "info": "Ledger and Index canister IDs are usually available on the project’s website. ",
-        "info_index": "The Index canister ID is optional, but without it, $oisy_short can’t display transaction history.",
-        "custom_tokens_not_supported": "The selected network does not support custom tokens."
-      },
-      "error": {
-        "loading_metadata": "Error while loading the metadata of the token.",
-        "no_metadata": "No metadata for the token is provided. This is unexpected.",
-        "unexpected_ledger": "Something went wrong while validating the Ledger canister.",
-        "unexpected_index": "Something went wrong while validating the Index canister.",
-        "unexpected_index_ledger": "Something went wrong while loading the Ledger ID related to the Index canister.",
-        "invalid_ledger_id": "The Ledger ID is not related to the Index canister.",
-        "missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
-        "missing_contract_address": "The contract address is missing. Did you provide a value?",
-        "missing_token_address": "The token address is missing. Did you provide a value?",
-        "no_network": "No network is selected. This is unexpected."
-      },
-      "warning": {
-        "do_not_close_manage": "$oisy_name is preparing and securing the new tokens. Please don't close this tab until it's completed."
-      }
-    },
-    "manage": {
-      "text": {
-        "title": "Manage tokens",
-        "manage_list": "Manage tokens",
-        "do_not_see_import": "Don’t see your token? Import",
-        "manage_for_network": "Managing tokens for $network",
-        "network": "Network",
-        "all_tokens_zero_balance": "All tokens have zero balance."
-      },
-      "placeholder": {
-        "select_network": "Select the network"
-      },
-      "info": {
-        "no_changes": "No changes need to be saved."
-      },
-      "error": {
-        "unexpected_build": "An unexpected error happened while building the list of known tokens.",
-        "empty": "No tokens to enable or disable have been selected."
-      }
-    },
-    "hide": {
-      "title": "Hide token?",
-      "token": "Hide $token",
-      "info": "You can add this token back in the future by going into <strong>“Manage tokens”</strong> in your wallet view.",
-      "confirm": "Hide",
-      "hiding": "Hiding..."
-    },
-    "alt": {
-      "context_menu": "Context menu for to the selected token",
-      "open_etherscan": "Open the details of the token on Etherscan",
-      "open_blockstream": "Open the details of the token on Blockstream",
-      "open_dashboard": "Open the details of the token on the ICP Dashboard",
-      "open_contract_address_block_explorer": "Open the contract address on a block explorer",
-      "open_token_address_block_explorer": "Open the token address on a block explorer",
-      "token_group_number": "Total number of tokens in the group for native token $token"
-    },
-    "placeholder": {
-      "enter_contract_address": "Enter an ERC20 contract address",
-      "enter_token_address": "Enter an SPL token address",
-      "search_token": "Search for the token"
-    },
-    "warning": {
-      "trust_token": "Make sure you trust the token you are adding. If the token you are adding is controlled by a malicious party, they could try and scam you e.g., by making you believe you received a significant amount of tokens in order to trick you into sending them tokens in return or perform other undesired actions. Learn more about scams and security risks e.g. <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://support.metamask.io/hc/en-us/articles/4403988839451\">here</a>."
-    },
-    "error": {
-      "invalid_contract_address": "Contract address is invalid.",
-      "invalid_token_address": "Token address is invalid.",
-      "invalid_ledger": "The selected token is not linked with an Icrc Ledger canister.",
-      "no_metadata": "No metadata were fetched.",
-      "unexpected": "Something went wrong while saving the token.",
-      "unexpected_hiding": "Something went wrong while hiding the token.",
-      "already_available": "Token is already available.",
-      "loading_metadata": "Error while loading the metadata of the token.",
-      "not_toggleable": "Token is not toggleable, it can not be hidden.",
-      "incomplete_metadata": "No name or symbol is provided in the metadata.",
-      "duplicate_metadata": "A token with a similar name or symbol already exists.",
-      "unexpected_undefined": "Token is undefined. This is unexpected."
-    }
-  },
-  "fee": {
-    "text": {
-      "fee": "Fee",
-      "estimated_btc": "Estimated BTC Network Fee",
-      "estimated_inter_network": "Estimated Inter-network Fee",
-      "estimated_eth": "Estimated Ethereum Fee",
-      "max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>",
-      "convert_fee": "Conversion fee",
-      "convert_inter_network_fee": "Inter-network fee",
-      "convert_btc_network_fee": "Bitcoin network fee",
-      "zero_fee": "Free",
-      "total_fee": "Total fee",
-      "ata_fee": "ATA fee"
-    },
-    "assertion": {
-      "insufficient_funds_for_fee": "Insufficient balance to cover the fees."
-    },
-    "error": {
-      "cannot_fetch_gas_fee": "Cannot fetch gas fee."
-    }
-  },
-  "info": {
-    "bitcoin": {
-      "title": "Receive BTC & convert to ckBTC",
-      "description": "Convert Bitcoin into ckBTC and benefit from the fastest and cheapest Bitcoin transaction available. The conversion process can take up to an hour.",
-      "note": "You can convert ckBTC at any time back to BTC.",
-      "how_to": "How to convert to ckBTC"
-    },
-    "ethereum": {
-      "title": "Convert to $ckToken",
-      "description": "With a few steps, convert your native $network $token to its twinned ICP $ckToken directly within the $oisy_name. The conversion process can take up to 20 minutes.",
-      "note": "You can convert $ckToken at any time back to $token.",
-      "how_to": "How to convert to $ckToken",
-      "how_to_short": "How to convert $token"
-    }
-  },
-  "wallet_connect": {
-    "text": {
-      "name": "WalletConnect",
-      "session_proposal": "Session Proposal",
-      "connect": "Connect",
-      "connecting": "Connecting...",
-      "disconnect": "Disconnect",
-      "scan_qr": "Scan QR code",
-      "or_use_link": "or use WalletConnect link",
-      "proposer": "Proposer",
-      "review": "Review $chain_name ($key) required permissions",
-      "method": "Method",
-      "methods": "Methods",
-      "events": "Events",
-      "message": "Message",
-      "hex_data": "HEX Data",
-      "base64_data": "Base-64 Data",
-      "raw_copied": "Raw transaction data copied to clipboard.",
-      "sign_message": "Sign Message"
-    },
-    "alt": {
-      "connect_input": "e.g. wc:a281567bb3e4..."
-    },
-    "domain": {
-      "title": "Domain Verification",
-      "valid": "Valid ✅",
-      "valid_description": "The validation of the proposer's domain passed.",
-      "invalid": "Invalid ❌",
-      "invalid_description": "The domain of the proposer's website does not match the sender of the request.",
-      "security_risk": "Security risk ⚠️",
-      "security_risk_description": "The proposer's website is flagged as unsafe.",
-      "unknown": "Unknown ❓",
-      "unknown_description": "The domain of the proposer cannot be verified."
-    },
-    "info": {
-      "disconnected": "WalletConnect disconnected.",
-      "session_ended": "WalletConnect session was ended.",
-      "connected": "WalletConnect connected.",
-      "eth_transaction_executed": "WalletConnect eth_sendTransaction request executed.",
-      "sol_transaction_executed": "WalletConnect \"$method\" request executed.",
-      "sign_executed": "WalletConnect sign request executed."
-    },
-    "error": {
-      "qr_code_read": "Cannot read QR code.",
-      "missing_uri": "A URI to connect to should be provided.",
-      "disconnect": "An unexpected error happened while disconnecting the wallet. Resetting the connection anyway.",
-      "connect": "An unexpected error happened while trying to connect the wallet.",
-      "manual_workflow": "Please finalize the manual workflow that has already been initiated by opening the WalletConnect modal.",
-      "skipping_request": "Skipping the WalletConnect request as another action is currently in progress through an overlay.",
-      "method_not_support": "Requested method \"$method\" is not supported.",
-      "unexpected_pair": "An unexpected error happened while trying to pair the wallet.",
-      "no_connection_opened": "Unexpected error: No connection opened.",
-      "no_session_approval": "Unexpected error: No session proposal available.",
-      "unexpected": "Unexpected error while communicating with WalletConnect.",
-      "request_rejected": "WalletConnect request rejected",
-      "unknown_parameter": "Unknown parameter.",
-      "wallet_not_initialized": "Unexpected error. Your wallet address is not initialized.",
-      "from_address_not_wallet": "From address requested for the transaction is not the address of this wallet.",
-      "unknown_destination": "Unknown destination address.",
-      "request_not_defined": "Unexpected error: Request is not defined therefore cannot be processed.",
-      "unexpected_processing_request": "Unexpected error while processing the request with WalletConnect."
-    }
-  },
-  "transaction": {
-    "text": {
-      "details": "Transaction details",
-      "hash": "Transaction hash",
-      "hash_copied": "Transaction hash $hash copied to clipboard.",
-      "id": "Transaction ID",
-      "id_copied": "Transaction ID copied to clipboard.",
-      "timestamp": "Timestamp",
-      "type": "Type",
-      "from": "From",
-      "from_copied": "From address copied to clipboard.",
-      "to": "To",
-      "to_copied": "To address copied to clipboard.",
-      "block": "Block",
-      "interacted_with": "Interacted With (To)",
-      "status": "Status",
-      "confirmations": "Confirmations"
-    },
-    "status": {
-      "confirmed": "Confirmed",
-      "included": "Included",
-      "finalised": "Finalised",
-      "finalized": "Finalised",
-      "processed": "Processed",
-      "pending": "Pending...",
-      "safe": "Safe",
-      "unconfirmed": "Unconfirmed"
-    },
-    "label": {
-      "reimbursement": "Reimbursement",
-      "twin_token_sent": "$twinToken sent",
-      "ck_token_sent": "$ckToken sent",
-      "twin_token_converted": "Converted from $twinToken",
-      "ck_token_converted": "Converted from $ckToken",
-      "receiving_twin_token": "Receiving $twinToken",
-      "sending_twin_token": "Sending $twinToken",
-      "sending_twin_token_failed": "Sending $twinToken failed",
-      "converting_twin_token": "Converting $twinToken to $ckToken",
-      "converting_ck_token": "Converting $ckToken to $twinToken",
-      "twin_network": "$twinNetwork network",
-      "no_date_available": "No Date Available"
-    },
-    "alt": {
-      "open_block_explorer": "Open this transaction on a block explorer",
-      "open_from_block_explorer": "Open the 'From' address on a block explorer",
-      "open_to_block_explorer": "Open the 'To' address on a block explorer"
-    },
-    "error": {
-      "get_block_number": "Cannot get block number.",
-      "failed_get_transaction": "Failed to get the transaction from the provided (hash: $hash). Please reload the wallet dapp.",
-      "failed_get_mined_transaction": "Failed to get the mined transaction (hash: $hash). Please reload the wallet dapp."
-    }
-  },
-  "transactions": {
-    "text": {
-      "title": "Transactions",
-      "buy_or_receive": "Make your first transaction, and buy or receive tokens now!",
-      "transaction_history": "Your transaction history will appear here",
-      "open_transactions": "Open the list of $token transactions",
-      "mainnet_btc_transactions_info": "BTC transaction information is obtained from central third parties and should be independently verified.",
-      "transaction_history_unavailable": "Transaction history unavailable",
-      "missing_index_canister_explanation": "The token ledger is working fine, but the index canister is missing, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual.",
-      "index_canister_not_working_explanation": "The token ledger is working fine, but the index canister is having issues, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual."
-    },
-    "error": {
-      "loading_transactions": "Error while loading the transactions.",
-      "loading_transactions_symbol": "Error while loading the $symbol transactions.",
-      "no_token_loading_transaction": "Token not found. Transactions cannot be loaded.",
-      "uncertified_transactions_removed": "Several uncertified transactions were identified and subsequently removed from the displayed lists.",
-      "loading_pending_ck_ethereum_transactions": "Something went wrong while fetching the pending $network transactions.",
-      "get_transaction_for_hash": "Failed to get the transaction from the provided (hash: $hash).",
-      "unexpected_transaction_for_hash": "Something went wrong while loading the pending for hash: $hash."
-    }
-  },
-  "about": {
-    "why_oisy": {
-      "text": {
-        "label": "Why $oisy_short",
-        "title": "Why $oisy_short",
-        "hold_crypto": {
-          "title": "Unified Management of All Your Digital Assets",
-          "description": "$oisy_short allows you to manage all your digital assets — including Bitcoin, Solana, Ethereum, ICP, and more — in a single, unified wallet. No more juggling multiple wallets for different cryptocurrencies — enjoy a seamless and efficient experience across various platforms."
-        },
-        "network_custody": {
-          "title": "No more private key anxiety with Network Custody",
-          "description": "$oisy_name implements network custody, an innovative approach that leverages the Internet Computer's advanced cryptography to eliminate the need for you to handle private keys directly. This provides a secure and user-friendly alternative to traditional methods, aligning with the “Onchain is the New Online“ movement — a shift toward solutions that enhance security and resilience against cyber attacks by running on a distributed network."
-        },
-        "fully_on_chain": {
-          "title": "Tamper-Proof Security with a Fully On-Chain Wallet",
-          "description": "Not only are your keys secured, but the entire wallet application is stored <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/capabilities\">fully on-chain</a> and served directly into your browser from the Internet Computer. This means the entire wallet benefits from a decentralized trust model, making it tamper-proof and highly secure."
-        },
-        "cross_device": {
-          "title": "Access your wallet anytime from anywhere",
-          "description": "Using <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://identity.ic0.app/\">Internet Identity</a>, $oisy_short can easily be used across all devices you have linked to your private decentralized identity. This ensures seamless and secure access to your wallet whether you're on a smartphone, tablet, or desktop."
-        },
-        "verifiable_credentials": {
-          "title": "Unlock Extra Features with Verifiable Credentials",
-          "description": "$oisy_short integrates with the Internet Computer's <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/docs/current/developer-docs/identity/verifiable-credentials/overview\">verifiable credentials</a> platform. Access additional features like airdrops and exclusive functionalities by acquiring certain types of credentials, enhancing your overall experience."
-        },
-        "open_source": {
-          "title": "Trust in Transparency with Open Source",
-          "description": "$oisy_short is an <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"$oisy_repo_url\">open-source</a> project led by a dedicated team within the <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://dfinity.org/\">DFINITY foundation</a>, supported by over 200 world-leading cryptographers and engineers. Open sourcing ensures transparency, allowing the community to audit, contribute, and trust in the wallet's integrity."
-        }
-      }
-    }
-  },
-  "vip": {
-    "reward": {
-      "text": {
-        "open_wallet": "Take me to the wallet",
-        "title_successful": "Congratulations!",
-        "title_failed": "Invalid invitation code",
-        "reward_received": "Welcome to $oisy_short!",
-        "reward_failed": "Code is expired",
-        "reward_received_description": "You will receive your welcome gift any moment.",
-        "reward_failed_description": "Request a new one and try again"
-      },
-      "error": {
-        "loading_reward": "Error while loading a new reward code.",
-        "loading_user_data": "Failed to load user data from reward canister.",
-        "claiming_reward": "Error while claiming reward."
-      }
-    },
-    "invitation": {
-      "text": {
-        "title": "Generate invitation link",
-        "invitation_link_copied": "Invitation link copied to clipboard.",
-        "generate_new_link": "Generate new link",
-        "generating_new_code": "Generating new code",
-        "regenerate_countdown_text": "New link will be generated in $counter sec"
-      }
-    }
-  },
-  "signer": {
-    "sign_in": {
-      "text": {
-        "access_your_wallet": "Access your $oisy_name",
-        "open_or_create": "Open or create your wallet to securely connect to the dApp and start managing your assets."
-      }
-    },
-    "idle": {
-      "text": {
-        "waiting": "Waiting for the dApp interaction..."
-      },
-      "alt": {
-        "img_placeholder": "The astronaut logo moves its eyes from left to right while waiting for messages from the relying party dapp"
-      }
-    },
-    "permissions": {
-      "text": {
-        "title": "Review permissions",
-        "requested_permissions": "Requested permissions",
-        "your_wallet_address": "Your wallet address",
-        "icrc27_accounts": "View your $oisy_name address",
-        "icrc49_call_canister": "Request approval for transactions"
-      },
-      "error": {
-        "no_confirm_callback": "No callback to confirm the permissions, which is unexpected. Close the wallet and try again."
-      }
-    },
-    "origin": {
-      "text": {
-        "request_from": "Request from:",
-        "invalid_origin": "Invalid origin️!!"
-      },
-      "alt": {
-        "link_to_dapp": "Link to the dApp requesting permissions"
-      }
-    },
-    "consent_message": {
-      "text": {
-        "loading": "Loading consent message..."
-      },
-      "warning": {
-        "token_without_consent_message": "This token does not provide confirmation messages, so the information below was extracted by $oisy_short."
-      },
-      "error": {
-        "no_approve_callback": "No callback to approve the consent message, which is unexpected. Close the wallet and try again.",
-        "no_reject_callback": "No callback to reject the consent message, which is unexpected. Close the wallet and try again.",
-        "retrieve": "An error occurred while retrieving the consent message"
-      }
-    },
-    "call_canister": {
-      "text": {
-        "processing": "Processing the request...",
-        "executed": "The request has been executed",
-        "close_window": "You can close this window",
-        "error": "Request failed due to an error",
-        "try_again": "Please try again. If the issue persists, contact the developer of the dapp where you initiated the request."
-      },
-      "error": {
-        "cannot_call": "The call cannot be processed"
-      }
-    }
-  },
-  "carousel": {
-    "text": {
-      "next_slide": "Next slide",
-      "prev_slide": "Previous slide",
-      "indicator": "Jump to slide $index"
-    }
-  },
-  "license_agreement": {
-    "text": {
-      "accept_terms": "By clicking this button, you agree to the",
-      "accept_terms_link": "License Agreement",
-      "title": "$oisy_name License Agreement (“License Agreement”)",
-      "paragraph_1": "Thank you for your interest in $oisy_name, a browser-based, self-custodial and multi-chain wallet decentralized application hosted on the Internet Computer public blockchain network (“$oisy_short”). For more information about $oisy_short, its open-source code and related licenses, please refer to the $oisy_short github repository found here: $oisy_repo_url.",
-      "paragraph_2": "This License Agreement governs your use of $oisy_short (\"You\"). BY USING $oisy_short, YOU AGREE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THIS LICENSE AGREEMENT. IF YOU DO NOT AGREE, YOU MAY NOT USE $oisy_short.",
-      "paragraph_3": "If You choose to use $oisy_short, You and the DFINITY Foundation, including its affiliates and subsidiaries (collectively “DFINITY”), acknowledge and agree as follows:",
-      "limited_license": "<strong>1. LIMITED LICENSE.</strong> Subject to the terms and conditions contained in this License Agreement, DFINITY grants You a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to use $oisy_short only for the purposes of receiving, holding and sending tokens such as native ICP, ICRC-1, ETH, and ERC20 tokens, as well as other tokens which may be made available from time to time. You may create derivative works to the extent permitted by the licensing terms governing use of any open-sourced components included within $oisy_short.",
-      "restrictions": "<strong>2. RESTRICTIONS.</strong> You are responsible for all activities related to your use of $oisy_short, regardless of whether the activities are authorized by You or undertaken by You, your employees or a third party on your behalf. YOU UNDERSTAND THAT DFINITY IS NOT RESPONSIBLE FOR ANY ACTIVITIES OR TRANSACTIONS (WHETHER COMPLETED OR OTHERWISE) ASSOCIATED WITH YOUR $oisy_name. You will not misrepresent or embellish the relationship between You and DFINITY, including expressing or implying that DFINITY supports, sponsors, endorses, or contributes to You or your business endeavors through your use of $oisy_short. You will not imply any relationship or affiliation with DFINITY except as expressly permitted by this License Agreement. You are prohibited from using the $oisy_short name, logo or any other trademarks related to $oisy_short in any manner that may imply an endorsement or affiliation, misrepresent your relationship with $oisy_short or create confusion regarding the source of $oisy_short.",
-      "applicable_laws": "<strong>3. APPLICABLE LAWS.</strong> You will comply with all applicable laws and regulations (including without limitation laws and regulations related to export controls, money laundering or economic sanctions) in connection with your use of $oisy_short and any transactions associated with your $oisy_name.",
-      "reservation_rights": "<strong>4. RESERVATION OF DFINITY’S RIGHT.</strong> $oisy_short is owned by DFINITY and licensed, not sold, to You. $oisy_short’s content, visual interfaces, interactive features, information, graphics, design, compilation, computer code, products, services, and all other elements of $oisy_short and related documentation, are protected by applicable intellectual property laws. As between You and DFINITY, all DFINITY materials and $oisy_short, including intellectual property rights therein and thereto, are the sole and exclusive property of DFINITY or its subsidiaries or affiliated companies and/or its third-party licensors, subject to any open-source software licenses. DFINITY reserves all rights not expressly granted in this License Agreement. You do not acquire any right, title, or interest to the DFINITY materials or $oisy_short, whether by implication, estoppel, or otherwise, except for the limited rights set forth in this License Agreement and the rights conferred by the licensing terms governing use of any open-sourced components included within $oisy_short. This License Agreement does not grant you any right to use the $oisy_short name, logo or other trademarks related to $oisy_short or DFINITY.",
-      "feedback": "<strong>5. FEEDBACK.</strong> If You provide DFINITY with any comments, ideas, bug reports, feedback, enhancements, recommendations or modifications in relation to $oisy_short (\"Feedback\"), such Feedback is provided on a non-confidential basis, and DFINITY shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the DFINITY materials, $oisy_short or other services. You hereby grant DFINITY a perpetual, irrevocable, transferable, sublicensable, nonexclusive, royalty free license under all rights necessary to so incorporate and use your Feedback for any purpose, including to make and sell products and services, and agree to provide DFINITY with any assistance required to document, perfect and maintain DFINITY’s rights to the Feedback. You agree to allow DFINITY to contact You for Feedback from time to time, but may opt-out by sending written notice to legalnotice@dfinity.org.",
-      "termination": "<strong>6. TERMS AND TERMINATION.</strong> This License Agreement will remain in effect until terminated. The License Agreement, and your rights and licenses hereunder, will terminate immediately upon your breach of the License Agreement. You may terminate the License Agreement at any time by emptying your $oisy_name of tokens and ceasing all use of $oisy_short. DFINITY may terminate this License Agreement at any time for any reason, including without limitation any actual or suspected misuse or abuse by You of $oisy_short or any violation of this License Agreement. Sections 3 through 13 shall survive any termination of this License Agreement.",
-      "warranty_liability": "<strong>7. WARRANTY DISCLAIMER AND LIMITATION OF LIABILITY.</strong> TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, $oisy_short IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, DFINITY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OR CONDITIONS OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE, QUALITY, RESULTS, AND NON-INFRINGEMENT. DFINITY DOES NOT GUARANTEE THAT $oisy_short WILL ALWAYS BE AVAILABLE, SAFE, OR SECURE (NOW AND IN THE FUTURE). DFINITY EXPRESSLY DISCLAIMS ANY WARRANTIES OF ANY KIND WITH RESPECT TO THE ACCURACY OR FUNCTIONALITY OF $oisy_short, AND WITH RESPECT TO THE ACCURACY, VALIDITY, OR COMPLETENESS OF ANY INFORMATION OR FEATURES (NOW AND IN THE FUTURE) MADE AVAILABLE THROUGH YOUR USE OF $oisy_short, OR THE QUALITY OR CONSISTENCY OF $oisy_short OR RESULTS OBTAINED THROUGH ITS USE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, UNDER NO CIRCUMSTANCES WILL DFINITY BE LIABLE FOR ANY CONSEQUENTIAL, SPECIAL, INDIRECT, INCIDENTAL OR PUNITIVE DAMAGES WHATSOEVER ARISING OUT OF THE USE OR INABILITY TO USE AND ACCESS $oisy_short OR DFINITY MATERIALS, EVEN IF DFINITY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL DFINITY'S AGGREGATE LIABILITY FOR DAMAGES ARISING OUT OF THIS LICENSE AGREEMENT OR YOUR USE OR INABILITY TO USE $oisy_short EXCEED 100 CHF.",
-      "indemnity": "<strong>8. INDEMNITY.</strong> You agree to indemnify, defend and hold DFINITY and its affiliates, officers, directors, suppliers, licensors, and other customers harmless from and against any and all liability and costs, including reasonable attorneys' fees incurred by such parties, in connection with your use or misuse of $oisy_short or your violation of this License Agreement or any applicable law or regulation.",
-      "governing_law": "<strong>9. GOVERNING LAW; VENUE.</strong> Any claim relating to $oisy_short shall be governed by the laws of Switzerland, to the exclusion of the rules on conflicts of laws. Any claim or dispute related to this License Agreement or in relation to it shall (including for non-contractual disputes or claims and their interpretation) be subject to the exclusive jurisdiction of the Courts of Zurich, Switzerland, subject to an appeal at the Swiss Federal Court.",
-      "entire_agreement": "<strong>10. ENTIRE AGREEMENT AND SEVERABILITY.</strong> This License Agreement is the entire agreement between You and DFINITY, and supersedes any and all prior agreements, negotiations, or other communications between You and DFINITY, whether oral or written, with respect to the subject matter hereof. DFINITY may make changes to this License Agreement when new versions of $oisy_short are made available. In the event that any provision of this License Agreement is held to be invalid or unenforceable, then: (a) such provision shall be deemed reformed to the extent strictly necessary to render such provision valid and enforceable, or if not capable of such reformation shall be deemed severed from this License Agreement; and (b) the validity and enforceability of all of the other provisions hereof, shall in no way be affected or impaired thereby.",
-      "assignment": "<strong>11. ASSIGNMENT.</strong> You may not assign this License Agreement without the prior written consent of DFINITY, whether expressly or by operation of law, including in connection with a merger or change of control, and any such attempted assignment shall be void and of no effect. DFINITY may assign this License Agreement without restriction and without any notice to You. Subject to the foregoing, this License Agreement shall be binding on the parties and their respective successors and permitted assigns.",
-      "no_waiver": "<strong>12. NO WAIVER.</strong> The failure to exercise, or delay in exercising, a right, power, or remedy provided in this License Agreement or by law shall not constitute a waiver of that right, power, or remedy. DFINITY 's waiver of any obligation or breach of this License Agreement shall not operate as a waiver of any other obligation or subsequent breach of the License Agreement.",
-      "english_version": "<strong>13. ENGLISH VERSION.</strong> The English language version of this License Agreement shall be the official and controlling version of the agreement if any conflict should arise. All communications and notices made pursuant to this License Agreement must be in the English language."
-    },
-    "alt": {
-      "license_agreement": "The $oisy_name License Agreement"
-    }
-  },
-  "activity": {
-    "text": {
-      "title": "Recent Activity"
-    },
-    "info": {
-      "btc_transactions": "BTC transaction information is obtained from central third parties and should be independently verified."
-    },
-    "warning": {
-      "no_index_canister": "Transactions for $token_list can not be displayed. No Index canister available.",
-      "unavailable_index_canister": "Transactions for $token_list can not be displayed. Index canister is currently unavailable."
-    }
-  }
+	"core": {
+		"text": {
+			"cancel": "Cancel",
+			"next": "Next",
+			"save": "Save",
+			"back": "Back",
+			"done": "Done",
+			"close": "Close",
+			"refresh": "Refresh",
+			"name": "Name",
+			"symbol": "Symbol",
+			"decimals": "Decimals",
+			"amount": "Amount",
+			"max": "Max",
+			"reject": "Reject",
+			"approve": "Approve",
+			"view": "View",
+			"copy": "Copy",
+			"clear_filter": "Clear filter",
+			"not_available": "n/a",
+			"new": "New"
+		},
+		"info": {
+			"test_banner": "For testing purposes only!"
+		},
+		"alt": {
+			"logo": "$name logo",
+			"go_to_home": "Go to the $oisy_name home page",
+			"back": "Go back to the previous page"
+		},
+		"warning": {
+			"do_not_close": "Don't close this tab until the transaction is done"
+		}
+	},
+	"navigation": {
+		"text": {
+			"tokens": "Assets",
+			"settings": "Settings",
+			"dapp_explorer": "Explore",
+			"activity": "Activity",
+			"airdrops": "Rewards",
+			"source_code_on_github": "Source code on GitHub",
+			"view_on_explorer": "View on explorer",
+			"source_code": "Source code",
+			"changelog": "Changelog",
+			"documentation": "Documentation",
+			"support": "Support",
+			"confirm_navigate": "Are you sure you want to navigate away?",
+			"vip_qr_code": "VIP QR codes"
+		},
+		"alt": {
+			"tokens": "Go to the assets view",
+			"settings": "Open your settings",
+			"dapp_explorer": "Open dapp explorer",
+			"activity": "Open the activity view",
+			"airdrops": "Open the Rewards view",
+			"more_settings": "More settings",
+			"menu": "Your wallet address, settings, sign-out and external links",
+			"changelog": "Open the changelog of $oisy_name on GitHub to review the latest updates",
+			"documentation": "Open the $oisy_name documentation",
+			"support": "Open the Support section of the $oisy_name documentation",
+			"open_twitter": "Open the DFINITY X/Twitter feed",
+			"vip_qr_code": "Generate an invitation link"
+		},
+		"short": {
+			"documentation": "Docs"
+		}
+	},
+	"auth": {
+		"text": {
+			"title_part_1": "$oisy_name",
+			"title_part_2": "100% Decentralized",
+			"logout": "Logout",
+			"authenticate": "Open or Create",
+			"asset_types": "Bitcoin, Solana, Ethereum, ICP, and more",
+			"instant_and_private": "Instant and private access anywhere",
+			"advanced_cryptography": "100% onchain: peace of mind through advanced cryptography"
+		},
+		"alt": {
+			"preview": "Preview of $oisy_name once signed in, both on desktop and mobile"
+		},
+		"warning": {
+			"not_signed_in": "You are not signed in. Please sign in to continue.",
+			"session_expired": "You have been logged out because your session has expired."
+		},
+		"error": {
+			"no_internet_identity": "No internet identity.",
+			"invalid_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential. Please contact the issuer and request the credential again.",
+			"error_validating_pouh_credential_oisy": "Sorry, but there was an error while validating the Humanity Credential in $oisy_short: $error",
+			"error_validating_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential.",
+			"error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
+			"missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
+			"no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?",
+			"error_while_signing_in": "Something went wrong while sign-in.",
+			"unexpected_issue_with_syncing": "Unexpected issue while syncing the status of your authentication."
+		}
+	},
+	"dapps": {
+		"text": {
+			"all_dapps": "All dapps",
+			"featured": "Featured",
+			"sign_in": "Sign-in to explore the ecosystem.",
+			"title": "Explore Apps",
+			"open_dapp": "Open $dAppName",
+			"submit_your_dapp": "Submit your dapp"
+		},
+		"alt": {
+			"learn_more": "Learn more about $dAppName",
+			"logo": "Logo of $dAppName",
+			"show_all": "Show all decentralised applications",
+			"show_tag": "Show decentralised applications with the tag $tag",
+			"open_dapp": "Open the app $dAppName",
+			"open_telegram": "Open $dAppName on Telegram",
+			"open_open_chat": "Open $dAppName on OpenChat",
+			"open_twitter": "Open the $dAppName X/Twitter feed",
+			"source_code_on_github": "View source code of $dAppName on github",
+			"submit_your_dapp": "Submit your dapp to be shown in the dapp-explorer",
+			"tags": "Tags related to $dAppName",
+			"website": "Image of $dAppName"
+		}
+	},
+	"airdrops": {
+		"text": {
+			"title": "Rewards",
+			"active_campaigns": "Active Opportunities",
+			"upcoming_campaigns": "Upcoming Opportunities",
+			"active_date": "Due on",
+			"participate_title": "Participate and earn Sprinkles",
+			"share": "Share on X",
+			"learn_more": "Learn more",
+			"check_status": "Check Status & Eligibility",
+			"requirements_title": "Requirements",
+			"modal_button_text": "Got it",
+			"activity_button_text": "Check on Recent Activity",
+			"activity_button_text_short": "Check activity",
+			"no_balance_title": "Earn $oisy_short Sprinkles",
+			"no_balance_description": "Check back later to see your rewards",
+			"open_wallet": "Take me to the wallet",
+			"state_modal_title": "Congratulations on earning today’s $oisy_short Sprinkles!",
+			"state_modal_title_jackpot": "Congratulations on earning today’s largest $oisy_short Sprinkles!",
+			"state_modal_content_text": "Share your victory on Twitter to qualify for another chance to earn.",
+			"carousel_slide_title": "$oisy_short Sprinkles are now Live!",
+			"carousel_slide_cta": "Learn more",
+			"sprinkles_earned": "You've earned $noOfSprinkles sprinkles, totaling $amount! \uD83C\uDF89",
+			"youre_eligible": "You're eligible!"
+		},
+		"alt": {
+			"upcoming_campaigns": "Keep an eye out for upcoming token drops! Subscribe to $oisy_short on X and follow us to catch all the latest updates."
+		}
+	},
+	"footer": {
+		"text": {
+			"incubated_with": "Incubated with",
+			"by": "by",
+			"dfinity_foundation": "DFINITY Foundation",
+			"copyright": "© 2025"
+		},
+		"alt": {
+			"dfinity": "Go to DFINITY Foundation website"
+		}
+	},
+	"wallet": {
+		"text": {
+			"address": "Address",
+			"wallet_address": "Wallet address",
+			"your_addresses": "Your addresses",
+			"address_copied": "Address copied to clipboard.",
+			"wallet_address_copied": "Wallet address copied to clipboard.",
+			"display_wallet_address_qr": "Display wallet address as a QR code",
+			"icp_deposits": "Note: For ICP deposits, use the 'Receive' button in your ICP account to get the right address.",
+			"use_address_from_to": "Use this address to transfer $token to and from your wallet."
+		},
+		"alt": {
+			"open_etherscan": "Open your address on Etherscan",
+			"open_solscan": "Open your address on Solscan",
+			"qrcode_address": "Scan this QR code to copy the address to receive $token tokens"
+		}
+	},
+	"init": {
+		"text": {
+			"initializing_wallet": "Preparing your wallet...",
+			"securing_session": "Securing session with Internet Identity",
+			"retrieving_public_keys": "Retrieving your public keys for Bitcoin, Ethereum and Solana",
+			"done": "Enjoy $oisy_short"
+		},
+		"info": {
+			"hold_loading": "Hold tight, we are loading some information...",
+			"hold_loading_wallet": "Hold tight, we are loading some initial data for your wallet..."
+		},
+		"error": {
+			"no_alchemy_config": "No Alchemy config for network $network",
+			"no_alchemy_provider": "No Alchemy provider for network $network",
+			"no_alchemy_erc20_provider": "No Alchemy ERC20 provider for network $network",
+			"no_etherscan_provider": "No Etherscan provider for network $network",
+			"no_etherscan_rest_api": "No Etherscan Rest API for network $network",
+			"no_infura_provider": "No Infura provider for network $network",
+			"no_infura_cketh_provider": "No Infura CkETH provider for network $network",
+			"no_infura_erc20_provider": "No Infura ERC20 provider for network $network",
+			"no_infura_erc20_icp_provider": "No Infura ERC20 Icp provider for network $network",
+			"no_solana_rpc": "No Solana RPC for network $network",
+			"no_solana_network": "No Solana network for network $network",
+			"eth_address_unknown": "ETH address is unknown.",
+			"loading_address": "Error while loading the $symbol address.",
+			"loading_balance": "Error while loading the ETH balance.",
+			"loading_balance_symbol": "Error while loading $symbol balance.",
+			"erc20_contracts": "Error while loading the ERC20 contracts.",
+			"spl_tokens": "Error while loading the SPL tokens.",
+			"minter_ckbtc_btc": "A configured minter is required to convert ckBTC to BTC.",
+			"minter_cketh_eth": "A configured minter is required to convert ckETH to ETH.",
+			"minter_ckerc20_erc20": "A configured minter is required to convert ckERC20 to Erc20.",
+			"ledger_cketh_eth": "A configured ckETH ledger is required to convert ckErc20 to Erc20.",
+			"minter_btc": "A configured minter is required to retrieve BTC.",
+			"minter_ckbtc_info": "A configured minter is required to fetch the ckBTC info",
+			"minter_cketh_info": "A configured minter is required to fetch the ckETH info",
+			"minter_ckbtc_loading_info": "Error while loading the ckBTC minter information.",
+			"minter_cketh_loading_info": "Error while loading the ckETH minter information.",
+			"btc_fees_estimation": "Error while querying the estimation of the BTC fees.",
+			"btc_withdrawal_statuses": "Error while fetching the BTC withdrawal statuses.",
+			"transaction_price": "Error while loading the estimation of the price of a transaction.",
+			"icrc_canisters": "Error while loading the ICRC canisters.",
+			"erc20_user_tokens": "Error while loading the ERC20 user tokens.",
+			"spl_user_tokens": "Error while loading the SPL user tokens.",
+			"erc20_user_token": "Error while enabling the ERC20 twin token.",
+			"icrc_custom_token": "Error while loading the ICRC custom token.",
+			"loading_wallet_timeout": "Your wallet requires some initial data which has not been loaded yet. Please try again.",
+			"allow_signing": "An issue occurred while setting up your wallet for signing. You've been signed out. If the issue persists, contact support.",
+			"btc_wallet_error": "Error while loading BTC wallet information.",
+			"sol_wallet_error": "Error while loading SOL wallet information."
+		}
+	},
+	"hero": {
+		"text": {
+			"available_balance": "Available balance",
+			"unavailable_balance": "$ value is not available",
+			"top_up": "Top up your wallet to start using it!",
+			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
+		}
+	},
+	"settings": {
+		"text": {
+			"title": "Settings",
+			"principal": "Your Principal",
+			"principal_copied": "Principal copied to clipboard",
+			"principal_description": "Your ID for the $oisy_name. Created by your Internet Identity.",
+			"session": "Your session expires in",
+			"session_description": "All sessions last 1 hour. After 1 hour, you will need to authenticate again with Internet Identity.",
+			"testnets": "Show test networks",
+			"testnets_description": "Display the test networks (Sepolia) and twin tokens on testnets (ckTESTBTC and ckSepolia).",
+			"hide_zero_balances_description": "Enable this feature to declutter your wallet view by hiding all tokens with a zero balance.",
+			"credentials_title": "Credentials",
+			"pouh_credential": "Humanity Credential",
+			"pouh_credential_description": "The Humanity Credential is a proof of humanity. It is issued by Decide AI.",
+			"present_pouh_credential": "Present",
+			"pouh_credential_verified": "Verified ✅",
+			"appearance": "Appearance",
+			"appearance_light": "Light",
+			"appearance_dark": "Dark",
+			"appearance_system": "System"
+		},
+		"alt": {
+			"testnets_toggle": "Toggle to show or hide testnets",
+			"github_release": "$oisy_short release notes on GitHub",
+			"appearance_light": "Enables light mode",
+			"appearance_dark": "Enables dark mode",
+			"appearance_system": "Enables your operating systems color mode"
+		},
+		"error": {
+			"loading_profile": "Error while loading the profile. Please refresh the page to have the full experience."
+		}
+	},
+	"networks": {
+		"title": "Current network. Access to selection.",
+		"test_networks": "Test networks",
+		"more": "More networks coming soon...",
+		"chain_fusion": "Chain Fusion (all networks)",
+		"network": "Network"
+	},
+	"receive": {
+		"text": {
+			"receive": "Receive",
+			"address": "Receive address",
+			"receive_token": "Receive $token"
+		},
+		"icp": {
+			"text": {
+				"account_id": "ICP Account ID",
+				"use_for_all_tokens": "Use for all tokens when receiving from wallets, users, or other apps that support this address format.",
+				"use_for_icrc_deposit": "Use for receiving ICRC-1 tokens in the ICP network, such as SNS, ck tokens, etc.",
+				"use_for_icp_deposit": "Use for ICP deposits from exchanges or other wallets that only support Account IDs.",
+				"your_private_eth_address": "Your private address for all ERC20 tokens.",
+				"display_account_id_qr": "Display ICP Account ID as a QR code",
+				"account_id_copied": "ICP Account ID copied to clipboard.",
+				"principal": "ICP Principal",
+				"internet_computer_principal_copied": "Internet Computer Principal copied to clipboard.",
+				"display_internet_computer_principal_qr": "Display Internet Computer Principal as a QR code",
+				"icp_account": "ICP Account (for exchanges)",
+				"icp_account_copied": "ICP Account copied to clipboard.",
+				"display_icp_account_qr": "Display ICP Account as a QR code"
+			}
+		},
+		"ethereum": {
+			"text": {
+				"checking_status": "Checking $token status...",
+				"from_network": "Receive from $network Network",
+				"eth_to_cketh_description": "Converting $token into $ckToken requires a call to a smart contract on $network and passing your IC principal as argument – $oisy_name simplifies this procedure by enabling you to perform the conversion directly within the wallet.",
+				"learn_how_to_convert": "Learn how to convert $token to $ckToken",
+				"metamask": "Receive from Metamask",
+				"ethereum": "Ethereum",
+				"ethereum_address": "Address",
+				"ethereum_address_copied": "Ethereum address copied to clipboard.",
+				"display_ethereum_address_qr": "Display Ethereum address as a QR code"
+			},
+			"error": {
+				"no_metamask": "Metamask is not available."
+			}
+		},
+		"bitcoin": {
+			"text": {
+				"bitcoin": "Bitcoin",
+				"checking_status": "Checking BTC status...",
+				"refresh_status": "Refresh BTC status",
+				"initializing": "Initializing...",
+				"checking_incoming": "Checking for incoming BTC...",
+				"refreshing_wallet": "Refreshing wallet...",
+				"bitcoin_address": "Bitcoin",
+				"bitcoin_testnet_address": "Bitcoin (Testnet)",
+				"bitcoin_regtest_address": "Bitcoin (Regtest)",
+				"display_bitcoin_address_qr": "Display Bitcoin Address as a QR code",
+				"bitcoin_address_copied": "Bitcoin Address copied to clipboard.",
+				"from_network": "Transfer Bitcoin on the BTC network to this address to receive ckBTC.",
+				"fee_applied": "Please note that an estimated inter-network fee of $fee BTC will be applied."
+			},
+			"info": {
+				"no_new_btc": "No new confirmed BTC.",
+				"check_btc_progress": "Checking for incoming BTC already in progress."
+			},
+			"error": {
+				"unexpected_btc": "Something went wrong while checking for incoming BTC."
+			}
+		},
+		"solana": {
+			"text": {
+				"solana_address": "Solana Address",
+				"solana_testnet_address": "Solana Testnet Address",
+				"solana_devnet_address": "Solana Devnet Address",
+				"solana_local_address": "Solana Local Address",
+				"solana_address_copied": "Solana address copied to clipboard",
+				"display_solana_address_qr": "Display Solana address as QR code"
+			}
+		}
+	},
+	"send": {
+		"text": {
+			"send": "Send",
+			"destination": "Destination",
+			"source": "Source",
+			"balance": "Balance",
+			"review": "Review",
+			"signing_approval": "Signing approval...",
+			"approving": "Approving...",
+			"approving_fees": "Approving fees...",
+			"approving_transfer": "Approving transfer...",
+			"approving_wallet_connect": "Approving WalletConnect request...",
+			"refreshing_ui": "Refreshing UI",
+			"initializing": "Initializing transaction...",
+			"signing_transaction": "Signing transaction...",
+			"sending": "Sending...",
+			"signing": "Signing...",
+			"signing_message": "Signing message...",
+			"network": "Network",
+			"source_network": "Source network",
+			"destination_network": "Destination network",
+			"initializing_transaction": "Initializing transaction",
+			"convert_to_native_icp": "Convert to native ICP",
+			"open_qr_modal": "Start QR Code scan for transaction details",
+			"scan_qr": "Scan QR Code"
+		},
+		"placeholder": {
+			"enter_eth_address": "Enter public address (0x)",
+			"enter_recipient_address": "Enter recipient address",
+			"enter_wallet_address": "Enter wallet address",
+			"select_network": "Select network"
+		},
+		"info": {
+			"ckbtc_certified": "Please wait until the ckBTC parameters have been certified.",
+			"cketh_certified": "Please wait until the ckETH parameters have been certified.",
+			"pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete.",
+			"no_available_utxos": "You won't have available utxos to perform this transaction."
+		},
+		"assertion": {
+			"invalid_destination_address": "Invalid destination address",
+			"insufficient_funds": "Insufficient funds.",
+			"unknown_minimum_ckbtc_amount": "The minimum amount of ckBTC required for converting to BTC is unknown.",
+			"unknown_minimum_cketh_amount": "The minimum amount of ckETH required for converting to ETH is unknown.",
+			"unknown_minimum_amount": "The minimum amount of $sourceTokenSymbol required for converting to $destinationTokenSymbol is unknown.",
+			"minimum_ckbtc_amount": "The amount falls below the minimum of $amount ckBTC required for converting to BTC.",
+			"minimum_cketh_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
+			"minimum_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
+			"minimum_ledger_fees": "The amount falls below the ledger fees $symbol.",
+			"minimum_cketh_balance": "The $symbol balance falls below the estimated fee of $amount.",
+			"unknown_cketh": "The ckETH token cannot be retrieved.",
+			"destination_address_invalid": "Destination address is invalid.",
+			"amount_invalid": "Amount is invalid.",
+			"insufficient_funds_for_gas": "Insufficient funds for gas",
+			"insufficient_funds_for_amount": "Insufficient funds for amount",
+			"insufficient_ethereum_funds_to_cover_the_fees": "Insufficient Ethereum funds to cover the fees",
+			"insufficient_solana_funds_to_cover_the_fees": "Insufficient Solana funds to cover the fees",
+			"not_enough_tokens_for_gas": "Not enough $symbol for gas. Balance: $balance $symbol",
+			"gas_fees_not_defined": "Gas fees are not defined.",
+			"max_gas_fee_per_gas_undefined": "Max fee per gas or max priority fee per gas is undefined.",
+			"address_unknown": "Address is unknown.",
+			"minter_info_not_loaded": "Try again in a few seconds, a ckETH configuration parameter is not yet loaded.",
+			"minter_info_not_certified": "Try again in a few seconds, a ckETH configuration parameter has not been certified.",
+			"cketh_max_transaction_fee_missing": "The maximum transaction fee for ckETH is missing.",
+			"utxos_fee_missing": "UTXOs fee is missing."
+		},
+		"error": {
+			"unexpected": "Something went wrong while sending the transaction.",
+			"destination_address_unknown": "ETH destination address is unknown",
+			"metamask_connected": "Cannot get your accounts. Is your Metamask open and already connected?",
+			"metamask_no_accounts": "No Metamask accounts found.",
+			"metamask_switch_network": "Cannot request Metamask to switch to chain ID $chain_id. Is your Metamask using $network_name?",
+			"erc20_data_undefined": "Erc20 transaction Data cannot be undefined or null.",
+			"data_undefined": "Transaction Data cannot be undefined or null.",
+			"no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
+			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
+			"incompatible_token": "The token is incompatible. Please try again with a compatible token.",
+			"no_btc_network_id": "Current network ($networkId) is not a Bitcoin network.",
+			"no_solana_network_id": "Current network ($networkId) is not a Solana network.",
+			"no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later.",
+			"unexpected_utxos_fee": "Something went wrong while calculating transaction fee.",
+			"unable_to_retrieve_amount": "n/a (unable to retrieve)",
+			"solana_transaction_expired": "Your send transaction was not processed by the Solana network and expired, most likely because the provided priority fee was not sufficient. We updated it to the latest recommended amount, so please try sending it again."
+		}
+	},
+	"convert": {
+		"text": {
+			"converting": "Converting...",
+			"convert_to_btc": "Convert to BTC",
+			"convert_to_ckbtc": "Convert to ckBTC",
+			"convert_to_token": "Convert to $token",
+			"convert_to_cketh": "Convert to ckETH",
+			"convert_to_ckerc20": "Convert to $ckErc20",
+			"convert_eth_to_cketh": "Convert $token to $ckToken",
+			"cketh_conversions_may_take": "ckETH conversions may take up to 20 minutes",
+			"ckerc20_conversions_may_take": "$ckErc20 conversions may take up to 20 minutes",
+			"how_to_convert_eth_to_cketh": "Here is how to can convert $token to $ckToken on $oisy_name",
+			"send_eth": "Send $token to your $oisy_name address",
+			"wait_eth_current_balance": "Wait for $token to arrive. Current balance",
+			"set_amount": "Set amount for conversion",
+			"check_balance_for_fees": "Check $token balance for conversion fees",
+			"fees_explanation": "You need enough $token to cover the smart contract execution fees.",
+			"current_balance": "👉 Current balance:",
+			"review_button": "Review",
+			"convert_button": "Convert",
+			"input_reset_button": "Reset input value",
+			"swap_to_token": "Convert $sourceToken → $destinationToken",
+			"review": "Review transaction",
+			"max_balance": "Max",
+			"source_network": "Source network",
+			"destination_network": "Destination network",
+			"conversion_may_take": "Conversion may take up to 1 hour",
+			"executing_transaction": "Executing transaction...",
+			"initializing": "Initializing transaction...",
+			"refreshing_ui": "Refreshing UI",
+			"unsupported_token_conversion": "Conversion for the selected token is not supported.",
+			"calculating_max_amount": "Calculating..."
+		},
+		"assertion": {
+			"insufficient_funds": "Insufficient balance"
+		},
+		"error": {
+			"loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized.",
+			"unexpected": "Something went wrong while converting tokens.",
+			"unexpected_missing_data": "Something went wrong while initiating a convert transaction."
+		}
+	},
+	"swap": {
+		"text": {
+			"swap": "Swap",
+			"select_destination_token": "Select token to receive",
+			"select_source_token": "Select token to pay",
+			"switch_tokens_button": "Switch tokens",
+			"review": "Review transaction",
+			"review_button": "Review swap",
+			"max_slippage": "Max slippage",
+			"max_balance": "Max",
+			"not_available": "n/a",
+			"value_difference": "Value difference",
+			"total_fee": "Total estimated fee",
+			"network_fee": "Network fee",
+			"approval_fee": "Approval fee",
+			"gas_fee": "Gas fee",
+			"lp_fee": "LP fee",
+			"max_slippage_info": "Enter value between 0% and 50%",
+			"max_slippage_warning": "Risk warning: high slippage may lead to losses due to market volatility",
+			"max_slippage_error": "Slippage tolerance cannot be 0% or exceed 50%",
+			"swap_button": "Swap now",
+			"swap_is_not_offered": "This swap is currently not offered.",
+			"executing_transaction": "Executing transaction...",
+			"initializing": "Initializing transaction...",
+			"swapping": "Swapping...",
+			"refreshing_ui": "Refreshing UI",
+			"swap_provider": "Swap provider"
+		},
+		"error": {
+			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
+			"unexpected": "Something went wrong while swapping tokens.",
+			"unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
+			"slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again."
+		}
+	},
+	"buy": {
+		"text": {
+			"buy": "Buy",
+			"buy_dev": "Buy (Dev Environment)"
+		},
+		"onramper": {
+			"title": "Buy through Onramper"
+		}
+	},
+	"tokens": {
+		"text": {
+			"title": "Tokens",
+			"contract_address": "Contract address",
+			"token_address": "Token address",
+			"balance": "Balance",
+			"hide_zero_balances": "Hide zero balances",
+			"hide_zeros": "Hide zeros",
+			"all_tokens_with_zero_hidden": "All assets with zero balance are currently hidden",
+			"buy_or_receive": "Buy or receive your first tokens now to see them in the list",
+			"initializing": "Initializing...",
+			"updating_ui": "Updating the UI...",
+			"show_token": "Show token",
+			"hide_token": "Hide token",
+			"select_token": "Select token",
+			"exchange_is_not_available": "USD value is currently not available.",
+			"source_token_title": "You pay",
+			"destination_token_title": "You receive"
+		},
+		"details": {
+			"title": "Token details",
+			"token": "Token",
+			"network": "Network",
+			"contract_address_copied": "Contract address copied to clipboard.",
+			"token_address_copied": "Token address copied to clipboard.",
+			"twin_token": "Twin token",
+			"standard": "Standard"
+		},
+		"balance": {
+			"error": {
+				"not_applicable": "n/a"
+			}
+		},
+		"import": {
+			"text": {
+				"title": "Import token",
+				"review": "Review",
+				"saving": "Saving...",
+				"updating": "Updating token list",
+				"ledger_canister_id": "Ledger Canister ID",
+				"index_canister_id": "Index Canister ID",
+				"minter_canister_id": "Minter Canister ID",
+				"ledger_canister_id_copied": "Ledger Canister ID copied to clipboard.",
+				"index_canister_id_copied": "Index Canister ID copied to clipboard.",
+				"minter_canister_id_copied": "Minter Canister ID copied to clipboard.",
+				"verifying": "Verifying token details...",
+				"add_the_token": "Add the token",
+				"info": "Ledger and Index canister IDs are usually available on the project’s website. ",
+				"info_index": "The Index canister ID is optional, but without it, $oisy_short can’t display transaction history.",
+				"custom_tokens_not_supported": "The selected network does not support custom tokens."
+			},
+			"error": {
+				"loading_metadata": "Error while loading the metadata of the token.",
+				"no_metadata": "No metadata for the token is provided. This is unexpected.",
+				"unexpected_ledger": "Something went wrong while validating the Ledger canister.",
+				"unexpected_index": "Something went wrong while validating the Index canister.",
+				"unexpected_index_ledger": "Something went wrong while loading the Ledger ID related to the Index canister.",
+				"invalid_ledger_id": "The Ledger ID is not related to the Index canister.",
+				"missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
+				"missing_contract_address": "The contract address is missing. Did you provide a value?",
+				"missing_token_address": "The token address is missing. Did you provide a value?",
+				"no_network": "No network is selected. This is unexpected."
+			},
+			"warning": {
+				"do_not_close_manage": "$oisy_name is preparing and securing the new tokens. Please don't close this tab until it's completed."
+			}
+		},
+		"manage": {
+			"text": {
+				"title": "Manage tokens",
+				"manage_list": "Manage tokens",
+				"do_not_see_import": "Don’t see your token? Import",
+				"manage_for_network": "Managing tokens for $network",
+				"network": "Network",
+				"all_tokens_zero_balance": "All tokens have zero balance."
+			},
+			"placeholder": {
+				"select_network": "Select the network"
+			},
+			"info": {
+				"no_changes": "No changes need to be saved."
+			},
+			"error": {
+				"unexpected_build": "An unexpected error happened while building the list of known tokens.",
+				"empty": "No tokens to enable or disable have been selected."
+			}
+		},
+		"hide": {
+			"title": "Hide token?",
+			"token": "Hide $token",
+			"info": "You can add this token back in the future by going into <strong>“Manage tokens”</strong> in your wallet view.",
+			"confirm": "Hide",
+			"hiding": "Hiding..."
+		},
+		"alt": {
+			"context_menu": "Context menu for to the selected token",
+			"open_etherscan": "Open the details of the token on Etherscan",
+			"open_blockstream": "Open the details of the token on Blockstream",
+			"open_dashboard": "Open the details of the token on the ICP Dashboard",
+			"open_contract_address_block_explorer": "Open the contract address on a block explorer",
+			"open_token_address_block_explorer": "Open the token address on a block explorer",
+			"token_group_number": "Total number of tokens in the group for native token $token"
+		},
+		"placeholder": {
+			"enter_contract_address": "Enter an ERC20 contract address",
+			"enter_token_address": "Enter an SPL token address",
+			"search_token": "Search for the token"
+		},
+		"warning": {
+			"trust_token": "Make sure you trust the token you are adding. If the token you are adding is controlled by a malicious party, they could try and scam you e.g., by making you believe you received a significant amount of tokens in order to trick you into sending them tokens in return or perform other undesired actions. Learn more about scams and security risks e.g. <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://support.metamask.io/hc/en-us/articles/4403988839451\">here</a>."
+		},
+		"error": {
+			"invalid_contract_address": "Contract address is invalid.",
+			"invalid_token_address": "Token address is invalid.",
+			"invalid_ledger": "The selected token is not linked with an Icrc Ledger canister.",
+			"no_metadata": "No metadata were fetched.",
+			"unexpected": "Something went wrong while saving the token.",
+			"unexpected_hiding": "Something went wrong while hiding the token.",
+			"already_available": "Token is already available.",
+			"loading_metadata": "Error while loading the metadata of the token.",
+			"not_toggleable": "Token is not toggleable, it can not be hidden.",
+			"incomplete_metadata": "No name or symbol is provided in the metadata.",
+			"duplicate_metadata": "A token with a similar name or symbol already exists.",
+			"unexpected_undefined": "Token is undefined. This is unexpected."
+		}
+	},
+	"fee": {
+		"text": {
+			"fee": "Fee",
+			"estimated_btc": "Estimated BTC Network Fee",
+			"estimated_inter_network": "Estimated Inter-network Fee",
+			"estimated_eth": "Estimated Ethereum Fee",
+			"max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>",
+			"convert_fee": "Conversion fee",
+			"convert_inter_network_fee": "Inter-network fee",
+			"convert_btc_network_fee": "Bitcoin network fee",
+			"zero_fee": "Free",
+			"total_fee": "Total fee",
+			"ata_fee": "ATA fee"
+		},
+		"assertion": {
+			"insufficient_funds_for_fee": "Insufficient balance to cover the fees."
+		},
+		"error": {
+			"cannot_fetch_gas_fee": "Cannot fetch gas fee."
+		}
+	},
+	"info": {
+		"bitcoin": {
+			"title": "Receive BTC & convert to ckBTC",
+			"description": "Convert Bitcoin into ckBTC and benefit from the fastest and cheapest Bitcoin transaction available. The conversion process can take up to an hour.",
+			"note": "You can convert ckBTC at any time back to BTC.",
+			"how_to": "How to convert to ckBTC"
+		},
+		"ethereum": {
+			"title": "Convert to $ckToken",
+			"description": "With a few steps, convert your native $network $token to its twinned ICP $ckToken directly within the $oisy_name. The conversion process can take up to 20 minutes.",
+			"note": "You can convert $ckToken at any time back to $token.",
+			"how_to": "How to convert to $ckToken",
+			"how_to_short": "How to convert $token"
+		}
+	},
+	"wallet_connect": {
+		"text": {
+			"name": "WalletConnect",
+			"session_proposal": "Session Proposal",
+			"connect": "Connect",
+			"connecting": "Connecting...",
+			"disconnect": "Disconnect",
+			"scan_qr": "Scan QR code",
+			"or_use_link": "or use WalletConnect link",
+			"proposer": "Proposer",
+			"review": "Review $chain_name ($key) required permissions",
+			"method": "Method",
+			"methods": "Methods",
+			"events": "Events",
+			"message": "Message",
+			"hex_data": "HEX Data",
+			"base64_data": "Base-64 Data",
+			"raw_copied": "Raw transaction data copied to clipboard.",
+			"sign_message": "Sign Message"
+		},
+		"alt": {
+			"connect_input": "e.g. wc:a281567bb3e4..."
+		},
+		"domain": {
+			"title": "Domain Verification",
+			"valid": "Valid ✅",
+			"valid_description": "The validation of the proposer's domain passed.",
+			"invalid": "Invalid ❌",
+			"invalid_description": "The domain of the proposer's website does not match the sender of the request.",
+			"security_risk": "Security risk ⚠️",
+			"security_risk_description": "The proposer's website is flagged as unsafe.",
+			"unknown": "Unknown ❓",
+			"unknown_description": "The domain of the proposer cannot be verified."
+		},
+		"info": {
+			"disconnected": "WalletConnect disconnected.",
+			"session_ended": "WalletConnect session was ended.",
+			"connected": "WalletConnect connected.",
+			"eth_transaction_executed": "WalletConnect eth_sendTransaction request executed.",
+			"sol_transaction_executed": "WalletConnect \"$method\" request executed.",
+			"sign_executed": "WalletConnect sign request executed."
+		},
+		"error": {
+			"qr_code_read": "Cannot read QR code.",
+			"missing_uri": "A URI to connect to should be provided.",
+			"disconnect": "An unexpected error happened while disconnecting the wallet. Resetting the connection anyway.",
+			"connect": "An unexpected error happened while trying to connect the wallet.",
+			"manual_workflow": "Please finalize the manual workflow that has already been initiated by opening the WalletConnect modal.",
+			"skipping_request": "Skipping the WalletConnect request as another action is currently in progress through an overlay.",
+			"method_not_support": "Requested method \"$method\" is not supported.",
+			"unexpected_pair": "An unexpected error happened while trying to pair the wallet.",
+			"no_connection_opened": "Unexpected error: No connection opened.",
+			"no_session_approval": "Unexpected error: No session proposal available.",
+			"unexpected": "Unexpected error while communicating with WalletConnect.",
+			"request_rejected": "WalletConnect request rejected",
+			"unknown_parameter": "Unknown parameter.",
+			"wallet_not_initialized": "Unexpected error. Your wallet address is not initialized.",
+			"from_address_not_wallet": "From address requested for the transaction is not the address of this wallet.",
+			"unknown_destination": "Unknown destination address.",
+			"request_not_defined": "Unexpected error: Request is not defined therefore cannot be processed.",
+			"unexpected_processing_request": "Unexpected error while processing the request with WalletConnect."
+		}
+	},
+	"transaction": {
+		"text": {
+			"details": "Transaction details",
+			"hash": "Transaction hash",
+			"hash_copied": "Transaction hash $hash copied to clipboard.",
+			"id": "Transaction ID",
+			"id_copied": "Transaction ID copied to clipboard.",
+			"timestamp": "Timestamp",
+			"type": "Type",
+			"from": "From",
+			"from_copied": "From address copied to clipboard.",
+			"to": "To",
+			"to_copied": "To address copied to clipboard.",
+			"block": "Block",
+			"interacted_with": "Interacted With (To)",
+			"status": "Status",
+			"confirmations": "Confirmations"
+		},
+		"status": {
+			"confirmed": "Confirmed",
+			"included": "Included",
+			"finalised": "Finalised",
+			"finalized": "Finalised",
+			"processed": "Processed",
+			"pending": "Pending...",
+			"safe": "Safe",
+			"unconfirmed": "Unconfirmed"
+		},
+		"label": {
+			"reimbursement": "Reimbursement",
+			"twin_token_sent": "$twinToken sent",
+			"ck_token_sent": "$ckToken sent",
+			"twin_token_converted": "Converted from $twinToken",
+			"ck_token_converted": "Converted from $ckToken",
+			"receiving_twin_token": "Receiving $twinToken",
+			"sending_twin_token": "Sending $twinToken",
+			"sending_twin_token_failed": "Sending $twinToken failed",
+			"converting_twin_token": "Converting $twinToken to $ckToken",
+			"converting_ck_token": "Converting $ckToken to $twinToken",
+			"twin_network": "$twinNetwork network",
+			"no_date_available": "No Date Available"
+		},
+		"alt": {
+			"open_block_explorer": "Open this transaction on a block explorer",
+			"open_from_block_explorer": "Open the 'From' address on a block explorer",
+			"open_to_block_explorer": "Open the 'To' address on a block explorer"
+		},
+		"error": {
+			"get_block_number": "Cannot get block number.",
+			"failed_get_transaction": "Failed to get the transaction from the provided (hash: $hash). Please reload the wallet dapp.",
+			"failed_get_mined_transaction": "Failed to get the mined transaction (hash: $hash). Please reload the wallet dapp."
+		}
+	},
+	"transactions": {
+		"text": {
+			"title": "Transactions",
+			"buy_or_receive": "Make your first transaction, and buy or receive tokens now!",
+			"transaction_history": "Your transaction history will appear here",
+			"open_transactions": "Open the list of $token transactions",
+			"mainnet_btc_transactions_info": "BTC transaction information is obtained from central third parties and should be independently verified.",
+			"transaction_history_unavailable": "Transaction history unavailable",
+			"missing_index_canister_explanation": "The token ledger is working fine, but the index canister is missing, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual.",
+			"index_canister_not_working_explanation": "The token ledger is working fine, but the index canister is having issues, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual."
+		},
+		"error": {
+			"loading_transactions": "Error while loading the transactions.",
+			"loading_transactions_symbol": "Error while loading the $symbol transactions.",
+			"no_token_loading_transaction": "Token not found. Transactions cannot be loaded.",
+			"uncertified_transactions_removed": "Several uncertified transactions were identified and subsequently removed from the displayed lists.",
+			"loading_pending_ck_ethereum_transactions": "Something went wrong while fetching the pending $network transactions.",
+			"get_transaction_for_hash": "Failed to get the transaction from the provided (hash: $hash).",
+			"unexpected_transaction_for_hash": "Something went wrong while loading the pending for hash: $hash."
+		}
+	},
+	"about": {
+		"why_oisy": {
+			"text": {
+				"label": "Why $oisy_short",
+				"title": "Why $oisy_short",
+				"hold_crypto": {
+					"title": "Unified Management of All Your Digital Assets",
+					"description": "$oisy_short allows you to manage all your digital assets — including Bitcoin, Solana, Ethereum, ICP, and more — in a single, unified wallet. No more juggling multiple wallets for different cryptocurrencies — enjoy a seamless and efficient experience across various platforms."
+				},
+				"network_custody": {
+					"title": "No more private key anxiety with Network Custody",
+					"description": "$oisy_name implements network custody, an innovative approach that leverages the Internet Computer's advanced cryptography to eliminate the need for you to handle private keys directly. This provides a secure and user-friendly alternative to traditional methods, aligning with the “Onchain is the New Online“ movement — a shift toward solutions that enhance security and resilience against cyber attacks by running on a distributed network."
+				},
+				"fully_on_chain": {
+					"title": "Tamper-Proof Security with a Fully On-Chain Wallet",
+					"description": "Not only are your keys secured, but the entire wallet application is stored <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/capabilities\">fully on-chain</a> and served directly into your browser from the Internet Computer. This means the entire wallet benefits from a decentralized trust model, making it tamper-proof and highly secure."
+				},
+				"cross_device": {
+					"title": "Access your wallet anytime from anywhere",
+					"description": "Using <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://identity.ic0.app/\">Internet Identity</a>, $oisy_short can easily be used across all devices you have linked to your private decentralized identity. This ensures seamless and secure access to your wallet whether you're on a smartphone, tablet, or desktop."
+				},
+				"verifiable_credentials": {
+					"title": "Unlock Extra Features with Verifiable Credentials",
+					"description": "$oisy_short integrates with the Internet Computer's <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/docs/current/developer-docs/identity/verifiable-credentials/overview\">verifiable credentials</a> platform. Access additional features like airdrops and exclusive functionalities by acquiring certain types of credentials, enhancing your overall experience."
+				},
+				"open_source": {
+					"title": "Trust in Transparency with Open Source",
+					"description": "$oisy_short is an <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"$oisy_repo_url\">open-source</a> project led by a dedicated team within the <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://dfinity.org/\">DFINITY foundation</a>, supported by over 200 world-leading cryptographers and engineers. Open sourcing ensures transparency, allowing the community to audit, contribute, and trust in the wallet's integrity."
+				}
+			}
+		}
+	},
+	"vip": {
+		"reward": {
+			"text": {
+				"open_wallet": "Take me to the wallet",
+				"title_successful": "Congratulations!",
+				"title_failed": "Invalid invitation code",
+				"reward_received": "Welcome to $oisy_short!",
+				"reward_failed": "Code is expired",
+				"reward_received_description": "You will receive your welcome gift any moment.",
+				"reward_failed_description": "Request a new one and try again"
+			},
+			"error": {
+				"loading_reward": "Error while loading a new reward code.",
+				"loading_user_data": "Failed to load user data from reward canister.",
+				"claiming_reward": "Error while claiming reward."
+			}
+		},
+		"invitation": {
+			"text": {
+				"title": "Generate invitation link",
+				"invitation_link_copied": "Invitation link copied to clipboard.",
+				"generate_new_link": "Generate new link",
+				"generating_new_code": "Generating new code",
+				"regenerate_countdown_text": "New link will be generated in $counter sec"
+			}
+		}
+	},
+	"signer": {
+		"sign_in": {
+			"text": {
+				"access_your_wallet": "Access your $oisy_name",
+				"open_or_create": "Open or create your wallet to securely connect to the dApp and start managing your assets."
+			}
+		},
+		"idle": {
+			"text": {
+				"waiting": "Waiting for the dApp interaction..."
+			},
+			"alt": {
+				"img_placeholder": "The astronaut logo moves its eyes from left to right while waiting for messages from the relying party dapp"
+			}
+		},
+		"permissions": {
+			"text": {
+				"title": "Review permissions",
+				"requested_permissions": "Requested permissions",
+				"your_wallet_address": "Your wallet address",
+				"icrc27_accounts": "View your $oisy_name address",
+				"icrc49_call_canister": "Request approval for transactions"
+			},
+			"error": {
+				"no_confirm_callback": "No callback to confirm the permissions, which is unexpected. Close the wallet and try again."
+			}
+		},
+		"origin": {
+			"text": {
+				"request_from": "Request from:",
+				"invalid_origin": "Invalid origin️!!"
+			},
+			"alt": {
+				"link_to_dapp": "Link to the dApp requesting permissions"
+			}
+		},
+		"consent_message": {
+			"text": {
+				"loading": "Loading consent message..."
+			},
+			"warning": {
+				"token_without_consent_message": "This token does not provide confirmation messages, so the information below was extracted by $oisy_short."
+			},
+			"error": {
+				"no_approve_callback": "No callback to approve the consent message, which is unexpected. Close the wallet and try again.",
+				"no_reject_callback": "No callback to reject the consent message, which is unexpected. Close the wallet and try again.",
+				"retrieve": "An error occurred while retrieving the consent message"
+			}
+		},
+		"call_canister": {
+			"text": {
+				"processing": "Processing the request...",
+				"executed": "The request has been executed",
+				"close_window": "You can close this window",
+				"error": "Request failed due to an error",
+				"try_again": "Please try again. If the issue persists, contact the developer of the dapp where you initiated the request."
+			},
+			"error": {
+				"cannot_call": "The call cannot be processed"
+			}
+		}
+	},
+	"carousel": {
+		"text": {
+			"next_slide": "Next slide",
+			"prev_slide": "Previous slide",
+			"indicator": "Jump to slide $index"
+		}
+	},
+	"license_agreement": {
+		"text": {
+			"accept_terms": "By clicking this button, you agree to the",
+			"accept_terms_link": "License Agreement",
+			"title": "$oisy_name License Agreement (“License Agreement”)",
+			"paragraph_1": "Thank you for your interest in $oisy_name, a browser-based, self-custodial and multi-chain wallet decentralized application hosted on the Internet Computer public blockchain network (“$oisy_short”). For more information about $oisy_short, its open-source code and related licenses, please refer to the $oisy_short github repository found here: $oisy_repo_url.",
+			"paragraph_2": "This License Agreement governs your use of $oisy_short (\"You\"). BY USING $oisy_short, YOU AGREE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THIS LICENSE AGREEMENT. IF YOU DO NOT AGREE, YOU MAY NOT USE $oisy_short.",
+			"paragraph_3": "If You choose to use $oisy_short, You and the DFINITY Foundation, including its affiliates and subsidiaries (collectively “DFINITY”), acknowledge and agree as follows:",
+			"limited_license": "<strong>1. LIMITED LICENSE.</strong> Subject to the terms and conditions contained in this License Agreement, DFINITY grants You a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to use $oisy_short only for the purposes of receiving, holding and sending tokens such as native ICP, ICRC-1, ETH, and ERC20 tokens, as well as other tokens which may be made available from time to time. You may create derivative works to the extent permitted by the licensing terms governing use of any open-sourced components included within $oisy_short.",
+			"restrictions": "<strong>2. RESTRICTIONS.</strong> You are responsible for all activities related to your use of $oisy_short, regardless of whether the activities are authorized by You or undertaken by You, your employees or a third party on your behalf. YOU UNDERSTAND THAT DFINITY IS NOT RESPONSIBLE FOR ANY ACTIVITIES OR TRANSACTIONS (WHETHER COMPLETED OR OTHERWISE) ASSOCIATED WITH YOUR $oisy_name. You will not misrepresent or embellish the relationship between You and DFINITY, including expressing or implying that DFINITY supports, sponsors, endorses, or contributes to You or your business endeavors through your use of $oisy_short. You will not imply any relationship or affiliation with DFINITY except as expressly permitted by this License Agreement. You are prohibited from using the $oisy_short name, logo or any other trademarks related to $oisy_short in any manner that may imply an endorsement or affiliation, misrepresent your relationship with $oisy_short or create confusion regarding the source of $oisy_short.",
+			"applicable_laws": "<strong>3. APPLICABLE LAWS.</strong> You will comply with all applicable laws and regulations (including without limitation laws and regulations related to export controls, money laundering or economic sanctions) in connection with your use of $oisy_short and any transactions associated with your $oisy_name.",
+			"reservation_rights": "<strong>4. RESERVATION OF DFINITY’S RIGHT.</strong> $oisy_short is owned by DFINITY and licensed, not sold, to You. $oisy_short’s content, visual interfaces, interactive features, information, graphics, design, compilation, computer code, products, services, and all other elements of $oisy_short and related documentation, are protected by applicable intellectual property laws. As between You and DFINITY, all DFINITY materials and $oisy_short, including intellectual property rights therein and thereto, are the sole and exclusive property of DFINITY or its subsidiaries or affiliated companies and/or its third-party licensors, subject to any open-source software licenses. DFINITY reserves all rights not expressly granted in this License Agreement. You do not acquire any right, title, or interest to the DFINITY materials or $oisy_short, whether by implication, estoppel, or otherwise, except for the limited rights set forth in this License Agreement and the rights conferred by the licensing terms governing use of any open-sourced components included within $oisy_short. This License Agreement does not grant you any right to use the $oisy_short name, logo or other trademarks related to $oisy_short or DFINITY.",
+			"feedback": "<strong>5. FEEDBACK.</strong> If You provide DFINITY with any comments, ideas, bug reports, feedback, enhancements, recommendations or modifications in relation to $oisy_short (\"Feedback\"), such Feedback is provided on a non-confidential basis, and DFINITY shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the DFINITY materials, $oisy_short or other services. You hereby grant DFINITY a perpetual, irrevocable, transferable, sublicensable, nonexclusive, royalty free license under all rights necessary to so incorporate and use your Feedback for any purpose, including to make and sell products and services, and agree to provide DFINITY with any assistance required to document, perfect and maintain DFINITY’s rights to the Feedback. You agree to allow DFINITY to contact You for Feedback from time to time, but may opt-out by sending written notice to legalnotice@dfinity.org.",
+			"termination": "<strong>6. TERMS AND TERMINATION.</strong> This License Agreement will remain in effect until terminated. The License Agreement, and your rights and licenses hereunder, will terminate immediately upon your breach of the License Agreement. You may terminate the License Agreement at any time by emptying your $oisy_name of tokens and ceasing all use of $oisy_short. DFINITY may terminate this License Agreement at any time for any reason, including without limitation any actual or suspected misuse or abuse by You of $oisy_short or any violation of this License Agreement. Sections 3 through 13 shall survive any termination of this License Agreement.",
+			"warranty_liability": "<strong>7. WARRANTY DISCLAIMER AND LIMITATION OF LIABILITY.</strong> TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, $oisy_short IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, DFINITY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OR CONDITIONS OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE, QUALITY, RESULTS, AND NON-INFRINGEMENT. DFINITY DOES NOT GUARANTEE THAT $oisy_short WILL ALWAYS BE AVAILABLE, SAFE, OR SECURE (NOW AND IN THE FUTURE). DFINITY EXPRESSLY DISCLAIMS ANY WARRANTIES OF ANY KIND WITH RESPECT TO THE ACCURACY OR FUNCTIONALITY OF $oisy_short, AND WITH RESPECT TO THE ACCURACY, VALIDITY, OR COMPLETENESS OF ANY INFORMATION OR FEATURES (NOW AND IN THE FUTURE) MADE AVAILABLE THROUGH YOUR USE OF $oisy_short, OR THE QUALITY OR CONSISTENCY OF $oisy_short OR RESULTS OBTAINED THROUGH ITS USE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, UNDER NO CIRCUMSTANCES WILL DFINITY BE LIABLE FOR ANY CONSEQUENTIAL, SPECIAL, INDIRECT, INCIDENTAL OR PUNITIVE DAMAGES WHATSOEVER ARISING OUT OF THE USE OR INABILITY TO USE AND ACCESS $oisy_short OR DFINITY MATERIALS, EVEN IF DFINITY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL DFINITY'S AGGREGATE LIABILITY FOR DAMAGES ARISING OUT OF THIS LICENSE AGREEMENT OR YOUR USE OR INABILITY TO USE $oisy_short EXCEED 100 CHF.",
+			"indemnity": "<strong>8. INDEMNITY.</strong> You agree to indemnify, defend and hold DFINITY and its affiliates, officers, directors, suppliers, licensors, and other customers harmless from and against any and all liability and costs, including reasonable attorneys' fees incurred by such parties, in connection with your use or misuse of $oisy_short or your violation of this License Agreement or any applicable law or regulation.",
+			"governing_law": "<strong>9. GOVERNING LAW; VENUE.</strong> Any claim relating to $oisy_short shall be governed by the laws of Switzerland, to the exclusion of the rules on conflicts of laws. Any claim or dispute related to this License Agreement or in relation to it shall (including for non-contractual disputes or claims and their interpretation) be subject to the exclusive jurisdiction of the Courts of Zurich, Switzerland, subject to an appeal at the Swiss Federal Court.",
+			"entire_agreement": "<strong>10. ENTIRE AGREEMENT AND SEVERABILITY.</strong> This License Agreement is the entire agreement between You and DFINITY, and supersedes any and all prior agreements, negotiations, or other communications between You and DFINITY, whether oral or written, with respect to the subject matter hereof. DFINITY may make changes to this License Agreement when new versions of $oisy_short are made available. In the event that any provision of this License Agreement is held to be invalid or unenforceable, then: (a) such provision shall be deemed reformed to the extent strictly necessary to render such provision valid and enforceable, or if not capable of such reformation shall be deemed severed from this License Agreement; and (b) the validity and enforceability of all of the other provisions hereof, shall in no way be affected or impaired thereby.",
+			"assignment": "<strong>11. ASSIGNMENT.</strong> You may not assign this License Agreement without the prior written consent of DFINITY, whether expressly or by operation of law, including in connection with a merger or change of control, and any such attempted assignment shall be void and of no effect. DFINITY may assign this License Agreement without restriction and without any notice to You. Subject to the foregoing, this License Agreement shall be binding on the parties and their respective successors and permitted assigns.",
+			"no_waiver": "<strong>12. NO WAIVER.</strong> The failure to exercise, or delay in exercising, a right, power, or remedy provided in this License Agreement or by law shall not constitute a waiver of that right, power, or remedy. DFINITY 's waiver of any obligation or breach of this License Agreement shall not operate as a waiver of any other obligation or subsequent breach of the License Agreement.",
+			"english_version": "<strong>13. ENGLISH VERSION.</strong> The English language version of this License Agreement shall be the official and controlling version of the agreement if any conflict should arise. All communications and notices made pursuant to this License Agreement must be in the English language."
+		},
+		"alt": {
+			"license_agreement": "The $oisy_name License Agreement"
+		}
+	},
+	"activity": {
+		"text": {
+			"title": "Recent Activity"
+		},
+		"info": {
+			"btc_transactions": "BTC transaction information is obtained from central third parties and should be independently verified."
+		},
+		"warning": {
+			"no_index_canister": "Transactions for $token_list can not be displayed. No Index canister available.",
+			"unavailable_index_canister": "Transactions for $token_list can not be displayed. Index canister is currently unavailable."
+		}
+	}
 }

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1,989 +1,988 @@
 {
-	"core": {
-		"text": {
-			"cancel": "Cancel",
-			"next": "Next",
-			"save": "Save",
-			"back": "Back",
-			"done": "Done",
-			"close": "Close",
-			"refresh": "Refresh",
-			"name": "Name",
-			"symbol": "Symbol",
-			"decimals": "Decimals",
-			"amount": "Amount",
-			"max": "Max",
-			"reject": "Reject",
-			"approve": "Approve",
-			"view": "View",
-			"copy": "Copy",
-			"clear_filter": "Clear filter",
-			"not_available": "n/a",
-			"new": "New"
-		},
-		"info": {
-			"test_banner": "For testing purposes only!"
-		},
-		"alt": {
-			"logo": "$name logo",
-			"go_to_home": "Go to the $oisy_name home page",
-			"back": "Go back to the previous page"
-		},
-		"warning": {
-			"do_not_close": "Don't close this tab until the transaction is done"
-		}
-	},
-	"navigation": {
-		"text": {
-			"tokens": "Assets",
-			"settings": "Settings",
-			"dapp_explorer": "Explore",
-			"activity": "Activity",
-			"airdrops": "Rewards",
-			"source_code_on_github": "Source code on GitHub",
-			"view_on_explorer": "View on explorer",
-			"source_code": "Source code",
-			"changelog": "Changelog",
-			"documentation": "Documentation",
-			"support": "Support",
-			"confirm_navigate": "Are you sure you want to navigate away?",
-			"vip_qr_code": "VIP QR codes"
-		},
-		"alt": {
-			"tokens": "Go to the assets view",
-			"settings": "Open your settings",
-			"dapp_explorer": "Open dapp explorer",
-			"activity": "Open the activity view",
-			"airdrops": "Open the Rewards view",
-			"more_settings": "More settings",
-			"menu": "Your wallet address, settings, sign-out and external links",
-			"changelog": "Open the changelog of $oisy_name on GitHub to review the latest updates",
-			"documentation": "Open the $oisy_name documentation",
-			"support": "Open the Support section of the $oisy_name documentation",
-			"open_twitter": "Open the DFINITY X/Twitter feed",
-			"vip_qr_code": "Generate an invitation link"
-		},
-		"short": {
-			"documentation": "Docs"
-		}
-	},
-	"auth": {
-		"text": {
-			"title_part_1": "$oisy_name",
-			"title_part_2": "100% Decentralized",
-			"logout": "Logout",
-			"authenticate": "Open or Create",
-			"asset_types": "Bitcoin, Solana, Ethereum, ICP, and more",
-			"instant_and_private": "Instant and private access anywhere",
-			"advanced_cryptography": "100% onchain: peace of mind through advanced cryptography"
-		},
-		"alt": {
-			"preview": "Preview of $oisy_name once signed in, both on desktop and mobile"
-		},
-		"warning": {
-			"not_signed_in": "You are not signed in. Please sign in to continue.",
-			"session_expired": "You have been logged out because your session has expired."
-		},
-		"error": {
-			"no_internet_identity": "No internet identity.",
-			"invalid_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential. Please contact the issuer and request the credential again.",
-			"error_validating_pouh_credential_oisy": "Sorry, but there was an error while validating the Humanity Credential in $oisy_short: $error",
-			"error_validating_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential.",
-			"error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
-			"missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
-			"no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?",
-			"error_while_signing_in": "Something went wrong while sign-in.",
-			"unexpected_issue_with_syncing": "Unexpected issue while syncing the status of your authentication."
-		}
-	},
-	"dapps": {
-		"text": {
-			"all_dapps": "All dapps",
-			"featured": "Featured",
-			"sign_in": "Sign-in to explore the ecosystem.",
-			"title": "Explore Apps",
-			"open_dapp": "Open $dAppName",
-			"submit_your_dapp": "Submit your dapp"
-		},
-		"alt": {
-			"learn_more": "Learn more about $dAppName",
-			"logo": "Logo of $dAppName",
-			"show_all": "Show all decentralised applications",
-			"show_tag": "Show decentralised applications with the tag $tag",
-			"open_dapp": "Open the app $dAppName",
-			"open_telegram": "Open $dAppName on Telegram",
-			"open_open_chat": "Open $dAppName on OpenChat",
-			"open_twitter": "Open the $dAppName X/Twitter feed",
-			"source_code_on_github": "View source code of $dAppName on github",
-			"submit_your_dapp": "Submit your dapp to be shown in the dapp-explorer",
-			"tags": "Tags related to $dAppName",
-			"website": "Image of $dAppName"
-		}
-	},
-	"airdrops": {
-		"text": {
-			"title": "Rewards",
-			"active_campaigns": "Active Opportunities",
-			"upcoming_campaigns": "Upcoming Opportunities",
-			"active_date": "Due on",
-			"participate_title": "Participate and earn Sprinkles",
-			"share": "Share on X",
-			"learn_more": "Learn more",
-			"check_status": "Check Status & Eligibility",
-			"requirements_title": "Requirements",
-			"modal_button_text": "Got it",
-			"activity_button_text": "Check on Recent Activity",
-			"activity_button_text_short": "Check activity",
-			"no_balance_title": "Earn $oisy_short Sprinkles",
-			"no_balance_description": "Check back later to see your rewards",
-			"open_wallet": "Take me to the wallet",
-			"state_modal_title": "Congratulations on earning today’s $oisy_short Sprinkles!",
-			"state_modal_title_jackpot": "Congratulations on earning today’s largest $oisy_short Sprinkles!",
-			"state_modal_content_text": "Share your victory on Twitter to qualify for another chance to earn.",
-			"carousel_slide_title": "$oisy_short Sprinkles are now Live!",
-			"carousel_slide_cta": "Learn more",
-			"sprinkles_earned": "You've earned $noOfSprinkles sprinkles, totaling $amount! \uD83C\uDF89",
-			"youre_eligible": "You're eligible!"
-		},
-		"alt": {
-			"upcoming_campaigns": "Keep an eye out for upcoming token drops! Subscribe to $oisy_short on X and follow us to catch all the latest updates."
-		}
-	},
-	"footer": {
-		"text": {
-			"incubated_with": "Incubated with",
-			"by": "by",
-			"dfinity_foundation": "DFINITY Foundation",
-			"copyright": "© 2025"
-		},
-		"alt": {
-			"dfinity": "Go to DFINITY Foundation website"
-		}
-	},
-	"wallet": {
-		"text": {
-			"address": "Address",
-			"wallet_address": "Wallet address",
-			"your_addresses": "Your addresses",
-			"address_copied": "Address copied to clipboard.",
-			"wallet_address_copied": "Wallet address copied to clipboard.",
-			"display_wallet_address_qr": "Display wallet address as a QR code",
-			"icp_deposits": "Note: For ICP deposits, use the 'Receive' button in your ICP account to get the right address.",
-			"use_address_from_to": "Use this address to transfer $token to and from your wallet."
-		},
-		"alt": {
-			"open_etherscan": "Open your address on Etherscan",
-			"open_solscan": "Open your address on Solscan",
-			"qrcode_address": "Scan this QR code to copy the address to receive $token tokens"
-		}
-	},
-	"init": {
-		"text": {
-			"initializing_wallet": "Preparing your wallet...",
-			"securing_session": "Securing session with Internet Identity",
-			"retrieving_public_keys": "Retrieving your public keys for Bitcoin, Ethereum and Solana",
-			"done": "Enjoy $oisy_short"
-		},
-		"info": {
-			"hold_loading": "Hold tight, we are loading some information...",
-			"hold_loading_wallet": "Hold tight, we are loading some initial data for your wallet..."
-		},
-		"error": {
-			"no_alchemy_config": "No Alchemy config for network $network",
-			"no_alchemy_provider": "No Alchemy provider for network $network",
-			"no_alchemy_erc20_provider": "No Alchemy ERC20 provider for network $network",
-			"no_etherscan_provider": "No Etherscan provider for network $network",
-			"no_etherscan_rest_api": "No Etherscan Rest API for network $network",
-			"no_infura_provider": "No Infura provider for network $network",
-			"no_infura_cketh_provider": "No Infura CkETH provider for network $network",
-			"no_infura_erc20_provider": "No Infura ERC20 provider for network $network",
-			"no_infura_erc20_icp_provider": "No Infura ERC20 Icp provider for network $network",
-			"no_solana_rpc": "No Solana RPC for network $network",
-			"no_solana_network": "No Solana network for network $network",
-			"eth_address_unknown": "ETH address is unknown.",
-			"loading_address": "Error while loading the $symbol address.",
-			"loading_balance": "Error while loading the ETH balance.",
-			"loading_balance_symbol": "Error while loading $symbol balance.",
-			"erc20_contracts": "Error while loading the ERC20 contracts.",
-			"spl_tokens": "Error while loading the SPL tokens.",
-			"minter_ckbtc_btc": "A configured minter is required to convert ckBTC to BTC.",
-			"minter_cketh_eth": "A configured minter is required to convert ckETH to ETH.",
-			"minter_ckerc20_erc20": "A configured minter is required to convert ckERC20 to Erc20.",
-			"ledger_cketh_eth": "A configured ckETH ledger is required to convert ckErc20 to Erc20.",
-			"minter_btc": "A configured minter is required to retrieve BTC.",
-			"minter_ckbtc_info": "A configured minter is required to fetch the ckBTC info",
-			"minter_cketh_info": "A configured minter is required to fetch the ckETH info",
-			"minter_ckbtc_loading_info": "Error while loading the ckBTC minter information.",
-			"minter_cketh_loading_info": "Error while loading the ckETH minter information.",
-			"btc_fees_estimation": "Error while querying the estimation of the BTC fees.",
-			"btc_withdrawal_statuses": "Error while fetching the BTC withdrawal statuses.",
-			"transaction_price": "Error while loading the estimation of the price of a transaction.",
-			"icrc_canisters": "Error while loading the ICRC canisters.",
-			"erc20_user_tokens": "Error while loading the ERC20 user tokens.",
-			"spl_user_tokens": "Error while loading the SPL user tokens.",
-			"erc20_user_token": "Error while enabling the ERC20 twin token.",
-			"icrc_custom_token": "Error while loading the ICRC custom token.",
-			"loading_wallet_timeout": "Your wallet requires some initial data which has not been loaded yet. Please try again.",
-			"allow_signing": "An issue occurred while setting up your wallet for signing. You've been signed out. If the issue persists, contact support.",
-			"btc_wallet_error": "Error while loading BTC wallet information.",
-			"sol_wallet_error": "Error while loading SOL wallet information."
-		}
-	},
-	"hero": {
-		"text": {
-			"available_balance": "Available balance",
-			"unavailable_balance": "$ value is not available",
-			"top_up": "Top up your wallet to start using it!",
-			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
-		}
-	},
-	"settings": {
-		"text": {
-			"title": "Settings",
-			"principal": "Your Principal",
-			"principal_copied": "Principal copied to clipboard",
-			"principal_description": "Your ID for the $oisy_name. Created by your Internet Identity.",
-			"session": "Your session expires in",
-			"session_description": "All sessions last 1 hour. After 1 hour, you will need to authenticate again with Internet Identity.",
-			"testnets": "Show test networks",
-			"testnets_description": "Display the test networks (Sepolia) and twin tokens on testnets (ckTESTBTC and ckSepolia).",
-			"hide_zero_balances_description": "Enable this feature to declutter your wallet view by hiding all tokens with a zero balance.",
-			"credentials_title": "Credentials",
-			"pouh_credential": "Humanity Credential",
-			"pouh_credential_description": "The Humanity Credential is a proof of humanity. It is issued by Decide AI.",
-			"present_pouh_credential": "Present",
-			"pouh_credential_verified": "Verified ✅",
-			"appearance": "Appearance",
-			"appearance_light": "Light",
-			"appearance_dark": "Dark",
-			"appearance_system": "System"
-		},
-		"alt": {
-			"testnets_toggle": "Toggle to show or hide testnets",
-			"github_release": "$oisy_short release notes on GitHub",
-			"appearance_light": "Enables light mode",
-			"appearance_dark": "Enables dark mode",
-			"appearance_system": "Enables your operating systems color mode"
-		},
-		"error": {
-			"loading_profile": "Error while loading the profile. Please refresh the page to have the full experience."
-		}
-	},
-	"networks": {
-		"title": "Current network. Access to selection.",
-		"test_networks": "Test networks",
-		"more": "More networks coming soon...",
-		"chain_fusion": "Chain Fusion (all networks)",
-		"network": "Network"
-	},
-	"receive": {
-		"text": {
-			"receive": "Receive",
-			"address": "Receive address",
-			"receive_token": "Receive $token"
-		},
-		"icp": {
-			"text": {
-				"account_id": "ICP Account ID",
-				"use_for_all_tokens": "Use for all tokens when receiving from wallets, users, or other apps that support this address format.",
-				"use_for_icrc_deposit": "Use for receiving ICRC-1 tokens in the ICP network, such as SNS, ck tokens, etc.",
-				"use_for_icp_deposit": "Use for ICP deposits from exchanges or other wallets that only support Account IDs.",
-				"your_private_eth_address": "Your private address for all ERC20 tokens.",
-				"display_account_id_qr": "Display ICP Account ID as a QR code",
-				"account_id_copied": "ICP Account ID copied to clipboard.",
-				"principal": "ICP Principal",
-				"internet_computer_principal_copied": "Internet Computer Principal copied to clipboard.",
-				"display_internet_computer_principal_qr": "Display Internet Computer Principal as a QR code",
-				"icp_account": "ICP Account (for exchanges)",
-				"icp_account_copied": "ICP Account copied to clipboard.",
-				"display_icp_account_qr": "Display ICP Account as a QR code"
-			}
-		},
-		"ethereum": {
-			"text": {
-				"checking_status": "Checking $token status...",
-				"from_network": "Receive from $network Network",
-				"eth_to_cketh_description": "Converting $token into $ckToken requires a call to a smart contract on $network and passing your IC principal as argument – $oisy_name simplifies this procedure by enabling you to perform the conversion directly within the wallet.",
-				"learn_how_to_convert": "Learn how to convert $token to $ckToken",
-				"metamask": "Receive from Metamask",
-				"ethereum": "Ethereum",
-				"ethereum_address": "Address",
-				"ethereum_address_copied": "Ethereum address copied to clipboard.",
-				"display_ethereum_address_qr": "Display Ethereum address as a QR code"
-			},
-			"error": {
-				"no_metamask": "Metamask is not available."
-			}
-		},
-		"bitcoin": {
-			"text": {
-				"bitcoin": "Bitcoin",
-				"checking_status": "Checking BTC status...",
-				"refresh_status": "Refresh BTC status",
-				"initializing": "Initializing...",
-				"checking_incoming": "Checking for incoming BTC...",
-				"refreshing_wallet": "Refreshing wallet...",
-				"bitcoin_address": "Bitcoin",
-				"bitcoin_testnet_address": "Bitcoin (Testnet)",
-				"bitcoin_regtest_address": "Bitcoin (Regtest)",
-				"display_bitcoin_address_qr": "Display Bitcoin Address as a QR code",
-				"bitcoin_address_copied": "Bitcoin Address copied to clipboard.",
-				"from_network": "Transfer Bitcoin on the BTC network to this address to receive ckBTC.",
-				"fee_applied": "Please note that an estimated inter-network fee of $fee BTC will be applied."
-			},
-			"info": {
-				"no_new_btc": "No new confirmed BTC.",
-				"check_btc_progress": "Checking for incoming BTC already in progress."
-			},
-			"error": {
-				"unexpected_btc": "Something went wrong while checking for incoming BTC."
-			}
-		},
-		"solana": {
-			"text": {
-				"solana_address": "Solana Address",
-				"solana_testnet_address": "Solana Testnet Address",
-				"solana_devnet_address": "Solana Devnet Address",
-				"solana_local_address": "Solana Local Address",
-				"solana_address_copied": "Solana address copied to clipboard",
-				"display_solana_address_qr": "Display Solana address as QR code"
-			}
-		}
-	},
-	"send": {
-		"text": {
-			"send": "Send",
-			"destination": "Destination",
-			"source": "Source",
-			"balance": "Balance",
-			"review": "Review",
-			"signing_approval": "Signing approval...",
-			"approving": "Approving...",
-			"approving_fees": "Approving fees...",
-			"approving_transfer": "Approving transfer...",
-			"approving_wallet_connect": "Approving WalletConnect request...",
-			"refreshing_ui": "Refreshing UI",
-			"initializing": "Initializing transaction...",
-			"signing_transaction": "Signing transaction...",
-			"sending": "Sending...",
-			"signing": "Signing...",
-			"signing_message": "Signing message...",
-			"network": "Network",
-			"source_network": "Source network",
-			"destination_network": "Destination network",
-			"initializing_transaction": "Initializing transaction",
-			"convert_to_native_icp": "Convert to native ICP",
-			"open_qr_modal": "Start QR Code scan for transaction details",
-			"scan_qr": "Scan QR Code"
-		},
-		"placeholder": {
-			"enter_eth_address": "Enter public address (0x)",
-			"enter_recipient_address": "Enter recipient address",
-			"enter_wallet_address": "Enter wallet address",
-			"select_network": "Select network"
-		},
-		"info": {
-			"ckbtc_certified": "Please wait until the ckBTC parameters have been certified.",
-			"cketh_certified": "Please wait until the ckETH parameters have been certified.",
-			"pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete.",
-			"no_available_utxos": "You won't have available utxos to perform this transaction.",
-			"ata_will_be_calculated": "You provided a non-ATA address. The ATA address will be calculated automatically based on your input."
-		},
-		"assertion": {
-			"invalid_destination_address": "Invalid destination address",
-			"insufficient_funds": "Insufficient funds.",
-			"unknown_minimum_ckbtc_amount": "The minimum amount of ckBTC required for converting to BTC is unknown.",
-			"unknown_minimum_cketh_amount": "The minimum amount of ckETH required for converting to ETH is unknown.",
-			"unknown_minimum_amount": "The minimum amount of $sourceTokenSymbol required for converting to $destinationTokenSymbol is unknown.",
-			"minimum_ckbtc_amount": "The amount falls below the minimum of $amount ckBTC required for converting to BTC.",
-			"minimum_cketh_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
-			"minimum_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
-			"minimum_ledger_fees": "The amount falls below the ledger fees $symbol.",
-			"minimum_cketh_balance": "The $symbol balance falls below the estimated fee of $amount.",
-			"unknown_cketh": "The ckETH token cannot be retrieved.",
-			"destination_address_invalid": "Destination address is invalid.",
-			"amount_invalid": "Amount is invalid.",
-			"insufficient_funds_for_gas": "Insufficient funds for gas",
-			"insufficient_funds_for_amount": "Insufficient funds for amount",
-			"insufficient_ethereum_funds_to_cover_the_fees": "Insufficient Ethereum funds to cover the fees",
-			"insufficient_solana_funds_to_cover_the_fees": "Insufficient Solana funds to cover the fees",
-			"not_enough_tokens_for_gas": "Not enough $symbol for gas. Balance: $balance $symbol",
-			"gas_fees_not_defined": "Gas fees are not defined.",
-			"max_gas_fee_per_gas_undefined": "Max fee per gas or max priority fee per gas is undefined.",
-			"address_unknown": "Address is unknown.",
-			"minter_info_not_loaded": "Try again in a few seconds, a ckETH configuration parameter is not yet loaded.",
-			"minter_info_not_certified": "Try again in a few seconds, a ckETH configuration parameter has not been certified.",
-			"cketh_max_transaction_fee_missing": "The maximum transaction fee for ckETH is missing.",
-			"utxos_fee_missing": "UTXOs fee is missing."
-		},
-		"error": {
-			"unexpected": "Something went wrong while sending the transaction.",
-			"destination_address_unknown": "ETH destination address is unknown",
-			"metamask_connected": "Cannot get your accounts. Is your Metamask open and already connected?",
-			"metamask_no_accounts": "No Metamask accounts found.",
-			"metamask_switch_network": "Cannot request Metamask to switch to chain ID $chain_id. Is your Metamask using $network_name?",
-			"erc20_data_undefined": "Erc20 transaction Data cannot be undefined or null.",
-			"data_undefined": "Transaction Data cannot be undefined or null.",
-			"no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
-			"invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
-			"incompatible_token": "The token is incompatible. Please try again with a compatible token.",
-			"no_btc_network_id": "Current network ($networkId) is not a Bitcoin network.",
-			"no_solana_network_id": "Current network ($networkId) is not a Solana network.",
-			"no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later.",
-			"unexpected_utxos_fee": "Something went wrong while calculating transaction fee.",
-			"unable_to_retrieve_amount": "n/a (unable to retrieve)",
-			"solana_transaction_expired": "Your send transaction was not processed by the Solana network and expired, most likely because the provided priority fee was not sufficient. We updated it to the latest recommended amount, so please try sending it again."
-		}
-	},
-	"convert": {
-		"text": {
-			"converting": "Converting...",
-			"convert_to_btc": "Convert to BTC",
-			"convert_to_ckbtc": "Convert to ckBTC",
-			"convert_to_token": "Convert to $token",
-			"convert_to_cketh": "Convert to ckETH",
-			"convert_to_ckerc20": "Convert to $ckErc20",
-			"convert_eth_to_cketh": "Convert $token to $ckToken",
-			"cketh_conversions_may_take": "ckETH conversions may take up to 20 minutes",
-			"ckerc20_conversions_may_take": "$ckErc20 conversions may take up to 20 minutes",
-			"how_to_convert_eth_to_cketh": "Here is how to can convert $token to $ckToken on $oisy_name",
-			"send_eth": "Send $token to your $oisy_name address",
-			"wait_eth_current_balance": "Wait for $token to arrive. Current balance",
-			"set_amount": "Set amount for conversion",
-			"check_balance_for_fees": "Check $token balance for conversion fees",
-			"fees_explanation": "You need enough $token to cover the smart contract execution fees.",
-			"current_balance": "👉 Current balance:",
-			"review_button": "Review",
-			"convert_button": "Convert",
-			"input_reset_button": "Reset input value",
-			"swap_to_token": "Convert $sourceToken → $destinationToken",
-			"review": "Review transaction",
-			"max_balance": "Max",
-			"source_network": "Source network",
-			"destination_network": "Destination network",
-			"conversion_may_take": "Conversion may take up to 1 hour",
-			"executing_transaction": "Executing transaction...",
-			"initializing": "Initializing transaction...",
-			"refreshing_ui": "Refreshing UI",
-			"unsupported_token_conversion": "Conversion for the selected token is not supported.",
-			"calculating_max_amount": "Calculating..."
-		},
-		"assertion": {
-			"insufficient_funds": "Insufficient balance"
-		},
-		"error": {
-			"loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized.",
-			"unexpected": "Something went wrong while converting tokens.",
-			"unexpected_missing_data": "Something went wrong while initiating a convert transaction."
-		}
-	},
-	"swap": {
-		"text": {
-			"swap": "Swap",
-			"select_destination_token": "Select token to receive",
-			"select_source_token": "Select token to pay",
-			"switch_tokens_button": "Switch tokens",
-			"review": "Review transaction",
-			"review_button": "Review swap",
-			"max_slippage": "Max slippage",
-			"max_balance": "Max",
-			"not_available": "n/a",
-			"value_difference": "Value difference",
-			"total_fee": "Total estimated fee",
-			"network_fee": "Network fee",
-			"approval_fee": "Approval fee",
-			"gas_fee": "Gas fee",
-			"lp_fee": "LP fee",
-			"max_slippage_info": "Enter value between 0% and 50%",
-			"max_slippage_warning": "Risk warning: high slippage may lead to losses due to market volatility",
-			"max_slippage_error": "Slippage tolerance cannot be 0% or exceed 50%",
-			"swap_button": "Swap now",
-			"swap_is_not_offered": "This swap is currently not offered.",
-			"executing_transaction": "Executing transaction...",
-			"initializing": "Initializing transaction...",
-			"swapping": "Swapping...",
-			"refreshing_ui": "Refreshing UI",
-			"swap_provider": "Swap provider"
-		},
-		"error": {
-			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
-			"unexpected": "Something went wrong while swapping tokens.",
-			"unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
-			"slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again."
-		}
-	},
-	"buy": {
-		"text": {
-			"buy": "Buy",
-			"buy_dev": "Buy (Dev Environment)"
-		},
-		"onramper": {
-			"title": "Buy through Onramper"
-		}
-	},
-	"tokens": {
-		"text": {
-			"title": "Tokens",
-			"contract_address": "Contract address",
-			"token_address": "Token address",
-			"balance": "Balance",
-			"hide_zero_balances": "Hide zero balances",
-			"hide_zeros": "Hide zeros",
-			"all_tokens_with_zero_hidden": "All assets with zero balance are currently hidden",
-			"buy_or_receive": "Buy or receive your first tokens now to see them in the list",
-			"initializing": "Initializing...",
-			"updating_ui": "Updating the UI...",
-			"show_token": "Show token",
-			"hide_token": "Hide token",
-			"select_token": "Select token",
-			"exchange_is_not_available": "USD value is currently not available.",
-			"source_token_title": "You pay",
-			"destination_token_title": "You receive"
-		},
-		"details": {
-			"title": "Token details",
-			"token": "Token",
-			"network": "Network",
-			"contract_address_copied": "Contract address copied to clipboard.",
-			"token_address_copied": "Token address copied to clipboard.",
-			"twin_token": "Twin token",
-			"standard": "Standard"
-		},
-		"balance": {
-			"error": {
-				"not_applicable": "n/a"
-			}
-		},
-		"import": {
-			"text": {
-				"title": "Import token",
-				"review": "Review",
-				"saving": "Saving...",
-				"updating": "Updating token list",
-				"ledger_canister_id": "Ledger Canister ID",
-				"index_canister_id": "Index Canister ID",
-				"minter_canister_id": "Minter Canister ID",
-				"ledger_canister_id_copied": "Ledger Canister ID copied to clipboard.",
-				"index_canister_id_copied": "Index Canister ID copied to clipboard.",
-				"minter_canister_id_copied": "Minter Canister ID copied to clipboard.",
-				"verifying": "Verifying token details...",
-				"add_the_token": "Add the token",
-				"info": "Ledger and Index canister IDs are usually available on the project’s website. ",
-				"info_index": "The Index canister ID is optional, but without it, $oisy_short can’t display transaction history.",
-				"custom_tokens_not_supported": "The selected network does not support custom tokens."
-			},
-			"error": {
-				"loading_metadata": "Error while loading the metadata of the token.",
-				"no_metadata": "No metadata for the token is provided. This is unexpected.",
-				"unexpected_ledger": "Something went wrong while validating the Ledger canister.",
-				"unexpected_index": "Something went wrong while validating the Index canister.",
-				"unexpected_index_ledger": "Something went wrong while loading the Ledger ID related to the Index canister.",
-				"invalid_ledger_id": "The Ledger ID is not related to the Index canister.",
-				"missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
-				"missing_contract_address": "The contract address is missing. Did you provide a value?",
-				"missing_token_address": "The token address is missing. Did you provide a value?",
-				"no_network": "No network is selected. This is unexpected."
-			},
-			"warning": {
-				"do_not_close_manage": "$oisy_name is preparing and securing the new tokens. Please don't close this tab until it's completed."
-			}
-		},
-		"manage": {
-			"text": {
-				"title": "Manage tokens",
-				"manage_list": "Manage tokens",
-				"do_not_see_import": "Don’t see your token? Import",
-				"manage_for_network": "Managing tokens for $network",
-				"network": "Network",
-				"all_tokens_zero_balance": "All tokens have zero balance."
-			},
-			"placeholder": {
-				"select_network": "Select the network"
-			},
-			"info": {
-				"no_changes": "No changes need to be saved."
-			},
-			"error": {
-				"unexpected_build": "An unexpected error happened while building the list of known tokens.",
-				"empty": "No tokens to enable or disable have been selected."
-			}
-		},
-		"hide": {
-			"title": "Hide token?",
-			"token": "Hide $token",
-			"info": "You can add this token back in the future by going into <strong>“Manage tokens”</strong> in your wallet view.",
-			"confirm": "Hide",
-			"hiding": "Hiding..."
-		},
-		"alt": {
-			"context_menu": "Context menu for to the selected token",
-			"open_etherscan": "Open the details of the token on Etherscan",
-			"open_blockstream": "Open the details of the token on Blockstream",
-			"open_dashboard": "Open the details of the token on the ICP Dashboard",
-			"open_contract_address_block_explorer": "Open the contract address on a block explorer",
-			"open_token_address_block_explorer": "Open the token address on a block explorer",
-			"token_group_number": "Total number of tokens in the group for native token $token"
-		},
-		"placeholder": {
-			"enter_contract_address": "Enter an ERC20 contract address",
-			"enter_token_address": "Enter an SPL token address",
-			"search_token": "Search for the token"
-		},
-		"warning": {
-			"trust_token": "Make sure you trust the token you are adding. If the token you are adding is controlled by a malicious party, they could try and scam you e.g., by making you believe you received a significant amount of tokens in order to trick you into sending them tokens in return or perform other undesired actions. Learn more about scams and security risks e.g. <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://support.metamask.io/hc/en-us/articles/4403988839451\">here</a>."
-		},
-		"error": {
-			"invalid_contract_address": "Contract address is invalid.",
-			"invalid_token_address": "Token address is invalid.",
-			"invalid_ledger": "The selected token is not linked with an Icrc Ledger canister.",
-			"no_metadata": "No metadata were fetched.",
-			"unexpected": "Something went wrong while saving the token.",
-			"unexpected_hiding": "Something went wrong while hiding the token.",
-			"already_available": "Token is already available.",
-			"loading_metadata": "Error while loading the metadata of the token.",
-			"not_toggleable": "Token is not toggleable, it can not be hidden.",
-			"incomplete_metadata": "No name or symbol is provided in the metadata.",
-			"duplicate_metadata": "A token with a similar name or symbol already exists.",
-			"unexpected_undefined": "Token is undefined. This is unexpected."
-		}
-	},
-	"fee": {
-		"text": {
-			"fee": "Fee",
-			"estimated_btc": "Estimated BTC Network Fee",
-			"estimated_inter_network": "Estimated Inter-network Fee",
-			"estimated_eth": "Estimated Ethereum Fee",
-			"max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>",
-			"convert_fee": "Conversion fee",
-			"convert_inter_network_fee": "Inter-network fee",
-			"convert_btc_network_fee": "Bitcoin network fee",
-			"zero_fee": "Free",
-			"total_fee": "Total fee",
-			"ata_fee": "ATA fee"
-		},
-		"assertion": {
-			"insufficient_funds_for_fee": "Insufficient balance to cover the fees."
-		},
-		"error": {
-			"cannot_fetch_gas_fee": "Cannot fetch gas fee."
-		}
-	},
-	"info": {
-		"bitcoin": {
-			"title": "Receive BTC & convert to ckBTC",
-			"description": "Convert Bitcoin into ckBTC and benefit from the fastest and cheapest Bitcoin transaction available. The conversion process can take up to an hour.",
-			"note": "You can convert ckBTC at any time back to BTC.",
-			"how_to": "How to convert to ckBTC"
-		},
-		"ethereum": {
-			"title": "Convert to $ckToken",
-			"description": "With a few steps, convert your native $network $token to its twinned ICP $ckToken directly within the $oisy_name. The conversion process can take up to 20 minutes.",
-			"note": "You can convert $ckToken at any time back to $token.",
-			"how_to": "How to convert to $ckToken",
-			"how_to_short": "How to convert $token"
-		}
-	},
-	"wallet_connect": {
-		"text": {
-			"name": "WalletConnect",
-			"session_proposal": "Session Proposal",
-			"connect": "Connect",
-			"connecting": "Connecting...",
-			"disconnect": "Disconnect",
-			"scan_qr": "Scan QR code",
-			"or_use_link": "or use WalletConnect link",
-			"proposer": "Proposer",
-			"review": "Review $chain_name ($key) required permissions",
-			"method": "Method",
-			"methods": "Methods",
-			"events": "Events",
-			"message": "Message",
-			"hex_data": "HEX Data",
-			"base64_data": "Base-64 Data",
-			"raw_copied": "Raw transaction data copied to clipboard.",
-			"sign_message": "Sign Message"
-		},
-		"alt": {
-			"connect_input": "e.g. wc:a281567bb3e4..."
-		},
-		"domain": {
-			"title": "Domain Verification",
-			"valid": "Valid ✅",
-			"valid_description": "The validation of the proposer's domain passed.",
-			"invalid": "Invalid ❌",
-			"invalid_description": "The domain of the proposer's website does not match the sender of the request.",
-			"security_risk": "Security risk ⚠️",
-			"security_risk_description": "The proposer's website is flagged as unsafe.",
-			"unknown": "Unknown ❓",
-			"unknown_description": "The domain of the proposer cannot be verified."
-		},
-		"info": {
-			"disconnected": "WalletConnect disconnected.",
-			"session_ended": "WalletConnect session was ended.",
-			"connected": "WalletConnect connected.",
-			"eth_transaction_executed": "WalletConnect eth_sendTransaction request executed.",
-			"sol_transaction_executed": "WalletConnect \"$method\" request executed.",
-			"sign_executed": "WalletConnect sign request executed."
-		},
-		"error": {
-			"qr_code_read": "Cannot read QR code.",
-			"missing_uri": "A URI to connect to should be provided.",
-			"disconnect": "An unexpected error happened while disconnecting the wallet. Resetting the connection anyway.",
-			"connect": "An unexpected error happened while trying to connect the wallet.",
-			"manual_workflow": "Please finalize the manual workflow that has already been initiated by opening the WalletConnect modal.",
-			"skipping_request": "Skipping the WalletConnect request as another action is currently in progress through an overlay.",
-			"method_not_support": "Requested method \"$method\" is not supported.",
-			"unexpected_pair": "An unexpected error happened while trying to pair the wallet.",
-			"no_connection_opened": "Unexpected error: No connection opened.",
-			"no_session_approval": "Unexpected error: No session proposal available.",
-			"unexpected": "Unexpected error while communicating with WalletConnect.",
-			"request_rejected": "WalletConnect request rejected",
-			"unknown_parameter": "Unknown parameter.",
-			"wallet_not_initialized": "Unexpected error. Your wallet address is not initialized.",
-			"from_address_not_wallet": "From address requested for the transaction is not the address of this wallet.",
-			"unknown_destination": "Unknown destination address.",
-			"request_not_defined": "Unexpected error: Request is not defined therefore cannot be processed.",
-			"unexpected_processing_request": "Unexpected error while processing the request with WalletConnect."
-		}
-	},
-	"transaction": {
-		"text": {
-			"details": "Transaction details",
-			"hash": "Transaction hash",
-			"hash_copied": "Transaction hash $hash copied to clipboard.",
-			"id": "Transaction ID",
-			"id_copied": "Transaction ID copied to clipboard.",
-			"timestamp": "Timestamp",
-			"type": "Type",
-			"from": "From",
-			"from_copied": "From address copied to clipboard.",
-			"to": "To",
-			"to_copied": "To address copied to clipboard.",
-			"block": "Block",
-			"interacted_with": "Interacted With (To)",
-			"status": "Status",
-			"confirmations": "Confirmations"
-		},
-		"status": {
-			"confirmed": "Confirmed",
-			"included": "Included",
-			"finalised": "Finalised",
-			"finalized": "Finalised",
-			"processed": "Processed",
-			"pending": "Pending...",
-			"safe": "Safe",
-			"unconfirmed": "Unconfirmed"
-		},
-		"label": {
-			"reimbursement": "Reimbursement",
-			"twin_token_sent": "$twinToken sent",
-			"ck_token_sent": "$ckToken sent",
-			"twin_token_converted": "Converted from $twinToken",
-			"ck_token_converted": "Converted from $ckToken",
-			"receiving_twin_token": "Receiving $twinToken",
-			"sending_twin_token": "Sending $twinToken",
-			"sending_twin_token_failed": "Sending $twinToken failed",
-			"converting_twin_token": "Converting $twinToken to $ckToken",
-			"converting_ck_token": "Converting $ckToken to $twinToken",
-			"twin_network": "$twinNetwork network",
-			"no_date_available": "No Date Available"
-		},
-		"alt": {
-			"open_block_explorer": "Open this transaction on a block explorer",
-			"open_from_block_explorer": "Open the 'From' address on a block explorer",
-			"open_to_block_explorer": "Open the 'To' address on a block explorer"
-		},
-		"error": {
-			"get_block_number": "Cannot get block number.",
-			"failed_get_transaction": "Failed to get the transaction from the provided (hash: $hash). Please reload the wallet dapp.",
-			"failed_get_mined_transaction": "Failed to get the mined transaction (hash: $hash). Please reload the wallet dapp."
-		}
-	},
-	"transactions": {
-		"text": {
-			"title": "Transactions",
-			"buy_or_receive": "Make your first transaction, and buy or receive tokens now!",
-			"transaction_history": "Your transaction history will appear here",
-			"open_transactions": "Open the list of $token transactions",
-			"mainnet_btc_transactions_info": "BTC transaction information is obtained from central third parties and should be independently verified.",
-			"transaction_history_unavailable": "Transaction history unavailable",
-			"missing_index_canister_explanation": "The token ledger is working fine, but the index canister is missing, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual.",
-			"index_canister_not_working_explanation": "The token ledger is working fine, but the index canister is having issues, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual."
-		},
-		"error": {
-			"loading_transactions": "Error while loading the transactions.",
-			"loading_transactions_symbol": "Error while loading the $symbol transactions.",
-			"no_token_loading_transaction": "Token not found. Transactions cannot be loaded.",
-			"uncertified_transactions_removed": "Several uncertified transactions were identified and subsequently removed from the displayed lists.",
-			"loading_pending_ck_ethereum_transactions": "Something went wrong while fetching the pending $network transactions.",
-			"get_transaction_for_hash": "Failed to get the transaction from the provided (hash: $hash).",
-			"unexpected_transaction_for_hash": "Something went wrong while loading the pending for hash: $hash."
-		}
-	},
-	"about": {
-		"why_oisy": {
-			"text": {
-				"label": "Why $oisy_short",
-				"title": "Why $oisy_short",
-				"hold_crypto": {
-					"title": "Unified Management of All Your Digital Assets",
-					"description": "$oisy_short allows you to manage all your digital assets — including Bitcoin, Solana, Ethereum, ICP, and more — in a single, unified wallet. No more juggling multiple wallets for different cryptocurrencies — enjoy a seamless and efficient experience across various platforms."
-				},
-				"network_custody": {
-					"title": "No more private key anxiety with Network Custody",
-					"description": "$oisy_name implements network custody, an innovative approach that leverages the Internet Computer's advanced cryptography to eliminate the need for you to handle private keys directly. This provides a secure and user-friendly alternative to traditional methods, aligning with the “Onchain is the New Online“ movement — a shift toward solutions that enhance security and resilience against cyber attacks by running on a distributed network."
-				},
-				"fully_on_chain": {
-					"title": "Tamper-Proof Security with a Fully On-Chain Wallet",
-					"description": "Not only are your keys secured, but the entire wallet application is stored <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/capabilities\">fully on-chain</a> and served directly into your browser from the Internet Computer. This means the entire wallet benefits from a decentralized trust model, making it tamper-proof and highly secure."
-				},
-				"cross_device": {
-					"title": "Access your wallet anytime from anywhere",
-					"description": "Using <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://identity.ic0.app/\">Internet Identity</a>, $oisy_short can easily be used across all devices you have linked to your private decentralized identity. This ensures seamless and secure access to your wallet whether you're on a smartphone, tablet, or desktop."
-				},
-				"verifiable_credentials": {
-					"title": "Unlock Extra Features with Verifiable Credentials",
-					"description": "$oisy_short integrates with the Internet Computer's <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/docs/current/developer-docs/identity/verifiable-credentials/overview\">verifiable credentials</a> platform. Access additional features like airdrops and exclusive functionalities by acquiring certain types of credentials, enhancing your overall experience."
-				},
-				"open_source": {
-					"title": "Trust in Transparency with Open Source",
-					"description": "$oisy_short is an <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"$oisy_repo_url\">open-source</a> project led by a dedicated team within the <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://dfinity.org/\">DFINITY foundation</a>, supported by over 200 world-leading cryptographers and engineers. Open sourcing ensures transparency, allowing the community to audit, contribute, and trust in the wallet's integrity."
-				}
-			}
-		}
-	},
-	"vip": {
-		"reward": {
-			"text": {
-				"open_wallet": "Take me to the wallet",
-				"title_successful": "Congratulations!",
-				"title_failed": "Invalid invitation code",
-				"reward_received": "Welcome to $oisy_short!",
-				"reward_failed": "Code is expired",
-				"reward_received_description": "You will receive your welcome gift any moment.",
-				"reward_failed_description": "Request a new one and try again"
-			},
-			"error": {
-				"loading_reward": "Error while loading a new reward code.",
-				"loading_user_data": "Failed to load user data from reward canister.",
-				"claiming_reward": "Error while claiming reward."
-			}
-		},
-		"invitation": {
-			"text": {
-				"title": "Generate invitation link",
-				"invitation_link_copied": "Invitation link copied to clipboard.",
-				"generate_new_link": "Generate new link",
-				"generating_new_code": "Generating new code",
-				"regenerate_countdown_text": "New link will be generated in $counter sec"
-			}
-		}
-	},
-	"signer": {
-		"sign_in": {
-			"text": {
-				"access_your_wallet": "Access your $oisy_name",
-				"open_or_create": "Open or create your wallet to securely connect to the dApp and start managing your assets."
-			}
-		},
-		"idle": {
-			"text": {
-				"waiting": "Waiting for the dApp interaction..."
-			},
-			"alt": {
-				"img_placeholder": "The astronaut logo moves its eyes from left to right while waiting for messages from the relying party dapp"
-			}
-		},
-		"permissions": {
-			"text": {
-				"title": "Review permissions",
-				"requested_permissions": "Requested permissions",
-				"your_wallet_address": "Your wallet address",
-				"icrc27_accounts": "View your $oisy_name address",
-				"icrc49_call_canister": "Request approval for transactions"
-			},
-			"error": {
-				"no_confirm_callback": "No callback to confirm the permissions, which is unexpected. Close the wallet and try again."
-			}
-		},
-		"origin": {
-			"text": {
-				"request_from": "Request from:",
-				"invalid_origin": "Invalid origin️!!"
-			},
-			"alt": {
-				"link_to_dapp": "Link to the dApp requesting permissions"
-			}
-		},
-		"consent_message": {
-			"text": {
-				"loading": "Loading consent message..."
-			},
-			"warning": {
-				"token_without_consent_message": "This token does not provide confirmation messages, so the information below was extracted by $oisy_short."
-			},
-			"error": {
-				"no_approve_callback": "No callback to approve the consent message, which is unexpected. Close the wallet and try again.",
-				"no_reject_callback": "No callback to reject the consent message, which is unexpected. Close the wallet and try again.",
-				"retrieve": "An error occurred while retrieving the consent message"
-			}
-		},
-		"call_canister": {
-			"text": {
-				"processing": "Processing the request...",
-				"executed": "The request has been executed",
-				"close_window": "You can close this window",
-				"error": "Request failed due to an error",
-				"try_again": "Please try again. If the issue persists, contact the developer of the dapp where you initiated the request."
-			},
-			"error": {
-				"cannot_call": "The call cannot be processed"
-			}
-		}
-	},
-	"carousel": {
-		"text": {
-			"next_slide": "Next slide",
-			"prev_slide": "Previous slide",
-			"indicator": "Jump to slide $index"
-		}
-	},
-	"license_agreement": {
-		"text": {
-			"accept_terms": "By clicking this button, you agree to the",
-			"accept_terms_link": "License Agreement",
-			"title": "$oisy_name License Agreement (“License Agreement”)",
-			"paragraph_1": "Thank you for your interest in $oisy_name, a browser-based, self-custodial and multi-chain wallet decentralized application hosted on the Internet Computer public blockchain network (“$oisy_short”). For more information about $oisy_short, its open-source code and related licenses, please refer to the $oisy_short github repository found here: $oisy_repo_url.",
-			"paragraph_2": "This License Agreement governs your use of $oisy_short (\"You\"). BY USING $oisy_short, YOU AGREE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THIS LICENSE AGREEMENT. IF YOU DO NOT AGREE, YOU MAY NOT USE $oisy_short.",
-			"paragraph_3": "If You choose to use $oisy_short, You and the DFINITY Foundation, including its affiliates and subsidiaries (collectively “DFINITY”), acknowledge and agree as follows:",
-			"limited_license": "<strong>1. LIMITED LICENSE.</strong> Subject to the terms and conditions contained in this License Agreement, DFINITY grants You a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to use $oisy_short only for the purposes of receiving, holding and sending tokens such as native ICP, ICRC-1, ETH, and ERC20 tokens, as well as other tokens which may be made available from time to time. You may create derivative works to the extent permitted by the licensing terms governing use of any open-sourced components included within $oisy_short.",
-			"restrictions": "<strong>2. RESTRICTIONS.</strong> You are responsible for all activities related to your use of $oisy_short, regardless of whether the activities are authorized by You or undertaken by You, your employees or a third party on your behalf. YOU UNDERSTAND THAT DFINITY IS NOT RESPONSIBLE FOR ANY ACTIVITIES OR TRANSACTIONS (WHETHER COMPLETED OR OTHERWISE) ASSOCIATED WITH YOUR $oisy_name. You will not misrepresent or embellish the relationship between You and DFINITY, including expressing or implying that DFINITY supports, sponsors, endorses, or contributes to You or your business endeavors through your use of $oisy_short. You will not imply any relationship or affiliation with DFINITY except as expressly permitted by this License Agreement. You are prohibited from using the $oisy_short name, logo or any other trademarks related to $oisy_short in any manner that may imply an endorsement or affiliation, misrepresent your relationship with $oisy_short or create confusion regarding the source of $oisy_short.",
-			"applicable_laws": "<strong>3. APPLICABLE LAWS.</strong> You will comply with all applicable laws and regulations (including without limitation laws and regulations related to export controls, money laundering or economic sanctions) in connection with your use of $oisy_short and any transactions associated with your $oisy_name.",
-			"reservation_rights": "<strong>4. RESERVATION OF DFINITY’S RIGHT.</strong> $oisy_short is owned by DFINITY and licensed, not sold, to You. $oisy_short’s content, visual interfaces, interactive features, information, graphics, design, compilation, computer code, products, services, and all other elements of $oisy_short and related documentation, are protected by applicable intellectual property laws. As between You and DFINITY, all DFINITY materials and $oisy_short, including intellectual property rights therein and thereto, are the sole and exclusive property of DFINITY or its subsidiaries or affiliated companies and/or its third-party licensors, subject to any open-source software licenses. DFINITY reserves all rights not expressly granted in this License Agreement. You do not acquire any right, title, or interest to the DFINITY materials or $oisy_short, whether by implication, estoppel, or otherwise, except for the limited rights set forth in this License Agreement and the rights conferred by the licensing terms governing use of any open-sourced components included within $oisy_short. This License Agreement does not grant you any right to use the $oisy_short name, logo or other trademarks related to $oisy_short or DFINITY.",
-			"feedback": "<strong>5. FEEDBACK.</strong> If You provide DFINITY with any comments, ideas, bug reports, feedback, enhancements, recommendations or modifications in relation to $oisy_short (\"Feedback\"), such Feedback is provided on a non-confidential basis, and DFINITY shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the DFINITY materials, $oisy_short or other services. You hereby grant DFINITY a perpetual, irrevocable, transferable, sublicensable, nonexclusive, royalty free license under all rights necessary to so incorporate and use your Feedback for any purpose, including to make and sell products and services, and agree to provide DFINITY with any assistance required to document, perfect and maintain DFINITY’s rights to the Feedback. You agree to allow DFINITY to contact You for Feedback from time to time, but may opt-out by sending written notice to legalnotice@dfinity.org.",
-			"termination": "<strong>6. TERMS AND TERMINATION.</strong> This License Agreement will remain in effect until terminated. The License Agreement, and your rights and licenses hereunder, will terminate immediately upon your breach of the License Agreement. You may terminate the License Agreement at any time by emptying your $oisy_name of tokens and ceasing all use of $oisy_short. DFINITY may terminate this License Agreement at any time for any reason, including without limitation any actual or suspected misuse or abuse by You of $oisy_short or any violation of this License Agreement. Sections 3 through 13 shall survive any termination of this License Agreement.",
-			"warranty_liability": "<strong>7. WARRANTY DISCLAIMER AND LIMITATION OF LIABILITY.</strong> TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, $oisy_short IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, DFINITY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OR CONDITIONS OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE, QUALITY, RESULTS, AND NON-INFRINGEMENT. DFINITY DOES NOT GUARANTEE THAT $oisy_short WILL ALWAYS BE AVAILABLE, SAFE, OR SECURE (NOW AND IN THE FUTURE). DFINITY EXPRESSLY DISCLAIMS ANY WARRANTIES OF ANY KIND WITH RESPECT TO THE ACCURACY OR FUNCTIONALITY OF $oisy_short, AND WITH RESPECT TO THE ACCURACY, VALIDITY, OR COMPLETENESS OF ANY INFORMATION OR FEATURES (NOW AND IN THE FUTURE) MADE AVAILABLE THROUGH YOUR USE OF $oisy_short, OR THE QUALITY OR CONSISTENCY OF $oisy_short OR RESULTS OBTAINED THROUGH ITS USE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, UNDER NO CIRCUMSTANCES WILL DFINITY BE LIABLE FOR ANY CONSEQUENTIAL, SPECIAL, INDIRECT, INCIDENTAL OR PUNITIVE DAMAGES WHATSOEVER ARISING OUT OF THE USE OR INABILITY TO USE AND ACCESS $oisy_short OR DFINITY MATERIALS, EVEN IF DFINITY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL DFINITY'S AGGREGATE LIABILITY FOR DAMAGES ARISING OUT OF THIS LICENSE AGREEMENT OR YOUR USE OR INABILITY TO USE $oisy_short EXCEED 100 CHF.",
-			"indemnity": "<strong>8. INDEMNITY.</strong> You agree to indemnify, defend and hold DFINITY and its affiliates, officers, directors, suppliers, licensors, and other customers harmless from and against any and all liability and costs, including reasonable attorneys' fees incurred by such parties, in connection with your use or misuse of $oisy_short or your violation of this License Agreement or any applicable law or regulation.",
-			"governing_law": "<strong>9. GOVERNING LAW; VENUE.</strong> Any claim relating to $oisy_short shall be governed by the laws of Switzerland, to the exclusion of the rules on conflicts of laws. Any claim or dispute related to this License Agreement or in relation to it shall (including for non-contractual disputes or claims and their interpretation) be subject to the exclusive jurisdiction of the Courts of Zurich, Switzerland, subject to an appeal at the Swiss Federal Court.",
-			"entire_agreement": "<strong>10. ENTIRE AGREEMENT AND SEVERABILITY.</strong> This License Agreement is the entire agreement between You and DFINITY, and supersedes any and all prior agreements, negotiations, or other communications between You and DFINITY, whether oral or written, with respect to the subject matter hereof. DFINITY may make changes to this License Agreement when new versions of $oisy_short are made available. In the event that any provision of this License Agreement is held to be invalid or unenforceable, then: (a) such provision shall be deemed reformed to the extent strictly necessary to render such provision valid and enforceable, or if not capable of such reformation shall be deemed severed from this License Agreement; and (b) the validity and enforceability of all of the other provisions hereof, shall in no way be affected or impaired thereby.",
-			"assignment": "<strong>11. ASSIGNMENT.</strong> You may not assign this License Agreement without the prior written consent of DFINITY, whether expressly or by operation of law, including in connection with a merger or change of control, and any such attempted assignment shall be void and of no effect. DFINITY may assign this License Agreement without restriction and without any notice to You. Subject to the foregoing, this License Agreement shall be binding on the parties and their respective successors and permitted assigns.",
-			"no_waiver": "<strong>12. NO WAIVER.</strong> The failure to exercise, or delay in exercising, a right, power, or remedy provided in this License Agreement or by law shall not constitute a waiver of that right, power, or remedy. DFINITY 's waiver of any obligation or breach of this License Agreement shall not operate as a waiver of any other obligation or subsequent breach of the License Agreement.",
-			"english_version": "<strong>13. ENGLISH VERSION.</strong> The English language version of this License Agreement shall be the official and controlling version of the agreement if any conflict should arise. All communications and notices made pursuant to this License Agreement must be in the English language."
-		},
-		"alt": {
-			"license_agreement": "The $oisy_name License Agreement"
-		}
-	},
-	"activity": {
-		"text": {
-			"title": "Recent Activity"
-		},
-		"info": {
-			"btc_transactions": "BTC transaction information is obtained from central third parties and should be independently verified."
-		},
-		"warning": {
-			"no_index_canister": "Transactions for $token_list can not be displayed. No Index canister available.",
-			"unavailable_index_canister": "Transactions for $token_list can not be displayed. Index canister is currently unavailable."
-		}
-	}
+  "core": {
+    "text": {
+      "cancel": "Cancel",
+      "next": "Next",
+      "save": "Save",
+      "back": "Back",
+      "done": "Done",
+      "close": "Close",
+      "refresh": "Refresh",
+      "name": "Name",
+      "symbol": "Symbol",
+      "decimals": "Decimals",
+      "amount": "Amount",
+      "max": "Max",
+      "reject": "Reject",
+      "approve": "Approve",
+      "view": "View",
+      "copy": "Copy",
+      "clear_filter": "Clear filter",
+      "not_available": "n/a",
+      "new": "New"
+    },
+    "info": {
+      "test_banner": "For testing purposes only!"
+    },
+    "alt": {
+      "logo": "$name logo",
+      "go_to_home": "Go to the $oisy_name home page",
+      "back": "Go back to the previous page"
+    },
+    "warning": {
+      "do_not_close": "Don't close this tab until the transaction is done"
+    }
+  },
+  "navigation": {
+    "text": {
+      "tokens": "Assets",
+      "settings": "Settings",
+      "dapp_explorer": "Explore",
+      "activity": "Activity",
+      "airdrops": "Rewards",
+      "source_code_on_github": "Source code on GitHub",
+      "view_on_explorer": "View on explorer",
+      "source_code": "Source code",
+      "changelog": "Changelog",
+      "documentation": "Documentation",
+      "support": "Support",
+      "confirm_navigate": "Are you sure you want to navigate away?",
+      "vip_qr_code": "VIP QR codes"
+    },
+    "alt": {
+      "tokens": "Go to the assets view",
+      "settings": "Open your settings",
+      "dapp_explorer": "Open dapp explorer",
+      "activity": "Open the activity view",
+      "airdrops": "Open the Rewards view",
+      "more_settings": "More settings",
+      "menu": "Your wallet address, settings, sign-out and external links",
+      "changelog": "Open the changelog of $oisy_name on GitHub to review the latest updates",
+      "documentation": "Open the $oisy_name documentation",
+      "support": "Open the Support section of the $oisy_name documentation",
+      "open_twitter": "Open the DFINITY X/Twitter feed",
+      "vip_qr_code": "Generate an invitation link"
+    },
+    "short": {
+      "documentation": "Docs"
+    }
+  },
+  "auth": {
+    "text": {
+      "title_part_1": "$oisy_name",
+      "title_part_2": "100% Decentralized",
+      "logout": "Logout",
+      "authenticate": "Open or Create",
+      "asset_types": "Bitcoin, Solana, Ethereum, ICP, and more",
+      "instant_and_private": "Instant and private access anywhere",
+      "advanced_cryptography": "100% onchain: peace of mind through advanced cryptography"
+    },
+    "alt": {
+      "preview": "Preview of $oisy_name once signed in, both on desktop and mobile"
+    },
+    "warning": {
+      "not_signed_in": "You are not signed in. Please sign in to continue.",
+      "session_expired": "You have been logged out because your session has expired."
+    },
+    "error": {
+      "no_internet_identity": "No internet identity.",
+      "invalid_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential. Please contact the issuer and request the credential again.",
+      "error_validating_pouh_credential_oisy": "Sorry, but there was an error while validating the Humanity Credential in $oisy_short: $error",
+      "error_validating_pouh_credential": "Sorry, but there was an error while validating the Humanity Credential.",
+      "error_requesting_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential.",
+      "missing_pouh_issuer_origin": "Sorry, but there was an error while requesting the Humanity Credential. The issuer origin is missing.",
+      "no_pouh_credential": "Sorry, but there was an error while requesting the Humanity Credential. Do you have a valid credential in Decide AI?",
+      "error_while_signing_in": "Something went wrong while sign-in.",
+      "unexpected_issue_with_syncing": "Unexpected issue while syncing the status of your authentication."
+    }
+  },
+  "dapps": {
+    "text": {
+      "all_dapps": "All dapps",
+      "featured": "Featured",
+      "sign_in": "Sign-in to explore the ecosystem.",
+      "title": "Explore Apps",
+      "open_dapp": "Open $dAppName",
+      "submit_your_dapp": "Submit your dapp"
+    },
+    "alt": {
+      "learn_more": "Learn more about $dAppName",
+      "logo": "Logo of $dAppName",
+      "show_all": "Show all decentralised applications",
+      "show_tag": "Show decentralised applications with the tag $tag",
+      "open_dapp": "Open the app $dAppName",
+      "open_telegram": "Open $dAppName on Telegram",
+      "open_open_chat": "Open $dAppName on OpenChat",
+      "open_twitter": "Open the $dAppName X/Twitter feed",
+      "source_code_on_github": "View source code of $dAppName on github",
+      "submit_your_dapp": "Submit your dapp to be shown in the dapp-explorer",
+      "tags": "Tags related to $dAppName",
+      "website": "Image of $dAppName"
+    }
+  },
+  "airdrops": {
+    "text": {
+      "title": "Rewards",
+      "active_campaigns": "Active Opportunities",
+      "upcoming_campaigns": "Upcoming Opportunities",
+      "active_date": "Due on",
+      "participate_title": "Participate and earn Sprinkles",
+      "share": "Share on X",
+      "learn_more": "Learn more",
+      "check_status": "Check Status & Eligibility",
+      "requirements_title": "Requirements",
+      "modal_button_text": "Got it",
+      "activity_button_text": "Check on Recent Activity",
+      "activity_button_text_short": "Check activity",
+      "no_balance_title": "Earn $oisy_short Sprinkles",
+      "no_balance_description": "Check back later to see your rewards",
+      "open_wallet": "Take me to the wallet",
+      "state_modal_title": "Congratulations on earning today’s $oisy_short Sprinkles!",
+      "state_modal_title_jackpot": "Congratulations on earning today’s largest $oisy_short Sprinkles!",
+      "state_modal_content_text": "Share your victory on Twitter to qualify for another chance to earn.",
+      "carousel_slide_title": "$oisy_short Sprinkles are now Live!",
+      "carousel_slide_cta": "Learn more",
+      "sprinkles_earned": "You've earned $noOfSprinkles sprinkles, totaling $amount! \uD83C\uDF89",
+      "youre_eligible": "You're eligible!"
+    },
+    "alt": {
+      "upcoming_campaigns": "Keep an eye out for upcoming token drops! Subscribe to $oisy_short on X and follow us to catch all the latest updates."
+    }
+  },
+  "footer": {
+    "text": {
+      "incubated_with": "Incubated with",
+      "by": "by",
+      "dfinity_foundation": "DFINITY Foundation",
+      "copyright": "© 2025"
+    },
+    "alt": {
+      "dfinity": "Go to DFINITY Foundation website"
+    }
+  },
+  "wallet": {
+    "text": {
+      "address": "Address",
+      "wallet_address": "Wallet address",
+      "your_addresses": "Your addresses",
+      "address_copied": "Address copied to clipboard.",
+      "wallet_address_copied": "Wallet address copied to clipboard.",
+      "display_wallet_address_qr": "Display wallet address as a QR code",
+      "icp_deposits": "Note: For ICP deposits, use the 'Receive' button in your ICP account to get the right address.",
+      "use_address_from_to": "Use this address to transfer $token to and from your wallet."
+    },
+    "alt": {
+      "open_etherscan": "Open your address on Etherscan",
+      "open_solscan": "Open your address on Solscan",
+      "qrcode_address": "Scan this QR code to copy the address to receive $token tokens"
+    }
+  },
+  "init": {
+    "text": {
+      "initializing_wallet": "Preparing your wallet...",
+      "securing_session": "Securing session with Internet Identity",
+      "retrieving_public_keys": "Retrieving your public keys for Bitcoin, Ethereum and Solana",
+      "done": "Enjoy $oisy_short"
+    },
+    "info": {
+      "hold_loading": "Hold tight, we are loading some information...",
+      "hold_loading_wallet": "Hold tight, we are loading some initial data for your wallet..."
+    },
+    "error": {
+      "no_alchemy_config": "No Alchemy config for network $network",
+      "no_alchemy_provider": "No Alchemy provider for network $network",
+      "no_alchemy_erc20_provider": "No Alchemy ERC20 provider for network $network",
+      "no_etherscan_provider": "No Etherscan provider for network $network",
+      "no_etherscan_rest_api": "No Etherscan Rest API for network $network",
+      "no_infura_provider": "No Infura provider for network $network",
+      "no_infura_cketh_provider": "No Infura CkETH provider for network $network",
+      "no_infura_erc20_provider": "No Infura ERC20 provider for network $network",
+      "no_infura_erc20_icp_provider": "No Infura ERC20 Icp provider for network $network",
+      "no_solana_rpc": "No Solana RPC for network $network",
+      "no_solana_network": "No Solana network for network $network",
+      "eth_address_unknown": "ETH address is unknown.",
+      "loading_address": "Error while loading the $symbol address.",
+      "loading_balance": "Error while loading the ETH balance.",
+      "loading_balance_symbol": "Error while loading $symbol balance.",
+      "erc20_contracts": "Error while loading the ERC20 contracts.",
+      "spl_tokens": "Error while loading the SPL tokens.",
+      "minter_ckbtc_btc": "A configured minter is required to convert ckBTC to BTC.",
+      "minter_cketh_eth": "A configured minter is required to convert ckETH to ETH.",
+      "minter_ckerc20_erc20": "A configured minter is required to convert ckERC20 to Erc20.",
+      "ledger_cketh_eth": "A configured ckETH ledger is required to convert ckErc20 to Erc20.",
+      "minter_btc": "A configured minter is required to retrieve BTC.",
+      "minter_ckbtc_info": "A configured minter is required to fetch the ckBTC info",
+      "minter_cketh_info": "A configured minter is required to fetch the ckETH info",
+      "minter_ckbtc_loading_info": "Error while loading the ckBTC minter information.",
+      "minter_cketh_loading_info": "Error while loading the ckETH minter information.",
+      "btc_fees_estimation": "Error while querying the estimation of the BTC fees.",
+      "btc_withdrawal_statuses": "Error while fetching the BTC withdrawal statuses.",
+      "transaction_price": "Error while loading the estimation of the price of a transaction.",
+      "icrc_canisters": "Error while loading the ICRC canisters.",
+      "erc20_user_tokens": "Error while loading the ERC20 user tokens.",
+      "spl_user_tokens": "Error while loading the SPL user tokens.",
+      "erc20_user_token": "Error while enabling the ERC20 twin token.",
+      "icrc_custom_token": "Error while loading the ICRC custom token.",
+      "loading_wallet_timeout": "Your wallet requires some initial data which has not been loaded yet. Please try again.",
+      "allow_signing": "An issue occurred while setting up your wallet for signing. You've been signed out. If the issue persists, contact support.",
+      "btc_wallet_error": "Error while loading BTC wallet information.",
+      "sol_wallet_error": "Error while loading SOL wallet information."
+    }
+  },
+  "hero": {
+    "text": {
+      "available_balance": "Available balance",
+      "unavailable_balance": "$ value is not available",
+      "top_up": "Top up your wallet to start using it!",
+      "learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."
+    }
+  },
+  "settings": {
+    "text": {
+      "title": "Settings",
+      "principal": "Your Principal",
+      "principal_copied": "Principal copied to clipboard",
+      "principal_description": "Your ID for the $oisy_name. Created by your Internet Identity.",
+      "session": "Your session expires in",
+      "session_description": "All sessions last 1 hour. After 1 hour, you will need to authenticate again with Internet Identity.",
+      "testnets": "Show test networks",
+      "testnets_description": "Display the test networks (Sepolia) and twin tokens on testnets (ckTESTBTC and ckSepolia).",
+      "hide_zero_balances_description": "Enable this feature to declutter your wallet view by hiding all tokens with a zero balance.",
+      "credentials_title": "Credentials",
+      "pouh_credential": "Humanity Credential",
+      "pouh_credential_description": "The Humanity Credential is a proof of humanity. It is issued by Decide AI.",
+      "present_pouh_credential": "Present",
+      "pouh_credential_verified": "Verified ✅",
+      "appearance": "Appearance",
+      "appearance_light": "Light",
+      "appearance_dark": "Dark",
+      "appearance_system": "System"
+    },
+    "alt": {
+      "testnets_toggle": "Toggle to show or hide testnets",
+      "github_release": "$oisy_short release notes on GitHub",
+      "appearance_light": "Enables light mode",
+      "appearance_dark": "Enables dark mode",
+      "appearance_system": "Enables your operating systems color mode"
+    },
+    "error": {
+      "loading_profile": "Error while loading the profile. Please refresh the page to have the full experience."
+    }
+  },
+  "networks": {
+    "title": "Current network. Access to selection.",
+    "test_networks": "Test networks",
+    "more": "More networks coming soon...",
+    "chain_fusion": "Chain Fusion (all networks)",
+    "network": "Network"
+  },
+  "receive": {
+    "text": {
+      "receive": "Receive",
+      "address": "Receive address",
+      "receive_token": "Receive $token"
+    },
+    "icp": {
+      "text": {
+        "account_id": "ICP Account ID",
+        "use_for_all_tokens": "Use for all tokens when receiving from wallets, users, or other apps that support this address format.",
+        "use_for_icrc_deposit": "Use for receiving ICRC-1 tokens in the ICP network, such as SNS, ck tokens, etc.",
+        "use_for_icp_deposit": "Use for ICP deposits from exchanges or other wallets that only support Account IDs.",
+        "your_private_eth_address": "Your private address for all ERC20 tokens.",
+        "display_account_id_qr": "Display ICP Account ID as a QR code",
+        "account_id_copied": "ICP Account ID copied to clipboard.",
+        "principal": "ICP Principal",
+        "internet_computer_principal_copied": "Internet Computer Principal copied to clipboard.",
+        "display_internet_computer_principal_qr": "Display Internet Computer Principal as a QR code",
+        "icp_account": "ICP Account (for exchanges)",
+        "icp_account_copied": "ICP Account copied to clipboard.",
+        "display_icp_account_qr": "Display ICP Account as a QR code"
+      }
+    },
+    "ethereum": {
+      "text": {
+        "checking_status": "Checking $token status...",
+        "from_network": "Receive from $network Network",
+        "eth_to_cketh_description": "Converting $token into $ckToken requires a call to a smart contract on $network and passing your IC principal as argument – $oisy_name simplifies this procedure by enabling you to perform the conversion directly within the wallet.",
+        "learn_how_to_convert": "Learn how to convert $token to $ckToken",
+        "metamask": "Receive from Metamask",
+        "ethereum": "Ethereum",
+        "ethereum_address": "Address",
+        "ethereum_address_copied": "Ethereum address copied to clipboard.",
+        "display_ethereum_address_qr": "Display Ethereum address as a QR code"
+      },
+      "error": {
+        "no_metamask": "Metamask is not available."
+      }
+    },
+    "bitcoin": {
+      "text": {
+        "bitcoin": "Bitcoin",
+        "checking_status": "Checking BTC status...",
+        "refresh_status": "Refresh BTC status",
+        "initializing": "Initializing...",
+        "checking_incoming": "Checking for incoming BTC...",
+        "refreshing_wallet": "Refreshing wallet...",
+        "bitcoin_address": "Bitcoin",
+        "bitcoin_testnet_address": "Bitcoin (Testnet)",
+        "bitcoin_regtest_address": "Bitcoin (Regtest)",
+        "display_bitcoin_address_qr": "Display Bitcoin Address as a QR code",
+        "bitcoin_address_copied": "Bitcoin Address copied to clipboard.",
+        "from_network": "Transfer Bitcoin on the BTC network to this address to receive ckBTC.",
+        "fee_applied": "Please note that an estimated inter-network fee of $fee BTC will be applied."
+      },
+      "info": {
+        "no_new_btc": "No new confirmed BTC.",
+        "check_btc_progress": "Checking for incoming BTC already in progress."
+      },
+      "error": {
+        "unexpected_btc": "Something went wrong while checking for incoming BTC."
+      }
+    },
+    "solana": {
+      "text": {
+        "solana_address": "Solana Address",
+        "solana_testnet_address": "Solana Testnet Address",
+        "solana_devnet_address": "Solana Devnet Address",
+        "solana_local_address": "Solana Local Address",
+        "solana_address_copied": "Solana address copied to clipboard",
+        "display_solana_address_qr": "Display Solana address as QR code"
+      }
+    }
+  },
+  "send": {
+    "text": {
+      "send": "Send",
+      "destination": "Destination",
+      "source": "Source",
+      "balance": "Balance",
+      "review": "Review",
+      "signing_approval": "Signing approval...",
+      "approving": "Approving...",
+      "approving_fees": "Approving fees...",
+      "approving_transfer": "Approving transfer...",
+      "approving_wallet_connect": "Approving WalletConnect request...",
+      "refreshing_ui": "Refreshing UI",
+      "initializing": "Initializing transaction...",
+      "signing_transaction": "Signing transaction...",
+      "sending": "Sending...",
+      "signing": "Signing...",
+      "signing_message": "Signing message...",
+      "network": "Network",
+      "source_network": "Source network",
+      "destination_network": "Destination network",
+      "initializing_transaction": "Initializing transaction",
+      "convert_to_native_icp": "Convert to native ICP",
+      "open_qr_modal": "Start QR Code scan for transaction details",
+      "scan_qr": "Scan QR Code"
+    },
+    "placeholder": {
+      "enter_eth_address": "Enter public address (0x)",
+      "enter_recipient_address": "Enter recipient address",
+      "enter_wallet_address": "Enter wallet address",
+      "select_network": "Select network"
+    },
+    "info": {
+      "ckbtc_certified": "Please wait until the ckBTC parameters have been certified.",
+      "cketh_certified": "Please wait until the ckETH parameters have been certified.",
+      "pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete.",
+      "no_available_utxos": "You won't have available utxos to perform this transaction."
+    },
+    "assertion": {
+      "invalid_destination_address": "Invalid destination address",
+      "insufficient_funds": "Insufficient funds.",
+      "unknown_minimum_ckbtc_amount": "The minimum amount of ckBTC required for converting to BTC is unknown.",
+      "unknown_minimum_cketh_amount": "The minimum amount of ckETH required for converting to ETH is unknown.",
+      "unknown_minimum_amount": "The minimum amount of $sourceTokenSymbol required for converting to $destinationTokenSymbol is unknown.",
+      "minimum_ckbtc_amount": "The amount falls below the minimum of $amount ckBTC required for converting to BTC.",
+      "minimum_cketh_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
+      "minimum_amount": "The amount falls below the minimum withdrawal amount of $amount $symbol.",
+      "minimum_ledger_fees": "The amount falls below the ledger fees $symbol.",
+      "minimum_cketh_balance": "The $symbol balance falls below the estimated fee of $amount.",
+      "unknown_cketh": "The ckETH token cannot be retrieved.",
+      "destination_address_invalid": "Destination address is invalid.",
+      "amount_invalid": "Amount is invalid.",
+      "insufficient_funds_for_gas": "Insufficient funds for gas",
+      "insufficient_funds_for_amount": "Insufficient funds for amount",
+      "insufficient_ethereum_funds_to_cover_the_fees": "Insufficient Ethereum funds to cover the fees",
+      "insufficient_solana_funds_to_cover_the_fees": "Insufficient Solana funds to cover the fees",
+      "not_enough_tokens_for_gas": "Not enough $symbol for gas. Balance: $balance $symbol",
+      "gas_fees_not_defined": "Gas fees are not defined.",
+      "max_gas_fee_per_gas_undefined": "Max fee per gas or max priority fee per gas is undefined.",
+      "address_unknown": "Address is unknown.",
+      "minter_info_not_loaded": "Try again in a few seconds, a ckETH configuration parameter is not yet loaded.",
+      "minter_info_not_certified": "Try again in a few seconds, a ckETH configuration parameter has not been certified.",
+      "cketh_max_transaction_fee_missing": "The maximum transaction fee for ckETH is missing.",
+      "utxos_fee_missing": "UTXOs fee is missing."
+    },
+    "error": {
+      "unexpected": "Something went wrong while sending the transaction.",
+      "destination_address_unknown": "ETH destination address is unknown",
+      "metamask_connected": "Cannot get your accounts. Is your Metamask open and already connected?",
+      "metamask_no_accounts": "No Metamask accounts found.",
+      "metamask_switch_network": "Cannot request Metamask to switch to chain ID $chain_id. Is your Metamask using $network_name?",
+      "erc20_data_undefined": "Erc20 transaction Data cannot be undefined or null.",
+      "data_undefined": "Transaction Data cannot be undefined or null.",
+      "no_identity_calculate_fee": "No identity provided to calculate the fee for its principal.",
+      "invalid_destination": "The destination is invalid. Please try again with a valid wallet address or destination.",
+      "incompatible_token": "The token is incompatible. Please try again with a compatible token.",
+      "no_btc_network_id": "Current network ($networkId) is not a Bitcoin network.",
+      "no_solana_network_id": "Current network ($networkId) is not a Solana network.",
+      "no_pending_bitcoin_transaction": "There was an error loading the pending Bitcoin transactions. Please try again later.",
+      "unexpected_utxos_fee": "Something went wrong while calculating transaction fee.",
+      "unable_to_retrieve_amount": "n/a (unable to retrieve)",
+      "solana_transaction_expired": "Your send transaction was not processed by the Solana network and expired, most likely because the provided priority fee was not sufficient. We updated it to the latest recommended amount, so please try sending it again."
+    }
+  },
+  "convert": {
+    "text": {
+      "converting": "Converting...",
+      "convert_to_btc": "Convert to BTC",
+      "convert_to_ckbtc": "Convert to ckBTC",
+      "convert_to_token": "Convert to $token",
+      "convert_to_cketh": "Convert to ckETH",
+      "convert_to_ckerc20": "Convert to $ckErc20",
+      "convert_eth_to_cketh": "Convert $token to $ckToken",
+      "cketh_conversions_may_take": "ckETH conversions may take up to 20 minutes",
+      "ckerc20_conversions_may_take": "$ckErc20 conversions may take up to 20 minutes",
+      "how_to_convert_eth_to_cketh": "Here is how to can convert $token to $ckToken on $oisy_name",
+      "send_eth": "Send $token to your $oisy_name address",
+      "wait_eth_current_balance": "Wait for $token to arrive. Current balance",
+      "set_amount": "Set amount for conversion",
+      "check_balance_for_fees": "Check $token balance for conversion fees",
+      "fees_explanation": "You need enough $token to cover the smart contract execution fees.",
+      "current_balance": "👉 Current balance:",
+      "review_button": "Review",
+      "convert_button": "Convert",
+      "input_reset_button": "Reset input value",
+      "swap_to_token": "Convert $sourceToken → $destinationToken",
+      "review": "Review transaction",
+      "max_balance": "Max",
+      "source_network": "Source network",
+      "destination_network": "Destination network",
+      "conversion_may_take": "Conversion may take up to 1 hour",
+      "executing_transaction": "Executing transaction...",
+      "initializing": "Initializing transaction...",
+      "refreshing_ui": "Refreshing UI",
+      "unsupported_token_conversion": "Conversion for the selected token is not supported.",
+      "calculating_max_amount": "Calculating..."
+    },
+    "assertion": {
+      "insufficient_funds": "Insufficient balance"
+    },
+    "error": {
+      "loading_cketh_helper": "Error while loading the ckETH helper contract address. No minter canister ID has been initialized.",
+      "unexpected": "Something went wrong while converting tokens.",
+      "unexpected_missing_data": "Something went wrong while initiating a convert transaction."
+    }
+  },
+  "swap": {
+    "text": {
+      "swap": "Swap",
+      "select_destination_token": "Select token to receive",
+      "select_source_token": "Select token to pay",
+      "switch_tokens_button": "Switch tokens",
+      "review": "Review transaction",
+      "review_button": "Review swap",
+      "max_slippage": "Max slippage",
+      "max_balance": "Max",
+      "not_available": "n/a",
+      "value_difference": "Value difference",
+      "total_fee": "Total estimated fee",
+      "network_fee": "Network fee",
+      "approval_fee": "Approval fee",
+      "gas_fee": "Gas fee",
+      "lp_fee": "LP fee",
+      "max_slippage_info": "Enter value between 0% and 50%",
+      "max_slippage_warning": "Risk warning: high slippage may lead to losses due to market volatility",
+      "max_slippage_error": "Slippage tolerance cannot be 0% or exceed 50%",
+      "swap_button": "Swap now",
+      "swap_is_not_offered": "This swap is currently not offered.",
+      "executing_transaction": "Executing transaction...",
+      "initializing": "Initializing transaction...",
+      "swapping": "Swapping...",
+      "refreshing_ui": "Refreshing UI",
+      "swap_provider": "Swap provider"
+    },
+    "error": {
+      "kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
+      "unexpected": "Something went wrong while swapping tokens.",
+      "unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
+      "slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again."
+    }
+  },
+  "buy": {
+    "text": {
+      "buy": "Buy",
+      "buy_dev": "Buy (Dev Environment)"
+    },
+    "onramper": {
+      "title": "Buy through Onramper"
+    }
+  },
+  "tokens": {
+    "text": {
+      "title": "Tokens",
+      "contract_address": "Contract address",
+      "token_address": "Token address",
+      "balance": "Balance",
+      "hide_zero_balances": "Hide zero balances",
+      "hide_zeros": "Hide zeros",
+      "all_tokens_with_zero_hidden": "All assets with zero balance are currently hidden",
+      "buy_or_receive": "Buy or receive your first tokens now to see them in the list",
+      "initializing": "Initializing...",
+      "updating_ui": "Updating the UI...",
+      "show_token": "Show token",
+      "hide_token": "Hide token",
+      "select_token": "Select token",
+      "exchange_is_not_available": "USD value is currently not available.",
+      "source_token_title": "You pay",
+      "destination_token_title": "You receive"
+    },
+    "details": {
+      "title": "Token details",
+      "token": "Token",
+      "network": "Network",
+      "contract_address_copied": "Contract address copied to clipboard.",
+      "token_address_copied": "Token address copied to clipboard.",
+      "twin_token": "Twin token",
+      "standard": "Standard"
+    },
+    "balance": {
+      "error": {
+        "not_applicable": "n/a"
+      }
+    },
+    "import": {
+      "text": {
+        "title": "Import token",
+        "review": "Review",
+        "saving": "Saving...",
+        "updating": "Updating token list",
+        "ledger_canister_id": "Ledger Canister ID",
+        "index_canister_id": "Index Canister ID",
+        "minter_canister_id": "Minter Canister ID",
+        "ledger_canister_id_copied": "Ledger Canister ID copied to clipboard.",
+        "index_canister_id_copied": "Index Canister ID copied to clipboard.",
+        "minter_canister_id_copied": "Minter Canister ID copied to clipboard.",
+        "verifying": "Verifying token details...",
+        "add_the_token": "Add the token",
+        "info": "Ledger and Index canister IDs are usually available on the project’s website. ",
+        "info_index": "The Index canister ID is optional, but without it, $oisy_short can’t display transaction history.",
+        "custom_tokens_not_supported": "The selected network does not support custom tokens."
+      },
+      "error": {
+        "loading_metadata": "Error while loading the metadata of the token.",
+        "no_metadata": "No metadata for the token is provided. This is unexpected.",
+        "unexpected_ledger": "Something went wrong while validating the Ledger canister.",
+        "unexpected_index": "Something went wrong while validating the Index canister.",
+        "unexpected_index_ledger": "Something went wrong while loading the Ledger ID related to the Index canister.",
+        "invalid_ledger_id": "The Ledger ID is not related to the Index canister.",
+        "missing_ledger_id": "The Ledger ID is missing. Did you provide a value?",
+        "missing_contract_address": "The contract address is missing. Did you provide a value?",
+        "missing_token_address": "The token address is missing. Did you provide a value?",
+        "no_network": "No network is selected. This is unexpected."
+      },
+      "warning": {
+        "do_not_close_manage": "$oisy_name is preparing and securing the new tokens. Please don't close this tab until it's completed."
+      }
+    },
+    "manage": {
+      "text": {
+        "title": "Manage tokens",
+        "manage_list": "Manage tokens",
+        "do_not_see_import": "Don’t see your token? Import",
+        "manage_for_network": "Managing tokens for $network",
+        "network": "Network",
+        "all_tokens_zero_balance": "All tokens have zero balance."
+      },
+      "placeholder": {
+        "select_network": "Select the network"
+      },
+      "info": {
+        "no_changes": "No changes need to be saved."
+      },
+      "error": {
+        "unexpected_build": "An unexpected error happened while building the list of known tokens.",
+        "empty": "No tokens to enable or disable have been selected."
+      }
+    },
+    "hide": {
+      "title": "Hide token?",
+      "token": "Hide $token",
+      "info": "You can add this token back in the future by going into <strong>“Manage tokens”</strong> in your wallet view.",
+      "confirm": "Hide",
+      "hiding": "Hiding..."
+    },
+    "alt": {
+      "context_menu": "Context menu for to the selected token",
+      "open_etherscan": "Open the details of the token on Etherscan",
+      "open_blockstream": "Open the details of the token on Blockstream",
+      "open_dashboard": "Open the details of the token on the ICP Dashboard",
+      "open_contract_address_block_explorer": "Open the contract address on a block explorer",
+      "open_token_address_block_explorer": "Open the token address on a block explorer",
+      "token_group_number": "Total number of tokens in the group for native token $token"
+    },
+    "placeholder": {
+      "enter_contract_address": "Enter an ERC20 contract address",
+      "enter_token_address": "Enter an SPL token address",
+      "search_token": "Search for the token"
+    },
+    "warning": {
+      "trust_token": "Make sure you trust the token you are adding. If the token you are adding is controlled by a malicious party, they could try and scam you e.g., by making you believe you received a significant amount of tokens in order to trick you into sending them tokens in return or perform other undesired actions. Learn more about scams and security risks e.g. <a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://support.metamask.io/hc/en-us/articles/4403988839451\">here</a>."
+    },
+    "error": {
+      "invalid_contract_address": "Contract address is invalid.",
+      "invalid_token_address": "Token address is invalid.",
+      "invalid_ledger": "The selected token is not linked with an Icrc Ledger canister.",
+      "no_metadata": "No metadata were fetched.",
+      "unexpected": "Something went wrong while saving the token.",
+      "unexpected_hiding": "Something went wrong while hiding the token.",
+      "already_available": "Token is already available.",
+      "loading_metadata": "Error while loading the metadata of the token.",
+      "not_toggleable": "Token is not toggleable, it can not be hidden.",
+      "incomplete_metadata": "No name or symbol is provided in the metadata.",
+      "duplicate_metadata": "A token with a similar name or symbol already exists.",
+      "unexpected_undefined": "Token is undefined. This is unexpected."
+    }
+  },
+  "fee": {
+    "text": {
+      "fee": "Fee",
+      "estimated_btc": "Estimated BTC Network Fee",
+      "estimated_inter_network": "Estimated Inter-network Fee",
+      "estimated_eth": "Estimated Ethereum Fee",
+      "max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>",
+      "convert_fee": "Conversion fee",
+      "convert_inter_network_fee": "Inter-network fee",
+      "convert_btc_network_fee": "Bitcoin network fee",
+      "zero_fee": "Free",
+      "total_fee": "Total fee",
+      "ata_fee": "ATA fee"
+    },
+    "assertion": {
+      "insufficient_funds_for_fee": "Insufficient balance to cover the fees."
+    },
+    "error": {
+      "cannot_fetch_gas_fee": "Cannot fetch gas fee."
+    }
+  },
+  "info": {
+    "bitcoin": {
+      "title": "Receive BTC & convert to ckBTC",
+      "description": "Convert Bitcoin into ckBTC and benefit from the fastest and cheapest Bitcoin transaction available. The conversion process can take up to an hour.",
+      "note": "You can convert ckBTC at any time back to BTC.",
+      "how_to": "How to convert to ckBTC"
+    },
+    "ethereum": {
+      "title": "Convert to $ckToken",
+      "description": "With a few steps, convert your native $network $token to its twinned ICP $ckToken directly within the $oisy_name. The conversion process can take up to 20 minutes.",
+      "note": "You can convert $ckToken at any time back to $token.",
+      "how_to": "How to convert to $ckToken",
+      "how_to_short": "How to convert $token"
+    }
+  },
+  "wallet_connect": {
+    "text": {
+      "name": "WalletConnect",
+      "session_proposal": "Session Proposal",
+      "connect": "Connect",
+      "connecting": "Connecting...",
+      "disconnect": "Disconnect",
+      "scan_qr": "Scan QR code",
+      "or_use_link": "or use WalletConnect link",
+      "proposer": "Proposer",
+      "review": "Review $chain_name ($key) required permissions",
+      "method": "Method",
+      "methods": "Methods",
+      "events": "Events",
+      "message": "Message",
+      "hex_data": "HEX Data",
+      "base64_data": "Base-64 Data",
+      "raw_copied": "Raw transaction data copied to clipboard.",
+      "sign_message": "Sign Message"
+    },
+    "alt": {
+      "connect_input": "e.g. wc:a281567bb3e4..."
+    },
+    "domain": {
+      "title": "Domain Verification",
+      "valid": "Valid ✅",
+      "valid_description": "The validation of the proposer's domain passed.",
+      "invalid": "Invalid ❌",
+      "invalid_description": "The domain of the proposer's website does not match the sender of the request.",
+      "security_risk": "Security risk ⚠️",
+      "security_risk_description": "The proposer's website is flagged as unsafe.",
+      "unknown": "Unknown ❓",
+      "unknown_description": "The domain of the proposer cannot be verified."
+    },
+    "info": {
+      "disconnected": "WalletConnect disconnected.",
+      "session_ended": "WalletConnect session was ended.",
+      "connected": "WalletConnect connected.",
+      "eth_transaction_executed": "WalletConnect eth_sendTransaction request executed.",
+      "sol_transaction_executed": "WalletConnect \"$method\" request executed.",
+      "sign_executed": "WalletConnect sign request executed."
+    },
+    "error": {
+      "qr_code_read": "Cannot read QR code.",
+      "missing_uri": "A URI to connect to should be provided.",
+      "disconnect": "An unexpected error happened while disconnecting the wallet. Resetting the connection anyway.",
+      "connect": "An unexpected error happened while trying to connect the wallet.",
+      "manual_workflow": "Please finalize the manual workflow that has already been initiated by opening the WalletConnect modal.",
+      "skipping_request": "Skipping the WalletConnect request as another action is currently in progress through an overlay.",
+      "method_not_support": "Requested method \"$method\" is not supported.",
+      "unexpected_pair": "An unexpected error happened while trying to pair the wallet.",
+      "no_connection_opened": "Unexpected error: No connection opened.",
+      "no_session_approval": "Unexpected error: No session proposal available.",
+      "unexpected": "Unexpected error while communicating with WalletConnect.",
+      "request_rejected": "WalletConnect request rejected",
+      "unknown_parameter": "Unknown parameter.",
+      "wallet_not_initialized": "Unexpected error. Your wallet address is not initialized.",
+      "from_address_not_wallet": "From address requested for the transaction is not the address of this wallet.",
+      "unknown_destination": "Unknown destination address.",
+      "request_not_defined": "Unexpected error: Request is not defined therefore cannot be processed.",
+      "unexpected_processing_request": "Unexpected error while processing the request with WalletConnect."
+    }
+  },
+  "transaction": {
+    "text": {
+      "details": "Transaction details",
+      "hash": "Transaction hash",
+      "hash_copied": "Transaction hash $hash copied to clipboard.",
+      "id": "Transaction ID",
+      "id_copied": "Transaction ID copied to clipboard.",
+      "timestamp": "Timestamp",
+      "type": "Type",
+      "from": "From",
+      "from_copied": "From address copied to clipboard.",
+      "to": "To",
+      "to_copied": "To address copied to clipboard.",
+      "block": "Block",
+      "interacted_with": "Interacted With (To)",
+      "status": "Status",
+      "confirmations": "Confirmations"
+    },
+    "status": {
+      "confirmed": "Confirmed",
+      "included": "Included",
+      "finalised": "Finalised",
+      "finalized": "Finalised",
+      "processed": "Processed",
+      "pending": "Pending...",
+      "safe": "Safe",
+      "unconfirmed": "Unconfirmed"
+    },
+    "label": {
+      "reimbursement": "Reimbursement",
+      "twin_token_sent": "$twinToken sent",
+      "ck_token_sent": "$ckToken sent",
+      "twin_token_converted": "Converted from $twinToken",
+      "ck_token_converted": "Converted from $ckToken",
+      "receiving_twin_token": "Receiving $twinToken",
+      "sending_twin_token": "Sending $twinToken",
+      "sending_twin_token_failed": "Sending $twinToken failed",
+      "converting_twin_token": "Converting $twinToken to $ckToken",
+      "converting_ck_token": "Converting $ckToken to $twinToken",
+      "twin_network": "$twinNetwork network",
+      "no_date_available": "No Date Available"
+    },
+    "alt": {
+      "open_block_explorer": "Open this transaction on a block explorer",
+      "open_from_block_explorer": "Open the 'From' address on a block explorer",
+      "open_to_block_explorer": "Open the 'To' address on a block explorer"
+    },
+    "error": {
+      "get_block_number": "Cannot get block number.",
+      "failed_get_transaction": "Failed to get the transaction from the provided (hash: $hash). Please reload the wallet dapp.",
+      "failed_get_mined_transaction": "Failed to get the mined transaction (hash: $hash). Please reload the wallet dapp."
+    }
+  },
+  "transactions": {
+    "text": {
+      "title": "Transactions",
+      "buy_or_receive": "Make your first transaction, and buy or receive tokens now!",
+      "transaction_history": "Your transaction history will appear here",
+      "open_transactions": "Open the list of $token transactions",
+      "mainnet_btc_transactions_info": "BTC transaction information is obtained from central third parties and should be independently verified.",
+      "transaction_history_unavailable": "Transaction history unavailable",
+      "missing_index_canister_explanation": "The token ledger is working fine, but the index canister is missing, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual.",
+      "index_canister_not_working_explanation": "The token ledger is working fine, but the index canister is having issues, so $oisy_short can’t fetch a list of transactions. You can still Send and Receive your tokens as usual."
+    },
+    "error": {
+      "loading_transactions": "Error while loading the transactions.",
+      "loading_transactions_symbol": "Error while loading the $symbol transactions.",
+      "no_token_loading_transaction": "Token not found. Transactions cannot be loaded.",
+      "uncertified_transactions_removed": "Several uncertified transactions were identified and subsequently removed from the displayed lists.",
+      "loading_pending_ck_ethereum_transactions": "Something went wrong while fetching the pending $network transactions.",
+      "get_transaction_for_hash": "Failed to get the transaction from the provided (hash: $hash).",
+      "unexpected_transaction_for_hash": "Something went wrong while loading the pending for hash: $hash."
+    }
+  },
+  "about": {
+    "why_oisy": {
+      "text": {
+        "label": "Why $oisy_short",
+        "title": "Why $oisy_short",
+        "hold_crypto": {
+          "title": "Unified Management of All Your Digital Assets",
+          "description": "$oisy_short allows you to manage all your digital assets — including Bitcoin, Solana, Ethereum, ICP, and more — in a single, unified wallet. No more juggling multiple wallets for different cryptocurrencies — enjoy a seamless and efficient experience across various platforms."
+        },
+        "network_custody": {
+          "title": "No more private key anxiety with Network Custody",
+          "description": "$oisy_name implements network custody, an innovative approach that leverages the Internet Computer's advanced cryptography to eliminate the need for you to handle private keys directly. This provides a secure and user-friendly alternative to traditional methods, aligning with the “Onchain is the New Online“ movement — a shift toward solutions that enhance security and resilience against cyber attacks by running on a distributed network."
+        },
+        "fully_on_chain": {
+          "title": "Tamper-Proof Security with a Fully On-Chain Wallet",
+          "description": "Not only are your keys secured, but the entire wallet application is stored <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/capabilities\">fully on-chain</a> and served directly into your browser from the Internet Computer. This means the entire wallet benefits from a decentralized trust model, making it tamper-proof and highly secure."
+        },
+        "cross_device": {
+          "title": "Access your wallet anytime from anywhere",
+          "description": "Using <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://identity.ic0.app/\">Internet Identity</a>, $oisy_short can easily be used across all devices you have linked to your private decentralized identity. This ensures seamless and secure access to your wallet whether you're on a smartphone, tablet, or desktop."
+        },
+        "verifiable_credentials": {
+          "title": "Unlock Extra Features with Verifiable Credentials",
+          "description": "$oisy_short integrates with the Internet Computer's <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://internetcomputer.org/docs/current/developer-docs/identity/verifiable-credentials/overview\">verifiable credentials</a> platform. Access additional features like airdrops and exclusive functionalities by acquiring certain types of credentials, enhancing your overall experience."
+        },
+        "open_source": {
+          "title": "Trust in Transparency with Open Source",
+          "description": "$oisy_short is an <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"$oisy_repo_url\">open-source</a> project led by a dedicated team within the <a class='no-underline blue-link' rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://dfinity.org/\">DFINITY foundation</a>, supported by over 200 world-leading cryptographers and engineers. Open sourcing ensures transparency, allowing the community to audit, contribute, and trust in the wallet's integrity."
+        }
+      }
+    }
+  },
+  "vip": {
+    "reward": {
+      "text": {
+        "open_wallet": "Take me to the wallet",
+        "title_successful": "Congratulations!",
+        "title_failed": "Invalid invitation code",
+        "reward_received": "Welcome to $oisy_short!",
+        "reward_failed": "Code is expired",
+        "reward_received_description": "You will receive your welcome gift any moment.",
+        "reward_failed_description": "Request a new one and try again"
+      },
+      "error": {
+        "loading_reward": "Error while loading a new reward code.",
+        "loading_user_data": "Failed to load user data from reward canister.",
+        "claiming_reward": "Error while claiming reward."
+      }
+    },
+    "invitation": {
+      "text": {
+        "title": "Generate invitation link",
+        "invitation_link_copied": "Invitation link copied to clipboard.",
+        "generate_new_link": "Generate new link",
+        "generating_new_code": "Generating new code",
+        "regenerate_countdown_text": "New link will be generated in $counter sec"
+      }
+    }
+  },
+  "signer": {
+    "sign_in": {
+      "text": {
+        "access_your_wallet": "Access your $oisy_name",
+        "open_or_create": "Open or create your wallet to securely connect to the dApp and start managing your assets."
+      }
+    },
+    "idle": {
+      "text": {
+        "waiting": "Waiting for the dApp interaction..."
+      },
+      "alt": {
+        "img_placeholder": "The astronaut logo moves its eyes from left to right while waiting for messages from the relying party dapp"
+      }
+    },
+    "permissions": {
+      "text": {
+        "title": "Review permissions",
+        "requested_permissions": "Requested permissions",
+        "your_wallet_address": "Your wallet address",
+        "icrc27_accounts": "View your $oisy_name address",
+        "icrc49_call_canister": "Request approval for transactions"
+      },
+      "error": {
+        "no_confirm_callback": "No callback to confirm the permissions, which is unexpected. Close the wallet and try again."
+      }
+    },
+    "origin": {
+      "text": {
+        "request_from": "Request from:",
+        "invalid_origin": "Invalid origin️!!"
+      },
+      "alt": {
+        "link_to_dapp": "Link to the dApp requesting permissions"
+      }
+    },
+    "consent_message": {
+      "text": {
+        "loading": "Loading consent message..."
+      },
+      "warning": {
+        "token_without_consent_message": "This token does not provide confirmation messages, so the information below was extracted by $oisy_short."
+      },
+      "error": {
+        "no_approve_callback": "No callback to approve the consent message, which is unexpected. Close the wallet and try again.",
+        "no_reject_callback": "No callback to reject the consent message, which is unexpected. Close the wallet and try again.",
+        "retrieve": "An error occurred while retrieving the consent message"
+      }
+    },
+    "call_canister": {
+      "text": {
+        "processing": "Processing the request...",
+        "executed": "The request has been executed",
+        "close_window": "You can close this window",
+        "error": "Request failed due to an error",
+        "try_again": "Please try again. If the issue persists, contact the developer of the dapp where you initiated the request."
+      },
+      "error": {
+        "cannot_call": "The call cannot be processed"
+      }
+    }
+  },
+  "carousel": {
+    "text": {
+      "next_slide": "Next slide",
+      "prev_slide": "Previous slide",
+      "indicator": "Jump to slide $index"
+    }
+  },
+  "license_agreement": {
+    "text": {
+      "accept_terms": "By clicking this button, you agree to the",
+      "accept_terms_link": "License Agreement",
+      "title": "$oisy_name License Agreement (“License Agreement”)",
+      "paragraph_1": "Thank you for your interest in $oisy_name, a browser-based, self-custodial and multi-chain wallet decentralized application hosted on the Internet Computer public blockchain network (“$oisy_short”). For more information about $oisy_short, its open-source code and related licenses, please refer to the $oisy_short github repository found here: $oisy_repo_url.",
+      "paragraph_2": "This License Agreement governs your use of $oisy_short (\"You\"). BY USING $oisy_short, YOU AGREE THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THIS LICENSE AGREEMENT. IF YOU DO NOT AGREE, YOU MAY NOT USE $oisy_short.",
+      "paragraph_3": "If You choose to use $oisy_short, You and the DFINITY Foundation, including its affiliates and subsidiaries (collectively “DFINITY”), acknowledge and agree as follows:",
+      "limited_license": "<strong>1. LIMITED LICENSE.</strong> Subject to the terms and conditions contained in this License Agreement, DFINITY grants You a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to use $oisy_short only for the purposes of receiving, holding and sending tokens such as native ICP, ICRC-1, ETH, and ERC20 tokens, as well as other tokens which may be made available from time to time. You may create derivative works to the extent permitted by the licensing terms governing use of any open-sourced components included within $oisy_short.",
+      "restrictions": "<strong>2. RESTRICTIONS.</strong> You are responsible for all activities related to your use of $oisy_short, regardless of whether the activities are authorized by You or undertaken by You, your employees or a third party on your behalf. YOU UNDERSTAND THAT DFINITY IS NOT RESPONSIBLE FOR ANY ACTIVITIES OR TRANSACTIONS (WHETHER COMPLETED OR OTHERWISE) ASSOCIATED WITH YOUR $oisy_name. You will not misrepresent or embellish the relationship between You and DFINITY, including expressing or implying that DFINITY supports, sponsors, endorses, or contributes to You or your business endeavors through your use of $oisy_short. You will not imply any relationship or affiliation with DFINITY except as expressly permitted by this License Agreement. You are prohibited from using the $oisy_short name, logo or any other trademarks related to $oisy_short in any manner that may imply an endorsement or affiliation, misrepresent your relationship with $oisy_short or create confusion regarding the source of $oisy_short.",
+      "applicable_laws": "<strong>3. APPLICABLE LAWS.</strong> You will comply with all applicable laws and regulations (including without limitation laws and regulations related to export controls, money laundering or economic sanctions) in connection with your use of $oisy_short and any transactions associated with your $oisy_name.",
+      "reservation_rights": "<strong>4. RESERVATION OF DFINITY’S RIGHT.</strong> $oisy_short is owned by DFINITY and licensed, not sold, to You. $oisy_short’s content, visual interfaces, interactive features, information, graphics, design, compilation, computer code, products, services, and all other elements of $oisy_short and related documentation, are protected by applicable intellectual property laws. As between You and DFINITY, all DFINITY materials and $oisy_short, including intellectual property rights therein and thereto, are the sole and exclusive property of DFINITY or its subsidiaries or affiliated companies and/or its third-party licensors, subject to any open-source software licenses. DFINITY reserves all rights not expressly granted in this License Agreement. You do not acquire any right, title, or interest to the DFINITY materials or $oisy_short, whether by implication, estoppel, or otherwise, except for the limited rights set forth in this License Agreement and the rights conferred by the licensing terms governing use of any open-sourced components included within $oisy_short. This License Agreement does not grant you any right to use the $oisy_short name, logo or other trademarks related to $oisy_short or DFINITY.",
+      "feedback": "<strong>5. FEEDBACK.</strong> If You provide DFINITY with any comments, ideas, bug reports, feedback, enhancements, recommendations or modifications in relation to $oisy_short (\"Feedback\"), such Feedback is provided on a non-confidential basis, and DFINITY shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the DFINITY materials, $oisy_short or other services. You hereby grant DFINITY a perpetual, irrevocable, transferable, sublicensable, nonexclusive, royalty free license under all rights necessary to so incorporate and use your Feedback for any purpose, including to make and sell products and services, and agree to provide DFINITY with any assistance required to document, perfect and maintain DFINITY’s rights to the Feedback. You agree to allow DFINITY to contact You for Feedback from time to time, but may opt-out by sending written notice to legalnotice@dfinity.org.",
+      "termination": "<strong>6. TERMS AND TERMINATION.</strong> This License Agreement will remain in effect until terminated. The License Agreement, and your rights and licenses hereunder, will terminate immediately upon your breach of the License Agreement. You may terminate the License Agreement at any time by emptying your $oisy_name of tokens and ceasing all use of $oisy_short. DFINITY may terminate this License Agreement at any time for any reason, including without limitation any actual or suspected misuse or abuse by You of $oisy_short or any violation of this License Agreement. Sections 3 through 13 shall survive any termination of this License Agreement.",
+      "warranty_liability": "<strong>7. WARRANTY DISCLAIMER AND LIMITATION OF LIABILITY.</strong> TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, $oisy_short IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, DFINITY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OR CONDITIONS OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE, QUALITY, RESULTS, AND NON-INFRINGEMENT. DFINITY DOES NOT GUARANTEE THAT $oisy_short WILL ALWAYS BE AVAILABLE, SAFE, OR SECURE (NOW AND IN THE FUTURE). DFINITY EXPRESSLY DISCLAIMS ANY WARRANTIES OF ANY KIND WITH RESPECT TO THE ACCURACY OR FUNCTIONALITY OF $oisy_short, AND WITH RESPECT TO THE ACCURACY, VALIDITY, OR COMPLETENESS OF ANY INFORMATION OR FEATURES (NOW AND IN THE FUTURE) MADE AVAILABLE THROUGH YOUR USE OF $oisy_short, OR THE QUALITY OR CONSISTENCY OF $oisy_short OR RESULTS OBTAINED THROUGH ITS USE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, UNDER NO CIRCUMSTANCES WILL DFINITY BE LIABLE FOR ANY CONSEQUENTIAL, SPECIAL, INDIRECT, INCIDENTAL OR PUNITIVE DAMAGES WHATSOEVER ARISING OUT OF THE USE OR INABILITY TO USE AND ACCESS $oisy_short OR DFINITY MATERIALS, EVEN IF DFINITY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL DFINITY'S AGGREGATE LIABILITY FOR DAMAGES ARISING OUT OF THIS LICENSE AGREEMENT OR YOUR USE OR INABILITY TO USE $oisy_short EXCEED 100 CHF.",
+      "indemnity": "<strong>8. INDEMNITY.</strong> You agree to indemnify, defend and hold DFINITY and its affiliates, officers, directors, suppliers, licensors, and other customers harmless from and against any and all liability and costs, including reasonable attorneys' fees incurred by such parties, in connection with your use or misuse of $oisy_short or your violation of this License Agreement or any applicable law or regulation.",
+      "governing_law": "<strong>9. GOVERNING LAW; VENUE.</strong> Any claim relating to $oisy_short shall be governed by the laws of Switzerland, to the exclusion of the rules on conflicts of laws. Any claim or dispute related to this License Agreement or in relation to it shall (including for non-contractual disputes or claims and their interpretation) be subject to the exclusive jurisdiction of the Courts of Zurich, Switzerland, subject to an appeal at the Swiss Federal Court.",
+      "entire_agreement": "<strong>10. ENTIRE AGREEMENT AND SEVERABILITY.</strong> This License Agreement is the entire agreement between You and DFINITY, and supersedes any and all prior agreements, negotiations, or other communications between You and DFINITY, whether oral or written, with respect to the subject matter hereof. DFINITY may make changes to this License Agreement when new versions of $oisy_short are made available. In the event that any provision of this License Agreement is held to be invalid or unenforceable, then: (a) such provision shall be deemed reformed to the extent strictly necessary to render such provision valid and enforceable, or if not capable of such reformation shall be deemed severed from this License Agreement; and (b) the validity and enforceability of all of the other provisions hereof, shall in no way be affected or impaired thereby.",
+      "assignment": "<strong>11. ASSIGNMENT.</strong> You may not assign this License Agreement without the prior written consent of DFINITY, whether expressly or by operation of law, including in connection with a merger or change of control, and any such attempted assignment shall be void and of no effect. DFINITY may assign this License Agreement without restriction and without any notice to You. Subject to the foregoing, this License Agreement shall be binding on the parties and their respective successors and permitted assigns.",
+      "no_waiver": "<strong>12. NO WAIVER.</strong> The failure to exercise, or delay in exercising, a right, power, or remedy provided in this License Agreement or by law shall not constitute a waiver of that right, power, or remedy. DFINITY 's waiver of any obligation or breach of this License Agreement shall not operate as a waiver of any other obligation or subsequent breach of the License Agreement.",
+      "english_version": "<strong>13. ENGLISH VERSION.</strong> The English language version of this License Agreement shall be the official and controlling version of the agreement if any conflict should arise. All communications and notices made pursuant to this License Agreement must be in the English language."
+    },
+    "alt": {
+      "license_agreement": "The $oisy_name License Agreement"
+    }
+  },
+  "activity": {
+    "text": {
+      "title": "Recent Activity"
+    },
+    "info": {
+      "btc_transactions": "BTC transaction information is obtained from central third parties and should be independently verified."
+    },
+    "warning": {
+      "no_index_canister": "Transactions for $token_list can not be displayed. No Index canister available.",
+      "unavailable_index_canister": "Transactions for $token_list can not be displayed. Index canister is currently unavailable."
+    }
+  }
 }

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -358,7 +358,6 @@ interface I18nSend {
 		cketh_certified: string;
 		pending_bitcoin_transaction: string;
 		no_available_utxos: string;
-		ata_will_be_calculated: string;
 	};
 	assertion: {
 		invalid_destination_address: string;

--- a/src/frontend/src/sol/components/send/SolSendDestination.svelte
+++ b/src/frontend/src/sol/components/send/SolSendDestination.svelte
@@ -7,13 +7,10 @@
 	export let destination = '';
 	export let invalidDestination = false;
 
-
 	const dispatch = createEventDispatcher();
 
 	let isInvalidDestination: () => boolean;
 	$: isInvalidDestination = (): boolean => isInvalidDestinationSol(destination);
-
-
 </script>
 
 <SendInputDestination

--- a/src/frontend/src/sol/components/send/SolSendDestination.svelte
+++ b/src/frontend/src/sol/components/send/SolSendDestination.svelte
@@ -1,40 +1,19 @@
 <script lang="ts">
-	import { assertNonNullish, debounce, notEmptyString } from '@dfinity/utils';
-	import { createEventDispatcher, getContext } from 'svelte';
-	import { slide } from 'svelte/transition';
+	import { createEventDispatcher } from 'svelte';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
-	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { SolanaNetworkType } from '$sol/types/network';
-	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
-	import { isAtaAddress } from '$sol/utils/sol-address.utils';
 	import { isInvalidDestinationSol } from '$sol/utils/sol-send.utils';
 
 	export let destination = '';
 	export let invalidDestination = false;
 
-	const { sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
 	let isInvalidDestination: () => boolean;
 	$: isInvalidDestination = (): boolean => isInvalidDestinationSol(destination);
 
-	let network: SolanaNetworkType | undefined;
-	$: network = mapNetworkIdToNetwork($sendTokenNetworkId);
 
-	let isAtaDestination = true;
-
-	const updateIsAtaDestination = async () => {
-		assertNonNullish(network, 'No Solana network provided to start Solana wallet worker.');
-
-		isAtaDestination = await isAtaAddress({ address: destination, network });
-	};
-
-	const debounceUpdateIsAtaDestination = debounce(updateIsAtaDestination);
-
-	$: destination, debounceUpdateIsAtaDestination();
 </script>
 
 <SendInputDestination
@@ -46,8 +25,4 @@
 	onQRButtonClick={() => dispatch('icQRCodeScan')}
 />
 
-{#if notEmptyString(destination) && !invalidDestination && !isAtaDestination}
-	<p transition:slide={SLIDE_DURATION} class="pb-3 text-warning-primary">
-		{$i18n.send.info.ata_will_be_calculated}
-	</p>
-{/if}
+<!--TODO: PRODSEC: add some sort of warning/info when the destination input is not an ATA address, either here or in the confirmation review step-->

--- a/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
@@ -6,8 +6,7 @@ import * as solanaApi from '$sol/api/solana.api';
 import SolSendForm from '$sol/components/send/SolSendForm.svelte';
 import { SOL_FEE_CONTEXT_KEY, initFeeContext, initFeeStore } from '$sol/stores/sol-fee.store';
 import * as solAddressUtils from '$sol/utils/sol-address.utils';
-import en from '$tests/mocks/i18n.mock';
-import { mockAtaAddress, mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
+import { mockAtaAddress, mockSolAddress } from '$tests/mocks/sol.mock';
 import { render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 
@@ -97,20 +96,6 @@ describe('SolSendForm', () => {
 			);
 
 			vi.spyOn(solAddressUtils, 'isAtaAddress').mockResolvedValue(true);
-		});
-
-		it('should warn the user if the destination is not an ATA address', async () => {
-			vi.spyOn(solAddressUtils, 'isAtaAddress').mockResolvedValue(false);
-
-			const { getByText } = render(SolSendForm, {
-				props: { ...props, destination: mockSolAddress2 },
-				context: mockContext
-			});
-
-			// Wait for the warning to be displayed
-			await new Promise((resolve) => setTimeout(resolve, 1000));
-
-			expect(getByText(en.send.info.ata_will_be_calculated)).toBeInTheDocument();
 		});
 
 		it('should not render ATA creation fee if the destination is empty', () => {


### PR DESCRIPTION
# Motivation

The PRODSEC review suggested that we warn/inform the user when the destination input for Solana is not an ATA address, since we will derive it in our code.

This information can happen either in the form or in the confirmation review, or both, or in whichever form it is acceptable to have the user aware.

However, we are going to revisit how to show this information further on. For the current release we temporarily remove it.
