### PR TITLE
refactor(frontend): move store userSettingsNetworks

### DIFF
--- a/src/frontend/src/lib/derived/testnets.derived.ts
+++ b/src/frontend/src/lib/derived/testnets.derived.ts
@@ -1,4 +1,4 @@
-import { userSettingsNetworks } from '$lib/derived/user-networks.derived';
+import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
 import { derived, type Readable } from 'svelte/store';
 
 export const testnets: Readable<boolean> = derived(

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -1,4 +1,4 @@
-import type { NetworkSettingsFor, NetworksSettings } from '$declarations/backend/backend.did';
+import type { NetworkSettingsFor } from '$declarations/backend/backend.did';
 import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
@@ -13,16 +13,11 @@ import {
 	SOLANA_MAINNET_NETWORK_ID,
 	SOLANA_TESTNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
-import { userSettings } from '$lib/derived/user-profile.derived';
+import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
 import type { NetworkId } from '$lib/types/network';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
-
-export const userSettingsNetworks: Readable<NetworksSettings | undefined> = derived(
-	[userSettings],
-	([$userSettings]) => $userSettings?.networks
-);
 
 export const userNetworks: Readable<UserNetworks> = derived(
 	[userSettingsNetworks],

--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -1,4 +1,4 @@
-import type { Settings, UserProfile } from '$declarations/backend/backend.did';
+import type { NetworksSettings, Settings, UserProfile } from '$declarations/backend/backend.did';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { fromNullishNullable, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -20,4 +20,9 @@ export const userProfileVersion: Readable<bigint | undefined> = derived(
 export const userSettings: Readable<Settings | undefined> = derived(
 	[userProfile],
 	([$userProfile]) => fromNullishNullable($userProfile?.settings)
+);
+
+export const userSettingsNetworks: Readable<NetworksSettings | undefined> = derived(
+	[userSettings],
+	([$userSettings]) => $userSettings?.networks
 );

--- a/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_MAINNET_NETWORKS_IDS } from '$env/networks/networks.env';
-import { userNetworks, userSettingsNetworks } from '$lib/derived/user-networks.derived';
+import { userNetworks } from '$lib/derived/user-networks.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { mockUserNetworks } from '$tests/mocks/user-networks.mock';
@@ -13,18 +13,6 @@ import { get } from 'svelte/store';
 
 describe('user-networks.derived', () => {
 	const certified = true;
-
-	describe('userSettingsNetworks', () => {
-		it('should return undefined when user profile is not set', () => {
-			userProfileStore.reset();
-			expect(get(userSettingsNetworks)).toBeUndefined();
-		});
-
-		it('should return user profile if it is not nullish', () => {
-			userProfileStore.set({ certified, profile: mockUserProfile });
-			expect(get(userSettingsNetworks)).toEqual(mockNetworksSettings);
-		});
-	});
 
 	describe('userNetworks', () => {
 		const expectedMainnets: UserNetworks = SUPPORTED_MAINNET_NETWORKS_IDS.reduce<UserNetworks>(

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -2,10 +2,12 @@ import {
 	userProfile,
 	userProfileLoaded,
 	userProfileVersion,
-	userSettings
+	userSettings,
+	userSettingsNetworks
 } from '$lib/derived/user-profile.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import {
+	mockNetworksSettings,
 	mockUserProfile,
 	mockUserProfileVersion,
 	mockUserSettings
@@ -70,6 +72,18 @@ describe('user-profile.derived', () => {
 		it('should return undefined if user settings are nullish', () => {
 			userProfileStore.set({ certified, profile: { ...mockUserProfile, settings: [] } });
 			expect(get(userSettings)).toBeUndefined();
+		});
+	});
+
+	describe('userSettingsNetworks', () => {
+		it('should return undefined when user profile is not set', () => {
+			userProfileStore.reset();
+			expect(get(userSettingsNetworks)).toBeUndefined();
+		});
+
+		it('should return user profile if it is not nullish', () => {
+			userProfileStore.set({ certified, profile: mockUserProfile });
+			expect(get(userSettingsNetworks)).toEqual(mockNetworksSettings);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Since we are going to use the `userSettingsNetworks` store in other modules and we risk to cross-import, it is better to move it to the user-profile module.