### PR TITLE
refactor(frontend): extract util to map an ETH address to a known name

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -20,6 +20,8 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import type { OptionString } from '$lib/types/string';
+	import { mapAddressToName } from '$eth/utils/transactions.utils';
 
 	export let transaction: EthTransactionUi;
 	export let token: OptionToken;
@@ -42,15 +44,21 @@
 	let toExplorerUrl: string | undefined;
 	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
 
-	// To avoid possible confusion, we display the token name instead of the address, in case the destination is a known ERC20 token
-	// TODO: check if can try and fetch metadata for the putative token if it is not in the list
-	let fromDisplay: string;
-	$: fromDisplay = $erc20Tokens.find(({ address }) => address === from)?.name ?? from;
 
-	// To avoid possible confusion, we display the token name instead of the address, in case the destination is a known ERC20 token
-	// TODO: check if can try and fetch metadata for the putative token if it is not in the list
-	let toDisplay: string | undefined;
-	$: toDisplay = $erc20Tokens.find(({ address }) => address === to)?.name ?? to;
+	let fromDisplay: OptionString;
+	$: fromDisplay = nonNullish(token) ? mapAddressToName({
+		address: from,
+		networkId: token.network.id,
+		erc20Tokens: $erc20Tokens
+	}) : from;
+
+
+	let toDisplay: OptionString;
+	$: toDisplay = nonNullish(token) ? mapAddressToName({
+		address: to,
+		networkId: token.network.id,
+		erc20Tokens: $erc20Tokens
+	}) : to;
 </script>
 
 <Modal on:nnsClose={modalStore.close}>

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -6,6 +6,7 @@
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { explorerUrl as explorerUrlStore } from '$eth/derived/network.derived';
 	import type { EthTransactionUi } from '$eth/types/eth-transaction';
+	import { mapAddressToName } from '$eth/utils/transactions.utils';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
@@ -13,6 +14,7 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionString } from '$lib/types/string';
 	import type { OptionToken } from '$lib/types/token';
 	import {
 		formatSecondsToDate,
@@ -20,8 +22,6 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import type { OptionString } from '$lib/types/string';
-	import { mapAddressToName } from '$eth/utils/transactions.utils';
 
 	export let transaction: EthTransactionUi;
 	export let token: OptionToken;
@@ -44,21 +44,23 @@
 	let toExplorerUrl: string | undefined;
 	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
 
-
 	let fromDisplay: OptionString;
-	$: fromDisplay = nonNullish(token) ? (mapAddressToName({
-		address: from,
-		networkId: token.network.id,
-		erc20Tokens: $erc20Tokens
-	}) ?? from) : from;
-
+	$: fromDisplay = nonNullish(token)
+		? (mapAddressToName({
+				address: from,
+				networkId: token.network.id,
+				erc20Tokens: $erc20Tokens
+			}) ?? from)
+		: from;
 
 	let toDisplay: OptionString;
-	$: toDisplay = nonNullish(token) ? (mapAddressToName({
-		address: to,
-		networkId: token.network.id,
-		erc20Tokens: $erc20Tokens
-	}) ?? to) : to;
+	$: toDisplay = nonNullish(token)
+		? (mapAddressToName({
+				address: to,
+				networkId: token.network.id,
+				erc20Tokens: $erc20Tokens
+			}) ?? to)
+		: to;
 </script>
 
 <Modal on:nnsClose={modalStore.close}>

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -46,19 +46,19 @@
 
 
 	let fromDisplay: OptionString;
-	$: fromDisplay = nonNullish(token) ? mapAddressToName({
+	$: fromDisplay = nonNullish(token) ? (mapAddressToName({
 		address: from,
 		networkId: token.network.id,
 		erc20Tokens: $erc20Tokens
-	}) : from;
+	}) ?? from) : from;
 
 
 	let toDisplay: OptionString;
-	$: toDisplay = nonNullish(token) ? mapAddressToName({
+	$: toDisplay = nonNullish(token) ? (mapAddressToName({
 		address: to,
 		networkId: token.network.id,
 		erc20Tokens: $erc20Tokens
-	}) : to;
+	}) ?? to) : to;
 </script>
 
 <Modal on:nnsClose={modalStore.close}>

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -1,6 +1,9 @@
 import { ERC20_APPROVE_HASH } from '$eth/constants/erc20.constants';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { EthTransactionUi } from '$eth/types/eth-transaction';
 import type { OptionEthAddress } from '$lib/types/address';
+import type { NetworkId } from '$lib/types/network';
+import type { OptionString } from '$lib/types/string';
 import type { Transaction } from '$lib/types/transaction';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { BigNumber } from '@ethersproject/bignumber';
@@ -20,6 +23,26 @@ export const decodeErc20AbiDataValue = (data: string): BigNumber => {
 
 	return value;
 };
+
+/**
+ * It will try to map an address to a name among the known addresses (e.g. ERC20 tokens, CK minters).
+ *
+ * The string will be used to be displayed instead of the address and make it more user-friendly, avoiding confusions.
+ */
+// TODO: check if can try and fetch metadata for the putative token if it is not in the list
+export const mapAddressToName = ({
+	address,
+	networkId,
+	erc20Tokens
+}: {
+	address: OptionEthAddress;
+	networkId: NetworkId;
+	erc20Tokens: Erc20Token[];
+}): OptionString =>
+	erc20Tokens.find(
+		({ address: tokenAddress, network: { id: tokenNetworkId } }) =>
+			tokenAddress === address && tokenNetworkId === networkId
+	)?.name ?? address;
 
 /**
  * It maps a transaction to an Ethereum transaction UI object

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -42,7 +42,7 @@ export const mapAddressToName = ({
 	erc20Tokens.find(
 		({ address: tokenAddress, network: { id: tokenNetworkId } }) =>
 			tokenAddress === address && tokenNetworkId === networkId
-	)?.name ?? address;
+	)?.name;
 
 /**
  * It maps a transaction to an Ethereum transaction UI object

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -34,14 +34,14 @@ describe('transactions.utils', () => {
 			erc20Tokens: mockErc20Tokens
 		};
 
-		it('should return nullish value if the address is nullish', () => {
+		it('should return undefined if the address is nullish', () => {
 			expect(mapAddressToName({ ...mockParams, address: undefined })).toBeUndefined();
 
-			expect(mapAddressToName({ ...mockParams, address: null })).toBeNull();
+			expect(mapAddressToName({ ...mockParams, address: null })).toBeUndefined();
 		});
 
-		it('should return the original address if it does not match any known ERC20 token', () => {
-			expect(mapAddressToName(mockParams)).toBe(mockAddress);
+		it('should return undefined if it does not match any known ERC20 token', () => {
+			expect(mapAddressToName(mockParams)).toBeUndefined();
 		});
 
 		it('should return the token name if the address matches a known ERC20 token', () => {
@@ -58,24 +58,24 @@ describe('transactions.utils', () => {
 			).toBe(SEPOLIA_USDC_TOKEN.name);
 		});
 
-		it('should return the original address if the network does not match', () => {
+		it('should return undefined if the network does not match', () => {
 			expect(
 				mapAddressToName({
 					...mockParams,
 					address: PEPE_TOKEN.address,
 					networkId: SEPOLIA_NETWORK_ID
 				})
-			).toBe(PEPE_TOKEN.address);
+			).toBeUndefined();
 		});
 
-		it('should return the original address if the ERC20 token is not found', () => {
+		it('should return undefined if the ERC20 token is not found', () => {
 			expect(
 				mapAddressToName({
 					...mockParams,
 					address: PEPE_TOKEN.address,
 					erc20Tokens: [USDC_TOKEN, SEPOLIA_USDC_TOKEN]
 				})
-			).toBe(PEPE_TOKEN.address);
+			).toBeUndefined();
 
 			expect(
 				mapAddressToName({
@@ -84,13 +84,13 @@ describe('transactions.utils', () => {
 					networkId: SEPOLIA_NETWORK_ID,
 					erc20Tokens: [USDC_TOKEN, PEPE_TOKEN]
 				})
-			).toBe(SEPOLIA_USDC_TOKEN.address);
+			).toBeUndefined();
 		});
 
-		it('should return the original address if the ERC20 token list is empty', () => {
+		it('should return undefined if the ERC20 token list is empty', () => {
 			expect(
 				mapAddressToName({ ...mockParams, address: PEPE_TOKEN.address, erc20Tokens: [] })
-			).toBe(PEPE_TOKEN.address);
+			).toBeUndefined();
 		});
 	});
 

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -1,7 +1,11 @@
-import { mapEthTransactionUi } from '$eth/utils/transactions.utils';
+import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
+import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
+import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { mapAddressToName, mapEthTransactionUi } from '$eth/utils/transactions.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { Transaction } from '$lib/types/transaction';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
 
 const transaction: Transaction = {
 	blockNumber: 123456,
@@ -18,84 +22,157 @@ const ckMinterInfoAddresses: OptionEthAddress[] = ['0xffff'];
 
 const $ethAddress: OptionEthAddress = '0xffff';
 
-describe('mapEthTransactionUi', () => {
-	it('should map to "withdraw" when the "from" address is in ckMinterInfoAddresses', () => {
-		const ckMinterInfoAddresses: OptionEthAddress[] = ['0x1234'];
+describe('transactions.utils', () => {
+	describe('mapAddressToName', () => {
+		const mockAddress = mockEthAddress;
+		const mockNetworkId = ETHEREUM_NETWORK_ID;
+		const mockErc20Tokens = [USDC_TOKEN, SEPOLIA_USDC_TOKEN, PEPE_TOKEN];
 
-		const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+		const mockParams = {
+			address: mockAddress,
+			networkId: mockNetworkId,
+			erc20Tokens: mockErc20Tokens
+		};
 
-		expect(result.type).toBe('withdraw');
-	});
+		it('should return nullish value if the address is nullish', () => {
+			expect(mapAddressToName({ ...mockParams, address: undefined })).toBeUndefined();
 
-	it('should map to "deposit" when the "to" address is in ckMinterInfoAddresses', () => {
-		const ckMinterInfoAddresses: OptionEthAddress[] = ['0xabcd'];
-
-		const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
-
-		expect(result.type).toBe('deposit');
-	});
-
-	it('should map to "send" when the "from" address matches the $ethAddress', () => {
-		const result = mapEthTransactionUi({
-			transaction,
-			ckMinterInfoAddresses,
-			$ethAddress: '0x1234'
+			expect(mapAddressToName({ ...mockParams, address: null })).toBeNull();
 		});
 
-		expect(result.type).toBe('send');
-	});
-
-	it('should map to "receive" when none of the other conditions match', () => {
-		const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
-
-		expect(result.type).toBe('receive');
-	});
-
-	it('should map to "receive" when it does not match MinterInfoAddresses and $ethAddress is undefined', () => {
-		const result = mapEthTransactionUi({
-			transaction,
-			ckMinterInfoAddresses,
-			$ethAddress: undefined
+		it('should return the original address if it does not match any known ERC20 token', () => {
+			expect(mapAddressToName(mockParams)).toBe(mockAddress);
 		});
 
-		expect(result.type).toBe('receive');
-	});
+		it('should return the token name if the address matches a known ERC20 token', () => {
+			expect(mapAddressToName({ ...mockParams, address: PEPE_TOKEN.address })).toBe(
+				PEPE_TOKEN.name
+			);
 
-	it('should not map to "withdraw" or to "deposit" when the MinterInfoAddresses are empty', () => {
-		const ckMinterInfoAddresses: OptionEthAddress[] = [];
-
-		const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
-
-		expect(result.type).not.toBe('withdraw');
-		expect(result.type).not.toBe('deposit');
-	});
-
-	it('should not map to "withdraw" or to "deposit" when the MinterInfoAddresses are undefined', () => {
-		const ckMinterInfoAddresses: OptionEthAddress[] = [undefined];
-
-		const result = mapEthTransactionUi({
-			transaction,
-			ckMinterInfoAddresses,
-			$ethAddress: undefined
+			expect(
+				mapAddressToName({
+					...mockParams,
+					address: SEPOLIA_USDC_TOKEN.address,
+					networkId: SEPOLIA_NETWORK_ID
+				})
+			).toBe(SEPOLIA_USDC_TOKEN.name);
 		});
 
-		expect(result.type).not.toBe('withdraw');
-		expect(result.type).not.toBe('deposit');
-	});
-
-	it('should map an ID to the transaction hash if it exists', () => {
-		const result = mapEthTransactionUi({
-			transaction: { ...transaction, hash: '0x1234' },
-			ckMinterInfoAddresses,
-			$ethAddress
+		it('should return the original address if the network does not match', () => {
+			expect(
+				mapAddressToName({
+					...mockParams,
+					address: PEPE_TOKEN.address,
+					networkId: SEPOLIA_NETWORK_ID
+				})
+			).toBe(PEPE_TOKEN.address);
 		});
 
-		expect(result.id).toBe('0x1234');
+		it('should return the original address if the ERC20 token is not found', () => {
+			expect(
+				mapAddressToName({
+					...mockParams,
+					address: PEPE_TOKEN.address,
+					erc20Tokens: [USDC_TOKEN, SEPOLIA_USDC_TOKEN]
+				})
+			).toBe(PEPE_TOKEN.address);
+
+			expect(
+				mapAddressToName({
+					...mockParams,
+					address: SEPOLIA_USDC_TOKEN.address,
+					networkId: SEPOLIA_NETWORK_ID,
+					erc20Tokens: [USDC_TOKEN, PEPE_TOKEN]
+				})
+			).toBe(SEPOLIA_USDC_TOKEN.address);
+		});
+
+		it('should return the original address if the ERC20 token list is empty', () => {
+			expect(
+				mapAddressToName({ ...mockParams, address: PEPE_TOKEN.address, erc20Tokens: [] })
+			).toBe(PEPE_TOKEN.address);
+		});
 	});
 
-	it('should map an ID to undefined if the transaction hash does not exist', () => {
-		const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+	describe('mapEthTransactionUi', () => {
+		it('should map to "withdraw" when the "from" address is in ckMinterInfoAddresses', () => {
+			const ckMinterInfoAddresses: OptionEthAddress[] = ['0x1234'];
 
-		expect(result.id).toBeUndefined;
+			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+
+			expect(result.type).toBe('withdraw');
+		});
+
+		it('should map to "deposit" when the "to" address is in ckMinterInfoAddresses', () => {
+			const ckMinterInfoAddresses: OptionEthAddress[] = ['0xabcd'];
+
+			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+
+			expect(result.type).toBe('deposit');
+		});
+
+		it('should map to "send" when the "from" address matches the $ethAddress', () => {
+			const result = mapEthTransactionUi({
+				transaction,
+				ckMinterInfoAddresses,
+				$ethAddress: '0x1234'
+			});
+
+			expect(result.type).toBe('send');
+		});
+
+		it('should map to "receive" when none of the other conditions match', () => {
+			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+
+			expect(result.type).toBe('receive');
+		});
+
+		it('should map to "receive" when it does not match MinterInfoAddresses and $ethAddress is undefined', () => {
+			const result = mapEthTransactionUi({
+				transaction,
+				ckMinterInfoAddresses,
+				$ethAddress: undefined
+			});
+
+			expect(result.type).toBe('receive');
+		});
+
+		it('should not map to "withdraw" or to "deposit" when the MinterInfoAddresses are empty', () => {
+			const ckMinterInfoAddresses: OptionEthAddress[] = [];
+
+			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+
+			expect(result.type).not.toBe('withdraw');
+			expect(result.type).not.toBe('deposit');
+		});
+
+		it('should not map to "withdraw" or to "deposit" when the MinterInfoAddresses are undefined', () => {
+			const ckMinterInfoAddresses: OptionEthAddress[] = [undefined];
+
+			const result = mapEthTransactionUi({
+				transaction,
+				ckMinterInfoAddresses,
+				$ethAddress: undefined
+			});
+
+			expect(result.type).not.toBe('withdraw');
+			expect(result.type).not.toBe('deposit');
+		});
+
+		it('should map an ID to the transaction hash if it exists', () => {
+			const result = mapEthTransactionUi({
+				transaction: { ...transaction, hash: '0x1234' },
+				ckMinterInfoAddresses,
+				$ethAddress
+			});
+
+			expect(result.id).toBe('0x1234');
+		});
+
+		it('should map an ID to undefined if the transaction hash does not exist', () => {
+			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
+
+			expect(result.id).toBeUndefined;
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

This PR is just to extract an util that maps an Ethereum address to a known name (if found). And to add tests.
