### PR TITLE
feat(frontend): use the new token selector in Send and Swap flows

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -1,27 +1,12 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
-	import { combinedDerivedSortedNetworkTokensUi } from '$lib/derived/network-tokens.derived';
-	import type { TokenUi } from '$lib/types/token';
-
-	const dispatch = createEventDispatcher();
-
-	let tokens: TokenUi[];
-	$: tokens = $combinedDerivedSortedNetworkTokensUi.filter(
-		({ balance }) => (balance ?? ZERO_BI) > ZERO_BI
-	);
 
 	let loading: boolean;
 	$: loading = $erc20UserTokensNotInitialized;
-
-	const onIcTokenButtonClick = ({ detail: token }: CustomEvent<TokenUi>) => {
-		dispatch('icSendToken', token);
-	};
 </script>
 
-<ModalTokensList {tokens} {loading} on:icTokenButtonClick={onIcTokenButtonClick}>
+<ModalTokensList {loading} on:icSelectNetworkFilter>
 	<ButtonCloseModal slot="toolbar" />
 </ModalTokensList>

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -2,6 +2,7 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
@@ -12,6 +13,11 @@
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext, initSwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
@@ -23,6 +29,14 @@
 		initSwapContext({
 			sourceToken: $swappableTokens.sourceToken,
 			destinationToken: $swappableTokens.destinationToken
+		})
+	);
+
+	setContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		initModalTokensListContext({
+			tokens: [],
+			filterNetwork: ICP_NETWORK
 		})
 	);
 

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -7,11 +7,17 @@
 	import { allKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { Token, TokenUi } from '$lib/types/token';
 	import { pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
 
 	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
+
+	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher<{
 		icSelectToken: IcTokenToggleable;
@@ -27,11 +33,17 @@
 		$balances: $balancesStore
 	});
 
+	$: tokens, setTokens(tokens);
+
 	const onIcTokenButtonClick = ({ detail: token }: CustomEvent<TokenUi<IcTokenToggleable>>) => {
 		dispatch('icSelectToken', token);
 	};
 </script>
 
-<ModalTokensList {tokens} loading={false} on:icTokenButtonClick={onIcTokenButtonClick}>
+<ModalTokensList
+	loading={false}
+	networkSelectorViewOnly={true}
+	on:icTokenButtonClick={onIcTokenButtonClick}
+>
 	<ButtonCancel slot="toolbar" fullWidth={true} on:click={() => dispatch('icCloseTokensList')} />
 </ModalTokensList>

--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -32,7 +32,11 @@ export const sendWizardStepsWithQrCodeScan = (params: SendWizardStepsParams): Wi
 export const allSendWizardSteps = (params: SendWizardStepsParams): WizardSteps => [
 	{
 		name: WizardStepsSend.TOKENS_LIST,
-		title: params.i18n.send.text.send
+		title: params.i18n.send.text.select_token
+	},
+	{
+		name: WizardStepsSend.FILTER_NETWORKS,
+		title: params.i18n.send.text.select_network_filter
 	},
 	...sendWizardStepsWithQrCodeScan(params)
 ];

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -1,5 +1,6 @@
 export enum WizardStepsSend {
 	TOKENS_LIST = 'Tokens List',
+	FILTER_NETWORKS = 'Filter Networks',
 	SEND = 'Send',
 	REVIEW = 'Review',
 	SENDING = 'Sending',

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -389,7 +389,9 @@
 			"initializing_transaction": "Initializing transaction",
 			"convert_to_native_icp": "Convert to native ICP",
 			"open_qr_modal": "Start QR Code scan for transaction details",
-			"scan_qr": "Scan QR Code"
+			"scan_qr": "Scan QR Code",
+			"select_token": "Select token to send",
+			"select_network_filter": "Select network filter"
 		},
 		"placeholder": {
 			"enter_eth_address": "Enter public address (0x)",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -361,6 +361,8 @@ interface I18nSend {
 		convert_to_native_icp: string;
 		open_qr_modal: string;
 		scan_qr: string;
+		select_token: string;
+		select_network_filter: string;
 	};
 	placeholder: {
 		enter_eth_address: string;


### PR DESCRIPTION
# Motivation

This PR integrates the new token selector into the send and swap flow. In the send flow, it also adds an additional wizard step for selecting a network filter. And in the swap flow, the network selector button is view-only since all tokens belong to a single network (ICP).


<img width="593" alt="Screenshot 2025-03-31 at 17 30 58" src="https://github.com/user-attachments/assets/72f1fb5b-04ad-4f15-9474-6cfe74c1394d" />
<img width="584" alt="Screenshot 2025-03-31 at 17 31 04" src="https://github.com/user-attachments/assets/7b93bc6a-373e-4cf8-b1bb-76c8bda6fc51" />
<img width="578" alt="Screenshot 2025-03-31 at 17 35 06" src="https://github.com/user-attachments/assets/0070c610-dad0-42cf-b5f3-1221a76f2def" />
