### PR TITLE
chore(frontend): remove deprecated color class

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -26,6 +26,6 @@
 	{/each}
 
 	{#if nonNullish(altText) && rewards.length === 0}
-		<span class="text-misty-rose">{altText}</span>
+		<span>{altText}</span>
 	{/if}
 </div>


### PR DESCRIPTION
# Motivation

Color `misty-rose` does not exists anymore.
