### PR TITLE
refactor(devops): remove possible attacker-controllable code in CI for binding checks

### DIFF
--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -23,9 +23,13 @@ jobs:
       - name: Check if commits can be added
         id: check_can_add_commit
         run: |
-          echo steps.app-token.outputs.token null ${{ steps.app-token.outputs.token == null}}
-          echo steps.app-token.outputs.token empty ${{ steps.app-token.outputs.token == ''}}
-          echo "can_add_commit=${{ steps.app-token.outputs.token != '' && github.event_name == 'pull_request' }}" >> $GITHUB_OUTPUT
+          echo steps.app-token.outputs.token null $TOKEN_IS_NULL
+          echo steps.app-token.outputs.token empty $TOKEN_IS_EMPTY
+          echo "can_add_commit=$CAN_ADD_COMMIT" >> $GITHUB_OUTPUT
+        env:
+          TOKEN_IS_NULL: ${{ steps.app-token.outputs.token == null }}
+          TOKEN_IS_EMPTY: ${{ steps.app-token.outputs.token == '' }}
+          CAN_ADD_COMMIT: ${{ steps.app-token.outputs.token != '' && github.event_name == 'pull_request' }}
 
       - name: Checkout code
         if: steps.check_can_add_commit.outputs.can_add_commit == 'true'
@@ -122,7 +126,7 @@ jobs:
           exit 1
 
   binding-checks-pass:
-    needs: ['generate']
+    needs: [ 'generate' ]
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/binding-checks.yml
+++ b/.github/workflows/binding-checks.yml
@@ -126,7 +126,7 @@ jobs:
           exit 1
 
   binding-checks-pass:
-    needs: [ 'generate' ]
+    needs: ['generate']
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#template-injection) is to disallow possible injections via template expansions. So we remove them in CI `binding-checks`, in favour of env variables.