### PR TITLE
fix(frontend): Loader Text - added Base and BNB to the retrieve keys text

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -226,7 +226,7 @@
 		"text": {
 			"initializing_wallet": "Preparing your wallet...",
 			"securing_session": "Securing session with Internet Identity",
-			"retrieving_public_keys": "Retrieving your public keys for Bitcoin, Ethereum and Solana",
+			"retrieving_public_keys": "Retrieving your public keys for Bitcoin, Ethereum, Solana, Base and BNB",
 			"done": "Enjoy $oisy_short"
 		},
 		"alt": {


### PR DESCRIPTION
# Motivation

We'd like to reflect that we have new networks in the app.

# Changes

Added Base and BNB to the texts

# Tests

![image](https://github.com/user-attachments/assets/bb849664-da0c-43f1-9972-786317742a2e)

![image](https://github.com/user-attachments/assets/37d9ca70-f544-4c76-9ef9-3f6f824a9f54)

