### PR TITLE
feat(frontend): add timer to Ethereum transactions loader

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -41,19 +41,19 @@
 			return;
 		}
 
+
 		// We don't reload the same token in a row.
-		if (tokenIdLoaded === tokenId) {
+		if (tokenIdLoaded === tokenId && !reload) {
 			loading = false;
 			return;
 		}
 
+
 		tokenIdLoaded = tokenId;
 
+
 		const { success } = reload
-			? await reloadEthereumTransactions({
-					tokenId,
-					networkId
-				})
+			? await reloadEthereumTransactions({ tokenId, networkId })
 			: await loadEthereumTransactions({ tokenId, networkId });
 
 		if (!success) {
@@ -79,15 +79,18 @@
 		await reload();
 
 		timer = setInterval(reload, WALLET_TIMER_INTERVAL_MILLIS);
+
 	};
 
 	const stopTimer = () => {
+
 		if (isNullish(timer)) {
 			return;
 		}
 
 		clearInterval(timer);
 		timer = undefined;
+
 	};
 
 	onMount(startTimer);

--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -51,9 +51,9 @@
 
 		const { success } = reload
 			? await reloadEthereumTransactions({
-				tokenId,
-				networkId
-			})
+					tokenId,
+					networkId
+				})
 			: await loadEthereumTransactions({ tokenId, networkId });
 
 		if (!success) {

--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -1,15 +1,27 @@
 <script lang="ts">
 	import { tokenNotInitialized } from '$eth/derived/nav.derived';
-	import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
+	import { loadEthereumTransactions, reloadEthereumTransactions } from '$eth/services/eth-transactions.services';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import type { TokenId } from '$lib/types/token';
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+	import { onDestroy, onMount } from 'svelte';
 
 	let tokenIdLoaded: TokenId | undefined = undefined;
 
-	const load = async () => {
+	let loading = false;
+
+	const load = async ({ reloading = false }: { reloading?: boolean } = {}) => {
+		if (loading) {
+			return;
+		}
+
+		loading = true;
+
 		if ($tokenNotInitialized) {
 			tokenIdLoaded = undefined;
+			loading = false;
 			return;
 		}
 
@@ -22,24 +34,67 @@
 		// This prevents the glitch load of ETH transaction with a token ID for ICP.
 		if (!isNetworkIdEthereum(networkId)) {
 			tokenIdLoaded = undefined;
+			loading = false;
 			return;
 		}
 
 		// We don't reload the same token in a row.
 		if (tokenIdLoaded === tokenId) {
+			loading = false;
 			return;
 		}
 
 		tokenIdLoaded = tokenId;
 
-		const { success } = await loadEthereumTransactions({ tokenId, networkId });
+		const { success } = reloading ? await reloadEthereumTransactions({
+			tokenId,
+			networkId
+		}) : await loadEthereumTransactions({ tokenId, networkId });
 
 		if (!success) {
 			tokenIdLoaded = undefined;
 		}
+
+		loading = false;
 	};
 
+
 	$: $tokenWithFallback, $tokenNotInitialized, (async () => await load())();
+
+
+	let timer: NodeJS.Timeout | undefined = undefined;
+
+
+	const reload = async () => {
+		await load({ reloading: true });
+	};
+
+
+	const startTimer = async () => {
+		if (nonNullish(timer)) {
+			return;
+		}
+
+		await reload();
+
+		timer = setInterval(reload, WALLET_TIMER_INTERVAL_MILLIS);
+	};
+
+	const stopTimer = () => {
+		if (isNullish(timer)) {
+			return;
+		}
+
+		clearInterval(timer);
+		timer = undefined;
+	};
+
+
+	onMount(startTimer);
+
+	onDestroy(stopTimer);
+
+
 </script>
 
 <slot />

--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { onDestroy, onMount } from 'svelte';
 	import { tokenNotInitialized } from '$eth/derived/nav.derived';
-	import { loadEthereumTransactions, reloadEthereumTransactions } from '$eth/services/eth-transactions.services';
+	import {
+		loadEthereumTransactions,
+		reloadEthereumTransactions
+	} from '$eth/services/eth-transactions.services';
+	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import type { TokenId } from '$lib/types/token';
 	import { isNetworkIdEthereum } from '$lib/utils/network.utils';
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
-	import { onDestroy, onMount } from 'svelte';
 
 	let tokenIdLoaded: TokenId | undefined = undefined;
 
@@ -46,10 +49,12 @@
 
 		tokenIdLoaded = tokenId;
 
-		const { success } = reloading ? await reloadEthereumTransactions({
-			tokenId,
-			networkId
-		}) : await loadEthereumTransactions({ tokenId, networkId });
+		const { success } = reloading
+			? await reloadEthereumTransactions({
+					tokenId,
+					networkId
+				})
+			: await loadEthereumTransactions({ tokenId, networkId });
 
 		if (!success) {
 			tokenIdLoaded = undefined;
@@ -58,17 +63,13 @@
 		loading = false;
 	};
 
-
 	$: $tokenWithFallback, $tokenNotInitialized, (async () => await load())();
 
-
 	let timer: NodeJS.Timeout | undefined = undefined;
-
 
 	const reload = async () => {
 		await load({ reloading: true });
 	};
-
 
 	const startTimer = async () => {
 		if (nonNullish(timer)) {
@@ -89,12 +90,9 @@
 		timer = undefined;
 	};
 
-
 	onMount(startTimer);
 
 	onDestroy(stopTimer);
-
-
 </script>
 
 <slot />

--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -41,16 +41,13 @@
 			return;
 		}
 
-
 		// We don't reload the same token in a row.
 		if (tokenIdLoaded === tokenId && !reload) {
 			loading = false;
 			return;
 		}
 
-
 		tokenIdLoaded = tokenId;
-
 
 		const { success } = reload
 			? await reloadEthereumTransactions({ tokenId, networkId })
@@ -79,18 +76,15 @@
 		await reload();
 
 		timer = setInterval(reload, WALLET_TIMER_INTERVAL_MILLIS);
-
 	};
 
 	const stopTimer = () => {
-
 		if (isNullish(timer)) {
 			return;
 		}
 
 		clearInterval(timer);
 		timer = undefined;
-
 	};
 
 	onMount(startTimer);

--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -15,7 +15,7 @@
 
 	let loading = false;
 
-	const load = async ({ reloading = false }: { reloading?: boolean } = {}) => {
+	const load = async ({ reload = false }: { reload?: boolean } = {}) => {
 		if (loading) {
 			return;
 		}
@@ -49,11 +49,11 @@
 
 		tokenIdLoaded = tokenId;
 
-		const { success } = reloading
+		const { success } = reload
 			? await reloadEthereumTransactions({
-					tokenId,
-					networkId
-				})
+				tokenId,
+				networkId
+			})
 			: await loadEthereumTransactions({ tokenId, networkId });
 
 		if (!success) {
@@ -68,7 +68,7 @@
 	let timer: NodeJS.Timeout | undefined = undefined;
 
 	const reload = async () => {
-		await load({ reloading: true });
+		await load({ reload: true });
 	};
 
 	const startTimer = async () => {

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -29,7 +29,6 @@ describe('LoaderEthTransactions', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		// vi.useFakeTimers();
 
 		mockLoadTransactions.mockResolvedValue({ success: true });
 		mockReloadTransactions.mockResolvedValue({ success: true });
@@ -41,10 +40,6 @@ describe('LoaderEthTransactions', () => {
 			{ data: { ...SEPOLIA_PEPE_TOKEN, enabled: true }, certified: false }
 		]);
 	});
-
-	// afterEach(() => {
-	// 	vi.useRealTimers();
-	// });
 
 	it('should not load transactions if token is not initialized', async () => {
 		render(LoaderEthTransactions);

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -3,26 +3,36 @@ import { SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SEPOLIA_TOKEN, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import LoaderEthTransactions from '$eth/components/loaders/LoaderEthTransactions.svelte';
-import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
+import {
+	loadEthereumTransactions,
+	reloadEthereumTransactions
+} from '$eth/services/eth-transactions.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
+import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { token } from '$lib/stores/token.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render, waitFor } from '@testing-library/svelte';
 import type { MockedFunction } from 'vitest';
 
 vi.mock('$eth/services/eth-transactions.services', () => ({
-	loadEthereumTransactions: vi.fn()
+	loadEthereumTransactions: vi.fn(),
+	reloadEthereumTransactions: vi.fn()
 }));
 
 describe('LoaderEthTransactions', () => {
 	const mockLoadTransactions = loadEthereumTransactions as MockedFunction<
 		typeof loadEthereumTransactions
 	>;
+	const mockReloadTransactions = reloadEthereumTransactions as MockedFunction<
+		typeof reloadEthereumTransactions
+	>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// vi.useFakeTimers();
 
 		mockLoadTransactions.mockResolvedValue({ success: true });
+		mockReloadTransactions.mockResolvedValue({ success: true });
 
 		mockPage.reset();
 		token.reset();
@@ -31,6 +41,10 @@ describe('LoaderEthTransactions', () => {
 			{ data: { ...SEPOLIA_PEPE_TOKEN, enabled: true }, certified: false }
 		]);
 	});
+
+	// afterEach(() => {
+	// 	vi.useRealTimers();
+	// });
 
 	it('should not load transactions if token is not initialized', async () => {
 		render(LoaderEthTransactions);
@@ -192,5 +206,28 @@ describe('LoaderEthTransactions', () => {
 		await waitFor(() => {
 			expect(loadEthereumTransactions).toHaveBeenCalledTimes(2);
 		});
+	});
+
+	it('should call the load function every interval', async () => {
+		vi.useFakeTimers();
+
+		render(LoaderEthTransactions);
+
+		mockPage.mock({ token: SEPOLIA_TOKEN.name });
+		token.set(SEPOLIA_TOKEN);
+
+		await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+		expect(reloadEthereumTransactions).toHaveBeenCalledOnce();
+
+		await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+		expect(reloadEthereumTransactions).toHaveBeenCalledTimes(2);
+
+		await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS * 5);
+
+		expect(reloadEthereumTransactions).toHaveBeenCalledTimes(7);
+
+		vi.useRealTimers();
 	});
 });


### PR DESCRIPTION
# Motivation

When we are in an Ethereum transaction page, we are not refreshing the transaction list. We just listen to new transactions, but ideally we should have a timer to refresh every certain amount of time.

# Changes

- Create functions to reload transactions.
- Create timer utils to start and stop.
- Assign `onMount` and `onDestroy`.

# Tests

Added tests.
