### PR TITLE
fix(frontend): remove track event which breaks sign-on on Safari

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -2,8 +2,6 @@
 	import SigningInHelpLink from '$lib/components/auth/SigningInHelpLink.svelte';
 	import LicenseLink from '$lib/components/license-agreement/LicenseLink.svelte';
 	import ButtonAuthenticate from '$lib/components/ui/ButtonAuthenticate.svelte';
-	import { TRACK_COUNT_SIGN_IN_CLICK } from '$lib/constants/analytics.contants';
-	import { trackEvent } from '$lib/services/analytics.services';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -12,11 +10,8 @@
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
 
 	const onClick = async () => {
-		await trackEvent({
-			name: TRACK_COUNT_SIGN_IN_CLICK
-		});
-
 		const { success } = await signIn({});
+
 		if (success === 'cancelled' || success === 'error') {
 			modalStore.openAuthHelp(false);
 		}

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -1,5 +1,4 @@
 // Authentication
-export const TRACK_COUNT_SIGN_IN_CLICK = 'sign_in_click_count';
 export const TRACK_COUNT_LEGACY_SIGN_IN_CLICK = 'sign_in_legacy_click_count';
 export const TRACK_COUNT_SIGN_IN_SUCCESS = 'sign_in_success_count';
 export const TRACK_SIGN_IN_CANCELLED_COUNT = 'sign_in_cancelled_count';


### PR DESCRIPTION
# Motivation

Safari expects popups to be triggered directly by a user interaction, such as a click event. If anything interferes with that interaction—like an intermediate event handler—Safari considers it suspicious, blocks the popup, and requires the user to manually confirm its opening.

This is what's currently happening: the addition of a track event between the click action and the sign-in with Internet Identity (which opens in a popup) breaks the expected flow.

It's also worth noting that even if the user manually confirms the popup, the sign-up process will still fail, as communication between the dapps will be blocked.

The issue currently occurs on production.

# Changes

- Delete / remove track event for analytics

# Screenshot

Issue replicated locally.

<img width="1535" alt="Capture d’écran 2025-04-09 à 22 03 22" src="https://github.com/user-attachments/assets/c85e1556-9c28-4d0d-9275-a5c35575337e" />

