### PR TITLE
chore(frontend): add type to token groups

### DIFF
--- a/src/frontend/src/env/tokens/groups/groups.btc.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.btc.env.ts
@@ -1,12 +1,12 @@
 import bitcoin from '$btc/assets/bitcoin.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const BTC_TOKEN_GROUP_SYMBOL = 'BTC';
 
 export const BTC_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(BTC_TOKEN_GROUP_SYMBOL);
 
-export const BTC_TOKEN_GROUP = {
+export const BTC_TOKEN_GROUP: TokenGroup = {
 	id: BTC_TOKEN_GROUP_ID,
 	icon: bitcoin,
 	name: 'Bitcoin',

--- a/src/frontend/src/env/tokens/groups/groups.eth.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.eth.env.ts
@@ -1,12 +1,12 @@
 import eth from '$icp-eth/assets/eth.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const ETH_TOKEN_GROUP_SYMBOL = 'ETH';
 
 export const ETH_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(ETH_TOKEN_GROUP_SYMBOL);
 
-export const ETH_TOKEN_GROUP = {
+export const ETH_TOKEN_GROUP: TokenGroup = {
 	id: ETH_TOKEN_GROUP_ID,
 	icon: eth,
 	name: 'Ethereum',

--- a/src/frontend/src/env/tokens/groups/groups.eurc.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.eurc.env.ts
@@ -1,12 +1,12 @@
 import eurc from '$eth/assets/eurc.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const EURC_TOKEN_GROUP_SYMBOL = 'EURC';
 
 export const EURC_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(EURC_TOKEN_GROUP_SYMBOL);
 
-export const EURC_TOKEN_GROUP = {
+export const EURC_TOKEN_GROUP: TokenGroup = {
 	id: EURC_TOKEN_GROUP_ID,
 	icon: eurc,
 	name: 'Euro Coin',

--- a/src/frontend/src/env/tokens/groups/groups.link.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.link.env.ts
@@ -1,12 +1,12 @@
 import link from '$icp-eth/assets/link.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const LINK_TOKEN_GROUP_SYMBOL = 'LINK';
 
 export const LINK_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(LINK_TOKEN_GROUP_SYMBOL);
 
-export const LINK_TOKEN_GROUP = {
+export const LINK_TOKEN_GROUP: TokenGroup = {
 	id: LINK_TOKEN_GROUP_ID,
 	icon: link,
 	name: 'ChainLink Token',

--- a/src/frontend/src/env/tokens/groups/groups.oct.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.oct.env.ts
@@ -1,12 +1,12 @@
 import oct from '$icp-eth/assets/oct.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const OCT_TOKEN_GROUP_SYMBOL = 'OCT';
 
 export const OCT_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(OCT_TOKEN_GROUP_SYMBOL);
 
-export const OCT_TOKEN_GROUP = {
+export const OCT_TOKEN_GROUP: TokenGroup = {
 	id: OCT_TOKEN_GROUP_ID,
 	icon: oct,
 	name: 'Octopus Network Token',

--- a/src/frontend/src/env/tokens/groups/groups.pepe.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.pepe.env.ts
@@ -1,12 +1,12 @@
 import pepe from '$icp-eth/assets/pepe.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const PEPE_TOKEN_GROUP_SYMBOL = 'PEPE';
 
 export const PEPE_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(PEPE_TOKEN_GROUP_SYMBOL);
 
-export const PEPE_TOKEN_GROUP = {
+export const PEPE_TOKEN_GROUP: TokenGroup = {
 	id: PEPE_TOKEN_GROUP_ID,
 	icon: pepe,
 	name: 'Pepe',

--- a/src/frontend/src/env/tokens/groups/groups.shib.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.shib.env.ts
@@ -1,12 +1,12 @@
 import shib from '$icp-eth/assets/shib.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const SHIB_TOKEN_GROUP_SYMBOL = 'SHIB';
 
 export const SHIB_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(SHIB_TOKEN_GROUP_SYMBOL);
 
-export const SHIB_TOKEN_GROUP = {
+export const SHIB_TOKEN_GROUP: TokenGroup = {
 	id: SHIB_TOKEN_GROUP_ID,
 	icon: shib,
 	name: 'SHIBA INU',

--- a/src/frontend/src/env/tokens/groups/groups.uni.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.uni.env.ts
@@ -1,12 +1,12 @@
 import uni from '$icp-eth/assets/uni.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const UNI_TOKEN_GROUP_SYMBOL = 'UNI';
 
 export const UNI_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(UNI_TOKEN_GROUP_SYMBOL);
 
-export const UNI_TOKEN_GROUP = {
+export const UNI_TOKEN_GROUP: TokenGroup = {
 	id: UNI_TOKEN_GROUP_ID,
 	icon: uni,
 	name: 'Uniswap',

--- a/src/frontend/src/env/tokens/groups/groups.usdc.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.usdc.env.ts
@@ -1,12 +1,12 @@
 import usdc from '$eth/assets/usdc.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const USDC_TOKEN_GROUP_SYMBOL = 'USDC';
 
 export const USDC_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(USDC_TOKEN_GROUP_SYMBOL);
 
-export const USDC_TOKEN_GROUP = {
+export const USDC_TOKEN_GROUP: TokenGroup = {
 	id: USDC_TOKEN_GROUP_ID,
 	icon: usdc,
 	name: 'USDC',

--- a/src/frontend/src/env/tokens/groups/groups.usdt.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.usdt.env.ts
@@ -1,12 +1,12 @@
 import usdt from '$eth/assets/usdt.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const USDT_TOKEN_GROUP_SYMBOL = 'USDT';
 
 export const USDT_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(USDT_TOKEN_GROUP_SYMBOL);
 
-export const USDT_TOKEN_GROUP = {
+export const USDT_TOKEN_GROUP: TokenGroup = {
 	id: USDT_TOKEN_GROUP_ID,
 	icon: usdt,
 	name: 'Tether USD',

--- a/src/frontend/src/env/tokens/groups/groups.wbtc.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.wbtc.env.ts
@@ -1,12 +1,12 @@
 import wbtc from '$icp-eth/assets/wbtc.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const WBTC_TOKEN_GROUP_SYMBOL = 'WBTC';
 
 export const WBTC_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(WBTC_TOKEN_GROUP_SYMBOL);
 
-export const WBTC_TOKEN_GROUP = {
+export const WBTC_TOKEN_GROUP: TokenGroup = {
 	id: WBTC_TOKEN_GROUP_ID,
 	icon: wbtc,
 	name: 'Wrapped BTC',

--- a/src/frontend/src/env/tokens/groups/groups.wsteth.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.wsteth.env.ts
@@ -1,12 +1,12 @@
 import wsteth from '$icp-eth/assets/wsteth.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const WSTETH_TOKEN_GROUP_SYMBOL = 'wstETH';
 
 export const WSTETH_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(WSTETH_TOKEN_GROUP_SYMBOL);
 
-export const WSTETH_TOKEN_GROUP = {
+export const WSTETH_TOKEN_GROUP: TokenGroup = {
 	id: WSTETH_TOKEN_GROUP_ID,
 	icon: wsteth,
 	name: 'Wrapped liquid staked Ether 2.0',

--- a/src/frontend/src/env/tokens/groups/groups.xaut.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.xaut.env.ts
@@ -1,12 +1,12 @@
 import xaut from '$eth/assets/xaut.svg';
-import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenGroup, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 
 const XAUT_TOKEN_GROUP_SYMBOL = 'XAUt';
 
 export const XAUT_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(XAUT_TOKEN_GROUP_SYMBOL);
 
-export const XAUT_TOKEN_GROUP = {
+export const XAUT_TOKEN_GROUP: TokenGroup = {
 	id: XAUT_TOKEN_GROUP_ID,
 	icon: xaut,
 	name: 'Tether Gold',


### PR DESCRIPTION
# Motivation

Better to explicitly define the type of the token groups using interface `TokenGroup`.
