### PR TITLE
chore(frontend): format btc tests with vitest/padding-around-all

### DIFF
--- a/src/frontend/src/tests/btc/derived/btc-pending-sent-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/btc-pending-sent-transactions.derived.spec.ts
@@ -44,12 +44,14 @@ describe('initPendingSentTransactionsStatus', () => {
 
 		it('should return "loading" if BTC address mainnet is not loaded', () => {
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.LOADING);
 		});
 
 		it('should return "loading" if pending transactions are not loaded yet for the address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.LOADING);
 		});
 
@@ -57,12 +59,14 @@ describe('initPendingSentTransactionsStatus', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			btcPendingSentTransactionsStore.setPendingTransactionsError({ address: mockAddressMainnet });
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.ERROR);
 		});
 
 		it('should return "BtcPendingSentTransactionsStatus.NONE" if address is not the mainnet bitcoin address', () => {
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
 			const store = initPendingSentTransactionsStatus('another-address');
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.NONE);
 		});
 
@@ -73,6 +77,7 @@ describe('initPendingSentTransactionsStatus', () => {
 				pendingTransactions: [pendingTransactionMock]
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.SOME);
 		});
 
@@ -83,6 +88,7 @@ describe('initPendingSentTransactionsStatus', () => {
 				pendingTransactions: []
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.NONE);
 		});
 	});
@@ -104,17 +110,20 @@ describe('initPendingSentTransactionsStatus', () => {
 			);
 
 			btcAddressTestnetStore.set({ certified: true, data: mockAddressMainnet });
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressMainnet))).toBe(
 				BtcPendingSentTransactionsStatus.LOADING
 			);
 
 			btcAddressTestnetStore.set({ certified: true, data: mockAddressRegtest });
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressMainnet))).toBe(
 				BtcPendingSentTransactionsStatus.LOADING
 			);
 
 			btcAddressTestnetStore.reset();
 			btcAddressMainnetStore.set({ certified: true, data: mockAddressMainnet });
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
 				BtcPendingSentTransactionsStatus.LOADING
 			);
@@ -122,6 +131,7 @@ describe('initPendingSentTransactionsStatus', () => {
 
 		it('should return "loading" if pending transactions are not loaded yet for the address', () => {
 			loadAllAddresses();
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
 				BtcPendingSentTransactionsStatus.LOADING
 			);
@@ -133,10 +143,13 @@ describe('initPendingSentTransactionsStatus', () => {
 		it('should return "error" if pending transactions are `null`', () => {
 			loadAllAddresses();
 			btcPendingSentTransactionsStore.setPendingTransactionsError({ address: mockAddressTestnet });
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
 				BtcPendingSentTransactionsStatus.ERROR
 			);
+
 			btcPendingSentTransactionsStore.setPendingTransactionsError({ address: mockAddressMainnet });
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressMainnet))).toBe(
 				BtcPendingSentTransactionsStatus.ERROR
 			);
@@ -144,6 +157,7 @@ describe('initPendingSentTransactionsStatus', () => {
 
 		it('should return "BtcPendingSentTransactionsStatus.NONE" if address is not a bitcoin address', () => {
 			loadAllAddresses();
+
 			expect(get(initPendingSentTransactionsStatus('another-address'))).toBe(
 				BtcPendingSentTransactionsStatus.NONE
 			);
@@ -155,6 +169,7 @@ describe('initPendingSentTransactionsStatus', () => {
 				address: mockAddressTestnet,
 				pendingTransactions: [pendingTransactionMock]
 			});
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
 				BtcPendingSentTransactionsStatus.SOME
 			);
@@ -166,6 +181,7 @@ describe('initPendingSentTransactionsStatus', () => {
 				address: mockAddressTestnet,
 				pendingTransactions: []
 			});
+
 			expect(get(initPendingSentTransactionsStatus(mockAddressTestnet))).toBe(
 				BtcPendingSentTransactionsStatus.NONE
 			);
@@ -178,6 +194,7 @@ describe('initPendingSentTransactionsStatus', () => {
 				pendingTransactions: [pendingTransactionMock]
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.SOME);
 		});
 
@@ -188,6 +205,7 @@ describe('initPendingSentTransactionsStatus', () => {
 				pendingTransactions: []
 			});
 			const store = initPendingSentTransactionsStatus(mockAddressMainnet);
+
 			expect(get(store)).toBe(BtcPendingSentTransactionsStatus.NONE);
 		});
 	});

--- a/src/frontend/src/tests/btc/schema/btc-post-message.schema.spec.ts
+++ b/src/frontend/src/tests/btc/schema/btc-post-message.schema.spec.ts
@@ -16,6 +16,7 @@ describe('btc-post-message.schema', () => {
 					newTransactions: mockValidTransactions
 				}
 			};
+
 			expect(BtcPostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -25,6 +26,7 @@ describe('btc-post-message.schema', () => {
 					balance: mockValidBalance
 				}
 			};
+
 			expect(() => BtcPostMessageDataResponseWalletSchema.parse(invalidData)).toThrow();
 		});
 
@@ -35,6 +37,7 @@ describe('btc-post-message.schema', () => {
 					newTransactions: mockValidTransactions
 				}
 			};
+
 			expect(BtcPostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -45,6 +48,7 @@ describe('btc-post-message.schema', () => {
 					newTransactions: 'invalid_json'
 				}
 			};
+
 			expect(BtcPostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 	});

--- a/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/btc-pending-sent-transactions.store.spec.ts
@@ -36,6 +36,7 @@ describe('btcPendingSentTransactionsStore', () => {
 
 	it('should initialize with an empty store', () => {
 		const storeData = get(btcPendingSentTransactionsStore);
+
 		expect(storeData).toEqual({});
 	});
 
@@ -46,6 +47,7 @@ describe('btcPendingSentTransactionsStore', () => {
 		btcPendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
 		const storeData = get(btcPendingSentTransactionsStore);
+
 		expect(storeData[address].data).toEqual(pendingTransactions);
 	});
 
@@ -54,6 +56,7 @@ describe('btcPendingSentTransactionsStore', () => {
 		btcPendingSentTransactionsStore.setPendingTransactionsError({ address });
 
 		const storeData = get(btcPendingSentTransactionsStore);
+
 		expect(storeData[address].data).toBeNull();
 	});
 
@@ -62,9 +65,11 @@ describe('btcPendingSentTransactionsStore', () => {
 		const pendingTransactions: Array<PendingTransaction> = [pendingTransactionMock1];
 
 		btcPendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
+
 		expect(get(btcPendingSentTransactionsStore)[address].data).toEqual(pendingTransactions);
 
 		btcPendingSentTransactionsStore.setPendingTransactionsError({ address });
+
 		expect(get(btcPendingSentTransactionsStore)[address].data).toBeNull();
 	});
 
@@ -75,6 +80,7 @@ describe('btcPendingSentTransactionsStore', () => {
 		btcPendingSentTransactionsStore.setPendingTransactions({ address, pendingTransactions });
 
 		const storeData = get(btcPendingSentTransactionsStore);
+
 		expect(storeData[address].certified).toEqual(true);
 	});
 
@@ -95,6 +101,7 @@ describe('btcPendingSentTransactionsStore', () => {
 		});
 
 		const storeData = get(btcPendingSentTransactionsStore);
+
 		expect(storeData[address].data).toEqual(newPendingTransactions);
 	});
 
@@ -116,6 +123,7 @@ describe('btcPendingSentTransactionsStore', () => {
 		});
 
 		const storeData = get(btcPendingSentTransactionsStore);
+
 		expect(storeData[address1].data).toEqual(pendingTransactions1);
 		expect(storeData[address2].data).toEqual(pendingTransactions2);
 	});

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -176,6 +176,7 @@ describe('btc-wallet.worker', () => {
 
 		it('should stop the scheduler', () => {
 			scheduler.stop();
+
 			expect(scheduler['timer']['timer']).toBeUndefined();
 		});
 


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) on the `btc` test folder.

