### PR TITLE
refactor(frontend): Network switcher should display enabled networks depending on if testnets are enabled

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -9,13 +9,13 @@
 	import { NETWORKS_SWITCHER_DROPDOWN } from '$lib/constants/test-ids.constants';
 	import { selectedNetwork, networkId } from '$lib/derived/network.derived';
 	import { networksMainnets, networksTestnets } from '$lib/derived/networks.derived';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { SettingsModalType } from '$lib/enums/settings-modal-types';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { NetworkId } from '$lib/types/network';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
-	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 
 	export let disabled = false;
 

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { SUPPORTED_NETWORKS } from '$env/networks/networks.env';
+	import { SUPPORTED_MAINNET_NETWORKS, SUPPORTED_NETWORKS } from '$env/networks/networks.env';
 	import IconManage from '$lib/components/icons/lucide/IconManage.svelte';
 	import NetworkSwitcherList from '$lib/components/networks/NetworkSwitcherList.svelte';
 	import NetworkSwitcherLogo from '$lib/components/networks/NetworkSwitcherLogo.svelte';
@@ -15,6 +15,7 @@
 	import type { NetworkId } from '$lib/types/network';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
+	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 
 	export let disabled = false;
 
@@ -29,6 +30,17 @@
 
 		dropdown?.close();
 	};
+
+	let enabledNetworks: number;
+	$: enabledNetworks =
+		$networksMainnets.length +
+		($testnetsEnabled && $networksTestnets.length > 0 ? $networksTestnets.length : 0);
+
+	let totalNetworks: number;
+	$: totalNetworks =
+		$testnetsEnabled && $networksTestnets.length > 0
+			? SUPPORTED_NETWORKS.length
+			: SUPPORTED_MAINNET_NETWORKS.length;
 </script>
 
 <Dropdown
@@ -57,12 +69,14 @@
 					}}><IconManage />{$i18n.networks.manage}</Button
 				>
 			</span>
-			<span class="ml-4 mr-2 flex text-nowrap text-right text-base">
-				{replacePlaceholders($i18n.networks.number_of_enabled, {
-					$numNetworksEnabled: `${$networksMainnets.length + $networksTestnets.length}`,
-					$numNetworksTotal: `${SUPPORTED_NETWORKS.length}`
-				})}</span
-			>
+			{#if enabledNetworks < totalNetworks}
+				<span class="ml-4 mr-2 flex text-nowrap text-right text-base">
+					{replacePlaceholders($i18n.networks.number_of_enabled, {
+						$numNetworksEnabled: `${enabledNetworks}`,
+						$numNetworksTotal: `${totalNetworks}`
+					})}
+				</span>
+			{/if}
 		</div>
 	</div>
 </Dropdown>


### PR DESCRIPTION
# Motivation

If we have no testnets enabled, we shouldnt show n of 10 networks enabled, but consider the total to be only the amount of mainnets.

Only if testnets and at least one of the them is enabled, we display n of 10 (all supported) networks.

Also, if all are selected we dont display the count at all.

# Changes

Changes logic on when and how to display.

# Tests

Case 1 - testnets disabled, all mainnets enabled
![image](https://github.com/user-attachments/assets/68058cf9-8bdc-46d7-ad4e-1f9a7275eb1e)
![image](https://github.com/user-attachments/assets/b8857403-9e6c-4b45-a7c7-493bf4d7c0fa)

Case 2 - testnets disabled, 3/4 mainnets enabled
![image](https://github.com/user-attachments/assets/92a9b2f6-1582-42b4-8d74-78679b0f2b0e)
![image](https://github.com/user-attachments/assets/a8a29820-a3f0-4db3-802e-068e692e6e22)

Case 3 - testnets enabled, but not individual testnets enabled:
![image](https://github.com/user-attachments/assets/29e597d0-6c44-4b4d-9b0a-ac75a2b3b293)
![image](https://github.com/user-attachments/assets/e9617904-ca22-4124-a702-f4a5c2e277ad)

Case 4 - testnets enabled, a few individual testnets enabled as well:
![image](https://github.com/user-attachments/assets/e8f5bdb3-ab99-4c9c-8d76-d18158c6ed09)
![image](https://github.com/user-attachments/assets/7dbba6c6-873b-455c-bcb0-b85ab8afde6f)

Case 5 - testnets enabled, all individual testnets enabled:
![image](https://github.com/user-attachments/assets/c7ad3111-7799-4de4-adaa-4d7ce3502873)
![image](https://github.com/user-attachments/assets/720bcd30-cf42-4be9-a7fc-a9a015a505e3)
