### PR TITLE
build(frontend): bump vite (GHSA-356w-63v5-8wf4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
 				"tailwindcss": "4.1.3",
 				"tslib": "^2.8.1",
 				"typescript": "^5.4.5",
-				"vite": "^6.2.5",
+				"vite": "^6.2.6",
 				"vite-node": "^3.0.9",
 				"vitest": "^3.1.1",
 				"vitest-mock-extended": "^3.1.0"
@@ -12869,9 +12869,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-			"integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+			"version": "6.2.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+			"integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"tailwindcss": "4.1.3",
 		"tslib": "^2.8.1",
 		"typescript": "^5.4.5",
-		"vite": "^6.2.5",
+		"vite": "^6.2.6",
 		"vite-node": "^3.0.9",
 		"vitest": "^3.1.1",
 		"vitest-mock-extended": "^3.1.0"


### PR DESCRIPTION
# Motivation

Resolve another Vite server vunerability ([GHSA-356w-63v5-8wf4](https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4))

# Changes

- Bump vite v6.2.6
