### PR TITLE
feat(frontend): added try/catch for plausible init

### DIFF
--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -45,7 +45,7 @@ export const initPlausibleAnalytics = () => {
 			});
 			plausibleTracker.enableAutoPageviews();
 		}
-	} catch (_err) {
+	} catch (_err: unknown) {
 		console.warn('An unexpected error occurred during initialization.');
 	}
 };

--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -36,13 +36,17 @@ export const initPlausibleAnalytics = () => {
 		return;
 	}
 
-	if (isNullish(plausibleTracker)) {
-		plausibleTracker = Plausible({
-			domain: PLAUSIBLE_DOMAIN,
-			hashMode: false,
-			trackLocalhost: false
-		});
-		plausibleTracker.enableAutoPageviews();
+	try {
+		if (isNullish(plausibleTracker)) {
+			plausibleTracker = Plausible({
+				domain: PLAUSIBLE_DOMAIN,
+				hashMode: false,
+				trackLocalhost: false
+			});
+			plausibleTracker.enableAutoPageviews();
+		}
+	} catch (_err) {
+		console.warn('An unexpected error occurred during initialization.');
 	}
 };
 

--- a/src/frontend/src/tests/lib/services/analytics.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/analytics.service.spec.ts
@@ -87,4 +87,27 @@ describe('plausible analytics service', () => {
 
 		expect(trackEventMock).not.toHaveBeenCalled();
 	});
+
+	it('should catch and log errors if Plausible initialization fails', async () => {
+		vi.doMock('$env/plausible.env', () => ({
+			PLAUSIBLE_ENABLED: true,
+			PLAUSIBLE_DOMAIN: 'oisy.com'
+		}));
+
+		vi.mocked(Plausible).mockImplementation(() => {
+			throw new Error();
+		});
+
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const { initPlausibleAnalytics } = await import('$lib/services/analytics.services');
+
+		initPlausibleAnalytics();
+
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			'An unexpected error occurred during initialization.'
+		);
+
+		consoleWarnSpy.mockRestore();
+	});
 });


### PR DESCRIPTION
# Motivation

We aim to track analytics using Plausible. The goal is to ensure that pageviews and custom events are tracked correctly across the app.

# Changes

Added try-catch block to prevent app initialization from breaking if Plausible fails to load

# Tests

Covered new logic with the tests.