### PR TITLE
feat(frontend): load native Ethereum balances only for enabled tokens

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { debounce } from '@dfinity/utils';
-	import { loadEthBalances, loadErc20Balances } from '$eth/services/eth-balance.services';
+	import { loadErc20Balances, loadEthBalances } from '$eth/services/eth-balance.services';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
+	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 
 	const load = async () => {
 		await Promise.allSettled([
 			// We might require Ethereum balance on IC network as well given that one can convert ckETH to ETH.
-			loadEthBalances(),
+			loadEthBalances($enabledEthereumTokens),
 			loadErc20Balances({
 				address: $ethAddress,
 				erc20Tokens: $enabledErc20Tokens

--- a/src/frontend/src/eth/services/eth-balance.services.ts
+++ b/src/frontend/src/eth/services/eth-balance.services.ts
@@ -1,4 +1,3 @@
-import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import type { Erc20Token } from '$eth/types/erc20';
@@ -23,7 +22,7 @@ export const reloadEthereumBalance = (token: Token): Promise<ResultSuccess> => {
 	return loadErc20Balance({ token: token as Erc20Token });
 };
 
-export const loadEthBalance = async ({
+const loadEthBalance = async ({
 	networkId,
 	tokenId
 }: {
@@ -110,9 +109,9 @@ const loadErc20Balance = async ({
 	return { success: true };
 };
 
-export const loadEthBalances = async (): Promise<ResultSuccess> => {
+export const loadEthBalances = async (tokens: Token[]): Promise<ResultSuccess> => {
 	const results = await Promise.all([
-		...SUPPORTED_ETHEREUM_TOKENS.map(({ network: { id: networkId }, id: tokenId }) =>
+		...tokens.map(({ network: { id: networkId }, id: tokenId }) =>
 			loadEthBalance({ networkId, tokenId })
 		)
 	]);

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
@@ -1,0 +1,93 @@
+import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import LoaderEthBalances from '$eth/components/loaders/LoaderEthBalances.svelte';
+import { loadErc20Balances, loadEthBalances } from '$eth/services/eth-balance.services';
+import type { Erc20Token } from '$eth/types/erc20';
+import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
+import { ethAddressStore } from '$lib/stores/address.store';
+import { createMockErc20Tokens } from '$tests/mocks/erc20-tokens.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
+import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
+import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
+import { render } from '@testing-library/svelte';
+
+vi.mock('$eth/services/eth-balance.services', () => ({
+	loadEthBalances: vi.fn(),
+	loadErc20Balances: vi.fn()
+}));
+
+describe('LoaderEthBalances', () => {
+	const mockErc20DefaultTokens: Erc20Token[] = createMockErc20Tokens({
+		n: 3,
+		networkEnv: 'testnet'
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.useFakeTimers();
+
+		setupTestnetsStore('disabled');
+		setupUserNetworksStore('allEnabled');
+
+		ethAddressStore.set({ data: mockEthAddress, certified: false });
+
+		vi.spyOn(enabledErc20Tokens, 'subscribe').mockImplementation((fn) => {
+			fn(mockErc20DefaultTokens);
+			return () => {};
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should call `loadEthBalances` on mount', async () => {
+		render(LoaderEthBalances);
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(loadEthBalances).toHaveBeenCalledOnce();
+		expect(loadEthBalances).toHaveBeenNthCalledWith(1, [ETHEREUM_TOKEN]);
+	});
+
+	it('should call `loadEthBalances` on mount for testnet', async () => {
+		setupTestnetsStore('enabled');
+
+		render(LoaderEthBalances);
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(loadEthBalances).toHaveBeenCalledOnce();
+		expect(loadEthBalances).toHaveBeenNthCalledWith(1, [ETHEREUM_TOKEN, SEPOLIA_TOKEN]);
+	});
+
+	it('should call `loadErc20Balances` on mount', async () => {
+		render(LoaderEthBalances);
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(loadErc20Balances).toHaveBeenCalledOnce();
+		expect(loadErc20Balances).toHaveBeenNthCalledWith(1, {
+			address: mockEthAddress,
+			erc20Tokens: mockErc20DefaultTokens
+		});
+	});
+
+	// TODO: modify the component to be Svelte v5 and check if the children are rendered
+	it('should not handle errors', async () => {
+		vi.mocked(loadEthBalances).mockRejectedValue(new Error('Error loading balances'));
+
+		render(LoaderEthBalances);
+
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(loadEthBalances).toHaveBeenCalledOnce();
+		expect(loadEthBalances).toHaveBeenNthCalledWith(1, [ETHEREUM_TOKEN]);
+
+		expect(loadErc20Balances).toHaveBeenCalledOnce();
+		expect(loadErc20Balances).toHaveBeenNthCalledWith(1, {
+			address: mockEthAddress,
+			erc20Tokens: mockErc20DefaultTokens
+		});
+	});
+});

--- a/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
@@ -1,0 +1,326 @@
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import {
+	ETHEREUM_TOKEN,
+	ETHEREUM_TOKEN_ID,
+	SEPOLIA_TOKEN,
+	SEPOLIA_TOKEN_ID
+} from '$env/tokens/tokens.eth.env';
+import * as infuraErc20ProvidersLib from '$eth/providers/infura-erc20.providers';
+import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
+import * as infuraProvidersLib from '$eth/providers/infura.providers';
+import { infuraProviders } from '$eth/providers/infura.providers';
+import {
+	loadErc20Balances,
+	loadEthBalances,
+	reloadEthereumBalance
+} from '$eth/services/eth-balance.services';
+import type { Erc20Token } from '$eth/types/erc20';
+import { ethAddressStore } from '$lib/stores/address.store';
+import { balancesStore } from '$lib/stores/balances.store';
+import * as toastsStore from '$lib/stores/toasts.store';
+import { toastsError } from '$lib/stores/toasts.store';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { createMockErc20Tokens, mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
+import en from '$tests/mocks/i18n.mock';
+import { Contract } from 'ethers/contract';
+import { InfuraProvider as InfuraProviderLib } from 'ethers/providers';
+import { get } from 'svelte/store';
+import type { MockedClass } from 'vitest';
+
+vi.mock('ethers/providers', () => {
+	const provider = vi.fn();
+	provider.prototype.getBalance = vi.fn();
+	return { InfuraProvider: provider };
+});
+
+vi.mock('ethers/contract', () => {
+	const contract = vi.fn();
+	contract.prototype.balaceOf = vi.fn();
+	return { Contract: contract };
+});
+
+describe('eth-balance.services', () => {
+	describe('loadEthBalances', () => {
+		const mockTokens = [ETHEREUM_TOKEN, SEPOLIA_TOKEN];
+
+		const mockBalance = 123n;
+
+		const mockError = new Error('Error loading ETH balance');
+
+		const mockGetBalance = vi.fn();
+		const mockProvider = InfuraProviderLib as MockedClass<typeof InfuraProviderLib>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(toastsStore, 'toastsError');
+			vi.spyOn(infuraProvidersLib, 'infuraProviders');
+
+			mockProvider.prototype.getBalance = mockGetBalance;
+			mockGetBalance.mockResolvedValue(mockBalance);
+
+			ethAddressStore.set({ data: mockEthAddress, certified: false });
+		});
+
+		it('should handle a nullish ETH address', async () => {
+			ethAddressStore.reset();
+
+			const result = await loadEthBalances(mockTokens);
+
+			expect(result).toEqual({ success: false });
+
+			expect(toastsError).toHaveBeenCalledTimes(mockTokens.length);
+			mockTokens.forEach((_, index) => {
+				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
+					msg: { text: en.init.error.eth_address_unknown }
+				});
+			});
+		});
+
+		it('should call the balance provider', async () => {
+			const result = await loadEthBalances(mockTokens);
+
+			expect(result).toEqual({ success: true });
+
+			expect(infuraProviders).toHaveBeenCalledTimes(mockTokens.length);
+			expect(mockGetBalance).toHaveBeenCalledTimes(mockTokens.length);
+			mockTokens.forEach((token, index) => {
+				expect(infuraProviders).toHaveBeenNthCalledWith(index + 1, token.network.id);
+				expect(mockGetBalance).toHaveBeenNthCalledWith(index + 1, mockEthAddress);
+			});
+		});
+
+		it('should save the token balance', async () => {
+			const result = await loadEthBalances(mockTokens);
+
+			expect(result).toEqual({ success: true });
+
+			mockTokens.forEach(({ id }) => {
+				expect(get(balancesStore)?.[id]).toEqual({ certified: false, data: mockBalance });
+			});
+		});
+
+		it('should handle errors when loading ETH balances for a single token', async () => {
+			mockGetBalance.mockRejectedValueOnce(mockError);
+
+			const result = await loadEthBalances(mockTokens);
+
+			expect(result).toEqual({ success: false });
+
+			expect(toastsError).toHaveBeenCalledOnce();
+			expect(toastsError).toHaveBeenNthCalledWith(1, {
+				msg: { text: en.init.error.loading_balance },
+				err: mockError
+			});
+
+			expect(get(balancesStore)?.[ETHEREUM_TOKEN_ID]).toEqual(null);
+			expect(get(balancesStore)?.[SEPOLIA_TOKEN_ID]).toEqual({
+				certified: false,
+				data: mockBalance
+			});
+		});
+
+		it('should handle errors when loading ETH balances for all tokens', async () => {
+			mockGetBalance.mockRejectedValue(mockError);
+
+			const result = await loadEthBalances(mockTokens);
+
+			expect(result).toEqual({ success: false });
+
+			expect(toastsError).toHaveBeenCalledTimes(mockTokens.length);
+			mockTokens.forEach((_, index) => {
+				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
+					msg: { text: en.init.error.loading_balance },
+					err: mockError
+				});
+			});
+
+			mockTokens.forEach(({ id }) => {
+				expect(get(balancesStore)?.[id]).toEqual(null);
+			});
+		});
+	});
+
+	describe('loadErc20Balances', () => {
+		const mockErc20DefaultTokens: Erc20Token[] = createMockErc20Tokens({
+			n: 3,
+			networkEnv: 'testnet'
+		});
+
+		const mockParams = {
+			address: mockEthAddress,
+			erc20Tokens: mockErc20DefaultTokens
+		};
+
+		const mockBalance = 123n;
+
+		const mockError = new Error('Error loading ETH balance');
+
+		const mockGetBalance = vi.fn();
+		const mockContract = Contract as MockedClass<typeof Contract>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(toastsStore, 'toastsError');
+			vi.spyOn(infuraErc20ProvidersLib, 'infuraErc20Providers');
+
+			mockContract.prototype.balanceOf =
+				mockGetBalance as unknown as typeof mockContract.prototype.balanceOf;
+			mockGetBalance.mockResolvedValue(mockBalance);
+
+			ethAddressStore.reset();
+		});
+
+		it('should handle a nullish ETH address (both input and store)', async () => {
+			const result = await loadErc20Balances({ ...mockParams, address: null });
+
+			expect(result).toEqual({ success: false });
+
+			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+			mockErc20DefaultTokens.forEach((_, index) => {
+				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
+					msg: { text: en.init.error.eth_address_unknown }
+				});
+			});
+		});
+
+		it('should use the ETH address store if the input address is nullish', async () => {
+			ethAddressStore.set({ data: mockEthAddress, certified: false });
+
+			const result = await loadErc20Balances({ ...mockParams, address: null });
+
+			expect(result).toEqual({ success: true });
+
+			expect(toastsError).not.toHaveBeenCalled();
+		});
+
+		it('should call the balance provider', async () => {
+			const result = await loadErc20Balances(mockParams);
+
+			expect(result).toEqual({ success: true });
+
+			expect(infuraErc20Providers).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+			expect(mockGetBalance).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+			mockErc20DefaultTokens.forEach((token, index) => {
+				expect(infuraErc20Providers).toHaveBeenNthCalledWith(index + 1, token.network.id);
+				expect(mockGetBalance).toHaveBeenNthCalledWith(index + 1, mockEthAddress);
+			});
+		});
+
+		it('should save the token balance', async () => {
+			const result = await loadErc20Balances(mockParams);
+
+			expect(result).toEqual({ success: true });
+
+			mockErc20DefaultTokens.forEach(({ id }) => {
+				expect(get(balancesStore)?.[id]).toEqual({ certified: false, data: mockBalance });
+			});
+		});
+
+		it('should handle errors when loading ERC20 balances for a single token', async () => {
+			mockGetBalance.mockRejectedValueOnce(mockError);
+
+			const result = await loadErc20Balances(mockParams);
+
+			expect(result).toEqual({ success: false });
+
+			expect(toastsError).toHaveBeenCalledOnce();
+			expect(toastsError).toHaveBeenNthCalledWith(1, {
+				msg: {
+					text: replacePlaceholders(en.init.error.loading_balance_symbol, {
+						$symbol: mockErc20DefaultTokens[0].symbol
+					})
+				},
+				err: mockError
+			});
+
+			expect(get(balancesStore)?.[mockErc20DefaultTokens[0].id]).toEqual(null);
+			mockErc20DefaultTokens.slice(1).forEach(({ id }) => {
+				expect(get(balancesStore)?.[id]).toEqual({ certified: false, data: mockBalance });
+			});
+		});
+
+		it('should handle errors when loading ERC20 balances for all tokens', async () => {
+			mockGetBalance.mockRejectedValue(mockError);
+
+			const result = await loadErc20Balances(mockParams);
+
+			expect(result).toEqual({ success: false });
+
+			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+			mockErc20DefaultTokens.forEach((_, index) => {
+				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
+					msg: {
+						text: replacePlaceholders(en.init.error.loading_balance_symbol, {
+							$symbol: mockErc20DefaultTokens[index].symbol
+						})
+					},
+					err: mockError
+				});
+			});
+
+			mockErc20DefaultTokens.forEach(({ id }) => {
+				expect(get(balancesStore)?.[id]).toEqual(null);
+			});
+		});
+	});
+
+	describe('reloadEthereumBalance', () => {
+		const mockBalance = 123n;
+
+		const mockGetBalance = vi.fn();
+		const mockProvider = InfuraProviderLib as MockedClass<typeof InfuraProviderLib>;
+		const mockContract = Contract as MockedClass<typeof Contract>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(toastsStore, 'toastsError');
+			vi.spyOn(infuraProvidersLib, 'infuraProviders');
+			vi.spyOn(infuraErc20ProvidersLib, 'infuraErc20Providers');
+
+			mockProvider.prototype.getBalance = mockGetBalance;
+			mockContract.prototype.balanceOf =
+				mockGetBalance as unknown as typeof mockContract.prototype.balanceOf;
+			mockGetBalance.mockResolvedValue(mockBalance);
+
+			ethAddressStore.set({ data: mockEthAddress, certified: false });
+		});
+
+		it('should load balance for a native Ethereum token', async () => {
+			const result = await reloadEthereumBalance(ETHEREUM_TOKEN);
+
+			expect(result).toEqual({ success: true });
+
+			expect(get(balancesStore)?.[ETHEREUM_TOKEN_ID]).toEqual({
+				certified: false,
+				data: mockBalance
+			});
+
+			expect(infuraProviders).toHaveBeenCalledOnce();
+			expect(infuraProviders).toHaveBeenNthCalledWith(1, ETHEREUM_NETWORK_ID);
+
+			expect(mockGetBalance).toHaveBeenCalledOnce();
+			expect(mockGetBalance).toHaveBeenNthCalledWith(1, mockEthAddress);
+		});
+
+		it('should load balance for a non-native Ethereum token', async () => {
+			const result = await reloadEthereumBalance(mockValidErc20Token);
+
+			expect(result).toEqual({ success: true });
+
+			expect(get(balancesStore)?.[mockValidErc20Token.id]).toEqual({
+				certified: false,
+				data: mockBalance
+			});
+
+			expect(infuraErc20Providers).toHaveBeenCalledOnce();
+			expect(infuraErc20Providers).toHaveBeenNthCalledWith(1, mockValidErc20Token.network.id);
+
+			expect(mockGetBalance).toHaveBeenCalledOnce();
+			expect(mockGetBalance).toHaveBeenNthCalledWith(1, mockEthAddress);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Since we are now using enabled/disabled networks, it makes sense to load the Ethereum native tokens balances ONLY for the enabled tokens.

# Changes

- Add input `tokens` to service `loadEthBalances` that had instead the hardcoded list of native Ethereum tokens otherwise.
- Use enabled tokens derived store in component `LoaderEthBalances`.

# Tests

Since we are here, I created tests for both the service and the component.
