### PR TITLE
feat(frontend): add `EthListener` to EVM networks

### DIFF
--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -6,7 +6,7 @@
 	import type { OptionToken } from '$lib/types/token';
 	import {
 		isNetworkIdBitcoin,
-		isNetworkIdEthereum,
+		isNetworkIdEthereum, isNetworkIdEvm,
 		isNetworkIdICP
 	} from '$lib/utils/network.utils';
 
@@ -21,7 +21,7 @@
 	<BitcoinListener>
 		<slot />
 	</BitcoinListener>
-{:else if isNetworkIdEthereum(token.network.id)}
+{:else if isNetworkIdEthereum(token.network.id) ||  isNetworkIdEvm(token.network.id)}
 	<EthListener {token}>
 		<slot />
 	</EthListener>

--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -6,7 +6,8 @@
 	import type { OptionToken } from '$lib/types/token';
 	import {
 		isNetworkIdBitcoin,
-		isNetworkIdEthereum, isNetworkIdEvm,
+		isNetworkIdEthereum,
+		isNetworkIdEvm,
 		isNetworkIdICP
 	} from '$lib/utils/network.utils';
 
@@ -21,7 +22,7 @@
 	<BitcoinListener>
 		<slot />
 	</BitcoinListener>
-{:else if isNetworkIdEthereum(token.network.id) ||  isNetworkIdEvm(token.network.id)}
+{:else if isNetworkIdEthereum(token.network.id) || isNetworkIdEvm(token.network.id)}
 	<EthListener {token}>
 		<slot />
 	</EthListener>

--- a/src/frontend/src/tests/lib/components/core/Listener.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Listener.spec.ts
@@ -41,6 +41,7 @@ describe('Listener', () => {
 		vi.spyOn(networkUtils, 'isNetworkIdICP').mockReturnValueOnce(false);
 		vi.spyOn(networkUtils, 'isNetworkIdBitcoin').mockReturnValueOnce(false);
 		vi.spyOn(networkUtils, 'isNetworkIdEthereum').mockReturnValueOnce(false);
+		vi.spyOn(networkUtils, 'isNetworkIdEvm').mockReturnValueOnce(false);
 
 		const { container } = render(Listener, {
 			props: { token: ICP_TOKEN }


### PR DESCRIPTION
# Motivation

As per the rest of the features, the `EthListener` should be enabled for EVM networks.
