### PR TITLE
chore(frontend): format eth tests with vitest/padding-around-all

### DIFF
--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -83,6 +83,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -96,6 +97,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -104,6 +106,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		// same number of calls as before
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -117,7 +120,9 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		const expectedTokens = [ETHEREUM_TOKEN, ...mockMainnetErc20UserTokens];
+
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -137,7 +142,9 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		const expectedTokens = [SEPOLIA_TOKEN, ...mockSepoliaErc20UserTokens];
+
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -165,6 +172,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -179,7 +187,9 @@ describe('LoaderMultipleEthTransactions', () => {
 			...expectedTokens,
 			...mockAdditionalTokens.map(({ data: token }) => token)
 		];
+
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedNewTokens.length);
+
 		expectedNewTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -200,6 +210,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -214,7 +225,9 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		// the number of calls as before + mockAdditionalTokens.length
 		const expectedNewTokens = [...expectedTokens, ...mockAdditionalTokens];
+
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedNewTokens.length);
+
 		expectedNewTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -239,7 +252,9 @@ describe('LoaderMultipleEthTransactions', () => {
 			...expectedNewTokens,
 			...mockNewAdditionalTokens.map(({ data: token }) => token)
 		];
+
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedNewTokensWithSepolia.length);
+
 		expectedNewTokensWithSepolia.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -258,6 +273,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+
 		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
@@ -272,7 +288,9 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		// the number of calls as before + the failed call + mockAdditionalTokens.length
 		const expectedNewTokens = [...expectedTokens, ETHEREUM_TOKEN, ...mockAdditionalTokens];
+
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedNewTokens.length);
+
 		expectedNewTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});

--- a/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
@@ -47,23 +47,29 @@ describe('EthSendForm', () => {
 		});
 
 		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+
 		expect(amount).not.toBeNull();
 
 		const destination: HTMLInputElement | null = container.querySelector(destinationSelector);
+
 		expect(destination).not.toBeNull();
 
 		const network: HTMLDivElement | null = container.querySelector(networkSelector);
+
 		expect(network).not.toBeNull();
 
 		const maxFeeEth: HTMLDivElement | null = container.querySelector(maxFeeEthSelector);
+
 		expect(maxFeeEth).not.toBeNull();
 
 		const sendInfoMessageBox: HTMLDivElement | null = container.querySelector(
 			sendInfoMessageBoxSelector
 		);
+
 		expect(sendInfoMessageBox).not.toBeNull();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
+
 		expect(toolbar).not.toBeNull();
 	});
 
@@ -74,23 +80,29 @@ describe('EthSendForm', () => {
 		});
 
 		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+
 		expect(amount).not.toBeNull();
 
 		const destination: HTMLInputElement | null = container.querySelector(destinationSelector);
+
 		expect(destination).toBeNull();
 
 		const network: HTMLDivElement | null = container.querySelector(networkSelector);
+
 		expect(network).not.toBeNull();
 
 		const maxFeeEth: HTMLDivElement | null = container.querySelector(maxFeeEthSelector);
+
 		expect(maxFeeEth).not.toBeNull();
 
 		const sendInfoMessageBox: HTMLDivElement | null = container.querySelector(
 			sendInfoMessageBoxSelector
 		);
+
 		expect(sendInfoMessageBox).not.toBeNull();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
+
 		expect(toolbar).not.toBeNull();
 	});
 });

--- a/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
@@ -71,6 +71,7 @@ describe('eth-balance.services', () => {
 			expect(result).toEqual({ success: false });
 
 			expect(toastsError).toHaveBeenCalledTimes(mockTokens.length);
+
 			mockTokens.forEach((_, index) => {
 				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
 					msg: { text: en.init.error.eth_address_unknown }
@@ -85,6 +86,7 @@ describe('eth-balance.services', () => {
 
 			expect(infuraProviders).toHaveBeenCalledTimes(mockTokens.length);
 			expect(mockGetBalance).toHaveBeenCalledTimes(mockTokens.length);
+
 			mockTokens.forEach((token, index) => {
 				expect(infuraProviders).toHaveBeenNthCalledWith(index + 1, token.network.id);
 				expect(mockGetBalance).toHaveBeenNthCalledWith(index + 1, mockEthAddress);
@@ -129,6 +131,7 @@ describe('eth-balance.services', () => {
 			expect(result).toEqual({ success: false });
 
 			expect(toastsError).toHaveBeenCalledTimes(mockTokens.length);
+
 			mockTokens.forEach((_, index) => {
 				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
 					msg: { text: en.init.error.loading_balance },
@@ -179,6 +182,7 @@ describe('eth-balance.services', () => {
 			expect(result).toEqual({ success: false });
 
 			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+
 			mockErc20DefaultTokens.forEach((_, index) => {
 				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
 					msg: { text: en.init.error.eth_address_unknown }
@@ -203,6 +207,7 @@ describe('eth-balance.services', () => {
 
 			expect(infuraErc20Providers).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
 			expect(mockGetBalance).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+
 			mockErc20DefaultTokens.forEach((token, index) => {
 				expect(infuraErc20Providers).toHaveBeenNthCalledWith(index + 1, token.network.id);
 				expect(mockGetBalance).toHaveBeenNthCalledWith(index + 1, mockEthAddress);
@@ -237,6 +242,7 @@ describe('eth-balance.services', () => {
 			});
 
 			expect(get(balancesStore)?.[mockErc20DefaultTokens[0].id]).toEqual(null);
+
 			mockErc20DefaultTokens.slice(1).forEach(({ id }) => {
 				expect(get(balancesStore)?.[id]).toEqual({ certified: false, data: mockBalance });
 			});
@@ -250,6 +256,7 @@ describe('eth-balance.services', () => {
 			expect(result).toEqual({ success: false });
 
 			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
+
 			mockErc20DefaultTokens.forEach((_, index) => {
 				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
 					msg: {

--- a/src/frontend/src/tests/eth/services/eth-transactions-batch.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions-batch.services.spec.ts
@@ -54,6 +54,7 @@ describe('eth-transactions-batch.services', () => {
 			const result = await generator.next();
 
 			expect(loadEthereumTransactions).toHaveBeenCalledTimes(mockTokensNotLoaded.length);
+
 			mockTokensNotLoaded.forEach((token) => {
 				expect(loadEthereumTransactions).toHaveBeenCalledWith({
 					tokenId: token.id,
@@ -106,6 +107,7 @@ describe('eth-transactions-batch.services', () => {
 			expect(batch).toHaveBeenCalled();
 
 			const result = await generator.next();
+
 			expect(result.value).toEqual(expectedReturn);
 		});
 

--- a/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/qr-code.utils.spec.ts
@@ -33,11 +33,13 @@ describe('decodeQrCode', () => {
 
 	it('should return { result } when result is not success', () => {
 		const response = decodeQrCode({ status: 'cancelled', ...otherProps });
+
 		expect(response).toEqual({ status: 'cancelled' });
 	});
 
 	it('should return { status: "cancelled" } when code is nullish', () => {
 		const response = decodeQrCode({ status: 'success', code: undefined, ...otherProps });
+
 		expect(response).toEqual({ status: 'cancelled' });
 	});
 
@@ -45,6 +47,7 @@ describe('decodeQrCode', () => {
 		mockDecodeQrCodeUrn.mockReturnValue(undefined);
 
 		const response = decodeQrCode({ status: 'success', code: urn, ...otherProps });
+
 		expect(response).toEqual({ status: 'success', destination: urn });
 
 		expect(mockDecodeQrCodeUrn).toHaveBeenCalledWith(urn);
@@ -63,6 +66,7 @@ describe('decodeQrCode', () => {
 			code: urn,
 			...otherProps
 		});
+
 		expect(response).toEqual({ status: 'token_incompatible' });
 
 		expect(mockDecodeQrCodeUrn).toHaveBeenCalledWith(urn);
@@ -82,6 +86,7 @@ describe('decodeQrCode', () => {
 			code: urn,
 			...otherProps
 		});
+
 		expect(response).toEqual({
 			status: 'success',
 			destination,


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) on the `eth` test folder.

