### PR TITLE
refactor(frontend): move Etherescan mocks to vitest setup

### DIFF
--- a/src/frontend/src/tests/btc/components/convert/ConvertToCkBTC.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/ConvertToCkBTC.spec.ts
@@ -9,12 +9,6 @@ import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('ConvertToCkBTC', () => {
 	const buttonId = 'convert-to-ckbtc-button';
 	const mockCkBtcToken = {

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -40,6 +40,7 @@ import { mockPage } from '$tests/mocks/page.store.mock';
 import type { MinterInfo } from '@dfinity/cketh';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
+import { InfuraProvider } from 'ethers/providers';
 import { get, readable, writable } from 'svelte/store';
 import { type MockInstance } from 'vitest';
 
@@ -50,17 +51,6 @@ vi.mock('$lib/services/auth.services', () => ({
 vi.mock('$eth/services/fee.services', () => ({
 	getErc20FeeData: vi.fn()
 }));
-
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	provider.prototype.getFeeData = vi.fn().mockResolvedValue({
-		lastBaseFeePerGas: null,
-		maxFeePerGas: null,
-		maxPriorityFeePerGas: null,
-		gasPrice: null
-	});
-	return { InfuraProvider: provider, JsonRpcProvider: provider, EtherscanProvider: provider };
-});
 
 describe('EthConvertTokenWizard', () => {
 	const sendAmount = 0.001;
@@ -154,6 +144,13 @@ describe('EthConvertTokenWizard', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+
+		InfuraProvider.prototype.getFeeData = vi.fn().mockResolvedValue({
+			lastBaseFeePerGas: null,
+			maxFeePerGas: null,
+			maxPriorityFeePerGas: null,
+			gasPrice: null
+		});
 
 		mockPage.reset();
 

--- a/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
@@ -20,12 +20,6 @@ import en from '$tests/mocks/i18n.mock';
 import { EtherscanProvider as EtherscanProviderLib } from 'ethers/providers';
 import type { MockedClass } from 'vitest';
 
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	provider.prototype.fetch = vi.fn().mockResolvedValue([]);
-	return { EtherscanProvider: provider };
-});
-
 vi.mock('$env/rest/etherscan.env', () => ({
 	ETHERSCAN_API_KEY: 'test-api-key'
 }));

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -20,12 +20,6 @@ import en from '$tests/mocks/i18n.mock';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider };
-});
-
 vi.mock('$eth/rest/etherscan.rest', () => ({
 	etherscanRests: vi.fn()
 }));

--- a/src/frontend/src/tests/icp-eth/components/info/InfoEthereum.spec.ts
+++ b/src/frontend/src/tests/icp-eth/components/info/InfoEthereum.spec.ts
@@ -4,12 +4,6 @@ import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('InfoEthereum', () => {
 	const props = {
 		sourceToken: mockValidIcToken,

--- a/src/frontend/src/tests/icp/components/convert/HowToConvertEthereumModal.spec.ts
+++ b/src/frontend/src/tests/icp/components/convert/HowToConvertEthereumModal.spec.ts
@@ -11,12 +11,6 @@ import { HOW_TO_CONVERT_ETHEREUM_INFO } from '$lib/constants/test-ids.constants'
 import { render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('HowToConvertEthereumModal', () => {
 	const props = {
 		sourceToken: ETHEREUM_TOKEN,

--- a/src/frontend/src/tests/icp/components/info/Info.spec.ts
+++ b/src/frontend/src/tests/icp/components/info/Info.spec.ts
@@ -17,12 +17,6 @@ import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render, waitFor } from '@testing-library/svelte';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('Info', () => {
 	const mockCkBtcToken = {
 		...mockValidIcCkToken,

--- a/src/frontend/src/tests/icp/components/receive/IcReceiveCkEthereumModal.spec.ts
+++ b/src/frontend/src/tests/icp/components/receive/IcReceiveCkEthereumModal.spec.ts
@@ -16,12 +16,6 @@ import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('IcReceiveCkEthereumModal', () => {
 	const props = {
 		sourceToken: ETHEREUM_TOKEN,

--- a/src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts
@@ -6,12 +6,6 @@ import { token } from '$lib/stores/token.store';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('IcTransactions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/frontend/src/tests/lib/components/convert/ConvertModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertModal.spec.ts
@@ -5,12 +5,6 @@ import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('ConvertModal', () => {
 	const props = {
 		sourceToken: BTC_MAINNET_TOKEN,

--- a/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
@@ -37,12 +37,6 @@ import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('ConvertWizard', () => {
 	const sendAmount = 20;
 

--- a/src/frontend/src/tests/lib/components/core/Listener.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Listener.spec.ts
@@ -6,12 +6,6 @@ import * as networkUtils from '$lib/utils/network.utils';
 import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('Listener', () => {
 	const mockAuthStore = (value = true) =>
 		vi.spyOn(authStore, 'authNotSignedIn', 'get').mockImplementation(() => readable(value));

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -44,12 +44,6 @@ import { toNullable } from '@dfinity/utils';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 vi.mock('@dfinity/utils', async () => {
 	const mod = await vi.importActual<object>('@dfinity/utils');
 	return {

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -16,12 +16,6 @@ import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('AllTransactions', () => {
 	const customIcrcToken: IcrcCustomToken = {
 		...mockValidIcToken,

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -17,12 +17,6 @@ import en from '$tests/mocks/i18n.mock';
 import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
 import { render } from '@testing-library/svelte';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('AllTransactionsList', () => {
 	beforeAll(() => {
 		vi.resetAllMocks();

--- a/src/frontend/src/tests/lib/components/transactions/Transactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/Transactions.spec.ts
@@ -8,12 +8,6 @@ import { mockPage } from '$tests/mocks/page.store.mock';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('Transactions', () => {
 	const timeout = 12000;
 	const mockGoTo = vi.fn();

--- a/src/frontend/src/tests/lib/utils/listener.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/listener.utils.spec.ts
@@ -6,12 +6,6 @@ import EthListener from '$eth/components/core/EthListener.svelte';
 import type { OptionToken } from '$lib/types/token';
 import { mapListeners } from '$lib/utils/listener.utils';
 
-// We need to mock these nested dependencies too because otherwise there is an error raise in the importing of `WebSocket` from `ws` inside the `ethers/provider` package
-vi.mock('ethers/providers', () => {
-	const provider = vi.fn();
-	return { EtherscanProvider: provider, InfuraProvider: provider, JsonRpcProvider: provider };
-});
-
 describe('mapListeners', () => {
 	it('should return an empty array if all tokens are nullish', () => {
 		const tokens: OptionToken[] = [null, undefined, null];

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -61,6 +61,23 @@ vi.mock(import('$lib/actors/agents.ic'), async (importOriginal) => {
 	};
 });
 
+vi.mock('ethers/providers', () => {
+	const provider = vi.fn();
+
+	const plugin = vi.fn();
+
+	const network = vi.fn();
+	network.prototype.attachPlugin = vi.fn();
+
+	return {
+		EtherscanProvider: provider,
+		InfuraProvider: provider,
+		JsonRpcProvider: provider,
+		EtherscanPlugin: plugin,
+		Network: network
+	};
+});
+
 failTestsThatLogToConsole();
 
 if (process.env.ALLOW_LOGGING_FOR_DEBUGGING) {


### PR DESCRIPTION
# Motivation

For the coming PR https://github.com/dfinity/oisy-wallet/pull/6021 , we will have to mock more methods for Etherscan throughout the code. So it makes sense to extract the mocks and put them in a single place.
