### PR TITLE
feat(frontend): add EVM networks to derived stores for ERC20 tokens

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -6,6 +6,7 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import type { EthereumNetwork } from '$eth/types/network';
+import { enabledEvmNetworksIds } from '$evm/derived/networks.derived';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { derived, type Readable } from 'svelte/store';
@@ -14,10 +15,10 @@ import { derived, type Readable } from 'svelte/store';
  * The list of ERC20 default tokens - i.e. the statically configured ERC20 tokens of Oisy + their metadata, unique ids etc. fetched at runtime.
  */
 const erc20DefaultTokens: Readable<Erc20Token[]> = derived(
-	[erc20DefaultTokensStore, enabledEthereumNetworksIds],
-	([$erc20TokensStore, $enabledEthereumNetworksIds]) =>
+	[erc20DefaultTokensStore, enabledEthereumNetworksIds, enabledEvmNetworksIds],
+	([$erc20TokensStore, $enabledEthereumNetworksIds, $enabledEvmNetworksIds]) =>
 		($erc20TokensStore ?? []).filter(({ network: { id: networkId } }) =>
-			$enabledEthereumNetworksIds.includes(networkId)
+			[...$enabledEthereumNetworksIds, ...$enabledEvmNetworksIds].includes(networkId)
 		)
 );
 
@@ -35,14 +36,14 @@ const erc20DefaultTokensAddresses: Readable<string[]> = derived(
  * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "user token" in the backend.
  */
 export const erc20UserTokens: Readable<Erc20UserToken[]> = derived(
-	[erc20UserTokensStore, enabledEthereumNetworksIds],
-	([$erc20UserTokensStore, $enabledEthereumNetworksIds]) =>
+	[erc20UserTokensStore, enabledEthereumNetworksIds, enabledEvmNetworksIds],
+	([$erc20UserTokensStore, $enabledEthereumNetworksIds, $enabledEvmNetworksIds]) =>
 		$erc20UserTokensStore?.reduce<Erc20UserToken[]>((acc, { data: token }) => {
 			const {
 				network: { id: networkId }
 			} = token;
 
-			if ($enabledEthereumNetworksIds.includes(networkId)) {
+			if ([...$enabledEthereumNetworksIds, ...$enabledEvmNetworksIds].includes(networkId)) {
 				return [...acc, token];
 			}
 

--- a/src/frontend/src/evm/derived/networks.derived.ts
+++ b/src/frontend/src/evm/derived/networks.derived.ts
@@ -2,10 +2,16 @@ import { EVM_NETWORKS_ENABLED } from '$env/networks/networks-evm/networks.evm.en
 import type { EthereumNetwork } from '$eth/types/network';
 import { enabledBaseNetworks } from '$evm/base/derived/networks.derived';
 import { enabledBscNetworks } from '$evm/bsc/derived/networks.derived';
+import type { NetworkId } from '$lib/types/network';
 import { derived, type Readable } from 'svelte/store';
 
 export const enabledEvmNetworks: Readable<EthereumNetwork[]> = derived(
 	[enabledBaseNetworks, enabledBscNetworks],
 	([$enabledBaseNetworks, $enabledBscNetworks]) =>
 		EVM_NETWORKS_ENABLED ? [...$enabledBaseNetworks, ...$enabledBscNetworks] : []
+);
+
+export const enabledEvmNetworksIds: Readable<NetworkId[]> = derived(
+	[enabledEvmNetworks],
+	([$enabledEvmNetworks]) => $enabledEvmNetworks.map(({ id }) => id)
 );


### PR DESCRIPTION
# Motivation

The ERC20 derived store (both default and user tokens) now includes ERC20 from other networks. So, we must include the EVM networks among the checks when filtering.
