### PR TITLE
refactor(frontend): extract parts of NetworksSwitcher into components

### DIFF
--- a/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
+++ b/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import NetworkComponent from '$lib/components/networks/Network.svelte';
 	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
-	import type { Network } from '$lib/types/network';
+	import type { Network, NetworkId } from '$lib/types/network';
 
 	export let network: Network;
+	export let selectedNetworkId: NetworkId | undefined = undefined;
 
 	let usdBalance: number;
 	$: usdBalance = $enabledMainnetTokensUsdBalancesPerNetwork[network.id] ?? 0;
 </script>
 
-<NetworkComponent {network} {usdBalance} on:icSelected />
+<NetworkComponent {network} {usdBalance} {selectedNetworkId} on:icSelected />

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -4,6 +4,7 @@
 	import type { Network, NetworkId } from '$lib/types/network';
 
 	export let network: Network;
+	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let usdBalance: number | undefined = undefined;
 	export let testIdPrefix = NETWORKS_SWITCHER_SELECTOR;
 
@@ -15,6 +16,7 @@
 
 <NetworkButton
 	{id}
+	{selectedNetworkId}
 	{name}
 	{usdBalance}
 	{icon}

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
-	import { page } from '$app/stores';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { networkId } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
-	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
 
 	export let id: NetworkId | undefined;
+	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let name: string;
 	export let icon: string | undefined;
 	export let usdBalance: number | undefined = undefined;
@@ -20,19 +18,13 @@
 
 	const dispatch = createEventDispatcher();
 
-	const onClick = async () => {
-		await switchNetwork(id);
-
-		if (isRouteTransactions($page)) {
-			await gotoReplaceRoot();
-		}
-
+	const onClick = () => {
 		// A small delay to give the user a visual feedback that the network is checked
-		setTimeout(() => dispatch('icSelected'), 500);
+		setTimeout(() => dispatch('icSelected', id), 500);
 	};
 </script>
 
-<LogoButton {testId} on:click={onClick} selectable selected={id === $networkId} dividers>
+<LogoButton {testId} on:click={onClick} selectable selected={id === selectedNetworkId} dividers>
 	<Logo slot="logo" src={icon} />
 
 	<span slot="title" class="mr-2 text-sm font-normal md:text-base">

--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { slide } from 'svelte/transition';
+	import chainFusion from '$lib/assets/chain_fusion.svg';
+	import MainnetNetwork from '$lib/components/networks/MainnetNetwork.svelte';
+	import Network from '$lib/components/networks/Network.svelte';
+	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
+	import { SLIDE_EASING } from '$lib/constants/transition.constants';
+	import { networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
+	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { NetworkId } from '$lib/types/network';
+
+	export let selectedNetworkId: NetworkId | undefined = undefined;
+
+	let mainnetTokensUsdBalance: number;
+	$: mainnetTokensUsdBalance = $networksMainnets.reduce(
+		(acc, { id }) => acc + ($enabledMainnetTokensUsdBalancesPerNetwork[id] ?? 0),
+		0
+	);
+</script>
+
+<NetworkButton
+	id={undefined}
+	name={$i18n.networks.chain_fusion}
+	icon={chainFusion}
+	usdBalance={mainnetTokensUsdBalance}
+	{selectedNetworkId}
+	on:icSelected
+/>
+
+<ul class="flex list-none flex-col">
+	{#each $networksMainnets as network (network.id)}
+		<li transition:slide={SLIDE_EASING}
+			><MainnetNetwork {network} {selectedNetworkId} on:icSelected /></li
+		>
+	{/each}
+</ul>
+
+{#if $testnetsEnabled}
+	<span class="my-5 flex px-3 font-bold" transition:slide={SLIDE_EASING}
+		>{$i18n.networks.test_networks}</span
+	>
+
+	<ul class="flex list-none flex-col" transition:slide={SLIDE_EASING}>
+		{#each $networksTestnets as network (network.id)}
+			<li transition:slide={SLIDE_EASING}
+				><Network {network} {selectedNetworkId} on:icSelected /></li
+			>
+		{/each}
+	</ul>
+{/if}

--- a/src/frontend/src/lib/components/networks/NetworkSwitcherLogo.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherLogo.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import chainFusion from '$lib/assets/chain_fusion.svg';
+	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import type { Network } from '$lib/types/network';
+
+	export let network: Network | undefined;
+</script>
+
+{#if nonNullish(network)}
+	<NetworkLogo {network} size="xs" />
+{:else}
+	<Logo src={chainFusion} size="xs" />
+{/if}

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -1,36 +1,34 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
-	import { slide } from 'svelte/transition';
+	import { page } from '$app/stores';
 	import { SUPPORTED_NETWORKS } from '$env/networks/networks.env';
-	import chainFusion from '$lib/assets/chain_fusion.svg';
 	import IconManage from '$lib/components/icons/lucide/IconManage.svelte';
-	import MainnetNetwork from '$lib/components/networks/MainnetNetwork.svelte';
-	import Network from '$lib/components/networks/Network.svelte';
-	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
-	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import NetworkSwitcherList from '$lib/components/networks/NetworkSwitcherList.svelte';
+	import NetworkSwitcherLogo from '$lib/components/networks/NetworkSwitcherLogo.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import Dropdown from '$lib/components/ui/Dropdown.svelte';
-	import Logo from '$lib/components/ui/Logo.svelte';
 	import { NETWORKS_SWITCHER_DROPDOWN } from '$lib/constants/test-ids.constants';
-	import { SLIDE_EASING } from '$lib/constants/transition.constants';
-	import { selectedNetwork } from '$lib/derived/network.derived';
+	import { selectedNetwork, networkId } from '$lib/derived/network.derived';
 	import { networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
-	import { testnetsEnabled } from '$lib/derived/testnets.derived';
-	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
 	import { SettingsModalType } from '$lib/enums/settings-modal-types';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { NetworkId } from '$lib/types/network';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
 
 	export let disabled = false;
 
 	let dropdown: Dropdown | undefined;
 
-	let mainnetTokensUsdBalance: number;
-	$: mainnetTokensUsdBalance = $networksMainnets.reduce(
-		(acc, { id }) => acc + ($enabledMainnetTokensUsdBalancesPerNetwork[id] ?? 0),
-		0
-	);
+	const onNetworkSelect = async ({ detail: networkId }: CustomEvent<NetworkId>) => {
+		await switchNetwork(networkId);
+
+		if (isRouteTransactions($page)) {
+			await gotoReplaceRoot();
+		}
+
+		dropdown?.close();
+	};
 </script>
 
 <Dropdown
@@ -40,44 +38,14 @@
 	{disabled}
 	asModalOnMobile
 >
-	{#if nonNullish($selectedNetwork)}
-		<NetworkLogo network={$selectedNetwork} size="xs" />
-	{:else}
-		<Logo src={chainFusion} size="xs" />
-	{/if}
+	<NetworkSwitcherLogo network={$selectedNetwork} />
+
 	<span class="hidden md:block">{$selectedNetwork?.name ?? $i18n.networks.chain_fusion}</span>
 
 	<svelte:fragment slot="title">{$i18n.networks.filter}</svelte:fragment>
+
 	<div slot="items">
-		<NetworkButton
-			id={undefined}
-			name={$i18n.networks.chain_fusion}
-			icon={chainFusion}
-			usdBalance={mainnetTokensUsdBalance}
-			on:icSelected={dropdown.close}
-		/>
-
-		<ul class="flex list-none flex-col">
-			{#each $networksMainnets as network (network.id)}
-				<li transition:slide={SLIDE_EASING}
-					><MainnetNetwork {network} on:icSelected={dropdown.close} /></li
-				>
-			{/each}
-		</ul>
-
-		{#if $testnetsEnabled}
-			<span class="my-5 flex px-3 font-bold" transition:slide={SLIDE_EASING}
-				>{$i18n.networks.test_networks}</span
-			>
-
-			<ul class="flex list-none flex-col" transition:slide={SLIDE_EASING}>
-				{#each $networksTestnets as network (network.id)}
-					<li transition:slide={SLIDE_EASING}
-						><Network {network} on:icSelected={dropdown.close} /></li
-					>
-				{/each}
-			</ul>
-		{/if}
+		<NetworkSwitcherList on:icSelected={onNetworkSelect} selectedNetworkId={$networkId} />
 
 		<div class="mb-2 ml-2 mt-5 flex flex-row justify-between text-nowrap">
 			<span class="flex">


### PR DESCRIPTION
# Motivation

After some iterations, we finally landed on how do we want to re-use NetworksSwitch in the ModalTokensList component - we only re-use particular parts of it. This PR extract them into their own components.