### PR TITLE
chore(devops): dfx deploy ckbtc_minter

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -241,8 +241,10 @@
 		},
 		"ckbtc_minter": {
 			"type": "custom",
+			"build": "scripts/build.ckbtc_minter.sh",
 			"candid": "target/ic/ckbtc_minter.did",
 			"wasm": "target/ic/ckbtc_minter.wasm",
+			"init_arg_file": "target/ic/ckbtc_minter.args.did",
 			"specified_id": "ml52i-qqaaa-aaaar-qaaba-cai",
 			"remote": {
 				"id": {

--- a/scripts/build.ckbtc_minter.args.sh
+++ b/scripts/build.ckbtc_minter.args.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+[[ "${1:-}" != "--help" ]] || {
+  cat <<-EOF
+
+	Populates the ckbtc_minter init args file.
+
+	# Prerequisites
+	This is expected to be run via dfx, and in particular that
+	environment variables provided by dfx are set.
+
+	EOF
+  exit 0
+}
+set -euxo pipefail
+
+: START populating the ckbtc_minter install args file...
+ARGS_FILE="$(jq -re .canisters.ckbtc_minter.init_arg_file dfx.json)"
+mkdir -p "$(dirname "$ARGS_FILE")"
+
+cat <<EOF >"$ARGS_FILE"
+(variant {
+  Init = record {
+       btc_network = variant { Regtest };
+       ledger_id = principal "$CANISTER_ID_CKBTC_LEDGER";
+       ecdsa_key_name = "dfx_test_key";
+       retrieve_btc_min_amount = 10_000;
+       max_time_in_queue_nanos = 420_000_000_000;
+       min_confirmations = opt 12;
+       mode = variant { GeneralAvailability };
+       kyt_fee = opt 1_333;
+       kyt_principal = opt principal "$CANISTER_ID_CKBTC_KYT";
+   }
+})
+EOF
+: FINISH populating the ckbtc_minter install args file.

--- a/scripts/build.ckbtc_minter.sh
+++ b/scripts/build.ckbtc_minter.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+[[ "${1:-}" != "--help" ]] || {
+  cat <<-EOF
+
+	Assembles the ckbtc_minter canister deploy artefacts.
+
+	# Prerequisites
+	This is expected to be run by dfx.  In particular,
+	the code that creates the arguments uses environment
+	variables set by dfx.
+
+	EOF
+  exit 0
+}
+
+set -euo pipefail
+
+# Install ICP index locally as documented in:
+# https://internetcomputer.org/docs/current/developer-docs/integrations/ledger/ledger-local-setup
+
+scripts/download.ckbtc.sh
+scripts/build.ckbtc_minter.args.sh

--- a/scripts/deploy.ckbtc.sh
+++ b/scripts/deploy.ckbtc.sh
@@ -18,19 +18,7 @@ KYTID="$(dfx canister id ckbtc_kyt --network "$DFX_NETWORK")"
 echo "$KYTID"
 
 echo "Step 2: deploy minter canister..."
-dfx deploy ckbtc_minter --specified-id ml52i-qqaaa-aaaar-qaaba-cai --network "$DFX_NETWORK" --argument "(variant {
-  Init = record {
-       btc_network = variant { Regtest };
-       ledger_id = principal \"$LEDGERID\";
-       ecdsa_key_name = \"dfx_test_key\";
-       retrieve_btc_min_amount = 10_000;
-       max_time_in_queue_nanos = 420_000_000_000;
-       min_confirmations = opt 12;
-       mode = variant { GeneralAvailability };
-       kyt_fee = opt 1_333;
-       kyt_principal = opt principal \"$KYTID\";
-   }
-})"
+dfx deploy ckbtc_minter --network "$DFX_NETWORK"
 
 echo "Step 3: deploy ledger canister..."
 PRINCIPAL="$(dfx identity get-principal)"


### PR DESCRIPTION
# Motivation
`dfx deploy X` should just work for all canisters.

# Changes
- Set default arguments for `ckbtc_minter`, so that `dfx deploy` just works.

# Tests
Existing CI should suffice