### PR TITLE
Chore(frontend)/add lang property to style block of loader

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -207,10 +207,10 @@
 	</div>
 {/if}
 
-<style>
-	:root:has(.login-modal) {
-		--alert-max-width: 90vw;
-		--alert-max-height: initial;
-		--dialog-border-radius: calc(var(--border-radius-sm) * 3);
-	}
+<style lang="scss">
+  :root:has(.login-modal) {
+    --alert-max-width: 90vw;
+    --alert-max-height: initial;
+    --dialog-border-radius: calc(var(--border-radius-sm) * 3);
+  }
 </style>


### PR DESCRIPTION
# Motivation

To be lint-compliant with the new rules (PR https://github.com/dfinity/oisy-wallet/pull/5619), we set the `lang` property of the `<style>` block of component `Loader`.
