### PR TITLE
refactor(devops): pin docker actions to specific version

### DIFF
--- a/.github/actions/docker-build-backend/action.yml
+++ b/.github/actions/docker-build-backend/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: { }
+outputs: {}
 
 runs:
   using: 'composite'

--- a/.github/actions/docker-build-backend/action.yml
+++ b/.github/actions/docker-build-backend/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: Dfx Network
     required: true
 
-outputs: {}
+outputs: { }
 
 runs:
   using: 'composite'
@@ -26,7 +26,7 @@ runs:
       run: scripts/docker-build.pre
 
     - name: Build ${{ inputs.name }}
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
       with:
         context: .
         file: Dockerfile


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/5682 I forgot one instance of action `docker/build-push-action`.

One of [zizmor security suggestions](https://woodruffw.github.io/zizmor/audits/#unpinned-uses) is to pin the third party actions to a specific commit, to avoid possible liabilities. So we pin [docker/setup-buildx-action to version v3.10.0](https://github.com/docker/setup-buildx-action/tree/v3.10.0) and [docker/build-push-action to version v5.4.0](https://github.com/docker/build-push-action/releases/tag/v5.4.0).