### PR TITLE
refactor(frontend): Remove chain fusion text just all networks

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -277,7 +277,7 @@
 		"title": "Current network. Access to selection.",
 		"test_networks": "Test networks",
 		"more": "More networks coming soon...",
-		"chain_fusion": "Chain Fusion (all networks)",
+		"chain_fusion": "All networks",
 		"network": "Network",
 		"filter": "Filter networks"
 	},


### PR DESCRIPTION
# Motivation

To save space in the redesigned network switcher we change the chain fusion text slightly.

# Changes

Changed text from `Chain Fusion (all networks)` to `All networks`

# Tests

Before:
![image](https://github.com/user-attachments/assets/4b3df538-14e9-4c2b-ac0c-c37b1d19ed83)

After:
![image](https://github.com/user-attachments/assets/899e4731-e344-4e93-97e0-571cf1fd8f6e)
