### PR TITLE
fix(frontend): Network name in token group

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -42,7 +42,7 @@
 		</span>
 
 		<span class:text-sm={condensed} slot="title">
-			{condensed ? data.name : data.symbol}
+			{asNetwork ? data.network.name : data.symbol}
 		</span>
 
 		<span class:text-sm={condensed} slot="subtitle">


### PR DESCRIPTION
# Motivation

In the homepage token list, grouped tokens should display the network name, not the token name since the group itself is displaying it already. Exception is the ck twin tokens, which should display the symbol.

# Changes

If token card displayed as network (`!isCkToken` condition), render network name instead of symbol.

# Tests

![image](https://github.com/user-attachments/assets/32a01875-8bc0-4a67-ac86-eefac2f68c2f)
