### PR TITLE
build(frontend): bump sveltekit and vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 				"@playwright/test": "^1.51.1",
 				"@rollup/plugin-inject": "^5.0.5",
 				"@sveltejs/adapter-static": "^3.0.8",
-				"@sveltejs/kit": "^2.20.2",
+				"@sveltejs/kit": "^2.20.4",
 				"@sveltejs/vite-plugin-svelte": "^5.0.3",
 				"@tailwindcss/postcss": "4.1.3",
 				"@testing-library/jest-dom": "^6.6.3",
@@ -73,7 +73,7 @@
 				"typescript": "^5.4.5",
 				"vite": "^6.2.5",
 				"vite-node": "^3.0.9",
-				"vitest": "^3.0.9",
+				"vitest": "^3.1.1",
 				"vitest-mock-extended": "^3.1.0"
 			},
 			"engines": {
@@ -171,9 +171,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.26.10",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
-			"integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+			"integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4035,9 +4035,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.20.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.2.tgz",
-			"integrity": "sha512-Dv8TOAZC9vyfcAB9TMsvUEJsRbklRTeNfcYBPaeH6KnABJ99i3CvCB2eNx8fiiliIqe+9GIchBg4RodRH5p1BQ==",
+			"version": "2.20.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.4.tgz",
+			"integrity": "sha512-B3Y1mb1Qjt57zXLVch5tfqsK/ebHe6uYTcFSnGFNwRpId3+fplLgQK6Z2zhDVBezSsPuhDq6Pry+9PA88ocN6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"@playwright/test": "^1.51.1",
 		"@rollup/plugin-inject": "^5.0.5",
 		"@sveltejs/adapter-static": "^3.0.8",
-		"@sveltejs/kit": "^2.20.2",
+		"@sveltejs/kit": "^2.20.4",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@tailwindcss/postcss": "4.1.3",
 		"@testing-library/jest-dom": "^6.6.3",
@@ -125,7 +125,7 @@
 		"typescript": "^5.4.5",
 		"vite": "^6.2.5",
 		"vite-node": "^3.0.9",
-		"vitest": "^3.0.9",
+		"vitest": "^3.1.1",
 		"vitest-mock-extended": "^3.1.0"
 	},
 	"type": "module",


### PR DESCRIPTION
# Motivation

There is yet again a new Vite server security disclosure ([CVE-2025-31486](https://github.com/advisories/GHSA-xcj6-pq6g-qj4x)). We are not affected because we do not use the Vite server and also the library is already up-to-date in the repo. Nevertheless, I go through all repo to update related dependencies and as a result this PR bumps SvelteKit and Vitest.

Nothing critical, just because I'm doing some maintenance.
