### PR TITLE
feat(frontend): use errors context in ETH/IC/BTC convert flows

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -11,6 +11,10 @@
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
+	import {
+		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+		type TokenActionValidationErrorsContext
+	} from '$lib/stores/token-action-validation-errors.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
@@ -21,10 +25,10 @@
 
 	const { store: storeUtxosFeeData } = getContext<UtxosFeeContext>(UTXOS_FEE_CONTEXT_KEY);
 
-	let insufficientFunds: boolean;
-	let insufficientFundsForFee: boolean;
+	const { insufficientFunds, insufficientFundsForFee } =
+		getContext<TokenActionValidationErrorsContext>(TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY);
 
-	$: amountError = insufficientFunds || insufficientFundsForFee;
+	$: amountError = $insufficientFunds || $insufficientFundsForFee;
 
 	let hasPendingTransactionsStore: Readable<BtcPendingSentTransactionsStatus>;
 	$: hasPendingTransactionsStore = initPendingSentTransactionsStatus(source);
@@ -34,8 +38,8 @@
 
 	let invalid: boolean;
 	$: invalid =
-		insufficientFunds ||
-		insufficientFundsForFee ||
+		$insufficientFunds ||
+		$insufficientFundsForFee ||
 		invalidAmount(sendAmount) ||
 		$hasPendingTransactionsStore !== BtcPendingSentTransactionsStatus.NONE ||
 		isNullish($storeUtxosFeeData?.utxosFee?.utxos) ||
@@ -44,15 +48,7 @@
 	let totalFee: bigint | undefined;
 </script>
 
-<ConvertForm
-	on:icNext
-	bind:sendAmount
-	bind:receiveAmount
-	bind:insufficientFunds
-	bind:insufficientFundsForFee
-	{totalFee}
-	disabled={invalid}
->
+<ConvertForm on:icNext bind:sendAmount bind:receiveAmount {totalFee} disabled={invalid}>
 	<svelte:fragment slot="message">
 		{#if nonNullish($hasPendingTransactionsStore)}
 			<div class="mb-4" data-tid="btc-convert-form-send-warnings">

--- a/src/frontend/src/eth/components/convert/EthConvertForm.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertForm.svelte
@@ -8,6 +8,10 @@
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+		type TokenActionValidationErrorsContext
+	} from '$lib/stores/token-action-validation-errors.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 
@@ -19,13 +23,13 @@
 
 	const { minGasFee, maxGasFee } = getContext<FeeContext>(FEE_CONTEXT_KEY);
 
-	let insufficientFunds: boolean;
-	let insufficientFundsForFee: boolean;
+	const { insufficientFunds, insufficientFundsForFee } =
+		getContext<TokenActionValidationErrorsContext>(TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY);
 
 	let invalid: boolean;
 	$: invalid =
-		insufficientFunds ||
-		insufficientFundsForFee ||
+		$insufficientFunds ||
+		$insufficientFundsForFee ||
 		invalidAmount(sendAmount) ||
 		isNullishOrEmpty(destination);
 </script>
@@ -34,8 +38,6 @@
 	on:icNext
 	bind:sendAmount
 	bind:receiveAmount
-	bind:insufficientFunds
-	bind:insufficientFundsForFee
 	totalFee={$maxGasFee?.toBigInt()}
 	minFee={$minGasFee?.toBigInt()}
 	disabled={invalid}

--- a/src/frontend/src/lib/components/convert/ConvertAmount.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmount.svelte
@@ -11,12 +11,6 @@
 	export let destinationTokenFee: bigint | undefined = undefined;
 	export let minFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
-	export let insufficientFunds: boolean;
-	export let insufficientFundsForFee: boolean;
-	export let amountLessThanLedgerFee: boolean | undefined = undefined;
-	export let minimumAmountNotReached: boolean | undefined = undefined;
-	export let unknownMinimumAmount: boolean | undefined = undefined;
-	export let minterInfoNotCertified: boolean | undefined = undefined;
 	export let exchangeValueUnit: DisplayUnit = 'usd';
 
 	let inputUnit: DisplayUnit;
@@ -27,12 +21,6 @@
 	<div class="mb-2">
 		<ConvertAmountSource
 			bind:sendAmount
-			bind:insufficientFunds
-			bind:insufficientFundsForFee
-			bind:amountLessThanLedgerFee
-			bind:minimumAmountNotReached
-			bind:unknownMinimumAmount
-			bind:minterInfoNotCertified
 			bind:exchangeValueUnit
 			{inputUnit}
 			{totalFee}

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -8,6 +8,10 @@
 	import { ZERO_BI } from '$lib/constants/app.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+		type TokenActionValidationErrorsContext
+	} from '$lib/stores/token-action-validation-errors.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
@@ -18,26 +22,19 @@
 	export let totalFee: bigint | undefined;
 	export let minFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
-	export let insufficientFunds: boolean;
-	export let insufficientFundsForFee: boolean;
-	export let amountLessThanLedgerFee: boolean | undefined = undefined;
-	export let minimumAmountNotReached: boolean | undefined = undefined;
-	export let unknownMinimumAmount: boolean | undefined = undefined;
-	export let minterInfoNotCertified: boolean | undefined = undefined;
 	export let exchangeValueUnit: DisplayUnit = 'usd';
 	export let inputUnit: DisplayUnit = 'token';
 
 	let errorType: TokenActionErrorType = undefined;
 
-	$: insufficientFunds = nonNullish(errorType) && errorType === 'insufficient-funds';
-	$: insufficientFundsForFee = nonNullish(errorType) && errorType === 'insufficient-funds-for-fee';
-	$: amountLessThanLedgerFee = nonNullish(errorType) && errorType === 'amount-less-than-ledger-fee';
-	$: minimumAmountNotReached = nonNullish(errorType) && errorType === 'minimum-amount-not-reached';
-	$: unknownMinimumAmount = nonNullish(errorType) && errorType === 'unknown-minimum-amount';
-	$: minterInfoNotCertified = nonNullish(errorType) && errorType === 'minter-info-not-certified';
-
 	const { sourceToken, sourceTokenBalance, sourceTokenExchangeRate, balanceForFee, minterInfo } =
 		getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
+
+	const { setErrorType } = getContext<TokenActionValidationErrorsContext>(
+		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY
+	);
+
+	$: errorType, setErrorType(errorType);
 
 	$: customValidate = (userAmount: bigint): TokenActionErrorType =>
 		validateUserAmount({

--- a/src/frontend/src/lib/components/convert/ConvertForm.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertForm.svelte
@@ -15,12 +15,6 @@
 	export let minFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
 	export let disabled: boolean;
-	export let insufficientFunds: boolean;
-	export let insufficientFundsForFee: boolean;
-	export let amountLessThanLedgerFee: boolean | undefined = undefined;
-	export let minimumAmountNotReached: boolean | undefined = undefined;
-	export let unknownMinimumAmount: boolean | undefined = undefined;
-	export let minterInfoNotCertified: boolean | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -31,12 +25,6 @@
 	<ConvertAmount
 		bind:sendAmount
 		bind:receiveAmount
-		bind:insufficientFunds
-		bind:insufficientFundsForFee
-		bind:amountLessThanLedgerFee
-		bind:minimumAmountNotReached
-		bind:unknownMinimumAmount
-		bind:minterInfoNotCertified
 		bind:exchangeValueUnit
 		{totalFee}
 		{destinationTokenFee}

--- a/src/frontend/src/lib/components/convert/ConvertModal.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertModal.svelte
@@ -11,6 +11,11 @@
 		initConvertContext
 	} from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initTokenActionValidationErrorsContext,
+		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+		type TokenActionValidationErrorsContext
+	} from '$lib/stores/token-action-validation-errors.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
@@ -25,6 +30,11 @@
 			sourceToken,
 			destinationToken
 		})
+	);
+
+	setContext<TokenActionValidationErrorsContext>(
+		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+		initTokenActionValidationErrorsContext()
 	);
 
 	let sendAmount: OptionAmount = undefined;

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
@@ -8,6 +8,7 @@ import {
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
+import { TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY } from '$lib/stores/token-action-validation-errors.store';
 import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -33,7 +34,8 @@ describe('BtcConvertForm', () => {
 					sourceTokenBalance: readable(BigNumber.from(sourceTokenBalance)),
 					destinationToken: readable(ICP_TOKEN)
 				}
-			]
+			],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, { setErrorType: () => {} }]
 		]);
 	const props = {
 		source: mockBtcAddress,

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
@@ -2,7 +2,11 @@ import BtcConvertTokenWizard from '$btc/components/convert/BtcConvertTokenWizard
 import * as btcPendingSentTransactionsStore from '$btc/services/btc-pending-sent-transactions.services';
 import * as btcSendApi from '$btc/services/btc-send.services';
 import * as utxosFeeStore from '$btc/stores/utxos-fee.store';
-import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeStore } from '$btc/stores/utxos-fee.store';
+import {
+	UTXOS_FEE_CONTEXT_KEY,
+	type UtxosFeeContext,
+	type UtxosFeeStore
+} from '$btc/stores/utxos-fee.store';
 import type { UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
@@ -14,7 +18,16 @@ import * as signerApi from '$lib/api/signer.api';
 import * as addressesStore from '$lib/derived/address.derived';
 import { ProgressStepsConvert } from '$lib/enums/progress-steps';
 import { WizardStepsConvert } from '$lib/enums/wizard-steps';
-import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
+import {
+	CONVERT_CONTEXT_KEY,
+	initConvertContext,
+	type ConvertContext
+} from '$lib/stores/convert.store';
+import {
+	TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+	initTokenActionValidationErrorsContext,
+	type TokenActionValidationErrorsContext
+} from '$lib/stores/token-action-validation-errors.store';
 import type { Token } from '$lib/types/token';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
@@ -41,15 +54,10 @@ describe('BtcConvertTokenWizard', () => {
 		sourceToken?: Token;
 		mockUtxosFeeStore: UtxosFeeStore;
 	}) =>
-		new Map([
+		new Map<symbol, ConvertContext | TokenActionValidationErrorsContext | UtxosFeeContext>([
 			[UTXOS_FEE_CONTEXT_KEY, { store: mockUtxosFeeStore }],
-			[
-				CONVERT_CONTEXT_KEY,
-				{
-					sourceToken: readable(sourceToken),
-					destinationToken: readable(ICP_TOKEN)
-				}
-			]
+			[CONVERT_CONTEXT_KEY, initConvertContext({ sourceToken, destinationToken: ICP_TOKEN })],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);
 	const props = {
 		currentStep: {

--- a/src/frontend/src/tests/eth/components/convert/EthConvertForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertForm.spec.ts
@@ -13,6 +13,11 @@ import {
 	initConvertContext,
 	type ConvertContext
 } from '$lib/stores/convert.store';
+import {
+	TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+	initTokenActionValidationErrorsContext,
+	type TokenActionValidationErrorsContext
+} from '$lib/stores/token-action-validation-errors.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
 import { BigNumber } from 'alchemy-sdk';
@@ -21,7 +26,7 @@ import { writable } from 'svelte/store';
 describe('EthConvertForm', () => {
 	let store: FeeStore;
 	const mockContext = ({ feeStore }: { feeStore: FeeStore }) =>
-		new Map<symbol, ConvertContext | FeeContext>([
+		new Map<symbol, ConvertContext | FeeContext | TokenActionValidationErrorsContext>([
 			[
 				FEE_CONTEXT_KEY,
 				initFeeContext({
@@ -38,7 +43,8 @@ describe('EthConvertForm', () => {
 					sourceToken: ETHEREUM_TOKEN,
 					destinationToken: ICP_TOKEN
 				})
-			]
+			],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);
 
 	const props = {

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -13,7 +13,16 @@ import { ProgressStepsConvert } from '$lib/enums/progress-steps';
 import { WizardStepsConvert } from '$lib/enums/wizard-steps';
 import { ethAddressStore } from '$lib/stores/address.store';
 import { initCertifiedSetterStore } from '$lib/stores/certified-setter.store';
-import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
+import {
+	CONVERT_CONTEXT_KEY,
+	initConvertContext,
+	type ConvertContext
+} from '$lib/stores/convert.store';
+import {
+	TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+	initTokenActionValidationErrorsContext,
+	type TokenActionValidationErrorsContext
+} from '$lib/stores/token-action-validation-errors.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import { stringifyJson } from '$lib/utils/json.utils';
 import { parseToken } from '$lib/utils/parse.utils';
@@ -53,14 +62,12 @@ describe('EthConvertTokenWizard', () => {
 	const sendAmount = 0.001;
 	const transactionId = 'txid';
 	const mockContext = () =>
-		new Map([
+		new Map<symbol, ConvertContext | TokenActionValidationErrorsContext>([
 			[
 				CONVERT_CONTEXT_KEY,
-				{
-					sourceToken: readable(ETHEREUM_TOKEN),
-					destinationToken: readable(SEPOLIA_TOKEN)
-				}
-			]
+				initConvertContext({ sourceToken: ETHEREUM_TOKEN, destinationToken: SEPOLIA_TOKEN })
+			],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);
 	const mockMinterInfo = mockCkMinterInfo;
 	const mockFees = {

--- a/src/frontend/src/tests/icp/components/convert/IcConvertForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/IcConvertForm.spec.ts
@@ -15,13 +15,21 @@ import {
 	initConvertContext,
 	type ConvertContext
 } from '$lib/stores/convert.store';
+import {
+	TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+	initTokenActionValidationErrorsContext,
+	type TokenActionValidationErrorsContext
+} from '$lib/stores/token-action-validation-errors.store';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
 
 describe('IcConvertForm', () => {
 	const mockContext = () =>
-		new Map<symbol, ConvertContext | BitcoinFeeContext | EthereumFeeContext>([
+		new Map<
+			symbol,
+			ConvertContext | BitcoinFeeContext | EthereumFeeContext | TokenActionValidationErrorsContext
+		>([
 			[ETHEREUM_FEE_CONTEXT_KEY, { store: initEthereumFeeStore() }],
 			[BITCOIN_FEE_CONTEXT_KEY, { store: initBitcoinFeeStore() }],
 			[
@@ -30,7 +38,8 @@ describe('IcConvertForm', () => {
 					sourceToken: mockValidIcCkToken,
 					destinationToken: ICP_TOKEN
 				})
-			]
+			],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);
 
 	const props = {

--- a/src/frontend/src/tests/icp/components/convert/IcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/IcConvertTokenWizard.spec.ts
@@ -20,6 +20,11 @@ import {
 	initConvertContext,
 	type ConvertContext
 } from '$lib/stores/convert.store';
+import {
+	TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+	initTokenActionValidationErrorsContext,
+	type TokenActionValidationErrorsContext
+} from '$lib/stores/token-action-validation-errors.store';
 import { stringifyJson } from '$lib/utils/json.utils';
 import { parseToken } from '$lib/utils/parse.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
@@ -45,7 +50,10 @@ describe('IcConvertTokenWizard', () => {
 	} as IcCkToken;
 
 	const mockContext = () =>
-		new Map<symbol, ConvertContext | BitcoinFeeContext | EthereumFeeContext>([
+		new Map<
+			symbol,
+			ConvertContext | BitcoinFeeContext | EthereumFeeContext | TokenActionValidationErrorsContext
+		>([
 			[ETHEREUM_FEE_CONTEXT_KEY, { store: initEthereumFeeStore() }],
 			[BITCOIN_FEE_CONTEXT_KEY, { store: initBitcoinFeeStore() }],
 			[
@@ -54,7 +62,8 @@ describe('IcConvertTokenWizard', () => {
 					sourceToken: ckBtcToken,
 					destinationToken: BTC_MAINNET_TOKEN
 				})
-			]
+			],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);
 
 	const props = {

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountSource.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountSource.spec.ts
@@ -3,6 +3,7 @@ import ConvertAmountSource from '$lib/components/convert/ConvertAmountSource.sve
 import { ZERO_BI } from '$lib/constants/app.constants';
 import { TOKEN_INPUT_AMOUNT_EXCHANGE } from '$lib/constants/test-ids.constants';
 import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
+import { TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY } from '$lib/stores/token-action-validation-errors.store';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
@@ -34,7 +35,8 @@ describe('ConvertAmountSource', () => {
 					sourceTokenBalance: readable(balance),
 					sourceTokenExchangeRate: readable(exchangeRate)
 				}
-			]
+			],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, { setErrorType: () => {} }]
 		]);
 
 	const balanceTestId = 'convert-amount-source-balance';

--- a/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
@@ -1,15 +1,27 @@
-import { initUtxosFeeStore, UTXOS_FEE_CONTEXT_KEY } from '$btc/stores/utxos-fee.store';
+import {
+	initUtxosFeeStore,
+	UTXOS_FEE_CONTEXT_KEY,
+	type UtxosFeeContext
+} from '$btc/stores/utxos-fee.store';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import ConvertWizard from '$lib/components/convert/ConvertWizard.svelte';
 import { ProgressStepsConvert } from '$lib/enums/progress-steps';
 import { WizardStepsConvert } from '$lib/enums/wizard-steps';
-import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
+import {
+	CONVERT_CONTEXT_KEY,
+	initConvertContext,
+	type ConvertContext
+} from '$lib/stores/convert.store';
+import {
+	initTokenActionValidationErrorsContext,
+	TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
+	type TokenActionValidationErrorsContext
+} from '$lib/stores/token-action-validation-errors.store';
 import type { Token } from '$lib/types/token';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
-import { readable } from 'svelte/store';
 
 describe('ConvertWizard', () => {
 	const sendAmount = 20;
@@ -25,15 +37,10 @@ describe('ConvertWizard', () => {
 	};
 
 	const mockContext = (sourceToken: Token) =>
-		new Map([
+		new Map<symbol, ConvertContext | TokenActionValidationErrorsContext | UtxosFeeContext>([
 			[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }],
-			[
-				CONVERT_CONTEXT_KEY,
-				{
-					sourceToken: readable(sourceToken),
-					destinationToken: readable(ICP_TOKEN)
-				}
-			]
+			[CONVERT_CONTEXT_KEY, initConvertContext({ sourceToken, destinationToken: ICP_TOKEN })],
+			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);
 
 	it('should display BTC convert wizard if sourceToken network is BTC', () => {


### PR DESCRIPTION
# Motivation

In this PR, all convert flows are updated to use the TokenActionValidationErrors context.

# Changes

1. Start using the TokenActionValidationErrors context in all convert flows.
2. Remove outdated props.

# Tests

Existing tests have been adjusted.
