### PR TITLE
feat(backend): Validate account ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,6 +3486,7 @@ dependencies = [
  "ic-verifiable-credentials",
  "serde",
  "serde_bytes",
+ "sha2 0.10.8",
  "strum 0.26.3",
  "strum_macros 0.26.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3476,6 +3476,7 @@ dependencies = [
  "bs58",
  "candid",
  "getrandom",
+ "hex",
  "ic-canister-sig-creation",
  "ic-cdk 0.16.0",
  "ic-cdk-macros 0.16.0",

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+hex = {workspace = true}
 
 [lints]
 workspace = true

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -16,6 +16,7 @@ ic-metrics-encoder = { workspace = true }
 ic-verifiable-credentials = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+sha2 = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 hex = {workspace = true}

--- a/src/shared/src/types/account.rs
+++ b/src/shared/src/types/account.rs
@@ -145,7 +145,7 @@ pub enum BtcAddress {
     /// use a script hash instead of a public key hash is to accommodate multisig arrangements.
     ///
     /// ## Format
-    /// P2WSH addresses are exactly 62 characters in length, starting with `bc1p`.
+    /// P2WSH addresses are exactly 62 characters in length, starting with `bc1q`.
     ///
     /// ## Example
     /// - `bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak`

--- a/src/shared/src/types/account.rs
+++ b/src/shared/src/types/account.rs
@@ -16,11 +16,20 @@ use crate::types::network::marker_trait::{
     InternetComputer, Network, SolanaDevnet, SolanaLocal, SolanaMainnet, SolanaTestnet,
 };
 
+pub mod conversion;
+
 /// A marker trait, used to indicate that a type is an account identifier for a given network.
 pub trait AccountId<T>
 where
     T: Network,
 {
+}
+
+pub enum TokenAccountId {
+    Icrcv2(Icrcv2AccountId),
+    Sol(SolPrincipal),
+    Btc(BtcAddress),
+    Eth(EthAddress),
 }
 
 /// An account identifier for Internet Computer tokens.

--- a/src/shared/src/types/account.rs
+++ b/src/shared/src/types/account.rs
@@ -25,6 +25,7 @@ where
 {
 }
 
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum TokenAccountId {
     Icrcv2(Icrcv2AccountId),
     Sol(SolPrincipal),

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -1,0 +1,48 @@
+//! Conversion functions for account identifiers.
+use std::{str::FromStr, string::ParseError};
+
+use super::{BtcAddress, EthAddress, Icrcv2AccountId, SolPrincipal, TokenAccountId};
+
+impl FromStr for TokenAccountId {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        SolPrincipal::from_str(s)
+            .map(TokenAccountId::Sol)
+            .or_else(|_| BtcAddress::from_str(s).map(TokenAccountId::Btc))
+            .or_else(|_| EthAddress::from_str(s).map(TokenAccountId::Eth))
+            .or_else(|_| Icrcv2AccountId::from_str(s).map(TokenAccountId::Icrcv2))
+    }
+}
+
+impl FromStr for Icrcv2AccountId {
+    type Err = ParseError;
+
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        todo!()
+    }
+}
+
+impl FromStr for SolPrincipal {
+    type Err = ParseError;
+
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        todo!()
+    }
+}
+
+impl FromStr for BtcAddress {
+    type Err = ParseError;
+
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        todo!()
+    }
+}
+
+impl FromStr for EthAddress {
+    type Err = ParseError;
+
+    fn from_str(_: &str) -> Result<Self, Self::Err> {
+        todo!()
+    }
+}

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -3,11 +3,11 @@ use std::str::FromStr;
 
 use candid::{CandidType, Deserialize, Principal};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use super::{
     BtcAddress, EthAddress, IcrcSubaccountId, Icrcv2AccountId, SolPrincipal, TokenAccountId,
 };
-use sha2::{Sha256, Digest};
 
 #[cfg(test)]
 mod tests;
@@ -107,7 +107,7 @@ impl BtcAddress {
             .ok_or(ParseError())
     }
     */
-    fn address_checksum(bytes: &[u8]) -> [u8;4] {
+    fn address_checksum(bytes: &[u8]) -> [u8; 4] {
         let hash = {
             let mut hasher = Sha256::new();
             hasher.update(bytes);
@@ -119,6 +119,7 @@ impl BtcAddress {
         checksum.copy_from_slice(&hash[0..4]);
         checksum
     }
+
     pub fn from_p2pkh(s: &str) -> Result<Self, ParseError> {
         if !(s.len() >= 27 && s.len() <= 34) {
             panic!("Invalid P2PKH address length: {}", s.len());
@@ -139,6 +140,7 @@ impl BtcAddress {
         }
         Ok(BtcAddress::P2PKH(s.to_string()))
     }
+
     pub fn from_p2sh(s: &str) -> Result<Self, ParseError> {
         let body = s; // No prefix to strip
         if !body.starts_with("3") {

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -35,6 +35,30 @@ impl FromStr for TokenAccountId {
     }
 }
 
+impl From<SolPrincipal> for TokenAccountId {
+    fn from(value: SolPrincipal) -> Self {
+        TokenAccountId::Sol(value)
+    }
+}
+
+impl From<BtcAddress> for TokenAccountId {
+    fn from(value: BtcAddress) -> Self {
+        TokenAccountId::Btc(value)
+    }
+}
+
+impl From<EthAddress> for TokenAccountId {
+    fn from(value: EthAddress) -> Self {
+        TokenAccountId::Eth(value)
+    }
+}
+
+impl From<Icrcv2AccountId> for TokenAccountId {
+    fn from(value: Icrcv2AccountId) -> Self {
+        TokenAccountId::Icrcv2(value)
+    }
+}
+
 impl FromStr for Icrcv2AccountId {
     type Err = ParseError;
 

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use super::{
     BtcAddress, EthAddress, IcrcSubaccountId, Icrcv2AccountId, SolPrincipal, TokenAccountId,
 };
+use sha2::{Sha256, Digest};
 
 #[cfg(test)]
 mod tests;
@@ -58,14 +59,6 @@ impl FromStr for SolPrincipal {
     }
 }
 
-impl FromStr for BtcAddress {
-    type Err = ParseError;
-
-    fn from_str(_: &str) -> Result<Self, Self::Err> {
-        todo!()
-    }
-}
-
 impl FromStr for EthAddress {
     type Err = ParseError;
 
@@ -91,5 +84,62 @@ impl FromStr for IcrcSubaccountId {
         } else {
             Err(ParseError())
         }
+    }
+}
+
+impl FromStr for BtcAddress {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_p2pkh(s)
+    }
+}
+
+impl BtcAddress {
+    /*
+    const MAINNET_PREFIX: &str = "bc";
+    const TESTNET_PREFIX: &str = "tb";
+
+    /// Removes the mainnet or testnet prefix from a Bitcoin address
+    fn strip_prefix(s: &str) -> Result<&str, ParseError> {
+        s.strip_prefix(Self::MAINNET_PREFIX)
+            .or_else(|| s.strip_prefix(Self::TESTNET_PREFIX))
+            .ok_or(ParseError())
+    }
+    */
+    fn address_checksum(bytes: &[u8]) -> [u8;4] {
+        let hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(bytes);
+            let ans = hasher.finalize_reset();
+            hasher.update(ans);
+            hasher.finalize()
+        };
+        let mut checksum = [0u8; 4];
+        checksum.copy_from_slice(&hash[0..4]);
+        checksum
+    }
+    pub fn from_p2pkh(s: &str) -> Result<Self, ParseError> {
+        if !(s.len() >= 27 && s.len() <= 34) {
+            panic!("Invalid P2PKH address length: {}", s.len());
+            //return Err(ParseError());
+        }
+        let body = s; // No prefix to strip
+        let bytes = bs58::decode(body).into_vec().map_err(|_| ParseError())?;
+        if bytes.len() != 25 {
+            panic!("Invalid P2PKH address length: {}", bytes.len());
+            //return Err(ParseError());
+        }
+        if bytes[0] != 0x00 {
+            panic!("Invalid P2PKH address prefix: {}", bytes[0]);
+            //return Err(ParseError());
+        }
+        let checksum = &bytes[21..25];
+        let expected_checksum = Self::address_checksum(&bytes[0..21]);
+        if checksum != expected_checksum {
+            panic!("Invalid P2PKH address checksum: {:?}", checksum);
+            //return Err(ParseError());
+        }
+        Ok(BtcAddress::P2PKH(s.to_string()))
     }
 }

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -142,12 +142,10 @@ impl BtcAddress {
     pub fn from_p2sh(s: &str) -> Result<Self, ParseError> {
         let body = s; // No prefix to strip
         if !body.starts_with("3") {
-            panic!("Invalid P2SH address prefix: {}", body);
-            //return Err(ParseError());
+            return Err(ParseError());
         }
         if body.len() != 34 {
-            panic!("Invalid P2SH address length: {}", body.len());
-            //return Err(ParseError());
+            return Err(ParseError());
         }
         Ok(BtcAddress::P2SH(s.to_string()))
     }

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -48,8 +48,13 @@ impl FromStr for Icrcv2AccountId {
 impl FromStr for SolPrincipal {
     type Err = ParseError;
 
-    fn from_str(_: &str) -> Result<Self, Self::Err> {
-        todo!()
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = bs58::decode(s).into_vec().map_err(|_| ParseError())?;
+        if bytes.len() == 32 {
+            Ok(SolPrincipal(s.to_string()))
+        } else {
+            Err(ParseError())
+        }
     }
 }
 

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -94,6 +94,7 @@ impl FromStr for BtcAddress {
         Self::from_p2pkh(s)
             .or_else(|_| Self::from_p2sh(s))
             .or_else(|_| Self::from_p2wpkh(s))
+            .or_else(|_| Self::from_p2wsh(s))
     }
 }
 
@@ -107,6 +108,7 @@ impl BtcAddress {
             .or_else(|| s.strip_prefix(Self::TESTNET_PREFIX))
             .ok_or(ParseError())
     }
+
     fn address_checksum(bytes: &[u8]) -> [u8; 4] {
         let hash = {
             let mut hasher = Sha256::new();
@@ -160,5 +162,16 @@ impl BtcAddress {
             return Err(ParseError());
         }
         Ok(BtcAddress::P2WPKH(s.to_string()))
+    }
+
+    pub fn from_p2wsh(s: &str) -> Result<Self, ParseError> {
+        let body = Self::strip_prefix(s)?;
+        if !body.starts_with("1q") {
+            return Err(ParseError());
+        }
+        if s.len() != 62 {
+            return Err(ParseError());
+        }
+        Ok(BtcAddress::P2WSH(s.to_string()))
     }
 }

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -98,7 +98,6 @@ impl FromStr for BtcAddress {
 }
 
 impl BtcAddress {
-    /*
     const MAINNET_PREFIX: &str = "bc";
     const TESTNET_PREFIX: &str = "tb";
 
@@ -108,7 +107,6 @@ impl BtcAddress {
             .or_else(|| s.strip_prefix(Self::TESTNET_PREFIX))
             .ok_or(ParseError())
     }
-    */
     fn address_checksum(bytes: &[u8]) -> [u8; 4] {
         let hash = {
             let mut hasher = Sha256::new();
@@ -154,7 +152,8 @@ impl BtcAddress {
     }
 
     pub fn from_p2wpkh(s: &str) -> Result<Self, ParseError> {
-        if !s.starts_with("bc1") {
+        let body = Self::strip_prefix(s)?;
+        if !body.starts_with('1') {
             return Err(ParseError());
         }
         if s.len() != 42 {

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -69,8 +69,14 @@ impl FromStr for BtcAddress {
 impl FromStr for EthAddress {
     type Err = ParseError;
 
-    fn from_str(_: &str) -> Result<Self, Self::Err> {
-        todo!()
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(hex_encoded) = s.strip_prefix("0x") {
+            let mut bytes = [0u8; 20];
+            hex::decode_to_slice(hex_encoded, &mut bytes).map_err(|_| ParseError())?;
+            Ok(EthAddress::Public(s.to_string()))
+        } else {
+            Err(ParseError())
+        }
     }
 }
 

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -72,7 +72,13 @@ impl FromStr for EthAddress {
 impl FromStr for IcrcSubaccountId {
     type Err = ParseError;
 
-    fn from_str(_: &str) -> Result<Self, Self::Err> {
-        todo!()
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() == 64 {
+            let mut bytes = [0u8; 32];
+            hex::decode_to_slice(s, &mut bytes).map_err(|_| ParseError())?;
+            Ok(IcrcSubaccountId(bytes))
+        } else {
+            Err(ParseError())
+        }
     }
 }

--- a/src/shared/src/types/account/conversion.rs
+++ b/src/shared/src/types/account/conversion.rs
@@ -91,7 +91,9 @@ impl FromStr for BtcAddress {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_p2pkh(s).or_else(|_| Self::from_p2sh(s))
+        Self::from_p2pkh(s)
+            .or_else(|_| Self::from_p2sh(s))
+            .or_else(|_| Self::from_p2wpkh(s))
     }
 }
 
@@ -122,8 +124,7 @@ impl BtcAddress {
 
     pub fn from_p2pkh(s: &str) -> Result<Self, ParseError> {
         if !(s.len() >= 27 && s.len() <= 34) {
-            panic!("Invalid P2PKH address length: {}", s.len());
-            //return Err(ParseError());
+            return Err(ParseError());
         }
         let body = s; // No prefix to strip
         let bytes = bs58::decode(body).into_vec().map_err(|_| ParseError())?;
@@ -150,5 +151,15 @@ impl BtcAddress {
             return Err(ParseError());
         }
         Ok(BtcAddress::P2SH(s.to_string()))
+    }
+
+    pub fn from_p2wpkh(s: &str) -> Result<Self, ParseError> {
+        if !s.starts_with("bc1") {
+            return Err(ParseError());
+        }
+        if s.len() != 42 {
+            return Err(ParseError());
+        }
+        Ok(BtcAddress::P2WPKH(s.to_string()))
     }
 }

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -1,0 +1,29 @@
+//! Tests for parsing account identifiers.
+
+use candid::Principal;
+
+use super::*;
+
+struct TestVector {
+    name: &'static str,
+    input: &'static str,
+    expected: TokenAccountId,
+}
+
+fn test_vectors() -> Vec<TestVector> {
+    vec![TestVector {
+        name: "ICRC: Short principal",
+        input: "un4fu-tqaaa-aaaab-qadjq-cai",
+        expected: TokenAccountId::Icrcv2(Icrcv2AccountId::WithPrincipal {
+            owner: Principal::from_text("un4fu-tqaaa-aaaab-qadjq-cai").unwrap(),
+            subaccount: None,
+        }),
+    }]
+}
+
+#[test]
+fn account_ids_can_be_parsed() {
+    for vector in test_vectors() {
+        assert_eq!(vector.expected, vector.input.parse().unwrap(), "{}", vector.name);
+    }
+}

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -153,6 +153,13 @@ fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
                 "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c".to_string(),
             )),
         },
+        TestVector {
+            name: "BTC: P2WSH",
+            input: "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak",
+            expected: Ok(BtcAddress::P2WSH(
+                "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak".to_string(),
+            )),
+        },
     ]
 }
 #[test]

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -12,6 +12,30 @@ struct TestVector<T: Eq + Debug> {
     expected: Result<T, ParseError>,
 }
 
+fn icrc2_subaccount_test_vectors() -> Vec<TestVector<IcrcSubaccountId>> {
+    vec![
+        TestVector {
+            name: "ICRC: Subaccount ID",
+            input: "7bd35240a80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
+            expected: Ok(IcrcSubaccountId([
+                0x7b, 0xd3, 0x52, 0x40, 0xa8, 0x0a, 0x87, 0x52, 0x99, 0x24, 0x70, 0xeb, 0xd6, 0xdd,
+                0x38, 0xcd, 0x58, 0xab, 0xd6, 0x06, 0x30, 0x19, 0x8d, 0x9e, 0x79, 0xa0, 0x19, 0x41,
+                0x8e, 0xb5, 0x33, 0xf7,
+            ])),
+        },
+        TestVector {
+            name: "ICRC: Incorrect length",
+            input: "234143",
+            expected: Err(ParseError()),
+        },
+        TestVector {
+            name: "ICRC: Invalid characters",
+            input: "7bd35240a80a8752992470ebd6dd38cd58abd6O630198d9e79aO19418eb533f7",
+            expected: Err(ParseError()),
+        },
+    ]
+}
+
 fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
     vec![
         TestVector {
@@ -36,16 +60,26 @@ fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
         TestVector {
             name: "ICRC: Account ID",
             input: "7bd35240a80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
-            expected: Ok(Icrcv2AccountId::Account(IcrcSubaccountId::from_str(
-                "7bd35240a80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
-            ))),
+            expected: Ok(Icrcv2AccountId::Account(
+                IcrcSubaccountId::from_str(
+                    "7bd35240a80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
+                )
+                .expect("Test setup err: Failed to parse subaccount ID"),
+            )),
         },
         TestVector {
             name: "ICRC: Invalid principal",
             input: "invalid",
-            expected: Err(ParseError),
+            expected: Err(ParseError()),
         },
     ]
+}
+
+#[test]
+fn icrc2_subaccount_ids_can_be_parsed() {
+    for vector in icrc2_subaccount_test_vectors() {
+        assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
+    }
 }
 
 #[test]

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -146,6 +146,13 @@ fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
                 "342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey".to_string(),
             )),
         },
+        TestVector {
+            name: "BTC: P2WPKH",
+            input: "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c",
+            expected: Ok(BtcAddress::P2WPKH(
+                "bc1q34aq5drpuwy3wgl9lhup9892qp6svr8ldzyy7c".to_string(),
+            )),
+        },
     ]
 }
 #[test]

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -13,32 +13,44 @@ struct TestVector<T: Eq + Debug> {
 }
 
 fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
-    vec![TestVector {
-        name: "ICRC: Short principal",
-        input: "un4fu-tqaaa-aaaab-qadjq-cai",
-        expected: Ok(Icrcv2AccountId::WithPrincipal {
-            owner: Principal::from_text("un4fu-tqaaa-aaaab-qadjq-cai").unwrap(),
-            subaccount: None,
-        }),
-    },
-    TestVector {
-        name: "ICRC: Long principal",
-        input: "nggqm-p5ozz-i5hfv-bejmq-2gtow-4dtqw-vjatn-4b4yw-s5mzs-i46su-6ae",
-        expected: Ok(Icrcv2AccountId::WithPrincipal {
-            owner: Principal::from_text("nggqm-p5ozz-i5hfv-bejmq-2gtow-4dtqw-vjatn-4b4yw-s5mzs-i46su-6ae").unwrap(),
-            subaccount: None,
-        }),
-    }]
+    vec![
+        TestVector {
+            name: "ICRC: Short principal",
+            input: "un4fu-tqaaa-aaaab-qadjq-cai",
+            expected: Ok(Icrcv2AccountId::WithPrincipal {
+                owner: Principal::from_text("un4fu-tqaaa-aaaab-qadjq-cai").unwrap(),
+                subaccount: None,
+            }),
+        },
+        TestVector {
+            name: "ICRC: Long principal",
+            input: "nggqm-p5ozz-i5hfv-bejmq-2gtow-4dtqw-vjatn-4b4yw-s5mzs-i46su-6ae",
+            expected: Ok(Icrcv2AccountId::WithPrincipal {
+                owner: Principal::from_text(
+                    "nggqm-p5ozz-i5hfv-bejmq-2gtow-4dtqw-vjatn-4b4yw-s5mzs-i46su-6ae",
+                )
+                .unwrap(),
+                subaccount: None,
+            }),
+        },
+        TestVector {
+            name: "ICRC: Account ID",
+            input: "7bd35240a80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
+            expected: Ok(Icrcv2AccountId::Account(IcrcSubaccountId::from_str(
+                "7bd35240a80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
+            ))),
+        },
+        TestVector {
+            name: "ICRC: Invalid principal",
+            input: "invalid",
+            expected: Err(ParseError),
+        },
+    ]
 }
 
 #[test]
 fn icrc2_account_ids_can_be_parsed() {
     for vector in icrc2_test_vectors() {
-        assert_eq!(
-            vector.expected,
-            vector.input.parse(),
-            "{}",
-            vector.name
-        );
+        assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
     }
 }

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -1,29 +1,36 @@
 //! Tests for parsing account identifiers.
 
+use std::fmt::Debug;
+
 use candid::Principal;
 
 use super::*;
 
-struct TestVector {
+struct TestVector<T: Eq + Debug> {
     name: &'static str,
     input: &'static str,
-    expected: TokenAccountId,
+    expected: T,
 }
 
-fn test_vectors() -> Vec<TestVector> {
+fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
     vec![TestVector {
         name: "ICRC: Short principal",
         input: "un4fu-tqaaa-aaaab-qadjq-cai",
-        expected: TokenAccountId::Icrcv2(Icrcv2AccountId::WithPrincipal {
+        expected: Icrcv2AccountId::WithPrincipal {
             owner: Principal::from_text("un4fu-tqaaa-aaaab-qadjq-cai").unwrap(),
             subaccount: None,
-        }),
+        },
     }]
 }
 
 #[test]
-fn account_ids_can_be_parsed() {
-    for vector in test_vectors() {
-        assert_eq!(vector.expected, vector.input.parse().unwrap(), "{}", vector.name);
+fn icrc2_account_ids_can_be_parsed() {
+    for vector in icrc2_test_vectors() {
+        assert_eq!(
+            vector.expected,
+            vector.input.parse().unwrap(),
+            "{}",
+            vector.name
+        );
     }
 }

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -80,6 +80,28 @@ fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
     ]
 }
 
+fn solana_test_vectors() -> Vec<TestVector<SolPrincipal>> {
+    vec![
+        TestVector {
+            name: "Solana: Valid Solana ID",
+            input: "14grJpemFaf88c8tiVb77W7TYg2W3ir6pfkKz3YjhhZ5",
+            expected: Ok(SolPrincipal(
+                "14grJpemFaf88c8tiVb77W7TYg2W3ir6pfkKz3YjhhZ5".to_string(),
+            )),
+        },
+        TestVector {
+            name: "Solana: Invalid base58",
+            input: "14grJpemFaf88c8tiVb77 W7TYg2W3ir6pfkKz3YjhhZ5", /* Valid ID witha  space
+                                                                     * inserted */
+            expected: Err(ParseError()),
+        },
+        TestVector {
+            name: "Solana: Invalid length",
+            input: "J8kUFc4Vo61", // Base 58 encoded "foghorn"
+            expected: Err(ParseError()),
+        },
+    ]
+}
 #[test]
 fn icrc2_subaccount_ids_can_be_parsed() {
     for vector in icrc2_subaccount_test_vectors() {
@@ -90,6 +112,13 @@ fn icrc2_subaccount_ids_can_be_parsed() {
 #[test]
 fn icrc2_account_ids_can_be_parsed() {
     for vector in icrc2_test_vectors() {
+        assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
+    }
+}
+
+#[test]
+fn solana_account_ids_can_be_parsed() {
+    for vector in solana_test_vectors() {
         assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
     }
 }

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -139,7 +139,6 @@ fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
                 "1RainRzqJtJxHTngafpCejDLfYq2y4KBc".to_string(),
             )),
         },
-        
         TestVector {
             name: "BTC: P2SH",
             input: "342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey",

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -9,17 +9,25 @@ use super::*;
 struct TestVector<T: Eq + Debug> {
     name: &'static str,
     input: &'static str,
-    expected: T,
+    expected: Result<T, ParseError>,
 }
 
 fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
     vec![TestVector {
         name: "ICRC: Short principal",
         input: "un4fu-tqaaa-aaaab-qadjq-cai",
-        expected: Icrcv2AccountId::WithPrincipal {
+        expected: Ok(Icrcv2AccountId::WithPrincipal {
             owner: Principal::from_text("un4fu-tqaaa-aaaab-qadjq-cai").unwrap(),
             subaccount: None,
-        },
+        }),
+    },
+    TestVector {
+        name: "ICRC: Long principal",
+        input: "nggqm-p5ozz-i5hfv-bejmq-2gtow-4dtqw-vjatn-4b4yw-s5mzs-i46su-6ae",
+        expected: Ok(Icrcv2AccountId::WithPrincipal {
+            owner: Principal::from_text("nggqm-p5ozz-i5hfv-bejmq-2gtow-4dtqw-vjatn-4b4yw-s5mzs-i46su-6ae").unwrap(),
+            subaccount: None,
+        }),
     }]
 }
 
@@ -28,7 +36,7 @@ fn icrc2_account_ids_can_be_parsed() {
     for vector in icrc2_test_vectors() {
         assert_eq!(
             vector.expected,
-            vector.input.parse().unwrap(),
+            vector.input.parse(),
             "{}",
             vector.name
         );

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -26,12 +26,12 @@ fn icrc2_subaccount_test_vectors() -> Vec<TestVector<IcrcSubaccountId>> {
         TestVector {
             name: "ICRC: Incorrect length",
             input: "234143",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidLength),
         },
         TestVector {
             name: "ICRC: Invalid characters",
             input: "7bd35240a80a8752992470ebd6dd38cd58abd6O630198d9e79aO19418eb533f7",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidEncoding),
         },
     ]
 }
@@ -70,12 +70,12 @@ fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
         TestVector {
             name: "ICRC: Invalid principal",
             input: "invalid",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::UnsupportedFormat),
         },
         TestVector {
             name: "ICRC: Invalid subaccount ID",
             input: "7bd3524Oa80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidEncoding),
         },
     ]
 }
@@ -93,12 +93,12 @@ fn solana_test_vectors() -> Vec<TestVector<SolPrincipal>> {
             name: "Solana: Invalid base58",
             input: "14grJpemFaf88c8tiVb77 W7TYg2W3ir6pfkKz3YjhhZ5", /* Valid ID witha  space
                                                                      * inserted */
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidEncoding),
         },
         TestVector {
             name: "Solana: Invalid length",
             input: "J8kUFc4Vo61", // Base 58 encoded "foghorn"
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidLength),
         },
     ]
 }
@@ -115,17 +115,17 @@ fn eth_test_vectors() -> Vec<TestVector<EthAddress>> {
         TestVector {
             name: "Ethereum: Invalid length",
             input: "0x000000000000000000000000000000000000000",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidLength),
         },
         TestVector {
             name: "Ethereum: Missing prefix",
             input: "0000000000000000000000000000000000000000",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidPrefix),
         },
         TestVector {
             name: "Ethereum: Invalid characters",
             input: "0x000000000000000000000000000000000000000O",
-            expected: Err(ParseError()),
+            expected: Err(ParseError::InvalidEncoding),
         },
     ]
 }
@@ -158,6 +158,13 @@ fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
             input: "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak",
             expected: Ok(BtcAddress::P2WSH(
                 "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak".to_string(),
+            )),
+        },
+        TestVector {
+            name: "BTC: P2TR",
+            input: "bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k",
+            expected: Ok(BtcAddress::P2TR(
+                "bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k".to_string(),
             )),
         },
     ]

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -139,15 +139,14 @@ fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
                 "1RainRzqJtJxHTngafpCejDLfYq2y4KBc".to_string(),
             )),
         },
-        /*
+        
         TestVector {
             name: "BTC: P2SH",
-            input: "3A1nY4ZKZJfWJ9Mzg5YvN12vB14Y5Y7Y",
+            input: "342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey",
             expected: Ok(BtcAddress::P2SH(
-                "3A1nY4ZKZJfWJ9Mzg5YvN12vB14Y5Y7Y".to_string(),
+                "342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey".to_string(),
             )),
         },
-        */
     ]
 }
 #[test]

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -130,6 +130,26 @@ fn eth_test_vectors() -> Vec<TestVector<EthAddress>> {
     ]
 }
 
+fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
+    vec![
+        TestVector {
+            name: "BTC: P2PKH",
+            input: "1RainRzqJtJxHTngafpCejDLfYq2y4KBc",
+            expected: Ok(BtcAddress::P2PKH(
+                "1RainRzqJtJxHTngafpCejDLfYq2y4KBc".to_string(),
+            )),
+        },
+        /*
+        TestVector {
+            name: "BTC: P2SH",
+            input: "3A1nY4ZKZJfWJ9Mzg5YvN12vB14Y5Y7Y",
+            expected: Ok(BtcAddress::P2SH(
+                "3A1nY4ZKZJfWJ9Mzg5YvN12vB14Y5Y7Y".to_string(),
+            )),
+        },
+        */
+    ]
+}
 #[test]
 fn icrc2_subaccount_ids_can_be_parsed() {
     for vector in icrc2_subaccount_test_vectors() {
@@ -154,6 +174,13 @@ fn solana_account_ids_can_be_parsed() {
 #[test]
 fn eth_account_ids_can_be_parsed() {
     for vector in eth_test_vectors() {
+        assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
+    }
+}
+
+#[test]
+fn btc_account_ids_can_be_parsed() {
+    for vector in btc_test_vectors() {
         assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
     }
 }

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -169,6 +169,97 @@ fn btc_test_vectors() -> Vec<TestVector<BtcAddress>> {
         },
     ]
 }
+
+impl From<TestVector<Icrcv2AccountId>> for TestVector<TokenAccountId> {
+    fn from(value: TestVector<Icrcv2AccountId>) -> Self {
+        let TestVector {
+            name,
+            input,
+            expected,
+        } = value;
+        TestVector {
+            name,
+            input,
+            expected: expected
+                .map(TokenAccountId::Icrcv2)
+                .map_err(|_| ParseError::UnsupportedFormat),
+        }
+    }
+}
+
+impl From<TestVector<SolPrincipal>> for TestVector<TokenAccountId> {
+    fn from(value: TestVector<SolPrincipal>) -> Self {
+        let TestVector {
+            name,
+            input,
+            expected,
+        } = value;
+        TestVector {
+            name,
+            input,
+            expected: expected
+                .map(TokenAccountId::Sol)
+                .map_err(|_| ParseError::UnsupportedFormat),
+        }
+    }
+}
+
+impl From<TestVector<EthAddress>> for TestVector<TokenAccountId> {
+    fn from(value: TestVector<EthAddress>) -> Self {
+        let TestVector {
+            name,
+            input,
+            expected,
+        } = value;
+        TestVector {
+            name,
+            input,
+            expected: expected
+                .map(TokenAccountId::Eth)
+                .map_err(|_| ParseError::UnsupportedFormat),
+        }
+    }
+}
+
+impl From<TestVector<BtcAddress>> for TestVector<TokenAccountId> {
+    fn from(value: TestVector<BtcAddress>) -> Self {
+        let TestVector {
+            name,
+            input,
+            expected,
+        } = value;
+        TestVector {
+            name,
+            input,
+            expected: expected
+                .map(TokenAccountId::Btc)
+                .map_err(|_| ParseError::UnsupportedFormat),
+        }
+    }
+}
+
+fn all_test_vectors() -> Vec<TestVector<TokenAccountId>> {
+    icrc2_test_vectors()
+        .into_iter()
+        .map(TestVector::<TokenAccountId>::from)
+        .chain(
+            solana_test_vectors()
+                .into_iter()
+                .map(TestVector::<TokenAccountId>::from),
+        )
+        .chain(
+            eth_test_vectors()
+                .into_iter()
+                .map(TestVector::<TokenAccountId>::from),
+        )
+        .chain(
+            btc_test_vectors()
+                .into_iter()
+                .map(TestVector::<TokenAccountId>::from),
+        )
+        .collect()
+}
+
 #[test]
 fn icrc2_subaccount_ids_can_be_parsed() {
     for vector in icrc2_subaccount_test_vectors() {
@@ -200,6 +291,13 @@ fn eth_account_ids_can_be_parsed() {
 #[test]
 fn btc_account_ids_can_be_parsed() {
     for vector in btc_test_vectors() {
+        assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
+    }
+}
+
+#[test]
+fn all_test_vectors_can_be_parsed() {
+    for vector in all_test_vectors() {
         assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
     }
 }

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -72,6 +72,11 @@ fn icrc2_test_vectors() -> Vec<TestVector<Icrcv2AccountId>> {
             input: "invalid",
             expected: Err(ParseError()),
         },
+        TestVector {
+            name: "ICRC: Invalid subaccount ID",
+            input: "7bd3524Oa80a8752992470ebd6dd38cd58abd60630198d9e79a019418eb533f7",
+            expected: Err(ParseError()),
+        },
     ]
 }
 

--- a/src/shared/src/types/account/conversion/tests.rs
+++ b/src/shared/src/types/account/conversion/tests.rs
@@ -102,6 +102,34 @@ fn solana_test_vectors() -> Vec<TestVector<SolPrincipal>> {
         },
     ]
 }
+
+fn eth_test_vectors() -> Vec<TestVector<EthAddress>> {
+    vec![
+        TestVector {
+            name: "Ethereum: Valid Ethereum ID",
+            input: "0x0000000000000000000000000000000000000000",
+            expected: Ok(
+                EthAddress::from_str("0x0000000000000000000000000000000000000000").unwrap(),
+            ),
+        },
+        TestVector {
+            name: "Ethereum: Invalid length",
+            input: "0x000000000000000000000000000000000000000",
+            expected: Err(ParseError()),
+        },
+        TestVector {
+            name: "Ethereum: Missing prefix",
+            input: "0000000000000000000000000000000000000000",
+            expected: Err(ParseError()),
+        },
+        TestVector {
+            name: "Ethereum: Invalid characters",
+            input: "0x000000000000000000000000000000000000000O",
+            expected: Err(ParseError()),
+        },
+    ]
+}
+
 #[test]
 fn icrc2_subaccount_ids_can_be_parsed() {
     for vector in icrc2_subaccount_test_vectors() {
@@ -119,6 +147,13 @@ fn icrc2_account_ids_can_be_parsed() {
 #[test]
 fn solana_account_ids_can_be_parsed() {
     for vector in solana_test_vectors() {
+        assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
+    }
+}
+
+#[test]
+fn eth_account_ids_can_be_parsed() {
+    for vector in eth_test_vectors() {
         assert_eq!(vector.expected, vector.input.parse(), "{}", vector.name);
     }
 }

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -12,6 +12,7 @@ pub struct NetworkSettings {
     pub is_testnet: bool,
 }
 
+/// A flat list of logical networks.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub enum NetworkSettingsFor {
     #[default]
@@ -29,6 +30,57 @@ pub enum NetworkSettingsFor {
     BaseSepolia,
     BscMainnet,
     BscTestnet,
+}
+
+/// A list of logical networks grouped by type.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum NetworkId {
+    InternetComputer(ICPNetworkId),
+    Bitcoin(BitcoinNetworkId),
+    Ethereum(EthereumNetworkId),
+    Solana(SolanaNetworkId),
+}
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(u64)]
+pub enum ICPNetworkId {
+    #[default]
+    Mainnet,
+    Local,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(u64)]
+pub enum BitcoinNetworkId {
+    #[default]
+    Mainnet,
+}
+
+/// The authoritative list of EVM networks.
+///
+/// See: <https://chainlist.org>
+///
+/// Note: This supercedes the `UserToken ChainId` type that specifies an integer but not the
+/// corresponding network name.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(u64)]
+#[non_exhaustive] // Note: This allows chain IDs to be used that are not yet included in this list.
+pub enum EthereumNetworkId {
+    #[default]
+    Mainnet = 1,
+    BaseMainnet = 8453,
+    BaseSepolia = 84532,
+    BNBSmartChainMainnet = 56,
+    BNBSmartChainTestnet = 97,
+    Sepolia = 11155111,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub enum SolanaNetworkId {
+    #[default]
+    Mainnet,
+    Testnet,
+    Devnet,
+    Local,
 }
 
 pub type NetworkSettingsMap = BTreeMap<NetworkSettingsFor, NetworkSettings>;

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -57,7 +57,9 @@ pub enum BitcoinNetworkId {
 
 /// The authoritative list of EVM networks.
 ///
-/// See: <https://chainlist.org>
+/// List of chain IDs: <https://chainlist.org>
+///
+/// List of RPC endpoints: <https://www.alchemy.com/chain-connect>
 ///
 /// Note: This supercedes the `UserToken ChainId` type that specifies an integer but not the
 /// corresponding network name.
@@ -76,7 +78,7 @@ pub enum EthereumNetworkId {
 
 /// Solana networks, or "clusters".
 ///
-/// See: <https://docs.solana.com/clusters>
+/// See: <https://docs.solana.com/clusters> for more information, including RPC endpoints.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub enum SolanaNetworkId {
     #[default]

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use candid::{CandidType, Deserialize};
 
-use crate::types::Version;
+use crate::types::{network::marker_trait::Network, Version};
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub struct NetworkSettings {
@@ -40,6 +40,8 @@ pub enum NetworkId {
     Ethereum(EthereumNetworkId),
     Solana(SolanaNetworkId),
 }
+impl Network for NetworkId {}
+
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[repr(u64)]
 pub enum ICPNetworkId {
@@ -47,6 +49,7 @@ pub enum ICPNetworkId {
     Mainnet,
     Local,
 }
+impl Network for ICPNetworkId {}
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 #[repr(u64)]
@@ -54,6 +57,7 @@ pub enum BitcoinNetworkId {
     #[default]
     Mainnet,
 }
+impl Network for BitcoinNetworkId {}
 
 /// The authoritative list of EVM networks.
 ///
@@ -75,7 +79,7 @@ pub enum EthereumNetworkId {
     BNBSmartChainTestnet = 97,
     Sepolia = 11_155_111,
 }
-
+impl Network for EthereumNetworkId {}
 /// Solana networks, or "clusters".
 ///
 /// See: <https://docs.solana.com/clusters> for more information, including RPC endpoints.
@@ -87,6 +91,7 @@ pub enum SolanaNetworkId {
     Devnet,
     Local,
 }
+impl Network for SolanaNetworkId {}
 
 pub type NetworkSettingsMap = BTreeMap<NetworkSettingsFor, NetworkSettings>;
 

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -73,7 +73,7 @@ pub enum EthereumNetworkId {
     BaseSepolia = 84532,
     BNBSmartChainMainnet = 56,
     BNBSmartChainTestnet = 97,
-    Sepolia = 11155111,
+    Sepolia = 11_155_111,
 }
 
 /// Solana networks, or "clusters".

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -74,6 +74,9 @@ pub enum EthereumNetworkId {
     Sepolia = 11155111,
 }
 
+/// Solana networks, or "clusters".
+///
+/// See: <https://docs.solana.com/clusters>
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub enum SolanaNetworkId {
     #[default]


### PR DESCRIPTION
# Motivation
We wish to be able to determine account ID formats

# Changes
- Implement validators for each account ID format
- Parse strings to the first compatible account ID format.

# Tests
Unit tests are included.