### PR TITLE
fix(frontend): test for `mapEthTransactionUi` was not being called correctly

### DIFF
--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -216,10 +216,10 @@ describe('transactions.utils', () => {
 			expect(result.id).toBe('0x1234');
 		});
 
-		it('should map an ID to undefined if the transaction hash does not exist', () => {
+		it('should map an ID to empty string if the transaction hash does not exist', () => {
 			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
 
-			expect(result.id).toBeUndefined;
+			expect(result.id).toBe('');
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

In the tests for `mapEthTransactionUi` util, the last one was not being called correctly: it should verify that it maps an ID to `undefined` if the transaction hash does not exist. However, since `.toBeUndefined` was not being called, it was giving false positives.

Now that we fix it, we can see that, in fact, the utils maps it not to be `undefined` but an empty string.