### PR TITLE
fix(frontend): Add test ids for new testnet toggler in network settings

### DIFF
--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -10,7 +10,10 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { POUH_ENABLED } from '$lib/constants/credentials.constants';
-	import { SETTINGS_ADDRESS_LABEL } from '$lib/constants/test-ids.constants';
+	import {
+		ACTIVE_NETWORKS_EDIT_BUTTON,
+		SETTINGS_ADDRESS_LABEL
+	} from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { userHasPouhCredential } from '$lib/derived/has-pouh-credential';
 	import {
@@ -97,7 +100,7 @@
 			<EnabledNetworksPreviewIcons />
 
 			<Button
-				testId="active-networks-edit-button"
+				testId={ACTIVE_NETWORKS_EDIT_BUTTON}
 				link
 				on:click={() => openSettingsModal(SettingsModalEnum.ENABLED_NETWORKS)}
 				>{$i18n.core.text.edit} ></Button

--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -96,7 +96,10 @@
 		<svelte:fragment slot="value">
 			<EnabledNetworksPreviewIcons />
 
-			<Button link on:click={() => openSettingsModal(SettingsModalEnum.ENABLED_NETWORKS)}
+			<Button
+				testId="active-networks-edit-button"
+				link
+				on:click={() => openSettingsModal(SettingsModalEnum.ENABLED_NETWORKS)}
 				>{$i18n.core.text.edit} ></Button
 			>
 		</svelte:fragment>

--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -28,6 +28,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { UserNetworks } from '$lib/types/user-networks';
 	import { emit } from '$lib/utils/events.utils';
+	import { TESTNET_CHECKBOX } from '$lib/constants/test-ids.constants';
 
 	let enabledNetworks = { ...$userNetworks };
 	const enabledNetworksInitial = { ...enabledNetworks };
@@ -106,7 +107,7 @@
 		<svelte:fragment slot="title">{$i18n.settings.text.networks}</svelte:fragment>
 		<div class="font-bold" slot="title-action"
 			><Checkbox
-				testId="testnets-checkbox"
+				testId={TESTNET_CHECKBOX}
 				text="inline"
 				inputId="toggle-testnets-switcher"
 				bind:checked={enabledTestnet}

--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -106,6 +106,7 @@
 		<svelte:fragment slot="title">{$i18n.settings.text.networks}</svelte:fragment>
 		<div class="font-bold" slot="title-action"
 			><Checkbox
+				testId="testnets-checkbox"
 				text="inline"
 				inputId="toggle-testnets-switcher"
 				bind:checked={enabledTestnet}

--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -16,6 +16,7 @@
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import { TESTNET_CHECKBOX } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
@@ -28,7 +29,6 @@
 	import type { Network } from '$lib/types/network';
 	import type { UserNetworks } from '$lib/types/user-networks';
 	import { emit } from '$lib/utils/events.utils';
-	import { TESTNET_CHECKBOX } from '$lib/constants/test-ids.constants';
 
 	let enabledNetworks = { ...$userNetworks };
 	const enabledNetworksInitial = { ...enabledNetworks };

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -67,6 +67,8 @@ export const DESTINATION_INPUT = 'destination-input';
 export const IN_PROGRESS_MODAL = 'in-progress-modal';
 
 export const TESTNET_TOGGLE = 'testnet-toggle';
+export const TESTNET_CHECKBOX = 'testnets-checkbox';
+export const ACTIVE_NETWORKS_EDIT_BUTTON = 'active-networks-edit-button';
 
 export const CAROUSEL_CONTAINER = 'carousel-container';
 export const CAROUSEL_SLIDE = 'carousel-slide';


### PR DESCRIPTION
# Motivation

We need to adjust the e2e tests to work with the adjusted testnet toggler (its a checkbox now which opens in the active networks settings modal)

# Changes

- Added test id for edit button in settings
- Added test id for enable testnet checkbox