### PR TITLE
feat(frontend): Update rewards campaign end date

### DIFF
--- a/src/frontend/src/env/reward-campaigns.json
+++ b/src/frontend/src/env/reward-campaigns.json
@@ -16,6 +16,6 @@
 		"airdropHref": "https://x.com/intent/post?text=Just%20scored%20free%20Bitcoin%20from%20%40OISY%20Wallet.%0A%0AThey%E2%80%99re%20dropping%20%24BTC%20all%20day%2C%20every%20day.%0A%0AIf%20you%E2%80%99re%20not%20on%20OISY.com%2C%20you%E2%80%99re%20missing%20out.",
 		"learnMoreHref": "https://docs.oisy.com/rewards/oisy-sprinkles",
 		"startDate": "2025-02-05T14:28:02.288Z",
-		"endDate": "2025-03-27T00:00:00.000Z"
+		"endDate": "2025-04-07T00:00:00.000Z"
 	}
 ]


### PR DESCRIPTION
# Motivation

Current end date shows March 27.
We need a bit more time to have the next episode ready.

# Changes

Change March 27 to April 7

### NOTE: this needs to go into a "Hotfix" based off of 1.3.2

