### PR TITLE
fix(frontend): Check icon fixes

### DIFF
--- a/src/frontend/src/lib/components/icons/IconCheck.svelte
+++ b/src/frontend/src/lib/components/icons/IconCheck.svelte
@@ -1,9 +1,13 @@
 <!-- source: DFINITY foundation -->
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<script lang="ts">
+	export let size = '32';
+</script>
+
+<svg width={size} height={size} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path
 		fill-rule="evenodd"
 		clip-rule="evenodd"
 		d="M27.6095 7.05727C28.1302 7.57797 28.1302 8.42219 27.6095 8.94289L12.9428 23.6096C12.4221 24.1303 11.5779 24.1303 11.0572 23.6096L4.39052 16.9429C3.86983 16.4222 3.86983 15.578 4.39052 15.0573C4.91122 14.5366 5.75544 14.5366 6.27614 15.0573L12 20.7811L25.7239 7.05727C26.2446 6.53657 27.0888 6.53657 27.6095 7.05727Z"
-		fill="white"
+		fill="currentColor"
 	/>
 </svg>

--- a/src/frontend/src/lib/components/signer/SignerAlert.svelte
+++ b/src/frontend/src/lib/components/signer/SignerAlert.svelte
@@ -11,7 +11,7 @@
 
 <div class="flex justify-center pb-5 pt-8">
 	<div
-		class="flex h-20 w-20 items-center justify-center rounded-full"
+		class="flex h-20 w-20 items-center justify-center rounded-full text-white"
 		class:bg-error-primary={alertType === 'error'}
 		class:bg-brand-primary={alertType === 'ok'}
 	>


### PR DESCRIPTION
# Motivation

In order to repurpose the check icon, we refactor it a bit to reuse it in upcoming PRs regarding the Settings page refactoring.

# Changes

- Changed fixed white color for check icon to `currentColor` so we can dynamically set color
- Added `text-white` to only current occurrence of the icon so the color doesn't change there
