### PR TITLE
refactor(frontend): upgrades ButtonHero to svelte5

### DIFF
--- a/src/frontend/src/btc/components/convert/ConvertToCkBTC.svelte
+++ b/src/frontend/src/btc/components/convert/ConvertToCkBTC.svelte
@@ -57,7 +57,7 @@
 </script>
 
 <ButtonHero
-	on:click={async () => await openConvert()}
+	onclick={async () => await openConvert()}
 	disabled={$networkBitcoinMainnetDisabled ||
 		$isBusy ||
 		$outflowActionsDisabled ||

--- a/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
+++ b/src/frontend/src/icp-eth/components/convert/ConvertETH.svelte
@@ -80,7 +80,7 @@
 
 <CkEthLoader {nativeTokenId}>
 	<ButtonHero
-		on:click={async () => await openConvert()}
+		onclick={async () => await openConvert()}
 		disabled={isNetworkDisabled || $isBusy || $outflowActionsDisabled}
 		{ariaLabel}
 	>

--- a/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
+++ b/src/frontend/src/icp/components/convert/ConvertToBTC.svelte
@@ -38,7 +38,7 @@
 
 <ButtonHero
 	disabled={$networkBitcoinMainnetDisabled || $isBusy || $outflowActionsDisabled}
-	on:click={async () => await openConvert()}
+	onclick={async () => await openConvert()}
 	ariaLabel={$i18n.convert.text.convert_to_btc}
 >
 	<IconCkConvert size="28" slot="icon" />

--- a/src/frontend/src/lib/components/buy/Buy.svelte
+++ b/src/frontend/src/lib/components/buy/Buy.svelte
@@ -7,7 +7,7 @@
 	const modalId = Symbol();
 </script>
 
-<BuyButton on:click={() => modalStore.openBuy(modalId)} />
+<BuyButton onclick={() => modalStore.openBuy(modalId)} />
 
 {#if $modalBuy && $modalStore?.id === modalId}
 	<BuyModal />

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -10,7 +10,7 @@
 		onclick: () => void;
 	}
 
-	let {onclick}: Props = $props();
+	let { onclick }: Props = $props();
 </script>
 
 <ButtonHero

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -5,10 +5,16 @@
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
+
+	interface Props {
+		onclick: () => void;
+	}
+
+	let {onclick}: Props = $props();
 </script>
 
 <ButtonHero
-	on:click
+	{onclick}
 	disabled={$isBusy || isNullishOrEmpty(ONRAMPER_API_KEY)}
 	ariaLabel={$i18n.send.text.send}
 >

--- a/src/frontend/src/lib/components/hero/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/hero/ButtonHero.svelte
@@ -3,15 +3,19 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 
-	export let disabled = false;
-	export let testId: string | undefined = undefined;
-	export let ariaLabel: string;
+	interface Props {
+		onclick: () => void;
+		disabled?: boolean;
+		ariaLabel: string;
+		testId?: string | undefined;
+	}
+	let { onclick, disabled = false, testId = undefined, ariaLabel }: Props = $props();
 
 	const { loading } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
 <Button
-	on:click
+	on:click={onclick}
 	{ariaLabel}
 	{disabled}
 	loading={$loading}

--- a/src/frontend/src/lib/components/receive/ReceiveButton.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveButton.svelte
@@ -9,7 +9,7 @@
 		onclick: () => void;
 	}
 
-	let {onclick}: Props = $props();
+	let { onclick }: Props = $props();
 </script>
 
 <ButtonHero

--- a/src/frontend/src/lib/components/receive/ReceiveButton.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveButton.svelte
@@ -4,10 +4,16 @@
 	import { RECEIVE_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		onclick: () => void;
+	}
+
+	let {onclick}: Props = $props();
 </script>
 
 <ButtonHero
-	on:click
+	{onclick}
 	disabled={$isBusy}
 	ariaLabel={$i18n.receive.text.receive}
 	testId={RECEIVE_TOKENS_MODAL_OPEN_BUTTON}

--- a/src/frontend/src/lib/components/receive/ReceiveButtonWithModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveButtonWithModal.svelte
@@ -10,7 +10,7 @@
 	$: definedModalId = modalId ?? Symbol();
 </script>
 
-<ReceiveButton on:click={async () => await open(definedModalId)} />
+<ReceiveButton onclick={async () => await open(definedModalId)} />
 
 {#if isOpen && $modalStore?.id === definedModalId}
 	<slot name="modal" />

--- a/src/frontend/src/lib/components/send/SendButton.svelte
+++ b/src/frontend/src/lib/components/send/SendButton.svelte
@@ -11,7 +11,7 @@
 		onclick: () => void;
 	}
 
-	let {onclick}: Props = $props();
+	let { onclick }: Props = $props();
 
 	const { outflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>

--- a/src/frontend/src/lib/components/send/SendButton.svelte
+++ b/src/frontend/src/lib/components/send/SendButton.svelte
@@ -7,11 +7,17 @@
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
 
+	interface Props {
+		onclick: () => void;
+	}
+
+	let {onclick}: Props = $props();
+
 	const { outflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
 <ButtonHero
-	on:click
+	{onclick}
 	disabled={$isBusy || $outflowActionsDisabled}
 	ariaLabel={$i18n.send.text.send}
 	testId={SEND_TOKENS_MODAL_OPEN_BUTTON}

--- a/src/frontend/src/lib/components/send/SendButtonWithModal.svelte
+++ b/src/frontend/src/lib/components/send/SendButtonWithModal.svelte
@@ -8,7 +8,7 @@
 	const modalId = Symbol();
 </script>
 
-<SendButton on:click={() => open(modalId)} />
+<SendButton onclick={() => open(modalId)} />
 
 {#if isOpen && $modalStore?.id === modalId}
 	<slot name="modal" />

--- a/src/frontend/src/lib/components/swap/SwapButton.svelte
+++ b/src/frontend/src/lib/components/swap/SwapButton.svelte
@@ -9,7 +9,7 @@
 		onclick: () => void;
 	}
 
-	let {onclick}: Props = $props();
+	let { onclick }: Props = $props();
 </script>
 
 <ButtonHero

--- a/src/frontend/src/lib/components/swap/SwapButton.svelte
+++ b/src/frontend/src/lib/components/swap/SwapButton.svelte
@@ -4,10 +4,16 @@
 	import { SWAP_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		onclick: () => void;
+	}
+
+	let {onclick}: Props = $props();
 </script>
 
 <ButtonHero
-	on:click
+	{onclick}
 	disabled={$isBusy}
 	testId={SWAP_TOKENS_MODAL_OPEN_BUTTON}
 	ariaLabel={$i18n.swap.text.swap}

--- a/src/frontend/src/lib/components/swap/SwapButtonWithModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapButtonWithModal.svelte
@@ -8,7 +8,7 @@
 	const modalId = Symbol();
 </script>
 
-<SwapButton on:click={() => open(modalId)} />
+<SwapButton onclick={() => open(modalId)} />
 
 {#if isOpen && $modalStore?.id === modalId}
 	<slot />


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- Upgrades ButtonHero
- Upgrades BuyButton
- Upgrades SwapButton
- Upgrades ReceiveButton
- Upgrades SendButton

