### PR TITLE
refactor(devops): pin docker actions to specific version

### DIFF
--- a/.github/actions/docker-build-backend/action.yml
+++ b/.github/actions/docker-build-backend/action.yml
@@ -13,13 +13,13 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: {}
+outputs: { }
 
 runs:
   using: 'composite'
   steps:
     - name: Set up docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Prepare docker build inputs
       shell: bash

--- a/.github/actions/docker-build-backend/action.yml
+++ b/.github/actions/docker-build-backend/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: { }
+outputs: {}
 
 runs:
   using: 'composite'

--- a/.github/actions/docker-build-base/action.yml
+++ b/.github/actions/docker-build-base/action.yml
@@ -2,7 +2,7 @@ name: Build Base Docker Image
 
 description: The image shared by all builds, containing pre-built rust deps
 
-outputs: {}
+outputs: { }
 
 runs:
   using: 'composite'
@@ -15,10 +15,10 @@ runs:
     # more information, see
     # https://github.com/docker/build-push-action/issues/539
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Build base Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
       with:
         context: .
         file: Dockerfile

--- a/.github/actions/docker-build-base/action.yml
+++ b/.github/actions/docker-build-base/action.yml
@@ -2,7 +2,7 @@ name: Build Base Docker Image
 
 description: The image shared by all builds, containing pre-built rust deps
 
-outputs: {}
+outputs: { }
 
 runs:
   using: 'composite'
@@ -18,7 +18,7 @@ runs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Build base Docker image
-      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
       with:
         context: .
         file: Dockerfile

--- a/.github/actions/docker-build-base/action.yml
+++ b/.github/actions/docker-build-base/action.yml
@@ -2,7 +2,7 @@ name: Build Base Docker Image
 
 description: The image shared by all builds, containing pre-built rust deps
 
-outputs: { }
+outputs: {}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#unpinned-uses) is to pin the third party actions to a specific commit, to avoid possible liabilities. So we pin [docker/setup-buildx-action to version v3.10.0](https://github.com/docker/setup-buildx-action/tree/v3.10.0) and [docker/build-push-action to version v5.4.0](https://github.com/docker/build-push-action/releases/tag/v5.4.0).