### PR TITLE
chore(frontend): apply Svelte rule spaced-html-comment

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -53,7 +53,7 @@
 			/>
 		</div>
 	{:else if badge?.type === 'icon'}
-		<!-- TODO: use new mapping color when merged-->
+		<!-- TODO: use new mapping color when merged -->
 		<div
 			class="absolute -bottom-1 -right-1 h-6 w-6 items-center justify-center rounded-full bg-brand-tertiary p-1 text-primary-inverted"
 			aria-label={badge.ariaLabel}

--- a/src/frontend/src/sol/components/send/SolSendDestination.svelte
+++ b/src/frontend/src/sol/components/send/SolSendDestination.svelte
@@ -21,4 +21,4 @@
 	onQRButtonClick={() => dispatch('icQRCodeScan')}
 />
 
-<!--TODO: PRODSEC: add some sort of warning/info when the destination input is not an ATA address, either here or in the confirmation review step-->
+<!-- TODO: PRODSEC: add some sort of warning/info when the destination input is not an ATA address, either here or in the confirmation review step -->

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <ContentWithToolbar>
-	<!-- TODO: add address for devnet and testnet-->
+	<!-- TODO: add address for devnet and testnet -->
 	<SendData
 		amount={amountDisplay}
 		{destination}
@@ -44,7 +44,7 @@
 	>
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />
 
-		<!-- TODO: add checks for insufficient funds if and when we are able to correctly parse the amount-->
+		<!-- TODO: add checks for insufficient funds if and when we are able to correctly parse the amount -->
 
 		<ReviewNetwork sourceNetwork={network} slot="network" />
 	</SendData>


### PR DESCRIPTION
# Motivation

In library eslint-config-oisy-wallet we are adding rule [svelte/spaced-html-comment](https://sveltejs.github.io/eslint-plugin-svelte/rules/spaced-html-comment/) (PR https://github.com/dfinity/eslint-config-oisy-wallet/pull/57).

So we apply the rule formatting here first, adding whitespaces in the comments, where needed.
