### PR TITLE
feat(frontend): switch to ledger ids instead of symbols on kong swap

### DIFF
--- a/src/frontend/src/lib/canisters/kong_backend.canister.ts
+++ b/src/frontend/src/lib/canisters/kong_backend.canister.ts
@@ -9,6 +9,7 @@ import { getAgent } from '$lib/actors/agents.ic';
 import { mapKongBackendCanisterError } from '$lib/canisters/kong_backend.errors';
 import type { KongSwapAmountsParams, KongSwapParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { getKongIcTokenIdentifier } from '$lib/utils/swap.utils';
 import { Canister, createServices, toNullable } from '@dfinity/utils';
 
 export class KongBackendCanister extends Canister<KongBackendService> {
@@ -39,7 +40,11 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 			certified: false
 		});
 
-		const response = await swap_amounts(sourceToken.symbol, sourceAmount, destinationToken.symbol);
+		const response = await swap_amounts(
+			getKongIcTokenIdentifier(sourceToken),
+			sourceAmount,
+			getKongIcTokenIdentifier(destinationToken)
+		);
 
 		if ('Ok' in response) {
 			return response.Ok;
@@ -63,8 +68,8 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 		});
 
 		const response = await swap_async({
-			pay_token: sourceToken.symbol,
-			receive_token: destinationToken.symbol,
+			pay_token: getKongIcTokenIdentifier(sourceToken),
+			receive_token: getKongIcTokenIdentifier(destinationToken),
 			pay_amount: sendAmount,
 			max_slippage: toNullable(maxSlippage),
 			receive_address: toNullable(receiveAddress),

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -1,5 +1,5 @@
 import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
-import type { IcToken } from '$icp/types/ic-token';
+import { isIcToken } from '$icp/validation/ic-token.validation';
 import type { ProviderFee } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { findToken } from '$lib/utils/tokens.utils';
@@ -48,5 +48,5 @@ export const getNetworkFee = ({
 	};
 };
 
-export const getKongIcTokenIdentifier = (token: Token) =>
-	`IC.${(token as IcToken).ledgerCanisterId}`;
+export const getKongIcTokenIdentifier = (token: Token): string =>
+	isIcToken(token) ? `IC.${token.ledgerCanisterId}` : '';

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -1,4 +1,5 @@
 import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
+import type { IcToken } from '$icp/types/ic-token';
 import type { ProviderFee } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { findToken } from '$lib/utils/tokens.utils';
@@ -46,3 +47,6 @@ export const getNetworkFee = ({
 		token
 	};
 };
+
+export const getKongIcTokenIdentifier = (token: Token) =>
+	`IC.${(token as IcToken).ledgerCanisterId}`;

--- a/src/frontend/src/tests/lib/canisters/kong_backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/kong_backend.canister.spec.ts
@@ -9,6 +9,7 @@ import type { IcCkToken } from '$icp/types/ic-token';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { KongBackendCanister } from '$lib/canisters/kong_backend.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { getKongIcTokenIdentifier } from '$lib/utils/swap.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockKongBackendTokens } from '$tests/mocks/kong_backend.mock';
 import { type ActorSubclass } from '@dfinity/agent';
@@ -113,9 +114,9 @@ describe('kong_backend.canister', () => {
 
 			expect(res).toEqual(response.Ok);
 			expect(service.swap_amounts).toHaveBeenCalledWith(
-				sourceToken.symbol,
+				getKongIcTokenIdentifier(sourceToken),
 				sourceAmount,
-				destinationToken.symbol
+				getKongIcTokenIdentifier(destinationToken)
 			);
 		});
 
@@ -174,8 +175,8 @@ describe('kong_backend.canister', () => {
 
 			expect(res).toEqual(response.Ok);
 			expect(service.swap_async).toHaveBeenCalledWith({
-				pay_token: swapParams.sourceToken.symbol,
-				receive_token: swapParams.destinationToken.symbol,
+				pay_token: getKongIcTokenIdentifier(swapParams.sourceToken),
+				receive_token: getKongIcTokenIdentifier(swapParams.destinationToken),
 				pay_amount: swapParams.sendAmount,
 				max_slippage: toNullable(swapParams.maxSlippage),
 				receive_address: toNullable(swapParams.receiveAddress),

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -1,7 +1,13 @@
 import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_SYMBOL, ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import { getLiquidityFees, getNetworkFee, getSwapRoute } from '$lib/utils/swap.utils';
+import {
+	getKongIcTokenIdentifier,
+	getLiquidityFees,
+	getNetworkFee,
+	getSwapRoute
+} from '$lib/utils/swap.utils';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockTokens } from '$tests/mocks/tokens.mock';
 
 describe('swap utils', () => {
@@ -103,6 +109,14 @@ describe('swap utils', () => {
 			const networkFee = getNetworkFee({ transactions, tokens: [] });
 
 			expect(networkFee).toBeUndefined();
+		});
+	});
+
+	describe('getKongIcTokenIdentifier', () => {
+		it('returns correct kong token identifier', () => {
+			expect(getKongIcTokenIdentifier(mockValidIcToken)).toBe(
+				`IC.${mockValidIcToken.ledgerCanisterId}`
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -1,4 +1,5 @@
 import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_SYMBOL, ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import {
@@ -113,10 +114,14 @@ describe('swap utils', () => {
 	});
 
 	describe('getKongIcTokenIdentifier', () => {
-		it('returns correct kong token identifier', () => {
+		it('returns correct kong token identifier for IC token', () => {
 			expect(getKongIcTokenIdentifier(mockValidIcToken)).toBe(
 				`IC.${mockValidIcToken.ledgerCanisterId}`
 			);
+		});
+
+		it('returns empty string for non-IC token', () => {
+			expect(getKongIcTokenIdentifier(BTC_MAINNET_TOKEN)).toBe('');
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

As suggested by the Kong team, we need to use ledger ids (prefixed with `IC.`) instead of token symbols for communicating with their endpoints.