### PR TITLE
chore(frontend): format icp tests with vitest/padding-around-all

### DIFF
--- a/src/frontend/src/tests/icp/components/send/IcSendForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendForm.spec.ts
@@ -47,23 +47,29 @@ describe('IcSendForm', () => {
 		});
 
 		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+
 		expect(amount).not.toBeNull();
 
 		const destination: HTMLInputElement | null = container.querySelector(destinationSelector);
+
 		expect(destination).not.toBeNull();
 
 		const network: HTMLDivElement | null = container.querySelector(networkSelector);
+
 		expect(network).not.toBeNull();
 
 		const fee: HTMLParagraphElement | null = container.querySelector(feeSelector);
+
 		expect(fee).not.toBeNull();
 
 		const ethereumEstimatedFee: HTMLParagraphElement | null = container.querySelector(
 			ethereumEstimatedFeeSelector
 		);
+
 		expect(ethereumEstimatedFee).not.toBeNull();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
+
 		expect(toolbar).not.toBeNull();
 	});
 
@@ -74,23 +80,29 @@ describe('IcSendForm', () => {
 		});
 
 		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+
 		expect(amount).not.toBeNull();
 
 		const destination: HTMLInputElement | null = container.querySelector(destinationSelector);
+
 		expect(destination).toBeNull();
 
 		const network: HTMLDivElement | null = container.querySelector(networkSelector);
+
 		expect(network).not.toBeNull();
 
 		const fee: HTMLParagraphElement | null = container.querySelector(feeSelector);
+
 		expect(fee).not.toBeNull();
 
 		const ethereumEstimatedFee: HTMLParagraphElement | null = container.querySelector(
 			ethereumEstimatedFeeSelector
 		);
+
 		expect(ethereumEstimatedFee).not.toBeNull();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
+
 		expect(toolbar).not.toBeNull();
 	});
 });

--- a/src/frontend/src/tests/icp/derived/ckbtc-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ckbtc-transactions.derived.spec.ts
@@ -10,6 +10,7 @@ describe('ckBtcPendingUtxoTransactions', () => {
 		token.set(ETHEREUM_TOKEN);
 
 		const result = get(ckBtcPendingUtxoTransactions);
+
 		expect(result).toEqual([]);
 	});
 
@@ -25,6 +26,7 @@ describe('ckBtcPendingUtxoTransactions', () => {
 
 		it('derived pending UTXOs is always not certified', () => {
 			const result = get(ckBtcPendingUtxoTransactions);
+
 			expect(result[0].certified).toBe(false);
 		});
 	});

--- a/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
@@ -25,6 +25,7 @@ describe('ic-transactions.derived', () => {
 
 	it('should return an empty array when all source stores are empty', () => {
 		const result = get(icTransactions);
+
 		expect(result).toEqual([]);
 	});
 
@@ -39,6 +40,7 @@ describe('ic-transactions.derived', () => {
 		icTransactionsStore.nullify(ICP_TOKEN_ID);
 
 		const result = get(icTransactions);
+
 		expect(result).toHaveLength(0);
 		expect(result).toEqual([]);
 	});
@@ -55,6 +57,7 @@ describe('ic-transactions.derived', () => {
 			});
 
 			const result = get(icTransactions);
+
 			expect(result).toEqual([...transactions]);
 		});
 	});
@@ -68,6 +71,7 @@ describe('ic-transactions.derived', () => {
 
 		it('should derive only pending ckBTC', () => {
 			const result = get(icTransactions);
+
 			expect(result).toEqual([
 				{
 					data: mockCkBtcPendingUtxoTransaction,
@@ -83,6 +87,7 @@ describe('ic-transactions.derived', () => {
 			});
 
 			const result = get(icTransactions);
+
 			expect(result).toEqual([
 				{
 					data: mockCkBtcPendingUtxoTransaction,
@@ -127,6 +132,7 @@ describe('ic-transactions.derived', () => {
 
 		it('should derive only pending ckETH', () => {
 			const result = get(icTransactions);
+
 			expect(result).toEqual([
 				{
 					data: mockPendingCkEth,
@@ -142,6 +148,7 @@ describe('ic-transactions.derived', () => {
 			});
 
 			const result = get(icTransactions);
+
 			expect(result).toEqual([
 				{
 					data: mockPendingCkEth,

--- a/src/frontend/src/tests/icp/schema/ic-token.schema.spec.ts
+++ b/src/frontend/src/tests/icp/schema/ic-token.schema.spec.ts
@@ -51,11 +51,13 @@ describe('ic-token.schema', () => {
 	describe('IcFeeSchema', () => {
 		it('should validate with correct data', () => {
 			const validData = mockFee;
+
 			expect(IcFeeSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should fail with invalid fee type', () => {
 			const invalidData = { fee: 1000 };
+
 			expect(() => IcFeeSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -72,6 +74,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				position: 'first'
 			};
+
 			expect(() => IcAppMetadataSchema.parse(invalidData)).toThrow();
 		});
 
@@ -80,6 +83,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				explorerUrl: 'http://localhost:8080'
 			};
+
 			expect(() => IcAppMetadataSchema.parse(invalidData)).toThrow();
 		});
 
@@ -88,6 +92,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				exchangeCoinId: 'test'
 			};
+
 			expect(() => IcAppMetadataSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -103,6 +108,7 @@ describe('ic-token.schema', () => {
 			const validData = {
 				ledgerCanisterId: mockCanisters.ledgerCanisterId
 			};
+
 			expect(IcCanistersSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -111,6 +117,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				ledgerCanisterId: 'abc'
 			};
+
 			expect(() => IcCanistersSchema.parse(invalidData)).toThrow();
 		});
 
@@ -119,6 +126,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				indexCanisterId: 'abc'
 			};
+
 			expect(() => IcCanistersSchema.parse(invalidData)).toThrow();
 		});
 
@@ -126,6 +134,7 @@ describe('ic-token.schema', () => {
 			const invalidData = {
 				indexCanisterId: IC_CKBTC_INDEX_CANISTER_ID
 			};
+
 			expect(() => IcCanistersSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -155,11 +164,13 @@ describe('ic-token.schema', () => {
 			const invalidData = {
 				ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID
 			};
+
 			expect(() => IcCanistersStrictSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should fail for token with missing index canister field', () => {
 			const { indexCanisterId: _, ...tokenWithoutIndexCanisterId } = validToken;
+
 			expect(() => IcCanistersStrictSchema.parse(tokenWithoutIndexCanisterId)).toThrow();
 		});
 	});
@@ -179,6 +190,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				twinToken: { id: 'not-a-symbol' }
 			};
+
 			expect(() => IcCkLinkedAssetsSchema.parse(invalidData)).toThrow();
 		});
 
@@ -187,6 +199,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				feeLedgerCanisterId: 123
 			};
+
 			expect(() => IcCkLinkedAssetsSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -204,6 +217,7 @@ describe('ic-token.schema', () => {
 
 		it('should fail with missing minterCanisterId', () => {
 			const { minterCanisterId: _, ...invalidData } = validData;
+
 			expect(() => IcCkMetadataSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -220,6 +234,7 @@ describe('ic-token.schema', () => {
 
 		it('should validate without Index canister', () => {
 			const { indexCanisterId: _, ...restValidData } = validData;
+
 			expect(IcInterfaceSchema.parse(restValidData)).toEqual(restValidData);
 		});
 
@@ -228,6 +243,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				ledgerCanisterId: 123
 			};
+
 			expect(() => IcInterfaceSchema.parse(invalidData)).toThrow();
 		});
 
@@ -236,6 +252,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				position: 'first'
 			};
+
 			expect(() => IcInterfaceSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -257,6 +274,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				id: 'not-a-symbol'
 			};
+
 			expect(() => IcTokenSchema.parse(invalidData)).toThrow();
 		});
 
@@ -265,6 +283,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				fee: 1000
 			};
+
 			expect(() => IcTokenSchema.parse(invalidData)).toThrow();
 		});
 
@@ -273,6 +292,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				ledgerCanisterId: 123
 			};
+
 			expect(() => IcTokenSchema.parse(invalidData)).toThrow();
 		});
 
@@ -281,6 +301,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				position: 'first'
 			};
+
 			expect(() => IcTokenSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -304,6 +325,7 @@ describe('ic-token.schema', () => {
 				...validData,
 				id
 			};
+
 			expect(() => IcTokenWithoutIdSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -320,6 +342,7 @@ describe('ic-token.schema', () => {
 			const validData = {
 				...mockIcToken
 			};
+
 			expect(IcCkTokenSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -329,6 +352,7 @@ describe('ic-token.schema', () => {
 				twinToken: mockToken,
 				minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID
 			};
+
 			expect(IcCkTokenSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -337,6 +361,7 @@ describe('ic-token.schema', () => {
 				...mockIcToken,
 				twinToken: mockToken
 			};
+
 			expect(IcCkTokenSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -359,11 +384,13 @@ describe('ic-token.schema', () => {
 				...validData,
 				ledgerCanisterId: 123
 			};
+
 			expect(() => IcCkInterfaceSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should fail with incorrect IcCkMetadataSchema data', () => {
 			const { minterCanisterId: _, ...invalidData } = validData;
+
 			expect(() => IcCkInterfaceSchema.parse(invalidData)).toThrow();
 		});
 	});

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -240,6 +240,7 @@ describe('icrc.services', () => {
 
 			it('should reset all and toasts on list custom tokens error', async () => {
 				const tokens = get(icrcCustomTokensStore);
+
 				expect(tokens).toHaveLength(1);
 
 				const err = new Error('test');
@@ -248,6 +249,7 @@ describe('icrc.services', () => {
 				await loadCustomTokens({ identity: mockIdentity });
 
 				const afterTokens = get(icrcCustomTokensStore);
+
 				expect(afterTokens).toBeNull();
 
 				testToastsError(err);
@@ -262,6 +264,7 @@ describe('icrc.services', () => {
 				await loadCustomTokens({ identity: mockIdentity });
 
 				const afterTokens = get(icrcCustomTokensStore);
+
 				expect(afterTokens).toBeNull();
 
 				testToastsError(err);

--- a/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
+++ b/src/frontend/src/tests/icp/utils/map-icrc-data.spec.ts
@@ -37,12 +37,14 @@ describe('mapIcrcData', () => {
 
 		it('should map ICRC tokens correctly', () => {
 			const result = mapIcrcData(token);
+
 			expect(result).toEqual(expected);
 		});
 	});
 
 	it('should handle empty input', () => {
 		const result = mapIcrcData({});
+
 		expect(result).toEqual({});
 	});
 });

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -129,6 +129,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 		it('should start the scheduler with an interval', async () => {
 			await scheduler.start(startData);
+
 			expect(scheduler['timer']['timer']).toBeDefined();
 		});
 
@@ -141,6 +142,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 		it('should stop the scheduler', () => {
 			scheduler.stop();
+
 			expect(scheduler['timer']['timer']).toBeUndefined();
 		});
 
@@ -230,6 +232,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 		it('should start the scheduler with an interval', async () => {
 			await scheduler.start(startData);
+
 			expect(scheduler['timer']['timer']).toBeDefined();
 		});
 
@@ -243,6 +246,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 		it('should stop the scheduler', () => {
 			scheduler.stop();
+
 			expect(scheduler['timer']['timer']).toBeUndefined();
 		});
 

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
@@ -97,6 +97,7 @@ describe('ic-wallet-balance.worker', () => {
 
 		it('should start the scheduler with an interval', async () => {
 			await scheduler.start(startData);
+
 			expect(scheduler['timer']['timer']).toBeDefined();
 		});
 
@@ -109,6 +110,7 @@ describe('ic-wallet-balance.worker', () => {
 
 		it('should stop the scheduler', () => {
 			scheduler.stop();
+
 			expect(scheduler['timer']['timer']).toBeUndefined();
 		});
 


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) on the `icp` test folder.

