### PR TITLE
test(frontend): convert balance input to string in BtcSendReview tests

### DIFF
--- a/src/frontend/src/tests/btc/components/send/BtcSendReview.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendReview.spec.ts
@@ -154,7 +154,7 @@ describe('BtcSendReview', () => {
 		const { getByTestId } = render(BtcSendReview, {
 			props: {
 				...props,
-				amount: defaultBalance
+				amount: defaultBalance.toString()
 			},
 			context: mockContext()
 		});


### PR DESCRIPTION
# Motivation

There is a small unsafe type in the tests for `BtcSendReview`.
