### PR TITLE
refactor(frontend): upgrades RewardStateModal to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -19,7 +19,11 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	export let jackpot = false;
+	interface Props {
+		jackpot?: boolean;
+	}
+
+	let {jackpot = false}: Props = $props();
 
 	// TODO At the moment the selected campaign is hardcoded. In the future this should be configurable from the outside.
 	const reward: RewardDescription | undefined = rewardCampaigns.find(

--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -23,7 +23,7 @@
 		jackpot?: boolean;
 	}
 
-	let {jackpot = false}: Props = $props();
+	let { jackpot = false }: Props = $props();
 
 	// TODO At the moment the selected campaign is hardcoded. In the future this should be configurable from the outside.
 	const reward: RewardDescription | undefined = rewardCampaigns.find(


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- Upgrades `RewardStateModal`

