### PR TITLE
refactor(frontend): skip tests instead of commenting them

### DIFF
--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -56,12 +56,13 @@ describe('network.schema', () => {
 			expect(NetworkBuySchema.parse(validBuy)).toEqual(validBuy);
 		});
 
-		// TODO: uncomment the below when we have a way to validate OnramperNetworkId
+		// TODO: unskip the below when we have a way to validate OnramperNetworkId
 		// For now this test is failing because the OnramperNetworkId is not correctly validated
-		// it('should fail validation with an invalid onramperId', () => {
-		// 	const invalidBuy = { onramperId: 'invalid-id' };
-		// 	expect(() => NetworkBuySchema.parse(invalidBuy)).toThrow();
-		// });
+		it.skip('should fail validation with an invalid onramperId', () => {
+			const invalidBuy = { onramperId: 'invalid-id' };
+
+			expect(() => NetworkBuySchema.parse(invalidBuy)).toThrow();
+		});
 	});
 
 	describe('NetworkAppMetadataSchema', () => {


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/no-commented-out-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-commented-out-tests.md) that suggests to use the `.skip` clause instead of commenting tests.