### PR TITLE
fix(e2e): snapshots tests should run on main

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   oisy-backend-wasm:
     runs-on: ubuntu-24.04
-    if: ${{ github.ref == 'refs/heads/main' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     needs: check-e2e-changes
     permissions:
       contents: write
@@ -62,13 +62,13 @@ jobs:
 
   e2e:
     runs-on: ${{ matrix.os }}
-    needs: ['oisy-backend-wasm', 'check-e2e-changes']
+    needs: [ 'oisy-backend-wasm', 'check-e2e-changes' ]
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     env:
       MATRIX_OS: ${{ matrix.os }}
-    if: ${{ github.ref == 'refs/heads/main' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     outputs:
       ubuntu_status: ${{ steps.set_snapshot_output.outputs.ubuntu_status }}
       macos_status: ${{ steps.set_snapshot_output.outputs.macos_status }}
@@ -162,7 +162,7 @@ jobs:
   finalize-snapshots-update:
     name: Finalize Snapshots Update
     runs-on: ubuntu-24.04
-    needs: [e2e]
+    needs: [ e2e ]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -250,12 +250,12 @@ jobs:
             ```
 
   may-merge-e2e:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     steps:
       - name: Cleared for merging
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,10 +62,10 @@ jobs:
 
   e2e:
     runs-on: ${{ matrix.os }}
-    needs: [ 'oisy-backend-wasm', 'check-e2e-changes' ]
+    needs: ['oisy-backend-wasm', 'check-e2e-changes']
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     env:
       MATRIX_OS: ${{ matrix.os }}
     if: ${{ github.ref == 'refs/heads/main' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
@@ -162,7 +162,7 @@ jobs:
   finalize-snapshots-update:
     name: Finalize Snapshots Update
     runs-on: ubuntu-24.04
-    needs: [ e2e ]
+    needs: [e2e]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -251,11 +251,11 @@ jobs:
 
   may-merge-e2e:
     if: ${{ github.ref != 'refs/heads/main' }}
-    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
+    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Cleared for merging
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   oisy-backend-wasm:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.ref == 'refs/heads/main' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     needs: check-e2e-changes
     permissions:
       contents: write
@@ -68,7 +68,7 @@ jobs:
         os: [ ubuntu-24.04, macos-14 ]
     env:
       MATRIX_OS: ${{ matrix.os }}
-    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.ref == 'refs/heads/main' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     outputs:
       ubuntu_status: ${{ steps.set_snapshot_output.outputs.ubuntu_status }}
       macos_status: ${{ steps.set_snapshot_output.outputs.macos_status }}
@@ -250,7 +250,7 @@ jobs:
             ```
 
   may-merge-e2e:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.ref != 'refs/heads/main' }}
     needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   oisy-backend-wasm:
     runs-on: ubuntu-24.04
-    if: ${{ needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     needs: check-e2e-changes
     permissions:
       contents: write
@@ -62,13 +62,13 @@ jobs:
 
   e2e:
     runs-on: ${{ matrix.os }}
-    needs: oisy-backend-wasm
+    needs: [ 'oisy-backend-wasm', 'check-e2e-changes' ]
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     env:
       MATRIX_OS: ${{ matrix.os }}
-    if: ${{ needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     outputs:
       ubuntu_status: ${{ steps.set_snapshot_output.outputs.ubuntu_status }}
       macos_status: ${{ steps.set_snapshot_output.outputs.macos_status }}
@@ -162,7 +162,7 @@ jobs:
   finalize-snapshots-update:
     name: Finalize Snapshots Update
     runs-on: ubuntu-24.04
-    needs: [e2e]
+    needs: [ e2e ]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -250,12 +250,12 @@ jobs:
             ```
 
   may-merge-e2e:
-    if: always()
-    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     steps:
       - name: Cleared for merging
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,10 +62,10 @@ jobs:
 
   e2e:
     runs-on: ${{ matrix.os }}
-    needs: [ 'oisy-backend-wasm', 'check-e2e-changes' ]
+    needs: ['oisy-backend-wasm', 'check-e2e-changes']
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     env:
       MATRIX_OS: ${{ matrix.os }}
     if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
@@ -162,7 +162,7 @@ jobs:
   finalize-snapshots-update:
     name: Finalize Snapshots Update
     runs-on: ubuntu-24.04
-    needs: [ e2e ]
+    needs: [e2e]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -251,11 +251,11 @@ jobs:
 
   may-merge-e2e:
     if: always()
-    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
+    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Cleared for merging
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -250,7 +250,7 @@ jobs:
             ```
 
   may-merge-e2e:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: always()
     needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
# Motivation

The E2E tests are running only for changes in E2e-related files. But we need it to always run on `main`, for each new push.