### PR TITLE
fix(frontend): correct Coingecko ID for BNB

### DIFF
--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -48,7 +48,7 @@ export const exchanges: Readable<ExchangesData> = derived(
 		const btcPrice = $exchangeStore?.bitcoin;
 		const icpPrice = $exchangeStore?.['internet-computer'];
 		const solPrice = $exchangeStore?.solana;
-		const bnbPrice = $exchangeStore?.bnb;
+		const bnbPrice = $exchangeStore?.binancecoin;
 
 		return {
 			// TODO: improve feed price on testnets, for now we assume that 1 token mainnet = 1 token testnet

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -59,7 +59,7 @@ export const exchangeRateSOLToUsd = (): Promise<CoingeckoSimplePriceResponse | n
 
 export const exchangeRateBNBToUsd = (): Promise<CoingeckoSimplePriceResponse | null> =>
 	simplePrice({
-		ids: 'bnb',
+		ids: 'binancecoin',
 		vs_currencies: 'usd'
 	});
 

--- a/src/frontend/src/lib/validation/coingecko.validation.ts
+++ b/src/frontend/src/lib/validation/coingecko.validation.ts
@@ -5,5 +5,5 @@ export const CoingeckoCoinsIdSchema = z.enum([
 	'bitcoin',
 	'internet-computer',
 	'solana',
-	'bnb'
+	'binancecoin'
 ]);


### PR DESCRIPTION
# Motivation

Coingecko ID for BNB token should be `binancecoin` instead of `bnb`.
