### PR TITLE
fix(build): Revert PR #5963: Fix code scanning alert no. 4

### DIFF
--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readdirSync } from 'node:fs';
-import { open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const deleteIndexes = async ({ dest = `./src/declarations` }) => {
@@ -50,13 +50,7 @@ export const idlFactory = ({ IDL }) => {`
 export const init = ({ IDL }) => {`
 					);
 
-					// Open the file for writing only if it does not already exist (wx flag).
-					// This avoids a potential file system race condition warning.
-					const fd = await open(factoryPath, 'wx');
-
-					await writeFile(fd, cleanInit, 'utf8');
-
-					await fd.close();
+					await writeFile(factoryPath, cleanInit, 'utf8');
 
 					resolve();
 				};


### PR DESCRIPTION
# Motivation

As @bitdivine found, the PR #5963 is causing issues with bindings creation (since the files may already exists). So for now, we will revert it, and find another solution.
