### PR TITLE
refactor(frontend): use `toBeDefined` in tests for Info banner

### DIFF
--- a/src/frontend/src/tests/icp-eth/components/info/InfoEthereum.spec.ts
+++ b/src/frontend/src/tests/icp-eth/components/info/InfoEthereum.spec.ts
@@ -27,7 +27,7 @@ describe('InfoEthereum', () => {
 					$ckToken: mockValidIcCkToken.symbol
 				})
 			)
-		);
+		).toBeDefined();
 	});
 
 	it('should render description correctly', () => {
@@ -43,7 +43,7 @@ describe('InfoEthereum', () => {
 					$network: mockValidIcToken.network.name
 				})
 			)
-		);
+		).toBeDefined();
 	});
 
 	it('should render note correctly', () => {
@@ -58,7 +58,7 @@ describe('InfoEthereum', () => {
 					$ckToken: mockValidIcCkToken.symbol
 				})
 			)
-		);
+		).toBeDefined();
 	});
 
 	it('should render how-to message correctly', () => {
@@ -72,6 +72,6 @@ describe('InfoEthereum', () => {
 					$ckToken: mockValidIcCkToken.symbol
 				})
 			)
-		);
+		).toBeDefined();
 	});
 });

--- a/src/frontend/src/tests/icp/components/info/InfoBitcoin.spec.ts
+++ b/src/frontend/src/tests/icp/components/info/InfoBitcoin.spec.ts
@@ -6,24 +6,24 @@ describe('InfoBitcoin', () => {
 	it('should render title correctly', () => {
 		const { getByText } = render(InfoBitcoin);
 
-		expect(getByText(en.info.bitcoin.title));
+		expect(getByText(en.info.bitcoin.title)).toBeDefined();
 	});
 
 	it('should render description correctly', () => {
 		const { getByText } = render(InfoBitcoin);
 
-		expect(getByText(en.info.bitcoin.description));
+		expect(getByText(en.info.bitcoin.description)).toBeDefined();
 	});
 
 	it('should render note correctly', () => {
 		const { getByText } = render(InfoBitcoin);
 
-		expect(getByText(en.info.bitcoin.note));
+		expect(getByText(en.info.bitcoin.note)).toBeDefined();
 	});
 
 	it('should how-to message correctly', () => {
 		const { getByText } = render(InfoBitcoin);
 
-		expect(getByText(en.info.bitcoin.how_to));
+		expect(getByText(en.info.bitcoin.how_to)).toBeDefined();
 	});
 });


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises a few warnings. For example, it requires an explicit statement after `expect(...)`.

In this specific case there is not much difference since `getByText` would fail if it doesn't find anything, but for consistency, we add `toBeDefined()` at the end.
