### PR TITLE
fix(build): CI to update `ic-js` was not working

### DIFF
--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -64,7 +64,8 @@ jobs:
           NEXT_TAG: ${{ inputs.next && 'next' || '' }}
 
       - name: Update package
-        run: npm run update:$PKG_SCRIPT --script-shell bash
+        shell: bash
+        run: npm run update:$PKG_SCRIPT
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -64,7 +64,7 @@ jobs:
           NEXT_TAG: ${{ inputs.next && 'next' || '' }}
 
       - name: Update package
-        run: npm run update:$PKG_SCRIPT --shell bash
+        run: npm run update:$PKG_SCRIPT --script-shell bash
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Update package
         run: npm run update:$PKG_SCRIPT
+        shell: bash
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -64,9 +64,7 @@ jobs:
           NEXT_TAG: ${{ inputs.next && 'next' || '' }}
 
       - name: Update package
-        run: |
-          npm run update:$PKG_SCRIPT
-        shell: bash
+        run: npm run update:$PKG_SCRIPT --shell bash
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -64,8 +64,7 @@ jobs:
           NEXT_TAG: ${{ inputs.next && 'next' || '' }}
 
       - name: Update package
-        shell: bash
-        run: npm run update:$PKG_SCRIPT
+        run: npm run update:$PKG_SCRIPT --script-shell bash
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Update package
         run: npm run update:$PKG_SCRIPT
-        shell: bash
+        shell: sh
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Update package
         run: npm run update:$PKG_SCRIPT
-        shell: sh
+        shell: zsh
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -64,8 +64,9 @@ jobs:
           NEXT_TAG: ${{ inputs.next && 'next' || '' }}
 
       - name: Update package
-        run: npm run update:$PKG_SCRIPT
-        shell: zsh
+        run: |
+          npm run update:$PKG_SCRIPT
+        shell: bash
         env:
           PKG_SCRIPT: ${{ env.PKG_NAME }}${{ env.PKG_TAG && ':' || '' }}${{ env.PKG_TAG }}
 


### PR DESCRIPTION
# Motivation

The CI to update `ic-js` was not working correctly because we use brackets in the script to loop through the packages. But `sh` (that is the default shell of GitHub) does not recognize this syntax (see [failed CI](https://github.com/dfinity/oisy-wallet/actions/runs/14593319705/job/40933323682)).

So, we forcibly run the script in `bash` (see [working CI](https://github.com/dfinity/oisy-wallet/actions/runs/14620237906)).
