### PR TITLE
refactor(frontend): explicit type for method transactions of class EtherscanRest

### DIFF
--- a/src/frontend/src/eth/rest/etherscan.rest.ts
+++ b/src/frontend/src/eth/rest/etherscan.rest.ts
@@ -57,18 +57,14 @@ export class EtherscanRest {
 				gasPrice,
 				hash,
 				blockNumber,
-				blockHash,
 				timeStamp,
-				confirmations,
 				from,
 				to,
 				value
-			}) => ({
+			}: EtherscanRestTransaction): Transaction => ({
 				hash,
 				blockNumber: parseInt(blockNumber),
-				blockHash,
 				timestamp: parseInt(timeStamp),
-				confirmations,
 				from,
 				to,
 				nonce: parseInt(nonce),

--- a/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
+++ b/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
@@ -74,9 +74,7 @@ describe('etherscan.rest', () => {
 				{
 					hash: '0x123abc',
 					blockNumber: 123456,
-					blockHash: '0x456def',
 					timestamp: 1697049600,
-					confirmations: '10',
 					from: '0xabc...',
 					to: '0xdef...',
 					nonce: 1,


### PR DESCRIPTION
# Motivation

To be more type-safe, we explicitly set the type of the mapper in method `transactions` of class `EtherscanRest`, and clean the unnecessary values.
