### PR TITLE
refactor(frontend): export ConvertWizardStepsParams

### DIFF
--- a/src/frontend/src/lib/config/convert.config.ts
+++ b/src/frontend/src/lib/config/convert.config.ts
@@ -3,7 +3,7 @@ import type { WizardStepsParams } from '$lib/types/steps';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import type { WizardSteps } from '@dfinity/gix-components';
 
-interface ConvertWizardStepsParams extends WizardStepsParams {
+export interface ConvertWizardStepsParams extends WizardStepsParams {
 	sourceToken: string;
 	destinationToken: string;
 }


### PR DESCRIPTION
# Motivation

One of the preparations needed for the next steps - we need to export ConvertWizardStepsParams.
