### PR TITLE
feat(frontend): mark SNS token Seers as deprecated

### DIFF
--- a/src/frontend/src/env/tokens/tokens.sns.deprecated.env.ts
+++ b/src/frontend/src/env/tokens/tokens.sns.deprecated.env.ts
@@ -11,5 +11,12 @@ export const DEPRECATED_SNES: Record<
 		alternativeName: undefined,
 		url: undefined,
 		icon: undefined
+	},
+	['rffwt-piaaa-aaaaq-aabqq-cai']: {
+		name: '---- (formerly Seers)',
+		symbol: '--- (SEER)',
+		alternativeName: undefined,
+		url: undefined,
+		icon: undefined
 	}
 };


### PR DESCRIPTION
# Motivation

The remaining ICP from Seers were emptied, the dapp canister was unregistered from the DAO, and ultimately it was renamed renamed to `---- ex Seers ---- / ---- please unlist ----`.

So we mark the ICRC token Seers as deprecated.

Proposals:
https://nns.ic0.app/proposal/?u=u67kc-jyaaa-aaaaq-aabpq-cai&proposal=380
https://nns.ic0.app/proposal/?u=u67kc-jyaaa-aaaaq-aabpq-cai&proposal=381
https://nns.ic0.app/proposal/?u=u67kc-jyaaa-aaaaq-aabpq-cai&proposal=382

Credits to @peterpeterparker 


