### PR TITLE
feat(frontend): implemented fallback logic for icrcUsdPrices

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -9,11 +9,7 @@
 	let balance: TokenUi['balance'];
 	let usdBalance: TokenUi['usdBalance'];
 
-	$: {
-		({ balance, usdBalance } = data);
-
-		console.log({ balance, usdBalance });
-	}
+	$: ({ balance, usdBalance } = data);
 </script>
 
 <TokenExchangeValueSkeleton {data}>

--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -9,7 +9,11 @@
 	let balance: TokenUi['balance'];
 	let usdBalance: TokenUi['usdBalance'];
 
-	$: ({ balance, usdBalance } = data);
+	$: {
+		({ balance, usdBalance } = data);
+
+		console.log({ balance, usdBalance });
+	}
 </script>
 
 <TokenExchangeValueSkeleton {data}>

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -1,14 +1,37 @@
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
+import { fetchBatchKongSwapPrices } from '$lib/rest/kongswap.rest';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import type {
 	CoingeckoSimplePriceResponse,
 	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
 import type { PostMessageDataResponseExchange } from '$lib/types/post-message';
+import {
+	findMissingLedgerCanisterIds,
+	formatKongSwapToCoingeckoPrices
+} from '$lib/utils/exchange.utils';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { nonNullish } from '@dfinity/utils';
+
+const fetchIcrcPricesFromCoingecko = (
+	ledgerCanisterIds: LedgerCanisterIdText[]
+): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
+	simpleTokenPrice({
+		id: 'internet-computer',
+		vs_currencies: 'usd',
+		contract_addresses: ledgerCanisterIds.map((id) => id.toLowerCase()),
+		include_market_cap: true
+	});
+
+const fetchIcrcPricesFromKongSwap = async (
+	missingIds: LedgerCanisterIdText[]
+): Promise<CoingeckoSimpleTokenPriceResponse> => {
+	const tokens = await fetchBatchKongSwapPrices(missingIds);
+
+	return formatKongSwapToCoingeckoPrices(tokens);
+};
 
 export const exchangeRateETHToUsd = (): Promise<CoingeckoSimplePriceResponse | null> =>
 	simplePrice({
@@ -44,15 +67,30 @@ export const exchangeRateERC20ToUsd = (
 		include_market_cap: true
 	});
 
-export const exchangeRateICRCToUsd = (
+export const exchangeRateICRCToUsd = async (
 	ledgerCanisterIds: LedgerCanisterIdText[]
-): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
-	simpleTokenPrice({
-		id: 'internet-computer',
-		vs_currencies: 'usd',
-		contract_addresses: ledgerCanisterIds.map((ledgerCanisterId) => ledgerCanisterId.toLowerCase()),
-		include_market_cap: true
+): Promise<CoingeckoSimpleTokenPriceResponse | null> => {
+	if (ledgerCanisterIds.length === 0) {
+		return null;
+	}
+
+	const coingeckoPrices = await fetchIcrcPricesFromCoingecko(ledgerCanisterIds);
+	const missingIds = findMissingLedgerCanisterIds({
+		allLedgerCanisterIds: ledgerCanisterIds,
+		coingeckoResponse: coingeckoPrices
 	});
+	if (missingIds.length === 0) {
+		return coingeckoPrices;
+	}
+
+	const kongSwapPrices = await fetchIcrcPricesFromKongSwap(missingIds);
+	const exchangeRatePrices: CoingeckoSimpleTokenPriceResponse = {
+		...(coingeckoPrices ?? {}),
+		...(kongSwapPrices ?? {})
+	};
+
+	return exchangeRatePrices;
+};
 
 export const exchangeRateSPLToUsd = (
 	tokenAddresses: SplTokenAddress[]

--- a/src/frontend/src/tests/lib/services/exchange.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/exchange.services.spec.ts
@@ -1,0 +1,123 @@
+import { exchangeRateICRCToUsd } from '$lib/services/exchange.services';
+import type { CoingeckoSimpleTokenPriceResponse } from '$lib/types/coingecko';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { simpleTokenPrice } from '$lib/rest/coingecko.rest';
+import { fetchBatchKongSwapPrices } from '$lib/rest/kongswap.rest';
+import {
+	findMissingLedgerCanisterIds,
+	formatKongSwapToCoingeckoPrices
+} from '$lib/utils/exchange.utils';
+import {
+	MOCK_CANISTER_ID_1,
+	MOCK_CANISTER_ID_2,
+	createMockCoingeckoTokenPrice
+} from '$tests/mocks/exchanges.mock';
+
+vi.mock('$lib/rest/coingecko.rest', () => ({
+	simpleTokenPrice: vi.fn()
+}));
+vi.mock('$lib/rest/kongswap.rest', () => ({
+	fetchBatchKongSwapPrices: vi.fn()
+}));
+vi.mock('$lib/utils/exchange.utils', () => ({
+	formatKongSwapToCoingeckoPrices: vi.fn(),
+	findMissingLedgerCanisterIds: vi.fn()
+}));
+
+const mockPrice1 = createMockCoingeckoTokenPrice({ usd: 1.11 });
+const mockPrice2 = createMockCoingeckoTokenPrice({ usd: 2.22 });
+
+describe('exchangeRateICRCToUsd', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns null if no canister IDs are provided', async () => {
+		const result = await exchangeRateICRCToUsd([]);
+		expect(result).toBeNull();
+		expect(simpleTokenPrice).not.toHaveBeenCalled();
+		expect(findMissingLedgerCanisterIds).not.toHaveBeenCalled();
+		expect(fetchBatchKongSwapPrices).not.toHaveBeenCalled();
+	});
+
+	it('returns only coingecko prices when all tokens are present', async () => {
+		const coingeckoResponse: CoingeckoSimpleTokenPriceResponse = {
+			[MOCK_CANISTER_ID_1.toLowerCase()]: mockPrice1,
+			[MOCK_CANISTER_ID_2.toLowerCase()]: mockPrice2
+		};
+
+		vi.mocked(simpleTokenPrice).mockResolvedValue(coingeckoResponse);
+		vi.mocked(findMissingLedgerCanisterIds).mockReturnValue([]);
+
+		const result = await exchangeRateICRCToUsd([MOCK_CANISTER_ID_1, MOCK_CANISTER_ID_2]);
+
+		expect(simpleTokenPrice).toHaveBeenCalledOnce();
+		expect(findMissingLedgerCanisterIds).toHaveBeenCalledWith({
+			allLedgerCanisterIds: [MOCK_CANISTER_ID_1, MOCK_CANISTER_ID_2],
+			coingeckoResponse
+		});
+		expect(fetchBatchKongSwapPrices).not.toHaveBeenCalled();
+		expect(result).toEqual(coingeckoResponse);
+	});
+
+	it('merges KongSwap prices when Coingecko is missing some tokens', async () => {
+		const partialCoingecko: CoingeckoSimpleTokenPriceResponse = {
+			[MOCK_CANISTER_ID_1.toLowerCase()]: mockPrice1
+		};
+		const fallbackKongSwap: CoingeckoSimpleTokenPriceResponse = {
+			[MOCK_CANISTER_ID_2.toLowerCase()]: mockPrice2
+		};
+
+		vi.mocked(simpleTokenPrice).mockResolvedValue(partialCoingecko);
+		vi.mocked(findMissingLedgerCanisterIds).mockReturnValue([MOCK_CANISTER_ID_2]);
+		vi.mocked(fetchBatchKongSwapPrices).mockResolvedValue(['mockRawToken' as never]);
+		vi.mocked(formatKongSwapToCoingeckoPrices).mockReturnValue(fallbackKongSwap);
+
+		const result = await exchangeRateICRCToUsd([MOCK_CANISTER_ID_1, MOCK_CANISTER_ID_2]);
+
+		expect(simpleTokenPrice).toHaveBeenCalledOnce();
+		expect(findMissingLedgerCanisterIds).toHaveBeenCalledWith({
+			allLedgerCanisterIds: [MOCK_CANISTER_ID_1, MOCK_CANISTER_ID_2],
+			coingeckoResponse: partialCoingecko
+		});
+		expect(fetchBatchKongSwapPrices).toHaveBeenCalledWith([MOCK_CANISTER_ID_2]);
+		expect(formatKongSwapToCoingeckoPrices).toHaveBeenCalled();
+		expect(result).toEqual({
+			[MOCK_CANISTER_ID_1.toLowerCase()]: mockPrice1,
+			[MOCK_CANISTER_ID_2.toLowerCase()]: mockPrice2
+		});
+	});
+
+	it('returns only KongSwap prices if Coingecko returns null', async () => {
+		vi.mocked(simpleTokenPrice).mockResolvedValue(null);
+		vi.mocked(findMissingLedgerCanisterIds).mockReturnValue([MOCK_CANISTER_ID_1]);
+		vi.mocked(fetchBatchKongSwapPrices).mockResolvedValue(['mockRawToken' as never]);
+		vi.mocked(formatKongSwapToCoingeckoPrices).mockReturnValue({
+			[MOCK_CANISTER_ID_1.toLowerCase()]: mockPrice1
+		});
+
+		const result = await exchangeRateICRCToUsd([MOCK_CANISTER_ID_1]);
+
+		expect(simpleTokenPrice).toHaveBeenCalledOnce();
+		expect(fetchBatchKongSwapPrices).toHaveBeenCalled();
+		expect(result).toEqual({
+			[MOCK_CANISTER_ID_1.toLowerCase()]: mockPrice1
+		});
+	});
+
+	it('skips KongSwap call if no tokens are missing', async () => {
+		const coingeckoResponse: CoingeckoSimpleTokenPriceResponse = {
+			[MOCK_CANISTER_ID_1.toLowerCase()]: mockPrice1
+		};
+
+		vi.mocked(simpleTokenPrice).mockResolvedValue(coingeckoResponse);
+		vi.mocked(findMissingLedgerCanisterIds).mockReturnValue([]);
+
+		const result = await exchangeRateICRCToUsd([MOCK_CANISTER_ID_1]);
+
+		expect(fetchBatchKongSwapPrices).not.toHaveBeenCalled();
+		expect(formatKongSwapToCoingeckoPrices).not.toHaveBeenCalled();
+		expect(result).toEqual(coingeckoResponse);
+	});
+});


### PR DESCRIPTION
# Motivation

Some ICRC tokens are not available via our primary price provider (CoinGecko). To ensure complete price coverage, we need to support a fallback data source.

# Changes

Implemented fallback logic in the exchangeRateICRCToUsd service to fetch missing token prices from KongSwap when not available via CoinGecko.

# Tests

Added test coverage for new utility methods.
