### PR TITLE
feat(frontend): avoid having all networks disabled

### DIFF
--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -7,12 +7,17 @@ import { derived, type Readable } from 'svelte/store';
 
 export const networks: Readable<Network[]> = derived(
 	[enabledBitcoinNetworks, enabledEthereumNetworks, enabledSolanaNetworks],
-	([$enabledBitcoinNetworks, $enabledEthereumNetworks, $enabledSolanaNetworks]) => [
-		...$enabledBitcoinNetworks,
-		...$enabledEthereumNetworks,
-		ICP_NETWORK,
-		...$enabledSolanaNetworks
-	]
+	([$enabledBitcoinNetworks, $enabledEthereumNetworks, $enabledSolanaNetworks]) => {
+		const networks: Network[] = [
+			...$enabledBitcoinNetworks,
+			...$enabledEthereumNetworks,
+			ICP_NETWORK,
+			...$enabledSolanaNetworks
+		];
+
+		// We do not allow the user to have no networks enabled, so we return ICP network if no networks are enabled.
+		return networks.length > 0 ? networks : [ICP_NETWORK];
+	}
 );
 
 interface NetworksEnvs {


### PR DESCRIPTION
# MISSING TESTS

# Motivation

Since we are going to use the networks that are enabled/disabled in the user profile, there may be a risk of having all networks disabled. In this case, we prefer to avoid any possible issue, and return at least one network.

