### PR TITLE
feat(frontend): add BTC token group data

### DIFF
--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -4,6 +4,7 @@ import {
 	CKETH_EXPLORER_URL,
 	CKETH_SEPOLIA_EXPLORER_URL
 } from '$env/explorers.env';
+import { BTC_TOKEN_GROUP } from '$env/tokens/groups/groups.btc.env';
 import { ETH_TOKEN_GROUP } from '$env/tokens/groups/groups.eth.env';
 import { EURC_TOKEN_GROUP } from '$env/tokens/groups/groups.eurc.env';
 import { LINK_TOKEN_GROUP } from '$env/tokens/groups/groups.link.env';
@@ -102,6 +103,7 @@ const CKBTC_IC_DATA: IcCkInterface | undefined =
 				exchangeCoinId: 'bitcoin',
 				position: 1,
 				twinToken: BTC_MAINNET_TOKEN,
+				groupData: BTC_TOKEN_GROUP,
 				explorerUrl: CKBTC_EXPLORER_URL
 			}
 		: undefined;

--- a/src/frontend/src/env/tokens/groups/groups.btc.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.btc.env.ts
@@ -1,0 +1,9 @@
+import bitcoin from '$icp/assets/bitcoin.svg';
+
+const BTC_TOKEN_GROUP_SYMBOL = 'BTC';
+
+export const BTC_TOKEN_GROUP = {
+	icon: bitcoin,
+	name: 'Bitcoin',
+	symbol: BTC_TOKEN_GROUP_SYMBOL
+};

--- a/src/frontend/src/env/tokens/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens.btc.env.ts
@@ -4,6 +4,7 @@ import {
 	BTC_REGTEST_NETWORK,
 	BTC_TESTNET_NETWORK
 } from '$env/networks/networks.btc.env';
+import { BTC_TOKEN_GROUP } from '$env/tokens/groups/groups.btc.env';
 import bitcoin from '$icp/assets/bitcoin.svg';
 import bitcoinTestnet from '$icp/assets/bitcoin_testnet.svg';
 import type { Token, TokenId, TokenWithLinkedData } from '$lib/types/token';
@@ -25,7 +26,8 @@ export const BTC_MAINNET_TOKEN: TokenWithLinkedData = {
 	symbol: BTC_MAINNET_SYMBOL,
 	decimals: BTC_DECIMALS,
 	icon: bitcoin,
-	twinTokenSymbol: 'ckBTC'
+	twinTokenSymbol: 'ckBTC',
+	groupData: BTC_TOKEN_GROUP
 };
 
 export const BTC_TESTNET_SYMBOL = 'BTC (Testnet)';


### PR DESCRIPTION
# Motivation

Splitting PR https://github.com/dfinity/oisy-wallet/pull/5918.

We are going to use `groupData` to group similar ("twin") tokens. Currently we are using different props depending on the type of token (for example `twinToken` for ICRC, or `twinTokenSymbol` for ERC20). With groupData, we aim to have a single center of aggregation for "twin" tokens.

In this PR we create the group for token BTC.
