### PR TITLE
refactor(frontend): rename BSC network to BSC mainnet network

### DIFF
--- a/src/frontend/src/env/networks/networks-evm/networks.evm.bsc.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.bsc.env.ts
@@ -13,12 +13,12 @@ export const BSC_MAINNET_ENABLED = parseEnabledMainnetBoolEnvVar(
 	import.meta.env.VITE_BSC_MAINNET_DISABLED
 );
 
-export const BSC_NETWORK_SYMBOL = 'BSC';
+export const BSC_MAINNET_NETWORK_SYMBOL = 'BSC';
 
-export const BSC_NETWORK_ID: NetworkId = parseNetworkId(BSC_NETWORK_SYMBOL);
+export const BSC_MAINNET_NETWORK_ID: NetworkId = parseNetworkId(BSC_MAINNET_NETWORK_SYMBOL);
 
-export const BSC_NETWORK: EthereumNetwork = {
-	id: BSC_NETWORK_ID,
+export const BSC_MAINNET_NETWORK: EthereumNetwork = {
+	id: BSC_MAINNET_NETWORK_ID,
 	env: 'mainnet',
 	name: 'BNB Smart Chain',
 	chainId: 56n,
@@ -44,6 +44,6 @@ export const BSC_TESTNET_NETWORK: EthereumNetwork = {
 
 export const SUPPORTED_BSC_NETWORKS: EthereumNetwork[] = defineSupportedNetworks({
 	mainnetFlag: BSC_MAINNET_ENABLED,
-	mainnetNetworks: [BSC_NETWORK],
+	mainnetNetworks: [BSC_MAINNET_NETWORK],
 	testnetNetworks: [BSC_TESTNET_NETWORK]
 });

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env.ts
@@ -1,4 +1,7 @@
-import { BSC_NETWORK, BSC_TESTNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import {
+	BSC_MAINNET_NETWORK,
+	BSC_TESTNET_NETWORK
+} from '$env/networks/networks-evm/networks.evm.bsc.env';
 import bnb from '$evm/bsc/assets/bnb.svg';
 import type { RequiredToken, TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -11,7 +14,7 @@ export const BNB_MAINNET_TOKEN_ID: TokenId = parseTokenId(BNB_MAINNET_SYMBOL);
 
 export const BNB_MAINNET_TOKEN: RequiredToken = {
 	id: BNB_MAINNET_TOKEN_ID,
-	network: BSC_NETWORK,
+	network: BSC_MAINNET_NETWORK,
 	standard: 'ethereum',
 	category: 'default',
 	name: 'BNB',

--- a/src/frontend/src/evm/bsc/derived/networks.derived.ts
+++ b/src/frontend/src/evm/bsc/derived/networks.derived.ts
@@ -1,6 +1,6 @@
 import {
 	BSC_MAINNET_ENABLED,
-	BSC_NETWORK,
+	BSC_MAINNET_NETWORK,
 	BSC_TESTNET_NETWORK
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import type { EthereumNetwork } from '$eth/types/network';
@@ -16,7 +16,7 @@ export const enabledBscNetworks: Readable<EthereumNetwork[]> = derived(
 			$testnetsEnabled,
 			$userNetworks,
 			mainnetFlag: BSC_MAINNET_ENABLED,
-			mainnetNetworks: [BSC_NETWORK],
+			mainnetNetworks: [BSC_MAINNET_NETWORK],
 			testnetNetworks: [BSC_TESTNET_NETWORK]
 		})
 );

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -4,7 +4,7 @@ import {
 	BASE_SEPOLIA_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.base.env';
 import {
-	BSC_NETWORK_ID,
+	BSC_MAINNET_NETWORK_ID,
 	BSC_TESTNET_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import {
@@ -90,7 +90,7 @@ export const userNetworks: Readable<UserNetworks> = derived(
 				return BASE_SEPOLIA_NETWORK_ID;
 			}
 			if ('BscMainnet' in key) {
-				return BSC_NETWORK_ID;
+				return BSC_MAINNET_NETWORK_ID;
 			}
 			if ('BscTestnet' in key) {
 				return BSC_TESTNET_NETWORK_ID;

--- a/src/frontend/src/lib/utils/user-networks.utils.ts
+++ b/src/frontend/src/lib/utils/user-networks.utils.ts
@@ -4,7 +4,7 @@ import {
 	BASE_SEPOLIA_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.base.env';
 import {
-	BSC_NETWORK_ID,
+	BSC_MAINNET_NETWORK_ID,
 	BSC_TESTNET_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import {
@@ -50,7 +50,7 @@ const networkIdToKey = (networkId: NetworkId): NetworkSettingsFor | undefined =>
 			return { BaseMainnet: null };
 		case BASE_SEPOLIA_NETWORK_ID:
 			return { BaseSepolia: null };
-		case BSC_NETWORK_ID:
+		case BSC_MAINNET_NETWORK_ID:
 			return { BscMainnet: null };
 		case BSC_TESTNET_NETWORK_ID:
 			return { BscTestnet: null };

--- a/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
@@ -2,7 +2,10 @@ import {
 	BASE_NETWORK,
 	BASE_SEPOLIA_NETWORK
 } from '$env/networks/networks-evm/networks.evm.base.env';
-import { BSC_NETWORK, BSC_TESTNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import {
+	BSC_MAINNET_NETWORK,
+	BSC_TESTNET_NETWORK
+} from '$env/networks/networks-evm/networks.evm.bsc.env';
 import * as btcEnv from '$env/networks/networks.btc.env';
 import { BTC_MAINNET_NETWORK } from '$env/networks/networks.btc.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
@@ -145,7 +148,7 @@ describe('network-tokens.derived', () => {
 					tokens: [BASE_SEPOLIA_ETH_TOKEN]
 				},
 				{
-					network: BSC_NETWORK,
+					network: BSC_MAINNET_NETWORK,
 					tokens: [BNB_MAINNET_TOKEN]
 				},
 				{

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -3,7 +3,7 @@ import {
 	BASE_SEPOLIA_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.base.env';
 import {
-	BSC_NETWORK_ID,
+	BSC_MAINNET_NETWORK_ID,
 	BSC_TESTNET_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import * as btcNetworkEnv from '$env/networks/networks.btc.env';
@@ -114,7 +114,7 @@ describe('network utils', () => {
 		const allEvmNetworkIds = [
 			BASE_NETWORK_ID,
 			BASE_SEPOLIA_NETWORK_ID,
-			BSC_NETWORK_ID,
+			BSC_MAINNET_NETWORK_ID,
 			BSC_TESTNET_NETWORK_ID
 		];
 


### PR DESCRIPTION
# Motivation

For consistency (see BTC mainnet network), we rename `BSC_*` to `BSC_MAINNET_*`.
