### PR TITLE
style(frontend): SigningInHelpLink alignment on mobile

### DIFF
--- a/src/frontend/src/lib/components/auth/SigningInHelpLink.svelte
+++ b/src/frontend/src/lib/components/auth/SigningInHelpLink.svelte
@@ -15,7 +15,7 @@
 	};
 </script>
 
-<span class={`${styleClass} flex flex-row gap-1`}>
+<span class={`${styleClass} flex flex-row justify-center gap-1 md:justify-start`}>
 	{$i18n.auth.help.text.need_help}
 	<Button link inlineLink on:click={onClick}>{$i18n.auth.help.text.sign_in}</Button>
 </span>


### PR DESCRIPTION
Before:
<img width="510" alt="Screenshot 2025-04-10 at 12 58 57" src="https://github.com/user-attachments/assets/e820a075-a852-4793-8cab-97808fd0e7fe" />

After:
<img width="507" alt="Screenshot 2025-04-10 at 13 15 09" src="https://github.com/user-attachments/assets/2ec84fb9-f95e-4f94-b2c0-e5bbd5c0abc6" />
