### PR TITLE
feat(frontend): add XAUT token group data

### DIFF
--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -9,6 +9,7 @@ import { EURC_TOKEN_GROUP } from '$env/tokens/groups/groups.eurc.env';
 import { LINK_TOKEN_GROUP } from '$env/tokens/groups/groups.link.env';
 import { OCT_TOKEN_GROUP } from '$env/tokens/groups/groups.oct.env';
 import { USDC_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
+import { XAUT_TOKEN_GROUP } from '$env/tokens/groups/groups.xaut.env';
 import { EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
@@ -393,7 +394,8 @@ const CKXAUT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_
 	? {
 			...CKERC20_PRODUCTION_DATA.ckXAUT,
 			position: 11,
-			twinToken: XAUT_TOKEN
+			twinToken: XAUT_TOKEN,
+			groupData: XAUT_TOKEN_GROUP
 		}
 	: undefined;
 

--- a/src/frontend/src/env/tokens/groups/groups.xaut.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.xaut.env.ts
@@ -1,0 +1,9 @@
+import xaut from '$eth/assets/xaut.svg';
+
+const XAUT_TOKEN_GROUP_SYMBOL = 'XAUt';
+
+export const XAUT_TOKEN_GROUP = {
+	icon: xaut,
+	name: 'Tether Gold',
+	symbol: XAUT_TOKEN_GROUP_SYMBOL
+};

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
@@ -1,4 +1,5 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { XAUT_TOKEN_GROUP } from '$env/tokens/groups/groups.xaut.env';
 import xaut from '$eth/assets/xaut.svg';
 import type { RequiredErc20Token } from '$eth/types/erc20';
 import type { TokenId } from '$lib/types/token';
@@ -21,5 +22,6 @@ export const XAUT_TOKEN: RequiredErc20Token = {
 	icon: xaut,
 	address: '0x68749665FF8D2d112Fa859AA293F07A622782F38',
 	exchange: 'erc20',
-	twinTokenSymbol: 'ckXAUT'
+	twinTokenSymbol: 'ckXAUT',
+	groupData: XAUT_TOKEN_GROUP
 };


### PR DESCRIPTION
# Motivation

Splitting PR https://github.com/dfinity/oisy-wallet/pull/5918.

We are going to use `groupData` to group similar ("twin") tokens. Currently we are using different props depending on the type of token (for example `twinToken` for ICRC, or `twinTokenSymbol` for ERC20). With groupData, we aim to have a single center of aggregation for "twin" tokens.

In this PR we create the group for token XAUt.
