### PR TITLE
feat(frontend): stores to check if Solana networks are enabled

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -65,7 +65,8 @@
 		networkBitcoinRegtestEnabled,
 		networkSolanaMainnetEnabled,
 		networkSolanaTestnetEnabled,
-		networkSolanaDevnetEnabled, networkSolanaLocalEnabled
+		networkSolanaDevnetEnabled,
+		networkSolanaLocalEnabled
 	} from '$lib/derived/networks.derived';
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -231,18 +232,18 @@
 	let receiveAddressList: Omit<ReceiveAddressProps, 'token' | 'qrCodeAriaLabel' | 'label'>[];
 	$: receiveAddressList = receiveAddressCoreList.map(
 		({
-			 address,
-			 token: addressToken,
-			 qrCodeAriaLabel,
-			 label: addressLabel,
-			 copyAriaLabel,
-			 labelRef,
-			 network,
-			 testId,
-			 title,
-			 text,
-			 condition
-		 }) => ({
+			address,
+			token: addressToken,
+			qrCodeAriaLabel,
+			label: addressLabel,
+			copyAriaLabel,
+			labelRef,
+			network,
+			testId,
+			title,
+			text,
+			condition
+		}) => ({
 			labelRef,
 			address,
 			network,
@@ -271,18 +272,7 @@
 
 <ContentWithToolbar>
 	<div class="flex flex-col gap-2">
-		{#each receiveAddressList as {
-			title,
-			text,
-			condition,
-			on,
-			labelRef,
-			address,
-			network,
-			testId,
-			copyAriaLabel,
-			qrCodeAction
-		} (labelRef)}
+		{#each receiveAddressList as { title, text, condition, on, labelRef, address, network, testId, copyAriaLabel, qrCodeAction } (labelRef)}
 			{#if condition !== false}
 				{#if nonNullish(text)}
 					<ReceiveAddress

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -62,7 +62,10 @@
 		networkSepoliaEnabled,
 		networkBitcoinMainnetEnabled,
 		networkBitcoinTestnetEnabled,
-		networkBitcoinRegtestEnabled
+		networkBitcoinRegtestEnabled,
+		networkSolanaMainnetEnabled,
+		networkSolanaTestnetEnabled,
+		networkSolanaDevnetEnabled, networkSolanaLocalEnabled
 	} from '$lib/derived/networks.derived';
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -184,7 +187,8 @@
 			title: $i18n.receive.solana.text.solana_address,
 			label: $i18n.receive.solana.text.solana_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
-			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr
+			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
+			condition: $networkSolanaMainnetEnabled
 		},
 		{
 			labelRef: 'solAddressTestnet',
@@ -196,7 +200,7 @@
 			label: $i18n.receive.solana.text.solana_testnet_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
 			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
-			condition: $testnetsEnabled
+			condition: $networkSolanaTestnetEnabled && $testnetsEnabled
 		},
 		{
 			labelRef: 'solAddressDevnet',
@@ -208,7 +212,7 @@
 			label: $i18n.receive.solana.text.solana_devnet_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
 			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
-			condition: $testnetsEnabled
+			condition: $networkSolanaDevnetEnabled && $testnetsEnabled
 		},
 		{
 			labelRef: 'solAddressLocal',
@@ -220,25 +224,25 @@
 			label: $i18n.receive.solana.text.solana_local_address,
 			copyAriaLabel: $i18n.receive.solana.text.solana_address_copied,
 			qrCodeAriaLabel: $i18n.receive.solana.text.display_solana_address_qr,
-			condition: $testnetsEnabled && LOCAL
+			condition: $networkSolanaLocalEnabled && $testnetsEnabled && LOCAL
 		}
 	];
 
 	let receiveAddressList: Omit<ReceiveAddressProps, 'token' | 'qrCodeAriaLabel' | 'label'>[];
 	$: receiveAddressList = receiveAddressCoreList.map(
 		({
-			address,
-			token: addressToken,
-			qrCodeAriaLabel,
-			label: addressLabel,
-			copyAriaLabel,
-			labelRef,
-			network,
-			testId,
-			title,
-			text,
-			condition
-		}) => ({
+			 address,
+			 token: addressToken,
+			 qrCodeAriaLabel,
+			 label: addressLabel,
+			 copyAriaLabel,
+			 labelRef,
+			 network,
+			 testId,
+			 title,
+			 text,
+			 condition
+		 }) => ({
 			labelRef,
 			address,
 			network,
@@ -267,7 +271,18 @@
 
 <ContentWithToolbar>
 	<div class="flex flex-col gap-2">
-		{#each receiveAddressList as { title, text, condition, on, labelRef, address, network, testId, copyAriaLabel, qrCodeAction } (labelRef)}
+		{#each receiveAddressList as {
+			title,
+			text,
+			condition,
+			on,
+			labelRef,
+			address,
+			network,
+			testId,
+			copyAriaLabel,
+			qrCodeAction
+		} (labelRef)}
 			{#if condition !== false}
 				{#if nonNullish(text)}
 					<ReceiveAddress

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -99,22 +99,18 @@ export const networkBitcoinMainnetDisabled: Readable<boolean> = derived(
 	([$networkBitcoinMainnetEnabled]) => !$networkBitcoinMainnetEnabled
 );
 
-export const networkSolanaMainnetEnabled: Readable<boolean> = derived(
-	[networksMainnets],
-	([$networksMainnets]) => $networksMainnets.some(({ id }) => id === SOLANA_MAINNET_NETWORK_ID)
+export const networkSolanaMainnetEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
+	$networks.some(({ id }) => id === SOLANA_MAINNET_NETWORK_ID)
 );
 
-export const networkSolanaTestnetEnabled: Readable<boolean> = derived(
-	[networksTestnets],
-	([$networksTestnets]) => $networksTestnets.some(({ id }) => id === SOLANA_TESTNET_NETWORK_ID)
+export const networkSolanaTestnetEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
+	$networks.some(({ id }) => id === SOLANA_TESTNET_NETWORK_ID)
 );
 
-export const networkSolanaDevnetEnabled: Readable<boolean> = derived(
-	[networksTestnets],
-	([$networksTestnets]) => $networksTestnets.some(({ id }) => id === SOLANA_DEVNET_NETWORK_ID)
+export const networkSolanaDevnetEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
+	$networks.some(({ id }) => id === SOLANA_DEVNET_NETWORK_ID)
 );
 
-export const networkSolanaLocalEnabled: Readable<boolean> = derived(
-	[networksTestnets],
-	([$networksTestnets]) => $networksTestnets.some(({ id }) => id === SOLANA_LOCAL_NETWORK_ID)
+export const networkSolanaLocalEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
+	$networks.some(({ id }) => id === SOLANA_LOCAL_NETWORK_ID)
 );

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -6,6 +6,12 @@ import {
 } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import {
+	SOLANA_DEVNET_NETWORK_ID,
+	SOLANA_LOCAL_NETWORK_ID,
+	SOLANA_MAINNET_NETWORK_ID,
+	SOLANA_TESTNET_NETWORK_ID
+} from '$env/networks/networks.sol.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { enabledSolanaNetworks } from '$sol/derived/networks.derived';
@@ -91,4 +97,24 @@ export const networkBitcoinRegtestEnabled: Readable<boolean> = derived(
 export const networkBitcoinMainnetDisabled: Readable<boolean> = derived(
 	[networkBitcoinMainnetEnabled],
 	([$networkBitcoinMainnetEnabled]) => !$networkBitcoinMainnetEnabled
+);
+
+export const networkSolanaMainnetEnabled: Readable<boolean> = derived(
+	[networksMainnets],
+	([$networksMainnets]) => $networksMainnets.some(({ id }) => id === SOLANA_MAINNET_NETWORK_ID)
+);
+
+export const networkSolanaTestnetEnabled: Readable<boolean> = derived(
+	[networksTestnets],
+	([$networksTestnets]) => $networksTestnets.some(({ id }) => id === SOLANA_TESTNET_NETWORK_ID)
+);
+
+export const networkSolanaDevnetEnabled: Readable<boolean> = derived(
+	[networksTestnets],
+	([$networksTestnets]) => $networksTestnets.some(({ id }) => id === SOLANA_DEVNET_NETWORK_ID)
+);
+
+export const networkSolanaLocalEnabled: Readable<boolean> = derived(
+	[networksTestnets],
+	([$networksTestnets]) => $networksTestnets.some(({ id }) => id === SOLANA_LOCAL_NETWORK_ID)
 );


### PR DESCRIPTION
# Motivation

We will start to enable and disable network according to the user preference. That means that we could have the Solana networks disabled.

To that scope we need to turn off some features that would not be possible if the networks are turned off.

# Changes

- Create derived stores to check if Solana networks are enabled: Mainnet, Testnet, Devnet and Local.
- Use the stores to hide the Solana addresses.

# Next Steps

- Use the store to hide the Solana tokens.

# Tests

I simulated the Solana disabled network:

![Screenshot 2025-03-31 at 08 04 26](https://github.com/user-attachments/assets/dc774a2c-3264-4fcd-b1b2-63288b3b93f4)



