### PR TITLE
chore(frontend): Cleanup ICP network envs

### DIFF
--- a/src/frontend/src/env/networks/networks.env.ts
+++ b/src/frontend/src/env/networks/networks.env.ts
@@ -6,28 +6,10 @@ import {
 } from '$env/explorers.env';
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
-import icpLight from '$icp/assets/icp_light.svg';
 import bitcoinMainnetBW from '$lib/assets/networks/bitcoin-mainnet-bw.svg';
 import bitcoinTestnetBW from '$lib/assets/networks/bitcoin-testnet-bw.svg';
-import icpBW from '$lib/assets/networks/icp-bw.svg';
-import type { Network, NetworkId } from '$lib/types/network';
+import type { NetworkId } from '$lib/types/network';
 import { parseNetworkId } from '$lib/validation/network.validation';
-
-/**
- * ICP
- */
-export const ICP_NETWORK_SYMBOL = 'ICP';
-
-export const ICP_NETWORK_ID: NetworkId = parseNetworkId(ICP_NETWORK_SYMBOL);
-
-export const ICP_NETWORK: Network = {
-	id: ICP_NETWORK_ID,
-	env: 'mainnet',
-	name: 'Internet Computer',
-	icon: icpLight,
-	iconBW: icpBW,
-	buy: { onramperId: 'icp' }
-};
 
 /**
  * BTC

--- a/src/frontend/src/env/networks/networks.icp.env.ts
+++ b/src/frontend/src/env/networks/networks.icp.env.ts
@@ -1,5 +1,9 @@
+import icpLight from '$icp/assets/icp_light.svg';
+import icpBW from '$lib/assets/networks/icp-bw.svg';
 import { LOCAL } from '$lib/constants/app.constants';
 import type { OptionCanisterIdText } from '$lib/types/canister';
+import type { Network, NetworkId } from '$lib/types/network';
+import { parseNetworkId } from '$lib/validation/network.validation';
 
 export const ICP_LEDGER_CANISTER_ID =
 	(LOCAL
@@ -12,3 +16,19 @@ export const ICP_INDEX_CANISTER_ID =
 		? (import.meta.env.VITE_LOCAL_ICP_INDEX_CANISTER_ID as OptionCanisterIdText)
 		: (import.meta.env.VITE_IC_ICP_INDEX_CANISTER_ID as OptionCanisterIdText)) ??
 	'qhbym-qaaaa-aaaaa-aaafq-cai';
+
+/**
+ * ICP
+ */
+export const ICP_NETWORK_SYMBOL = 'ICP';
+
+export const ICP_NETWORK_ID: NetworkId = parseNetworkId(ICP_NETWORK_SYMBOL);
+
+export const ICP_NETWORK: Network = {
+	id: ICP_NETWORK_ID,
+	env: 'mainnet',
+	name: 'Internet Computer',
+	icon: icpLight,
+	iconBW: icpBW,
+	buy: { onramperId: 'icp' }
+};

--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -1,6 +1,9 @@
 import { ICP_EXPLORER_URL } from '$env/explorers.env';
-import { ICP_NETWORK } from '$env/networks/networks.env';
-import { ICP_INDEX_CANISTER_ID, ICP_LEDGER_CANISTER_ID } from '$env/networks/networks.icp.env';
+import {
+	ICP_INDEX_CANISTER_ID,
+	ICP_LEDGER_CANISTER_ID,
+	ICP_NETWORK
+} from '$env/networks/networks.icp.env';
 import icpLight from '$icp/assets/icp_light.svg';
 import { ICP_TRANSACTION_FEE_E8S } from '$icp/constants/icp.constants';
 import type { IcToken } from '$icp/types/ic-token';

--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -3,6 +3,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import EthConvertForm from '$eth/components/convert/EthConvertForm.svelte';
 	import EthConvertProgress from '$eth/components/convert/EthConvertProgress.svelte';
 	import EthConvertReview from '$eth/components/convert/EthConvertReview.svelte';
@@ -45,7 +46,6 @@
 	import type { TokenId } from '$lib/types/token';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let currentStep: WizardStep | undefined;
 	export let sendAmount: OptionAmount;

--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -3,7 +3,6 @@
 	import { isNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import EthConvertForm from '$eth/components/convert/EthConvertForm.svelte';
 	import EthConvertProgress from '$eth/components/convert/EthConvertProgress.svelte';
 	import EthConvertReview from '$eth/components/convert/EthConvertReview.svelte';
@@ -46,6 +45,7 @@
 	import type { TokenId } from '$lib/types/token';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let currentStep: WizardStep | undefined;
 	export let sendAmount: OptionAmount;

--- a/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { setContext } from 'svelte';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import EthSendTokenModal from '$eth/components/send/EthSendTokenModal.svelte';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
@@ -8,7 +9,6 @@
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	/**
 	 * Send modal context store

--- a/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkETH.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { setContext } from 'svelte';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import EthSendTokenModal from '$eth/components/send/EthSendTokenModal.svelte';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
@@ -9,6 +8,7 @@
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	/**
 	 * Send modal context store

--- a/src/frontend/src/eth/components/send/SendNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendNetwork.svelte
@@ -3,6 +3,7 @@
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import { isDestinationContractAddress } from '$eth/utils/send.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { toCkEthHelperContractAddress } from '$icp-eth/utils/cketh.utils';
@@ -10,7 +11,6 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network } from '$lib/types/network';
 	import { isEthAddress, isIcpAccountIdentifier } from '$lib/utils/account.utils';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let network: Network | undefined = undefined;
 	export let destination: string | undefined = undefined;

--- a/src/frontend/src/eth/components/send/SendNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendNetwork.svelte
@@ -2,7 +2,6 @@
 	import { Dropdown, DropdownItem } from '@dfinity/gix-components';
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import { isDestinationContractAddress } from '$eth/utils/send.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
@@ -11,6 +10,7 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network } from '$lib/types/network';
 	import { isEthAddress, isIcpAccountIdentifier } from '$lib/utils/account.utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let network: Network | undefined = undefined;
 	export let destination: string | undefined = undefined;

--- a/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import { ERC20_CONTRACT_ICP, ERC20_CONTRACT_ICP_GOERLI } from '$env/tokens/tokens.erc20.env';
 	import icpDark from '$eth/assets/icp_dark.svg';
 	import type { Erc20Token } from '$eth/types/erc20';
@@ -13,7 +14,6 @@
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkICP } from '$lib/utils/network.utils';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let sourceNetwork: EthereumNetwork;
 	export let targetNetwork: Network | undefined = undefined;

--- a/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import { ERC20_CONTRACT_ICP, ERC20_CONTRACT_ICP_GOERLI } from '$env/tokens/tokens.erc20.env';
 	import icpDark from '$eth/assets/icp_dark.svg';
 	import type { Erc20Token } from '$eth/types/erc20';
@@ -14,6 +13,7 @@
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkICP } from '$lib/utils/network.utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let sourceNetwork: EthereumNetwork;
 	export let targetNetwork: Network | undefined = undefined;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -4,6 +4,7 @@
 	import type { WalletKitTypes } from '@reown/walletkit';
 	import { getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import FeeContext from '$eth/components/fee/FeeContext.svelte';
 	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
@@ -36,7 +37,6 @@
 	import type { Network } from '$lib/types/network';
 	import type { TokenId } from '$lib/types/token';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let request: WalletKitTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -4,7 +4,6 @@
 	import type { WalletKitTypes } from '@reown/walletkit';
 	import { getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import FeeContext from '$eth/components/fee/FeeContext.svelte';
 	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
@@ -37,6 +36,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { TokenId } from '$lib/types/token';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let request: WalletKitTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
 	import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
@@ -19,6 +18,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	/**
 	 * Props

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
 	import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
@@ -18,7 +19,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import { closeModal } from '$lib/utils/modal.utils';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	/**
 	 * Props

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { createEventDispatcher } from 'svelte';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import IcReceiveInfoCkEthereum from '$icp/components/receive/IcReceiveInfoCkEthereum.svelte';
@@ -23,7 +24,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import { closeModal } from '$lib/utils/modal.utils';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	/**
 	 * Props

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { createEventDispatcher } from 'svelte';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
 	import IcReceiveInfoCkEthereum from '$icp/components/receive/IcReceiveInfoCkEthereum.svelte';
@@ -24,6 +23,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	/**
 	 * Props

--- a/src/frontend/src/icp/components/receive/IcReceiveInfoICP.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveInfoICP.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import {
@@ -18,7 +19,6 @@
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ReceiveQRCode } from '$lib/types/receive';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	const { close } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 

--- a/src/frontend/src/icp/components/receive/IcReceiveInfoICP.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveInfoICP.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import {
@@ -19,6 +18,7 @@
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ReceiveQRCode } from '$lib/types/receive';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	const { close } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 

--- a/src/frontend/src/icp/components/receive/IcReceiveWalletAddress.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveWalletAddress.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import {
 		RECEIVE_TOKEN_CONTEXT_KEY,
@@ -8,7 +9,6 @@
 	import ReceiveAddress from '$lib/components/receive/ReceiveAddress.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	const { token } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 

--- a/src/frontend/src/icp/components/receive/IcReceiveWalletAddress.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveWalletAddress.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import {
 		RECEIVE_TOKEN_CONTEXT_KEY,
@@ -9,6 +8,7 @@
 	import ReceiveAddress from '$lib/components/receive/ReceiveAddress.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	const { token } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 

--- a/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
+++ b/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { ICP_NETWORK } from '$env/networks/networks.env';
 	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
 	import type { NetworkId } from '$lib/types/network';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let networkId: NetworkId | undefined = undefined;
 </script>

--- a/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
+++ b/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
 	import type { NetworkId } from '$lib/types/network';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	export let networkId: NetworkId | undefined = undefined;
 </script>

--- a/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
@@ -1,5 +1,5 @@
 import { SNS_EXPLORER_URL } from '$env/explorers.env';
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { EnvSnsTokenSchema, EnvSnsTokensSchema } from '$env/schema/env-sns-token.schema';
 import snsTokens from '$env/tokens/tokens.sns.json';
 import type { EnvSnsToken } from '$env/types/env-sns-token';

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { DEPRECATED_SNES } from '$env/tokens/tokens.sns.deprecated.env';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcCkInterface, IcFee, IcInterface, IcToken } from '$icp/types/ic-token';

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Spinner } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
+	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.env';
 	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 	import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
@@ -17,6 +17,7 @@
 	import { token } from '$lib/stores/token.store';
 	import type { OnramperId, OnramperNetworkId, OnramperNetworkWallet } from '$lib/types/onramper';
 	import { buildOnramperLink, mapOnramperNetworkWallets } from '$lib/utils/onramper.utils';
+	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 
 	let defaultCrypto: OnramperId | undefined;
 	$: defaultCrypto =

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -3,6 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.env';
 	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 	import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
@@ -17,7 +18,6 @@
 	import { token } from '$lib/stores/token.store';
 	import type { OnramperId, OnramperNetworkId, OnramperNetworkWallet } from '$lib/types/onramper';
 	import { buildOnramperLink, mapOnramperNetworkWallets } from '$lib/utils/onramper.utils';
-	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 
 	let defaultCrypto: OnramperId | undefined;
 	$: defaultCrypto =

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -4,8 +4,7 @@
 	import {
 		BTC_MAINNET_NETWORK,
 		BTC_REGTEST_NETWORK,
-		BTC_TESTNET_NETWORK,
-		ICP_NETWORK
+		BTC_TESTNET_NETWORK
 	} from '$env/networks/networks.env';
 	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import {
@@ -63,6 +62,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -7,6 +7,7 @@
 		BTC_TESTNET_NETWORK
 	} from '$env/networks/networks.env';
 	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import {
 		SOLANA_MAINNET_NETWORK,
 		SOLANA_TESTNET_NETWORK,
@@ -62,7 +63,6 @@
 	import type { Network } from '$lib/types/network';
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -1,5 +1,5 @@
 import { enabledBitcoinNetworks } from '$btc/derived/networks.derived';
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { enabledSolanaNetworks } from '$sol/derived/networks.derived';

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -3,13 +3,13 @@ import { SUPPORTED_BITCOIN_NETWORKS_IDS } from '$env/networks/networks.btc.env';
 import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
-	BTC_TESTNET_NETWORK_ID,
-	ICP_NETWORK_ID
+	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.env';
 import {
 	SEPOLIA_NETWORK_ID,
 	SUPPORTED_ETHEREUM_NETWORKS_IDS
 } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,

--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
@@ -6,7 +6,8 @@ import {
 	UTXOS_FEE_CONTEXT_KEY,
 	type UtxosFeeStore
 } from '$btc/stores/utxos-fee.store';
-import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import * as authServices from '$lib/services/auth.services';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockUtxosFee } from '$tests/mocks/btc.mock';

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthConvertTokenWizard from '$eth/components/convert/EthConvertTokenWizard.svelte';
 import * as tokensDerived from '$eth/derived/token.derived';

--- a/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
@@ -1,9 +1,9 @@
-import { ICP_NETWORK_ID } from '$env/networks/networks.env';
 import {
 	ETHEREUM_NETWORK_ID,
 	ETHERSCAN_NETWORK_HOMESTEAD,
 	SEPOLIA_NETWORK_ID
 } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { EtherscanProvider, etherscanProviders } from '$eth/providers/etherscan.providers';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';

--- a/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
+++ b/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
@@ -1,9 +1,9 @@
-import { ICP_NETWORK_ID } from '$env/networks/networks.env';
 import {
 	ETHEREUM_NETWORK_ID,
 	ETHERSCAN_API_URL_HOMESTEAD,
 	SEPOLIA_NETWORK_ID
 } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { EtherscanRest, etherscanRests } from '$eth/rest/etherscan.rest';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { loadAndAssertAddCustomToken } from '$icp/services/ic-add-custom-tokens.service';
 import type { IcCanisters, IcToken } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -1,5 +1,5 @@
 import type { CustomToken } from '$declarations/backend/backend.did';
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import {
 	loadCustomTokens,
 	loadDisabledIcrcTokensBalances,

--- a/src/frontend/src/tests/lib/components/hero/ContextMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/ContextMenu.spec.ts
@@ -1,4 +1,5 @@
-import { BTC_MAINNET_NETWORK, ICP_NETWORK } from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 import ContextMenu from '$lib/components/hero/ContextMenu.svelte';
 import { DEFAULT_ETHEREUM_NETWORK } from '$lib/constants/networks.constants';

--- a/src/frontend/src/tests/lib/components/networks/NetworkLogo.spec.ts
+++ b/src/frontend/src/tests/lib/components/networks/NetworkLogo.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';

--- a/src/frontend/src/tests/lib/components/transactions/Transactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/Transactions.spec.ts
@@ -1,5 +1,5 @@
 import * as appNavigation from '$app/navigation';
-import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.env';
+import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import Transactions from '$lib/components/transactions/Transactions.svelte';
 import { MANAGE_TOKENS_MODAL_CLOSE } from '$lib/constants/test-ids.constants';

--- a/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
@@ -1,7 +1,8 @@
 import * as btcEnv from '$env/networks/networks.btc.env';
-import { BTC_MAINNET_NETWORK, ICP_NETWORK } from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK } from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
 import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK,
 	SOLANA_MAINNET_NETWORK,

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -1,6 +1,6 @@
 import * as appNavigation from '$app/navigation';
-import { ICP_NETWORK_ID } from '$env/networks/networks.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	AppPath,
 	NETWORK_PARAM,

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -3,9 +3,7 @@ import {
 	BTC_MAINNET_NETWORK,
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
-	BTC_TESTNET_NETWORK_ID,
-	ICP_NETWORK,
-	ICP_NETWORK_ID
+	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
 import {
@@ -14,6 +12,7 @@ import {
 	SEPOLIA_NETWORK,
 	SEPOLIA_NETWORK_ID
 } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { CKBTC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
 import {
 	SOLANA_DEVNET_NETWORK,

--- a/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
@@ -1,9 +1,10 @@
-import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.env';
 import {
 	ETHEREUM_NETWORK,
 	ETHEREUM_NETWORK_ID,
 	SEPOLIA_NETWORK
 } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { ONRAMPER_API_KEY, ONRAMPER_BASE_URL } from '$env/rest/onramper.env';
 import type { OnramperNetworkWallet, OnramperWalletAddress } from '$lib/types/onramper';
 import type { Option } from '$lib/types/utils';

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import {
 	BTC_MAINNET_TOKEN,
 	BTC_REGTEST_TOKEN,

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -1,5 +1,6 @@
-import { BTC_MAINNET_NETWORK_ID, ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import {
 	BTC_MAINNET_SYMBOL,

--- a/src/frontend/src/tests/mocks/tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/tokens.mock.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';

--- a/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK_ID } from '$env/networks/networks.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 import { decode } from '$sol/services/wallet-connect.services';
 import type { MappedSolTransaction } from '$sol/types/sol-transaction';


### PR DESCRIPTION
# Motivation

We discovered circular imports regarding the network envs, to combat this we cleanup the network env definitions and move them to their respective file.

We start here with ICP network envs.

# Changes

Moved all ICP definitions to corresponding networks file