### PR TITLE
chore(frontend): format sol tests with vitest/padding-around-all

### DIFF
--- a/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
@@ -67,18 +67,23 @@ describe('SolSendForm', () => {
 		});
 
 		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+
 		expect(amount).not.toBeNull();
 
 		const destination: HTMLInputElement | null = container.querySelector(destinationSelector);
+
 		expect(destination).not.toBeNull();
 
 		const network: HTMLDivElement | null = container.querySelector(networkSelector);
+
 		expect(network).not.toBeNull();
 
 		const fee: HTMLParagraphElement | null = container.querySelector(feeSelector);
+
 		expect(fee).not.toBeNull();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
+
 		expect(toolbar).not.toBeNull();
 	});
 
@@ -105,6 +110,7 @@ describe('SolSendForm', () => {
 			});
 
 			const ataFee: HTMLParagraphElement | null = container.querySelector(ataFeeSelector);
+
 			expect(ataFee).toBeNull();
 		});
 
@@ -120,6 +126,7 @@ describe('SolSendForm', () => {
 			await new Promise((resolve) => setTimeout(resolve, 100));
 
 			const ataFee: HTMLParagraphElement | null = container.querySelector(ataFeeSelector);
+
 			expect(ataFee).not.toBeNull();
 		});
 
@@ -137,6 +144,7 @@ describe('SolSendForm', () => {
 			await new Promise((resolve) => setTimeout(resolve, 5000));
 
 			const ataFee: HTMLParagraphElement | null = container.querySelector(ataFeeSelector);
+
 			expect(ataFee).toBeNull();
 		}, 60000);
 	});

--- a/src/frontend/src/tests/sol/components/tokens/SolTokenMenu.spec.ts
+++ b/src/frontend/src/tests/sol/components/tokens/SolTokenMenu.spec.ts
@@ -88,6 +88,7 @@ describe('SolTokenMenu', () => {
 
 			await waitFor(() => {
 				const a = queryByTestId(TOKEN_MENU_SOL_EXPLORER_LINK);
+
 				expect(a).not.toBeNull();
 				expect((a as HTMLAnchorElement).href).toEqual(
 					replacePlaceholders(explorerUrl, { $args: `account/${mockSolAddress}/` })
@@ -108,6 +109,7 @@ describe('SolTokenMenu', () => {
 
 		await waitFor(() => {
 			const a = queryByTestId(TOKEN_MENU_SOL_EXPLORER_LINK);
+
 			expect(a).not.toBeNull();
 			expect((a as HTMLAnchorElement).href).toEqual(
 				replacePlaceholders((mockToken.network as SolanaNetwork).explorerUrl ?? '', {

--- a/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
@@ -28,6 +28,7 @@ describe('sol-transactions.derived', () => {
 	describe('solTransactions', () => {
 		it('should return an empty array when transactions store is empty', () => {
 			const result = get(solTransactions);
+
 			expect(result).toEqual([]);
 		});
 
@@ -40,6 +41,7 @@ describe('sol-transactions.derived', () => {
 			solTransactionsStore.nullify(SOLANA_TOKEN_ID);
 
 			const result = get(solTransactions);
+
 			expect(result).toHaveLength(0);
 			expect(result).toEqual([]);
 		});
@@ -51,6 +53,7 @@ describe('sol-transactions.derived', () => {
 			});
 
 			const result = get(solTransactions);
+
 			expect(result).toEqual(transactions.map(({ data }) => data));
 		});
 	});
@@ -59,6 +62,7 @@ describe('sol-transactions.derived', () => {
 		it('should return false when transactions store is empty', () => {
 			solTransactionsStore.reset(SOLANA_TOKEN_ID);
 			const result = get(solTransactionsInitialized);
+
 			expect(result).toBe(false);
 		});
 
@@ -71,6 +75,7 @@ describe('sol-transactions.derived', () => {
 			solTransactionsStore.nullify(SOLANA_TOKEN_ID);
 
 			const result = get(solTransactionsInitialized);
+
 			expect(result).toBe(false);
 		});
 
@@ -81,6 +86,7 @@ describe('sol-transactions.derived', () => {
 			});
 
 			const result = get(solTransactionsInitialized);
+
 			expect(result).toBe(true);
 		});
 	});
@@ -89,6 +95,7 @@ describe('sol-transactions.derived', () => {
 		it('should return true when transactions store is empty', () => {
 			solTransactionsStore.reset(SOLANA_TOKEN_ID);
 			const result = get(solTransactionsNotInitialized);
+
 			expect(result).toBe(true);
 		});
 
@@ -101,6 +108,7 @@ describe('sol-transactions.derived', () => {
 			solTransactionsStore.nullify(SOLANA_TOKEN_ID);
 
 			const result = get(solTransactionsNotInitialized);
+
 			expect(result).toBe(true);
 		});
 
@@ -111,6 +119,7 @@ describe('sol-transactions.derived', () => {
 			});
 
 			const result = get(solTransactionsNotInitialized);
+
 			expect(result).toBe(false);
 		});
 	});

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -161,6 +161,7 @@ describe('sol-wallet.scheduler', () => {
 
 		it('should stop the scheduler', () => {
 			scheduler.stop();
+
 			expect(scheduler['timer']['timer']).toBeUndefined();
 		});
 

--- a/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
@@ -80,6 +80,7 @@ describe('sol-address.services', () => {
 			// eslint-disable-next-line local-rules/prefer-object-params
 			async (_, getAddress, networkType) => {
 				const result = await getAddress(mockIdentity);
+
 				expect(result).toBe(mockSolAddress);
 				expect(spyGetSchnorrPublicKey).toHaveBeenCalledWith({
 					identity: mockIdentity,
@@ -105,6 +106,7 @@ describe('sol-address.services', () => {
 		// eslint-disable-next-line local-rules/prefer-object-params
 		it.each(loadCases)('should load %s address into store', async (_, loadAddress, store) => {
 			const result = await loadAddress();
+
 			expect(result).toEqual({ success: true });
 			expect(get(store)).toEqual({
 				data: mockSolAddress,

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -94,6 +94,7 @@ describe('sol-signatures.services', () => {
 				wallet: mockSolAddress,
 				limit: Number(WALLET_PAGINATION)
 			});
+
 			mockTokensList.forEach(({ address }, index) => {
 				expect(spyFetchSignatures).toHaveBeenNthCalledWith(index + 2, {
 					network: mockNetwork,

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -166,6 +166,7 @@ describe('sol-transactions.services', () => {
 			await expect(fetchSolTransactionsForSignature(mockParams)).resolves.toEqual(expectedResults);
 
 			expect(spyMapSolParsedInstruction).toHaveBeenCalledTimes(nInstructions);
+
 			mockAllInstructions.forEach((instruction, index) => {
 				expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(index + 1, {
 					instruction: { ...instruction, programAddress: instruction.programId },
@@ -201,6 +202,7 @@ describe('sol-transactions.services', () => {
 			);
 
 			expect(spyMapSolParsedInstruction).toHaveBeenCalledTimes(innerInstructions.length);
+
 			innerInstructions.forEach((instruction, index) => {
 				expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(index + 1, {
 					instruction: { ...instruction, programAddress: instruction.programId },
@@ -331,6 +333,7 @@ describe('sol-transactions.services', () => {
 			);
 
 			expect(spyMapSolParsedInstruction).toHaveBeenCalledTimes(nInstructions);
+
 			mockAllInstructions.forEach((instruction, index) => {
 				expect(spyMapSolParsedInstruction).toHaveBeenNthCalledWith(index + 1, {
 					instruction: { ...instruction, programAddress: instruction.programId },
@@ -418,6 +421,7 @@ describe('sol-transactions.services', () => {
 			});
 
 			const storeData = get(solTransactionsStore)?.[SOLANA_TOKEN_ID];
+
 			expect(storeData).toEqual(mockCertifiedTransactions);
 		});
 
@@ -432,7 +436,9 @@ describe('sol-transactions.services', () => {
 			});
 
 			expect(transactions).toEqual([]);
+
 			const storeData = get(solTransactionsStore)?.[SOLANA_TOKEN_ID];
+
 			expect(storeData).toBeNull();
 		});
 

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -61,6 +61,7 @@ describe('sol-instructions.utils', () => {
 				instruction,
 				network
 			});
+
 			expect(result).toBeUndefined();
 		});
 

--- a/src/frontend/src/tests/sol/utils/sol-sign.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-sign.utils.spec.ts
@@ -66,6 +66,7 @@ describe('sol-sign.utils', () => {
 			const signatures = await signer.signTransactions(transactions);
 
 			expect(spySignWithSchnorr).toHaveBeenCalledTimes(transactions.length);
+
 			transactions.forEach((_, index) => {
 				expect(spySignWithSchnorr).toHaveBeenNthCalledWith(index + 1, {
 					identity: mockIdentity,
@@ -74,6 +75,7 @@ describe('sol-sign.utils', () => {
 					message: Array.from(mockTransaction.messageBytes)
 				});
 			});
+
 			expect(signatures).toEqual([
 				{ [mockSolAddress]: Uint8Array.from([4, 5, 6]) },
 				{ [mockSolAddress]: Uint8Array.from([7, 8, 9]) }


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) on the `sol` test folder.

