### PR TITLE
fix(frontend): Fix modal content width

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -187,6 +187,7 @@ div.modal {
 
 		& > div.container {
 			border-radius: 0;
+			max-width: 100% !important;
 		}
 	}
 


### PR DESCRIPTION
# Motivation

The modal contents are not taking full width for a certain screen width region.

# Changes

Force max width to 100%

# Tests

Before:
![image](https://github.com/user-attachments/assets/7140e8bf-08a6-4132-b5c8-7878350e1540)

After:
![image](https://github.com/user-attachments/assets/df1809a5-1f67-42d6-88b7-4330dc3e5588)

