### PR TITLE
feat(frontend): HowToConvertEthereumWizardSteps component

### DIFF
--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { WizardStep } from '@dfinity/gix-components';
+	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
+	import ReceiveAddressQRCode from '$lib/components/receive/ReceiveAddressQRCode.svelte';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { WizardStepsHowToConvert } from '$lib/enums/wizard-steps';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		currentStep: WizardStep | undefined;
+		formCancelAction?: 'back' | 'close';
+	}
+
+	let { currentStep, formCancelAction = 'close' }: Props = $props();
+</script>
+
+{#if currentStep?.name === WizardStepsHowToConvert.INFO}
+	<HowToConvertEthereumInfo on:icQRCode on:icConvert on:icBack {formCancelAction} />
+{:else if currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE}
+	<ReceiveAddressQRCode
+		address={$ethAddress ?? ''}
+		addressToken={ETHEREUM_TOKEN}
+		network={ETHEREUM_NETWORK}
+		qrCodeAction={{
+			enabled: true,
+			ariaLabel: $i18n.receive.ethereum.text.display_ethereum_address_qr
+		}}
+		copyAriaLabel={$i18n.receive.ethereum.text.ethereum_address_copied}
+		on:icBack
+	/>
+{/if}

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -31,3 +31,8 @@ export enum WizardStepsAuthHelp {
 	HELP_IDENTITY = 'Help Identity',
 	HELP_OTHER = 'Help Other'
 }
+
+export enum WizardStepsHowToConvert {
+	INFO = 'Info',
+	ETH_QR_CODE = 'ETH QR Code'
+}


### PR DESCRIPTION
# Motivation

The following wizard steps will be re-used in both Receive and HowTo flows, therefore it makes sense to make them re-usable.
