### PR TITLE
feat(frontend): map CK minter contract name for ERC20 transactions

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -22,6 +22,10 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
+	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
+	import { isNetworkIdSepolia } from '$lib/utils/network.utils';
+	import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 
 	export let transaction: EthTransactionUi;
 	export let token: OptionToken;
@@ -44,22 +48,27 @@
 	let toExplorerUrl: string | undefined;
 	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
 
+	let ckMinterInfo: OptionCertifiedMinterInfo;
+	$: ckMinterInfo = $ckEthMinterInfoStore?.[isNetworkIdSepolia(token?.network.id) ? SEPOLIA_TOKEN_ID : ETHEREUM_TOKEN_ID];
+
 	let fromDisplay: OptionString;
 	$: fromDisplay = nonNullish(token)
 		? (mapAddressToName({
-				address: from,
-				networkId: token.network.id,
-				erc20Tokens: $erc20Tokens
-			}) ?? from)
+			address: from,
+			networkId: token.network.id,
+			erc20Tokens: $erc20Tokens,
+			ckMinterInfo
+		}) ?? from)
 		: from;
 
 	let toDisplay: OptionString;
 	$: toDisplay = nonNullish(token)
 		? (mapAddressToName({
-				address: to,
-				networkId: token.network.id,
-				erc20Tokens: $erc20Tokens
-			}) ?? to)
+			address: to,
+			networkId: token.network.id,
+			erc20Tokens: $erc20Tokens,
+			ckMinterInfo
+		}) ?? to)
 		: to;
 </script>
 

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -2,11 +2,14 @@
 	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { BigNumber } from '@ethersproject/bignumber';
+	import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 	import EthTransactionStatus from '$eth/components/transactions/EthTransactionStatus.svelte';
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { explorerUrl as explorerUrlStore } from '$eth/derived/network.derived';
 	import type { EthTransactionUi } from '$eth/types/eth-transaction';
 	import { mapAddressToName } from '$eth/utils/transactions.utils';
+	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
+	import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
@@ -22,10 +25,7 @@
 		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
-	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { isNetworkIdSepolia } from '$lib/utils/network.utils';
-	import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 
 	export let transaction: EthTransactionUi;
 	export let token: OptionToken;
@@ -49,26 +49,29 @@
 	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
 
 	let ckMinterInfo: OptionCertifiedMinterInfo;
-	$: ckMinterInfo = $ckEthMinterInfoStore?.[isNetworkIdSepolia(token?.network.id) ? SEPOLIA_TOKEN_ID : ETHEREUM_TOKEN_ID];
+	$: ckMinterInfo =
+		$ckEthMinterInfoStore?.[
+			isNetworkIdSepolia(token?.network.id) ? SEPOLIA_TOKEN_ID : ETHEREUM_TOKEN_ID
+		];
 
 	let fromDisplay: OptionString;
 	$: fromDisplay = nonNullish(token)
 		? (mapAddressToName({
-			address: from,
-			networkId: token.network.id,
-			erc20Tokens: $erc20Tokens,
-			ckMinterInfo
-		}) ?? from)
+				address: from,
+				networkId: token.network.id,
+				erc20Tokens: $erc20Tokens,
+				ckMinterInfo
+			}) ?? from)
 		: from;
 
 	let toDisplay: OptionString;
 	$: toDisplay = nonNullish(token)
 		? (mapAddressToName({
-			address: to,
-			networkId: token.network.id,
-			erc20Tokens: $erc20Tokens,
-			ckMinterInfo
-		}) ?? to)
+				address: to,
+				networkId: token.network.id,
+				erc20Tokens: $erc20Tokens,
+				ckMinterInfo
+			}) ?? to)
 		: to;
 </script>
 

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -4,7 +4,8 @@ import type { EthTransactionUi } from '$eth/types/eth-transaction';
 import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
 import {
 	toCkErc20HelperContractAddress,
-	toCkEthHelperContractAddress
+	toCkEthHelperContractAddress,
+	toCkMinterAddress
 } from '$icp-eth/utils/cketh.utils';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
@@ -53,6 +54,7 @@ export const mapAddressToName = ({
 
 	const ckEthHelperContractAddress = toCkEthHelperContractAddress(ckMinterInfo);
 	const ckErc20HelperContractAddress = toCkErc20HelperContractAddress(ckMinterInfo);
+	const ckMinerAddress = toCkMinterAddress(ckMinterInfo);
 
 	return (
 		putativeErc20TokenName ??
@@ -60,7 +62,9 @@ export const mapAddressToName = ({
 			? 'ckETH Minter Helper Contract'
 			: address === ckErc20HelperContractAddress
 				? 'ckERC20 Minter Helper Contract'
-				: undefined)
+				: address === ckMinerAddress
+					? 'CK Ethereum Minter'
+					: undefined)
 	);
 };
 

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -58,6 +58,7 @@ export const mapAddressToName = ({
 
 	return (
 		putativeErc20TokenName ??
+		// TODO: find a way to get the contracts name more dynamically
 		(address === ckEthHelperContractAddress
 			? 'ckETH Minter Helper Contract'
 			: address === ckErc20HelperContractAddress

--- a/src/frontend/src/icp-eth/utils/cketh.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh.utils.ts
@@ -10,7 +10,7 @@ export const toCkErc20HelperContractAddress = (
 	minterInfo: OptionCertifiedMinterInfo
 ): OptionEthAddress => fromNullishNullable(minterInfo?.data.erc20_helper_contract_address);
 
-const toCkMinterAddress = (minterInfo: OptionCertifiedMinterInfo): OptionEthAddress =>
+export const toCkMinterAddress = (minterInfo: OptionCertifiedMinterInfo): OptionEthAddress =>
 	fromNullishNullable(minterInfo?.data.minter_address);
 
 export const toCkMinterInfoAddresses = (

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -17,12 +17,13 @@ import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
 import { stringifyJson } from '$lib/utils/json.utils';
 import { parseToken } from '$lib/utils/parse.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockCkMinterInfo } from '$tests/mocks/ck-minter.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
-import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import type { MinterInfo } from '@dfinity/cketh';
-import { assertNonNullish, nonNullish, toNullable } from '@dfinity/utils';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { BigNumber } from 'alchemy-sdk';
 import { get, readable, writable } from 'svelte/store';
@@ -60,29 +61,7 @@ describe('EthConvertTokenWizard', () => {
 				}
 			]
 		]);
-	const mockMinterInfo = {
-		deposit_with_subaccount_helper_contract_address: toNullable(''),
-		eth_balance: toNullable(100n),
-		eth_helper_contract_address: toNullable(''),
-		last_observed_block_number: toNullable(100n),
-		evm_rpc_id: toNullable(mockPrincipal),
-		erc20_helper_contract_address: toNullable(''),
-		last_erc20_scraped_block_number: toNullable(100n),
-		supported_ckerc20_tokens: toNullable([]),
-		last_gas_fee_estimate: toNullable({
-			max_priority_fee_per_gas: 100n,
-			max_fee_per_gas: 100n,
-			timestamp: 100n
-		}),
-		cketh_ledger_id: toNullable(mockPrincipal),
-		smart_contract_address: toNullable(''),
-		last_eth_scraped_block_number: toNullable(100n),
-		minimum_withdrawal_amount: toNullable(100n),
-		erc20_balances: toNullable([]),
-		minter_address: toNullable(''),
-		last_deposit_with_subaccount_scraped_block_number: toNullable(100n),
-		ethereum_block_height: toNullable({ Safe: null })
-	};
+	const mockMinterInfo = mockCkMinterInfo;
 	const mockFees = {
 		gas: BigNumber.from(100n),
 		maxFeePerGas: BigNumber.from(100n),

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -9,6 +9,7 @@ import type { NetworkId } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
 import type { Transaction } from '$lib/types/transaction';
 import {
+	mockCkEthereumMinterAddress,
 	mockCkMinterInfo,
 	mockErc20HelperContractAddress,
 	mockEthHelperContractAddress
@@ -123,6 +124,15 @@ describe('transactions.utils', () => {
 					address: mockErc20HelperContractAddress
 				})
 			).toBe('ckERC20 Minter Helper Contract');
+		});
+
+		it('should return the CK Minter name if the address matches the CK Minter', () => {
+			expect(
+				mapAddressToName({
+					...mockParams,
+					address: mockCkEthereumMinterAddress
+				})
+			).toBe('CK Ethereum Minter');
 		});
 
 		it('should return undefined if the CK Helper Contract info are nullish', () => {

--- a/src/frontend/src/tests/icp/components/convert/IcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/IcConvertTokenWizard.spec.ts
@@ -24,6 +24,7 @@ import { stringifyJson } from '$lib/utils/json.utils';
 import { parseToken } from '$lib/utils/parse.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -74,6 +75,12 @@ describe('IcConvertTokenWizard', () => {
 			data: address
 		});
 	};
+	const mockEthAddressStore = (address = mockEthAddress) => {
+		ethAddressStore.set({
+			certified: true,
+			data: address
+		});
+	};
 
 	const clickConvertButton = async (container: HTMLElement) => {
 		const convertButtonSelector = '[data-tid="convert-review-button-next"]';
@@ -93,6 +100,7 @@ describe('IcConvertTokenWizard', () => {
 	it('should call send if all requirements are met', async () => {
 		mockAuthStore();
 		mockBtcAddressStore();
+		mockEthAddressStore();
 
 		const { container } = render(IcConvertTokenWizard, {
 			props,
@@ -125,6 +133,7 @@ describe('IcConvertTokenWizard', () => {
 
 	it('should not call send if authIdentity is not defined', async () => {
 		mockBtcAddressStore();
+		mockEthAddressStore();
 
 		const { container } = render(IcConvertTokenWizard, {
 			props,
@@ -139,6 +148,7 @@ describe('IcConvertTokenWizard', () => {
 	it('should not call send if sendAmount is not defined', async () => {
 		mockAuthStore();
 		mockBtcAddressStore();
+		mockEthAddressStore();
 
 		const { container } = render(IcConvertTokenWizard, {
 			props: {
@@ -156,6 +166,7 @@ describe('IcConvertTokenWizard', () => {
 	it('should not call send if sendAmount is invalid', async () => {
 		mockAuthStore();
 		mockBtcAddressStore();
+		mockEthAddressStore();
 
 		const { container } = render(IcConvertTokenWizard, {
 			props: {
@@ -173,6 +184,7 @@ describe('IcConvertTokenWizard', () => {
 	it('should render convert form if currentStep is CONVERT', () => {
 		mockAuthStore();
 		mockBtcAddressStore();
+		mockEthAddressStore();
 
 		const { getByTestId } = render(IcConvertTokenWizard, {
 			props: {
@@ -191,6 +203,7 @@ describe('IcConvertTokenWizard', () => {
 	it('should render convert progress if currentStep is CONVERTING', () => {
 		mockAuthStore();
 		mockBtcAddressStore();
+		mockEthAddressStore();
 
 		const { container } = render(IcConvertTokenWizard, {
 			props: {

--- a/src/frontend/src/tests/mocks/ck-minter.mock.ts
+++ b/src/frontend/src/tests/mocks/ck-minter.mock.ts
@@ -1,0 +1,30 @@
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+import { toNullable } from '@dfinity/utils';
+
+export const mockEthHelperContractAddress = 'eth-helper-contract-address';
+
+export const mockErc20HelperContractAddress = 'erc20-helper-contract-address';
+
+export const mockCkMinterInfo = {
+	deposit_with_subaccount_helper_contract_address: toNullable(''),
+	eth_balance: toNullable(100n),
+	eth_helper_contract_address: toNullable(mockEthHelperContractAddress),
+	last_observed_block_number: toNullable(100n),
+	evm_rpc_id: toNullable(mockPrincipal),
+	erc20_helper_contract_address: toNullable(mockErc20HelperContractAddress),
+	last_erc20_scraped_block_number: toNullable(100n),
+	supported_ckerc20_tokens: toNullable([]),
+	last_gas_fee_estimate: toNullable({
+		max_priority_fee_per_gas: 100n,
+		max_fee_per_gas: 100n,
+		timestamp: 100n
+	}),
+	cketh_ledger_id: toNullable(mockPrincipal),
+	smart_contract_address: toNullable(''),
+	last_eth_scraped_block_number: toNullable(100n),
+	minimum_withdrawal_amount: toNullable(100n),
+	erc20_balances: toNullable([]),
+	minter_address: toNullable(''),
+	last_deposit_with_subaccount_scraped_block_number: toNullable(100n),
+	ethereum_block_height: toNullable({ Safe: null })
+};

--- a/src/frontend/src/tests/mocks/ck-minter.mock.ts
+++ b/src/frontend/src/tests/mocks/ck-minter.mock.ts
@@ -5,6 +5,8 @@ export const mockEthHelperContractAddress = 'eth-helper-contract-address';
 
 export const mockErc20HelperContractAddress = 'erc20-helper-contract-address';
 
+export const mockCkEthereumMinterAddress = 'ck-minter-address';
+
 export const mockCkMinterInfo = {
 	deposit_with_subaccount_helper_contract_address: toNullable(''),
 	eth_balance: toNullable(100n),
@@ -24,7 +26,7 @@ export const mockCkMinterInfo = {
 	last_eth_scraped_block_number: toNullable(100n),
 	minimum_withdrawal_amount: toNullable(100n),
 	erc20_balances: toNullable([]),
-	minter_address: toNullable(''),
+	minter_address: toNullable(mockCkEthereumMinterAddress),
 	last_deposit_with_subaccount_scraped_block_number: toNullable(100n),
 	ethereum_block_height: toNullable({ Safe: null })
 };


### PR DESCRIPTION
# Motivation

We are already mapping the known ERC20 token names to display instead of their addresses in a transaction detail. A further step is to map the CK Minter too: if we know their address, we can map it and display a better name instead of the address.

# Changes

- Export util `toCkMinterAddress`
- Add mapping of relevant CK minter addresses in util `mapAddressToName`.
- Provide CK Minter Info to the caller of `mapAddressToName` in component `EthTransactionModal`.

# Tests

Added tests.
