### PR TITLE
feat(frontend): use enabled Bitcoin networks instead of all of them

### DIFF
--- a/src/frontend/src/env/networks/networks.env.ts
+++ b/src/frontend/src/env/networks/networks.env.ts
@@ -6,6 +6,7 @@ import {
 	ETHEREUM_EXPLORER_URL,
 	SEPOLIA_EXPLORER_URL
 } from '$env/explorers.env';
+import { BTC_MAINNET_ENABLED } from '$env/networks/networks.btc.env';
 import { ETH_MAINNET_ENABLED } from '$env/networks/networks.eth.env';
 import sepolia from '$eth/assets/sepolia.svg';
 import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
@@ -132,10 +133,12 @@ export const BTC_REGTEST_NETWORK: BitcoinNetwork = {
 	explorerUrl: BTC_REGTEST_EXPLORER_URL
 };
 
-export const BITCOIN_NETWORKS: BitcoinNetwork[] = [
-	BTC_MAINNET_NETWORK,
+const SUPPORTED_BITCOIN_NETWORKS: BitcoinNetwork[] = [
+	...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
 	BTC_TESTNET_NETWORK,
 	...(LOCAL ? [BTC_REGTEST_NETWORK] : [])
 ];
 
-export const BITCOIN_NETWORKS_IDS: symbol[] = BITCOIN_NETWORKS.map(({ id }) => id);
+export const SUPPORTED_BITCOIN_NETWORKS_IDS: symbol[] = SUPPORTED_BITCOIN_NETWORKS.map(
+	({ id }) => id
+);

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,11 +1,11 @@
 import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import {
-	BITCOIN_NETWORKS_IDS,
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID,
 	ICP_NETWORK_ID,
 	SEPOLIA_NETWORK_ID,
+	SUPPORTED_BITCOIN_NETWORKS_IDS,
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
 } from '$env/networks/networks.env';
 import {
@@ -35,7 +35,7 @@ export const isNetworkIdEthereum: IsNetworkIdUtil = (id) =>
 	nonNullish(id) && SUPPORTED_ETHEREUM_NETWORKS_IDS.includes(id);
 
 export const isNetworkIdBitcoin: IsNetworkIdUtil = (id) =>
-	nonNullish(id) && BITCOIN_NETWORKS_IDS.includes(id);
+	nonNullish(id) && SUPPORTED_BITCOIN_NETWORKS_IDS.includes(id);
 
 export const isNetworkIdBTCMainnet: IsNetworkIdUtil = (networkId) =>
 	BTC_MAINNET_NETWORK_ID === networkId;

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -125,7 +125,7 @@ describe('network utils', () => {
 		});
 
 		it('should return false for Bitcoin regtest network ID when it is not LOCAL env', () => {
-			vi.spyOn(networkEnv, 'BITCOIN_NETWORKS_IDS', 'get').mockImplementationOnce(() => [
+			vi.spyOn(networkEnv, 'SUPPORTED_BITCOIN_NETWORKS_IDS', 'get').mockImplementationOnce(() => [
 				BTC_MAINNET_NETWORK_ID,
 				BTC_TESTNET_NETWORK_ID
 			]);


### PR DESCRIPTION
# Motivation

Since we have a flag to enable/disable Bitcoin mainnet, we should use the correct list of Bitcoin networks, in case the mainnet is not present.
