### PR TITLE
feat(frontend): Notification blob on hide zero balance menu

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensMenu.svelte
@@ -9,6 +9,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { emit } from '$lib/utils/events.utils';
+	import NotificationBlob from '$lib/components/ui/NotificationBlob.svelte';
+	import { hideZeroBalances } from '$lib/derived/settings.derived';
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
@@ -33,7 +35,9 @@
 	colorStyle="muted"
 	styleClass={visible ? 'active' : ''}
 >
-	<IconManage slot="icon" />
+	<NotificationBlob slot="icon" display={$hideZeroBalances} position="top-right">
+		<IconManage />
+	</NotificationBlob>
 </ButtonIcon>
 
 <Popover bind:visible anchor={button} invisibleBackdrop direction="rtl">

--- a/src/frontend/src/lib/components/ui/NotificationBlob.svelte
+++ b/src/frontend/src/lib/components/ui/NotificationBlob.svelte
@@ -5,7 +5,7 @@
 
 <div class="relative">
 	<div
-		class="duration-250 absolute h-2 w-2 rounded-full bg-brand-primary shadow shadow-white transition"
+		class="duration-250 shadow-primary absolute h-2 w-2 rounded-full bg-brand-primary shadow transition"
 		class:-top-1={position.indexOf('top') >= 0}
 		class:-left-1={position.indexOf('left') >= 0}
 		class:-right-1={position.indexOf('right') >= 0}

--- a/src/frontend/src/lib/components/ui/NotificationBlob.svelte
+++ b/src/frontend/src/lib/components/ui/NotificationBlob.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	export let position: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' = 'top-left';
+	export let display = true;
+</script>
+
+<div class="relative">
+	<div
+		class="duration-250 absolute h-2 w-2 rounded-full bg-brand-primary shadow shadow-white transition"
+		class:-top-1={position.indexOf('top') >= 0}
+		class:-left-1={position.indexOf('left') >= 0}
+		class:-right-1={position.indexOf('right') >= 0}
+		class:-bottom-1={position.indexOf('bottom') >= 0}
+		class:opacity-100={display}
+		class:opacity-0={!display}
+	></div>
+	<slot />
+</div>


### PR DESCRIPTION
# Motivation

Here were adding a notification blob to indicate to the user when he has hidden zero balance token cards.

# Changes

- Added `<NotificationBlob/>` component for reusability
- Added the blob to the icon that opens the zero balance menu

# Tests
![image](https://github.com/user-attachments/assets/cd2d5a13-ceca-4027-8cb1-5f5b52b1cfac)
![image](https://github.com/user-attachments/assets/701f044f-b63f-496a-a002-493ea2c3afbb)
