### PR TITLE
refactor(frontend): IcWalletTransactionsScheduler --> IcWalletBalanceAndTransactionsScheduler

### DIFF
--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -19,7 +19,7 @@ interface IcWalletStore<T> {
 	transactions: IndexedTransactions<T>;
 }
 
-export class IcWalletTransactionsScheduler<
+export class IcWalletBalanceAndTransactionsScheduler<
 	T extends IcrcTransaction | Transaction,
 	TWithId extends IcrcTransactionWithId | TransactionWithId,
 	PostMessageDataRequest
@@ -93,7 +93,7 @@ export class IcWalletTransactionsScheduler<
 		if (newExtendedTransactions.length === 0 && !newBalance) {
 			// We execute postMessage at least once because developer may have no transaction at all so, we want to display the balance zero
 			if (!this.initialized) {
-				this.postMessageWalletTransactions({
+				this.postMessageWalletBalanceAndTransactions({
 					transactions: [],
 					balance,
 					certified,
@@ -127,7 +127,7 @@ export class IcWalletTransactionsScheduler<
 			this.mapTransaction({ transaction, jobData })
 		);
 
-		this.postMessageWalletTransactions({
+		this.postMessageWalletBalanceAndTransactions({
 			transactions: newUiTransactions,
 			balance,
 			certified,
@@ -138,7 +138,7 @@ export class IcWalletTransactionsScheduler<
 		this.initialized = true;
 	};
 
-	private postMessageWalletTransactions({
+	private postMessageWalletBalanceAndTransactions({
 		transactions: newTransactions,
 		balance: data,
 		certified,

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -1,5 +1,5 @@
 import { getTransactions as getTransactionsApi } from '$icp/api/icp-index.api';
-import { IcWalletTransactionsScheduler } from '$icp/schedulers/ic-wallet-transactions.scheduler';
+import { IcWalletBalanceAndTransactionsScheduler } from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic-transaction';
 import { mapIcpTransaction, mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
@@ -34,12 +34,12 @@ const mapTransaction = ({
 	jobData: SchedulerJobData<PostMessageDataRequest>;
 }): IcTransactionUi => mapIcpTransaction({ transaction, identity });
 
-const initIcpWalletTransactionsScheduler = (): IcWalletTransactionsScheduler<
+const initIcpWalletBalanceAndTransactionsScheduler = (): IcWalletBalanceAndTransactionsScheduler<
 	Transaction,
 	TransactionWithId,
 	PostMessageDataRequest
 > =>
-	new IcWalletTransactionsScheduler(
+	new IcWalletBalanceAndTransactionsScheduler(
 		getTransactions,
 		mapTransactionIcpToSelf,
 		mapTransaction,
@@ -49,7 +49,7 @@ const initIcpWalletTransactionsScheduler = (): IcWalletTransactionsScheduler<
 // Exposed for test purposes
 export const initIcpWalletScheduler = (
 	_data: PostMessageDataRequest | undefined
-): IcWalletScheduler<PostMessageDataRequest> => initIcpWalletTransactionsScheduler();
+): IcWalletScheduler<PostMessageDataRequest> => initIcpWalletBalanceAndTransactionsScheduler();
 
 let scheduler: IcWalletScheduler<PostMessageDataRequest> | undefined;
 

--- a/src/frontend/src/icp/workers/icrc-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icrc-wallet.worker.ts
@@ -1,7 +1,7 @@
 import { getTransactions as getTransactionsApi } from '$icp/api/icrc-index-ng.api';
 import { balance } from '$icp/api/icrc-ledger.api';
+import { IcWalletBalanceAndTransactionsScheduler } from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
 import { IcWalletBalanceScheduler } from '$icp/schedulers/ic-wallet-balance.scheduler';
-import { IcWalletTransactionsScheduler } from '$icp/schedulers/ic-wallet-transactions.scheduler';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { mapCkBTCTransaction } from '$icp/utils/ckbtc-transactions.utils';
@@ -81,12 +81,12 @@ const getBalance = ({
 
 const MSG_SYNC_ICRC_WALLET = 'syncIcrcWallet';
 
-const initIcrcWalletTransactionsScheduler = (): IcWalletTransactionsScheduler<
+const initIcrcWalletBalanceAndTransactionsScheduler = (): IcWalletBalanceAndTransactionsScheduler<
 	IcrcTransaction,
 	IcrcTransactionWithId,
 	PostMessageDataRequestIcrcStrict
 > =>
-	new IcWalletTransactionsScheduler(
+	new IcWalletBalanceAndTransactionsScheduler(
 		getTransactions,
 		mapTransactionIcrcToSelf,
 		mapTransaction,
@@ -103,7 +103,7 @@ export const initIcrcWalletScheduler = (
 	const { success: withIndexCanister } = PostMessageDataRequestIcrcStrictSchema.safeParse(data);
 
 	return withIndexCanister
-		? initIcrcWalletTransactionsScheduler()
+		? initIcrcWalletBalanceAndTransactionsScheduler()
 		: initIcrcWalletBalanceScheduler();
 };
 

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -13,7 +13,7 @@ import { arrayOfNumberToUint8Array, jsonReplacer } from '@dfinity/utils';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-describe('ic-wallet-transactions.worker', () => {
+describe('ic-wallet-balance-and-transactions.worker', () => {
 	let spyGetTransactions: MockInstance;
 
 	let originalPostmessage: unknown;


### PR DESCRIPTION
# Motivation

Technically speaking, the scheduler/worker for the ICRC wallets fetches both transactions and balance. Since we are going to change the logic a bit to have different functions internally, one for transactions and one for balance, it seems correct to rename `IcWalletTransactionsScheduler` to `IcWalletBalanceAndTransactionsScheduler`, even if a little verbose.
