### PR TITLE
chore(rewards): Bump rewards canister

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -444,8 +444,8 @@
 		},
 		"rewards": {
 			"type": "custom",
-			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.2.3-referrer.3/rewards.did",
-			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.2.3-referrer.3/rewards.wasm.gz",
+			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.3.1/rewards.did",
+			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.3.1/rewards.wasm.gz",
 			"remote": {
 				"id": {
 					"ic": "nynz6-haaaa-aaaan-qzqda-cai",

--- a/src/declarations/rewards/rewards.did
+++ b/src/declarations/rewards/rewards.did
@@ -170,6 +170,31 @@ type RewardInfo = record {
     /// The amount of tokens awarded.
     amount : nat;
 };
+/// Possible errors for `set_referrer()`
+type SetReferrerError = variant {
+  /// The caller is attempting to refer themselves.
+  SelfReferral;
+  /// The caller already has a different referrer.
+  ///
+  /// (Repeatedly setting the referrer to the same value will cause no issues.)
+  AlreadyHasReferrer;
+  /// The referrer code is unknown.
+  UnknownReferrer;
+  /// Only new users may set a referrer.
+  ///
+  /// A small allowance for existing state is made, in case the front-end
+  /// sends a snapshot before setting the referrer.
+  NotNewUser;
+  /// The caller is anonymous.
+  AnonymousCaller;
+};
+/// Result of calling `set_referrer()`
+type SetReferrerResponse = variant {
+    /// The referrer was set successfully.
+    Ok;
+    /// Ther was an error setting the referrer.
+    Err : SetReferrerError;
+};
 type SetSprinkleTimestampArg = record {
     /// The total amount that will be distributed across all users in the current/next sprinkle
     total_sprinkle_amount: nat;
@@ -250,7 +275,11 @@ type Transaction_Spl = record {
   amount : nat64;
 };
 type UsageAndHolding = record {
+  // Account valuation at the time of the last snapshot.
   approx_usd_valuation : float64;
+  // Time of account creation or first recorded activity.
+  first_activity_ns : opt nat64;
+  // Time of last recorded activity.
   last_activity_ns : opt nat64;
 };
 type UsageAwardConfig = record {
@@ -274,6 +303,10 @@ type UsageAwardState = record {
   referred_by : opt nat32;
     /// User's code for inviting others to the platform, and referral stats. 
   referrer_info : opt ReferrerInfo;
+  /// The time of the first activity.
+  first_activity_ns : opt nat64;
+  /// The time of the last activity.
+  last_activity_ns : opt nat64;
 };
 type UsageAwardStats = record {
   user_count : nat64;
@@ -371,7 +404,7 @@ service : (opt Config) -> {
     register_snapshot_for : (principal, UserSnapshot) -> ();
     stats_usage_vs_holding : () -> (UsageVsHoldingStats) query;
     /// Sets a timestamp for a sprinkle event in the future. The sprinkle will be executed
-  set_referrer : (nat32) -> ();
+  set_referrer : (nat32) -> (SetReferrerResponse);
     /// as soon as possible after the timestamp.
     /// Gives information about the current status of the canister.
     status : () -> (StatusResponse) query;

--- a/src/declarations/rewards/rewards.did.d.ts
+++ b/src/declarations/rewards/rewards.did.d.ts
@@ -117,6 +117,13 @@ export interface RewardInfo {
 	amount: bigint;
 	campaign_name: [] | [string];
 }
+export type SetReferrerError =
+	| { SelfReferral: null }
+	| { AlreadyHasReferrer: null }
+	| { UnknownReferrer: null }
+	| { NotNewUser: null }
+	| { AnonymousCaller: null };
+export type SetReferrerResponse = { Ok: null } | { Err: SetReferrerError };
 export interface SetSprinkleTimestampArg {
 	total_sprinkle_amount: bigint;
 	min_account_amount: bigint;
@@ -162,6 +169,7 @@ export interface Transaction_Spl {
 	amount: bigint;
 }
 export interface UsageAndHolding {
+	first_activity_ns: [] | [bigint];
 	approx_usd_valuation: number;
 	last_activity_ns: [] | [bigint];
 }
@@ -179,8 +187,10 @@ export interface UsageAwardEvent {
 	campaign_name: [] | [string];
 }
 export interface UsageAwardState {
+	first_activity_ns: [] | [bigint];
 	snapshots: Array<UserSnapshot>;
 	referred_by: [] | [number];
+	last_activity_ns: [] | [bigint];
 	referrer_info: [] | [ReferrerInfo];
 }
 export interface UsageAwardStats {
@@ -256,7 +266,7 @@ export interface _SERVICE {
 	referrer_info_for: ActorMethod<[Principal], [] | [ReferrerInfo]>;
 	register_airdrop_recipient: ActorMethod<[UserSnapshot], undefined>;
 	register_snapshot_for: ActorMethod<[Principal, UserSnapshot], undefined>;
-	set_referrer: ActorMethod<[number], undefined>;
+	set_referrer: ActorMethod<[number], SetReferrerResponse>;
 	stats_usage_vs_holding: ActorMethod<[], UsageVsHoldingStats>;
 	status: ActorMethod<[], StatusResponse>;
 	trigger_usage_award_event: ActorMethod<[UsageAwardEvent], undefined>;

--- a/src/declarations/rewards/rewards.factory.certified.did.js
+++ b/src/declarations/rewards/rewards.factory.certified.did.js
@@ -161,7 +161,19 @@ export const idlFactory = ({ IDL }) => {
 		accounts: IDL.Vec(AccountSnapshotFor),
 		timestamp: IDL.Opt(IDL.Nat64)
 	});
+	const SetReferrerError = IDL.Variant({
+		SelfReferral: IDL.Null,
+		AlreadyHasReferrer: IDL.Null,
+		UnknownReferrer: IDL.Null,
+		NotNewUser: IDL.Null,
+		AnonymousCaller: IDL.Null
+	});
+	const SetReferrerResponse = IDL.Variant({
+		Ok: IDL.Null,
+		Err: SetReferrerError
+	});
 	const UsageAndHolding = IDL.Record({
+		first_activity_ns: IDL.Opt(IDL.Nat64),
 		approx_usd_valuation: IDL.Float64,
 		last_activity_ns: IDL.Opt(IDL.Nat64)
 	});
@@ -224,8 +236,10 @@ export const idlFactory = ({ IDL }) => {
 		sprinkles: IDL.Vec(RewardInfo)
 	});
 	const UsageAwardState = IDL.Record({
+		first_activity_ns: IDL.Opt(IDL.Nat64),
 		snapshots: IDL.Vec(UserSnapshot),
 		referred_by: IDL.Opt(IDL.Nat32),
+		last_activity_ns: IDL.Opt(IDL.Nat64),
 		referrer_info: IDL.Opt(ReferrerInfo)
 	});
 	const VipStats = IDL.Record({
@@ -249,7 +263,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer_info_for: IDL.Func([IDL.Principal], [IDL.Opt(ReferrerInfo)]),
 		register_airdrop_recipient: IDL.Func([UserSnapshot], [], []),
 		register_snapshot_for: IDL.Func([IDL.Principal, UserSnapshot], [], []),
-		set_referrer: IDL.Func([IDL.Nat32], [], []),
+		set_referrer: IDL.Func([IDL.Nat32], [SetReferrerResponse], []),
 		stats_usage_vs_holding: IDL.Func([], [UsageVsHoldingStats]),
 		status: IDL.Func([], [StatusResponse]),
 		trigger_usage_award_event: IDL.Func([UsageAwardEvent], [], []),

--- a/src/declarations/rewards/rewards.factory.did.js
+++ b/src/declarations/rewards/rewards.factory.did.js
@@ -161,7 +161,19 @@ export const idlFactory = ({ IDL }) => {
 		accounts: IDL.Vec(AccountSnapshotFor),
 		timestamp: IDL.Opt(IDL.Nat64)
 	});
+	const SetReferrerError = IDL.Variant({
+		SelfReferral: IDL.Null,
+		AlreadyHasReferrer: IDL.Null,
+		UnknownReferrer: IDL.Null,
+		NotNewUser: IDL.Null,
+		AnonymousCaller: IDL.Null
+	});
+	const SetReferrerResponse = IDL.Variant({
+		Ok: IDL.Null,
+		Err: SetReferrerError
+	});
 	const UsageAndHolding = IDL.Record({
+		first_activity_ns: IDL.Opt(IDL.Nat64),
 		approx_usd_valuation: IDL.Float64,
 		last_activity_ns: IDL.Opt(IDL.Nat64)
 	});
@@ -224,8 +236,10 @@ export const idlFactory = ({ IDL }) => {
 		sprinkles: IDL.Vec(RewardInfo)
 	});
 	const UsageAwardState = IDL.Record({
+		first_activity_ns: IDL.Opt(IDL.Nat64),
 		snapshots: IDL.Vec(UserSnapshot),
 		referred_by: IDL.Opt(IDL.Nat32),
+		last_activity_ns: IDL.Opt(IDL.Nat64),
 		referrer_info: IDL.Opt(ReferrerInfo)
 	});
 	const VipStats = IDL.Record({
@@ -250,7 +264,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer_info_for: IDL.Func([IDL.Principal], [IDL.Opt(ReferrerInfo)], ['query']),
 		register_airdrop_recipient: IDL.Func([UserSnapshot], [], []),
 		register_snapshot_for: IDL.Func([IDL.Principal, UserSnapshot], [], []),
-		set_referrer: IDL.Func([IDL.Nat32], [], []),
+		set_referrer: IDL.Func([IDL.Nat32], [SetReferrerResponse], []),
 		stats_usage_vs_holding: IDL.Func([], [UsageVsHoldingStats], ['query']),
 		status: IDL.Func([], [StatusResponse], ['query']),
 		trigger_usage_award_event: IDL.Func([UsageAwardEvent], [], []),

--- a/src/frontend/src/lib/api/reward.api.ts
+++ b/src/frontend/src/lib/api/reward.api.ts
@@ -2,6 +2,7 @@ import type {
 	ClaimVipRewardResponse,
 	NewVipRewardResponse,
 	ReferrerInfo,
+	SetReferrerResponse,
 	UserData,
 	UserSnapshot,
 	VipReward
@@ -56,7 +57,7 @@ export const setReferrer = async ({
 	identity
 }: CanisterApiFunctionParams<{
 	referrerCode: number;
-}>): Promise<void> => {
+}>): Promise<SetReferrerResponse> => {
 	const { setReferrer } = await rewardCanister({ identity });
 
 	return setReferrer(referrerCode);

--- a/src/frontend/src/lib/canisters/reward.canister.ts
+++ b/src/frontend/src/lib/canisters/reward.canister.ts
@@ -3,6 +3,7 @@ import type {
 	NewVipRewardResponse,
 	ReferrerInfo,
 	_SERVICE as RewardService,
+	SetReferrerResponse,
 	UserData,
 	UserSnapshot,
 	VipReward
@@ -56,7 +57,7 @@ export class RewardCanister extends Canister<RewardService> {
 		return referrer_info();
 	};
 
-	setReferrer = (referralCode: number): Promise<void> => {
+	setReferrer = (referralCode: number): Promise<SetReferrerResponse> => {
 		const { set_referrer } = this.caller({ certified: true });
 
 		return set_referrer(referralCode);

--- a/src/frontend/src/lib/services/reward.services.ts
+++ b/src/frontend/src/lib/services/reward.services.ts
@@ -1,4 +1,4 @@
-import type { ReferrerInfo, RewardInfo, VipReward } from '$declarations/rewards/rewards.did';
+import type { ReferrerInfo, RewardInfo, SetReferrerResponse, VipReward } from '$declarations/rewards/rewards.did';
 import type { IcToken } from '$icp/types/ic-token';
 import {
 	claimVipReward as claimVipRewardApi,
@@ -256,7 +256,7 @@ const updateReferrer = async ({
 }: {
 	identity: Identity;
 	referrerCode: number;
-}): Promise<void> =>
+}): Promise<SetReferrerResponse> =>
 	await setReferrerApi({
 		identity,
 		referrerCode,

--- a/src/frontend/src/lib/services/reward.services.ts
+++ b/src/frontend/src/lib/services/reward.services.ts
@@ -1,4 +1,9 @@
-import type { ReferrerInfo, RewardInfo, SetReferrerResponse, VipReward } from '$declarations/rewards/rewards.did';
+import type {
+	ReferrerInfo,
+	RewardInfo,
+	SetReferrerResponse,
+	VipReward
+} from '$declarations/rewards/rewards.did';
 import type { IcToken } from '$icp/types/ic-token';
 import {
 	claimVipReward as claimVipRewardApi,

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -281,9 +281,7 @@ describe('reward-code', () => {
 		const mockedReferrerCode = 123456;
 
 		it('should successfully set referrer', async () => {
-			const setReferrerSpy = vi
-				.spyOn(rewardApi, 'setReferrer')
-				.mockResolvedValueOnce(undefined as void);
+			const setReferrerSpy = vi.spyOn(rewardApi, 'setReferrer').mockResolvedValueOnce({ Ok: null });
 
 			const result = await setReferrer({
 				identity: mockIdentity,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,10 +79,10 @@ export default defineConfig(
 				// TODO: increase the thresholds slowly up to an acceptable 80% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 57.83,
-					branches: 82.13,
-					functions: 71.56,
-					lines: 57.83
+					statements: 57,
+					branches: 82,
+					functions: 71,
+					lines: 57
 				}
 			}
 		}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,10 +79,10 @@ export default defineConfig(
 				// TODO: increase the thresholds slowly up to an acceptable 80% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 57.95,
+					statements: 57.83,
 					branches: 82.13,
-					functions: 71.98,
-					lines: 57.95
+					functions: 71.56,
+					lines: 57.83
 				}
 			}
 		}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,10 +79,10 @@ export default defineConfig(
 				// TODO: increase the thresholds slowly up to an acceptable 80% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 57.83,
+					statements: 57.95,
 					branches: 82.13,
-					functions: 71.56,
-					lines: 57.83
+					functions: 71.98,
+					lines: 57.95
 				}
 			}
 		}


### PR DESCRIPTION
# Motivation
A new release of the rewards canister is available.

# Changes
- Bump the rewards canister version to 0.3.1:
  - Implements the referrer logic
  - Adds return values to `set_referrer()` to explain why a given call might fail.

# Tests
CI should update bindings.