### PR TITLE
feat(frontend): IC convert forms update

### DIFF
--- a/src/frontend/src/icp/components/convert/IcConvertReview.svelte
+++ b/src/frontend/src/icp/components/convert/IcConvertReview.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import IcTokenFees from '$icp/components/fee/IcTokenFees.svelte';
+	import DestinationValue from '$lib/components/address/DestinationValue.svelte';
 	import ConvertReview from '$lib/components/convert/ConvertReview.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import type { OptionAmount } from '$lib/types/send';
 
 	export let sendAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
+	export let destination = '';
+	export let isDestinationCustom = false;
 
 	const { sourceToken, sourceTokenExchangeRate, destinationToken } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 </script>
 
 <ConvertReview on:icConvert on:icBack {sendAmount} {receiveAmount}>
+	<svelte:fragment slot="destination">
+		<DestinationValue token={$destinationToken} {destination} {isDestinationCustom} />
+	</svelte:fragment>
+
 	<IcTokenFees
 		sourceToken={$sourceToken}
 		sourceTokenExchangeRate={$sourceTokenExchangeRate}

--- a/src/frontend/src/icp/components/fee/IcTokenFees.svelte
+++ b/src/frontend/src/icp/components/fee/IcTokenFees.svelte
@@ -27,6 +27,7 @@
 	export let sourceToken: Token;
 	export let sourceTokenExchangeRate: number | undefined = undefined;
 	export let totalSourceTokenFee: bigint | undefined = undefined;
+	export let totalDestinationTokenFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
 
 	const { store: bitcoinStoreFeeData } = getContext<BitcoinFeeContext>(BITCOIN_FEE_CONTEXT_KEY);
@@ -63,6 +64,7 @@
 	$: bitcoinFeeExchangeRate = $exchanges?.[BTC_MAINNET_TOKEN_ID]?.usd;
 
 	$: totalSourceTokenFee = icTokenFee;
+	$: totalDestinationTokenFee = bitcoinEstimatedFee;
 </script>
 
 <FeeDisplay

--- a/src/frontend/src/lib/config/convert.config.ts
+++ b/src/frontend/src/lib/config/convert.config.ts
@@ -1,4 +1,4 @@
-import { WizardStepsConvert } from '$lib/enums/wizard-steps';
+import { WizardStepsConvert, WizardStepsSend } from '$lib/enums/wizard-steps';
 import type { WizardStepsParams } from '$lib/types/steps';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import type { WizardSteps } from '@dfinity/gix-components';
@@ -27,5 +27,13 @@ export const convertWizardSteps = ({
 	{
 		name: WizardStepsConvert.CONVERTING,
 		title: i18n.convert.text.executing_transaction
+	},
+	{
+		name: WizardStepsConvert.DESTINATION,
+		title: i18n.convert.text.conversion_destination
+	},
+	{
+		name: WizardStepsSend.QR_CODE_SCAN,
+		title: i18n.send.text.scan_qr
 	}
 ];

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -13,6 +13,8 @@ export enum WizardStepsSign {
 
 export enum WizardStepsConvert {
 	CONVERT = 'Convert',
+	DESTINATION = 'Destination Address',
+	QR_CODE_SCAN = 'QR Code Scan',
 	REVIEW = 'Review',
 	CONVERTING = 'Converting'
 }

--- a/src/frontend/src/tests/icp/components/convert/IcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/IcConvertTokenWizard.spec.ts
@@ -131,6 +131,44 @@ describe('IcConvertTokenWizard', () => {
 		);
 	});
 
+	it('should call send with custom destination if it is set', async () => {
+		const customDestination = 'customDestination';
+		mockAuthStore();
+		mockBtcAddressStore();
+		mockEthAddressStore();
+
+		const { container } = render(IcConvertTokenWizard, {
+			props: {
+				...props,
+				customDestination
+			},
+			context: mockContext()
+		});
+
+		await clickConvertButton(container);
+
+		const args = sendSpy.mock.calls[0][0];
+
+		expect(sendSpy).toHaveBeenCalledOnce();
+		expect(stringifyJson({ value: args })).toBe(
+			stringifyJson({
+				value: {
+					to: customDestination,
+					amount: parseToken({
+						value: `${sendAmount}`,
+						unitName: ckBtcToken.decimals
+					}),
+					identity: mockIdentity,
+					progress: () => {},
+					ckErc20ToErc20MaxCkEthFees: undefined,
+					token: ckBtcToken,
+					targetNetworkId: BTC_MAINNET_TOKEN.network.id,
+					sendCompleted: () => {}
+				}
+			})
+		);
+	});
+
 	it('should not call send if authIdentity is not defined', async () => {
 		mockBtcAddressStore();
 		mockEthAddressStore();


### PR DESCRIPTION
# Motivation

As the next step of the preparation for ckBTC -> BTC conversion, we need to update IC convert form components.

# Changes

1. Display destination address in both convert and review steps forms.
2. Pass `destinationTokenFee` to update `receiveAmount` accordingly.

<img width="551" alt="Screenshot 2025-03-17 at 10 25 55" src="https://github.com/user-attachments/assets/a0b896ea-cf62-4afe-a4af-5d0f88dcc14c" />
