### PR TITLE
refactor(frontend): move supported tokens constants to respective modules

### DIFF
--- a/src/frontend/src/env/tokens/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens.btc.env.ts
@@ -1,4 +1,5 @@
 import {
+	BTC_MAINNET_ENABLED,
 	BTC_MAINNET_NETWORK,
 	BTC_REGTEST_NETWORK,
 	BTC_TESTNET_NETWORK
@@ -6,6 +7,7 @@ import {
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import type { Token, TokenId, TokenWithLinkedData } from '$lib/types/token';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 
 export const BTC_DECIMALS = 8;
@@ -55,3 +57,12 @@ export const BTC_REGTEST_TOKEN: Token = {
 	decimals: BTC_DECIMALS,
 	icon: bitcoinTestnet
 };
+
+// The following tokens are used as fallback for any Bitcoin token defined in the token store.
+// That means that the order of the tokens in the array is important, to have a correct fallback chain.
+export const SUPPORTED_BITCOIN_TOKENS: Token[] = defineSupportedTokens({
+	mainnetFlag: BTC_MAINNET_ENABLED,
+	mainnetTokens: [BTC_MAINNET_TOKEN],
+	testnetTokens: [BTC_TESTNET_TOKEN],
+	localTokens: [BTC_REGTEST_TOKEN]
+});

--- a/src/frontend/src/env/tokens/tokens.sol.env.ts
+++ b/src/frontend/src/env/tokens/tokens.sol.env.ts
@@ -1,10 +1,12 @@
 import {
+	SOL_MAINNET_ENABLED,
 	SOLANA_DEVNET_NETWORK,
 	SOLANA_LOCAL_NETWORK,
 	SOLANA_MAINNET_NETWORK,
 	SOLANA_TESTNET_NETWORK
 } from '$env/networks/networks.sol.env';
-import type { RequiredToken, TokenId } from '$lib/types/token';
+import type { RequiredToken, Token, TokenId } from '$lib/types/token';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 import sol from '$sol/assets/sol.svg';
 
@@ -72,3 +74,10 @@ export const SOLANA_LOCAL_TOKEN: RequiredToken = {
 	decimals: SOLANA_DEFAULT_DECIMALS,
 	icon: sol
 };
+
+export const SUPPORTED_SOLANA_TOKENS: Token[] = defineSupportedTokens({
+	mainnetFlag: SOL_MAINNET_ENABLED,
+	mainnetTokens: [SOLANA_TOKEN],
+	testnetTokens: [SOLANA_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN],
+	localTokens: [SOLANA_LOCAL_TOKEN]
+});

--- a/src/frontend/src/lib/constants/tokens.constants.ts
+++ b/src/frontend/src/lib/constants/tokens.constants.ts
@@ -1,38 +1,9 @@
-import { BTC_MAINNET_ENABLED } from '$env/networks/networks.btc.env';
-import { SOL_MAINNET_ENABLED } from '$env/networks/networks.sol.env';
-import {
-	BTC_MAINNET_TOKEN,
-	BTC_REGTEST_TOKEN,
-	BTC_TESTNET_TOKEN
-} from '$env/tokens/tokens.btc.env';
+import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
 import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
-import {
-	SOLANA_DEVNET_TOKEN,
-	SOLANA_LOCAL_TOKEN,
-	SOLANA_TESTNET_TOKEN,
-	SOLANA_TOKEN
-} from '$env/tokens/tokens.sol.env';
-import type { Token } from '$lib/types/token';
-import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
+import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
 
 export const [DEFAULT_ETHEREUM_TOKEN] = SUPPORTED_ETHEREUM_TOKENS;
 
-// The following tokens are used as fallback for any Bitcoin token defined in the token store.
-// That means that the order of the tokens in the array is important, to have a correct fallback chain.
-const SUPPORTED_BITCOIN_TOKENS: Token[] = defineSupportedTokens({
-	mainnetFlag: BTC_MAINNET_ENABLED,
-	mainnetTokens: [BTC_MAINNET_TOKEN],
-	testnetTokens: [BTC_TESTNET_TOKEN],
-	localTokens: [BTC_REGTEST_TOKEN]
-});
-
 export const [DEFAULT_BITCOIN_TOKEN] = SUPPORTED_BITCOIN_TOKENS;
-
-const SUPPORTED_SOLANA_TOKENS: Token[] = defineSupportedTokens({
-	mainnetFlag: SOL_MAINNET_ENABLED,
-	mainnetTokens: [SOLANA_TOKEN],
-	testnetTokens: [SOLANA_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN],
-	localTokens: [SOLANA_LOCAL_TOKEN]
-});
 
 export const [DEFAULT_SOLANA_TOKEN] = SUPPORTED_SOLANA_TOKENS;


### PR DESCRIPTION
# Motivation

As per suggestion https://github.com/dfinity/oisy-wallet/pull/5995#discussion_r2053560449 , to keep the code more organized and consistent, we move the definition of supported tokens to each respective module.
