### PR TITLE
refactor(frontend): move SendTokenContext to SendModal

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -2,6 +2,7 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { createEventDispatcher, setContext } from 'svelte';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
+	import SendTokenContext from '$lib/components/send/SendTokenContext.svelte';
 	import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 	import SendWizard from '$lib/components/send/SendWizard.svelte';
 	import ModalNetworksFilter from '$lib/components/tokens/ModalNetworksFilter.svelte';
@@ -20,6 +21,7 @@
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
+	import { token } from '$lib/stores/token.store';
 	import type { Network, NetworkId } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
 	import { closeModal } from '$lib/utils/modal.utils';
@@ -97,50 +99,52 @@
 	$: source = $icrcAccountIdentifierText ?? '';
 </script>
 
-<WizardModal
-	{steps}
-	bind:currentStep
-	bind:this={modal}
-	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING ||
-		currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
-	testId={SEND_TOKENS_MODAL}
->
-	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
+<SendTokenContext token={$token}>
+	<WizardModal
+		{steps}
+		bind:currentStep
+		bind:this={modal}
+		on:nnsClose={close}
+		disablePointerEvents={currentStep?.name === WizardStepsSend.SENDING ||
+			currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
+		testId={SEND_TOKENS_MODAL}
+	>
+		<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
-	{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
-		<SendTokensList
-			on:icSendToken={nextStep}
-			on:icSelectNetworkFilter={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
-		/>
-	{:else if currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
-		<ModalNetworksFilter on:icNetworkFilter={() => goToStep(WizardStepsSend.TOKENS_LIST)} />
-	{:else}
-		<SendWizard
-			{source}
-			{currentStep}
-			bind:destination
-			bind:networkId
-			bind:targetNetwork
-			bind:amount
-			bind:sendProgressStep
-			formCancelAction={isTransactionsPage ? 'close' : 'back'}
-			on:icBack={modal.back}
-			on:icSendBack={() => goToStep(WizardStepsSend.TOKENS_LIST)}
-			on:icNext={modal.next}
-			on:icClose={close}
-			on:icQRCodeScan={() =>
-				goToWizardStep({
-					modal,
-					steps,
-					stepName: WizardStepsSend.QR_CODE_SCAN
-				})}
-			on:icQRCodeBack={() =>
-				goToWizardStep({
-					modal,
-					steps,
-					stepName: WizardStepsSend.SEND
-				})}
-		/>
-	{/if}
-</WizardModal>
+		{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
+			<SendTokensList
+				on:icSendToken={nextStep}
+				on:icSelectNetworkFilter={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
+			/>
+		{:else if currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
+			<ModalNetworksFilter on:icNetworkFilter={() => goToStep(WizardStepsSend.TOKENS_LIST)} />
+		{:else}
+			<SendWizard
+				{source}
+				{currentStep}
+				bind:destination
+				bind:networkId
+				bind:targetNetwork
+				bind:amount
+				bind:sendProgressStep
+				formCancelAction={isTransactionsPage ? 'close' : 'back'}
+				on:icBack={modal.back}
+				on:icSendBack={() => goToStep(WizardStepsSend.TOKENS_LIST)}
+				on:icNext={modal.next}
+				on:icClose={close}
+				on:icQRCodeScan={() =>
+					goToWizardStep({
+						modal,
+						steps,
+						stepName: WizardStepsSend.QR_CODE_SCAN
+					})}
+				on:icQRCodeBack={() =>
+					goToWizardStep({
+						modal,
+						steps,
+						stepName: WizardStepsSend.SEND
+					})}
+			/>
+		{/if}
+	</WizardModal>
+</SendTokenContext>

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { type WizardStep } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
 	import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
 	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
@@ -8,8 +9,7 @@
 	import { selectedEvmNetwork } from '$evm/derived/network.derived';
 	import { evmNativeToken } from '$evm/derived/token.derived';
 	import IcSendTokenWizard from '$icp/components/send/IcSendTokenWizard.svelte';
-	import SendTokenContext from '$lib/components/send/SendTokenContext.svelte';
-	import { token } from '$lib/stores/token.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network, NetworkId } from '$lib/types/network';
 	import {
 		isNetworkIdEthereum,
@@ -28,89 +28,89 @@
 	export let sendProgressStep: string;
 	export let currentStep: WizardStep | undefined;
 	export let formCancelAction: 'back' | 'close' = 'back';
+
+	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
 </script>
 
-<SendTokenContext token={$token}>
-	{#if isNetworkIdEthereum($token?.network.id)}
-		<EthSendTokenWizard
-			{currentStep}
-			{formCancelAction}
-			sourceNetwork={$selectedEthereumNetworkWithFallback}
-			nativeEthereumToken={$ethereumToken}
-			bind:destination
-			bind:targetNetwork
-			bind:amount
-			bind:sendProgressStep
-			on:icBack
-			on:icSendBack
-			on:icNext
-			on:icClose
-			on:icQRCodeScan
-			on:icQRCodeBack
-		/>
-	{:else if isNetworkIdEvm($token?.network.id) && nonNullish($selectedEvmNetwork) && nonNullish($evmNativeToken)}
-		<!--			TODO: use store evmNativeToken here when we adapt the fee context to fetch the EVM fees -->
-		<EthSendTokenWizard
-			{currentStep}
-			{formCancelAction}
-			sourceNetwork={$selectedEvmNetwork}
-			nativeEthereumToken={$ethereumToken}
-			bind:destination
-			bind:targetNetwork
-			bind:amount
-			bind:sendProgressStep
-			on:icBack
-			on:icSendBack
-			on:icNext
-			on:icClose
-			on:icQRCodeScan
-			on:icQRCodeBack
-		/>
-	{:else if isNetworkIdICP($token?.network.id)}
-		<IcSendTokenWizard
-			{source}
-			{currentStep}
-			{formCancelAction}
-			bind:destination
-			bind:networkId
-			bind:amount
-			bind:sendProgressStep
-			on:icSendBack
-			on:icBack
-			on:icNext
-			on:icClose
-			on:icQRCodeScan
-			on:icQRCodeBack
-		/>
-	{:else if isNetworkIdBitcoin($token?.network.id)}
-		<BtcSendTokenWizard
-			{currentStep}
-			{formCancelAction}
-			bind:destination
-			bind:amount
-			bind:sendProgressStep
-			on:icBack
-			on:icNext
-			on:icClose
-			on:icSendBack
-			on:icQRCodeScan
-			on:icQRCodeBack
-		/>
-	{:else if isNetworkIdSolana($token?.network.id)}
-		<SolSendTokenWizard
-			{currentStep}
-			{formCancelAction}
-			bind:destination
-			bind:amount
-			bind:sendProgressStep
-			on:icBack
-			on:icNext
-			on:icClose
-			on:icSendBack
-			on:icQRCodeScan
-			on:icQRCodeBack
-		/>
-	{:else}
-		<slot />
-	{/if}
-</SendTokenContext>
+{#if isNetworkIdEthereum($sendToken.network.id)}
+	<EthSendTokenWizard
+		{currentStep}
+		{formCancelAction}
+		sourceNetwork={$selectedEthereumNetworkWithFallback}
+		nativeEthereumToken={$ethereumToken}
+		bind:destination
+		bind:targetNetwork
+		bind:amount
+		bind:sendProgressStep
+		on:icBack
+		on:icSendBack
+		on:icNext
+		on:icClose
+		on:icQRCodeScan
+		on:icQRCodeBack
+	/>
+{:else if isNetworkIdEvm($sendToken.network.id) && nonNullish($selectedEvmNetwork) && nonNullish($evmNativeToken)}
+	<!--			TODO: use store evmNativeToken here when we adapt the fee context to fetch the EVM fees -->
+	<EthSendTokenWizard
+		{currentStep}
+		{formCancelAction}
+		sourceNetwork={$selectedEvmNetwork}
+		nativeEthereumToken={$ethereumToken}
+		bind:destination
+		bind:targetNetwork
+		bind:amount
+		bind:sendProgressStep
+		on:icBack
+		on:icSendBack
+		on:icNext
+		on:icClose
+		on:icQRCodeScan
+		on:icQRCodeBack
+	/>
+{:else if isNetworkIdICP($sendToken.network.id)}
+	<IcSendTokenWizard
+		{source}
+		{currentStep}
+		{formCancelAction}
+		bind:destination
+		bind:networkId
+		bind:amount
+		bind:sendProgressStep
+		on:icSendBack
+		on:icBack
+		on:icNext
+		on:icClose
+		on:icQRCodeScan
+		on:icQRCodeBack
+	/>
+{:else if isNetworkIdBitcoin($sendToken.network.id)}
+	<BtcSendTokenWizard
+		{currentStep}
+		{formCancelAction}
+		bind:destination
+		bind:amount
+		bind:sendProgressStep
+		on:icBack
+		on:icNext
+		on:icClose
+		on:icSendBack
+		on:icQRCodeScan
+		on:icQRCodeBack
+	/>
+{:else if isNetworkIdSolana($sendToken.network.id)}
+	<SolSendTokenWizard
+		{currentStep}
+		{formCancelAction}
+		bind:destination
+		bind:amount
+		bind:sendProgressStep
+		on:icBack
+		on:icNext
+		on:icClose
+		on:icSendBack
+		on:icQRCodeScan
+		on:icQRCodeBack
+	/>
+{:else}
+	<slot />
+{/if}


### PR DESCRIPTION
# Motivation

We need to move SendTokenContext to SendModal in order to have access to the context in the future Destination wizard step (will be added to SendModal).
