### PR TITLE
feat(frontend): explicit type of method getTransaction of Solana RPC

### DIFF
--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -90,7 +90,7 @@ export const fetchSignatures = async ({
 	return await fetchSignaturesBatch(before);
 };
 
-export const getTransactionFromSolanaRpc = async ({
+export const getRpcTransaction = async ({
 	signature: { signature },
 	network
 }: {
@@ -114,7 +114,7 @@ export const fetchTransactionDetailForSignature = async ({
 }): Promise<SolRpcTransaction | null> => {
 	const { confirmationStatus } = signature;
 
-	const rpcTransaction: SolRpcTransactionRaw | null = await getTransactionFromSolanaRpc({
+	const rpcTransaction: SolRpcTransactionRaw | null = await getRpcTransaction({
 		signature,
 		network
 	});

--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -106,18 +106,18 @@ export const getTransactionFromSolanaRpc = async ({
 };
 
 export const fetchTransactionDetailForSignature = async ({
-	signature: { signature, confirmationStatus },
+	signature,
 	network
 }: {
 	signature: SolSignature;
 	network: SolanaNetworkType;
 }): Promise<SolRpcTransaction | null> => {
-	const { getTransaction } = solanaHttpRpc(network);
+	const { confirmationStatus } = signature;
 
-	const rpcTransaction: SolRpcTransactionRaw | null = await getTransaction(signature, {
-		maxSupportedTransactionVersion: 0,
-		encoding: 'jsonParsed'
-	}).send();
+	const rpcTransaction: SolRpcTransactionRaw | null = await getTransactionFromSolanaRpc({
+		signature,
+		network
+	});
 
 	if (isNullish(rpcTransaction)) {
 		return null;
@@ -128,7 +128,7 @@ export const fetchTransactionDetailForSignature = async ({
 		version: rpcTransaction.version,
 		confirmationStatus,
 		id: signature.toString(),
-		signature
+		signature: signature.signature
 	};
 };
 

--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -3,7 +3,7 @@ import { last } from '$lib/utils/array.utils';
 import { ATA_SIZE } from '$sol/constants/ata.constants';
 import { solanaHttpRpc } from '$sol/providers/sol-rpc.providers';
 import type { SolanaNetworkType } from '$sol/types/network';
-import type { SolSignature } from '$sol/types/sol-transaction';
+import type { SolRpcTransactionDetail, SolSignature } from '$sol/types/sol-transaction';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { address as solAddress, type Address, type Lamports, type Signature } from '@solana/kit';
@@ -92,7 +92,7 @@ export const fetchTransactionDetailForSignature = async ({
 }: {
 	signature: SolSignature;
 	network: SolanaNetworkType;
-}) => {
+}): Promise<SolRpcTransactionDetail | null> => {
 	const { getTransaction } = solanaHttpRpc(network);
 
 	const rpcTransaction = await getTransaction(signature, {
@@ -106,7 +106,6 @@ export const fetchTransactionDetailForSignature = async ({
 
 	return {
 		...rpcTransaction,
-		version: rpcTransaction.version,
 		confirmationStatus,
 		id: signature.toString(),
 		signature

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -16,6 +16,7 @@ import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { GetSolTransactionsParams } from '$sol/types/sol-api';
 import type {
 	SolMappedTransaction,
+	SolRpcTransaction,
 	SolSignature,
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
@@ -42,7 +43,10 @@ export const fetchSolTransactionsForSignature = async ({
 	tokenAddress?: SplTokenAddress;
 	tokenOwnerAddress?: SolAddress;
 }): Promise<SolTransactionUi[]> => {
-	const transactionDetail = await fetchTransactionDetailForSignature({ signature, network });
+	const transactionDetail: SolRpcTransaction | null = await fetchTransactionDetailForSignature({
+		signature,
+		network
+	});
 
 	if (isNullish(transactionDetail)) {
 		return [];

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -4,11 +4,9 @@ import type { TransactionId, TransactionType, TransactionUiCommon } from '$lib/t
 import type { getTransactionFromSolanaRpc } from '$sol/api/solana.api';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type {
-	Address,
 	Commitment,
 	FullySignedTransaction,
 	GetSignaturesForAddressApi,
-	GetTransactionApi,
 	Signature,
 	TransactionWithBlockhashLifetime
 } from '@solana/kit';
@@ -27,38 +25,9 @@ export interface SolTransactionUi extends TransactionUiCommon {
 	fee?: bigint;
 }
 
-const getTransactionApi = null as unknown as GetTransactionApi;
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function jsonParsedResultProducer() {
-	return getTransactionApi.getTransaction('' as Signature, {
-		encoding: 'jsonParsed',
-		maxSupportedTransactionVersion: 0
-	});
-}
-
-type SolRpcTransactionRawWithBug = NonNullable<ReturnType<typeof jsonParsedResultProducer>>;
-
 export type SolRpcTransactionRaw = NonNullable<
 	Awaited<ReturnType<typeof getTransactionFromSolanaRpc>>
 >;
-
-// This is a temporary type that we are using to cast the parsed account keys of an RPC Solana Transaction.
-// We need to do this, because in the current version of @solana/kit (v2.0.0) there is a bug: https://github.com/anza-xyz/solana-web3.js/issues/80
-// TODO: Remove this type and its usage when the bug is fixed and released.
-type ParsedAccounts = {
-	pubkey: Address;
-	signer: boolean;
-	source: string;
-	writable: boolean;
-}[];
-export type SolRpcTransactionRawOld = Omit<SolRpcTransactionRawWithBug, 'transaction'> & {
-	transaction: Omit<SolRpcTransactionRawWithBug['transaction'], 'message'> & {
-		message: Omit<SolRpcTransactionRawWithBug['transaction']['message'], 'accountKeys'> & {
-			accountKeys: ParsedAccounts;
-		};
-	};
-};
 
 export type SolRpcTransaction = SolRpcTransactionRaw & {
 	id: string;

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -1,13 +1,12 @@
 import { solTransactionTypes } from '$lib/schema/transaction.schema';
 import type { SolAddress } from '$lib/types/address';
 import type { TransactionId, TransactionType, TransactionUiCommon } from '$lib/types/transaction';
-import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type {
-	Address,
 	Commitment,
 	FullySignedTransaction,
 	GetSignaturesForAddressApi,
+	GetTransactionApi,
 	Signature,
 	TransactionWithBlockhashLifetime
 } from '@solana/kit';
@@ -26,25 +25,22 @@ export interface SolTransactionUi extends TransactionUiCommon {
 	fee?: bigint;
 }
 
-type SolRpcTransactionRawWithBug = NonNullable<
-	Awaited<ReturnType<typeof fetchTransactionDetailForSignature>>
->;
+const getTransactionApi = null as unknown as GetTransactionApi;
 
-// This is a temporary type that we are using to cast the parsed account keys of an RPC Solana Transaction.
-// We need to do this, because in the current version of @solana/kit (v2.0.0) there is a bug: https://github.com/anza-xyz/solana-web3.js/issues/80
-// TODO: Remove this type and its usage when the bug is fixed and released.
-type ParsedAccounts = {
-	pubkey: Address;
-	signer: boolean;
-	source: string;
-	writable: boolean;
-}[];
-export type SolRpcTransactionRaw = Omit<SolRpcTransactionRawWithBug, 'transaction'> & {
-	transaction: Omit<SolRpcTransactionRawWithBug['transaction'], 'message'> & {
-		message: Omit<SolRpcTransactionRawWithBug['transaction']['message'], 'accountKeys'> & {
-			accountKeys: ParsedAccounts;
-		};
-	};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function jsonParsedResultProducer() {
+	return getTransactionApi.getTransaction('' as Signature, {
+		encoding: 'jsonParsed',
+		maxSupportedTransactionVersion: 0
+	});
+}
+
+export type SolRpcTransactionRaw = ReturnType<typeof jsonParsedResultProducer>;
+
+export type SolRpcTransactionDetail = NonNullable<SolRpcTransactionRaw> & {
+	confirmationStatus: Commitment | null;
+	id: string;
+	signature: Signature;
 };
 
 export type SolRpcTransaction = SolRpcTransactionRaw & {

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -1,7 +1,7 @@
 import { solTransactionTypes } from '$lib/schema/transaction.schema';
 import type { SolAddress } from '$lib/types/address';
 import type { TransactionId, TransactionType, TransactionUiCommon } from '$lib/types/transaction';
-import type { getTransactionFromSolanaRpc } from '$sol/api/solana.api';
+import type { getRpcTransaction } from '$sol/api/solana.api';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type {
 	Commitment,
@@ -25,9 +25,7 @@ export interface SolTransactionUi extends TransactionUiCommon {
 	fee?: bigint;
 }
 
-export type SolRpcTransactionRaw = NonNullable<
-	Awaited<ReturnType<typeof getTransactionFromSolanaRpc>>
->;
+export type SolRpcTransactionRaw = NonNullable<Awaited<ReturnType<typeof getRpcTransaction>>>;
 
 export type SolRpcTransaction = SolRpcTransactionRaw & {
 	id: string;

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -1,8 +1,10 @@
 import { solTransactionTypes } from '$lib/schema/transaction.schema';
 import type { SolAddress } from '$lib/types/address';
 import type { TransactionId, TransactionType, TransactionUiCommon } from '$lib/types/transaction';
+import type { getTransactionFromSolanaRpc } from '$sol/api/solana.api';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type {
+	Address,
 	Commitment,
 	FullySignedTransaction,
 	GetSignaturesForAddressApi,
@@ -35,12 +37,27 @@ function jsonParsedResultProducer() {
 	});
 }
 
-export type SolRpcTransactionRaw = ReturnType<typeof jsonParsedResultProducer>;
+type SolRpcTransactionRawWithBug = NonNullable<ReturnType<typeof jsonParsedResultProducer>>;
 
-export type SolRpcTransactionDetail = NonNullable<SolRpcTransactionRaw> & {
-	confirmationStatus: Commitment | null;
-	id: string;
-	signature: Signature;
+export type SolRpcTransactionRaw = NonNullable<
+	Awaited<ReturnType<typeof getTransactionFromSolanaRpc>>
+>;
+
+// This is a temporary type that we are using to cast the parsed account keys of an RPC Solana Transaction.
+// We need to do this, because in the current version of @solana/kit (v2.0.0) there is a bug: https://github.com/anza-xyz/solana-web3.js/issues/80
+// TODO: Remove this type and its usage when the bug is fixed and released.
+type ParsedAccounts = {
+	pubkey: Address;
+	signer: boolean;
+	source: string;
+	writable: boolean;
+}[];
+export type SolRpcTransactionRawOld = Omit<SolRpcTransactionRawWithBug, 'transaction'> & {
+	transaction: Omit<SolRpcTransactionRawWithBug['transaction'], 'message'> & {
+		message: Omit<SolRpcTransactionRawWithBug['transaction']['message'], 'accountKeys'> & {
+			accountKeys: ParsedAccounts;
+		};
+	};
 };
 
 export type SolRpcTransaction = SolRpcTransactionRaw & {

--- a/src/frontend/src/tests/mocks/sol-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-transactions.mock.ts
@@ -7,7 +7,7 @@ import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store
 import type { SolTransactionMessage } from '$sol/types/sol-send';
 import type {
 	SolRpcTransaction,
-	SolRpcTransactionRaw,
+	SolRpcTransactionDetail,
 	SolSignedTransaction,
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
@@ -74,20 +74,32 @@ export const mockSolRpcReceiveTransaction: SolRpcTransaction = {
 				{
 					pubkey: address('devwuNsNYACyiEYxRNqMNseBpNnGfnd4ZwNHL7sphqv'),
 					signer: false,
-					source: 'program',
+					source: 'lookupTable',
 					writable: false
 				},
 				{
 					pubkey: address(mockSolAddress),
 					signer: true,
-					source: 'external',
+					source: 'lookupTable',
 					writable: true
 				},
 				{
 					pubkey: address(SYSTEM_PROGRAM_ADDRESS),
 					signer: false,
-					source: 'program',
+					source: 'lookupTable',
 					writable: false
+				}
+			],
+			addressTableLookups: [
+				{
+					accountKey: address('8GU6nusbxwVrwkAkcQCnLfJj1cE4sGH5xCLmss5WEuP4'),
+					readableIndexes: [146],
+					writableIndexes: [148, 149, 156, 152]
+				},
+				{
+					accountKey: address('9W6BH3BLditrazBMnT87jc5ZdKRLtUFmWqkLviWtdzXm'),
+					readableIndexes: [69, 67, 10, 70, 68, 73],
+					writableIndexes: [66, 63, 71, 72]
 				}
 			],
 			instructions: [
@@ -142,26 +154,38 @@ export const mockSolRpcSendTransaction: SolRpcTransaction = {
 				{
 					pubkey: address(mockSolAddress),
 					signer: true,
-					source: 'external',
+					source: 'lookupTable',
 					writable: true
 				},
 				{
 					pubkey: address('4DAtqyYPYCj2WK4RpPQwCNxz3xYLm5G9vTuZqnP2ZzcQ'),
 					signer: false,
-					source: 'external',
+					source: 'lookupTable',
 					writable: true
 				},
 				{
 					pubkey: address(SYSTEM_PROGRAM_ADDRESS),
 					signer: false,
-					source: 'program',
+					source: 'lookupTable',
 					writable: false
 				},
 				{
 					pubkey: address(COMPUTE_BUDGET_PROGRAM_ADDRESS),
 					signer: false,
-					source: 'program',
+					source: 'lookupTable',
 					writable: false
+				}
+			],
+			addressTableLookups: [
+				{
+					accountKey: address('8GU6nusbxwVrwkAkcQCnLfJj1cE4sGH5xCLmss5WEuP4'),
+					readableIndexes: [146],
+					writableIndexes: [148, 149, 156, 152]
+				},
+				{
+					accountKey: address('9W6BH3BLditrazBMnT87jc5ZdKRLtUFmWqkLviWtdzXm'),
+					readableIndexes: [69, 67, 10, 70, 68, 73],
+					writableIndexes: [66, 63, 71, 72]
 				}
 			],
 			instructions: [
@@ -194,7 +218,7 @@ export const mockSolRpcSendTransaction: SolRpcTransaction = {
 	version: 'legacy'
 };
 
-export const mockSolTransactionDetail: SolRpcTransactionRaw = {
+export const mockSolTransactionDetail: SolRpcTransactionDetail = {
 	blockTime: 1740654097n as UnixTimestamp,
 	meta: {
 		computeUnitsConsumed: 208718n,
@@ -1049,18 +1073,18 @@ export const mockSolTransactionDetail: SolRpcTransactionRaw = {
 					writable: false
 				}
 			],
-			// addressTableLookups: [
-			// 	{
-			// 		accountKey: '8GU6nusbxwVrwkAkcQCnLfJj1cE4sGH5xCLmss5WEuP4',
-			// 		readonlyIndexes: [146],
-			// 		writableIndexes: [148, 149, 156, 152]
-			// 	},
-			// 	{
-			// 		accountKey: '9W6BH3BLditrazBMnT87jc5ZdKRLtUFmWqkLviWtdzXm',
-			// 		readonlyIndexes: [69, 67, 10, 70, 68, 73],
-			// 		writableIndexes: [66, 63, 71, 72]
-			// 	}
-			// ],
+			addressTableLookups: [
+				{
+					accountKey: address('8GU6nusbxwVrwkAkcQCnLfJj1cE4sGH5xCLmss5WEuP4'),
+					readableIndexes: [146],
+					writableIndexes: [148, 149, 156, 152]
+				},
+				{
+					accountKey: address('9W6BH3BLditrazBMnT87jc5ZdKRLtUFmWqkLviWtdzXm'),
+					readableIndexes: [69, 67, 10, 70, 68, 73],
+					writableIndexes: [66, 63, 71, 72]
+				}
+			],
 			instructions: [
 				{
 					accounts: [],

--- a/src/frontend/src/tests/mocks/sol-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-transactions.mock.ts
@@ -7,7 +7,6 @@ import type { SolCertifiedTransaction } from '$sol/stores/sol-transactions.store
 import type { SolTransactionMessage } from '$sol/types/sol-send';
 import type {
 	SolRpcTransaction,
-	SolRpcTransactionDetail,
 	SolSignedTransaction,
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
@@ -218,7 +217,7 @@ export const mockSolRpcSendTransaction: SolRpcTransaction = {
 	version: 'legacy'
 };
 
-export const mockSolTransactionDetail: SolRpcTransactionDetail = {
+export const mockSolTransactionDetail: SolRpcTransaction = {
 	blockTime: 1740654097n as UnixTimestamp,
 	meta: {
 		computeUnitsConsumed: 208718n,

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -10,7 +10,7 @@ import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type {
 	SolMappedTransaction,
-	SolRpcTransactionDetail,
+	SolRpcTransaction,
 	SolSignature,
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
@@ -60,15 +60,15 @@ describe('sol-transactions.services', () => {
 	describe('fetchSolTransactionsForSignature', () => {
 		const network: SolanaNetworkType = 'mainnet';
 
-		const mockTransactionDetail: SolRpcTransactionDetail = mockSolTransactionDetail;
+		const mockTransactionDetail: SolRpcTransaction = mockSolTransactionDetail;
 
-		const mockTransactionDetailOnlyInnerInstructions: SolRpcTransactionDetail = {
+		const mockTransactionDetailOnlyInnerInstructions: SolRpcTransaction = {
 			...mockTransactionDetail,
 			transaction: {
 				...mockTransactionDetail.transaction,
 				message: { ...mockTransactionDetail.transaction.message, instructions: [] }
 			}
-		};
+		} as SolRpcTransaction;
 
 		const mockSignature: SolSignature = {
 			...mockSolSignatureResponse(),

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -10,7 +10,7 @@ import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type {
 	SolMappedTransaction,
-	SolRpcTransactionRaw,
+	SolRpcTransactionDetail,
 	SolSignature,
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
@@ -60,9 +60,9 @@ describe('sol-transactions.services', () => {
 	describe('fetchSolTransactionsForSignature', () => {
 		const network: SolanaNetworkType = 'mainnet';
 
-		const mockTransactionDetail: SolRpcTransactionRaw = mockSolTransactionDetail;
+		const mockTransactionDetail: SolRpcTransactionDetail = mockSolTransactionDetail;
 
-		const mockTransactionDetailOnlyInnerInstructions: SolRpcTransactionRaw = {
+		const mockTransactionDetailOnlyInnerInstructions: SolRpcTransactionDetail = {
 			...mockTransactionDetail,
 			transaction: {
 				...mockTransactionDetail.transaction,


### PR DESCRIPTION
# Motivation

We want to have a more explicit type for the getTransaction method of Solana RPC.

However, according to [Solana dev forum](https://solana.stackexchange.com/questions/17643/how-to-infer-or-find-basic-types-for-return-values-in-solana-web3-js-v2-library/17673#17673), exporting ‘result types’ from `@solana/kit` is impractical, because the RPC is fluid to the point where its result types change depending on the particular inputs to the calls themselves.

So, we must first create a sub-function and extract the type from there, in a more fluid way.

# Changes

- Create function that just wraps the `getTransaction` method of the Solana RPC.
- Extract the type for such type.
- Use it in the code.

# Tests

Adapted a few mock, the rest is sufficient.
