### PR TITLE
feat(frontend): util to define the supported tokens for a specific chain

### DIFF
--- a/src/frontend/src/env/networks/networks-evm/networks.evm.base.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.base.env.ts
@@ -5,6 +5,7 @@ import baseSepoliaIconDark from '$lib/assets/networks/dark/base-sepolia.svg';
 import baseMainnetIconLight from '$lib/assets/networks/light/base-mainnet.svg';
 import baseSepoliaIconLight from '$lib/assets/networks/light/base-sepolia.svg';
 import type { NetworkId } from '$lib/types/network';
+import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
 import { parseEnabledMainnetBoolEnvVar } from '$lib/utils/env.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 
@@ -41,7 +42,8 @@ export const BASE_SEPOLIA_NETWORK: EthereumNetwork = {
 	explorerUrl: BASE_SEPOLIA_EXPLORER_URL
 };
 
-export const SUPPORTED_BASE_NETWORKS: [...EthereumNetwork[], EthereumNetwork] = [
-	...(BASE_MAINNET_ENABLED ? [BASE_NETWORK] : []),
-	BASE_SEPOLIA_NETWORK
-];
+export const SUPPORTED_BASE_NETWORKS: EthereumNetwork[] = defineSupportedNetworks({
+	mainnetFlag: BASE_MAINNET_ENABLED,
+	mainnetNetworks: [BASE_NETWORK],
+	testnetNetworks: [BASE_SEPOLIA_NETWORK]
+});

--- a/src/frontend/src/env/networks/networks-evm/networks.evm.bsc.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.bsc.env.ts
@@ -5,6 +5,7 @@ import bscTestnetIconDark from '$lib/assets/networks/dark/bsc-testnet.svg';
 import bscMainnetIconLight from '$lib/assets/networks/light/bsc-mainnet.svg';
 import bscTestnetIconLight from '$lib/assets/networks/light/bsc-testnet.svg';
 import type { NetworkId } from '$lib/types/network';
+import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
 import { parseEnabledMainnetBoolEnvVar } from '$lib/utils/env.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 
@@ -41,7 +42,8 @@ export const BSC_TESTNET_NETWORK: EthereumNetwork = {
 	explorerUrl: BSC_TESTNET_EXPLORER_URL
 };
 
-export const SUPPORTED_BSC_NETWORKS: [...EthereumNetwork[], EthereumNetwork] = [
-	...(BSC_MAINNET_ENABLED ? [BSC_NETWORK] : []),
-	BSC_TESTNET_NETWORK
-];
+export const SUPPORTED_BSC_NETWORKS: EthereumNetwork[] = defineSupportedNetworks({
+	mainnetFlag: BSC_MAINNET_ENABLED,
+	mainnetNetworks: [BSC_NETWORK],
+	testnetNetworks: [BSC_TESTNET_NETWORK]
+});

--- a/src/frontend/src/env/networks/networks.btc.env.ts
+++ b/src/frontend/src/env/networks/networks.btc.env.ts
@@ -10,8 +10,8 @@ import bitcoinTestnetIconDark from '$lib/assets/networks/dark/bitcoin-testnet.sv
 import bitcoinMainnetIconLight from '$lib/assets/networks/light/bitcoin-mainnet.svg';
 import bitcoinRegtestIconLight from '$lib/assets/networks/light/bitcoin-regtest.svg';
 import bitcoinTestnetIconLight from '$lib/assets/networks/light/bitcoin-testnet.svg';
-import { LOCAL } from '$lib/constants/app.constants';
 import type { NetworkId } from '$lib/types/network';
+import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
 import { parseEnabledMainnetBoolEnvVar } from '$lib/utils/env.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 
@@ -61,11 +61,12 @@ export const BTC_REGTEST_NETWORK: BitcoinNetwork = {
 	iconDark: bitcoinRegtestIconDark
 };
 
-export const SUPPORTED_BITCOIN_NETWORKS: BitcoinNetwork[] = [
-	...(BTC_MAINNET_ENABLED ? [BTC_MAINNET_NETWORK] : []),
-	BTC_TESTNET_NETWORK,
-	...(LOCAL ? [BTC_REGTEST_NETWORK] : [])
-];
+export const SUPPORTED_BITCOIN_NETWORKS: BitcoinNetwork[] = defineSupportedNetworks({
+	mainnetFlag: BTC_MAINNET_ENABLED,
+	mainnetNetworks: [BTC_MAINNET_NETWORK],
+	testnetNetworks: [BTC_TESTNET_NETWORK],
+	localNetworks: [BTC_REGTEST_NETWORK]
+});
 
 export const SUPPORTED_BITCOIN_NETWORKS_IDS: NetworkId[] = SUPPORTED_BITCOIN_NETWORKS.map(
 	({ id }) => id

--- a/src/frontend/src/env/networks/networks.eth.env.ts
+++ b/src/frontend/src/env/networks/networks.eth.env.ts
@@ -5,6 +5,7 @@ import sepoliaIconDark from '$lib/assets/networks/dark/ethereum-sepolia.svg';
 import ethereumIconLight from '$lib/assets/networks/light/ethereum-mainnet.svg';
 import sepoliaIconLight from '$lib/assets/networks/light/ethereum-sepolia.svg';
 import type { NetworkId } from '$lib/types/network';
+import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
 import { parseEnabledMainnetBoolEnvVar } from '$lib/utils/env.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 import { Network } from 'alchemy-sdk';
@@ -70,10 +71,11 @@ export const { chainId: SEPOLIA_NETWORK_CHAIN_ID } = SEPOLIA_NETWORK;
  * However, from a UX perspective, we use a store to enable the list of networks based on the testnets flag.
  * That's why those constants are prefixed with SUPPORTED_.
  */
-export const SUPPORTED_ETHEREUM_NETWORKS: [...EthereumNetwork[], EthereumNetwork] = [
-	...(ETH_MAINNET_ENABLED ? [ETHEREUM_NETWORK] : []),
-	SEPOLIA_NETWORK
-];
+export const SUPPORTED_ETHEREUM_NETWORKS: EthereumNetwork[] = defineSupportedNetworks({
+	mainnetFlag: ETH_MAINNET_ENABLED,
+	mainnetNetworks: [ETHEREUM_NETWORK],
+	testnetNetworks: [SEPOLIA_NETWORK]
+});
 
 export const SUPPORTED_ETHEREUM_NETWORKS_IDS: NetworkId[] = SUPPORTED_ETHEREUM_NETWORKS.map(
 	({ id }) => id

--- a/src/frontend/src/env/networks/networks.sol.env.ts
+++ b/src/frontend/src/env/networks/networks.sol.env.ts
@@ -14,8 +14,8 @@ import solTestnetIconDark from '$lib/assets/networks/dark/solana-testnet.svg';
 import solDevnetIconLight from '$lib/assets/networks/light/solana-devnet.svg';
 import solMainnetIconLight from '$lib/assets/networks/light/solana-mainnet.svg';
 import solTestnetIconLight from '$lib/assets/networks/light/solana-testnet.svg';
-import { LOCAL } from '$lib/constants/app.constants';
 import type { Network, NetworkId } from '$lib/types/network';
+import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
 import { parseEnabledMainnetBoolEnvVar } from '$lib/utils/env.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 import type { SolanaNetwork } from '$sol/types/network';
@@ -99,12 +99,12 @@ export const SOLANA_LOCAL_NETWORK: SolanaNetwork = {
 	iconDark: solDevnetIconDark
 };
 
-export const SUPPORTED_SOLANA_NETWORKS: Network[] = [
-	...(SOL_MAINNET_ENABLED ? [SOLANA_MAINNET_NETWORK] : []),
-	SOLANA_TESTNET_NETWORK,
-	SOLANA_DEVNET_NETWORK,
-	...(LOCAL ? [SOLANA_LOCAL_NETWORK] : [])
-];
+export const SUPPORTED_SOLANA_NETWORKS: Network[] = defineSupportedNetworks({
+	mainnetFlag: SOL_MAINNET_ENABLED,
+	mainnetNetworks: [SOLANA_MAINNET_NETWORK],
+	testnetNetworks: [SOLANA_TESTNET_NETWORK, SOLANA_DEVNET_NETWORK],
+	localNetworks: [SOLANA_LOCAL_NETWORK]
+});
 
 export const SUPPORTED_SOLANA_NETWORKS_IDS: NetworkId[] = SUPPORTED_SOLANA_NETWORKS.map(
 	({ id }) => id

--- a/src/frontend/src/lib/utils/env.networks.utils.ts
+++ b/src/frontend/src/lib/utils/env.networks.utils.ts
@@ -1,0 +1,18 @@
+import { LOCAL } from '$lib/constants/app.constants';
+import type { Network } from '$lib/types/network';
+
+export const defineSupportedNetworks = <T extends Network>({
+	mainnetFlag,
+	mainnetNetworks,
+	testnetNetworks = [],
+	localNetworks = []
+}: {
+	mainnetFlag: boolean;
+	mainnetNetworks: T[];
+	testnetNetworks?: T[];
+	localNetworks?: T[];
+}): T[] => [
+	...(mainnetFlag ? mainnetNetworks : []),
+	...testnetNetworks,
+	...(LOCAL ? localNetworks : [])
+];

--- a/src/frontend/src/tests/lib/utils/env.networks.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/env.networks.utils.spec.ts
@@ -1,0 +1,73 @@
+import {
+	SOLANA_DEVNET_NETWORK,
+	SOLANA_LOCAL_NETWORK,
+	SOLANA_MAINNET_NETWORK,
+	SOLANA_TESTNET_NETWORK
+} from '$env/networks/networks.sol.env';
+import * as appContants from '$lib/constants/app.constants';
+import type { Network } from '$lib/types/network';
+import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
+
+describe('env.networks.utils', () => {
+	describe('defineSupportedNetworks', () => {
+		const mainnetNetworks: Network[] = [SOLANA_MAINNET_NETWORK];
+		const testnetNetworks: Network[] = [SOLANA_TESTNET_NETWORK, SOLANA_DEVNET_NETWORK];
+		const localNetworks: Network[] = [SOLANA_LOCAL_NETWORK];
+
+		const mockBaseParams = {
+			mainnetFlag: true,
+			mainnetNetworks,
+			testnetNetworks,
+			localNetworks
+		};
+
+		beforeEach(() => {
+			vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValue(false);
+		});
+
+		const mockParams = { ...mockBaseParams, $testnetsEnabled: true };
+
+		it('should return mainnet and testnet networks', () => {
+			expect(defineSupportedNetworks(mockParams)).toEqual([...mainnetNetworks, ...testnetNetworks]);
+		});
+
+		it('should return only testnet networks when mainnet disabled', () => {
+			expect(defineSupportedNetworks({ ...mockParams, mainnetFlag: false })).toEqual(
+				testnetNetworks
+			);
+		});
+
+		it('should return only mainnet networks when no testnet network is provided', () => {
+			const { testnetNetworks: _, ...params } = mockParams;
+
+			expect(defineSupportedNetworks(params)).toEqual(mainnetNetworks);
+		});
+
+		describe('when local networks are enabled', () => {
+			beforeEach(() => {
+				vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(true);
+			});
+
+			it('should return all networks', () => {
+				expect(defineSupportedNetworks(mockParams)).toEqual([
+					...mainnetNetworks,
+					...testnetNetworks,
+					...localNetworks
+				]);
+			});
+
+			it('should return only testnet and local networks when mainnet disabled', () => {
+				expect(defineSupportedNetworks({ ...mockParams, mainnetFlag: false })).toEqual([
+					...testnetNetworks,
+					...localNetworks
+				]);
+			});
+
+			it('should return only mainnet and testnet networks when no local network is provided', () => {
+				const { localNetworks: _, ...params } = mockParams;
+
+				expect(defineSupportedNetworks(params)).toEqual([...mainnetNetworks, ...testnetNetworks]);
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We are adding more networks, so to avoid repetition of code, we can create utils re-used for all the chains with different params.

In this case, we create an util that defines the supported tokens for a chain, and we use it in the env constants.

# Changes

- Create util that replicate existing code of `SUPPORTED_BASE_NETWORKS`, `SUPPORTED_BSC_NETWORKS`, `SUPPORTED_BITCOIN_NETWORKS`, `SUPPORTED_ETHEREUM_NETWORKS` and `SUPPORTED_SOLANA_NETWORKS`.

# Tests

Added new tests.
