### PR TITLE
fix(frontend): Fixes auth help modal on Safari

### DIFF
--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { themeStore } from '@dfinity/gix-components';
-	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
-	import Img from '$lib/components/ui/Img.svelte';
-	import { i18n } from '$lib/stores/i18n.store';
-	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { nonNullish } from '@dfinity/utils';
 	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
+	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
+	import Img from '$lib/components/ui/Img.svelte';
 	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
 	let ariaLabel: string;
 	$: ariaLabel = replaceOisyPlaceholders($i18n.auth.alt.preview);

--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -4,6 +4,9 @@
 	import Img from '$lib/components/ui/Img.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { nonNullish } from '@dfinity/utils';
+	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
+	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
 
 	let ariaLabel: string;
 	$: ariaLabel = replaceOisyPlaceholders($i18n.auth.alt.preview);
@@ -27,3 +30,7 @@
 		</div>
 	</div>
 </div>
+
+{#if $modalAuthHelp && nonNullish($modalAuthHelpData)}
+	<AuthHelpModal usesIdentityHelp={$modalAuthHelpData} />
+{/if}

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import type { Component } from 'svelte';
-	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
 	import ButtonAuthenticateWithLicense from '$lib/components/auth/ButtonAuthenticateWithLicense.svelte';
 	import IconScanFace from '$lib/components/icons/lucide/IconScanFace.svelte';
 	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
 	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
-	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
@@ -49,7 +46,3 @@
 
 	<ButtonAuthenticateWithLicense />
 </div>
-
-{#if $modalAuthHelp && nonNullish($modalAuthHelpData)}
-	<AuthHelpModal usesIdentityHelp={$modalAuthHelpData} />
-{/if}


### PR DESCRIPTION
# Motivation

On Safari the auth help modal was offset initially presumably due to a rendering bug.

# Changes

We could solve the issue by placing the modal on the root of the page instead of in a nested element.

# Tests

Tested on FE3 on Stefans machine.