### PR TITLE
feat(frontend): remove unnecessary properties in Ethereum Transaction interface

### DIFF
--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -16,11 +16,7 @@ export type TransactionId = z.infer<typeof TransactionIdSchema>;
 
 export type EthersTransaction = Pick<
 	ethers.Transaction,
-	| 'nonce'
-	| 'gasLimit'
-	| 'gasPrice'
-	| 'data'
-	| 'chainId'
+	'nonce' | 'gasLimit' | 'gasPrice' | 'data' | 'chainId'
 > & {
 	// TODO: use ethers.Transaction.value type again once we upgrade to ethers v6
 	value: bigint;

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -16,17 +16,7 @@ export type TransactionId = z.infer<typeof TransactionIdSchema>;
 
 export type EthersTransaction = Pick<
 	ethers.Transaction,
-	| 'hash'
-	| 'to'
-	| 'from'
-	| 'nonce'
-	| 'gasLimit'
-	| 'gasPrice'
-	| 'data'
-	| 'chainId'
-	| 'type'
-	| 'maxPriorityFeePerGas'
-	| 'maxFeePerGas'
+	'hash' | 'to' | 'from' | 'nonce' | 'gasLimit' | 'gasPrice' | 'data' | 'chainId'
 > & {
 	// TODO: use ethers.Transaction.value type again once we upgrade to ethers v6
 	value: bigint;


### PR DESCRIPTION
# Motivation

In the entire code we don't use the props `type`, `maxPriorityFeePerGas` and `maxFeePerGas` of interface EthersTransaction (and its derived). So we can remove them.

This will help us with the migration to `ethers` v6 too, since their types change.
