### PR TITLE
fix(build): Fix code scanning alert no. 6: avoid possible race condition when creating ckERC20 tokens.

### DIFF
--- a/scripts/build.tokens.ckerc20.ts
+++ b/scripts/build.tokens.ckerc20.ts
@@ -15,7 +15,7 @@ import {
 } from '@dfinity/cketh';
 import { Principal } from '@dfinity/principal';
 import { fromNullable, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
-import { existsSync, writeFileSync } from 'node:fs';
+import { closeSync, existsSync, openSync, writeFileSync, writeSync } from 'node:fs';
 import { join } from 'node:path';
 import { agent, loadMetadata } from './build.tokens.utils';
 import { CK_ERC20_JSON_FILE } from './constants.mjs';
@@ -162,11 +162,16 @@ const saveTokenLogo = ({ name, logoData }: { name: EnvTokenSymbol; logoData: str
 		return;
 	}
 
+	// Open the file for writing only if it does not already exist (wx flag).
+	// This avoids a potential file system race condition warning.
+	const fd = openSync(file, 'wx');
+
 	const [encoding, encodedStr] = logoData.split(';')[1].split(',');
 
 	const svgContent = Buffer.from(encodedStr, encoding as BufferEncoding).toString('utf-8');
 
-	writeFileSync(file, svgContent, 'utf-8');
+	writeSync(fd, svgContent, 0, 'utf-8');
+	closeSync(fd);
 };
 
 const findCkErc20 = async () => {


### PR DESCRIPTION
# Motivation

Fixes https://github.com/dfinity/oisy-wallet/security/code-scanning/6

In the script to build ckERC20 tokens, there may be a race condition (CodeQL [js/file-system-race](https://github.com/github/codeql/blob/626c752a0b8cfd98bcf1f4b622d73bbe6f078a4c/javascript/ql/src/Security/CWE-367/FileSystemRace.ql)) when creating the logo file:

```ts
...
if (existsSync(file)) {
  return;
}
...
writeFileSync(file, svgContent, 'utf-8');
// The file may have changed since it was checked
...
```

So, to avoid it, we do similar to other scripts and open the file before writing it.

