### PR TITLE
fix(frontend): Fix blurry text on modals with scrollable content

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -191,6 +191,9 @@ div.modal {
 	}
 
 	div.container {
+		// hack for fixing blurry text/content on Mac OS when modal content scroll bar is showing
+		border-radius: 0 !important;
+
 		// If using ContentWithToolbar, we need to set some padding manually
 		& > div.content div.stretch {
 			--dialog-padding-x: 12px;


### PR DESCRIPTION
# Motivation

On some display, text inside of modals with scrollable content can look blurry. Discovered on Mac OS

# Changes

Added a `border-radius: 0` to the content element solves it, even though its a slightly different problem than the one described below:

https://stackoverflow.com/questions/54667653/text-blur-after-scroll-bar-hide-with-webkit

# Tests

In the below screenshots in one of the affected display we can see that adding the `border-radius: 0` hack seems to work to solve the blurry text issue.

We can also observe that the scrollbar is not anymore cut off in the top right side because of the border radius change, which fits perfectly now.

Before:
![image](https://github.com/user-attachments/assets/782ed210-ce41-439f-b2b0-4c7517b131d5)

After:
![image](https://github.com/user-attachments/assets/ff6a9758-2cb1-42dd-8ecf-e3d107b7d81e)