### PR TITLE
feat(frontend): map Solana program Token2022 as legacy Token program

### DIFF
--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -588,6 +588,158 @@ describe('sol-instructions.utils', () => {
 				});
 			});
 
+			it('should map a valid `closeAccount` instruction', async () => {
+				const mockCloseAccountInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'closeAccount',
+						info: {
+							destination: mockSolAddress2,
+							account: mockSolAddress
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockCloseAccountInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 0n,
+					from: mockSolAddress,
+					to: mockSolAddress2
+				});
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockCloseAccountInstruction,
+						network,
+						cumulativeBalances: { [mockSolAddress]: 100n }
+					})
+				).resolves.toEqual({
+					value: 100n,
+					from: mockSolAddress,
+					to: mockSolAddress2
+				});
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockCloseAccountInstruction,
+						network,
+						cumulativeBalances: { [mockSolAddress2]: 100n }
+					})
+				).resolves.toEqual({
+					value: 0n,
+					from: mockSolAddress,
+					to: mockSolAddress2
+				});
+			});
+
+			it('should map a valid `mintTo` instruction', async () => {
+				const mockMintToInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'mintTo',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							amount: '12345'
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockMintToInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockTokenAddress,
+					to: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
+			it('should map a valid `burn` instruction', async () => {
+				const mockBurnInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'burn',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							amount: '12345'
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockBurnInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockSolAddress,
+					to: mockTokenAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
+			it('should map a valid `mintToChecked` instruction', async () => {
+				const mockMintToCheckedInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'mintToChecked',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							tokenAmount: { amount: '12345' }
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockMintToCheckedInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockTokenAddress,
+					to: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
+			it('should map a valid `burnChecked` instruction', async () => {
+				const mockBurnCheckedInstruction: SolRpcInstruction = {
+					...mockTokenInstruction,
+					parsed: {
+						type: 'burnChecked',
+						info: {
+							account: mockSolAddress,
+							mint: mockTokenAddress,
+							tokenAmount: { amount: '12345' }
+						}
+					}
+				};
+
+				await expect(
+					mapSolParsedInstruction({
+						instruction: mockBurnCheckedInstruction,
+						network
+					})
+				).resolves.toEqual({
+					value: 12345n,
+					from: mockSolAddress,
+					to: mockTokenAddress,
+					tokenAddress: mockTokenAddress
+				});
+			});
+
 			it('should return undefined for non-mapped instruction', async () => {
 				const result = await mapSolParsedInstruction({
 					instruction: { ...mockTokenInstruction, parsed: { type: 'other-type', info: {} } },


### PR DESCRIPTION
# Motivation

Solana program [Token-2022](https://spl.solana.com/token-2022) is a superset of the functionality provided by the [Token Program](https://spl.solana.com/token).

So, it makes sense (according to PRODSEC's suggestion too) that we map the Token-2022 instructions exactly as the legacy Token program, at least for the ones that are in common.

This will even help with avoiding duplicated code.
