### PR TITLE
chore(rust): Bump rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 targets = ["wasm32-unknown-unknown"]

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -900,7 +900,7 @@ pub async fn step_migration() {
             }
             eprintln!("Migration failed: {err:?}");
         });
-    };
+    }
 }
 
 /// Gets account creation timestamps.

--- a/src/backend/src/state.rs
+++ b/src/backend/src/state.rs
@@ -1,5 +1,6 @@
-use candid::Principal;
 use std::sync::LazyLock;
+
+use candid::Principal;
 
 const MAINNET_CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
 const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
@@ -10,7 +11,11 @@ const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
 // - If that variable is not set for any reason, e.g. because we are not building with dfx, we
 //   default to the mainnet canister ID, which is also the recommended ID to use in test
 //   environments.
-    pub static CYCLES_LEDGER: LazyLock<Principal> = LazyLock::new(|| Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
-        .unwrap_or_else(|e| unreachable!("The cycles_ledger canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}")));
-    pub static SIGNER: LazyLock<Principal> = LazyLock::new(|| Principal::from_text(option_env!("CANISTER_ID_SIGNER").unwrap_or(MAINNET_SIGNER_CANISTER_ID))
-        .unwrap_or_else(|e| unreachable!("The signer canister ID from mainnet or dfx valid and should have been parsed.  Is this being compiled in some strange way? {e}")));
+pub static CYCLES_LEDGER: LazyLock<Principal> = LazyLock::new(|| {
+    Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
+        .unwrap_or_else(|e| unreachable!("The cycles_ledger canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"))
+});
+pub static SIGNER: LazyLock<Principal> = LazyLock::new(|| {
+    Principal::from_text(option_env!("CANISTER_ID_SIGNER").unwrap_or(MAINNET_SIGNER_CANISTER_ID))
+        .unwrap_or_else(|e| unreachable!("The signer canister ID from mainnet or dfx valid and should have been parsed.  Is this being compiled in some strange way? {e}"))
+});

--- a/src/backend/src/state.rs
+++ b/src/backend/src/state.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 const MAINNET_CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
 const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
@@ -10,9 +10,7 @@ const MAINNET_SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
 // - If that variable is not set for any reason, e.g. because we are not building with dfx, we
 //   default to the mainnet canister ID, which is also the recommended ID to use in test
 //   environments.
-lazy_static! {
-    pub static ref CYCLES_LEDGER: Principal = Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
-        .unwrap_or_else(|e| unreachable!("The cycles_ledger canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
-    pub static ref SIGNER: Principal = Principal::from_text(option_env!("CANISTER_ID_SIGNER").unwrap_or(MAINNET_SIGNER_CANISTER_ID))
-        .unwrap_or_else(|e| unreachable!("The signer canister ID from mainnet or dfx valid and should have been parsed.  Is this being compiled in some strange way? {e}"));
-}
+    pub static CYCLES_LEDGER: LazyLock<Principal> = LazyLock::new(|| Principal::from_text(option_env!("CANISTER_ID_CYCLES_LEDGER").unwrap_or(MAINNET_CYCLES_LEDGER_CANISTER_ID))
+        .unwrap_or_else(|e| unreachable!("The cycles_ledger canister ID from DFX and mainnet are valid and should have been parsed.  Is this being compiled in some strange way? {e}")));
+    pub static SIGNER: LazyLock<Principal> = LazyLock::new(|| Principal::from_text(option_env!("CANISTER_ID_SIGNER").unwrap_or(MAINNET_SIGNER_CANISTER_ID))
+        .unwrap_or_else(|e| unreachable!("The signer canister ID from mainnet or dfx valid and should have been parsed.  Is this being compiled in some strange way? {e}")));

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -1,7 +1,8 @@
+use std::sync::LazyLock;
+
 use candid::Principal;
-use lazy_static::lazy_static;
 use shared::types::{
-    custom_token::{CustomToken, CustomTokenId, IcrcToken, SplToken, SplTokenId, Token},
+    custom_token::{CustomToken, IcrcToken, SplToken, SplTokenId, Token},
     TokenVersion,
 };
 
@@ -11,51 +12,49 @@ use crate::utils::{
     pocketic::{setup, PicCanisterTrait},
 };
 
-lazy_static! {
-    static ref ICRC_TOKEN: IcrcToken = IcrcToken {
+static ICRC_TOKEN: LazyLock<IcrcToken> = LazyLock::new(|| IcrcToken {
+    ledger_id: Principal::from_text("ddsp7-7iaaa-aaaaq-aacqq-cai").unwrap(),
+    index_id: Some(Principal::from_text("dnqcx-eyaaa-aaaaq-aacrq-cai").unwrap()),
+});
+static USER_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
+    token: Token::Icrc(ICRC_TOKEN.clone()),
+    enabled: true,
+    version: None,
+});
+static ANOTHER_USER_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
+    token: Token::Icrc(IcrcToken {
+        ledger_id: Principal::from_text("uf2wh-taaaa-aaaaq-aabna-cai").unwrap(),
+        index_id: Some(Principal::from_text("ux4b6-7qaaa-aaaaq-aaboa-cai").unwrap()),
+    }),
+    enabled: true,
+    version: None,
+});
+static USER_TOKEN_NO_INDEX: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
+    token: Token::Icrc(IcrcToken {
         ledger_id: Principal::from_text("ddsp7-7iaaa-aaaaq-aacqq-cai").unwrap(),
-        index_id: Some(Principal::from_text("dnqcx-eyaaa-aaaaq-aacrq-cai").unwrap()),
-    };
-    static ref USER_TOKEN: CustomToken = CustomToken {
-        token: Token::Icrc(ICRC_TOKEN.clone()),
-        enabled: true,
-        version: None,
-    };
-    static ref USER_TOKEN_ID: CustomTokenId = CustomTokenId::Icrc(ICRC_TOKEN.ledger_id);
-    static ref ANOTHER_USER_TOKEN: CustomToken = CustomToken {
-        token: Token::Icrc(IcrcToken {
-            ledger_id: Principal::from_text("uf2wh-taaaa-aaaaq-aabna-cai").unwrap(),
-            index_id: Some(Principal::from_text("ux4b6-7qaaa-aaaaq-aaboa-cai").unwrap()),
-        }),
-        enabled: true,
-        version: None,
-    };
-    static ref USER_TOKEN_NO_INDEX: CustomToken = CustomToken {
-        token: Token::Icrc(IcrcToken {
-            ledger_id: Principal::from_text("ddsp7-7iaaa-aaaaq-aacqq-cai").unwrap(),
-            index_id: None,
-        }),
-        enabled: true,
-        version: None,
-    };
-    static ref SPL_TOKEN_ID: SplTokenId =
-        SplTokenId("AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC9wajM".to_string());
-    static ref SPL_TOKEN: CustomToken = CustomToken {
-        token: Token::SplMainnet(SplToken {
-            token_address: SPL_TOKEN_ID.clone(),
-            symbol: Some("BOOONDOGGLE".to_string()),
-            decimals: Some(u8::MAX),
-        }),
-        enabled: true,
-        version: None,
-    };
-    static ref CUSTOM_SPL_TOKEN_ID: CustomTokenId = CustomTokenId::SolMainnet(SPL_TOKEN_ID.clone());
-    static ref LOTS_OF_CUSTOM_TOKENS: Vec<CustomToken> = vec![
+        index_id: None,
+    }),
+    enabled: true,
+    version: None,
+});
+static SPL_TOKEN_ID: LazyLock<SplTokenId> =
+    LazyLock::new(|| SplTokenId("AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC9wajM".to_string()));
+static SPL_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
+    token: Token::SplMainnet(SplToken {
+        token_address: SPL_TOKEN_ID.clone(),
+        symbol: Some("BOOONDOGGLE".to_string()),
+        decimals: Some(u8::MAX),
+    }),
+    enabled: true,
+    version: None,
+});
+static LOTS_OF_CUSTOM_TOKENS: LazyLock<Vec<CustomToken>> = LazyLock::new(|| {
+    vec![
         USER_TOKEN.clone(),
         ANOTHER_USER_TOKEN.clone(),
         SPL_TOKEN.clone(),
-    ];
-}
+    ]
+});
 
 #[test]
 fn test_add_custom_tokens() {


### PR DESCRIPTION
# Motivation
A new version of Rust is available

# Changes
- Update Rust
- Make corresponding changes:
  - `lazy_lock` is now provided by an equivalent compiler built-in.

# Tests
Existing tests should suffice