### PR TITLE
fix(build): Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,13 +2,6 @@ import { default as config } from '@dfinity/eslint-config-oisy-wallet/svelte';
 
 export default [
 	...config,
-
-	{
-		rules: {
-			'object-shorthand': 'error'
-		}
-	},
-
 	{
 		ignores: [
 			'**/.DS_Store',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,13 @@ import { default as config } from '@dfinity/eslint-config-oisy-wallet/svelte';
 
 export default [
 	...config,
+
+	{
+		rules: {
+			'object-shorthand': 'error'
+		}
+	},
+
 	{
 		ignores: [
 			'**/.DS_Store',

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
 				"prettier-plugin-organize-imports": "^4.1.0",
 				"prettier-plugin-svelte": "^3.3.3",
 				"prettier-plugin-tailwindcss": "^0.6.11",
+				"sanitize-html": "^2.15.0",
 				"sass": "^1.86.1",
 				"svelte": "^5.25.3",
 				"svelte-check": "^4.1.5",
@@ -6536,6 +6537,50 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
 		"node_modules/dompurify": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
@@ -6543,6 +6588,21 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/dotenv": {
@@ -6911,7 +6971,6 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -8388,6 +8447,26 @@
 			"integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -8869,6 +8948,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -10376,6 +10465,13 @@
 				"xml2js": "^0.5.0"
 			}
 		},
+		"node_modules/parse-srcset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/parse5": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -11398,6 +11494,21 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
+		},
+		"node_modules/sanitize-html": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.15.0.tgz",
+			"integrity": "sha512-wIjst57vJGpLyBP8ioUbg6ThwJie5SuSIjHxJg53v5Fg+kUK+AXlb7bK3RNXpp315MvwM+0OBGCV6h5pPHsVhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"deepmerge": "^4.2.2",
+				"escape-string-regexp": "^4.0.0",
+				"htmlparser2": "^8.0.0",
+				"is-plain-object": "^5.0.0",
+				"parse-srcset": "^1.0.2",
+				"postcss": "^8.3.11"
+			}
 		},
 		"node_modules/sass": {
 			"version": "1.86.1",

--- a/package.json
+++ b/package.json
@@ -89,8 +89,7 @@
 		"idb-keyval": "^6.2.1",
 		"plausible-tracker": "^0.3.9",
 		"svelte-confetti": "^2.3.1",
-		"zod": "^3.23.8",
-		"sanitize-html": "^2.15.0"
+		"zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@dfinity/eslint-config-oisy-wallet": "^0.1.3",
@@ -119,6 +118,7 @@
 		"prettier-plugin-organize-imports": "^4.1.0",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
+		"sanitize-html": "^2.15.0",
 		"sass": "^1.86.1",
 		"svelte": "^5.25.3",
 		"svelte-check": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
 		"idb-keyval": "^6.2.1",
 		"plausible-tracker": "^0.3.9",
 		"svelte-confetti": "^2.3.1",
-		"zod": "^3.23.8"
+		"zod": "^3.23.8",
+		"sanitize-html": "^2.15.0"
 	},
 	"devDependencies": {
 		"@dfinity/eslint-config-oisy-wallet": "^0.1.3",

--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -4,8 +4,8 @@ import { config } from 'dotenv';
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { ENV, findHtmlFiles } from './build.utils.mjs';
 import sanitizeHtml from 'sanitize-html';
+import { ENV, findHtmlFiles } from './build.utils.mjs';
 
 config({ path: `.env.${ENV}` });
 
@@ -117,7 +117,7 @@ const extractStartScript = (htmlFile) => {
 
 	// 3. Replace original SvelteKit script tag content with empty
 	return sanitizeHtml(indexHtml, {
-		allowedTags: sanitizeHtml.defaults.allowedTags.filter(tag => tag !== 'script'),
+		allowedTags: sanitizeHtml.defaults.allowedTags.filter((tag) => tag !== 'script'),
 		allowedAttributes: false
 	});
 };


### PR DESCRIPTION
Potential fix for [https://github.com/dfinity/oisy-wallet/security/code-scanning/2](https://github.com/dfinity/oisy-wallet/security/code-scanning/2)

To fix the problem, we should use a well-tested sanitization library instead of relying on custom regular expressions. This will ensure that all edge cases are handled correctly and reduce the risk of security vulnerabilities. One such library is `sanitize-html`, which is widely used and well-maintained.

The best way to fix the problem without changing existing functionality is to replace the custom regular expression with a call to `sanitize-html` to remove script tags. This involves installing the `sanitize-html` package and updating the relevant code to use this library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
