### PR TITLE
chore(frontend): format tests removing unnecessary imports

### DIFF
--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
@@ -226,7 +226,7 @@ describe('UtxosFeeContext', () => {
 		});
 	});
 
-	it('should call selectUtxosFee and reset store if new amount is 10x bigger than previous value ', async () => {
+	it('should call selectUtxosFee and reset store if new amount is 10x bigger than previous value', async () => {
 		const selectUtxosFeeSpy = mockBtcSendApi();
 		const resetSpy = vi.spyOn(store, 'reset');
 

--- a/src/frontend/src/tests/btc/components/tokens/BtcTokenModal.spec.ts
+++ b/src/frontend/src/tests/btc/components/tokens/BtcTokenModal.spec.ts
@@ -2,7 +2,7 @@ import BtcTokenModal from '$btc/components/tokens/BtcTokenModal.svelte';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { token } from '$lib/stores/token.store';
 import { render } from '@testing-library/svelte';
-import { beforeEach } from 'node:test';
+import { beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 
 describe('BtcTokenModal', () => {

--- a/src/frontend/src/tests/btc/components/tokens/BtcTokenModal.spec.ts
+++ b/src/frontend/src/tests/btc/components/tokens/BtcTokenModal.spec.ts
@@ -2,7 +2,6 @@ import BtcTokenModal from '$btc/components/tokens/BtcTokenModal.svelte';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { token } from '$lib/stores/token.store';
 import { render } from '@testing-library/svelte';
-import { beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 
 describe('BtcTokenModal', () => {

--- a/src/frontend/src/tests/lib/components/core/Menu.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Menu.spec.ts
@@ -8,7 +8,7 @@ import {
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { render, waitFor } from '@testing-library/svelte';
-import { beforeEach } from 'node:test';
+import { beforeEach } from 'vitest';
 
 describe('Menu', () => {
 	const menuButtonSelector = `button[data-tid="${NAVIGATION_MENU_BUTTON}"]`;

--- a/src/frontend/src/tests/lib/components/core/Menu.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Menu.spec.ts
@@ -8,7 +8,6 @@ import {
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { render, waitFor } from '@testing-library/svelte';
-import { beforeEach } from 'vitest';
 
 describe('Menu', () => {
 	const menuButtonSelector = `button[data-tid="${NAVIGATION_MENU_BUTTON}"]`;

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -6,7 +6,6 @@ import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { waitFor } from '@testing-library/svelte';
-import { beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 
 vi.mock('$lib/api/backend.api');

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -6,7 +6,7 @@ import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { waitFor } from '@testing-library/svelte';
-import { beforeEach } from 'node:test';
+import { beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 
 vi.mock('$lib/api/backend.api');


### PR DESCRIPTION
# Motivation

We remove the not needed  `import { beforeEach } from 'node:test';`

UNRELATED: removed an unnecessary whitespace
