### PR TITLE
refactor(devops): pin actions/cache to specific version

### DIFF
--- a/.github/actions/deploy-backend/action.yml
+++ b/.github/actions/deploy-backend/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Restore cargo cache
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           /home/runner/.cargo/registry

--- a/.github/actions/oisy-backend/action.yml
+++ b/.github/actions/oisy-backend/action.yml
@@ -7,13 +7,13 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: {}
+outputs: { }
 
 runs:
   using: 'composite'
   steps:
     - name: Cache backend canister WASM
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       id: backend-wasm-cache
       with:
         path: |

--- a/.github/actions/oisy-backend/action.yml
+++ b/.github/actions/oisy-backend/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: { }
+outputs: {}
 
 runs:
   using: 'composite'

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           persist-credentials: false
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -227,7 +227,7 @@ jobs:
           DFX_DEPLOY_KEY: ${{ steps.set-outputs.outputs.DFX_DEPLOY_KEY }}
 
       - name: Restore cargo cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             /home/runner/.cargo/registry


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#unpinned-uses) is to pin the third party actions to a specific commit, to avoid possible liabilities. So we pin [actions/cache to version v4.2.3](https://github.com/actions/cache/tree/v4.2.3).