### PR TITLE
fix(frontend): issue with modal content

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -185,8 +185,6 @@ div.modal {
 	div.wrapper.dialog > div.container-wrapper {
 		margin: 0 !important;
 
-		align-items: center;
-
 		& > div.container {
 			border-radius: 0;
 		}


### PR DESCRIPTION
# Motivation

Debugging showed that the align-items rule is not really necessary for NetworksSelector. Additionally, it was causing issue for other modals. The solution is to remove it completely.
