### PR TITLE
refactor(frontend): remove unnecessary reactive statement

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -71,8 +71,7 @@
 	// i.e. Ethereum or Sepolia "main" token.
 	export let nativeEthereumToken: Token;
 
-	let destinationEditable = true;
-	$: destinationEditable = sendPurpose === 'send';
+	const destinationEditable = sendPurpose === 'send';
 
 	let sendWithApproval: boolean;
 	$: sendWithApproval = shouldSendWithApproval({

--- a/src/frontend/src/eth/components/send/SendInfo.svelte
+++ b/src/frontend/src/eth/components/send/SendInfo.svelte
@@ -8,8 +8,9 @@
 
 	const { sendToken, sendPurpose } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	let displayInfo: boolean;
-	$: displayInfo = ['convert-eth-to-cketh', 'convert-erc20-to-ckerc20'].includes(sendPurpose);
+	const displayInfo: boolean = ['convert-eth-to-cketh', 'convert-erc20-to-ckerc20'].includes(
+		sendPurpose
+	);
 
 	let sendTokenAsErc20: Erc20Token | undefined;
 	$: sendTokenAsErc20 = $sendToken.standard === 'erc20' ? ($sendToken as Erc20Token) : undefined;

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -73,8 +73,7 @@
 	const { sendTokenDecimals, sendToken, sendTokenSymbol, sendPurpose } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	let simplifiedForm = false;
-	$: simplifiedForm = sendPurpose === 'convert-cketh-to-eth';
+	const simplifiedForm = sendPurpose === 'convert-cketh-to-eth';
 
 	/**
 	 * Send

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -36,8 +36,9 @@
 		...temporaryHiddenDappsIds
 	];
 
-	let featuredAirdrop: RewardDescription | undefined;
-	$: featuredAirdrop = rewardCampaigns.find(({ id }) => id === FEATURED_REWARD_CAROUSEL_SLIDE_ID);
+	const featuredAirdrop: RewardDescription | undefined = rewardCampaigns.find(
+		({ id }) => id === FEATURED_REWARD_CAROUSEL_SLIDE_ID
+	);
 
 	let featureAirdropSlide: CarouselSlideOisyDappDescription | undefined;
 	$: featureAirdropSlide = nonNullish(featuredAirdrop)

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -70,8 +70,7 @@
 			themeName: 'dark' // we always pass dark, as some card elements arent styled correctly (white text on white background) in light theme / onramper bug?
 		}));
 
-	let themeLoaded: boolean;
-	$: themeLoaded = false;
+	let themeLoaded = false;
 	const changeThemeOnIframeLoad = (e: Event) => {
 		try {
 			const styles = window.getComputedStyle(document.body);

--- a/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
+++ b/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
@@ -13,13 +13,13 @@
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { isOngoingCampaign, isUpcomingCampaign } from '$lib/utils/rewards.utils';
 
-	let ongoingCampaigns: RewardDescription[];
-	$: ongoingCampaigns = rewardCampaigns.filter(({ startDate, endDate }) =>
+	const ongoingCampaigns: RewardDescription[] = rewardCampaigns.filter(({ startDate, endDate }) =>
 		isOngoingCampaign({ startDate, endDate })
 	);
 
-	let upcomingCampaigns: RewardDescription[];
-	$: upcomingCampaigns = rewardCampaigns.filter(({ startDate }) => isUpcomingCampaign(startDate));
+	const upcomingCampaigns: RewardDescription[] = rewardCampaigns.filter(({ startDate }) =>
+		isUpcomingCampaign(startDate)
+	);
 </script>
 
 <div class="relative mb-6 flex items-end md:mb-10">

--- a/src/frontend/src/lib/components/rewards/RewardEarnings.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardEarnings.svelte
@@ -28,8 +28,7 @@
 
 	let ckBtcToken: IcToken | undefined;
 	$: ckBtcToken = findTwinToken({ tokenToPair: BTC_MAINNET_TOKEN, tokens: $tokens });
-	let ckBtcReward: bigint;
-	$: ckBtcReward = ZERO_BI;
+	let ckBtcReward: bigint = ZERO_BI;
 	let ckBtcRewardUsd: number;
 	$: ckBtcRewardUsd = nonNullish(ckBtcToken)
 		? (calculateTokenUsdAmount({
@@ -41,8 +40,7 @@
 
 	let ckUsdcToken: IcToken | undefined;
 	$: ckUsdcToken = findTwinToken({ tokenToPair: USDC_TOKEN, tokens: $tokens });
-	let ckUsdcReward: bigint;
-	$: ckUsdcReward = ZERO_BI;
+	let ckUsdcReward: bigint = ZERO_BI;
 	let ckUsdcRewardUsd: number;
 	$: ckUsdcRewardUsd = nonNullish(ckUsdcToken)
 		? (calculateTokenUsdAmount({
@@ -52,24 +50,19 @@
 			}) ?? 0)
 		: 0;
 
-	let icpToken: IcToken | undefined;
-	$: icpToken = ICP_TOKEN;
-	let icpReward: bigint;
-	$: icpReward = ZERO_BI;
+	let icpReward: bigint = ZERO_BI;
 	let icpRewardUsd: number;
-	$: icpRewardUsd = nonNullish(icpToken)
-		? (calculateTokenUsdAmount({
-				amount: icpReward,
-				token: icpToken,
-				$exchanges: $exchanges
-			}) ?? 0)
-		: 0;
+	$: icpRewardUsd =
+		calculateTokenUsdAmount({
+			amount: icpReward,
+			token: ICP_TOKEN,
+			$exchanges: $exchanges
+		}) ?? 0;
 
 	let totalRewardUsd: number;
 	$: totalRewardUsd = ckBtcRewardUsd + ckUsdcRewardUsd + icpRewardUsd;
 
-	let loading: boolean;
-	$: loading = true;
+	let loading = true;
 
 	const loadRewards = async ({
 		ckBtcToken,
@@ -98,7 +91,7 @@
 		loading = false;
 	};
 
-	$: loadRewards({ ckBtcToken, ckUsdcToken, icpToken });
+	$: loadRewards({ ckBtcToken, ckUsdcToken, icpToken: ICP_TOKEN });
 
 	const gotoActivity = async () => {
 		await goto(
@@ -139,7 +132,7 @@
 				amount={ckUsdcReward}
 				usdAmount={ckUsdcRewardUsd}
 			/>
-			<RewardEarningsCard {loading} token={icpToken} amount={icpReward} usdAmount={icpRewardUsd} />
+			<RewardEarningsCard {loading} token={ICP_TOKEN} amount={icpReward} usdAmount={icpRewardUsd} />
 		</div>
 
 		<div class="my-5 w-full justify-items-center text-center">

--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -22,8 +22,9 @@
 	export let jackpot = false;
 
 	// TODO At the moment the selected campaign is hardcoded. In the future this should be configurable from the outside.
-	let reward: RewardDescription | undefined;
-	$: reward = rewardCampaigns.find((campaign) => campaign.id === 'OISY Airdrop #1');
+	const reward: RewardDescription | undefined = rewardCampaigns.find(
+		(campaign) => campaign.id === 'OISY Airdrop #1'
+	);
 </script>
 
 <Sprinkles type={jackpot ? 'page-jackpot' : 'page'} />

--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -32,8 +32,9 @@
 	let liquidityFees: ProviderFee[] | undefined;
 	$: liquidityFees = $swapAmountsStore?.swapAmounts?.liquidityFees;
 
-	let kongSwapDApp: OisyDappDescription | undefined;
-	$: kongSwapDApp = dAppDescriptions.find(({ id }) => id === 'kongswap');
+	const kongSwapDApp: OisyDappDescription | undefined = dAppDescriptions.find(
+		({ id }) => id === 'kongswap'
+	);
 
 	// TODO: this state - websiteURL - isn't one and should become a local variable
 	let websiteURL: Option<URL>;

--- a/src/frontend/src/sol/components/send/SolSendReview.svelte
+++ b/src/frontend/src/sol/components/send/SolSendReview.svelte
@@ -14,8 +14,7 @@
 	export let source: string;
 
 	// TODO: add checks for insufficient funds for fee, when we calculate the fee
-	let insufficientFundsForFee: boolean;
-	$: insufficientFundsForFee = false;
+	const insufficientFundsForFee = false;
 
 	let disableSend: boolean;
 	$: disableSend = insufficientFundsForFee || invalid;


### PR DESCRIPTION
# Motivation

We want to bump library @dfinity/eslint-config-oisy-wallet (PR https://github.com/dfinity/oisy-wallet/pull/5418).

However, that causes some Svelte lint issues linked to new enabled rules.

In this PR, we tackle [no-reactive-literals](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-reactive-literals/) :  

> This rule reports on any assignment of a static, unchanging value within a reactive statement because it’s not necessary.

# Changes

Replace all reactive-declared variables with mutable (or constants when possible) declarations.

# Tests

Existing tests will suffice.
