### PR TITLE
refactor(frontend): rename event that click the authentication button

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import LicenseLink from '$lib/components/license-agreement/LicenseLink.svelte';
 	import ButtonAuthenticate from '$lib/components/ui/ButtonAuthenticate.svelte';
-	import { TRACK_COUNT_AUTHENTICATION_CLICK } from '$lib/constants/analytics.contants';
+	import { TRACK_COUNT_SIGN_IN_CLICK } from '$lib/constants/analytics.contants';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -11,7 +11,7 @@
 
 	const onClick = async () => {
 		await trackEvent({
-			name: TRACK_COUNT_AUTHENTICATION_CLICK
+			name: TRACK_COUNT_SIGN_IN_CLICK
 		});
 
 		await signIn({});

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -1,5 +1,5 @@
 // Authentication
-export const TRACK_COUNT_AUTHENTICATION_CLICK = 'authentication_click_count';
+export const TRACK_COUNT_SIGN_IN_CLICK = 'sign_in_click_count';
 export const TRACK_COUNT_SIGN_IN_SUCCESS = 'sign_in_success_count';
 export const TRACK_SIGN_IN_CANCELLED_COUNT = 'sign_in_cancelled_count';
 export const TRACK_SIGN_IN_ERROR_COUNT = 'sign_in_error_count';


### PR DESCRIPTION
# Motivation

To be more consistent, we rename the event `TRACK_COUNT_AUTHENTICATION_CLICK` to `TRACK_COUNT_SIGN_IN_CLICK`.
