### PR TITLE
feat(frontend): added initPlausible on init app

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -12,7 +12,11 @@
 		TRACK_SYNC_AUTH_ERROR_COUNT,
 		TRACK_SYNC_AUTH_NOT_AUTHENTICATED_COUNT
 	} from '$lib/constants/analytics.contants';
-	import { initAnalytics, trackEvent } from '$lib/services/analytics.services';
+	import {
+		initAnalytics,
+		initPlausibleAnalytics,
+		trackEvent
+	} from '$lib/services/analytics.services';
 	import { displayAndCleanLogoutMsg } from '$lib/services/auth.services';
 	import { initAuthWorker } from '$lib/services/worker.auth.services';
 	import { authStore, type AuthStoreData } from '$lib/stores/auth.store';
@@ -24,7 +28,8 @@
 	 * Init dApp
 	 */
 
-	const init = async () => await Promise.all([syncAuthStore(), initAnalytics(), i18n.init()]);
+	const init = async () =>
+		await Promise.all([syncAuthStore(), initAnalytics(), initPlausibleAnalytics(), i18n.init()]);
 
 	const syncAuthStore = async () => {
 		if (!browser) {

--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -1,0 +1,36 @@
+import * as analytics from '$lib/services/analytics.services';
+import App from '$routes/+layout.svelte';
+import { render } from '@testing-library/svelte';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/services/worker.auth.services', () => ({
+	initAuthWorker: vi.fn().mockResolvedValue({
+		syncAuthIdle: vi.fn()
+	})
+}));
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+describe('App Layout', () => {
+	it('should initialize analytics tracking on mount', () => {
+		const spy = vi.spyOn(analytics, 'initPlausibleAnalytics');
+
+		expect(spy).not.toHaveBeenCalled();
+
+		render(App);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
# Motivation

We aim to track analytics using Plausible. The goal is to ensure that pageviews and custom events are tracked correctly across the app.

# Changes

Added initPlausibleAnalytics on app init.

# Tests

Covered logic with tests.