### PR TITLE
refactor(frontend): ZERO_BI --> ZERO

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -5,7 +5,7 @@
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { OptionAmount } from '$lib/types/send';
@@ -26,11 +26,11 @@
 
 	const customValidate = (userAmount: bigint): Error | undefined => {
 		// calculate-UTXOs-fee endpoint only accepts "userAmount > 0"
-		if (invalidAmount(Number(userAmount)) || userAmount === ZERO_BI) {
+		if (invalidAmount(Number(userAmount)) || userAmount === ZERO) {
 			return new BtcAmountAssertionError($i18n.send.assertion.amount_invalid);
 		}
 
-		if (userAmount > ($sendBalance ?? ZERO_BI)) {
+		if (userAmount > ($sendBalance ?? ZERO)) {
 			return new BtcAmountAssertionError($i18n.send.assertion.insufficient_funds);
 		}
 	};

--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -6,7 +6,7 @@
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -47,11 +47,11 @@
 					}),
 					unitName: $sendTokenDecimals
 				})
-			: ZERO_BI;
+			: ZERO;
 
 		// If ETH, the balance should cover the user entered amount plus the min gas fee
 		if (isSupportedEthTokenId($sendTokenId)) {
-			const total = userAmount + ($minGasFee ?? ZERO_BI);
+			const total = userAmount + ($minGasFee ?? ZERO);
 
 			if (total > parsedSendBalance) {
 				return new InsufficientFundsError($i18n.send.assertion.insufficient_funds_for_gas);
@@ -66,7 +66,7 @@
 		}
 
 		// Finally, if ERC20, the ETH balance should be less or greater than the max gas fee
-		const ethBalance = $balancesStore?.[nativeEthereumToken.id]?.data ?? ZERO_BI;
+		const ethBalance = $balancesStore?.[nativeEthereumToken.id]?.data ?? ZERO;
 		if (nonNullish($maxGasFee) && ethBalance < $maxGasFee) {
 			return new InsufficientFundsError(
 				$i18n.send.assertion.insufficient_ethereum_funds_to_cover_the_fees

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -25,7 +25,7 @@
 	import { toCkEthHelperContractAddress } from '$icp-eth/utils/cketh.utils';
 	import SendProgress from '$lib/components/ui/InProgressWizard.svelte';
 	import WalletConnectModalTitle from '$lib/components/wallet-connect/WalletConnectModalTitle.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
@@ -139,7 +139,7 @@
 	let sendProgressStep: string = ProgressStepsSend.INITIALIZATION;
 
 	let amount: bigint;
-	$: amount = BigInt(firstTransaction?.value ?? ZERO_BI);
+	$: amount = BigInt(firstTransaction?.value ?? ZERO);
 
 	const send = async () => {
 		const { success } = await sendServices({

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -21,7 +21,7 @@ import {
 	toCkEthHelperContractAddress
 } from '$icp-eth/utils/cketh.utils';
 import { signTransaction } from '$lib/api/signer.api';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';
@@ -89,7 +89,7 @@ const erc20PrepareTransaction = async ({
 	return prepare({
 		data,
 		to: contractAddress,
-		amount: ZERO_BI,
+		amount: ZERO,
 		...rest
 	});
 };
@@ -165,7 +165,7 @@ const ckErc20HelperContractPrepareTransaction = async ({
 	return prepare({
 		data,
 		to: contractAddress,
-		amount: ZERO_BI,
+		amount: ZERO,
 		...rest
 	});
 };
@@ -224,7 +224,7 @@ const erc20ContractPrepareApprove = async ({
 	return prepare({
 		data,
 		to,
-		amount: ZERO_BI,
+		amount: ZERO,
 		...rest
 	});
 };
@@ -467,7 +467,7 @@ const resetExistingApprovalToZero = async (
 > =>
 	await prepareAndSignApproval({
 		...params,
-		amount: ZERO_BI
+		amount: ZERO
 	});
 
 const checkExistingApproval = async ({
@@ -494,7 +494,7 @@ const checkExistingApproval = async ({
 	}
 
 	// If the existing pre-approved amount is not enough but non-null, we need to reset the allowance first, before approving the new amount.
-	if (preApprovedAmount > ZERO_BI) {
+	if (preApprovedAmount > ZERO) {
 		await resetExistingApprovalToZero({
 			...rest,
 			token,

--- a/src/frontend/src/eth/utils/fee.utils.ts
+++ b/src/frontend/src/eth/utils/fee.utils.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { TransactionFeeData } from '$lib/types/transaction';
 import { isNullish } from '@dfinity/utils';
 
@@ -11,4 +11,4 @@ export const maxGasFee = ({
 export const minGasFee = ({
 	maxPriorityFeePerGas,
 	gas: estimatedGasFee
-}: TransactionFeeData): bigint => (maxPriorityFeePerGas ?? ZERO_BI) * estimatedGasFee;
+}: TransactionFeeData): bigint => (maxPriorityFeePerGas ?? ZERO) * estimatedGasFee;

--- a/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
+++ b/src/frontend/src/icp-eth/components/fee/FeeAmountDisplay.svelte
@@ -2,7 +2,7 @@
 	import { debounce, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -19,7 +19,7 @@
 
 	let balance: Exclude<OptionBalance, null>;
 	$: balance = nonNullish($balancesStore)
-		? ($balancesStore[feeTokenId]?.data ?? ZERO_BI)
+		? ($balancesStore[feeTokenId]?.data ?? ZERO)
 		: undefined;
 
 	let insufficientFeeFunds = false;

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumInfo.svelte
@@ -13,7 +13,7 @@
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { HOW_TO_CONVERT_ETHEREUM_INFO } from '$lib/constants/test-ids.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
@@ -63,7 +63,7 @@
 			<p class="break-normal pt-4">
 				{$i18n.convert.text.current_balance}&nbsp;<output class="font-bold"
 					>{formatToken({
-						value: $ckEthereumNativeTokenBalance ?? ZERO_BI,
+						value: $ckEthereumNativeTokenBalance ?? ZERO,
 						unitName: $ckEthereumNativeToken.decimals
 					})}
 					{$ckEthereumNativeToken.symbol}</output
@@ -119,7 +119,7 @@
 
 				<p class="mb-6">
 					{formatToken({
-						value: $sendBalance ?? ZERO_BI,
+						value: $sendBalance ?? ZERO,
 						unitName: $sendTokenDecimals,
 						displayDecimals: $sendTokenDecimals
 					})}

--- a/src/frontend/src/icp/components/convert/IcConvertForm.svelte
+++ b/src/frontend/src/icp/components/convert/IcConvertForm.svelte
@@ -11,7 +11,7 @@
 	import DestinationValue from '$lib/components/address/DestinationValue.svelte';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { IC_CONVERT_FORM_TEST_ID } from '$lib/constants/test-ids.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -61,10 +61,10 @@
 	let formattedMinterMinimumAmount: string | undefined;
 	$: formattedMinterMinimumAmount = formatToken({
 		value: isCkBtc
-			? ($ckBtcMinterInfoStore?.[$sourceToken.id]?.data.retrieve_btc_min_amount ?? ZERO_BI)
+			? ($ckBtcMinterInfoStore?.[$sourceToken.id]?.data.retrieve_btc_min_amount ?? ZERO)
 			: (fromNullable(
 					$ckEthMinterInfoStore?.[$ckEthereumNativeTokenId]?.data.minimum_withdrawal_amount ?? []
-				) ?? ZERO_BI),
+				) ?? ZERO),
 		unitName: $sourceToken.decimals,
 		displayDecimals: $sourceToken.decimals
 	});
@@ -81,7 +81,7 @@
 		? replacePlaceholders($i18n.send.assertion.not_enough_tokens_for_gas, {
 				$symbol: tokenForFee.symbol,
 				$balance: formatToken({
-					value: $balanceForFee ?? ZERO_BI,
+					value: $balanceForFee ?? ZERO,
 					unitName: tokenForFee.decimals,
 					displayDecimals: tokenForFee.decimals
 				})

--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -5,18 +5,12 @@
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
 	import { eip1559TransactionPriceStore } from '$icp/stores/cketh.store';
-	import {
-		ETHEREUM_FEE_CONTEXT_KEY,
-		type EthereumFeeContext
-	} from '$icp/stores/ethereum-fee.store';
+	import { ETHEREUM_FEE_CONTEXT_KEY, type EthereumFeeContext } from '$icp/stores/ethereum-fee.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import { isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 	import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
-	import {
-		isConvertCkErc20ToErc20,
-		isConvertCkEthToEth
-	} from '$icp-eth/utils/cketh-transactions.utils';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { isConvertCkErc20ToErc20, isConvertCkEthToEth } from '$icp-eth/utils/cketh-transactions.utils';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { tokenId } from '$lib/derived/token.derived';
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
@@ -53,7 +47,7 @@
 	// See https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/ckerc20.adoc#withdrawal-ckerc20-to-erc20
 	let maxTransactionFeePlusLedgerApproveCkEth: bigint | undefined = undefined;
 	$: maxTransactionFeePlusLedgerApproveCkEth = nonNullish(maxTransactionFeeCkEth)
-		? maxTransactionFeeCkEth + (tokenCkEth?.fee ?? ZERO_BI)
+		? maxTransactionFeeCkEth + (tokenCkEth?.fee ?? ZERO)
 		: undefined;
 
 	let maxTransactionFee: bigint | undefined = undefined;

--- a/src/frontend/src/icp/components/send/IcSendAmount.svelte
+++ b/src/frontend/src/icp/components/send/IcSendAmount.svelte
@@ -4,10 +4,7 @@
 	import { ethereumFeeTokenCkEth } from '$icp/derived/ethereum-fee.derived';
 	import { tokenCkErc20Ledger, tokenCkEthLedger } from '$icp/derived/ic-token.derived';
 	import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
-	import {
-		ETHEREUM_FEE_CONTEXT_KEY,
-		type EthereumFeeContext
-	} from '$icp/stores/ethereum-fee.store';
+	import { ETHEREUM_FEE_CONTEXT_KEY, type EthereumFeeContext } from '$icp/stores/ethereum-fee.store';
 	import { IcAmountAssertionError } from '$icp/types/ic-send';
 	import type { OptionIcToken } from '$icp/types/ic-token';
 	import { assertCkBTCUserInputAmount } from '$icp/utils/ckbtc.utils';
@@ -21,7 +18,7 @@
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { balance } from '$lib/derived/balances.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -88,9 +85,9 @@
 		}
 
 		const assertBalance = (): IcAmountAssertionError | undefined => {
-			const total = userAmount + (fee ?? ZERO_BI);
+			const total = userAmount + (fee ?? ZERO);
 
-			if (total > ($balance ?? ZERO_BI)) {
+			if (total > ($balance ?? ZERO)) {
 				return new IcAmountAssertionError($i18n.send.assertion.insufficient_funds);
 			}
 
@@ -158,7 +155,7 @@
 					error={nonNullish(amountError)}
 					balance={$sendBalance}
 					token={$sendToken}
-					fee={fee ?? ZERO_BI}
+					fee={fee ?? ZERO}
 				/>
 			{/if}
 		</svelte:fragment>

--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -2,7 +2,7 @@ import { getLedgerId, getTransactions as getTransactionsIcrc } from '$icp/api/ic
 import { balance, metadata } from '$icp/api/icrc-ledger.api';
 import type { IcCanisters, IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
 import { mapIcrcToken } from '$icp/utils/icrc.utils';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -190,7 +190,7 @@ const loadIndexBalance = async ({
 			indexCanisterId,
 			identity,
 			owner: identity.getPrincipal(),
-			maxResults: ZERO_BI,
+			maxResults: ZERO,
 			certified: true
 		});
 

--- a/src/frontend/src/icp/utils/ckbtc.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc.utils.ts
@@ -1,6 +1,6 @@
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
 import { IcAmountAssertionError } from '$icp/types/ic-send';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { Option } from '$lib/types/utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -19,7 +19,7 @@ export const assertCkBTCUserInputAmount = ({
 }): IcAmountAssertionError | undefined => {
 	// We skip validation checks here for zero because it makes the UI/UX ungraceful.
 	// e.g. user enters 0. and an error gets displayed.
-	if (amount === ZERO_BI) {
+	if (amount === ZERO) {
 		return undefined;
 	}
 
@@ -32,7 +32,7 @@ export const assertCkBTCUserInputAmount = ({
 		certified: infoCertified
 	} = minterInfo;
 
-	if ((amount ?? ZERO_BI) < retrieveBtcMinAmount) {
+	if ((amount ?? ZERO) < retrieveBtcMinAmount) {
 		return new IcAmountAssertionError(
 			replacePlaceholders(i18n.send.assertion.minimum_ckbtc_amount, {
 				$amount: formatToken({

--- a/src/frontend/src/icp/utils/cketh.utils.ts
+++ b/src/frontend/src/icp/utils/cketh.utils.ts
@@ -2,7 +2,7 @@ import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
 import type { EthereumFeeStoreData } from '$icp/stores/ethereum-fee.store';
 import { IcAmountAssertionError } from '$icp/types/ic-send';
 import type { IcToken } from '$icp/types/ic-token';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { OptionBalance } from '$lib/types/balance';
 import type { Option } from '$lib/types/utils';
 import { formatToken } from '$lib/utils/format.utils';
@@ -24,7 +24,7 @@ export const assertCkETHMinWithdrawalAmount = ({
 }): IcAmountAssertionError | undefined => {
 	// We skip validation checks here for zero because it makes the UI/UX ungraceful.
 	// e.g. user enters 0. and an error gets displayed.
-	if (amount === ZERO_BI) {
+	if (amount === ZERO) {
 		return undefined;
 	}
 
@@ -38,9 +38,9 @@ export const assertCkETHMinWithdrawalAmount = ({
 	} = minterInfo;
 
 	// The `minimum_withdrawal_amount` is optional in the minter info because the team decided to make all fields optional for maintainability reasons. That's why we assume that it is most likely set.
-	const minWithdrawalAmount = fromNullable(minimum_withdrawal_amount) ?? ZERO_BI;
+	const minWithdrawalAmount = fromNullable(minimum_withdrawal_amount) ?? ZERO;
 
-	if ((amount ?? ZERO_BI) < minWithdrawalAmount) {
+	if ((amount ?? ZERO) < minWithdrawalAmount) {
 		return new IcAmountAssertionError(
 			replacePlaceholders(i18n.send.assertion.minimum_cketh_amount, {
 				$amount: formatToken({
@@ -73,7 +73,7 @@ export const assertCkETHMinFee = ({
 }): IcAmountAssertionError | undefined => {
 	// We skip validation checks here for zero because it makes the UI/UX ungraceful.
 	// e.g. user enters 0. and an error gets displayed.
-	if (amount === ZERO_BI) {
+	if (amount === ZERO) {
 		return undefined;
 	}
 
@@ -99,10 +99,10 @@ export const assertCkETHBalanceEstimatedFee = ({
 	feeStoreData: EthereumFeeStoreData;
 	i18n: I18n;
 }): IcAmountAssertionError | undefined => {
-	const ethBalance = balance ?? ZERO_BI;
+	const ethBalance = balance ?? ZERO;
 
 	// We skip validation checks here for zero balance because it makes the UI/UX ungraceful if the balance is just not yet loaded.
-	if (ethBalance === ZERO_BI) {
+	if (ethBalance === ZERO) {
 		return undefined;
 	}
 
@@ -112,7 +112,7 @@ export const assertCkETHBalanceEstimatedFee = ({
 
 	const { decimals, symbol } = tokenCkEth;
 
-	const estimatedFee = feeStoreData?.maxTransactionFee ?? ZERO_BI;
+	const estimatedFee = feeStoreData?.maxTransactionFee ?? ZERO;
 
 	if (estimatedFee > ethBalance) {
 		return new IcAmountAssertionError(

--- a/src/frontend/src/icp/utils/icp-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icp-transactions.utils.ts
@@ -1,11 +1,11 @@
 import { ICP_EXPLORER_URL } from '$env/explorers.env';
 import type {
+	IcpTransaction,
 	IcTransactionAddOnsInfo,
-	IcTransactionUi,
-	IcpTransaction
+	IcTransactionUi
 } from '$icp/types/ic-transaction';
 import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Tokens, Transaction, TransactionWithId } from '@dfinity/ledger-icp';
 import { fromNullable, jsonReplacer, nonNullish } from '@dfinity/utils';
@@ -93,7 +93,7 @@ export const mapIcpTransaction = ({
 		incoming: boolean | undefined;
 		fee: Tokens;
 		amount: Tokens;
-	}): bigint => amount.e8s + (incoming === false ? fee.e8s : ZERO_BI);
+	}): bigint => amount.e8s + (incoming === false ? fee.e8s : ZERO);
 
 	if ('Approve' in operation) {
 		return {

--- a/src/frontend/src/icp/utils/icrc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icrc-transactions.utils.ts
@@ -1,10 +1,10 @@
 import type {
+	IcrcTransaction,
 	IcTransactionType,
-	IcTransactionUi,
-	IcrcTransaction
+	IcTransactionUi
 } from '$icp/types/ic-transaction';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
 import { encodeIcrcAccount, type IcrcTransactionWithId } from '@dfinity/ledger-icrc';
 import {
@@ -118,12 +118,12 @@ export const mapIcrcTransaction = ({
 					: 'receive';
 
 	const value = isApprove
-		? ZERO_BI
+		? ZERO
 		: nonNullish(data?.amount)
 			? data.amount +
 				(isTransfer && source.incoming === false
-					? (fromNullishNullable(fromNullable(transfer)?.fee) ?? ZERO_BI)
-					: ZERO_BI)
+					? (fromNullishNullable(fromNullable(transfer)?.fee) ?? ZERO)
+					: ZERO)
 			: undefined;
 
 	return {

--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { MAX_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionBalance } from '$lib/types/balance';
@@ -16,7 +16,7 @@
 	export let fee: bigint | undefined = undefined;
 
 	let isZeroBalance: boolean;
-	$: isZeroBalance = isNullish(balance) || balance === ZERO_BI;
+	$: isZeroBalance = isNullish(balance) || balance === ZERO;
 
 	let maxAmount: number | undefined;
 	$: maxAmount = nonNullish(token)

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -4,7 +4,7 @@
 	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
@@ -49,7 +49,7 @@
 		});
 
 	let isZeroBalance: boolean;
-	$: isZeroBalance = isNullish($sourceTokenBalance) || $sourceTokenBalance === ZERO_BI;
+	$: isZeroBalance = isNullish($sourceTokenBalance) || $sourceTokenBalance === ZERO;
 
 	let maxAmount: number | undefined;
 	$: maxAmount = nonNullish(totalFee)

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -3,7 +3,7 @@
 	import { getContext } from 'svelte';
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { AMOUNT_DATA } from '$lib/constants/test-ids.constants';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -19,7 +19,7 @@
 		data-tid={AMOUNT_DATA}
 		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"
 	>
-		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !(token.balance === ZERO_BI)}
+		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !(token.balance === ZERO)}
 			<Amount amount={token.balance} decimals={token.decimals} symbol={token.symbol} />
 		{:else}
 			<span class:animate-pulse={$loading}>0.00</span>

--- a/src/frontend/src/lib/components/rewards/RewardEarnings.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardEarnings.svelte
@@ -8,11 +8,10 @@
 	import type { IcToken } from '$icp/types/ic-token';
 	import RewardEarningsCard from '$lib/components/rewards/RewardEarningsCard.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { exchanges } from '$lib/derived/exchange.derived';
 	import { networkId } from '$lib/derived/network.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
@@ -28,7 +27,7 @@
 
 	let ckBtcToken: IcToken | undefined;
 	$: ckBtcToken = findTwinToken({ tokenToPair: BTC_MAINNET_TOKEN, tokens: $tokens });
-	let ckBtcReward: bigint = ZERO_BI;
+	let ckBtcReward: bigint = ZERO;
 	let ckBtcRewardUsd: number;
 	$: ckBtcRewardUsd = nonNullish(ckBtcToken)
 		? (calculateTokenUsdAmount({
@@ -40,7 +39,7 @@
 
 	let ckUsdcToken: IcToken | undefined;
 	$: ckUsdcToken = findTwinToken({ tokenToPair: USDC_TOKEN, tokens: $tokens });
-	let ckUsdcReward: bigint = ZERO_BI;
+	let ckUsdcReward: bigint = ZERO;
 	let ckUsdcRewardUsd: number;
 	$: ckUsdcRewardUsd = nonNullish(ckUsdcToken)
 		? (calculateTokenUsdAmount({
@@ -50,7 +49,7 @@
 			}) ?? 0)
 		: 0;
 
-	let icpReward: bigint = ZERO_BI;
+	let icpReward: bigint = ZERO;
 	let icpRewardUsd: number;
 	$: icpRewardUsd =
 		calculateTokenUsdAmount({

--- a/src/frontend/src/lib/components/rewards/RewardEarningsCard.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardEarningsCard.svelte
@@ -4,7 +4,7 @@
 	import Sprinkles from '$lib/components/sprinkles/Sprinkles.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
-	import { EIGHT_DECIMALS, ZERO_BI } from '$lib/constants/app.constants';
+	import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 	import type { AmountString } from '$lib/types/amount';
 	import { formatToken, formatUSD } from '$lib/utils/format.utils';
 
@@ -26,13 +26,13 @@
 
 {#if nonNullish(token)}
 	<div
-		class={`relative w-1/3 rounded-xl p-2 text-center text-sm text-primary-inverted md:text-base ${amount > ZERO_BI ? 'bg-success-primary' : 'bg-tertiary-inverted'}`}
+		class={`relative w-1/3 rounded-xl p-2 text-center text-sm text-primary-inverted md:text-base ${amount > ZERO ? 'bg-success-primary' : 'bg-tertiary-inverted'}`}
 		class:transition={loading}
 		class:duration-500={loading}
 		class:ease-in-out={loading}
 		class:animate-pulse={loading}
 	>
-		{#if amount > ZERO_BI}
+		{#if amount > ZERO}
 			<Sprinkles type="box" />
 		{/if}
 

--- a/src/frontend/src/lib/components/send/SendSource.svelte
+++ b/src/frontend/src/lib/components/send/SendSource.svelte
@@ -2,7 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionBalance } from '$lib/types/balance';
 	import type { OptionToken } from '$lib/types/token';
@@ -22,7 +22,7 @@
 	<svelte:fragment slot="label">{$i18n.send.text.balance}</svelte:fragment>
 	{#if nonNullish(token)}
 		<ExchangeAmountDisplay
-			amount={balance ?? ZERO_BI}
+			amount={balance ?? ZERO}
 			decimals={token.decimals}
 			symbol={token.symbol}
 			{exchangeRate}

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -18,14 +18,11 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { SWAP_SLIPPAGE_INVALID_VALUE } from '$lib/constants/swap.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import {
-		SWAP_AMOUNTS_CONTEXT_KEY,
-		type SwapAmountsContext
-	} from '$lib/stores/swap-amounts.store';
+	import { SWAP_AMOUNTS_CONTEXT_KEY, type SwapAmountsContext } from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
@@ -74,7 +71,7 @@
 
 	let totalFee: bigint | undefined;
 	// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
-	$: totalFee = (sourceTokenFee ?? ZERO_BI) * ($isSourceTokenIcrc2 ? 2n : 1n);
+	$: totalFee = (sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n);
 
 	let swapAmountsLoading = false;
 	$: swapAmountsLoading =

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -6,7 +6,7 @@
 	import IconExpand from '$lib/components/icons/IconExpand.svelte';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { TOKEN_GROUP } from '$lib/constants/test-ids.constants';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -50,7 +50,7 @@
 	// list of tokens that should display with a "show more" button for not displayed ones
 	let truncatedTokens: TokenUi[];
 	$: truncatedTokens = filteredTokens.filter((token) => {
-		const totalBalance = filteredTokens.reduce((p, c) => p + BigInt(c.balance ?? 0n), ZERO_BI);
+		const totalBalance = filteredTokens.reduce((p, c) => p + BigInt(c.balance ?? 0n), ZERO);
 		// Only include tokens with a balance
 		return (
 			(token.balance ?? 0n) > 0n ||

--- a/src/frontend/src/lib/components/tokens/TokenInputBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputBalance.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import type { Balance } from '$lib/types/balance';
 	import type { Token } from '$lib/types/token';
 	import { formatToken } from '$lib/utils/format.utils';
@@ -15,7 +15,7 @@
 
 	<div class="ml-1 font-semibold">
 		{formatToken({
-			value: balance ?? ZERO_BI,
+			value: balance ?? ZERO,
 			unitName: token.decimals
 		})}
 		{token.symbol}

--- a/src/frontend/src/lib/components/ui/Amount.svelte
+++ b/src/frontend/src/lib/components/ui/Amount.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { EIGHT_DECIMALS, ZERO_BI } from '$lib/constants/app.constants';
+	import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 	import { formatToken } from '$lib/utils/format.utils';
 
 	export let amount: bigint;
@@ -23,7 +23,7 @@
 	});
 </script>
 
-<span class:text-success-primary={formatPositiveAmount && amount > ZERO_BI}>
+<span class:text-success-primary={formatPositiveAmount && amount > ZERO}>
 	<data value={detailedValue}>
 		{displayValue}
 	</data>

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -120,7 +120,7 @@ export const NANO_SECONDS_IN_MINUTE = NANO_SECONDS_IN_SECOND * 60n;
 // Just a value that looks good visually.
 export const EIGHT_DECIMALS = 8;
 
-export const ZERO_BI = 0n;
+export const ZERO = 0n;
 
 // Wallets
 export const WALLET_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 2) * 1000; // 30 seconds in milliseconds

--- a/src/frontend/src/lib/derived/balances.derived.ts
+++ b/src/frontend/src/lib/derived/balances.derived.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { token } from '$lib/stores/token.store';
@@ -20,7 +20,7 @@ export const balanceZero: Readable<boolean> = derived(
 		nonNullish($balanceStore) &&
 		nonNullish($token) &&
 		nonNullish($balanceStore?.[$token.id]) &&
-		$balanceStore[$token.id]?.data === ZERO_BI
+		$balanceStore[$token.id]?.data === ZERO
 );
 
 // TODO: Create tests for this store

--- a/src/frontend/src/lib/derived/swap.derived.ts
+++ b/src/frontend/src/lib/derived/swap.derived.ts
@@ -1,7 +1,7 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { isIcToken } from '$icp/validation/ic-token.validation';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { allKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
 import { pageToken } from '$lib/derived/page-token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
@@ -50,7 +50,7 @@ export const swappableTokens: Readable<SwappableTokens> = derived(
 			return { sourceToken: undefined, destinationToken: undefined };
 		}
 
-		if (balance > ZERO_BI) {
+		if (balance > ZERO) {
 			return { sourceToken: selectedToken, destinationToken: undefined };
 		}
 		return { sourceToken: undefined, destinationToken: selectedToken };

--- a/src/frontend/src/lib/services/reward.services.ts
+++ b/src/frontend/src/lib/services/reward.services.ts
@@ -13,7 +13,7 @@ import {
 	getUserInfo as getUserInfoApi,
 	setReferrer as setReferrerApi
 } from '$lib/api/reward.api';
-import { MILLISECONDS_IN_DAY, ZERO_BI } from '$lib/constants/app.constants';
+import { MILLISECONDS_IN_DAY, ZERO } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { AlreadyClaimedError, InvalidCodeError, UserNotVipError } from '$lib/types/errors';
@@ -76,7 +76,7 @@ const queryRewards = async (params: {
 
 	return {
 		rewards: nonNullish(awards) ? awards.map(mapRewardsInfo) : [],
-		lastTimestamp: fromNullable(last_snapshot_timestamp) ?? ZERO_BI
+		lastTimestamp: fromNullable(last_snapshot_timestamp) ?? ZERO
 	};
 };
 
@@ -109,7 +109,7 @@ export const getRewards = async (params: { identity: Identity }): Promise<Reward
 		});
 	}
 
-	return { rewards: [], lastTimestamp: ZERO_BI };
+	return { rewards: [], lastTimestamp: ZERO };
 };
 
 const updateReward = async (identity: Identity): Promise<VipReward> => {
@@ -337,9 +337,9 @@ export const getUserRewardsTokenAmounts = async ({
 	amountOfRewards: number;
 }> => {
 	const initialRewards = {
-		ckBtcReward: ZERO_BI,
-		ckUsdcReward: ZERO_BI,
-		icpReward: ZERO_BI,
+		ckBtcReward: ZERO,
+		ckUsdcReward: ZERO,
+		icpReward: ZERO,
 		amountOfRewards: 0
 	};
 

--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -25,7 +25,7 @@ import { registerAirdropRecipient } from '$lib/api/reward.api';
 import {
 	NANO_SECONDS_IN_MILLISECOND,
 	NANO_SECONDS_IN_SECOND,
-	ZERO_BI
+	ZERO
 } from '$lib/constants/app.constants';
 import {
 	btcAddressMainnet,
@@ -89,8 +89,8 @@ const toBaseTransaction = ({
 	'value' | 'timestamp'
 >): Omit<Transaction_Icrc | Transaction_Spl, 'counterparty'> => ({
 	transaction_type: toTransactionType(type),
-	timestamp: (timestamp ?? ZERO_BI) * NANO_SECONDS_IN_SECOND,
-	amount: value ?? ZERO_BI,
+	timestamp: (timestamp ?? ZERO) * NANO_SECONDS_IN_SECOND,
+	amount: value ?? ZERO,
 	network: {}
 });
 
@@ -105,7 +105,7 @@ const toIcrcTransaction = ({
 
 	return {
 		...toBaseTransaction({ type, value, timestamp }),
-		timestamp: timestamp ?? ZERO_BI,
+		timestamp: timestamp ?? ZERO,
 		// TODO: use correct value when the Rewards canister is updated to accept account identifiers
 		counterparty: Principal.anonymous()
 	};
@@ -128,8 +128,8 @@ const toSplTransaction = ({
 		// TODO: this is a temporary hack to release v1. Adjust as soon as the rewards canister has more tokens.
 		...toBaseTransaction({
 			type: type === 'deposit' ? 'send' : type === 'withdraw' ? 'receive' : type,
-			value: BigInt(value ?? ZERO_BI),
-			timestamp: BigInt(timestamp ?? ZERO_BI)
+			value: BigInt(value ?? ZERO),
+			timestamp: BigInt(timestamp ?? ZERO)
 		}),
 		// in case it's a BTC tx, "to" is an array
 		counterparty: address === from ? (Array.isArray(to) ? to[0] : to) : from
@@ -287,7 +287,7 @@ const takeAccountSnapshots = (timestamp: bigint): AccountSnapshotFor[] => {
 	return allTokens.reduce<AccountSnapshotFor[]>((acc, token) => {
 		const balance = balances[token.id]?.data;
 
-		if (isNullish(balance) || balance === ZERO_BI) {
+		if (isNullish(balance) || balance === ZERO) {
 			return acc;
 		}
 

--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Network } from '$lib/types/network';
@@ -44,7 +44,7 @@ export const initModalTokensListContext = (
 			});
 
 			return $filterZeroBalance
-				? pinnedWithBalance.filter(({ balance }) => (balance ?? ZERO_BI) > ZERO_BI)
+				? pinnedWithBalance.filter(({ balance }) => (balance ?? ZERO) > ZERO)
 				: pinnedWithBalance;
 		}
 	);

--- a/src/frontend/src/lib/utils/assert-amount.utils.ts
+++ b/src/frontend/src/lib/utils/assert-amount.utils.ts
@@ -1,6 +1,6 @@
 import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { Balance } from '$lib/types/balance';
 import type { TokenActionErrorType } from '$lib/types/token-action';
 import type { Option } from '$lib/types/utils';
@@ -53,7 +53,7 @@ const assertMinterInfo = ({
 		'retrieve_btc_min_amount' in data
 			? data.retrieve_btc_min_amount
 			: 'minimum_withdrawal_amount' in data
-				? (fromNullable(data.minimum_withdrawal_amount) ?? ZERO_BI)
+				? (fromNullable(data.minimum_withdrawal_amount) ?? ZERO)
 				: undefined;
 
 	if (nonNullish(minimumAmount) && userAmount < minimumAmount) {

--- a/src/frontend/src/lib/utils/balances.utils.ts
+++ b/src/frontend/src/lib/utils/balances.utils.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { type BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TokenId } from '$lib/types/token';
@@ -11,7 +11,7 @@ export const checkAnyNonZeroBalance = ($balancesStore: CertifiedStoreData<Balanc
 		(tokenId) =>
 			!(
 				isNullish($balancesStore[tokenId as TokenId]?.data) ||
-				$balancesStore[tokenId as TokenId]?.data === ZERO_BI
+				$balancesStore[tokenId as TokenId]?.data === ZERO
 			)
 	);
 
@@ -38,5 +38,5 @@ export const checkAllBalancesZero = ({
 	Object.getOwnPropertySymbols($balancesStore).every((tokenId) => {
 		const balance: Option<BalancesData> = $balancesStore[tokenId as TokenId];
 
-		return balance === null || balance?.data === ZERO_BI || balance?.data === null;
+		return balance === null || balance?.data === ZERO || balance?.data === null;
 	});

--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -1,5 +1,5 @@
 import type { LedgerCanisterIdText } from '$icp/types/canister';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { OptionBalance } from '$lib/types/balance';
 import type {
 	CoingeckoSimpleTokenPrice,
@@ -26,7 +26,7 @@ export const usdValue = ({
 					displayDecimals: decimals
 				})
 			) * exchangeRate
-		: Number(ZERO_BI);
+		: Number(ZERO);
 
 export const formatKongSwapToCoingeckoPrices = (
 	tokens: KongSwapToken[]

--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { getRewards } from '$lib/services/reward.services';
 import type { RewardResponseInfo, RewardResult } from '$lib/types/reward';
 import type { Identity } from '@dfinity/agent';
@@ -47,4 +47,4 @@ export const isUpcomingCampaign = (startDate: Date) => {
 };
 
 export const getRewardsBalance = (rewards: RewardResponseInfo[]): bigint =>
-	rewards.reduce<bigint>((total, { amount }) => total + amount, ZERO_BI);
+	rewards.reduce<bigint>((total, { amount }) => total + amount, ZERO);

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -1,6 +1,6 @@
 import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
 import { isIcToken } from '$icp/validation/ic-token.validation';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { ProviderFee } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { findToken } from '$lib/utils/tokens.utils';
@@ -44,7 +44,7 @@ export const getNetworkFee = ({
 	}
 
 	return {
-		fee: transactions.reduce((acc, { gas_fee }) => acc + gas_fee, ZERO_BI),
+		fee: transactions.reduce((acc, { gas_fee }) => acc + gas_fee, ZERO),
 		token
 	};
 };

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { TokenId, TokenUi } from '$lib/types/token';
 import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-group';
 import { sumBalances, sumUsdBalances } from '$lib/utils/token.utils';
@@ -42,14 +42,13 @@ export const groupTokensByTwin = (tokens: TokenUi[]): TokenUiOrGroupUi[] => {
 
 			return (
 				(b.usdBalance ?? 0) - (a.usdBalance ?? 0) ||
-				+((b.balance ?? ZERO_BI) > (a.balance ?? ZERO_BI)) -
-					+((b.balance ?? ZERO_BI) < (a.balance ?? ZERO_BI))
+				+((b.balance ?? ZERO) > (a.balance ?? ZERO)) - +((b.balance ?? ZERO) < (a.balance ?? ZERO))
 			);
 		});
 };
 
 const hasBalance = ({ token, showZeroBalances }: { token: TokenUi; showZeroBalances: boolean }) =>
-	Number(token.balance ?? ZERO_BI) || Number(token.usdBalance ?? ZERO_BI) || showZeroBalances;
+	Number(token.balance ?? ZERO) || Number(token.usdBalance ?? ZERO) || showZeroBalances;
 
 /**
  * Function to create a list of TokenUiOrGroupUi, filtering out all groups that do not have at least

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -6,7 +6,7 @@ import { ERC20_SUGGESTED_TOKENS } from '$env/tokens/tokens.erc20.env';
 import type { ContractAddressText } from '$eth/types/address';
 import type { IcCkToken } from '$icp/types/ic-token';
 import { isIcCkToken } from '$icp/validation/ic-token.validation';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { OptionBalance } from '$lib/types/balance';
@@ -31,7 +31,7 @@ import { isNullish, nonNullish } from '@dfinity/utils';
  */
 export const getMaxTransactionAmount = ({
 	balance,
-	fee = ZERO_BI,
+	fee = ZERO,
 	tokenDecimals,
 	tokenStandard
 }: {
@@ -41,11 +41,11 @@ export const getMaxTransactionAmount = ({
 	tokenStandard: TokenStandard;
 }): number => {
 	const value =
-		(balance ?? ZERO_BI) - (tokenStandard !== 'erc20' && tokenStandard !== 'spl' ? fee : ZERO_BI);
+		(balance ?? ZERO) - (tokenStandard !== 'erc20' && tokenStandard !== 'spl' ? fee : ZERO);
 
 	return Number(
-		value <= ZERO_BI
-			? ZERO_BI
+		value <= ZERO
+			? ZERO
 			: formatToken({
 					value,
 					unitName: tokenDecimals,

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -1,6 +1,6 @@
 import { icTokenIcrcCustomToken, isDeprecatedSns } from '$icp/utils/icrc.utils';
 import { isIcCkToken, isIcToken } from '$icp/validation/ic-token.validation';
-import { LOCAL, ZERO_BI } from '$lib/constants/app.constants';
+import { LOCAL, ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
@@ -102,7 +102,7 @@ export const pinTokensWithBalanceAtTop = <T extends Token>({
 				$exchanges
 			});
 
-			return (tokenUI.usdBalance ?? 0) > 0 || (tokenUI.balance ?? ZERO_BI) > 0
+			return (tokenUI.usdBalance ?? 0) > 0 || (tokenUI.balance ?? ZERO) > 0
 				? [[...acc[0], tokenUI], acc[1]]
 				: [acc[0], [...acc[1], tokenUI]];
 		},
@@ -113,8 +113,8 @@ export const pinTokensWithBalanceAtTop = <T extends Token>({
 		...positiveBalances.sort(
 			(a, b) =>
 				(b.usdBalance ?? 0) - (a.usdBalance ?? 0) ||
-				+((b.balance ?? ZERO_BI) > (a.balance ?? ZERO_BI)) -
-					+((b.balance ?? ZERO_BI) < (a.balance ?? ZERO_BI)) ||
+				+((b.balance ?? ZERO) > (a.balance ?? ZERO)) -
+					+((b.balance ?? ZERO) < (a.balance ?? ZERO)) ||
 				a.name.localeCompare(b.name) ||
 				a.network.name.localeCompare(b.network.name)
 		),

--- a/src/frontend/src/lib/utils/user-amount.utils.ts
+++ b/src/frontend/src/lib/utils/user-amount.utils.ts
@@ -6,7 +6,7 @@ import {
 	isTokenCkErc20Ledger,
 	isTokenCkEthLedger
 } from '$icp/utils/ic-send.utils';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { Balance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
 import type { TokenActionErrorType } from '$lib/types/token-action';
@@ -51,7 +51,7 @@ export const validateUserAmount = ({
 				}),
 				unitName: token.decimals
 			})
-		: ZERO_BI;
+		: ZERO;
 
 	// if the function called in the swap flow, we only need to check the basic assertAmount condition
 	// if convert or send - we identify token type and check some network-specific conditions
@@ -67,7 +67,7 @@ export const validateUserAmount = ({
 		return assertErc20Amount({
 			userAmount,
 			balance: parsedSendBalance,
-			balanceForFee: balanceForFee ?? ZERO_BI,
+			balanceForFee: balanceForFee ?? ZERO,
 			fee
 		});
 	}
@@ -94,7 +94,7 @@ export const validateUserAmount = ({
 		return assertCkErc20Amount({
 			userAmount,
 			balance: parsedSendBalance,
-			balanceForFee: balanceForFee ?? ZERO_BI,
+			balanceForFee: balanceForFee ?? ZERO,
 			ethereumEstimateFee,
 			fee
 		});

--- a/src/frontend/src/sol/components/send/SolSendAmount.svelte
+++ b/src/frontend/src/sol/components/send/SolSendAmount.svelte
@@ -10,7 +10,7 @@
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -18,11 +18,7 @@
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import { invalidAmount } from '$lib/utils/input.utils';
-	import {
-		isNetworkIdSOLDevnet,
-		isNetworkIdSOLLocal,
-		isNetworkIdSOLTestnet
-	} from '$lib/utils/network.utils';
+	import { isNetworkIdSOLDevnet, isNetworkIdSOLLocal, isNetworkIdSOLTestnet } from '$lib/utils/network.utils';
 	import { type FeeContext, SOL_FEE_CONTEXT_KEY } from '$sol/stores/sol-fee.store';
 	import { SolAmountAssertionError } from '$sol/types/sol-send';
 
@@ -48,12 +44,12 @@
 				: SOLANA_TOKEN;
 
 	const customValidate = (userAmount: bigint): Error | undefined => {
-		if (invalidAmount(Number(userAmount)) || userAmount === ZERO_BI) {
+		if (invalidAmount(Number(userAmount)) || userAmount === ZERO) {
 			return new SolAmountAssertionError($i18n.send.assertion.amount_invalid);
 		}
 
 		if (nonNullish($sendBalance) && $sendTokenStandard === 'solana') {
-			const total = userAmount + ($fee ?? ZERO_BI);
+			const total = userAmount + ($fee ?? ZERO);
 
 			if (total > $sendBalance) {
 				return new InsufficientFundsError($i18n.send.assertion.insufficient_funds_for_gas);
@@ -62,11 +58,11 @@
 			return;
 		}
 
-		if (userAmount > ($sendBalance ?? ZERO_BI)) {
+		if (userAmount > ($sendBalance ?? ZERO)) {
 			return new InsufficientFundsError($i18n.send.assertion.insufficient_funds);
 		}
 
-		const solBalance = $balancesStore?.[solanaNativeToken.id]?.data ?? ZERO_BI;
+		const solBalance = $balancesStore?.[solanaNativeToken.id]?.data ?? ZERO;
 		if (nonNullish($fee) && solBalance < $fee) {
 			return new InsufficientFundsError(
 				$i18n.send.assertion.insufficient_solana_funds_to_cover_the_fees
@@ -108,7 +104,7 @@
 					error={nonNullish(amountError)}
 					balance={$sendBalance}
 					token={$sendToken}
-					fee={$fee ?? ZERO_BI}
+					fee={$fee ?? ZERO}
 				/>
 			{/if}
 		</svelte:fragment>

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -14,11 +14,8 @@
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
-	import {
-		TRACK_COUNT_SOL_SEND_ERROR,
-		TRACK_COUNT_SOL_SEND_SUCCESS
-	} from '$lib/constants/analytics.contants';
-	import { ZERO_BI } from '$lib/constants/app.constants';
+	import { TRACK_COUNT_SOL_SEND_ERROR, TRACK_COUNT_SOL_SEND_SUCCESS } from '$lib/constants/analytics.contants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import {
 		solAddressDevnet,
 		solAddressLocal,
@@ -52,10 +49,10 @@
 	import { sendSteps } from '$sol/constants/steps.constants';
 	import { sendSol } from '$sol/services/sol-send.services';
 	import {
-		SOL_FEE_CONTEXT_KEY,
 		type FeeContext as FeeContextType,
 		initFeeContext,
-		initFeeStore
+		initFeeStore,
+		SOL_FEE_CONTEXT_KEY
 	} from '$sol/stores/sol-fee.store';
 
 	export let currentStep: WizardStep | undefined;
@@ -164,7 +161,7 @@
 					value: `${amount}`,
 					unitName: $sendTokenDecimals
 				}),
-				prioritizationFee: $prioritizationFeeStore ?? ZERO_BI,
+				prioritizationFee: $prioritizationFeeStore ?? ZERO,
 				destination,
 				source
 			});

--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { ProgressStepsSendSol } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { OptionSolAddress, SolAddress } from '$lib/types/address';
@@ -311,7 +311,7 @@ export const sendSol = async ({
 	progress(ProgressStepsSendSol.SIGN);
 
 	const { signedTransaction, signature } = await signTransaction(
-		prioritizationFee > ZERO_BI ? transactionMessageWithComputeUnitPrice : transactionMessage
+		prioritizationFee > ZERO ? transactionMessageWithComputeUnitPrice : transactionMessage
 	);
 
 	progress(ProgressStepsSendSol.SEND);

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -5,7 +5,7 @@ import {
 	SOLANA_TESTNET_TOKEN_ID,
 	SOLANA_TOKEN_ID
 } from '$env/tokens/tokens.sol.env';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
 import { getSolTransactions } from '$sol/services/sol-signatures.services';
@@ -145,8 +145,8 @@ export const fetchSolTransactionsForSignature = async ({
 				...accCumulativeBalances,
 				// We include WSOL in the calculation, because it is used to affect the SOL balance of the ATA.
 				...((isNullish(mappedTokenAddress) || mappedTokenAddress === WSOL_TOKEN.address) && {
-					[from]: (accCumulativeBalances[from] ?? ZERO_BI) - value,
-					[to]: (accCumulativeBalances[to] ?? ZERO_BI) + value
+					[from]: (accCumulativeBalances[from] ?? ZERO) - value,
+					[to]: (accCumulativeBalances[to] ?? ZERO) + value
 				})
 			};
 
@@ -164,7 +164,7 @@ export const fetchSolTransactionsForSignature = async ({
 			const newTransaction: SolTransactionUi = {
 				id: `${signature.signature}-${idx}-${instruction.programId}`,
 				signature: signature.signature,
-				timestamp: blockTime ?? ZERO_BI,
+				timestamp: blockTime ?? ZERO,
 				value,
 				type: address === from || ataAddress === from ? 'send' : 'receive',
 				from,
@@ -173,8 +173,7 @@ export const fetchSolTransactionsForSignature = async ({
 				// Since the fee is assigned to a single signature, it is not entirely correct to assign it to each transaction.
 				// Particularly, we are repeating the same fee for each instruction in the transaction.
 				// However, we should have it anyway saved in the transaction, so we can display it in the UI.
-				...(nonNullish(fee) &&
-					nonNullish(feePayer) && { fee: address === feePayer ? fee : ZERO_BI })
+				...(nonNullish(fee) && nonNullish(feePayer) && { fee: address === feePayer ? fee : ZERO })
 			};
 
 			return {

--- a/src/frontend/src/sol/services/spl-accounts.services.ts
+++ b/src/frontend/src/sol/services/spl-accounts.services.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import { checkIfAccountExists, loadTokenBalance } from '$sol/api/solana.api';
 import type { SolanaNetworkType } from '$sol/types/network';
@@ -79,5 +79,5 @@ export const loadSplTokenBalance = async ({
 		network
 	});
 
-	return balance ?? ZERO_BI;
+	return balance ?? ZERO;
 };

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import {
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
@@ -207,7 +207,7 @@ const mapTokenParsedInstruction = async ({
 
 		// In case of `closeAccount` transaction we take the accumulated balance of SOL (or WSOL) of the Associated Token Account (this is the `from` address).
 		// We do this because the entire amount of SOL (or WSOL) is redeemed by the owner of the ATA.
-		const value = cumulativeBalances?.[from] ?? ZERO_BI;
+		const value = cumulativeBalances?.[from] ?? ZERO;
 
 		return { value, from, to };
 	}

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { SolTransactionMessage } from '$sol/types/sol-send';
 import type { MappedSolTransaction } from '$sol/types/sol-transaction';
 import { mapSolInstruction } from '$sol/utils/sol-instructions.utils';
@@ -44,7 +44,7 @@ export const mapSolTransactionMessage = ({
 
 			return {
 				...acc,
-				amount: nonNullish(amount) ? (acc.amount ?? ZERO_BI) + amount : acc.amount,
+				amount: nonNullish(amount) ? (acc.amount ?? ZERO) + amount : acc.amount,
 				source,
 				destination,
 				payer

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -7,7 +7,7 @@ import {
 	mapAddressToName,
 	mapEthTransactionUi
 } from '$eth/utils/transactions.utils';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { EthAddress, OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
@@ -27,8 +27,8 @@ const transaction: Transaction = {
 	to: '0xabcd',
 	timestamp: 1670000000,
 	nonce: 1,
-	gasLimit: ZERO_BI,
-	value: ZERO_BI,
+	gasLimit: ZERO,
+	value: ZERO,
 	chainId: 1n
 };
 

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -3,7 +3,7 @@ import { autoLoadCustomToken, setCustomToken } from '$icp-eth/services/custom-to
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { BackendCanister } from '$lib/canisters/backend.canister';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
@@ -121,7 +121,7 @@ describe('custom-token.services', () => {
 
 					await assertSetCustomToken({
 						customTokens,
-						expectedVersion: [customTokens[0].version ?? ZERO_BI],
+						expectedVersion: [customTokens[0].version ?? ZERO],
 						indexCanisterId
 					});
 				}

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -2,7 +2,7 @@ import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { loadAndAssertAddCustomToken } from '$icp/services/ic-add-custom-tokens.service';
 import type { IcCanisters, IcToken } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -375,7 +375,7 @@ describe('ic-add-custom-tokens.service', () => {
 					expect(spyGetTransactions).toHaveBeenNthCalledWith(1, {
 						account: getIcrcAccount(mockIdentity.getPrincipal()),
 						certified: true,
-						max_results: ZERO_BI,
+						max_results: ZERO,
 						start: undefined
 					});
 				});

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -4,7 +4,7 @@ import { mapIcpTransaction } from '$icp/utils/icp-transactions.utils';
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
 import { initIcpWalletScheduler } from '$icp/workers/icp-wallet.worker';
 import { initIcrcWalletScheduler } from '$icp/workers/icrc-wallet.worker';
-import { WALLET_TIMER_INTERVAL_MILLIS, ZERO_BI } from '$lib/constants/app.constants';
+import { WALLET_TIMER_INTERVAL_MILLIS, ZERO } from '$lib/constants/app.constants';
 import * as authUtils from '$lib/utils/auth.utils';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import type { TestUtil } from '$tests/types/utils';
@@ -465,7 +465,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 		const mockTransaction: TransactionWithIdIcp = {
 			id: 123n,
 			transaction: {
-				memo: ZERO_BI,
+				memo: ZERO,
 				icrc1_memo: [],
 				operation: {
 					Transfer: {

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -10,7 +10,7 @@ import type {
 
 import { BackendCanister } from '$lib/canisters/backend.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { AddUserCredentialParams, BtcSelectUserUtxosFeeParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
@@ -50,7 +50,7 @@ describe('backend.canister', () => {
 	const addUserCredentialParams = {
 		credentialJwt: 'test-credential-jwt',
 		issuerCanisterId: mockPrincipal,
-		currentUserVersion: ZERO_BI,
+		currentUserVersion: ZERO,
 		credentialSpec: {
 			arguments: [],
 			credential_type: ''
@@ -615,7 +615,7 @@ describe('backend.canister', () => {
 				Ok: {
 					status: { Executed: null }, // or { Skipped: null } or { Failed: null }, depending on your scenario
 					challenge_completion: [], // Provide appropriately if challenge completion data exists
-					allowed_cycles: ZERO_BI // Replace with proper value
+					allowed_cycles: ZERO // Replace with proper value
 				}
 			};
 

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountSource.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountSource.svelte.spec.ts
@@ -1,6 +1,6 @@
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import ConvertAmountSource from '$lib/components/convert/ConvertAmountSource.svelte';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { TOKEN_INPUT_AMOUNT_EXCHANGE } from '$lib/constants/test-ids.constants';
 import { CONVERT_CONTEXT_KEY } from '$lib/stores/convert.store';
 import { TOKEN_ACTION_VALIDATION_ERRORS_CONTEXT_KEY } from '$lib/stores/token-action-validation-errors.store';
@@ -145,7 +145,7 @@ describe('ConvertAmountSource', () => {
 
 		const { getByTestId } = render(ConvertAmountSource, {
 			props: testProps,
-			context: mockContext(ZERO_BI)
+			context: mockContext(ZERO)
 		});
 
 		await fireEvent.click(getByTestId(balanceTestId));

--- a/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
@@ -1,5 +1,5 @@
 import { ICP_TOKEN, ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import { swappableTokens } from '$lib/derived/swap.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { bn2Bi } from '$tests/mocks/balances.mock';
@@ -34,7 +34,7 @@ describe('swap.derived', () => {
 
 			balancesStore.set({
 				tokenId: ICP_TOKEN_ID,
-				data: { data: ZERO_BI, certified: true }
+				data: { data: ZERO, certified: true }
 			});
 
 			const tokens = get(swappableTokens);

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -10,7 +10,7 @@ import * as rewardApi from '$lib/api/reward.api';
 import {
 	MILLISECONDS_IN_DAY,
 	NANO_SECONDS_IN_MILLISECOND,
-	ZERO_BI
+	ZERO
 } from '$lib/constants/app.constants';
 import {
 	claimVipReward,
@@ -525,9 +525,9 @@ describe('reward-code', () => {
 						getMockReward({ ledgerCanisterId: null, amount: 1000n }),
 						getMockReward({ ledgerCanisterId: 'invalid', amount: 1000n }),
 						getMockReward({ ledgerCanisterId: undefined, amount: 1000n }),
-						getMockReward({ ledgerCanisterId: mockCkBtcToken.ledgerCanisterId, amount: ZERO_BI }),
-						getMockReward({ ledgerCanisterId: mockCkUsdcToken.ledgerCanisterId, amount: ZERO_BI }),
-						getMockReward({ ledgerCanisterId: mockIcpToken.ledgerCanisterId, amount: ZERO_BI })
+						getMockReward({ ledgerCanisterId: mockCkBtcToken.ledgerCanisterId, amount: ZERO }),
+						getMockReward({ ledgerCanisterId: mockCkUsdcToken.ledgerCanisterId, amount: ZERO }),
+						getMockReward({ ledgerCanisterId: mockIcpToken.ledgerCanisterId, amount: ZERO })
 					]
 				]
 			});

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -16,7 +16,7 @@ import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import type { IcCkToken } from '$icp/types/ic-token';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { registerAirdropRecipient } from '$lib/api/reward.api';
-import { NANO_SECONDS_IN_MILLISECOND, ZERO_BI } from '$lib/constants/app.constants';
+import { NANO_SECONDS_IN_MILLISECOND, ZERO } from '$lib/constants/app.constants';
 import * as addressStore from '$lib/derived/address.derived';
 import * as authStore from '$lib/derived/auth.derived';
 import * as exchangeDerived from '$lib/derived/exchange.derived';
@@ -92,8 +92,8 @@ describe('user-snapshot.services', () => {
 					last_transactions: mockIcTransactions.slice(0, 5).map(
 						({ value, timestamp }: IcTransactionUi): Transaction_Icrc => ({
 							transaction_type: { Send: null },
-							timestamp: timestamp ?? ZERO_BI,
-							amount: value ?? ZERO_BI,
+							timestamp: timestamp ?? ZERO,
+							amount: value ?? ZERO,
 							network: {},
 							counterparty: Principal.anonymous()
 						})
@@ -157,8 +157,8 @@ describe('user-snapshot.services', () => {
 					last_transactions: mockSolTransactions.slice(0, 5).map(
 						({ value, timestamp, to }: SolTransactionUi): Transaction_Spl => ({
 							transaction_type: { Send: null },
-							timestamp: (timestamp ?? ZERO_BI) * NANO_SECONDS_IN_MILLISECOND,
-							amount: value ?? ZERO_BI,
+							timestamp: (timestamp ?? ZERO) * NANO_SECONDS_IN_MILLISECOND,
+							amount: value ?? ZERO,
 							network: {},
 							counterparty: to ?? ''
 						})
@@ -324,11 +324,11 @@ describe('user-snapshot.services', () => {
 		it('should not include tokens with zero balance', async () => {
 			balancesStore.set({
 				tokenId: mockValidIcToken.id,
-				data: { data: ZERO_BI, certified }
+				data: { data: ZERO, certified }
 			});
 			balancesStore.set({
 				tokenId: ETHEREUM_TOKEN.id,
-				data: { data: ZERO_BI, certified }
+				data: { data: ZERO, certified }
 			});
 
 			await registerUserSnapshot();

--- a/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
@@ -3,7 +3,7 @@ import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcToken } from '$icp/types/ic-token';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import * as exchanges from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { initModalTokensListContext } from '$lib/stores/modal-tokens-list.store';
@@ -122,7 +122,7 @@ describe('modalTokensListStore', () => {
 
 		balancesStore.set({
 			tokenId: mockToken2.id,
-			data: { data: ZERO_BI, certified: true }
+			data: { data: ZERO, certified: true }
 		});
 
 		expect(get(filterNetwork)).toBe(ICP_NETWORK);

--- a/src/frontend/src/tests/lib/utils/balances.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/balances.utils.spec.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import { checkAllBalancesZero, checkAnyNonZeroBalance } from '$lib/utils/balances.utils';
@@ -8,7 +8,7 @@ describe('checkAnyNonZeroBalance', () => {
 	it('should return true if there is at least one non-zero balance', () => {
 		const mockBalancesStore: CertifiedStoreData<BalancesData> = {
 			[Symbol('token1')]: { data: bn1Bi },
-			[Symbol('token2')]: { data: ZERO_BI }
+			[Symbol('token2')]: { data: ZERO }
 		} as unknown as CertifiedStoreData<BalancesData>;
 
 		expect(checkAnyNonZeroBalance(mockBalancesStore)).toBe(true);
@@ -25,8 +25,8 @@ describe('checkAnyNonZeroBalance', () => {
 
 	it('should return false if all balances are zero', () => {
 		const mockBalancesStore = {
-			[Symbol('token1')]: { data: ZERO_BI },
-			[Symbol('token2')]: { data: ZERO_BI }
+			[Symbol('token1')]: { data: ZERO },
+			[Symbol('token2')]: { data: ZERO }
 		} as unknown as CertifiedStoreData<BalancesData>;
 
 		expect(checkAnyNonZeroBalance(mockBalancesStore)).toBe(false);
@@ -63,7 +63,7 @@ describe('checkAllBalancesZero', () => {
 	it('should return false if there is at least one non-zero balance', () => {
 		const mockBalancesStore: CertifiedStoreData<BalancesData> = {
 			[Symbol('token1')]: { data: bn1Bi },
-			[Symbol('token2')]: { data: ZERO_BI }
+			[Symbol('token2')]: { data: ZERO }
 		} as unknown as CertifiedStoreData<BalancesData>;
 
 		expect(checkAllBalancesZero({ $balancesStore: mockBalancesStore, minLength: 1 })).toBe(false);
@@ -80,7 +80,7 @@ describe('checkAllBalancesZero', () => {
 
 	it('should return false if there is at least one zero balance and one undefined balance', () => {
 		const mockBalancesStore = {
-			[Symbol('token1')]: { data: ZERO_BI },
+			[Symbol('token1')]: { data: ZERO },
 			[Symbol('token2')]: undefined
 		} as unknown as CertifiedStoreData<BalancesData>;
 
@@ -89,7 +89,7 @@ describe('checkAllBalancesZero', () => {
 
 	it('should return true if there is at least one zero balance and one null balance', () => {
 		const mockBalancesStore = {
-			[Symbol('token1')]: { data: ZERO_BI },
+			[Symbol('token1')]: { data: ZERO },
 			[Symbol('token2')]: null
 		} as unknown as CertifiedStoreData<BalancesData>;
 
@@ -98,8 +98,8 @@ describe('checkAllBalancesZero', () => {
 
 	it('should return true if all balances are zero', () => {
 		const mockBalancesStore = {
-			[Symbol('token1')]: { data: ZERO_BI },
-			[Symbol('token2')]: { data: ZERO_BI }
+			[Symbol('token1')]: { data: ZERO },
+			[Symbol('token2')]: { data: ZERO }
 		} as unknown as CertifiedStoreData<BalancesData>;
 
 		expect(checkAllBalancesZero({ $balancesStore: mockBalancesStore, minLength: 1 })).toBe(true);
@@ -133,8 +133,8 @@ describe('checkAllBalancesZero', () => {
 
 	it('should return false if minimum length is not met', () => {
 		const mockBalancesStore = {
-			[Symbol('token1')]: { data: ZERO_BI },
-			[Symbol('token2')]: { data: ZERO_BI }
+			[Symbol('token1')]: { data: ZERO },
+			[Symbol('token2')]: { data: ZERO }
 		} as unknown as CertifiedStoreData<BalancesData>;
 
 		expect(checkAllBalancesZero({ $balancesStore: mockBalancesStore, minLength: 3 })).toBe(false);
@@ -142,9 +142,9 @@ describe('checkAllBalancesZero', () => {
 
 	it('should return true if minimum length is met', () => {
 		const mockBalancesStore = {
-			[Symbol('token1')]: { data: ZERO_BI },
-			[Symbol('token2')]: { data: ZERO_BI },
-			[Symbol('token3')]: { data: ZERO_BI }
+			[Symbol('token1')]: { data: ZERO },
+			[Symbol('token2')]: { data: ZERO },
+			[Symbol('token3')]: { data: ZERO }
 		} as unknown as CertifiedStoreData<BalancesData>;
 
 		expect(checkAllBalancesZero({ $balancesStore: mockBalancesStore, minLength: 3 })).toBe(true);

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import {
 	formatSecondsToNormalizedDate,
 	formatToken,
@@ -68,19 +68,19 @@ describe('format.utils', () => {
 		});
 
 		it('should format zero with default parameters', () => {
-			expect(formatToken({ value: ZERO_BI })).toBe('0');
+			expect(formatToken({ value: ZERO })).toBe('0');
 		});
 
 		it('should format zero with specified displayDecimals', () => {
-			expect(formatToken({ value: ZERO_BI, displayDecimals: 2 })).toBe('0');
+			expect(formatToken({ value: ZERO, displayDecimals: 2 })).toBe('0');
 		});
 
 		it('should format zero with trailing zeros', () => {
-			expect(formatToken({ value: ZERO_BI, trailingZeros: true })).toBe('0.0000');
+			expect(formatToken({ value: ZERO, trailingZeros: true })).toBe('0.0000');
 		});
 
 		it('should format zero with specified displayDecimals and trailing zeros', () => {
-			expect(formatToken({ value: ZERO_BI, displayDecimals: 2, trailingZeros: true })).toBe('0.00');
+			expect(formatToken({ value: ZERO, displayDecimals: 2, trailingZeros: true })).toBe('0.00');
 		});
 
 		it('should format value with different unitName', () => {
@@ -298,7 +298,7 @@ describe('format.utils', () => {
 
 			expect(
 				formatTokenBigintToNumber({
-					value: ZERO_BI
+					value: ZERO
 				})
 			).toBe(0);
 		});

--- a/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
@@ -1,6 +1,6 @@
 import type { RewardInfo, UserData } from '$declarations/rewards/rewards.did';
 import * as rewardApi from '$lib/api/reward.api';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { RewardResponseInfo } from '$lib/types/reward';
 import {
 	INITIAL_REWARD_RESULT,
@@ -234,7 +234,7 @@ describe('rewards.utils', () => {
 
 			const result = getRewardsBalance(mockedRewards);
 
-			expect(result).toEqual(ZERO_BI);
+			expect(result).toEqual(ZERO);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -2,7 +2,7 @@ import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_SYMBOL, ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import {
 	getKongIcTokenIdentifier,
 	getLiquidityFees,
@@ -14,7 +14,7 @@ import { mockTokens } from '$tests/mocks/tokens.mock';
 
 describe('swap utils', () => {
 	const ICP_LP_FEE = 4271n;
-	const ICP_GAS_FEE = ZERO_BI;
+	const ICP_GAS_FEE = ZERO;
 
 	const ETH_LP_FEE = 4267n;
 	const ETH_GAS_FEE = 10000n;

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { TokenUi } from '$lib/types/token';
 import type { TokenUiGroup } from '$lib/types/token-group';
 import {
@@ -252,7 +252,7 @@ describe('token-group.utils', () => {
 				{ ...tokens[0], balance: bn2Bi, usdBalance: 0 }, // BTC
 				{ ...tokens[2], balance: bn2Bi, usdBalance: 0 }, // ETH
 				{ ...tokens[3], balance: bn1Bi, usdBalance: 0 }, // ckETH
-				{ ...tokens[1], balance: ZERO_BI, usdBalance: 0 } // ckBTC
+				{ ...tokens[1], balance: ZERO, usdBalance: 0 } // ckBTC
 			];
 
 			const groupedTokens = groupTokensByTwin(reorderedTokens as TokenUi[]);
@@ -275,9 +275,9 @@ describe('token-group.utils', () => {
 
 	describe('filterTokenGroups', () => {
 		const reorderedTokens = [
-			{ ...tokens[0], balance: ZERO_BI, usdBalance: 0 }, // BTC
-			{ ...tokens[4], balance: ZERO_BI, usdBalance: 0 }, // ICP
-			{ ...tokens[1], balance: ZERO_BI, usdBalance: 0 } // ckBTC
+			{ ...tokens[0], balance: ZERO, usdBalance: 0 }, // BTC
+			{ ...tokens[4], balance: ZERO, usdBalance: 0 }, // ICP
+			{ ...tokens[1], balance: ZERO, usdBalance: 0 } // ckBTC
 		];
 
 		it('should give me all token groups', () => {
@@ -292,7 +292,7 @@ describe('token-group.utils', () => {
 			const customReorderedTokens = [
 				...reorderedTokens,
 				{ ...tokens[2], balance: bn2Bi, usdBalance: 0 }, // ETH
-				{ ...tokens[3], balance: ZERO_BI, usdBalance: 0 } // ckETH
+				{ ...tokens[3], balance: ZERO, usdBalance: 0 } // ckETH
 			];
 			const groupedTokens = groupTokensByTwin(customReorderedTokens as TokenUi[]);
 
@@ -309,8 +309,8 @@ describe('token-group.utils', () => {
 		it('should give me only token groups where at least one token has a usd balance', () => {
 			const customReorderedTokens = [
 				...reorderedTokens,
-				{ ...tokens[2], balance: ZERO_BI, usdBalance: 0 }, // ETH
-				{ ...tokens[3], balance: ZERO_BI, usdBalance: 1 } // ckETH
+				{ ...tokens[2], balance: ZERO, usdBalance: 0 }, // ETH
+				{ ...tokens[3], balance: ZERO, usdBalance: 1 } // ckETH
 			];
 			const groupedTokens = groupTokensByTwin(customReorderedTokens as TokenUi[]);
 

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -17,7 +17,7 @@ import {
 	SOLANA_TOKEN
 } from '$env/tokens/tokens.sol.env';
 import * as appContants from '$lib/constants/app.constants';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { ExchangesData } from '$lib/types/exchange';
@@ -213,9 +213,9 @@ describe('pinTokensWithBalanceAtTop', () => {
 
 	it('should return the same array if all tokens have no balance', () => {
 		const newBalances: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: ZERO_BI, certified },
-			[BTC_MAINNET_TOKEN.id]: { data: ZERO_BI, certified },
-			[ETHEREUM_TOKEN.id]: { data: ZERO_BI, certified }
+			[ICP_TOKEN.id]: { data: ZERO, certified },
+			[BTC_MAINNET_TOKEN.id]: { data: ZERO, certified },
+			[ETHEREUM_TOKEN.id]: { data: ZERO, certified }
 		};
 
 		const result = pinTokensWithBalanceAtTop({
@@ -233,9 +233,9 @@ describe('pinTokensWithBalanceAtTop', () => {
 
 	it('should sort only tokens with non-zero balances and leave untouched the rest', () => {
 		const newBalances: CertifiedStoreData<BalancesData> = {
-			[ICP_TOKEN.id]: { data: ZERO_BI, certified },
+			[ICP_TOKEN.id]: { data: ZERO, certified },
 			[BTC_MAINNET_TOKEN.id]: { data: bn1Bi, certified },
-			[ETHEREUM_TOKEN.id]: { data: ZERO_BI, certified }
+			[ETHEREUM_TOKEN.id]: { data: ZERO, certified }
 		};
 
 		const result = pinTokensWithBalanceAtTop({
@@ -368,10 +368,10 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 
 	it('should return a dictionary with correct balances if all token balances are 0', () => {
 		const balances = {
-			[ICP_TOKEN.id]: { data: ZERO_BI, certified },
-			[BTC_MAINNET_TOKEN.id]: { data: ZERO_BI, certified },
-			[ETHEREUM_TOKEN.id]: { data: ZERO_BI, certified },
-			[BTC_TESTNET_TOKEN.id]: { data: ZERO_BI, certified }
+			[ICP_TOKEN.id]: { data: ZERO, certified },
+			[BTC_MAINNET_TOKEN.id]: { data: ZERO, certified },
+			[ETHEREUM_TOKEN.id]: { data: ZERO, certified },
+			[BTC_TESTNET_TOKEN.id]: { data: ZERO, certified }
 		};
 		const tokens = [...mockTokens, BTC_TESTNET_TOKEN];
 
@@ -382,9 +382,9 @@ describe('sumMainnetTokensUsdBalancesPerNetwork', () => {
 		});
 
 		expect(result).toEqual({
-			[BTC_MAINNET_NETWORK_ID]: Number(ZERO_BI),
-			[ETHEREUM_NETWORK_ID]: Number(ZERO_BI),
-			[ICP_NETWORK_ID]: Number(ZERO_BI)
+			[BTC_MAINNET_NETWORK_ID]: Number(ZERO),
+			[ETHEREUM_NETWORK_ID]: Number(ZERO),
+			[ICP_NETWORK_ID]: Number(ZERO)
 		});
 	});
 

--- a/src/frontend/src/tests/mocks/sol-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-transactions.mock.ts
@@ -1,4 +1,4 @@
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import {
 	COMPUTE_BUDGET_PROGRAM_ADDRESS,
 	SYSTEM_PROGRAM_ADDRESS,
@@ -36,7 +36,7 @@ export const createMockSolTransactionsUi = (n: number): SolTransactionUi[] =>
 export const createMockSolTransactionUi = (id: string): SolTransactionUi => ({
 	id,
 	signature: signature(mockSignature),
-	timestamp: ZERO_BI,
+	timestamp: ZERO,
 	type: 'send',
 	value: 100n,
 	from: 'sender',

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -1,5 +1,5 @@
 import { DEVNET_EURC_TOKEN } from '$env/tokens/tokens-spl/tokens.eurc.env';
-import { WALLET_PAGINATION, ZERO_BI } from '$lib/constants/app.constants';
+import { WALLET_PAGINATION, ZERO } from '$lib/constants/app.constants';
 import {
 	checkIfAccountExists,
 	estimatePriorityFee,
@@ -179,7 +179,7 @@ describe('solana.api', () => {
 
 		it('should handle zero balance', async () => {
 			mockGetTokenAccountBalance.mockReturnValueOnce({
-				send: () => Promise.resolve({ value: { amount: ZERO_BI } })
+				send: () => Promise.resolve({ value: { amount: ZERO } })
 			});
 
 			const balance = await loadTokenBalance({

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -1,5 +1,5 @@
 import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import * as solanaApi from '$sol/api/solana.api';
 import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import * as solSignaturesServices from '$sol/services/sol-signatures.services';
@@ -108,7 +108,7 @@ describe('sol-transactions.services', () => {
 		const expected: SolTransactionUi = {
 			id: mockSignature.signature,
 			signature: mockSignature.signature,
-			timestamp: mockTransactionDetail.blockTime ?? ZERO_BI,
+			timestamp: mockTransactionDetail.blockTime ?? ZERO,
 			value: mockMappedTransaction.value,
 			from: mockSolAddress,
 			to: mockSolAddress2,

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -1,5 +1,5 @@
 import { JUP_TOKEN } from '$env/tokens/tokens-spl/tokens.jup.env';
-import { ZERO_BI } from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
 import {
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
 	SYSTEM_PROGRAM_ADDRESS,
@@ -307,7 +307,7 @@ describe('sol-instructions.utils', () => {
 						network
 					})
 				).resolves.toEqual({
-					value: ZERO_BI,
+					value: ZERO,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});
@@ -331,7 +331,7 @@ describe('sol-instructions.utils', () => {
 						cumulativeBalances: { [mockSolAddress2]: 100n }
 					})
 				).resolves.toEqual({
-					value: ZERO_BI,
+					value: ZERO,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});
@@ -607,7 +607,7 @@ describe('sol-instructions.utils', () => {
 						network
 					})
 				).resolves.toEqual({
-					value: ZERO_BI,
+					value: ZERO,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});
@@ -631,7 +631,7 @@ describe('sol-instructions.utils', () => {
 						cumulativeBalances: { [mockSolAddress2]: 100n }
 					})
 				).resolves.toEqual({
-					value: ZERO_BI,
+					value: ZERO,
 					from: mockSolAddress,
 					to: mockSolAddress2
 				});


### PR DESCRIPTION
# Motivation

The constant `ZERO_BI` was called like that because we had `ZERO` before, that was the `BigNumber` equivalent. Now that we deprecated `BigNumber`, we can rename `ZERO_BI` to `ZERO`, to make it more understandable.
