### PR TITLE
feat(build): temporary replace correct BSC API url for package `ethers`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
 				"typescript": "^5.4.5",
 				"vite": "^6.3.2",
 				"vite-node": "^3.0.9",
+				"vite-plugin-filter-replace": "^0.1.14",
 				"vitest": "^3.1.1",
 				"vitest-mock-extended": "^3.1.0"
 			},
@@ -13193,6 +13194,16 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/vite-plugin-filter-replace": {
+			"version": "0.1.14",
+			"resolved": "https://registry.npmjs.org/vite-plugin-filter-replace/-/vite-plugin-filter-replace-0.1.14.tgz",
+			"integrity": "sha512-3onEAYgjJQTCJN+/f8+1vOUH3X/tRmXsfxmgH3QtpReGKi+xtP1jMpAEnYsNqw9mI2shZmxFm3LS+n52XczwYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"magic-string": "^0.30.17"
+			}
 		},
 		"node_modules/vite/node_modules/fdir": {
 			"version": "6.4.4",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
 		"typescript": "^5.4.5",
 		"vite": "^6.3.2",
 		"vite-node": "^3.0.9",
+		"vite-plugin-filter-replace": "^0.1.14",
 		"vitest": "^3.1.1",
 		"vitest-mock-extended": "^3.1.0"
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { basename, dirname, resolve } from 'node:path';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
+import replace from 'vite-plugin-filter-replace';
 import { CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds } from './vite.utils';
 
 // npm run dev = local
@@ -13,7 +14,29 @@ import { CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds } from './v
 const network = process.env.DFX_NETWORK ?? 'local';
 
 const config: UserConfig = {
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit(),
+		// TODO: uninstall `vite-plugin-filter-replace` and remove this when `ethers` package updates the URL too - issue https://github.com/ethers-io/ethers.js/issues/4951
+		replace(
+			[
+				{
+					filter: ['node_modules/ethers'],
+					replace: {
+						from: 'bnbsmartchain-mainnet.infura.io',
+						to: 'bsc-mainnet.infura.io'
+					}
+				},
+				{
+					filter: ['node_modules/ethers'],
+					replace: {
+						from: 'bnbsmartchain-testnet.infura.io',
+						to: 'bsc-testnet.infura.io'
+					}
+				}
+			],
+			{ enforce: 'pre' }
+		)
+	],
 	resolve: {
 		alias: {
 			$declarations: resolve('./src/declarations')


### PR DESCRIPTION
# Motivation

There is a known issue with `ethers` package: the BNB Smart Chain (BSC) API URLs are not updated (see issue https://github.com/ethers-io/ethers.js/issues/4951). However we have the BSC network among our list of networks, so we need to temporarily patch it to the correct URL.

To do that we use a no-so-known plugin called [vite-plugin-filter-replace](https://www.npmjs.com/package/vite-plugin-filter-replace).

# Changes

- Install `vite-plugin-filter-replace`.
- Adapt `vite` configs to replace the wrong BSC API URLs.

# Tests

Tested in test canister and it works as expected:

![Screenshot 2025-04-25 at 15 50 47](https://github.com/user-attachments/assets/8ab90c5a-a99c-42a5-a2d2-3251a81089ba)

