### PR TITLE
ix(frontend): added kongswap rest to obtain alternate icrc price source

### DIFF
--- a/src/frontend/src/env/rest/kongswap.env.ts
+++ b/src/frontend/src/env/rest/kongswap.env.ts
@@ -1,0 +1,7 @@
+import { UrlSchema } from '$lib/validation/url.validation';
+import { safeParse } from '$lib/validation/utils.validation';
+
+export const KONGSWAP_API_URL = safeParse({
+	schema: UrlSchema,
+	value: 'https://api.kongswap.io/api'
+});

--- a/src/frontend/src/lib/rest/kongswap.rest.ts
+++ b/src/frontend/src/lib/rest/kongswap.rest.ts
@@ -1,0 +1,31 @@
+import { KONGSWAP_API_URL } from '$env/rest/kongswap.env';
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import type { KongSwapToken } from '$lib/types/kongswap';
+
+const fetchKongSwap = async <T>(endpoint: string): Promise<T | null> => {
+	const response = await fetch(`${KONGSWAP_API_URL}/${endpoint}`, {
+		method: 'GET',
+		headers: { 'Content-Type': 'application/json' }
+	});
+
+	if (!response.ok) {
+		throw new Error('Fetching KongSwap failed.');
+	}
+
+	return response.json();
+};
+
+export const getKongSwapTokenById = (id: LedgerCanisterIdText): Promise<KongSwapToken | null> =>
+	fetchKongSwap<KongSwapToken>(`tokens/${id.toLowerCase()}`);
+
+export const fetchBatchKongSwapPrices = (
+	canisterIds: LedgerCanisterIdText[]
+): Promise<(KongSwapToken | null)[]> =>
+	Promise.all(
+		canisterIds.map((id) =>
+			getKongSwapTokenById(id).catch((error) => {
+				console.warn(`KongSwap fallback failed for ${id}`, error);
+				return null;
+			})
+		)
+	);

--- a/src/frontend/src/lib/types/kongswap.ts
+++ b/src/frontend/src/lib/types/kongswap.ts
@@ -1,0 +1,62 @@
+import { PrincipalTextSchema } from '@dfinity/zod-schemas';
+import * as z from 'zod';
+
+const NumberAsStringSchema = z.string().refine((val) => !isNaN(Number(val)), {
+	message: 'Invalid number string'
+});
+
+const DateTimeSchema = z
+	.string()
+	.refine((val) => !isNaN(new Date(val).getTime()), { message: 'Invalid ISO date' });
+
+const KongSwapTokenMetricsSchema = z.object({
+	token_id: z.number(),
+	total_supply: NumberAsStringSchema.nullable(),
+	market_cap: NumberAsStringSchema.nullable(),
+	price: NumberAsStringSchema,
+	updated_at: DateTimeSchema,
+	volume_24h: NumberAsStringSchema,
+	tvl: NumberAsStringSchema,
+	price_change_24h: NumberAsStringSchema,
+	previous_price: NumberAsStringSchema.nullable()
+});
+
+const KongSwapTokenBaseSchema = z.object({
+	token_id: z.number(),
+	name: z.string(),
+	symbol: z.string(),
+	canister_id: PrincipalTextSchema,
+	address: z.string().nullable(),
+	decimals: z.number(),
+	fee: z.number(),
+	fee_fixed: z.string().nullable(),
+	has_custom_logo: z.boolean(),
+	icrc1: z.boolean(),
+	icrc2: z.boolean(),
+	icrc3: z.boolean(),
+	is_removed: z.boolean(),
+	logo_url: z.string().nullable(),
+	logo_updated_at: DateTimeSchema.nullable(),
+	token_type: z.string()
+});
+
+const _KongSwapTokenSchema = z.object({
+	token: KongSwapTokenBaseSchema,
+	metrics: KongSwapTokenMetricsSchema
+});
+
+const KongSwapTokenWithMetricsSchema = KongSwapTokenBaseSchema.extend({
+	metrics: KongSwapTokenMetricsSchema
+});
+
+const _KongSwapTokensSchema = z.object({
+	items: z.array(KongSwapTokenWithMetricsSchema),
+	total_pages: z.number(),
+	total_count: z.number(),
+	page: z.number(),
+	limit: z.number()
+});
+
+export type KongSwapTokenMetrics = z.infer<typeof KongSwapTokenMetricsSchema>;
+export type KongSwapTokens = z.infer<typeof _KongSwapTokensSchema>;
+export type KongSwapToken = z.infer<typeof _KongSwapTokenSchema>;


### PR DESCRIPTION
# Motivation

Some ICRC tokens are not available via our primary price provider (CoinGecko). To ensure complete price coverage, we need to support a fallback data source.

# Changes

Integrated KongSwap as a secondary price source for ICRC tokens.