### PR TITLE
refactor(frontend): rename loading function for ICRC wallet worker

### DIFF
--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -32,7 +32,7 @@ export class IcWalletBalanceAndTransactionsScheduler<
 	private initialized = false;
 
 	constructor(
-		private getTransactions: (
+		private getBalanceAndTransactions: (
 			data: SchedulerJobParams<PostMessageDataRequest>
 		) => Promise<GetTransactions & { transactions: TWithId[] }>,
 		private mapToSelfTransaction: (
@@ -56,7 +56,7 @@ export class IcWalletBalanceAndTransactionsScheduler<
 	}: SchedulerJobData<PostMessageDataRequest>) => {
 		await queryAndUpdate<GetTransactions & { transactions: TWithId[] }>({
 			request: ({ identity: _, certified }) =>
-				this.getTransactions({ ...data, identity, certified }),
+				this.getBalanceAndTransactions({ ...data, identity, certified }),
 			onLoad: ({ certified, ...rest }) => {
 				this.syncTransactions({ jobData: { identity, ...data }, certified, ...rest });
 				this.cleanTransactions({ certified });

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -1,4 +1,4 @@
-import { getTransactions as getTransactionsApi } from '$icp/api/icp-index.api';
+import { getTransactions } from '$icp/api/icp-index.api';
 import { IcWalletBalanceAndTransactionsScheduler } from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic-transaction';
@@ -12,11 +12,11 @@ import type {
 } from '@dfinity/ledger-icp';
 import { isNullish } from '@dfinity/utils';
 
-const getTransactions = ({
+const getBalanceAndTransactions = ({
 	identity,
 	certified
 }: SchedulerJobParams<PostMessageDataRequest>): Promise<GetAccountIdentifierTransactionsResponse> =>
-	getTransactionsApi({
+	getTransactions({
 		identity,
 		certified,
 		owner: identity.getPrincipal(),
@@ -40,7 +40,7 @@ const initIcpWalletBalanceAndTransactionsScheduler = (): IcWalletBalanceAndTrans
 	PostMessageDataRequest
 > =>
 	new IcWalletBalanceAndTransactionsScheduler(
-		getTransactions,
+		getBalanceAndTransactions,
 		mapTransactionIcpToSelf,
 		mapTransaction,
 		'syncIcpWallet'

--- a/src/frontend/src/icp/workers/icrc-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icrc-wallet.worker.ts
@@ -26,7 +26,7 @@ import {
 } from '@dfinity/ledger-icrc';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 
-const getTransactions = ({
+const getBalanceAndTransactions = ({
 	identity,
 	certified,
 	data
@@ -87,7 +87,7 @@ const initIcrcWalletBalanceAndTransactionsScheduler = (): IcWalletBalanceAndTran
 	PostMessageDataRequestIcrcStrict
 > =>
 	new IcWalletBalanceAndTransactionsScheduler(
-		getTransactions,
+		getBalanceAndTransactions,
 		mapTransactionIcrcToSelf,
 		mapTransaction,
 		MSG_SYNC_ICRC_WALLET


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/5708 I forgot to rename the loading function inside the ICRC wallet worker: for consistency we rename it from `getTransactions` to `getBalanceAndTransactions`.
