### PR TITLE
feat(rewards): Add the GOLD rewards API

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -448,8 +448,8 @@
 		},
 		"rewards": {
 			"type": "custom",
-			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.3.1/rewards.did",
-			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.3.1/rewards.wasm.gz",
+			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.4.0-api.1/rewards.did",
+			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.4.0-api.1/rewards.wasm.gz",
 			"remote": {
 				"id": {
 					"ic": "nynz6-haaaa-aaaan-qzqda-cai",

--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readdirSync } from 'node:fs';
-import { open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const deleteIndexes = async ({ dest = `./src/declarations` }) => {
@@ -50,13 +50,7 @@ export const idlFactory = ({ IDL }) => {`
 export const init = ({ IDL }) => {`
 					);
 
-					// Open the file for writing only if it does not already exist (wx flag).
-					// This avoids a potential file system race condition warning.
-					const fd = await open(factoryPath, 'wx');
-
-					await writeFile(fd, cleanInit, 'utf8');
-
-					await fd.close();
+					await writeFile(factoryPath, cleanInit, 'utf8');
 
 					resolve();
 				};

--- a/src/declarations/rewards/rewards.did
+++ b/src/declarations/rewards/rewards.did
@@ -54,6 +54,10 @@ type CandidDuration = variant {
   Hours : nat64;
   Nanoseconds : nat64;
 };
+type ClaimedVipReward = record {
+    /// The campaign ID
+    campaign_id: text;
+};
 type ClaimVipRewardResponse = variant {
     /// The code has been claimed already
     AlreadyClaimed;
@@ -350,6 +354,10 @@ type UserData = record {
     last_snapshot_timestamp : opt nat64;
     /// Very Important Powers
     is_vip : opt bool;
+    /// Super Important Powers
+    ///
+    /// Values are: Campaign IDs such as "vip" or "gold".
+    superpowers: opt vec text;
     /// Sprinkles the user has received
     sprinkles : vec RewardInfo;
 };
@@ -380,7 +388,7 @@ service : (opt Config) -> {
     /// has taken place.  For testing, it can be convenient to call it directly.
     claim_usage_award : (UsageAwardEvent, principal) -> ();
     /// Requests rewards from a VIP token.
-    claim_vip_reward : (VipReward) -> (ClaimVipRewardResponse);
+    claim_vip_reward : (VipReward) -> (ClaimVipRewardResponse, opt ClaimedVipReward);
     /// Retrieves the current configuration of the canister.
     config : () -> (Config) query;
     /// Configures bonuses for using & holding assets in Oisy.
@@ -391,8 +399,8 @@ service : (opt Config) -> {
     last_activity_histogram : (LastActivityHistogramRequest) -> (
       LastActivityHistogramResponse,
     ) query;
-    /// Gets a VIP reward token.
-    new_vip_reward : () -> (NewVipRewardResponse);
+    /// Gets a VIP reward token for a given campaign ID.
+    new_vip_reward : (opt ClaimedVipReward) -> (NewVipRewardResponse);
     /// Public endpoint to query general information with regards to rewards distributed by this canister.
     public_rewards_info : () -> (PublicRewardsInfo) query;
     /// Get or create referrer info for the caller.
@@ -404,7 +412,7 @@ service : (opt Config) -> {
     register_snapshot_for : (principal, UserSnapshot) -> ();
     stats_usage_vs_holding : () -> (UsageVsHoldingStats) query;
     /// Sets a timestamp for a sprinkle event in the future. The sprinkle will be executed
-  set_referrer : (nat32) -> (SetReferrerResponse);
+    set_referrer : (nat32) -> (SetReferrerResponse);
     /// as soon as possible after the timestamp.
     /// Gives information about the current status of the canister.
     status : () -> (StatusResponse) query;

--- a/src/declarations/rewards/rewards.did.d.ts
+++ b/src/declarations/rewards/rewards.did.d.ts
@@ -53,6 +53,9 @@ export type ClaimVipRewardResponse =
 	| { AlreadyClaimed: null }
 	| { Success: null }
 	| { InvalidCode: null };
+export interface ClaimedVipReward {
+	campaign_id: string;
+}
 export interface Config {
 	usage_awards_config: [] | [UsageAwardConfig];
 	batch_sizes: [] | [BatchSizes];
@@ -223,6 +226,7 @@ export interface UsageWinnersResponse {
 	winners: Array<Principal>;
 }
 export interface UserData {
+	superpowers: [] | [Array<string>];
 	airdrops: Array<RewardInfo>;
 	usage_awards: [] | [Array<RewardInfo>];
 	last_snapshot_timestamp: [] | [bigint];
@@ -252,7 +256,7 @@ export interface VipStats {
 }
 export interface _SERVICE {
 	claim_usage_award: ActorMethod<[UsageAwardEvent, Principal], undefined>;
-	claim_vip_reward: ActorMethod<[VipReward], ClaimVipRewardResponse>;
+	claim_vip_reward: ActorMethod<[VipReward], [ClaimVipRewardResponse, [] | [ClaimedVipReward]]>;
 	config: ActorMethod<[], Config>;
 	configure_usage_awards: ActorMethod<[UsageAwardConfig], undefined>;
 	configure_vip: ActorMethod<[VipConfig], undefined>;
@@ -260,7 +264,7 @@ export interface _SERVICE {
 		[LastActivityHistogramRequest],
 		LastActivityHistogramResponse
 	>;
-	new_vip_reward: ActorMethod<[], NewVipRewardResponse>;
+	new_vip_reward: ActorMethod<[[] | [ClaimedVipReward]], NewVipRewardResponse>;
 	public_rewards_info: ActorMethod<[], PublicRewardsInfo>;
 	referrer_info: ActorMethod<[], ReferrerInfo>;
 	referrer_info_for: ActorMethod<[Principal], [] | [ReferrerInfo]>;

--- a/src/declarations/rewards/rewards.factory.certified.did.js
+++ b/src/declarations/rewards/rewards.factory.certified.did.js
@@ -69,6 +69,7 @@ export const idlFactory = ({ IDL }) => {
 		Success: IDL.Null,
 		InvalidCode: IDL.Null
 	});
+	const ClaimedVipReward = IDL.Record({ campaign_id: IDL.Text });
 	const LastActivityHistogramRequest = IDL.Record({
 		bucket_count: IDL.Nat32,
 		bucket_duration: CandidDuration
@@ -229,6 +230,7 @@ export const idlFactory = ({ IDL }) => {
 		campaign_name: IDL.Opt(IDL.Text)
 	});
 	const UserData = IDL.Record({
+		superpowers: IDL.Opt(IDL.Vec(IDL.Text)),
 		airdrops: IDL.Vec(RewardInfo),
 		usage_awards: IDL.Opt(IDL.Vec(RewardInfo)),
 		last_snapshot_timestamp: IDL.Opt(IDL.Nat64),
@@ -249,7 +251,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		claim_usage_award: IDL.Func([UsageAwardEvent, IDL.Principal], [], []),
-		claim_vip_reward: IDL.Func([VipReward], [ClaimVipRewardResponse], []),
+		claim_vip_reward: IDL.Func(
+			[VipReward],
+			[ClaimVipRewardResponse, IDL.Opt(ClaimedVipReward)],
+			[]
+		),
 		config: IDL.Func([], [Config]),
 		configure_usage_awards: IDL.Func([UsageAwardConfig], [], []),
 		configure_vip: IDL.Func([VipConfig], [], []),
@@ -257,7 +263,7 @@ export const idlFactory = ({ IDL }) => {
 			[LastActivityHistogramRequest],
 			[LastActivityHistogramResponse]
 		),
-		new_vip_reward: IDL.Func([], [NewVipRewardResponse], []),
+		new_vip_reward: IDL.Func([IDL.Opt(ClaimedVipReward)], [NewVipRewardResponse], []),
 		public_rewards_info: IDL.Func([], [PublicRewardsInfo]),
 		referrer_info: IDL.Func([], [ReferrerInfo], []),
 		referrer_info_for: IDL.Func([IDL.Principal], [IDL.Opt(ReferrerInfo)]),

--- a/src/declarations/rewards/rewards.factory.did.js
+++ b/src/declarations/rewards/rewards.factory.did.js
@@ -69,6 +69,7 @@ export const idlFactory = ({ IDL }) => {
 		Success: IDL.Null,
 		InvalidCode: IDL.Null
 	});
+	const ClaimedVipReward = IDL.Record({ campaign_id: IDL.Text });
 	const LastActivityHistogramRequest = IDL.Record({
 		bucket_count: IDL.Nat32,
 		bucket_duration: CandidDuration
@@ -229,6 +230,7 @@ export const idlFactory = ({ IDL }) => {
 		campaign_name: IDL.Opt(IDL.Text)
 	});
 	const UserData = IDL.Record({
+		superpowers: IDL.Opt(IDL.Vec(IDL.Text)),
 		airdrops: IDL.Vec(RewardInfo),
 		usage_awards: IDL.Opt(IDL.Vec(RewardInfo)),
 		last_snapshot_timestamp: IDL.Opt(IDL.Nat64),
@@ -249,7 +251,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		claim_usage_award: IDL.Func([UsageAwardEvent, IDL.Principal], [], []),
-		claim_vip_reward: IDL.Func([VipReward], [ClaimVipRewardResponse], []),
+		claim_vip_reward: IDL.Func(
+			[VipReward],
+			[ClaimVipRewardResponse, IDL.Opt(ClaimedVipReward)],
+			[]
+		),
 		config: IDL.Func([], [Config], ['query']),
 		configure_usage_awards: IDL.Func([UsageAwardConfig], [], []),
 		configure_vip: IDL.Func([VipConfig], [], []),
@@ -258,7 +264,7 @@ export const idlFactory = ({ IDL }) => {
 			[LastActivityHistogramResponse],
 			['query']
 		),
-		new_vip_reward: IDL.Func([], [NewVipRewardResponse], []),
+		new_vip_reward: IDL.Func([IDL.Opt(ClaimedVipReward)], [NewVipRewardResponse], []),
 		public_rewards_info: IDL.Func([], [PublicRewardsInfo], ['query']),
 		referrer_info: IDL.Func([], [ReferrerInfo], []),
 		referrer_info_for: IDL.Func([IDL.Principal], [IDL.Opt(ReferrerInfo)], ['query']),


### PR DESCRIPTION
# Motivation
We would like to have multiple QR code promotional campaigns.

The API for this has been discussed and agreed in principle.

# Changes
- Update the rewards canister to one that has the agreed API:
  - Defined but without implementation
  - Rearranged a little to make it backwards compatible

# Tests
This API is deployed on staging.