### PR TITLE
feat(shared): Define network IDs

### DIFF
--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -12,6 +12,7 @@ pub struct NetworkSettings {
     pub is_testnet: bool,
 }
 
+/// A flat list of logical networks.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub enum NetworkSettingsFor {
     #[default]
@@ -29,6 +30,57 @@ pub enum NetworkSettingsFor {
     BaseSepolia,
     BscMainnet,
     BscTestnet,
+}
+
+/// A list of logical networks grouped by type.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum NetworkId {
+    InternetComputer(ICPNetworkId),
+    Bitcoin(BitcoinNetworkId),
+    Ethereum(EthereumNetworkId),
+    Solana(SolanaNetworkId),
+}
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(u64)]
+pub enum ICPNetworkId {
+    #[default]
+    Mainnet,
+    Local,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(u64)]
+pub enum BitcoinNetworkId {
+    #[default]
+    Mainnet,
+}
+
+/// The authoritative list of EVM networks.
+///
+/// See: <https://chainlist.org>
+///
+/// Note: This supercedes the `UserToken ChainId` type that specifies an integer but not the
+/// corresponding network name.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(u64)]
+#[non_exhaustive] // Note: This allows chain IDs to be used that are not yet included in this list.
+pub enum EthereumNetworkId {
+    #[default]
+    Mainnet = 1,
+    BaseMainnet = 8453,
+    BaseSepolia = 84532,
+    BNBSmartChainMainnet = 56,
+    BNBSmartChainTestnet = 97,
+    Sepolia = 11155111,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub enum SolanaNetworkId {
+    #[default]
+    Mainnet,
+    Testnet,
+    Devnet,
+    Local,
 }
 
 pub type NetworkSettingsMap = BTreeMap<NetworkSettingsFor, NetworkSettings>;

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -73,8 +73,8 @@ impl Network for BitcoinNetworkId {}
 pub enum EthereumNetworkId {
     #[default]
     Mainnet = 1,
-    BaseMainnet = 8453,
-    BaseSepolia = 84532,
+    BaseMainnet = 8_453,
+    BaseSepolia = 84_532,
     BNBSmartChainMainnet = 56,
     BNBSmartChainTestnet = 97,
     Sepolia = 11_155_111,

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -57,7 +57,9 @@ pub enum BitcoinNetworkId {
 
 /// The authoritative list of EVM networks.
 ///
-/// See: <https://chainlist.org>
+/// List of chain IDs: <https://chainlist.org>
+///
+/// List of RPC endpoints: <https://www.alchemy.com/chain-connect>
 ///
 /// Note: This supercedes the `UserToken ChainId` type that specifies an integer but not the
 /// corresponding network name.
@@ -76,7 +78,7 @@ pub enum EthereumNetworkId {
 
 /// Solana networks, or "clusters".
 ///
-/// See: <https://docs.solana.com/clusters>
+/// See: <https://docs.solana.com/clusters> for more information, including RPC endpoints.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub enum SolanaNetworkId {
     #[default]

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use candid::{CandidType, Deserialize};
 
-use crate::types::Version;
+use crate::types::{network::marker_trait::Network, Version};
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub struct NetworkSettings {
@@ -40,6 +40,8 @@ pub enum NetworkId {
     Ethereum(EthereumNetworkId),
     Solana(SolanaNetworkId),
 }
+impl Network for NetworkId {}
+
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[repr(u64)]
 pub enum ICPNetworkId {
@@ -47,6 +49,7 @@ pub enum ICPNetworkId {
     Mainnet,
     Local,
 }
+impl Network for ICPNetworkId {}
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[repr(u64)]
@@ -54,6 +57,7 @@ pub enum BitcoinNetworkId {
     #[default]
     Mainnet,
 }
+impl Network for BitcoinNetworkId {}
 
 /// The authoritative list of EVM networks.
 ///
@@ -75,7 +79,7 @@ pub enum EthereumNetworkId {
     BNBSmartChainTestnet = 97,
     Sepolia = 11_155_111,
 }
-
+impl Network for EthereumNetworkId {}
 /// Solana networks, or "clusters".
 ///
 /// See: <https://docs.solana.com/clusters> for more information, including RPC endpoints.
@@ -87,6 +91,7 @@ pub enum SolanaNetworkId {
     Devnet,
     Local,
 }
+impl Network for SolanaNetworkId {}
 
 pub type NetworkSettingsMap = BTreeMap<NetworkSettingsFor, NetworkSettings>;
 

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -73,7 +73,7 @@ pub enum EthereumNetworkId {
     BaseSepolia = 84532,
     BNBSmartChainMainnet = 56,
     BNBSmartChainTestnet = 97,
-    Sepolia = 11155111,
+    Sepolia = 11_155_111,
 }
 
 /// Solana networks, or "clusters".

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -74,6 +74,9 @@ pub enum EthereumNetworkId {
     Sepolia = 11155111,
 }
 
+/// Solana networks, or "clusters".
+///
+/// See: <https://docs.solana.com/clusters>
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub enum SolanaNetworkId {
     #[default]


### PR DESCRIPTION
# Motivation
Network IDs are fragmented in the code, with different systems in different parts of the code.

# Changes
- Add a network ID that:
  - Supports arbitrary EVM network IDs, as specified in chainlist.org
  - Groups mainnet & testnets

# Tests
The type is currently unused.