### PR TITLE
feat(frontend): implemented fallback logic for icrcUsdPrices

### DIFF
--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -1,14 +1,37 @@
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
+import { fetchBatchKongSwapPrices } from '$lib/rest/kongswap.rest';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import type {
 	CoingeckoSimplePriceResponse,
 	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
 import type { PostMessageDataResponseExchange } from '$lib/types/post-message';
+import { findMissingCanisterIds, formatKongSwapToCoingeckoPrices } from '$lib/utils/exchange.utils';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { nonNullish } from '@dfinity/utils';
+
+const fetchIcrcPricesFromCoingecko = (
+	ledgerCanisterIds: LedgerCanisterIdText[]
+): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
+	simpleTokenPrice({
+		id: 'internet-computer',
+		vs_currencies: 'usd',
+		contract_addresses: ledgerCanisterIds.map((id) => id.toLowerCase()),
+		include_market_cap: true
+	});
+
+const fetchIcrcPricesFromKongSwap = async (
+	missingIds: LedgerCanisterIdText[]
+): Promise<CoingeckoSimpleTokenPriceResponse> => {
+	if (missingIds.length === 0) {
+		return {};
+	}
+	const tokens = await fetchBatchKongSwapPrices(missingIds);
+
+	return formatKongSwapToCoingeckoPrices(tokens);
+};
 
 export const exchangeRateETHToUsd = (): Promise<CoingeckoSimplePriceResponse | null> =>
 	simplePrice({
@@ -44,15 +67,30 @@ export const exchangeRateERC20ToUsd = (
 		include_market_cap: true
 	});
 
-export const exchangeRateICRCToUsd = (
+export const exchangeRateICRCToUsd = async (
 	ledgerCanisterIds: LedgerCanisterIdText[]
-): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
-	simpleTokenPrice({
-		id: 'internet-computer',
-		vs_currencies: 'usd',
-		contract_addresses: ledgerCanisterIds.map((ledgerCanisterId) => ledgerCanisterId.toLowerCase()),
-		include_market_cap: true
+): Promise<CoingeckoSimpleTokenPriceResponse | null> => {
+	if (ledgerCanisterIds.length === 0) {
+		return null;
+	}
+
+	const coingeckoPrices = await fetchIcrcPricesFromCoingecko(ledgerCanisterIds);
+	const missingIds = findMissingCanisterIds({
+		allIds: ledgerCanisterIds,
+		coingeckoResponse: coingeckoPrices
 	});
+	if (missingIds.length === 0) {
+		return coingeckoPrices;
+	}
+
+	const kongSwapPrices = await fetchIcrcPricesFromKongSwap(missingIds);
+	const exchangeRatePrices: CoingeckoSimpleTokenPriceResponse = {
+		...(coingeckoPrices ?? {}),
+		...(kongSwapPrices ?? {})
+	};
+
+	return exchangeRatePrices;
+};
 
 export const exchangeRateSPLToUsd = (
 	tokenAddresses: SplTokenAddress[]

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,7 +1,13 @@
+import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { ZERO } from '$lib/constants/app.constants';
 import type { OptionBalance } from '$lib/types/balance';
+import type {
+	CoingeckoSimpleTokenPrice,
+	CoingeckoSimpleTokenPriceResponse
+} from '$lib/types/coingecko';
+import type { KongSwapToken, KongSwapTokenMetrics } from '$lib/types/kongswap';
 import { formatToken } from '$lib/utils/format.utils';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const usdValue = ({
 	decimals,
@@ -21,3 +27,40 @@ export const usdValue = ({
 				})
 			) * exchangeRate
 		: ZERO.toNumber();
+
+export const formatKongSwapToCoingeckoPrices = (
+	tokens: (KongSwapToken | null)[]
+): CoingeckoSimpleTokenPriceResponse =>
+	tokens.reduce<CoingeckoSimpleTokenPriceResponse>((acc, tokenData) => {
+		const token = tokenData?.token;
+		const metrics = tokenData?.metrics;
+
+		if (isNullish(token) || isNullish(metrics?.price)) {
+			return acc;
+		}
+
+		acc[token.canister_id.toLowerCase()] = mapMetricsToCoingeckoPrice(metrics);
+		return acc;
+	}, {});
+
+const mapMetricsToCoingeckoPrice = (metrics: KongSwapTokenMetrics): CoingeckoSimpleTokenPrice => {
+	const { price, market_cap, volume_24h, price_change_24h, updated_at } = metrics;
+	return {
+		usd: Number(price),
+		usd_market_cap: Number(market_cap),
+		usd_24h_vol: Number(volume_24h),
+		usd_24h_change: Number(price_change_24h),
+		last_updated_at: new Date(updated_at).getTime()
+	};
+};
+
+export const findMissingCanisterIds = ({
+	allIds,
+	coingeckoResponse
+}: {
+	allIds: LedgerCanisterIdText[];
+	coingeckoResponse: CoingeckoSimpleTokenPriceResponse | null;
+}): LedgerCanisterIdText[] => {
+	const found = new Set(Object.keys(coingeckoResponse ?? {}));
+	return allIds.filter((id) => !found.has(id.toLowerCase()));
+};

--- a/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
@@ -1,0 +1,79 @@
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import type { CoingeckoSimpleTokenPriceResponse } from '$lib/types/coingecko';
+import { findMissingCanisterIds, formatKongSwapToCoingeckoPrices } from '$lib/utils/exchange.utils';
+import {
+	createMockCoingeckoTokenPrice,
+	createMockKongSwapToken
+} from '$tests/mocks/exchanges.mock';
+import { describe, expect, it } from 'vitest';
+
+describe('formatKongSwapToCoingeckoPrices', () => {
+	it('formats a valid token correctly', () => {
+		const token = createMockKongSwapToken({ canisterId: 'test-canister-1' });
+		const result = formatKongSwapToCoingeckoPrices([token]);
+
+		expect(result).toHaveProperty('test-canister-1');
+		expect(result['test-canister-1'].usd).toBe(1);
+		expect(result['test-canister-1'].usd_market_cap).toBe(1000000);
+	});
+
+	it('skips null tokens', () => {
+		const result = formatKongSwapToCoingeckoPrices([null]);
+		expect(result).toEqual({});
+	});
+
+	it('skips tokens with missing price', () => {
+		const token = createMockKongSwapToken({
+			canisterId: 'test-missing-price',
+			metrics: { price: null as unknown as string }
+		});
+		const result = formatKongSwapToCoingeckoPrices([token]);
+		expect(result).toEqual({});
+	});
+
+	it('normalizes canister_id to lowercase', () => {
+		const token = createMockKongSwapToken({ canisterId: 'TeSt-CaNiStEr-3' });
+		const result = formatKongSwapToCoingeckoPrices([token]);
+
+		expect(result).toHaveProperty('test-canister-3');
+	});
+});
+
+describe('findMissingCanisterIds', () => {
+	it('returns IDs not found in coingecko response', () => {
+		const allIds: LedgerCanisterIdText[] = ['can-1', 'can-2', 'can-3'];
+		const coingecko: CoingeckoSimpleTokenPriceResponse = {
+			'can-1': createMockCoingeckoTokenPrice()
+		};
+
+		const result = findMissingCanisterIds({
+			allIds,
+			coingeckoResponse: coingecko
+		});
+
+		expect(result).toEqual(['can-2', 'can-3']);
+	});
+
+	it('returns all IDs if response is null', () => {
+		const ids: LedgerCanisterIdText[] = ['can-4', 'can-5'];
+		const result = findMissingCanisterIds({
+			allIds: ids,
+			coingeckoResponse: null
+		});
+		expect(result).toEqual(ids);
+	});
+
+	it('matches canister IDs case-insensitively', () => {
+		const ids: LedgerCanisterIdText[] = ['CAN-1', 'can-2'];
+		const coingecko: CoingeckoSimpleTokenPriceResponse = {
+			'can-1': createMockCoingeckoTokenPrice()
+		};
+
+		const result = findMissingCanisterIds({
+			allIds: ids,
+			coingeckoResponse: coingecko
+		});
+
+		expect(result).toEqual(['can-2']);
+	});
+});

--- a/src/frontend/src/tests/mocks/exchanges.mock.ts
+++ b/src/frontend/src/tests/mocks/exchanges.mock.ts
@@ -1,4 +1,6 @@
+import type { CoingeckoSimpleTokenPrice } from '$lib/types/coingecko';
 import type { ExchangesData } from '$lib/types/exchange';
+import type { KongSwapToken, KongSwapTokenMetrics } from '$lib/types/kongswap';
 import { mockTokens } from './tokens.mock';
 
 export const mockOneUsd = 1;
@@ -7,3 +9,60 @@ export const mockExchanges: ExchangesData = mockTokens.reduce<ExchangesData>((ac
 	acc[token.id] = { usd: mockOneUsd };
 	return acc;
 }, {});
+
+export const createMockKongSwapToken = ({
+	canisterId = 'test-canister-1',
+	token = {},
+	metrics = {}
+}: {
+	canisterId?: string;
+	token?: Partial<KongSwapToken['token']>;
+	metrics?: Partial<KongSwapTokenMetrics>;
+}): KongSwapToken => {
+	const tokenDefaults = {
+		canister_id: canisterId,
+		address: canisterId,
+		name: 'Mock Token',
+		symbol: 'MOCK',
+		token_id: 1,
+		decimals: 8,
+		fee: 0.0001,
+		fee_fixed: '10',
+		has_custom_logo: false,
+		icrc1: true,
+		icrc2: true,
+		icrc3: false,
+		is_removed: false,
+		logo_url: null,
+		logo_updated_at: null,
+		token_type: 'Ic'
+	};
+
+	const metricsDefaults: KongSwapTokenMetrics = {
+		token_id: 1,
+		price: '1.00',
+		market_cap: '1000000',
+		volume_24h: '50000',
+		price_change_24h: '2.5',
+		updated_at: '2024-01-01T00:00:00.000Z',
+		total_supply: '100000000',
+		tvl: '250000',
+		previous_price: '0.95'
+	};
+
+	return {
+		token: { ...tokenDefaults, ...token },
+		metrics: { ...metricsDefaults, ...metrics }
+	};
+};
+
+export const createMockCoingeckoTokenPrice = (
+	overrides: Partial<CoingeckoSimpleTokenPrice> = {}
+): CoingeckoSimpleTokenPrice => ({
+	usd: 1.23,
+	usd_market_cap: 123456,
+	usd_24h_vol: 7890,
+	usd_24h_change: -1.5,
+	last_updated_at: Date.now(),
+	...overrides
+});


### PR DESCRIPTION
# Motivation

Some ICRC tokens are not available via our primary price provider (CoinGecko). To ensure complete price coverage, we need to support a fallback data source.

# Changes

Implemented fallback logic in the exchangeRateICRCToUsd service to fetch missing token prices from KongSwap when not available via CoinGecko.

# Tests

Added test coverage for new utility methods.
