### PR TITLE
style(frontend): increase fonts for Network filter labels

### DIFF
--- a/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
+++ b/src/frontend/src/lib/components/networks/MainnetNetwork.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
 	import NetworkComponent from '$lib/components/networks/Network.svelte';
 	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
+	import type { LabelSize } from '$lib/types/components';
 	import type { Network, NetworkId } from '$lib/types/network';
 
 	export let network: Network;
 	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let delayOnNetworkSelect = true;
+	export let labelsSize: LabelSize = 'md';
 
 	let usdBalance: number;
 	$: usdBalance = $enabledMainnetTokensUsdBalancesPerNetwork[network.id] ?? 0;
 </script>
 
-<NetworkComponent {network} {usdBalance} {selectedNetworkId} {delayOnNetworkSelect} on:icSelected />
+<NetworkComponent
+	{network}
+	{usdBalance}
+	{selectedNetworkId}
+	{delayOnNetworkSelect}
+	{labelsSize}
+	on:icSelected
+/>

--- a/src/frontend/src/lib/components/networks/Network.svelte
+++ b/src/frontend/src/lib/components/networks/Network.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import NetworkButton from '$lib/components/networks/NetworkButton.svelte';
 	import { NETWORKS_SWITCHER_SELECTOR } from '$lib/constants/test-ids.constants';
+	import type { LabelSize } from '$lib/types/components';
 	import type { Network, NetworkId } from '$lib/types/network';
 
 	export let network: Network;
@@ -8,6 +9,7 @@
 	export let usdBalance: number | undefined = undefined;
 	export let testIdPrefix = NETWORKS_SWITCHER_SELECTOR;
 	export let delayOnNetworkSelect = true;
+	export let labelsSize: LabelSize = 'md';
 
 	let id: NetworkId;
 	let name: string;
@@ -22,6 +24,7 @@
 	{usdBalance}
 	{delayOnNetworkSelect}
 	{icon}
+	{labelsSize}
 	isTestnet={network.env === 'testnet'}
 	testId={`${testIdPrefix}-${id.description}`}
 	on:icSelected

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -5,6 +5,7 @@
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { LabelSize } from '$lib/types/components';
 	import type { NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
 
@@ -16,6 +17,7 @@
 	export let isTestnet = false;
 	export let testId: string | undefined = undefined;
 	export let delayOnNetworkSelect = true;
+	export let labelsSize: LabelSize = 'md';
 
 	const dispatch = createEventDispatcher();
 
@@ -30,14 +32,23 @@
 <LogoButton {testId} on:click={onClick} selectable selected={id === selectedNetworkId} dividers>
 	<Logo slot="logo" src={icon} />
 
-	<span slot="title" class="mr-2 text-sm font-normal md:text-base">
+	<span
+		slot="title"
+		class="mr-2 font-normal md:text-base"
+		class:text-sm={labelsSize === 'md'}
+		class:md:text-base={labelsSize === 'md'}
+		class:text-base={labelsSize === 'lg'}
+		class:md:text-lg={labelsSize === 'lg'}
+	>
 		{name}
 	</span>
 
 	<span slot="description-end">
-		{#if nonNullish(usdBalance)}
-			{formatUSD({ value: usdBalance })}
-		{/if}
+		<span class:text-sm={labelsSize === 'lg'} class:md:text-base={labelsSize === 'lg'}>
+			{#if nonNullish(usdBalance)}
+				{formatUSD({ value: usdBalance })}
+			{/if}
+		</span>
 
 		{#if isTestnet}
 			<span class="inline-flex">

--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -9,10 +9,12 @@
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { enabledMainnetTokensUsdBalancesPerNetwork } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { LabelSize } from '$lib/types/components';
 	import type { NetworkId } from '$lib/types/network';
 
 	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let delayOnNetworkSelect = true;
+	export let labelsSize: LabelSize = 'md';
 
 	let mainnetTokensUsdBalance: number;
 	$: mainnetTokensUsdBalance = $networksMainnets.reduce(
@@ -28,13 +30,20 @@
 	usdBalance={mainnetTokensUsdBalance}
 	{selectedNetworkId}
 	{delayOnNetworkSelect}
+	{labelsSize}
 	on:icSelected
 />
 
 <ul class="flex list-none flex-col">
 	{#each $networksMainnets as network (network.id)}
 		<li class="logo-button-list-item" transition:slide={SLIDE_EASING}
-			><MainnetNetwork {network} {selectedNetworkId} {delayOnNetworkSelect} on:icSelected /></li
+			><MainnetNetwork
+				{network}
+				{selectedNetworkId}
+				{delayOnNetworkSelect}
+				{labelsSize}
+				on:icSelected
+			/></li
 		>
 	{/each}
 </ul>
@@ -47,7 +56,13 @@
 	<ul class="flex list-none flex-col" transition:slide={SLIDE_EASING}>
 		{#each $networksTestnets as network (network.id)}
 			<li class="logo-button-list-item" transition:slide={SLIDE_EASING}
-				><Network {network} {selectedNetworkId} {delayOnNetworkSelect} on:icSelected /></li
+				><Network
+					{network}
+					{selectedNetworkId}
+					{delayOnNetworkSelect}
+					{labelsSize}
+					on:icSelected
+				/></li
 			>
 		{/each}
 	</ul>

--- a/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
@@ -33,6 +33,7 @@
 		on:icSelected={onNetworkSelect}
 		selectedNetworkId={$filterNetwork?.id}
 		delayOnNetworkSelect={false}
+		labelsSize="lg"
 	/>
 
 	<ButtonGroup slot="toolbar">

--- a/src/frontend/src/lib/types/components.ts
+++ b/src/frontend/src/lib/types/components.ts
@@ -1,3 +1,5 @@
 export type Size = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
+export type LabelSize = 'md' | 'lg';
+
 export type LogoSize = Size;


### PR DESCRIPTION
# Motivation

As requested by the design team, we need to increate some fonts in the ModalNetworksFilter component. The global NetworksSwitcher should stay unaffected.

<img width="559" alt="Screenshot 2025-04-02 at 16 55 28" src="https://github.com/user-attachments/assets/6a76175d-c63b-420e-b537-2a8392fc6cfa" />
