### PR TITLE
feat(frontend): Use wizard for address book

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -2,23 +2,25 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import AddressBookStep from '$lib/components/address-book/AddressBookStep.svelte';
 	import { ADDRESS_BOOK_MODAL } from '$lib/constants/test-ids.constants';
+	import { AddressBookSteps } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import type { Contact } from '$lib/types/contact';
-
-	type StepName = 'addressBook';
 
 	const steps: WizardSteps = [
 		{
-			name: 'addressBook',
+			name: AddressBookSteps.ADDRESS_BOOK,
 			title: $i18n.address_book.text.title
 		}
-	] satisfies { name: StepName; title: string }[] as WizardSteps;
+	] satisfies { name: AddressBookSteps; title: string }[] as WizardSteps;
 
 	let currentStep: WizardStep | undefined = $state();
 	let modal: WizardModal | undefined = $state();
-	let currentStepName = $derived(currentStep?.name as StepName);
+	let currentStepName = $derived(currentStep?.name as AddressBookSteps | undefined);
 
 	let contacts: Contact[] = $state([]);
+
+	const close = () => modalStore.close();
 </script>
 
 <WizardModal
@@ -27,10 +29,11 @@
 	bind:this={modal}
 	disablePointerEvents={true}
 	testId={ADDRESS_BOOK_MODAL}
+	on:nnsClose={close}
 >
 	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
-	{#if currentStepName === 'addressBook'}
+	{#if currentStepName === AddressBookSteps.ADDRESS_BOOK}
 		<AddressBookStep {contacts}></AddressBookStep>
 	{/if}
 </WizardModal>

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -1,24 +1,36 @@
 <script lang="ts">
-	import { Modal } from '@dfinity/gix-components';
-	import EmptyAddressBook from '$lib/components/address-book/EmptyAddressBook.svelte';
-	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
-	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import AddressBookStep from '$lib/components/address-book/AddressBookStep.svelte';
+	import { ADDRESS_BOOK_MODAL } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
+	import type { Contact } from '$lib/types/contact';
 
-	const contacts = [];
+	type StepName = 'addressBook';
+
+	const steps: WizardSteps = [
+		{
+			name: 'addressBook',
+			title: $i18n.address_book.text.title
+		}
+	] satisfies { name: StepName; title: string }[] as WizardSteps;
+
+	let currentStep: WizardStep | undefined = $state();
+	let modal: WizardModal | undefined = $state();
+	let currentStepName = $derived(currentStep?.name as StepName);
+
+	let contacts: Contact[] = $state([]);
 </script>
 
-<Modal on:nnsClose={modalStore.close}>
-	<span class="text-xl" slot="title">{$i18n.address_book.text.title}</span>
+<WizardModal
+	{steps}
+	bind:currentStep
+	bind:this={modal}
+	disablePointerEvents={true}
+	testId={ADDRESS_BOOK_MODAL}
+>
+	<svelte:fragment slot="title">{currentStep?.title ?? ''}</svelte:fragment>
 
-	<ContentWithToolbar styleClass="mx-2 flex flex-col justify-center items-center">
-		{#if contacts.length === 0}
-			<EmptyAddressBook></EmptyAddressBook>
-		{:else}
-			TODO Add contact list here
-		{/if}
-
-		<ButtonCloseModal slot="toolbar" />
-	</ContentWithToolbar>
-</Modal>
+	{#if currentStepName === 'addressBook'}
+		<AddressBookStep {contacts}></AddressBookStep>
+	{/if}
+</WizardModal>

--- a/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import EmptyAddressBook from '$lib/components/address-book/EmptyAddressBook.svelte';
+	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import type { Contact } from '$lib/types/contact';
+
+	let { contacts }: { contacts: Contact[] } = $props();
+</script>
+
+<ContentWithToolbar styleClass="mx-2 flex flex-col justify-center">
+	{#if contacts.length === 0}
+		<EmptyAddressBook></EmptyAddressBook>
+	{:else}
+		<div class="p-6">
+			<h3>TODO Add contact list here</h3>
+		</div>
+	{/if}
+
+	<ButtonCloseModal slot="toolbar" />
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
@@ -9,7 +9,7 @@
 
 <ContentWithToolbar styleClass="mx-2 flex flex-col justify-center">
 	{#if contacts.length === 0}
-		<EmptyAddressBook></EmptyAddressBook>
+		<EmptyAddressBook />
 	{:else}
 		<div class="p-6">
 			<h3>TODO Add contact list here</h3>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -12,6 +12,8 @@ export const MAX_BUTTON = 'max-button';
 export const LOADER_MODAL = 'loader-modal';
 export const BUTTON_MODAL_CLOSE = 'close-modal';
 
+export const MODAL_TITLE = 'modal-title';
+
 export const TOKEN_CARD = 'token-card';
 export const TOKEN_GROUP = 'token-group';
 export const TOKEN_BALANCE = 'token-balance';
@@ -175,3 +177,5 @@ export const HOW_TO_CONVERT_ETHEREUM_INFO = 'how-to-convert-ethereum-info';
 export const HOW_TO_CONVERT_ETHEREUM_QR_CODE = 'how-to-convert-ethereum-qr-code';
 
 export const MODAL_TOKEN_LIST_DEFAULT_NO_RESULTS = 'modal-token-list-item-default-no-results';
+
+export const ADDRESS_BOOK_MODAL = 'address-book-modal';

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -83,3 +83,7 @@ export enum ProgressStepsUpdateBalanceCkBtc {
 	RELOAD = 'reload',
 	DONE = 'done'
 }
+
+export enum AddressBookSteps {
+	ADDRESS_BOOK = 'address_book'
+}

--- a/src/frontend/src/lib/types/contact.ts
+++ b/src/frontend/src/lib/types/contact.ts
@@ -1,0 +1,3 @@
+export interface Contact {
+	name: string;
+}

--- a/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
@@ -1,13 +1,13 @@
 import AddressBookModal from '$lib/components/address-book/AddressBookModal.svelte';
 import { ADDRESS_BOOK_MODAL, MODAL_TITLE } from '$lib/constants/test-ids.constants';
 import en from '$tests/mocks/i18n.mock';
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 
 describe('AddressBookModal', () => {
 	it('should render the address book step initially', () => {
-		render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
-		expect(screen.getByTestId(ADDRESS_BOOK_MODAL)).toBeInTheDocument();
-		expect(screen.getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+		expect(getByTestId(ADDRESS_BOOK_MODAL)).toBeInTheDocument();
+		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
 	});
 });

--- a/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
@@ -1,0 +1,13 @@
+import AddressBookModal from '$lib/components/address-book/AddressBookModal.svelte';
+import { ADDRESS_BOOK_MODAL, MODAL_TITLE } from '$lib/constants/test-ids.constants';
+import en from '$tests/mocks/i18n.mock';
+import { render, screen } from '@testing-library/svelte';
+
+describe('AddressBookModal', () => {
+	it('should render the address book step initially', () => {
+		render(AddressBookModal);
+
+		expect(screen.getByTestId(ADDRESS_BOOK_MODAL)).toBeInTheDocument();
+		expect(screen.getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+	});
+});


### PR DESCRIPTION
# Motivation

In order to add more modals (like show contact and edit contact), the address book should use the `WizardModal` from gix components.

# Changes

- Added step component for the address book.
- Migrated the address book modal to `WizardModal`

# Tests

See this PR to see full feature demo: https://github.com/dfinity/oisy-wallet/pull/6071
