### PR TITLE
feat(frontend): allow WizardStepsHowToConvert to be passed as stepName

### DIFF
--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -1,6 +1,7 @@
 import {
 	type WizardStepsAuthHelp,
 	type WizardStepsConvert,
+	type WizardStepsHowToConvert,
 	type WizardStepsSend
 } from '$lib/enums/wizard-steps';
 import { type WizardModal, type WizardSteps } from '@dfinity/gix-components';
@@ -12,7 +13,7 @@ export const goToWizardStep = ({
 }: {
 	modal: WizardModal;
 	steps: WizardSteps;
-	stepName: WizardStepsSend | WizardStepsConvert | WizardStepsAuthHelp;
+	stepName: WizardStepsSend | WizardStepsConvert | WizardStepsAuthHelp | WizardStepsHowToConvert;
 }) => {
 	const stepNumber = steps.findIndex(({ name }) => name === stepName);
 	modal.set(Math.max(stepNumber, 0));


### PR DESCRIPTION
# Motivation

One of the preparations needed for the next steps -  we need to allow WizardStepsHowToConvert to be passed as stepName.