### PR TITLE
feat(frontend): add ETH token group data

### DIFF
--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -4,6 +4,7 @@ import {
 	CKETH_EXPLORER_URL,
 	CKETH_SEPOLIA_EXPLORER_URL
 } from '$env/explorers.env';
+import { ETH_TOKEN_GROUP } from '$env/tokens/groups/groups.eth.env';
 import { EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
@@ -183,6 +184,7 @@ const CKETH_IC_DATA: IcCkInterface | undefined =
 				exchangeCoinId: 'ethereum',
 				position: 1,
 				twinToken: ETHEREUM_TOKEN,
+				groupData: ETH_TOKEN_GROUP,
 				explorerUrl: CKETH_EXPLORER_URL
 			}
 		: undefined;

--- a/src/frontend/src/env/tokens/groups/groups.eth.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.eth.env.ts
@@ -1,0 +1,9 @@
+import eth from '$icp-eth/assets/eth.svg';
+
+const ETH_TOKEN_GROUP_SYMBOL = 'ETH';
+
+export const ETH_TOKEN_GROUP = {
+	icon: eth,
+	name: 'Ethereum',
+	symbol: ETH_TOKEN_GROUP_SYMBOL
+};

--- a/src/frontend/src/env/tokens/tokens.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens.eth.env.ts
@@ -3,6 +3,7 @@ import {
 	ETHEREUM_NETWORK,
 	SEPOLIA_NETWORK
 } from '$env/networks/networks.eth.env';
+import { ETH_TOKEN_GROUP } from '$env/tokens/groups/groups.eth.env';
 import eth from '$icp-eth/assets/eth.svg';
 import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -23,6 +24,7 @@ export const ETHEREUM_TOKEN: RequiredTokenWithLinkedData = {
 	decimals: ETHEREUM_DEFAULT_DECIMALS,
 	icon: eth,
 	twinTokenSymbol: 'ckETH',
+	groupData: ETH_TOKEN_GROUP,
 	buy: {
 		onramperId: 'eth'
 	}


### PR DESCRIPTION
# Motivation

Splitting PR https://github.com/dfinity/oisy-wallet/pull/5918.

We are going to use `groupData` to group similar ("twin") tokens. Currently we are using different props depending on the type of token (for example `twinToken` for ICRC, or `twinTokenSymbol` for ERC20). With groupData, we aim to have a single center of aggregation for "twin" tokens.

In this PR we create the group for token ETH.
