### PR TITLE
fix(frontend): revert PR #6039: use `pageToken` store in `Actions` component

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -32,6 +32,7 @@
 	import { isRouteTransactions } from '$lib/utils/nav.utils';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 	import SolReceive from '$sol/components/receive/SolReceive.svelte';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
 
 	let convertEth = false;
 	$: convertEth = $ethToCkETHEnabled && $erc20UserTokensInitialized;
@@ -62,18 +63,16 @@
 
 <div role="toolbar" class="flex w-full justify-center pt-10">
 	<HeroButtonGroup>
-		{#if $pseudoNetworkChainFusion}
+		{#if $networkICP}
+			<IcReceive token={$tokenWithFallback} />
+		{:else if $networkEthereum}
+			<EthReceive token={$tokenWithFallback} />
+		{:else if $networkBitcoin}
+			<BtcReceive />
+		{:else if $networkSolana}
+			<SolReceive token={$tokenWithFallback} />
+		{:else if $pseudoNetworkChainFusion}
 			<Receive />
-		{:else if nonNullish($pageToken)}
-			{#if $networkICP}
-				<IcReceive token={$pageToken} />
-			{:else if $networkEthereum}
-				<EthReceive token={$pageToken} />
-			{:else if $networkBitcoin}
-				<BtcReceive />
-			{:else if $networkSolana}
-				<SolReceive token={$pageToken} />
-			{/if}
 		{/if}
 
 		{#if sendAction}

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -29,10 +29,10 @@
 	} from '$lib/derived/network.derived';
 	import { networkBitcoinMainnetEnabled } from '$lib/derived/networks.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
+	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { isRouteTransactions } from '$lib/utils/nav.utils';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 	import SolReceive from '$sol/components/receive/SolReceive.svelte';
-	import { tokenWithFallback } from '$lib/derived/token.derived';
 
 	let convertEth = false;
 	$: convertEth = $ethToCkETHEnabled && $erc20UserTokensInitialized;


### PR DESCRIPTION
# Motivation

Reverting PR #6039, since there can be a race condition for slower networks where `pageToken` is not immediately loaded.
