### PR TITLE
refactor(frontend): replace duplicated util formatTokenAmount

### DIFF
--- a/src/frontend/src/lib/components/fee/FeeDisplay.svelte
+++ b/src/frontend/src/lib/components/fee/FeeDisplay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import ConvertAmountDisplay from '$lib/components/convert/ConvertAmountDisplay.svelte';
-	import { formatTokenAmount } from '$lib/utils/format.utils';
+	import { formatToken } from '$lib/utils/format.utils';
 
 	export let feeAmount: bigint | undefined = undefined;
 	export let symbol: string;
@@ -12,7 +12,7 @@
 
 	let formattedFeeAmount: string | undefined;
 	$: formattedFeeAmount = nonNullish(feeAmount)
-		? formatTokenAmount({ value: feeAmount, unitName: decimals, displayDecimals: decimals })
+		? formatToken({ value: feeAmount, unitName: decimals, displayDecimals: decimals })
 		: undefined;
 </script>
 
@@ -22,5 +22,6 @@
 	{symbol}
 	{zeroAmountLabel}
 	{displayExchangeRate}
-	><slot slot="label" name="label" />
+>
+	<slot slot="label" name="label" />
 </ConvertAmountDisplay>

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -21,10 +21,10 @@
 	$: sourceTokenTransferFeeDisplay =
 		nonNullish($sourceToken) && nonNullish($icTokenFeeStore?.[$sourceToken.symbol])
 			? formatToken({
-				value: $icTokenFeeStore[$sourceToken.symbol],
-				displayDecimals: $sourceToken.decimals,
-				unitName: $sourceToken.decimals
-			})
+					value: $icTokenFeeStore[$sourceToken.symbol],
+					displayDecimals: $sourceToken.decimals,
+					unitName: $sourceToken.decimals
+				})
 			: '0';
 
 	let sourceTokenTransferFee: number;

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -10,7 +10,7 @@
 	import { EXCHANGE_USD_AMOUNT_THRESHOLD } from '$lib/constants/exchange.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
-	import { formatTokenAmount, formatUSD } from '$lib/utils/format.utils';
+	import { formatToken, formatUSD } from '$lib/utils/format.utils';
 
 	const { destinationToken, sourceToken, sourceTokenExchangeRate, isSourceTokenIcrc2 } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
@@ -20,11 +20,11 @@
 	let sourceTokenTransferFeeDisplay: string;
 	$: sourceTokenTransferFeeDisplay =
 		nonNullish($sourceToken) && nonNullish($icTokenFeeStore?.[$sourceToken.symbol])
-			? formatTokenAmount({
-					value: $icTokenFeeStore[$sourceToken.symbol],
-					displayDecimals: $sourceToken.decimals,
-					unitName: $sourceToken.decimals
-				})
+			? formatToken({
+				value: $icTokenFeeStore[$sourceToken.symbol],
+				displayDecimals: $sourceToken.decimals,
+				unitName: $sourceToken.decimals
+			})
 			: '0';
 
 	let sourceTokenTransferFee: number;

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -15,10 +15,6 @@ interface FormatTokenParams {
 	showPlusSign?: boolean;
 }
 
-type FormatTokenAmountParams = Omit<FormatTokenParams, 'value'> & {
-	value: bigint;
-};
-
 export const formatToken = ({
 	value,
 	unitName = ETHEREUM_DEFAULT_DECIMALS,
@@ -40,15 +36,8 @@ export const formatToken = ({
 	return `${showPlusSign && +res > 0 ? '+' : ''}${formatted}`;
 };
 
-// TODO: remove this function since it is duplicated of formatToken
-export const formatTokenAmount = ({ value, ...restParams }: FormatTokenAmountParams): string =>
-	formatToken({
-		value,
-		...restParams
-	});
-
-export const formatTokenBigintToNumber = (params: FormatTokenAmountParams): number =>
-	Number(formatTokenAmount(params));
+export const formatTokenBigintToNumber = (params: FormatTokenParams): number =>
+	Number(formatToken(params));
 
 /**
  * Shortens the text from the middle. Ex: "12345678901234567890" -> "1234567...5678901"


### PR DESCRIPTION
# Motivation

Util `formatTokenAmount` is a duplicated of `formatToken`, so we replace the first with the latter.
