### PR TITLE
refactor(frontend): generalize convert-related type

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -7,9 +7,9 @@
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
 
@@ -26,7 +26,7 @@
 	export let exchangeValueUnit: DisplayUnit = 'usd';
 	export let inputUnit: DisplayUnit = 'token';
 
-	let errorType: ConvertAmountErrorType = undefined;
+	let errorType: TokenActionErrorType = undefined;
 
 	$: insufficientFunds = nonNullish(errorType) && errorType === 'insufficient-funds';
 	$: insufficientFundsForFee = nonNullish(errorType) && errorType === 'insufficient-funds-for-fee';
@@ -38,7 +38,7 @@
 	const { sourceToken, sourceTokenBalance, sourceTokenExchangeRate, balanceForFee, minterInfo } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
-	$: customValidate = (userAmount: BigNumber): ConvertAmountErrorType =>
+	$: customValidate = (userAmount: BigNumber): TokenActionErrorType =>
 		validateUserAmount({
 			userAmount,
 			token: $sourceToken,

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -27,9 +27,9 @@
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
-	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
 
@@ -52,7 +52,7 @@
 
 	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
 
-	let errorType: ConvertAmountErrorType = undefined;
+	let errorType: TokenActionErrorType = undefined;
 	let amountSetToMax = false;
 	let exchangeValueUnit: DisplayUnit = 'usd';
 	let inputUnit: DisplayUnit;
@@ -108,7 +108,7 @@
 		switchTokens();
 	};
 
-	$: customValidate = (userAmount: BigNumber): ConvertAmountErrorType =>
+	$: customValidate = (userAmount: BigNumber): TokenActionErrorType =>
 		nonNullish($sourceToken)
 			? validateUserAmount({
 					userAmount,

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -12,10 +12,10 @@
 	import { logoSizes } from '$lib/constants/components.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { ConvertAmountErrorType } from '$lib/types/convert';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
@@ -26,14 +26,14 @@
 	export let exchangeRate: number | undefined = undefined;
 	export let disabled = false;
 	export let placeholder = '0';
-	export let errorType: ConvertAmountErrorType = undefined;
+	export let errorType: TokenActionErrorType = undefined;
 	// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
 	export let error: Error | undefined = undefined;
 	export let amountSetToMax = false;
 	export let loading = false;
 	export let isSelectable = true;
 	export let autofocus = false;
-	export let customValidate: (userAmount: BigNumber) => ConvertAmountErrorType = () => undefined;
+	export let customValidate: (userAmount: BigNumber) => TokenActionErrorType = () => undefined;
 	export let customErrorValidate: (userAmount: BigNumber) => Error | undefined = () => undefined;
 
 	const dispatch = createEventDispatcher();

--- a/src/frontend/src/lib/types/token-action.ts
+++ b/src/frontend/src/lib/types/token-action.ts
@@ -1,5 +1,4 @@
-// TODO: rename the type as it will be reused in both convert and send flows
-export type ConvertAmountErrorType =
+export type TokenActionErrorType =
 	| 'insufficient-funds'
 	| 'insufficient-funds-for-fee'
 	| 'unknown-minimum-amount'

--- a/src/frontend/src/lib/utils/assert-amount.utils.ts
+++ b/src/frontend/src/lib/utils/assert-amount.utils.ts
@@ -1,6 +1,6 @@
 import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
-import type { ConvertAmountErrorType } from '$lib/types/convert';
+import type { TokenActionErrorType } from '$lib/types/token-action';
 import type { Option } from '$lib/types/utils';
 import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -19,7 +19,7 @@ interface CommonParamsWithBalanceForFee extends CommonParams {
 	balanceForFee: BigNumber;
 }
 
-const assertBalance = ({ userAmount, balance }: CommonParams): ConvertAmountErrorType => {
+const assertBalance = ({ userAmount, balance }: CommonParams): TokenActionErrorType => {
 	if (userAmount.gt(balance)) {
 		return 'insufficient-funds';
 	}
@@ -29,7 +29,7 @@ const assertUserAmountWithFee = ({
 	userAmount,
 	balance,
 	fee
-}: CommonParams): ConvertAmountErrorType => {
+}: CommonParams): TokenActionErrorType => {
 	if (nonNullish(fee) && userAmount.add(fee).gt(balance)) {
 		return 'insufficient-funds-for-fee';
 	}
@@ -41,7 +41,7 @@ const assertMinterInfo = ({
 }: {
 	userAmount: BigNumber;
 	minterInfo: Option<CkBtcMinterInfoData | CkEthMinterInfoData>;
-}): ConvertAmountErrorType => {
+}): TokenActionErrorType => {
 	if (isNullish(minterInfo)) {
 		return 'unknown-minimum-amount';
 	}
@@ -69,7 +69,7 @@ export const assertErc20Amount = ({
 	balance,
 	balanceForFee,
 	fee
-}: CommonParamsWithBalanceForFee): ConvertAmountErrorType => {
+}: CommonParamsWithBalanceForFee): TokenActionErrorType => {
 	const assertBalanceError = assertBalance({ userAmount, balance });
 	if (nonNullish(assertBalanceError)) {
 		return assertBalanceError;
@@ -95,7 +95,7 @@ export const assertCkEthAmount = ({
 	balance,
 	minterInfo,
 	fee
-}: CommonParamsWithMinter): ConvertAmountErrorType => {
+}: CommonParamsWithMinter): TokenActionErrorType => {
 	const assertBalanceError = assertBalance({ userAmount, balance });
 	if (nonNullish(assertBalanceError)) {
 		return assertBalanceError;
@@ -119,7 +119,7 @@ export const assertCkErc20Amount = ({
 	balanceForFee,
 	fee,
 	ethereumEstimateFee
-}: CommonParamsWithBalanceForFee & { ethereumEstimateFee?: bigint }): ConvertAmountErrorType => {
+}: CommonParamsWithBalanceForFee & { ethereumEstimateFee?: bigint }): TokenActionErrorType => {
 	const assertBalanceError = assertBalance({ userAmount, balance });
 	if (nonNullish(assertBalanceError)) {
 		return assertBalanceError;
@@ -136,5 +136,5 @@ export const assertCkErc20Amount = ({
 	return assertUserAmountWithFee({ userAmount, balance, fee });
 };
 
-export const assertAmount = ({ userAmount, balance, fee }: CommonParams): ConvertAmountErrorType =>
+export const assertAmount = ({ userAmount, balance, fee }: CommonParams): TokenActionErrorType =>
 	assertBalance({ userAmount, balance }) ?? assertUserAmountWithFee({ userAmount, balance, fee });

--- a/src/frontend/src/lib/utils/user-amount.utils.ts
+++ b/src/frontend/src/lib/utils/user-amount.utils.ts
@@ -7,8 +7,8 @@ import {
 	isTokenCkEthLedger
 } from '$icp/utils/ic-send.utils';
 import { ZERO } from '$lib/constants/app.constants';
-import type { ConvertAmountErrorType } from '$lib/types/convert';
 import type { Token } from '$lib/types/token';
+import type { TokenActionErrorType } from '$lib/types/token-action';
 import type { Option } from '$lib/types/utils';
 import {
 	assertAmount,
@@ -40,7 +40,7 @@ export const validateUserAmount = ({
 	ethereumEstimateFee?: bigint;
 	minterInfo?: Option<CkBtcMinterInfoData | CkEthMinterInfoData>;
 	isSwapFlow?: boolean;
-}): ConvertAmountErrorType => {
+}): TokenActionErrorType => {
 	// We should align balance and userAmount to avoid issues caused by comparing formatted and unformatted BN
 	const parsedSendBalance = nonNullish(balance)
 		? parseToken({


### PR DESCRIPTION
# Motivation

The first step of creating a context for validation errors in send/convert/swap flows is to generalize convert-related type.
