### PR TITLE
feat(frontend): update IcReceiveCkEthereum components

### DIFF
--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -1,36 +1,32 @@
 <script lang="ts">
-	import { getContext, setContext } from 'svelte';
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import FeeStoreContext from '$eth/components/fee/FeeStoreContext.svelte';
 	import { erc20UserTokens } from '$eth/derived/erc20.derived';
+	import { ethereumToken } from '$eth/derived/token.derived';
 	import IcReceiveCkEthereumModal from '$icp/components/receive/IcReceiveCkEthereumModal.svelte';
 	import {
 		RECEIVE_TOKEN_CONTEXT_KEY,
 		type ReceiveTokenContext
 	} from '$icp/stores/receive-token.store';
+	import type { IcCkToken, OptionIcCkToken } from '$icp/types/ic-token';
 	import { autoLoadUserToken } from '$icp-eth/services/user-token.services';
 	import ReceiveButtonWithModal from '$lib/components/receive/ReceiveButtonWithModal.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalCkETHReceive } from '$lib/derived/modal.derived';
+	import { pageToken } from '$lib/derived/page-token.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { Token } from '$lib/types/token';
 
 	const { ckEthereumTwinToken, open, close } =
 		getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
-	/**
-	 * Send modal context store
-	 */
+	let destinationToken: OptionIcCkToken;
+	$: destinationToken = nonNullish($pageToken) ? ($pageToken as IcCkToken) : undefined;
 
-	const { sendToken, ...rest } = initSendContext({
-		sendPurpose: 'convert-eth-to-cketh',
-		token: $ckEthereumTwinToken
-	});
-	setContext<SendContext>(SEND_CONTEXT_KEY, {
-		sendToken,
-		...rest
-	});
-
-	$: sendToken.set($ckEthereumTwinToken);
+	let sourceToken: Token;
+	$: sourceToken = $ckEthereumTwinToken;
 
 	const openReceive = async (modalId: symbol) => {
 		const { result } = await autoLoadUserToken({
@@ -50,5 +46,11 @@
 </script>
 
 <ReceiveButtonWithModal open={openModal} isOpen={$modalCkETHReceive}>
-	<IcReceiveCkEthereumModal on:nnsClose={close} slot="modal" />
+	<svelte:fragment slot="modal">
+		{#if nonNullish(sourceToken) && nonNullish(destinationToken)}
+			<FeeStoreContext token={$ethereumToken}>
+				<IcReceiveCkEthereumModal on:nnsClose={close} {sourceToken} {destinationToken} />
+			</FeeStoreContext>
+		{/if}
+	</svelte:fragment>
 </ReceiveButtonWithModal>

--- a/src/frontend/src/icp/components/receive/IcReceiveInfoCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveInfoCkEthereum.svelte
@@ -44,7 +44,7 @@
 	</Value>
 
 	<div class="flex w-full flex-col gap-3" slot="toolbar">
-		<Button paddingSmall colorStyle="secondary" on:click={() => dispatch('icConvert')}>
+		<Button paddingSmall colorStyle="secondary" on:click={() => dispatch('icHowToConvert')}>
 			<span class="text-dark-slate-blue font-bold"
 				>{replacePlaceholders(
 					replaceOisyPlaceholders($i18n.receive.ethereum.text.learn_how_to_convert),

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -2,6 +2,7 @@ import {
 	type WizardStepsAuthHelp,
 	type WizardStepsConvert,
 	type WizardStepsHowToConvert,
+	type WizardStepsReceive,
 	type WizardStepsSend
 } from '$lib/enums/wizard-steps';
 import { type WizardModal, type WizardSteps } from '@dfinity/gix-components';
@@ -13,7 +14,12 @@ export const goToWizardStep = ({
 }: {
 	modal: WizardModal;
 	steps: WizardSteps;
-	stepName: WizardStepsSend | WizardStepsConvert | WizardStepsAuthHelp | WizardStepsHowToConvert;
+	stepName:
+		| WizardStepsSend
+		| WizardStepsConvert
+		| WizardStepsAuthHelp
+		| WizardStepsHowToConvert
+		| WizardStepsReceive;
 }) => {
 	const stepNumber = steps.findIndex(({ name }) => name === stepName);
 	modal.set(Math.max(stepNumber, 0));

--- a/src/frontend/src/tests/icp/components/receive/IcReceiveCkEthereumModal.spec.ts
+++ b/src/frontend/src/tests/icp/components/receive/IcReceiveCkEthereumModal.spec.ts
@@ -1,13 +1,20 @@
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import {
+	FEE_CONTEXT_KEY,
+	initFeeContext,
+	initFeeStore,
+	type FeeContext
+} from '$eth/stores/fee.store';
 import IcReceiveCkEthereumModal from '$icp/components/receive/IcReceiveCkEthereumModal.svelte';
 import {
 	RECEIVE_TOKEN_CONTEXT_KEY,
 	initReceiveTokenContext,
 	type ReceiveTokenContext
 } from '$icp/stores/receive-token.store';
-import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
 
 // We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
 vi.mock('ethers/providers', () => {
@@ -16,13 +23,21 @@ vi.mock('ethers/providers', () => {
 });
 
 describe('IcReceiveCkEthereumModal', () => {
+	const props = {
+		sourceToken: ETHEREUM_TOKEN,
+		destinationToken: ICP_TOKEN
+	};
+
 	const mockContext = () =>
-		new Map<symbol, SendContext | ReceiveTokenContext>([
+		new Map<symbol, ReceiveTokenContext | FeeContext>([
 			[
-				SEND_CONTEXT_KEY,
-				initSendContext({
-					sendPurpose: 'convert-eth-to-cketh',
-					token: ETHEREUM_TOKEN
+				FEE_CONTEXT_KEY,
+				initFeeContext({
+					feeStore: initFeeStore(),
+					feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
+					feeExchangeRateStore: writable(100),
+					feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
+					feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals)
 				})
 			],
 			[
@@ -33,6 +48,7 @@ describe('IcReceiveCkEthereumModal', () => {
 
 	it('should render receive info on initial render', () => {
 		const { getByText } = render(IcReceiveCkEthereumModal, {
+			props,
 			context: mockContext()
 		});
 


### PR DESCRIPTION
# Motivation

Similar as with the HowToConvert flow, we need to migrate the IcReceive modal from Send to Convert wizard.

The current functionality of the modal stays unchanged, except of the wizard that gets opened on the "conversion" button click.

Note: I'll migrate the affected by this PR components to Svelte 5 in follow up PRs.


https://github.com/user-attachments/assets/e9e60f8b-9686-4cf1-bd7f-53d186dd78ad

