### PR TITLE
feat(frontend): handle BTC tx multiple recipients case

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -3,6 +3,7 @@
 	import type { BtcTransactionStatus, BtcTransactionUi } from '$btc/types/btc';
 	import type { BtcTransactionType } from '$btc/types/btc-transaction';
 	import { BTC_MAINNET_EXPLORER_URL, BTC_TESTNET_EXPLORER_URL } from '$env/explorers.env';
+	import TransactionAddress from '$lib/components/transactions/TransactionAddress.svelte';
 	import TransactionModal from '$lib/components/transactions/TransactionModal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -13,7 +14,7 @@
 	export let token: OptionToken;
 
 	let from: string;
-	let to: string | undefined;
+	let to: string[] | undefined;
 	let type: BtcTransactionType;
 	let value: bigint | undefined;
 	let timestamp: bigint | undefined;
@@ -34,9 +35,6 @@
 	let txExplorerUrl: string | undefined;
 	$: txExplorerUrl = nonNullish(explorerUrl) ? `${explorerUrl}/tx/${id}` : undefined;
 
-	let toExplorerUrl: string | undefined;
-	$: toExplorerUrl = nonNullish(explorerUrl) ? `${explorerUrl}/address/${to}` : undefined;
-
 	let fromExplorerUrl: string | undefined;
 	$: fromExplorerUrl =
 		nonNullish(explorerUrl) && nonNullish(to) ? `${explorerUrl}/address/${from}` : undefined;
@@ -44,12 +42,10 @@
 
 <TransactionModal
 	commonData={{
-		to,
 		from,
 		timestamp,
 		blockNumber,
 		txExplorerUrl,
-		toExplorerUrl,
 		fromExplorerUrl
 	}}
 	hash={id}
@@ -71,4 +67,24 @@
 		<svelte:fragment slot="label">{$i18n.transaction.text.status}</svelte:fragment>
 		{`${$i18n.transaction.status[status]}`}
 	</Value>
+
+	<svelte:fragment slot="transaction-custom-to">
+		{#if nonNullish(to)}
+			<Value ref="recipients">
+				<svelte:fragment slot="label">{$i18n.transaction.text.to}</svelte:fragment>
+
+				<ul class="list-none">
+					{#each to as address, index (`${address}-${index}`)}
+						<li>
+							<TransactionAddress
+								{address}
+								explorerUrl={`${explorerUrl}/address/${address}`}
+								copiedText={$i18n.transaction.text.to_copied}
+							/>
+						</li>
+					{/each}
+				</ul>
+			</Value>
+		{/if}
+	</svelte:fragment>
 </TransactionModal>

--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -78,7 +78,9 @@
 						<li>
 							<TransactionAddress
 								{address}
-								explorerUrl={`${explorerUrl}/address/${address}`}
+								explorerUrl={nonNullish(explorerUrl)
+									? `${explorerUrl}/address/${address}`
+									: undefined}
 								copiedText={$i18n.transaction.text.to_copied}
 							/>
 						</li>

--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -3,12 +3,15 @@ import type { TransactionId, TransactionStatus, TransactionUiCommon } from '$lib
 
 export type BtcTransactionStatus = TransactionStatus;
 
-export interface BtcTransactionUi extends TransactionUiCommon {
+export interface BtcTransactionUi extends Omit<TransactionUiCommon, 'to'> {
 	id: TransactionId;
 	type: BtcTransactionType;
 	status: BtcTransactionStatus;
 	value?: bigint;
 	confirmations?: number;
+
+	// BTC transaction can have multiple recipients
+	to?: string[];
 
 	/* TODO: add one more field "confirmations", a number that represents the acceptance of a new block by the blockchain network.
 	 1. Use https://blockchain.info/latestblock to get info about the latest block height.

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -28,7 +28,6 @@ export const mapBtcTransaction = ({
 		}
 	);
 
-	// let totalValue: number | undefined = undefined;
 	const { totalOutputValue, totalValue, to } = out.reduce<{
 		to: string[];
 		totalValue: number | undefined;

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -28,9 +28,10 @@ export const mapBtcTransaction = ({
 		}
 	);
 
-	let totalValue: number | undefined = undefined;
-	const { totalOutputValue, to } = out.reduce<{
+	// let totalValue: number | undefined = undefined;
+	const { totalOutputValue, totalValue, to } = out.reduce<{
 		to: string[];
+		totalValue: number | undefined;
 		totalOutputValue: number;
 	}>(
 		(acc, output) => {
@@ -39,16 +40,16 @@ export const mapBtcTransaction = ({
 			const isValidOutput =
 				(isTypeSend && addr !== btcAddress) || (!isTypeSend && addr === btcAddress);
 
-			totalValue = isValidOutput ? (totalValue ?? 0) + value : totalValue;
-
 			return {
 				...acc,
+				totalValue: isValidOutput ? (acc.totalValue ?? 0) + value : acc.totalValue,
 				to: isValidOutput ? [...acc.to, addr] : acc.to,
 				totalOutputValue: acc.totalOutputValue + value
 			};
 		},
 		{
 			totalOutputValue: 0,
+			totalValue: undefined,
 			to: []
 		}
 	);

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -28,33 +28,28 @@ export const mapBtcTransaction = ({
 		}
 	);
 
-	const { totalOutputValue, value, to } = out.reduce<{
+	let totalValue: number | undefined = undefined;
+	const { totalOutputValue, to } = out.reduce<{
+		to: string[];
 		totalOutputValue: number;
-		value: number | undefined;
-		to: string | undefined;
 	}>(
-		(acc, { addr, value }) => {
+		(acc, output) => {
+			const { addr, value } = output;
 			// TODO: test what happens when user sends to the current address (hence isValidOutput = false)
 			const isValidOutput =
 				(isTypeSend && addr !== btcAddress) || (!isTypeSend && addr === btcAddress);
 
-			if (isNullish(acc.value) && isValidOutput) {
-				acc.value = (acc.value ?? 0) + value;
-			}
-
-			if (isNullish(acc.to) && isValidOutput) {
-				acc.to = addr;
-			}
+			totalValue = isValidOutput ? (totalValue ?? 0) + value : totalValue;
 
 			return {
 				...acc,
+				to: isValidOutput ? [...acc.to, addr] : acc.to,
 				totalOutputValue: acc.totalOutputValue + value
 			};
 		},
 		{
 			totalOutputValue: 0,
-			value: undefined,
-			to: undefined
+			to: []
 		}
 	);
 
@@ -74,7 +69,9 @@ export const mapBtcTransaction = ({
 	return {
 		id: hash,
 		timestamp: BigInt(time),
-		value: nonNullish(value) ? BigInt(isTypeSend ? value + utxosFee : value) : undefined,
+		value: nonNullish(totalValue)
+			? BigInt(isTypeSend ? totalValue + utxosFee : totalValue)
+			: undefined,
 		status,
 		blockNumber: block_index ?? undefined,
 		type: isTypeSend ? 'send' : 'receive',

--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -132,7 +132,8 @@ const toSplTransaction = ({
 			value: BigNumber.from(value ?? ZERO_BI).toBigInt(),
 			timestamp: BigInt(timestamp ?? ZERO_BI)
 		}),
-		counterparty: address === from ? to : from
+		// in case it's a BTC tx, "to" is an array
+		counterparty: address === from ? (Array.isArray(to) ? to[0] : to) : from
 	};
 };
 

--- a/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
@@ -14,7 +14,7 @@ describe('btc-transactions.derived', () => {
 			type: 'send',
 			value: 100n,
 			from: 'sender',
-			to: 'receiver',
+			to: ['receiver'],
 			status: 'pending'
 		});
 

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -14,14 +14,17 @@ describe('mapBtcTransaction', () => {
 		inputs: [
 			{
 				...mockBtcTransaction.inputs[0],
-				prev_out: { ...mockBtcTransaction.inputs[0].prev_out, addr: mockBtcAddress }
+				prev_out: {
+					...mockBtcTransaction.inputs[0].prev_out,
+					addr: mockBtcAddress
+				}
 			}
 		]
 	} as BitcoinTransaction;
-	const sendTransactionFee =
-		mockBtcTransaction.inputs[0].prev_out.value -
-		mockBtcTransaction.out.reduce((acc, { value }) => acc + value, 0);
-	const sendTransactionValue = BigInt(mockBtcTransaction.out[0].value + sendTransactionFee);
+	const sendTransactionValue = 202174416n;
+	const to = mockBtcTransaction.out
+		.map(({ addr }) => addr)
+		.filter((addr) => addr !== mockBtcAddress);
 
 	it('should map correctly when receive transaction is pending', () => {
 		const result = mapBtcTransaction({
@@ -88,7 +91,7 @@ describe('mapBtcTransaction', () => {
 		const expectedResult = {
 			...mockBtcTransactionUi,
 			from: mockBtcAddress,
-			to: mockBtcTransaction.out[0].addr,
+			to,
 			value: sendTransactionValue,
 			type: 'send',
 			blockNumber: undefined,
@@ -114,7 +117,7 @@ describe('mapBtcTransaction', () => {
 			...mockBtcTransactionUi,
 			status: 'unconfirmed',
 			from: mockBtcAddress,
-			to: mockBtcTransaction.out[0].addr,
+			to,
 			value: sendTransactionValue,
 			type: 'send',
 			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
@@ -137,7 +140,7 @@ describe('mapBtcTransaction', () => {
 		const expectedResult = {
 			...mockBtcTransactionUi,
 			from: mockBtcAddress,
-			to: mockBtcTransaction.out[0].addr,
+			to,
 			value: sendTransactionValue,
 			type: 'send',
 			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1

--- a/src/frontend/src/tests/mocks/btc-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/btc-transactions.mock.ts
@@ -7,7 +7,7 @@ export const mockBtcTransactionUi: BtcTransactionUi = {
 	id: 'e793cab7e155a0e8f825c4609548faf759c57715fecac587580a1d716bb2b89e',
 	status: 'confirmed',
 	timestamp: 1727175987n,
-	to: 'bc1qt0nkp96r7p95xfacyp98pww2eu64yzuf78l4a2wy0sttt83hux4q6u2nl7',
+	to: ['bc1qt0nkp96r7p95xfacyp98pww2eu64yzuf78l4a2wy0sttt83hux4q6u2nl7'],
 	type: 'receive',
 	value: 126527n,
 	confirmations: 1


### PR DESCRIPTION
# Motivation

As suggested by the external audit, we need to properly handle BTC transactions with multiple valid outputs. This case is not reproducible via OISY at the moment, but we might extend the BTC functionality in the future. 

# Changes

1. Instead of using the first valid output to get a value, we calculate a sum from all the valid entries.
2. Instead of using the first valid output to get a recipient address, we collect all valid entries as an array.
3. Update UI to display all the recipients as a list of address. The UI can be improved later, if and when this case becomes real.

# Tests

Existing tests adjusted.

<img width="567" alt="Screenshot 2025-04-03 at 19 45 28" src="https://github.com/user-attachments/assets/0d6774d3-047c-4f41-9e0a-4209561dafcc" />

