### PR TITLE
fix(frontend): fixes conversion info box typo

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -450,7 +450,7 @@
 			"convert_eth_to_cketh": "Convert $token to $ckToken",
 			"cketh_conversions_may_take": "ckETH conversions may take up to 20 minutes",
 			"ckerc20_conversions_may_take": "$ckErc20 conversions may take up to 20 minutes",
-			"how_to_convert_eth_to_cketh": "Here is how to can convert $token to $ckToken on $oisy_name",
+			"how_to_convert_eth_to_cketh": "Here is how you can convert $token to $ckToken on $oisy_name",
 			"send_eth": "Send $token to your $oisy_name address",
 			"wait_eth_current_balance": "Wait for $token to arrive. Current balance",
 			"set_amount": "Set amount for conversion",


### PR DESCRIPTION
# Motivation

There was a typo on the conversion info box.

# Changes

- resolves typo

# Tests

**before:**
<img width="433" alt="image" src="https://github.com/user-attachments/assets/f5b0d4c9-6212-4499-b911-8b8fb4c0d29c" />

**after:**
<img width="430" alt="image" src="https://github.com/user-attachments/assets/be633de0-b8b8-4d27-b558-4b2ce44e58dd" />
