### PR TITLE
feat(build): temporary replace correct BSC API url for package `ethers`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { basename, dirname, resolve } from 'node:path';
-import { defineConfig, loadEnv, type UserConfig } from 'vite';
+import { defineConfig, loadEnv, type Plugin, type UserConfig } from 'vite';
 import { CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds } from './vite.utils';
 
 // npm run dev = local
@@ -12,8 +12,31 @@ import { CSS_CONFIG_OPTIONS, defineViteReplacements, readCanisterIds } from './v
 // dfx deploy --network staging = staging
 const network = process.env.DFX_NETWORK ?? 'local';
 
+// TODO: remove this when `ethers` package updates the URL too - issue https://github.com/ethers-io/ethers.js/issues/4951
+function ethersRewritePlugin(): Plugin {
+	return {
+		name: 'vite-plugin-ethers-rewrite',
+		enforce: 'pre',
+		// eslint-disable-next-line local-rules/prefer-object-params
+		transform(code, id) {
+			if (!id.includes('node_modules/ethers')) {
+				return;
+			}
+
+			const replaced = code
+				.replaceAll('bnbsmartchain-mainnet.infura.io', 'bsc-mainnet.infura.io')
+				.replaceAll('bnbsmartchain-testnet.infura.io', 'bsc-testnet.infura.io');
+
+			return {
+				code: replaced,
+				map: null
+			};
+		}
+	};
+}
+
 const config: UserConfig = {
-	plugins: [sveltekit()],
+	plugins: [sveltekit(), ethersRewritePlugin()],
 	resolve: {
 		alias: {
 			$declarations: resolve('./src/declarations')


### PR DESCRIPTION
# Motivation

There is a known issue with `ethers` package: the BNB Smart Chain (BSC) API URLs are not updated (see issue https://github.com/ethers-io/ethers.js/issues/4951). However we have the BSC network among our list of networks, so we need to temporarily patch it to the correct URL.

To do that we create a custom plugin and apply it (credits to @peterpeterparker ).

# Changes

- Create custom plugin to replace the URLs.
- Adapt `vite` configs to replace the wrong BSC API URLs.

# Tests

Tested in test canister and it works as expected:

![Screenshot 2025-04-25 at 15 50 47](https://github.com/user-attachments/assets/8ab90c5a-a99c-42a5-a2d2-3251a81089ba)

