### PR TITLE
feat(frontend): remove unnecessary reactive declarations for functions

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -24,7 +24,7 @@
 
 	// TODO: Enable Max button by passing the `calculateMax` prop - https://dfinity.atlassian.net/browse/GIX-3114
 
-	$: customValidate = (userAmount: bigint): Error | undefined => {
+	const customValidate = (userAmount: bigint): Error | undefined => {
 		// calculate-UTXOs-fee endpoint only accepts "userAmount > 0"
 		if (invalidAmount(Number(userAmount)) || userAmount === ZERO_BI) {
 			return new BtcAmountAssertionError($i18n.send.assertion.amount_invalid);

--- a/src/frontend/src/btc/components/send/BtcSendDestination.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendDestination.svelte
@@ -11,8 +11,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	let isInvalidDestination: () => boolean;
-	$: isInvalidDestination = (): boolean =>
+	const isInvalidDestination = (): boolean =>
 		isInvalidDestinationBtc({
 			destination,
 			networkId

--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -32,7 +32,7 @@
 	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken, sendTokenExchangeRate } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	$: customValidate = (userAmount: bigint): Error | undefined => {
+	const customValidate = (userAmount: bigint): Error | undefined => {
 		if (isNullish($storeFeeData)) {
 			return;
 		}

--- a/src/frontend/src/eth/components/send/EthSendDestination.svelte
+++ b/src/frontend/src/eth/components/send/EthSendDestination.svelte
@@ -24,8 +24,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	let isInvalidDestination: () => boolean;
-	$: isInvalidDestination = (): boolean => {
+	const isInvalidDestination = (): boolean => {
 		if (isNullishOrEmpty(destination)) {
 			return false;
 		}

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -223,10 +223,10 @@
 	const back = () => dispatch('icSendBack');
 
 	const onDecodeQrCode = ({
-														status,
-														code,
-														expectedToken
-													}: {
+		status,
+		code,
+		expectedToken
+	}: {
 		status: QrStatus;
 		code?: string;
 		expectedToken: OptionToken;

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -222,11 +222,11 @@
 	const close = () => dispatch('icClose');
 	const back = () => dispatch('icSendBack');
 
-	$: onDecodeQrCode = ({
-		status,
-		code,
-		expectedToken
-	}: {
+	const onDecodeQrCode = ({
+														status,
+														code,
+														expectedToken
+													}: {
 		status: QrStatus;
 		code?: string;
 		expectedToken: OptionToken;

--- a/src/frontend/src/icp/components/send/IcSendAmount.svelte
+++ b/src/frontend/src/icp/components/send/IcSendAmount.svelte
@@ -47,7 +47,7 @@
 
 	const { store: ethereumFeeStore } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
 
-	$: customValidate = (userAmount: bigint): Error | undefined => {
+	const customValidate = (userAmount: bigint): Error | undefined => {
 		if (isNullish(fee) || isNullish($sendToken)) {
 			return;
 		}

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -35,7 +35,7 @@
 
 	$: errorType, setErrorType(errorType);
 
-	$: customValidate = (userAmount: bigint): TokenActionErrorType =>
+	const customValidate = (userAmount: bigint): TokenActionErrorType =>
 		validateUserAmount({
 			userAmount,
 			token: $sourceToken,

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -61,10 +61,10 @@
 	$: receiveAmount =
 		nonNullish($destinationToken) && $swapAmountsStore?.swapAmounts?.receiveAmount
 			? formatTokenBigintToNumber({
-					value: $swapAmountsStore?.swapAmounts.receiveAmount,
-					unitName: $destinationToken.decimals,
-					displayDecimals: $destinationToken.decimals
-				})
+				value: $swapAmountsStore?.swapAmounts.receiveAmount,
+				unitName: $destinationToken.decimals,
+				displayDecimals: $destinationToken.decimals
+			})
 			: undefined;
 
 	let sourceTokenFee: bigint | undefined;
@@ -108,15 +108,15 @@
 		switchTokens();
 	};
 
-	$: customValidate = (userAmount: bigint): TokenActionErrorType =>
+	const customValidate = (userAmount: bigint): TokenActionErrorType =>
 		nonNullish($sourceToken)
 			? validateUserAmount({
-					userAmount,
-					token: $sourceToken,
-					balance: $sourceTokenBalance,
-					fee: totalFee,
-					isSwapFlow: true
-				})
+				userAmount,
+				token: $sourceToken,
+				balance: $sourceTokenBalance,
+				fee: totalFee,
+				isSwapFlow: true
+			})
 			: undefined;
 </script>
 
@@ -185,7 +185,7 @@
 					{#if nonNullish($destinationToken)}
 						{#if $swapAmountsStore?.swapAmounts === null}
 							<div transition:slide={SLIDE_DURATION} class="text-error-primary"
-								>{$i18n.swap.text.swap_is_not_offered}</div
+							>{$i18n.swap.text.swap_is_not_offered}</div
 							>
 						{:else}
 							<div class="flex gap-3 text-tertiary">

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -61,10 +61,10 @@
 	$: receiveAmount =
 		nonNullish($destinationToken) && $swapAmountsStore?.swapAmounts?.receiveAmount
 			? formatTokenBigintToNumber({
-				value: $swapAmountsStore?.swapAmounts.receiveAmount,
-				unitName: $destinationToken.decimals,
-				displayDecimals: $destinationToken.decimals
-			})
+					value: $swapAmountsStore?.swapAmounts.receiveAmount,
+					unitName: $destinationToken.decimals,
+					displayDecimals: $destinationToken.decimals
+				})
 			: undefined;
 
 	let sourceTokenFee: bigint | undefined;
@@ -111,12 +111,12 @@
 	const customValidate = (userAmount: bigint): TokenActionErrorType =>
 		nonNullish($sourceToken)
 			? validateUserAmount({
-				userAmount,
-				token: $sourceToken,
-				balance: $sourceTokenBalance,
-				fee: totalFee,
-				isSwapFlow: true
-			})
+					userAmount,
+					token: $sourceToken,
+					balance: $sourceTokenBalance,
+					fee: totalFee,
+					isSwapFlow: true
+				})
 			: undefined;
 </script>
 
@@ -185,7 +185,7 @@
 					{#if nonNullish($destinationToken)}
 						{#if $swapAmountsStore?.swapAmounts === null}
 							<div transition:slide={SLIDE_DURATION} class="text-error-primary"
-							>{$i18n.swap.text.swap_is_not_offered}</div
+								>{$i18n.swap.text.swap_is_not_offered}</div
 							>
 						{:else}
 							<div class="flex gap-3 text-tertiary">

--- a/src/frontend/src/sol/components/send/SolSendAmount.svelte
+++ b/src/frontend/src/sol/components/send/SolSendAmount.svelte
@@ -47,7 +47,7 @@
 				? SOLANA_LOCAL_TOKEN
 				: SOLANA_TOKEN;
 
-	$: customValidate = (userAmount: bigint): Error | undefined => {
+	const customValidate = (userAmount: bigint): Error | undefined => {
 		if (invalidAmount(Number(userAmount)) || userAmount === ZERO_BI) {
 			return new SolAmountAssertionError($i18n.send.assertion.amount_invalid);
 		}

--- a/src/frontend/src/sol/components/send/SolSendDestination.svelte
+++ b/src/frontend/src/sol/components/send/SolSendDestination.svelte
@@ -9,8 +9,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	let isInvalidDestination: () => boolean;
-	$: isInvalidDestination = (): boolean => isInvalidDestinationSol(destination);
+	const isInvalidDestination = (): boolean => isInvalidDestinationSol(destination);
 </script>
 
 <SendInputDestination


### PR DESCRIPTION
# Motivation

We want to bump library @dfinity/eslint-config-oisy-wallet (PR https://github.com/dfinity/oisy-wallet/pull/5418).

However, that causes some Svelte lint issues linked to new enabled rules.

In this PR, we tackle [no-reactive-functions](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-reactive-functions/) :  

> This rule reports whenever a function is defined in a reactive statement. This isn’t necessary, as each time the function is executed it’ll already have access to the latest values necessary. Redefining the function in the reactive statement is just a waste of CPU cycles.

# Changes

Replace all reactive-declared functions with constants. 

# Tests

Existing tests will suffice.
