### PR TITLE
refactor(devops): pin actions/setup-node to specific version

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version-file: '.node-version'
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#unpinned-uses) is to pin the third party actions to a specific commit, to avoid possible liabilities. So we pin [actions/setup-node to version v4.3.0](https://github.com/actions/setup-node/tree/v4.3.0).