### PR TITLE
feat(frontend): extract store selectedEthereumNetwork without fallback

### DIFF
--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -8,7 +8,7 @@
 	import EthConvertProgress from '$eth/components/convert/EthConvertProgress.svelte';
 	import EthConvertReview from '$eth/components/convert/EthConvertReview.svelte';
 	import FeeContext from '$eth/components/fee/FeeContext.svelte';
-	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
+	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
 	import { ethereumToken } from '$eth/derived/token.derived';
 	import { send as executeSend } from '$eth/services/send.services';
 	import {
@@ -162,7 +162,7 @@
 				maxFeePerGas,
 				maxPriorityFeePerGas,
 				gas,
-				sourceNetwork: $selectedEthereumNetwork,
+				sourceNetwork: $selectedEthereumNetworkWithFallback,
 				targetNetwork: ICP_NETWORK,
 				identity: $authIdentity,
 				minterInfo: $ckEthMinterInfoStore?.[$ethereumToken.id]
@@ -198,7 +198,7 @@
 	amount={sendAmount}
 	{destination}
 	observe={currentStep?.name !== WizardStepsConvert.CONVERTING}
-	sourceNetwork={$selectedEthereumNetwork}
+	sourceNetwork={$selectedEthereumNetworkWithFallback}
 	targetNetwork={ICP_NETWORK}
 	nativeEthereumToken={$ethereumToken}
 >

--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { metamaskAvailable } from '$eth/derived/metamask.derived';
-	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
+	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
 	import { openMetamaskTransaction } from '$eth/services/metamask.services';
 	import IconMetamask from '$lib/components/icons/IconMetamask.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -20,7 +20,7 @@
 
 		await openMetamaskTransaction({
 			address: $ethAddress,
-			network: $selectedEthereumNetwork
+			network: $selectedEthereumNetworkWithFallback
 		});
 	};
 

--- a/src/frontend/src/eth/derived/network.derived.ts
+++ b/src/frontend/src/eth/derived/network.derived.ts
@@ -4,13 +4,18 @@ import { DEFAULT_ETHEREUM_NETWORK } from '$lib/constants/networks.constants';
 import { networkId } from '$lib/derived/network.derived';
 import { derived, type Readable } from 'svelte/store';
 
-export const selectedEthereumNetwork: Readable<EthereumNetwork> = derived(
+const selectedEthereumNetwork: Readable<EthereumNetwork | undefined> = derived(
 	[enabledEthereumNetworks, networkId],
 	([$enabledEthereumNetworks, $networkId]) =>
-		$enabledEthereumNetworks.find(({ id }) => id === $networkId) ?? DEFAULT_ETHEREUM_NETWORK
+		$enabledEthereumNetworks.find(({ id }) => id === $networkId)
+);
+
+export const selectedEthereumNetworkWithFallback: Readable<EthereumNetwork> = derived(
+	[selectedEthereumNetwork],
+	([$selectedEthereumNetwork]) => $selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK
 );
 
 export const explorerUrl: Readable<string> = derived(
-	[selectedEthereumNetwork],
+	[selectedEthereumNetworkWithFallback],
 	([{ explorerUrl }]) => explorerUrl
 );

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -1,4 +1,4 @@
-import { selectedEthereumNetwork } from '$eth/derived/network.derived';
+import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
@@ -8,7 +8,7 @@ import { derived, type Readable } from 'svelte/store';
  * Ethereum (Ethereum or Sepolia) token - i.e. not ERC20.
  */
 export const ethereumToken: Readable<RequiredTokenWithLinkedData> = derived(
-	[enabledEthereumTokens, selectedEthereumNetwork],
+	[enabledEthereumTokens, selectedEthereumNetworkWithFallback],
 	([$enabledEthereumTokens, { id }]) =>
 		$enabledEthereumTokens.find(({ network: { id: networkId } }) => id === networkId) ??
 		DEFAULT_ETHEREUM_TOKEN

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -2,7 +2,7 @@
 	import { type WizardStep } from '@dfinity/gix-components';
 	import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
-	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
+	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
 	import { ethereumToken } from '$eth/derived/token.derived';
 	import IcSendTokenWizard from '$icp/components/send/IcSendTokenWizard.svelte';
 	import SendTokenContext from '$lib/components/send/SendTokenContext.svelte';
@@ -31,7 +31,7 @@
 		<EthSendTokenWizard
 			{currentStep}
 			{formCancelAction}
-			sourceNetwork={$selectedEthereumNetwork}
+			sourceNetwork={$selectedEthereumNetworkWithFallback}
 			nativeEthereumToken={$ethereumToken}
 			bind:destination
 			bind:targetNetwork


### PR DESCRIPTION
# Motivation

It is useful to extract a derived store to have the selected Ethereum network as `undefined`, if we are not in the Ethereum network. Basically, without fallback.

We will use it in further PR for enabled/disabled networks.

# Changes

- Rename store `selectedEthereumNetwork` to `selectedEthereumNetworkWithFallback`.
- Extract store `selectedEthereumNetwork` with no fallback network.

# Tests

Existing tests are sufficient.
