### PR TITLE
feat(frontend): change value type of Ethereum transaction from BigNumber to BigInt

### DIFF
--- a/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
@@ -34,7 +34,7 @@ export class AlchemyErc20Provider {
 	}: {
 		contract: Erc20Token;
 		address: EthAddress;
-		listener: (params: { hash: string; value: BigNumber }) => Promise<void>;
+		listener: (params: { hash: string; value: bigint }) => Promise<void>;
 	}): WebSocketListener => {
 		const erc20Contract = new ethers.Contract(contract.address, ERC20_ABI, this.provider);
 
@@ -47,7 +47,7 @@ export class AlchemyErc20Provider {
 		) => {
 			const { transactionHash: hash, args } = transaction;
 			const [_from_, _to_, value] = args;
-			await listener({ hash, value });
+			await listener({ hash, value: value?.toBigInt() });
 		};
 
 		const filterToAddress = erc20Contract.filters.Transfer(null, address);

--- a/src/frontend/src/eth/rest/etherscan.rest.ts
+++ b/src/frontend/src/eth/rest/etherscan.rest.ts
@@ -70,7 +70,7 @@ export class EtherscanRest {
 				nonce: parseInt(nonce),
 				gasLimit: BigNumber.from(gas),
 				gasPrice: BigNumber.from(gasPrice),
-				value: BigNumber.from(value),
+				value: BigNumber.from(value).toBigInt(),
 				// Chain ID is not delivered by the Etherscan API so, we naively set 0
 				chainId: 0
 			})

--- a/src/frontend/src/eth/services/eth-listener.services.ts
+++ b/src/frontend/src/eth/services/eth-listener.services.ts
@@ -10,7 +10,6 @@ import type { EthAddress } from '$lib/types/address';
 import type { WebSocketListener } from '$lib/types/listener';
 import type { NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
-import type { BigNumber } from '@ethersproject/bignumber';
 
 export const initTransactionsListener = ({
 	token,
@@ -33,7 +32,7 @@ export const initTransactionsListener = ({
 
 	return initErc20PendingTransactionsListenerProvider({
 		address,
-		listener: async (params: { hash: string; value: BigNumber }) =>
+		listener: async (params: { hash: string; value: bigint }) =>
 			await processErc20Transaction({ token, ...params, type: 'mined' }),
 		contract: token as Erc20Token
 	});

--- a/src/frontend/src/eth/services/eth-transaction.services.ts
+++ b/src/frontend/src/eth/services/eth-transaction.services.ts
@@ -11,7 +11,6 @@ import type { Token } from '$lib/types/token';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { TransactionResponse } from '@ethersproject/abstract-provider';
-import type { BigNumber } from '@ethersproject/bignumber';
 import { get } from 'svelte/store';
 
 export const processTransactionSent = async ({
@@ -40,7 +39,7 @@ export const processErc20Transaction = async ({
 	...rest
 }: {
 	hash: string;
-	value: BigNumber;
+	value: bigint;
 	token: Token;
 	type: 'pending' | 'mined';
 }) => {
@@ -59,7 +58,7 @@ const processPendingTransaction = async ({
 }: {
 	hash: string;
 	token: Token;
-	value?: BigNumber;
+	value?: bigint;
 }) => {
 	const {
 		id: tokenId,

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -68,9 +68,19 @@ const loadEthTransactions = async ({
 		const transactions = await transactionsProviders({ address });
 
 		if (updateOnly) {
-			transactions.forEach((transaction) => ethTransactionsStore.update({ tokenId, transaction }));
+			// TODO: De-deconstruct the transactions when we upgrade to ethers v6
+			transactions.forEach(({ value, ...rest }) =>
+				ethTransactionsStore.update({ tokenId, transaction: { ...rest, value: value.toBigInt() } })
+			);
 		} else {
-			ethTransactionsStore.set({ tokenId, transactions });
+			ethTransactionsStore.set({
+				tokenId,
+				// TODO: Remove the mapping of the transactions when we upgrade to ethers v6
+				transactions: transactions.map(({ value, ...rest }) => ({
+					...rest,
+					value: value.toBigInt()
+				}))
+			});
 		}
 	} catch (err: unknown) {
 		ethTransactionsStore.nullify(tokenId);

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -12,7 +12,6 @@ import type { NetworkId } from '$lib/types/network';
 import type { OptionString } from '$lib/types/string';
 import type { Transaction } from '$lib/types/transaction';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { BigNumber } from '@ethersproject/bignumber';
 import { ethers } from 'ethers';
 
 export const isTransactionPending = ({ blockNumber }: EthTransactionUi): boolean =>
@@ -21,13 +20,13 @@ export const isTransactionPending = ({ blockNumber }: EthTransactionUi): boolean
 export const isErc20TransactionApprove = (data: string | undefined): boolean =>
 	nonNullish(data) && data.startsWith(ERC20_APPROVE_HASH);
 
-export const decodeErc20AbiDataValue = (data: string): BigNumber => {
+export const decodeErc20AbiDataValue = (data: string): bigint => {
 	const [_to, value] = ethers.utils.defaultAbiCoder.decode(
 		['address', 'uint256'],
 		ethers.utils.hexDataSlice(data, 4)
 	);
 
-	return value;
+	return value.toBigInt();
 };
 
 /**

--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -22,11 +22,11 @@ import { toastsError } from '$lib/stores/toasts.store';
 import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
+import type { TransactionResponseWithBigInt } from '$lib/types/transaction';
 import { emit } from '$lib/utils/events.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { encodePrincipalToEthAddress } from '@dfinity/cketh';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { TransactionResponse } from '@ethersproject/abstract-provider';
 import type { Log } from 'alchemy-sdk';
 import { get } from 'svelte/store';
 
@@ -154,8 +154,9 @@ const loadPendingTransactions = async ({
 		}
 
 		const { getTransaction } = alchemyProviders(twinTokenNetworkId);
-		const loadTransaction = ({ transactionHash }: Log): Promise<TransactionResponse | null> =>
-			getTransaction(transactionHash);
+		const loadTransaction = ({
+			transactionHash
+		}: Log): Promise<TransactionResponseWithBigInt | null> => getTransaction(transactionHash);
 
 		const pendingTransactions = await Promise.all(pendingLogs.map(loadTransaction));
 

--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -8,7 +8,6 @@ import type { OptionToken } from '$lib/types/token';
 import type { EthersTransaction } from '$lib/types/transaction';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { nonNullish } from '@dfinity/utils';
-import type { BigNumber } from '@ethersproject/bignumber';
 import type { Transaction } from '@ethersproject/transactions';
 import { ethers } from 'ethers';
 import { get } from 'svelte/store';
@@ -46,7 +45,7 @@ const mapPendingTransaction = ({
 }: {
 	transaction: Omit<Transaction, 'value' | 'data'>;
 	token: IcToken;
-	value: BigNumber;
+	value: bigint;
 } & IcCkLinkedAssets): IcTransactionUi => {
 	const explorerUrl = (twinToken.network as EthereumNetwork).explorerUrl;
 
@@ -70,21 +69,21 @@ const mapPendingTransaction = ({
 			$token: twinTokenSymbol,
 			$ckToken: symbol
 		}),
-		value: value.toBigInt(),
+		value,
 		fromExplorerUrl: `${explorerUrl}/address/${from}`,
 		toExplorerUrl: `${explorerUrl}/address/${to}`,
 		txExplorerUrl: `${explorerUrl}/tx/${hash}`
 	};
 };
 
-const decodeCkErc20DepositAbiDataValue = (data: string): BigNumber => {
+const decodeCkErc20DepositAbiDataValue = (data: string): bigint => {
 	// Types are equals to the internalTypes of the CKERC20_ABI for the deposit
 	const [_to, value] = ethers.utils.defaultAbiCoder.decode(
 		['address', 'uint256', 'bytes32'],
 		ethers.utils.hexDataSlice(data, 4)
 	);
 
-	return value;
+	return value.toBigInt();
 };
 
 export const isConvertCkEthToEth = ({

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -23,12 +23,18 @@ export type EthersTransaction = Pick<
 	| 'gasLimit'
 	| 'gasPrice'
 	| 'data'
-	| 'value'
 	| 'chainId'
 	| 'type'
 	| 'maxPriorityFeePerGas'
 	| 'maxFeePerGas'
->;
+> & {
+	// TODO: use ethers.Transaction.value type again once we upgrade to ethers v6
+	value: bigint;
+};
+
+// TODO: Remove this type when upgrading to ethers v6 since TransactionResponse will be with BigInt
+export type TransactionResponseWithBigInt = Omit<TransactionResponse, 'value'> &
+	Pick<EthersTransaction, 'value'>;
 
 export type Transaction = Omit<EthersTransaction, 'data'> &
 	Pick<TransactionResponse, 'blockNumber' | 'from' | 'to' | 'timestamp'> & {

--- a/src/frontend/src/tests/eth/stores/eth-transactions.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/eth-transactions.store.spec.ts
@@ -2,7 +2,6 @@ import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env'
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { bn3Bi } from '$tests/mocks/balances.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
-import { BigNumber } from '@ethersproject/bignumber';
 import { get } from 'svelte/store';
 
 describe('eth-transactions.store', () => {
@@ -79,7 +78,7 @@ describe('eth-transactions.store', () => {
 	describe('update', () => {
 		const updatedTransaction = {
 			...mockTransactions[0],
-			value: mockTransactions[0].value.add(BigNumber.from(bn3Bi))
+			value: mockTransactions[0].value + bn3Bi
 		};
 
 		beforeEach(() => {

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -3,7 +3,7 @@ import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import type { Erc20Token } from '$eth/types/erc20';
 import { mapAddressToName, mapEthTransactionUi } from '$eth/utils/transactions.utils';
-import { ZERO } from '$lib/constants/app.constants';
+import { ZERO, ZERO_BI } from '$lib/constants/app.constants';
 import type { EthAddress, OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
@@ -24,7 +24,7 @@ const transaction: Transaction = {
 	timestamp: 1670000000,
 	nonce: 1,
 	gasLimit: ZERO,
-	value: ZERO,
+	value: ZERO_BI,
 	chainId: 1
 };
 

--- a/src/frontend/src/tests/mocks/eth-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/eth-transactions.mock.ts
@@ -11,7 +11,7 @@ export const mockEthTransactionUi: Transaction = {
 	from: mockEthAddress,
 	timestamp: 123456789,
 	to: mockEthAddress2,
-	value: BigNumber.from(bn1Bi),
+	value: bn1Bi,
 	hash: '0x123456789'
 };
 


### PR DESCRIPTION
# Motivation

In preparation for the upgrade to Ethers v6 , we already change the type of Ethers transactions to return a `value` prop that is a `BigInt` value instead of `BigNumber` (see [documentation](https://docs.ethers.org/v6/migrating/#migrate-bigint)).

# Changes

- Change type `EthersTransaction` to return value as `BigInt`.
- Add type `TransactionResponseWithBigInt` to use in the mapper of Alchemy (we use `alchemy-sdk` instead of `ethers` for Alchemy, and they did not yet bumped to v6, see https://github.com/alchemyplatform/alchemy-sdk-js/issues/489).
- Map `AlchemyProvider` transactions to return a `BigInt` for the `value`.
- Migrate listeners and mappers of Ethereum from `BigNumber` to `BigInt`.

# Tests

Adapted existing tests.
