### PR TITLE
refactor(frontend): use SendForm in EthSendForm

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -275,7 +275,6 @@
 			bind:network={targetNetwork}
 			{nativeEthereumToken}
 			{destinationEditable}
-			{sourceNetwork}
 		>
 			<svelte:fragment slot="cancel">
 				{#if formCancelAction === 'back'}

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -51,7 +51,7 @@
 				on:icQRCodeScan
 			>
 				<label for="destination" slot="label" class="font-bold">
-					{$i18n.send.text.destination}]
+					{$i18n.send.text.destination}
 				</label>
 			</IcSendDestination>
 		{/if}

--- a/src/frontend/src/lib/components/send/SendForm.svelte
+++ b/src/frontend/src/lib/components/send/SendForm.svelte
@@ -11,7 +11,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { OptionToken } from '$lib/types/token';
 
-	export let source: string;
+	export let source: string | undefined = undefined;
 	export let disabled: boolean | undefined = false;
 	export let token: OptionToken;
 	export let balance: OptionBalance;
@@ -29,7 +29,7 @@
 
 		<slot name="destination" />
 
-		{#if !hideSource}
+		{#if !hideSource && nonNullish(source)}
 			<SendSource {token} {balance} {source} />
 		{/if}
 
@@ -38,6 +38,8 @@
 		{/if}
 
 		<slot name="fee" />
+
+		<slot name="info" />
 
 		<ButtonGroup slot="toolbar" testId="toolbar">
 			<slot name="cancel" />

--- a/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
@@ -30,8 +30,7 @@ describe('EthSendForm', () => {
 		destination: '0xF2777205439a8c7be0425cbb21D8DB7426Df5DE9',
 		amount: '22000000',
 		network: ETHEREUM_NETWORK,
-		nativeEthereumToken: ETHEREUM_TOKEN,
-		sourceNetwork: ETHEREUM_NETWORK
+		nativeEthereumToken: ETHEREUM_TOKEN
 	};
 
 	const amountSelector = `input[data-tid="${TOKEN_INPUT_CURRENCY_TOKEN}"]`;


### PR DESCRIPTION
# Motivation

ETH is the last Send flow where common send form components are not used. In this PR, updating the EthSendForm component. 

# Changes

`EthSendForm` is now aligned with the other send flows.

# Tests

Existing tests should be enough. Additionaly, tested the send process manually.
