### PR TITLE
feat(frontend): Add testnet badge for network button

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -6,14 +6,17 @@
 	import { page } from '$app/stores';
 	import TextWithLogo from '$lib/components/ui/TextWithLogo.svelte';
 	import { networkId } from '$lib/derived/network.derived';
+	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
+	import Badge from '$lib/components/ui/Badge.svelte';
 
 	export let id: NetworkId | undefined;
 	export let name: string;
 	export let icon: string | undefined;
 	export let usdBalance: number | undefined = undefined;
+	export let isTestnet = false;
 	export let testId: string | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
@@ -45,5 +48,11 @@
 
 	{#if id === $networkId}
 		<span in:fade><IconCheck size="20px" /></span>
+	{/if}
+
+	{#if isTestnet}
+		<span class="inline-flex">
+			<Badge styleClass="pt-0 pb-0">{$i18n.networks.testnet}</Badge>
+		</span>
 	{/if}
 </button>

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -4,13 +4,13 @@
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { page } from '$app/stores';
+	import Badge from '$lib/components/ui/Badge.svelte';
 	import TextWithLogo from '$lib/components/ui/TextWithLogo.svelte';
 	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
-	import Badge from '$lib/components/ui/Badge.svelte';
 
 	export let id: NetworkId | undefined;
 	export let name: string;

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -279,6 +279,7 @@
 		"more": "More networks coming soon...",
 		"chain_fusion": "Chain Fusion (all networks)",
 		"network": "Network",
+		"testnet": "Testnet",
 		"filter": "Filter networks"
 	},
 	"receive": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -259,6 +259,7 @@ interface I18nNetworks {
 	more: string;
 	chain_fusion: string;
 	network: string;
+	testnet: string;
 	filter: string;
 }
 


### PR DESCRIPTION
# Motivation

We want to display a badge on th network buttons inside of the network switcher.

# Changes

- Added prop `isTestnet`
- Added testnet badge
- Added testnet translation

# Tests

![image](https://github.com/user-attachments/assets/34fc9792-82d1-44fd-b09a-dd4e055165d4)

