### PR TITLE
chore(frontend): add key to Svelte loops

### DIFF
--- a/src/frontend/src/lib/components/about/AboutWhyOisyModal.svelte
+++ b/src/frontend/src/lib/components/about/AboutWhyOisyModal.svelte
@@ -59,9 +59,9 @@
 		<ImgBanner styleClass="max-h-56" src={CoverWhyOisy} alt={$i18n.about.why_oisy.text.title} />
 
 		<div class="mt-5 flex flex-col gap-6">
-			{#each features as feature}
-				<AboutFeatureItem title={feature.title} description={feature.description}>
-					<svelte:component this={feature.icon} slot="icon" />
+			{#each features as { title, description, icon } (title)}
+				<AboutFeatureItem {title} {description}>
+					<svelte:component this={icon} slot="icon" />
 				</AboutFeatureItem>
 			{/each}
 		</div>

--- a/src/frontend/src/lib/components/carousel/Indicators.svelte
+++ b/src/frontend/src/lib/components/carousel/Indicators.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <div class="flex items-center">
-	{#each { length: totalSlides } as _, index}
+	{#each { length: totalSlides } as _, index (`indicator-${index}`)}
 		<Indicator on:click={() => onIndicatorClick(index)} {index} {currentSlide} {totalSlides} />
 	{/each}
 </div>

--- a/src/frontend/src/lib/components/core/MultipleListeners.svelte
+++ b/src/frontend/src/lib/components/core/MultipleListeners.svelte
@@ -10,7 +10,7 @@
 	$: listeners = $authSignedIn ? mapListeners(tokens) : [];
 </script>
 
-{#each listeners as { token, listener }}
+{#each listeners as { token, listener } (token.id)}
 	<svelte:component this={listener} {token} />
 {/each}
 

--- a/src/frontend/src/lib/components/dapps/DappTags.svelte
+++ b/src/frontend/src/lib/components/dapps/DappTags.svelte
@@ -11,7 +11,7 @@
 	aria-label={replacePlaceholders($i18n.dapps.alt.tags, { $dAppName: dAppName })}
 	class="flex list-none flex-wrap gap-2"
 >
-	{#each tags as tag}
+	{#each tags as tag (tag)}
 		<li class="flex">
 			<Badge>
 				{tag}

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -47,10 +47,10 @@
 		ariaLabel={$i18n.dapps.alt.show_all}
 		on:click={() => (selectedTag = undefined)}
 		styleClass="text-nowrap max-w-fit text-sm"
-		colorStyle={selectedTag === undefined ? 'primary' : 'tertiary'}
-		>{$i18n.dapps.text.all_dapps}</Button
-	>
-	{#each uniqueTags as tag}
+		colorStyle={selectedTag === undefined ? 'primary' : 'tertiary'}>
+		{$i18n.dapps.text.all_dapps}
+	</Button>
+	{#each uniqueTags as tag (tag)}
 		<Button
 			paddingSmall
 			ariaLabel={replacePlaceholders($i18n.dapps.alt.show_tag, { $tag: tag })}
@@ -62,7 +62,7 @@
 </div>
 
 <ul class="mt-10 grid list-none grid-cols-2 flex-row gap-x-4 gap-y-10 md:grid-cols-3">
-	{#each filteredDapps as dApp}
+	{#each filteredDapps as dApp (dApp.id)}
 		<li class="flex" in:fade>
 			<DappCard
 				on:click={() => {
@@ -77,9 +77,9 @@
 <SubmitDappButton />
 
 <style lang="postcss">
-	@media (max-width: 360px) {
-		ul {
-			@apply grid-cols-1;
-		}
-	}
+    @media (max-width: 360px) {
+        ul {
+            @apply grid-cols-1;
+        }
+    }
 </style>

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -47,7 +47,8 @@
 		ariaLabel={$i18n.dapps.alt.show_all}
 		on:click={() => (selectedTag = undefined)}
 		styleClass="text-nowrap max-w-fit text-sm"
-		colorStyle={selectedTag === undefined ? 'primary' : 'tertiary'}>
+		colorStyle={selectedTag === undefined ? 'primary' : 'tertiary'}
+	>
 		{$i18n.dapps.text.all_dapps}
 	</Button>
 	{#each uniqueTags as tag (tag)}
@@ -77,9 +78,9 @@
 <SubmitDappButton />
 
 <style lang="postcss">
-    @media (max-width: 360px) {
-        ul {
-            @apply grid-cols-1;
-        }
-    }
+	@media (max-width: 360px) {
+		ul {
+			@apply grid-cols-1;
+		}
+	}
 </style>

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -34,7 +34,7 @@
 	</div>
 
 	<div class="mb-7 flex flex-col items-center gap-2 md:items-start md:gap-3 md:text-lg">
-		{#each infoList as { label, icon }}
+		{#each infoList as { label, icon } (label)}
 			<div class="flex items-center gap-4">
 				<div class="hidden md:block">
 					<svelte:component this={icon} />

--- a/src/frontend/src/lib/components/license-agreement/LicenseAgreement.svelte
+++ b/src/frontend/src/lib/components/license-agreement/LicenseAgreement.svelte
@@ -27,7 +27,9 @@
 <h1 class="text-5xl">{replaceOisyPlaceholders($i18n.license_agreement.text.title)}</h1>
 
 <section class="mt-12">
-	{#each agreementList as agreement}
-		<p><Html text={replaceOisyPlaceholders(agreement)} /></p>
+	{#each agreementList as agreement, index (`agreement-${index}`)}
+		<p>
+			<Html text={replaceOisyPlaceholders(agreement)} />
+		</p>
 	{/each}
 </section>

--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -103,7 +103,7 @@
 						<option disabled selected value={undefined} class:hidden={nonNullish(networkName)}
 							>{$i18n.tokens.manage.placeholder.select_network}</option
 						>
-						{#each availableNetworks as network}
+						{#each availableNetworks as network (network.id)}
 							<DropdownItem value={network.name}>{network.name}</DropdownItem>
 						{/each}
 					</Dropdown>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -45,7 +45,7 @@
 				/>
 			</li>
 
-			{#each $networksMainnets as network}
+			{#each $networksMainnets as network (network.id)}
 				<li>
 					<MainnetNetwork {network} on:icSelected={dropdown.close} />
 				</li>
@@ -56,7 +56,7 @@
 
 		{#if $testnets}
 			<ul class="mb-2 flex list-none flex-col font-normal" transition:slide={SLIDE_EASING}>
-				{#each $networksTestnets as network}
+				{#each $networksTestnets as network (network.id)}
 					<li>
 						<Network {network} on:icSelected={dropdown.close} />
 					</li>

--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -15,7 +15,7 @@
 <div class="mb-10 flex flex-col gap-4" data-tid={testId}>
 	<span class="text-lg font-bold first-letter:capitalize">{title}</span>
 
-	{#each rewards as reward}
+	{#each rewards as reward (reward.id)}
 		<div in:slide={SLIDE_DURATION} class="mt-4">
 			<RewardCard
 				on:click={() => modalStore.openRewardDetails(reward)}

--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -16,13 +16,18 @@
 </script>
 
 {#if reward.requirements.length > 0}
-	<span class="text-md font-semibold"
-		>{$i18n.rewards.text.requirements_title}
-	</span>{#if isEligible}<span class="inline-flex pl-3"
-			><Badge variant="success">{$i18n.rewards.text.youre_eligible}</Badge></span
-		>{/if}
+	<span class="text-md font-semibold">
+		{$i18n.rewards.text.requirements_title}
+	</span>
+	{#if isEligible}
+		<span class="inline-flex pl-3">
+			<Badge variant="success">
+				{$i18n.rewards.text.youre_eligible}
+			</Badge>
+		</span>
+	{/if}
 	<ul class="list-none">
-		{#each reward.requirements as requirement, i}
+		{#each reward.requirements as requirement, i (requirement)}
 			<li class="flex gap-2 pt-1">
 				<span
 					class="flex w-full flex-row"

--- a/src/frontend/src/lib/components/settings/ThemeSelector.svelte
+++ b/src/frontend/src/lib/components/settings/ThemeSelector.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <div class="flex flex-row">
-	{#each THEME_VALUES as theme}
+	{#each THEME_VALUES as theme (theme)}
 		<ThemeSelectorCard
 			label={$i18n.settings.text[`appearance_${theme}`]}
 			selected={selectedCard === theme}

--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -95,8 +95,8 @@
 			<p class="break-normal font-bold">{$i18n.signer.permissions.text.requested_permissions}</p>
 
 			<ul class="mt-2.5 flex list-none flex-col gap-1">
-				{#each scopes as scope}
-					{@const { icon, label } = listItems[scope.scope.method]}
+				{#each scopes as { scope: { method } } (method)}
+					{@const { icon, label } = listItems[method]}
 
 					<li class="flex items-center gap-2 break-normal pb-1.5">
 						<svelte:component this={icon} size="24" />

--- a/src/frontend/src/lib/components/swap/SwapLiquidityFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapLiquidityFees.svelte
@@ -11,13 +11,8 @@
 	<svelte:fragment slot="label">{$i18n.swap.text.included_liquidity_fees}</svelte:fragment>
 
 	<div slot="main-value" class="flex flex-col">
-		{#each liquidityFees as liquidityFee}
-			<FeeDisplay
-				feeAmount={liquidityFee.fee}
-				symbol={liquidityFee.token.symbol}
-				decimals={liquidityFee.token.decimals}
-				displayExchangeRate={false}
-			/>
+		{#each liquidityFees as { fee, token: { symbol, decimals, id } } (id)}
+			<FeeDisplay feeAmount={fee} {symbol} {decimals} displayExchangeRate={false} />
 		{/each}
 	</div>
 </ModalValue>

--- a/src/frontend/src/lib/components/swap/SwapRoute.svelte
+++ b/src/frontend/src/lib/components/swap/SwapRoute.svelte
@@ -9,8 +9,9 @@
 	<svelte:fragment slot="label">{$i18n.swap.text.swap_route}</svelte:fragment>
 
 	<svelte:fragment slot="main-value">
-		{#each route as r}
-			{r}{#if r !== route[route.length - 1]}&nbsp;→&nbsp;{/if}
+		{#each route as r (r)}
+			{r}
+			{#if r !== route[route.length - 1]}&nbsp;→&nbsp;{/if}
 		{/each}
 	</svelte:fragment>
 </ModalValue>

--- a/src/frontend/src/lib/components/swap/SwapSlippage.svelte
+++ b/src/frontend/src/lib/components/swap/SwapSlippage.svelte
@@ -90,7 +90,7 @@
 					</TokenInputCurrency>
 				</TokenInputContainer>
 
-				{#each SWAP_SLIPPAGE_PRESET_VALUES as presetValue}
+				{#each SWAP_SLIPPAGE_PRESET_VALUES as presetValue (presetValue)}
 					<Button
 						on:click={() => onPresetValueClick(presetValue)}
 						colorStyle="secondary-light"

--- a/src/frontend/src/lib/components/ui/Json.svelte
+++ b/src/frontend/src/lib/components/ui/Json.svelte
@@ -101,7 +101,7 @@
 		>
 		<!-- children -->
 		<ul>
-			{#each children as [key, value]}
+			{#each children as [key, value] (key)}
 				<li>
 					<svelte:self json={value} _key={key} {defaultExpandedLevel} _level={_level + 1} />
 				</li>
@@ -141,6 +141,7 @@
 		flex-direction: column;
 		gap: var(--padding-0_5x);
 	}
+
 	.key {
 		display: inline-block;
 		position: relative;
@@ -149,10 +150,12 @@
 
 		margin-right: var(--padding-0_5x);
 	}
+
 	.value {
 		// Values can be strings of JSON and long. We want to break the value, so that the keys stay on the same line.
 		word-break: break-all;
 	}
+
 	.arrow {
 		touch-action: manipulation;
 		cursor: pointer;
@@ -169,9 +172,11 @@
 		&:hover {
 			color: var(--primary-contrast);
 			background: var(--primary);
+
 			&::before {
 				color: var(--primary);
 			}
+
 			.bracket {
 				color: var(--primary-contrast);
 			}
@@ -187,9 +192,11 @@
 			transform: translate(calc(-1 * var(--padding-1_5x)), calc(0.8 * var(--padding)));
 			font-size: var(--padding);
 		}
+
 		&.expanded::before {
 			content: '▼';
 		}
+
 		&.collapsed::before {
 			content: '▶';
 		}
@@ -199,27 +206,35 @@
 	.bracket {
 		color: var(--json-bracket-color);
 	}
+
 	.value {
 		color: var(--json-value-color);
 	}
+
 	.value.string {
 		color: var(--json-string-color);
 	}
+
 	.value.number {
 		color: var(--json-number-color);
 	}
+
 	.value.null {
 		color: var(--json-null-color);
 	}
+
 	.value.principal {
 		color: var(--json-principal-color);
 	}
+
 	.value.hash {
 		color: var(--json-hash-color);
 	}
+
 	.value.bigint {
 		color: var(--json-bigint-color);
 	}
+
 	.value.boolean {
 		color: var(--json-boolean-color);
 	}

--- a/src/frontend/src/lib/components/ui/SkeletonCards.svelte
+++ b/src/frontend/src/lib/components/ui/SkeletonCards.svelte
@@ -9,6 +9,6 @@
 	$: cards = Array.from({ length: rows }, (_, i) => i);
 </script>
 
-{#each cards as i}
+{#each cards as i (`${testIdPrefix ?? 'skeleton-card'}-${i}`)}
 	<SkeletonCard testId={nonNullish(testIdPrefix) ? `${testIdPrefix}-${i}` : undefined} />
 {/each}

--- a/src/frontend/src/lib/components/ui/StaticSteps.svelte
+++ b/src/frontend/src/lib/components/ui/StaticSteps.svelte
@@ -6,7 +6,7 @@
 	export let steps: [StaticStep, ...StaticStep[]];
 </script>
 
-{#each steps as { text, state, progressLabel }, i}
+{#each steps as { text, state, progressLabel, step }, i (step)}
 	{@const last = i === steps.length - 1}
 	<div class={`step ${state} ${last ? 'last' : ''}`}>
 		{#if state === 'completed'}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectReview.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectReview.svelte
@@ -57,11 +57,11 @@
 
 		<WalletConnectDomainVerification {proposal} />
 
-		{#each Object.entries(params.requiredNamespaces) as [key, value]}
+		{#each Object.entries(params.requiredNamespaces) as [key, value] (key)}
 			{@const allMethods = value.methods}
 			{@const allEvents = value.events}
 
-			{#each value.chains ?? [] as chainId}
+			{#each value.chains ?? [] as chainId (chainId)}
 				{@const chainName = EIP155_CHAINS[chainId]?.name ?? ''}
 
 				<p class="mt-6 font-bold">


### PR DESCRIPTION
# Motivation

We want to bump library @dfinity/eslint-config-oisy-wallet (PR https://github.com/dfinity/oisy-wallet/pull/5418).

However, that causes some Svelte lint issues linked to new enabled rules.

In this PR, we tackle [require-each-key](https://sveltejs.github.io/eslint-plugin-svelte/rules/require-each-key/) :  

> This rule reports {#each} block without key.

# Changes

Add a specific key to each loop in the Svelte component.

# Tests

Existing tests will suffice.
