### PR TITLE
feat(frontend): adds rowReverse flag to ExternalLink.svelte

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthHelpIdentityForm.svelte
+++ b/src/frontend/src/lib/components/auth/AuthHelpIdentityForm.svelte
@@ -58,7 +58,7 @@
 					ariaLabel={$i18n.auth.help.alt.identity_learn_more}
 					href={OISY_FIND_INTERNET_IDENTITY_URL}
 					testId={HELP_AUTH_LEARN_MORE_LINK}
-					rowReverse
+					iconAsLast
 				>
 					{replaceOisyPlaceholders($i18n.auth.help.text.identity_learn_more)}
 				</ExternalLink>

--- a/src/frontend/src/lib/components/auth/AuthHelpIdentityForm.svelte
+++ b/src/frontend/src/lib/components/auth/AuthHelpIdentityForm.svelte
@@ -54,10 +54,11 @@
 			</p>
 			<p class="mb-0">
 				<ExternalLink
-					styleClass="font-semibold flex flex-row-reverse"
+					styleClass="font-semibold"
 					ariaLabel={$i18n.auth.help.alt.identity_learn_more}
 					href={OISY_FIND_INTERNET_IDENTITY_URL}
 					testId={HELP_AUTH_LEARN_MORE_LINK}
+					rowReverse
 				>
 					{replaceOisyPlaceholders($i18n.auth.help.text.identity_learn_more)}
 				</ExternalLink>

--- a/src/frontend/src/lib/components/auth/AuthHelpOtherForm.svelte
+++ b/src/frontend/src/lib/components/auth/AuthHelpOtherForm.svelte
@@ -36,40 +36,44 @@
 		</p>
 		<p>
 			<ExternalLink
-				styleClass="font-semibold flex flex-row-reverse"
+				styleClass="font-semibold"
 				ariaLabel={replaceOisyPlaceholders($i18n.auth.help.alt.other_introduction)}
 				href={OISY_DOCS_URL}
 				testId={HELP_AUTH_INTRODUCTION_LINK}
+				rowReverse
 			>
 				{replaceOisyPlaceholders($i18n.auth.help.text.other_introduction)}
 			</ExternalLink>
 		</p>
 		<p>
 			<ExternalLink
-				styleClass="font-semibold flex flex-row-reverse"
+				styleClass="font-semibold"
 				ariaLabel={replaceOisyPlaceholders($i18n.auth.help.alt.other_docs)}
 				href={OISY_INTERNET_IDENTITY_URL}
 				testId={HELP_AUTH_DOCS_LINK}
+				rowReverse
 			>
 				{replaceOisyPlaceholders($i18n.auth.help.text.other_docs)}
 			</ExternalLink>
 		</p>
 		<p>
 			<ExternalLink
-				styleClass="font-semibold flex flex-row-reverse"
+				styleClass="font-semibold"
 				ariaLabel={$i18n.auth.help.alt.other_private_key}
 				href={OISY_FAQ_URL}
 				testId={HELP_AUTH_PRIVATE_KEY_LINK}
+				rowReverse
 			>
 				{$i18n.auth.help.text.other_private_key}
 			</ExternalLink>
 		</p>
 		<p class="mb-0">
 			<ExternalLink
-				styleClass="font-semibold flex flex-row-reverse"
+				styleClass="font-semibold"
 				ariaLabel={replaceOisyPlaceholders($i18n.auth.help.alt.other_asset_control)}
 				href={OISY_ACCESS_CONTROL_URL}
 				testId={HELP_AUTH_ASSET_CONTROL_LINK}
+				rowReverse
 			>
 				{replaceOisyPlaceholders($i18n.auth.help.text.other_asset_control)}
 			</ExternalLink>

--- a/src/frontend/src/lib/components/auth/AuthHelpOtherForm.svelte
+++ b/src/frontend/src/lib/components/auth/AuthHelpOtherForm.svelte
@@ -40,7 +40,7 @@
 				ariaLabel={replaceOisyPlaceholders($i18n.auth.help.alt.other_introduction)}
 				href={OISY_DOCS_URL}
 				testId={HELP_AUTH_INTRODUCTION_LINK}
-				rowReverse
+				iconAsLast
 			>
 				{replaceOisyPlaceholders($i18n.auth.help.text.other_introduction)}
 			</ExternalLink>
@@ -51,7 +51,7 @@
 				ariaLabel={replaceOisyPlaceholders($i18n.auth.help.alt.other_docs)}
 				href={OISY_INTERNET_IDENTITY_URL}
 				testId={HELP_AUTH_DOCS_LINK}
-				rowReverse
+				iconAsLast
 			>
 				{replaceOisyPlaceholders($i18n.auth.help.text.other_docs)}
 			</ExternalLink>
@@ -62,7 +62,7 @@
 				ariaLabel={$i18n.auth.help.alt.other_private_key}
 				href={OISY_FAQ_URL}
 				testId={HELP_AUTH_PRIVATE_KEY_LINK}
-				rowReverse
+				iconAsLast
 			>
 				{$i18n.auth.help.text.other_private_key}
 			</ExternalLink>
@@ -73,7 +73,7 @@
 				ariaLabel={replaceOisyPlaceholders($i18n.auth.help.alt.other_asset_control)}
 				href={OISY_ACCESS_CONTROL_URL}
 				testId={HELP_AUTH_ASSET_CONTROL_LINK}
-				rowReverse
+				iconAsLast
 			>
 				{replaceOisyPlaceholders($i18n.auth.help.text.other_asset_control)}
 			</ExternalLink>

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -141,8 +141,9 @@
 					})}
 					asButton
 					fullWidth
-					styleClass="primary padding-sm flex-1 flex-row-reverse"
+					styleClass="primary padding-sm flex-1"
 					href={websiteURL.toString()}
+					rowReverse
 					trackEvent={{ name: TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK, metadata: { dappId } }}
 					>{callToAction ??
 						replacePlaceholders($i18n.dapps.text.open_dapp, {

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -143,7 +143,7 @@
 					fullWidth
 					styleClass="primary padding-sm flex-1"
 					href={websiteURL.toString()}
-					rowReverse
+					iconAsLast
 					trackEvent={{ name: TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK, metadata: { dappId } }}
 					>{callToAction ??
 						replacePlaceholders($i18n.dapps.text.open_dapp, {

--- a/src/frontend/src/lib/components/referral/ReferralCodeModal.svelte
+++ b/src/frontend/src/lib/components/referral/ReferralCodeModal.svelte
@@ -101,7 +101,7 @@
 					ariaLabel={$i18n.referral.invitation.text.learn_more}
 					styleClass="font-semibold min-w-30"
 					testId={REFERRAL_CODE_LEARN_MORE}
-					rowReverse
+					iconAsLast
 				>
 					{$i18n.referral.invitation.text.learn_more}
 				</ExternalLink>

--- a/src/frontend/src/lib/components/referral/ReferralCodeModal.svelte
+++ b/src/frontend/src/lib/components/referral/ReferralCodeModal.svelte
@@ -99,8 +99,9 @@
 				<ExternalLink
 					href={OISY_REFERRAL_URL}
 					ariaLabel={$i18n.referral.invitation.text.learn_more}
-					styleClass="font-semibold min-w-30 flex-row-reverse"
+					styleClass="font-semibold min-w-30"
 					testId={REFERRAL_CODE_LEARN_MORE}
+					rowReverse
 				>
 					{$i18n.referral.invitation.text.learn_more}
 				</ExternalLink>

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -17,7 +17,7 @@
 	export let asMenuItem = false;
 	export let asMenuItemCondensed = false;
 	export let asButton = false;
-	export let rowReverse = false;
+	export let iconAsLast = false;
 
 	const onClick = () => {
 		if (isNullish(trackEvent)) {
@@ -45,7 +45,7 @@
 	class:w-full={fullWidth}
 	class:nav-item={asMenuItem}
 	class:nav-item-condensed={asMenuItemCondensed}
-	class:flex-row-reverse={rowReverse}
+	class:flex-row-reverse={iconAsLast}
 	on:click={onClick}
 >
 	{#if iconVisible}

--- a/src/frontend/src/lib/components/ui/ExternalLink.svelte
+++ b/src/frontend/src/lib/components/ui/ExternalLink.svelte
@@ -17,6 +17,7 @@
 	export let asMenuItem = false;
 	export let asMenuItemCondensed = false;
 	export let asButton = false;
+	export let rowReverse = false;
 
 	const onClick = () => {
 		if (isNullish(trackEvent)) {
@@ -44,6 +45,7 @@
 	class:w-full={fullWidth}
 	class:nav-item={asMenuItem}
 	class:nav-item-condensed={asMenuItemCondensed}
+	class:flex-row-reverse={rowReverse}
 	on:click={onClick}
 >
 	{#if iconVisible}


### PR DESCRIPTION
# Motivation

Instead of defining the `flex-row-reverse` of external links over the `styleClass` we added a `rowReverse` flag.

# Changes

- adds `rowReverse` flag on external link
