### PR TITLE
fix(frontend): Update missing network logo

### DIFF
--- a/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
@@ -4,13 +4,13 @@
 	import { ERC20_CONTRACT_ICP, ERC20_CONTRACT_ICP_GOERLI } from '$env/tokens/tokens.erc20.env';
 	import type { Erc20Token } from '$eth/types/erc20';
 	import type { EthereumNetwork } from '$eth/types/network';
+	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
 	import { isNetworkICP } from '$lib/utils/network.utils';
-	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 
 	export let sourceNetwork: EthereumNetwork;
 	export let targetNetwork: Network | undefined = undefined;

--- a/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
+++ b/src/frontend/src/eth/components/send/SendReviewNetwork.svelte
@@ -2,18 +2,15 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import { ERC20_CONTRACT_ICP, ERC20_CONTRACT_ICP_GOERLI } from '$env/tokens/tokens.erc20.env';
-	import icpDark from '$eth/assets/icp_dark.svg';
 	import type { Erc20Token } from '$eth/types/erc20';
 	import type { EthereumNetwork } from '$eth/types/network';
-	import eth from '$icp-eth/assets/eth.svg';
 	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
-	import Logo from '$lib/components/ui/Logo.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkICP } from '$lib/utils/network.utils';
+	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 
 	export let sourceNetwork: EthereumNetwork;
 	export let targetNetwork: Network | undefined = undefined;
@@ -41,20 +38,10 @@
 		<span class="flex gap-1">
 			{#if nativeIcp}
 				{$i18n.send.text.convert_to_native_icp}
-				<Logo
-					src={icpDark}
-					alt={replacePlaceholders($i18n.core.alt.logo, {
-						$name: ICP_NETWORK.name
-					})}
-				/>
+				<NetworkLogo network={ICP_NETWORK} />
 			{:else}
 				{targetNetwork.name}
-				<Logo
-					src={targetNetwork.icon ?? eth}
-					alt={replacePlaceholders($i18n.core.alt.logo, {
-						$name: targetNetwork.name
-					})}
-				/>
+				<NetworkLogo network={targetNetwork} />
 			{/if}
 		</span>
 	</Value>


### PR DESCRIPTION
# Motivation

In the network icons refactoring we missed one of the logos.

# Changes

Updated so it uses the NetworkLogo component

#Tests 
![image](https://github.com/user-attachments/assets/a2e4640a-8329-432d-a2f3-b35d15b525c5)
