### PR TITLE
feat(devops): Add testnets 5&6

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -19,6 +19,8 @@ on:
           - test_fe_2
           - test_fe_3
           - test_fe_4
+          - test_fe_5
+          - test_fe_6
           - test_be_1
           - audit
       canister:

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,25 +1,27 @@
 {
-	"airdrop_deprecated": {
-		"ic": "fiefn-syaaa-aaaan-qectq-cai",
-		"staging": "t7tos-nyaaa-aaaad-aadkq-cai"
-	},
-	"backend": {
-		"audit": "vhcnk-oqaaa-aaaah-araya-cai",
-		"beta": "yrinv-sqaaa-aaaan-qzmxq-cai",
-		"e2e": "odvuj-myaaa-aaaal-qskqq-cai",
-		"ic": "doked-biaaa-aaaar-qag2a-cai",
-		"staging": "d3nvo-aaaaa-aaaar-qagzq-cai",
-		"test_be_1": "jloto-byaaa-aaaap-anryq-cai"
-	},
-	"frontend": {
-		"audit": "vadl6-diaaa-aaaah-arayq-cai",
-		"beta": "v7iq7-yiaaa-aaaan-qmrtq-cai",
-		"e2e": "okw7v-2qaaa-aaaal-qskra-cai",
-		"ic": "cha4i-riaaa-aaaan-qeccq-cai",
-		"staging": "tewsx-xaaaa-aaaad-aadia-cai",
-		"test_fe_1": "6qzfn-gyaaa-aaaar-qaisa-cai",
-		"test_fe_2": "6xydz-laaaa-aaaar-qaisq-cai",
-		"test_fe_3": "dxvmu-wiaaa-aaaah-aqzaa-cai",
-		"test_fe_4": "gwqec-uqaaa-aaaak-qlnza-cai"
-	}
+  "airdrop_deprecated": {
+    "ic": "fiefn-syaaa-aaaan-qectq-cai",
+    "staging": "t7tos-nyaaa-aaaad-aadkq-cai"
+  },
+  "backend": {
+    "audit": "vhcnk-oqaaa-aaaah-araya-cai",
+    "beta": "yrinv-sqaaa-aaaan-qzmxq-cai",
+    "e2e": "odvuj-myaaa-aaaal-qskqq-cai",
+    "ic": "doked-biaaa-aaaar-qag2a-cai",
+    "staging": "d3nvo-aaaaa-aaaar-qagzq-cai",
+    "test_be_1": "jloto-byaaa-aaaap-anryq-cai"
+  },
+  "frontend": {
+    "audit": "vadl6-diaaa-aaaah-arayq-cai",
+    "beta": "v7iq7-yiaaa-aaaan-qmrtq-cai",
+    "e2e": "okw7v-2qaaa-aaaal-qskra-cai",
+    "ic": "cha4i-riaaa-aaaan-qeccq-cai",
+    "staging": "tewsx-xaaaa-aaaad-aadia-cai",
+    "test_fe_1": "6qzfn-gyaaa-aaaar-qaisa-cai",
+    "test_fe_2": "6xydz-laaaa-aaaar-qaisq-cai",
+    "test_fe_3": "dxvmu-wiaaa-aaaah-aqzaa-cai",
+    "test_fe_4": "gwqec-uqaaa-aaaak-qlnza-cai",
+    "test_fe_5": "c4fs2-pqaaa-aaaal-qsl7a-cai",
+    "test_fe_6": "ehrur-ziaaa-aaaaj-az7lq-cai"
+  }
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,27 +1,27 @@
 {
-  "airdrop_deprecated": {
-    "ic": "fiefn-syaaa-aaaan-qectq-cai",
-    "staging": "t7tos-nyaaa-aaaad-aadkq-cai"
-  },
-  "backend": {
-    "audit": "vhcnk-oqaaa-aaaah-araya-cai",
-    "beta": "yrinv-sqaaa-aaaan-qzmxq-cai",
-    "e2e": "odvuj-myaaa-aaaal-qskqq-cai",
-    "ic": "doked-biaaa-aaaar-qag2a-cai",
-    "staging": "d3nvo-aaaaa-aaaar-qagzq-cai",
-    "test_be_1": "jloto-byaaa-aaaap-anryq-cai"
-  },
-  "frontend": {
-    "audit": "vadl6-diaaa-aaaah-arayq-cai",
-    "beta": "v7iq7-yiaaa-aaaan-qmrtq-cai",
-    "e2e": "okw7v-2qaaa-aaaal-qskra-cai",
-    "ic": "cha4i-riaaa-aaaan-qeccq-cai",
-    "staging": "tewsx-xaaaa-aaaad-aadia-cai",
-    "test_fe_1": "6qzfn-gyaaa-aaaar-qaisa-cai",
-    "test_fe_2": "6xydz-laaaa-aaaar-qaisq-cai",
-    "test_fe_3": "dxvmu-wiaaa-aaaah-aqzaa-cai",
-    "test_fe_4": "gwqec-uqaaa-aaaak-qlnza-cai",
-    "test_fe_5": "c4fs2-pqaaa-aaaal-qsl7a-cai",
-    "test_fe_6": "ehrur-ziaaa-aaaaj-az7lq-cai"
-  }
+	"airdrop_deprecated": {
+		"ic": "fiefn-syaaa-aaaan-qectq-cai",
+		"staging": "t7tos-nyaaa-aaaad-aadkq-cai"
+	},
+	"backend": {
+		"audit": "vhcnk-oqaaa-aaaah-araya-cai",
+		"beta": "yrinv-sqaaa-aaaan-qzmxq-cai",
+		"e2e": "odvuj-myaaa-aaaal-qskqq-cai",
+		"ic": "doked-biaaa-aaaar-qag2a-cai",
+		"staging": "d3nvo-aaaaa-aaaar-qagzq-cai",
+		"test_be_1": "jloto-byaaa-aaaap-anryq-cai"
+	},
+	"frontend": {
+		"audit": "vadl6-diaaa-aaaah-arayq-cai",
+		"beta": "v7iq7-yiaaa-aaaan-qmrtq-cai",
+		"e2e": "okw7v-2qaaa-aaaal-qskra-cai",
+		"ic": "cha4i-riaaa-aaaan-qeccq-cai",
+		"staging": "tewsx-xaaaa-aaaad-aadia-cai",
+		"test_fe_1": "6qzfn-gyaaa-aaaar-qaisa-cai",
+		"test_fe_2": "6xydz-laaaa-aaaar-qaisq-cai",
+		"test_fe_3": "dxvmu-wiaaa-aaaah-aqzaa-cai",
+		"test_fe_4": "gwqec-uqaaa-aaaak-qlnza-cai",
+		"test_fe_5": "c4fs2-pqaaa-aaaal-qsl7a-cai",
+		"test_fe_6": "ehrur-ziaaa-aaaaj-az7lq-cai"
+	}
 }

--- a/dfx.json
+++ b/dfx.json
@@ -18,6 +18,8 @@
 					"test_fe_2": "tdxud-2yaaa-aaaad-aadiq-cai",
 					"test_fe_3": "tdxud-2yaaa-aaaad-aadiq-cai",
 					"test_fe_4": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_5": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_6": "tdxud-2yaaa-aaaad-aadiq-cai",
 					"audit": "tdxud-2yaaa-aaaad-aadiq-cai",
 					"staging": "tdxud-2yaaa-aaaad-aadiq-cai",
 					"e2e": "tdxud-2yaaa-aaaad-aadiq-cai"
@@ -40,6 +42,8 @@
 					"test_fe_2": "2ipq2-uqaaa-aaaar-qailq-cai",
 					"test_fe_3": "2ipq2-uqaaa-aaaar-qailq-cai",
 					"test_fe_4": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"test_fe_5": "2ipq2-uqaaa-aaaar-qailq-cai",
+					"test_fe_6": "2ipq2-uqaaa-aaaar-qailq-cai",
 					"audit": "2ipq2-uqaaa-aaaar-qailq-cai",
 					"staging": "2ipq2-uqaaa-aaaar-qailq-cai",
 					"e2e": "2ipq2-uqaaa-aaaar-qailq-cai"
@@ -60,7 +64,9 @@
 					"test_fe_1": "d3nvo-aaaaa-aaaar-qagzq-cai",
 					"test_fe_2": "d3nvo-aaaaa-aaaar-qagzq-cai",
 					"test_fe_3": "d3nvo-aaaaa-aaaar-qagzq-cai",
-					"test_fe_4": "d3nvo-aaaaa-aaaar-qagzq-cai"
+					"test_fe_4": "d3nvo-aaaaa-aaaar-qagzq-cai",
+					"test_fe_5": "d3nvo-aaaaa-aaaar-qagzq-cai",
+					"test_fe_6": "d3nvo-aaaaa-aaaar-qagzq-cai"
 				}
 			}
 		},
@@ -105,6 +111,8 @@
 					"test_fe_2": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"test_fe_3": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"test_fe_4": "rdmx6-jaaaa-aaaaa-aaadq-cai",
+					"test_fe_5": "rdmx6-jaaaa-aaaaa-aaadq-cai",
+					"test_fe_6": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"audit": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"staging": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"beta": "rdmx6-jaaaa-aaaaa-aaadq-cai",
@@ -126,6 +134,8 @@
 					"test_fe_2": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"test_fe_3": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"test_fe_4": "um5iw-rqaaa-aaaaq-qaaba-cai",
+					"test_fe_5": "um5iw-rqaaa-aaaaq-qaaba-cai",
+					"test_fe_6": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"audit": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"staging": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"beta": "um5iw-rqaaa-aaaaq-qaaba-cai",
@@ -147,6 +157,8 @@
 					"test_fe_2": "2vxsx-fae",
 					"test_fe_3": "2vxsx-fae",
 					"test_fe_4": "2vxsx-fae",
+					"test_fe_5": "2vxsx-fae",
+					"test_fe_6": "2vxsx-fae",
 					"audit": "2vxsx-fae",
 					"staging": "2vxsx-fae",
 					"beta": "2vxsx-fae",
@@ -168,6 +180,8 @@
 					"test_fe_2": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"test_fe_3": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"test_fe_4": "qbw6f-caaaa-aaaah-qdcwa-cai",
+					"test_fe_5": "qbw6f-caaaa-aaaah-qdcwa-cai",
+					"test_fe_6": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"audit": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"staging": "qbw6f-caaaa-aaaah-qdcwa-cai",
 					"beta": "qgxyr-pyaaa-aaaah-qdcwq-cai",
@@ -190,6 +204,8 @@
 					"test_fe_2": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"test_fe_3": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"test_fe_4": "ryjl3-tyaaa-aaaaa-aaaba-cai",
+					"test_fe_5": "ryjl3-tyaaa-aaaaa-aaaba-cai",
+					"test_fe_6": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"audit": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"staging": "ryjl3-tyaaa-aaaaa-aaaba-cai",
 					"beta": "ryjl3-tyaaa-aaaaa-aaaba-cai",
@@ -213,6 +229,8 @@
 					"test_fe_2": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"test_fe_3": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"test_fe_4": "qhbym-qaaaa-aaaaa-aaafq-cai",
+					"test_fe_5": "qhbym-qaaaa-aaaaa-aaafq-cai",
+					"test_fe_6": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"audit": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"staging": "qhbym-qaaaa-aaaaa-aaafq-cai",
 					"beta": "qhbym-qaaaa-aaaaa-aaafq-cai",
@@ -234,6 +252,8 @@
 					"test_fe_2": "ml52i-qqaaa-aaaar-qaaba-cai",
 					"test_fe_3": "ml52i-qqaaa-aaaar-qaaba-cai",
 					"test_fe_4": "ml52i-qqaaa-aaaar-qaaba-cai",
+					"test_fe_5": "ml52i-qqaaa-aaaar-qaaba-cai",
+					"test_fe_6": "ml52i-qqaaa-aaaar-qaaba-cai",
 					"audit": "ml52i-qqaaa-aaaar-qaaba-cai",
 					"staging": "ml52i-qqaaa-aaaar-qaaba-cai",
 					"e2e": "ml52i-qqaaa-aaaar-qaaba-cai"
@@ -253,6 +273,8 @@
 					"test_fe_2": "mc6ru-gyaaa-aaaar-qaaaq-cai",
 					"test_fe_3": "mc6ru-gyaaa-aaaar-qaaaq-cai",
 					"test_fe_4": "mc6ru-gyaaa-aaaar-qaaaq-cai",
+					"test_fe_5": "mc6ru-gyaaa-aaaar-qaaaq-cai",
+					"test_fe_6": "mc6ru-gyaaa-aaaar-qaaaq-cai",
 					"audit": "mc6ru-gyaaa-aaaar-qaaaq-cai",
 					"staging": "mc6ru-gyaaa-aaaar-qaaaq-cai",
 					"e2e": "mc6ru-gyaaa-aaaar-qaaaq-cai"
@@ -272,6 +294,8 @@
 					"test_fe_2": "mm444-5iaaa-aaaar-qaabq-cai",
 					"test_fe_3": "mm444-5iaaa-aaaar-qaabq-cai",
 					"test_fe_4": "mm444-5iaaa-aaaar-qaabq-cai",
+					"test_fe_5": "mm444-5iaaa-aaaar-qaabq-cai",
+					"test_fe_6": "mm444-5iaaa-aaaar-qaabq-cai",
 					"audit": "mm444-5iaaa-aaaar-qaabq-cai",
 					"staging": "mm444-5iaaa-aaaar-qaabq-cai",
 					"e2e": "mm444-5iaaa-aaaar-qaabq-cai"
@@ -291,6 +315,8 @@
 					"test_fe_2": "pvm5g-xaaaa-aaaar-qaaia-cai",
 					"test_fe_3": "pvm5g-xaaaa-aaaar-qaaia-cai",
 					"test_fe_4": "pvm5g-xaaaa-aaaar-qaaia-cai",
+					"test_fe_5": "pvm5g-xaaaa-aaaar-qaaia-cai",
+					"test_fe_6": "pvm5g-xaaaa-aaaar-qaaia-cai",
 					"audit": "pvm5g-xaaaa-aaaar-qaaia-cai",
 					"staging": "pvm5g-xaaaa-aaaar-qaaia-cai",
 					"e2e": "pvm5g-xaaaa-aaaar-qaaia-cai"
@@ -312,6 +338,8 @@
 					"test_fe_2": "jzenf-aiaaa-aaaar-qaa7q-cai",
 					"test_fe_3": "jzenf-aiaaa-aaaar-qaa7q-cai",
 					"test_fe_4": "jzenf-aiaaa-aaaar-qaa7q-cai",
+					"test_fe_5": "jzenf-aiaaa-aaaar-qaa7q-cai",
+					"test_fe_6": "jzenf-aiaaa-aaaar-qaa7q-cai",
 					"audit": "jzenf-aiaaa-aaaar-qaa7q-cai",
 					"staging": "jzenf-aiaaa-aaaar-qaa7q-cai",
 					"e2e": "jzenf-aiaaa-aaaar-qaa7q-cai"
@@ -335,6 +363,8 @@
 					"test_fe_2": "apia6-jaaaa-aaaar-qabma-cai",
 					"test_fe_3": "apia6-jaaaa-aaaar-qabma-cai",
 					"test_fe_4": "apia6-jaaaa-aaaar-qabma-cai",
+					"test_fe_5": "apia6-jaaaa-aaaar-qabma-cai",
+					"test_fe_6": "apia6-jaaaa-aaaar-qabma-cai",
 					"audit": "apia6-jaaaa-aaaar-qabma-cai",
 					"staging": "apia6-jaaaa-aaaar-qabma-cai",
 					"e2e": "apia6-jaaaa-aaaar-qabma-cai"
@@ -358,6 +388,8 @@
 					"test_fe_2": "sh5u2-cqaaa-aaaar-qacna-cai",
 					"test_fe_3": "sh5u2-cqaaa-aaaar-qacna-cai",
 					"test_fe_4": "sh5u2-cqaaa-aaaar-qacna-cai",
+					"test_fe_5": "sh5u2-cqaaa-aaaar-qacna-cai",
+					"test_fe_6": "sh5u2-cqaaa-aaaar-qacna-cai",
 					"audit": "sh5u2-cqaaa-aaaar-qacna-cai",
 					"staging": "sh5u2-cqaaa-aaaar-qacna-cai",
 					"e2e": "sh5u2-cqaaa-aaaar-qacna-cai"
@@ -380,6 +412,8 @@
 					"test_fe_2": "yfumr-cyaaa-aaaar-qaela-cai",
 					"test_fe_3": "yfumr-cyaaa-aaaar-qaela-cai",
 					"test_fe_4": "yfumr-cyaaa-aaaar-qaela-cai",
+					"test_fe_5": "yfumr-cyaaa-aaaar-qaela-cai",
+					"test_fe_6": "yfumr-cyaaa-aaaar-qaela-cai",
 					"audit": "yfumr-cyaaa-aaaar-qaela-cai",
 					"staging": "yfumr-cyaaa-aaaar-qaela-cai"
 				}
@@ -401,6 +435,8 @@
 					"test_fe_2": "ycvkf-paaaa-aaaar-qaelq-cai",
 					"test_fe_3": "ycvkf-paaaa-aaaar-qaelq-cai",
 					"test_fe_4": "ycvkf-paaaa-aaaar-qaelq-cai",
+					"test_fe_5": "ycvkf-paaaa-aaaar-qaelq-cai",
+					"test_fe_6": "ycvkf-paaaa-aaaar-qaelq-cai",
 					"audit": "ycvkf-paaaa-aaaar-qaelq-cai",
 					"staging": "ycvkf-paaaa-aaaar-qaelq-cai"
 				}
@@ -420,6 +456,8 @@
 					"test_fe_2": "vi6cu-aiaaa-aaaad-aad7q-cai",
 					"test_fe_3": "vi6cu-aiaaa-aaaad-aad7q-cai",
 					"test_fe_4": "vi6cu-aiaaa-aaaad-aad7q-cai",
+					"test_fe_5": "vi6cu-aiaaa-aaaad-aad7q-cai",
+					"test_fe_6": "vi6cu-aiaaa-aaaad-aad7q-cai",
 					"e2e": "vi6cu-aiaaa-aaaad-aad7q-cai",
 					"audit": "vi6cu-aiaaa-aaaad-aad7q-cai"
 				}
@@ -451,6 +489,14 @@
 			"type": "persistent"
 		},
 		"test_fe_4": {
+			"providers": ["https://icp0.io"],
+			"type": "persistent"
+		},
+		"test_fe_5": {
+			"providers": ["https://icp0.io"],
+			"type": "persistent"
+		},
+		"test_fe_6": {
 			"providers": ["https://icp0.io"],
 			"type": "persistent"
 		},

--- a/scripts/build.ic-domains.test.expected
+++ b/scripts/build.ic-domains.test.expected
@@ -7,4 +7,6 @@ fe1.oisy.com test_fe_1
 fe2.oisy.com test_fe_2
 fe3.oisy.com test_fe_3
 fe4.oisy.com test_fe_4
+fe5.oisy.com test_fe_5
+fe6.oisy.com test_fe_6
 e2e.oisy.com e2e

--- a/scripts/domains.json
+++ b/scripts/domains.json
@@ -5,6 +5,8 @@
 		"test_fe_2": "https://fe2.oisy.com",
 		"test_fe_3": "https://fe3.oisy.com",
 		"test_fe_4": "https://fe4.oisy.com",
+		"test_fe_5": "https://fe5.oisy.com",
+		"test_fe_6": "https://fe6.oisy.com",
 		"staging": "https://staging.oisy.com",
 		"beta": "https://beta.oisy.com",
 		"audit": "https://audit.oisy.com",


### PR DESCRIPTION
# Motivation
We would like more test environments

# Changes
- Add test networks `test_fe_5` and `test_fe_6`.

# Tests
## Cycleops
Canisters have been added to cycleops
## Controllers
Added the same controllers as fe1:
```
$ dfx canister info frontend --network test_fe_1
Controllers: 2yjpj-uumzi-wnefi-5tum7-qt6yq-7gtxo-i4jt5-enll5-pma6q-2gild-mqe 4jngj-yiaaa-aaaal-ajk5q-cai 5vdms-kaaaa-aaaap-aa3uq-cai bzhxb-2565m-do3pw-yqhb3-jon2m-phepr-lccqh-zv7qq-q52q2-ognw4-yqe cvthj-wyaaa-aaaad-aaaaq-cai octm5-iokwb-gqpnh-ex5pj-cxu6r-tewzp-eqeti-c4zte-qiuge-7mw3m-mqe rwwce-664pe-wijgn-qwcil-ufg26-rr23o-6wyhl-nga3p-2oejc-dpw52-cae vfm3e-ya34n-35cug-tvdt3-yajjv-ct5pn-a5j43-djtk7-ipzr7-22fv3-iqe yit3i-lyaaa-aaaan-qeavq-cai yo6ep-dyaaa-aaaal-ajs6q-cai

$ for user in 2yjpj-uumzi-wnefi-5tum7-qt6yq-7gtxo-i4jt5-enll5-pma6q-2gild-mqe 4jngj-yiaaa-aaaal-ajk5q-cai 5vdms-kaaaa-aaaap-aa3uq-cai bzhxb-2565m-do3pw-yqhb3-jon2m-phepr-lccqh-zv7qq-q52q2-ognw4-yqe cvthj-wyaaa-aaaad-aaaaq-cai octm5-iokwb-gqpnh-ex5pj-cxu6r-tewzp-eqeti-c4zte-qiuge-7mw3m-mqe rwwce-664pe-wijgn-qwcil-ufg26-rr2
3o-6wyhl-nga3p-2oejc-dpw52-cae vfm3e-ya34n-35cug-tvdt3-yajjv-ct5pn-a5j43-djtk7-ipzr7-22fv3-iqe yit3i-lyaaa-aaaan-qeavq-cai yo6ep-dyaaa-aaaal-ajs6q-cai ; do for network in test_fe_5 test_fe_6 ; do dfx canister update-settings frontend --add-controller "$user" --network "$network" ; done ; done
```
### Domain names
Requested: https://dfinity.slack.com/archives/CGJND92DA/p1744224209354169
