### PR TITLE
feat(devops): create guard for deployments in prod

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -59,10 +59,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event.inputs.network }}-${{ github.event.inputs.canister }}
   cancel-in-progress: false
 
-permissions: {}
+permissions: { }
 
 jobs:
   deployment:
+    if: "${{ github.event.inputs.network != 'ic' && github.event.inputs.network != 'prod' && inputs.network != 'ic' && inputs.network != 'prod' }}"
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -301,6 +302,11 @@ jobs:
 
       - name: Deploy Frontend to Environment
         run: |
+          if [ "$NETWORK" == "ic" ] || [ "$NETWORK" == "prod" ]; then
+            echo "Deployment to NETWORK=$NETWORK is not allowed"
+            exit 1
+          fi
+          
           if [ "$deploy_frontend" == "true" ] ; then
             dfx deploy frontend --network $NETWORK
           fi
@@ -326,6 +332,11 @@ jobs:
 
       - name: Deploy Backend to Environment
         run: |
+          if [ "$NETWORK" == "ic" ] || [ "$NETWORK" == "prod" ]; then
+            echo "Deployment to NETWORK=$NETWORK is not allowed"
+            exit 1
+          fi
+          
           DFX_DEPLOY_FLAGS=() # Arguments to be added to the dfx deploy command.
           [[ "$FORCE_BACKEND" != "true" ]] || DFX_DEPLOY_FLAGS+=('--yes' '--upgrade-unchanged') # Corresponds to: dfx deploy --yes --upgrade-unchanged
 

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -59,7 +59,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event.inputs.network }}-${{ github.event.inputs.canister }}
   cancel-in-progress: false
 
-permissions: { }
+permissions: {}
 
 jobs:
   deployment:
@@ -306,7 +306,7 @@ jobs:
             echo "Deployment to NETWORK=$NETWORK is not allowed"
             exit 1
           fi
-          
+
           if [ "$deploy_frontend" == "true" ] ; then
             dfx deploy frontend --network $NETWORK
           fi
@@ -336,7 +336,7 @@ jobs:
             echo "Deployment to NETWORK=$NETWORK is not allowed"
             exit 1
           fi
-          
+
           DFX_DEPLOY_FLAGS=() # Arguments to be added to the dfx deploy command.
           [[ "$FORCE_BACKEND" != "true" ]] || DFX_DEPLOY_FLAGS+=('--yes' '--upgrade-unchanged') # Corresponds to: dfx deploy --yes --upgrade-unchanged
 


### PR DESCRIPTION
# Motivation

As safe measure (thread in PR https://github.com/dfinity/oisy-wallet/pull/5728), we want to avoid the deployment job to run for production environment.
