### PR TITLE
fix(build): Fix code scanning alert no. 14: Bad HTML filtering regexp

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -127,7 +127,7 @@ const extractStartScript = (htmlFile) => {
  * Browsers that supports the 'strict-dynamic' rule will ignore these backwards directives (CSP 3).
  */
 const updateCSP = (indexHtml) => {
-	const sw = /<script[\s\S]*?>([\s\S]*?)<\/script\s*>/gim;
+	const sw = /<script[\s\S]*?>([\s\S]*?)<\/script[^\S\r\n]*[^>]*?>/gim;
 
 	const indexHashes = [];
 

--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -127,7 +127,7 @@ const extractStartScript = (htmlFile) => {
  * Browsers that supports the 'strict-dynamic' rule will ignore these backwards directives (CSP 3).
  */
 const updateCSP = (indexHtml) => {
-	const sw = /<script[\s\S]*?>([\s\S]*?)<\/script>/gim;
+	const sw = /<script[\s\S]*?>([\s\S]*?)<\/script\s*>/gim;
 
 	const indexHashes = [];
 


### PR DESCRIPTION
# Motivation

Fixes https://github.com/dfinity/oisy-wallet/security/code-scanning/14

To fix the problem, we need to modify the regular expression to include </script > (with a whitespace in the end).

