### PR TITLE
chore(devops): Delete unneeded lines

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,10 +4,6 @@ set -euxo pipefail
 dfx canister create --all
 dfx deploy backend
 dfx deploy signer
-
-mkdir -p ./target/ic
-
-./scripts/download.icp.sh
 dfx deploy icp_ledger
 dfx deploy icp_index
 


### PR DESCRIPTION
# Motivation
Two deploy lies are unneeded.

# Changes
- mkdir is not needed, as the commands that care do (and should) create the directory themselves.
- Downloading Wasms is also not needed, as the relevant commands do that themselves

# Tests
Existing CI