### PR TITLE
chore(devops): Allow caching in testnet deployments

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # Staging is deployed with every commit to main, so needs to be fast, hence the use of caching.
+      #
+      # Similarly, deployments to test environments need to be fast, to make developers productive.
+      #
+      # Production builds are verified independently, so bad builds, due to cache poisoning
+      # or any other reason, would be detected.
+      - deploy-to-environment.yml


### PR DESCRIPTION
# Motivation
There is a zizmor lint about using caching for release artefacts, as the cache could be poisoned.

For us, the release artefacts are the Wasm, arguments and frontend deployed to production.  These artefacts are verified independently, so the concern doesn't apply.

We make frequent deployments to staging and test environments; the time taken for uncached builds is unreasonable.

There is no real protection against a hostile employee adding values to any cache key of their choice.  So I believe that production builds are safe, and we need to accept the residual risk of a hypothetical evil employee making an evil test build.

# Alternative considered
- Zizmor uses a fuzzy test to determine that the deployment workflow creates release artefacts.  It might be possible to try to tell Zizmor that this is not a release artefact.

# Changes
- Ada zizmor configuration file & allow caching.

# Tests
### Zizmor now accepts caching in the depoyment workflow
- Tested locally, and can doubtless also be observed in CI.