### PR TITLE
chore(devops): Print hashes when deploying

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -328,6 +328,10 @@ jobs:
 
       - name: Deploy Backend to Environment
         run: |
+          {
+            echo "## Backend deployment"
+            scripts/build.report.sh
+          } >> "$GITHUB_STEP_SUMMARY"
           DFX_DEPLOY_FLAGS=() # Arguments to be added to the dfx deploy command.
           [[ "$FORCE_BACKEND" != "true" ]] || DFX_DEPLOY_FLAGS+=('--yes' '--upgrade-unchanged') # Corresponds to: dfx deploy --yes --upgrade-unchanged
 

--- a/scripts/build.report.sh
+++ b/scripts/build.report.sh
@@ -15,5 +15,5 @@ ic-wasm <(gunzip <"./out/${CANISTER}.wasm.gz") metadata >out/metadata_keys.txt
   printf "\n%s\n" "$CANISTER metadata keys:"
   cat out/metadata_keys.txt
   printf "\n%s\n\n" "To see metadata, use ic-wasm.  For example, to see the git tags:" " ic-wasm <(gunzip < ./out/$CANISTER.wasm.gz) metadata git:tags"
-  ic-wasm <(gunzip < "./out/$CANISTER.wasm.gz") metadata git:tags # Should match the text in the line above.
+  ic-wasm <(gunzip <"./out/$CANISTER.wasm.gz") metadata git:tags # Should match the text in the line above.
 } | tee -a out/report.txt

--- a/scripts/build.report.sh
+++ b/scripts/build.report.sh
@@ -15,4 +15,5 @@ ic-wasm <(gunzip <"./out/${CANISTER}.wasm.gz") metadata >out/metadata_keys.txt
   printf "\n%s\n" "$CANISTER metadata keys:"
   cat out/metadata_keys.txt
   printf "\n%s\n\n" "To see metadata, use ic-wasm.  For example, to see the git tags:" " ic-wasm <(gunzip < ./out/$CANISTER.wasm.gz) metadata git:tags"
+  ic-wasm <(gunzip < "./out/$CANISTER.wasm.gz") metadata git:tags # Should match the text in the line above.
 } | tee -a out/report.txt


### PR DESCRIPTION
# Motivation
Make it easy to see the backend metadata when deploying to a testnet.

# Changes
- Print the build report, including tags, when deploying to the backend to a testnet.

# Tests
