### PR TITLE
fix(frontend): tokens filter input reset button

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -31,6 +31,7 @@
 	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 	import { filterTokens, pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 	import SolManageTokenToggle from '$sol/components/tokens/SolManageTokenToggle.svelte';
@@ -148,7 +149,7 @@
 <div class="mb-4">
 	<InputSearch
 		bind:filter
-		noMatch={noTokensMatch}
+		showResetButton={!isNullishOrEmpty(filter)}
 		placeholder={$i18n.tokens.placeholder.search_token}
 		autofocus={isDesktop()}
 	/>

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { debounce, nonNullish } from '@dfinity/utils';
+	import { debounce, nonNullish, notEmptyString } from '@dfinity/utils';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import BtcManageTokenToggle from '$btc/components/tokens/BtcManageTokenToggle.svelte';
@@ -31,7 +31,6 @@
 	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 	import { filterTokens, pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 	import SolManageTokenToggle from '$sol/components/tokens/SolManageTokenToggle.svelte';
@@ -149,7 +148,7 @@
 <div class="mb-4">
 	<InputSearch
 		bind:filter
-		showResetButton={!isNullishOrEmpty(filter)}
+		showResetButton={notEmptyString(filter)}
 		placeholder={$i18n.tokens.placeholder.search_token}
 		autofocus={isDesktop()}
 	/>

--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { notEmptyString } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import NetworkSwitcherLogo from '$lib/components/networks/NetworkSwitcherLogo.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
@@ -11,7 +12,6 @@
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import { isDesktop } from '$lib/utils/device.utils';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
 	export let networkSelectorViewOnly = false;
 	export let loading: boolean;
@@ -33,7 +33,7 @@
 	<div class="mr-3 flex-1">
 		<InputSearch
 			bind:filter
-			showResetButton={!isNullishOrEmpty(filter)}
+			showResetButton={notEmptyString(filter)}
 			placeholder={$i18n.tokens.placeholder.search_token}
 			autofocus={isDesktop()}
 		/>

--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -11,6 +11,7 @@
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import { isDesktop } from '$lib/utils/device.utils';
+	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
 	export let networkSelectorViewOnly = false;
 	export let loading: boolean;
@@ -32,7 +33,7 @@
 	<div class="mr-3 flex-1">
 		<InputSearch
 			bind:filter
-			noMatch={noTokensMatch}
+			showResetButton={!isNullishOrEmpty(filter)}
 			placeholder={$i18n.tokens.placeholder.search_token}
 			autofocus={isDesktop()}
 		/>

--- a/src/frontend/src/lib/components/ui/InputSearch.svelte
+++ b/src/frontend/src/lib/components/ui/InputSearch.svelte
@@ -5,14 +5,14 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	export let filter = '';
-	export let noMatch = false;
+	export let showResetButton = false;
 	export let placeholder: string;
 	export let autofocus = false;
 </script>
 
 <InputTextWithAction name="filter" required={false} bind:value={filter} {placeholder} {autofocus}>
 	<svelte:fragment slot="inner-end">
-		{#if noMatch}
+		{#if showResetButton}
 			<button on:click={() => (filter = '')} aria-label={$i18n.core.text.clear_filter}>
 				<IconClose />
 			</button>


### PR DESCRIPTION
# Motivation

We need to show the reset button when user start typing something and not only when there are no matching tokens found.

# Changes

1. Rename the input prop.
2. Adjust its usage in ManageTokens and ModalTokensList.

# Tests

No tests affected.
