### PR TITLE
fix(frontend): scrollable content of ModalTokensList

### DIFF
--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -2,7 +2,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import TokensSkeletons from '$lib/components/tokens/TokensSkeletons.svelte';
-	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import InputSearch from '$lib/components/ui/InputSearch.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenUi } from '$lib/types/token';
@@ -23,35 +23,33 @@
 	$: noTokensMatch = filteredTokens.length === 0;
 </script>
 
-<ContentWithToolbar>
-	<!-- TODO: Add network selector component here -->
-	<InputSearch
-		bind:filter
-		noMatch={noTokensMatch}
-		placeholder={$i18n.tokens.placeholder.search_token}
-		autofocus={isDesktop()}
-	/>
+<!-- TODO: Add network selector component here -->
+<InputSearch
+	bind:filter
+	noMatch={noTokensMatch}
+	placeholder={$i18n.tokens.placeholder.search_token}
+	autofocus={isDesktop()}
+/>
 
-	<div class="my-6 flex flex-col overflow-y-hidden sm:max-h-[26rem]">
-		<div class="tokens-scroll flex flex-col gap-6 overflow-y-auto overscroll-contain">
-			<TokensSkeletons {loading}>
-				{#if noTokensMatch}
-					<p class="text-primary">
-						{$i18n.tokens.manage.text.all_tokens_zero_balance}
-					</p>
-				{:else}
-					<div class="flex flex-col">
-						{#each filteredTokens as token (token.id)}
-							<ModalTokensListItem
-								on:click={() => dispatch('icTokenButtonClick', token)}
-								data={token}
-							/>
-						{/each}
-					</div>
-				{/if}
-			</TokensSkeletons>
-		</div>
+<div class="my-6 flex flex-col overflow-y-hidden sm:max-h-[26rem]">
+	<div class="gap-6 overflow-y-auto overscroll-contain">
+		<TokensSkeletons {loading}>
+			{#if noTokensMatch}
+				<p class="text-primary">
+					{$i18n.tokens.manage.text.all_tokens_zero_balance}
+				</p>
+			{:else}
+				{#each filteredTokens as token (token.id)}
+					<ModalTokensListItem
+						on:click={() => dispatch('icTokenButtonClick', token)}
+						data={token}
+					/>
+				{/each}
+			{/if}
+		</TokensSkeletons>
 	</div>
+</div>
 
-	<slot name="toolbar" slot="toolbar" />
-</ContentWithToolbar>
+<ButtonGroup>
+	<slot name="toolbar" />
+</ButtonGroup>


### PR DESCRIPTION
# Motivation

I noticed today that on some screen sizes the TokensList modal displays with unwanted scrollbar. It appeared to be an issue with the `stretch` class that was giving this unexpected effect to the list. The solution is to not use `ContentWithToolbar` in this particular case. Also, I cleaned up the component by removing some unnecessary HTML/CSS.

<img width="586" alt="Screenshot 2025-03-26 at 16 46 22" src="https://github.com/user-attachments/assets/436ea7b2-4c78-49e5-9c85-329b019182f4" />
