### PR TITLE
fix(frontend): Carousel incorrect width display next card

### DIFF
--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -285,7 +285,7 @@
 	out:slide={SLIDE_PARAMS}
 >
 	<div class="w-full overflow-hidden" bind:this={container}>
-		<div data-tid={CAROUSEL_SLIDE} class="flex" bind:this={sliderFrame}>
+		<div data-tid={CAROUSEL_SLIDE} class="flex" bind:this={sliderFrame} style="width: 9999px">
 			<slot />
 		</div>
 	</div>


### PR DESCRIPTION
# Motivation

Under certain screen sizes, it was possible for the next card to show up slightly. This is due to the introduction of the scroll bar in the main nav.

Before carousel initialisation:
![image](https://github.com/user-attachments/assets/c6ef8193-e2f5-412a-85da-73d1251a7fff)

After initialisation the scroll bar disappears as the carousel receives its final height, the calculations are still done with the scroll bar included:
![image](https://github.com/user-attachments/assets/26f12529-83f9-4ea2-91cd-eafe05c703b7)


# Changes

If we can get the carousel to have the same height as when the dimensions have calculated and applied, the scrollbar would be included in the calculations only when it should. To do this, we added a starting width style of 9999px to the frame slider container, which after the carousel gets initialized will receive its correct width.

# Tests

![ezgif-6cfd4d0fc428b1](https://github.com/user-attachments/assets/18502d2f-2e2f-4a31-994c-37afebe10d4d)
