### PR TITLE
feat(frontend): renames goToWizardStep function

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertModal.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertModal.svelte
@@ -19,7 +19,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
-	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	export let sourceToken: Token;
 	export let destinationToken: Token;
@@ -67,7 +67,7 @@
 		});
 
 	const goToStep = (stepName: WizardStepsConvert) =>
-		goToWizardSendStep({
+		goToWizardStep({
 			modal,
 			steps,
 			stepName

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -23,7 +23,7 @@
 	import type { Network, NetworkId } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
-	import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	export let destination = '';
 	export let targetNetwork: Network | undefined = undefined;
@@ -86,7 +86,7 @@
 	};
 
 	const goToStep = (stepName: WizardStepsSend) =>
-		goToWizardSendStep({
+		goToWizardStep({
 			modal,
 			steps,
 			stepName
@@ -130,13 +130,13 @@
 			on:icNext={modal.next}
 			on:icClose={close}
 			on:icQRCodeScan={() =>
-				goToWizardSendStep({
+				goToWizardStep({
 					modal,
 					steps,
 					stepName: WizardStepsSend.QR_CODE_SCAN
 				})}
 			on:icQRCodeBack={() =>
-				goToWizardSendStep({
+				goToWizardStep({
 					modal,
 					steps,
 					stepName: WizardStepsSend.SEND

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -1,7 +1,7 @@
 import type { WizardStepsConvert, WizardStepsSend } from '$lib/enums/wizard-steps';
 import { type WizardModal, type WizardSteps } from '@dfinity/gix-components';
 
-export const goToWizardSendStep = ({
+export const goToWizardStep = ({
 	modal,
 	steps,
 	stepName

--- a/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/wizard-modal.utils.spec.ts
@@ -1,5 +1,5 @@
 import type { WizardStepsSend } from '$lib/enums/wizard-steps';
-import { goToWizardSendStep } from '$lib/utils/wizard-modal.utils';
+import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 import { type WizardModal, type WizardSteps } from '@dfinity/gix-components';
 
 const mockModal = {
@@ -21,7 +21,7 @@ describe('goToWizardStep', () => {
 	it('should set the modal to the correct step number for each step', () => {
 		mockSteps.forEach((step, index) => {
 			mockModal.set.mockClear();
-			goToWizardSendStep({
+			goToWizardStep({
 				modal: mockModal as unknown as WizardModal,
 				steps: mockSteps,
 				stepName: step.name as WizardStepsSend
@@ -32,7 +32,7 @@ describe('goToWizardStep', () => {
 	});
 
 	it('should set the modal to 0 if step name is not found', () => {
-		goToWizardSendStep({
+		goToWizardStep({
 			modal: mockModal as unknown as WizardModal,
 			steps: mockSteps,
 			stepName: 'nonExistentStep' as WizardStepsSend


### PR DESCRIPTION
# Motivation

The function `goToWizardSendStep` should be renamed to `goToWizardStep` since it is not only used for the `send` flow.

# Changes

- renames function
