### PR TITLE
style(frontend): hide ModalTokensList network label on small screens

### DIFF
--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -47,7 +47,7 @@
 	>
 		<NetworkSwitcherLogo network={$filterNetwork} />
 
-		{$filterNetwork?.name ?? $i18n.networks.chain_fusion}
+		<span class="hidden md:block">{$filterNetwork?.name ?? $i18n.networks.chain_fusion}</span>
 	</button>
 </div>
 


### PR DESCRIPTION
# Motivation

Similar to the global NetworksSwitcher, we'd like to hide the label on smaller screens in the ModalTokensList component.
