### PR TITLE
feat(frontend): component TransactionModal will use bigint instead of BigNumber

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import type { BtcTransactionStatus, BtcTransactionUi } from '$btc/types/btc';
 	import type { BtcTransactionType } from '$btc/types/btc-transaction';
 	import { BTC_MAINNET_EXPLORER_URL, BTC_TESTNET_EXPLORER_URL } from '$env/explorers.env';
@@ -56,7 +55,7 @@
 		fromExplorerUrl
 	}}
 	hash={id}
-	value={nonNullish(value) ? BigNumber.from(value) : undefined}
+	{value}
 	{token}
 	sendToLabel={$i18n.transaction.text.to}
 	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}

--- a/src/frontend/src/lib/components/transactions/TransactionModal.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionModal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import type { BigNumber } from '@ethersproject/bignumber';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
@@ -20,7 +19,7 @@
 
 	export let commonData: TransactionUiCommon;
 	export let hash: string | undefined;
-	export let value: BigNumber | undefined;
+	export let value: bigint | undefined;
 	export let token: OptionToken;
 	export let typeLabel: string;
 	export let sendToLabel: string | undefined;
@@ -123,7 +122,7 @@
 				<svelte:fragment slot="label">{$i18n.core.text.amount}</svelte:fragment>
 				<output>
 					{formatToken({
-						value: value.toBigInt(),
+						value,
 						unitName: token.decimals,
 						displayDecimals: token.decimals
 					})}

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { BigNumber } from '@ethersproject/bignumber';
 	import type { Commitment } from '@solana/kit';
 	import TransactionModal from '$lib/components/transactions/TransactionModal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
@@ -53,7 +52,7 @@
 		fromExplorerUrl
 	}}
 	hash={id}
-	value={nonNullish(value) ? BigNumber.from(value) : undefined}
+	{value}
 	{token}
 	sendToLabel={$i18n.transaction.text.to}
 	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}


### PR DESCRIPTION
# Motivation

We need to migrate to `ethers` v6: one of the biggest change was the deprecation of `BigNumber` in favour of built-in `bigint` (see [documentation](https://docs.ethers.org/v6/migrating/#migrate-bigint)).

To smooth the migration, we replace `BigNumber` with `bigint` in component `TransactionModal`.

# Changes

- Make component `TransactionModal` accept `amount` as `bigint` instead of `BigNumber`.
- Adapt the rest of the usages.

# Tests

Existing tests were sufficient.
