### PR TITLE
feat(shared): List of token standards

### DIFF
--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -18,6 +18,7 @@ pub mod signer;
 pub mod snapshot;
 pub mod token;
 pub mod token_id;
+pub mod token_standard;
 pub mod transaction;
 pub mod user_profile;
 pub mod verifiable_credential;

--- a/src/shared/src/types/token_standard.rs
+++ b/src/shared/src/types/token_standard.rs
@@ -1,0 +1,41 @@
+//! Token standards
+
+pub enum TokenStandard {
+    /// Standard for the Internet Computer
+    ///
+    /// # Used for:
+    /// - ICP (native ICP token)
+    /// - Cycles (Native stablecoin for execution fees)
+    /// - SNS tokens (Standardized DAOs on the Internet Computer)
+    /// - Other ICRC-1 ledger deployments on ICP.
+    ///
+    /// - [ICRC-1 Spec](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md)
+    ICRC1,
+    /// Standard for the Ethereum blockchain
+    ///
+    /// # Used for:
+    /// - ETH
+    /// - Most tokens on ETH and other EVM networks.
+    ///
+    /// - [ERC20 Spec](https://eips.ethereum.org/EIPS/eip-20)
+    ERC20,
+    /// Standard for the Bitcoin blockchain
+    ///
+    /// # Used for:
+    /// - Bitcoin
+    ///
+    /// - [Invoice Address](https://en.bitcoin.it/wiki/Invoice_address)
+    Bitcoin,
+    /// Standard for the Solana blockchain
+    ///
+    /// # Used for:
+    /// - SOL (native SOL token)
+    /// - Most tokens on Solana.
+    ///
+    /// - [Solana Token Guide](https://solana.com/docs/tokens)
+    /// - [SPL token documentation](https://spl.solana.com/token)
+    ///
+    /// Note: It seems that Solana tokens are defined by the library rather than by a
+    /// specification, but I may be wrong.
+    Spl,
+}


### PR DESCRIPTION
# Motivation
We would like to be able to tell which tokens an address can be used with.  This can be determined, at one level, by the token standard, which specifies e.g. the address format and can therefore be used to determine whether a given address is at least theoretically valid for a given token.

# Changes
- Ad a list of token standards.

# Tests
None - the list is not used yet.