### PR TITLE
chore(build): remove deprecated resolution-mode in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-resolution-mode=highest


### PR DESCRIPTION
# Motivation

The experimental `resolution-mode` was deprecated in recent versions of `npm`, so we remove it from `.npmrc`.

There is no difference, since we were already using it with the default value of getting the highest version.
