### PR TITLE
feat(frontend): enabled BTC for onramper in mainnet integration

### DIFF
--- a/src/frontend/src/env/tokens/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens.btc.env.ts
@@ -27,7 +27,8 @@ export const BTC_MAINNET_TOKEN: TokenWithLinkedData = {
 	decimals: BTC_DECIMALS,
 	icon: bitcoin,
 	twinTokenSymbol: 'ckBTC',
-	groupData: BTC_TOKEN_GROUP
+	groupData: BTC_TOKEN_GROUP,
+	buy: { onramperId: 'btc' }
 };
 
 export const BTC_TESTNET_SYMBOL = 'BTC (Testnet)';


### PR DESCRIPTION
# Motivation

Bitcoin purchases are currently unavailable due to a missing Onramper configuration in the Bitcoin token settings. Users must be able to purchase Bitcoin as intended

# Changes

- Added buy.onramperId property for **bitcoin** in `tokens.btc.env.ts`

# Tests

- Successfully bought bitcoins with  Revolut Pay and Guardarian
