### PR TITLE
refactor(frontend): use importOriginal in tests for layout page

### DIFF
--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -3,12 +3,9 @@ import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import App from '$routes/+layout.svelte';
 import { render } from '@testing-library/svelte';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-vi.mock('$lib/services/worker.auth.services', async () => {
-	const actual = await vi.importActual<typeof import('$lib/services/worker.auth.services')>(
-		'$lib/services/worker.auth.services'
-	);
+vi.mock(import('$lib/services/worker.auth.services'), async (importOriginal) => {
+	const actual = await importOriginal();
 	return {
 		...actual,
 		initAuthWorker: vi.fn().mockResolvedValue({


### PR DESCRIPTION
# Motivation

As per new lint rule (PR https://github.com/dfinity/oisy-wallet/pull/5675),  we should avoid using `import()` type annotations. So we remove it.
