### PR TITLE
refactor(devops): pin release-drafter/release-drafter to specific version

### DIFF
--- a/.github/actions/release-notes/action.yml
+++ b/.github/actions/release-notes/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Publish Release Notes
       id: publish_release
-      uses: release-drafter/release-drafter@v6
+      uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
       env:
         GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       with:


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#unpinned-uses) is to pin the third party actions to a specific commit, to avoid possible liabilities. So we pin [release-drafter/release-drafter to version v6.1.0](https://github.com/release-drafter/release-drafter/tree/v6.1.0).