### PR TITLE
chore(frontend): Cleanup ETH network envs

### DIFF
--- a/src/frontend/src/env/eip155-chains.env.ts
+++ b/src/frontend/src/env/eip155-chains.env.ts
@@ -3,7 +3,7 @@ import {
 	ETHEREUM_NETWORK_CHAIN_ID,
 	SEPOLIA_NETWORK,
 	SEPOLIA_NETWORK_CHAIN_ID
-} from '$env/networks/networks.env';
+} from '$env/networks/networks.eth.env';
 
 export const EIP155_CHAINS: Record<string, { chainId: number; name: string }> = {
 	[`eip155:${ETHEREUM_NETWORK_CHAIN_ID}`]: {

--- a/src/frontend/src/env/networks/networks.env.ts
+++ b/src/frontend/src/env/networks/networks.env.ts
@@ -2,77 +2,16 @@ import type { BitcoinNetwork } from '$btc/types/network';
 import {
 	BTC_MAINNET_EXPLORER_URL,
 	BTC_REGTEST_EXPLORER_URL,
-	BTC_TESTNET_EXPLORER_URL,
-	ETHEREUM_EXPLORER_URL,
-	SEPOLIA_EXPLORER_URL
+	BTC_TESTNET_EXPLORER_URL
 } from '$env/explorers.env';
-import { ETH_MAINNET_ENABLED } from '$env/networks/networks.eth.env';
-import sepolia from '$eth/assets/sepolia.svg';
-import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
-import eth from '$icp-eth/assets/eth.svg';
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import icpLight from '$icp/assets/icp_light.svg';
 import bitcoinMainnetBW from '$lib/assets/networks/bitcoin-mainnet-bw.svg';
 import bitcoinTestnetBW from '$lib/assets/networks/bitcoin-testnet-bw.svg';
-import ethereumBW from '$lib/assets/networks/ethereum-bw.svg';
 import icpBW from '$lib/assets/networks/icp-bw.svg';
-import sepoliaBW from '$lib/assets/networks/sepolia-bw.svg';
 import type { Network, NetworkId } from '$lib/types/network';
 import { parseNetworkId } from '$lib/validation/network.validation';
-
-/**
- * Ethereum
- */
-export const ETHEREUM_NETWORK_SYMBOL = 'ETH';
-
-export const ETHEREUM_NETWORK_ID: NetworkId = parseNetworkId(ETHEREUM_NETWORK_SYMBOL);
-
-export const ETHEREUM_NETWORK: EthereumNetwork = {
-	id: ETHEREUM_NETWORK_ID,
-	env: 'mainnet',
-	name: 'Ethereum',
-	chainId: 1n,
-	icon: eth,
-	iconBW: ethereumBW,
-	explorerUrl: ETHEREUM_EXPLORER_URL,
-	buy: { onramperId: 'ethereum' }
-};
-
-export const { chainId: ETHEREUM_NETWORK_CHAIN_ID } = ETHEREUM_NETWORK;
-
-export const SEPOLIA_NETWORK_SYMBOL = 'SepoliaETH';
-
-export const SEPOLIA_NETWORK_ID: NetworkId = parseNetworkId(SEPOLIA_NETWORK_SYMBOL);
-
-export const SEPOLIA_NETWORK: EthereumNetwork = {
-	id: SEPOLIA_NETWORK_ID,
-	env: 'testnet',
-	name: 'Sepolia',
-	chainId: 11155111n,
-	icon: sepolia,
-	iconBW: sepoliaBW,
-	explorerUrl: SEPOLIA_EXPLORER_URL
-};
-
-export const { chainId: SEPOLIA_NETWORK_CHAIN_ID } = SEPOLIA_NETWORK;
-
-/**
- * Some functions, such as when we load the user's custom tokens, require knowing all the networks.
- * However, from a UX perspective, we use a store to enable the list of networks based on the testnets flag.
- * That's why those constants are prefixed with SUPPORTED_.
- */
-export const SUPPORTED_ETHEREUM_NETWORKS: [...EthereumNetwork[], EthereumNetwork] = [
-	...(ETH_MAINNET_ENABLED ? [ETHEREUM_NETWORK] : []),
-	SEPOLIA_NETWORK
-];
-
-export const SUPPORTED_ETHEREUM_NETWORKS_IDS: NetworkId[] = SUPPORTED_ETHEREUM_NETWORKS.map(
-	({ id }) => id
-);
-
-export const SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS: EthereumChainId[] =
-	SUPPORTED_ETHEREUM_NETWORKS.map(({ chainId }) => chainId);
 
 /**
  * ICP

--- a/src/frontend/src/env/networks/networks.eth.env.ts
+++ b/src/frontend/src/env/networks/networks.eth.env.ts
@@ -1,3 +1,11 @@
+import { ETHEREUM_EXPLORER_URL, SEPOLIA_EXPLORER_URL } from '$env/explorers.env';
+import sepolia from '$eth/assets/sepolia.svg';
+import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
+import eth from '$icp-eth/assets/eth.svg';
+import ethereumBW from '$lib/assets/networks/ethereum-bw.svg';
+import sepoliaBW from '$lib/assets/networks/sepolia-bw.svg';
+import type { NetworkId } from '$lib/types/network';
+import { parseNetworkId } from '$lib/validation/network.validation';
 import type { Networkish } from '@ethersproject/networks';
 import { Network } from 'alchemy-sdk';
 
@@ -18,3 +26,56 @@ export const ALCHEMY_JSON_RPC_URL_SEPOLIA = 'https://eth-sepolia.g.alchemy.com/v
 
 export const ALCHEMY_NETWORK_MAINNET: Network = Network.ETH_MAINNET;
 export const ALCHEMY_NETWORK_SEPOLIA: Network = Network.ETH_SEPOLIA;
+
+/**
+ * Ethereum
+ */
+export const ETHEREUM_NETWORK_SYMBOL = 'ETH';
+
+export const ETHEREUM_NETWORK_ID: NetworkId = parseNetworkId(ETHEREUM_NETWORK_SYMBOL);
+
+export const ETHEREUM_NETWORK: EthereumNetwork = {
+	id: ETHEREUM_NETWORK_ID,
+	env: 'mainnet',
+	name: 'Ethereum',
+	chainId: 1n,
+	icon: eth,
+	iconBW: ethereumBW,
+	explorerUrl: ETHEREUM_EXPLORER_URL,
+	buy: { onramperId: 'ethereum' }
+};
+
+export const { chainId: ETHEREUM_NETWORK_CHAIN_ID } = ETHEREUM_NETWORK;
+
+export const SEPOLIA_NETWORK_SYMBOL = 'SepoliaETH';
+
+export const SEPOLIA_NETWORK_ID: NetworkId = parseNetworkId(SEPOLIA_NETWORK_SYMBOL);
+
+export const SEPOLIA_NETWORK: EthereumNetwork = {
+	id: SEPOLIA_NETWORK_ID,
+	env: 'testnet',
+	name: 'Sepolia',
+	chainId: 11155111n,
+	icon: sepolia,
+	iconBW: sepoliaBW,
+	explorerUrl: SEPOLIA_EXPLORER_URL
+};
+
+export const { chainId: SEPOLIA_NETWORK_CHAIN_ID } = SEPOLIA_NETWORK;
+
+/**
+ * Some functions, such as when we load the user's custom tokens, require knowing all the networks.
+ * However, from a UX perspective, we use a store to enable the list of networks based on the testnets flag.
+ * That's why those constants are prefixed with SUPPORTED_.
+ */
+export const SUPPORTED_ETHEREUM_NETWORKS: [...EthereumNetwork[], EthereumNetwork] = [
+	...(ETH_MAINNET_ENABLED ? [ETHEREUM_NETWORK] : []),
+	SEPOLIA_NETWORK
+];
+
+export const SUPPORTED_ETHEREUM_NETWORKS_IDS: NetworkId[] = SUPPORTED_ETHEREUM_NETWORKS.map(
+	({ id }) => id
+);
+
+export const SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS: EthereumChainId[] =
+	SUPPORTED_ETHEREUM_NETWORKS.map(({ chainId }) => chainId);

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.eurc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.eurc.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import eurc from '$eth/assets/eurc.svg';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.link.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.link.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import link from '$icp-eth/assets/link.svg';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.oct.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.oct.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import oct from '$icp-eth/assets/oct.svg';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.pepe.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.pepe.env.ts
@@ -1,8 +1,8 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import pepe from '$icp-eth/assets/pepe.svg';
 import type { TokenId } from '$lib/types/token';
 
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import { parseTokenId } from '$lib/validation/token.validation';
 
 export const PEPE_DECIMALS = 18;

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.shib.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.shib.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import shib from '$icp-eth/assets/shib.svg';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.uni.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.uni.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import uni from '$icp-eth/assets/uni.svg';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.usdc.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import usdc from '$eth/assets/usdc.svg';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.usdt.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import usdt from '$eth/assets/usdt.svg';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.wbtc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.wbtc.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import wbtc from '$icp-eth/assets/wbtc.svg';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.wsteth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.wsteth.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import wsteth from '$icp-eth/assets/wsteth.svg';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import xaut from '$eth/assets/xaut.svg';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import type { TokenId } from '$lib/types/token';

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -1,5 +1,8 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
-import { ETH_MAINNET_ENABLED } from '$env/networks/networks.eth.env';
+import {
+	ETH_MAINNET_ENABLED,
+	ETHEREUM_NETWORK,
+	SEPOLIA_NETWORK
+} from '$env/networks/networks.eth.env';
 import { EURC_TOKEN, SEPOLIA_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';

--- a/src/frontend/src/env/tokens/tokens.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens.eth.env.ts
@@ -1,5 +1,8 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
-import { ETH_MAINNET_ENABLED } from '$env/networks/networks.eth.env';
+import {
+	ETH_MAINNET_ENABLED,
+	ETHEREUM_NETWORK,
+	SEPOLIA_NETWORK
+} from '$env/networks/networks.eth.env';
 import eth from '$icp-eth/assets/eth.svg';
 import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';

--- a/src/frontend/src/eth/components/send/SendNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendNetwork.svelte
@@ -2,7 +2,7 @@
 	import { Dropdown, DropdownItem } from '@dfinity/gix-components';
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { ETHEREUM_NETWORK, ICP_NETWORK } from '$env/networks/networks.env';
+	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import { isDestinationContractAddress } from '$eth/utils/send.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { toCkEthHelperContractAddress } from '$icp-eth/utils/cketh.utils';
@@ -10,6 +10,7 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network } from '$lib/types/network';
 	import { isEthAddress, isIcpAccountIdentifier } from '$lib/utils/account.utils';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	export let network: Network | undefined = undefined;
 	export let destination: string | undefined = undefined;

--- a/src/frontend/src/eth/components/send/SendNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendNetwork.svelte
@@ -3,6 +3,7 @@
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { ICP_NETWORK } from '$env/networks/networks.env';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import { isDestinationContractAddress } from '$eth/utils/send.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { toCkEthHelperContractAddress } from '$icp-eth/utils/cketh.utils';
@@ -10,7 +11,6 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network } from '$lib/types/network';
 	import { isEthAddress, isIcpAccountIdentifier } from '$lib/utils/account.utils';
-	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	export let network: Network | undefined = undefined;
 	export let destination: string | undefined = undefined;

--- a/src/frontend/src/eth/derived/networks.derived.ts
+++ b/src/frontend/src/eth/derived/networks.derived.ts
@@ -1,5 +1,8 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
-import { ETH_MAINNET_ENABLED } from '$env/networks/networks.eth.env';
+import {
+	ETH_MAINNET_ENABLED,
+	ETHEREUM_NETWORK,
+	SEPOLIA_NETWORK
+} from '$env/networks/networks.eth.env';
 import type { EthereumNetwork } from '$eth/types/network';
 import { testnets } from '$lib/derived/testnets.derived';
 import type { NetworkId } from '$lib/types/network';

--- a/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
@@ -1,7 +1,8 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
 import {
 	ALCHEMY_JSON_RPC_URL_MAINNET,
-	ALCHEMY_JSON_RPC_URL_SEPOLIA
+	ALCHEMY_JSON_RPC_URL_SEPOLIA,
+	ETHEREUM_NETWORK_ID,
+	SEPOLIA_NETWORK_ID
 } from '$env/networks/networks.eth.env';
 import { ALCHEMY_API_KEY } from '$env/rest/alchemy.env';
 import { ERC20_ABI } from '$eth/constants/erc20.constants';

--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -1,5 +1,9 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
-import { ALCHEMY_NETWORK_MAINNET, ALCHEMY_NETWORK_SEPOLIA } from '$env/networks/networks.eth.env';
+import {
+	ALCHEMY_NETWORK_MAINNET,
+	ALCHEMY_NETWORK_SEPOLIA,
+	ETHEREUM_NETWORK_ID,
+	SEPOLIA_NETWORK_ID
+} from '$env/networks/networks.eth.env';
 import { ALCHEMY_API_KEY } from '$env/rest/alchemy.env';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';

--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -1,7 +1,8 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
 import {
+	ETHEREUM_NETWORK_ID,
 	ETHERSCAN_NETWORK_HOMESTEAD,
-	ETHERSCAN_NETWORK_SEPOLIA
+	ETHERSCAN_NETWORK_SEPOLIA,
+	SEPOLIA_NETWORK_ID
 } from '$env/networks/networks.eth.env';
 import { ETHERSCAN_API_KEY } from '$env/rest/etherscan.env';
 import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/eth/providers/infura-ckerc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-ckerc20.providers.ts
@@ -1,5 +1,9 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
-import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks/networks.eth.env';
+import {
+	ETHEREUM_NETWORK_ID,
+	INFURA_NETWORK_HOMESTEAD,
+	INFURA_NETWORK_SEPOLIA,
+	SEPOLIA_NETWORK_ID
+} from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { CKERC20_ABI } from '$eth/constants/ckerc20.constants';
 import type { Erc20ContractAddress } from '$eth/types/erc20';

--- a/src/frontend/src/eth/providers/infura-cketh.providers.ts
+++ b/src/frontend/src/eth/providers/infura-cketh.providers.ts
@@ -1,5 +1,9 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
-import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks/networks.eth.env';
+import {
+	ETHEREUM_NETWORK_ID,
+	INFURA_NETWORK_HOMESTEAD,
+	INFURA_NETWORK_SEPOLIA,
+	SEPOLIA_NETWORK_ID
+} from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { CKETH_ABI } from '$eth/constants/cketh.constants';
 import type { ContractAddress } from '$eth/types/address';

--- a/src/frontend/src/eth/providers/infura-erc20-icp.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20-icp.providers.ts
@@ -1,5 +1,9 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
-import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks/networks.eth.env';
+import {
+	ETHEREUM_NETWORK_ID,
+	INFURA_NETWORK_HOMESTEAD,
+	INFURA_NETWORK_SEPOLIA,
+	SEPOLIA_NETWORK_ID
+} from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { ERC20_ICP_ABI } from '$eth/constants/erc20-icp.constants';
 import type { Erc20Provider, PopulateTransactionParams } from '$eth/types/contracts-providers';

--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -1,5 +1,9 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
-import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks/networks.eth.env';
+import {
+	ETHEREUM_NETWORK_ID,
+	INFURA_NETWORK_HOMESTEAD,
+	INFURA_NETWORK_SEPOLIA,
+	SEPOLIA_NETWORK_ID
+} from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { ERC20_ABI } from '$eth/constants/erc20.constants';
 import type { Erc20Provider } from '$eth/types/contracts-providers';

--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -1,5 +1,9 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
-import { INFURA_NETWORK_HOMESTEAD, INFURA_NETWORK_SEPOLIA } from '$env/networks/networks.eth.env';
+import {
+	ETHEREUM_NETWORK_ID,
+	INFURA_NETWORK_HOMESTEAD,
+	INFURA_NETWORK_SEPOLIA,
+	SEPOLIA_NETWORK_ID
+} from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';

--- a/src/frontend/src/eth/rest/etherscan.rest.ts
+++ b/src/frontend/src/eth/rest/etherscan.rest.ts
@@ -1,7 +1,8 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
 import {
+	ETHEREUM_NETWORK_ID,
 	ETHERSCAN_API_URL_HOMESTEAD,
-	ETHERSCAN_API_URL_SEPOLIA
+	ETHERSCAN_API_URL_SEPOLIA,
+	SEPOLIA_NETWORK_ID
 } from '$env/networks/networks.eth.env';
 import { ETHERSCAN_API_KEY } from '$env/rest/etherscan.env';
 import type { Erc20Token } from '$eth/types/erc20';

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -2,7 +2,7 @@ import type { UserToken } from '$declarations/backend/backend.did';
 import {
 	SUPPORTED_ETHEREUM_NETWORKS,
 	SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS
-} from '$env/networks/networks.env';
+} from '$env/networks/networks.eth.env';
 import { ERC20_CONTRACTS, ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';

--- a/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
+++ b/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { WizardStep, WizardSteps } from '@dfinity/gix-components';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
 	import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
@@ -13,7 +14,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
-	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	export let destination = '';
 	export let targetNetwork: Network | undefined = undefined;

--- a/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
+++ b/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { WizardStep, WizardSteps } from '@dfinity/gix-components';
-	import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
 	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
 	import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
@@ -14,6 +13,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	export let destination = '';
 	export let targetNetwork: Network | undefined = undefined;

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
-	import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
 	import { tokenCkErc20Ledger } from '$icp/derived/ic-token.derived';
 	import {
 		ckEthereumNativeToken,
@@ -21,6 +20,7 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	export let formCancelAction: 'back' | 'close' = 'back';
 

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import { tokenCkErc20Ledger } from '$icp/derived/ic-token.derived';
 	import {
 		ckEthereumNativeToken,
@@ -20,7 +21,6 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	export let formCancelAction: 'back' | 'close' = 'back';
 

--- a/src/frontend/src/icp/stores/receive-token.store.ts
+++ b/src/frontend/src/icp/stores/receive-token.store.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { IcCkToken, IcToken } from '$icp/types/ic-token';

--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import {
 	CKBTC_LEDGER_CANISTER_IDS,
 	CKERC20_LEDGER_CANISTER_IDS,

--- a/src/frontend/src/lib/api/idb.api.ts
+++ b/src/frontend/src/lib/api/idb.api.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
 import {
 	SOLANA_DEVNET_NETWORK_SYMBOL,
 	SOLANA_LOCAL_NETWORK_SYMBOL,

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import { Spinner } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import {
-		BTC_MAINNET_NETWORK_ID,
-		ETHEREUM_NETWORK_ID,
-		ICP_NETWORK_ID
-	} from '$env/networks/networks.env';
+	import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
 	import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
@@ -20,6 +16,7 @@
 	import { token } from '$lib/stores/token.store';
 	import type { OnramperId, OnramperNetworkId, OnramperNetworkWallet } from '$lib/types/onramper';
 	import { buildOnramperLink, mapOnramperNetworkWallets } from '$lib/utils/onramper.utils';
+	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 
 	let defaultCrypto: OnramperId | undefined;
 	$: defaultCrypto =

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -2,6 +2,7 @@
 	import { Spinner } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
+	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 	import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
@@ -16,7 +17,6 @@
 	import { token } from '$lib/stores/token.store';
 	import type { OnramperId, OnramperNetworkId, OnramperNetworkWallet } from '$lib/types/onramper';
 	import { buildOnramperLink, mapOnramperNetworkWallets } from '$lib/utils/onramper.utils';
-	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 
 	let defaultCrypto: OnramperId | undefined;
 	$: defaultCrypto =

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -7,6 +7,7 @@
 		BTC_TESTNET_NETWORK,
 		ICP_NETWORK
 	} from '$env/networks/networks.env';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import {
 		SOLANA_MAINNET_NETWORK,
 		SOLANA_TESTNET_NETWORK,
@@ -62,7 +63,6 @@
 	import type { Network } from '$lib/types/network';
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
-	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -5,7 +5,6 @@
 		BTC_MAINNET_NETWORK,
 		BTC_REGTEST_NETWORK,
 		BTC_TESTNET_NETWORK,
-		ETHEREUM_NETWORK,
 		ICP_NETWORK
 	} from '$env/networks/networks.env';
 	import {
@@ -63,6 +62,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/constants/networks.constants.ts
+++ b/src/frontend/src/lib/constants/networks.constants.ts
@@ -1,3 +1,3 @@
-import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.env';
+import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 
 export const [DEFAULT_ETHEREUM_NETWORK] = SUPPORTED_ETHEREUM_NETWORKS;

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -4,10 +4,12 @@ import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID,
-	ICP_NETWORK_ID,
+	ICP_NETWORK_ID
+} from '$env/networks/networks.env';
+import {
 	SEPOLIA_NETWORK_ID,
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
-} from '$env/networks/networks.env';
+} from '$env/networks/networks.eth.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,

--- a/src/frontend/src/tests/btc/services/btc-pending-sent-transactions.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-pending-sent-transactions.services.spec.ts
@@ -1,7 +1,8 @@
 import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import type { PendingTransaction } from '$declarations/backend/backend.did';
-import { BTC_MAINNET_NETWORK_ID, ETHEREUM_NETWORK_ID } from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import * as backendAPI from '$lib/api/backend.api';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { get } from 'svelte/store';

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -1,4 +1,4 @@
-import { SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
+import { SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SEPOLIA_TOKEN, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';

--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -1,5 +1,5 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
+import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
 import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';

--- a/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthSendForm from '$eth/components/send/EthSendForm.svelte';
 import { FEE_CONTEXT_KEY, initFeeContext, initFeeStore } from '$eth/stores/fee.store';

--- a/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
@@ -1,9 +1,9 @@
+import { ICP_NETWORK_ID } from '$env/networks/networks.env';
 import {
 	ETHEREUM_NETWORK_ID,
-	ICP_NETWORK_ID,
+	ETHERSCAN_NETWORK_HOMESTEAD,
 	SEPOLIA_NETWORK_ID
-} from '$env/networks/networks.env';
-import { ETHERSCAN_NETWORK_HOMESTEAD } from '$env/networks/networks.eth.env';
+} from '$env/networks/networks.eth.env';
 import { EtherscanProvider, etherscanProviders } from '$eth/providers/etherscan.providers';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';

--- a/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
+++ b/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
@@ -1,9 +1,9 @@
+import { ICP_NETWORK_ID } from '$env/networks/networks.env';
 import {
 	ETHEREUM_NETWORK_ID,
-	ICP_NETWORK_ID,
+	ETHERSCAN_API_URL_HOMESTEAD,
 	SEPOLIA_NETWORK_ID
-} from '$env/networks/networks.env';
-import { ETHERSCAN_API_URL_HOMESTEAD } from '$env/networks/networks.eth.env';
+} from '$env/networks/networks.eth.env';
 import { EtherscanRest, etherscanRests } from '$eth/rest/etherscan.rest';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import type { Erc20Token } from '$eth/types/erc20';

--- a/src/frontend/src/tests/icp/components/send/IcSendForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendForm.spec.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import IcSendForm from '$icp/components/send/IcSendForm.svelte';
 import { BITCOIN_FEE_CONTEXT_KEY, initBitcoinFeeStore } from '$icp/stores/bitcoin-fee.store';

--- a/src/frontend/src/tests/icp/schema/ic-token.schema.spec.ts
+++ b/src/frontend/src/tests/icp/schema/ic-token.schema.spec.ts
@@ -1,4 +1,4 @@
-import { SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import {
 	IC_CKBTC_INDEX_CANISTER_ID,
 	IC_CKBTC_LEDGER_CANISTER_ID,

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -1,6 +1,5 @@
 import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 import * as btcEnv from '$env/networks/networks.btc.env';
-import * as networkEnv from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { BTC_MAINNET_TOKEN_ID } from '$env/tokens/tokens.btc.env';
@@ -25,7 +24,7 @@ describe('AllTransactionsList', () => {
 		vi.spyOn(btcEnv, 'BTC_MAINNET_ENABLED', 'get').mockImplementation(() => true);
 		vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => true);
 
-		vi.spyOn(networkEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(() => [
+		vi.spyOn(ethEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(() => [
 			ETHEREUM_NETWORK_ID,
 			SEPOLIA_NETWORK_ID
 		]);

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -1,8 +1,8 @@
 import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 import * as btcEnv from '$env/networks/networks.btc.env';
 import * as networkEnv from '$env/networks/networks.env';
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
+import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { BTC_MAINNET_TOKEN_ID } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';

--- a/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
@@ -1,11 +1,7 @@
 import * as btcEnv from '$env/networks/networks.btc.env';
-import {
-	BTC_MAINNET_NETWORK,
-	ETHEREUM_NETWORK,
-	ICP_NETWORK,
-	SEPOLIA_NETWORK
-} from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK, ICP_NETWORK } from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import {
 	SOLANA_DEVNET_NETWORK,
 	SOLANA_MAINNET_NETWORK,

--- a/src/frontend/src/tests/lib/schema/token.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/token.schema.spec.ts
@@ -1,4 +1,4 @@
-import { SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import {
 	TokenAppearanceSchema,
 	TokenBuyableSchema,

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -6,8 +6,8 @@ import type {
 	UserSnapshot
 } from '$declarations/rewards/rewards.did';
 import * as networkEnv from '$env/networks/networks.env';
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
+import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
 import * as airdropEnv from '$env/reward-campaigns.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -5,7 +5,6 @@ import type {
 	Transaction_Spl,
 	UserSnapshot
 } from '$declarations/rewards/rewards.did';
-import * as networkEnv from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
@@ -203,7 +202,7 @@ describe('user-snapshot.services', () => {
 			);
 			// TODO: this is a temporary hack to release v1. Adjust as soon as the rewards canister has more tokens.
 			vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-			vi.spyOn(networkEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(() => [
+			vi.spyOn(ethEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(() => [
 				ETHEREUM_NETWORK_ID,
 				SEPOLIA_NETWORK_ID
 			]);

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -1,5 +1,6 @@
 import * as appNavigation from '$app/navigation';
-import { ETHEREUM_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import {
 	AppPath,
 	NETWORK_PARAM,

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -5,13 +5,15 @@ import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID,
+	ICP_NETWORK,
+	ICP_NETWORK_ID
+} from '$env/networks/networks.env';
+import {
 	ETHEREUM_NETWORK,
 	ETHEREUM_NETWORK_ID,
-	ICP_NETWORK,
-	ICP_NETWORK_ID,
 	SEPOLIA_NETWORK,
 	SEPOLIA_NETWORK_ID
-} from '$env/networks/networks.env';
+} from '$env/networks/networks.eth.env';
 import { CKBTC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
 import {
 	SOLANA_DEVNET_NETWORK,

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -1,5 +1,4 @@
 import * as btcNetworkEnv from '$env/networks/networks.btc.env';
-import * as networkEnv from '$env/networks/networks.env';
 import {
 	BTC_MAINNET_NETWORK,
 	BTC_MAINNET_NETWORK_ID,
@@ -8,6 +7,7 @@ import {
 	ICP_NETWORK,
 	ICP_NETWORK_ID
 } from '$env/networks/networks.env';
+import * as ethEnv from '$env/networks/networks.eth.env';
 import {
 	ETHEREUM_NETWORK,
 	ETHEREUM_NETWORK_ID,
@@ -88,7 +88,7 @@ describe('network utils', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();
 
-			vi.spyOn(networkEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(
+			vi.spyOn(ethEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(
 				() => allEthereumNetworkIds
 			);
 		});

--- a/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
@@ -1,11 +1,9 @@
+import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.env';
 import {
-	BTC_MAINNET_NETWORK_ID,
 	ETHEREUM_NETWORK,
 	ETHEREUM_NETWORK_ID,
-	ICP_NETWORK,
-	ICP_NETWORK_ID,
 	SEPOLIA_NETWORK
-} from '$env/networks/networks.env';
+} from '$env/networks/networks.eth.env';
 import { ONRAMPER_API_KEY, ONRAMPER_BASE_URL } from '$env/rest/onramper.env';
 import type { OnramperNetworkWallet, OnramperWalletAddress } from '$lib/types/onramper';
 import type { Option } from '$lib/types/utils';

--- a/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
@@ -1,4 +1,4 @@
-import { SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import { SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { CardData } from '$lib/types/token-card';

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -1,8 +1,5 @@
-import {
-	BTC_MAINNET_NETWORK_ID,
-	ETHEREUM_NETWORK_ID,
-	ICP_NETWORK_ID
-} from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import {
 	BTC_MAINNET_SYMBOL,

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1,5 +1,5 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
-import * as networkEnv from '$env/networks/networks.env';
+import * as ethEnv from '$env/networks/networks.eth.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { PEPE_TOKEN, PEPE_TOKEN_ID } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { BONK_TOKEN, BONK_TOKEN_ID } from '$env/tokens/tokens-spl/tokens.bonk.env';
@@ -162,7 +162,7 @@ describe('transactions.utils', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();
 
-			vi.spyOn(networkEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(() => [
+			vi.spyOn(ethEnv, 'SUPPORTED_ETHEREUM_NETWORKS_IDS', 'get').mockImplementation(() => [
 				ETHEREUM_NETWORK_ID,
 				SEPOLIA_NETWORK_ID
 			]);

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1,6 +1,6 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import * as networkEnv from '$env/networks/networks.env';
-import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { PEPE_TOKEN, PEPE_TOKEN_ID } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { BONK_TOKEN, BONK_TOKEN_ID } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import {

--- a/src/frontend/src/tests/mocks/erc20-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/erc20-tokens.mock.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import type { NetworkEnvironment } from '$lib/types/network';


### PR DESCRIPTION
# Motivation

We discovered circular imports regarding the network envs, to combat this we cleanup the network env definitions and move them to their respective file.

We start here with ETH network envs.

# Changes

Moved all ETH definitions to corresponding networks file
