### PR TITLE
fix(frontend): Do not parse environment variables

### DIFF
--- a/src/frontend/src/env/actions.env.ts
+++ b/src/frontend/src/env/actions.env.ts
@@ -1,3 +1,2 @@
 // TODO: to be removed when the feature is fully implemented
-export const SWAP_ACTION_ENABLED =
-	JSON.parse(import.meta.env.VITE_SWAP_ACTION_ENABLED ?? false) === true;
+export const SWAP_ACTION_ENABLED = import.meta.env.VITE_SWAP_ACTION_ENABLED === 'true';

--- a/src/frontend/src/env/exchange.env.ts
+++ b/src/frontend/src/env/exchange.env.ts
@@ -1,2 +1,1 @@
-export const EXCHANGE_DISABLED =
-	JSON.parse(import.meta.env.VITE_EXCHANGE_DISABLED ?? false) === true;
+export const EXCHANGE_DISABLED = import.meta.env.VITE_EXCHANGE_DISABLED === 'true';

--- a/src/frontend/src/env/networks/networks.btc.env.ts
+++ b/src/frontend/src/env/networks/networks.btc.env.ts
@@ -12,8 +12,7 @@ import { LOCAL } from '$lib/constants/app.constants';
 import type { NetworkId } from '$lib/types/network';
 import { parseNetworkId } from '$lib/validation/network.validation';
 
-export const BTC_MAINNET_ENABLED =
-	JSON.parse(import.meta.env.VITE_BITCOIN_MAINNET_DISABLED ?? false) === false;
+export const BTC_MAINNET_ENABLED = import.meta.env.VITE_BITCOIN_MAINNET_DISABLED === 'true';
 
 /**
  * BTC

--- a/src/frontend/src/env/networks/networks.env.ts
+++ b/src/frontend/src/env/networks/networks.env.ts
@@ -7,8 +7,7 @@ import { SUPPORTED_SOLANA_NETWORKS } from '$env/networks/networks.sol.env';
 import type { Network, NetworkId } from '$lib/types/network';
 
 // TODO: to be removed when the feature is fully implemented
-export const USER_NETWORKS_FEATURE_ENABLED =
-	JSON.parse(import.meta.env.VITE_USER_NETWORKS_FEATURE_ENABLED ?? false) === true;
+export const USER_NETWORKS_FEATURE_ENABLED = import.meta.env.VITE_USER_NETWORKS_FEATURE_ENABLED === 'true';
 
 export const SUPPORTED_NETWORKS: Network[] = [
 	ICP_NETWORK,

--- a/src/frontend/src/env/networks/networks.eth.env.ts
+++ b/src/frontend/src/env/networks/networks.eth.env.ts
@@ -9,8 +9,7 @@ import { parseNetworkId } from '$lib/validation/network.validation';
 import type { Networkish } from '@ethersproject/networks';
 import { Network } from 'alchemy-sdk';
 
-export const ETH_MAINNET_ENABLED =
-	JSON.parse(import.meta.env.VITE_ETHEREUM_MAINNET_DISABLED ?? false) === false;
+export const ETH_MAINNET_ENABLED = import.meta.env.VITE_ETHEREUM_MAINNET_DISABLED === 'true';
 
 export const INFURA_NETWORK_HOMESTEAD: Networkish = 'homestead';
 export const INFURA_NETWORK_SEPOLIA: Networkish = 'sepolia';

--- a/src/frontend/src/env/networks/networks.sol.env.ts
+++ b/src/frontend/src/env/networks/networks.sol.env.ts
@@ -17,8 +17,7 @@ import type { Network, NetworkId } from '$lib/types/network';
 import { parseNetworkId } from '$lib/validation/network.validation';
 import type { SolanaNetwork } from '$sol/types/network';
 
-export const SOL_MAINNET_ENABLED =
-	JSON.parse(import.meta.env.VITE_SOLANA_MAINNET_DISABLED ?? false) === false;
+export const SOL_MAINNET_ENABLED = import.meta.env.VITE_SOLANA_MAINNET_DISABLED === 'true';
 
 /**
  * RPC URLs

--- a/src/frontend/src/env/plausible.env.ts
+++ b/src/frontend/src/env/plausible.env.ts
@@ -2,5 +2,4 @@ import { PROD } from '$lib/constants/app.constants';
 
 export const PLAUSIBLE_DOMAIN = PROD ? 'oisy.com' : 'staging.oisy.com';
 
-export const PLAUSIBLE_ENABLED =
-	JSON.parse(import.meta.env.VITE_PLAUSIBLE_ENABLED ?? false) === true;
+export const PLAUSIBLE_ENABLED = import.meta.env.VITE_PLAUSIBLE_ENABLED === 'true';

--- a/src/frontend/src/env/reward-campaigns.env.ts
+++ b/src/frontend/src/env/reward-campaigns.env.ts
@@ -7,7 +7,6 @@ const parseResult = z.array(RewardEventsSchema).safeParse(rewardCampaignsJson);
 export const rewardCampaigns: RewardDescription[] = parseResult.success ? parseResult.data : [];
 
 // TODO: remove this feature flag when user snapshot live on production
-export const USER_SNAPSHOT_ENABLED =
-	JSON.parse(import.meta.env.VITE_USER_SNAPSHOT_ENABLED ?? false) === true;
+export const USER_SNAPSHOT_ENABLED = import.meta.env.VITE_USER_SNAPSHOT_ENABLED === 'true';
 
 export const FEATURED_REWARD_CAROUSEL_SLIDE_ID = 'OISY Airdrop #1';

--- a/src/frontend/src/env/rewards.env.ts
+++ b/src/frontend/src/env/rewards.env.ts
@@ -1,2 +1,2 @@
 // TODO: to be removed when the feature is fully implemented
-export const REWARDS_ENABLED = JSON.parse(import.meta.env.VITE_AIRDROPS_ENABLED ?? false) === true;
+export const REWARDS_ENABLED = import.meta.env.VITE_AIRDROPS_ENABLED === 'true';

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -11,7 +11,7 @@ export const STAGING = MODE === 'staging' || TEST_FE || MODE === 'audit' || MODE
 export const BETA = MODE === 'beta';
 export const PROD = MODE === 'ic';
 
-export const TEST = JSON.parse(import.meta.env.TEST ?? false) === true;
+export const TEST = import.meta.env.TEST === 'true';
 
 const MAINNET_DOMAIN = 'icp0.io';
 

--- a/src/frontend/src/lib/constants/credentials.constants.ts
+++ b/src/frontend/src/lib/constants/credentials.constants.ts
@@ -1,3 +1,3 @@
 // This credential type is defined by the issuer Decide AI
 export const POUH_CREDENTIAL_TYPE = 'ProofOfUniqueness';
-export const POUH_ENABLED = JSON.parse(import.meta.env.VITE_POUH_ENABLED ?? false) === true;
+export const POUH_ENABLED = import.meta.env.VITE_POUH_ENABLED === 'true';


### PR DESCRIPTION
# Motivation

The application should not crash when an environment variable is set to empty string.

# Changes

Compare all boolean environment variables to 'true' instead of parsing the content.

# Tests

FE still working.