### PR TITLE
refactor(devops): include scripts folder in Docker frontend dependencies

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -26,6 +26,7 @@ RUN npm ci
 COPY .env.* *.js *.cjs *.mjs *.ts *.json .npmrc .nvmrc .
 COPY src/frontend/ src/frontend
 COPY src/declarations/ src/declarations
+COPY scripts/ scripts/
 
 ARG network="staging"
 ENV ENV=$network


### PR DESCRIPTION
# Motivation

For building the frontend, we require the `scripts` folder too.
