### PR TITLE
test(frontend): do not reset console mock

### DIFF
--- a/src/frontend/src/tests/lib/services/address.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/address.services.spec.ts
@@ -32,7 +32,6 @@ describe('address.services', () => {
 	const mockIdentity = Ed25519KeyIdentity.generate();
 
 	beforeEach(() => {
-		vi.resetAllMocks();
 		vi.clearAllMocks();
 
 		authStore.setForTesting(mockIdentity);

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -35,7 +35,7 @@ describe('manage-tokens.services', () => {
 		};
 
 		beforeEach(() => {
-			vi.resetAllMocks();
+			vi.clearAllMocks();
 
 			vi.spyOn(toastsStore, 'toastsError');
 		});

--- a/src/frontend/src/tests/lib/utils/info.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/info.utils.spec.ts
@@ -5,7 +5,7 @@ describe('info.utils', () => {
 		const key = 'someKey' as HideInfoKey;
 
 		beforeEach(() => {
-			vi.resetAllMocks();
+			vi.clearAllMocks();
 
 			sessionStorage.clear();
 		});

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -31,7 +31,7 @@ vi.mock('@solana-program/token', () => ({
 	findAssociatedTokenPda: vi.fn()
 }));
 
-describe('sol-transactions.services', () => {
+describe('sol-signatures.services', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.resetAllMocks();

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -50,8 +50,6 @@ describe('sol-transactions.services', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.resetAllMocks();
-		vi.resetAllMocks();
 
 		solTransactionsStore.reset(SOLANA_TOKEN_ID);
 		spyGetTransactions = vi.spyOn(solSignaturesServices, 'getSolTransactions');

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -31,7 +31,6 @@ describe('sol-instructions.utils', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.resetAllMocks();
 	});
 
 	describe('mapSolParsedInstruction', () => {


### PR DESCRIPTION
# Motivation

We are mocking the console directly in the `vitest.setup` file. So, we need to avoid resetting it when we have tests that could raise a console log.
