### PR TITLE
feat(devops): restrict permissions to Backend Github CI Actions

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -22,6 +22,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -36,6 +38,8 @@ jobs:
 
   workspace-dependencies:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - run: sudo snap install yq
@@ -43,9 +47,11 @@ jobs:
         run: ./scripts/lint.cargo-workspace-dependencies.sh
 
   may-merge:
-    needs: ['lint', 'workspace-dependencies']
+    needs: [ 'lint', 'workspace-dependencies' ]
     if: ${{ always() }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./scripts/lint.cargo-workspace-dependencies.sh
 
   may-merge:
-    needs: [ 'lint', 'workspace-dependencies' ]
+    needs: ['lint', 'workspace-dependencies']
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    needs: [ 'docker-build' ]
+    needs: ['docker-build']
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +80,7 @@ jobs:
         run: ./scripts/test.backend.sh
 
   may-merge:
-    needs: [ 'tests' ]
+    needs: ['tests']
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -22,6 +22,8 @@ on:
 jobs:
   docker-build-base:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +33,8 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: docker-build-base
     strategy:
       matrix:
@@ -51,7 +55,9 @@ jobs:
 
   tests:
     runs-on: ubuntu-24.04
-    needs: ['docker-build']
+    permissions:
+      contents: read
+    needs: [ 'docker-build' ]
     steps:
       - uses: actions/checkout@v4
 
@@ -74,9 +80,11 @@ jobs:
         run: ./scripts/test.backend.sh
 
   may-merge:
-    needs: ['tests']
+    needs: [ 'tests' ]
     if: ${{ always() }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1
@@ -117,9 +120,11 @@ jobs:
           exit 1
 
   binding-checks-pass:
-    needs: ['generate']
+    needs: [ 'generate' ]
     if: ${{ always() }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -120,7 +120,7 @@ jobs:
           exit 1
 
   binding-checks-pass:
-    needs: [ 'generate' ]
+    needs: ['generate']
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   lint-shell:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/formatting-checks.yml
+++ b/.github/workflows/formatting-checks.yml
@@ -22,6 +22,9 @@ on:
 jobs:
   format:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,8 @@ name: Release
 
 on:
   release:
-    types: [released]
+    types: [ released ]
   workflow_dispatch:
-
-permissions:
-  contents: write
 
 jobs:
   #####################
@@ -15,6 +12,8 @@ jobs:
 
   docker-build-base:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,6 +23,8 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: docker-build-base
     strategy:
       matrix:
@@ -44,6 +45,8 @@ jobs:
 
   candid:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -61,7 +64,9 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
-    needs: ['docker-build', 'candid']
+    permissions:
+      contents: write
+    needs: [ 'docker-build', 'candid' ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [ released ]
+    types: [released]
   workflow_dispatch:
 
 jobs:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    needs: [ 'docker-build', 'candid' ]
+    needs: ['docker-build', 'candid']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   rust-update:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
# Motivation

After PR https://github.com/dfinity/oisy-wallet/pull/5542 , since we keep improving our security liabilities in the Github CI folder, we start by restricting the permissions at the jobs level for the majority of the CIs.
