### PR TITLE
fix(frontend): Logo button dividers

### DIFF
--- a/src/frontend/src/lib/components/ui/LogoButton.svelte
+++ b/src/frontend/src/lib/components/ui/LogoButton.svelte
@@ -33,7 +33,6 @@
 <div
 	class="flex"
 	class:w-full={dividers}
-	class:logo-button-list-item={dividers}
 	class:hover:bg-brand-subtle-10={hover}
 	class:rounded-lg={rounded}
 >


### PR DESCRIPTION
# Motivation

Fixes a mistake that only displays the first divider instead of all but the last one

# Changes

Removed class on logo button root div

# Tests

![image](https://github.com/user-attachments/assets/8c5bd8ed-a7cb-4494-8737-15f8ce34df5d)