### PR TITLE
feat(frontend): receive wizard config

### DIFF
--- a/src/frontend/src/eth/config/receive.config.ts
+++ b/src/frontend/src/eth/config/receive.config.ts
@@ -1,0 +1,20 @@
+import { howToConvertWizardSteps } from '$icp-eth/config/how-to-convert.config';
+import { type ConvertWizardStepsParams } from '$lib/config/convert.config';
+import { WizardStepsReceive } from '$lib/enums/wizard-steps';
+import type { WizardSteps } from '@dfinity/gix-components';
+
+export const receiveWizardSteps = ({
+	i18n,
+	sourceToken,
+	destinationToken
+}: ConvertWizardStepsParams): WizardSteps => [
+	{
+		name: WizardStepsReceive.RECEIVE,
+		title: i18n.receive.text.receive
+	},
+	{
+		name: WizardStepsReceive.QR_CODE,
+		title: i18n.receive.text.address
+	},
+	...howToConvertWizardSteps({ i18n, sourceToken, destinationToken })
+];

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -36,3 +36,8 @@ export enum WizardStepsHowToConvert {
 	INFO = 'Info',
 	ETH_QR_CODE = 'ETH QR Code'
 }
+
+export enum WizardStepsReceive {
+	RECEIVE = 'Receive',
+	QR_CODE = 'QR Code'
+}


### PR DESCRIPTION
# Motivation

Previously, the receive config was defined directly in the component. As a part of migration to the convert flow, I'm moving it to a separate file.