### PR TITLE
fix(frontend): disable evaluation of pow feature flag

### DIFF
--- a/src/frontend/src/env/pow.env.ts
+++ b/src/frontend/src/env/pow.env.ts
@@ -1,5 +1,7 @@
-import { parseBoolEnvVar } from '$lib/utils/env.utils';
+// TODO remove this hardocded assignement once VITE_POW_FEATURE_ENABLED is correctly set in github
+export const POW_FEATURE_ENABLED = false;
 
-export const POW_FEATURE_ENABLED = parseBoolEnvVar(import.meta.env.VITE_POW_FEATURE_ENABLED);
+// TODO enable this feature flag evaluation logic once VITE_POW_FEATURE_ENABLED is set in github
+// export const POW_FEATURE_ENABLED = parseBoolEnvVar(import.meta.env.VITE_POW_FEATURE_ENABLED);
 
 export const POW_CHALLENGE_INTERVAL_MILLIS = 120000;


### PR DESCRIPTION
# Motivation

After the merge of [PR](https://github.com/dfinity/oisy-wallet/pull/6120) on friday, this error suddenly appreas in oiwsy-wallet: Unexpected end of JSON input. For the moment we disable the evaluation of the VITE_POW_FEATURE_ENABLED and just set it to false, to avoid the issue until a fallback is implemented and  the secret VITE_POW_FEATURE_ENABLED is set to false.