### PR TITLE
refactor(frontend): upgrades RewardsRequirements to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -12,7 +12,7 @@
 		requirementsFulfilled: boolean[];
 	}
 
-	let { loading = true, reward, isEligible = false, requirementsFulfilled }: Props = $props;
+	let { loading = true, reward, isEligible = false, requirementsFulfilled }: Props = $props();
 
 	const isRequirementFulfilled = (index: number) =>
 		(reward.requirements.length === requirementsFulfilled.length && requirementsFulfilled[index]) ??

--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -5,10 +5,14 @@
 	import { REWARDS_REQUIREMENTS_STATUS } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	export let loading = true;
-	export let reward: RewardDescription;
-	export let isEligible = false;
-	export let requirementsFulfilled: boolean[];
+	interface Props {
+		loading: boolean;
+		reward: RewardDescription;
+		isEligible: boolean;
+		requirementsFulfilled: boolean[];
+	}
+
+	let {loading = true, reward, isEligible = false, requirementsFulfilled}: Props = $props;
 
 	const isRequirementFulfilled = (index: number) =>
 		(reward.requirements.length === requirementsFulfilled.length && requirementsFulfilled[index]) ??

--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -12,7 +12,7 @@
 		requirementsFulfilled: boolean[];
 	}
 
-	let {loading = true, reward, isEligible = false, requirementsFulfilled}: Props = $props;
+	let { loading = true, reward, isEligible = false, requirementsFulfilled }: Props = $props;
 
 	const isRequirementFulfilled = (index: number) =>
 		(reward.requirements.length === requirementsFulfilled.length && requirementsFulfilled[index]) ??

--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -6,9 +6,9 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
-		loading: boolean;
+		loading?: boolean;
 		reward: RewardDescription;
-		isEligible: boolean;
+		isEligible?: boolean;
 		requirementsFulfilled: boolean[];
 	}
 


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- Upgrades `RewardsRequirements`

