### PR TITLE
feat(frontend): service loadEthereumTransactions can be update only

### DIFF
--- a/src/frontend/src/eth/services/eth-transaction.services.ts
+++ b/src/frontend/src/eth/services/eth-transaction.services.ts
@@ -120,7 +120,7 @@ const processMinedTransaction = async ({ token }: { token: Token }) => {
 	} = token;
 
 	// Reload transactions as a transaction has been mined
-	await loadEthereumTransactions({ tokenId, networkId });
+	await loadEthereumTransactions({ tokenId, networkId, updateOnly: true });
 
 	// Reload balance as a transaction has been mined
 	await reloadEthereumBalance(token);

--- a/src/frontend/src/eth/services/eth-transaction.services.ts
+++ b/src/frontend/src/eth/services/eth-transaction.services.ts
@@ -1,6 +1,6 @@
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { reloadEthereumBalance } from '$eth/services/eth-balance.services';
-import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
+import { reloadEthereumTransactions } from '$eth/services/eth-transactions.services';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
@@ -120,7 +120,7 @@ const processMinedTransaction = async ({ token }: { token: Token }) => {
 	} = token;
 
 	// Reload transactions as a transaction has been mined
-	await loadEthereumTransactions({ tokenId, networkId, updateOnly: true });
+	await reloadEthereumTransactions({ tokenId, networkId });
 
 	// Reload balance as a transaction has been mined
 	await reloadEthereumBalance(token);

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -31,6 +31,13 @@ export const loadEthereumTransactions = ({
 	return loadErc20Transactions({ networkId, tokenId, updateOnly });
 };
 
+// If we use the update method instead of the set method, we can keep the existing transactions and just update their data.
+// Plus we add new transactions to the existing ones.
+export const reloadEthereumTransactions = (params: {
+	tokenId: TokenId;
+	networkId: NetworkId;
+}): Promise<ResultSuccess> => loadEthereumTransactions({ ...params, updateOnly: true });
+
 const loadEthTransactions = async ({
 	networkId,
 	tokenId,

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -32,7 +32,7 @@ export const loadEthereumTransactions = ({
 };
 
 // If we use the update method instead of the set method, we can keep the existing transactions and just update their data.
-// Plus we add new transactions to the existing ones.
+// Plus, we add new transactions to the existing ones.
 export const reloadEthereumTransactions = (params: {
 	tokenId: TokenId;
 	networkId: NetworkId;

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -116,6 +116,28 @@ describe('eth-transactions.services', () => {
 				expect(get(ethTransactionsStore)).toEqual({ [mockTokenId]: mockTransactions });
 			});
 
+			it('should handle ERC20 token transactions correctly when it is update only', async () => {
+				const mockTransactions = createMockEthTransactions(3);
+				mockTransactionsRest.mockResolvedValueOnce(mockTransactions);
+
+				const existingTransactions = createMockEthTransactions(5);
+				ethTransactionsStore.set({
+					tokenId: mockTokenId,
+					transactions: [...existingTransactions, mockTransactions[0]]
+				});
+
+				const result = await loadEthereumTransactions({
+					networkId: mockNetworkId,
+					tokenId: mockTokenId,
+					updateOnly: true
+				});
+
+				expect(result).toEqual({ success: true });
+				expect(get(ethTransactionsStore)).toEqual({
+					[mockTokenId]: [...existingTransactions, ...mockTransactions]
+				});
+			});
+
 			it('should handle errors during transaction fetching gracefully', async () => {
 				const mockTransactions = createMockEthTransactions(5);
 				ethTransactionsStore.set({ tokenId: mockTokenId, transactions: mockTransactions });

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -5,7 +5,10 @@ import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { USDT_TOKEN_ID } from '$env/tokens/tokens-erc20/tokens.usdt.env';
 import * as foo from '$eth/rest/etherscan.rest';
 import { EtherscanRest } from '$eth/rest/etherscan.rest';
-import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
+import {
+	loadEthereumTransactions,
+	reloadEthereumTransactions
+} from '$eth/services/eth-transactions.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { ethAddressStore } from '$lib/stores/address.store';
@@ -22,40 +25,43 @@ vi.mock('$eth/rest/etherscan.rest', () => ({
 }));
 
 describe('eth-transactions.services', () => {
+	let spyToastsError: MockInstance;
+	let spyToastsErrorNoTrace: MockInstance;
+
+	const mockErc20UserTokens = [USDC_TOKEN, LINK_TOKEN, PEPE_TOKEN].map((token) => ({
+		data: { ...token, enabled: true },
+		certified: false
+	}));
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		spyToastsError = vi.spyOn(toastsStore, 'toastsError');
+		spyToastsErrorNoTrace = vi.spyOn(toastsStore, 'toastsErrorNoTrace');
+
+		// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		ethAddressStore.set({ data: mockEthAddress, certified: false });
+		erc20UserTokensStore.setAll(mockErc20UserTokens);
+	});
+
 	describe('loadEthereumTransactions', () => {
-		let spyToastsError: MockInstance;
-		let spyToastsErrorNoTrace: MockInstance;
-
-		beforeEach(() => {
-			vi.resetAllMocks();
-
-			spyToastsError = vi.spyOn(toastsStore, 'toastsError');
-			spyToastsErrorNoTrace = vi.spyOn(toastsStore, 'toastsErrorNoTrace');
-
-			// we mock console.error and console.warn just to avoid unnecessary logs while running the tests
-			vi.spyOn(console, 'error').mockImplementation(() => {});
-			vi.spyOn(console, 'warn').mockImplementation(() => {});
-		});
-
 		describe('when token is ERC20', () => {
+			let etherscanRestsSpy: MockInstance;
+
+			const mockTransactionsRest = vi.fn();
+
 			const {
 				id: mockTokenId,
 				network: { id: mockNetworkId },
 				symbol: mockSymbol
 			} = USDC_TOKEN;
 
-			const mockErc20UserTokens = [USDC_TOKEN, LINK_TOKEN, PEPE_TOKEN].map((token) => ({
-				data: { ...token, enabled: true },
-				certified: false
-			}));
-
-			const mockTransactionsRest = vi.fn();
-			let etherscanRestsSpy: MockInstance;
+			const mockTransactions = createMockEthTransactions(3);
 
 			beforeEach(() => {
-				ethAddressStore.set({ data: mockEthAddress, certified: false });
-				erc20UserTokensStore.setAll(mockErc20UserTokens);
-
 				etherscanRestsSpy = vi.spyOn(foo, 'etherscanRests');
 
 				etherscanRestsSpy.mockReturnValue({
@@ -104,7 +110,6 @@ describe('eth-transactions.services', () => {
 			});
 
 			it('should handle ERC20 token transactions correctly', async () => {
-				const mockTransactions = createMockEthTransactions(3);
 				mockTransactionsRest.mockResolvedValueOnce(mockTransactions);
 
 				const result = await loadEthereumTransactions({
@@ -117,7 +122,6 @@ describe('eth-transactions.services', () => {
 			});
 
 			it('should handle ERC20 token transactions correctly when it is update only', async () => {
-				const mockTransactions = createMockEthTransactions(3);
 				mockTransactionsRest.mockResolvedValueOnce(mockTransactions);
 
 				const existingTransactions = createMockEthTransactions(5);
@@ -139,7 +143,6 @@ describe('eth-transactions.services', () => {
 			});
 
 			it('should handle errors during transaction fetching gracefully', async () => {
-				const mockTransactions = createMockEthTransactions(5);
 				ethTransactionsStore.set({ tokenId: mockTokenId, transactions: mockTransactions });
 
 				const mockError = new Error('Mock Error');
@@ -162,5 +165,46 @@ describe('eth-transactions.services', () => {
 				});
 			});
 		}, 60000);
+	});
+
+	describe('reloadEthereumTransactions', () => {
+		let etherscanRestsSpy: MockInstance;
+
+		const mockTransactionsRest = vi.fn();
+
+		const {
+			id: mockTokenId,
+			network: { id: mockNetworkId }
+		} = USDC_TOKEN;
+
+		const mockTransactions = createMockEthTransactions(3);
+
+		beforeEach(() => {
+			etherscanRestsSpy = vi.spyOn(foo, 'etherscanRests');
+
+			etherscanRestsSpy.mockReturnValue({
+				transactions: mockTransactionsRest
+			} as unknown as EtherscanRest);
+		});
+
+		it('should handle ERC20 token transactions correctly', async () => {
+			mockTransactionsRest.mockResolvedValueOnce(mockTransactions);
+
+			const existingTransactions = createMockEthTransactions(5);
+			ethTransactionsStore.set({
+				tokenId: mockTokenId,
+				transactions: [...existingTransactions, mockTransactions[0]]
+			});
+
+			const result = await reloadEthereumTransactions({
+				networkId: mockNetworkId,
+				tokenId: mockTokenId
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(get(ethTransactionsStore)).toEqual({
+				[mockTokenId]: [...existingTransactions, ...mockTransactions]
+			});
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The service `loadEthereumTransactions` typically re-set the transactions, using the method `set` of the transaction store: it ignores the existing transactions and overrwrites everything with the new ones.

However, we prefer to have a "refresh" when using such a service in processing mined transaction (function `processMinedTransaction`), using method `update` of the transaction store. There is no practical difference, but it allows to just refresh the data of the pending transactions, instead of completing removing it and add the respective mined ones.

It seems more correct/coherent this way.

# Changes

- Add prop `updateOnly` to `loadEthereumTransactions` (defaults to `false`): it will use method `update` for each transaction, instead of `set` for all.
- Create new service `reloadEthereumTransactions` that has `updateOnly` as `true`.\
- Use new service when processing mined transactions.

# Tests

Adapted/added tests.
