### PR TITLE
feat(frontend): component Amount will use bigint instead of BigNumber

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import type { BtcTransactionStatus, BtcTransactionUi } from '$btc/types/btc';
 	import type { BtcTransactionType } from '$btc/types/btc-transaction';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
@@ -22,10 +21,8 @@
 	let label: string;
 	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
 
-	let amount: BigNumber | undefined;
-	$: amount = nonNullish(value)
-		? BigNumber.from(type === 'send' ? value * BigInt(-1) : value)
-		: undefined;
+	let amount: bigint | undefined;
+	$: amount = nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined;
 </script>
 
 <Transaction

--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -60,8 +60,8 @@
 					? $i18n.send.text.send
 					: $i18n.receive.text.receive;
 
-	let amount: BigNumber;
-	$: amount = type === 'send' || type === 'deposit' ? value.mul(BigNumber.from(-1)) : value;
+	let amount: bigint;
+	$: amount = value.toBigInt() * (type === 'send' || type === 'deposit' ? -1n : 1n);
 
 	let transactionDate: number | undefined;
 	$: transactionDate = timestamp ?? displayTimestamp;

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import IcTransactionLabel from '$icp/components/transactions/IcTransactionLabel.svelte';
 	import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic-transaction';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
@@ -33,8 +32,8 @@
 	let status: TransactionStatus;
 	$: status = pending ? 'pending' : 'confirmed';
 
-	let amount: BigNumber | undefined;
-	$: amount = nonNullish(value) ? BigNumber.from(incoming ? value : value * -1n) : value;
+	let amount: bigint | undefined;
+	$: amount = nonNullish(value) ? (incoming ? value : value * -1n) : value;
 
 	let timestamp: number | undefined;
 	$: timestamp = nonNullish(timestampNanoseconds)

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from 'alchemy-sdk';
 	import { getContext } from 'svelte';
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
@@ -21,11 +20,7 @@
 		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"
 	>
 		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !(token.balance === ZERO_BI)}
-			<Amount
-				amount={BigNumber.from(token.balance)}
-				decimals={token.decimals}
-				symbol={token.symbol}
-			/>
+			<Amount amount={token.balance} decimals={token.decimals} symbol={token.symbol} />
 		{:else}
 			<span class:animate-pulse={$loading}>0.00</span>
 		{/if}

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import type { ComponentType } from 'svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TransactionStatusComponent from '$lib/components/transactions/TransactionStatus.svelte';
@@ -12,7 +11,7 @@
 	import { formatSecondsToDate } from '$lib/utils/format.utils';
 	import { mapTransactionIcon } from '$lib/utils/transaction.utils';
 
-	export let amount: BigNumber | undefined;
+	export let amount: bigint | undefined;
 	export let type: TransactionType;
 	export let status: TransactionStatus;
 	export let timestamp: number | undefined;

--- a/src/frontend/src/lib/components/ui/Amount.svelte
+++ b/src/frontend/src/lib/components/ui/Amount.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
-	import type { BigNumber } from '@ethersproject/bignumber';
-	import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
+	import { EIGHT_DECIMALS, ZERO_BI } from '$lib/constants/app.constants';
 	import { formatToken } from '$lib/utils/format.utils';
 
-	export let amount: BigNumber;
+	export let amount: bigint;
 	export let decimals: number;
 	export let symbol: string;
 	export let formatPositiveAmount = false;
 
 	let detailedValue: string;
 	$: detailedValue = formatToken({
-		value: amount.toBigInt(),
+		value: amount,
 		unitName: decimals,
 		displayDecimals: decimals
 	});
 
 	let displayValue: string;
 	$: displayValue = formatToken({
-		value: amount.toBigInt(),
+		value: amount,
 		unitName: decimals,
 		displayDecimals: EIGHT_DECIMALS,
 		showPlusSign: formatPositiveAmount
 	});
 </script>
 
-<span class:text-success-primary={formatPositiveAmount && amount.gt(0)}>
+<span class:text-success-primary={formatPositiveAmount && amount > ZERO_BI}>
 	<data value={detailedValue}>
 		{displayValue}
 	</data>

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import type { Commitment } from '@solana/kit';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -29,12 +28,8 @@
 	let transactionStatus: TransactionStatus;
 	$: transactionStatus = pending ? 'pending' : 'confirmed';
 
-	let amount: BigNumber | undefined;
-	$: amount = nonNullish(value)
-		? type === 'send'
-			? BigNumber.from(value * -1n)
-			: BigNumber.from(value)
-		: value;
+	let amount: bigint | undefined;
+	$: amount = nonNullish(value) ? (type === 'send' ? value * -1n : value) : value;
 </script>
 
 <Transaction


### PR DESCRIPTION
# Motivation

We need to migrate to `ethers` v6: one of the biggest change was the deprecation of `BigNumber` in favour of built-in `bigint` (see [documentation](https://docs.ethers.org/v6/migrating/#migrate-bigint)).

To smooth the migration, we replace `BigNumber` with `bigint` in the component `AMount`.

# Changes

- Make component `Amount` accept `amount` as `bigint` instead of `BigNumber`.
- Adapt the rest of the usages.

# Tests

Existing tests were sufficient.
