### PR TITLE
fix(frontend): lint issue with self-closing tag

### DIFF
--- a/src/frontend/src/lib/components/address/DestinationWizardStepSection.svelte
+++ b/src/frontend/src/lib/components/address/DestinationWizardStepSection.svelte
@@ -10,7 +10,7 @@
 		class:bg-off-white={isActive}
 		class:border-primary-inverted={!isActive}
 		class:bg-primary={!isActive}
-	/>
+	></span>
 
 	{label}
 </button>


### PR DESCRIPTION
# Motivation

In Svelte v5, it is a lint issue if we have self-closing tags, like `<span ... />` for example:

```bash
/home/runner/work/oisy-wallet/oisy-wallet/src/frontend/src/lib/components/address/DestinationWizardStepSection.svelte
  7:2  error  Self-closing HTML tags for non-void elements are ambiguous — use `<span ...></span>` rather than `<span ... />`
https://svelte.dev/e/element_invalid_self_closing_tag(element_invalid_self_closing_tag)  svelte/valid-compile
```

See: https://github.com/dfinity/oisy-wallet/actions/runs/13922303045/job/38958179256?pr=3929


