### PR TITLE
fix(frontend): format of the BTC fees

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDisplay.svelte
@@ -19,7 +19,7 @@
 	<svelte:fragment slot="main-value">
 		{#if nonNullish(amount)}
 			<div in:fade data-tid="convert-amount-display-value">
-				{nonNullish(amount) && amount === 0 && nonNullish(zeroAmountLabel)
+				{nonNullish(amount) && Number(amount) === 0 && nonNullish(zeroAmountLabel)
 					? zeroAmountLabel
 					: `${amount} ${symbol}`}
 			</div>

--- a/src/frontend/src/lib/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/lib/components/fee/FeeDisplay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import ConvertAmountDisplay from '$lib/components/convert/ConvertAmountDisplay.svelte';
-	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
+	import { formatTokenAmount } from '$lib/utils/format.utils';
 
 	export let feeAmount: bigint | undefined = undefined;
 	export let symbol: string;
@@ -10,13 +10,9 @@
 	export let displayExchangeRate = true;
 	export let zeroAmountLabel: string | undefined = undefined;
 
-	let formattedFeeAmount: number | undefined;
+	let formattedFeeAmount: string | undefined;
 	$: formattedFeeAmount = nonNullish(feeAmount)
-		? formatTokenBigintToNumber({
-				value: feeAmount,
-				unitName: decimals,
-				displayDecimals: decimals
-			})
+		? formatTokenAmount({ value: feeAmount, unitName: decimals, displayDecimals: decimals })
 		: undefined;
 </script>
 


### PR DESCRIPTION
# Motivation

This PR fixes the way of how a very low amounts (e.g. BTC fees) are displayed in the conversion flows. 

Before:
<img width="551" alt="Screenshot 2025-03-17 at 10 25 55" src="https://github.com/user-attachments/assets/b738f59f-62db-4d4f-b7f7-289b8f5c9713" />

After:
<img width="559" alt="Screenshot 2025-03-18 at 16 27 38" src="https://github.com/user-attachments/assets/f9642621-1c81-42f6-80fe-687908e37f9f" />
