### PR TITLE
feat(frontend): use EVM native token for Send flow of EVM networks

### DIFF
--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -50,12 +50,11 @@
 		on:icTokensList
 	/>
 {:else if isNetworkIdEvm($sendToken.network.id) && nonNullish($selectedEvmNetwork) && nonNullish($evmNativeToken)}
-	<!--			TODO: use store evmNativeToken here when we adapt the fee context to fetch the EVM fees -->
 	<EthSendTokenWizard
 		{currentStep}
 		{formCancelAction}
 		sourceNetwork={$selectedEvmNetwork}
-		nativeEthereumToken={$ethereumToken}
+		nativeEthereumToken={$evmNativeToken}
 		bind:destination
 		bind:targetNetwork
 		bind:amount


### PR DESCRIPTION
# Motivation

We can use directly the EVM native token instead of the Ethereum one inside the Send flow for EVM networks.
