### PR TITLE
feat(frontend): use convert wizard in HowToConvert flow

### DIFF
--- a/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
+++ b/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
@@ -1,36 +1,21 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
+	import { nonNullish } from '@dfinity/utils';
+	import FeeStoreContext from '$eth/components/fee/FeeStoreContext.svelte';
+	import { ethereumToken } from '$eth/derived/token.derived';
 	import HowToConvertEthereumModal from '$icp/components/convert/HowToConvertEthereumModal.svelte';
+	import type { IcCkToken, IcToken } from '$icp/types/ic-token';
 	import eth from '$icp-eth/assets/eth.svg';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { modalHowToConvertToTwinTokenEth } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { Token } from '$lib/types/token';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let twinToken: Token;
-	export let ckTokenSymbol: string;
+	export let sourceToken: IcToken;
+	export let destinationToken: IcCkToken;
 
 	const openReceive = () => modalStore.openHowToConvertToTwinTokenEth();
-
-	/**
-	 * Send modal context store
-	 */
-
-	const { sendToken, ...rest } = initSendContext({
-		sendPurpose:
-			twinToken.standard === 'erc20' ? 'convert-erc20-to-ckerc20' : 'convert-eth-to-cketh',
-		token: twinToken
-	});
-	setContext<SendContext>(SEND_CONTEXT_KEY, {
-		sendToken,
-		...rest
-	});
-
-	$: sendToken.set(twinToken);
 </script>
 
 <div class="pr-2">
@@ -38,38 +23,40 @@
 		<Logo
 			src={eth}
 			alt={replacePlaceholders($i18n.core.alt.logo, {
-				$name: twinToken.name
+				$name: sourceToken.name
 			})}
 		/>
 		<span class="w-[70%]"
 			>{replacePlaceholders($i18n.info.ethereum.title, {
-				$ckToken: ckTokenSymbol
+				$ckToken: destinationToken.symbol
 			})}</span
 		>
 	</h4>
 
 	<p class="mt-3 text-tertiary">
 		{replacePlaceholders(replaceOisyPlaceholders($i18n.info.ethereum.description), {
-			$token: twinToken.symbol,
-			$ckToken: ckTokenSymbol,
-			$network: twinToken.network.name
+			$token: sourceToken.symbol,
+			$ckToken: destinationToken.symbol,
+			$network: sourceToken.network.name
 		})}
 	</p>
 
 	<p class="mt-3 text-tertiary">
 		{replacePlaceholders(replaceOisyPlaceholders($i18n.info.ethereum.note), {
-			$token: twinToken.symbol,
-			$ckToken: ckTokenSymbol
+			$token: sourceToken.symbol,
+			$ckToken: destinationToken.symbol
 		})}
 	</p>
 
 	<button class="primary mt-6" disabled={$isBusy} on:click={openReceive}>
 		{replacePlaceholders($i18n.info.ethereum.how_to, {
-			$ckToken: ckTokenSymbol
+			$ckToken: destinationToken.symbol
 		})}</button
 	>
 </div>
 
-{#if $modalHowToConvertToTwinTokenEth}
-	<HowToConvertEthereumModal />
+{#if $modalHowToConvertToTwinTokenEth && nonNullish(sourceToken) && nonNullish(destinationToken)}
+	<FeeStoreContext token={$ethereumToken}>
+		<HowToConvertEthereumModal {sourceToken} {destinationToken} />
+	</FeeStoreContext>
 {/if}

--- a/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
+++ b/src/frontend/src/icp-eth/components/send/ConvertETHToCkETHWizard.svelte
@@ -12,6 +12,7 @@
 	import ReceiveAddressQRCode from '$lib/components/receive/ReceiveAddressQRCode.svelte';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { token } from '$lib/stores/token.store';
 	import type { Network } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
 
@@ -22,7 +23,12 @@
 	export let currentStep: WizardStep | undefined;
 
 	let steps: WizardSteps;
-	$: steps = howToConvertWizardSteps({ i18n: $i18n, twinToken: $ckEthereumTwinToken });
+	// TODO: this component will be removed completely after Receive modals are migrated to the Convert wizard
+	$: steps = howToConvertWizardSteps({
+		i18n: $i18n,
+		sourceToken: $ckEthereumTwinToken.symbol,
+		destinationToken: $token?.symbol ?? ''
+	});
 
 	// TODO: ETH or Sepolia for addressToken
 </script>

--- a/src/frontend/src/icp-eth/config/how-to-convert.config.ts
+++ b/src/frontend/src/icp-eth/config/how-to-convert.config.ts
@@ -1,39 +1,22 @@
-import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
-import { sendWizardSteps } from '$lib/config/send.config';
-import type { Token } from '$lib/types/token';
+import { convertWizardSteps, type ConvertWizardStepsParams } from '$lib/config/convert.config';
+import { WizardStepsHowToConvert } from '$lib/enums/wizard-steps';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import type { WizardSteps } from '@dfinity/gix-components';
 
 export const howToConvertWizardSteps = ({
 	i18n,
-	twinToken
-}: {
-	i18n: I18n;
-	twinToken: Token;
-}): WizardSteps => {
-	const [send, ...rest] = sendWizardSteps({ i18n });
-
-	const { id: tokenId, symbol } = twinToken;
-
-	return [
-		{
-			name: 'Info',
-			title: replacePlaceholders(i18n.info.ethereum.how_to_short, {
-				$token: symbol
-			})
-		},
-		{
-			name: 'ETH QR code',
-			title: i18n.receive.text.address
-		},
-		{
-			...send,
-			title: [SEPOLIA_TOKEN_ID, ETHEREUM_TOKEN_ID].includes(tokenId)
-				? i18n.convert.text.convert_to_cketh
-				: replacePlaceholders(i18n.convert.text.convert_to_ckerc20, {
-						$ckErc20: symbol
-					})
-		},
-		...rest
-	];
-};
+	sourceToken,
+	destinationToken
+}: ConvertWizardStepsParams): WizardSteps => [
+	{
+		name: WizardStepsHowToConvert.INFO,
+		title: replacePlaceholders(i18n.info.ethereum.how_to_short, {
+			$token: destinationToken
+		})
+	},
+	{
+		name: WizardStepsHowToConvert.ETH_QR_CODE,
+		title: i18n.receive.text.address
+	},
+	...convertWizardSteps({ i18n, sourceToken, destinationToken })
+];

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -17,9 +17,9 @@
 	import { HOW_TO_CONVERT_ETHEREUM_INFO } from '$lib/constants/test-ids.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 
@@ -30,7 +30,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	const { sendBalance, sendTokenDecimals, sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sourceTokenBalance, sourceToken } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 </script>
 
 <ContentWithToolbar testId={HOW_TO_CONVERT_ETHEREUM_INFO}>
@@ -119,11 +119,11 @@
 
 				<p class="mb-6">
 					{formatToken({
-						value: $sendBalance ?? ZERO_BI,
-						unitName: $sendTokenDecimals,
-						displayDecimals: $sendTokenDecimals
+						value: $sourceTokenBalance ?? ZERO_BI,
+						unitName: $sourceToken.decimals,
+						displayDecimals: $sourceToken.decimals
 					})}
-					{$sendToken.symbol}
+					{$sourceToken.symbol}
 				</p>
 			</Value>
 		</div>

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumModal.svelte
@@ -1,86 +1,81 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
-	import HowToConvertEthereumInfo from '$icp/components/convert/HowToConvertEthereumInfo.svelte';
-	import ConvertETHToCkETHWizard from '$icp-eth/components/send/ConvertETHToCkETHWizard.svelte';
+	import EthConvertTokenWizard from '$eth/components/convert/EthConvertTokenWizard.svelte';
+	import HowToConvertEthereumWizardSteps from '$icp/components/convert/HowToConvertEthereumWizardSteps.svelte';
 	import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
-	import {
-		ckEthereumTwinTokenStandard,
-		ckEthereumTwinToken,
-		ckEthereumNativeTokenId
-	} from '$icp-eth/derived/cketh.derived';
-	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
-	import {
-		toCkErc20HelperContractAddress,
-		toCkEthHelperContractAddress
-	} from '$icp-eth/utils/cketh.utils';
-	import { ProgressStepsSend } from '$lib/enums/progress-steps';
-	import { WizardStepsSend } from '$lib/enums/wizard-steps';
+	import ConvertContexts from '$lib/components/convert/ConvertContexts.svelte';
+	import { ProgressStepsConvert, ProgressStepsSend } from '$lib/enums/progress-steps';
+	import { WizardStepsHowToConvert, WizardStepsConvert } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { Network } from '$lib/types/network';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
-	/**
-	 * Props
-	 */
+	export let sourceToken: Token;
+	export let destinationToken: Token;
 
-	let destination = '';
-	$: destination =
-		$ckEthereumTwinTokenStandard === 'erc20'
-			? (toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]) ?? '')
-			: (toCkEthHelperContractAddress($ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]) ?? '');
-
-	let targetNetwork: Network | undefined = ICP_NETWORK;
-
-	let amount: number | undefined = undefined;
-	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
-
-	/**
-	 * Wizard modal
-	 */
+	let sendAmount: OptionAmount = undefined;
+	let receiveAmount: number | undefined = undefined;
+	let convertProgressStep: string = ProgressStepsConvert.INITIALIZATION;
 
 	let steps: WizardSteps;
-	$: steps = howToConvertWizardSteps({ i18n: $i18n, twinToken: $ckEthereumTwinToken });
+	$: steps = howToConvertWizardSteps({
+		i18n: $i18n,
+		sourceToken: sourceToken.symbol,
+		destinationToken: destinationToken.symbol
+	});
 
 	let currentStep: WizardStep | undefined;
 	let modal: WizardModal;
 
 	const close = () =>
 		closeModal(() => {
-			destination = '';
-			amount = undefined;
-			targetNetwork = undefined;
+			sendAmount = undefined;
+			receiveAmount = undefined;
 
-			sendProgressStep = ProgressStepsSend.INITIALIZATION;
+			convertProgressStep = ProgressStepsSend.INITIALIZATION;
 
 			currentStep = undefined;
 		});
+
+	const goToStep = (stepName: WizardStepsHowToConvert | WizardStepsConvert) =>
+		goToWizardStep({
+			modal,
+			steps,
+			stepName
+		});
 </script>
 
-<WizardModal
-	{steps}
-	bind:currentStep
-	bind:this={modal}
-	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING}
->
-	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
-
-	<ConvertETHToCkETHWizard
-		on:icBack={modal.back}
-		on:icNext={modal.next}
-		on:icClose={close}
-		on:icSendBack={() => modal.set(0)}
-		bind:destination
-		bind:targetNetwork
-		bind:amount
-		bind:sendProgressStep
-		{currentStep}
+<ConvertContexts {sourceToken} {destinationToken}>
+	<WizardModal
+		{steps}
+		bind:currentStep
+		bind:this={modal}
+		on:nnsClose={close}
+		disablePointerEvents={currentStep?.name === WizardStepsConvert.CONVERTING}
 	>
-		<HowToConvertEthereumInfo
-			on:icQRCode={modal.next}
-			on:icConvert={() => modal.set(2)}
-			formCancelAction="close"
-		/>
-	</ConvertETHToCkETHWizard>
-</WizardModal>
+		<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
+
+		<EthConvertTokenWizard
+			{currentStep}
+			formCancelAction="back"
+			bind:sendAmount
+			bind:receiveAmount
+			bind:convertProgressStep
+			on:icBack={() =>
+				currentStep?.name === WizardStepsConvert.CONVERT
+					? goToStep(WizardStepsHowToConvert.INFO)
+					: modal.back()}
+			on:icNext={modal.next}
+			on:icClose={close}
+		>
+			<HowToConvertEthereumWizardSteps
+				{currentStep}
+				on:icQRCode={() => goToStep(WizardStepsHowToConvert.ETH_QR_CODE)}
+				on:icConvert={() => goToStep(WizardStepsConvert.CONVERT)}
+				on:icBack={modal.back}
+			/>
+		</EthConvertTokenWizard>
+	</WizardModal>
+</ConvertContexts>

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -22,6 +22,7 @@
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { token } from '$lib/stores/token.store';
 	import type { Network } from '$lib/types/network';
 	import { closeModal } from '$lib/utils/modal.utils';
 
@@ -45,7 +46,12 @@
 	 */
 
 	let howToSteps: WizardSteps;
-	$: howToSteps = howToConvertWizardSteps({ i18n: $i18n, twinToken: $ckEthereumTwinToken });
+	// TODO: update this component to use Convert wizard
+	$: howToSteps = howToConvertWizardSteps({
+		i18n: $i18n,
+		sourceToken: $ckEthereumTwinToken.symbol,
+		destinationToken: $token?.symbol ?? ''
+	});
 
 	let steps: WizardSteps;
 	$: steps = [

--- a/src/frontend/src/tests/icp-eth/components/info/InfoEthereum.spec.ts
+++ b/src/frontend/src/tests/icp-eth/components/info/InfoEthereum.spec.ts
@@ -12,8 +12,8 @@ vi.mock('ethers/providers', () => {
 
 describe('InfoEthereum', () => {
 	const props = {
-		ckTokenSymbol: mockValidIcCkToken.symbol,
-		twinToken: mockValidIcToken
+		sourceToken: mockValidIcToken,
+		destinationToken: mockValidIcCkToken
 	};
 
 	it('should render title correctly', () => {

--- a/src/frontend/src/tests/icp/components/convert/HowToConvertEthereumModal.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/HowToConvertEthereumModal.spec.ts
@@ -1,8 +1,15 @@
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import {
+	FEE_CONTEXT_KEY,
+	initFeeContext,
+	initFeeStore,
+	type FeeContext
+} from '$eth/stores/fee.store';
 import HowToConvertEthereumModal from '$icp/components/convert/HowToConvertEthereumModal.svelte';
 import { HOW_TO_CONVERT_ETHEREUM_INFO } from '$lib/constants/test-ids.constants';
-import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import { render } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
 
 // We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
 vi.mock('ethers/providers', () => {
@@ -11,19 +18,28 @@ vi.mock('ethers/providers', () => {
 });
 
 describe('HowToConvertEthereumModal', () => {
+	const props = {
+		sourceToken: ETHEREUM_TOKEN,
+		destinationToken: ICP_TOKEN
+	};
+
 	const mockContext = () =>
-		new Map<symbol, SendContext>([
+		new Map<symbol, FeeContext>([
 			[
-				SEND_CONTEXT_KEY,
-				initSendContext({
-					sendPurpose: 'convert-eth-to-cketh',
-					token: ETHEREUM_TOKEN
+				FEE_CONTEXT_KEY,
+				initFeeContext({
+					feeStore: initFeeStore(),
+					feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
+					feeExchangeRateStore: writable(100),
+					feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
+					feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals)
 				})
 			]
 		]);
 
 	it('should render convert info on initial render', () => {
 		const { getByTestId } = render(HowToConvertEthereumModal, {
+			props,
 			context: mockContext()
 		});
 

--- a/src/frontend/src/tests/icp/components/convert/HowToConvertEthereumWizardSteps.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/HowToConvertEthereumWizardSteps.spec.ts
@@ -1,21 +1,26 @@
-import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import HowToConvertEthereumWizardSteps from '$icp/components/convert/HowToConvertEthereumWizardSteps.svelte';
 import {
 	HOW_TO_CONVERT_ETHEREUM_INFO,
 	HOW_TO_CONVERT_ETHEREUM_QR_CODE
 } from '$lib/constants/test-ids.constants';
 import { WizardStepsHowToConvert } from '$lib/enums/wizard-steps';
-import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import {
+	CONVERT_CONTEXT_KEY,
+	initConvertContext,
+	type ConvertContext
+} from '$lib/stores/convert.store';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('HowToConvertEthereumWizardSteps', () => {
 	const mockContext = () =>
-		new Map<symbol, SendContext>([
+		new Map<symbol, ConvertContext>([
 			[
-				SEND_CONTEXT_KEY,
-				initSendContext({
-					sendPurpose: 'convert-eth-to-cketh',
-					token: ETHEREUM_TOKEN
+				CONVERT_CONTEXT_KEY,
+				initConvertContext({
+					sourceToken: mockValidIcCkToken,
+					destinationToken: ICP_TOKEN
 				})
 			]
 		]);

--- a/src/frontend/src/tests/icp/components/info/Info.spec.ts
+++ b/src/frontend/src/tests/icp/components/info/Info.spec.ts
@@ -88,8 +88,7 @@ describe('Info', () => {
 			});
 		});
 
-		// TODO: unskip after Info components are migrated to the Convert wizard
-		it.skip('should not render bitcoin info if network is not enabled', async () => {
+		it('should not render bitcoin info if network is not enabled', async () => {
 			mockEnabledToken();
 			const { getByText } = render(Info);
 
@@ -104,8 +103,7 @@ describe('Info', () => {
 			});
 		});
 
-		// TODO: unskip after Info components are migrated to the Convert wizard
-		it.skip('should not render bitcoin info if page token is not set', async () => {
+		it('should not render bitcoin info if page token is not set', async () => {
 			mockEnabledToken(mockCkBtcToken);
 			const { getByText } = render(Info);
 


### PR DESCRIPTION
# Motivation

We need to migrate the HowToConvert modals from Send to Convert wizard. This update simplifies a lot of things but requires quite a few changes in all related components.

The current functionality of the modal stays unchanged, except of the wizard that gets opened on the "conversion" button click.

Note: I'll migrate the affected by this PR components to Svelte 5 in follow up PRs.


https://github.com/user-attachments/assets/4e82f321-be4c-4fc2-a354-3b9b4ad4a9d4


