### PR TITLE
fix(frontend): remove race condition from Loader component

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -208,9 +208,9 @@
 {/if}
 
 <style>
-    :root:has(.login-modal) {
-        --alert-max-width: 90vw;
-        --alert-max-height: initial;
-        --dialog-border-radius: calc(var(--border-radius-sm) * 3);
-    }
+	:root:has(.login-modal) {
+		--alert-max-width: 90vw;
+		--alert-max-height: initial;
+		--dialog-border-radius: calc(var(--border-radius-sm) * 3);
+	}
 </style>

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -108,8 +108,6 @@
 
 	let progressModal = false;
 
-	let initiatingLoader = true;
-
 	const debounceLoadEthAddress = debounce(loadEthAddress);
 
 	const debounceLoadBtcAddressMainnet = debounce(loadBtcAddressMainnet);
@@ -121,7 +119,7 @@
 	const debounceLoadSolAddressDevnet = debounce(loadSolAddressDevnet);
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
-	$: if (!initiatingLoader) {
+	$: if (progressStep === ProgressStepsLoader.DONE) {
 		if ($networkEthereumEnabled && isNullish($ethAddress)) {
 			debounceLoadEthAddress();
 		}
@@ -170,16 +168,12 @@
 	};
 
 	onMount(async () => {
-		initiatingLoader = true;
-
 		await initLoader({
 			identity: $authIdentity,
 			validateAddresses,
 			progressAndLoad,
 			setProgressModal
 		});
-
-		initiatingLoader = false;
 	});
 </script>
 
@@ -214,9 +208,9 @@
 {/if}
 
 <style>
-	:root:has(.login-modal) {
-		--alert-max-width: 90vw;
-		--alert-max-height: initial;
-		--dialog-border-radius: calc(var(--border-radius-sm) * 3);
-	}
+    :root:has(.login-modal) {
+        --alert-max-width: 90vw;
+        --alert-max-height: initial;
+        --dialog-border-radius: calc(var(--border-radius-sm) * 3);
+    }
 </style>

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -108,6 +108,8 @@
 
 	let progressModal = false;
 
+	let initiatingLoader = true;
+
 	const debounceLoadEthAddress = debounce(loadEthAddress);
 
 	const debounceLoadBtcAddressMainnet = debounce(loadBtcAddressMainnet);
@@ -119,7 +121,7 @@
 	const debounceLoadSolAddressDevnet = debounce(loadSolAddressDevnet);
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
-	$: {
+	$: if (!initiatingLoader) {
 		if ($networkEthereumEnabled && isNullish($ethAddress)) {
 			debounceLoadEthAddress();
 		}
@@ -168,12 +170,16 @@
 	};
 
 	onMount(async () => {
+		initiatingLoader = true;
+
 		await initLoader({
 			identity: $authIdentity,
 			validateAddresses,
 			progressAndLoad,
 			setProgressModal
 		});
+
+		initiatingLoader = false;
 	});
 </script>
 

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -147,7 +147,7 @@ describe('Loader', () => {
 	it('should not call any address loaders', async () => {
 		setupTestnetsStore('enabled');
 		setupUserNetworksStore('allEnabled');
-		
+
 		vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
 
 		render(Loader);

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -144,32 +144,10 @@ describe('Loader', () => {
 		});
 	});
 
-	it('should not call any address loaders', async () => {
-		setupTestnetsStore('enabled');
-		setupUserNetworksStore('allEnabled');
-
-		vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
-
-		render(Loader);
-
-		await waitFor(() => {
-			expect(loadEthAddress).not.toHaveBeenCalled();
-			expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
-			expect(loadSolAddressMainnet).not.toHaveBeenCalled();
-
-			expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
-			expect(loadSolAddressTestnet).not.toHaveBeenCalled();
-			expect(loadSolAddressDevnet).not.toHaveBeenCalled();
-
-			expect(loadBtcAddressRegtest).not.toHaveBeenCalled();
-			expect(loadSolAddressLocal).not.toHaveBeenCalled();
-		});
-	});
-
 	describe('while loading', () => {
 		beforeEach(() => {
 			loading.set(true);
-			vi.mocked(initLoader).mockImplementation(
+			vi.mocked(initLoader).mockImplementationOnce(
 				async ({ setProgressModal }: { setProgressModal: (value: boolean) => void }) => {
 					setProgressModal(true);
 					await Promise.resolve();
@@ -195,6 +173,28 @@ describe('Loader', () => {
 			await waitFor(() => {
 				const banner = getByAltText(altText);
 				expect(banner).toBeInTheDocument();
+			});
+		});
+
+		it('should not call any address loaders', async () => {
+			setupTestnetsStore('enabled');
+			setupUserNetworksStore('allEnabled');
+
+			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
+
+			render(Loader);
+
+			await waitFor(() => {
+				expect(loadEthAddress).not.toHaveBeenCalled();
+				expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
+				expect(loadSolAddressMainnet).not.toHaveBeenCalled();
+
+				expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
+				expect(loadSolAddressTestnet).not.toHaveBeenCalled();
+				expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+
+				expect(loadBtcAddressRegtest).not.toHaveBeenCalled();
+				expect(loadSolAddressLocal).not.toHaveBeenCalled();
 			});
 		});
 	});
@@ -265,10 +265,10 @@ describe('Loader', () => {
 			});
 
 			it('should call loaders only for the enabled mainnet networks', async () => {
+				setupUserNetworksStore('allDisabled');
+
 				render(Loader);
 
-				// Toggle the reactive statement
-				setupUserNetworksStore('allDisabled');
 				userProfileStore.set({
 					certified: false,
 					profile: {
@@ -302,10 +302,10 @@ describe('Loader', () => {
 			});
 
 			it('should call loaders only for the enabled networks', async () => {
+				setupUserNetworksStore('allDisabled');
+
 				render(Loader);
 
-				// Toggle the reactive statement
-				setupUserNetworksStore('allDisabled');
 				userProfileStore.set({
 					certified: false,
 					profile: {
@@ -335,10 +335,10 @@ describe('Loader', () => {
 			});
 
 			it('should call testnet loaders if addresses are not loaded yet', async () => {
+				setupUserNetworksStore('allDisabled');
+
 				render(Loader);
 
-				// Toggle the reactive statement
-				setupUserNetworksStore('allDisabled');
 				setupUserNetworksStore('allEnabled');
 
 				await waitFor(() => {

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -144,7 +144,7 @@ describe('Loader', () => {
 		});
 	});
 
-	it('should not call only any address loaders', async () => {
+	it('should not call any address loaders', async () => {
 		setupTestnetsStore('disabled');
 		setupUserNetworksStore('allEnabled');
 

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -145,8 +145,10 @@ describe('Loader', () => {
 	});
 
 	it('should not call any address loaders', async () => {
-		setupTestnetsStore('disabled');
+		setupTestnetsStore('enabled');
 		setupUserNetworksStore('allEnabled');
+		
+		vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
 
 		render(Loader);
 

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -144,6 +144,26 @@ describe('Loader', () => {
 		});
 	});
 
+	it('should not call only any address loaders', async () => {
+		setupTestnetsStore('disabled');
+		setupUserNetworksStore('allEnabled');
+
+		render(Loader);
+
+		await waitFor(() => {
+			expect(loadEthAddress).not.toHaveBeenCalled();
+			expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
+			expect(loadSolAddressMainnet).not.toHaveBeenCalled();
+
+			expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
+			expect(loadSolAddressTestnet).not.toHaveBeenCalled();
+			expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+
+			expect(loadBtcAddressRegtest).not.toHaveBeenCalled();
+			expect(loadSolAddressLocal).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('while loading', () => {
 		beforeEach(() => {
 			loading.set(true);
@@ -204,33 +224,49 @@ describe('Loader', () => {
 				setupTestnetsStore('disabled');
 			});
 
-			it('should call only mainnet loaders if addresses are not loaded yet', () => {
+			it('should call only mainnet loaders if addresses are not loaded yet', async () => {
 				setupTestnetsStore('disabled');
 
 				render(Loader);
 
-				expect(loadEthAddress).toHaveBeenCalledOnce();
-				expect(loadBtcAddressMainnet).toHaveBeenCalledOnce();
-				expect(loadSolAddressMainnet).toHaveBeenCalledOnce();
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
+				setupUserNetworksStore('onlyMainnets');
 
-				expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
-				expect(loadSolAddressTestnet).not.toHaveBeenCalled();
-				expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+				await waitFor(() => {
+					expect(loadEthAddress).toHaveBeenCalledOnce();
+					expect(loadBtcAddressMainnet).toHaveBeenCalledOnce();
+					expect(loadSolAddressMainnet).toHaveBeenCalledOnce();
+
+					expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
+					expect(loadSolAddressTestnet).not.toHaveBeenCalled();
+					expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+				});
 			});
 
-			it('should not call loaders if addresses are already loaded', () => {
+			it('should not call loaders if addresses are already loaded', async () => {
 				ethAddressStore.set({ data: mockEthAddress, certified: false });
 				btcAddressMainnetStore.set({ data: mockBtcAddress, certified: false });
 				solAddressMainnetStore.set({ data: mockSolAddress, certified: false });
 
 				render(Loader);
 
-				expect(loadEthAddress).not.toHaveBeenCalled();
-				expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
-				expect(loadSolAddressMainnet).not.toHaveBeenCalled();
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
+				setupUserNetworksStore('onlyMainnets');
+
+				await waitFor(() => {
+					expect(loadEthAddress).not.toHaveBeenCalled();
+					expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
+					expect(loadSolAddressMainnet).not.toHaveBeenCalled();
+				});
 			});
 
-			it('should call loaders only for the enabled mainnet networks', () => {
+			it('should call loaders only for the enabled mainnet networks', async () => {
+				render(Loader);
+
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
 				userProfileStore.set({
 					certified: false,
 					profile: {
@@ -249,10 +285,10 @@ describe('Loader', () => {
 					}
 				});
 
-				render(Loader);
-
-				expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
-				expect(loadSolAddressMainnet).toHaveBeenCalledOnce();
+				await waitFor(() => {
+					expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
+					expect(loadSolAddressMainnet).toHaveBeenCalledOnce();
+				});
 			});
 		});
 
@@ -263,7 +299,11 @@ describe('Loader', () => {
 				setupTestnetsStore('enabled');
 			});
 
-			it('should call loaders only for the enabled networks', () => {
+			it('should call loaders only for the enabled networks', async () => {
+				render(Loader);
+
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
 				userProfileStore.set({
 					certified: false,
 					profile: {
@@ -284,27 +324,33 @@ describe('Loader', () => {
 					}
 				});
 
-				render(Loader);
-
-				expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
-				expect(loadSolAddressMainnet).toHaveBeenCalledOnce();
-				expect(loadSolAddressTestnet).toHaveBeenCalledOnce();
-				expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+				await waitFor(() => {
+					expect(loadBtcAddressMainnet).not.toHaveBeenCalled();
+					expect(loadSolAddressMainnet).toHaveBeenCalledOnce();
+					expect(loadSolAddressTestnet).toHaveBeenCalledOnce();
+					expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+				});
 			});
 
-			it('should call testnet loaders if addresses are not loaded yet', () => {
+			it('should call testnet loaders if addresses are not loaded yet', async () => {
 				render(Loader);
 
-				expect(loadEthAddress).toHaveBeenCalledOnce();
-				expect(loadBtcAddressTestnet).toHaveBeenCalledOnce();
-				expect(loadSolAddressTestnet).toHaveBeenCalledOnce();
-				expect(loadSolAddressDevnet).toHaveBeenCalledOnce();
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
+				setupUserNetworksStore('allEnabled');
 
-				expect(loadBtcAddressRegtest).not.toHaveBeenCalled();
-				expect(loadSolAddressLocal).not.toHaveBeenCalled();
+				await waitFor(() => {
+					expect(loadEthAddress).toHaveBeenCalledOnce();
+					expect(loadBtcAddressTestnet).toHaveBeenCalledOnce();
+					expect(loadSolAddressTestnet).toHaveBeenCalledOnce();
+					expect(loadSolAddressDevnet).toHaveBeenCalledOnce();
+
+					expect(loadBtcAddressRegtest).not.toHaveBeenCalled();
+					expect(loadSolAddressLocal).not.toHaveBeenCalled();
+				});
 			});
 
-			it('should not call loaders if addresses are already loaded', () => {
+			it('should not call loaders if addresses are already loaded', async () => {
 				ethAddressStore.set({ data: mockEthAddress, certified: false });
 				btcAddressTestnetStore.set({ data: mockBtcAddress, certified: false });
 				solAddressTestnetStore.set({ data: mockSolAddress, certified: false });
@@ -312,19 +358,31 @@ describe('Loader', () => {
 
 				render(Loader);
 
-				expect(loadEthAddress).not.toHaveBeenCalled();
-				expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
-				expect(loadSolAddressTestnet).not.toHaveBeenCalled();
-				expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
+				setupUserNetworksStore('allEnabled');
+
+				await waitFor(() => {
+					expect(loadEthAddress).not.toHaveBeenCalled();
+					expect(loadBtcAddressTestnet).not.toHaveBeenCalled();
+					expect(loadSolAddressTestnet).not.toHaveBeenCalled();
+					expect(loadSolAddressDevnet).not.toHaveBeenCalled();
+				});
 			});
 
-			it('should call local addresses loaders when in local env', () => {
+			it('should call local addresses loaders when in local env', async () => {
 				vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
 
 				render(Loader);
 
-				expect(loadBtcAddressRegtest).toHaveBeenCalledOnce();
-				expect(loadSolAddressLocal).toHaveBeenCalledOnce();
+				// Toggle the reactive statement
+				setupUserNetworksStore('allDisabled');
+				setupUserNetworksStore('allEnabled');
+
+				await waitFor(() => {
+					expect(loadBtcAddressRegtest).toHaveBeenCalledOnce();
+					expect(loadSolAddressLocal).toHaveBeenCalledOnce();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

The `Loader` component should await initialization before running the reactive statement. Otherwise there will be a race condition where the component is trying to load the addresses but the signer allowance is not initialized yet:

![Screenshot 2025-04-03 at 08 31 01](https://github.com/user-attachments/assets/de9486a7-c784-41eb-9319-bc19e7d0e1c2)

