### PR TITLE
refactor(devops): remove possible attacker-controllable code in CI for frontend checks

### DIFF
--- a/.github/actions/oisy-backend/action.yml
+++ b/.github/actions/oisy-backend/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: {}
+outputs: { }
 
 runs:
   using: 'composite'

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./scripts/lint.cargo-workspace-dependencies.sh
 
   may-merge:
-    needs: ['lint', 'workspace-dependencies']
+    needs: [ 'lint', 'workspace-dependencies' ]
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Check if commits can be added
         id: check_can_add_commit
         run: |
-          echo "can_add_commit=${{ steps.app-token.outputs.token != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
+          echo "can_add_commit=$CAN_ADD_COMMIT" >> $GITHUB_OUTPUT
+        env:
+          CAN_ADD_COMMIT: ${{ steps.app-token.outputs.token != '' && github.event_name == 'pull_request' }}
       - name: Checkout for pull request
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -124,7 +126,7 @@ jobs:
 
   may-merge:
     if: always()
-    needs: ['format', 'lint', 'check', 'test', 'config']
+    needs: [ 'format', 'lint', 'check', 'test', 'config' ]
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#template-injection) is to disallow possible injections via template expansions. So we remove them in CI `frontend-checks`, in favour of env variables.