### PR TITLE
fix(frontend): tokens list adjustments and fixes

### DIFF
--- a/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
+++ b/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
@@ -5,9 +5,10 @@
 
 	export let network: Network;
 	export let selectedNetworkId: NetworkId | undefined = undefined;
+	export let delayOnNetworkSelect = true;
 
 	let usdBalance: number;
 	$: usdBalance = $enabledMainnetTokensUsdBalancesPerNetwork[network.id] ?? 0;
 </script>
 
-<NetworkComponent {network} {usdBalance} {selectedNetworkId} on:icSelected />
+<NetworkComponent {network} {usdBalance} {selectedNetworkId} {delayOnNetworkSelect} on:icSelected />

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -7,6 +7,7 @@
 	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let usdBalance: number | undefined = undefined;
 	export let testIdPrefix = NETWORKS_SWITCHER_SELECTOR;
+	export let delayOnNetworkSelect = true;
 
 	let id: NetworkId;
 	let name: string;
@@ -19,6 +20,7 @@
 	{selectedNetworkId}
 	{name}
 	{usdBalance}
+	{delayOnNetworkSelect}
 	{icon}
 	isTestnet={network.env === 'testnet'}
 	testId={`${testIdPrefix}-${id.description}`}

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -15,12 +15,15 @@
 	export let usdBalance: number | undefined = undefined;
 	export let isTestnet = false;
 	export let testId: string | undefined = undefined;
+	export let delayOnNetworkSelect = true;
 
 	const dispatch = createEventDispatcher();
 
+	const onIcSelected = () => dispatch('icSelected', id);
+
 	const onClick = () => {
-		// A small delay to give the user a visual feedback that the network is checked
-		setTimeout(() => dispatch('icSelected', id), 500);
+		// If rendered in the dropdown, we add a small delay to give the user a visual feedback that the network is checked
+		delayOnNetworkSelect ? setTimeout(onIcSelected, 500) : onIcSelected();
 	};
 </script>
 

--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -12,6 +12,7 @@
 	import type { NetworkId } from '$lib/types/network';
 
 	export let selectedNetworkId: NetworkId | undefined = undefined;
+	export let delayOnNetworkSelect = true;
 
 	let mainnetTokensUsdBalance: number;
 	$: mainnetTokensUsdBalance = $networksMainnets.reduce(
@@ -26,18 +27,19 @@
 	icon={chainFusion}
 	usdBalance={mainnetTokensUsdBalance}
 	{selectedNetworkId}
+	{delayOnNetworkSelect}
 	on:icSelected
 />
 
 <ul class="flex list-none flex-col">
 	{#each $networksMainnets as network (network.id)}
 		<li transition:slide={SLIDE_EASING}
-			><MainnetNetwork {network} {selectedNetworkId} on:icSelected /></li
+			><MainnetNetwork {network} {selectedNetworkId} {delayOnNetworkSelect} on:icSelected /></li
 		>
 	{/each}
 </ul>
 
-{#if $testnetsEnabled}
+{#if $testnetsEnabled && $networksTestnets.length}
 	<span class="my-5 flex px-3 font-bold" transition:slide={SLIDE_EASING}
 		>{$i18n.networks.test_networks}</span
 	>
@@ -45,7 +47,7 @@
 	<ul class="flex list-none flex-col" transition:slide={SLIDE_EASING}>
 		{#each $networksTestnets as network (network.id)}
 			<li transition:slide={SLIDE_EASING}
-				><Network {network} {selectedNetworkId} on:icSelected /></li
+				><Network {network} {selectedNetworkId} {delayOnNetworkSelect} on:icSelected /></li
 			>
 		{/each}
 	</ul>

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -102,7 +102,8 @@
 	bind:currentStep
 	bind:this={modal}
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
+	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING ||
+		currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
 	testId={SEND_TOKENS_MODAL}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
+	import { selectedNetwork } from '$lib/derived/network.derived';
 	import type { Token } from '$lib/types/token';
 
 	const dispatch = createEventDispatcher();
@@ -15,6 +17,11 @@
 	};
 </script>
 
-<ModalTokensList {loading} on:icSelectNetworkFilter on:icTokenButtonClick={onIcTokenButtonClick}>
+<ModalTokensList
+	{loading}
+	on:icSelectNetworkFilter
+	on:icTokenButtonClick={onIcTokenButtonClick}
+	networkSelectorViewOnly={nonNullish($selectedNetwork)}
+>
 	<ButtonCloseModal slot="toolbar" />
 </ModalTokensList>

--- a/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
@@ -29,7 +29,11 @@
 </script>
 
 <ContentWithToolbar>
-	<NetworkSwitcherList on:icSelected={onNetworkSelect} selectedNetworkId={$filterNetwork?.id} />
+	<NetworkSwitcherList
+		on:icSelected={onNetworkSelect}
+		selectedNetworkId={$filterNetwork?.id}
+		delayOnNetworkSelect={false}
+	/>
 
 	<ButtonGroup slot="toolbar">
 		<ButtonBack on:click={back} />


### PR DESCRIPTION
# Motivation

This PR implements some adjustments and improvements that were found during the testing session:

1. The network selector modal should only be closable by clicking the "Back" button.
2. The synthetic delay on network select should not be used when NetworksSwitcherList in rendered as a modal.
3. If $selectedNetwork is preselected by the user before opening the send modal, we should disable the Network filter button.
