### PR TITLE
feat(frontend): hide ck conversion button when Ethereum is disabled

### DIFF
--- a/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
@@ -27,9 +27,12 @@
 
 	const { outflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 
+	let isNetworkDisabled = false;
+	$: isNetworkDisabled = (nativeTokenId === ETHEREUM_TOKEN_ID && $networkEthereumDisabled) ||
+		(nativeTokenId === SEPOLIA_TOKEN_ID && $networkSepoliaDisabled);
+
 	const isDisabled = (): boolean =>
-		(nativeTokenId === ETHEREUM_TOKEN_ID && $networkEthereumDisabled) ||
-		(nativeTokenId === SEPOLIA_TOKEN_ID && $networkSepoliaDisabled) ||
+		isNetworkDisabled ||
 		$ethAddressNotLoaded ||
 		// We can convert to ETH - i.e. we can convert to Ethereum or Sepolia, not an ERC20 token
 		isNotSupportedEthTokenId(nativeTokenId) ||
@@ -77,7 +80,7 @@
 <CkEthLoader {nativeTokenId}>
 	<ButtonHero
 		on:click={async () => await openConvert()}
-		disabled={$isBusy || $outflowActionsDisabled}
+		disabled={isNetworkDisabled || $isBusy || $outflowActionsDisabled}
 		{ariaLabel}
 	>
 		<slot name="icon" slot="icon" />

--- a/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
@@ -28,7 +28,8 @@
 	const { outflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 
 	let isNetworkDisabled = false;
-	$: isNetworkDisabled = (nativeTokenId === ETHEREUM_TOKEN_ID && $networkEthereumDisabled) ||
+	$: isNetworkDisabled =
+		(nativeTokenId === ETHEREUM_TOKEN_ID && $networkEthereumDisabled) ||
 		(nativeTokenId === SEPOLIA_TOKEN_ID && $networkSepoliaDisabled);
 
 	const isDisabled = (): boolean =>


### PR DESCRIPTION
# Motivation

We are using the enabled/disabled networks. That means that we need to hide the CK-conversion buttons in the ICRC tokens in case Ethereum networks are disabled.

# Changes

- Simplify component `ConvertEth` to have a reusable `isNetworkDisabled` reactive variable.
- Use the variable to disable the conversion button (for good measure).
- Create derived store `ckEthereumNativeTokenEnabledNetwork` that identifies if there is a twin token network enabled.
- Use the new store in ethToCkETHEnabled and erc20ToCkErc20Enabled.
- I moved the last two derived store at the end of the file, since the declaration was being done after them.

# Tests

Local replica:


https://github.com/user-attachments/assets/e47e594c-0cd0-4ca8-8ca6-d202f8507802



