### PR TITLE
fix(frontend): Solana fees are set only if user is payer

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -15,6 +15,7 @@ import {
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type {
+	ParsedAccount,
 	SolMappedTransaction,
 	SolSignature,
 	SolTransactionUi
@@ -28,6 +29,11 @@ import { address as solAddress } from '@solana/kit';
 interface LoadNextSolTransactionsParams extends GetSolTransactionsParams {
 	signalEnd: () => void;
 }
+
+// The fee payer is always the first signer
+// https://solana.com/docs/core/fees#base-transaction-fee
+const extractFeePayer = (accountKeys: ParsedAccount[]): ParsedAccount | undefined =>
+	accountKeys.length > 0 ? accountKeys.filter(({ signer }) => signer)[0] : undefined;
 
 export const fetchSolTransactionsForSignature = async ({
 	signature,
@@ -52,12 +58,14 @@ export const fetchSolTransactionsForSignature = async ({
 		blockTime,
 		confirmationStatus: status,
 		transaction: {
-			message: { instructions }
+			message: { instructions, accountKeys }
 		},
 		meta
 	} = transactionDetail;
 
 	const { fee } = meta ?? {};
+	const { pubkey: feePayer } = extractFeePayer([...(accountKeys ?? [])]) ?? {};
+
 	const putativeInnerInstructions = meta?.innerInstructions ?? [];
 
 	// Inside the instructions there could be some that we are unable to decode, but that may have
@@ -160,7 +168,7 @@ export const fetchSolTransactionsForSignature = async ({
 				// Since the fee is assigned to a single signature, it is not entirely correct to assign it to each transaction.
 				// Particularly, we are repeating the same fee for each instruction in the transaction.
 				// However, we should have it anyway saved in the transaction, so we can display it in the UI.
-				fee
+				...(nonNullish(fee) && nonNullish(feePayer) && { fee: address === feePayer ? fee : 0n })
 			};
 
 			return {

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -33,12 +33,14 @@ type SolRpcTransactionRawWithBug = NonNullable<
 // This is a temporary type that we are using to cast the parsed account keys of an RPC Solana Transaction.
 // We need to do this, because in the current version of @solana/kit (v2.0.0) there is a bug: https://github.com/anza-xyz/solana-web3.js/issues/80
 // TODO: Remove this type and its usage when the bug is fixed and released.
-type ParsedAccounts = {
+export interface ParsedAccount {
 	pubkey: Address;
 	signer: boolean;
 	source: string;
 	writable: boolean;
-}[];
+}
+
+type ParsedAccounts = ParsedAccount[];
 export type SolRpcTransactionRaw = Omit<SolRpcTransactionRawWithBug, 'transaction'> & {
 	transaction: Omit<SolRpcTransactionRawWithBug['transaction'], 'message'> & {
 		message: Omit<SolRpcTransactionRawWithBug['transaction']['message'], 'accountKeys'> & {

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -25,8 +25,9 @@ export interface SolTransactionUi extends TransactionUiCommon {
 	fee?: bigint;
 }
 
-
 export type SolRpcTransactionRaw = NonNullable<Awaited<ReturnType<typeof getRpcTransaction>>>;
+
+export type ParsedAccount = SolRpcTransactionRaw['transaction']['message']['accountKeys'][number];
 
 export type SolRpcTransaction = SolRpcTransactionRaw & {
 	id: string;

--- a/src/frontend/src/tests/mocks/sol.mock.ts
+++ b/src/frontend/src/tests/mocks/sol.mock.ts
@@ -1,6 +1,6 @@
 import type { SolAddress } from '$lib/types/address';
 
-export const mockSolAddress: SolAddress = 'AeZDiNSSTvGxxD92vao15YRV7f4c4Q1GfcKnwezXucZa';
+export const mockSolAddress: SolAddress = '7q6RDbnn2SWnvews2qYCCAMCZzntDLM8scJfUEBmEMf1';
 
 export const mockSolAddress2: SolAddress = '4GsmSut5stEKJHsGfiTeP5c6VbPyt4KmtCQ9TAM56JR8';
 


### PR DESCRIPTION
# Motivation

According to [Solana documentation](https://solana.com/docs/core/fees#base-transaction-fee), the first signer is the fee payer. So we set the fee in a `SolTransactionUi` only if the user is the fee payer.

# Changes

- Create small function to extract the fee payer from `accountKeys`: it filters all the signers and returns the first.
- Use the fee payer to set the fee prop in `fetchSolTransactionsForSignature`.

# Tests

Current tests are sufficient and works.