### PR TITLE
refactor(frontend): sort hooks in tests

### DIFF
--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -85,11 +85,6 @@ describe('btc-wallet.worker', () => {
 		window.postMessage = postMessageMock;
 	});
 
-	afterAll(() => {
-		// @ts-expect-error redo original
-		window.postMessage = originalPostmessage;
-	});
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
@@ -112,6 +107,11 @@ describe('btc-wallet.worker', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	afterAll(() => {
+		// @ts-expect-error redo original
+		window.postMessage = originalPostmessage;
 	});
 
 	const testWorker = ({

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -86,11 +86,6 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 		window.postMessage = postMessageMock;
 	});
 
-	afterAll(() => {
-		// @ts-expect-error redo original
-		window.postMessage = originalPostmessage;
-	});
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
@@ -100,6 +95,11 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	afterAll(() => {
+		// @ts-expect-error redo original
+		window.postMessage = originalPostmessage;
 	});
 
 	const initWithTransactions = <PostMessageDataRequest>({

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
@@ -56,11 +56,6 @@ describe('ic-wallet-balance.worker', () => {
 		window.postMessage = postMessageMock;
 	});
 
-	afterAll(() => {
-		// @ts-expect-error redo original
-		window.postMessage = originalPostmessage;
-	});
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
@@ -70,6 +65,11 @@ describe('ic-wallet-balance.worker', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	afterAll(() => {
+		// @ts-expect-error redo original
+		window.postMessage = originalPostmessage;
 	});
 
 	const initWithBalance = <PostMessageDataRequest>({

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -74,11 +74,6 @@ describe('sol-wallet.scheduler', () => {
 		window.postMessage = postMessageMock;
 	});
 
-	afterAll(() => {
-		// @ts-expect-error redo original
-		window.postMessage = originalPostMessage;
-	});
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
@@ -98,6 +93,11 @@ describe('sol-wallet.scheduler', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	afterAll(() => {
+		// @ts-expect-error redo original
+		window.postMessage = originalPostMessage;
 	});
 
 	const testWorker = ({


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/prefer-hooks-in-order](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md) that enforces a specific order for hooks:

```ts
  // consistent order of hooks
  ['beforeAll', 'beforeEach', 'afterEach', 'afterAll']
```