### PR TITLE
refactor(frontend): use ZERO_BI instead of 0n

### DIFF
--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -90,7 +90,7 @@ const erc20PrepareTransaction = async ({
 	return prepare({
 		data,
 		to: contractAddress,
-		amount: 0n,
+		amount: ZERO_BI,
 		...rest
 	});
 };
@@ -166,7 +166,7 @@ const ckErc20HelperContractPrepareTransaction = async ({
 	return prepare({
 		data,
 		to: contractAddress,
-		amount: 0n,
+		amount: ZERO_BI,
 		...rest
 	});
 };
@@ -225,7 +225,7 @@ const erc20ContractPrepareApprove = async ({
 	return prepare({
 		data,
 		to,
-		amount: 0n,
+		amount: ZERO_BI,
 		...rest
 	});
 };

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -21,7 +21,7 @@ import {
 	toCkEthHelperContractAddress
 } from '$icp-eth/utils/cketh.utils';
 import { signTransaction } from '$lib/api/signer.api';
-import { ZERO } from '$lib/constants/app.constants';
+import { ZERO, ZERO_BI } from '$lib/constants/app.constants';
 import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';

--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -19,6 +19,7 @@
 	import { tokenId } from '$lib/derived/token.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
+	import { ZERO_BI } from '$lib/constants/app.constants';
 
 	export let networkId: NetworkId | undefined = undefined;
 
@@ -52,7 +53,7 @@
 	// See https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/ckerc20.adoc#withdrawal-ckerc20-to-erc20
 	let maxTransactionFeePlusLedgerApproveCkEth: bigint | undefined = undefined;
 	$: maxTransactionFeePlusLedgerApproveCkEth = nonNullish(maxTransactionFeeCkEth)
-		? maxTransactionFeeCkEth + (tokenCkEth?.fee ?? 0n)
+		? maxTransactionFeeCkEth + (tokenCkEth?.fee ?? ZERO_BI)
 		: undefined;
 
 	let maxTransactionFee: bigint | undefined = undefined;

--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -16,10 +16,10 @@
 		isConvertCkErc20ToErc20,
 		isConvertCkEthToEth
 	} from '$icp-eth/utils/cketh-transactions.utils';
+	import { ZERO_BI } from '$lib/constants/app.constants';
 	import { tokenId } from '$lib/derived/token.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
-	import { ZERO_BI } from '$lib/constants/app.constants';
 
 	export let networkId: NetworkId | undefined = undefined;
 

--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -19,7 +19,10 @@ export const loadAndAssertAddCustomToken = async ({
 	icrcTokens,
 	ledgerCanisterId,
 	indexCanisterId
-}: Partial<IcCanisters> & { identity: OptionIdentity; icrcTokens: IcToken[] }): Promise<{
+}: Partial<IcCanisters> & {
+	identity: OptionIdentity;
+	icrcTokens: IcToken[];
+}): Promise<{
 	result: 'success' | 'error';
 	data?: {
 		token: IcTokenWithoutId;
@@ -178,13 +181,15 @@ const loadLedgerBalance = async ({
 const loadIndexBalance = async ({
 	identity,
 	indexCanisterId
-}: Required<Pick<IcCanisters, 'indexCanisterId'>> & { identity: Identity }): Promise<bigint> => {
+}: Required<Pick<IcCanisters, 'indexCanisterId'>> & {
+	identity: Identity;
+}): Promise<bigint> => {
 	try {
 		const { balance } = await getTransactionsIcrc({
 			indexCanisterId,
 			identity,
 			owner: identity.getPrincipal(),
-			maxResults: 0n,
+			maxResults: ZERO_BI,
 			certified: true
 		});
 

--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -2,6 +2,7 @@ import { getLedgerId, getTransactions as getTransactionsIcrc } from '$icp/api/ic
 import { balance, metadata } from '$icp/api/icrc-ledger.api';
 import type { IcCanisters, IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
 import { mapIcrcToken } from '$icp/utils/icrc.utils';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';

--- a/src/frontend/src/icp/utils/ckbtc.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc.utils.ts
@@ -32,7 +32,7 @@ export const assertCkBTCUserInputAmount = ({
 		certified: infoCertified
 	} = minterInfo;
 
-	if ((amount ?? 0n) < retrieveBtcMinAmount) {
+	if ((amount ?? ZERO_BI) < retrieveBtcMinAmount) {
 		return new IcAmountAssertionError(
 			replacePlaceholders(i18n.send.assertion.minimum_ckbtc_amount, {
 				$amount: formatToken({

--- a/src/frontend/src/icp/utils/cketh.utils.ts
+++ b/src/frontend/src/icp/utils/cketh.utils.ts
@@ -38,9 +38,9 @@ export const assertCkETHMinWithdrawalAmount = ({
 	} = minterInfo;
 
 	// The `minimum_withdrawal_amount` is optional in the minter info because the team decided to make all fields optional for maintainability reasons. That's why we assume that it is most likely set.
-	const minWithdrawalAmount = fromNullable(minimum_withdrawal_amount) ?? 0n;
+	const minWithdrawalAmount = fromNullable(minimum_withdrawal_amount) ?? ZERO_BI;
 
-	if ((amount ?? 0n) < minWithdrawalAmount) {
+	if ((amount ?? ZERO_BI) < minWithdrawalAmount) {
 		return new IcAmountAssertionError(
 			replacePlaceholders(i18n.send.assertion.minimum_cketh_amount, {
 				$amount: formatToken({

--- a/src/frontend/src/icp/utils/icp-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icp-transactions.utils.ts
@@ -5,6 +5,7 @@ import type {
 	IcpTransaction
 } from '$icp/types/ic-transaction';
 import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Tokens, Transaction, TransactionWithId } from '@dfinity/ledger-icp';
 import { fromNullable, jsonReplacer, nonNullish } from '@dfinity/utils';

--- a/src/frontend/src/icp/utils/icp-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icp-transactions.utils.ts
@@ -92,7 +92,7 @@ export const mapIcpTransaction = ({
 		incoming: boolean | undefined;
 		fee: Tokens;
 		amount: Tokens;
-	}): bigint => amount.e8s + (incoming === false ? fee.e8s : 0n);
+	}): bigint => amount.e8s + (incoming === false ? fee.e8s : ZERO_BI);
 
 	if ('Approve' in operation) {
 		return {

--- a/src/frontend/src/icp/utils/icrc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icrc-transactions.utils.ts
@@ -4,6 +4,7 @@ import type {
 	IcrcTransaction
 } from '$icp/types/ic-transaction';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
 import { encodeIcrcAccount, type IcrcTransactionWithId } from '@dfinity/ledger-icrc';
 import {
@@ -117,12 +118,12 @@ export const mapIcrcTransaction = ({
 					: 'receive';
 
 	const value = isApprove
-		? 0n
+		? ZERO_BI
 		: nonNullish(data?.amount)
 			? data.amount +
 				(isTransfer && source.incoming === false
-					? (fromNullishNullable(fromNullable(transfer)?.fee) ?? 0n)
-					: 0n)
+					? (fromNullishNullable(fromNullable(transfer)?.fee) ?? ZERO_BI)
+					: ZERO_BI)
 			: undefined;
 
 	return {

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -19,6 +19,7 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
+	import { ZERO_BI } from '$lib/constants/app.constants';
 	import { SWAP_SLIPPAGE_INVALID_VALUE } from '$lib/constants/swap.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -32,7 +33,6 @@
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
-	import { ZERO_BI } from '$lib/constants/app.constants';
 
 	export let swapAmount: OptionAmount;
 	export let receiveAmount: number | undefined;

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -32,6 +32,7 @@
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
+	import { ZERO_BI } from '$lib/constants/app.constants';
 
 	export let swapAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
@@ -74,7 +75,7 @@
 
 	let totalFee: bigint | undefined;
 	// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
-	$: totalFee = (sourceTokenFee ?? 0n) * (isSourceTokenIcrc2 ? 2n : 1n);
+	$: totalFee = (sourceTokenFee ?? ZERO_BI) * (isSourceTokenIcrc2 ? 2n : 1n);
 
 	let swapAmountsLoading = false;
 	$: swapAmountsLoading =

--- a/src/frontend/src/lib/services/reward-code.services.ts
+++ b/src/frontend/src/lib/services/reward-code.services.ts
@@ -6,7 +6,7 @@ import {
 	getUserInfo,
 	getUserInfo as getUserInfoApi
 } from '$lib/api/reward.api';
-import { MILLISECONDS_IN_DAY, ZERO } from '$lib/constants/app.constants';
+import { MILLISECONDS_IN_DAY, ZERO, ZERO_BI } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { AlreadyClaimedError, InvalidCodeError, UserNotVipError } from '$lib/types/errors';

--- a/src/frontend/src/lib/services/reward-code.services.ts
+++ b/src/frontend/src/lib/services/reward-code.services.ts
@@ -70,7 +70,7 @@ const queryRewards = async (params: {
 
 	return {
 		rewards: nonNullish(awards) ? awards.map(mapRewardsInfo) : [],
-		lastTimestamp: fromNullable(last_snapshot_timestamp) ?? 0n
+		lastTimestamp: fromNullable(last_snapshot_timestamp) ?? ZERO_BI
 	};
 };
 
@@ -102,7 +102,7 @@ export const getRewards = async (params: { identity: Identity }): Promise<Reward
 		});
 	}
 
-	return { rewards: [], lastTimestamp: 0n };
+	return { rewards: [], lastTimestamp: ZERO_BI };
 };
 
 const updateReward = async (identity: Identity): Promise<VipReward> => {

--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -90,8 +90,8 @@ const toBaseTransaction = ({
 	'value' | 'timestamp'
 >): Omit<Transaction_Icrc | Transaction_Spl, 'counterparty'> => ({
 	transaction_type: toTransactionType(type),
-	timestamp: (timestamp ?? 0n) * NANO_SECONDS_IN_SECOND,
-	amount: value ?? 0n,
+	timestamp: (timestamp ?? ZERO_BI) * NANO_SECONDS_IN_SECOND,
+	amount: value ?? ZERO_BI,
 	network: {}
 });
 
@@ -106,7 +106,7 @@ const toIcrcTransaction = ({
 
 	return {
 		...toBaseTransaction({ type, value, timestamp }),
-		timestamp: timestamp ?? 0n,
+		timestamp: timestamp ?? ZERO_BI,
 		// TODO: use correct value when the Rewards canister is updated to accept account identifiers
 		counterparty: Principal.anonymous()
 	};
@@ -129,8 +129,8 @@ const toSplTransaction = ({
 		// TODO: this is a temporary hack to release v1. Adjust as soon as the rewards canister has more tokens.
 		...toBaseTransaction({
 			type: type === 'deposit' ? 'send' : type === 'withdraw' ? 'receive' : type,
-			value: BigNumber.from(value ?? 0n).toBigInt(),
-			timestamp: BigInt(timestamp ?? 0n)
+			value: BigNumber.from(value ?? ZERO_BI).toBigInt(),
+			timestamp: BigInt(timestamp ?? ZERO_BI)
 		}),
 		counterparty: address === from ? to : from
 	};

--- a/src/frontend/src/lib/utils/assert-amount.utils.ts
+++ b/src/frontend/src/lib/utils/assert-amount.utils.ts
@@ -52,7 +52,7 @@ const assertMinterInfo = ({
 		'retrieve_btc_min_amount' in data
 			? data.retrieve_btc_min_amount
 			: 'minimum_withdrawal_amount' in data
-				? (fromNullable(data.minimum_withdrawal_amount) ?? 0n)
+				? (fromNullable(data.minimum_withdrawal_amount) ?? ZERO_BI)
 				: undefined;
 
 	if (nonNullish(minimumAmount) && userAmount < minimumAmount) {

--- a/src/frontend/src/lib/utils/assert-amount.utils.ts
+++ b/src/frontend/src/lib/utils/assert-amount.utils.ts
@@ -1,5 +1,6 @@
 import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { Balance } from '$lib/types/balance';
 import type { TokenActionErrorType } from '$lib/types/token-action';
 import type { Option } from '$lib/types/utils';

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -49,7 +49,7 @@ export const groupTokensByTwin = (tokens: TokenUi[]): TokenUiOrGroupUi[] => {
 };
 
 const hasBalance = ({ token, showZeroBalances }: { token: TokenUi; showZeroBalances: boolean }) =>
-	Number(token.balance ?? 0n) || Number(token.usdBalance ?? 0n) || showZeroBalances;
+	Number(token.balance ?? ZERO_BI) || Number(token.usdBalance ?? ZERO_BI) || showZeroBalances;
 
 /**
  * Function to create a list of TokenUiOrGroupUi, filtering out all groups that do not have at least

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -6,7 +6,7 @@ import { ERC20_SUGGESTED_TOKENS } from '$env/tokens/tokens.erc20.env';
 import type { ContractAddressText } from '$eth/types/address';
 import type { IcCkToken } from '$icp/types/ic-token';
 import { isIcCkToken } from '$icp/validation/ic-token.validation';
-import { ZERO } from '$lib/constants/app.constants';
+import { ZERO, ZERO_BI } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { CanisterIdText } from '$lib/types/canister';

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -40,7 +40,7 @@ export const getMaxTransactionAmount = ({
 	tokenDecimals: number;
 	tokenStandard: TokenStandard;
 }): number => {
-	const value = balance.sub(tokenStandard !== 'erc20' && tokenStandard !== 'spl' ? fee : 0n);
+	const value = balance.sub(tokenStandard !== 'erc20' && tokenStandard !== 'spl' ? fee : ZERO_BI);
 
 	return Number(
 		value.isNegative()

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -18,6 +18,7 @@
 		TRACK_COUNT_SOL_SEND_ERROR,
 		TRACK_COUNT_SOL_SEND_SUCCESS
 	} from '$lib/constants/analytics.contants';
+	import { ZERO_BI } from '$lib/constants/app.constants';
 	import {
 		solAddressDevnet,
 		solAddressLocal,
@@ -56,7 +57,6 @@
 		initFeeContext,
 		initFeeStore
 	} from '$sol/stores/sol-fee.store';
-	import { ZERO_BI } from '$lib/constants/app.constants';
 
 	export let currentStep: WizardStep | undefined;
 	export let destination = '';

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -56,6 +56,7 @@
 		initFeeContext,
 		initFeeStore
 	} from '$sol/stores/sol-fee.store';
+	import { ZERO_BI } from '$lib/constants/app.constants';
 
 	export let currentStep: WizardStep | undefined;
 	export let destination = '';
@@ -163,7 +164,7 @@
 					value: `${amount}`,
 					unitName: $sendTokenDecimals
 				}).toBigInt(),
-				prioritizationFee: $prioritizationFeeStore ?? 0n,
+				prioritizationFee: $prioritizationFeeStore ?? ZERO_BI,
 				destination,
 				source
 			});

--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -1,3 +1,4 @@
+import { ZERO_BI } from '$lib/constants/app.constants';
 import { ProgressStepsSendSol } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { OptionSolAddress, SolAddress } from '$lib/types/address';
@@ -310,7 +311,7 @@ export const sendSol = async ({
 	progress(ProgressStepsSendSol.SIGN);
 
 	const { signedTransaction, signature } = await signTransaction(
-		prioritizationFee > 0n ? transactionMessageWithComputeUnitPrice : transactionMessage
+		prioritizationFee > ZERO_BI ? transactionMessageWithComputeUnitPrice : transactionMessage
 	);
 
 	progress(ProgressStepsSendSol.SEND);

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -5,6 +5,7 @@ import {
 	SOLANA_TESTNET_TOKEN_ID,
 	SOLANA_TOKEN_ID
 } from '$env/tokens/tokens.sol.env';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
 import { getSolTransactions } from '$sol/services/sol-signatures.services';

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -144,8 +144,8 @@ export const fetchSolTransactionsForSignature = async ({
 				...accCumulativeBalances,
 				// We include WSOL in the calculation, because it is used to affect the SOL balance of the ATA.
 				...((isNullish(mappedTokenAddress) || mappedTokenAddress === WSOL_TOKEN.address) && {
-					[from]: (accCumulativeBalances[from] ?? 0n) - value,
-					[to]: (accCumulativeBalances[to] ?? 0n) + value
+					[from]: (accCumulativeBalances[from] ?? ZERO_BI) - value,
+					[to]: (accCumulativeBalances[to] ?? ZERO_BI) + value
 				})
 			};
 
@@ -163,7 +163,7 @@ export const fetchSolTransactionsForSignature = async ({
 			const newTransaction: SolTransactionUi = {
 				id: `${signature.signature}-${idx}-${instruction.programId}`,
 				signature: signature.signature,
-				timestamp: blockTime ?? 0n,
+				timestamp: blockTime ?? ZERO_BI,
 				value,
 				type: address === from || ataAddress === from ? 'send' : 'receive',
 				from,
@@ -172,7 +172,8 @@ export const fetchSolTransactionsForSignature = async ({
 				// Since the fee is assigned to a single signature, it is not entirely correct to assign it to each transaction.
 				// Particularly, we are repeating the same fee for each instruction in the transaction.
 				// However, we should have it anyway saved in the transaction, so we can display it in the UI.
-				...(nonNullish(fee) && nonNullish(feePayer) && { fee: address === feePayer ? fee : 0n })
+				...(nonNullish(fee) &&
+					nonNullish(feePayer) && { fee: address === feePayer ? fee : ZERO_BI })
 			};
 
 			return {

--- a/src/frontend/src/sol/services/spl-accounts.services.ts
+++ b/src/frontend/src/sol/services/spl-accounts.services.ts
@@ -1,3 +1,4 @@
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import { checkIfAccountExists, loadTokenBalance } from '$sol/api/solana.api';
 import type { SolanaNetworkType } from '$sol/types/network';

--- a/src/frontend/src/sol/services/spl-accounts.services.ts
+++ b/src/frontend/src/sol/services/spl-accounts.services.ts
@@ -78,5 +78,5 @@ export const loadSplTokenBalance = async ({
 		network
 	});
 
-	return balance ?? 0n;
+	return balance ?? ZERO_BI;
 };

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -206,7 +206,7 @@ const mapTokenParsedInstruction = async ({
 
 		// In case of `closeAccount` transaction we take the accumulated balance of SOL (or WSOL) of the Associated Token Account (this is the `from` address).
 		// We do this because the entire amount of SOL (or WSOL) is redeemed by the owner of the ATA.
-		const value = cumulativeBalances?.[from] ?? 0n;
+		const value = cumulativeBalances?.[from] ?? ZERO_BI;
 
 		return { value, from, to };
 	}

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -1,3 +1,4 @@
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import {
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -1,3 +1,4 @@
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { SolTransactionMessage } from '$sol/types/sol-send';
 import type { MappedSolTransaction } from '$sol/types/sol-transaction';
 import { mapSolInstruction } from '$sol/utils/sol-instructions.utils';

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -43,7 +43,7 @@ export const mapSolTransactionMessage = ({
 
 			return {
 				...acc,
-				amount: nonNullish(amount) ? (acc.amount ?? 0n) + amount : acc.amount,
+				amount: nonNullish(amount) ? (acc.amount ?? ZERO_BI) + amount : acc.amount,
 				source,
 				destination,
 				payer

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -120,7 +120,7 @@ describe('custom-token.services', () => {
 
 					await assertSetCustomToken({
 						customTokens,
-						expectedVersion: [customTokens[0].version ?? 0n],
+						expectedVersion: [customTokens[0].version ?? ZERO_BI],
 						indexCanisterId
 					});
 				}

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -3,6 +3,7 @@ import { autoLoadCustomToken, setCustomToken } from '$icp-eth/services/custom-to
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { BackendCanister } from '$lib/canisters/backend.canister';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -374,7 +374,7 @@ describe('ic-add-custom-tokens.service', () => {
 					expect(spyGetTransactions).toHaveBeenNthCalledWith(1, {
 						account: getIcrcAccount(mockIdentity.getPrincipal()),
 						certified: true,
-						max_results: 0n,
+						max_results: ZERO_BI,
 						start: undefined
 					});
 				});

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -2,6 +2,7 @@ import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { loadAndAssertAddCustomToken } from '$icp/services/ic-add-custom-tokens.service';
 import type { IcCanisters, IcToken } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';

--- a/src/frontend/src/tests/icp/workers/ic-wallet-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-transactions.worker.spec.ts
@@ -313,7 +313,7 @@ describe('ic-wallet-transactions.worker', () => {
 		const mockTransaction: TransactionWithIdIcp = {
 			id: 123n,
 			transaction: {
-				memo: 0n,
+				memo: ZERO_BI,
 				icrc1_memo: [],
 				operation: {
 					Transfer: {

--- a/src/frontend/src/tests/icp/workers/ic-wallet-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-transactions.worker.spec.ts
@@ -4,7 +4,7 @@ import { mapIcpTransaction } from '$icp/utils/icp-transactions.utils';
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
 import { initIcpWalletScheduler } from '$icp/workers/icp-wallet.worker';
 import { initIcrcWalletScheduler } from '$icp/workers/icrc-wallet.worker';
-import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+import { WALLET_TIMER_INTERVAL_MILLIS, ZERO_BI } from '$lib/constants/app.constants';
 import * as authUtils from '$lib/utils/auth.utils';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import { IndexCanister, type TransactionWithId as TransactionWithIdIcp } from '@dfinity/ledger-icp';

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -45,7 +45,7 @@ describe('backend.canister', () => {
 	const addUserCredentialParams = {
 		credentialJwt: 'test-credential-jwt',
 		issuerCanisterId: mockPrincipal,
-		currentUserVersion: 0n,
+		currentUserVersion: ZERO_BI,
 		credentialSpec: {
 			arguments: [],
 			credential_type: ''

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -8,6 +8,7 @@ import type {
 } from '$declarations/backend/backend.did';
 import { BackendCanister } from '$lib/canisters/backend.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { AddUserCredentialParams, BtcSelectUserUtxosFeeParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';

--- a/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
@@ -6,7 +6,11 @@ import type {
 } from '$declarations/rewards/rewards.did';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as rewardApi from '$lib/api/reward.api';
-import { MILLISECONDS_IN_DAY, NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
+import {
+	MILLISECONDS_IN_DAY,
+	NANO_SECONDS_IN_MILLISECOND,
+	ZERO_BI
+} from '$lib/constants/app.constants';
 import {
 	claimVipReward,
 	getNewReward,

--- a/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward-code.services.spec.ts
@@ -416,9 +416,9 @@ describe('reward-code', () => {
 						getMockReward({ ledgerCanisterId: null, amount: 1000n }),
 						getMockReward({ ledgerCanisterId: 'invalid', amount: 1000n }),
 						getMockReward({ ledgerCanisterId: undefined, amount: 1000n }),
-						getMockReward({ ledgerCanisterId: mockCkBtcToken.ledgerCanisterId, amount: 0n }),
-						getMockReward({ ledgerCanisterId: mockCkUsdcToken.ledgerCanisterId, amount: 0n }),
-						getMockReward({ ledgerCanisterId: mockIcpToken.ledgerCanisterId, amount: 0n })
+						getMockReward({ ledgerCanisterId: mockCkBtcToken.ledgerCanisterId, amount: ZERO_BI }),
+						getMockReward({ ledgerCanisterId: mockCkUsdcToken.ledgerCanisterId, amount: ZERO_BI }),
+						getMockReward({ ledgerCanisterId: mockIcpToken.ledgerCanisterId, amount: ZERO_BI })
 					]
 				]
 			});

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -92,8 +92,8 @@ describe('user-snapshot.services', () => {
 					last_transactions: mockIcTransactions.slice(0, 5).map(
 						({ value, timestamp }: IcTransactionUi): Transaction_Icrc => ({
 							transaction_type: { Send: null },
-							timestamp: timestamp ?? 0n,
-							amount: value ?? 0n,
+							timestamp: timestamp ?? ZERO_BI,
+							amount: value ?? ZERO_BI,
 							network: {},
 							counterparty: Principal.anonymous()
 						})
@@ -157,8 +157,8 @@ describe('user-snapshot.services', () => {
 					last_transactions: mockSolTransactions.slice(0, 5).map(
 						({ value, timestamp, to }: SolTransactionUi): Transaction_Spl => ({
 							transaction_type: { Send: null },
-							timestamp: (timestamp ?? 0n) * NANO_SECONDS_IN_MILLISECOND,
-							amount: value ?? 0n,
+							timestamp: (timestamp ?? ZERO_BI) * NANO_SECONDS_IN_MILLISECOND,
+							amount: value ?? ZERO_BI,
 							network: {},
 							counterparty: to ?? ''
 						})

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -298,7 +298,7 @@ describe('format.utils', () => {
 
 			expect(
 				formatTokenBigintToNumber({
-					value: 0n
+					value: ZERO_BI
 				})
 			).toBe(0);
 		});

--- a/src/frontend/src/tests/mocks/sol-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-transactions.mock.ts
@@ -1,3 +1,4 @@
+import { ZERO_BI } from '$lib/constants/app.constants';
 import {
 	COMPUTE_BUDGET_PROGRAM_ADDRESS,
 	SYSTEM_PROGRAM_ADDRESS,

--- a/src/frontend/src/tests/mocks/sol-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-transactions.mock.ts
@@ -35,7 +35,7 @@ export const createMockSolTransactionsUi = (n: number): SolTransactionUi[] =>
 export const createMockSolTransactionUi = (id: string): SolTransactionUi => ({
 	id,
 	signature: signature(mockSignature),
-	timestamp: 0n,
+	timestamp: ZERO_BI,
 	type: 'send',
 	value: BigInt(100),
 	from: 'sender',

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -1,5 +1,5 @@
 import { DEVNET_EURC_TOKEN } from '$env/tokens/tokens-spl/tokens.eurc.env';
-import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { WALLET_PAGINATION, ZERO_BI } from '$lib/constants/app.constants';
 import {
 	checkIfAccountExists,
 	estimatePriorityFee,

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -179,7 +179,7 @@ describe('solana.api', () => {
 
 		it('should handle zero balance', async () => {
 			mockGetTokenAccountBalance.mockReturnValueOnce({
-				send: () => Promise.resolve({ value: { amount: 0n } })
+				send: () => Promise.resolve({ value: { amount: ZERO_BI } })
 			});
 
 			const balance = await loadTokenBalance({

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -107,7 +107,7 @@ describe('sol-transactions.services', () => {
 		const expected: SolTransactionUi = {
 			id: mockSignature.signature,
 			signature: mockSignature.signature,
-			timestamp: mockTransactionDetail.blockTime ?? 0n,
+			timestamp: mockTransactionDetail.blockTime ?? ZERO_BI,
 			value: mockMappedTransaction.value,
 			from: mockSolAddress,
 			to: mockSolAddress2,

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -1,4 +1,5 @@
 import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import * as solanaApi from '$sol/api/solana.api';
 import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import * as solSignaturesServices from '$sol/services/sol-signatures.services';

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -1,4 +1,5 @@
 import { JUP_TOKEN } from '$env/tokens/tokens-spl/tokens.jup.env';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import {
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
 	SYSTEM_PROGRAM_ADDRESS,

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -305,7 +305,7 @@ describe('sol-instructions.utils', () => {
 						network
 					})
 				).resolves.toEqual({
-					value: 0n,
+					value: ZERO_BI,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});
@@ -329,7 +329,7 @@ describe('sol-instructions.utils', () => {
 						cumulativeBalances: { [mockSolAddress2]: 100n }
 					})
 				).resolves.toEqual({
-					value: 0n,
+					value: ZERO_BI,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});
@@ -605,7 +605,7 @@ describe('sol-instructions.utils', () => {
 						network
 					})
 				).resolves.toEqual({
-					value: 0n,
+					value: ZERO_BI,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});
@@ -629,7 +629,7 @@ describe('sol-instructions.utils', () => {
 						cumulativeBalances: { [mockSolAddress2]: 100n }
 					})
 				).resolves.toEqual({
-					value: 0n,
+					value: ZERO_BI,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});


### PR DESCRIPTION
# Motivation

Replacing instances of `0n` with `ZERO_BI`.
