### PR TITLE
refactor(backend): Move type submodules to a separate files

### DIFF
--- a/src/backend/src/config.rs
+++ b/src/backend/src/config.rs
@@ -1,5 +1,8 @@
 use ic_verifiable_credentials::VcFlowSigners;
-use shared::types::{user_profile::AddUserCredentialRequest, Config, CredentialType};
+use shared::types::{
+    backend_config::Config, user_profile::AddUserCredentialRequest,
+    verifiable_credential::CredentialType,
+};
 
 pub fn find_credential_config(
     request: &AddUserCredentialRequest,

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -30,7 +30,7 @@ use shared::{
         },
         custom_token::{CustomToken, CustomTokenId},
         dapp::{AddDappSettingsError, AddHiddenDappIdRequest},
-        networks::{SaveTestnetsSettingsError, SetShowTestnetsRequest},
+        network::{SaveTestnetsSettingsError, SetShowTestnetsRequest},
         signer::topup::{TopUpCyclesLedgerRequest, TopUpCyclesLedgerResult},
         snapshot::UserSnapshot,
         token::{UserToken, UserTokenId},

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -22,6 +22,7 @@ use shared::{
     metrics::get_metrics,
     std_canister_status,
     types::{
+        backend_config::{Arg, Config, Guards, InitArg},
         bitcoin::{
             BtcAddPendingTransactionError, BtcAddPendingTransactionRequest,
             BtcGetPendingTransactionsError, BtcGetPendingTransactionsReponse,
@@ -30,6 +31,7 @@ use shared::{
         },
         custom_token::{CustomToken, CustomTokenId},
         dapp::{AddDappSettingsError, AddHiddenDappIdRequest},
+        migration::{Migration, MigrationProgress, MigrationReport},
         network::{SaveTestnetsSettingsError, SetShowTestnetsRequest},
         signer::topup::{TopUpCyclesLedgerRequest, TopUpCyclesLedgerResult},
         snapshot::UserSnapshot,
@@ -39,8 +41,7 @@ use shared::{
             ListUserCreationTimestampsResponse, ListUsersRequest, ListUsersResponse, OisyUser,
             UserProfile,
         },
-        Arg, Config, Guards, InitArg, Migration, MigrationProgress, MigrationReport, Stats,
-        Timestamp,
+        Stats, Timestamp,
     },
 };
 use signer::{btc_principal_to_p2wpkh_address, AllowSigningError};

--- a/src/backend/src/migrate.rs
+++ b/src/backend/src/migrate.rs
@@ -7,8 +7,11 @@ use serde::Deserialize;
 use shared::{
     backend_api::Service,
     types::{
-        custom_token::CustomToken, token::UserToken, user_profile::StoredUserProfile,
-        MigrationError, MigrationProgress, Timestamp,
+        custom_token::CustomToken,
+        migration::{MigrationError, MigrationProgress},
+        token::UserToken,
+        user_profile::StoredUserProfile,
+        Timestamp,
     },
 };
 use steps::{

--- a/src/backend/src/migrate/steps.rs
+++ b/src/backend/src/migrate/steps.rs
@@ -1,7 +1,11 @@
 use ic_cdk::eprintln;
 use shared::{
     backend_api::Service,
-    types::{ApiEnabled, Guards, Migration, MigrationError, Stats},
+    types::{
+        backend_config::Guards,
+        migration::{ApiEnabled, Migration, MigrationError},
+        Stats,
+    },
 };
 
 use crate::{modify_state_config, mutate_state};

--- a/src/backend/src/types.rs
+++ b/src/backend/src/types.rs
@@ -3,7 +3,8 @@ use ic_stable_structures::{
     memory_manager::VirtualMemory, DefaultMemoryImpl, StableBTreeMap, StableCell,
 };
 use shared::types::{
-    custom_token::CustomToken, token::UserToken, user_profile::StoredUserProfile, Config, Timestamp,
+    backend_config::Config, custom_token::CustomToken, token::UserToken,
+    user_profile::StoredUserProfile, Timestamp,
 };
 
 pub type VMem = VirtualMemory<DefaultMemoryImpl>;

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -3,7 +3,8 @@ use shared::types::{
     dapp::AddDappSettingsError,
     network::SaveTestnetsSettingsError,
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
-    CredentialType, Version,
+    verifiable_credential::CredentialType,
+    Version,
 };
 
 use crate::{user_profile_model::UserProfileModel, StoredPrincipal};

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -1,7 +1,7 @@
 use ic_cdk::api::time;
 use shared::types::{
     dapp::AddDappSettingsError,
-    networks::SaveTestnetsSettingsError,
+    network::SaveTestnetsSettingsError,
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
     CredentialType, Version,
 };

--- a/src/backend/tests/it/config.rs
+++ b/src/backend/tests/it/config.rs
@@ -1,5 +1,8 @@
 use candid::Principal;
-use shared::types::{user_profile::UserProfile, Arg, Config};
+use shared::types::{
+    backend_config::{Arg, Config},
+    user_profile::UserProfile,
+};
 
 use crate::utils::pocketic::{controller, init_arg, setup, PicCanisterTrait};
 

--- a/src/backend/tests/it/guard.rs
+++ b/src/backend/tests/it/guard.rs
@@ -1,7 +1,10 @@
 //! Tests that the guard APIs are working as expected.
 
 use candid::Principal;
-use shared::types::{ApiEnabled, Config, Guards};
+use shared::types::{
+    backend_config::{Config, Guards},
+    migration::ApiEnabled,
+};
 
 use crate::utils::{
     mock::USER_1,

--- a/src/backend/tests/it/migration.rs
+++ b/src/backend/tests/it/migration.rs
@@ -5,8 +5,10 @@ use std::sync::Arc;
 use candid::Principal;
 use pocket_ic::PocketIcBuilder;
 use shared::types::{
+    backend_config::Guards,
     custom_token::{CustomToken, IcrcToken, Token},
-    ApiEnabled, Guards, MigrationProgress, MigrationReport, Stats,
+    migration::{ApiEnabled, MigrationProgress, MigrationReport},
+    Stats,
 };
 
 use crate::{
@@ -132,7 +134,7 @@ impl MigrationTestEnv {
     fn assert_canister_locks_are(&self, old: Option<Guards>, new: Option<Guards>, context: &str) {
         assert_eq!(
             self.old_backend
-                .query::<shared::types::Config>(controller(), "config", ())
+                .query::<shared::types::backend_config::Config>(controller(), "config", ())
                 .expect("Failed to get config")
                 .api,
             old,
@@ -140,7 +142,7 @@ impl MigrationTestEnv {
         );
         assert_eq!(
             self.new_backend
-                .query::<shared::types::Config>(controller(), "config", ())
+                .query::<shared::types::backend_config::Config>(controller(), "config", ())
                 .expect("Failed to get config")
                 .api,
             new,
@@ -220,7 +222,7 @@ fn test_migration() {
                 .expect("Failed to start migration"),
             Ok(MigrationReport {
                 to: pic_setup.new_backend.canister_id(),
-                progress: shared::types::MigrationProgress::Pending
+                progress: shared::types::migration::MigrationProgress::Pending
             }),
         );
         // Stop the timer so that we can control the migration.
@@ -272,7 +274,7 @@ fn test_migration() {
     // Keep stepping until the user tokens have been migrated.
     {
         while let Some(MigrationReport {
-            progress: shared::types::MigrationProgress::MigratedUserTokensUpTo(_),
+            progress: shared::types::migration::MigrationProgress::MigratedUserTokensUpTo(_),
             ..
         }) = pic_setup.migration_state()
         {
@@ -286,7 +288,7 @@ fn test_migration() {
     // Keep stepping until the custom tokens have been migrated.
     {
         while let Some(MigrationReport {
-            progress: shared::types::MigrationProgress::MigratedCustomTokensUpTo(_),
+            progress: shared::types::migration::MigrationProgress::MigratedCustomTokensUpTo(_),
             ..
         }) = pic_setup.migration_state()
         {
@@ -300,7 +302,7 @@ fn test_migration() {
     // Keep stepping until the user timestamps have been migrated.
     {
         while let Some(MigrationReport {
-            progress: shared::types::MigrationProgress::MigratedUserTimestampsUpTo(_),
+            progress: shared::types::migration::MigrationProgress::MigratedUserTimestampsUpTo(_),
             ..
         }) = pic_setup.migration_state()
         {
@@ -314,7 +316,7 @@ fn test_migration() {
     // Keep stepping until the user profiles have been migrated.
     {
         while let Some(MigrationReport {
-            progress: shared::types::MigrationProgress::MigratedUserProfilesUpTo(_),
+            progress: shared::types::migration::MigrationProgress::MigratedUserProfilesUpTo(_),
             ..
         }) = pic_setup.migration_state()
         {

--- a/src/backend/tests/it/settings/networks_settings.rs
+++ b/src/backend/tests/it/settings/networks_settings.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use shared::types::{
-    networks::{SaveTestnetsSettingsError, SetShowTestnetsRequest},
+    network::{SaveTestnetsSettingsError, SetShowTestnetsRequest},
     user_profile::{GetUserProfileError, UserProfile},
 };
 

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -13,8 +13,9 @@ use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 pub use pic_canister::PicCanisterTrait;
 use pocket_ic::{CallError, PocketIc, PocketIcBuilder};
 use shared::types::{
+    backend_config::{Arg, InitArg},
     user_profile::{OisyUser, UserProfile},
-    Arg, CredentialType, InitArg, SupportedCredential,
+    verifiable_credential::{CredentialType, SupportedCredential},
 };
 
 use super::mock::{

--- a/src/shared/src/backend_api.rs
+++ b/src/shared/src/backend_api.rs
@@ -3,7 +3,7 @@
 use candid::{self, Principal};
 use ic_cdk::api::call::CallResult as Result;
 
-use crate::types::{Guards, Stats};
+use crate::types::{backend_config::Guards, Stats};
 
 /// Client for the backend canister, implementing a subset of the API.
 ///

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -8,15 +8,17 @@ use strum::IntoEnumIterator;
 
 use crate::{
     types::{
+        backend_config::{Config, InitArg},
         custom_token::{CustomToken, CustomTokenId, IcrcToken, SplToken, SplTokenId, Token},
         dapp::{AddDappSettingsError, DappCarouselSettings, DappSettings},
+        migration::{ApiEnabled, Migration, MigrationProgress, MigrationReport},
         network::{NetworksSettings, SaveTestnetsSettingsError},
         settings::Settings,
         token::UserToken,
         user_profile::{
             AddUserCredentialError, OisyUser, StoredUserProfile, UserCredential, UserProfile,
         },
-        ApiEnabled, Config, CredentialType, InitArg, Migration, MigrationProgress, MigrationReport,
+        verifiable_credential::CredentialType,
         Timestamp, TokenVersion, Version,
     },
     validate::{validate_on_deserialize, Validate},

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -10,7 +10,7 @@ use crate::{
     types::{
         custom_token::{CustomToken, CustomTokenId, IcrcToken, SplToken, SplTokenId, Token},
         dapp::{AddDappSettingsError, DappCarouselSettings, DappSettings},
-        networks::{NetworksSettings, SaveTestnetsSettingsError},
+        network::{NetworksSettings, SaveTestnetsSettingsError},
         settings::Settings,
         token::UserToken,
         user_profile::{

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -7,6 +7,7 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 pub type Timestamp = u64;
 
 pub mod account;
+pub mod bitcoin;
 pub mod custom_token;
 pub mod network;
 pub mod number;
@@ -117,66 +118,6 @@ pub trait TokenVersion: Debug {
 
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
-
-pub mod bitcoin {
-    use candid::CandidType;
-    use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};
-    use serde::Deserialize;
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct SelectedUtxosFeeRequest {
-        pub amount_satoshis: u64,
-        pub network: BitcoinNetwork,
-        pub min_confirmations: Option<u32>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct SelectedUtxosFeeResponse {
-        pub utxos: Vec<Utxo>,
-        pub fee_satoshis: u64,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum SelectedUtxosFeeError {
-        InternalError { msg: String },
-        PendingTransactions,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct BtcAddPendingTransactionRequest {
-        pub txid: Vec<u8>,
-        pub utxos: Vec<Utxo>,
-        pub address: String,
-        pub network: BitcoinNetwork,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum BtcAddPendingTransactionError {
-        InternalError { msg: String },
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct BtcGetPendingTransactionsRequest {
-        pub address: String,
-        pub network: BitcoinNetwork,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct PendingTransaction {
-        pub txid: Vec<u8>,
-        pub utxos: Vec<Utxo>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct BtcGetPendingTransactionsReponse {
-        pub transactions: Vec<PendingTransaction>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum BtcGetPendingTransactionsError {
-        InternalError { msg: String },
-    }
-}
 
 /// Types related to the signer & topping up the cycles ledger account for use with the signer.
 pub mod signer {

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -11,6 +11,7 @@ pub mod network;
 pub mod number;
 pub mod snapshot;
 pub mod token_id;
+pub mod transaction;
 
 #[cfg(test)]
 mod tests;
@@ -95,46 +96,6 @@ pub struct Config {
     /// Used to validate the id alias credential which includes the derivation origin of the id
     /// alias.
     pub derivation_origin: Option<String>,
-}
-
-pub mod transaction {
-    use candid::{CandidType, Deserialize, Nat};
-    use serde::Serialize;
-
-    use super::account::AccountId;
-    use crate::types::network::marker_trait::Network;
-
-    #[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-    #[repr(u8)]
-    pub enum TransactionType {
-        Send = 0,
-        Receive = 1,
-    }
-
-    #[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-    pub struct Transaction<N, A>
-    where
-        A: AccountId<N>,
-        N: Network,
-    {
-        pub network: N,
-        pub transaction_type: TransactionType,
-        pub amount: u64,
-        pub timestamp: u64,
-        pub counterparty: A,
-    }
-
-    #[derive(CandidType, Deserialize)]
-    pub struct SignRequest {
-        pub chain_id: Nat,
-        pub to: String,
-        pub gas: Nat,
-        pub max_fee_per_gas: Nat,
-        pub max_priority_fee_per_gas: Nat,
-        pub value: Nat,
-        pub nonce: Nat,
-        pub data: Option<String>,
-    }
 }
 
 pub type Version = u64;

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -9,6 +9,7 @@ pub type Timestamp = u64;
 pub mod account;
 pub mod bitcoin;
 pub mod custom_token;
+pub mod dapp;
 pub mod network;
 pub mod number;
 pub mod signer;
@@ -119,50 +120,6 @@ pub trait TokenVersion: Debug {
 
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
-
-pub mod dapp {
-    use candid::{CandidType, Deserialize};
-
-    use crate::types::Version;
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-    pub struct DappCarouselSettings {
-        pub hidden_dapp_ids: Vec<String>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-    pub struct DappSettings {
-        pub dapp_carousel: DappCarouselSettings,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum AddDappSettingsError {
-        DappIdTooLong,
-        UserNotFound,
-        VersionMismatch,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct AddHiddenDappIdRequest {
-        pub dapp_id: String,
-        pub current_user_version: Option<Version>,
-    }
-
-    impl AddHiddenDappIdRequest {
-        /// The maximum supported dApp ID length.
-        pub const MAX_LEN: usize = 32;
-
-        /// Checks whether the request is syntactically valid
-        ///
-        /// # Errors
-        /// - If the dApp ID is too long.
-        pub fn check(&self) -> Result<(), AddDappSettingsError> {
-            (self.dapp_id.len() < Self::MAX_LEN)
-                .then_some(())
-                .ok_or(AddDappSettingsError::DappIdTooLong)
-        }
-    }
-}
 
 pub mod settings {
     use candid::{CandidType, Deserialize};

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -10,6 +10,7 @@ pub mod account;
 pub mod network;
 pub mod number;
 pub mod snapshot;
+pub mod token;
 pub mod token_id;
 pub mod transaction;
 
@@ -111,32 +112,6 @@ pub trait TokenVersion: Debug {
     fn with_initial_version(&self) -> Self
     where
         Self: Sized + Clone;
-}
-
-/// ERC20 specific user defined tokens
-pub mod token {
-    use candid::{CandidType, Deserialize};
-    use serde::Serialize;
-
-    use crate::types::Version;
-
-    pub type ChainId = u64;
-
-    #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct UserToken {
-        pub contract_address: String,
-        pub chain_id: ChainId,
-        pub symbol: Option<String>,
-        pub decimals: Option<u8>,
-        pub version: Option<Version>,
-        pub enabled: Option<bool>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone)]
-    pub struct UserTokenId {
-        pub contract_address: String,
-        pub chain_id: ChainId,
-    }
 }
 
 /// The default maximum length of a token symbol.

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -18,6 +18,7 @@ pub mod snapshot;
 pub mod token;
 pub mod token_id;
 pub mod transaction;
+pub mod user_profile;
 
 #[cfg(test)]
 mod tests;
@@ -121,89 +122,6 @@ pub trait TokenVersion: Debug {
 
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
-
-/// Types specifics to the user profile.
-pub mod user_profile {
-    use std::collections::BTreeMap;
-
-    use candid::{CandidType, Deserialize, Principal};
-    use ic_verifiable_credentials::issuer_api::CredentialSpec;
-
-    use super::{CredentialType, Timestamp};
-    use crate::types::{settings::Settings, Version};
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct UserCredential {
-        pub credential_type: CredentialType,
-        pub verified_date_timestamp: Option<Timestamp>,
-        pub issuer: String,
-    }
-
-    // Used in the endpoint
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct UserProfile {
-        pub settings: Option<Settings>,
-        pub credentials: Vec<UserCredential>,
-        pub created_timestamp: Timestamp,
-        pub updated_timestamp: Timestamp,
-        pub version: Option<Version>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct StoredUserProfile {
-        pub settings: Option<Settings>,
-        pub credentials: BTreeMap<CredentialType, UserCredential>,
-        pub created_timestamp: Timestamp,
-        pub updated_timestamp: Timestamp,
-        pub version: Option<Version>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct AddUserCredentialRequest {
-        pub credential_jwt: String,
-        pub credential_spec: CredentialSpec,
-        pub issuer_canister_id: Principal,
-        pub current_user_version: Option<Version>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum AddUserCredentialError {
-        InvalidCredential,
-        ConfigurationError,
-        UserNotFound,
-        VersionMismatch,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct ListUsersRequest {
-        pub updated_after_timestamp: Option<Timestamp>,
-        pub matches_max_length: Option<u64>,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct OisyUser {
-        pub principal: Principal,
-        pub pouh_verified: bool,
-        pub updated_timestamp: Timestamp,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct ListUsersResponse {
-        pub users: Vec<OisyUser>,
-        pub matches_max_length: u64,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct ListUserCreationTimestampsResponse {
-        pub creation_timestamps: Vec<Timestamp>,
-        pub matches_max_length: u64,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum GetUserProfileError {
-        NotFound,
-    }
-}
 
 /// The current state of progress of a user data migration.
 #[derive(

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -7,6 +7,7 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 pub type Timestamp = u64;
 
 pub mod account;
+pub mod custom_token;
 pub mod network;
 pub mod number;
 pub mod snapshot;
@@ -116,69 +117,6 @@ pub trait TokenVersion: Debug {
 
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
-
-/// Extendable custom user defined tokens
-pub mod custom_token {
-    use candid::{CandidType, Deserialize, Principal};
-
-    use crate::types::Version;
-
-    pub type LedgerId = Principal;
-    pub type IndexId = Principal;
-
-    /// An ICRC-1 compliant token on the Internet Computer.
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    #[serde(remote = "Self")]
-    pub struct IcrcToken {
-        pub ledger_id: LedgerId,
-        pub index_id: Option<IndexId>,
-    }
-
-    /// A Solana token
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    #[serde(remote = "Self")]
-    pub struct SplToken {
-        pub token_address: SplTokenId,
-        pub symbol: Option<String>,
-        pub decimals: Option<u8>,
-    }
-
-    /// A network-specific unique Solana token identifier.
-    #[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
-    #[serde(remote = "Self")]
-    pub struct SplTokenId(pub String);
-
-    /// A variant describing any token
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    #[repr(u8)]
-    pub enum Token {
-        Icrc(IcrcToken) = 0,
-        SplMainnet(SplToken) = 1,
-        SplDevnet(SplToken) = 2,
-    }
-
-    /// User preferences for any token
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    #[serde(remote = "Self")]
-    pub struct CustomToken {
-        pub token: Token,
-        pub enabled: bool,
-        pub version: Option<Version>,
-    }
-
-    /// A cross-chain token identifier.
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq)]
-    #[serde(remote = "Self")]
-    #[repr(u8)]
-    pub enum CustomTokenId {
-        /// An ICRC-1 compliant token on the Internet Computer mainnet.
-        Icrc(LedgerId) = 0,
-        /// A Solana token on the Solana mainnet.
-        SolMainnet(SplTokenId) = 1,
-        /// A Solana token on the Solana devnet.
-        SolDevnet(SplTokenId) = 2,
-    }
-}
 
 pub mod bitcoin {
     use candid::CandidType;

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -1,8 +1,6 @@
 use std::fmt::Debug;
 
-use candid::{CandidType, Deserialize, Principal};
-use ic_cdk_timers::TimerId;
-use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+use candid::{CandidType, Deserialize};
 
 pub type Timestamp = u64;
 

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -120,58 +120,6 @@ pub trait TokenVersion: Debug {
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
 
-pub mod networks {
-    use std::collections::BTreeMap;
-
-    use candid::{CandidType, Deserialize};
-
-    use crate::types::Version;
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-    pub struct NetworkSettings {
-        pub enabled: bool,
-        pub is_testnet: bool,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default, Ord, PartialOrd)]
-    pub enum NetworkSettingsFor {
-        #[default]
-        InternetComputer,
-        BitcoinMainnet,
-        BitcoinTestnet,
-        BitcoinRegtest,
-        EthereumMainnet,
-        EthereumSepolia,
-        SolanaMainnet,
-        SolanaTestnet,
-        SolanaDevnet,
-        SolanaLocal,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-    pub struct TestnetsSettings {
-        pub show_testnets: bool,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-    pub struct NetworksSettings {
-        pub networks: BTreeMap<NetworkSettingsFor, NetworkSettings>,
-        pub testnets: TestnetsSettings,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub enum SaveTestnetsSettingsError {
-        UserNotFound,
-        VersionMismatch,
-    }
-
-    #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-    pub struct SetShowTestnetsRequest {
-        pub show_testnets: bool,
-        pub current_user_version: Option<Version>,
-    }
-}
-
 pub mod dapp {
     use candid::{CandidType, Deserialize};
 
@@ -219,7 +167,7 @@ pub mod dapp {
 pub mod settings {
     use candid::{CandidType, Deserialize};
 
-    use crate::types::{dapp::DappSettings, networks::NetworksSettings};
+    use crate::types::{dapp::DappSettings, network::NetworksSettings};
 
     #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
     pub struct Settings {

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -12,6 +12,7 @@ pub mod custom_token;
 pub mod dapp;
 pub mod network;
 pub mod number;
+pub mod settings;
 pub mod signer;
 pub mod snapshot;
 pub mod token;
@@ -120,18 +121,6 @@ pub trait TokenVersion: Debug {
 
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
-
-pub mod settings {
-    use candid::{CandidType, Deserialize};
-
-    use crate::types::{dapp::DappSettings, network::NetworksSettings};
-
-    #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-    pub struct Settings {
-        pub networks: NetworksSettings,
-        pub dapp: DappSettings,
-    }
-}
 
 /// Types specifics to the user profile.
 pub mod user_profile {

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -11,6 +11,7 @@ pub mod bitcoin;
 pub mod custom_token;
 pub mod network;
 pub mod number;
+pub mod signer;
 pub mod snapshot;
 pub mod token;
 pub mod token_id;
@@ -118,94 +119,6 @@ pub trait TokenVersion: Debug {
 
 /// The default maximum length of a token symbol.
 pub const MAX_SYMBOL_LENGTH: usize = 20;
-
-/// Types related to the signer & topping up the cycles ledger account for use with the signer.
-pub mod signer {
-    use super::{CandidType, Debug, Deserialize};
-    /// Types related to topping up the cycles ledger account for use with the signer.
-    pub mod topup {
-        use candid::Nat;
-
-        use super::{CandidType, Debug, Deserialize};
-        /// A request to top up the cycles ledger.
-        #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
-        pub struct TopUpCyclesLedgerRequest {
-            /// If the cycles ledger account balance is below this threshold, top it up.
-            pub threshold: Option<Nat>,
-            /// The percentage of the backend canister's own cycles to send to the cycles ledger.
-            pub percentage: Option<u8>,
-        }
-        impl TopUpCyclesLedgerRequest {
-            /// Checks that the request is valid.
-            ///
-            /// # Errors
-            /// - If the percentage is out of bounds.
-            pub fn check(&self) -> Result<(), TopUpCyclesLedgerError> {
-                if let Some(percentage) = self.percentage {
-                    if !(MIN_PERCENTAGE..=MAX_PERCENTAGE).contains(&percentage) {
-                        return Err(TopUpCyclesLedgerError::InvalidArgPercentageOutOfRange {
-                            percentage,
-                            min: MIN_PERCENTAGE,
-                            max: MAX_PERCENTAGE,
-                        });
-                    }
-                }
-                Ok(())
-            }
-
-            /// The requested threshold for topping up the cycles ledger, if provided, else the
-            /// default.
-            #[must_use]
-            pub fn threshold(&self) -> Nat {
-                self.threshold
-                    .clone()
-                    .unwrap_or(Nat::from(DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD))
-            }
-
-            /// The requested percentage of the backend's own canisters to send to the cycles
-            /// ledger, if provided, else the default.
-            #[must_use]
-            pub fn percentage(&self) -> u8 {
-                self.percentage
-                    .unwrap_or(DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE)
-            }
-        }
-        /// The default cycles ledger top up threshold.  If the cycles ledger balance falls below
-        /// this, it should be topped up.
-        pub const DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD: u128 = 50_000_000_000_000; // 50T
-        /// The proportion of the backend canister's own cycles to send to the cycles ledger.
-        pub const DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE: u8 = 50;
-        /// The minimum sensible percentage to send to the cycles ledger.
-        /// - Note: With 0% the backend canister would never top up the cycles ledger.
-        pub const MIN_PERCENTAGE: u8 = 1;
-        /// The maximum sensible percentage to send to the cycles ledger.
-        /// - Note: With 100% the backend canister would be left with no cycles.
-        pub const MAX_PERCENTAGE: u8 = 99;
-
-        /// Possible error conditions when topping up the cycles ledger.
-        #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
-        pub enum TopUpCyclesLedgerError {
-            CouldNotGetBalanceFromCyclesLedger,
-            InvalidArgPercentageOutOfRange { percentage: u8, min: u8, max: u8 },
-            CouldNotTopUpCyclesLedger { available: Nat, tried_to_send: Nat },
-        }
-        /// Possible successful responses when topping up the cycles ledger.
-        #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
-        pub struct TopUpCyclesLedgerResponse {
-            /// The ledger balance after topping up.
-            pub ledger_balance: Nat,
-            /// The backend canister cycles after topping up.
-            pub backend_cycles: Nat,
-            /// The amount topped up.
-            /// - Zero if the ledger balance was already sufficient.
-            /// - The requested amount otherwise.
-            pub topped_up: Nat,
-        }
-
-        pub type TopUpCyclesLedgerResult =
-            Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>;
-    }
-}
 
 pub mod networks {
     use std::collections::BTreeMap;

--- a/src/shared/src/types/backend_config.rs
+++ b/src/shared/src/types/backend_config.rs
@@ -1,0 +1,61 @@
+use candid::Principal;
+
+#[derive(CandidType, Deserialize)]
+pub struct InitArg {
+    pub ecdsa_key_name: String,
+    pub allowed_callers: Vec<Principal>,
+    pub supported_credentials: Option<Vec<SupportedCredential>>,
+    /// Root of trust for checking canister signatures.
+    pub ic_root_key_der: Option<Vec<u8>>,
+    /// Enables or disables APIs
+    pub api: Option<Guards>,
+    /// Chain Fusion Signer canister id. Used to derive the bitcoin address in
+    /// `btc_select_user_utxos_fee`
+    pub cfs_canister_id: Option<Principal>,
+    /// Derivation origins when logging in the dapp with Internet Identity.
+    /// Used to validate the id alias credential which includes the derivation origin of the id
+    /// alias.
+    pub derivation_origin: Option<String>,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum Arg {
+    Init(InitArg),
+    Upgrade,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Config {
+    pub ecdsa_key_name: String,
+    // A list of allowed callers to restrict access to endpoints that do not particularly check or
+    // use the caller()
+    pub allowed_callers: Vec<Principal>,
+    pub supported_credentials: Option<Vec<SupportedCredential>>,
+    /// Root of trust for checking canister signatures.
+    pub ic_root_key_raw: Option<Vec<u8>>,
+    /// Enables or disables APIs
+    pub api: Option<Guards>,
+    /// Chain Fusion Signer canister id. Used to derive the bitcoin address in
+    /// `btc_select_user_utxos_fee`
+    pub cfs_canister_id: Option<Principal>,
+    /// Derivation origins when logging in the dapp with Internet Identity.
+    /// Used to validate the id alias credential which includes the derivation origin of the id
+    /// alias.
+    pub derivation_origin: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Guards {
+    pub threshold_key: ApiEnabled,
+    pub user_data: ApiEnabled,
+}
+#[test]
+fn guards_default() {
+    assert_eq!(
+        Guards::default(),
+        Guards {
+            threshold_key: ApiEnabled::Enabled,
+            user_data: ApiEnabled::Enabled,
+        }
+    );
+}

--- a/src/shared/src/types/backend_config.rs
+++ b/src/shared/src/types/backend_config.rs
@@ -1,4 +1,8 @@
-use candid::Principal;
+use std::fmt::Debug;
+
+use candid::{CandidType, Deserialize, Principal};
+
+use crate::types::{migration::ApiEnabled, verifiable_credential::SupportedCredential};
 
 #[derive(CandidType, Deserialize)]
 pub struct InitArg {

--- a/src/shared/src/types/bitcoin.rs
+++ b/src/shared/src/types/bitcoin.rs
@@ -1,0 +1,57 @@
+use candid::CandidType;
+use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};
+use serde::Deserialize;
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SelectedUtxosFeeRequest {
+    pub amount_satoshis: u64,
+    pub network: BitcoinNetwork,
+    pub min_confirmations: Option<u32>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SelectedUtxosFeeResponse {
+    pub utxos: Vec<Utxo>,
+    pub fee_satoshis: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum SelectedUtxosFeeError {
+    InternalError { msg: String },
+    PendingTransactions,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct BtcAddPendingTransactionRequest {
+    pub txid: Vec<u8>,
+    pub utxos: Vec<Utxo>,
+    pub address: String,
+    pub network: BitcoinNetwork,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum BtcAddPendingTransactionError {
+    InternalError { msg: String },
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct BtcGetPendingTransactionsRequest {
+    pub address: String,
+    pub network: BitcoinNetwork,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct PendingTransaction {
+    pub txid: Vec<u8>,
+    pub utxos: Vec<Utxo>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct BtcGetPendingTransactionsReponse {
+    pub transactions: Vec<PendingTransaction>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum BtcGetPendingTransactionsError {
+    InternalError { msg: String },
+}

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -1,0 +1,60 @@
+//! Extendable custom user defined tokens
+use candid::{CandidType, Deserialize, Principal};
+
+use crate::types::Version;
+
+pub type LedgerId = Principal;
+pub type IndexId = Principal;
+
+/// An ICRC-1 compliant token on the Internet Computer.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[serde(remote = "Self")]
+pub struct IcrcToken {
+    pub ledger_id: LedgerId,
+    pub index_id: Option<IndexId>,
+}
+
+/// A Solana token
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[serde(remote = "Self")]
+pub struct SplToken {
+    pub token_address: SplTokenId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+}
+
+/// A network-specific unique Solana token identifier.
+#[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
+#[serde(remote = "Self")]
+pub struct SplTokenId(pub String);
+
+/// A variant describing any token
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[repr(u8)]
+pub enum Token {
+    Icrc(IcrcToken) = 0,
+    SplMainnet(SplToken) = 1,
+    SplDevnet(SplToken) = 2,
+}
+
+/// User preferences for any token
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[serde(remote = "Self")]
+pub struct CustomToken {
+    pub token: Token,
+    pub enabled: bool,
+    pub version: Option<Version>,
+}
+
+/// A cross-chain token identifier.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq)]
+#[serde(remote = "Self")]
+#[repr(u8)]
+pub enum CustomTokenId {
+    /// An ICRC-1 compliant token on the Internet Computer mainnet.
+    Icrc(LedgerId) = 0,
+    /// A Solana token on the Solana mainnet.
+    SolMainnet(SplTokenId) = 1,
+    /// A Solana token on the Solana devnet.
+    SolDevnet(SplTokenId) = 2,
+}

--- a/src/shared/src/types/dapp.rs
+++ b/src/shared/src/types/dapp.rs
@@ -1,0 +1,42 @@
+
+use candid::{CandidType, Deserialize};
+
+use crate::types::Version;
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct DappCarouselSettings {
+    pub hidden_dapp_ids: Vec<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct DappSettings {
+    pub dapp_carousel: DappCarouselSettings,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum AddDappSettingsError {
+    DappIdTooLong,
+    UserNotFound,
+    VersionMismatch,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct AddHiddenDappIdRequest {
+    pub dapp_id: String,
+    pub current_user_version: Option<Version>,
+}
+
+impl AddHiddenDappIdRequest {
+    /// The maximum supported dApp ID length.
+    pub const MAX_LEN: usize = 32;
+
+    /// Checks whether the request is syntactically valid
+    ///
+    /// # Errors
+    /// - If the dApp ID is too long.
+    pub fn check(&self) -> Result<(), AddDappSettingsError> {
+        (self.dapp_id.len() < Self::MAX_LEN)
+            .then_some(())
+            .ok_or(AddDappSettingsError::DappIdTooLong)
+    }
+}

--- a/src/shared/src/types/dapp.rs
+++ b/src/shared/src/types/dapp.rs
@@ -1,4 +1,3 @@
-
 use candid::{CandidType, Deserialize};
 
 use crate::types::Version;

--- a/src/shared/src/types/migration.rs
+++ b/src/shared/src/types/migration.rs
@@ -1,0 +1,80 @@
+#[derive(CandidType, Deserialize, Eq, PartialEq, Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum ApiEnabled {
+    Enabled,
+    ReadOnly,
+    Disabled,
+}
+
+/// The current state of progress of a user data migration.
+#[derive(
+    CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Default, EnumCountMacro, EnumIter,
+)]
+pub enum MigrationProgress {
+    /// Migration has been requested.
+    #[default]
+    Pending,
+    /// APIs are being locked on the target canister.
+    LockingTarget,
+    /// Checking that the target canister is empty.
+    CheckingTarget,
+    /// Tokens have been migrated up to (but excluding) the given principal.
+    MigratedUserTokensUpTo(Option<Principal>),
+    /// Custom tokens have been migrated up to (but excluding) the given principal.
+    MigratedCustomTokensUpTo(Option<Principal>),
+    /// Migrated user profile timestamps up to the given principal.
+    MigratedUserTimestampsUpTo(Option<Principal>),
+    /// Migrated user profiles up to the given timestamp/user pair.
+    MigratedUserProfilesUpTo(Option<(Timestamp, Principal)>),
+    /// Checking that the target canister has all the data.
+    CheckingDataMigration,
+    /// Unlock user data operations in the target canister.
+    UnlockingTarget,
+    // Unlock signing operations in the current canister.
+    Unlocking,
+    /// Migration has been completed.
+    Completed,
+    /// Migration failed.
+    Failed(MigrationError),
+}
+
+#[derive(
+    CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug, Default, EnumCountMacro, EnumIter,
+)]
+pub enum MigrationError {
+    #[default]
+    Unknown,
+    /// No migration is in progress.
+    NoMigrationInProgress,
+    /// Failed to lock target canister.
+    TargetLockFailed,
+    /// Could not get target stats before starting migration.
+    CouldNotGetTargetPriorStats,
+    /// There were already user profiles in the target canister.
+    TargetCanisterNotEmpty(Stats),
+    /// Failed to migrate data.
+    DataMigrationFailed,
+    /// Could not get target stats after migration.
+    CouldNotGetTargetPostStats,
+    /// Target stats do not match source stats.
+    TargetStatsMismatch(Stats, Stats),
+    /// Could not unlock target canister.
+    TargetUnlockFailed,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Migration {
+    /// The canister that data is being migrated to.
+    pub to: Principal,
+    /// The current state of progress of a user data migration.
+    pub progress: MigrationProgress,
+    /// The timer id for the migration.
+    pub timer_id: TimerId,
+}
+
+/// A serializable report of a migration.
+#[derive(CandidType, Deserialize, Copy, Clone, Eq, PartialEq, Debug)]
+pub struct MigrationReport {
+    pub to: Principal,
+    pub progress: MigrationProgress,
+}

--- a/src/shared/src/types/migration.rs
+++ b/src/shared/src/types/migration.rs
@@ -1,3 +1,11 @@
+use std::fmt::Debug;
+
+use candid::{CandidType, Deserialize, Principal};
+use ic_cdk_timers::TimerId;
+use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+
+use crate::types::{Stats, Timestamp};
+
 #[derive(CandidType, Deserialize, Eq, PartialEq, Debug, Copy, Clone)]
 #[repr(u8)]
 pub enum ApiEnabled {

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -1,5 +1,55 @@
 //! Level 0 networks
 
+use std::collections::BTreeMap;
+
+use candid::{CandidType, Deserialize};
+
+use crate::types::Version;
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct NetworkSettings {
+    pub enabled: bool,
+    pub is_testnet: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default, Ord, PartialOrd)]
+pub enum NetworkSettingsFor {
+    #[default]
+    InternetComputer,
+    BitcoinMainnet,
+    BitcoinTestnet,
+    BitcoinRegtest,
+    EthereumMainnet,
+    EthereumSepolia,
+    SolanaMainnet,
+    SolanaTestnet,
+    SolanaDevnet,
+    SolanaLocal,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct TestnetsSettings {
+    pub show_testnets: bool,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct NetworksSettings {
+    pub networks: BTreeMap<NetworkSettingsFor, NetworkSettings>,
+    pub testnets: TestnetsSettings,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum SaveTestnetsSettingsError {
+    UserNotFound,
+    VersionMismatch,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct SetShowTestnetsRequest {
+    pub show_testnets: bool,
+    pub current_user_version: Option<Version>,
+}
+
 pub mod marker_trait {
     use candid::{CandidType, Deserialize};
     use serde::Serialize;

--- a/src/shared/src/types/settings.rs
+++ b/src/shared/src/types/settings.rs
@@ -1,0 +1,10 @@
+
+use candid::{CandidType, Deserialize};
+
+use crate::types::{dapp::DappSettings, network::NetworksSettings};
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct Settings {
+    pub networks: NetworksSettings,
+    pub dapp: DappSettings,
+}

--- a/src/shared/src/types/settings.rs
+++ b/src/shared/src/types/settings.rs
@@ -1,4 +1,3 @@
-
 use candid::{CandidType, Deserialize};
 
 use crate::types::{dapp::DappSettings, network::NetworksSettings};

--- a/src/shared/src/types/signer.rs
+++ b/src/shared/src/types/signer.rs
@@ -1,0 +1,85 @@
+//! Types related to the signer & topping up the cycles ledger account for use with the signer.
+
+use super::{CandidType, Debug, Deserialize};
+/// Types related to topping up the cycles ledger account for use with the signer.
+pub mod topup {
+    use candid::Nat;
+
+    use super::{CandidType, Debug, Deserialize};
+    /// A request to top up the cycles ledger.
+    #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+    pub struct TopUpCyclesLedgerRequest {
+        /// If the cycles ledger account balance is below this threshold, top it up.
+        pub threshold: Option<Nat>,
+        /// The percentage of the backend canister's own cycles to send to the cycles ledger.
+        pub percentage: Option<u8>,
+    }
+    impl TopUpCyclesLedgerRequest {
+        /// Checks that the request is valid.
+        ///
+        /// # Errors
+        /// - If the percentage is out of bounds.
+        pub fn check(&self) -> Result<(), TopUpCyclesLedgerError> {
+            if let Some(percentage) = self.percentage {
+                if !(MIN_PERCENTAGE..=MAX_PERCENTAGE).contains(&percentage) {
+                    return Err(TopUpCyclesLedgerError::InvalidArgPercentageOutOfRange {
+                        percentage,
+                        min: MIN_PERCENTAGE,
+                        max: MAX_PERCENTAGE,
+                    });
+                }
+            }
+            Ok(())
+        }
+
+        /// The requested threshold for topping up the cycles ledger, if provided, else the
+        /// default.
+        #[must_use]
+        pub fn threshold(&self) -> Nat {
+            self.threshold
+                .clone()
+                .unwrap_or(Nat::from(DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD))
+        }
+
+        /// The requested percentage of the backend's own canisters to send to the cycles
+        /// ledger, if provided, else the default.
+        #[must_use]
+        pub fn percentage(&self) -> u8 {
+            self.percentage
+                .unwrap_or(DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE)
+        }
+    }
+    /// The default cycles ledger top up threshold.  If the cycles ledger balance falls below
+    /// this, it should be topped up.
+    pub const DEFAULT_CYCLES_LEDGER_TOP_UP_THRESHOLD: u128 = 50_000_000_000_000; // 50T
+    /// The proportion of the backend canister's own cycles to send to the cycles ledger.
+    pub const DEFAULT_CYCLES_LEDGER_TOP_UP_PERCENTAGE: u8 = 50;
+    /// The minimum sensible percentage to send to the cycles ledger.
+    /// - Note: With 0% the backend canister would never top up the cycles ledger.
+    pub const MIN_PERCENTAGE: u8 = 1;
+    /// The maximum sensible percentage to send to the cycles ledger.
+    /// - Note: With 100% the backend canister would be left with no cycles.
+    pub const MAX_PERCENTAGE: u8 = 99;
+
+    /// Possible error conditions when topping up the cycles ledger.
+    #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
+    pub enum TopUpCyclesLedgerError {
+        CouldNotGetBalanceFromCyclesLedger,
+        InvalidArgPercentageOutOfRange { percentage: u8, min: u8, max: u8 },
+        CouldNotTopUpCyclesLedger { available: Nat, tried_to_send: Nat },
+    }
+    /// Possible successful responses when topping up the cycles ledger.
+    #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
+    pub struct TopUpCyclesLedgerResponse {
+        /// The ledger balance after topping up.
+        pub ledger_balance: Nat,
+        /// The backend canister cycles after topping up.
+        pub backend_cycles: Nat,
+        /// The amount topped up.
+        /// - Zero if the ledger balance was already sufficient.
+        /// - The requested amount otherwise.
+        pub topped_up: Nat,
+    }
+
+    pub type TopUpCyclesLedgerResult = Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>;
+}

--- a/src/shared/src/types/token.rs
+++ b/src/shared/src/types/token.rs
@@ -1,0 +1,23 @@
+//! ERC20 specific user defined tokens
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+
+use crate::types::Version;
+
+pub type ChainId = u64;
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct UserToken {
+    pub contract_address: String,
+    pub chain_id: ChainId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+    pub version: Option<Version>,
+    pub enabled: Option<bool>,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+pub struct UserTokenId {
+    pub contract_address: String,
+    pub chain_id: ChainId,
+}

--- a/src/shared/src/types/transaction.rs
+++ b/src/shared/src/types/transaction.rs
@@ -1,4 +1,3 @@
-
 use candid::{CandidType, Deserialize, Nat};
 use serde::Serialize;
 

--- a/src/shared/src/types/transaction.rs
+++ b/src/shared/src/types/transaction.rs
@@ -1,0 +1,38 @@
+
+use candid::{CandidType, Deserialize, Nat};
+use serde::Serialize;
+
+use super::account::AccountId;
+use crate::types::network::marker_trait::Network;
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum TransactionType {
+    Send = 0,
+    Receive = 1,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Transaction<N, A>
+where
+    A: AccountId<N>,
+    N: Network,
+{
+    pub network: N,
+    pub transaction_type: TransactionType,
+    pub amount: u64,
+    pub timestamp: u64,
+    pub counterparty: A,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct SignRequest {
+    pub chain_id: Nat,
+    pub to: String,
+    pub gas: Nat,
+    pub max_fee_per_gas: Nat,
+    pub max_priority_fee_per_gas: Nat,
+    pub value: Nat,
+    pub nonce: Nat,
+    pub data: Option<String>,
+}

--- a/src/shared/src/types/user_profile.rs
+++ b/src/shared/src/types/user_profile.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use candid::{CandidType, Deserialize, Principal};
 use ic_verifiable_credentials::issuer_api::CredentialSpec;
 
-use super::{CredentialType, Timestamp};
+use super::{verifiable_credential::CredentialType, Timestamp};
 use crate::types::{settings::Settings, Version};
 
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]

--- a/src/shared/src/types/user_profile.rs
+++ b/src/shared/src/types/user_profile.rs
@@ -1,0 +1,80 @@
+//! Types specifics to the user profile.
+use std::collections::BTreeMap;
+
+use candid::{CandidType, Deserialize, Principal};
+use ic_verifiable_credentials::issuer_api::CredentialSpec;
+
+use super::{CredentialType, Timestamp};
+use crate::types::{settings::Settings, Version};
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct UserCredential {
+    pub credential_type: CredentialType,
+    pub verified_date_timestamp: Option<Timestamp>,
+    pub issuer: String,
+}
+
+// Used in the endpoint
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct UserProfile {
+    pub settings: Option<Settings>,
+    pub credentials: Vec<UserCredential>,
+    pub created_timestamp: Timestamp,
+    pub updated_timestamp: Timestamp,
+    pub version: Option<Version>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct StoredUserProfile {
+    pub settings: Option<Settings>,
+    pub credentials: BTreeMap<CredentialType, UserCredential>,
+    pub created_timestamp: Timestamp,
+    pub updated_timestamp: Timestamp,
+    pub version: Option<Version>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct AddUserCredentialRequest {
+    pub credential_jwt: String,
+    pub credential_spec: CredentialSpec,
+    pub issuer_canister_id: Principal,
+    pub current_user_version: Option<Version>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum AddUserCredentialError {
+    InvalidCredential,
+    ConfigurationError,
+    UserNotFound,
+    VersionMismatch,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct ListUsersRequest {
+    pub updated_after_timestamp: Option<Timestamp>,
+    pub matches_max_length: Option<u64>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct OisyUser {
+    pub principal: Principal,
+    pub pouh_verified: bool,
+    pub updated_timestamp: Timestamp,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct ListUsersResponse {
+    pub users: Vec<OisyUser>,
+    pub matches_max_length: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct ListUserCreationTimestampsResponse {
+    pub creation_timestamps: Vec<Timestamp>,
+    pub matches_max_length: u64,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum GetUserProfileError {
+    NotFound,
+}

--- a/src/shared/src/types/verifiable_credential.rs
+++ b/src/shared/src/types/verifiable_credential.rs
@@ -1,0 +1,15 @@
+use candid::{CandidType, Deserialize, Principal};
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug, Ord, PartialOrd)]
+pub enum CredentialType {
+    ProofOfUniqueness,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SupportedCredential {
+    pub credential_type: CredentialType,
+    pub ii_origin: String,
+    pub ii_canister_id: Principal,
+    pub issuer_origin: String,
+    pub issuer_canister_id: Principal,
+}


### PR DESCRIPTION
# Motivation
The shared types file has become large and it is hard to see what is in there.  It contains submodules.  Nesting modules inside one file typically only make sense when the files are small.  This not being the case any more, it would be better to make them separate files.

# Changes
- Move all modules inside the shared types.rs into separate files.
- Move remaining types into modules such as migration.

# Tests
No functionality has changed.  If it compiles, it should be correct.
