### PR TITLE
test(frontend): add missing ConvertWizard tests

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -11,6 +11,7 @@
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
 	import type { UtxosFee } from '$btc/types/btc-send';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
+	import { BTC_CONVERT_FORM_TEST_ID } from '$lib/constants/test-ids.constants';
 	import {
 		TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY,
 		type TokenActionValidationErrorsContext
@@ -48,7 +49,14 @@
 	let totalFee: bigint | undefined;
 </script>
 
-<ConvertForm on:icNext bind:sendAmount bind:receiveAmount {totalFee} disabled={invalid}>
+<ConvertForm
+	on:icNext
+	bind:sendAmount
+	bind:receiveAmount
+	{totalFee}
+	disabled={invalid}
+	testId={BTC_CONVERT_FORM_TEST_ID}
+>
 	<svelte:fragment slot="message">
 		{#if nonNullish($hasPendingTransactionsStore)}
 			<div class="mb-4" data-tid="btc-convert-form-send-warnings">

--- a/src/frontend/src/eth/components/convert/EthConvertForm.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertForm.svelte
@@ -6,6 +6,7 @@
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { ETH_CONVERT_FORM_TEST_ID } from '$lib/constants/test-ids.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
@@ -41,6 +42,7 @@
 	totalFee={$maxGasFee?.toBigInt()}
 	minFee={$minGasFee?.toBigInt()}
 	disabled={invalid}
+	testId={ETH_CONVERT_FORM_TEST_ID}
 >
 	<svelte:fragment slot="message">
 		{#if isTokenErc20($sourceToken) && insufficientFundsForFee}

--- a/src/frontend/src/icp/components/convert/IcConvertForm.svelte
+++ b/src/frontend/src/icp/components/convert/IcConvertForm.svelte
@@ -12,6 +12,7 @@
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { IC_CONVERT_FORM_TEST_ID } from '$lib/constants/test-ids.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
@@ -117,6 +118,7 @@
 	totalFee={totalSourceTokenFee}
 	destinationTokenFee={totalDestinationTokenFee}
 	disabled={invalid}
+	testId={IC_CONVERT_FORM_TEST_ID}
 >
 	<svelte:fragment slot="message">
 		{#if nonNullish(errorMessage) || nonNullish(infoMessage)}

--- a/src/frontend/src/lib/components/convert/ConvertForm.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertForm.svelte
@@ -15,13 +15,14 @@
 	export let minFee: bigint | undefined = undefined;
 	export let ethereumEstimateFee: bigint | undefined = undefined;
 	export let disabled: boolean;
+	export let testId: string | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
 	let exchangeValueUnit: DisplayUnit = 'usd';
 </script>
 
-<ContentWithToolbar>
+<ContentWithToolbar {testId}>
 	<ConvertAmount
 		bind:sendAmount
 		bind:receiveAmount

--- a/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
+++ b/src/frontend/src/lib/components/ui/ContentWithToolbar.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	export let styleClass: string | undefined = undefined;
+	export let testId: string | undefined = undefined;
 </script>
 
-<div class={`stretch ${styleClass ?? ''}`}>
+<div class={`stretch ${styleClass ?? ''}`} data-tid={testId}>
 	<slot />
 </div>
 

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -118,3 +118,7 @@ export const REWARDS_REQUIREMENTS_STATUS = 'reward-requirement-status';
 
 export const ACTIVITY_TRANSACTIONS_PLACEHOLDER = 'all-transactions-placeholder';
 export const ACTIVITY_TRANSACTION_SKELETON_PREFIX = 'all-transactions-skeleton-card';
+
+export const BTC_CONVERT_FORM_TEST_ID = 'btc-convert-form-test-id';
+export const IC_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';
+export const ETH_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';

--- a/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
@@ -3,10 +3,16 @@ import {
 	UTXOS_FEE_CONTEXT_KEY,
 	type UtxosFeeContext
 } from '$btc/stores/utxos-fee.store';
+import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
-import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import ConvertWizard from '$lib/components/convert/ConvertWizard.svelte';
+import {
+	BTC_CONVERT_FORM_TEST_ID,
+	ETH_CONVERT_FORM_TEST_ID,
+	IC_CONVERT_FORM_TEST_ID
+} from '$lib/constants/test-ids.constants';
 import { ProgressStepsConvert } from '$lib/enums/progress-steps';
 import { WizardStepsConvert } from '$lib/enums/wizard-steps';
 import {
@@ -21,6 +27,7 @@ import {
 } from '$lib/stores/token-action-validation-errors.store';
 import type { Token } from '$lib/types/token';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('ConvertWizard', () => {
@@ -44,18 +51,36 @@ describe('ConvertWizard', () => {
 		]);
 
 	it('should display BTC convert wizard if sourceToken network is BTC', () => {
-		const { container } = render(ConvertWizard, {
+		const { getByTestId } = render(ConvertWizard, {
 			props,
 			context: mockContext(BTC_MAINNET_TOKEN)
 		});
 
-		expect(container).toHaveTextContent(en.fee.text.convert_btc_network_fee);
+		expect(getByTestId(BTC_CONVERT_FORM_TEST_ID)).toBeInTheDocument();
+	});
+
+	it('should display ETH convert wizard if sourceToken network is ETH', () => {
+		const { getByTestId } = render(ConvertWizard, {
+			props,
+			context: mockContext(SEPOLIA_TOKEN)
+		});
+
+		expect(getByTestId(ETH_CONVERT_FORM_TEST_ID)).toBeInTheDocument();
+	});
+
+	it('should display IC convert wizard if sourceToken network is IC', () => {
+		const { getByTestId } = render(ConvertWizard, {
+			props,
+			context: mockContext(mockValidIcCkToken)
+		});
+
+		expect(getByTestId(IC_CONVERT_FORM_TEST_ID)).toBeInTheDocument();
 	});
 
 	it('should not have any content if sourceToken network wizard is not implemented yet', () => {
 		const { container } = render(ConvertWizard, {
 			props,
-			context: mockContext(ETHEREUM_TOKEN)
+			context: mockContext(BONK_TOKEN)
 		});
 
 		expect(container).toHaveTextContent(en.convert.text.unsupported_token_conversion);


### PR DESCRIPTION
# Motivation

While working on another PR, I noticed that ConvertWizard.spec is missing some test suites.
