### PR TITLE
Av/release/1.3.10/1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "1.3.8",
+			"version": "1.3.9",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/agent": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "1.3.7",
+			"version": "1.3.8",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/agent": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {

--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -459,6 +459,13 @@ const VCHF_IC_DATA: IcInterface | undefined = nonNullish(ADDITIONAL_ICRC_PRODUCT
 		}
 	: undefined;
 
+const VEUR_IC_DATA: IcInterface | undefined = nonNullish(ADDITIONAL_ICRC_PRODUCTION_DATA?.VEUR)
+	? {
+			...ADDITIONAL_ICRC_PRODUCTION_DATA.VEUR,
+			position: 22
+		}
+	: undefined;
+
 export const CKERC20_LEDGER_CANISTER_TESTNET_IDS: CanisterIdText[] = [
 	...(nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) ? [LOCAL_CKUSDC_LEDGER_CANISTER_ID] : []),
 	...(nonNullish(CKUSDC_STAGING_DATA?.ledgerCanisterId)
@@ -533,7 +540,8 @@ const ADDITIONAL_ICRC_TOKENS: IcInterface[] = [
 	...(nonNullish(vUSD_IC_DATA) ? [vUSD_IC_DATA] : []),
 	...(nonNullish(RUGGY_IC_DATA) ? [RUGGY_IC_DATA] : []),
 	...(nonNullish(NAK_IC_DATA) ? [NAK_IC_DATA] : []),
-	...(nonNullish(VCHF_IC_DATA) ? [VCHF_IC_DATA] : [])
+	...(nonNullish(VCHF_IC_DATA) ? [VCHF_IC_DATA] : []),
+	...(nonNullish(VEUR_IC_DATA) ? [VEUR_IC_DATA] : [])
 ];
 
 export const ICRC_TOKENS: IcInterface[] = [

--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -452,6 +452,13 @@ const NAK_IC_DATA: IcInterface | undefined = nonNullish(ADDITIONAL_ICRC_PRODUCTI
 		}
 	: undefined;
 
+const VCHF_IC_DATA: IcInterface | undefined = nonNullish(ADDITIONAL_ICRC_PRODUCTION_DATA?.VCHF)
+	? {
+			...ADDITIONAL_ICRC_PRODUCTION_DATA.VCHF,
+			position: 21
+		}
+	: undefined;
+
 export const CKERC20_LEDGER_CANISTER_TESTNET_IDS: CanisterIdText[] = [
 	...(nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) ? [LOCAL_CKUSDC_LEDGER_CANISTER_ID] : []),
 	...(nonNullish(CKUSDC_STAGING_DATA?.ledgerCanisterId)
@@ -525,7 +532,8 @@ const ADDITIONAL_ICRC_TOKENS: IcInterface[] = [
 	...(nonNullish(nICP_IC_DATA) ? [nICP_IC_DATA] : []),
 	...(nonNullish(vUSD_IC_DATA) ? [vUSD_IC_DATA] : []),
 	...(nonNullish(RUGGY_IC_DATA) ? [RUGGY_IC_DATA] : []),
-	...(nonNullish(NAK_IC_DATA) ? [NAK_IC_DATA] : [])
+	...(nonNullish(NAK_IC_DATA) ? [NAK_IC_DATA] : []),
+	...(nonNullish(VCHF_IC_DATA) ? [VCHF_IC_DATA] : [])
 ];
 
 export const ICRC_TOKENS: IcInterface[] = [

--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -59,16 +59,6 @@
 			"__bigint__": "10000"
 		}
 	},
-	"vUSD": {
-		"ledgerCanisterId": "aiw2p-tyaaa-aaaam-aebyq-cai",
-		"name": "vUSD",
-		"indexCanisterId": "wdqhz-qyaaa-aaaam-aeccq-cai",
-		"decimals": 6,
-		"symbol": "vUSD",
-		"fee": {
-			"__bigint__": "0"
-		}
-	},
 	"RUGGY": {
 		"ledgerCanisterId": "icaf7-3aaaa-aaaam-qcx3q-cai",
 		"name": "RUGGY",

--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -82,5 +82,9 @@
 	"NAK": {
 		"indexCanisterId": "hmav7-uaaaa-aaaam-qdhnq-cai",
 		"ledgerCanisterId": "eig2s-waaaa-aaaam-qbg5a-cai"
+	},
+	"VCHF": {
+		"indexCanisterId": "4cx56-naaaa-aaaai-aqkaa-cai",
+		"ledgerCanisterId": "ly36x-wiaaa-aaaai-aqj7q-cai"
 	}
 }

--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -86,5 +86,9 @@
 	"VCHF": {
 		"indexCanisterId": "4cx56-naaaa-aaaai-aqkaa-cai",
 		"ledgerCanisterId": "ly36x-wiaaa-aaaai-aqj7q-cai"
+	},
+	"VEUR": {
+		"indexCanisterId": "wi24n-jqaaa-aaaan-qmr3a-cai",
+		"ledgerCanisterId": "wu6g4-6qaaa-aaaan-qmrza-cai"
 	}
 }

--- a/src/frontend/src/env/tokens/tokens.sns.json
+++ b/src/frontend/src/env/tokens/tokens.sns.json
@@ -128,7 +128,7 @@
 			"name": "Seers",
 			"symbol": "SEER",
 			"fee": {
-				"__bigint__": "100000"
+				"__bigint__": "100000000"
 			},
 			"alternativeName": "Seers",
 			"url": "https://seers.app"

--- a/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp-eth/utils/cketh-transactions.utils.ts
@@ -83,7 +83,7 @@ const decodeCkErc20DepositAbiDataValue = (data: string): bigint => {
 		dataSlice(data, 4)
 	);
 
-	return value.toBigInt();
+	return value;
 };
 
 export const isConvertCkEthToEth = ({


### PR DESCRIPTION
# Motivation

This is a PR to release `v1.3.10` that temporarily removes ICRC token vUSD, whose Ledger canister is currently having issues.

The PRs that were reviewed and included are:

- https://github.com/dfinity/oisy-wallet/pull/6043
- https://github.com/dfinity/oisy-wallet/pull/6044
