### PR TITLE
refactor(backend): clone_with_* --> with_*

### DIFF
--- a/src/backend/src/token.rs
+++ b/src/backend/src/token.rs
@@ -18,7 +18,7 @@ pub fn add_to_user_token<T>(
 
     if let Some(existing_token) = tokens.iter_mut().find(|token| find(*token)) {
         if token.get_version() == existing_token.get_version() {
-            *existing_token = token.clone_with_incremented_version();
+            *existing_token = token.with_incremented_version();
         } else {
             ic_cdk::trap("Version mismatch, token update not allowed");
         }
@@ -29,7 +29,7 @@ pub fn add_to_user_token<T>(
             ));
         }
 
-        tokens.push(token.clone_with_initial_version());
+        tokens.push(token.with_initial_version());
     }
 
     user_token.insert(stored_principal, Candid(tokens));

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -81,7 +81,7 @@ fn test_add_custom_token(user_token: &CustomToken) {
 
     let after_set = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
-    let expected_tokens: Vec<CustomToken> = vec![user_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<CustomToken> = vec![user_token.with_incremented_version()];
     assert_tokens_data_eq(&after_set.unwrap(), &expected_tokens);
 }
 
@@ -106,7 +106,7 @@ fn test_update_custom_token(user_token: &CustomToken) {
 
     let results = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
-    let expected_tokens: Vec<CustomToken> = vec![user_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<CustomToken> = vec![user_token.with_incremented_version()];
 
     assert!(results.is_ok());
 
@@ -124,8 +124,7 @@ fn test_update_custom_token(user_token: &CustomToken) {
 
     let updated_results = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
-    let expected_updated_tokens: Vec<CustomToken> =
-        vec![update_token.clone_with_incremented_version()];
+    let expected_updated_tokens: Vec<CustomToken> = vec![update_token.with_incremented_version()];
 
     assert!(updated_results.is_ok());
 
@@ -163,8 +162,8 @@ fn test_add_many_custom_tokens(user_token: &CustomToken) {
     let after_set = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
     let expected_tokens: Vec<CustomToken> = vec![
-        user_token.clone_with_incremented_version(),
-        ANOTHER_USER_TOKEN.clone_with_incremented_version(),
+        user_token.with_incremented_version(),
+        ANOTHER_USER_TOKEN.with_incremented_version(),
     ];
     assert_tokens_data_eq(&after_set.unwrap(), &expected_tokens);
 }
@@ -195,8 +194,8 @@ fn test_update_many_custom_tokens(user_token: &CustomToken) {
     assert!(results.is_ok());
 
     let expected_tokens: Vec<CustomToken> = vec![
-        user_token.clone_with_incremented_version(),
-        ANOTHER_USER_TOKEN.clone_with_incremented_version(),
+        user_token.with_incremented_version(),
+        ANOTHER_USER_TOKEN.with_incremented_version(),
     ];
 
     assert_custom_tokens_eq(results.clone().unwrap(), expected_tokens);
@@ -225,8 +224,8 @@ fn test_update_many_custom_tokens(user_token: &CustomToken) {
     assert!(updated_results.is_ok());
 
     let expected_update_tokens: Vec<CustomToken> = vec![
-        update_token.clone_with_incremented_version(),
-        update_another_token.clone_with_incremented_version(),
+        update_token.with_incremented_version(),
+        update_another_token.with_incremented_version(),
     ];
 
     let updated_tokens = updated_results.unwrap();
@@ -247,8 +246,8 @@ fn test_list_custom_tokens() {
     let results = pic_setup.query::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
     let expected_tokens: Vec<CustomToken> = vec![
-        USER_TOKEN.clone_with_incremented_version(),
-        ANOTHER_USER_TOKEN.clone_with_incremented_version(),
+        USER_TOKEN.with_incremented_version(),
+        ANOTHER_USER_TOKEN.with_incremented_version(),
     ];
 
     assert!(results.is_ok());

--- a/src/backend/tests/it/token.rs
+++ b/src/backend/tests/it/token.rs
@@ -63,7 +63,7 @@ fn test_update_user_token() {
 
     let results = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![update_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<UserToken> = vec![update_token.with_incremented_version()];
 
     assert!(results.is_ok());
 
@@ -109,8 +109,8 @@ fn test_list_user_tokens() {
     let results = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
     let expected_tokens: Vec<UserToken> = vec![
-        MOCK_TOKEN.clone_with_incremented_version(),
-        another_token.clone_with_incremented_version(),
+        MOCK_TOKEN.with_incremented_version(),
+        another_token.with_incremented_version(),
     ];
 
     assert!(results.is_ok());

--- a/src/backend/tests/it/upgrade/impls.rs
+++ b/src/backend/tests/it/upgrade/impls.rs
@@ -7,13 +7,13 @@ impl TokenVersion for UserTokenV0_0_19 {
         self.version
     }
 
-    fn clone_with_incremented_version(&self) -> Self {
+    fn with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 
-    fn clone_with_initial_version(&self) -> Self {
+    fn with_initial_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(1);
         cloned

--- a/src/backend/tests/it/upgrade/token_enabled.rs
+++ b/src/backend/tests/it/upgrade/token_enabled.rs
@@ -96,7 +96,7 @@ fn test_update_user_token_after_upgrade() {
 
     let updated_results = pic_setup.update::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![update_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<UserToken> = vec![update_token.with_incremented_version()];
 
     assert!(updated_results.is_ok());
 

--- a/src/backend/tests/it/upgrade/token_version.rs
+++ b/src/backend/tests/it/upgrade/token_version.rs
@@ -92,7 +92,7 @@ fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgr
     let mut token = POST_UPGRADE_TOKEN.clone();
     // The version number should be ignored but we can check that.
     for _ in 0..options.premature_increments {
-        token = token.clone_with_incremented_version();
+        token = token.with_incremented_version();
     }
 
     let result = pic_setup.update::<()>(caller, "add_user_token", token);
@@ -104,7 +104,7 @@ fn test_add_user_token_after_upgrade_with_options(options: AddUserTokenAfterUpgr
     let results = pic_setup.update::<Vec<UserTokenV0_0_19>>(caller, "list_user_tokens", ());
 
     let expected_tokens: Vec<UserTokenV0_0_19> =
-        vec![POST_UPGRADE_TOKEN.clone_with_incremented_version()];
+        vec![POST_UPGRADE_TOKEN.with_incremented_version()];
 
     assert!(results.is_ok());
 
@@ -149,7 +149,7 @@ fn test_update_user_token_after_upgrade() {
 
     let updated_results = pic_setup.update::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![update_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<UserToken> = vec![update_token.with_incremented_version()];
 
     assert!(updated_results.is_ok());
 

--- a/src/backend/tests/it/user_token.rs
+++ b/src/backend/tests/it/user_token.rs
@@ -51,7 +51,7 @@ fn test_add_user_token() {
 
     let after_set = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![MOCK_TOKEN.clone_with_incremented_version()];
+    let expected_tokens: Vec<UserToken> = vec![MOCK_TOKEN.with_incremented_version()];
     assert_tokens_data_eq(&after_set.unwrap(), &expected_tokens);
 }
 
@@ -75,8 +75,8 @@ fn test_add_many_user_tokens() {
     let after_set = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
     let expected_tokens: Vec<UserToken> = vec![
-        MOCK_TOKEN.clone_with_incremented_version(),
-        ANOTHER_TOKEN.clone_with_incremented_version(),
+        MOCK_TOKEN.with_incremented_version(),
+        ANOTHER_TOKEN.with_incremented_version(),
     ];
     assert_tokens_data_eq(&after_set.unwrap(), &expected_tokens);
 }
@@ -107,7 +107,7 @@ fn test_update_user_token() {
 
     let results = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![update_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<UserToken> = vec![update_token.with_incremented_version()];
 
     assert!(results.is_ok());
 
@@ -133,8 +133,8 @@ fn test_update_many_user_tokens() {
     assert!(add_token_results.is_ok());
 
     let expected_tokens: Vec<UserToken> = vec![
-        MOCK_TOKEN.clone_with_incremented_version(),
-        ANOTHER_TOKEN.clone_with_incremented_version(),
+        MOCK_TOKEN.with_incremented_version(),
+        ANOTHER_TOKEN.with_incremented_version(),
     ];
 
     assert_tokens_data_eq(&add_token_results.clone().unwrap(), &expected_tokens);
@@ -161,8 +161,8 @@ fn test_update_many_user_tokens() {
     let results = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
     let expected_tokens: Vec<UserToken> = vec![
-        update_token.clone_with_incremented_version(),
-        update_another_token.clone_with_incremented_version(),
+        update_token.with_incremented_version(),
+        update_another_token.with_incremented_version(),
     ];
 
     assert!(results.is_ok());
@@ -198,7 +198,7 @@ fn test_disable_user_token() {
 
     let results = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
-    let expected_tokens: Vec<UserToken> = vec![update_token.clone_with_incremented_version()];
+    let expected_tokens: Vec<UserToken> = vec![update_token.with_incremented_version()];
 
     assert!(results.is_ok());
 
@@ -220,8 +220,8 @@ fn test_list_user_tokens() {
     let results = pic_setup.query::<Vec<UserToken>>(caller, "list_user_tokens", ());
 
     let expected_tokens: Vec<UserToken> = vec![
-        MOCK_TOKEN.clone_with_incremented_version(),
-        ANOTHER_TOKEN.clone_with_incremented_version(),
+        MOCK_TOKEN.with_incremented_version(),
+        ANOTHER_TOKEN.with_incremented_version(),
     ];
 
     assert!(results.is_ok());

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -41,13 +41,13 @@ impl TokenVersion for UserToken {
         self.version
     }
 
-    fn clone_with_incremented_version(&self) -> Self {
+    fn with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 
-    fn clone_with_initial_version(&self) -> Self {
+    fn with_initial_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(1);
         cloned
@@ -92,13 +92,13 @@ impl TokenVersion for CustomToken {
         self.version
     }
 
-    fn clone_with_incremented_version(&self) -> Self {
+    fn with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 
-    fn clone_with_initial_version(&self) -> Self {
+    fn with_initial_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(1);
         cloned
@@ -118,13 +118,13 @@ impl TokenVersion for StoredUserProfile {
         self.version
     }
 
-    fn clone_with_incremented_version(&self) -> Self {
+    fn with_incremented_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(cloned.version.unwrap_or_default().wrapping_add(1));
         cloned
     }
 
-    fn clone_with_initial_version(&self) -> Self {
+    fn with_initial_version(&self) -> Self {
         let mut cloned = self.clone();
         cloned.version = Some(1);
         cloned
@@ -165,7 +165,7 @@ impl StoredUserProfile {
         if profile_version != self.version {
             return Err(AddUserCredentialError::VersionMismatch);
         }
-        let mut new_profile = self.clone_with_incremented_version();
+        let mut new_profile = self.with_incremented_version();
         let user_credential = UserCredential {
             credential_type: credential_type.clone(),
             verified_date_timestamp: Some(now),
@@ -199,7 +199,7 @@ impl StoredUserProfile {
             return Ok(self.clone());
         }
 
-        let mut new_profile = self.clone_with_incremented_version();
+        let mut new_profile = self.with_incremented_version();
         new_profile.settings = {
             let mut settings = new_profile.settings.unwrap_or_default();
             settings.networks.testnets.show_testnets = show_testnets;
@@ -233,7 +233,7 @@ impl StoredUserProfile {
             return Ok(self.clone());
         }
 
-        let mut new_profile = self.clone_with_incremented_version();
+        let mut new_profile = self.with_incremented_version();
         let mut new_settings = new_profile.settings.clone().unwrap_or_default();
         let mut new_dapp_settings = new_settings.dapp.clone();
         let mut new_dapp_carousel_settings = new_dapp_settings.dapp_carousel.clone();

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -113,11 +113,11 @@ pub trait TokenVersion: Debug {
     #[must_use]
     fn get_version(&self) -> Option<Version>;
     #[must_use]
-    fn clone_with_incremented_version(&self) -> Self
+    fn with_incremented_version(&self) -> Self
     where
         Self: Sized + Clone;
     #[must_use]
-    fn clone_with_initial_version(&self) -> Self
+    fn with_initial_version(&self) -> Self
     where
         Self: Sized + Clone;
 }


### PR DESCRIPTION
# Motivation

As suggested by @bitdivine in https://github.com/dfinity/oisy-wallet/pull/5281#discussion_r2001116924 , it is canonical to call the methods `.with_THING_BEING_CHANGED` instead of `.clone_with_THING_BEING_CHANGED`

