### PR TITLE
chore(frontend): format lib tests with vitest/padding-around-all

### DIFF
--- a/src/frontend/src/tests/lib/api/idb.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb.api.spec.ts
@@ -73,7 +73,9 @@ describe('idb.api', () => {
 			// eslint-disable-next-line local-rules/prefer-object-params
 			vi.mocked(idbKeyval.update).mockImplementation((_, updater) => {
 				const updated = updater(mockAddress) as typeof mockAddress;
+
 				expect(updated.lastUsedTimestamp).toBeGreaterThan(mockAddress.lastUsedTimestamp);
+
 				return Promise.resolve();
 			});
 
@@ -116,7 +118,9 @@ describe('idb.api', () => {
 			// eslint-disable-next-line local-rules/prefer-object-params
 			vi.mocked(idbKeyval.update).mockImplementation((_, updater) => {
 				const updated = updater(mockAddress) as typeof mockAddress;
+
 				expect(updated.lastUsedTimestamp).toBeGreaterThan(mockAddress.lastUsedTimestamp);
+
 				return Promise.resolve();
 			});
 
@@ -159,7 +163,9 @@ describe('idb.api', () => {
 			// eslint-disable-next-line local-rules/prefer-object-params
 			vi.mocked(idbKeyval.update).mockImplementation((_, updater) => {
 				const updated = updater(mockAddress) as typeof mockAddress;
+
 				expect(updated.lastUsedTimestamp).toBeGreaterThan(mockAddress.lastUsedTimestamp);
+
 				return Promise.resolve();
 			});
 
@@ -174,7 +180,9 @@ describe('idb.api', () => {
 			// eslint-disable-next-line local-rules/prefer-object-params
 			vi.mocked(idbKeyval.update).mockImplementation((_, updater) => {
 				const result = updater(undefined);
+
 				expect(result).toBeUndefined();
+
 				return Promise.resolve();
 			});
 

--- a/src/frontend/src/tests/lib/canisters/reward.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/reward.canister.spec.ts
@@ -45,6 +45,7 @@ describe('reward.canister', () => {
 			});
 
 			const userData = await getUserInfo(queryParams);
+
 			expect(service.user_info).toHaveBeenCalledWith();
 			expect(userData.is_vip.length).toBe(1);
 			expect(fromNullable(userData.is_vip) === true).toBeTruthy();
@@ -65,6 +66,7 @@ describe('reward.canister', () => {
 			});
 
 			const userData = await getUserInfo(queryParams);
+
 			expect(userData.is_vip.length).toBe(1);
 			expect(fromNullable(userData.is_vip) === true).toBeFalsy();
 		});
@@ -80,6 +82,7 @@ describe('reward.canister', () => {
 			});
 
 			const result = getUserInfo(queryParams);
+
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});
@@ -98,6 +101,7 @@ describe('reward.canister', () => {
 			});
 
 			const vipRewardResponse = await getNewVipReward();
+
 			expect(service.new_vip_reward).toHaveBeenCalledWith();
 			expect(vipRewardResponse).toEqual(mockedRewardResponse);
 		});
@@ -113,6 +117,7 @@ describe('reward.canister', () => {
 			});
 
 			const result = getNewVipReward();
+
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});
@@ -128,6 +133,7 @@ describe('reward.canister', () => {
 
 			const vipReward = { code: '1234567890' };
 			const claimResponse = await claimVipReward(vipReward);
+
 			expect(service.claim_vip_reward).toHaveBeenCalledWith(vipReward);
 			expect(claimResponse).toEqual(mockedClaimResponse);
 		});
@@ -143,6 +149,7 @@ describe('reward.canister', () => {
 			});
 
 			const result = claimVipReward({ code: '1234567890' });
+
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});
@@ -161,6 +168,7 @@ describe('reward.canister', () => {
 			});
 
 			const referrerInfo = await getReferrerInfo(queryParams);
+
 			expect(service.referrer_info).toHaveBeenCalledWith();
 			expect(referrerInfo).toEqual(mockedReferrerInfo);
 		});
@@ -176,6 +184,7 @@ describe('reward.canister', () => {
 			});
 
 			const result = getReferrerInfo(queryParams);
+
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});
@@ -189,6 +198,7 @@ describe('reward.canister', () => {
 			});
 
 			await setReferrer(mockedReferrerCode);
+
 			expect(service.set_referrer).toHaveBeenCalledWith(mockedReferrerCode);
 		});
 
@@ -203,6 +213,7 @@ describe('reward.canister', () => {
 			});
 
 			const result = setReferrer(mockedReferrerCode);
+
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});
@@ -219,6 +230,7 @@ describe('reward.canister', () => {
 			});
 
 			await registerAirdropRecipient(mockUserSnapshot);
+
 			expect(service.register_airdrop_recipient).toHaveBeenCalledWith(mockUserSnapshot);
 		});
 
@@ -233,6 +245,7 @@ describe('reward.canister', () => {
 			});
 
 			const result = registerAirdropRecipient(mockUserSnapshot);
+
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});

--- a/src/frontend/src/tests/lib/components/auth/AuthHelpForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/AuthHelpForm.spec.ts
@@ -33,6 +33,7 @@ describe('AuthHelpForm', () => {
 		});
 
 		const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
+
 		expect(imageBanner).toBeInTheDocument();
 
 		expect(getByText(get(i18n).auth.help.text.subtitle)).toBeInTheDocument();
@@ -40,20 +41,24 @@ describe('AuthHelpForm', () => {
 		const lostIdentityButton: HTMLButtonElement | null = container.querySelector(
 			lostIdentityButtonSelector
 		);
+
 		expect(lostIdentityButton).toBeInTheDocument();
 		expect(getByText(get(i18n).auth.help.text.lost_identity)).toBeInTheDocument();
 
 		const securityButton: HTMLButtonElement | null =
 			container.querySelector(securityButtonSelector);
+
 		expect(securityButton).toBeInTheDocument();
 		expect(getByText(get(i18n).auth.help.text.security)).toBeInTheDocument();
 
 		const gotConfusedButton: HTMLButtonElement | null =
 			container.querySelector(gotConfusedButtonSelector);
+
 		expect(gotConfusedButton).toBeInTheDocument();
 		expect(getByText(get(i18n).auth.help.text.got_confused)).toBeInTheDocument();
 
 		const otherButton: HTMLButtonElement | null = container.querySelector(otherButtonSelector);
+
 		expect(otherButton).toBeInTheDocument();
 		expect(getByText(get(i18n).auth.help.text.other)).toBeInTheDocument();
 
@@ -80,37 +85,53 @@ describe('AuthHelpForm', () => {
 		const lostIdentityButton: HTMLButtonElement | null = container.querySelector(
 			lostIdentityButtonSelector
 		);
+
 		expect(lostIdentityButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			lostIdentityButton?.click();
+
 			expect(onLostIdentityMock).toHaveBeenCalledOnce();
 		});
+
 		expect(analyticSpy).toHaveBeenCalledWith({ name: TRACK_HELP_LOST_INTERNET_IDENTITY });
 
 		const securityButton: HTMLButtonElement | null =
 			container.querySelector(securityButtonSelector);
+
 		expect(securityButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			securityButton?.click();
+
 			expect(onOtherMock).toHaveBeenCalledTimes(1);
 		});
+
 		expect(analyticSpy).toHaveBeenCalledWith({ name: TRACK_HELP_CONCERNED_ABOUT_SECURITY });
 
 		const gotConfusedButton: HTMLButtonElement | null =
 			container.querySelector(gotConfusedButtonSelector);
+
 		expect(gotConfusedButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			gotConfusedButton?.click();
+
 			expect(onOtherMock).toHaveBeenCalledTimes(2);
 		});
+
 		expect(analyticSpy).toHaveBeenCalledWith({ name: TRACK_HELP_GOT_CONFUSED });
 
 		const otherButton: HTMLButtonElement | null = container.querySelector(otherButtonSelector);
+
 		expect(otherButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			otherButton?.click();
+
 			expect(onOtherMock).toHaveBeenCalledTimes(3);
 		});
+
 		expect(analyticSpy).toHaveBeenCalledWith({ name: TRACK_HELP_OTHER });
 	});
 });

--- a/src/frontend/src/tests/lib/components/auth/AuthHelpIdentityForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/AuthHelpIdentityForm.spec.ts
@@ -30,16 +30,19 @@ describe('AuthHelpIdentityForm', () => {
 		});
 
 		const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
+
 		expect(imageBanner).toBeInTheDocument();
 
 		expect(getByText(get(i18n).auth.help.text.identity_legacy_description)).toBeInTheDocument();
 
 		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
 		expect(signInButton).toBeInTheDocument();
 		expect(getByText(get(i18n).auth.help.text.identity_legacy_sign_in)).toBeInTheDocument();
 
 		const learnMoreAnchor: HTMLAnchorElement | null =
 			container.querySelector(learnMoreAnchorSelector);
+
 		expect(learnMoreAnchor).toBeInTheDocument();
 		expect(learnMoreAnchor?.href).toBe(OISY_FIND_INTERNET_IDENTITY_URL);
 		expect(
@@ -47,9 +50,11 @@ describe('AuthHelpIdentityForm', () => {
 		).toBeInTheDocument();
 
 		const backButton: HTMLButtonElement | null = container.querySelector(backButtonSelector);
+
 		expect(backButton).toBeInTheDocument();
 
 		const doneButton: HTMLButtonElement | null = container.querySelector(doneButtonSelector);
+
 		expect(doneButton).toBeInTheDocument();
 	});
 
@@ -70,24 +75,33 @@ describe('AuthHelpIdentityForm', () => {
 		expect(authSpy).not.toHaveBeenCalled();
 
 		const backButton: HTMLButtonElement | null = container.querySelector(backButtonSelector);
+
 		expect(backButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			backButton?.click();
+
 			expect(onBackMock).toHaveBeenCalledOnce();
 		});
 
 		const doneButton: HTMLButtonElement | null = container.querySelector(doneButtonSelector);
+
 		expect(doneButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			doneButton?.click();
+
 			expect(onDoneMock).toHaveBeenCalledOnce();
 		});
 
 		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
 		expect(signInButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			signInButton?.click();
 		});
+
 		expect(onDoneMock).toHaveBeenCalledTimes(2);
 		expect(authSpy).toHaveBeenCalledWith({ domain: 'ic0.app' });
 	});

--- a/src/frontend/src/tests/lib/components/auth/AuthHelpOtherForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/AuthHelpOtherForm.spec.ts
@@ -39,6 +39,7 @@ describe('AuthHelpOtherForm', () => {
 		const introductionAnchor: HTMLAnchorElement | null = container.querySelector(
 			introductionAnchorSelector
 		);
+
 		expect(introductionAnchor).toBeInTheDocument();
 		expect(introductionAnchor?.href).toBe(`${OISY_DOCS_URL}/`);
 		expect(
@@ -46,6 +47,7 @@ describe('AuthHelpOtherForm', () => {
 		).toBeInTheDocument();
 
 		const docsAnchor: HTMLAnchorElement | null = container.querySelector(docsAnchorSelector);
+
 		expect(docsAnchor).toBeInTheDocument();
 		expect(docsAnchor?.href).toBe(OISY_INTERNET_IDENTITY_URL);
 		expect(
@@ -54,6 +56,7 @@ describe('AuthHelpOtherForm', () => {
 
 		const privateKeyAnchor: HTMLAnchorElement | null =
 			container.querySelector(privateKeyAnchorSelector);
+
 		expect(privateKeyAnchor).toBeInTheDocument();
 		expect(privateKeyAnchor?.href).toBe(OISY_FAQ_URL);
 		expect(
@@ -63,6 +66,7 @@ describe('AuthHelpOtherForm', () => {
 		const assetControlAnchor: HTMLAnchorElement | null = container.querySelector(
 			assetControlAnchorSelector
 		);
+
 		expect(assetControlAnchor).toBeInTheDocument();
 		expect(assetControlAnchor?.href).toBe(OISY_ACCESS_CONTROL_URL);
 		expect(
@@ -70,9 +74,11 @@ describe('AuthHelpOtherForm', () => {
 		).toBeInTheDocument();
 
 		const backButton: HTMLButtonElement | null = container.querySelector(backButtonSelector);
+
 		expect(backButton).toBeInTheDocument();
 
 		const doneButton: HTMLButtonElement | null = container.querySelector(doneButtonSelector);
+
 		expect(doneButton).toBeInTheDocument();
 	});
 
@@ -91,16 +97,22 @@ describe('AuthHelpOtherForm', () => {
 		expect(onDoneMock).not.toHaveBeenCalled();
 
 		const backButton: HTMLButtonElement | null = container.querySelector(backButtonSelector);
+
 		expect(backButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			backButton?.click();
+
 			expect(onBackMock).toHaveBeenCalledOnce();
 		});
 
 		const doneButton: HTMLButtonElement | null = container.querySelector(doneButtonSelector);
+
 		expect(doneButton).toBeInTheDocument();
+
 		await waitFor(() => {
 			doneButton?.click();
+
 			expect(onDoneMock).toHaveBeenCalledOnce();
 		});
 	});

--- a/src/frontend/src/tests/lib/components/auth/ButtonAuthenticateWithLicense.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/ButtonAuthenticateWithLicense.spec.ts
@@ -21,17 +21,20 @@ describe('ButtonAuthenticateWithLicense', () => {
 		const { container, getByText } = render(ButtonAuthenticateWithLicense);
 
 		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
 		expect(signInButton).toBeInTheDocument();
 
 		expect(getByText(get(i18n).license_agreement.text.accept_terms)).toBeInTheDocument();
 
 		const licenseLinkAnchor: HTMLAnchorElement | null =
 			container.querySelector(licenseLinkAnchorSelector);
+
 		expect(licenseLinkAnchor).toBeInTheDocument();
 
 		const SigningInHelpLinkSpan: HTMLSpanElement | null = container.querySelector(
 			SigningInHelpLinkSpanSelector
 		);
+
 		expect(SigningInHelpLinkSpan).toBeInTheDocument();
 	});
 
@@ -41,9 +44,11 @@ describe('ButtonAuthenticateWithLicense', () => {
 		const { container } = render(ButtonAuthenticateWithLicense);
 
 		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
 		expect(signInButton).toBeInTheDocument();
 
 		await waitFor(() => signInButton?.click());
+
 		expect(authSpy).toHaveBeenCalledOnce();
 
 		expect(get(modalStore)?.type).toBe('auth-help');
@@ -55,9 +60,11 @@ describe('ButtonAuthenticateWithLicense', () => {
 		const { container } = render(ButtonAuthenticateWithLicense);
 
 		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
 		expect(signInButton).toBeInTheDocument();
 
 		await waitFor(() => signInButton?.click());
+
 		expect(authSpy).toHaveBeenCalledOnce();
 
 		expect(get(modalStore)?.type).toBeUndefined();

--- a/src/frontend/src/tests/lib/components/convert/ConvertModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertModal.spec.ts
@@ -28,9 +28,11 @@ describe('ConvertModal', () => {
 		expect(container).toHaveTextContent(firstStepTitle);
 
 		await fireEvent.click(getByText(en.convert.text.review_button));
+
 		expect(container).toHaveTextContent(en.convert.text.review);
 
 		await fireEvent.click(getByText(en.core.text.back));
+
 		expect(container).toHaveTextContent(firstStepTitle);
 	});
 });

--- a/src/frontend/src/tests/lib/components/core/Menu.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Menu.spec.ts
@@ -38,7 +38,9 @@ describe('Menu', () => {
 	const openMenu = () => {
 		container = render(Menu).container;
 		const menuButton: HTMLButtonElement | null = container.querySelector(menuButtonSelector);
+
 		expect(menuButton).toBeInTheDocument();
+
 		menuButton?.click();
 	};
 
@@ -55,6 +57,7 @@ describe('Menu', () => {
 				if (element == null) {
 					throw new Error(`Element with selector "${selector}" not yet loaded`);
 				}
+
 				expect(element).toBeInTheDocument();
 			} else {
 				expect(element).toBeNull();

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -23,6 +23,7 @@ describe('DappsCarousel', () => {
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 
 		const { container } = render(DappsCarousel);
+
 		expect(container.textContent).toBe('');
 	});
 
@@ -33,6 +34,7 @@ describe('DappsCarousel', () => {
 		);
 
 		const { container } = render(DappsCarousel);
+
 		expect(container.textContent).toBe('');
 	});
 
@@ -43,6 +45,7 @@ describe('DappsCarousel', () => {
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue([]);
 
 		const { container } = render(DappsCarousel);
+
 		expect(container.textContent).toBe('');
 	});
 
@@ -69,6 +72,7 @@ describe('DappsCarousel', () => {
 		userProfileStore.set({ profile: userProfile, certified: false });
 
 		const { container } = render(DappsCarousel);
+
 		expect(container.textContent).toBe('');
 	});
 
@@ -76,6 +80,7 @@ describe('DappsCarousel', () => {
 		userProfileStore.reset();
 
 		const { container } = render(DappsCarousel);
+
 		expect(container.textContent).toBe('');
 	});
 
@@ -88,11 +93,13 @@ describe('DappsCarousel', () => {
 		userProfileStore.set({ profile: userProfile, certified: false });
 
 		const { getByTestId } = render(DappsCarousel);
+
 		expect(getByTestId(CAROUSEL_CONTAINER)).toBeInTheDocument();
 	});
 
 	it('should render the Carousel when data exist', () => {
 		const { getByTestId } = render(DappsCarousel);
+
 		expect(getByTestId(CAROUSEL_CONTAINER)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/hero/ContextMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/ContextMenu.spec.ts
@@ -33,6 +33,7 @@ describe('ContextMenu', () => {
 		const { container } = render(ContextMenu);
 
 		const button: HTMLButtonElement | null = container.querySelector(icTokenMenuButtonSelector);
+
 		expect(button).toBeInTheDocument();
 	});
 
@@ -42,6 +43,7 @@ describe('ContextMenu', () => {
 		const { container } = render(ContextMenu);
 
 		const button: HTMLButtonElement | null = container.querySelector(ethTokenMenuButtonSelector);
+
 		expect(button).toBeInTheDocument();
 	});
 
@@ -51,6 +53,7 @@ describe('ContextMenu', () => {
 		const { container } = render(ContextMenu);
 
 		const button: HTMLButtonElement | null = container.querySelector(btcTokenMenuButtonSelector);
+
 		expect(button).toBeInTheDocument();
 	});
 
@@ -60,6 +63,7 @@ describe('ContextMenu', () => {
 		const { container } = render(ContextMenu);
 
 		const button: HTMLButtonElement | null = container.querySelector(solTokenMenuButtonSelector);
+
 		expect(button).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -178,6 +178,7 @@ describe('Loader', () => {
 
 			await waitFor(() => {
 				const banner = getByAltText(altText);
+
 				expect(banner).toBeInTheDocument();
 			});
 		});

--- a/src/frontend/src/tests/lib/components/networks/NetworkLogo.spec.ts
+++ b/src/frontend/src/tests/lib/components/networks/NetworkLogo.spec.ts
@@ -16,6 +16,7 @@ describe('NetworkLogo', () => {
 		});
 
 		const logo = getByTestId(`${testId}-light`);
+
 		expect(logo).toBeTruthy();
 	});
 

--- a/src/frontend/src/tests/lib/components/rewards/AllRewardsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/AllRewardsList.spec.ts
@@ -17,14 +17,17 @@ describe('AllRewardsList', () => {
 		const activeCampaignContainer: HTMLDivElement | null = container.querySelector(
 			activeCampaignContainerSelector
 		);
+
 		expect(activeCampaignContainer).toBeInTheDocument();
 
 		const upcomingCampaignContainer: HTMLDivElement | null = container.querySelector(
 			upcomingCampaignContainerSelector
 		);
+
 		expect(upcomingCampaignContainer).toBeInTheDocument();
 
 		const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
+
 		expect(imageBanner).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/rewards/RewardCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardCard.spec.ts
@@ -26,9 +26,11 @@ describe('RewardCard', () => {
 		expect(getByText(mockedReward.oneLiner)).toBeInTheDocument();
 
 		const logo: HTMLDivElement | null = container.querySelector(logoSelector);
+
 		expect(logo).toBeInTheDocument();
 
 		const badge: HTMLSpanElement | null = container.querySelector(badgeSelector);
+
 		expect(badge).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/rewards/RewardModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardModal.spec.ts
@@ -27,11 +27,13 @@ describe('RewardModal', () => {
 
 		expect(getByText(mockedReward.title)).toBeInTheDocument();
 		expect(getByText(mockedReward.description)).toBeInTheDocument();
+
 		mockedReward.requirements.forEach((requirement: string) => {
 			expect(getByText(requirement)).toBeInTheDocument();
 		});
 
 		const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
+
 		expect(imageBanner).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/rewards/RewardStateModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardStateModal.spec.ts
@@ -35,10 +35,12 @@ describe('RewardStateModal', () => {
 		expect(getByText(get(i18n).rewards.text.state_modal_content_text)).toBeInTheDocument();
 
 		const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
+
 		expect(imageBanner).toBeInTheDocument();
 		expect(imageBanner?.src).toContain(rewardReceived);
 
 		const share: HTMLAnchorElement | null = container.querySelector(shareSelector);
+
 		expect(share).toBeInTheDocument();
 		expect(share?.href).toBe(mockedReward.airdropHref);
 	});
@@ -61,10 +63,12 @@ describe('RewardStateModal', () => {
 		expect(getByText(get(i18n).rewards.text.state_modal_content_text)).toBeInTheDocument();
 
 		const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
+
 		expect(imageBanner).toBeInTheDocument();
 		expect(imageBanner?.src).toContain(rewardJackpotReceived);
 
 		const share: HTMLAnchorElement | null = container.querySelector(shareSelector);
+
 		expect(share).toBeInTheDocument();
 		expect(share?.href).toBe(mockedReward.jackpotHref);
 	});

--- a/src/frontend/src/tests/lib/components/rewards/RewardsGroup.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardsGroup.spec.ts
@@ -26,6 +26,7 @@ describe('RewardsGroups', () => {
 		expect(getByText(title)).toBeInTheDocument();
 
 		const activeGroup: HTMLButtonElement | null = container.querySelector(activeGroupSelector);
+
 		expect(activeGroup).toBeInTheDocument();
 	});
 
@@ -45,6 +46,7 @@ describe('RewardsGroups', () => {
 		expect(getByText(altText)).toBeInTheDocument();
 
 		const activeGroup: HTMLButtonElement | null = container.querySelector(activeGroupSelector);
+
 		expect(activeGroup).not.toBeInTheDocument();
 	});
 
@@ -64,6 +66,7 @@ describe('RewardsGroups', () => {
 		expect(queryByText(altText)).not.toBeInTheDocument();
 
 		const activeGroup: HTMLButtonElement | null = container.querySelector(activeGroupSelector);
+
 		expect(activeGroup).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/rewards/RewardsRequirements.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardsRequirements.spec.ts
@@ -59,6 +59,7 @@ describe('RewardsRequirements', () => {
 				const requirementStatus: HTMLSpanElement | null = container.querySelector(
 					requirementStatusSelector(index)
 				);
+
 				expect(requirementStatus).toBeInTheDocument();
 				expect(requirementStatus?.className).toContain('text-success-primary');
 			});
@@ -78,6 +79,7 @@ describe('RewardsRequirements', () => {
 				const requirementStatus: HTMLSpanElement | null = container.querySelector(
 					requirementStatusSelector(index)
 				);
+
 				expect(requirementStatus).toBeInTheDocument();
 				expect(requirementStatus?.className).toContain('text-disabled');
 			});
@@ -97,6 +99,7 @@ describe('RewardsRequirements', () => {
 				const requirementStatus: HTMLSpanElement | null = container.querySelector(
 					requirementStatusSelector(index)
 				);
+
 				expect(requirementStatus).toBeInTheDocument();
 				expect(requirementStatus?.className).toContain('text-disabled');
 			});
@@ -116,6 +119,7 @@ describe('RewardsRequirements', () => {
 				const requirementStatus: HTMLSpanElement | null = container.querySelector(
 					requirementStatusSelector(index)
 				);
+
 				expect(requirementStatus).toBeInTheDocument();
 				expect(requirementStatus?.className).toContain('text-disabled');
 			});

--- a/src/frontend/src/tests/lib/components/settings/ThemeSelector.spec.ts
+++ b/src/frontend/src/tests/lib/components/settings/ThemeSelector.spec.ts
@@ -118,27 +118,35 @@ describe('ThemeSelector', () => {
 		const testIdLight = `${THEME_SELECTOR_CARD}-${Theme.LIGHT}`;
 
 		await fireEvent.click(getByTestId(testIdSystem));
+
 		expect(getByTestId(testIdSystem).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdDark));
+
 		expect(getByTestId(testIdDark).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdSystem));
+
 		expect(getByTestId(testIdSystem).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdLight));
+
 		expect(getByTestId(testIdLight).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdSystem));
+
 		expect(getByTestId(testIdSystem).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdDark));
+
 		expect(getByTestId(testIdDark).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdLight));
+
 		expect(getByTestId(testIdLight).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 
 		await fireEvent.click(getByTestId(testIdDark));
+
 		expect(getByTestId(testIdDark).getAttribute('aria-checked')).toBe(JSON.stringify(true));
 	});
 

--- a/src/frontend/src/tests/lib/components/share/ShareButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/share/ShareButton.spec.ts
@@ -53,6 +53,7 @@ describe('ShareButton', () => {
 			const { container } = render(ShareButton, { testId, shareAriaLabel });
 
 			const shareButton: HTMLButtonElement | null = container.querySelector(shareButtonSelector);
+
 			expect(shareButton).toBeInTheDocument();
 
 			shareButton?.click();

--- a/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
@@ -151,12 +151,14 @@ describe('SwapForm', () => {
 				const button = buttons[buttonIndex];
 
 				await fireEvent.click(button);
+
 				expect(sourceTokenExchangeValue).toHaveTextContent(`1 ${mockValidIcToken.symbol}`);
 				expect(destinationTokenExchangeValue).toHaveTextContent(`2 ${mockValidIcCkToken.symbol}`);
 				expect(sourceInput).toHaveValue('1');
 				expect(destinationInput).toHaveValue('0.02');
 
 				await fireEvent.click(button);
+
 				expect(sourceTokenExchangeValue).toHaveTextContent('$10.00');
 				expect(destinationTokenExchangeValue).toHaveTextContent('$0.04');
 				expect(sourceInput).toHaveValue('1');

--- a/src/frontend/src/tests/lib/components/tokens/TokenInputAmountExchange.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenInputAmountExchange.spec.ts
@@ -20,6 +20,7 @@ describe('TokenInputAmountExchange', () => {
 	it('renders token amount when in token mode', () => {
 		const { getByTestId } = render(TokenInputAmountExchange, defaultProps);
 		const valueElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE);
+
 		expect(valueElement).toHaveTextContent(`100 ${mockValidIcToken.symbol}`);
 	});
 
@@ -29,6 +30,7 @@ describe('TokenInputAmountExchange', () => {
 			displayUnit: 'usd' as DisplayUnit
 		});
 		const valueElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE);
+
 		expect(valueElement).toHaveTextContent('$200.00');
 	});
 
@@ -40,9 +42,11 @@ describe('TokenInputAmountExchange', () => {
 		expect(valueElement).toHaveTextContent(`100 ${mockValidIcToken.symbol}`);
 
 		await fireEvent.click(button);
+
 		expect(valueElement).toHaveTextContent('$200.00');
 
 		await fireEvent.click(button);
+
 		expect(valueElement).toHaveTextContent(`100 ${mockValidIcToken.symbol}`);
 	});
 
@@ -52,6 +56,7 @@ describe('TokenInputAmountExchange', () => {
 			exchangeRate: undefined
 		});
 		const unavailableElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_UNAVAILABLE);
+
 		expect(unavailableElement).toBeInTheDocument();
 	});
 
@@ -61,6 +66,7 @@ describe('TokenInputAmountExchange', () => {
 			amount: undefined
 		});
 		const valueElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE);
+
 		expect(valueElement).toHaveTextContent(`0 ${mockValidIcToken.symbol}`);
 	});
 
@@ -69,6 +75,7 @@ describe('TokenInputAmountExchange', () => {
 			...defaultProps
 		});
 		const valueElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE);
+
 		expect(valueElement).toHaveTextContent('0');
 	});
 
@@ -79,6 +86,7 @@ describe('TokenInputAmountExchange', () => {
 			displayUnit: 'usd' as DisplayUnit
 		});
 		const valueElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE);
+
 		expect(valueElement).toHaveTextContent('$246.91');
 	});
 
@@ -88,6 +96,7 @@ describe('TokenInputAmountExchange', () => {
 			amount: '0' as OptionAmount
 		});
 		const valueElement = getByTestId(TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE);
+
 		expect(valueElement).toHaveTextContent(`0 ${mockValidIcToken.symbol}`);
 	});
 });

--- a/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyToken.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyToken.spec.ts
@@ -18,6 +18,7 @@ describe('TokenInputCurrencyToken', () => {
 		const input = getByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
 
 		await fireEvent.input(input, { target: { value: '100' } });
+
 		expect(input).toHaveValue('100');
 	});
 
@@ -26,6 +27,7 @@ describe('TokenInputCurrencyToken', () => {
 		const input = getByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
 
 		await fireEvent.input(input, { target: { value: '' } });
+
 		expect(input).toHaveValue('');
 	});
 

--- a/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyUsd.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenInputCurrencyUsd.svelte.spec.ts
@@ -19,6 +19,7 @@ describe('TokenInputCurrencyUsd', () => {
 
 	it('renders in USD mode with $ sign', () => {
 		const { getByTestId } = render(TokenInputCurrencyUsd, defaultProps);
+
 		expect(getByTestId(TOKEN_INPUT_CURRENCY_USD_SYMBOL)).toHaveTextContent('$');
 	});
 
@@ -40,6 +41,7 @@ describe('TokenInputCurrencyUsd', () => {
 		const input = getByTestId(TOKEN_INPUT_CURRENCY_USD);
 
 		await fireEvent.input(input, { target: { value: '' } });
+
 		expect(input).toHaveValue('');
 	});
 
@@ -48,6 +50,7 @@ describe('TokenInputCurrencyUsd', () => {
 		const input = getByTestId(TOKEN_INPUT_CURRENCY_USD);
 
 		await fireEvent.input(input, { target: { value } });
+
 		expect(input).toHaveValue(value);
 	});
 

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -35,7 +35,9 @@ describe('AllTransactions', () => {
 		const title: HTMLHeadingElement | null = container.querySelector('h1');
 
 		expect(title).not.toBeNull();
+
 		assertNonNullish(title, 'Title not found');
+
 		expect(title).toBeInTheDocument();
 		expect(title.textContent).toBe(en.activity.text.title);
 	});

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -67,6 +67,7 @@ describe('AllTransactionsList', () => {
 				const skeleton: HTMLParagraphElement | null = container.querySelector(
 					`div[data-tid="all-transactions-skeleton-card-${i}"]`
 				);
+
 				expect(skeleton).toBeNull();
 			});
 		});
@@ -126,6 +127,7 @@ describe('AllTransactionsList', () => {
 				const skeleton: HTMLParagraphElement | null = container.querySelector(
 					`div[data-tid="all-transactions-skeleton-card-${i}"]`
 				);
+
 				expect(skeleton).toBeNull();
 			});
 		});
@@ -134,10 +136,12 @@ describe('AllTransactionsList', () => {
 			const { getByText, getByTestId } = render(AllTransactionsList);
 
 			const todayDateGroup = getByTestId('all-transactions-date-group-0');
+
 			expect(todayDateGroup).toBeInTheDocument();
 			expect(getByText('today')).toBeInTheDocument();
 
 			const yesterdayDateGroup = getByTestId('all-transactions-date-group-1');
+
 			expect(yesterdayDateGroup).toBeInTheDocument();
 			expect(getByText('yesterday')).toBeInTheDocument();
 		});

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsSkeletons.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsSkeletons.spec.ts
@@ -34,6 +34,7 @@ describe('AllTransactionsSkeletons', () => {
 
 		Array.from({ length: 5 }).forEach((_, i) => {
 			const skeleton = getByTestId(`${testIdPrefix}-${i}`);
+
 			expect(skeleton).toBeInTheDocument();
 		});
 	});
@@ -58,6 +59,7 @@ describe('AllTransactionsSkeletons', () => {
 
 			Array.from({ length: 5 }).forEach((_, i) => {
 				const skeleton = getByTestId(`${testIdPrefix}-${i}`);
+
 				expect(skeleton).toBeInTheDocument();
 			});
 		});
@@ -73,6 +75,7 @@ describe('AllTransactionsSkeletons', () => {
 				const skeleton: HTMLParagraphElement | null = container.querySelector(
 					`div[data-tid="${testIdPrefix}-${i}"]`
 				);
+
 				expect(skeleton).toBeDefined();
 			});
 
@@ -84,6 +87,7 @@ describe('AllTransactionsSkeletons', () => {
 				const skeleton: HTMLParagraphElement | null = container.querySelector(
 					`div[data-tid="${testIdPrefix}-${i}"]`
 				);
+
 				expect(skeleton).toBeNull();
 			});
 		});
@@ -108,6 +112,7 @@ describe('AllTransactionsSkeletons', () => {
 				const skeleton: HTMLParagraphElement | null = container.querySelector(
 					`div[data-tid="${testIdPrefix}-${i}"]`
 				);
+
 				expect(skeleton).toBeDefined();
 			});
 		});

--- a/src/frontend/src/tests/lib/components/transactions/Transactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/Transactions.spec.ts
@@ -57,6 +57,7 @@ describe('Transactions', () => {
 		await new Promise<void>((resolve) =>
 			setTimeout(() => {
 				expect(get(modalStore)).toBeNull();
+
 				resolve();
 			}, timeout)
 		);
@@ -70,6 +71,7 @@ describe('Transactions', () => {
 		await new Promise<void>((resolve) =>
 			setTimeout(() => {
 				expect(get(modalStore)).toBeNull();
+
 				resolve();
 			}, timeout)
 		);
@@ -129,6 +131,7 @@ describe('Transactions', () => {
 		await new Promise<void>((resolve) =>
 			setTimeout(() => {
 				expect(get(modalStore)).toBeNull();
+
 				resolve();
 			}, timeout)
 		);

--- a/src/frontend/src/tests/lib/components/transactions/TransactionsSkeletons.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/TransactionsSkeletons.spec.ts
@@ -9,6 +9,7 @@ describe('TransactionsSkeletons', () => {
 
 		Array.from({ length: 5 }).forEach((_, i) => {
 			const skeleton = getByTestId(`skeleton-card-${i}`);
+
 			expect(skeleton).toBeInTheDocument();
 		});
 	});

--- a/src/frontend/src/tests/lib/components/ui/SkeletonCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/SkeletonCard.spec.ts
@@ -6,6 +6,7 @@ describe('SkeletonCard', () => {
 		const { getByTestId } = render(SkeletonCard, { props: { testId: 'skeleton-card' } });
 
 		const skeleton = getByTestId('skeleton-card');
+
 		expect(skeleton).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/ui/SkeletonCards.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/SkeletonCards.spec.ts
@@ -9,6 +9,7 @@ describe('SkeletonCards', () => {
 
 		Array.from({ length: 5 }).forEach((_, i) => {
 			const skeleton = getByTestId(`skeleton-card-${i}`);
+
 			expect(skeleton).toBeInTheDocument();
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
@@ -46,6 +46,7 @@ describe('page-token.derived', () => {
 		'should find $name token',
 		(token) => {
 			mockPage.mock({ token: token.name, network: token.network.id.description });
+
 			expect(get(pageToken)).toBe(token);
 		}
 	);
@@ -59,6 +60,7 @@ describe('page-token.derived', () => {
 			});
 
 			mockPage.mock({ token: token.name, network: token.network.id.description });
+
 			expect(get(pageToken)).toBe(token);
 		}
 	);
@@ -71,6 +73,7 @@ describe('page-token.derived', () => {
 		vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 		mockPage.mock({ token: token.name, network: token.network.id.description });
+
 		expect(get(pageToken)).toBe(token);
 	});
 
@@ -99,6 +102,7 @@ describe('page-token.derived', () => {
 
 	it('should return undefined when token is not found in any list', () => {
 		mockPage.mock({ token: 'non-existent-token' });
+
 		expect(get(pageToken)).toBeUndefined();
 	});
 

--- a/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
@@ -10,6 +10,7 @@ describe('swap.derived', () => {
 	describe('swappableTokens', () => {
 		it('should return undefined for sourceToken and destinationToken', () => {
 			const tokens = get(swappableTokens);
+
 			expect(tokens.sourceToken).toBeUndefined();
 			expect(tokens.destinationToken).toBeUndefined();
 		});
@@ -23,6 +24,7 @@ describe('swap.derived', () => {
 			});
 
 			const tokens = get(swappableTokens);
+
 			expect(tokens.sourceToken).toEqual({ ...ICP_TOKEN, enabled: true });
 			expect(tokens.destinationToken).toBeUndefined();
 		});
@@ -36,6 +38,7 @@ describe('swap.derived', () => {
 			});
 
 			const tokens = get(swappableTokens);
+
 			expect(tokens.sourceToken).toBeUndefined();
 			expect(tokens.destinationToken).toEqual({ ...ICP_TOKEN, enabled: true });
 		});

--- a/src/frontend/src/tests/lib/derived/testnets.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/testnets.derived.spec.ts
@@ -14,11 +14,13 @@ describe('testnets.derived', () => {
 	describe('testnets', () => {
 		it('should return false when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(testnetsEnabled)).toBe(false);
 		});
 
 		it('should return false when settings are not set', () => {
 			userProfileStore.set({ certified, profile: { ...mockUserProfile, settings: [] } });
+
 			expect(get(testnetsEnabled)).toBe(false);
 		});
 
@@ -33,6 +35,7 @@ describe('testnets.derived', () => {
 					})
 				}
 			});
+
 			expect(get(testnetsEnabled)).toBe(true);
 
 			userProfileStore.set({
@@ -45,6 +48,7 @@ describe('testnets.derived', () => {
 					})
 				}
 			});
+
 			expect(get(testnetsEnabled)).toBe(false);
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/token.derived.spec.ts
@@ -37,41 +37,49 @@ describe('token.derived', () => {
 
 		it('should return true if default erc20 user token is toggleable', () => {
 			token.set(mockEr20UserToken);
+
 			expect(get(tokenToggleable)).toBe(true);
 		});
 
 		it('should return true if custom erc20 user token is toggleable', () => {
 			token.set({ ...mockEr20UserToken, category: 'custom' });
+
 			expect(get(tokenToggleable)).toBe(true);
 		});
 
 		it('should return false if default ethereum user token is toggleable', () => {
 			token.set({ ...mockEr20UserToken, standard: 'ethereum' });
+
 			expect(get(tokenToggleable)).toBe(false);
 		});
 
 		it('should return true if custom ethereum user token is toggleable', () => {
 			token.set({ ...mockEr20UserToken, category: 'custom', standard: 'ethereum' });
+
 			expect(get(tokenToggleable)).toBe(true);
 		});
 
 		it('should return false if icrc default token is toggleable', () => {
 			token.set(mockIcrcCustomToken);
+
 			expect(get(tokenToggleable)).toBe(false);
 		});
 
 		it('should return true if icrc custom token is toggleable', () => {
 			token.set({ ...mockIcrcCustomToken, category: 'custom' });
+
 			expect(get(tokenToggleable)).toBe(true);
 		});
 
 		it('should return false if btc token is toggleable', () => {
 			token.set(BTC_MAINNET_TOKEN);
+
 			expect(get(tokenToggleable)).toBe(false);
 		});
 
 		it('should return false if sepolia token is toggleable', () => {
 			token.set(SEPOLIA_TOKEN);
+
 			expect(get(tokenToggleable)).toBe(false);
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
@@ -45,6 +45,7 @@ describe('user-networks.derived', () => {
 
 		it('should return only mainnets when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(userNetworks)).toEqual(expectedMainnets);
 		});
 
@@ -59,11 +60,13 @@ describe('user-networks.derived', () => {
 					})
 				}
 			});
+
 			expect(get(userNetworks)).toEqual(expectedMainnets);
 		});
 
 		it('should return the user networks if they are set', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userNetworks)).toEqual(mockUserNetworks);
 		});
 
@@ -78,6 +81,7 @@ describe('user-networks.derived', () => {
 					})
 				}
 			});
+
 			expect(get(userNetworks)).toEqual({ ...expectedMainnets, ...expectedTestnets });
 		});
 
@@ -87,6 +91,7 @@ describe('user-networks.derived', () => {
 			);
 
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userNetworks)).toEqual(expectedMainnets);
 		});
 
@@ -107,6 +112,7 @@ describe('user-networks.derived', () => {
 					})
 				}
 			});
+
 			expect(get(userNetworks)).toEqual({
 				[SOLANA_MAINNET_NETWORK_ID]: { enabled: true, isTestnet: false },
 				[ICP_NETWORK_ID]: { enabled: true, isTestnet: false }

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -20,11 +20,13 @@ describe('user-profile.derived', () => {
 	describe('userProfileLoaded', () => {
 		it('should return false when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(userProfileLoaded)).toBe(false);
 		});
 
 		it('should return true when user profile is set', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userProfileLoaded)).toBe(true);
 		});
 	});
@@ -32,11 +34,13 @@ describe('user-profile.derived', () => {
 	describe('userProfile', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(userProfile)).toBeUndefined();
 		});
 
 		it('should return user profile if it is not nullish', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userProfile)).toEqual(mockUserProfile);
 		});
 	});
@@ -44,16 +48,19 @@ describe('user-profile.derived', () => {
 	describe('userProfileVersion', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(userProfileVersion)).toBeUndefined();
 		});
 
 		it('should return user profile version if it is not nullish', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userProfileVersion)).toEqual(mockUserProfileVersion);
 		});
 
 		it('should return undefined if user profile version is nullish', () => {
 			userProfileStore.set({ certified, profile: { ...mockUserProfile, version: [] } });
+
 			expect(get(userProfileVersion)).toBeUndefined();
 		});
 	});
@@ -61,16 +68,19 @@ describe('user-profile.derived', () => {
 	describe('userSettings', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(userSettings)).toBeUndefined();
 		});
 
 		it('should return user settings if they are not nullish', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userSettings)).toEqual(mockUserSettings);
 		});
 
 		it('should return undefined if user settings are nullish', () => {
 			userProfileStore.set({ certified, profile: { ...mockUserProfile, settings: [] } });
+
 			expect(get(userSettings)).toBeUndefined();
 		});
 	});
@@ -78,11 +88,13 @@ describe('user-profile.derived', () => {
 	describe('userSettingsNetworks', () => {
 		it('should return undefined when user profile is not set', () => {
 			userProfileStore.reset();
+
 			expect(get(userSettingsNetworks)).toBeUndefined();
 		});
 
 		it('should return user profile if it is not nullish', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
+
 			expect(get(userSettingsNetworks)).toEqual(mockNetworksSettings);
 		});
 	});

--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -12,11 +12,13 @@ describe('network.schema', () => {
 	describe('NetworkIdSchema', () => {
 		it('should validate with a symbol as NetworkId', () => {
 			const networkId = Symbol('NetworkId');
+
 			expect(NetworkIdSchema.parse(networkId)).toEqual(networkId);
 		});
 
 		it('should fail validation with a string instead of a symbol', () => {
 			const invalidNetworkId = 'NetworkId';
+
 			expect(() => NetworkIdSchema.parse(invalidNetworkId)).toThrow();
 		});
 	});
@@ -24,16 +26,19 @@ describe('network.schema', () => {
 	describe('NetworkEnvironmentSchema', () => {
 		it('should validate "mainnet" as a supported network environment', () => {
 			const validEnv = 'mainnet';
+
 			expect(NetworkEnvironmentSchema.parse(validEnv)).toEqual(validEnv);
 		});
 
 		it('should validate "testnet" as a supported network environment', () => {
 			const validEnv = 'testnet';
+
 			expect(NetworkEnvironmentSchema.parse(validEnv)).toEqual(validEnv);
 		});
 
 		it('should fail validation with an unsupported network environment', () => {
 			const invalidEnv = 'unsupported-env';
+
 			expect(() => NetworkEnvironmentSchema.parse(invalidEnv)).toThrow();
 		});
 	});
@@ -41,11 +46,13 @@ describe('network.schema', () => {
 	describe('NetworkBuySchema', () => {
 		it('should validate with an optional onramperId', () => {
 			const validBuy = { onramperId: 'icp' };
+
 			expect(NetworkBuySchema.parse(validBuy)).toEqual(validBuy);
 		});
 
 		it('should validate with an empty object (onramperId optional)', () => {
 			const validBuy = {};
+
 			expect(NetworkBuySchema.parse(validBuy)).toEqual(validBuy);
 		});
 
@@ -62,6 +69,7 @@ describe('network.schema', () => {
 			const validMetadata = {
 				explorerUrl: 'https://example.com/explorer'
 			};
+
 			expect(NetworkAppMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
 		});
 
@@ -69,11 +77,13 @@ describe('network.schema', () => {
 			const invalidMetadata = {
 				explorerUrl: 'invalid-url'
 			};
+
 			expect(() => NetworkAppMetadataSchema.parse(invalidMetadata)).toThrow();
 		});
 
 		it('should fail validation with missing explorer URL', () => {
 			const invalidMetadata = {};
+
 			expect(() => NetworkAppMetadataSchema.parse(invalidMetadata)).toThrow();
 		});
 	});
@@ -104,16 +114,19 @@ describe('network.schema', () => {
 
 		it('should fail validation when id is missing', () => {
 			const { id: _, ...invalidNetwork } = validNetwork;
+
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
 
 		it('should fail validation when env is missing', () => {
 			const { env: _, ...invalidNetwork } = validNetwork;
+
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
 
 		it('should fail validation when name is missing', () => {
 			const { name: _, ...invalidNetwork } = validNetwork;
+
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
 
@@ -122,6 +135,7 @@ describe('network.schema', () => {
 				...validNetwork,
 				iconLight: 'https://example.com/invalid-icon.png'
 			};
+
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
 
@@ -130,6 +144,7 @@ describe('network.schema', () => {
 				...validNetwork,
 				iconLight: 'https://example.com/invalid-icon-bw.png'
 			};
+
 			expect(() => NetworkSchema.parse(invalidNetwork)).toThrow();
 		});
 	});

--- a/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
@@ -176,21 +176,25 @@ describe('post-message.schema', () => {
 
 		it('should validate with correct structure for IcCanistersSchema and env field from NetworkSchema', () => {
 			const validData = { ...mockCanisters, ...mockEnv };
+
 			expect(PostMessageDataRequestIcrcSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should throw an error if env field is missing', () => {
 			const invalidData = { ...mockCanisters };
+
 			expect(() => PostMessageDataRequestIcrcSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should throw an error if IcCanistersSchema fields are missing', () => {
 			const invalidData = { ...mockEnv };
+
 			expect(() => PostMessageDataRequestIcrcSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should throw an error if env field is invalid', () => {
 			const invalidData = { ...mockCanisters, env: 'invalid_env' };
+
 			expect(() => PostMessageDataRequestIcrcSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -205,26 +209,31 @@ describe('post-message.schema', () => {
 
 		it('should validate with correct structure for IcCanistersSchema and env field from NetworkSchema', () => {
 			const validData = { ...mockCanisters, ...mockEnv };
+
 			expect(PostMessageDataRequestIcrcStrictSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should throw an error if env field is missing', () => {
 			const invalidData = { ...mockCanisters };
+
 			expect(() => PostMessageDataRequestIcrcStrictSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should throw an error if IcCanistersSchema fields are missing', () => {
 			const invalidData = { ...mockEnv };
+
 			expect(() => PostMessageDataRequestIcrcStrictSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should throw an error if env field is invalid', () => {
 			const invalidData = { ...mockCanisters, env: 'invalid_env' };
+
 			expect(() => PostMessageDataRequestIcrcStrictSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should throw an error if IcCanistersSchema fields is missing the index', () => {
 			const invalidData = { ledgerCanisterId: mockCanisters.ledgerCanisterId, ...mockEnv };
+
 			expect(() => PostMessageDataRequestIcrcStrictSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -244,6 +253,7 @@ describe('post-message.schema', () => {
 
 		it('should throw an error if minterCanisterId is invalid', () => {
 			const invalidData = { minterCanisterId: 'invalid_canister_id' };
+
 			expect(() => PostMessageDataRequestIcCkSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -258,6 +268,7 @@ describe('post-message.schema', () => {
 				bitcoinNetwork: mockValidBitcoinNetwork,
 				btcAddress: mockBtcAddress
 			};
+
 			expect(PostMessageDataRequestIcCkBTCUpdateBalanceSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -266,6 +277,7 @@ describe('post-message.schema', () => {
 				...mockValidMinterCanisterId,
 				bitcoinNetwork: mockValidBitcoinNetwork
 			};
+
 			expect(PostMessageDataRequestIcCkBTCUpdateBalanceSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -275,6 +287,7 @@ describe('post-message.schema', () => {
 				bitcoinNetwork: 'invalid_network',
 				btcAddress: mockBtcAddress
 			};
+
 			expect(PostMessageDataRequestIcCkBTCUpdateBalanceSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -284,6 +297,7 @@ describe('post-message.schema', () => {
 				bitcoinNetwork: mockValidBitcoinNetwork,
 				btcAddress: mockBtcAddress
 			};
+
 			expect(() => PostMessageDataRequestIcCkBTCUpdateBalanceSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -301,6 +315,7 @@ describe('post-message.schema', () => {
 				shouldFetchTransactions: true,
 				bitcoinNetwork: mockValidBitcoinNetwork
 			};
+
 			expect(PostMessageDataRequestBtcSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -310,6 +325,7 @@ describe('post-message.schema', () => {
 				shouldFetchTransactions: true,
 				bitcoinNetwork: mockValidBitcoinNetwork
 			};
+
 			expect(PostMessageDataRequestBtcSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -318,6 +334,7 @@ describe('post-message.schema', () => {
 				btcAddress: mockValidBtcAddress,
 				bitcoinNetwork: mockValidBitcoinNetwork
 			};
+
 			expect(() => PostMessageDataRequestBtcSchema.parse(invalidData)).toThrow();
 		});
 
@@ -327,6 +344,7 @@ describe('post-message.schema', () => {
 				shouldFetchTransactions: true,
 				bitcoinNetwork: 'invalid_network'
 			};
+
 			expect(PostMessageDataRequestBtcSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -391,11 +409,13 @@ describe('post-message.schema', () => {
 			const validData = {
 				authRemainingTime: 120
 			};
+
 			expect(PostMessageDataResponseAuthSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should throw an error if authRemainingTime is missing', () => {
 			const invalidData = {};
+
 			expect(() => PostMessageDataResponseAuthSchema.parse(invalidData)).toThrow();
 		});
 
@@ -403,6 +423,7 @@ describe('post-message.schema', () => {
 			const invalidData = {
 				authRemainingTime: 'not_a_number'
 			};
+
 			expect(() => PostMessageDataResponseAuthSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -418,6 +439,7 @@ describe('post-message.schema', () => {
 				currentIcpPrice: mockValidPrice,
 				currentIcrcPrices: mockValidPrice
 			};
+
 			expect(PostMessageDataResponseExchangeSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -429,6 +451,7 @@ describe('post-message.schema', () => {
 				currentIcpPrice: mockValidPrice,
 				currentIcrcPrices: mockValidPrice
 			};
+
 			expect(PostMessageDataResponseExchangeSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -438,11 +461,13 @@ describe('post-message.schema', () => {
 			const validData = {
 				err: 'An error occurred'
 			};
+
 			expect(PostMessageDataResponseExchangeErrorSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should validate when err is missing, as it is optional', () => {
 			const validData = {};
+
 			expect(PostMessageDataResponseExchangeErrorSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -450,6 +475,7 @@ describe('post-message.schema', () => {
 			const invalidData = {
 				err: 12345 // incorrect type
 			};
+
 			expect(() => PostMessageDataResponseExchangeErrorSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -457,11 +483,13 @@ describe('post-message.schema', () => {
 	describe('JsonTransactionsTextSchema', () => {
 		it('should validate a string successfully', () => {
 			const validData = JSON.stringify([{ id: 'tx1', amount: 500 }]);
+
 			expect(JsonTransactionsTextSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should fail validation for non-string values', () => {
 			const invalidData = 123n;
+
 			expect(() => JsonTransactionsTextSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -478,6 +506,7 @@ describe('post-message.schema', () => {
 				balance: mockValidBalance,
 				newTransactions: mockValidTransactions
 			};
+
 			expect(PostMessageWalletDataSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -485,6 +514,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				balance: mockValidBalance
 			};
+
 			expect(PostMessageWalletDataSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -493,6 +523,7 @@ describe('post-message.schema', () => {
 				balance: 'not_a_bigint',
 				newTransactions: mockValidTransactions
 			};
+
 			expect(PostMessageWalletDataSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -501,6 +532,7 @@ describe('post-message.schema', () => {
 				balance: mockValidBalance,
 				newTransactions: 'invalid_json'
 			};
+
 			expect(PostMessageWalletDataSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -519,6 +551,7 @@ describe('post-message.schema', () => {
 					newTransactions: mockValidTransactions
 				}
 			};
+
 			expect(PostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -528,6 +561,7 @@ describe('post-message.schema', () => {
 					balance: mockValidBalance
 				}
 			};
+
 			expect(PostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -538,6 +572,7 @@ describe('post-message.schema', () => {
 					newTransactions: mockValidTransactions
 				}
 			};
+
 			expect(PostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -548,6 +583,7 @@ describe('post-message.schema', () => {
 					newTransactions: 'invalid_json'
 				}
 			};
+
 			expect(PostMessageDataResponseWalletSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -557,26 +593,31 @@ describe('post-message.schema', () => {
 			const validData = {
 				error: 'An error occurred'
 			};
+
 			expect(PostMessageDataResponseErrorSchema.parse(validData)).toEqual(validData);
 
 			const validDataNumber = {
 				error: 12345
 			};
+
 			expect(PostMessageDataResponseErrorSchema.parse(validDataNumber)).toEqual(validDataNumber);
 
 			const validDataObject = {
 				error: { message: 'An error occurred' }
 			};
+
 			expect(PostMessageDataResponseErrorSchema.parse(validDataObject)).toEqual(validDataObject);
 
 			const validDataArray = {
 				error: ['Error 1', 'Error 2']
 			};
+
 			expect(PostMessageDataResponseErrorSchema.parse(validDataArray)).toEqual(validDataArray);
 		});
 
 		it('should validate when error is missing, as it’s optional in the base schema', () => {
 			const validData = {};
+
 			expect(PostMessageDataResponseErrorSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -586,11 +627,13 @@ describe('post-message.schema', () => {
 			const validData = {
 				transactionIds: ['tx1', 'tx2', 'tx3']
 			};
+
 			expect(PostMessageDataResponseWalletCleanUpSchema.parse(validData)).toEqual(validData);
 		});
 
 		it('should throw an error if transactionIds is missing', () => {
 			const invalidData = {};
+
 			expect(() => PostMessageDataResponseWalletCleanUpSchema.parse(invalidData)).toThrow();
 		});
 
@@ -598,6 +641,7 @@ describe('post-message.schema', () => {
 			const invalidData = {
 				transactionIds: 'not_an_array'
 			};
+
 			expect(() => PostMessageDataResponseWalletCleanUpSchema.parse(invalidData)).toThrow();
 		});
 
@@ -605,6 +649,7 @@ describe('post-message.schema', () => {
 			const invalidData = {
 				transactionIds: ['tx1', 123, 'tx3']
 			};
+
 			expect(() => PostMessageDataResponseWalletCleanUpSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -616,6 +661,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				json: mockValidJson
 			};
+
 			expect(PostMessageJsonDataResponseSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -623,6 +669,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				json: 'invalid_json'
 			};
+
 			expect(PostMessageJsonDataResponseSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -632,6 +679,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				state: 'idle'
 			};
+
 			expect(PostMessageSyncStateSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -639,6 +687,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				state: 'in_progress'
 			};
+
 			expect(PostMessageSyncStateSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -646,6 +695,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				state: 'error'
 			};
+
 			expect(PostMessageSyncStateSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -653,11 +703,13 @@ describe('post-message.schema', () => {
 			const invalidData = {
 				state: 'completed'
 			};
+
 			expect(() => PostMessageSyncStateSchema.parse(invalidData)).toThrow();
 		});
 
 		it('should throw an error if state is missing', () => {
 			const invalidData = {};
+
 			expect(() => PostMessageSyncStateSchema.parse(invalidData)).toThrow();
 		});
 	});
@@ -672,6 +724,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				address: mockValidBtcAddress
 			};
+
 			expect(PostMessageDataResponseBTCAddressSchema.parse(validData)).toEqual(validData);
 		});
 
@@ -679,6 +732,7 @@ describe('post-message.schema', () => {
 			const validData = {
 				address: 12345
 			};
+
 			expect(PostMessageDataResponseBTCAddressSchema.parse(validData)).toEqual(validData);
 		});
 	});
@@ -698,6 +752,7 @@ describe('post-message.schema', () => {
 				msg: validRequestMsg,
 				data: validData
 			};
+
 			expect(SchemaWithCustomData.parse(validPayload)).toEqual(validPayload);
 		});
 
@@ -706,6 +761,7 @@ describe('post-message.schema', () => {
 				msg: validResponseMsg,
 				data: validData
 			};
+
 			expect(SchemaWithCustomData.parse(validPayload)).toEqual(validPayload);
 		});
 
@@ -713,11 +769,13 @@ describe('post-message.schema', () => {
 			const validPayload = {
 				msg: validRequestMsg
 			};
+
 			expect(SchemaWithCustomData.parse(validPayload)).toEqual(validPayload);
 		});
 
 		it('should throw an error if msg is missing', () => {
 			const invalidPayload = { data: validData };
+
 			expect(() => SchemaWithCustomData.parse(invalidPayload)).toThrow();
 		});
 
@@ -726,6 +784,7 @@ describe('post-message.schema', () => {
 				msg: 'invalid_message',
 				data: validData
 			};
+
 			expect(() => SchemaWithCustomData.parse(invalidPayload)).toThrow();
 		});
 
@@ -734,6 +793,7 @@ describe('post-message.schema', () => {
 				msg: validRequestMsg,
 				data: { additionalInfo: 123 }
 			};
+
 			expect(() => SchemaWithCustomData.parse(invalidPayload)).toThrow();
 		});
 	});

--- a/src/frontend/src/tests/lib/schema/token.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/token.schema.spec.ts
@@ -15,11 +15,13 @@ describe('token.schema', () => {
 	describe('TokenIdSchema', () => {
 		it('should validate with a symbol as TokenId', () => {
 			const tokenId = Symbol('TokenId');
+
 			expect(TokenIdSchema.parse(tokenId)).toEqual(tokenId);
 		});
 
 		it('should fail validation with a string instead of a symbol', () => {
 			const invalidTokenId = 'TokenId';
+
 			expect(() => TokenIdSchema.parse(invalidTokenId)).toThrow();
 		});
 	});
@@ -27,36 +29,43 @@ describe('token.schema', () => {
 	describe('TokenStandardSchema', () => {
 		it('should validate "ethereum" as a supported token standard', () => {
 			const validStandard = 'ethereum';
+
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
 		it('should validate "erc20" as a supported token standard', () => {
 			const validStandard = 'erc20';
+
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
 		it('should validate "icp" as a supported token standard', () => {
 			const validStandard = 'icp';
+
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
 		it('should validate "icrc" as a supported token standard', () => {
 			const validStandard = 'icrc';
+
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
 		it('should validate "bitcoin" as a supported token standard', () => {
 			const validStandard = 'bitcoin';
+
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
 		it('should validate "solana" as a supported token standard', () => {
 			const validStandard = 'solana';
+
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
 		it('should fail validation with an unsupported token standard', () => {
 			const invalidStandard = 'unsupported-standard';
+
 			expect(() => TokenStandardSchema.parse(invalidStandard)).toThrow();
 		});
 	});
@@ -64,16 +73,19 @@ describe('token.schema', () => {
 	describe('TokenCategorySchema', () => {
 		it('should validate "default" as a supported token category', () => {
 			const validCategory = 'default';
+
 			expect(TokenCategorySchema.parse(validCategory)).toEqual(validCategory);
 		});
 
 		it('should validate "custom" as a supported token category', () => {
 			const validCategory = 'custom';
+
 			expect(TokenCategorySchema.parse(validCategory)).toEqual(validCategory);
 		});
 
 		it('should fail validation with an unsupported token category', () => {
 			const invalidCategory = 'unsupported-category';
+
 			expect(() => TokenCategorySchema.parse(invalidCategory)).toThrow();
 		});
 	});
@@ -86,6 +98,7 @@ describe('token.schema', () => {
 				decimals: 8,
 				icon: 'https://example.com/icon.png'
 			};
+
 			expect(TokenMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
 		});
 
@@ -96,6 +109,7 @@ describe('token.schema', () => {
 				decimals: 8,
 				icon: 'data:image/png;base64,iVBORw0KGgo=' // Very short base64 string
 			};
+
 			expect(TokenMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
 		});
 
@@ -105,6 +119,7 @@ describe('token.schema', () => {
 				symbol: 'STK',
 				decimals: 8
 			};
+
 			expect(TokenMetadataSchema.parse(validMetadata)).toEqual(validMetadata);
 		});
 
@@ -115,6 +130,7 @@ describe('token.schema', () => {
 				decimals: 'eight', // Should be a number
 				icon: 'https://example.com/icon.png'
 			};
+
 			expect(() => TokenMetadataSchema.parse(invalidMetadata)).toThrow();
 		});
 
@@ -124,6 +140,7 @@ describe('token.schema', () => {
 				decimals: 8,
 				icon: 'https://example.com/icon.png'
 			};
+
 			expect(() => TokenMetadataSchema.parse(invalidMetadata)).toThrow();
 		});
 
@@ -133,6 +150,7 @@ describe('token.schema', () => {
 				decimals: 8,
 				icon: 'https://example.com/icon.png'
 			};
+
 			expect(() => TokenMetadataSchema.parse(invalidMetadata)).toThrow();
 		});
 	});
@@ -143,6 +161,7 @@ describe('token.schema', () => {
 				oisySymbol: { oisySymbol: 'OSYM' },
 				oisyName: { prefix: 'OS', oisyName: 'OisyToken' }
 			};
+
 			expect(TokenAppearanceSchema.parse(validAppearance)).toEqual(validAppearance);
 		});
 
@@ -150,6 +169,7 @@ describe('token.schema', () => {
 			const validAppearance = {
 				oisySymbol: { oisySymbol: 'OSYM' }
 			};
+
 			expect(TokenAppearanceSchema.parse(validAppearance)).toEqual(validAppearance);
 		});
 
@@ -157,6 +177,7 @@ describe('token.schema', () => {
 			const invalidAppearance = {
 				oisySymbol: { oisySymbol: 123 }
 			};
+
 			expect(() => TokenAppearanceSchema.parse(invalidAppearance)).toThrow();
 		});
 	});
@@ -164,11 +185,13 @@ describe('token.schema', () => {
 	describe('TokenBuySchema', () => {
 		it('should validate with an optional onramperId', () => {
 			const validBuy = { onramperId: 'valid-id' };
+
 			expect(TokenBuySchema.parse(validBuy)).toEqual(validBuy);
 		});
 
 		it('should validate with an empty object (onramperId optional)', () => {
 			const validBuy = {};
+
 			expect(TokenBuySchema.parse(validBuy)).toEqual(validBuy);
 		});
 	});
@@ -178,11 +201,13 @@ describe('token.schema', () => {
 			const validBuyable = {
 				buy: { onramperId: 'valid-id' }
 			};
+
 			expect(TokenBuyableSchema.parse(validBuyable)).toEqual(validBuyable);
 		});
 
 		it('should validate with an empty object (buy optional)', () => {
 			const validBuyable = {};
+
 			expect(TokenBuyableSchema.parse(validBuyable)).toEqual(validBuyable);
 		});
 	});
@@ -218,36 +243,43 @@ describe('token.schema', () => {
 
 		it('should fail validation when id is missing', () => {
 			const { id: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 
 		it('should fail validation when network is missing', () => {
 			const { network: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 
 		it('should fail validation when standard is missing', () => {
 			const { standard: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 
 		it('should fail validation when category is missing', () => {
 			const { category: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 
 		it('should fail validation when name is missing', () => {
 			const { name: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 
 		it('should fail validation when symbol is missing', () => {
 			const { symbol: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 
 		it('should fail validation when decimals is missing', () => {
 			const { decimals: _, ...invalidToken } = validToken;
+
 			expect(() => TokenSchema.parse(invalidToken)).toThrow();
 		});
 	});

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -37,6 +37,7 @@ describe('auth.services', () => {
 			mockLocation(activityLocation);
 
 			expect(window.location.href).toEqual(activityLocation);
+
 			await signOut({ resetUrl: true });
 
 			expect(signOutSpy).toHaveBeenCalled();
@@ -47,6 +48,7 @@ describe('auth.services', () => {
 			const signOutSpy = vi.spyOn(authStore, 'signOut');
 
 			sessionStorage.setItem('key', 'value');
+
 			expect(sessionStorage.getItem('key')).toEqual('value');
 
 			await signOut({});

--- a/src/frontend/src/tests/lib/services/exchange.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/exchange.services.spec.ts
@@ -35,6 +35,7 @@ describe('exchangeRateICRCToUsd', () => {
 
 	it('returns null if no canister IDs are provided', async () => {
 		const result = await exchangeRateICRCToUsd([]);
+
 		expect(result).toBeNull();
 		expect(simpleTokenPrice).not.toHaveBeenCalled();
 		expect(findMissingLedgerCanisterIds).not.toHaveBeenCalled();

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -85,6 +85,7 @@ describe('load-user-profile.services', () => {
 				certified: true,
 				nullishIdentityErrorMessage
 			});
+
 			await waitFor(() =>
 				expect(get(userProfileStore)).toEqual({ certified: true, profile: mockProfile })
 			);

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -70,6 +70,7 @@ describe('manage-tokens.services', () => {
 			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsAddToken.DONE);
 
 			await new Promise((resolve) => setTimeout(resolve, 750));
+
 			expect(mockOnSuccess).toHaveBeenCalledOnce();
 		});
 

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -539,6 +539,7 @@ describe('reward-code', () => {
 				icpToken: mockIcpToken,
 				identity: mockIdentity
 			});
+
 			expect(result.ckBtcReward.toString()).toEqual('3000');
 			expect(result.ckUsdcReward.toString()).toEqual('4000');
 			expect(result.icpReward.toString()).toEqual('3000');
@@ -552,6 +553,7 @@ describe('reward-code', () => {
 				icpToken: mockIcpToken,
 				identity: mockIdentity
 			});
+
 			expect(result.ckBtcReward.toString()).toEqual('1000');
 			expect(result.ckUsdcReward.toString()).toEqual('0');
 			expect(result.icpReward.toString()).toEqual('0');
@@ -565,6 +567,7 @@ describe('reward-code', () => {
 				icpToken: mockIcpToken,
 				identity: mockIdentity
 			});
+
 			expect(result.ckBtcReward.toString()).toEqual('0');
 			expect(result.ckUsdcReward.toString()).toEqual('0');
 			expect(result.icpReward.toString()).toEqual('0');

--- a/src/frontend/src/tests/lib/services/token.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/token.services.spec.ts
@@ -24,6 +24,7 @@ describe('token.services', () => {
 		it('should set the token in tokenStore', async () => {
 			await loadTokenAndRun({ token: mockValidToken, callback: mockCallback });
 			const tokenStore = get(token);
+
 			expect(tokenStore).toBe(mockValidToken);
 		});
 
@@ -51,6 +52,7 @@ describe('token.services', () => {
 			).rejects.toThrow('Callback failed');
 
 			const tokenStore = get(token);
+
 			expect(tokenStore).toBe(mockValidToken);
 			expect(failingCallback).toHaveBeenCalled();
 		});

--- a/src/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -11,6 +11,7 @@ describe('auth.store', () => {
 			expect(() => authStore.setForTesting(identity)).not.toThrow();
 
 			const storeIdentity = get(authStore).identity;
+
 			expect(storeIdentity).toBe(identity);
 		});
 

--- a/src/frontend/src/tests/lib/stores/signer.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/signer.store.spec.ts
@@ -25,6 +25,7 @@ describe('SignerContext', () => {
 			const { accountsPrompt } = initSignerContext();
 
 			const payload = get(accountsPrompt.payload);
+
 			expect(payload).toBeUndefined();
 		});
 
@@ -36,6 +37,7 @@ describe('SignerContext', () => {
 			reset();
 
 			const payload = get(accountsPrompt.payload);
+
 			expect(payload).toBeNull();
 		});
 	});
@@ -45,6 +47,7 @@ describe('SignerContext', () => {
 			const { permissionsPrompt } = initSignerContext();
 
 			const payload = get(permissionsPrompt.payload);
+
 			expect(payload).toBeUndefined();
 		});
 
@@ -56,6 +59,7 @@ describe('SignerContext', () => {
 			reset();
 
 			const payload = get(permissionsPrompt.payload);
+
 			expect(payload).toBeNull();
 		});
 	});
@@ -65,6 +69,7 @@ describe('SignerContext', () => {
 			const { consentMessagePrompt } = initSignerContext();
 
 			const payload = get(consentMessagePrompt.payload);
+
 			expect(payload).toBeUndefined();
 		});
 
@@ -76,6 +81,7 @@ describe('SignerContext', () => {
 			reset();
 
 			const payload = get(consentMessagePrompt.payload);
+
 			expect(payload).toBeNull();
 		});
 	});
@@ -85,6 +91,7 @@ describe('SignerContext', () => {
 			const { callCanisterPrompt } = initSignerContext();
 
 			const payload = get(callCanisterPrompt.payload);
+
 			expect(payload).toBeUndefined();
 		});
 
@@ -96,6 +103,7 @@ describe('SignerContext', () => {
 			reset();
 
 			const payload = get(callCanisterPrompt.payload);
+
 			expect(payload).toBeNull();
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/credentials.spec.ts
+++ b/src/frontend/src/tests/lib/utils/credentials.spec.ts
@@ -21,6 +21,7 @@ describe('credentials utils', () => {
 				],
 				version: [0n]
 			};
+
 			expect(hasPouhCredential(profile)).toBe(true);
 		});
 
@@ -36,6 +37,7 @@ describe('credentials utils', () => {
 				],
 				version: [0n]
 			};
+
 			expect(hasPouhCredential(profile)).toBe(false);
 		});
 
@@ -44,6 +46,7 @@ describe('credentials utils', () => {
 				...mockUserProfile,
 				version: [0n]
 			};
+
 			expect(hasPouhCredential(profile)).toBe(false);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -6,17 +6,20 @@ describe('normalizeTimestampToSeconds', () => {
 		it('should divide nanosecond timestamp by NANO_SECONDS_IN_SECOND', () => {
 			const timestamp = 1e18;
 			const expected = timestamp / Number(NANO_SECONDS_IN_SECOND);
+
 			expect(normalizeTimestampToSeconds(timestamp)).toBe(expected);
 		});
 
 		it('should divide millisecond timestamp by MILLISECONDS_IN_SECOND', () => {
 			const timestamp = 1e13;
 			const expected = timestamp / Number(MILLISECONDS_IN_SECOND);
+
 			expect(normalizeTimestampToSeconds(timestamp)).toBe(expected);
 		});
 
 		it('should return timestamp as it is if it is in seconds', () => {
 			const timestamp = 1e10;
+
 			expect(normalizeTimestampToSeconds(timestamp)).toBe(timestamp);
 		});
 	});
@@ -25,17 +28,20 @@ describe('normalizeTimestampToSeconds', () => {
 		it('should divide nanosecond timestamp by NANO_SECONDS_IN_SECOND', () => {
 			const timestamp = 1_000_000_000_000_000_000n;
 			const expected = timestamp / BigInt(NANO_SECONDS_IN_SECOND);
+
 			expect(normalizeTimestampToSeconds(timestamp)).toBe(Number(expected));
 		});
 
 		it('should divide millisecond timestamp by MILLISECONDS_IN_SECOND', () => {
 			const timestamp = 10_000_000_000_000n;
 			const expected = timestamp / BigInt(MILLISECONDS_IN_SECOND);
+
 			expect(normalizeTimestampToSeconds(timestamp)).toBe(Number(expected));
 		});
 
 		it('should return timestamp as it is if it is in seconds', () => {
 			const timestamp = 10_000_000_000n;
+
 			expect(normalizeTimestampToSeconds(timestamp)).toBe(Number(timestamp));
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
@@ -35,6 +35,7 @@ describe('formatKongSwapToCoingeckoPrices', () => {
 			metrics: { price: null as unknown as string }
 		});
 		const result = formatKongSwapToCoingeckoPrices([mock]);
+
 		expect(result).toEqual({});
 	});
 
@@ -50,6 +51,7 @@ describe('formatKongSwapToCoingeckoPrices', () => {
 			}
 		});
 		const result = formatKongSwapToCoingeckoPrices([mock]);
+
 		expect(result[MOCK_CANISTER_ID_1.toLowerCase()].usd).toBe(1);
 		expect(result[MOCK_CANISTER_ID_1.toLowerCase()].usd_market_cap).toBeNaN();
 	});

--- a/src/frontend/src/tests/lib/utils/info.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/info.utils.spec.ts
@@ -48,11 +48,13 @@ describe('info.utils', () => {
 
 		it('should return true if the value for the key is "true"', () => {
 			sessionStorage.setItem(key, 'true');
+
 			expect(shouldHideInfo(key)).toBe(true);
 		});
 
 		it('should return false if the value for the key is "false"', () => {
 			sessionStorage.setItem(key, 'false');
+
 			expect(shouldHideInfo(key)).toBe(false);
 		});
 

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -130,11 +130,13 @@ describe('nav.utils', () => {
 		it('should call history.back when pop is true', async () => {
 			const historyBackMock = vi.spyOn(history, 'back');
 			await back({ pop: true });
+
 			expect(historyBackMock).toHaveBeenCalled();
 		});
 
 		it('should navigate to "/" when pop is false', async () => {
 			await back({ pop: false });
+
 			expect(mockGoTo).toHaveBeenCalledWith('/');
 		});
 	});
@@ -142,6 +144,7 @@ describe('nav.utils', () => {
 	describe('gotoReplaceRoot', () => {
 		it('should navigate to "/" with replaceState', async () => {
 			await gotoReplaceRoot();
+
 			expect(mockGoTo).toHaveBeenCalledWith('/', { replaceState: true });
 		});
 	});
@@ -174,6 +177,7 @@ describe('nav.utils', () => {
 					}
 				}
 			} as unknown as LoadEvent);
+
 			expect(result).toEqual({
 				[TOKEN_PARAM]: null,
 				[NETWORK_PARAM]: null,

--- a/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onramper.utils.spec.ts
@@ -49,6 +49,7 @@ describe('onramper.utils', () => {
 				`&networkWallets=bitcoin:${mockBtcAddress},icp:${mockAccountIdentifierText}`;
 
 			const result = buildOnramperLink(params);
+
 			expect(result).toBe(expectedUrl);
 		});
 
@@ -75,6 +76,7 @@ describe('onramper.utils', () => {
 				`&networkWallets=bitcoin:${mockBtcAddress}`;
 
 			const result = buildOnramperLink(params);
+
 			expect(result).toBe(expectedUrl);
 		});
 

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -21,6 +21,7 @@ describe('decodeUrn', () => {
 	it('should return undefined for an invalid URN', () => {
 		const urn = 'invalidURN';
 		const result = decodeQrCodeUrn(urn);
+
 		expect(result).toBeUndefined();
 	});
 
@@ -70,11 +71,13 @@ describe('decodeQrCode', () => {
 
 	it('should return { result } when result is not success', () => {
 		const response = decodeQrCode({ status: 'cancelled' });
+
 		expect(response).toEqual({ status: 'cancelled' });
 	});
 
 	it('should return { status: "cancelled" } when code is nullish', () => {
 		const response = decodeQrCode({ status: 'success', code: undefined });
+
 		expect(response).toEqual({ status: 'cancelled' });
 	});
 
@@ -82,6 +85,7 @@ describe('decodeQrCode', () => {
 		mockDecodePayment.mockReturnValue(undefined);
 
 		const response = decodeQrCode({ status: 'success', code });
+
 		expect(response).toEqual({ status: 'success', destination: code });
 
 		expect(mockDecodePayment).toHaveBeenCalledWith(code);
@@ -96,6 +100,7 @@ describe('decodeQrCode', () => {
 		mockDecodePayment.mockReturnValue(payment);
 
 		const response = decodeQrCode({ status: 'success', code, expectedToken: token });
+
 		expect(response).toEqual({ status: 'token_incompatible' });
 		expect(mockDecodePayment).toHaveBeenCalledWith(code);
 	});
@@ -109,6 +114,7 @@ describe('decodeQrCode', () => {
 		mockDecodePayment.mockReturnValue(payment);
 
 		const response = decodeQrCode({ status: 'success', code, expectedToken: token });
+
 		expect(response).toEqual({
 			status: 'success',
 			destination: address,

--- a/src/frontend/src/tests/lib/utils/screens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/screens.utils.spec.ts
@@ -19,14 +19,17 @@ describe('screens.utils tests', () => {
 
 			// Test case when screenWidth is smaller than the first screen width
 			let screenWidth = remToPx('28rem') - 1; // Just below 'xs'
+
 			expect(getActiveScreen({ screenWidth, availableScreensSortedByWidth })).toEqual(MIN_SCREEN);
 
 			// Test case when screenWidth is in between 'md' and 'lg'
 			screenWidth = remToPx('56rem'); // Between 'md' (48rem) and 'lg' (64rem)
+
 			expect(getActiveScreen({ screenWidth, availableScreensSortedByWidth })).toEqual('lg');
 
 			// Test case when screenWidth is larger than the largest screen width
 			screenWidth = remToPx('160rem'); // Beyond '2.5xl'
+
 			expect(getActiveScreen({ screenWidth, availableScreensSortedByWidth })).toEqual(MAX_SCREEN);
 		});
 
@@ -35,9 +38,11 @@ describe('screens.utils tests', () => {
 
 			// Test invalid screenWidth (negative or extremely large value)
 			let screenWidth = -1; // Invalid, negative width
+
 			expect(getActiveScreen({ screenWidth, availableScreensSortedByWidth })).toEqual(MIN_SCREEN);
 
 			screenWidth = 10000; // Unrealistically large screen width
+
 			expect(getActiveScreen({ screenWidth, availableScreensSortedByWidth })).toEqual(MAX_SCREEN);
 		});
 
@@ -46,6 +51,7 @@ describe('screens.utils tests', () => {
 
 			// Test for a screenWidth smaller than any available screen (smaller than 'xs')
 			const screenWidth = remToPx('10rem'); // Smaller than smallest screen (xs)
+
 			expect(getActiveScreen({ screenWidth, availableScreensSortedByWidth })).toEqual(MIN_SCREEN);
 		});
 	});
@@ -60,6 +66,7 @@ describe('screens.utils tests', () => {
 				up: 'sm',
 				down: 'xl'
 			});
+
 			expect(filteredScreens).toEqual(['sm', 'md', '1.5md', 'lg', '1.5lg', 'xl']);
 
 			// Test when filtering from 'md' to '2xl'
@@ -68,6 +75,7 @@ describe('screens.utils tests', () => {
 				up: 'md',
 				down: '2xl'
 			});
+
 			expect(filteredScreens).toEqual(['md', '1.5md', 'lg', '1.5lg', 'xl', '1.5xl', '2xl']);
 
 			// Test when "up" and "down" are the same
@@ -76,6 +84,7 @@ describe('screens.utils tests', () => {
 				up: 'xs',
 				down: 'xs'
 			});
+
 			expect(filteredScreens).toEqual(['xs']);
 		});
 
@@ -88,6 +97,7 @@ describe('screens.utils tests', () => {
 				up: 'invalid' as ScreensKeyType,
 				down: 'xl'
 			});
+
 			expect(filteredScreens).toEqual([]);
 
 			// Test with invalid "down" value
@@ -96,6 +106,7 @@ describe('screens.utils tests', () => {
 				up: 'sm',
 				down: 'invalid' as ScreensKeyType
 			});
+
 			expect(invalidFilteredScreens).toEqual([]);
 		});
 
@@ -134,6 +145,7 @@ describe('screens.utils tests', () => {
 				up: undefined as unknown as ScreensKeyType,
 				down: 'xl'
 			});
+
 			expect(filteredScreens).toEqual([]);
 
 			filteredScreens = filterScreens({
@@ -141,6 +153,7 @@ describe('screens.utils tests', () => {
 				up: 'sm',
 				down: null as unknown as ScreensKeyType
 			});
+
 			expect(filteredScreens).toEqual([]);
 		});
 	});
@@ -159,6 +172,7 @@ describe('screens.utils tests', () => {
 				filteredScreens,
 				activeScreen: 'lg'
 			});
+
 			expect(result).toEqual(true);
 
 			// Test with an activeScreen that is NOT in the filtered list
@@ -166,6 +180,7 @@ describe('screens.utils tests', () => {
 				filteredScreens,
 				activeScreen: '2.5xl'
 			});
+
 			expect(result2).toEqual(false);
 		});
 
@@ -182,6 +197,7 @@ describe('screens.utils tests', () => {
 				filteredScreens,
 				activeScreen: 'xs'
 			});
+
 			expect(result).toEqual(false);
 		});
 
@@ -198,12 +214,14 @@ describe('screens.utils tests', () => {
 				filteredScreens,
 				activeScreen: undefined as unknown as ScreensKeyType
 			});
+
 			expect(result).toEqual(false);
 
 			const result2 = shouldDisplayForScreen({
 				filteredScreens,
 				activeScreen: 'nonExistentScreen' as ScreensKeyType
 			});
+
 			expect(result2).toEqual(false);
 		});
 
@@ -215,6 +233,7 @@ describe('screens.utils tests', () => {
 				filteredScreens,
 				activeScreen: 'sm'
 			});
+
 			expect(result).toEqual(false);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -53,12 +53,14 @@ describe('swap utils', () => {
 	describe('getSwapRoute', () => {
 		it('should return a list of token symbols', () => {
 			const route = getSwapRoute(transactions);
+
 			expect(route.includes(ICP_SYMBOL));
 			expect(route.includes('ETH'));
 		});
 
 		it('should return an empty list', () => {
 			const route = getSwapRoute([]);
+
 			expect(route.length).toBe(0);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/time.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/time.utils.spec.ts
@@ -19,6 +19,7 @@ describe('time.utils', () => {
 			await randomWait({ min, max });
 
 			expect(setTimeoutMock).toHaveBeenCalled();
+
 			const calledTime = setTimeoutMock.mock.calls[0][1] as number;
 
 			expect(calledTime).toBeGreaterThanOrEqual(min);
@@ -31,6 +32,7 @@ describe('time.utils', () => {
 			await randomWait({});
 
 			expect(setTimeoutMock).toHaveBeenCalled();
+
 			const calledTime = setTimeoutMock.mock.calls[0][1] as number;
 
 			expect(calledTime).toBeGreaterThanOrEqual(1000);
@@ -46,6 +48,7 @@ describe('time.utils', () => {
 			await randomWait({ min, max });
 
 			expect(setTimeoutMock).toHaveBeenCalled();
+
 			const calledTime = setTimeoutMock.mock.calls[0][1] as number;
 
 			expect(calledTime).toBeGreaterThanOrEqual(max);

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -122,7 +122,9 @@ describe('token-group.utils', () => {
 			const [btcGroup, _, icpToken] = groupedTokens;
 
 			expect(btcGroup).toHaveProperty('group');
+
 			assert('group' in btcGroup);
+
 			expect(btcGroup.group.tokens).toHaveLength(2);
 			expect(btcGroup.group.tokens.map((t) => t.symbol)).toContain('BTC');
 			expect(btcGroup.group.tokens.map((t) => t.symbol)).toContain('ckBTC');
@@ -146,7 +148,9 @@ describe('token-group.utils', () => {
 			const [firstGroup] = groupedTokens;
 
 			expect(firstGroup).toHaveProperty('group');
+
 			assert('group' in firstGroup);
+
 			expect(firstGroup.group.tokens.map((t) => t.symbol)).toContain('BTC');
 			expect(firstGroup.group.tokens.map((t) => t.symbol)).toContain('ckBTC');
 		});
@@ -190,8 +194,10 @@ describe('token-group.utils', () => {
 			);
 
 			expect(btcGroup).toBeDefined();
+
 			assertNonNullish(btcGroup);
 			assert('group' in btcGroup);
+
 			expect(btcGroup.group.tokens).toHaveLength(2);
 			expect(btcGroup.group.tokens.map((t) => t.symbol)).toContain('BTC');
 			expect(btcGroup.group.tokens.map((t) => t.symbol)).toContain('ckBTC');
@@ -202,8 +208,10 @@ describe('token-group.utils', () => {
 			);
 
 			expect(ethGroup).toBeDefined();
+
 			assertNonNullish(ethGroup);
 			assert('group' in ethGroup);
+
 			expect(ethGroup.group.tokens).toHaveLength(2);
 			expect(ethGroup.group.tokens.map((t) => t.symbol)).toContain('ETH');
 			expect(ethGroup.group.tokens.map((t) => t.symbol)).toContain('ckETH');

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -55,12 +55,14 @@ describe('Token List Utils', () => {
 		it('should return all tokens when filter is an empty string', () => {
 			const list: TokenUiOrGroupUi[] = [tokenUi, tokenGroupUi];
 			const result = getFilteredTokenList({ filter: '', list });
+
 			expect(result).toHaveLength(2);
 		});
 
 		it('should filter the list based on token name', () => {
 			const list: TokenUiOrGroupUi[] = [tokenUi, tokenGroupUi];
 			const result = getFilteredTokenList({ filter: 'Bitcoin', list });
+
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual(tokenUi);
 		});
@@ -68,6 +70,7 @@ describe('Token List Utils', () => {
 		it('should filter the list based on token symbol', () => {
 			const list: TokenUiOrGroupUi[] = [tokenUi, tokenGroupUi];
 			const result = getFilteredTokenList({ filter: 'ETH', list });
+
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual(tokenGroupUi);
 		});
@@ -75,11 +78,13 @@ describe('Token List Utils', () => {
 		it('should return empty array if no token matches filter', () => {
 			const list: TokenUiOrGroupUi[] = [tokenUi, tokenGroupUi];
 			const result = getFilteredTokenList({ filter: 'Dogecoin', list });
+
 			expect(result).toHaveLength(0);
 		});
 
 		it('should return empty array if no tokens in the list', () => {
 			const result = getFilteredTokenList({ filter: 'Bitcoin', list: [] });
+
 			expect(result).toHaveLength(0);
 		});
 	});
@@ -88,6 +93,7 @@ describe('Token List Utils', () => {
 		it('should return tokens that match the filter', () => {
 			const list: TokenUi[] = [token1, token2, token3];
 			const result = getFilteredTokenGroup({ filter: 'ETH', list });
+
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual(token2);
 		});
@@ -95,11 +101,13 @@ describe('Token List Utils', () => {
 		it('should return an empty array if no tokens match the filter', () => {
 			const list: TokenUi[] = [token1, token2, token3];
 			const result = getFilteredTokenGroup({ filter: 'XRP', list });
+
 			expect(result).toHaveLength(0);
 		});
 
 		it('should return empty array if no tokens in the list', () => {
 			const result = getFilteredTokenGroup({ filter: 'Bitcoin', list: [] });
+
 			expect(result).toHaveLength(0);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/token-toggle.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-toggle.utils.spec.ts
@@ -12,21 +12,25 @@ import {
 describe('isEthereumUserTokenDisabled', () => {
 	it('should check if default ethereum user token is disabled for token toggle', () => {
 		const token: EthereumUserToken = { ...ETHEREUM_TOKEN, enabled: false };
+
 		expect(isEthereumTokenToggleDisabled(token)).toBe(true);
 	});
 
 	it('should check if custom ethereum user token is disabled for token toggle', () => {
 		const token: EthereumUserToken = { ...ETHEREUM_TOKEN, enabled: false, category: 'custom' };
+
 		expect(isEthereumTokenToggleDisabled(token)).toBe(false);
 	});
 
 	it('should check if default erc20 token is disabled for token toggle', () => {
 		const token: EthereumUserToken = { ...EURC_TOKEN, enabled: false };
+
 		expect(isEthereumTokenToggleDisabled(token)).toBe(false);
 	});
 
 	it('should check if custom erc20 token is disabled for token toggle', () => {
 		const token: EthereumUserToken = { ...WBTC_TOKEN, enabled: false, category: 'custom' };
+
 		expect(isEthereumTokenToggleDisabled(token)).toBe(false);
 	});
 });
@@ -34,6 +38,7 @@ describe('isEthereumUserTokenDisabled', () => {
 describe('isIcrcCustomTokenDisabled', () => {
 	it('should check if icp default token is disabled for token toggle', () => {
 		const token: IcrcCustomToken = { ...ICP_TOKEN, enabled: false };
+
 		expect(isIcrcTokenToggleDisabled(token)).toBe(true);
 	});
 
@@ -44,11 +49,13 @@ describe('isIcrcCustomTokenDisabled', () => {
 			category: 'custom',
 			ledgerCanisterId: 'mxzaz-hqaaa-aaaar-qaadu-cai'
 		};
+
 		expect(isIcrcTokenToggleDisabled(token)).toBe(false);
 	});
 
 	it('should check if icrc default token is disabled for token toggle', () => {
 		const token: IcrcCustomToken = { ...ICP_TOKEN, standard: 'icrc', enabled: false };
+
 		expect(isIcrcTokenToggleDisabled(token)).toBe(false);
 	});
 
@@ -59,6 +66,7 @@ describe('isIcrcCustomTokenDisabled', () => {
 			category: 'custom',
 			enabled: false
 		};
+
 		expect(isIcrcTokenToggleDisabled(token)).toBe(false);
 	});
 });

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -48,6 +48,7 @@ describe('token.utils', () => {
 					tokenDecimals,
 					tokenStandard
 				});
+
 				expect(result).toBe(Number(balance - fee) / 10 ** tokenDecimals);
 			});
 		});
@@ -60,6 +61,7 @@ describe('token.utils', () => {
 					tokenDecimals,
 					tokenStandard
 				});
+
 				expect(result).toBe(0);
 			});
 		});
@@ -72,6 +74,7 @@ describe('token.utils', () => {
 					tokenDecimals,
 					tokenStandard
 				});
+
 				expect(result).toBe(0);
 			});
 		});
@@ -84,6 +87,7 @@ describe('token.utils', () => {
 					tokenDecimals,
 					tokenStandard
 				});
+
 				expect(result).toBe(0);
 
 				result = getMaxTransactionAmount({
@@ -92,6 +96,7 @@ describe('token.utils', () => {
 					tokenDecimals,
 					tokenStandard
 				});
+
 				expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 			});
 		});
@@ -103,6 +108,7 @@ describe('token.utils', () => {
 				tokenDecimals,
 				tokenStandard: 'erc20'
 			});
+
 			expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 		});
 
@@ -113,6 +119,7 @@ describe('token.utils', () => {
 				tokenDecimals,
 				tokenStandard: 'spl'
 			});
+
 			expect(result).toBe(Number(balance) / 10 ** tokenDecimals);
 		});
 	});
@@ -134,6 +141,7 @@ describe('token.utils', () => {
 				$balances: mockBalances,
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual(Number(bn3Bi));
 		});
 
@@ -143,6 +151,7 @@ describe('token.utils', () => {
 				$balances: mockBalances,
 				$exchanges: {}
 			});
+
 			expect(result).toEqual(undefined);
 		});
 
@@ -152,6 +161,7 @@ describe('token.utils', () => {
 				$balances: {},
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual(0);
 		});
 
@@ -161,6 +171,7 @@ describe('token.utils', () => {
 				$balances: undefined,
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual(0);
 		});
 	});
@@ -182,6 +193,7 @@ describe('token.utils', () => {
 				amount: bn3Bi,
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual(Number(bn3Bi));
 		});
 
@@ -191,6 +203,7 @@ describe('token.utils', () => {
 				amount: bn3Bi,
 				$exchanges: {}
 			});
+
 			expect(result).toEqual(undefined);
 		});
 
@@ -200,6 +213,7 @@ describe('token.utils', () => {
 				amount: undefined,
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual(0);
 		});
 	});
@@ -221,6 +235,7 @@ describe('token.utils', () => {
 				$balances: mockBalances,
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual({
 				...ETHEREUM_TOKEN,
 				balance: bn3Bi,
@@ -230,6 +245,7 @@ describe('token.utils', () => {
 
 		it('should return an object TokenUi with undefined usdBalance if exchange rate is not available', () => {
 			const result = mapTokenUi({ token: ETHEREUM_TOKEN, $balances: mockBalances, $exchanges: {} });
+
 			expect(result).toEqual({
 				...ETHEREUM_TOKEN,
 				balance: bn3Bi,
@@ -243,6 +259,7 @@ describe('token.utils', () => {
 				$balances: undefined,
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual({
 				...ETHEREUM_TOKEN,
 				balance: undefined,
@@ -256,6 +273,7 @@ describe('token.utils', () => {
 				$balances: {},
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual({
 				...ETHEREUM_TOKEN,
 				balance: undefined,
@@ -269,6 +287,7 @@ describe('token.utils', () => {
 				$balances: { [ETHEREUM_TOKEN.id]: null },
 				$exchanges: mockExchanges
 			});
+
 			expect(result).toEqual({
 				...ETHEREUM_TOKEN,
 				balance: null,
@@ -416,6 +435,7 @@ describe('token.utils', () => {
 
 			it('should enable the token if no userToken', () => {
 				const result = mapDefaultTokenToToggleable({ defaultToken: token, userToken: undefined });
+
 				expect(result.enabled).toEqual(true);
 			});
 
@@ -424,6 +444,7 @@ describe('token.utils', () => {
 					defaultToken: token,
 					userToken: { ...token, enabled: false }
 				});
+
 				expect(result.enabled).toEqual(true);
 			});
 
@@ -432,6 +453,7 @@ describe('token.utils', () => {
 					defaultToken: token,
 					userToken: { ...token, enabled: true }
 				});
+
 				expect(result.enabled).toEqual(true);
 			});
 		});
@@ -440,6 +462,7 @@ describe('token.utils', () => {
 			...mockValidIcToken,
 			ledgerCanisterId: ckErc20Production.ckUSDT?.ledgerCanisterId
 		};
+
 		describe.each([
 			{
 				description: 'Suggested ICRC token ckUSDT',
@@ -455,6 +478,7 @@ describe('token.utils', () => {
 
 			it('should enable the token if no userToken', () => {
 				const result = mapDefaultTokenToToggleable({ defaultToken: token, userToken: undefined });
+
 				expect(result.enabled).toEqual(true);
 			});
 
@@ -463,6 +487,7 @@ describe('token.utils', () => {
 					defaultToken: token,
 					userToken: { ...token, enabled: false }
 				});
+
 				expect(result.enabled).toEqual(false);
 			});
 
@@ -471,6 +496,7 @@ describe('token.utils', () => {
 					defaultToken: token,
 					userToken: { ...token, enabled: true }
 				});
+
 				expect(result.enabled).toEqual(true);
 			});
 		});

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -45,6 +45,7 @@ describe('sortTokens', () => {
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 300, usd: mockOneUsd }
 		};
 		const sortedTokens = sortTokens({ $tokens: mockTokens, $exchanges, $tokensToPin: [] });
+
 		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, ICP_TOKEN, BTC_MAINNET_TOKEN]);
 	});
 
@@ -55,6 +56,7 @@ describe('sortTokens', () => {
 			[ETHEREUM_TOKEN.id]: { usd_market_cap: 200, usd: mockOneUsd }
 		};
 		const sortedTokens = sortTokens({ $tokens: mockTokens, $exchanges, $tokensToPin: [] });
+
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
@@ -65,6 +67,7 @@ describe('sortTokens', () => {
 			[ETHEREUM_TOKEN.id]: { usd: mockOneUsd }
 		};
 		const sortedTokens = sortTokens({ $tokens: mockTokens, $exchanges, $tokensToPin: [] });
+
 		expect(sortedTokens).toEqual([BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN]);
 	});
 
@@ -80,6 +83,7 @@ describe('sortTokens', () => {
 			$exchanges,
 			$tokensToPin: []
 		});
+
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
 				...token,
@@ -100,6 +104,7 @@ describe('sortTokens', () => {
 			$exchanges,
 			$tokensToPin: []
 		});
+
 		expect(sortedTokens).toEqual(
 			[BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN].map((token) => ({
 				...token,
@@ -120,6 +125,7 @@ describe('sortTokens', () => {
 			$exchanges,
 			$tokensToPin: tokensToPin
 		});
+
 		expect(sortedTokens).toEqual([ETHEREUM_TOKEN, BTC_MAINNET_TOKEN, ICP_TOKEN]);
 	});
 
@@ -136,6 +142,7 @@ describe('sortTokens', () => {
 			$exchanges: {},
 			$tokensToPin: []
 		});
+
 		expect(sortedTokens).toEqual([
 			BTC_MAINNET_TOKEN,
 			ETHEREUM_TOKEN,
@@ -263,6 +270,7 @@ describe('sumTokensUiUsdBalance', () => {
 		];
 
 		const result = sumTokensUiUsdBalance(tokens);
+
 		expect(result).toEqual(200);
 	});
 
@@ -274,11 +282,13 @@ describe('sumTokensUiUsdBalance', () => {
 		];
 
 		const result = sumTokensUiUsdBalance(tokens);
+
 		expect(result).toEqual(50);
 	});
 
 	it('should correctly calculate USD total balance when tokens list is empty', () => {
 		const result = sumTokensUiUsdBalance([]);
+
 		expect(result).toEqual(0);
 	});
 });
@@ -295,6 +305,7 @@ describe('filterEnabledTokens', () => {
 		];
 
 		const result = filterEnabledTokens([tokens]);
+
 		expect(result).toEqual([ENABLED_ICP_TOKEN, ENABLED_ETHEREUM_TOKEN]);
 	});
 
@@ -309,6 +320,7 @@ describe('filterEnabledTokens', () => {
 		];
 
 		const result = filterEnabledTokens([tokens]);
+
 		expect(result).toEqual([ENABLED_BY_DEFAULT_ICP_TOKEN, ENABLED_BY_DEFAULT_ETHEREUM_TOKEN]);
 	});
 });
@@ -336,6 +348,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			$balances: balances,
 			$exchanges: mockExchanges
 		});
+
 		expect(result).toEqual({
 			[BTC_MAINNET_NETWORK_ID]: Number(bn2Bi),
 			[ETHEREUM_NETWORK_ID]: Number(bn3Bi),
@@ -357,6 +370,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			$balances: balances,
 			$exchanges: mockExchanges
 		});
+
 		expect(result).toEqual({
 			[BTC_MAINNET_NETWORK_ID]: Number(ZERO_BI),
 			[ETHEREUM_NETWORK_ID]: Number(ZERO_BI),
@@ -376,6 +390,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			$balances: balances,
 			$exchanges: mockExchanges
 		});
+
 		expect(result).toEqual({});
 	});
 
@@ -385,6 +400,7 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 			$balances: mockBalances,
 			$exchanges: mockExchanges
 		});
+
 		expect(result).toEqual({});
 	});
 });
@@ -455,11 +471,13 @@ describe('filterTokens', () => {
 describe('findToken', () => {
 	it('should return the correct token by symbol', () => {
 		const result = findToken({ tokens: mockTokens, symbol: BTC_MAINNET_SYMBOL });
+
 		expect(result).toEqual(BTC_MAINNET_TOKEN);
 	});
 
 	it('should return undefined if token is not found', () => {
 		const result = findToken({ tokens: mockTokens, symbol: 'UNKNOWN_TOKEN' });
+
 		expect(result).toBeUndefined();
 	});
 });

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -385,6 +385,7 @@ describe('transactions.utils', () => {
 			const result = [transaction2, transaction1, transaction3].sort((a, b) =>
 				sortTransactions({ transactionA: a, transactionB: b })
 			);
+
 			expect(result).toEqual([transaction3, transaction2, transaction1]);
 		});
 
@@ -392,6 +393,7 @@ describe('transactions.utils', () => {
 			const result = [transaction1, transactionWithNullTimestamp, transaction2].sort((a, b) =>
 				sortTransactions({ transactionA: a, transactionB: b })
 			);
+
 			expect(result).toEqual([transaction2, transaction1, transactionWithNullTimestamp]);
 		});
 	});

--- a/src/frontend/src/tests/lib/validation/coingecko.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/coingecko.validation.spec.ts
@@ -3,36 +3,43 @@ import { CoingeckoCoinsIdSchema } from '$lib/validation/coingecko.validation';
 describe('CoingeckoCoinsIdSchema', () => {
 	it('should pass validation for "ethereum"', () => {
 		const validData = 'ethereum';
+
 		expect(CoingeckoCoinsIdSchema.parse(validData)).toEqual(validData);
 	});
 
 	it('should pass validation for "bitcoin"', () => {
 		const validData = 'bitcoin';
+
 		expect(CoingeckoCoinsIdSchema.parse(validData)).toEqual(validData);
 	});
 
 	it('should pass validation for "internet-computer"', () => {
 		const validData = 'internet-computer';
+
 		expect(CoingeckoCoinsIdSchema.parse(validData)).toEqual(validData);
 	});
 
 	it('should fail validation for an unsupported coin ID', () => {
 		const invalidData = 'dogecoin';
+
 		expect(() => CoingeckoCoinsIdSchema.parse(invalidData)).toThrow();
 	});
 
 	it('should fail validation for a number instead of a string', () => {
 		const invalidData = 123;
+
 		expect(() => CoingeckoCoinsIdSchema.parse(invalidData)).toThrow();
 	});
 
 	it('should fail validation for null', () => {
 		const invalidData = null;
+
 		expect(() => CoingeckoCoinsIdSchema.parse(invalidData)).toThrow();
 	});
 
 	it('should fail validation for undefined', () => {
 		const invalidData = undefined;
+
 		expect(() => CoingeckoCoinsIdSchema.parse(invalidData)).toThrow();
 	});
 });

--- a/src/frontend/src/tests/lib/validation/kongswap.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/kongswap.validation.spec.ts
@@ -11,6 +11,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema', () => {
 		const mock = createMockKongSwapToken({});
 
 		const parsed = KongSwapTokenSchema.safeParse(mock);
+
 		expect(parsed.success).toBe(true);
 	});
 
@@ -29,6 +30,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema', () => {
 			}
 		});
 		const parsed = KongSwapTokenSchema.safeParse(mock);
+
 		expect(parsed.success).toBe(true);
 	});
 
@@ -36,6 +38,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema', () => {
 		const mock = createMockKongSwapToken({});
 
 		const parsed = KongSwapTokenSchema.safeParse(mock);
+
 		expect(parsed.success).toBe(true);
 	});
 });
@@ -49,6 +52,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema — invalid field values', () =
 			...mock.token,
 			metrics: mock.metrics
 		});
+
 		expect(parsed.success).toBe(false);
 	});
 
@@ -60,6 +64,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema — invalid field values', () =
 			...mock.token,
 			metrics: mock.metrics
 		});
+
 		expect(parsed.success).toBe(false);
 	});
 
@@ -74,6 +79,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema — invalid field values', () =
 			...token,
 			metrics: mock.metrics
 		});
+
 		expect(parsed.success).toBe(false);
 	});
 });
@@ -86,6 +92,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema — missing required fields', (
 		delete invalid.token_id;
 
 		const parsed = KongSwapTokenWithMetricsSchema.safeParse(invalid);
+
 		expect(parsed.success).toBe(false);
 	});
 
@@ -96,6 +103,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema — missing required fields', (
 		delete invalid.name;
 
 		const parsed = KongSwapTokenWithMetricsSchema.safeParse(invalid);
+
 		expect(parsed.success).toBe(false);
 	});
 
@@ -106,6 +114,7 @@ describe('Schema: KongSwapTokenWithMetricsSchema — missing required fields', (
 		delete invalid.canister_id;
 
 		const parsed = KongSwapTokenWithMetricsSchema.safeParse(invalid);
+
 		expect(parsed.success).toBe(false);
 	});
 });
@@ -116,6 +125,7 @@ describe('Schema: KongSwapTokenMetricsSchema', () => {
 			metrics: { updated_at: 'invalid-date' }
 		});
 		const parsed = KongSwapTokenWithMetricsSchema.safeParse(mock.metrics);
+
 		expect(parsed.success).toBe(false);
 	});
 
@@ -124,6 +134,7 @@ describe('Schema: KongSwapTokenMetricsSchema', () => {
 			metrics: { volume_24h: 'NaN' }
 		});
 		const parsed = KongSwapTokenWithMetricsSchema.safeParse(mock.metrics);
+
 		expect(parsed.success).toBe(false);
 	});
 });
@@ -143,6 +154,7 @@ describe('Schema: KongSwapTokensSchema (paginated list)', () => {
 			total_count: 2,
 			total_pages: 1
 		});
+
 		expect(parsed.success).toBe(true);
 	});
 
@@ -161,6 +173,7 @@ describe('Schema: KongSwapTokensSchema (paginated list)', () => {
 			total_count: 2,
 			total_pages: 1
 		});
+
 		expect(parsed.success).toBe(false);
 	});
 });

--- a/src/frontend/src/tests/lib/validation/network.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/network.validation.spec.ts
@@ -4,11 +4,13 @@ describe('network.validation', () => {
 	describe('parseNetworkId', () => {
 		it('should correctly parse a string into a symbol NetworkId', () => {
 			const networkId = parseNetworkId('testNetworkId');
+
 			expect(typeof networkId).toBe('symbol');
 		});
 
 		it('should fail to parse non-string input', () => {
 			const invalidInput = 123;
+
 			expect(() => parseNetworkId(invalidInput as unknown as string)).toThrow();
 		});
 	});

--- a/src/frontend/src/tests/lib/validation/token.validation.spec.ts
+++ b/src/frontend/src/tests/lib/validation/token.validation.spec.ts
@@ -6,11 +6,13 @@ describe('token.validation', () => {
 	describe('parseTokenId', () => {
 		it('should correctly parse a string into a symbol TokenId', () => {
 			const tokenId = parseTokenId('testTokenId');
+
 			expect(typeof tokenId).toBe('symbol');
 		});
 
 		it('should fail to parse non-string input', () => {
 			const invalidInput = 123;
+
 			expect(() => parseTokenId(invalidInput as unknown as string)).toThrow();
 		});
 	});


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/padding-around-all](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/padding-around-all.md) on the `lib` test folder.

