### PR TITLE
feat(frontend): include testnets in default of userNetworks

### DIFF
--- a/src/frontend/src/env/networks/networks.env.ts
+++ b/src/frontend/src/env/networks/networks.env.ts
@@ -17,4 +17,10 @@ const SUPPORTED_MAINNET_NETWORKS: Network[] = SUPPORTED_NETWORKS.filter(
 	({ env }) => env === 'mainnet'
 );
 
+const SUPPORTED_TESTNET_NETWORKS: Network[] = SUPPORTED_NETWORKS.filter(
+	({ env }) => env === 'testnet'
+);
+
 export const SUPPORTED_MAINNET_NETWORKS_IDS = SUPPORTED_MAINNET_NETWORKS.map(({ id }) => id);
+
+export const SUPPORTED_TESTNET_NETWORKS_IDS = SUPPORTED_TESTNET_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -17,7 +17,6 @@ import {
 	SOLANA_TESTNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
 import { testnets } from '$lib/derived/testnets.derived';
-import { userSettings } from '$lib/derived/user-profile.derived';
 import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
 import type { NetworkId } from '$lib/types/network';
 import type { UserNetworks } from '$lib/types/user-networks';

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -4,7 +4,10 @@ import {
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
-import { SUPPORTED_MAINNET_NETWORKS_IDS } from '$env/networks/networks.env';
+import {
+	SUPPORTED_MAINNET_NETWORKS_IDS,
+	SUPPORTED_TESTNET_NETWORKS_IDS
+} from '$env/networks/networks.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
@@ -13,6 +16,7 @@ import {
 	SOLANA_MAINNET_NETWORK_ID,
 	SOLANA_TESTNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
+import { testnets } from '$lib/derived/testnets.derived';
 import { userSettings } from '$lib/derived/user-profile.derived';
 import type { NetworkId } from '$lib/types/network';
 import type { UserNetworks } from '$lib/types/user-networks';
@@ -25,19 +29,29 @@ export const userSettingsNetworks: Readable<NetworksSettings | undefined> = deri
 );
 
 export const userNetworks: Readable<UserNetworks> = derived(
-	[userSettingsNetworks],
-	([$userSettingsNetworks]) => {
+	[userSettingsNetworks, testnets],
+	([$userSettingsNetworks, $testnets]) => {
 		const userNetworks = $userSettingsNetworks?.networks;
 
 		if (isNullish(userNetworks) || userNetworks.length === 0) {
-			// Returning all mainnets enabled by default
-			return SUPPORTED_MAINNET_NETWORKS_IDS.reduce<UserNetworks>(
-				(acc, id) => ({
-					...acc,
-					[id]: { enabled: true, isTestnet: false }
-				}),
-				{}
-			);
+			// Returning all mainnets (and testnets if enabled) by default
+			return {
+				...SUPPORTED_MAINNET_NETWORKS_IDS.reduce<UserNetworks>(
+					(acc, id) => ({
+						...acc,
+						[id]: { enabled: true, isTestnet: false }
+					}),
+					{}
+				),
+				...($testnets &&
+					SUPPORTED_TESTNET_NETWORKS_IDS.reduce<UserNetworks>(
+						(acc, id) => ({
+							...acc,
+							[id]: { enabled: $testnets, isTestnet: true }
+						}),
+						{}
+					))
+			};
 		}
 
 		const keyToNetworkId = (key: NetworkSettingsFor): NetworkId => {

--- a/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
@@ -1,4 +1,7 @@
-import { SUPPORTED_MAINNET_NETWORKS_IDS } from '$env/networks/networks.env';
+import {
+	SUPPORTED_MAINNET_NETWORKS_IDS,
+	SUPPORTED_TESTNET_NETWORKS_IDS
+} from '$env/networks/networks.env';
 import { userNetworks, userSettingsNetworks } from '$lib/derived/user-networks.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { UserNetworks } from '$lib/types/user-networks';
@@ -35,6 +38,14 @@ describe('user-networks.derived', () => {
 			{}
 		);
 
+		const expectedTestnets: UserNetworks = SUPPORTED_TESTNET_NETWORKS_IDS.reduce<UserNetworks>(
+			(acc, id) => ({
+				...acc,
+				[id]: { enabled: true, isTestnet: true }
+			}),
+			{}
+		);
+
 		it('should return only mainnets when user profile is not set', () => {
 			userProfileStore.reset();
 			expect(get(userNetworks)).toEqual(expectedMainnets);
@@ -57,6 +68,20 @@ describe('user-networks.derived', () => {
 		it('should return the user networks if they are set', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
 			expect(get(userNetworks)).toEqual(mockUserNetworks);
+		});
+
+		it('should return all networks when user networks are nullish but testnets are enabled', () => {
+			userProfileStore.set({
+				certified,
+				profile: {
+					...mockUserProfile,
+					settings: toNullable({
+						...mockUserSettings,
+						networks: { ...mockNetworksSettings, networks: [], testnets: { show_testnets: true } }
+					})
+				}
+			});
+			expect(get(userNetworks)).toEqual({ ...expectedMainnets, ...expectedTestnets });
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
@@ -2,8 +2,6 @@ import {
 	SUPPORTED_MAINNET_NETWORKS_IDS,
 	SUPPORTED_TESTNET_NETWORKS_IDS
 } from '$env/networks/networks.env';
-import { userNetworks, userSettingsNetworks } from '$lib/derived/user-networks.derived';
-import { SUPPORTED_MAINNET_NETWORKS_IDS } from '$env/networks/networks.env';
 import { userNetworks } from '$lib/derived/user-networks.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { UserNetworks } from '$lib/types/user-networks';


### PR DESCRIPTION
# Motivation

The `userNetworks` store should consider if `testnets` are enabled or not. So that the default (in case nothing is set in the backend for the user's profile) will include both mainnets and testnets.

# Changes

- Create list of testnet networks IDs (similar to mainnets).
- Include `testnets` in the default response of the store `userNetworks` (basically when there are no settings about networks in thew user profile).

# Tests

Included tests.
