### PR TITLE
feat(frontend): use bigint mocked balance instead of BigNumber

### DIFF
--- a/src/frontend/src/tests/eth/stores/eth-transactions.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/eth-transactions.store.spec.ts
@@ -1,7 +1,8 @@
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
-import { bn3 } from '$tests/mocks/balances.mock';
+import { bn3Bi } from '$tests/mocks/balances.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
+import { BigNumber } from '@ethersproject/bignumber';
 import { get } from 'svelte/store';
 
 describe('eth-transactions.store', () => {
@@ -78,7 +79,7 @@ describe('eth-transactions.store', () => {
 	describe('update', () => {
 		const updatedTransaction = {
 			...mockTransactions[0],
-			value: mockTransactions[0].value.add(bn3)
+			value: mockTransactions[0].value.add(BigNumber.from(bn3Bi))
 		};
 
 		beforeEach(() => {

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -27,16 +27,7 @@ import {
 	sumMainnetTokensUsdBalancesPerNetwork,
 	sumTokensUiUsdBalance
 } from '$lib/utils/tokens.utils';
-import {
-	bn1,
-	bn1Bi,
-	bn2,
-	bn2Bi,
-	bn3,
-	bn3Bi,
-	certified,
-	mockBalances
-} from '$tests/mocks/balances.mock';
+import { bn1Bi, bn2Bi, bn3Bi, certified, mockBalances } from '$tests/mocks/balances.mock';
 import { mockExchanges, mockOneUsd } from '$tests/mocks/exchanges.mock';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockTokens, mockValidToken } from '$tests/mocks/tokens.mock';
@@ -336,7 +327,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 	it('should return a dictionary with correct balances for the list of mainnet and testnet tokens', () => {
 		const balances = {
 			...mockBalances,
-			[BTC_TESTNET_TOKEN.id]: { data: bn3, certified }
+			[BTC_TESTNET_TOKEN.id]: { data: bn3Bi, certified }
 		};
 		const tokens = [...mockTokens, BTC_TESTNET_TOKEN];
 
@@ -346,9 +337,9 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			$exchanges: mockExchanges
 		});
 		expect(result).toEqual({
-			[BTC_MAINNET_NETWORK_ID]: bn2.toNumber(),
-			[ETHEREUM_NETWORK_ID]: bn3.toNumber(),
-			[ICP_NETWORK_ID]: bn1.toNumber()
+			[BTC_MAINNET_NETWORK_ID]: Number(bn2Bi),
+			[ETHEREUM_NETWORK_ID]: Number(bn3Bi),
+			[ICP_NETWORK_ID]: Number(bn1Bi)
 		});
 	});
 
@@ -376,7 +367,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 	it('should return an empty dictionary if no mainnet tokens are in the list', () => {
 		const balances = {
 			...mockBalances,
-			[BTC_TESTNET_TOKEN.id]: { data: bn2, certified }
+			[BTC_TESTNET_TOKEN.id]: { data: bn2Bi, certified }
 		};
 		const tokens = [BTC_TESTNET_TOKEN];
 

--- a/src/frontend/src/tests/mocks/balances.mock.ts
+++ b/src/frontend/src/tests/mocks/balances.mock.ts
@@ -3,17 +3,12 @@ import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import { BigNumber } from 'alchemy-sdk';
 
 export const certified = true;
 
 export const bn1Bi = 1n;
 export const bn2Bi = 2n;
 export const bn3Bi = 3n;
-
-export const bn1 = BigNumber.from(bn1Bi);
-export const bn2 = BigNumber.from(bn2Bi);
-export const bn3 = BigNumber.from(bn3Bi);
 
 export const mockBalances: CertifiedStoreData<BalancesData> = {
 	[ICP_TOKEN.id]: { data: bn1Bi, certified },

--- a/src/frontend/src/tests/mocks/eth-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/eth-transactions.mock.ts
@@ -1,16 +1,17 @@
 import type { Transaction } from '$lib/types/transaction';
 import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mocks';
-import { bn1, bn3 } from './balances.mock';
+import { BigNumber } from 'ethers';
+import { bn1Bi, bn3Bi } from './balances.mock';
 
 export const mockEthTransactionUi: Transaction = {
 	blockNumber: 123213,
 	nonce: 123,
-	gasLimit: bn3,
+	gasLimit: BigNumber.from(bn3Bi),
 	chainId: 1,
 	from: mockEthAddress,
 	timestamp: 123456789,
 	to: mockEthAddress2,
-	value: bn1,
+	value: BigNumber.from(bn1Bi),
 	hash: '0x123456789'
 };
 


### PR DESCRIPTION
# Motivation

We have a few constants that are mocked balances as `BigNumber`. However, we are deprecating them in favour of `bigint`, for the coming upgrade to `ethers` v6.