### PR TITLE
feat(frontend): add EVM networks to Alchemy provider

### DIFF
--- a/src/frontend/src/env/networks/networks.eth.env.ts
+++ b/src/frontend/src/env/networks/networks.eth.env.ts
@@ -29,6 +29,10 @@ export const ALCHEMY_JSON_RPC_URL_SEPOLIA = 'https://eth-sepolia.g.alchemy.com/v
 
 export const ALCHEMY_NETWORK_MAINNET: Network = Network.ETH_MAINNET;
 export const ALCHEMY_NETWORK_SEPOLIA: Network = Network.ETH_SEPOLIA;
+export const ALCHEMY_NETWORK_BASE_MAINNET: Network = Network.BASE_MAINNET;
+export const ALCHEMY_NETWORK_BASE_SEPOLIA: Network = Network.BASE_SEPOLIA;
+export const ALCHEMY_NETWORK_BSC_MAINNET: Network = Network.BNB_MAINNET;
+export const ALCHEMY_NETWORK_BSC_TESTNET: Network = Network.BNB_TESTNET;
 
 /**
  * Ethereum

--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -1,4 +1,16 @@
 import {
+	BASE_NETWORK_ID,
+	BASE_SEPOLIA_NETWORK_ID
+} from '$env/networks/networks-evm/networks.evm.base.env';
+import {
+	BSC_MAINNET_NETWORK_ID,
+	BSC_TESTNET_NETWORK_ID
+} from '$env/networks/networks-evm/networks.evm.bsc.env';
+import {
+	ALCHEMY_NETWORK_BASE_MAINNET,
+	ALCHEMY_NETWORK_BASE_SEPOLIA,
+	ALCHEMY_NETWORK_BSC_MAINNET,
+	ALCHEMY_NETWORK_BSC_TESTNET,
 	ALCHEMY_NETWORK_MAINNET,
 	ALCHEMY_NETWORK_SEPOLIA,
 	ETHEREUM_NETWORK_ID,
@@ -26,6 +38,22 @@ const configs: Record<NetworkId, AlchemyConfig> = {
 	[SEPOLIA_NETWORK_ID]: {
 		apiKey: ALCHEMY_API_KEY,
 		network: ALCHEMY_NETWORK_SEPOLIA
+	},
+	[BASE_NETWORK_ID]: {
+		apiKey: ALCHEMY_API_KEY,
+		network: ALCHEMY_NETWORK_BASE_MAINNET
+	},
+	[BASE_SEPOLIA_NETWORK_ID]: {
+		apiKey: ALCHEMY_API_KEY,
+		network: ALCHEMY_NETWORK_BASE_SEPOLIA
+	},
+	[BSC_MAINNET_NETWORK_ID]: {
+		apiKey: ALCHEMY_API_KEY,
+		network: ALCHEMY_NETWORK_BSC_MAINNET
+	},
+	[BSC_TESTNET_NETWORK_ID]: {
+		apiKey: ALCHEMY_API_KEY,
+		network: ALCHEMY_NETWORK_BSC_TESTNET
 	}
 };
 
@@ -134,7 +162,11 @@ export class AlchemyProvider {
 
 const providers: Record<NetworkId, AlchemyProvider> = {
 	[ETHEREUM_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_MAINNET),
-	[SEPOLIA_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_SEPOLIA)
+	[SEPOLIA_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_SEPOLIA),
+	[BASE_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_BASE_MAINNET),
+	[BASE_SEPOLIA_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_BASE_SEPOLIA),
+	[BSC_MAINNET_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_BSC_MAINNET),
+	[BSC_TESTNET_NETWORK_ID]: new AlchemyProvider(ALCHEMY_NETWORK_BSC_TESTNET)
 };
 
 export const alchemyProviders = (networkId: NetworkId): AlchemyProvider => {

--- a/src/frontend/src/tests/eth/providers/alchemy.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/alchemy.providers.spec.ts
@@ -1,0 +1,90 @@
+import {
+	BASE_NETWORK,
+	BASE_SEPOLIA_NETWORK
+} from '$env/networks/networks-evm/networks.evm.base.env';
+import {
+	BSC_MAINNET_NETWORK,
+	BSC_TESTNET_NETWORK
+} from '$env/networks/networks-evm/networks.evm.bsc.env';
+import {
+	ALCHEMY_NETWORK_BASE_MAINNET,
+	ALCHEMY_NETWORK_BASE_SEPOLIA,
+	ALCHEMY_NETWORK_BSC_MAINNET,
+	ALCHEMY_NETWORK_BSC_TESTNET,
+	ALCHEMY_NETWORK_MAINNET,
+	ALCHEMY_NETWORK_SEPOLIA,
+	ETHEREUM_NETWORK,
+	SEPOLIA_NETWORK
+} from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { AlchemyProvider, alchemyProviders } from '$eth/providers/alchemy.providers';
+import type { EthereumNetwork } from '$eth/types/network';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import en from '$tests/mocks/i18n.mock';
+import { Alchemy, type Network } from 'alchemy-sdk';
+import { vi } from 'vitest';
+
+vi.mock(import('alchemy-sdk'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		Alchemy: vi.fn()
+	};
+});
+
+vi.mock('$env/rest/alchemy.env', () => ({
+	ALCHEMY_API_KEY: 'test-api-key'
+}));
+
+describe('alchemy.providers', () => {
+	const ALCHEMY_API_KEY = 'test-api-key';
+
+	const networks: EthereumNetwork[] = [
+		ETHEREUM_NETWORK,
+		SEPOLIA_NETWORK,
+		BASE_NETWORK,
+		BASE_SEPOLIA_NETWORK,
+		BSC_MAINNET_NETWORK,
+		BSC_TESTNET_NETWORK
+	];
+
+	const alchemyNames: Network[] = [
+		ALCHEMY_NETWORK_MAINNET,
+		ALCHEMY_NETWORK_SEPOLIA,
+		ALCHEMY_NETWORK_BASE_MAINNET,
+		ALCHEMY_NETWORK_BASE_SEPOLIA,
+		ALCHEMY_NETWORK_BSC_MAINNET,
+		ALCHEMY_NETWORK_BSC_TESTNET
+	];
+
+	it('should create the correct map of providers', () => {
+		expect(Alchemy).toHaveBeenCalledTimes(networks.length);
+
+		networks.forEach((_, index) => {
+			expect(Alchemy).toHaveBeenNthCalledWith(index + 1, {
+				apiKey: ALCHEMY_API_KEY,
+				network: alchemyNames[index]
+			});
+		});
+	});
+
+	describe('alchemyProviders', () => {
+		networks.forEach(({ id, name }) => {
+			it(`should return the correct provider for ${name} network`, () => {
+				const provider = alchemyProviders(id);
+
+				expect(provider).toBeInstanceOf(AlchemyProvider);
+
+				expect(provider).toHaveProperty('provider');
+			});
+		});
+
+		it('should throw an error for an unsupported network ID', () => {
+			expect(() => alchemyProviders(ICP_NETWORK_ID)).toThrowError(
+				replacePlaceholders(en.init.error.no_alchemy_provider, {
+					$network: ICP_NETWORK_ID.toString()
+				})
+			);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We add Base and BNB Smart Chain (BSC) among the networks of Alchemy providers.
