### PR TITLE
fix(frontend): issue with loading eth txs in batches

### DIFF
--- a/src/frontend/src/env/rest/etherscan.env.ts
+++ b/src/frontend/src/env/rest/etherscan.env.ts
@@ -4,4 +4,6 @@ export const ETHERSCAN_API_KEY = import.meta.env.VITE_ETHERSCAN_API_KEY;
 
 export const ETHERSCAN_REST_URL = 'https://api.etherscan.io/v2/api';
 
-export const ETHERSCAN_MAX_CALLS_PER_SECOND = BETA || PROD ? 10 : 5;
+// our plan allows making 5 requests/second on staging and 10 requests/second on prod
+// but since to fetch tx info for a token, we make 2 calls to Etherscan, the numbers should be divided by 2
+export const ETHERSCAN_MAX_CALLS_PER_SECOND = BETA || PROD ? 5 : 2;

--- a/src/frontend/src/eth/services/eth-transactions-batch.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions-batch.services.ts
@@ -15,16 +15,16 @@ export const batchLoadTransactions = ({
 	tokens: Token[];
 	tokensAlreadyLoaded: TokenId[];
 }): AsyncGenerator<PromiseSettledResult<ResultByToken>[]> => {
-	const promises = tokens.reduce<PromiseResult[]>(
+	const promises = tokens.reduce<(() => Promise<ResultByToken>)[]>(
 		(acc, { network: { id: networkId }, id: tokenId }) => {
 			if (tokensAlreadyLoaded.includes(tokenId)) {
 				return acc;
 			}
 
-			const promise = (async (): PromiseResult => {
+			const promise = async (): PromiseResult => {
 				const result = await loadEthereumTransactions({ tokenId, networkId });
 				return { ...result, tokenId };
-			})();
+			};
 
 			return [...acc, promise];
 		},

--- a/src/frontend/src/lib/services/batch.services.ts
+++ b/src/frontend/src/lib/services/batch.services.ts
@@ -2,12 +2,12 @@ export const batch = async function* <T>({
 	promises,
 	batchSize
 }: {
-	promises: Promise<T>[];
+	promises: (() => Promise<T>)[];
 	batchSize: number;
 }): AsyncGenerator<PromiseSettledResult<T>[]> {
 	for (let i = 0; i < promises.length; i += batchSize) {
 		const batch = promises.slice(i, i + batchSize);
-		const results = await Promise.allSettled(batch);
+		const results = await Promise.allSettled(batch.map((fn) => fn()));
 		yield results;
 		await new Promise((resolve) => setTimeout(resolve, 1000));
 	}

--- a/src/frontend/src/tests/eth/services/eth-transactions-batch.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions-batch.services.spec.ts
@@ -106,9 +106,15 @@ describe('eth-transactions-batch.services', () => {
 
 			expect(batch).toHaveBeenCalled();
 
-			const result = await generator.next();
+			const firstBatchResult = await generator.next();
 
-			expect(result.value).toEqual(expectedReturn);
+			expect(firstBatchResult.value).toEqual(
+				expectedReturn.slice(0, ETHERSCAN_MAX_CALLS_PER_SECOND)
+			);
+
+			const secondBatchResult = await generator.next();
+
+			expect(secondBatchResult.value).toEqual(expectedReturn.slice(ETHERSCAN_MAX_CALLS_PER_SECOND));
 		});
 
 		it('should respect ETHERSCAN_MAX_CALLS_PER_SECOND as batchSize', () => {

--- a/src/frontend/src/tests/lib/services/batch.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/batch.services.spec.ts
@@ -9,12 +9,10 @@ describe('batch.services', () => {
 
 		it('should execute promises in batches with throttling', async () => {
 			const results: number[] = [];
-			const promises = values.map((value) =>
-				(async () => {
-					results.push(value);
-					await delay(10);
-				})()
-			);
+			const promises = values.map((value) => async () => {
+				results.push(value);
+				await delay(10);
+			});
 
 			const generator = batch({
 				promises,
@@ -29,11 +27,9 @@ describe('batch.services', () => {
 		});
 
 		it('should wait 1 second between batches', async () => {
-			const promises = values.map(() =>
-				(async () => {
-					await delay(10);
-				})()
-			);
+			const promises = values.map(() => async () => {
+				await delay(10);
+			});
 
 			const generator = batch({
 				promises,
@@ -74,15 +70,13 @@ describe('batch.services', () => {
 		it('should process all promises even when some fail', async () => {
 			const results: number[] = [];
 
-			const promises = values.map((value) =>
-				(async () => {
-					if (value === 2) {
-						throw new Error('Test error');
-					}
-					results.push(value);
-					await delay(10);
-				})()
-			);
+			const promises = values.map((value) => async () => {
+				if (value === 2) {
+					throw new Error('Test error');
+				}
+				results.push(value);
+				await delay(10);
+			});
 
 			const generator = batch({
 				promises,


### PR DESCRIPTION
# Motivation

This PR fixes 2 related issues:
1. Batch mechanism for fetching ETH txs had an error - instead of creating an array with promises to execute them later by the `batch` function, it was invoking the async function immediately, hence all requests to Etherscan API were made at the same time. 
2. After fixing the error above, I realized `ETHERSCAN_MAX_CALLS_PER_SECOND` was not set correctly - to fetch tx data for a token, we make 2 requests to Etherscan API, therefore that constant should be set as `rate-limit-number / 2`. Our rate limit in BETA and PROD is 10, staging - 5.

# Changes

Fixed the functions and the const.

# Tests

Adjusted.
