### PR TITLE
refactor(frontend): reuse decodeErc20AbiDataValue for ckERC20 txs

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
@@ -24,7 +24,7 @@
 	export let targetNetwork: Network | undefined = undefined;
 
 	let amountDisplay: bigint;
-	$: amountDisplay = erc20Approve && nonNullish(data) ? decodeErc20AbiDataValue(data) : amount;
+	$: amountDisplay = erc20Approve && nonNullish(data) ? decodeErc20AbiDataValue({ data }) : amount;
 
 	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
 </script>

--- a/src/frontend/src/eth/services/eth-transaction.services.ts
+++ b/src/frontend/src/eth/services/eth-transaction.services.ts
@@ -26,7 +26,7 @@ export const processTransactionSent = async ({
 	}
 
 	// We adapt the value for display purpose because the transaction we get has an ETH value of 0x00
-	const value = decodeErc20AbiDataValue(transaction.data);
+	const value = decodeErc20AbiDataValue({ data: transaction.data });
 
 	await processErc20Transaction({ hash: transaction.hash, value, token, type: 'pending' });
 };

--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -21,9 +21,15 @@ export const isTransactionPending = ({ blockNumber }: EthTransactionUi): boolean
 export const isErc20TransactionApprove = (data: string | undefined): boolean =>
 	nonNullish(data) && data.startsWith(ERC20_APPROVE_HASH);
 
-export const decodeErc20AbiDataValue = (data: string): bigint => {
+export const decodeErc20AbiDataValue = ({
+	data,
+	bytesParam = false
+}: {
+	data: string;
+	bytesParam?: boolean;
+}): bigint => {
 	const [_to, value] = AbiCoder.defaultAbiCoder().decode(
-		['address', 'uint256'],
+		['address', 'uint256', ...(bytesParam ? ['bytes32'] : [])],
 		dataSlice(data, 4)
 	);
 

--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -1,4 +1,5 @@
 import type { EthereumNetwork } from '$eth/types/network';
+import { decodeErc20AbiDataValue } from '$eth/utils/transactions.utils';
 import type { IcCkLinkedAssets, IcToken } from '$icp/types/ic-token';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { isNetworkIdETH, isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
@@ -8,8 +9,6 @@ import type { OptionToken } from '$lib/types/token';
 import type { EthersTransaction } from '$lib/types/transaction';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { nonNullish } from '@dfinity/utils';
-import { AbiCoder } from 'ethers/abi';
-import { dataSlice } from 'ethers/utils';
 import { get } from 'svelte/store';
 
 export type MapCkEthereumPendingTransactionParams = {
@@ -76,15 +75,8 @@ const mapPendingTransaction = ({
 	};
 };
 
-const decodeCkErc20DepositAbiDataValue = (data: string): bigint => {
-	// Types are equals to the internalTypes of the CKERC20_ABI for the deposit
-	const [_to, value] = AbiCoder.defaultAbiCoder().decode(
-		['address', 'uint256', 'bytes32'],
-		dataSlice(data, 4)
-	);
-
-	return value;
-};
+const decodeCkErc20DepositAbiDataValue = (data: string): bigint =>
+	decodeErc20AbiDataValue({ data, bytesParam: true });
 
 export const isConvertCkEthToEth = ({
 	token,

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -2,7 +2,11 @@ import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import type { Erc20Token } from '$eth/types/erc20';
-import { mapAddressToName, mapEthTransactionUi } from '$eth/utils/transactions.utils';
+import {
+	decodeErc20AbiDataValue,
+	mapAddressToName,
+	mapEthTransactionUi
+} from '$eth/utils/transactions.utils';
 import { ZERO_BI } from '$lib/constants/app.constants';
 import type { EthAddress, OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
@@ -220,6 +224,29 @@ describe('transactions.utils', () => {
 			const result = mapEthTransactionUi({ transaction, ckMinterInfoAddresses, $ethAddress });
 
 			expect(result.id).toBe('');
+		});
+	});
+
+	describe('decodeErc20AbiDataValue', () => {
+		const txData =
+			'0x26b3293f000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000000000f42401db5f0b9209d75b4b358ddd228eb7097ccec7b8f65e0acef29e51271ce020000';
+		const result = 1000000n;
+
+		it('should decode ERC20 ABI data value correctly if bytesParam is false', () => {
+			expect(
+				decodeErc20AbiDataValue({
+					data: txData
+				})
+			).toBe(result);
+		});
+
+		it('should decode ERC20 ABI data value correctly if bytesParam is true', () => {
+			expect(
+				decodeErc20AbiDataValue({
+					data: txData,
+					bytesParam: true
+				})
+			).toBe(result);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Instead of having 2 different functions, it makes sense to re-use a single implementation.