### PR TITLE
refactor(frontend): extract sub-function that auto load token

### DIFF
--- a/src/frontend/src/lib/services/token.services.ts
+++ b/src/frontend/src/lib/services/token.services.ts
@@ -21,24 +21,81 @@ export const loadTokenAndRun = async ({
 	await callback();
 };
 
-export interface AutoLoadTokenParams<
-	T extends SaveUserToken | SaveCustomToken,
-	K extends Erc20Token | IcCkToken
-> {
-	tokens: T[];
-	sendToken: K;
+export interface AutoLoadSingleTokenParams<T extends SaveUserToken | SaveCustomToken> {
+	token: T | undefined;
 	identity: OptionIdentity;
-	expectedSendTokenStandard: TokenStandard;
-	assertSendTokenData: (sendToken: K) => AutoLoadTokenResult | undefined;
-	findToken: (params: { tokens: T[]; sendToken: K }) => T | undefined;
 	setToken: (params: { identity: Identity; token: T; enabled: boolean }) => Promise<void>;
 	loadTokens: (params: { identity: OptionIdentity }) => Promise<void>;
 	errorMessage: string;
 }
 
+export type AutoLoadTokenParams<
+	T extends SaveUserToken | SaveCustomToken,
+	K extends Erc20Token | IcCkToken
+> = Omit<AutoLoadSingleTokenParams<T>, 'token'> & {
+	tokens: T[];
+	sendToken: K;
+	expectedSendTokenStandard: TokenStandard;
+	assertSendTokenData: (sendToken: K) => AutoLoadTokenResult | undefined;
+	findToken: (params: { tokens: T[]; sendToken: K }) => T | undefined;
+};
+
 export interface AutoLoadTokenResult {
 	result: 'loaded' | 'skipped' | 'error';
 }
+
+/**
+ * A generic function to handle loading a specific token.
+ *
+ * @param {Object} params - The parameters for the function.
+ * @param {Token} params.token - The token to be loaded.
+ * @param {OptionIdentity} params.identity - The user's identity.
+ * @param {function} params.setToken - A function to enable the counterpart token.
+ * @param {function} params.loadTokens - A function to reload tokens.
+ * @param {string} params.errorMessage - A message to display in case of an error.
+ * @returns The result of the operation.
+ */
+export const autoLoadSingleToken = async <T extends SaveUserToken | SaveCustomToken>({
+	token,
+	identity,
+	setToken,
+	loadTokens,
+	errorMessage
+}: AutoLoadSingleTokenParams<T>): Promise<AutoLoadTokenResult> => {
+	if (isNullish(token)) {
+		return { result: 'skipped' };
+	}
+
+	if (token.enabled) {
+		return { result: 'skipped' };
+	}
+
+	busy.start();
+
+	try {
+		assertNonNullish(identity);
+
+		await setToken({
+			identity,
+			token,
+			enabled: true
+		});
+
+		// TODO(GIX-2740): Only reload the tokens we need.
+		await loadTokens({ identity });
+	} catch (err: unknown) {
+		toastsError({
+			msg: { text: errorMessage },
+			err
+		});
+
+		return { result: 'error' };
+	} finally {
+		busy.stop();
+	}
+
+	return { result: 'loaded' };
+};
 
 /**
  * A generic function to handle loading a token that is either:
@@ -83,37 +140,11 @@ export const autoLoadToken = async <
 
 	const counterpartToken = findToken({ tokens, sendToken });
 
-	if (isNullish(counterpartToken)) {
-		return { result: 'skipped' };
-	}
-
-	if (counterpartToken.enabled) {
-		return { result: 'skipped' };
-	}
-
-	busy.start();
-
-	try {
-		assertNonNullish(identity);
-
-		await setToken({
-			identity,
-			token: counterpartToken,
-			enabled: true
-		});
-
-		// TODO(GIX-2740): Only reload the tokens we need.
-		await loadTokens({ identity });
-	} catch (err: unknown) {
-		toastsError({
-			msg: { text: errorMessage },
-			err
-		});
-
-		return { result: 'error' };
-	} finally {
-		busy.stop();
-	}
-
-	return { result: 'loaded' };
+	return await autoLoadSingleToken({
+		token: counterpartToken,
+		identity,
+		setToken,
+		loadTokens,
+		errorMessage
+	});
 };

--- a/src/frontend/src/tests/lib/services/token.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/token.services.spec.ts
@@ -1,13 +1,17 @@
 import type { SaveUserToken } from '$eth/services/erc20-user-tokens-services';
 import type { Erc20Token } from '$eth/types/erc20';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import {
+	autoLoadSingleToken,
 	autoLoadToken,
 	loadTokenAndRun,
+	type AutoLoadSingleTokenParams,
 	type AutoLoadTokenParams
 } from '$lib/services/token.services';
 import { busy } from '$lib/stores/busy.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { token } from '$lib/stores/token.store';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
 import { get } from 'svelte/store';
@@ -55,6 +59,88 @@ describe('token.services', () => {
 
 			expect(tokenStore).toBe(mockValidToken);
 			expect(failingCallback).toHaveBeenCalled();
+		});
+	});
+
+	describe('autoLoadSingleToken', () => {
+		let mockSetToken: Mock;
+		let mockLoadTokens: Mock;
+
+		const mockErrorMessage = 'Error loading token';
+
+		let params: AutoLoadSingleTokenParams<IcrcCustomToken>;
+
+		let spyToastsError: MockInstance;
+		let spyBusyStart: MockInstance;
+		let spyBusyStop: MockInstance;
+
+		beforeEach(() => {
+			mockSetToken = vi.fn();
+			mockLoadTokens = vi.fn();
+
+			params = {
+				token: mockIcrcCustomToken,
+				identity: mockIdentity,
+				setToken: mockSetToken,
+				loadTokens: mockLoadTokens,
+				errorMessage: mockErrorMessage
+			};
+
+			spyToastsError = vi.spyOn(toastsStore, 'toastsError');
+			spyBusyStart = vi.spyOn(busy, 'start');
+			spyBusyStop = vi.spyOn(busy, 'stop');
+		});
+
+		it('should return "skipped" if token is nullish', async () => {
+			const result = await autoLoadSingleToken({ ...params, token: undefined });
+
+			expect(result.result).toBe('skipped');
+		});
+
+		it('should return "skipped" if token is already enabled', async () => {
+			const result = await autoLoadSingleToken({
+				...params,
+				token: { ...mockIcrcCustomToken, enabled: true }
+			});
+
+			expect(result.result).toBe('skipped');
+		});
+
+		it('should return "error" if setToken fails and show toast error', async () => {
+			const error = new Error('Set token failed');
+
+			mockSetToken.mockRejectedValue(error);
+
+			const { result } = await autoLoadSingleToken(params);
+
+			expect(result).toBe('error');
+
+			expect(spyToastsError).toHaveBeenCalledWith({
+				msg: { text: mockErrorMessage },
+				err: error
+			});
+
+			expect(spyBusyStart).toHaveBeenCalledTimes(1);
+			expect(spyBusyStop).toHaveBeenCalledTimes(1);
+		});
+
+		it('should enable token, reload tokens, and return "loaded" on success', async () => {
+			mockSetToken.mockResolvedValue(undefined);
+			mockLoadTokens.mockResolvedValue(undefined);
+
+			const { result } = await autoLoadSingleToken(params);
+
+			expect(result).toBe('loaded');
+
+			expect(mockSetToken).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				token: params.token,
+				enabled: true
+			});
+			expect(mockLoadTokens).toHaveBeenCalledWith({ identity: mockIdentity });
+
+			expect(spyBusyStart).toHaveBeenCalledTimes(1);
+			expect(spyBusyStop).toHaveBeenCalledTimes(1);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

From service `autoLoadToken` we extract a sub-function called `autoLoadToken` that will take as input the token directly, instead of searching it based on the input parameters.