### PR TITLE
fix(build): Fix code scanning alert no. 4: avoid possible race condition when updating `did` types

### DIFF
--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readdirSync } from 'node:fs';
-import { readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const deleteIndexes = async ({ dest = `./src/declarations` }) => {
@@ -50,7 +50,13 @@ export const idlFactory = ({ IDL }) => {`
 export const init = ({ IDL }) => {`
 					);
 
-					await writeFile(factoryPath, cleanInit, 'utf8');
+					// Open the file for writing only if it does not already exist (wx flag).
+					// This avoids a potential file system race condition warning.
+					const fd = await open(factoryPath, 'wx');
+
+					await writeFile(fd, cleanInit, 'utf8');
+
+					await fd.close();
 
 					resolve();
 				};


### PR DESCRIPTION
# Motivation

Fixes https://github.com/dfinity/oisy-wallet/security/code-scanning/4

In the script to update `did` types, there may be a race condition (CodeQL [js/file-system-race](https://github.com/github/codeql/blob/626c752a0b8cfd98bcf1f4b622d73bbe6f078a4c/javascript/ql/src/Security/CWE-367/FileSystemRace.ql)) when writing the file:

```ts
...
if (!existsSync(factoryPath)) {
  resolve();
  return;
}
...
await writeFile(factoryPath, cleanInit, 'utf8');
// The file may have changed since it was checked
...
```

So, to avoid it, we do similar to other scripts and open the file before writing it.

