### PR TITLE
feat(devops): round vitest coverage thresholds to floor integer

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
+      - name: Floor coverage thresholds (remove decimals)
+        run: |
+          sed -i -E 's/(lines|functions|branches|statements):[[:space:]]*([0-9]+)\.[0-9]+/\1: \2/g' vitest.config.ts
+
       - name: Check for Coverage Thresholds Changes
         id: check_changes
         run: |


### PR DESCRIPTION
# Motivation

To have some wiggle room and not get bombed with PRs, we round the thresholds to the closest (lower) integer.

# Tests

Run with CI https://github.com/dfinity/oisy-wallet/actions/runs/14444846353 and created PR https://github.com/dfinity/oisy-wallet/pull/5843
