### PR TITLE
feat(frontend): DestinationValue component

### DIFF
--- a/src/frontend/src/lib/components/address/DestinationValue.svelte
+++ b/src/frontend/src/lib/components/address/DestinationValue.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import IconAstronautHelmet from '$lib/components/icons/IconAstronautHelmet.svelte';
+	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { logoSizes } from '$lib/constants/components.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Token } from '$lib/types/token';
+	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+
+	export let token: Token;
+	export let destination = '';
+	export let isDestinationCustom = false;
+</script>
+
+<ModalValue>
+	<svelte:fragment slot="label">{$i18n.core.text.destination}</svelte:fragment>
+
+	<div class="flex items-center gap-2" slot="main-value">
+		{#if !isDestinationCustom}
+			<div
+				class="flex items-center justify-center"
+				style={`width: ${logoSizes['xxs']}; height: ${logoSizes['xxs']};`}
+			>
+				<IconAstronautHelmet />
+			</div>
+			<span>{$i18n.convert.text.default_destination}</span>
+		{:else}
+			<NetworkLogo network={token.network} blackAndWhite color="off-white" />
+			<span>{shortenWithMiddleEllipsis({ text: destination ?? '' })}</span>
+		{/if}
+
+		<slot />
+	</div>
+</ModalValue>


### PR DESCRIPTION
# Motivation

A small UI component for displaying either a label for default address or a custom address string. The "change" button can be optionally displayed via slots (the following PRs).

Default address:
<img width="537" alt="Screenshot 2025-03-18 at 00 11 57" src="https://github.com/user-attachments/assets/bdc21cc9-0a11-4aec-98b8-dd6271431748" />

Custom address:
<img width="520" alt="Screenshot 2025-03-18 at 00 12 05" src="https://github.com/user-attachments/assets/88120c89-2012-4690-8899-8946215fd907" />

