### PR TITLE
chore(frontend): de-duplicate test string titles

### DIFF
--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -280,7 +280,7 @@ describe('EthConvertTokenWizard', () => {
 		expect(sendSpy).not.toHaveBeenCalled();
 	});
 
-	it('should not call send if maxFeePerGas is null', async () => {
+	it('should not call send if maxPriorityFeePerGas is null', async () => {
 		const { container } = render(EthConvertTokenWizard, {
 			props,
 			context: mockContext({ ...mockFees, maxPriorityFeePerGas: null })

--- a/src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts
@@ -22,7 +22,7 @@ describe('IcTransactions', () => {
 		icTransactionsStore.reset(ICP_TOKEN_ID);
 	});
 
-	it('should render no transactions placeholder', () => {
+	it('should render no transactions placeholder when the transactions are empty', () => {
 		icTransactionsStore.append({
 			tokenId: ICP_TOKEN_ID,
 			transactions: []
@@ -33,7 +33,7 @@ describe('IcTransactions', () => {
 		expect(getByTestId(ACTIVITY_TRANSACTIONS_PLACEHOLDER)).not.toBeNull();
 	});
 
-	it('should render no transactions placeholder', () => {
+	it('should render no transactions placeholder when the transactions are null', () => {
 		icTransactionsStore.nullify(ICP_TOKEN_ID);
 
 		const { getByTestId } = render(IcTransactions);


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises quite a few issues. So, in preparation, for now we apply the rule [vitest/no-identical-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md) that warns about similar titles in tests strings.