### PR TITLE
refactor(frontend): move User profile loader to top level

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -21,11 +21,9 @@
 						<LoaderWallets>
 							<ExchangeWorker>
 								<LoaderMetamask>
-
 									<UserSnapshotWorker>
 										<slot />
 									</UserSnapshotWorker>
-
 								</LoaderMetamask>
 							</ExchangeWorker>
 						</LoaderWallets>

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -12,27 +12,29 @@
 	import UserSnapshotWorker from '$lib/components/rewards/UserSnapshotWorker.svelte';
 </script>
 
-<AddressGuard>
-	<Loader>
-		<VipRewardGuard>
-			<RewardGuard>
-				<LoaderEthBalances>
-					<LoaderWallets>
-						<ExchangeWorker>
-							<LoaderMetamask>
-								<LoaderUserProfile>
+<LoaderUserProfile>
+	<AddressGuard>
+		<Loader>
+			<VipRewardGuard>
+				<RewardGuard>
+					<LoaderEthBalances>
+						<LoaderWallets>
+							<ExchangeWorker>
+								<LoaderMetamask>
+
 									<UserSnapshotWorker>
 										<slot />
 									</UserSnapshotWorker>
-								</LoaderUserProfile>
-							</LoaderMetamask>
-						</ExchangeWorker>
-					</LoaderWallets>
-				</LoaderEthBalances>
-			</RewardGuard>
-		</VipRewardGuard>
-	</Loader>
-</AddressGuard>
+
+								</LoaderMetamask>
+							</ExchangeWorker>
+						</LoaderWallets>
+					</LoaderEthBalances>
+				</RewardGuard>
+			</VipRewardGuard>
+		</Loader>
+	</AddressGuard>
+</LoaderUserProfile>
 
 <!-- This listener is kept outside of the Loaders tree to prevent slow page loading on localhost/e2e -->
 <CkBTCUpdateBalanceListener />


### PR DESCRIPTION
# Motivation

We move the component `LoaderUserProfile` before the other loaders: we are going to user the enabled networks that are saved in the user profile in the backed. That will affect the rest: loading address, transactions, prices, and so forth.
