### PR TITLE
refactor(frontend): extract specific type for ethers transaction

### DIFF
--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -5,6 +5,7 @@ import { isNetworkIdETH, isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/u
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
 import type { OptionToken } from '$lib/types/token';
+import type { EthersTransaction } from '$lib/types/transaction';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { BigNumber } from '@ethersproject/bignumber';
@@ -13,7 +14,7 @@ import { ethers } from 'ethers';
 import { get } from 'svelte/store';
 
 export type MapCkEthereumPendingTransactionParams = {
-	transaction: Transaction;
+	transaction: EthersTransaction;
 	token: IcToken;
 } & IcCkLinkedAssets;
 

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -11,12 +11,28 @@ import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
 import type { BigNumber } from '@ethersproject/bignumber';
 import type { FeeData } from '@ethersproject/providers';
-import type { Transaction as EthTransaction } from '@ethersproject/transactions';
+import { ethers } from 'ethers';
 import * as z from 'zod';
 
 export type TransactionId = z.infer<typeof TransactionIdSchema>;
 
-export type Transaction = Omit<EthTransaction, 'data'> &
+export type EthersTransaction = Pick<
+	ethers.Transaction,
+	| 'hash'
+	| 'to'
+	| 'from'
+	| 'nonce'
+	| 'gasLimit'
+	| 'gasPrice'
+	| 'data'
+	| 'value'
+	| 'chainId'
+	| 'type'
+	| 'maxPriorityFeePerGas'
+	| 'maxFeePerGas'
+>;
+
+export type Transaction = Omit<EthersTransaction, 'data'> &
 	Pick<TransactionResponse, 'blockNumber' | 'from' | 'to' | 'timestamp'> & {
 		pendingTimestamp?: number;
 		displayTimestamp?: number;


### PR DESCRIPTION
# Motivation

We want to migrate to `ethers` v6. However, the `Transaction` type changes quite a bit, so we first define exactly what type of interface we need from `ethers.Transaction`