### PR TITLE
feat(frontend): new context for validation errors on token action

### DIFF
--- a/src/frontend/src/lib/stores/token-action-validation-errors.store.ts
+++ b/src/frontend/src/lib/stores/token-action-validation-errors.store.ts
@@ -1,0 +1,65 @@
+import type { TokenActionErrorType } from '$lib/types/token-action';
+import { nonNullish } from '@dfinity/utils';
+import { derived, writable, type Readable } from 'svelte/store';
+
+export interface TokenActionValidationErrorsData {
+	errorType?: TokenActionErrorType;
+}
+
+export const initTokenActionValidationErrorsContext = (
+	initialData: TokenActionValidationErrorsData = {}
+): TokenActionValidationErrorsContext => {
+	const data = writable<TokenActionValidationErrorsData>(initialData);
+	const { update } = data;
+
+	const insufficientFunds = derived(
+		[data],
+		([{ errorType }]) => nonNullish(errorType) && errorType === 'insufficient-funds'
+	);
+	const insufficientFundsForFee = derived(
+		[data],
+		([{ errorType }]) => nonNullish(errorType) && errorType === 'insufficient-funds-for-fee'
+	);
+	const amountLessThanLedgerFee = derived(
+		[data],
+		([{ errorType }]) => nonNullish(errorType) && errorType === 'amount-less-than-ledger-fee'
+	);
+	const minimumAmountNotReached = derived(
+		[data],
+		([{ errorType }]) => nonNullish(errorType) && errorType === 'minimum-amount-not-reached'
+	);
+	const unknownMinimumAmount = derived(
+		[data],
+		([{ errorType }]) => nonNullish(errorType) && errorType === 'unknown-minimum-amount'
+	);
+	const minterInfoNotCertified = derived(
+		[data],
+		([{ errorType }]) => nonNullish(errorType) && errorType === 'minter-info-not-certified'
+	);
+
+	return {
+		insufficientFunds,
+		insufficientFundsForFee,
+		amountLessThanLedgerFee,
+		minimumAmountNotReached,
+		unknownMinimumAmount,
+		minterInfoNotCertified,
+		setErrorType: (type: TokenActionErrorType) =>
+			update((state) => ({
+				...state,
+				errorType: type
+			}))
+	};
+};
+
+export interface TokenActionValidationErrorsContext {
+	insufficientFunds: Readable<boolean>;
+	insufficientFundsForFee: Readable<boolean>;
+	amountLessThanLedgerFee: Readable<boolean>;
+	minimumAmountNotReached: Readable<boolean>;
+	unknownMinimumAmount: Readable<boolean>;
+	minterInfoNotCertified: Readable<boolean>;
+	setErrorType: (type: TokenActionErrorType) => void;
+}
+
+export const TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY = Symbol('token-action-validation-errors');

--- a/src/frontend/src/tests/lib/stores/token-action-validation-errors.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/token-action-validation-errors.store.spec.ts
@@ -1,0 +1,168 @@
+import { initTokenActionValidationErrorsContext } from '$lib/stores/token-action-validation-errors.store';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
+import { get } from 'svelte/store';
+
+describe('tokenActionValidationErrorsStore', () => {
+	beforeEach(() => {
+		mockPage.reset();
+	});
+
+	it('should ensure derived stores update at most once when the store changes', async () => {
+		await testDerivedUpdates(() =>
+			initTokenActionValidationErrorsContext({
+				errorType: 'insufficient-funds'
+			})
+		);
+	});
+
+	it('should have all expected values on empty state', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified
+		} = initTokenActionValidationErrorsContext();
+
+		expect(get(insufficientFunds)).toBe(false);
+		expect(get(insufficientFundsForFee)).toBe(false);
+		expect(get(amountLessThanLedgerFee)).toBe(false);
+		expect(get(minimumAmountNotReached)).toBe(false);
+		expect(get(unknownMinimumAmount)).toBe(false);
+		expect(get(minterInfoNotCertified)).toBe(false);
+	});
+
+	it('should have all expected values on insufficient-funds error', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified,
+			setErrorType
+		} = initTokenActionValidationErrorsContext();
+
+		setErrorType('insufficient-funds');
+
+		expect(get(insufficientFunds)).toBe(true);
+
+		expect(get(insufficientFundsForFee)).toBe(false);
+		expect(get(amountLessThanLedgerFee)).toBe(false);
+		expect(get(minimumAmountNotReached)).toBe(false);
+		expect(get(unknownMinimumAmount)).toBe(false);
+		expect(get(minterInfoNotCertified)).toBe(false);
+	});
+
+	it('should have all expected values on insufficient-funds-for-fee error', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified,
+			setErrorType
+		} = initTokenActionValidationErrorsContext();
+
+		setErrorType('insufficient-funds-for-fee');
+
+		expect(get(insufficientFundsForFee)).toBe(true);
+
+		expect(get(insufficientFunds)).toBe(false);
+		expect(get(amountLessThanLedgerFee)).toBe(false);
+		expect(get(minimumAmountNotReached)).toBe(false);
+		expect(get(unknownMinimumAmount)).toBe(false);
+		expect(get(minterInfoNotCertified)).toBe(false);
+	});
+
+	it('should have all expected values on amount-less-than-ledger-fee error', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified,
+			setErrorType
+		} = initTokenActionValidationErrorsContext();
+
+		setErrorType('amount-less-than-ledger-fee');
+
+		expect(get(amountLessThanLedgerFee)).toBe(true);
+
+		expect(get(insufficientFundsForFee)).toBe(false);
+		expect(get(insufficientFunds)).toBe(false);
+		expect(get(minimumAmountNotReached)).toBe(false);
+		expect(get(unknownMinimumAmount)).toBe(false);
+		expect(get(minterInfoNotCertified)).toBe(false);
+	});
+
+	it('should have all expected values on minimum-amount-not-reached error', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified,
+			setErrorType
+		} = initTokenActionValidationErrorsContext();
+
+		setErrorType('minimum-amount-not-reached');
+
+		expect(get(minimumAmountNotReached)).toBe(true);
+
+		expect(get(amountLessThanLedgerFee)).toBe(false);
+		expect(get(insufficientFundsForFee)).toBe(false);
+		expect(get(insufficientFunds)).toBe(false);
+		expect(get(unknownMinimumAmount)).toBe(false);
+		expect(get(minterInfoNotCertified)).toBe(false);
+	});
+
+	it('should have all expected values on unknown-minimum-amount error', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified,
+			setErrorType
+		} = initTokenActionValidationErrorsContext();
+
+		setErrorType('unknown-minimum-amount');
+
+		expect(get(unknownMinimumAmount)).toBe(true);
+
+		expect(get(minimumAmountNotReached)).toBe(false);
+		expect(get(amountLessThanLedgerFee)).toBe(false);
+		expect(get(insufficientFundsForFee)).toBe(false);
+		expect(get(insufficientFunds)).toBe(false);
+		expect(get(minterInfoNotCertified)).toBe(false);
+	});
+
+	it('should have all expected values on minter-info-not-certified error', () => {
+		const {
+			insufficientFunds,
+			insufficientFundsForFee,
+			amountLessThanLedgerFee,
+			minimumAmountNotReached,
+			unknownMinimumAmount,
+			minterInfoNotCertified,
+			setErrorType
+		} = initTokenActionValidationErrorsContext();
+
+		setErrorType('minter-info-not-certified');
+
+		expect(get(minterInfoNotCertified)).toBe(true);
+
+		expect(get(unknownMinimumAmount)).toBe(false);
+		expect(get(minimumAmountNotReached)).toBe(false);
+		expect(get(amountLessThanLedgerFee)).toBe(false);
+		expect(get(insufficientFundsForFee)).toBe(false);
+		expect(get(insufficientFunds)).toBe(false);
+	});
+});


### PR DESCRIPTION
# Motivation

The next step of creating a context for validation errors in send/convert/swap flows is to actually create all required stores and context.
