### PR TITLE
chore(devops): Use zizmor in pedantic mode

### DIFF
--- a/scripts/lint.github.sh
+++ b/scripts/lint.github.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-zizmor .github
+zizmor --persona pedantic .github


### PR DESCRIPTION
# Motivation
During the audit, it was noted that we used third party GitHub actions pinned toa version, rather than a commit, thereby making it possible for an attacker to move the tag to a different commit and so exploit our CI.

This is detected by our GitHub linter, but only in pedantic mode: https://woodruffw.github.io/zizmor/audits/#unpinned-uses

# Changes
- Run zizmor in pedantic mode.

# Tests
See CI