### PR TITLE
feat(frontend): create util to check supported native EVM tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.eth.env.ts
@@ -1,9 +1,15 @@
 import {
+	BASE_MAINNET_ENABLED,
 	BASE_NETWORK,
 	BASE_SEPOLIA_NETWORK
 } from '$env/networks/networks-evm/networks.evm.base.env';
+import {
+	BNB_MAINNET_TOKEN,
+	BNB_TESTNET_TOKEN
+} from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import eth from '$icp-eth/assets/eth.svg';
 import type { RequiredToken, TokenId } from '$lib/types/token';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 
 const BASE_ETH_DECIMALS = 18;
@@ -40,3 +46,9 @@ export const BASE_SEPOLIA_ETH_TOKEN: RequiredToken = {
 	decimals: BASE_ETH_DECIMALS,
 	icon: eth
 };
+
+export const SUPPORTED_BASE_TOKENS: RequiredToken[] = defineSupportedTokens({
+	mainnetFlag: BASE_MAINNET_ENABLED,
+	mainnetTokens: [BNB_MAINNET_TOKEN],
+	testnetTokens: [BNB_TESTNET_TOKEN]
+});

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.eth.env.ts
@@ -3,10 +3,6 @@ import {
 	BASE_NETWORK,
 	BASE_SEPOLIA_NETWORK
 } from '$env/networks/networks-evm/networks.evm.base.env';
-import {
-	BNB_MAINNET_TOKEN,
-	BNB_TESTNET_TOKEN
-} from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import eth from '$icp-eth/assets/eth.svg';
 import type { RequiredToken, TokenId } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
@@ -49,6 +45,6 @@ export const BASE_SEPOLIA_ETH_TOKEN: RequiredToken = {
 
 export const SUPPORTED_BASE_TOKENS: RequiredToken[] = defineSupportedTokens({
 	mainnetFlag: BASE_MAINNET_ENABLED,
-	mainnetTokens: [BNB_MAINNET_TOKEN],
-	testnetTokens: [BNB_TESTNET_TOKEN]
+	mainnetTokens: [BASE_ETH_TOKEN],
+	testnetTokens: [BASE_SEPOLIA_ETH_TOKEN]
 });

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env.ts
@@ -1,9 +1,11 @@
 import {
+	BSC_MAINNET_ENABLED,
 	BSC_MAINNET_NETWORK,
 	BSC_TESTNET_NETWORK
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import bnb from '$evm/bsc/assets/bnb.svg';
 import type { RequiredToken, TokenId } from '$lib/types/token';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 
 const BNB_DECIMALS = 18;
@@ -40,3 +42,9 @@ export const BNB_TESTNET_TOKEN: RequiredToken = {
 	decimals: BNB_DECIMALS,
 	icon: bnb
 };
+
+export const SUPPORTED_BSC_TOKENS: RequiredToken[] = defineSupportedTokens({
+	mainnetFlag: BSC_MAINNET_ENABLED,
+	mainnetTokens: [BNB_MAINNET_TOKEN],
+	testnetTokens: [BNB_TESTNET_TOKEN]
+});

--- a/src/frontend/src/env/tokens/tokens-evm/tokens.evm.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens.evm.env.ts
@@ -1,0 +1,10 @@
+import { SUPPORTED_BASE_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
+import { SUPPORTED_BSC_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import type { RequiredToken, TokenId } from '$lib/types/token';
+
+export const SUPPORTED_EVM_TOKENS: RequiredToken[] = [
+	...SUPPORTED_BASE_TOKENS,
+	...SUPPORTED_BSC_TOKENS
+];
+
+export const SUPPORTED_EVM_TOKEN_IDS: TokenId[] = SUPPORTED_EVM_TOKENS.map(({ id }) => id);

--- a/src/frontend/src/env/tokens/tokens.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens.eth.env.ts
@@ -57,4 +57,6 @@ export const SUPPORTED_ETHEREUM_TOKENS: RequiredTokenWithLinkedData[] = defineSu
 	testnetTokens: [SEPOLIA_TOKEN]
 });
 
-export const SUPPORTED_ETHEREUM_TOKEN_IDS: symbol[] = SUPPORTED_ETHEREUM_TOKENS.map(({ id }) => id);
+export const SUPPORTED_ETHEREUM_TOKEN_IDS: TokenId[] = SUPPORTED_ETHEREUM_TOKENS.map(
+	({ id }) => id
+);

--- a/src/frontend/src/evm/utils/native-token.utils.ts
+++ b/src/frontend/src/evm/utils/native-token.utils.ts
@@ -1,0 +1,5 @@
+import { SUPPORTED_EVM_TOKEN_IDS } from '$env/tokens/tokens-evm/tokens.evm.env';
+import type { TokenId } from '$lib/types/token';
+
+export const isSupportedEvmNativeTokenId = (tokenId: TokenId): boolean =>
+	SUPPORTED_EVM_TOKEN_IDS.includes(tokenId);


### PR DESCRIPTION
# Motivation

We will need to use the EVM native tokens for all the same flows of the base Ethereum network. So, for now, we first create an util to check if a token is a native EVM token (similar to util `isSupportedEthTokenId`).