### PR TITLE
feat(frontend): ignore failed metadata fetched during loading of ICRC custom tokens

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -205,11 +205,13 @@ const loadCustomIcrcTokensData = async ({
 			return acc;
 		}
 
-		if (isNullish(result.value)) {
+		const { value } = result;
+
+		if (isNullish(value)) {
 			return acc;
 		}
 
-		return [...acc, result.value];
+		return [...acc, value];
 	}, []);
 };
 

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -185,7 +185,32 @@ const loadCustomIcrcTokensData = async ({
 				};
 	};
 
-	return (await Promise.all(tokens.map(requestIcrcCustomTokenMetadata))).filter(nonNullish);
+	const results = await Promise.allSettled(tokens.map(requestIcrcCustomTokenMetadata));
+
+	return results.reduce<IcrcCustomTokenWithoutId[]>((acc, result, index) => {
+		if (result.status !== 'fulfilled') {
+			// For development purposes, we want to see the error in the console.
+			console.error(result.reason);
+
+			const { token } = tokens[index];
+
+			if ('Icrc' in token) {
+				const {
+					Icrc: { ledger_id }
+				} = token;
+
+				icrcCustomTokensStore.reset(ledger_id.toString());
+			}
+
+			return acc;
+		}
+
+		if (isNullish(result.value)) {
+			return acc;
+		}
+
+		return [...acc, result.value];
+	}, []);
 };
 
 const loadIcrcCustomData = ({

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -207,11 +207,7 @@ const loadCustomIcrcTokensData = async ({
 
 		const { value } = result;
 
-		if (isNullish(value)) {
-			return acc;
-		}
-
-		return [...acc, value];
+		return [...acc, ...(nonNullish(value) ? [value] : [])];
 	}, []);
 };
 

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -226,7 +226,7 @@ describe('custom-token.services', () => {
 			});
 
 			it.each([undefined, IC_CKBTC_INDEX_CANISTER_ID])(
-				'should result with loaded but toastError if metadata fails with index ID %s',
+				'should result with loaded but console error if metadata fails with index ID %s',
 				async (indexCanisterId) => {
 					backendCanisterMock.setCustomToken.mockResolvedValue(undefined);
 
@@ -254,10 +254,11 @@ describe('custom-token.services', () => {
 
 					expect(result).toBe('loaded');
 
-					expect(spyToastsError).toHaveBeenNthCalledWith(1, {
-						msg: { text: get(i18n).init.error.icrc_canisters },
-						err
-					});
+					expect(spyToastsError).not.toHaveBeenCalled();
+
+					expect(console.error).toHaveBeenCalledTimes(2);
+					expect(console.error).toHaveBeenNthCalledWith(1, err);
+					expect(console.error).toHaveBeenNthCalledWith(2, err);
 				}
 			);
 		});

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -223,23 +223,26 @@ describe('icrc.services', () => {
 			let spyToastsError: MockInstance;
 
 			beforeEach(() => {
-				icrcCustomTokensStore.set({
-					data: mockIcrcCustomToken,
-					certified: true
-				});
+				icrcCustomTokensStore.setAll([
+					{
+						data: mockIcrcCustomToken,
+						certified: true
+					}
+				]);
+
+				ledgerCanisterMock.metadata.mockResolvedValue([
+					['icrc1:name', { Text: mockName }],
+					['icrc1:symbol', { Text: mockSymbol }],
+					['icrc1:decimals', { Nat: mockDecimals }],
+					['icrc1:fee', { Nat: mockFee }]
+				]);
 
 				spyToastsError = vi.spyOn(toastsStore, 'toastsError');
 			});
 
-			const testToastsError = (err: Error) => {
-				expect(spyToastsError).toHaveBeenNthCalledWith(1, {
-					msg: { text: get(i18n).init.error.icrc_canisters },
-					err
-				});
-			};
-
 			it('should reset all and toasts on list custom tokens error', async () => {
 				const tokens = get(icrcCustomTokensStore);
+
 				expect(tokens).toHaveLength(1);
 
 				const err = new Error('test');
@@ -248,12 +251,20 @@ describe('icrc.services', () => {
 				await loadCustomTokens({ identity: mockIdentity });
 
 				const afterTokens = get(icrcCustomTokensStore);
+
 				expect(afterTokens).toBeNull();
 
-				testToastsError(err);
+				expect(spyToastsError).toHaveBeenNthCalledWith(1, {
+					msg: { text: get(i18n).init.error.icrc_canisters },
+					err
+				});
 			});
 
-			it('should reset all and toasts on metadata error', async () => {
+			it('should ignore tokens on metadata error', async () => {
+				const tokens = get(icrcCustomTokensStore);
+
+				expect(tokens).toHaveLength(1);
+
 				backendCanisterMock.listCustomTokens.mockResolvedValue([mockCustomToken]);
 
 				const err = new Error('test');
@@ -262,9 +273,43 @@ describe('icrc.services', () => {
 				await loadCustomTokens({ identity: mockIdentity });
 
 				const afterTokens = get(icrcCustomTokensStore);
-				expect(afterTokens).toBeNull();
 
-				testToastsError(err);
+				expect(afterTokens).toEqual(tokens);
+
+				expect(spyToastsError).not.toHaveBeenCalled();
+
+				expect(console.error).toHaveBeenCalledTimes(2);
+				expect(console.error).toHaveBeenNthCalledWith(1, err);
+				expect(console.error).toHaveBeenNthCalledWith(2, err);
+			});
+
+			it('should reset tokens on metadata error', async () => {
+				const initialTokens = get(icrcCustomTokensStore);
+
+				expect(initialTokens).toHaveLength(1);
+
+				backendCanisterMock.listCustomTokens.mockResolvedValue([mockCustomToken]);
+
+				await loadCustomTokens({ identity: mockIdentity });
+
+				const tokens = get(icrcCustomTokensStore);
+
+				expect(tokens).toHaveLength(2);
+
+				const err = new Error('test');
+				ledgerCanisterMock.metadata.mockRejectedValue(err);
+
+				await loadCustomTokens({ identity: mockIdentity });
+
+				const afterTokens = get(icrcCustomTokensStore);
+
+				expect(afterTokens).toEqual(initialTokens);
+
+				expect(spyToastsError).not.toHaveBeenCalled();
+
+				expect(console.error).toHaveBeenCalledTimes(2);
+				expect(console.error).toHaveBeenNthCalledWith(1, err);
+				expect(console.error).toHaveBeenNthCalledWith(2, err);
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

There are some cases where the ledger canister fails completely (most recently we had the episode with [vUSD](https://github.com/dfinity/oisy-wallet/pull/6043)). In those cases, we prefer to ignore the failing ledger canisters and proceed with the working ones during the loading of metadata of ICRC custom tokens.

Otherwise the current implementation resets them all, and does not show anything.

# Changes

- Await all the promises to load metadata of ICRC custom tokens, successful and failing.
- Filter out the failing ones.
- Reset the ICRC custom token store for the failed.

# Tests

Adapted and added tests.
