### PR TITLE
chore(devops): pin-upload-artifact

### DIFF
--- a/.github/actions/docker-build-backend/action.yml
+++ b/.github/actions/docker-build-backend/action.yml
@@ -48,7 +48,7 @@ runs:
       shell: bash
 
     - name: 'Upload ${{ inputs.name }}'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         # name is the name used to display and retrieve the artifact
         name: ${{ inputs.name }}

--- a/.github/actions/oisy-backend/action.yml
+++ b/.github/actions/oisy-backend/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Upload backend canister WASM
       if: steps.backend-wasm-cache.outputs.cache-hit == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: backend.wasm.gz
         path: ./backend.wasm.gz

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -125,7 +125,7 @@ jobs:
         run: npm run e2e:ci
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-report-${{ matrix.os }}
@@ -133,7 +133,7 @@ jobs:
           retention-days: 3
 
       - name: Upload Playwright Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: test-results-${{ matrix.os }}
@@ -164,7 +164,7 @@ jobs:
 
       - name: Save changed snapshots
         if: steps.check_snapshots.outputs.CHANGES == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: snapshots-${{ matrix.os }}
           path: e2e/**/*.spec.ts-snapshots/**/*-${{ steps.set_snapshot_output.outputs.os_suffix }}.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: 'Upload ${{ matrix.name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.name }}
           path: ./src/${{ matrix.target }}/${{ matrix.name }}


### PR DESCRIPTION
# Motivation
Third party actions should be pinned as part of security hardening.

# Changes
- Pin upload-artifacts

# Tests
See CI