### PR TITLE
feat(frontend): update Swap flow with the new token selector

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -2,6 +2,7 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
@@ -12,6 +13,11 @@
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext, initSwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
@@ -23,6 +29,14 @@
 		initSwapContext({
 			sourceToken: $swappableTokens.sourceToken,
 			destinationToken: $swappableTokens.destinationToken
+		})
+	);
+
+	setContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		initModalTokensListContext({
+			tokens: [],
+			filterNetwork: ICP_NETWORK
 		})
 	);
 

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -7,11 +7,17 @@
 	import { allKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { Token, TokenUi } from '$lib/types/token';
 	import { pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
 
 	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
+
+	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher<{
 		icSelectToken: IcTokenToggleable;
@@ -27,11 +33,17 @@
 		$balances: $balancesStore
 	});
 
+	$: tokens, setTokens(tokens);
+
 	const onIcTokenButtonClick = ({ detail: token }: CustomEvent<TokenUi<IcTokenToggleable>>) => {
 		dispatch('icSelectToken', token);
 	};
 </script>
 
-<ModalTokensList {tokens} loading={false} on:icTokenButtonClick={onIcTokenButtonClick}>
+<ModalTokensList
+	loading={false}
+	networkSelectorViewOnly={true}
+	on:icTokenButtonClick={onIcTokenButtonClick}
+>
 	<ButtonCancel slot="toolbar" fullWidth={true} on:click={() => dispatch('icCloseTokensList')} />
 </ModalTokensList>


### PR DESCRIPTION
# Motivation

Similar to the send flow, we are introducing the new token selector into the Swap flow. The network filter in this case is view-only since all the swap tokens are from one single network.
