### PR TITLE
refactor(frontend): remove unnecessary check in building ICRC

### DIFF
--- a/scripts/build.tokens.icrc.ts
+++ b/scripts/build.tokens.icrc.ts
@@ -38,10 +38,6 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 				throw new Error(`Ledger canister ID is missing for token symbol ${key}.`);
 			}
 
-			if (isNullish(savedIndexCanisterId)) {
-				throw new Error(`Index canister ID is missing for token symbol ${key}.`);
-			}
-
 			const { tokens: accTokens, icons: accIcons } = await acc;
 
 			const valueWithMetadata = await loadMetadata(token);

--- a/scripts/build.tokens.icrc.ts
+++ b/scripts/build.tokens.icrc.ts
@@ -38,6 +38,10 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 				throw new Error(`Ledger canister ID is missing for token symbol ${key}.`);
 			}
 
+			if (isNullish(savedIndexCanisterId)) {
+				throw new Error(`Index canister ID is missing for token symbol ${key}.`);
+			}
+
 			const { tokens: accTokens, icons: accIcons } = await acc;
 
 			const valueWithMetadata = await loadMetadata(token);
@@ -53,12 +57,6 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 			}
 
 			const { ledgerCanisterId, name, icon, ...rest } = valueWithMetadata;
-
-			if (ledgerCanisterId !== savedLedgerCanisterId) {
-				throw new Error(
-					`Ledger canister ID mismatch for token symbol ${key}. Expected ${savedLedgerCanisterId}, got ${ledgerCanisterId}.`
-				);
-			}
 
 			return {
 				tokens: {


### PR DESCRIPTION
# Motivation

We check if the Ledger canister ID saved in the JSON file is different from the one fetched with the metadata. However, it does not really make sense to check since the metadata are fetched using the saved Ledger canister ID. It will always match with the returned value.
