### PR TITLE
feat(frontend): add ID to modal store that have data input

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -23,10 +23,12 @@
 
 	let amount: bigint | undefined;
 	$: amount = nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined;
+
+	const modalId = Symbol();
 </script>
 
 <Transaction
-	on:click={() => modalStore.openBtcTransaction({ transaction, token })}
+	on:click={() => modalStore.openBtcTransaction({id:modalId,data:{ transaction, token }})}
 	{amount}
 	{type}
 	timestamp={Number(timestamp)}

--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <Transaction
-	on:click={() => modalStore.openBtcTransaction({id:modalId,data:{ transaction, token }})}
+	on:click={() => modalStore.openBtcTransaction({ id: modalId, data: { transaction, token } })}
 	{amount}
 	{type}
 	timestamp={Number(timestamp)}

--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -64,10 +64,12 @@
 
 	let transactionDate: number | undefined;
 	$: transactionDate = timestamp ?? displayTimestamp;
+
+	const modalId = Symbol();
 </script>
 
 <Transaction
-	on:click={() => modalStore.openEthTransaction({ transaction, token })}
+	on:click={() => modalStore.openEthTransaction({id:modalId,data:{ transaction, token }})}
 	{amount}
 	{type}
 	timestamp={transactionDate}

--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -69,7 +69,7 @@
 </script>
 
 <Transaction
-	on:click={() => modalStore.openEthTransaction({id:modalId,data:{ transaction, token }})}
+	on:click={() => modalStore.openEthTransaction({ id: modalId, data: { transaction, token } })}
 	{amount}
 	{type}
 	timestamp={transactionDate}

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -39,10 +39,12 @@
 	$: timestamp = nonNullish(timestampNanoseconds)
 		? Number(timestampNanoseconds / NANO_SECONDS_IN_SECOND)
 		: undefined;
+
+	const modalId = Symbol();
 </script>
 
 <Transaction
-	on:click={() => modalStore.openIcTransaction({ transaction, token })}
+	on:click={() => modalStore.openIcTransaction({id:modalId ,data:{ transaction, token }})}
 	styleClass="block w-full border-0"
 	{amount}
 	{type}

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <Transaction
-	on:click={() => modalStore.openIcTransaction({id:modalId ,data:{ transaction, token }})}
+	on:click={() => modalStore.openIcTransaction({ id: modalId, data: { transaction, token } })}
 	styleClass="block w-full border-0"
 	{amount}
 	{type}

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -16,7 +16,7 @@
 		const { success } = await signIn({});
 
 		if (success === 'cancelled' || success === 'error') {
-			modalStore.openAuthHelp({id:modalId,data: false });
+			modalStore.openAuthHelp({ id: modalId, data: false });
 		}
 	};
 </script>

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -10,11 +10,13 @@
 	export let fullWidth = false;
 	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
 
+	const modalId = Symbol();
+
 	const onClick = async () => {
 		const { success } = await signIn({});
 
 		if (success === 'cancelled' || success === 'error') {
-			modalStore.openAuthHelp(false);
+			modalStore.openAuthHelp({id:modalId,data: false });
 		}
 	};
 </script>

--- a/src/frontend/src/lib/components/auth/SigningInHelpLink.svelte
+++ b/src/frontend/src/lib/components/auth/SigningInHelpLink.svelte
@@ -8,11 +8,13 @@
 	export let styleClass = '';
 	export let testId: string | undefined = undefined;
 
+	const modalId = Symbol();
+
 	const onClick = () => {
 		trackEvent({
 			name: TRACK_HELP_SIGNING_IN
 		});
-		modalStore.openAuthHelp(true);
+		modalStore.openAuthHelp({id:modalId,data: true });
 	};
 </script>
 

--- a/src/frontend/src/lib/components/auth/SigningInHelpLink.svelte
+++ b/src/frontend/src/lib/components/auth/SigningInHelpLink.svelte
@@ -14,7 +14,7 @@
 		trackEvent({
 			name: TRACK_HELP_SIGNING_IN
 		});
-		modalStore.openAuthHelp({id:modalId,data: true });
+		modalStore.openAuthHelp({ id: modalId, data: true });
 	};
 </script>
 

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -117,7 +117,7 @@
 			<ButtonMenu
 				ariaLabel={$i18n.navigation.alt.binance_qr_code}
 				testId={NAVIGATION_MENU_GOLD_BUTTON}
-				on:click={() => modalStore.openVipQrCode({id: vipModalId, data:QrCodeType.GOLD})}
+				on:click={() => modalStore.openVipQrCode({ id: vipModalId, data: QrCodeType.GOLD })}
 			>
 				<IconBinance size="20" />
 				{$i18n.navigation.text.binance_qr_code}
@@ -128,7 +128,7 @@
 			<ButtonMenu
 				ariaLabel={$i18n.navigation.alt.vip_qr_code}
 				testId={NAVIGATION_MENU_VIP_BUTTON}
-				on:click={() => modalStore.openVipQrCode({ id:goldModalId, data:  QrCodeType.VIP})}
+				on:click={() => modalStore.openVipQrCode({ id: goldModalId, data: QrCodeType.VIP })}
 			>
 				<IconVipQr size="20" />
 				{$i18n.navigation.text.vip_qr_code}

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -67,6 +67,9 @@
 
 	let addressesOption = true;
 	$: addressesOption = !settingsRoute && !dAppExplorerRoute && !activityRoute && !rewardsRoute;
+
+	const goldModalId = Symbol();
+	const vipModalId = Symbol();
 </script>
 
 <ButtonIcon
@@ -114,7 +117,7 @@
 			<ButtonMenu
 				ariaLabel={$i18n.navigation.alt.binance_qr_code}
 				testId={NAVIGATION_MENU_GOLD_BUTTON}
-				on:click={() => modalStore.openVipQrCode(QrCodeType.GOLD)}
+				on:click={() => modalStore.openVipQrCode({id: vipModalId, data:QrCodeType.GOLD})}
 			>
 				<IconBinance size="20" />
 				{$i18n.navigation.text.binance_qr_code}
@@ -125,7 +128,7 @@
 			<ButtonMenu
 				ariaLabel={$i18n.navigation.alt.vip_qr_code}
 				testId={NAVIGATION_MENU_VIP_BUTTON}
-				on:click={() => modalStore.openVipQrCode(QrCodeType.VIP)}
+				on:click={() => modalStore.openVipQrCode({ id:goldModalId, data:  QrCodeType.VIP})}
 			>
 				<IconVipQr size="20" />
 				{$i18n.navigation.text.vip_qr_code}

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -36,9 +36,9 @@
 		});
 
 		if (nonNullish(airdrop)) {
-			modalStore.openRewardDetails({id:rewardModalId,data: airdrop });
+			modalStore.openRewardDetails({ id: rewardModalId, data: airdrop });
 		} else {
-			modalStore.openDappDetails({id:dappModalId,data: dappsCarouselSlide });
+			modalStore.openDappDetails({ id: dappModalId, data: dappsCarouselSlide });
 		}
 	};
 

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -16,12 +16,16 @@
 
 	export let dappsCarouselSlide: CarouselSlideOisyDappDescription;
 	export let airdrop: RewardDescription | undefined = undefined;
+
 	$: ({
 		id: dappId,
 		carousel: { text, callToAction },
 		logo,
 		name: dAppName
 	} = dappsCarouselSlide);
+
+	const rewardModalId = Symbol();
+	const dappModalId = Symbol();
 
 	const open = () => {
 		trackEvent({
@@ -32,9 +36,9 @@
 		});
 
 		if (nonNullish(airdrop)) {
-			modalStore.openRewardDetails(airdrop);
+			modalStore.openRewardDetails({id:rewardModalId,data: airdrop });
 		} else {
-			modalStore.openDappDetails(dappsCarouselSlide);
+			modalStore.openDappDetails({id:dappModalId,data: dappsCarouselSlide });
 		}
 	};
 

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -37,7 +37,7 @@
 {#if nonNullish(featuredDapp) && nonNullish(featuredDapp.screenshots)}
 	<div class="mb-6 md:mb-10">
 		<DappPromoBanner
-			on:click={() => modalStore.openDappDetails({id:modalId, data:featuredDapp})}
+			on:click={() => modalStore.openDappDetails({ id: modalId, data: featuredDapp })}
 			dAppDescription={featuredDapp}
 		/>
 	</div>
@@ -69,7 +69,7 @@
 		<li class="flex" in:fade>
 			<DappCard
 				on:click={() => {
-					modalStore.openDappDetails({id:modalId, data:dApp});
+					modalStore.openDappDetails({ id: modalId, data: dApp });
 				}}
 				dAppDescription={dApp}
 			/>

--- a/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsExplorerSignedIn.svelte
@@ -28,6 +28,8 @@
 	$: filteredDapps = dAppDescriptions.filter(
 		({ tags }) => isNullish(selectedTag) || tags.includes(selectedTag)
 	);
+
+	const modalId = Symbol();
 </script>
 
 <PageTitle>{$i18n.dapps.text.title}</PageTitle>
@@ -35,7 +37,7 @@
 {#if nonNullish(featuredDapp) && nonNullish(featuredDapp.screenshots)}
 	<div class="mb-6 md:mb-10">
 		<DappPromoBanner
-			on:click={() => modalStore.openDappDetails(featuredDapp)}
+			on:click={() => modalStore.openDappDetails({id:modalId, data:featuredDapp})}
 			dAppDescription={featuredDapp}
 		/>
 	</div>
@@ -67,7 +69,7 @@
 		<li class="flex" in:fade>
 			<DappCard
 				on:click={() => {
-					modalStore.openDappDetails(dApp);
+					modalStore.openDappDetails({id:modalId, data:dApp});
 				}}
 				dAppDescription={dApp}
 			/>

--- a/src/frontend/src/lib/components/guard/RewardGuard.svelte
+++ b/src/frontend/src/lib/components/guard/RewardGuard.svelte
@@ -22,11 +22,11 @@
 			await loadRewardResult($authIdentity);
 		if (receivedReward) {
 			if (receivedJackpot) {
-				modalStore.openRewardState({id:modalId,data: receivedJackpot });
+				modalStore.openRewardState({ id: modalId, data: receivedJackpot });
 			} else if (receivedReferral) {
 				modalStore.openReferralState();
 			} else {
-				modalStore.openRewardState({id:modalId,data: false });
+				modalStore.openRewardState({ id: modalId, data: false });
 			}
 		}
 	});

--- a/src/frontend/src/lib/components/guard/RewardGuard.svelte
+++ b/src/frontend/src/lib/components/guard/RewardGuard.svelte
@@ -11,6 +11,8 @@
 	let isJackpot: boolean | undefined;
 	$: isJackpot = $modalRewardState ? ($modalStore?.data as boolean | undefined) : undefined;
 
+	const modalId = Symbol();
+
 	onMount(async () => {
 		if (isNullish($authIdentity)) {
 			return;
@@ -20,11 +22,11 @@
 			await loadRewardResult($authIdentity);
 		if (receivedReward) {
 			if (receivedJackpot) {
-				modalStore.openRewardState(receivedJackpot);
+				modalStore.openRewardState({id:modalId,data: receivedJackpot });
 			} else if (receivedReferral) {
 				modalStore.openReferralState();
 			} else {
-				modalStore.openRewardState(false);
+				modalStore.openRewardState({id:modalId,data: false });
 			}
 		}
 	});

--- a/src/frontend/src/lib/components/guard/UrlGuard.svelte
+++ b/src/frontend/src/lib/components/guard/UrlGuard.svelte
@@ -10,6 +10,8 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { removeSearchParam } from '$lib/utils/nav.utils';
 
+	const modalId = Symbol();
+
 	$: (async () => {
 		if (!$loading && $page.url.searchParams.has('code') && nonNullish($authIdentity)) {
 			const rewardCode = $page.url.searchParams.get('code');
@@ -17,10 +19,10 @@
 				const result = await claimVipReward({ identity: $authIdentity, code: rewardCode });
 
 				removeSearchParam({ url: $page.url, searchParam: 'code' });
-				modalStore.openVipRewardState({
+				modalStore.openVipRewardState({id:modalId,data:{
 					success: result.success,
 					codeType: result.campaignId ?? QrCodeType.VIP
-				});
+				}});
 			}
 		}
 

--- a/src/frontend/src/lib/components/guard/UrlGuard.svelte
+++ b/src/frontend/src/lib/components/guard/UrlGuard.svelte
@@ -19,10 +19,13 @@
 				const result = await claimVipReward({ identity: $authIdentity, code: rewardCode });
 
 				removeSearchParam({ url: $page.url, searchParam: 'code' });
-				modalStore.openVipRewardState({id:modalId,data:{
-					success: result.success,
-					codeType: result.campaignId ?? QrCodeType.VIP
-				}});
+				modalStore.openVipRewardState({
+					id: modalId,
+					data: {
+						success: result.success,
+						codeType: result.campaignId ?? QrCodeType.VIP
+					}
+				});
 			}
 		}
 

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -41,6 +41,8 @@
 		$testnetsEnabled && $networksTestnets.length > 0
 			? SUPPORTED_NETWORKS.length
 			: SUPPORTED_MAINNET_NETWORKS.length;
+
+	const modalId = Symbol();
 </script>
 
 <Dropdown
@@ -65,7 +67,7 @@
 					link
 					on:click={() => {
 						dropdown?.close();
-						modalStore.openSettings(SettingsModalType.ENABLED_NETWORKS);
+						modalStore.openSettings({id:modalId,data:SettingsModalType.ENABLED_NETWORKS});
 					}}><IconManage />{$i18n.networks.manage}</Button
 				>
 			</span>

--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -67,7 +67,7 @@
 					link
 					on:click={() => {
 						dropdown?.close();
-						modalStore.openSettings({id:modalId,data:SettingsModalType.ENABLED_NETWORKS});
+						modalStore.openSettings({ id: modalId, data: SettingsModalType.ENABLED_NETWORKS });
 					}}><IconManage />{$i18n.networks.manage}</Button
 				>
 			</span>

--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -21,7 +21,7 @@
 	{#each rewards as reward (reward.id)}
 		<div in:slide={SLIDE_DURATION} class="mt-4">
 			<RewardCard
-				on:click={() => modalStore.openRewardDetails({id:modalId, data:reward})}
+				on:click={() => modalStore.openRewardDetails({ id: modalId, data: reward })}
 				{reward}
 				testId={nonNullish(testId) ? `${testId}-${reward.id}` : undefined}
 			/>

--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -11,6 +11,8 @@
 	export let rewards: RewardDescription[];
 	export let altText: string | undefined = undefined;
 	export let testId: string | undefined = undefined;
+
+	const modalId = Symbol();
 </script>
 
 <div class="mb-10 flex flex-col gap-4" data-tid={testId}>
@@ -19,7 +21,7 @@
 	{#each rewards as reward (reward.id)}
 		<div in:slide={SLIDE_DURATION} class="mt-4">
 			<RewardCard
-				on:click={() => modalStore.openRewardDetails(reward)}
+				on:click={() => modalStore.openRewardDetails({id:modalId, data:reward})}
 				{reward}
 				testId={nonNullish(testId) ? `${testId}-${reward.id}` : undefined}
 			/>

--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -51,7 +51,9 @@
 		}
 	};
 
-	const openSettingsModal = (t: SettingsModalType) => modalStore.openSettings(t);
+	const modalId = Symbol();
+
+	const openSettingsModal = (t: SettingsModalType) => modalStore.openSettings({id:modalId,data: t });
 </script>
 
 <SettingsCard>

--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -53,7 +53,8 @@
 
 	const modalId = Symbol();
 
-	const openSettingsModal = (t: SettingsModalType) => modalStore.openSettings({id:modalId,data: t });
+	const openSettingsModal = (t: SettingsModalType) =>
+		modalStore.openSettings({ id: modalId, data: t });
 </script>
 
 <SettingsCard>

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -240,11 +240,11 @@
 				case SESSION_REQUEST_PERSONAL_SIGN:
 				case SESSION_REQUEST_SOL_SIGN_TRANSACTION:
 				case SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION: {
-					modalStore.openWalletConnectSign({id:signModalId,data: sessionRequest });
+					modalStore.openWalletConnectSign({ id: signModalId, data: sessionRequest });
 					return;
 				}
 				case SESSION_REQUEST_ETH_SEND_TRANSACTION: {
-					modalStore.openWalletConnectSend({id:sendModalId,data: sessionRequest });
+					modalStore.openWalletConnectSend({ id: sendModalId, data: sessionRequest });
 					return;
 				}
 				default: {

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -36,6 +36,9 @@
 
 	export let listener: OptionWalletConnectListener;
 
+	const signModalId = Symbol();
+	const sendModalId = Symbol();
+
 	const STEP_CONNECT: WizardStep = {
 		name: 'Connect',
 		title: $i18n.wallet_connect.text.name
@@ -237,11 +240,11 @@
 				case SESSION_REQUEST_PERSONAL_SIGN:
 				case SESSION_REQUEST_SOL_SIGN_TRANSACTION:
 				case SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION: {
-					modalStore.openWalletConnectSign(sessionRequest);
+					modalStore.openWalletConnectSign({id:signModalId,data: sessionRequest });
 					return;
 				}
 				case SESSION_REQUEST_ETH_SEND_TRANSACTION: {
-					modalStore.openWalletConnectSend(sessionRequest);
+					modalStore.openWalletConnectSend({id:sendModalId,data: sessionRequest });
 					return;
 				}
 				default: {

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -54,6 +54,8 @@ export interface Modal<T> {
 
 export type ModalData<T> = Option<Modal<T>>;
 
+type SetWithDataParams<D> = { id: symbol; data: D };
+
 export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openEthReceive: (id: symbol) => void;
 	openIcpReceive: (id: symbol) => void;
@@ -72,12 +74,12 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openConvertToTwinTokenEth: () => void;
 	openHowToConvertToTwinTokenEth: () => void;
 	openWalletConnectAuth: () => void;
-	openWalletConnectSign: <D extends T>(data: D) => void;
-	openWalletConnectSend: <D extends T>(data: D) => void;
-	openEthTransaction: <D extends T>(data: D) => void;
-	openIcTransaction: <D extends T>(data: D) => void;
-	openBtcTransaction: <D extends T>(data: D) => void;
-	openSolTransaction: <D extends T>(data: D) => void;
+	openWalletConnectSign: <D extends T>(params: SetWithDataParams<D>) => void;
+	openWalletConnectSend: <D extends T>(params: SetWithDataParams<D>) => void;
+	openEthTransaction: <D extends T>(params: SetWithDataParams<D>) => void;
+	openIcTransaction: <D extends T>(params: SetWithDataParams<D>) => void;
+	openBtcTransaction: <D extends T>(params: SetWithDataParams<D>) => void;
+	openSolTransaction: <D extends T>(params: SetWithDataParams<D>) => void;
 	openManageTokens: () => void;
 	openHideToken: () => void;
 	openIcHideToken: () => void;
@@ -87,17 +89,17 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openSolToken: () => void;
 	openReceiveBitcoin: () => void;
 	openAboutWhyOisy: () => void;
-	openVipQrCode: (data: QrCodeType) => void;
+	openVipQrCode: (params: SetWithDataParams<QrCodeType>) => void;
 	openReferralCode: () => void;
 	openAddressBook: () => void;
 	openReferralState: () => void;
-	openDappDetails: <D extends T>(data: D) => void;
-	openVipRewardState: (data: VipRewardStateData) => void;
-	openRewardDetails: <D extends T>(data: D) => void;
-	openRewardState: <D extends T>(data: D) => void;
+	openDappDetails: <D extends T>(params: SetWithDataParams<D>) => void;
+	openVipRewardState: (params: SetWithDataParams<VipRewardStateData>) => void;
+	openRewardDetails: <D extends T>(params: SetWithDataParams<D>) => void;
+	openRewardState: <D extends T>(params: SetWithDataParams<D>) => void;
 	// todo: type methods above accordingly, otherwise data will be typed as unknown without making use of generics
-	openSettings: (data: SettingsModalType) => void;
-	openAuthHelp: (data: boolean) => void;
+	openSettings: (params: SetWithDataParams<SettingsModalType>) => void;
+	openAuthHelp: (params: SetWithDataParams<boolean>) => void;
 	close: () => void;
 }
 
@@ -110,8 +112,8 @@ const initModalStore = <T>(): ModalStore<T> => {
 
 	const setTypeWithData =
 		(type: Modal<T>['type']) =>
-		<D extends T>(data: D) =>
-			set({ type, data });
+		<D extends T>({ id, data }: { id: symbol; data: D }) =>
+			set({ type, id, data });
 
 	return {
 		openEthReceive: setTypeWithId('eth-receive'),
@@ -146,17 +148,21 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openSolToken: setType('sol-token'),
 		openReceiveBitcoin: setType('receive-bitcoin'),
 		openAboutWhyOisy: setType('about-why-oisy'),
-		openVipQrCode: <(data: QrCodeType) => void>setTypeWithData('vip-qr-code'),
+		openVipQrCode: <(params: SetWithDataParams<QrCodeType>) => void>setTypeWithData('vip-qr-code'),
 		openReferralCode: setType('referral-code'),
 		openAddressBook: setType('address-book'),
 		openReferralState: setType('referral-state'),
 		openDappDetails: setTypeWithData('dapp-details'),
-		openVipRewardState: <(data: VipRewardStateData) => void>setTypeWithData('vip-reward-state'),
+		openVipRewardState: <(params: SetWithDataParams<VipRewardStateData>) => void>(
+			setTypeWithData('vip-reward-state')
+		),
 		openRewardDetails: setTypeWithData('reward-details'),
 		openRewardState: setTypeWithData('reward-state'),
 		// todo: explicitly define type here as well
-		openSettings: <(data: SettingsModalType) => void>setTypeWithData('settings'),
-		openAuthHelp: <(data: boolean) => void>setTypeWithData('auth-help'),
+		openSettings: <(params: SetWithDataParams<SettingsModalType>) => void>(
+			setTypeWithData('settings')
+		),
+		openAuthHelp: <(params: SetWithDataParams<boolean>) => void>setTypeWithData('auth-help'),
 		close: () => set(null),
 		subscribe
 	};

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <Transaction
-	on:click={() => modalStore.openSolTransaction({id:modalId, data:{ transaction, token }})}
+	on:click={() => modalStore.openSolTransaction({ id: modalId, data: { transaction, token } })}
 	{amount}
 	{type}
 	timestamp={nonNullish(timestamp) ? Number(timestamp) : timestamp}

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -30,10 +30,12 @@
 
 	let amount: bigint | undefined;
 	$: amount = nonNullish(value) ? (type === 'send' ? value * -1n : value) : value;
+
+	const modalId = Symbol();
 </script>
 
 <Transaction
-	on:click={() => modalStore.openSolTransaction({ transaction, token })}
+	on:click={() => modalStore.openSolTransaction({id:modalId, data:{ transaction, token }})}
 	{amount}
 	{type}
 	timestamp={nonNullish(timestamp) ? Number(timestamp) : timestamp}

--- a/src/frontend/src/tests/lib/components/guard/UrlGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/UrlGuard.spec.ts
@@ -48,6 +48,7 @@ describe('UrlGuard', () => {
 				});
 
 				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
 					data: { success: true, codeType: QrCodeType.VIP },
 					type: 'vip-reward-state'
 				});
@@ -81,6 +82,7 @@ describe('UrlGuard', () => {
 				});
 
 				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
 					data: { success: false, codeType: QrCodeType.VIP },
 					type: 'vip-reward-state'
 				});

--- a/src/frontend/src/tests/lib/stores/modal.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal.store.spec.ts
@@ -21,10 +21,11 @@ describe('modal.store', () => {
 	});
 
 	it('should open wallet-connect-sign modal with data', () => {
+		const id = Symbol('modalId');
 		const data = { value: 12345 };
-		modalStore.openWalletConnectSign(data);
+		modalStore.openWalletConnectSign({ id, data });
 
-		expect(get(modalStore)).toEqual({ type: 'wallet-connect-sign', data });
+		expect(get(modalStore)).toEqual({ type: 'wallet-connect-sign', id, data });
 	});
 
 	it('should open convert-ckbtc-btc modal without modalId', () => {


### PR DESCRIPTION
# Motivation

It is useful to have a defined ID for each modal. For now we start with the modals that were requiring data as input too.

# Changes

- Make method `setTypeWithData` of `modalStore` accept an ID too.
- Adapt usage of `modalStore` throughout the code for the modals that were changed: create modal ID and pass it.

# Tests

Adapted tests.
