### PR TITLE
feat(frontend): map MintTo and Burn transactions in Solana mapper

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -216,6 +216,38 @@ const mapTokenParsedInstruction = async ({
 
 		return { value, from, to };
 	}
+
+	if (type === 'mintTo') {
+		// We need to cast the type since it is not implied
+		const {
+			account: to,
+			mint: tokenAddress,
+			amount: value
+		} = info as {
+			account: SolAddress;
+			mint: SplTokenAddress;
+			amount: string;
+		};
+
+		// For a mint transaction, we consider the token as the source of the transaction
+		return { value: BigInt(value), from: tokenAddress, to, tokenAddress };
+	}
+
+	if (type === 'burn') {
+		// We need to cast the type since it is not implied
+		const {
+			account: from,
+			mint: tokenAddress,
+			amount: value
+		} = info as {
+			account: SolAddress;
+			mint: SplTokenAddress;
+			amount: string;
+		};
+
+		// For a burn transaction, we consider the token as the destination of the transaction
+		return { value: BigInt(value), from, to: tokenAddress, tokenAddress };
+	}
 };
 
 const mapToken2022ParsedInstruction = async ({

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -193,9 +193,7 @@ const mapTokenParsedInstruction = async ({
 			mint: tokenAddress
 		} = info as {
 			destination: SolAddress;
-			tokenAmount: {
-				amount: string;
-			};
+			tokenAmount: { amount: string };
 			source: SolAddress;
 			mint: SplTokenAddress;
 		};
@@ -243,6 +241,38 @@ const mapTokenParsedInstruction = async ({
 			account: SolAddress;
 			mint: SplTokenAddress;
 			amount: string;
+		};
+
+		// For a burn transaction, we consider the token as the destination of the transaction
+		return { value: BigInt(value), from, to: tokenAddress, tokenAddress };
+	}
+
+	if (type === 'mintToChecked') {
+		// We need to cast the type since it is not implied
+		const {
+			account: to,
+			mint: tokenAddress,
+			tokenAmount: { amount: value }
+		} = info as {
+			account: SolAddress;
+			mint: SplTokenAddress;
+			tokenAmount: { amount: string };
+		};
+
+		// For a mint transaction, we consider the token as the source of the transaction
+		return { value: BigInt(value), from: tokenAddress, to, tokenAddress };
+	}
+
+	if (type === 'burnChecked') {
+		// We need to cast the type since it is not implied
+		const {
+			account: from,
+			mint: tokenAddress,
+			tokenAmount: { amount: value }
+		} = info as {
+			account: SolAddress;
+			mint: SplTokenAddress;
+			tokenAmount: { amount: string };
 		};
 
 		// For a burn transaction, we consider the token as the destination of the transaction
@@ -323,9 +353,7 @@ const mapToken2022ParsedInstruction = async ({
 			mint: tokenAddress
 		} = info as {
 			destination: SolAddress;
-			tokenAmount: {
-				amount: string;
-			};
+			tokenAmount: { amount: string };
 			source: SolAddress;
 			mint: SplTokenAddress;
 		};

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -390,6 +390,58 @@ describe('sol-instructions.utils', () => {
 				});
 			});
 
+			it('should map a valid `mintToChecked` instruction', async () => {
+				const mockMintToCheckedInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'mintToChecked',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							tokenAmount: { amount: '12345' }
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockMintToCheckedInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockTokenAddress,
+					to: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
+			it('should map a valid `burnChecked` instruction', async () => {
+				const mockBurnCheckedInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'burnChecked',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							tokenAmount: { amount: '12345' }
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockBurnCheckedInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockSolAddress,
+					to: mockTokenAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
 			it('should return undefined for non-mapped instruction', async () => {
 				const result = await mapSolParsedInstruction({
 					instruction: { ...mockTokenInstruction, parsed: { type: 'other-type', info: {} } },

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -338,6 +338,58 @@ describe('sol-instructions.utils', () => {
 				});
 			});
 
+			it('should map a valid `mintTo` instruction', async () => {
+				const mockMintToInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'mintTo',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							amount: '12345'
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockMintToInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockTokenAddress,
+					to: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
+			it('should map a valid `burn` instruction', async () => {
+				const mockBurnInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'burn',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							amount: '12345'
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockBurnInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockSolAddress,
+					to: mockTokenAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
 			it('should return undefined for non-mapped instruction', async () => {
 				const result = await mapSolParsedInstruction({
 					instruction: { ...mockTokenInstruction, parsed: { type: 'other-type', info: {} } },


### PR DESCRIPTION
# Motivation

We extend the Solana mapper to `MintTo` and `Burn` transactions (and their `Checked` version) of the Token Program.
Practical examples used to map them:

- [Burn](https://solscan.io/tx/4RqjWLda38NSUmk88MYoq5AT2p6gcDfY73D4aZ6oKuaaeapshuM3SUsRsQpDKPdEB3zZkZeQLYo8tLDDcQWsdWyX)
- [MintTo](https://solscan.io/tx/5cFKsXTRLCQbmouPPLaYsMdVd137eTkm4nPxpxpnJ8qMQ17qVuXeyWtaNujJM6bSKczATsGcH7jBKNKCFj5uMRwE)
- [BurnChecked](https://solscan.io/tx/328K81kSv6bCMatwHs7HJYgJNm5SCEfKAqfYVYwuJEHcsXnWDxEhKvbbRFCrM3wzVkN7Spusjb3FWbC4N2RwNuBL)
- [MintToChecked](https://solscan.io/tx/2aeZQGnQxpCziLcCFRd1Nay4wTcHBH3TEKRRymTcSnZMnn9FcjhdzqrmcUmDU9eZcRuEH3SBbgxnRiyonphmA7yP)

# Changes

- Add mapper for `MintTo` and `MintToChecked`.
- Add mapper for `Burn` and `BurnChecked`.

# Tests

Added new tests.
