### PR TITLE
fix(frontend): enable CORS params in Blockchain API calls

### DIFF
--- a/src/frontend/src/lib/rest/blockchain.rest.ts
+++ b/src/frontend/src/lib/rest/blockchain.rest.ts
@@ -16,7 +16,13 @@ export const btcAddressData = ({
 	});
 
 const fetchBlockchainApi = async <T>({ endpointPath }: { endpointPath: string }): Promise<T> => {
-	const response = await fetch(`${BLOCKCHAIN_API_URL}/${endpointPath}`);
+	const url = new URL(`${BLOCKCHAIN_API_URL}/${endpointPath}`);
+
+	// Some API calls are available with CORS headers if you add a &cors=true parameter to the GET request
+	// https://www.blockchain.com/explorer/api/q
+	url.searchParams.set('cors', 'true');
+
+	const response = await fetch(url.toString());
 
 	if (!response.ok) {
 		throw new Error('Blockchain API response not ok.');

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -6,6 +6,7 @@ import * as blockchainRest from '$lib/rest/blockchain.rest';
 import * as blockstreamRest from '$lib/rest/blockstream.rest';
 import type { PostMessageDataRequestBtc } from '$lib/types/post-message';
 import * as authUtils from '$lib/utils/auth.utils';
+import { mockBlockchainResponse } from '$tests/mocks/blockchain.mock';
 import { mockBtcTransaction } from '$tests/mocks/btc-transactions.mock';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -96,16 +97,7 @@ describe('btc-wallet.worker', () => {
 
 		vi.spyOn(blockstreamRest, 'btcLatestBlockHeight').mockResolvedValue(1000);
 
-		vi.spyOn(blockchainRest, 'btcAddressData').mockResolvedValue({
-			txs: [mockBtcTransaction],
-			address: mockBtcAddress,
-			final_balance: 100,
-			total_received: 100,
-			hash160: 'hash160',
-			n_tx: 100,
-			n_unredeemed: 100,
-			total_sent: 100
-		});
+		vi.spyOn(blockchainRest, 'btcAddressData').mockResolvedValue(mockBlockchainResponse);
 
 		vi.spyOn(SignerCanister, 'create').mockResolvedValue(signerCanisterMock);
 		vi.spyOn(BitcoinCanister, 'create').mockReturnValue(bitcoinCanisterMock);

--- a/src/frontend/src/tests/lib/rest/blockchain.rest.spec.ts
+++ b/src/frontend/src/tests/lib/rest/blockchain.rest.spec.ts
@@ -1,0 +1,43 @@
+import { btcAddressData } from '$lib/rest/blockchain.rest';
+import { mockBlockchainResponse } from '$tests/mocks/blockchain.mock';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+
+describe('blockchain.rest', () => {
+	describe('btcAddressData', () => {
+		beforeEach(() => {
+			global.fetch = vi.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(mockBlockchainResponse)
+				})
+			) as unknown as typeof fetch;
+		});
+
+		it('fetches BTC address data with cors=true', async () => {
+			const result = await btcAddressData({ btcAddress: mockBtcAddress });
+
+			expect(result).toEqual(mockBlockchainResponse);
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.stringContaining(`rawaddr/${mockBtcAddress}?cors=true`)
+			);
+		});
+
+		it('throws an error when the response is not ok', async () => {
+			global.fetch = vi.fn(() =>
+				Promise.resolve({
+					ok: false,
+					json: () => Promise.resolve({ error: 'Not Found' })
+				})
+			) as unknown as typeof fetch;
+
+			await expect(btcAddressData({ btcAddress: mockBtcAddress })).rejects.toThrow(
+				'Blockchain API response not ok.'
+			);
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.stringContaining(`rawaddr/${mockBtcAddress}?cors=true`)
+			);
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/blockchain.mock.ts
+++ b/src/frontend/src/tests/mocks/blockchain.mock.ts
@@ -1,0 +1,14 @@
+import type { BitcoinAddressData } from '$lib/types/blockchain';
+import { mockBtcTransaction } from '$tests/mocks/btc-transactions.mock';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+
+export const mockBlockchainResponse: BitcoinAddressData = {
+	txs: [mockBtcTransaction],
+	address: mockBtcAddress,
+	final_balance: 100,
+	total_received: 100,
+	hash160: 'hash160',
+	n_tx: 100,
+	n_unredeemed: 100,
+	total_sent: 100
+};


### PR DESCRIPTION
# Motivation

Some of the Blockchain API calls require the CORS parameter turned on (see [documentation](https://www.blockchain.com/explorer/api/q)). Otherwise it raises an error:

![image](https://github.com/user-attachments/assets/a8536e60-e9e7-4ec0-be7b-b464c7e4fd7d)

**Credits to @dominikayyildiz** 

# Changes

Added the CORS parameter to `fetchBlockchainApi`

# Tests

Added some unittests, but I tested in test environment: 

### Before

![Screenshot 2025-04-15 at 10 18 34](https://github.com/user-attachments/assets/177e0c3e-fdc4-4fd4-9071-00d35ccbff2e)


### After

![Screenshot 2025-04-15 at 10 23 39](https://github.com/user-attachments/assets/2e4fd82b-3dd6-4d4e-944e-05ace48ecde2)
