### PR TITLE
refactor(frontend): rename Svelte type ComponentType to Component

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import Info from '$icp/components/info/Info.svelte';
@@ -37,7 +37,7 @@
 	let ckEthereum: boolean;
 	$: ckEthereum = $tokenCkEthLedger || $tokenCkErc20Ledger;
 
-	let additionalListener: ComponentType;
+	let additionalListener: Component;
 	$: additionalListener = $tokenCkBtcLedger
 		? IcTransactionsBtcListeners
 		: ckEthereum

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import ButtonAuthenticateWithLicense from '$lib/components/auth/ButtonAuthenticateWithLicense.svelte';
 	import IconScanFace from '$lib/components/icons/lucide/IconScanFace.svelte';
 	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
@@ -7,7 +7,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	let infoList: { label: string; icon: ComponentType }[];
+	let infoList: { label: string; icon: Component }[];
 	$: infoList = [
 		{
 			label: $i18n.auth.text.asset_types,

--- a/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import ReceiveAddressQRCode from '$lib/components/receive/ReceiveAddressQRCode.svelte';
 	import ReceiveTitle from '$lib/components/receive/ReceiveTitle.svelte';
 	import { RECEIVE_TOKENS_MODAL } from '$lib/constants/test-ids.constants';
@@ -9,7 +9,7 @@
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
 
-	export let infoCmp: ComponentType;
+	export let infoCmp: Component;
 
 	const steps: WizardSteps = [
 		{
@@ -53,8 +53,8 @@
 			<ReceiveTitle {addressToken} />
 		{:else}
 			{$i18n.receive.text.receive}
-		{/if}</svelte:fragment
-	>
+		{/if}
+	</svelte:fragment>
 
 	{#if currentStep?.name === steps[1].name && nonNullish(addressToken)}
 		<ReceiveAddressQRCode

--- a/src/frontend/src/lib/components/signer/SignerAlert.svelte
+++ b/src/frontend/src/lib/components/signer/SignerAlert.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import IconCheck from '$lib/components/icons/IconCheck.svelte';
 	import IconClose from '$lib/components/icons/IconClose.svelte';
 
 	export let alertType: 'ok' | 'error';
 
-	let icon: ComponentType;
+	let icon: Component;
 	$: icon = alertType === 'error' ? IconClose : IconCheck;
 </script>
 

--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -8,7 +8,7 @@
 		type PermissionsConfirmation
 	} from '@dfinity/oisy-wallet-signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { type ComponentType, getContext } from 'svelte';
+	import { type Component, getContext } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import IconAstronautHelmet from '$lib/components/icons/IconAstronautHelmet.svelte';
@@ -67,7 +67,7 @@
 
 	const onApprove = () => approvePermissions();
 
-	let listItems: Record<IcrcScopedMethod, { icon: ComponentType; label: string }>;
+	let listItems: Record<IcrcScopedMethod, { icon: Component; label: string }>;
 	$: listItems = {
 		icrc27_accounts: {
 			icon: IconWallet,

--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -8,7 +8,7 @@
 		type PermissionsConfirmation
 	} from '@dfinity/oisy-wallet-signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { type Component, getContext } from 'svelte';
+	import { type ComponentType as Component, getContext } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import IconAstronautHelmet from '$lib/components/icons/IconAstronautHelmet.svelte';
@@ -112,11 +112,11 @@
 
 				<div>
 					<label class="block text-sm font-bold" for="ic-wallet-address"
-						>{$i18n.signer.permissions.text.your_wallet_address}</label
+					>{$i18n.signer.permissions.text.your_wallet_address}</label
 					>
 
 					<output id="ic-wallet-address" class="break-all"
-						>{shortenWithMiddleEllipsis({ text: $icrcAccountIdentifierText ?? '' })}</output
+					>{shortenWithMiddleEllipsis({ text: $icrcAccountIdentifierText ?? '' })}</output
 					>
 				</div>
 			</div>

--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -112,11 +112,11 @@
 
 				<div>
 					<label class="block text-sm font-bold" for="ic-wallet-address"
-					>{$i18n.signer.permissions.text.your_wallet_address}</label
+						>{$i18n.signer.permissions.text.your_wallet_address}</label
 					>
 
 					<output id="ic-wallet-address" class="break-all"
-					>{shortenWithMiddleEllipsis({ text: $icrcAccountIdentifierText ?? '' })}</output
+						>{shortenWithMiddleEllipsis({ text: $icrcAccountIdentifierText ?? '' })}</output
 					>
 				</div>
 			</div>

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -12,7 +12,7 @@
 	export let badge:
 		| { type: 'network'; blackAndWhite?: boolean }
 		| { type: 'tokenCount'; count: number }
-		| { type: 'icon'; icon: ComponentType; ariaLabel: string }
+		| { type: 'icon'; icon: Component; ariaLabel: string }
 		| undefined = undefined;
 	export let logoSize: LogoSize = 'lg';
 	export let ring = false;

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { BigNumber } from '@ethersproject/bignumber';
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TransactionStatusComponent from '$lib/components/transactions/TransactionStatus.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
@@ -20,7 +20,7 @@
 	export let token: Token;
 	export let iconType: 'token' | 'transaction' = 'transaction';
 
-	let icon: ComponentType;
+	let icon: Component;
 	$: icon = mapTransactionIcon({ type, status });
 
 	let iconWithOpacity: boolean;

--- a/src/frontend/src/lib/components/ui/InProgress.svelte
+++ b/src/frontend/src/lib/components/ui/InProgress.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ProgressSteps as ProgressStepsCmp, type ProgressStep } from '@dfinity/gix-components';
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 	import StaticSteps from '$lib/components/ui/StaticSteps.svelte';
 	import type { ProgressSteps } from '$lib/types/progress-steps';
 	import type { StaticStep } from '$lib/types/steps';
@@ -9,7 +9,7 @@
 	export let steps: [ProgressStep | StaticStep, ...(ProgressStep | StaticStep)[]];
 	export let type: 'progress' | 'static' = 'progress';
 
-	let cmp: ComponentType;
+	let cmp: Component;
 	$: cmp = type === 'static' ? StaticSteps : ProgressStepsCmp;
 
 	let dynamicSteps: [ProgressStep | StaticStep, ...(ProgressStep | StaticStep)[]] = [...steps];

--- a/src/frontend/src/lib/components/ui/RoundedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/RoundedIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import type { ComponentType } from 'svelte';
+	import type { ComponentType as Component } from 'svelte';
 
-	export let icon: ComponentType;
+	export let icon: Component;
 	export let opacity = false;
 </script>
 

--- a/src/frontend/src/lib/types/listener.ts
+++ b/src/frontend/src/lib/types/listener.ts
@@ -1,5 +1,5 @@
 import type { Token } from '$lib/types/token';
-import type { ComponentType } from 'svelte';
+import type { ComponentType as Component } from 'svelte';
 
 export interface WalletWorker {
 	start: () => void;
@@ -11,7 +11,7 @@ export type InitWalletWorkerFn = (params: { token: Token }) => Promise<WalletWor
 
 export interface TokenToListener {
 	token: Token;
-	listener: ComponentType;
+	listener: Component;
 }
 
 export interface WebSocketListener {

--- a/src/frontend/src/lib/utils/transaction.utils.ts
+++ b/src/frontend/src/lib/utils/transaction.utils.ts
@@ -16,7 +16,7 @@ import type {
 } from '$lib/types/transaction';
 import { formatSecondsToNormalizedDate } from '$lib/utils/format.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { ComponentType } from 'svelte';
+import type { ComponentType as Component } from 'svelte';
 import { get } from 'svelte/store';
 
 export const mapTransactionIcon = ({
@@ -25,7 +25,7 @@ export const mapTransactionIcon = ({
 }: {
 	type: TransactionType;
 	status: TransactionStatus;
-}): ComponentType => {
+}): Component => {
 	const isConversionFrom = type === 'withdraw' || type === 'mint';
 
 	const isConversionTo = type === 'deposit' || type === 'burn' || type === 'approve';


### PR DESCRIPTION
# Motivation

Migrating to Svelte v5 will require to use `Component` instead of `ComponentType`. So, in preparation of it, we just rename the `ComponentType` imports to be `ComponentType as Component`.

