### PR TITLE
feat(devops): add vitest config in repo policies

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -15,3 +15,4 @@ src/frontend/src/**/*.svelte
 src/frontend/src/tests/**/*.spec.ts
 .github/actions/*.yml
 .github/workflows/*.yml
+vitest.config.ts


### PR DESCRIPTION
# Motivation

There is a new CI (PR https://github.com/dfinity/oisy-wallet/pull/5798) that auto-updates the vitest coverage thresholds.

To allow that we need to add `vitest.config.ts` file among the files allowed to be changed by a bot.
