### PR TITLE
refactor(frontend): upgrades RewardsGroup to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -7,10 +7,14 @@
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { modalStore } from '$lib/stores/modal.store';
 
-	export let title: string;
-	export let rewards: RewardDescription[];
-	export let altText: string | undefined = undefined;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		title: string;
+		rewards: RewardDescription[];
+		altText?: string | undefined;
+		testId?: string | undefined;
+	}
+
+	let {title, rewards, altText = undefined, testId = undefined}: Props = $props();
 
 	const modalId = Symbol();
 </script>

--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -14,7 +14,7 @@
 		testId?: string | undefined;
 	}
 
-	let {title, rewards, altText = undefined, testId = undefined}: Props = $props();
+	let { title, rewards, altText = undefined, testId = undefined }: Props = $props();
 
 	const modalId = Symbol();
 </script>


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- upgrades `RewardsGroup`

