### PR TITLE
feat(frontend): deprecated derived store `selectedEthereumNetworkWithFallback`

### DIFF
--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
-	import { isNullish } from '@dfinity/utils';
+	import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import EthConvertForm from '$eth/components/convert/EthConvertForm.svelte';
 	import EthConvertProgress from '$eth/components/convert/EthConvertProgress.svelte';
 	import EthConvertReview from '$eth/components/convert/EthConvertReview.svelte';
 	import FeeContext from '$eth/components/fee/FeeContext.svelte';
-	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
+	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { ethereumToken } from '$eth/derived/token.derived';
 	import { send as executeSend } from '$eth/services/send.services';
 	import { FEE_CONTEXT_KEY } from '$eth/stores/fee.store';
@@ -114,6 +114,9 @@
 
 		dispatch('icNext');
 
+		// This is a simple type check, since it should not happen since the user arrived here from a selected Ethereum network
+		assertNonNullish($selectedEthereumNetwork)
+
 		try {
 			await executeSend({
 				from: $ethAddress,
@@ -127,7 +130,7 @@
 				maxFeePerGas,
 				maxPriorityFeePerGas,
 				gas,
-				sourceNetwork: $selectedEthereumNetworkWithFallback,
+				sourceNetwork: $selectedEthereumNetwork,
 				targetNetwork: ICP_NETWORK,
 				identity: $authIdentity,
 				minterInfo: $ckEthMinterInfoStore?.[$ethereumToken.id]
@@ -156,6 +159,7 @@
 	const back = () => dispatch('icBack');
 </script>
 
+{#if nonNullish($selectedEthereumNetwork) }
 <FeeContext
 	sendToken={$sourceToken}
 	sendTokenId={$sourceToken.id}
@@ -163,7 +167,7 @@
 	{destination}
 	observe={currentStep?.name !== WizardStepsConvert.CONVERTING &&
 		currentStep?.name !== WizardStepsConvert.REVIEW}
-	sourceNetwork={$selectedEthereumNetworkWithFallback}
+	sourceNetwork={$selectedEthereumNetwork}
 	targetNetwork={ICP_NETWORK}
 	nativeEthereumToken={$ethereumToken}
 >
@@ -192,3 +196,4 @@
 		<slot />
 	{/if}
 </FeeContext>
+{/if}

--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { metamaskAvailable } from '$eth/derived/metamask.derived';
-	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
+	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { openMetamaskTransaction } from '$eth/services/metamask.services';
 	import IconMetamask from '$lib/components/icons/IconMetamask.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -9,6 +9,7 @@
 	import { tokenStandard } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
+	import { assertNonNullish } from '@dfinity/utils';
 
 	const receiveModal = async () => {
 		if (!$metamaskAvailable) {
@@ -18,9 +19,12 @@
 			return;
 		}
 
+		// This is a simple type check, since it should not happen since the user arrived here from a selected Ethereum network
+		assertNonNullish($selectedEthereumNetwork)
+
 		await openMetamaskTransaction({
 			address: $ethAddress,
-			network: $selectedEthereumNetworkWithFallback
+			network: $selectedEthereumNetwork
 		});
 	};
 

--- a/src/frontend/src/eth/derived/network.derived.ts
+++ b/src/frontend/src/eth/derived/network.derived.ts
@@ -12,13 +12,11 @@ export const selectedEthereumNetwork: Readable<EthereumNetwork | undefined> = de
 		$enabledEthereumNetworks.find(({ id }) => id === $networkId)
 );
 
-export const selectedEthereumNetworkWithFallback: Readable<EthereumNetwork> = derived(
-	[selectedEthereumNetwork],
-	([$selectedEthereumNetwork]) => $selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK
-);
-
+// TODO: make this store return `string | undefined`
 export const explorerUrl: Readable<string> = derived(
-	[selectedEvmNetwork, selectedEthereumNetworkWithFallback],
-	([$selectedEvmNetwork, { explorerUrl }]) =>
-		nonNullish($selectedEvmNetwork) ? $selectedEvmNetwork?.explorerUrl : explorerUrl
+	[selectedEvmNetwork, selectedEthereumNetwork],
+	([$selectedEvmNetwork, $selectedEthereumNetwork]) =>
+		nonNullish($selectedEvmNetwork)
+			? $selectedEvmNetwork?.explorerUrl
+			: ($selectedEthereumNetwork?.explorerUrl ?? DEFAULT_ETHEREUM_NETWORK.explorerUrl)
 );

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -1,4 +1,4 @@
-import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
+import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
@@ -8,10 +8,11 @@ import { derived, type Readable } from 'svelte/store';
  * Ethereum (Ethereum or Sepolia) token - i.e. not ERC20.
  */
 export const ethereumToken: Readable<RequiredTokenWithLinkedData> = derived(
-	[enabledEthereumTokens, selectedEthereumNetworkWithFallback],
-	([$enabledEthereumTokens, { id }]) =>
-		$enabledEthereumTokens.find(({ network: { id: networkId } }) => id === networkId) ??
-		DEFAULT_ETHEREUM_TOKEN
+	[enabledEthereumTokens, selectedEthereumNetwork],
+	([$enabledEthereumTokens, $selectedEthereumNetwork]) =>
+		$enabledEthereumTokens.find(
+			({ network: { id: networkId } }) => $selectedEthereumNetwork?.id === networkId
+		) ?? DEFAULT_ETHEREUM_TOKEN
 );
 
 export const ethereumTokenId: Readable<TokenId> = derived([ethereumToken], ([{ id }]) => id);

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -4,7 +4,7 @@
 	import { getContext } from 'svelte';
 	import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
-	import { selectedEthereumNetworkWithFallback } from '$eth/derived/network.derived';
+	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { ethereumToken } from '$eth/derived/token.derived';
 	import { selectedEvmNetwork } from '$evm/derived/network.derived';
 	import { evmNativeToken } from '$evm/derived/token.derived';
@@ -32,11 +32,11 @@
 	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
 </script>
 
-{#if isNetworkIdEthereum($sendToken.network.id)}
+{#if isNetworkIdEthereum($sendToken.network.id) && nonNullish($selectedEthereumNetwork)}
 	<EthSendTokenWizard
 		{currentStep}
 		{formCancelAction}
-		sourceNetwork={$selectedEthereumNetworkWithFallback}
+		sourceNetwork={$selectedEthereumNetwork}
 		nativeEthereumToken={$ethereumToken}
 		bind:destination
 		bind:targetNetwork

--- a/src/frontend/src/tests/eth/derived/network.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/network.derived.spec.ts
@@ -3,11 +3,7 @@ import { BSC_TESTNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc
 import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { SOLANA_DEVNET_NETWORK } from '$env/networks/networks.sol.env';
-import {
-	explorerUrl,
-	selectedEthereumNetwork,
-	selectedEthereumNetworkWithFallback
-} from '$eth/derived/network.derived';
+import { explorerUrl, selectedEthereumNetwork } from '$eth/derived/network.derived';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { Network } from '$lib/types/network';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -62,59 +58,6 @@ describe('network.derived', () => {
 			mockPage.mock({ network: 'mockNetwork' });
 
 			expect(get(selectedEthereumNetwork)).toBeUndefined();
-		});
-	});
-
-	describe('selectedEthereumNetworkWithFallback', () => {
-		beforeEach(() => {
-			vi.clearAllMocks();
-			vi.resetAllMocks();
-
-			setupTestnetsStore('enabled');
-			setupUserNetworksStore('allEnabled');
-		});
-
-		it('should return the current network when it is an Ethereum network', () => {
-			const networks: Network[] = [ETHEREUM_NETWORK, SEPOLIA_NETWORK];
-
-			networks.forEach((network) => {
-				mockPage.mock({ network: network.id.description });
-
-				expect(get(selectedEthereumNetworkWithFallback)).toEqual(network);
-			});
-		});
-
-		it('should fallback to the default Ethereum network if it is not an Ethereum network', () => {
-			const networks: Network[] = [
-				ICP_NETWORK,
-				BASE_NETWORK,
-				SOLANA_DEVNET_NETWORK,
-				BSC_TESTNET_NETWORK
-			];
-
-			networks.forEach((network) => {
-				mockPage.mock({ network: network.id.description });
-
-				expect(get(selectedEthereumNetworkWithFallback)).toEqual(ETHEREUM_NETWORK);
-			});
-		});
-
-		it('should fallback to the default Ethereum network if Sepolia network is disabled', () => {
-			setupTestnetsStore('disabled');
-
-			const networks: Network[] = [ETHEREUM_NETWORK, SEPOLIA_NETWORK];
-
-			networks.forEach((network) => {
-				mockPage.mock({ network: network.id.description });
-
-				expect(get(selectedEthereumNetworkWithFallback)).toEqual(ETHEREUM_NETWORK);
-			});
-		});
-
-		it('should fallback to the default Ethereum network if no match is found', () => {
-			mockPage.mock({ network: 'mockNetwork' });
-
-			expect(get(selectedEthereumNetworkWithFallback)).toEqual(ETHEREUM_NETWORK);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

We are now enabling and disabling networks, plus we are adding more EVM networks. That means that in some situations we should be aware if the correct network is being used.

To this purpose, we shall start removing the fallbacks from a few Ethereum derived stores.

We start from `selectedEthereumNetworkWithFallback`.

# Changes

- Substitute the usage of `selectedEthereumNetworkWithFallback` with `selectedEthereumNetwork`.
- Where necessary create non-nullish assertions, since it is expected that the derived store has a value when it is called in the correct context.
- Remove deprecated store `selectedEthereumNetworkWithFallback` and its tests.

# Tests

Local replica presented no changes when sending Sepolia tokens.
