### PR TITLE
fix(frontend): Fix tailwind screen size definitions

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,11 +10,13 @@ export default {
 		},
 		screens: {
 			...defaultTheme.screens,
-			'1.5md': '896px',
-			'1.5lg': '1152px',
-			'1.5xl': '1408px',
-			'2.5xl': '1728px',
-			'h-md': { raw: '(max-height: 1090px)' }
+			// we need to use rem instead of px because the default tailwind values changed to rem,
+			// and mixing units breaks custom screen definitions
+			'1.5md': '56rem', // 896px
+			'1.5lg': '72rem', // 1152px
+			'1.5xl': '88rem', // 1408px
+			'2.5xl': '108rem', // 1728px
+			'h-md': { raw: '(max-height: 68rem)' } // ~1090px
 		},
 		colors: {
 			// base colors, can be left in


### PR DESCRIPTION
# Motivation

Since we changed the default viewport sizes to be imported from tailwind itself, it broke our custom viewports leading to the missing footer issue.

# Changes

Specified viewports in rem instead of px to be able to use defaultTheme.screens since the newer tailwind versions at some point started using rem, and mixing units breaks the custom viewports

# Tests
![image](https://github.com/user-attachments/assets/53930a08-fe93-4c11-987e-b8013a3a03a0)