### PR TITLE
feat(frontend): remove ICRC token vUSD

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -59,16 +59,6 @@
 			"__bigint__": "10000"
 		}
 	},
-	"vUSD": {
-		"ledgerCanisterId": "aiw2p-tyaaa-aaaam-aebyq-cai",
-		"name": "vUSD",
-		"indexCanisterId": "wdqhz-qyaaa-aaaam-aeccq-cai",
-		"decimals": 6,
-		"symbol": "vUSD",
-		"fee": {
-			"__bigint__": "0"
-		}
-	},
 	"RUGGY": {
 		"ledgerCanisterId": "icaf7-3aaaa-aaaam-qcx3q-cai",
 		"name": "RUGGY",


### PR DESCRIPTION
# Motivation

The ledger canister of ICRC token vUSD is having some issues, apparently not fixable in the short-term. As hotfix, we temporarily remove it from the default list.

![image](https://github.com/user-attachments/assets/f9c4d5e5-ec7a-4b88-9dee-7d1fc4b151d2)

