### PR TITLE
feat(frontend): added plausible service

### DIFF
--- a/src/frontend/src/env/plausible.env.ts
+++ b/src/frontend/src/env/plausible.env.ts
@@ -1,0 +1,1 @@
+export const PLAUSIBLE_DOMAIN = 'oisy.com';

--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -1,7 +1,12 @@
+import { PLAUSIBLE_DOMAIN } from '$env/plausible.env';
 import { PROD } from '$lib/constants/app.constants';
 import type { TrackEventParams } from '$lib/types/analytics';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { initOrbiter, trackEvent as trackEventOrbiter } from '@junobuild/analytics';
+import Plausible from 'plausible-tracker';
+
+const domain = PLAUSIBLE_DOMAIN;
+let plausibleTracker: ReturnType<typeof Plausible> | null = null;
 
 export const initAnalytics = async () => {
 	if (!PROD) {
@@ -27,9 +32,28 @@ export const initAnalytics = async () => {
 	});
 };
 
+export const initPlausibleAnalytics = () => {
+	if (!PROD) {
+		return;
+	}
+
+	if (isNullish(plausibleTracker)) {
+		plausibleTracker = Plausible({
+			domain,
+			hashMode: false,
+			trackLocalhost: false
+		});
+		plausibleTracker.enableAutoPageviews();
+	}
+};
+
 export const trackEvent = async ({ name, metadata }: TrackEventParams) => {
 	if (!PROD) {
 		return;
+	}
+
+	if (nonNullish(plausibleTracker)) {
+		plausibleTracker.trackEvent(name, { props: metadata });
 	}
 
 	await trackEventOrbiter({

--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -5,7 +5,6 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 import { initOrbiter, trackEvent as trackEventOrbiter } from '@junobuild/analytics';
 import Plausible from 'plausible-tracker';
 
-const domain = PLAUSIBLE_DOMAIN;
 let plausibleTracker: ReturnType<typeof Plausible> | null = null;
 
 export const initAnalytics = async () => {
@@ -39,7 +38,7 @@ export const initPlausibleAnalytics = () => {
 
 	if (isNullish(plausibleTracker)) {
 		plausibleTracker = Plausible({
-			domain,
+			domain: PLAUSIBLE_DOMAIN,
 			hashMode: false,
 			trackLocalhost: false
 		});

--- a/src/frontend/src/tests/lib/services/analytics.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/analytics.service.spec.ts
@@ -1,0 +1,85 @@
+import type { TrackEventParams } from '$lib/types/analytics';
+import Plausible from 'plausible-tracker';
+
+const trackEventMock = vi.fn();
+const enableAutoPageviews = vi.fn();
+
+vi.mock('plausible-tracker', () => ({
+	default: vi.fn(() => ({
+		enableAutoPageviews,
+		trackEvent: trackEventMock
+	}))
+}));
+
+vi.mock('$lib/constants/app.constants', () => ({
+	PROD: true
+}));
+
+describe('plausible analytics service', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it('should initialize Plausible with correct config', async () => {
+		const { PLAUSIBLE_DOMAIN } = await import('$env/plausible.env');
+		const { initPlausibleAnalytics } = await import('$lib/services/analytics.services');
+
+		initPlausibleAnalytics();
+
+		expect(Plausible).toHaveBeenCalledWith({
+			domain: PLAUSIBLE_DOMAIN,
+			hashMode: false,
+			trackLocalhost: false
+		});
+	});
+
+	it('should enable auto pageviews', async () => {
+		const { initPlausibleAnalytics } = await import('$lib/services/analytics.services');
+
+		expect(enableAutoPageviews).toHaveBeenCalledTimes(0);
+
+		initPlausibleAnalytics();
+
+		expect(enableAutoPageviews).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call trackEvent if tracker is initialized', async () => {
+		const { trackEvent, initPlausibleAnalytics } = await import('$lib/services/analytics.services');
+
+		initPlausibleAnalytics();
+
+		const params: TrackEventParams = {
+			name: 'test_event_name',
+			metadata: { eventName: 'eventValue' }
+		};
+
+		await trackEvent(params);
+
+		expect(trackEventMock).toHaveBeenCalledWith('test_event_name', {
+			props: { eventName: 'eventValue' }
+		});
+	});
+
+	it('should NOT call trackEvent or init anything if PROD is false', async () => {
+		vi.doMock('$lib/constants/app.constants', () => ({
+			PROD: false
+		}));
+
+		const { initPlausibleAnalytics, trackEvent } = await import('$lib/services/analytics.services');
+
+		initPlausibleAnalytics();
+
+		expect(Plausible).not.toHaveBeenCalled();
+		expect(enableAutoPageviews).not.toHaveBeenCalled();
+
+		const params: TrackEventParams = {
+			name: 'test_event_name',
+			metadata: { eventName: 'eventValue' }
+		};
+
+		await trackEvent(params);
+
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
# Motivation

We aim to track analytics using Plausible. The goal is to ensure that pageviews and custom events are tracked correctly across the app.

# Changes

Integrated plausible-tracker

# Tests

Added unit tests for initPlausibleAnalytics and trackEvent
