### PR TITLE
refactor(frontend): generalize IcSendDestination component

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendDestination.svelte
+++ b/src/frontend/src/icp/components/send/IcSendDestination.svelte
@@ -1,35 +1,34 @@
 <script lang="ts">
 	import { debounce, isNullish } from '@dfinity/utils';
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { NetworkId } from '$lib/types/network';
+	import type { TokenStandard } from '$lib/types/token';
 	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 
 	export let destination = '';
 	export let networkId: NetworkId | undefined = undefined;
+	export let tokenStandard: TokenStandard;
 	export let invalidDestination = false;
 
 	const dispatch = createEventDispatcher();
-
-	const { sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let isInvalidDestination: () => boolean;
 
 	const init = () =>
 		(isInvalidDestination = (): boolean =>
-			isNullish($sendTokenStandard) ||
+			isNullish(tokenStandard) ||
 			isInvalidDestinationIc({
 				destination,
-				tokenStandard: $sendTokenStandard,
+				tokenStandard: tokenStandard,
 				networkId
 			}));
 
 	const debounceValidateInit = debounce(init);
 
-	$: destination, $sendTokenStandard, networkId, debounceValidateInit();
+	$: destination, tokenStandard, networkId, debounceValidateInit();
 
 	let inputPlaceholder: string;
 	$: inputPlaceholder = isNetworkIdEthereum(networkId)
@@ -46,4 +45,6 @@
 	{inputPlaceholder}
 	on:icQRCodeScan
 	onQRButtonClick={() => dispatch('icQRCodeScan')}
-/>
+>
+	<slot name="label" slot="label" />
+</SendInputDestination>

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -6,6 +6,7 @@
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
 	import type { IcAmountAssertionError } from '$icp/types/ic-send';
 	import SendForm from '$lib/components/send/SendForm.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { NetworkId } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
@@ -17,7 +18,7 @@
 	export let source: string;
 	export let simplifiedForm = false;
 
-	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendToken, sendBalance, sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let amountError: IcAmountAssertionError | undefined;
 	let invalidDestination: boolean;
@@ -42,7 +43,17 @@
 
 	<div slot="destination">
 		{#if !simplifiedForm}
-			<IcSendDestination bind:destination bind:invalidDestination {networkId} on:icQRCodeScan />
+			<IcSendDestination
+				tokenStandard={$sendTokenStandard}
+				bind:destination
+				bind:invalidDestination
+				{networkId}
+				on:icQRCodeScan
+			>
+				<label for="destination" slot="label" class="font-bold">
+					{$i18n.send.text.destination}]
+				</label>
+			</IcSendDestination>
 		{/if}
 	</div>
 

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -22,7 +22,8 @@
 	$: destination, networkId, isInvalidDestination, debounceValidate();
 </script>
 
-<label for="destination" class="font-bold">{$i18n.send.text.destination}</label>
+<slot name="label" />
+
 <div class="mb-4">
 	<InputTextWithAction
 		name="destination"


### PR DESCRIPTION
# Motivation

This PR includes a refactoring of the IcSendDestination component - this component should be reusable between send and convert flows.

# Changes
1. Switch from context usage to props.
2. Make label optional for now (it will be gone with the redesign of the send flow).
