### PR TITLE
fix(frontend): display correct balance on ckERC20 conversions

### DIFF
--- a/src/frontend/src/icp/components/convert/IcConvertForm.svelte
+++ b/src/frontend/src/icp/components/convert/IcConvertForm.svelte
@@ -16,6 +16,7 @@
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
+	import type { Token } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
@@ -68,16 +69,17 @@
 	let totalDestinationTokenFee: bigint | undefined;
 	let ethereumEstimateFee: bigint | undefined;
 
+	let tokenForFee: Token;
+	$: tokenForFee = isCkBtc ? $sourceToken : ($ethereumFeeTokenCkEth ?? $ckEthereumNativeToken);
+
 	let errorMessage: string | undefined;
 	$: errorMessage = insufficientFundsForFee
 		? replacePlaceholders($i18n.send.assertion.not_enough_tokens_for_gas, {
-				$symbol: isCkBtc
-					? $sourceToken.symbol
-					: ($ethereumFeeTokenCkEth ?? $ckEthereumNativeToken).symbol,
+				$symbol: tokenForFee.symbol,
 				$balance: formatToken({
 					value: $balanceForFee ?? ZERO,
-					unitName: $sourceToken.decimals,
-					displayDecimals: $sourceToken.decimals
+					unitName: tokenForFee.decimals,
+					displayDecimals: tokenForFee.decimals
 				})
 			})
 		: unknownMinimumAmount


### PR DESCRIPTION
# Motivation

This PR fixes a problem I just noticed on staging: the balance in the error message is calculated with incorrect decimals.

<img width="515" alt="Screenshot 2025-03-18 at 12 52 41" src="https://github.com/user-attachments/assets/2387d8ad-222f-4dbe-85a0-b021599bdaf9" />
