### PR TITLE
refactor(frontend): upgrades Badge to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardDateBadge.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardDateBadge.svelte
@@ -2,8 +2,12 @@
 	import DateBadge from '$lib/components/ui/DateBadge.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	export let date: Date;
-	export let testId: string | undefined = undefined;
+    interface Props {
+        date: Date;
+        testId?: string | undefined;
+    }
+
+    let {date, testId = undefined}: Props = $props();
 </script>
 
 <DateBadge variant="warning" {date} {testId} prefix={$i18n.rewards.text.active_date}></DateBadge>

--- a/src/frontend/src/lib/components/rewards/RewardDateBadge.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardDateBadge.svelte
@@ -2,12 +2,12 @@
 	import DateBadge from '$lib/components/ui/DateBadge.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
-    interface Props {
-        date: Date;
-        testId?: string | undefined;
-    }
+	interface Props {
+		date: Date;
+		testId?: string | undefined;
+	}
 
-    let {date, testId = undefined}: Props = $props();
+	let { date, testId = undefined }: Props = $props();
 </script>
 
 <DateBadge variant="warning" {date} {testId} prefix={$i18n.rewards.text.active_date}></DateBadge>

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import type { BadgeVariant } from '$lib/types/style';
-	import type {Snippet} from "svelte";
 
 	interface Props {
 		children?: Snippet;
@@ -9,7 +9,12 @@
 		variant?: BadgeVariant;
 	}
 
-	let {children, styleClass = undefined, testId = undefined, variant = 'default'}: Props = $props();
+	let {
+		children,
+		styleClass = undefined,
+		testId = undefined,
+		variant = 'default'
+	}: Props = $props();
 
 	const variantClassNames = {
 		default: 'bg-secondary text-primary border border-secondary',

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
 	import type { BadgeVariant } from '$lib/types/style';
+	import type {Snippet} from "svelte";
 
-	export let styleClass: string | undefined = undefined;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		children?: Snippet;
+		styleClass?: string | undefined;
+		testId?: string | undefined;
+		variant?: BadgeVariant;
+	}
+
+	let {children, styleClass = undefined, testId = undefined, variant = 'default'}: Props = $props();
 
 	const variantClassNames = {
 		default: 'bg-secondary text-primary border border-secondary',
@@ -12,8 +19,6 @@
 		success: 'bg-success-subtle-20 text-success-primary',
 		outline: 'border border-tertiary bg-off-white'
 	};
-
-	export let variant: BadgeVariant = 'default';
 </script>
 
 <span
@@ -23,6 +28,6 @@
 	]} {styleClass ?? ''}"
 >
 	<span class="inline-block min-w-0 truncate">
-		<slot />
+		{@render children?.()}
 	</span>
 </span>

--- a/src/frontend/src/lib/components/ui/DateBadge.svelte
+++ b/src/frontend/src/lib/components/ui/DateBadge.svelte
@@ -3,14 +3,17 @@
 	import type { BadgeVariant } from '$lib/types/style';
 	import { formatToShortDateString } from '$lib/utils/format.utils';
 
-	export let date: Date;
-	export let prefix: string | undefined = undefined;
-	export let suffix: string | undefined = undefined;
-	export let testId: string | undefined = undefined;
-	export let variant: BadgeVariant = 'default';
+	interface Props {
+		date: Date;
+		prefix?: string | undefined;
+		suffix?: string | undefined;
+		testId?: string | undefined;
+		variant?: BadgeVariant;
+	}
 
-	let formattedDate: string;
-	$: formattedDate = `${formatToShortDateString(date)} ${date.getDate()}`;
+	let {date, prefix = undefined, suffix = undefined, testId = undefined, variant = 'default'}: Props = $props();
+
+	const formattedDate: string = $derived(`${formatToShortDateString(date)} ${date.getDate()}`);
 </script>
 
 <Badge {testId} {variant}>

--- a/src/frontend/src/lib/components/ui/DateBadge.svelte
+++ b/src/frontend/src/lib/components/ui/DateBadge.svelte
@@ -19,7 +19,7 @@
 		variant = 'default'
 	}: Props = $props();
 
-	const formattedDate: string = $derived(`${formatToShortDateString(date)} ${date.getDate()}`);
+	const formattedDate = $derived(`${formatToShortDateString(date)} ${date.getDate()}`);
 </script>
 
 <Badge {testId} {variant}>

--- a/src/frontend/src/lib/components/ui/DateBadge.svelte
+++ b/src/frontend/src/lib/components/ui/DateBadge.svelte
@@ -11,7 +11,13 @@
 		variant?: BadgeVariant;
 	}
 
-	let {date, prefix = undefined, suffix = undefined, testId = undefined, variant = 'default'}: Props = $props();
+	let {
+		date,
+		prefix = undefined,
+		suffix = undefined,
+		testId = undefined,
+		variant = 'default'
+	}: Props = $props();
 
 	const formattedDate: string = $derived(`${formatToShortDateString(date)} ${date.getDate()}`);
 </script>


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- upgrades `RewardDateBadge`
- upgrades `DateBadge`
- upgrades `Badge`

