### PR TITLE
feat(frontend): Add avatar component

### DIFF
--- a/src/frontend/src/lib/components/address-book/Avatar.svelte
+++ b/src/frontend/src/lib/components/address-book/Avatar.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	export type AvatarVariants = 'xl' | 'lg' | 'md' | 'sm' | 'xs';
+	import IconAvatar from '$lib/components/icons/IconAvatar.svelte';
+
+	const { name, variant = 'md' }: { name?: string; variant?: AvatarVariants } = $props();
+
+	const size = $derived(
+		{
+			xl: 100,
+			lg: 64,
+			md: 48,
+			sm: 40,
+			xs: 32
+		}[variant]
+	);
+
+	const initials = $derived(
+		(nonNullish(name) ? name : '')
+			.split(' ')
+			.map((w) => w.slice(0, 1))
+			.join('')
+			.slice(0, 2)
+			.toUpperCase()
+	);
+</script>
+
+{#if !initials}
+	<div class="text-brand-primary">
+		<IconAvatar size={`${size}`}></IconAvatar>
+	</div>
+{:else}
+	<span
+		style={`width: ${size}px; height: ${size}px; font-size: ${Math.ceil((size * 4) / 10)}px`}
+		class="inline-block inline-flex items-center justify-center rounded-full bg-[lightgray] text-4xl"
+		>{initials}</span
+	>
+{/if}

--- a/src/frontend/src/lib/components/icons/IconAvatar.svelte
+++ b/src/frontend/src/lib/components/icons/IconAvatar.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	export let size = '100';
+</script>
+
+<svg
+	width={size}
+	height={size}
+	viewBox="0 0 100 100"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<g clip-path="url(#clip0_10499_77041)">
+		<path
+			d="M0 50C0 22.3858 22.3858 0 50 0V0C77.6142 0 100 22.3858 100 50V50C100 77.6142 77.6142 100 50 100V100C22.3858 100 0 77.6142 0 50V50Z"
+			fill="currentColor"
+			fill-opacity="0.1"
+		/>
+		<path
+			d="M50.0001 65.5C58.9945 65.5 66.2858 58.1127 66.2858 49C66.2858 39.8873 58.9945 32.5 50.0001 32.5C41.0058 32.5 33.7144 39.8873 33.7144 49C33.7144 58.1127 41.0058 65.5 50.0001 65.5Z"
+			fill="currentColor"
+			fill-opacity="0.2"
+		/>
+		<path
+			d="M78.5 90.25C78.5 90.25 70.7643 73.75 50 73.75C29.2357 73.75 21.5 90.25 21.5 90.25V101.5H78.5V90.25Z"
+			fill="currentColor"
+			fill-opacity="0.2"
+		/>
+	</g>
+	<defs>
+		<clipPath id="clip0_10499_77041">
+			<path
+				d="M0 50C0 22.3858 22.3858 0 50 0V0C77.6142 0 100 22.3858 100 50V50C100 77.6142 77.6142 100 50 100V100C22.3858 100 0 77.6142 0 50V50Z"
+				fill="white"
+			/>
+		</clipPath>
+	</defs>
+</svg>


### PR DESCRIPTION
# Motivation

An avatar circle is needed in multiple components of the address book. In order to not reimplement this functionality everywhere, this PR adds a gneral purpose avatar component.

Out of scope: Different colors since it is not decided yet which colors will be available and how the color will be selected.

Compare: https://www.figma.com/design/dUNegIE5geiWu7916IC07c/6.-OISY---Theme-library?node-id=7346-24689&t=ijJPPUCQYntRRkHa-0

# Changes

Add avatar component.

# Screenshots

![Screenshot_2025-04-17_13-14-14](https://github.com/user-attachments/assets/94b8b31e-38b1-4d1e-8800-12740efa2ca0)
![Screenshot_2025-04-17_13-14-34](https://github.com/user-attachments/assets/a7af26d7-c279-4e27-b8c2-58a471a5a123)
