### PR TITLE
ci(e2e): E2E tests should be triggered when labelling a PR

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [ opened, synchronize, labeled ]
   merge_group:
   workflow_dispatch:
 
@@ -66,10 +67,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-    needs: ['oisy-backend-wasm', 'check-e2e-changes']
+    needs: [ 'oisy-backend-wasm', 'check-e2e-changes' ]
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     env:
       MATRIX_OS: ${{ matrix.os }}
     if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
@@ -169,7 +170,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    needs: [e2e]
+    needs: [ e2e ]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -258,13 +259,13 @@ jobs:
 
   may-merge-e2e:
     if: always()
-    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
+    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ ubuntu-24.04, macos-14 ]
     steps:
       - name: Cleared for merging
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ opened, synchronize, labeled ]
+    types: [opened, synchronize, labeled]
   merge_group:
   workflow_dispatch:
 
@@ -71,10 +71,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-    needs: [ 'oisy-backend-wasm', 'check-e2e-changes' ]
+    needs: ['oisy-backend-wasm', 'check-e2e-changes']
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     env:
       MATRIX_OS: ${{ matrix.os }}
     if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
@@ -176,7 +176,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    needs: [ e2e ]
+    needs: [e2e]
     outputs:
       e2e-snapshots-changed: ${{ steps.e2e-check-snapshots.outputs.e2e-snapshots-changed }}
 
@@ -269,13 +269,13 @@ jobs:
 
   may-merge-e2e:
     if: always()
-    needs: [ 'check-e2e-changes', 'e2e', 'finalize-snapshots-update' ]
+    needs: ['check-e2e-changes', 'e2e', 'finalize-snapshots-update']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       matrix:
-        os: [ ubuntu-24.04, macos-14 ]
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Cleared for merging
         run: |


### PR DESCRIPTION
# Motivation

To trigger the CI that does the E2E tests for the label, we need to specify the types in the trigger for the pull requests.
