### PR TITLE
fix(devops): Always run final jobs

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -44,6 +44,7 @@ jobs:
 
   may-merge:
     needs: ['lint', 'workspace-dependencies']
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cleared for merging

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -75,6 +75,7 @@ jobs:
 
   may-merge:
     needs: ['tests']
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cleared for merging

--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -118,6 +118,7 @@ jobs:
 
   binding-checks-pass:
     needs: ['generate']
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Cleared for merging

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -100,7 +100,6 @@ jobs:
   may-merge-e2e:
     if: always()
     needs: ['check-e2e-changes', 'e2e']
-    if: ${{ always() }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -100,6 +100,7 @@ jobs:
   may-merge-e2e:
     if: always()
     needs: ['check-e2e-changes', 'e2e']
+    if: ${{ always() }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
# Motivation
Many of our workflows have a final job that checks whether all the other jobs succeeded.  This makes it much easier to manage which workflows need to pass for a PR to merge, than if all the individual jobs need to be listed in the ruleset.

However I noticed that many of the workflows omit the `always()` conditional on this final job.  Omitting always will make that final step pointless: If a job dependency, listed in `needs`, is skipped or fails, the dependent job will be skipped, and a skipped job is considered as not applicable when considering a merge rule.

Having PRs mergeable when required jobs fail is of course a bug.

# Changes
- Add `always()` as a conditional for all the final steps.

# Tests
