### PR TITLE
feat(frontend): service to check if an Index canister is sleepy or awake

### DIFF
--- a/src/frontend/src/icp/services/index-canister.services.ts
+++ b/src/frontend/src/icp/services/index-canister.services.ts
@@ -1,0 +1,65 @@
+import { getTransactions } from '$icp/api/icrc-index-ng.api';
+import { balance } from '$icp/api/icrc-ledger.api';
+import type { IndexCanisterIdText, LedgerCanisterIdText } from '$icp/types/canister';
+import type { Identity } from '@dfinity/agent';
+import { type QueryParams } from '@dfinity/utils';
+
+/**
+ * This function checks whether the Index canister is not in a "sleepy" state (not syncing new blocks from the Ledger canister).
+ *
+ * When the Index canister is low on cycles, it may happen that it does not sync new blocks from the Ledger canister.
+ * However, it does not return an error, it just provides a zero balance and empty transactions (as per our experience).
+ *
+ * In these cases, we can check if the Index canister is sleepy by comparing its balance with the Ledger canister balance.
+ * There is a small delay between the Ledger canister and the Index canister, so we wait for 5 seconds before checking again.
+ *
+ * @returns {Promise<boolean>} Whether the Index canister is awake.
+ */
+// TODO: compare the blocks number instead of balance, when ic-js is upgraded to provide the endpoints for both Ledger and Index canister.
+export const isIndexCanisterAwake = async ({
+	identity,
+	ledgerCanisterId,
+	indexCanisterId,
+	certified = true
+}: {
+	identity: Identity;
+	ledgerCanisterId: LedgerCanisterIdText;
+	indexCanisterId: IndexCanisterIdText;
+} & QueryParams): Promise<boolean> => {
+	const { balance: indexBalance, transactions } = await getTransactions({
+		identity,
+		indexCanisterId,
+		certified,
+		owner: identity.getPrincipal()
+	});
+
+	// If the Index canister has a balance or transactions, it is not sleepy (as per our experience).
+	if (indexBalance !== 0n || transactions.length > 0) {
+		return true;
+	}
+
+	const ledgerBalance = await balance({
+		identity,
+		ledgerCanisterId,
+		certified,
+		owner: identity.getPrincipal()
+	});
+
+	// If the Index canister balance (that is zero at this point) is the same balance as the Ledger canister balance, it is not sleepy.
+	if (indexBalance === ledgerBalance) {
+		return true;
+	}
+
+	// We try again in 5 seconds. That should be enough time for the Index canister to sync with the Ledger canister, if it is not sleepy.
+	await new Promise((resolve) => setTimeout(resolve, 5000));
+
+	const { balance: newIndexBalance, transactions: newTransactions } = await getTransactions({
+		identity,
+		indexCanisterId,
+		certified,
+		owner: identity.getPrincipal()
+	});
+
+	// If the Index canister has a different balance from its previous one (that was zero at this point), or if it has transactions, it is not "sleepy": it is updating its state, syncing with the Ledger canister.
+	return newIndexBalance !== indexBalance || newTransactions.length > 0;
+};

--- a/src/frontend/src/tests/icp/services/index-canister.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/index-canister.services.spec.ts
@@ -1,0 +1,202 @@
+import { getTransactions } from '$icp/api/icrc-index-ng.api';
+import { balance } from '$icp/api/icrc-ledger.api';
+import { isIndexCanisterAwake } from '$icp/services/index-canister.services';
+import { mockIndexCanisterId, mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import type { IcrcIndexNgGetTransactions, IcrcTransactionWithId } from '@dfinity/ledger-icrc';
+import { toNullable } from '@dfinity/utils';
+import { expect } from 'vitest';
+
+vi.mock('$icp/api/icrc-index-ng.api', () => ({
+	getTransactions: vi.fn()
+}));
+
+vi.mock('$icp/api/icrc-ledger.api', () => ({
+	balance: vi.fn()
+}));
+
+describe('index-canister.services', () => {
+	describe('isIndexCanisterAwake', () => {
+		const mockParams = {
+			identity: mockIdentity,
+			ledgerCanisterId: mockLedgerCanisterId,
+			indexCanisterId: mockIndexCanisterId
+		};
+
+		const mockTransactions: IcrcTransactionWithId[] = [
+			{ id: 1n, transaction: {} },
+			{ id: 2n, transaction: {} },
+			{ id: 3n, transaction: {} }
+		] as IcrcTransactionWithId[];
+
+		const mockGetTransactionsResponse: IcrcIndexNgGetTransactions = {
+			balance: 1000n,
+			transactions: mockTransactions,
+			oldest_tx_id: toNullable(123n)
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should call getTransactions with the correct parameters', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce(mockGetTransactionsResponse);
+
+			await isIndexCanisterAwake(mockParams);
+
+			expect(getTransactions).toHaveBeenCalledTimes(1);
+			expect(getTransactions).toHaveBeenNthCalledWith(1, {
+				identity: mockIdentity,
+				indexCanisterId: mockIndexCanisterId,
+				certified: true,
+				owner: mockIdentity.getPrincipal()
+			});
+		});
+
+		it('should return true if Index canister balance is not zero and it has transactions', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce(mockGetTransactionsResponse);
+
+			const result = await isIndexCanisterAwake(mockParams);
+
+			expect(result).toBe(true);
+
+			expect(balance).not.toHaveBeenCalled();
+		});
+
+		it('should return true if Index canister balance is not zero, but it has no transactions', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce({
+				...mockGetTransactionsResponse,
+				transactions: []
+			});
+
+			const result = await isIndexCanisterAwake(mockParams);
+
+			expect(result).toBe(true);
+
+			expect(balance).not.toHaveBeenCalled();
+		});
+
+		it('should return true if Index canister has transactions, but balance is zero', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce({
+				...mockGetTransactionsResponse,
+				balance: 0n
+			});
+
+			const result = await isIndexCanisterAwake(mockParams);
+
+			expect(result).toBe(true);
+
+			expect(balance).not.toHaveBeenCalled();
+		});
+
+		it('should call `balance` if Index canister has no transactions and balance is zero', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce({
+				...mockGetTransactionsResponse,
+				balance: 0n,
+				transactions: []
+			});
+			vi.mocked(balance).mockResolvedValueOnce(0n);
+
+			await isIndexCanisterAwake(mockParams);
+
+			expect(balance).toHaveBeenCalledTimes(1);
+			expect(balance).toHaveBeenNthCalledWith(1, {
+				identity: mockIdentity,
+				ledgerCanisterId: mockLedgerCanisterId,
+				certified: true,
+				owner: mockIdentity.getPrincipal()
+			});
+		});
+
+		it('should return true if Ledger canister and Index canister balances match and are zero', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce({
+				...mockGetTransactionsResponse,
+				balance: 0n,
+				transactions: []
+			});
+			vi.mocked(balance).mockResolvedValueOnce(0n);
+
+			const result = await isIndexCanisterAwake(mockParams);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if Index canister balance equals Ledger canister balance', async () => {
+			vi.mocked(getTransactions).mockResolvedValueOnce(mockGetTransactionsResponse);
+			vi.mocked(balance).mockResolvedValueOnce(mockGetTransactionsResponse.balance);
+
+			const result = await isIndexCanisterAwake(mockParams);
+
+			expect(result).toBe(true);
+		});
+
+		it('should call `getTransactions` again if Index canister balance or transactions do not change after an interval of time', async () => {
+			vi.useFakeTimers();
+
+			vi.mocked(getTransactions)
+				.mockResolvedValueOnce({ ...mockGetTransactionsResponse, balance: 0n, transactions: [] })
+				.mockResolvedValueOnce(mockGetTransactionsResponse);
+			vi.mocked(balance).mockResolvedValueOnce(mockGetTransactionsResponse.balance);
+
+			const promise = isIndexCanisterAwake(mockParams);
+
+			await vi.advanceTimersByTimeAsync(5000);
+
+			await promise;
+
+			expect(getTransactions).toHaveBeenCalledTimes(2);
+			expect(getTransactions).toHaveBeenNthCalledWith(1, {
+				identity: mockIdentity,
+				indexCanisterId: mockIndexCanisterId,
+				certified: true,
+				owner: mockIdentity.getPrincipal()
+			});
+			expect(getTransactions).toHaveBeenNthCalledWith(2, {
+				identity: mockIdentity,
+				indexCanisterId: mockIndexCanisterId,
+				certified: true,
+				owner: mockIdentity.getPrincipal()
+			});
+
+			vi.useRealTimers();
+		});
+
+		it('should return true if Index canister balance or transactions change after an interval of time', async () => {
+			vi.useFakeTimers();
+
+			vi.mocked(getTransactions)
+				.mockResolvedValueOnce({ ...mockGetTransactionsResponse, balance: 0n, transactions: [] })
+				.mockResolvedValueOnce(mockGetTransactionsResponse);
+			vi.mocked(balance).mockResolvedValueOnce(mockGetTransactionsResponse.balance);
+
+			const promise = isIndexCanisterAwake(mockParams);
+
+			await vi.advanceTimersByTimeAsync(5000);
+
+			const result = await promise;
+
+			expect(result).toBe(true);
+
+			vi.useRealTimers();
+		});
+
+		it('should return false if index balance stays the same after an interval of time', async () => {
+			vi.useFakeTimers();
+
+			vi.mocked(getTransactions)
+				.mockResolvedValueOnce({ ...mockGetTransactionsResponse, balance: 0n, transactions: [] })
+				.mockResolvedValueOnce({ ...mockGetTransactionsResponse, balance: 0n, transactions: [] });
+			vi.mocked(balance).mockResolvedValueOnce(mockGetTransactionsResponse.balance);
+
+			const promise = isIndexCanisterAwake(mockParams);
+
+			await vi.advanceTimersByTimeAsync(5000);
+
+			const result = await promise;
+
+			expect(result).toBe(false);
+
+			vi.useRealTimers();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We had a few cases where the Index canister is a particular state: it returns zero balance and no transactions, even if the ledger canister shows a balance. It may happen that if it is low in cycles, it goes in "power-saving" mode and in a "sleepy" state, where it does not update its state.

In these cases, however, it does not raise any error, nor we have any flag that point it out.

We need a workaround to know if we need to use only the Ledger canister and ignore the Index canister when the latter is "sleepy". One way of doing it is to compare the balances: if, after a certain amount of time (enough to run a syncing), the balance of the Index canister is zero (and no transaction), BUT the Ledger canister balance is not zero, then we have this particular state.

# Changes

- Create a service isIndexCanisterAwake to check if an Index canister is not updating its state (`sleepy` or `awake`):
  - if balance is not zero or if we have transactions, then it is `awake`;
  - if balance is zero BUT Ledger canister balance is zero too, than we can suppose it is `awake` (in any case it is ok);
  - if after 5 seconds (enough to sync), the balance is not different from zero or there are still no transactions, then it is sleepy (because the Ledger canister balance was not zero, so, something must change).

# Tests

Included tests.

# Future Improvements

A better check would be to compare the number of blocks synced by the Index canister and check how many there are in the Ledger canister. Given an acceptable range, if the two values diverge too much, we can suppose that the Index canister is "sleepy". We are working on it, awaiting for the endpoints to be open in `ic-js` with the next release.