### PR TITLE
chore(frontend): bump axios in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5835,9 +5835,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+			"integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",


### PR DESCRIPTION
# Motivation

We want to update `axios` since the current version raises [vulnerabilities](https://github.com/axios/axios/issues/6463).
