### PR TITLE
feat(frontend): add success return to service loadUserProfile

### DIFF
--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -5,6 +5,7 @@ import { toastsError } from '$lib/stores/toasts.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { UserProfileNotFoundError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/identity';
+import type { ResultSuccess } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -65,13 +66,13 @@ export const loadUserProfile = async ({
 }: {
 	identity: OptionIdentity;
 	reload?: boolean;
-}): Promise<void> => {
+}): Promise<ResultSuccess> => {
 	// We just want to verify that the store is empty, without being interested in the data.
 	// So we fetch it imperatively, instead of passing as parameter.
 	// If it is not empty, and we don't want to reload, we can return early.
 	// In any case, if `reload` is true, we will always fetch the profile.
 	if (nonNullish(get(userProfileStore)) && !reload) {
-		return;
+		return { success: true };
 	}
 
 	try {
@@ -95,5 +96,8 @@ export const loadUserProfile = async ({
 			msg: { text: settings.error.loading_profile },
 			err
 		});
+		return { success: false };
 	}
+
+	return { success: true };
 };

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -17,91 +17,111 @@ const mockProfile: UserProfile = {
 };
 const nullishIdentityErrorMessage = en.auth.error.no_internet_identity;
 
-describe('loadUserProfile', () => {
-	beforeEach(() => {
-		userProfileStore.reset();
-		vi.clearAllMocks();
-	});
-
-	it('should not create a user profile if uncertified profile is found', async () => {
-		const getUserProfileSpy = vi
-			.spyOn(backendApi, 'getUserProfile')
-			.mockResolvedValue({ Ok: mockProfile });
-		const createUserProfileSpy = vi.spyOn(backendApi, 'createUserProfile');
-
-		await loadUserProfile({ identity: mockIdentity });
-
-		expect(getUserProfileSpy).toHaveBeenCalledWith({
-			identity: mockIdentity,
-			certified: false,
-			nullishIdentityErrorMessage
+describe('load-user-profile.services', () => {
+	describe('loadUserProfile', () => {
+		beforeEach(() => {
+			userProfileStore.reset();
+			vi.clearAllMocks();
 		});
-		expect(createUserProfileSpy).not.toHaveBeenCalled();
-		expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
-	});
 
-	it('should create a user profile if uncertified profile is not found', async () => {
-		const getUserProfileSpy = vi
-			.spyOn(backendApi, 'getUserProfile')
-			.mockResolvedValue({ Err: { NotFound: null } });
-		const createUserProfileSpy = vi
-			.spyOn(backendApi, 'createUserProfile')
-			.mockResolvedValue(mockProfile);
+		it('should not create a user profile if uncertified profile is found', async () => {
+			const getUserProfileSpy = vi
+				.spyOn(backendApi, 'getUserProfile')
+				.mockResolvedValue({ Ok: mockProfile });
+			const createUserProfileSpy = vi.spyOn(backendApi, 'createUserProfile');
 
-		await loadUserProfile({ identity: mockIdentity });
+			const result = await loadUserProfile({ identity: mockIdentity });
 
-		expect(getUserProfileSpy).toHaveBeenCalledWith({
-			identity: mockIdentity,
-			certified: false,
-			nullishIdentityErrorMessage
+			expect(result).toEqual({ success: true });
+
+			expect(getUserProfileSpy).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				certified: false,
+				nullishIdentityErrorMessage
+			});
+			expect(createUserProfileSpy).not.toHaveBeenCalled();
+			expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
 		});
-		expect(createUserProfileSpy).toHaveBeenCalledWith({
-			identity: mockIdentity,
-			nullishIdentityErrorMessage
+
+		it('should create a user profile if uncertified profile is not found', async () => {
+			const getUserProfileSpy = vi
+				.spyOn(backendApi, 'getUserProfile')
+				.mockResolvedValue({ Err: { NotFound: null } });
+			const createUserProfileSpy = vi
+				.spyOn(backendApi, 'createUserProfile')
+				.mockResolvedValue(mockProfile);
+
+			const result = await loadUserProfile({ identity: mockIdentity });
+
+			expect(result).toEqual({ success: true });
+
+			expect(getUserProfileSpy).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				certified: false,
+				nullishIdentityErrorMessage
+			});
+			expect(createUserProfileSpy).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				nullishIdentityErrorMessage
+			});
+			expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile });
 		});
-		expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile });
-	});
 
-	it('should load the store with certified data when uncertified profile is found', async () => {
-		const getUserProfileSpy = vi
-			.spyOn(backendApi, 'getUserProfile')
-			.mockResolvedValue({ Ok: mockProfile });
+		it('should load the store with certified data when uncertified profile is found', async () => {
+			const getUserProfileSpy = vi
+				.spyOn(backendApi, 'getUserProfile')
+				.mockResolvedValue({ Ok: mockProfile });
 
-		await loadUserProfile({ identity: mockIdentity });
+			const result = await loadUserProfile({ identity: mockIdentity });
 
-		expect(getUserProfileSpy).toHaveBeenCalledWith({
-			identity: mockIdentity,
-			certified: false,
-			nullishIdentityErrorMessage
+			expect(result).toEqual({ success: true });
+
+			expect(getUserProfileSpy).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				certified: false,
+				nullishIdentityErrorMessage
+			});
+			expect(getUserProfileSpy).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				certified: true,
+				nullishIdentityErrorMessage
+			});
+			await waitFor(() =>
+				expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile })
+			);
 		});
-		expect(getUserProfileSpy).toHaveBeenCalledWith({
-			identity: mockIdentity,
-			certified: true,
-			nullishIdentityErrorMessage
+
+		it('should not load the user profile if reload is false and the store is not empty', async () => {
+			const anotherProfile: UserProfile = { ...mockProfile, version: [2n] };
+
+			userProfileStore.set({ certified: true, profile: anotherProfile });
+
+			const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile');
+
+			const result = await loadUserProfile({ identity: mockIdentity, reload: false });
+
+			expect(result).toEqual({ success: true });
+
+			expect(getUserProfileSpy).not.toHaveBeenCalled();
+			expect(get(userProfileStore)).toEqual({ certified: true, profile: anotherProfile });
 		});
-		await waitFor(() =>
-			expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile })
-		);
-	});
 
-	it('should not load the user profile if reload is false and the store is not empty', async () => {
-		const anotherProfile: UserProfile = { ...mockProfile, version: [2n] };
+		it('should load the user profile if reload is false but the store is nullish', async () => {
+			userProfileStore.reset();
 
-		userProfileStore.set({ certified: true, profile: anotherProfile });
+			const result = await loadUserProfile({ identity: mockIdentity, reload: false });
 
-		const getUserProfileSpy = vi.spyOn(backendApi, 'getUserProfile');
+			expect(result).toEqual({ success: true });
 
-		await loadUserProfile({ identity: mockIdentity, reload: false });
+			expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
+		});
 
-		expect(getUserProfileSpy).not.toHaveBeenCalled();
-		expect(get(userProfileStore)).toEqual({ certified: true, profile: anotherProfile });
-	});
+		it('should handle errors when loading the user profile', async () => {
+			vi.spyOn(backendApi, 'getUserProfile').mockRejectedValue(new Error('Error'));
 
-	it('should load the user profile if reload is false but the store is nullish', async () => {
-		userProfileStore.reset();
+			const result = await loadUserProfile({ identity: mockIdentity });
 
-		await loadUserProfile({ identity: mockIdentity, reload: false });
-
-		expect(get(userProfileStore)).toEqual({ certified: false, profile: mockProfile });
+			expect(result).toEqual({ success: false });
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

We will need to check if the `loadUserProfile` service had a successful run or not. So we make it return a value if successful or not.
