### PR TITLE
feat(frontend): use BigInt instead of BigNumber in Ethers transaction interace

### DIFF
--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -120,9 +120,15 @@ export class AlchemyProvider {
 			return transaction;
 		}
 
-		const { value, ...rest } = transaction;
+		const { value, gasLimit, gasPrice, chainId, ...rest } = transaction;
 
-		return { ...rest, value: value.toBigInt() };
+		return {
+			...rest,
+			value: value.toBigInt(),
+			gasLimit: gasLimit.toBigInt(),
+			gasPrice: gasPrice?.toBigInt(),
+			chainId: BigInt(chainId)
+		};
 	};
 }
 

--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -64,11 +64,11 @@ export class EtherscanProvider {
 				from,
 				to,
 				nonce: parseInt(nonce),
-				gasLimit: BigNumber.from(gas),
-				gasPrice: BigNumber.from(gasPrice),
+				gasLimit: BigNumber.from(gas).toBigInt(),
+				gasPrice: BigNumber.from(gasPrice).toBigInt(),
 				value: BigInt(value),
 				// Chain ID is not delivered by the Etherscan API so, we naively set 0
-				chainId: 0
+				chainId: 0n
 			})
 		);
 	}

--- a/src/frontend/src/eth/rest/etherscan.rest.ts
+++ b/src/frontend/src/eth/rest/etherscan.rest.ts
@@ -68,11 +68,11 @@ export class EtherscanRest {
 				from,
 				to,
 				nonce: parseInt(nonce),
-				gasLimit: BigNumber.from(gas),
-				gasPrice: BigNumber.from(gasPrice),
+				gasLimit: BigNumber.from(gas).toBigInt(),
+				gasPrice: BigNumber.from(gasPrice).toBigInt(),
 				value: BigInt(value),
 				// Chain ID is not delivered by the Etherscan API so, we naively set 0
-				chainId: 0
+				chainId: 0n
 			})
 		);
 	};

--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -8,7 +8,6 @@ import type { OptionToken } from '$lib/types/token';
 import type { EthersTransaction } from '$lib/types/transaction';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { nonNullish } from '@dfinity/utils';
-import type { Transaction } from '@ethersproject/transactions';
 import { ethers } from 'ethers';
 import { get } from 'svelte/store';
 
@@ -43,7 +42,7 @@ const mapPendingTransaction = ({
 	token,
 	value
 }: {
-	transaction: Omit<Transaction, 'value' | 'data'>;
+	transaction: Omit<MapCkEthereumPendingTransactionParams['transaction'], 'value' | 'data'>;
 	token: IcToken;
 	value: bigint;
 } & IcCkLinkedAssets): IcTransactionUi => {

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -8,27 +8,30 @@ import {
 } from '$lib/schema/transaction.schema';
 import type { Token } from '$lib/types/token';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
-import type { TransactionResponse } from '@ethersproject/abstract-provider';
+import type { TransactionResponse as AlchemyTransactionResponse } from 'alchemy-sdk';
 import { ethers } from 'ethers';
 import * as z from 'zod';
 
 export type TransactionId = z.infer<typeof TransactionIdSchema>;
 
-export type EthersTransaction = Pick<
-	ethers.Transaction,
-	'nonce' | 'gasLimit' | 'gasPrice' | 'data' | 'chainId'
-> & {
+export type EthersTransaction = Pick<ethers.Transaction, 'nonce' | 'data'> & {
 	// TODO: use ethers.Transaction.value type again once we upgrade to ethers v6
 	value: bigint;
+	gasLimit: bigint;
+	chainId: bigint;
 } & {
 	hash?: string;
 	from?: string;
 	to?: string;
+	gasPrice?: bigint;
 };
 
-// TODO: Remove this type when upgrading to ethers v6 since TransactionResponse will be with BigInt
-export type TransactionResponseWithBigInt = Omit<TransactionResponse, 'value'> &
-	Pick<EthersTransaction, 'value'>;
+// TODO: Remove this type when `alchemy-sdk` upgrades to `ethers` v6 since `TransactionResponse` will be with BigInt
+export type TransactionResponseWithBigInt = Omit<
+	AlchemyTransactionResponse,
+	'value' | 'gasLimit' | 'gasPrice' | 'chainId'
+> &
+	Pick<EthersTransaction, 'value' | 'gasLimit' | 'gasPrice' | 'chainId'>;
 
 export type Transaction = Omit<EthersTransaction, 'data' | 'from'> &
 	Required<Pick<EthersTransaction, 'from'>> & {

--- a/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
+++ b/src/frontend/src/tests/eth/rest/etherscan.rest.spec.ts
@@ -10,7 +10,6 @@ import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
-import { BigNumber } from 'ethers';
 import type { MockedFunction } from 'vitest';
 
 global.fetch = vi.fn();
@@ -50,10 +49,10 @@ describe('etherscan.rest', () => {
 			from: '0xabc...',
 			to: '0xdef...',
 			nonce: 1,
-			gasLimit: BigNumber.from('21000'),
-			gasPrice: BigNumber.from('20000000000'),
+			gasLimit: 21000n,
+			gasPrice: 20000000000n,
 			value: 1000000000000000000n,
-			chainId: 0
+			chainId: 0n
 		};
 
 		const mockEtherscanErrorResponse = {

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -3,7 +3,7 @@ import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import type { Erc20Token } from '$eth/types/erc20';
 import { mapAddressToName, mapEthTransactionUi } from '$eth/utils/transactions.utils';
-import { ZERO, ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO_BI } from '$lib/constants/app.constants';
 import type { EthAddress, OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
@@ -23,9 +23,9 @@ const transaction: Transaction = {
 	to: '0xabcd',
 	timestamp: 1670000000,
 	nonce: 1,
-	gasLimit: ZERO,
+	gasLimit: ZERO_BI,
 	value: ZERO_BI,
-	chainId: 1
+	chainId: 1n
 };
 
 const ckMinterInfoAddresses: EthAddress[] = ['0xffff'];

--- a/src/frontend/src/tests/mocks/eth-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/eth-transactions.mock.ts
@@ -1,13 +1,12 @@
 import type { Transaction } from '$lib/types/transaction';
 import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mocks';
-import { BigNumber } from 'ethers';
 import { bn1Bi, bn3Bi } from './balances.mock';
 
 export const mockEthTransactionUi: Transaction = {
 	blockNumber: 123213,
 	nonce: 123,
-	gasLimit: BigNumber.from(bn3Bi),
-	chainId: 1,
+	gasLimit: bn3Bi,
+	chainId: 1n,
 	from: mockEthAddress,
 	timestamp: 123456789,
 	to: mockEthAddress2,


### PR DESCRIPTION
# Motivation

We need to migrate to `ethers` v6: one of the biggest change was the deprecation of `BigNumber` in favour of built-in `bigint` (see [documentation](https://docs.ethers.org/v6/migrating/#migrate-bigint)).

Unfortunately, `alchemy-sdk` is still not updated to the newest version of `ethers` (issue https://github.com/alchemyplatform/alchemy-sdk-js/issues/489). That means that we have to adapt one to the other, until they bump it.

So, we set explicitly the types of `ethers` and adjust them in a mapper inside the `AlchemyProvider` class.

# Changes

- Explicitly set props `gasLimit`, `gasPrice` and chainId in interface `EthersTransaction`.
- Create mapper in class `AlchemyProvider`.
- Prepare type `TransactionResponseWithBigInt` to use `ethers` props instead of `alchemy-sdk`.
- Adapt the rest of the usages.

# Tests

Adapted tests.
