### PR TITLE
fix(frontend): Text wrap and aligning settings card and list item

### DIFF
--- a/src/frontend/src/lib/components/settings/SettingsCardItem.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsCardItem.svelte
@@ -29,5 +29,5 @@
 </div>
 
 {#if infoExpanded}
-	<span class="w-100 mt-1 flex text-sm text-tertiary" transition:slide><slot name="info" /></span>
+	<span class="mt-1 flex w-full text-sm text-tertiary" transition:slide><slot name="info" /></span>
 {/if}

--- a/src/frontend/src/lib/components/settings/SettingsListItem.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsListItem.svelte
@@ -6,14 +6,14 @@
 
 <div class="border-b-1 flex w-full items-center border-brand-subtle-20 last-of-type:border-b-0">
 	{#if selectable}
-		<button class="w-100 flex flex-1 flex-row py-1.5" on:click>
+		<button class="flex w-full flex-1 flex-row py-1.5" on:click>
 			<span class="grow-1 flex flex-row"><slot name="key" /></span>
 			<span class="flex grow-0 pt-0.5 text-brand-primary">
 				{#if selected}<IconCheck size="20" />{/if}
 			</span>
 		</button>
 	{:else}
-		<div class="w-100 flex flex-1 flex-row py-0.5">
+		<div class="flex w-full flex-1 flex-row py-0.5">
 			<span class="flex w-full flex-row pt-1"><slot name="key" /></span>
 			<span class="pt-1"><slot name="value" /></span>
 		</div>

--- a/src/frontend/src/lib/components/settings/SettingsListItem.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsListItem.svelte
@@ -6,14 +6,14 @@
 
 <div class="border-b-1 flex w-full items-center border-brand-subtle-20 last-of-type:border-b-0">
 	{#if selectable}
-		<button class="flex w-full flex-1 flex-row py-1.5" on:click>
+		<button class="flex w-full flex-1 flex-row py-1.5 text-left" on:click>
 			<span class="grow-1 flex flex-row"><slot name="key" /></span>
 			<span class="flex grow-0 pt-0.5 text-brand-primary">
 				{#if selected}<IconCheck size="20" />{/if}
 			</span>
 		</button>
 	{:else}
-		<div class="flex w-full flex-1 flex-row py-0.5">
+		<div class="flex w-full flex-1 flex-row py-0.5 text-left">
 			<span class="flex w-full flex-row pt-1"><slot name="key" /></span>
 			<span class="pt-1"><slot name="value" /></span>
 		</div>


### PR DESCRIPTION
# Motivation

Wrong classes were used for w-full and the text didnt break correctly. Also, in the list items the text was centered if the text fills the full width.

# Changes

- Changed all w-100 to w-full
- Added text-left to force aligning to left

# Tests
Before
![image](https://github.com/user-attachments/assets/e16e0550-319e-4768-8885-1ae568fac69b)

After
![image](https://github.com/user-attachments/assets/6ce1f0ed-60b4-4ad8-9d72-f78d8da4a82b)


Before
![image](https://github.com/user-attachments/assets/43d4588a-b5a7-44d1-95da-1d9235a5da64)

After
![image](https://github.com/user-attachments/assets/731eddb4-b71e-4364-b690-24584d8e92df)
