### PR TITLE
chore(frontend): remove unnecessary declaration brackets in Svelte components

### DIFF
--- a/src/frontend/src/icp/components/info/InfoBitcoin.svelte
+++ b/src/frontend/src/icp/components/info/InfoBitcoin.svelte
@@ -10,7 +10,7 @@
 
 <div class="pr-2">
 	<h4 class="flex items-center gap-2 font-medium">
-		<Logo src={bitcoin} alt={`Bitcoin logo`} />
+		<Logo src={bitcoin} alt="Bitcoin logo" />
 		<span>{$i18n.info.bitcoin.title}</span>
 	</h4>
 

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <span class="flex flex-col items-center gap-2">
-	<output class={`mt-8 inline-block break-all text-5xl font-bold`}>
+	<output class="mt-8 inline-block break-all text-5xl font-bold">
 		{#if $loaded}
 			{formatUSD({ value: totalUsd })}
 		{:else}

--- a/src/frontend/src/lib/components/rewards/RewardModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardModal.svelte
@@ -106,7 +106,7 @@
 			ariaLabel={$i18n.rewards.text.learn_more}
 			iconVisible={false}
 			asButton
-			styleClass={`rounded-xl px-3 py-2 secondary-light mb-3`}
+			styleClass="rounded-xl px-3 py-2 secondary-light mb-3"
 		>
 			{$i18n.rewards.text.learn_more}
 		</ExternalLink>

--- a/src/frontend/src/lib/components/rewards/Rewards.svelte
+++ b/src/frontend/src/lib/components/rewards/Rewards.svelte
@@ -14,7 +14,7 @@
 		ariaLabel={$i18n.rewards.text.learn_more}
 		iconVisible={false}
 		color="blue"
-		styleClass={`ml-auto font-semibold`}
+		styleClass="ml-auto font-semibold"
 	>
 		{$i18n.rewards.text.learn_more}
 	</ExternalLink>


### PR DESCRIPTION
# Motivation

We want to bump library @dfinity/eslint-config-oisy-wallet (PR https://github.com/dfinity/oisy-wallet/pull/5418).

However, that causes some Svelte lint issues linked to new enabled rules.

In this PR, we tackle [no-useless-mustaches](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-useless-mustaches/) :  

> This rule reports mustache interpolation with a string literal value.
The mustache interpolation with a string literal value can be changed to a static contents.

# Changes

Remove all unnecessary brackets in Svelte components and replace with string literals.

# Tests

Existing tests will suffice.
