### PR TITLE
feat(frontend): remove unnecessary store to check if ICP network is enabled

### DIFF
--- a/src/frontend/src/btc/components/convert/ConvertToCkBTC.svelte
+++ b/src/frontend/src/btc/components/convert/ConvertToCkBTC.svelte
@@ -18,7 +18,7 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { modalConvertBTCToCkBTC } from '$lib/derived/modal.derived';
-	import { networkBitcoinMainnetDisabled, networkICPDisabled } from '$lib/derived/networks.derived';
+	import { networkBitcoinMainnetDisabled } from '$lib/derived/networks.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -58,8 +58,7 @@
 
 <ButtonHero
 	on:click={async () => await openConvert()}
-	disabled={$networkICPDisabled ||
-		$networkBitcoinMainnetDisabled ||
+	disabled={$networkBitcoinMainnetDisabled ||
 		$isBusy ||
 		$outflowActionsDisabled ||
 		isNullish(ckBtcToken)}

--- a/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
@@ -15,11 +15,7 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { networkICP } from '$lib/derived/network.derived';
-	import {
-		networkEthereumDisabled,
-		networkICPDisabled,
-		networkSepoliaDisabled
-	} from '$lib/derived/networks.derived';
+	import { networkEthereumDisabled, networkSepoliaDisabled } from '$lib/derived/networks.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { waitWalletReady } from '$lib/services/actions.services';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
@@ -32,7 +28,6 @@
 	const { outflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 
 	const isDisabled = (): boolean =>
-		$networkICPDisabled ||
 		(nativeTokenId === ETHEREUM_TOKEN_ID && $networkEthereumDisabled) ||
 		(nativeTokenId === SEPOLIA_TOKEN_ID && $networkSepoliaDisabled) ||
 		$ethAddressNotLoaded ||

--- a/src/frontend/src/icp-eth/components/core/CkEthLoader.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthLoader.svelte
@@ -11,11 +11,7 @@
 	import { erc20ToCkErc20Enabled, ethToCkETHEnabled } from '$icp-eth/derived/cketh.derived';
 	import { loadCkEthMinterInfo } from '$icp-eth/services/cketh.services';
 	import { LOCAL } from '$lib/constants/app.constants';
-	import {
-		networkEthereumDisabled,
-		networkICPDisabled,
-		networkSepoliaDisabled
-	} from '$lib/derived/networks.derived';
+	import { networkEthereumDisabled, networkSepoliaDisabled } from '$lib/derived/networks.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { TokenId } from '$lib/types/token';
@@ -24,7 +20,6 @@
 
 	const load = async () => {
 		if (
-			$networkICPDisabled ||
 			(nativeTokenId === ETHEREUM_TOKEN_ID && $networkEthereumDisabled) ||
 			(nativeTokenId === SEPOLIA_TOKEN_ID && $networkSepoliaDisabled)
 		) {
@@ -63,8 +58,7 @@
 		});
 	};
 
-	$: $networkICPDisabled,
-		$networkEthereumDisabled,
+	$: $networkEthereumDisabled,
 		$networkSepoliaDisabled,
 		$ethToCkETHEnabled,
 		$erc20ToCkErc20Enabled,

--- a/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
@@ -9,7 +9,7 @@
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { modalConvertCkBTCToBTC } from '$lib/derived/modal.derived';
-	import { networkBitcoinMainnetDisabled, networkICPDisabled } from '$lib/derived/networks.derived';
+	import { networkBitcoinMainnetDisabled } from '$lib/derived/networks.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { tokenId } from '$lib/derived/token.derived';
 	import { waitWalletReady } from '$lib/services/actions.services';
@@ -37,10 +37,7 @@
 </script>
 
 <ButtonHero
-	disabled={$networkICPDisabled ||
-		$networkBitcoinMainnetDisabled ||
-		$isBusy ||
-		$outflowActionsDisabled}
+	disabled={$networkBitcoinMainnetDisabled || $isBusy || $outflowActionsDisabled}
 	on:click={async () => await openConvert()}
 	ariaLabel={$i18n.convert.text.convert_to_btc}
 >

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -57,7 +57,6 @@
 		solAddressTestnet
 	} from '$lib/derived/address.derived';
 	import {
-		networkICPEnabled,
 		networkEthereumEnabled,
 		networkSepoliaEnabled,
 		networkBitcoinMainnetEnabled,
@@ -160,8 +159,7 @@
 			label: $i18n.receive.icp.text.principal,
 			copyAriaLabel: $i18n.receive.icp.text.internet_computer_principal_copied,
 			qrCodeAriaLabel: $i18n.receive.icp.text.display_internet_computer_principal_qr,
-			text: $i18n.receive.icp.text.use_for_icrc_deposit,
-			condition: $networkICPEnabled
+			text: $i18n.receive.icp.text.use_for_icrc_deposit
 		},
 		{
 			labelRef: 'icpTokenAddress',
@@ -172,8 +170,7 @@
 			title: $i18n.receive.icp.text.icp_account,
 			label: $i18n.receive.icp.text.icp_account,
 			copyAriaLabel: $i18n.receive.icp.text.icp_account_copied,
-			qrCodeAriaLabel: $i18n.receive.icp.text.display_icp_account_qr,
-			condition: $networkICPEnabled
+			qrCodeAriaLabel: $i18n.receive.icp.text.display_icp_account_qr
 		},
 		{
 			labelRef: 'solAddressMainnet',

--- a/src/frontend/src/lib/components/swap/SwapButton.svelte
+++ b/src/frontend/src/lib/components/swap/SwapButton.svelte
@@ -2,11 +2,10 @@
 	import ButtonHero from '$lib/components/hero/ButtonHero.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
-	import { networkICPDisabled } from '$lib/derived/networks.derived.js';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
-<ButtonHero on:click disabled={$networkICPDisabled || $isBusy} ariaLabel={$i18n.swap.text.swap}>
+<ButtonHero on:click disabled={$isBusy} ariaLabel={$i18n.swap.text.swap}>
 	<IconCkConvert size="28" slot="icon" />
 
 	{$i18n.swap.text.swap}

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -5,7 +5,7 @@ import {
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 import type { Network } from '$lib/types/network';
 import { enabledSolanaNetworks } from '$sol/derived/networks.derived';
@@ -44,15 +44,6 @@ export const networksMainnets: Readable<Network[]> = derived(
 export const networksTestnets: Readable<Network[]> = derived(
 	[networksEnvs],
 	([{ testnets }]) => testnets
-);
-
-export const networkICPEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
-	$networks.some(({ id }) => id === ICP_NETWORK_ID)
-);
-
-export const networkICPDisabled: Readable<boolean> = derived(
-	[networkICPEnabled],
-	([$networkICPEnabled]) => !$networkICPEnabled
 );
 
 export const networkEthereumEnabled: Readable<boolean> = derived([networks], ([$networks]) =>


### PR DESCRIPTION
# Motivation

With PR https://github.com/dfinity/oisy-wallet/pull/5468 , I created a store to check if Internet Computer network was disabled or enabled by the user. However, it was decided that the user will ALWAYS have ICP network enabled.

So, to avoid confusion and wrongly rely on a store that is not 100% integrated, I remove it completely, because it is not even necessary anymore.

We can always re-add it in the future if needed.
