### PR TITLE
fix(frontend): issue with USD value not being displayed on convert

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDisplay.svelte
@@ -30,7 +30,9 @@
 		{/if}
 	</svelte:fragment>
 
-	{#if displayExchangeRate}
-		<ConvertAmountExchange slot="secondary-value" {amount} {exchangeRate} />
-	{/if}
+	<svelte:fragment slot="secondary-value">
+		{#if displayExchangeRate}
+			<ConvertAmountExchange {amount} {exchangeRate} />
+		{/if}
+	</svelte:fragment>
 </ModalValue>

--- a/src/frontend/src/lib/components/ui/ModalValue.svelte
+++ b/src/frontend/src/lib/components/ui/ModalValue.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 
 	export let ref: undefined | string = undefined;
 	export let labelStyleClass: string | undefined = undefined;
-
-	let secondaryValue: boolean;
-	$: secondaryValue = nonNullish($$slots['secondary-value']);
 </script>
 
 <div in:fade class="mb-2 flex w-full justify-between last:mb-0 md:items-center">
@@ -14,11 +10,11 @@
 		><slot name="label" /></label
 	>
 
-	<div class="flex flex-col items-end sm:flex-row sm:items-center">
-		<span class={`mb-1 text-sm font-bold sm:mb-0 ${secondaryValue ? 'sm:mr-2' : ''}`}
-			><slot name="main-value" /></span
-		>
+	<div
+		class="flex flex-col items-end gap-1 text-sm text-tertiary sm:flex-row sm:items-center sm:gap-2"
+	>
+		<span class="font-bold text-primary"><slot name="main-value" /></span>
 
-		<span class="text-sm text-tertiary"><slot name="secondary-value" /></span>
+		<slot name="secondary-value" />
 	</div>
 </div>


### PR DESCRIPTION
# Motivation

This PR fixes the issue that recently happened in ConvertAmountDisplay - the USD values stoped being displayed in the convert modal. It is now properly working in both Swap modal only token values does not need to be displayed, as well as in the Convert flow.

<img width="554" alt="Screenshot 2025-03-19 at 23 48 29" src="https://github.com/user-attachments/assets/4106a5cc-3c80-49aa-9097-c695195ccf32" />

<img width="554" alt="Screenshot 2025-03-19 at 23 48 44" src="https://github.com/user-attachments/assets/7ee9a127-54d0-46f8-84c8-885427e47226" />
