### PR TITLE
fix(frontend): added alternate icrc price source

### DIFF
--- a/src/frontend/src/env/rest/kongswap.env.ts
+++ b/src/frontend/src/env/rest/kongswap.env.ts
@@ -1,0 +1,7 @@
+import { UrlSchema } from '$lib/validation/url.validation';
+import { safeParse } from '$lib/validation/utils.validation';
+
+export const KONGSWAP_API_URL = safeParse({
+	schema: UrlSchema,
+	value: 'https://api.kongswap.io/api'
+});

--- a/src/frontend/src/lib/rest/kongswap.rest.ts
+++ b/src/frontend/src/lib/rest/kongswap.rest.ts
@@ -1,0 +1,35 @@
+import { KONGSWAP_API_URL } from '$env/rest/kongswap.env';
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import type { KongSwapToken } from '$lib/types/kongswap';
+
+const fetchKongSwap = async <T>(endpoint: string): Promise<T | null> => {
+	const response = await fetch(`${KONGSWAP_API_URL}/${endpoint}`, {
+		method: 'GET',
+		headers: { 'Content-Type': 'application/json' }
+	});
+
+	if (!response.ok) {
+		throw new Error('Fetching KongSwap failed.');
+	}
+
+	return response.json();
+};
+
+export const getKongSwapTokenById = async (
+	id: LedgerCanisterIdText
+): Promise<KongSwapToken | null> => {
+	return fetchKongSwap<KongSwapToken>(`tokens/${id.toLowerCase()}`);
+};
+
+export const fetchBatchKongSwapPrices = async (
+	canisterIds: LedgerCanisterIdText[]
+): Promise<(KongSwapToken | null)[]> => {
+	return Promise.all(
+		canisterIds.map((id) =>
+			getKongSwapTokenById(id).catch((error) => {
+				console.warn(`KongSwap fallback failed for ${id}`, error);
+				return null;
+			})
+		)
+	);
+};

--- a/src/frontend/src/lib/types/kongswap.ts
+++ b/src/frontend/src/lib/types/kongswap.ts
@@ -1,0 +1,62 @@
+import { PrincipalTextSchema } from '@dfinity/zod-schemas';
+import * as z from 'zod';
+
+const NumberAsStringSchema = z.string().refine((val) => !isNaN(Number(val)), {
+	message: 'Invalid number string'
+});
+
+const DateTimeSchema = z
+	.string()
+	.refine((val) => !isNaN(new Date(val).getTime()), { message: 'Invalid ISO date' });
+
+const KongSwapTokenMetricsSchema = z.object({
+	token_id: z.number(),
+	total_supply: NumberAsStringSchema.nullable(),
+	market_cap: NumberAsStringSchema.nullable(),
+	price: NumberAsStringSchema,
+	updated_at: DateTimeSchema,
+	volume_24h: NumberAsStringSchema,
+	tvl: NumberAsStringSchema,
+	price_change_24h: NumberAsStringSchema,
+	previous_price: NumberAsStringSchema.nullable()
+});
+
+const KongSwapTokenBaseSchema = z.object({
+	token_id: z.number(),
+	name: z.string(),
+	symbol: z.string(),
+	canister_id: PrincipalTextSchema,
+	address: z.string().nullable(),
+	decimals: z.number(),
+	fee: z.number(),
+	fee_fixed: z.string().nullable(),
+	has_custom_logo: z.boolean(),
+	icrc1: z.boolean(),
+	icrc2: z.boolean(),
+	icrc3: z.boolean(),
+	is_removed: z.boolean(),
+	logo_url: z.string().nullable(),
+	logo_updated_at: DateTimeSchema.nullable(),
+	token_type: z.string()
+});
+
+const KongSwapTokenSchema = z.object({
+	token: KongSwapTokenBaseSchema,
+	metrics: KongSwapTokenMetricsSchema
+});
+
+const KongSwapTokenWithMetricsSchema = KongSwapTokenBaseSchema.extend({
+	metrics: KongSwapTokenMetricsSchema
+});
+
+const KongSwapTokensSchema = z.object({
+	items: z.array(KongSwapTokenWithMetricsSchema),
+	total_pages: z.number(),
+	total_count: z.number(),
+	page: z.number(),
+	limit: z.number()
+});
+
+export type KongSwapTokenMetrics = z.infer<typeof KongSwapTokenMetricsSchema>;
+export type KongSwapTokens = z.infer<typeof KongSwapTokensSchema>;
+export type KongSwapToken = z.infer<typeof KongSwapTokenSchema>;

--- a/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
@@ -1,0 +1,74 @@
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import type { CoingeckoSimpleTokenPriceResponse } from '$lib/types/coingecko';
+import { findMissingCanisterIds, formatKongSwapToCoingeckoPrices } from '$lib/utils/exchange.utils';
+import {
+	createMockCoingeckoTokenPrice,
+	createMockKongSwapToken
+} from '$tests/mocks/exchanges.mock';
+import { describe, expect, it } from 'vitest';
+
+describe('formatKongSwapToCoingeckoPrices', () => {
+	it('formats a valid token correctly', () => {
+		const token = createMockKongSwapToken('test-canister-1');
+		const result = formatKongSwapToCoingeckoPrices([token]);
+
+		expect(result).toHaveProperty('test-canister-1');
+		expect(result['test-canister-1'].usd).toBe(1);
+		expect(result['test-canister-1'].usd_market_cap).toBe(1000000);
+	});
+
+	it('skips null tokens', () => {
+		const result = formatKongSwapToCoingeckoPrices([null]);
+		expect(result).toEqual({});
+	});
+
+	it('skips tokens with missing canister_id', () => {
+		const token = createMockKongSwapToken('test', {
+			token: { canister_id: '' }
+		});
+		const result = formatKongSwapToCoingeckoPrices([token]);
+		expect(result).toEqual({});
+	});
+
+	it('skips tokens with missing price', () => {
+		const token = createMockKongSwapToken('test-canister-2', {
+			metrics: { price: null as unknown as string }
+		});
+		const result = formatKongSwapToCoingeckoPrices([token]);
+		expect(result).toEqual({});
+	});
+
+	it('normalizes canister_id to lowercase', () => {
+		const token = createMockKongSwapToken('TeSt-CaNiStEr-3');
+		const result = formatKongSwapToCoingeckoPrices([token]);
+
+		expect(result).toHaveProperty('test-canister-3');
+	});
+});
+
+describe('findMissingCanisterIds', () => {
+	it('returns IDs not found in coingecko response', () => {
+		const allIds: LedgerCanisterIdText[] = ['can-1', 'can-2', 'can-3'];
+		const coingecko: CoingeckoSimpleTokenPriceResponse = {
+			'can-1': createMockCoingeckoTokenPrice()
+		};
+
+		const result = findMissingCanisterIds(allIds, coingecko);
+		expect(result).toEqual(['can-2', 'can-3']);
+	});
+
+	it('returns all IDs if response is null', () => {
+		const ids: LedgerCanisterIdText[] = ['can-4', 'can-5'];
+		const result = findMissingCanisterIds(ids, null);
+		expect(result).toEqual(ids);
+	});
+
+	it('matches canister IDs case-insensitively', () => {
+		const ids: LedgerCanisterIdText[] = ['CAN-1', 'can-2'];
+		const coingecko: CoingeckoSimpleTokenPriceResponse = {
+			'can-1': createMockCoingeckoTokenPrice()
+		};
+		const result = findMissingCanisterIds(ids, coingecko);
+		expect(result).toEqual(['can-2']);
+	});
+});

--- a/src/frontend/src/tests/mocks/exchanges.mock.ts
+++ b/src/frontend/src/tests/mocks/exchanges.mock.ts
@@ -1,4 +1,6 @@
+import type { CoingeckoSimpleTokenPrice } from '$lib/types/coingecko';
 import type { ExchangesData } from '$lib/types/exchange';
+import type { KongSwapToken, KongSwapTokenMetrics } from '$lib/types/kongswap';
 import { mockTokens } from './tokens.mock';
 
 export const mockOneUsd = 1;
@@ -7,3 +9,64 @@ export const mockExchanges: ExchangesData = mockTokens.reduce<ExchangesData>((ac
 	acc[token.id] = { usd: mockOneUsd };
 	return acc;
 }, {});
+
+export const createMockKongSwapToken = (
+	canisterId: string = 'test-canister-1',
+	options: {
+		token?: Partial<KongSwapToken['token']>;
+		metrics?: Partial<KongSwapTokenMetrics>;
+	} = {}
+): KongSwapToken => {
+	const tokenDefaults = {
+		canister_id: canisterId,
+		address: canisterId,
+		name: 'Mock Token',
+		symbol: 'MOCK',
+		token_id: 1,
+		decimals: 8,
+		fee: 0.0001,
+		fee_fixed: '10',
+		has_custom_logo: false,
+		icrc1: true,
+		icrc2: true,
+		icrc3: false,
+		is_removed: false,
+		logo_url: null,
+		logo_updated_at: null,
+		token_type: 'Ic'
+	};
+
+	const metricsDefaults: KongSwapTokenMetrics = {
+		token_id: 1,
+		price: '1.00',
+		market_cap: '1000000',
+		volume_24h: '50000',
+		price_change_24h: '2.5',
+		updated_at: '2024-01-01T00:00:00.000Z',
+		total_supply: '100000000',
+		tvl: '250000',
+		previous_price: '0.95'
+	};
+
+	return {
+		token: {
+			...tokenDefaults,
+			...(options.token ?? {})
+		},
+		metrics: {
+			...metricsDefaults,
+			...(options.metrics ?? {})
+		}
+	};
+};
+
+export const createMockCoingeckoTokenPrice = (
+	overrides: Partial<CoingeckoSimpleTokenPrice> = {}
+): CoingeckoSimpleTokenPrice => ({
+	usd: 1.23,
+	usd_market_cap: 123456,
+	usd_24h_vol: 7890,
+	usd_24h_change: -1.5,
+	last_updated_at: Date.now(),
+	...overrides
+});


### PR DESCRIPTION
# Motivation

Some ICRC tokens are not available via our primary price provider (CoinGecko). To ensure complete price coverage, we need to support a fallback data source.

# Changes

- Integrated KongSwap as a secondary price source for ICRC tokens.
- Implemented fallback logic in the exchangeRateICRCToUsd service to fetch missing token prices from KongSwap when not available via CoinGecko.

# Tests

Added full test coverage for new utility methods.
