### PR TITLE
feat(frontend): util validateUserAmount will use bigint instead of BigNumber

### DIFF
--- a/src/frontend/src/lib/utils/user-amount.utils.ts
+++ b/src/frontend/src/lib/utils/user-amount.utils.ts
@@ -6,7 +6,7 @@ import {
 	isTokenCkErc20Ledger,
 	isTokenCkEthLedger
 } from '$icp/utils/ic-send.utils';
-import { ZERO, ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { Balance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
 import type { TokenActionErrorType } from '$lib/types/token-action';
@@ -50,15 +50,15 @@ export const validateUserAmount = ({
 					displayDecimals: token.decimals
 				}),
 				unitName: token.decimals
-			})
-		: ZERO;
+			}).toBigInt()
+		: ZERO_BI;
 
 	// if the function called in the swap flow, we only need to check the basic assertAmount condition
 	// if convert or send - we identify token type and check some network-specific conditions
 	if (isSwapFlow) {
 		return assertAmount({
 			userAmount,
-			balance: parsedSendBalance.toBigInt(),
+			balance: parsedSendBalance,
 			fee
 		});
 	}
@@ -66,7 +66,7 @@ export const validateUserAmount = ({
 	if (isTokenErc20(token)) {
 		return assertErc20Amount({
 			userAmount,
-			balance: parsedSendBalance.toBigInt(),
+			balance: parsedSendBalance,
 			balanceForFee: balanceForFee ?? ZERO_BI,
 			fee
 		});
@@ -75,7 +75,7 @@ export const validateUserAmount = ({
 	if (isTokenCkBtcLedger(token)) {
 		return assertCkBtcAmount({
 			userAmount,
-			balance: parsedSendBalance.toBigInt(),
+			balance: parsedSendBalance,
 			minterInfo,
 			fee
 		});
@@ -84,7 +84,7 @@ export const validateUserAmount = ({
 	if (isTokenCkEthLedger(token)) {
 		return assertCkEthAmount({
 			userAmount,
-			balance: parsedSendBalance.toBigInt(),
+			balance: parsedSendBalance,
 			minterInfo,
 			fee
 		});
@@ -93,7 +93,7 @@ export const validateUserAmount = ({
 	if (isTokenCkErc20Ledger(token)) {
 		return assertCkErc20Amount({
 			userAmount,
-			balance: parsedSendBalance.toBigInt(),
+			balance: parsedSendBalance,
 			balanceForFee: balanceForFee ?? ZERO_BI,
 			ethereumEstimateFee,
 			fee
@@ -102,7 +102,7 @@ export const validateUserAmount = ({
 
 	return assertAmount({
 		userAmount,
-		balance: parsedSendBalance.toBigInt(),
+		balance: parsedSendBalance,
 		fee
 	});
 };


### PR DESCRIPTION
# Motivation

We need to migrate to `ethers` v6: one of the biggest change was the deprecation of `BigNumber` in favour of built-in `bigint` (see [documentation](https://docs.ethers.org/v6/migrating/#migrate-bigint)).

To smooth the migration, we replace `BigNumber` with `bigint` in the util `validateUserAmount` and its sub-functions.

# Changes

- Make util `validateUserAmount` accept `amount` as `bigint` instead of `BigNumber`.
- Adapt the rest of the usages.

# Tests

Existing tests were adapted and they works.
