### PR TITLE
refactor(frontend): use `.includes` in tests for `VipRewardStateModal`

### DIFF
--- a/src/frontend/src/tests/lib/components/qr/VipRewardStateModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/qr/VipRewardStateModal.spec.ts
@@ -1,7 +1,7 @@
 import failedVipReward from '$lib/assets/failed-vip-reward.svg';
 import successfulBinanceReward from '$lib/assets/successful-binance-reward.svg';
 import successfulVipReward from '$lib/assets/successful-vip-reward.svg';
-import RewardStateModal from '$lib/components/qr/VipRewardStateModal.svelte';
+import VipRewardStateModal from '$lib/components/qr/VipRewardStateModal.svelte';
 import { VIP_STATE_IMAGE_BANNER } from '$lib/constants/test-ids.constants';
 import { QrCodeType } from '$lib/enums/qr-code-types';
 import { i18n } from '$lib/stores/i18n.store';
@@ -9,16 +9,16 @@ import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-describe('RewardStateModal', () => {
+describe('VipRewardStateModal', () => {
 	const imageBannerSelector = `img[data-tid=${VIP_STATE_IMAGE_BANNER}]`;
 
 	describe('VIP type', () => {
 		it('should render expected texts in the positive case', () => {
-			const { container, getByText } = render(RewardStateModal, { isSuccessful: true });
+			const { container, getByText } = render(VipRewardStateModal, { isSuccessful: true });
 
 			const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
 			expect(imageBanner).toBeInTheDocument();
-			expect(imageBanner?.src.includes(successfulVipReward));
+			expect(imageBanner?.src).includes(successfulVipReward);
 
 			expect(getByText(get(i18n).vip.reward.text.title_successful)).toBeInTheDocument();
 			expect(
@@ -29,11 +29,11 @@ describe('RewardStateModal', () => {
 		});
 
 		it('should render expected texts in the negative case', () => {
-			const { container, getByText } = render(RewardStateModal, { isSuccessful: false });
+			const { container, getByText } = render(VipRewardStateModal, { isSuccessful: false });
 
 			const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
 			expect(imageBanner).toBeInTheDocument();
-			expect(imageBanner?.src.includes(failedVipReward));
+			expect(imageBanner?.src).includes(failedVipReward);
 
 			expect(getByText(get(i18n).vip.reward.text.title_failed)).toBeInTheDocument();
 			expect(getByText(get(i18n).vip.reward.text.reward_failed)).toBeInTheDocument();
@@ -44,14 +44,14 @@ describe('RewardStateModal', () => {
 
 	describe('Gold type', () => {
 		it('should render expected texts in the positive case', () => {
-			const { container, getByText } = render(RewardStateModal, {
+			const { container, getByText } = render(VipRewardStateModal, {
 				isSuccessful: true,
 				codeType: QrCodeType.GOLD
 			});
 
 			const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
 			expect(imageBanner).toBeInTheDocument();
-			expect(imageBanner?.src.includes(successfulBinanceReward));
+			expect(imageBanner?.src).includes(successfulBinanceReward);
 
 			expect(getByText(get(i18n).vip.reward.text.title_successful)).toBeInTheDocument();
 			expect(
@@ -62,14 +62,14 @@ describe('RewardStateModal', () => {
 		});
 
 		it('should render expected texts in the negative case', () => {
-			const { container, getByText } = render(RewardStateModal, {
+			const { container, getByText } = render(VipRewardStateModal, {
 				isSuccessful: false,
 				codeType: QrCodeType.GOLD
 			});
 
 			const imageBanner: HTMLImageElement | null = container.querySelector(imageBannerSelector);
 			expect(imageBanner).toBeInTheDocument();
-			expect(imageBanner?.src.includes(failedVipReward));
+			expect(imageBanner?.src).includes(failedVipReward);
 
 			expect(getByText(get(i18n).vip.reward.text.title_failed)).toBeInTheDocument();
 			expect(getByText(get(i18n).vip.reward.text.reward_failed)).toBeInTheDocument();


### PR DESCRIPTION
# Motivation

We are going to add the vitest linter (PR https://github.com/dfinity/oisy-wallet/pull/5797), but it raises a few warnings. For example, it requires an explicit statement after `expect(...)`.