### PR TITLE
refactor(devops): pin peter-evans/create-pull-request to specific version

### DIFF
--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Create Pull Request (With Paths)
       if: inputs.paths != ''
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
       with:
         token: ${{ inputs.token }}
         base: main
@@ -39,7 +39,7 @@ runs:
 
     - name: Create Pull Request (Without Paths)
       if: inputs.paths == ''
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
       with:
         token: ${{ inputs.token }}
         base: main


### PR DESCRIPTION
# Motivation

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#unpinned-uses) is to pin the third party actions to a specific commit, to avoid possible liabilities. So we pin [peter-evans/create-pull-request to version v6.0.5](https://github.com/peter-evans/create-pull-request/tree/v6.0.5).