### PR TITLE
refactor(frontend): rename store testnets to testnetsEnabled

### DIFF
--- a/src/frontend/src/btc/derived/btc-pending-sent-transactions-status.derived.ts
+++ b/src/frontend/src/btc/derived/btc-pending-sent-transactions-status.derived.ts
@@ -5,7 +5,7 @@ import {
 	btcAddressRegtest,
 	btcAddressTestnet
 } from '$lib/derived/address.derived';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -24,14 +24,14 @@ export const initPendingSentTransactionsStatus = (
 			btcAddressMainnet,
 			btcAddressTestnet,
 			btcAddressRegtest,
-			testnets,
+			testnetsEnabled,
 			btcPendingSentTransactionsStore
 		],
 		([
 			$btcAddressMainnet,
 			$btcAddressTestnet,
 			$btcAddressRegtest,
-			$testnets,
+			$testnetsEnabled,
 			$pendingTransactionsStore
 		]) => {
 			const pendingTransactionsData = $pendingTransactionsStore[address];
@@ -44,7 +44,7 @@ export const initPendingSentTransactionsStatus = (
 						: BtcPendingSentTransactionsStatus.NONE;
 			}
 
-			if (!$testnets) {
+			if (!$testnetsEnabled) {
 				if (nonNullish($btcAddressMainnet) && $btcAddressMainnet !== address) {
 					// If the address is not a bitcoin address, there are no pending transactions.
 					return BtcPendingSentTransactionsStatus.NONE;

--- a/src/frontend/src/btc/derived/networks.derived.ts
+++ b/src/frontend/src/btc/derived/networks.derived.ts
@@ -5,11 +5,14 @@ import {
 	BTC_TESTNET_NETWORK
 } from '$env/networks/networks.btc.env';
 import { LOCAL } from '$lib/constants/app.constants';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { Network } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
 
-export const enabledBitcoinNetworks: Readable<Network[]> = derived([testnets], ([$testnets]) => [
-	...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
-	...($testnets ? [BTC_TESTNET_NETWORK, ...(LOCAL ? [BTC_REGTEST_NETWORK] : [])] : [])
-]);
+export const enabledBitcoinNetworks: Readable<Network[]> = derived(
+	[testnetsEnabled],
+	([$testnetsEnabled]) => [
+		...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
+		...($testnetsEnabled ? [BTC_TESTNET_NETWORK, ...(LOCAL ? [BTC_REGTEST_NETWORK] : [])] : [])
+	]
+);

--- a/src/frontend/src/btc/derived/tokens.derived.ts
+++ b/src/frontend/src/btc/derived/tokens.derived.ts
@@ -5,11 +5,14 @@ import {
 	BTC_TESTNET_TOKEN
 } from '$env/tokens/tokens.btc.env';
 import { LOCAL } from '$lib/constants/app.constants';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
-export const enabledBitcoinTokens: Readable<Token[]> = derived([testnets], ([$testnets]) => [
-	...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
-	...($testnets ? [BTC_TESTNET_TOKEN, ...(LOCAL ? [BTC_REGTEST_TOKEN] : [])] : [])
-]);
+export const enabledBitcoinTokens: Readable<Token[]> = derived(
+	[testnetsEnabled],
+	([$testnetsEnabled]) => [
+		...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_TOKEN] : []),
+		...($testnetsEnabled ? [BTC_TESTNET_TOKEN, ...(LOCAL ? [BTC_REGTEST_TOKEN] : [])] : [])
+	]
+);

--- a/src/frontend/src/eth/derived/networks.derived.ts
+++ b/src/frontend/src/eth/derived/networks.derived.ts
@@ -4,15 +4,15 @@ import {
 	SEPOLIA_NETWORK
 } from '$env/networks/networks.eth.env';
 import type { EthereumNetwork } from '$eth/types/network';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { NetworkId } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
 
 export const enabledEthereumNetworks: Readable<EthereumNetwork[]> = derived(
-	[testnets],
-	([$testnets]) => [
+	[testnetsEnabled],
+	([$testnetsEnabled]) => [
 		...(ETH_MAINNET_ENABLED ? [ETHEREUM_NETWORK] : []),
-		...($testnets ? [SEPOLIA_NETWORK] : [])
+		...($testnetsEnabled ? [SEPOLIA_NETWORK] : [])
 	]
 );
 

--- a/src/frontend/src/eth/derived/tokens.derived.ts
+++ b/src/frontend/src/eth/derived/tokens.derived.ts
@@ -1,13 +1,13 @@
 import { ETH_MAINNET_ENABLED } from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { RequiredTokenWithLinkedData } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
 export const enabledEthereumTokens: Readable<RequiredTokenWithLinkedData[]> = derived(
-	[testnets],
-	([$testnets]) => [
+	[testnetsEnabled],
+	([$testnetsEnabled]) => [
 		...(ETH_MAINNET_ENABLED ? [ETHEREUM_TOKEN] : []),
-		...($testnets ? [SEPOLIA_TOKEN] : [])
+		...($testnetsEnabled ? [SEPOLIA_TOKEN] : [])
 	]
 );

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -10,7 +10,7 @@ import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { CanisterIdText } from '$lib/types/canister';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -20,10 +20,10 @@ import { derived, type Readable } from 'svelte/store';
  * The list of Icrc default tokens - i.e. the statically configured Icrc tokens of Oisy + their metadata, unique ids etc. fetched at runtime.
  */
 const icrcDefaultTokens: Readable<IcToken[]> = derived(
-	[icrcDefaultTokensStore, testnets],
-	([$icrcTokensStore, $testnets]) =>
+	[icrcDefaultTokensStore, testnetsEnabled],
+	([$icrcTokensStore, $testnetsEnabled]) =>
 		($icrcTokensStore?.map(({ data: token }) => token) ?? []).filter(
-			(token) => $testnets || !isTokenIcrcTestnet(token)
+			(token) => $testnetsEnabled || !isTokenIcrcTestnet(token)
 		)
 );
 
@@ -53,10 +53,10 @@ const icrcDefaultTokensCanisterIds: Readable<CanisterIdText[]> = derived(
  * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "custom token" in the backend.
  */
 const icrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
-	[icrcCustomTokensStore, testnets],
-	([$icrcCustomTokensStore, $testnets]) =>
+	[icrcCustomTokensStore, testnetsEnabled],
+	([$icrcCustomTokensStore, $testnetsEnabled]) =>
 		($icrcCustomTokensStore?.map(({ data: token }) => token) ?? []).filter(
-			(token) => $testnets || !isTokenIcrcTestnet(token)
+			(token) => $testnetsEnabled || !isTokenIcrcTestnet(token)
 		)
 );
 

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -18,7 +18,7 @@
 		solAddressTestnet
 	} from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { testnets } from '$lib/derived/testnets.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
 	import { loadAddresses, loadIdbAddresses } from '$lib/services/addresses.services';
 	import { signOut } from '$lib/services/auth.services';
@@ -98,7 +98,7 @@
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
 	$: {
-		if ($testnets) {
+		if ($testnetsEnabled) {
 			if (isNullish($btcAddressTestnet)) {
 				debounceLoadBtcAddressTestnet();
 			}

--- a/src/frontend/src/lib/components/networks/NetworksDropdown.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksDropdown.svelte
@@ -12,7 +12,7 @@
 	import { NETWORKS_SWITCHER_DROPDOWN } from '$lib/constants/test-ids.constants';
 	import { SLIDE_EASING } from '$lib/constants/transition.constants';
 	import { networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
-	import { testnets } from '$lib/derived/testnets.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network as NetworkType, NetworkId } from '$lib/types/network';
@@ -73,7 +73,7 @@
 
 		<span class="my-5 flex px-3 font-bold">{$i18n.networks.test_networks}</span>
 
-		{#if $testnets}
+		{#if $testnetsEnabled}
 			<ul class="flex list-none flex-col">
 				{#each $networksTestnets as network (network.id)}
 					<li transition:slide={SLIDE_EASING}>

--- a/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksTestnetsToggle.svelte
@@ -5,7 +5,7 @@
 	import { NETWORK_PARAM } from '$lib/constants/routes.constants';
 	import { TESTNET_TOGGLE } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { testnets } from '$lib/derived/testnets.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { userProfileVersion } from '$lib/derived/user-profile.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { emit } from '$lib/utils/events.utils';
@@ -14,7 +14,7 @@
 	// PR: https://github.com/dfinity/gix-components/pull/531
 
 	let checked: boolean;
-	$: checked = $testnets;
+	$: checked = $testnetsEnabled;
 
 	const toggleShowTestnets = async () => {
 		try {

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -223,18 +223,18 @@
 	let receiveAddressList: Omit<ReceiveAddressProps, 'token' | 'qrCodeAriaLabel' | 'label'>[];
 	$: receiveAddressList = receiveAddressCoreList.map(
 		({
-			 address,
-			 token: addressToken,
-			 qrCodeAriaLabel,
-			 label: addressLabel,
-			 copyAriaLabel,
-			 labelRef,
-			 network,
-			 testId,
-			 title,
-			 text,
-			 condition
-		 }) => ({
+			address,
+			token: addressToken,
+			qrCodeAriaLabel,
+			label: addressLabel,
+			copyAriaLabel,
+			labelRef,
+			network,
+			testId,
+			title,
+			text,
+			condition
+		}) => ({
 			labelRef,
 			address,
 			network,
@@ -263,18 +263,7 @@
 
 <ContentWithToolbar>
 	<div class="flex flex-col gap-2">
-		{#each receiveAddressList as {
-			title,
-			text,
-			condition,
-			on,
-			labelRef,
-			address,
-			network,
-			testId,
-			copyAriaLabel,
-			qrCodeAction
-		} (labelRef)}
+		{#each receiveAddressList as { title, text, condition, on, labelRef, address, network, testId, copyAriaLabel, qrCodeAction } (labelRef)}
 			{#if condition !== false}
 				{#if nonNullish(text)}
 					<ReceiveAddress

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -56,12 +56,13 @@
 		solAddressMainnet,
 		solAddressTestnet
 	} from '$lib/derived/address.derived';
-	import { networkICPEnabled ,
+	import {
+		networkICPEnabled,
 		networkEthereumEnabled,
 		networkSepoliaEnabled
 	} from '$lib/derived/networks.derived';
-	import { testnetsEnabled , testnets } from '$lib/derived/testnets.derived';
-			import { i18n } from '$lib/stores/i18n.store';
+	import { testnetsEnabled, testnets } from '$lib/derived/testnets.derived';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
 	import type { Network } from '$lib/types/network';

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -57,7 +57,7 @@
 		solAddressTestnet
 	} from '$lib/derived/address.derived';
 	import { networkICPEnabled } from '$lib/derived/networks.derived';
-	import { testnets } from '$lib/derived/testnets.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
@@ -115,7 +115,7 @@
 			label: $i18n.receive.bitcoin.text.bitcoin_testnet_address,
 			copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied,
 			qrCodeAriaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr,
-			condition: $testnets
+			condition: $testnetsEnabled
 		},
 		{
 			labelRef: 'btcAddressRegtest',
@@ -127,7 +127,7 @@
 			label: $i18n.receive.bitcoin.text.bitcoin_regtest_address,
 			copyAriaLabel: $i18n.receive.bitcoin.text.bitcoin_address_copied,
 			qrCodeAriaLabel: $i18n.receive.bitcoin.text.display_bitcoin_address_qr,
-			condition: $testnets && LOCAL
+			condition: $testnetsEnabled && LOCAL
 		},
 		{
 			labelRef: 'ethAddress',
@@ -187,7 +187,7 @@
 			label: $i18n.receive.solana.text.solana_testnet_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
 			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
-			condition: $testnets
+			condition: $testnetsEnabled
 		},
 		{
 			labelRef: 'solAddressDevnet',
@@ -199,7 +199,7 @@
 			label: $i18n.receive.solana.text.solana_devnet_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
 			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
-			condition: $testnets
+			condition: $testnetsEnabled
 		},
 		{
 			labelRef: 'solAddressLocal',
@@ -211,7 +211,7 @@
 			label: $i18n.receive.solana.text.solana_local_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
 			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
-			condition: $testnets && LOCAL
+			condition: $testnetsEnabled && LOCAL
 		}
 	];
 

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -61,7 +61,7 @@
 		networkEthereumEnabled,
 		networkSepoliaEnabled
 	} from '$lib/derived/networks.derived';
-	import { testnetsEnabled, testnets } from '$lib/derived/testnets.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
@@ -223,18 +223,18 @@
 	let receiveAddressList: Omit<ReceiveAddressProps, 'token' | 'qrCodeAriaLabel' | 'label'>[];
 	$: receiveAddressList = receiveAddressCoreList.map(
 		({
-			address,
-			token: addressToken,
-			qrCodeAriaLabel,
-			label: addressLabel,
-			copyAriaLabel,
-			labelRef,
-			network,
-			testId,
-			title,
-			text,
-			condition
-		}) => ({
+			 address,
+			 token: addressToken,
+			 qrCodeAriaLabel,
+			 label: addressLabel,
+			 copyAriaLabel,
+			 labelRef,
+			 network,
+			 testId,
+			 title,
+			 text,
+			 condition
+		 }) => ({
 			labelRef,
 			address,
 			network,
@@ -263,7 +263,18 @@
 
 <ContentWithToolbar>
 	<div class="flex flex-col gap-2">
-		{#each receiveAddressList as { title, text, condition, on, labelRef, address, network, testId, copyAriaLabel, qrCodeAction } (labelRef)}
+		{#each receiveAddressList as {
+			title,
+			text,
+			condition,
+			on,
+			labelRef,
+			address,
+			network,
+			testId,
+			copyAriaLabel,
+			qrCodeAction
+		} (labelRef)}
 			{#if condition !== false}
 				{#if nonNullish(text)}
 					<ReceiveAddress

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -56,15 +56,12 @@
 		solAddressMainnet,
 		solAddressTestnet
 	} from '$lib/derived/address.derived';
-	import { networkICPEnabled } from '$lib/derived/networks.derived';
-	import { testnetsEnabled } from '$lib/derived/testnets.derived';
-	import {
+	import { networkICPEnabled ,
 		networkEthereumEnabled,
-		networkICPEnabled,
 		networkSepoliaEnabled
 	} from '$lib/derived/networks.derived';
-	import { testnets } from '$lib/derived/testnets.derived';
-	import { i18n } from '$lib/stores/i18n.store';
+	import { testnetsEnabled , testnets } from '$lib/derived/testnets.derived';
+			import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionBtcAddress, OptionEthAddress } from '$lib/types/address';
 	import type { Network } from '$lib/types/network';

--- a/src/frontend/src/lib/derived/testnets.derived.ts
+++ b/src/frontend/src/lib/derived/testnets.derived.ts
@@ -1,7 +1,7 @@
 import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
 import { derived, type Readable } from 'svelte/store';
 
-export const testnets: Readable<boolean> = derived(
+export const testnetsEnabled: Readable<boolean> = derived(
 	[userSettingsNetworks],
 	([$userNetworksSettings]) => $userNetworksSettings?.testnets.show_testnets ?? false
 );

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -17,7 +17,7 @@ import {
 	SOLANA_MAINNET_NETWORK_ID,
 	SOLANA_TESTNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
 import type { NetworkId } from '$lib/types/network';
 import type { UserNetworks } from '$lib/types/user-networks';
@@ -25,8 +25,8 @@ import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const userNetworks: Readable<UserNetworks> = derived(
-	[userSettingsNetworks, testnets],
-	([$userSettingsNetworks, $testnets]) => {
+	[userSettingsNetworks, testnetsEnabled],
+	([$userSettingsNetworks, $testnetsEnabled]) => {
 		const userNetworks = $userSettingsNetworks?.networks;
 
 		if (isNullish(userNetworks) || userNetworks.length === 0 || !USER_NETWORKS_FEATURE_ENABLED) {
@@ -39,11 +39,11 @@ export const userNetworks: Readable<UserNetworks> = derived(
 					}),
 					{}
 				),
-				...($testnets &&
+				...($testnetsEnabled &&
 					SUPPORTED_TESTNET_NETWORKS_IDS.reduce<UserNetworks>(
 						(acc, id) => ({
 							...acc,
-							[id]: { enabled: $testnets, isTestnet: true }
+							[id]: { enabled: $testnetsEnabled, isTestnet: true }
 						}),
 						{}
 					))

--- a/src/frontend/src/sol/derived/networks.derived.ts
+++ b/src/frontend/src/sol/derived/networks.derived.ts
@@ -6,16 +6,16 @@ import {
 	SOLANA_TESTNET_NETWORK
 } from '$env/networks/networks.sol.env';
 import { LOCAL } from '$lib/constants/app.constants';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { NetworkId } from '$lib/types/network';
 import type { SolanaNetwork } from '$sol/types/network';
 import { derived, type Readable } from 'svelte/store';
 
 export const enabledSolanaNetworks: Readable<SolanaNetwork[]> = derived(
-	[testnets],
-	([$testnets]) => [
+	[testnetsEnabled],
+	([$testnetsEnabled]) => [
 		...(SOL_MAINNET_ENABLED ? [SOLANA_MAINNET_NETWORK] : []),
-		...($testnets
+		...($testnetsEnabled
 			? [SOLANA_TESTNET_NETWORK, SOLANA_DEVNET_NETWORK, ...(LOCAL ? [SOLANA_LOCAL_NETWORK] : [])]
 			: [])
 	]

--- a/src/frontend/src/sol/derived/tokens.derived.ts
+++ b/src/frontend/src/sol/derived/tokens.derived.ts
@@ -6,13 +6,16 @@ import {
 	SOLANA_TOKEN
 } from '$env/tokens/tokens.sol.env';
 import { LOCAL } from '$lib/constants/app.constants';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { RequiredToken } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
-export const enabledSolanaTokens: Readable<RequiredToken[]> = derived([testnets], ([$testnets]) => [
-	...(SOL_MAINNET_ENABLED ? [SOLANA_TOKEN] : []),
-	...($testnets
-		? [SOLANA_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, ...(LOCAL ? [SOLANA_LOCAL_TOKEN] : [])]
-		: [])
-]);
+export const enabledSolanaTokens: Readable<RequiredToken[]> = derived(
+	[testnetsEnabled],
+	([$testnetsEnabled]) => [
+		...(SOL_MAINNET_ENABLED ? [SOLANA_TOKEN] : []),
+		...($testnetsEnabled
+			? [SOLANA_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, ...(LOCAL ? [SOLANA_LOCAL_TOKEN] : [])]
+			: [])
+	]
+);

--- a/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
@@ -18,7 +18,7 @@ import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import * as appConstants from '$lib/constants/app.constants';
 import { pageToken } from '$lib/derived/page-token.derived';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
@@ -53,7 +53,7 @@ describe('page-token.derived', () => {
 	it.each([BTC_TESTNET_TOKEN, SOLANA_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, SEPOLIA_TOKEN])(
 		'should find $name token',
 		(token) => {
-			vi.spyOn(testnets, 'subscribe').mockImplementation((fn) => {
+			vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
 				fn(true);
 				return () => {};
 			});
@@ -64,7 +64,7 @@ describe('page-token.derived', () => {
 	);
 
 	it.each([BTC_REGTEST_TOKEN, SOLANA_LOCAL_TOKEN])('should find $name token', (token) => {
-		vi.spyOn(testnets, 'subscribe').mockImplementation((fn) => {
+		vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
 			fn(true);
 			return () => {};
 		});

--- a/src/frontend/src/tests/lib/derived/testnets.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/testnets.derived.spec.ts
@@ -1,4 +1,4 @@
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import {
 	mockNetworksSettings,
@@ -14,12 +14,12 @@ describe('testnets.derived', () => {
 	describe('testnets', () => {
 		it('should return false when user profile is not set', () => {
 			userProfileStore.reset();
-			expect(get(testnets)).toBe(false);
+			expect(get(testnetsEnabled)).toBe(false);
 		});
 
 		it('should return false when settings are not set', () => {
 			userProfileStore.set({ certified, profile: { ...mockUserProfile, settings: [] } });
-			expect(get(testnets)).toBe(false);
+			expect(get(testnetsEnabled)).toBe(false);
 		});
 
 		it('should return the value of show testnets settings', () => {
@@ -33,7 +33,7 @@ describe('testnets.derived', () => {
 					})
 				}
 			});
-			expect(get(testnets)).toBe(true);
+			expect(get(testnetsEnabled)).toBe(true);
 
 			userProfileStore.set({
 				certified,
@@ -45,7 +45,7 @@ describe('testnets.derived', () => {
 					})
 				}
 			});
-			expect(get(testnets)).toBe(false);
+			expect(get(testnetsEnabled)).toBe(false);
 		});
 	});
 });

--- a/src/frontend/src/tests/utils/derived.test-utils.ts
+++ b/src/frontend/src/tests/utils/derived.test-utils.ts
@@ -93,7 +93,7 @@ const derivedList: Record<string, Readable<unknown>> = {
 	routeToken,
 	selectedNetwork,
 	showZeroBalances,
-	testnets: testnetsEnabled,
+	testnetsEnabled,
 	tokenDecimals,
 	tokenId,
 	tokenStandard,

--- a/src/frontend/src/tests/utils/derived.test-utils.ts
+++ b/src/frontend/src/tests/utils/derived.test-utils.ts
@@ -34,7 +34,7 @@ import {
 import { networks, networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
 import { pageToken } from '$lib/derived/page-token.derived';
 import { hideZeroBalances, showZeroBalances } from '$lib/derived/settings.derived';
-import { testnets } from '$lib/derived/testnets.derived';
+import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import {
 	tokenDecimals,
 	tokenId,
@@ -93,7 +93,7 @@ const derivedList: Record<string, Readable<unknown>> = {
 	routeToken,
 	selectedNetwork,
 	showZeroBalances,
-	testnets,
+	testnets: testnetsEnabled,
 	tokenDecimals,
 	tokenId,
 	tokenStandard,


### PR DESCRIPTION
# Motivation

It makes more sense that the derived store `testnets` is renamed `testnetsEnabled`. 
