### PR TITLE
feat(frontend): update shared Convert components

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmount.svelte
@@ -8,6 +8,7 @@
 	export let sendAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
 	export let totalFee: bigint | undefined;
+	export let destinationTokenFee: bigint | undefined = undefined;
 	export let minFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
 	export let insufficientFunds: boolean;
@@ -46,5 +47,11 @@
 		<IconMoveDown />
 	</div>
 
-	<ConvertAmountDestination bind:receiveAmount bind:exchangeValueUnit {sendAmount} {inputUnit} />
+	<ConvertAmountDestination
+		bind:receiveAmount
+		bind:exchangeValueUnit
+		{sendAmount}
+		{destinationTokenFee}
+		{inputUnit}
+	/>
 </div>

--- a/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
@@ -7,17 +7,27 @@
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
+	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
 
 	export let sendAmount: OptionAmount = undefined;
 	export let receiveAmount: number | undefined = undefined;
+	export let destinationTokenFee: bigint | undefined = undefined;
 	export let exchangeValueUnit: DisplayUnit = 'usd';
 	export let inputUnit: DisplayUnit = 'token';
 
 	const { destinationToken, destinationTokenBalance, destinationTokenExchangeRate } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
-	// receiveAmount will always be equal to sendAmount unless there are some fees on the receiver end (future case)
-	$: receiveAmount = nonNullish(sendAmount) ? Number(sendAmount) : undefined;
+	$: receiveAmount = nonNullish(sendAmount)
+		? nonNullish(destinationTokenFee)
+			? Number(sendAmount) -
+				formatTokenBigintToNumber({
+					value: destinationTokenFee,
+					displayDecimals: $destinationToken.decimals,
+					unitName: $destinationToken.decimals
+				})
+			: Number(sendAmount)
+		: undefined;
 </script>
 
 <TokenInput

--- a/src/frontend/src/lib/components/convert/ConvertForm.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertForm.svelte
@@ -11,6 +11,7 @@
 	export let sendAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
 	export let totalFee: bigint | undefined;
+	export let destinationTokenFee: bigint | undefined = undefined;
 	export let minFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
 	export let disabled: boolean;
@@ -38,12 +39,15 @@
 		bind:minterInfoNotCertified
 		bind:exchangeValueUnit
 		{totalFee}
+		{destinationTokenFee}
 		{minFee}
 		{ethereumEstimateFee}
 	/>
 
 	<div class="mt-6">
 		<slot name="message" />
+
+		<slot name="destination" />
 
 		<slot name="fee" />
 	</div>

--- a/src/frontend/src/lib/components/convert/ConvertReview.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertReview.svelte
@@ -30,6 +30,8 @@
 
 	<ConvertReviewNetworks />
 
+	<slot name="destination" />
+
 	<slot name="fee" />
 
 	<slot name="info-message" />

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountDestination.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountDestination.spec.ts
@@ -29,7 +29,7 @@ describe('ConvertAmountDestination', () => {
 
 	const balanceTestId = 'convert-amount-destination-balance';
 
-	it('should display values correctly', () => {
+	it('should display values correctly if destinationTokenFee is not provided', () => {
 		const { getByTestId } = render(ConvertAmountDestination, {
 			props,
 			context: mockContext
@@ -46,6 +46,18 @@ describe('ConvertAmountDestination', () => {
 		});
 
 		expect(component.$$.ctx[component.$$.props['receiveAmount']]).toBe(receiveAmount);
+	});
+
+	it('should calculate receiveAmount correctly if destinationTokenFee is provided', () => {
+		const { component } = render(ConvertAmountDestination, {
+			props: {
+				...props,
+				destinationTokenFee: 1000n
+			},
+			context: mockContext
+		});
+
+		expect(component.$$.ctx[component.$$.props['receiveAmount']]).toBe(19.99999);
 	});
 
 	it('should calculate receiveAmount correctly if sendAmount is not provided', () => {


### PR DESCRIPTION
# Motivation

This PR includes some small updates of the shared Convert components.

# Changes

1. Update `receiveAmount` calculation - it now should deduct the amount needed for destination token fees (e.g. in case of ckBTC -> BTC conversion).
2. Add `destination` address slot to ConvertForm and ConvertReview components.

# Tests

Existing tests updated.

<img width="551" alt="Screenshot 2025-03-17 at 10 25 55" src="https://github.com/user-attachments/assets/73525789-c658-496d-aa75-40f45c0a1e07" />
