### PR TITLE
feat(frontend): do not update fees on ETH/ERC20 convert review step

### DIFF
--- a/src/frontend/src/eth/components/convert/ConvertToCkETH.svelte
+++ b/src/frontend/src/eth/components/convert/ConvertToCkETH.svelte
@@ -1,50 +1,16 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { setContext } from 'svelte';
-	import { writable } from 'svelte/store';
 	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+	import FeeStoreContext from '$eth/components/fee/FeeStoreContext.svelte';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
-	import {
-		FEE_CONTEXT_KEY,
-		type FeeContext as FeeContextType,
-		initFeeContext,
-		initFeeStore
-	} from '$eth/stores/fee.store';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
-	import { exchanges } from '$lib/derived/exchange.derived';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { TokenId } from '$lib/types/token';
 	import { findTwinToken } from '$lib/utils/token.utils';
-
-	let feeStore = initFeeStore();
-
-	let feeSymbolStore = writable<string | undefined>(undefined);
-	$: feeSymbolStore.set($ethereumToken.symbol);
-
-	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
-	$: feeTokenIdStore.set($ethereumToken.id);
-
-	let feeDecimalsStore = writable<number | undefined>(undefined);
-	$: feeDecimalsStore.set($ethereumToken.decimals);
-
-	let feeExchangeRateStore = writable<number | undefined>(undefined);
-	$: feeExchangeRateStore.set($exchanges?.[$ethereumToken.id]?.usd);
-
-	setContext<FeeContextType>(
-		FEE_CONTEXT_KEY,
-		initFeeContext({
-			feeStore,
-			feeSymbolStore,
-			feeTokenIdStore,
-			feeDecimalsStore,
-			feeExchangeRateStore
-		})
-	);
 
 	let ckEthToken: IcCkToken | undefined;
 	$: (() => {
@@ -65,5 +31,7 @@
 </ConvertETH>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckEthToken)}
-	<ConvertModal sourceToken={$ethereumToken} destinationToken={ckEthToken} />
+	<FeeStoreContext token={$ethereumToken}>
+		<ConvertModal sourceToken={$ethereumToken} destinationToken={ckEthToken} />
+	</FeeStoreContext>
 {/if}

--- a/src/frontend/src/eth/components/convert/ConvertToCkETH.svelte
+++ b/src/frontend/src/eth/components/convert/ConvertToCkETH.svelte
@@ -1,15 +1,50 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
 	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
+	import {
+		FEE_CONTEXT_KEY,
+		type FeeContext as FeeContextType,
+		initFeeContext,
+		initFeeStore
+	} from '$eth/stores/fee.store';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { TokenId } from '$lib/types/token';
 	import { findTwinToken } from '$lib/utils/token.utils';
+
+	let feeStore = initFeeStore();
+
+	let feeSymbolStore = writable<string | undefined>(undefined);
+	$: feeSymbolStore.set($ethereumToken.symbol);
+
+	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
+	$: feeTokenIdStore.set($ethereumToken.id);
+
+	let feeDecimalsStore = writable<number | undefined>(undefined);
+	$: feeDecimalsStore.set($ethereumToken.decimals);
+
+	let feeExchangeRateStore = writable<number | undefined>(undefined);
+	$: feeExchangeRateStore.set($exchanges?.[$ethereumToken.id]?.usd);
+
+	setContext<FeeContextType>(
+		FEE_CONTEXT_KEY,
+		initFeeContext({
+			feeStore,
+			feeSymbolStore,
+			feeTokenIdStore,
+			feeDecimalsStore,
+			feeExchangeRateStore
+		})
+	);
 
 	let ckEthToken: IcCkToken | undefined;
 	$: (() => {

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -142,7 +142,9 @@
 		});
 	};
 
-	onMount(() => debounceUpdateFeeData());
+	onMount(() => {
+		observe && debounceUpdateFeeData();
+	});
 	onDestroy(() => listener?.disconnect());
 
 	/**
@@ -151,7 +153,10 @@
 
 	$: obverseFeeData(observe);
 
-	$: $ckEthMinterInfoStore, debounceUpdateFeeData();
+	$: $ckEthMinterInfoStore,
+		() => {
+			observe && debounceUpdateFeeData();
+		};
 
 	/**
 	 * Expose a call to evaluate, so that consumers can re-evaluate imperatively, for example, when the amount or destination is manually updated by the user.

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -154,9 +154,9 @@
 	$: obverseFeeData(observe);
 
 	$: $ckEthMinterInfoStore,
-		() => {
+		(() => {
 			observe && debounceUpdateFeeData();
-		};
+		})();
 
 	/**
 	 * Expose a call to evaluate, so that consumers can re-evaluate imperatively, for example, when the amount or destination is manually updated by the user.

--- a/src/frontend/src/eth/components/fee/FeeStoreContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeStoreContext.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+	import {
+		FEE_CONTEXT_KEY,
+		type FeeContext as FeeContextType,
+		initFeeContext,
+		initFeeStore
+	} from '$eth/stores/fee.store';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import type { Token, TokenId } from '$lib/types/token';
+
+	export let token: Token;
+
+	let feeStore = initFeeStore();
+
+	let feeSymbolStore = writable<string | undefined>(undefined);
+	$: feeSymbolStore.set(token.symbol);
+
+	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
+	$: feeTokenIdStore.set(token.id);
+
+	let feeDecimalsStore = writable<number | undefined>(undefined);
+	$: feeDecimalsStore.set(token.decimals);
+
+	let feeExchangeRateStore = writable<number | undefined>(undefined);
+	$: feeExchangeRateStore.set($exchanges?.[token.id]?.usd);
+
+	setContext<FeeContextType>(
+		FEE_CONTEXT_KEY,
+		initFeeContext({
+			feeStore,
+			feeSymbolStore,
+			feeTokenIdStore,
+			feeDecimalsStore,
+			feeExchangeRateStore
+		})
+	);
+</script>
+
+<slot />

--- a/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
@@ -1,17 +1,52 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { ethereumTokenId } from '$eth/derived/token.derived';
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
+	import {
+		FEE_CONTEXT_KEY,
+		type FeeContext as FeeContextType,
+		initFeeContext,
+		initFeeStore
+	} from '$eth/stores/fee.store';
 	import type { OptionErc20Token } from '$eth/types/erc20';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { TokenId } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { findTwinToken } from '$lib/utils/token.utils';
+
+	let feeStore = initFeeStore();
+
+	let feeSymbolStore = writable<string | undefined>(undefined);
+	$: feeSymbolStore.set($ethereumToken.symbol);
+
+	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
+	$: feeTokenIdStore.set($ethereumToken.id);
+
+	let feeDecimalsStore = writable<number | undefined>(undefined);
+	$: feeDecimalsStore.set($ethereumToken.decimals);
+
+	let feeExchangeRateStore = writable<number | undefined>(undefined);
+	$: feeExchangeRateStore.set($exchanges?.[$ethereumToken.id]?.usd);
+
+	setContext<FeeContextType>(
+		FEE_CONTEXT_KEY,
+		initFeeContext({
+			feeStore,
+			feeSymbolStore,
+			feeTokenIdStore,
+			feeDecimalsStore,
+			feeExchangeRateStore
+		})
+	);
 
 	let convertToSymbol: string;
 	$: convertToSymbol = ($pageToken as OptionErc20Token)?.twinTokenSymbol ?? '';

--- a/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkERC20.svelte
@@ -1,52 +1,18 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { setContext } from 'svelte';
-	import { writable } from 'svelte/store';
+	import FeeStoreContext from '$eth/components/fee/FeeStoreContext.svelte';
 	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
-	import {
-		FEE_CONTEXT_KEY,
-		type FeeContext as FeeContextType,
-		initFeeContext,
-		initFeeStore
-	} from '$eth/stores/fee.store';
 	import type { OptionErc20Token } from '$eth/types/erc20';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertETH from '$icp-eth/components/convert/ConvertETH.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
-	import { exchanges } from '$lib/derived/exchange.derived';
 	import { modalConvertToTwinTokenCkEth } from '$lib/derived/modal.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { TokenId } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { findTwinToken } from '$lib/utils/token.utils';
-
-	let feeStore = initFeeStore();
-
-	let feeSymbolStore = writable<string | undefined>(undefined);
-	$: feeSymbolStore.set($ethereumToken.symbol);
-
-	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
-	$: feeTokenIdStore.set($ethereumToken.id);
-
-	let feeDecimalsStore = writable<number | undefined>(undefined);
-	$: feeDecimalsStore.set($ethereumToken.decimals);
-
-	let feeExchangeRateStore = writable<number | undefined>(undefined);
-	$: feeExchangeRateStore.set($exchanges?.[$ethereumToken.id]?.usd);
-
-	setContext<FeeContextType>(
-		FEE_CONTEXT_KEY,
-		initFeeContext({
-			feeStore,
-			feeSymbolStore,
-			feeTokenIdStore,
-			feeDecimalsStore,
-			feeExchangeRateStore
-		})
-	);
 
 	let convertToSymbol: string;
 	$: convertToSymbol = ($pageToken as OptionErc20Token)?.twinTokenSymbol ?? '';
@@ -75,5 +41,7 @@
 </ConvertETH>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckToken) && nonNullish($pageToken)}
-	<ConvertModal sourceToken={$pageToken} destinationToken={ckToken} />
+	<FeeStoreContext token={$ethereumToken}>
+		<ConvertModal sourceToken={$pageToken} destinationToken={ckToken} />
+	</FeeStoreContext>
 {/if}

--- a/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
@@ -7,6 +7,12 @@ import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import {
+	FEE_CONTEXT_KEY,
+	initFeeContext,
+	initFeeStore,
+	type FeeContext
+} from '$eth/stores/fee.store';
 import ConvertWizard from '$lib/components/convert/ConvertWizard.svelte';
 import {
 	BTC_CONVERT_FORM_TEST_ID,
@@ -29,6 +35,7 @@ import type { Token } from '$lib/types/token';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
 
 describe('ConvertWizard', () => {
 	const sendAmount = 20;
@@ -44,8 +51,21 @@ describe('ConvertWizard', () => {
 	};
 
 	const mockContext = (sourceToken: Token) =>
-		new Map<symbol, ConvertContext | TokenActionValidationErrorsContext | UtxosFeeContext>([
+		new Map<
+			symbol,
+			ConvertContext | TokenActionValidationErrorsContext | UtxosFeeContext | FeeContext
+		>([
 			[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }],
+			[
+				FEE_CONTEXT_KEY,
+				initFeeContext({
+					feeStore: initFeeStore(),
+					feeTokenIdStore: writable(sourceToken.id),
+					feeExchangeRateStore: writable(100),
+					feeSymbolStore: writable(sourceToken.symbol),
+					feeDecimalsStore: writable(sourceToken.decimals)
+				})
+			],
 			[CONVERT_CONTEXT_KEY, initConvertContext({ sourceToken, destinationToken: ICP_TOKEN })],
 			[TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY, initTokenActionValidationErrorsContext()]
 		]);


### PR DESCRIPTION
# Motivation

It was decided to stop updating fees when user is already on the conversion review step. To do that for ETH and ERC20, a few steps are required.

# Changes

1. Move fee context initialization from EthConvertTokenWizard to respective parent component (same as it's done for BTC) - ConvertToCkERC20 and ConvertToCkETH. The reason is that the wizard is being rerendered (and therefore fee context is reset) on each step change.
2. Stop observing when on the REVIEW step.
3. Update FeeContext to not trigger `updateFee` method on 

# Tests

Existing tests are updated. Also, tested both flows manually.
