### PR TITLE
feat(frontend): removed junobuild/analytics packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
 				"@dfinity/utils": "^2.12.0",
 				"@dfinity/verifiable-credentials": "^0.0.4",
 				"@dfinity/zod-schemas": "^0.0.2",
-				"@junobuild/analytics": "^0.0.31",
 				"@metamask/detect-provider": "^2.0.0",
 				"@reown/walletkit": "^1.2.2",
 				"@solana-program/compute-budget": "^0.7.0",
@@ -2538,46 +2537,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/@junobuild/analytics": {
-			"version": "0.0.31",
-			"resolved": "https://registry.npmjs.org/@junobuild/analytics/-/analytics-0.0.31.tgz",
-			"integrity": "sha512-reXR17+B/w6iwrQqAi2XS1n6ApSsu4tWZjwtezm0fp9OB+hOaKF/C4MLo76F8C2vY4YqopZC4h8a7nbDDvismA==",
-			"license": "MIT",
-			"dependencies": {
-				"@junobuild/utils": "*",
-				"idb-keyval": "^6.2.1",
-				"isbot": "^5.1.6",
-				"nanoid": "^5.0.9",
-				"web-vitals": "^4.2.3"
-			}
-		},
-		"node_modules/@junobuild/analytics/node_modules/nanoid": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
-			"integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
-		"node_modules/@junobuild/utils": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.27.tgz",
-			"integrity": "sha512-9H44YEQaq2MNFatEvlcK4BSHbCgv+mOoXuOLOO0vpMmjAck85Q2XwfSXypyW2ZflvVXWrJceCXXoEpJZmpJstQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@dfinity/principal": "^2.1.3"
 			}
 		},
 		"node_modules/@metamask/detect-provider": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
 		"@dfinity/utils": "^2.12.0",
 		"@dfinity/verifiable-credentials": "^0.0.4",
 		"@dfinity/zod-schemas": "^0.0.2",
-		"@junobuild/analytics": "^0.0.31",
 		"@metamask/detect-provider": "^2.0.0",
 		"@reown/walletkit": "^1.2.2",
 		"@solana-program/compute-budget": "^0.7.0",


### PR DESCRIPTION
# Motivation

Removed the Juno analytics packages, as we are now using Plausible for tracking and no longer need Juno.

# Changes

Removed the Juno analytics from package.json and package.lock.json

