### PR TITLE
refactor(frontend): explicitly set props of Ethers transaction interface

### DIFF
--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -37,9 +37,10 @@ export type EthersTransaction = Pick<
 export type TransactionResponseWithBigInt = Omit<TransactionResponse, 'value'> &
 	Pick<EthersTransaction, 'value'>;
 
-export type Transaction = Omit<EthersTransaction, 'data'> &
-	Pick<TransactionResponse, 'from' | 'timestamp'> & {
+export type Transaction = Omit<EthersTransaction, 'data' | 'from'> &
+	Required<Pick<EthersTransaction, 'from'>> & {
 		blockNumber?: number;
+		timestamp?: number;
 		pendingTimestamp?: number;
 		displayTimestamp?: number;
 	};

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -16,9 +16,6 @@ export type TransactionId = z.infer<typeof TransactionIdSchema>;
 
 export type EthersTransaction = Pick<
 	ethers.Transaction,
-	| 'hash'
-	| 'to'
-	| 'from'
 	| 'nonce'
 	| 'gasLimit'
 	| 'gasPrice'
@@ -30,6 +27,10 @@ export type EthersTransaction = Pick<
 > & {
 	// TODO: use ethers.Transaction.value type again once we upgrade to ethers v6
 	value: bigint;
+} & {
+	hash?: string;
+	from?: string;
+	to?: string;
 };
 
 // TODO: Remove this type when upgrading to ethers v6 since TransactionResponse will be with BigInt
@@ -37,7 +38,8 @@ export type TransactionResponseWithBigInt = Omit<TransactionResponse, 'value'> &
 	Pick<EthersTransaction, 'value'>;
 
 export type Transaction = Omit<EthersTransaction, 'data'> &
-	Pick<TransactionResponse, 'blockNumber' | 'from' | 'to' | 'timestamp'> & {
+	Pick<TransactionResponse, 'from' | 'timestamp'> & {
+		blockNumber?: number;
 		pendingTimestamp?: number;
 		displayTimestamp?: number;
 	};


### PR DESCRIPTION
# Motivation

Furthermore we explicitly specify props `hash`, `from` and `to` in interface `EthersTransaction`, and props `blockNumber` and `timestamp` in interface `Transaction`.

It does not change anything, since the new definitions are the same as the imbedded ones. However, in `ethers` v6 they will change to be null instead of undefined, so this helps us with maintaining the behaviours during migration.