### PR TITLE
feat(frontend): uses auth help modal

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthGuard.svelte
+++ b/src/frontend/src/lib/components/auth/AuthGuard.svelte
@@ -2,6 +2,9 @@
 	import { fade } from 'svelte/transition';
 	import LandingPage from '$lib/components/auth/LandingPage.svelte';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
+	import {modalAuthHelp, modalAuthHelpData} from "$lib/derived/modal.derived";
+	import {nonNullish} from "@dfinity/utils";
+	import AuthHelpModal from "$lib/components/auth/AuthHelpModal.svelte";
 </script>
 
 {#if $authNotSignedIn}
@@ -10,4 +13,8 @@
 	<div in:fade class="md:block md:overflow-y-auto">
 		<slot />
 	</div>
+{/if}
+
+{#if $modalAuthHelp && nonNullish($modalAuthHelpData)}
+	<AuthHelpModal usesIdentityHelp={$modalAuthHelpData} />
 {/if}

--- a/src/frontend/src/lib/components/auth/AuthGuard.svelte
+++ b/src/frontend/src/lib/components/auth/AuthGuard.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
+	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
 	import LandingPage from '$lib/components/auth/LandingPage.svelte';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
-	import {modalAuthHelp, modalAuthHelpData} from "$lib/derived/modal.derived";
-	import {nonNullish} from "@dfinity/utils";
-	import AuthHelpModal from "$lib/components/auth/AuthHelpModal.svelte";
+	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
 </script>
 
 {#if $authNotSignedIn}

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -5,7 +5,7 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import {modalStore} from "$lib/stores/modal.store";
+	import { modalStore } from '$lib/stores/modal.store';
 
 	export let fullWidth = false;
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -5,6 +5,7 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {modalStore} from "$lib/stores/modal.store";
 
 	export let fullWidth = false;
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
@@ -14,7 +15,10 @@
 			name: TRACK_COUNT_SIGN_IN_CLICK
 		});
 
-		await signIn({});
+		const { success } = await signIn({});
+		if (success !== 'ok') {
+			modalStore.openAuthHelp(false);
+		}
 	};
 </script>
 

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -16,7 +16,7 @@
 		});
 
 		const { success } = await signIn({});
-		if (success !== 'ok') {
+		if (success === 'cancelled' || 'error') {
 			modalStore.openAuthHelp(false);
 		}
 	};

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -16,7 +16,7 @@
 		});
 
 		const { success } = await signIn({});
-		if (success === 'cancelled' || 'error') {
+		if (success === 'cancelled' || success === 'error') {
 			modalStore.openAuthHelp(false);
 		}
 	};

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -180,5 +180,5 @@ export const modalAuthHelp: Readable<boolean> = derived(
 );
 export const modalAuthHelpData: Readable<boolean | undefined> = derived(
 	modalStore,
-	($modalStore) => $modalStore?.type === 'auth-help' ? $modalStore?.data as boolean : undefined
+	($modalStore) => ($modalStore?.type === 'auth-help' ? ($modalStore?.data as boolean) : undefined)
 );

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -174,7 +174,6 @@ export const modalSettingsData: Readable<SettingsModalType> = derived(
 	($modalStore) => $modalStore?.data as SettingsModalType
 );
 
-
 export const modalAuthHelp: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'auth-help'

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -173,3 +173,13 @@ export const modalSettingsData: Readable<SettingsModalType> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.data as SettingsModalType
 );
+
+
+export const modalAuthHelp: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'auth-help'
+);
+export const modalAuthHelpData: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.data as boolean
+);

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -178,7 +178,7 @@ export const modalAuthHelp: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'auth-help'
 );
-export const modalAuthHelpData: Readable<boolean> = derived(
+export const modalAuthHelpData: Readable<boolean | undefined> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'auth-help' ? $modalStore?.data as boolean : undefined
 );

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -180,5 +180,5 @@ export const modalAuthHelp: Readable<boolean> = derived(
 );
 export const modalAuthHelpData: Readable<boolean> = derived(
 	modalStore,
-	($modalStore) => $modalStore?.data as boolean
+	($modalStore) => $modalStore?.type === 'auth-help' ? $modalStore?.data as boolean : undefined
 );

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -43,7 +43,8 @@ export interface Modal<T> {
 		| 'vip-reward-state'
 		| 'reward-details'
 		| 'reward-state'
-		| 'settings';
+		| 'settings'
+		| 'auth-help';
 	data?: T;
 	id?: symbol;
 }
@@ -92,6 +93,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openRewardState: <D extends T>(data: D) => void;
 	// todo: type methods above accordingly, otherwise data will be typed as unknown without making use of generics
 	openSettings: (data: SettingsModalType) => void;
+	openAuthHelp: (data: boolean) => void;
 	close: () => void;
 }
 
@@ -149,6 +151,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openRewardState: setTypeWithData('reward-state'),
 		// todo: explicitly define type here as well
 		openSettings: <(data: SettingsModalType) => void>setTypeWithData('settings'),
+		openAuthHelp: <(data: boolean) => void>setTypeWithData('auth-help'),
 		close: () => set(null),
 		subscribe
 	};


### PR DESCRIPTION
# Motivation

When a user starts the login process and then closes it, the new help modal should appear.

# Changes

- opens auth help modal

# Tests


https://github.com/user-attachments/assets/5d6f5788-756a-4e85-990f-171303aed707


