### PR TITLE
fix(e2e): merge-e2e tag must resolve to true when no changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,7 +65,7 @@ jobs:
     needs: oisy-backend-wasm
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     env:
       MATRIX_OS: ${{ matrix.os }}
     if: ${{ needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
@@ -162,7 +162,7 @@ jobs:
   finalize-snapshots-update:
     name: Finalize Snapshots Update
     runs-on: ubuntu-24.04
-    needs: [e2e]
+    needs: [ e2e ]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -251,13 +251,19 @@ jobs:
 
   may-merge-e2e:
     if: always()
-    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
+    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/needs_success
-        with:
-          needs: '${{ toJson(needs) }}'
+      - name: Cleared for merging
+        run: |
+          if [ "${{ needs.check-e2e-changes.outputs.e2e-or-config-changed }}" == "false" ]; then
+            echo "No E2E or config changes detected. PR is cleared for merging."
+          elif [[ "${{ needs.e2e.result }}" == "success" ]] && [[ "${{ needs.finalize-snapshots-update.outputs.e2e-snapshots-changed }}" == "false" ]]; then
+            echo "This PR is cleared for merging"
+          else
+            echo "This PR is not cleared for merging"
+            exit 1
+          fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,7 +65,7 @@ jobs:
     needs: oisy-backend-wasm
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     env:
       MATRIX_OS: ${{ matrix.os }}
     if: ${{ needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
@@ -162,7 +162,7 @@ jobs:
   finalize-snapshots-update:
     name: Finalize Snapshots Update
     runs-on: ubuntu-24.04
-    needs: [ e2e ]
+    needs: [e2e]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -251,11 +251,11 @@ jobs:
 
   may-merge-e2e:
     if: always()
-    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
+    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Cleared for merging
         run: |


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/5045 , I need to change the final step to resolve the `merge-e2e` check to positive if there are no changes in the E2E files. This is the case for PRs that do not require E2E tests, otherwise it will not pass the CI checks (see https://github.com/dfinity/oisy-wallet/actions/runs/14154886004/job/39652848558?pr=5504).
