### PR TITLE
refactor(frontend): include chain ID check in derived store `erc20UserTokensToggleable`

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -8,6 +8,7 @@ import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import type { EthereumNetwork } from '$eth/types/network';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
+import { isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -19,15 +20,6 @@ const erc20DefaultTokens: Readable<Erc20Token[]> = derived(
 		($erc20TokensStore ?? []).filter(({ network: { id: networkId } }) =>
 			$enabledEthereumNetworksIds.includes(networkId)
 		)
-);
-
-/**
- * A flatten list of the default ERC20 contract addresses.
- */
-const erc20DefaultTokensAddresses: Readable<string[]> = derived(
-	[erc20DefaultTokens],
-	([$erc20DefaultTokens]) =>
-		$erc20DefaultTokens.map(({ address }) => mapAddressStartsWith0x(address).toLowerCase())
 );
 
 /**
@@ -85,11 +77,17 @@ const enabledErc20DefaultTokens: Readable<Erc20TokenToggleable[]> = derived(
  * We do so because the default statically configured are those to be used for various feature. This is notably useful for ERC20 <> ckERC20 conversion given that tokens on both sides (ETH an IC) should know about each others ("Twin Token" links).
  */
 const erc20UserTokensToggleable: Readable<Erc20UserToken[]> = derived(
-	[erc20UserTokens, erc20DefaultTokensAddresses],
-	([$erc20UserTokens, $erc20DefaultTokensAddresses]) =>
-		$erc20UserTokens.filter(
-			({ address }) =>
-				!$erc20DefaultTokensAddresses.includes(mapAddressStartsWith0x(address).toLowerCase())
+	[erc20UserTokens, erc20DefaultTokens],
+	([$erc20UserTokens, $erc20DefaultTokens]) =>
+		$erc20UserTokens.filter(({ address, network }) =>
+			isNullish(
+				$erc20DefaultTokens.find(
+					({ address: defaultAddress, network: defaultNetwork }) =>
+						mapAddressStartsWith0x(defaultAddress).toLowerCase() ===
+							mapAddressStartsWith0x(address).toLowerCase() &&
+						(defaultNetwork as EthereumNetwork).chainId === (network as EthereumNetwork).chainId
+				)
+			)
 		)
 );
 


### PR DESCRIPTION
# Motivation

Since we have now more ERC20 over different networks, like EVM networks (different chain IDs), it makes sense to include the chain ID in the checks.

# Changes

- Change derived store `erc20DefaultTokensAddresses` to check the chain IDs between user tokens and default tokens.
- Remove deprecated store `erc20DefaultTokensAddresses`.

# Tests

Current tests are sufficient.
