### PR TITLE
feat(frontend): show token name in transaction detail instead of address

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -19,6 +19,7 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { erc20Tokens } from '$eth/derived/erc20.derived';
 
 	export let transaction: EthTransactionUi;
 	export let token: OptionToken;
@@ -40,6 +41,10 @@
 
 	let toExplorerUrl: string | undefined;
 	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
+
+	// To avoid possible confusion, we display the token name instead of the address, in case the destination is a known ERC20 token
+	let toDisplay: string | undefined;
+	$: toDisplay = $erc20Tokens.find(({ address }) => address === to)?.name ?? to;
 </script>
 
 <Modal on:nnsClose={modalStore.close}>
@@ -49,19 +54,23 @@
 		{#if nonNullish(hash)}
 			<Value ref="hash">
 				<svelte:fragment slot="label">{$i18n.transaction.text.hash}</svelte:fragment>
-				<output>{shortenWithMiddleEllipsis({ text: hash })}</output><Copy
+				<output>{shortenWithMiddleEllipsis({ text: hash })}</output>
+				<Copy
 					value={hash}
 					text={replacePlaceholders($i18n.transaction.text.hash_copied, {
 						$hash: hash
 					})}
 					inline
-				/>{#if nonNullish(explorerUrl)}<ExternalLink
+				/>
+				{#if nonNullish(explorerUrl)}
+					<ExternalLink
 						iconSize="18"
 						href={explorerUrl}
 						ariaLabel={$i18n.transaction.alt.open_block_explorer}
 						inline
 						color="blue"
-					/>{/if}
+					/>
+				{/if}
 			</Value>
 		{/if}
 
@@ -88,33 +97,41 @@
 
 		<Value ref="from">
 			<svelte:fragment slot="label">{$i18n.transaction.text.from}</svelte:fragment>
-			<output>{from}</output><Copy
+			<output>{from}</output>
+			<Copy
 				value={from}
 				text={$i18n.transaction.text.from_copied}
 				inline
-			/>{#if nonNullish(fromExplorerUrl)}<ExternalLink
+			/>
+			{#if nonNullish(fromExplorerUrl)}
+				<ExternalLink
 					iconSize="18"
 					href={fromExplorerUrl}
 					ariaLabel={$i18n.transaction.alt.open_from_block_explorer}
 					inline
 					color="blue"
-				/>{/if}
+				/>
+			{/if}
 		</Value>
 
-		{#if nonNullish(to)}
+		{#if nonNullish(to) && nonNullish(toDisplay)}
 			<Value ref="to">
 				<svelte:fragment slot="label">{$i18n.transaction.text.interacted_with}</svelte:fragment>
-				<output>{to}</output><Copy
+				<output>{toDisplay}</output>
+				<Copy
 					value={to}
 					text={$i18n.transaction.text.to_copied}
 					inline
-				/>{#if nonNullish(toExplorerUrl)}<ExternalLink
+				/>
+				{#if nonNullish(toExplorerUrl)}
+					<ExternalLink
 						iconSize="18"
 						href={toExplorerUrl}
 						ariaLabel={$i18n.transaction.alt.open_to_block_explorer}
 						inline
 						color="blue"
-					/>{/if}
+					/>
+				{/if}
 			</Value>
 		{/if}
 

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -3,6 +3,7 @@
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { BigNumber } from '@ethersproject/bignumber';
 	import EthTransactionStatus from '$eth/components/transactions/EthTransactionStatus.svelte';
+	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { explorerUrl as explorerUrlStore } from '$eth/derived/network.derived';
 	import type { EthTransactionUi } from '$eth/types/eth-transaction';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
@@ -19,7 +20,6 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { erc20Tokens } from '$eth/derived/erc20.derived';
 
 	export let transaction: EthTransactionUi;
 	export let token: OptionToken;
@@ -98,11 +98,7 @@
 		<Value ref="from">
 			<svelte:fragment slot="label">{$i18n.transaction.text.from}</svelte:fragment>
 			<output>{from}</output>
-			<Copy
-				value={from}
-				text={$i18n.transaction.text.from_copied}
-				inline
-			/>
+			<Copy value={from} text={$i18n.transaction.text.from_copied} inline />
 			{#if nonNullish(fromExplorerUrl)}
 				<ExternalLink
 					iconSize="18"
@@ -118,11 +114,7 @@
 			<Value ref="to">
 				<svelte:fragment slot="label">{$i18n.transaction.text.interacted_with}</svelte:fragment>
 				<output>{toDisplay}</output>
-				<Copy
-					value={to}
-					text={$i18n.transaction.text.to_copied}
-					inline
-				/>
+				<Copy value={to} text={$i18n.transaction.text.to_copied} inline />
 				{#if nonNullish(toExplorerUrl)}
 					<ExternalLink
 						iconSize="18"

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -43,6 +43,12 @@
 	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
 
 	// To avoid possible confusion, we display the token name instead of the address, in case the destination is a known ERC20 token
+	// TODO: check if can try and fetch metadata for the putative token if it is not in the list
+	let fromDisplay: string;
+	$: fromDisplay = $erc20Tokens.find(({ address }) => address === from)?.name ?? from;
+
+	// To avoid possible confusion, we display the token name instead of the address, in case the destination is a known ERC20 token
+	// TODO: check if can try and fetch metadata for the putative token if it is not in the list
 	let toDisplay: string | undefined;
 	$: toDisplay = $erc20Tokens.find(({ address }) => address === to)?.name ?? to;
 </script>
@@ -97,7 +103,7 @@
 
 		<Value ref="from">
 			<svelte:fragment slot="label">{$i18n.transaction.text.from}</svelte:fragment>
-			<output>{from}</output>
+			<output>{fromDisplay}</output>
 			<Copy value={from} text={$i18n.transaction.text.from_copied} inline />
 			{#if nonNullish(fromExplorerUrl)}
 				<ExternalLink


### PR DESCRIPTION
# Motivation

When we show the transactions details of an Ethereum transaction, if `from` and/or `to` are token addresses, it would be better to show it, instead of its address. This is to avoid possible confusions on what that address refers too.

# Changes

- Create the `from` and `to` strings by searching among the known tokens.

# Tests

### Before

![Screenshot 2025-03-12 at 20 15 10](https://github.com/user-attachments/assets/9fd8817a-af33-4275-8984-dcc8644e938a)

### After

![Screenshot 2025-03-12 at 20 12 13](https://github.com/user-attachments/assets/8a8d0146-73d8-4394-838e-bbea5d9ee22f)

### Rest is unchanged

![Screenshot 2025-03-12 at 20 12 21](https://github.com/user-attachments/assets/fdb1a573-dcee-413d-b1d5-30e4fc58c16d)
![Screenshot 2025-03-12 at 20 12 32](https://github.com/user-attachments/assets/f9369a19-5a4f-43c9-95e7-a23dc3553c8c)
![Screenshot 2025-03-12 at 20 12 41](https://github.com/user-attachments/assets/5106cdf1-63ee-4636-b856-a2337f614025)

