### PR TITLE
feat(frontend): check for EVM enabled networks for the address loaders

### DIFF
--- a/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
@@ -1,6 +1,8 @@
 import { SUPPORTED_BASE_NETWORKS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORKS } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { SUPPORTED_NETWORKS } from '$env/networks/networks.env';
 import type { EthereumNetwork } from '$eth/types/network';
+import type { Network, NetworkId } from '$lib/types/network';
 import { parseBoolEnvVar } from '$lib/utils/env.utils';
 
 export const EVM_NETWORKS_ENABLED = parseBoolEnvVar(import.meta.env.VITE_EVM_NETWORKS_ENABLED);
@@ -8,3 +10,19 @@ export const EVM_NETWORKS_ENABLED = parseBoolEnvVar(import.meta.env.VITE_EVM_NET
 export const SUPPORTED_EVM_NETWORKS: EthereumNetwork[] = EVM_NETWORKS_ENABLED
 	? [...SUPPORTED_BASE_NETWORKS, ...SUPPORTED_BSC_NETWORKS]
 	: [];
+
+const SUPPORTED_EVM_MAINNET_NETWORKS: Network[] = SUPPORTED_NETWORKS.filter(
+	({ env }) => env === 'mainnet'
+);
+
+const SUPPORTED_EVM_TESTNET_NETWORKS: Network[] = SUPPORTED_NETWORKS.filter(
+	({ env }) => env === 'testnet'
+);
+
+export const SUPPORTED_EVM_MAINNET_NETWORKS_IDS: NetworkId[] = SUPPORTED_EVM_MAINNET_NETWORKS.map(
+	({ id }) => id
+);
+
+export const SUPPORTED_EVM_TESTNET_NETWORKS_IDS: NetworkId[] = SUPPORTED_EVM_TESTNET_NETWORKS.map(
+	({ id }) => id
+);

--- a/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
@@ -1,6 +1,5 @@
 import { SUPPORTED_BASE_NETWORKS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORKS } from '$env/networks/networks-evm/networks.evm.bsc.env';
-import { SUPPORTED_NETWORKS } from '$env/networks/networks.env';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { Network, NetworkId } from '$lib/types/network';
 import { parseBoolEnvVar } from '$lib/utils/env.utils';
@@ -11,11 +10,11 @@ export const SUPPORTED_EVM_NETWORKS: EthereumNetwork[] = EVM_NETWORKS_ENABLED
 	? [...SUPPORTED_BASE_NETWORKS, ...SUPPORTED_BSC_NETWORKS]
 	: [];
 
-const SUPPORTED_EVM_MAINNET_NETWORKS: Network[] = SUPPORTED_NETWORKS.filter(
+const SUPPORTED_EVM_MAINNET_NETWORKS: Network[] = SUPPORTED_EVM_NETWORKS.filter(
 	({ env }) => env === 'mainnet'
 );
 
-const SUPPORTED_EVM_TESTNET_NETWORKS: Network[] = SUPPORTED_NETWORKS.filter(
+const SUPPORTED_EVM_TESTNET_NETWORKS: Network[] = SUPPORTED_EVM_NETWORKS.filter(
 	({ env }) => env === 'testnet'
 );
 

--- a/src/frontend/src/lib/components/guard/AddressGuard.svelte
+++ b/src/frontend/src/lib/components/guard/AddressGuard.svelte
@@ -8,7 +8,11 @@
 		networkSolanaMainnetEnabled
 	} from '$lib/derived/networks.derived';
 	import { initSignerAllowance } from '$lib/services/loader.services';
-	import { btcAddressMainnetStore, ethAddressStore, solAddressMainnetStore } from '$lib/stores/address.store';
+	import {
+		btcAddressMainnetStore,
+		ethAddressStore,
+		solAddressMainnetStore
+	} from '$lib/stores/address.store';
 	import { validateSolAddressMainnet } from '$sol/services/sol-address.services';
 
 	let signerAllowanceLoaded = false;
@@ -32,7 +36,9 @@
 		}
 
 		await Promise.allSettled([
-			$networkEthereumEnabled || $networkEvmMainnetEnabled ? validateEthAddress($ethAddressStore) : Promise.resolve(),
+			$networkEthereumEnabled || $networkEvmMainnetEnabled
+				? validateEthAddress($ethAddressStore)
+				: Promise.resolve(),
 			$networkBitcoinMainnetEnabled
 				? validateBtcAddressMainnet($btcAddressMainnetStore)
 				: Promise.resolve(),

--- a/src/frontend/src/lib/components/guard/AddressGuard.svelte
+++ b/src/frontend/src/lib/components/guard/AddressGuard.svelte
@@ -4,14 +4,11 @@
 	import {
 		networkBitcoinMainnetEnabled,
 		networkEthereumEnabled,
+		networkEvmMainnetEnabled,
 		networkSolanaMainnetEnabled
 	} from '$lib/derived/networks.derived';
 	import { initSignerAllowance } from '$lib/services/loader.services';
-	import {
-		btcAddressMainnetStore,
-		ethAddressStore,
-		solAddressMainnetStore
-	} from '$lib/stores/address.store';
+	import { btcAddressMainnetStore, ethAddressStore, solAddressMainnetStore } from '$lib/stores/address.store';
 	import { validateSolAddressMainnet } from '$sol/services/sol-address.services';
 
 	let signerAllowanceLoaded = false;
@@ -35,7 +32,7 @@
 		}
 
 		await Promise.allSettled([
-			$networkEthereumEnabled ? validateEthAddress($ethAddressStore) : Promise.resolve(),
+			$networkEthereumEnabled || $networkEvmMainnetEnabled ? validateEthAddress($ethAddressStore) : Promise.resolve(),
 			$networkBitcoinMainnetEnabled
 				? validateBtcAddressMainnet($btcAddressMainnetStore)
 				: Promise.resolve(),
@@ -50,6 +47,7 @@
 		$solAddressMainnetStore,
 		$networkBitcoinMainnetEnabled,
 		$networkEthereumEnabled,
+		$networkEvmMainnetEnabled,
 		$networkSolanaMainnetEnabled,
 		(async () => await validateAddresses())();
 </script>

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -31,6 +31,8 @@
 		networkBitcoinRegtestEnabled,
 		networkBitcoinTestnetEnabled,
 		networkEthereumEnabled,
+		networkEvmMainnetEnabled,
+		networkEvmTestnetEnabled,
 		networkSepoliaEnabled,
 		networkSolanaDevnetEnabled,
 		networkSolanaLocalEnabled,
@@ -120,7 +122,7 @@
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
 	$: if (progressStep === ProgressStepsLoader.DONE) {
-		if ($networkEthereumEnabled && isNullish($ethAddress)) {
+		if (($networkEthereumEnabled || $networkEvmMainnetEnabled) && isNullish($ethAddress)) {
 			debounceLoadEthAddress();
 		}
 
@@ -133,9 +135,11 @@
 		}
 
 		if ($testnetsEnabled) {
-			if ($networkSepoliaEnabled && isNullish($ethAddress)) {
+			if (($networkSepoliaEnabled || $networkEvmTestnetEnabled) && isNullish($ethAddress)) {
 				debounceLoadEthAddress();
 			}
+
+	
 
 			if ($networkBitcoinTestnetEnabled && isNullish($btcAddressTestnet)) {
 				debounceLoadBtcAddressTestnet();

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -139,8 +139,6 @@
 				debounceLoadEthAddress();
 			}
 
-	
-
 			if ($networkBitcoinTestnetEnabled && isNullish($btcAddressTestnet)) {
 				debounceLoadBtcAddressTestnet();
 			}

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
-	import { BTC_MAINNET_NETWORK, BTC_REGTEST_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks/networks.btc.env';
+	import {
+		BTC_MAINNET_NETWORK,
+		BTC_REGTEST_NETWORK,
+		BTC_TESTNET_NETWORK
+	} from '$env/networks/networks.btc.env';
 	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import {
@@ -10,7 +14,11 @@
 		SOLANA_MAINNET_NETWORK,
 		SOLANA_TESTNET_NETWORK
 	} from '$env/networks/networks.sol.env';
-	import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens/tokens.btc.env';
+	import {
+		BTC_MAINNET_TOKEN,
+		BTC_REGTEST_TOKEN,
+		BTC_TESTNET_TOKEN
+	} from '$env/tokens/tokens.btc.env';
 	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import {
@@ -145,7 +153,11 @@
 			copyAriaLabel: $i18n.receive.ethereum.text.ethereum_address_copied,
 			qrCodeAriaLabel: $i18n.receive.ethereum.text.display_ethereum_address_qr,
 			text: $i18n.receive.icp.text.your_private_eth_address,
-			condition: $networkEthereumEnabled || $networkSepoliaEnabled || $networkEvmMainnetEnabled || $networkEvmTestnetEnabled
+			condition:
+				$networkEthereumEnabled ||
+				$networkSepoliaEnabled ||
+				$networkEvmMainnetEnabled ||
+				$networkEvmTestnetEnabled
 		},
 		{
 			labelRef: 'icrcTokenAddress',

--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -1,31 +1,23 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
-	import {
-		BTC_MAINNET_NETWORK,
-		BTC_REGTEST_NETWORK,
-		BTC_TESTNET_NETWORK
-	} from '$env/networks/networks.btc.env';
+	import { BTC_MAINNET_NETWORK, BTC_REGTEST_NETWORK, BTC_TESTNET_NETWORK } from '$env/networks/networks.btc.env';
 	import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import {
-		SOLANA_MAINNET_NETWORK,
-		SOLANA_TESTNET_NETWORK,
 		SOLANA_DEVNET_NETWORK,
-		SOLANA_LOCAL_NETWORK
+		SOLANA_LOCAL_NETWORK,
+		SOLANA_MAINNET_NETWORK,
+		SOLANA_TESTNET_NETWORK
 	} from '$env/networks/networks.sol.env';
-	import {
-		BTC_MAINNET_TOKEN,
-		BTC_REGTEST_TOKEN,
-		BTC_TESTNET_TOKEN
-	} from '$env/tokens/tokens.btc.env';
+	import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN, BTC_TESTNET_TOKEN } from '$env/tokens/tokens.btc.env';
 	import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import {
-		SOLANA_TOKEN,
-		SOLANA_TESTNET_TOKEN,
 		SOLANA_DEVNET_TOKEN,
-		SOLANA_LOCAL_TOKEN
+		SOLANA_LOCAL_TOKEN,
+		SOLANA_TESTNET_TOKEN,
+		SOLANA_TOKEN
 	} from '$env/tokens/tokens.sol.env';
 	import { icpAccountIdentifierText, icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import ReceiveAddress from '$lib/components/receive/ReceiveAddress.svelte';
@@ -33,18 +25,18 @@
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import { LOCAL } from '$lib/constants/app.constants';
 	import {
-		RECEIVE_TOKENS_MODAL_ICRC_SECTION,
-		RECEIVE_TOKENS_MODAL_ICP_SECTION,
-		RECEIVE_TOKENS_MODAL_ETH_SECTION,
 		RECEIVE_TOKENS_MODAL_BTC_MAINNET_SECTION,
-		RECEIVE_TOKENS_MODAL_DONE_BUTTON,
-		RECEIVE_TOKENS_MODAL_BTC_TESTNET_SECTION,
 		RECEIVE_TOKENS_MODAL_BTC_REGTEST_SECTION,
+		RECEIVE_TOKENS_MODAL_BTC_TESTNET_SECTION,
+		RECEIVE_TOKENS_MODAL_DONE_BUTTON,
+		RECEIVE_TOKENS_MODAL_ETH_SECTION,
+		RECEIVE_TOKENS_MODAL_ICP_SECTION,
+		RECEIVE_TOKENS_MODAL_ICRC_SECTION,
 		RECEIVE_TOKENS_MODAL_QR_CODE_BUTTON,
-		RECEIVE_TOKENS_MODAL_SOL_MAINNET_SECTION,
-		RECEIVE_TOKENS_MODAL_SOL_TESTNET_SECTION,
 		RECEIVE_TOKENS_MODAL_SOL_DEVNET_SECTION,
-		RECEIVE_TOKENS_MODAL_SOL_LOCAL_SECTION
+		RECEIVE_TOKENS_MODAL_SOL_LOCAL_SECTION,
+		RECEIVE_TOKENS_MODAL_SOL_MAINNET_SECTION,
+		RECEIVE_TOKENS_MODAL_SOL_TESTNET_SECTION
 	} from '$lib/constants/test-ids.constants';
 	import {
 		btcAddressMainnet,
@@ -57,15 +49,17 @@
 		solAddressTestnet
 	} from '$lib/derived/address.derived';
 	import {
-		networkEthereumEnabled,
-		networkSepoliaEnabled,
 		networkBitcoinMainnetEnabled,
-		networkBitcoinTestnetEnabled,
 		networkBitcoinRegtestEnabled,
-		networkSolanaMainnetEnabled,
-		networkSolanaTestnetEnabled,
+		networkBitcoinTestnetEnabled,
+		networkEthereumEnabled,
+		networkEvmMainnetEnabled,
+		networkEvmTestnetEnabled,
+		networkSepoliaEnabled,
 		networkSolanaDevnetEnabled,
-		networkSolanaLocalEnabled
+		networkSolanaLocalEnabled,
+		networkSolanaMainnetEnabled,
+		networkSolanaTestnetEnabled
 	} from '$lib/derived/networks.derived';
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -151,7 +145,7 @@
 			copyAriaLabel: $i18n.receive.ethereum.text.ethereum_address_copied,
 			qrCodeAriaLabel: $i18n.receive.ethereum.text.display_ethereum_address_qr,
 			text: $i18n.receive.icp.text.your_private_eth_address,
-			condition: $networkEthereumEnabled || $networkSepoliaEnabled
+			condition: $networkEthereumEnabled || $networkSepoliaEnabled || $networkEvmMainnetEnabled || $networkEvmTestnetEnabled
 		},
 		{
 			labelRef: 'icrcTokenAddress',

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -1,5 +1,9 @@
 import { enabledBitcoinNetworks } from '$btc/derived/networks.derived';
 import {
+	SUPPORTED_EVM_MAINNET_NETWORKS_IDS,
+	SUPPORTED_EVM_TESTNET_NETWORKS_IDS
+} from '$env/networks/networks-evm/networks.evm.env';
+import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID
@@ -58,6 +62,14 @@ export const networkEthereumEnabled: Readable<boolean> = derived([networks], ([$
 
 export const networkSepoliaEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
 	$networks.some(({ id }) => id === SEPOLIA_NETWORK_ID)
+);
+
+export const networkEvmMainnetEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
+	$networks.some(({ id }) => SUPPORTED_EVM_MAINNET_NETWORKS_IDS.includes(id))
+);
+
+export const networkEvmTestnetEnabled: Readable<boolean> = derived([networks], ([$networks]) =>
+	$networks.some(({ id }) => SUPPORTED_EVM_TESTNET_NETWORKS_IDS.includes(id))
 );
 
 export const networkEthereumDisabled: Readable<boolean> = derived(


### PR DESCRIPTION
# Motivation

We should include the EVM networks in the checks to load/verify the ETH address, since it is the same address for all of them. So, we create derived stores that are a mirror of the Ethereum ones and, apart form the ck-conversions, use them in the same exact code.

# Changes

- Create lists of EVM supported networks (mainnet and testnet).
- Derived store `networkEvmMainnetEnabled` that verifies if any EVM mainnet networks is enabled.
- Derived store `networkEvmTestnetEnabled` that verifies if any EVM testnet networks is enabled.
- Use the new derived stores in the same place as the respective Ethereum stores (apart form ck-conversions).

# Tests

Current tests are sufficient.
