### PR TITLE
refactor(frontend): move QrCode step to SendModal

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -7,7 +7,6 @@
 	import BtcSendReview from '$btc/components/send/BtcSendReview.svelte';
 	import { sendBtc } from '$btc/services/btc-send.services';
 	import type { UtxosFee } from '$btc/types/btc-send';
-	import SendQrCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import {
@@ -30,7 +29,6 @@
 		isNetworkIdBTCTestnet,
 		mapNetworkIdToBitcoinNetwork
 	} from '$lib/utils/network.utils';
-	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 
 	export let currentStep: WizardStep | undefined;
 	export let destination = '';
@@ -167,14 +165,6 @@
 			{/if}
 		</svelte:fragment>
 	</BtcSendForm>
-{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-	<SendQrCodeScan
-		expectedToken={$sendToken}
-		bind:destination
-		bind:amount
-		{decodeQrCode}
-		on:icQRCodeBack
-	/>
 {:else}
 	<slot />
 {/if}

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -7,8 +7,6 @@
 	import EthSendForm from '$eth/components/send/EthSendForm.svelte';
 	import EthSendReview from '$eth/components/send/EthSendReview.svelte';
 	import { sendSteps } from '$eth/constants/steps.constants';
-	import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
-	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import { send as executeSend } from '$eth/services/send.services';
 	import {
 		FEE_CONTEXT_KEY,
@@ -17,14 +15,12 @@
 		initFeeStore
 	} from '$eth/stores/fee.store';
 	import type { EthereumNetwork } from '$eth/types/network';
-	import { decodeQrCode } from '$eth/utils/qr-code.utils';
 	import { shouldSendWithApproval } from '$eth/utils/send.utils';
 	import { isErc20Icp } from '$eth/utils/token.utils';
 	import { assertCkEthMinterInfoLoaded } from '$icp-eth/services/cketh.services';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { toCkErc20HelperContractAddress } from '$icp-eth/utils/cketh.utils';
 	import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
-	import SendQRCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
@@ -42,9 +38,8 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { Network } from '$lib/types/network';
-	import type { QrResponse, QrStatus } from '$lib/types/qr-code';
 	import type { OptionAmount } from '$lib/types/send';
-	import type { OptionToken, Token, TokenId } from '$lib/types/token';
+	import type { Token, TokenId } from '$lib/types/token';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
@@ -217,23 +212,6 @@
 
 	const close = () => dispatch('icClose');
 	const back = () => dispatch('icSendBack');
-
-	const onDecodeQrCode = ({
-		status,
-		code,
-		expectedToken
-	}: {
-		status: QrStatus;
-		code?: string;
-		expectedToken: OptionToken;
-	}): QrResponse =>
-		decodeQrCode({
-			status,
-			code,
-			expectedToken,
-			ethereumTokens: $enabledEthereumTokens,
-			erc20Tokens: $enabledErc20Tokens
-		});
 </script>
 
 <FeeContext
@@ -279,14 +257,6 @@
 				{/if}
 			</svelte:fragment>
 		</EthSendForm>
-	{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-		<SendQRCodeScan
-			expectedToken={$sendToken}
-			bind:destination
-			bind:amount
-			decodeQrCode={onDecodeQrCode}
-			on:icQRCodeBack
-		/>
 	{:else}
 		<slot />
 	{/if}

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -25,7 +25,6 @@
 		isConvertCkErc20ToErc20,
 		isConvertCkEthToEth
 	} from '$icp-eth/utils/cketh-transactions.utils';
-	import SendQRCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import {
@@ -50,7 +49,6 @@
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
-	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 
 	/**
 	 * Props
@@ -207,14 +205,6 @@
 					{/if}
 				</svelte:fragment>
 			</IcSendForm>
-		{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-			<SendQRCodeScan
-				expectedToken={$sendToken}
-				bind:destination
-				bind:amount
-				{decodeQrCode}
-				on:icQRCodeBack
-			/>
 		{:else}
 			<slot />
 		{/if}

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -47,7 +47,6 @@
 		on:icNext
 		on:icClose
 		on:icQRCodeScan
-		on:icQRCodeBack
 	/>
 {:else if isNetworkIdEvm($sendToken.network.id) && nonNullish($selectedEvmNetwork) && nonNullish($evmNativeToken)}
 	<!--			TODO: use store evmNativeToken here when we adapt the fee context to fetch the EVM fees -->
@@ -65,7 +64,6 @@
 		on:icNext
 		on:icClose
 		on:icQRCodeScan
-		on:icQRCodeBack
 	/>
 {:else if isNetworkIdICP($sendToken.network.id)}
 	<IcSendTokenWizard
@@ -81,7 +79,6 @@
 		on:icNext
 		on:icClose
 		on:icQRCodeScan
-		on:icQRCodeBack
 	/>
 {:else if isNetworkIdBitcoin($sendToken.network.id)}
 	<BtcSendTokenWizard
@@ -95,7 +92,6 @@
 		on:icClose
 		on:icSendBack
 		on:icQRCodeScan
-		on:icQRCodeBack
 	/>
 {:else if isNetworkIdSolana($sendToken.network.id)}
 	<SolSendTokenWizard
@@ -109,7 +105,6 @@
 		on:icClose
 		on:icSendBack
 		on:icQRCodeScan
-		on:icQRCodeBack
 	/>
 {:else}
 	<slot />

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -10,7 +10,6 @@
 		SOLANA_TESTNET_TOKEN,
 		SOLANA_TOKEN
 	} from '$env/tokens/tokens.sol.env';
-	import SendQrCodeScan from '$lib/components/send/SendQRCodeScan.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
@@ -45,7 +44,6 @@
 		isNetworkIdSOLTestnet
 	} from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
-	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 	import SolFeeContext from '$sol/components/fee/SolFeeContext.svelte';
 	import SolSendForm from '$sol/components/send/SolSendForm.svelte';
 	import SolSendReview from '$sol/components/send/SolSendReview.svelte';
@@ -228,14 +226,6 @@
 				{/if}
 			</svelte:fragment>
 		</SolSendForm>
-	{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-		<SendQrCodeScan
-			expectedToken={$sendToken}
-			bind:destination
-			bind:amount
-			{decodeQrCode}
-			on:icQRCodeBack
-		/>
 	{:else}
 		<slot />
 	{/if}


### PR DESCRIPTION
# Motivation

Before extracting destination input into a separate wizard step, we need to refactor the Send flow by moving QrCode step up to the SendModal component. It also allows us to clean up the components and to avoid some code repetitions.
