### PR TITLE
docs(shared): User token comments

### DIFF
--- a/src/shared/src/types/token.rs
+++ b/src/shared/src/types/token.rs
@@ -1,11 +1,19 @@
 //! ERC20 specific user defined tokens
+//! 
+//! Note: These are legacy types and are likely to be phased out or adapted to fit into a consistent cross-chain approach.
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
 use crate::types::Version;
 
+/// EVM chain ID
+/// 
+/// IDs may be found on: <https://chainlist.org/>
 pub type ChainId = u64;
 
+/// EVM token information.
+/// 
+/// Note: This is a legacy type and is likely to be phased out or adapted to fit into a consistent cross-chain approach.
 #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct UserToken {
     pub contract_address: String,
@@ -16,6 +24,9 @@ pub struct UserToken {
     pub enabled: Option<bool>,
 }
 
+/// Unique identifier for an EVM token.
+/// 
+/// Note: This is a legacy type and is likely to be phased out or adapted to fit into a consistent cross-chain approach.
 #[derive(CandidType, Deserialize, Clone)]
 pub struct UserTokenId {
     pub contract_address: String,

--- a/src/shared/src/types/token.rs
+++ b/src/shared/src/types/token.rs
@@ -1,19 +1,21 @@
 //! ERC20 specific user defined tokens
-//! 
-//! Note: These are legacy types and are likely to be phased out or adapted to fit into a consistent cross-chain approach.
+//!
+//! Note: These are legacy types and are likely to be phased out or adapted to fit into a consistent
+//! cross-chain approach.
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 
 use crate::types::Version;
 
 /// EVM chain ID
-/// 
+///
 /// IDs may be found on: <https://chainlist.org/>
 pub type ChainId = u64;
 
 /// EVM token information.
-/// 
-/// Note: This is a legacy type and is likely to be phased out or adapted to fit into a consistent cross-chain approach.
+///
+/// Note: This is a legacy type and is likely to be phased out or adapted to fit into a consistent
+/// cross-chain approach.
 #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct UserToken {
     pub contract_address: String,
@@ -25,8 +27,9 @@ pub struct UserToken {
 }
 
 /// Unique identifier for an EVM token.
-/// 
-/// Note: This is a legacy type and is likely to be phased out or adapted to fit into a consistent cross-chain approach.
+///
+/// Note: This is a legacy type and is likely to be phased out or adapted to fit into a consistent
+/// cross-chain approach.
 #[derive(CandidType, Deserialize, Clone)]
 pub struct UserTokenId {
     pub contract_address: String,


### PR DESCRIPTION
# Motivation
The user token types are for EVM only.  This is not clear from the Rustdoc.

# Changes
- Make it clear in the `UserToken` types that they are for EVM only.

# Tests
N/A