### PR TITLE
feat(devops): add minimal devcontainer.json for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Internet Computer Development Environment",
+  "image": "mcr.microsoft.com/devcontainers/universal:latest",
+  
+  // Specify the machine type: 8-core with 32GB RAM
+  "hostRequirements": {
+    "cpus": 8,
+    "memory": "32gb",
+    "storage": "64gb"
+  },
+  
+  // Install Node.js version 22
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "latest"
+    }
+  },
+  
+  // Run commands after container is created - just install dfx
+  "postCreateCommand": "sh -c 'export DFXVM_INIT_YES=1 && curl -fsSL https://internetcomputer.org/install.sh | sh && source \"$HOME/.local/share/dfx/env\" && dfxvm install 0.23.0'",
+  
+  // Run any custom script for Rust setup if needed
+  "postAttachCommand": "./scripts/setup-rust && . \"$HOME/.cargo/env\"",
+  
+  // Environment variables to set
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:${containerEnv:HOME}/.local/share/dfx:${containerEnv:HOME}/.cargo/bin",
+    "DFXVM_INIT_YES": "1"
+  }
+}


### PR DESCRIPTION
# Motivation
We want to ensure other people can contribute to the project easily. As GitHub Codespaces now has a free tier version, we can prompt developers to kickstart a cloud instance to setup and try the project there. This PR adds a minimal devcontainer.json configuration that provisions an 8-core machine and installs the essential tools to get started with Oisy wallet locally.

_NB: GitHub Codespaces requires significant resources for Internet Computer development, given the amount it takes to compile some of the `cargo` dependencies._

# Changes
- Add .devcontainer/devcontainer.json with minimal configuration and a 8-core machine with 32GB RAM
- Install Internet Computer SDK (dfx) and run the Rust setup script

# Tests
Tested with GitHub Codespaces. The configuration successfully provisions an environment with dfx and Rust toolchain. If re-run within the same Codespace the Rust script will conflict.