### PR TITLE
feat(frontend): use Coingecko platform ID to map prices of all ERC20

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -1,7 +1,6 @@
 import { enabledEthereumNetworksIds } from '$eth/derived/networks.derived';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
-import type { ContractAddressText } from '$eth/types/address';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20TokenToggleable } from '$eth/types/erc20-token-toggleable';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
@@ -117,11 +116,6 @@ export const enabledErc20Tokens: Readable<Erc20TokenToggleable[]> = derived(
 		...$enabledErc20DefaultTokens,
 		...$enabledErc20UserTokens
 	]
-);
-
-export const enabledErc20TokensAddresses: Readable<ContractAddressText[]> = derived(
-	[enabledErc20Tokens],
-	([$enabledErc20Tokens]) => $enabledErc20Tokens.map(({ address }: Erc20Token) => address)
 );
 
 export const erc20UserTokensInitialized: Readable<boolean> = derived(

--- a/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
+++ b/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
@@ -1,25 +1,46 @@
-import { enabledErc20TokensAddresses } from '$eth/derived/erc20.derived';
-import type { ContractAddressText } from '$eth/types/address';
-import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
+import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcCkToken, IcToken } from '$icp/types/ic-token';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const enabledIcrcTwinTokensAddresses: Readable<ContractAddressText[]> = derived(
+const enabledErc20TokensAddresses: Readable<Erc20ContractAddressWithNetwork[]> = derived(
+	[enabledErc20Tokens],
+	([$enabledErc20Tokens]) =>
+		$enabledErc20Tokens.map(({ address, network: { exchange } }: Erc20Token) => ({
+			address,
+			coingeckoId: exchange?.coingeckoId ?? 'ethereum'
+		}))
+);
+
+const enabledIcrcTwinTokensAddresses: Readable<Erc20ContractAddressWithNetwork[]> = derived(
 	[enabledIcrcTokens],
 	([$enabledIcrcTokens]) =>
 		$enabledIcrcTokens
 			.filter((token: IcToken) =>
 				nonNullish(((token as Partial<IcCkToken>).twinToken as Erc20Token | undefined)?.address)
 			)
-			.map((token) => ((token as IcCkToken).twinToken as Erc20Token).address)
+			.map((token) => {
+				const {
+					address,
+					network: { exchange }
+				} = (token as IcCkToken).twinToken as Erc20Token;
+
+				return { address, coingeckoId: exchange?.coingeckoId ?? 'ethereum' };
+			})
 );
 
-export const enabledMergedErc20TokensAddresses: Readable<Erc20ContractAddress[]> = derived(
-	[enabledIcrcTwinTokensAddresses, enabledErc20TokensAddresses],
-	([$enabledIcrcTwinTokensAddresses, $enabledErc20TokensAddresses]) =>
-		[...new Set([...$enabledErc20TokensAddresses, ...$enabledIcrcTwinTokensAddresses])].map(
-			(address) => ({ address })
-		)
-);
+export const enabledMergedErc20TokensAddresses: Readable<Erc20ContractAddressWithNetwork[]> =
+	derived(
+		[enabledIcrcTwinTokensAddresses, enabledErc20TokensAddresses],
+		([$enabledIcrcTwinTokensAddresses, $enabledErc20TokensAddresses]) => [
+			...new Map(
+				[...$enabledErc20TokensAddresses, ...$enabledIcrcTwinTokensAddresses].map((item) => [
+					`${item.address}|${item.coingeckoId}`,
+					item
+				])
+			).values()
+		]
+	);

--- a/src/frontend/src/icp-eth/types/icrc-erc20.ts
+++ b/src/frontend/src/icp-eth/types/icrc-erc20.ts
@@ -1,0 +1,4 @@
+import type { Erc20ContractAddress } from '$eth/types/erc20';
+import type { NetworkExchange } from '$lib/types/network';
+
+export type Erc20ContractAddressWithNetwork = Erc20ContractAddress & Required<NetworkExchange>;

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -59,7 +59,7 @@ export const PostMessageDataRequestSchema = z.never();
 export const PostMessageDataResponseSchema = z.object({}).strict();
 
 export const PostMessageDataRequestExchangeTimerSchema = z.object({
-	// TODO: generate zod schema for Erc20AddressWithNetwork
+	// TODO: generate zod schema for Erc20ContractAddressWithNetwork
 	erc20Addresses: z.array(z.custom<Erc20ContractAddressWithNetwork>()),
 	icrcCanisterIds: z.array(CanisterIdTextSchema),
 	splAddresses: z.array(z.custom<SplTokenAddress>())

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -1,4 +1,4 @@
-import type { Erc20ContractAddress } from '$eth/types/erc20';
+import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import {
 	IcCanistersSchema,
 	IcCanistersStrictSchema,
@@ -59,8 +59,8 @@ export const PostMessageDataRequestSchema = z.never();
 export const PostMessageDataResponseSchema = z.object({}).strict();
 
 export const PostMessageDataRequestExchangeTimerSchema = z.object({
-	// TODO: generate zod schema for Erc20ContractAddress
-	erc20Addresses: z.array(z.custom<Erc20ContractAddress>()),
+	// TODO: generate zod schema for Erc20AddressWithNetwork
+	erc20Addresses: z.array(z.custom<Erc20ContractAddressWithNetwork>()),
 	icrcCanisterIds: z.array(CanisterIdTextSchema),
 	splAddresses: z.array(z.custom<SplTokenAddress>())
 });

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -1,10 +1,9 @@
-import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
 import { fetchBatchKongSwapPrices } from '$lib/rest/kongswap.rest';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import type {
-	CoingeckoPlatformId,
+	CoingeckoErc20PriceParams,
 	CoingeckoSimplePriceResponse,
 	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
@@ -67,10 +66,7 @@ export const exchangeRateBNBToUsd = (): Promise<CoingeckoSimplePriceResponse | n
 export const exchangeRateERC20ToUsd = ({
 	coingeckoPlatformId: id,
 	contractAddresses
-}: {
-	coingeckoPlatformId: CoingeckoPlatformId;
-	contractAddresses: Erc20ContractAddress[];
-}): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
+}: CoingeckoErc20PriceParams): Promise<CoingeckoSimpleTokenPriceResponse | null> =>
 	simpleTokenPrice({
 		id,
 		vs_currencies: 'usd',
@@ -95,12 +91,10 @@ export const exchangeRateICRCToUsd = async (
 	}
 
 	const kongSwapPrices = await fetchIcrcPricesFromKongSwap(missingIds);
-	const exchangeRatePrices: CoingeckoSimpleTokenPriceResponse = {
+	return {
 		...(coingeckoPrices ?? {}),
 		...(kongSwapPrices ?? {})
 	};
-
-	return exchangeRatePrices;
 };
 
 export const exchangeRateSPLToUsd = (

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -2,6 +2,7 @@
 
 // We are only interested in specific coin <> USD for now, therefore not an exhaustive list.
 // *refers to curl -l https://api.coingecko.com/api/v3/coins/list
+import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { EthAddress } from '$lib/types/address';
 import type { CoingeckoCoinsIdSchema } from '$lib/validation/coingecko.validation';
@@ -74,3 +75,8 @@ export type CoingeckoSimpleTokenPriceResponse = CoingeckoResponse<CoingeckoSimpl
 export type CoingeckoPriceResponse =
 	| CoingeckoSimplePriceResponse
 	| CoingeckoSimpleTokenPriceResponse;
+
+export type CoingeckoErc20PriceParams = {
+	coingeckoPlatformId: CoingeckoPlatformId;
+	contractAddresses: Erc20ContractAddress[];
+};

--- a/src/frontend/src/lib/types/network.ts
+++ b/src/frontend/src/lib/types/network.ts
@@ -1,9 +1,10 @@
-import type {
-	NetworkAppMetadataSchema,
-	NetworkBuySchema,
-	NetworkEnvironmentSchema,
-	NetworkIdSchema,
-	NetworkSchema
+import {
+	type NetworkAppMetadataSchema,
+	type NetworkBuySchema,
+	type NetworkEnvironmentSchema,
+	type NetworkExchangeSchema,
+	type NetworkIdSchema,
+	type NetworkSchema
 } from '$lib/schema/network.schema';
 import type * as z from 'zod';
 
@@ -12,6 +13,8 @@ export type NetworkId = z.infer<typeof NetworkIdSchema>;
 export type NetworkEnvironment = z.infer<typeof NetworkEnvironmentSchema>;
 
 export type Network = z.infer<typeof NetworkSchema>;
+
+export type NetworkExchange = z.infer<typeof NetworkExchangeSchema>;
 
 export type NetworkBuy = z.infer<typeof NetworkBuySchema>;
 

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -116,7 +116,7 @@ const syncExchange = async ({
 		] = await Promise.all([
 			exchangeRateETHToUsd(),
 			exchangeRateBTCToUsd(),
-			...erc20PriceParams.map((params) => exchangeRateERC20ToUsd(params)),
+			Promise.all(erc20PriceParams.map((params) => exchangeRateERC20ToUsd(params))),
 			exchangeRateICPToUsd(),
 			exchangeRateICRCToUsd(icrcLedgerCanisterIds),
 			exchangeRateSOLToUsd(),

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -104,6 +104,10 @@ const syncExchange = async ({
 	}, []);
 
 	try {
+		const erc20Prices = await Promise.all(
+			erc20PriceParams.map((params) => exchangeRateERC20ToUsd(params))
+		);
+
 		const [
 			currentEthPrice,
 			currentBtcPrice,
@@ -116,7 +120,7 @@ const syncExchange = async ({
 		] = await Promise.all([
 			exchangeRateETHToUsd(),
 			exchangeRateBTCToUsd(),
-			Promise.all(erc20PriceParams.map((params) => exchangeRateERC20ToUsd(params))),
+			erc20Prices.reduce((acc, prices) => ({ ...acc, ...prices }), {}),
 			exchangeRateICPToUsd(),
 			exchangeRateICRCToUsd(icrcLedgerCanisterIds),
 			exchangeRateSOLToUsd(),

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -1,4 +1,4 @@
-import type { Erc20ContractAddress } from '$eth/types/erc20';
+import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { SYNC_EXCHANGE_TIMER_INTERVAL } from '$lib/constants/exchange.constants';
 import {
@@ -11,6 +11,7 @@ import {
 	exchangeRateSOLToUsd,
 	exchangeRateSPLToUsd
 } from '$lib/services/exchange.services';
+import type { CoingeckoErc20PriceParams } from '$lib/types/coingecko';
 import type { PostMessage, PostMessageDataRequestExchangeTimer } from '$lib/types/post-message';
 import { errorDetailToString } from '$lib/utils/error.utils';
 import type { SplTokenAddress } from '$sol/types/spl';
@@ -68,7 +69,7 @@ const syncExchange = async ({
 	icrcLedgerCanisterIds,
 	splTokenAddresses
 }: {
-	erc20ContractAddresses: Erc20ContractAddress[];
+	erc20ContractAddresses: Erc20ContractAddressWithNetwork[];
 	icrcLedgerCanisterIds: LedgerCanisterIdText[];
 	splTokenAddresses: SplTokenAddress[];
 }) => {
@@ -78,6 +79,29 @@ const syncExchange = async ({
 	}
 
 	syncInProgress = true;
+
+	const erc20PriceParams: CoingeckoErc20PriceParams[] = erc20ContractAddresses.reduce<
+		CoingeckoErc20PriceParams[]
+	>((acc, { address, coingeckoId }) => {
+		if (
+			coingeckoId !== 'ethereum' &&
+			coingeckoId !== 'base' &&
+			coingeckoId !== 'binance-smart-chain'
+		) {
+			return acc;
+		}
+
+		const existing = acc.find(({ coingeckoPlatformId }) => coingeckoPlatformId === coingeckoId);
+
+		return [
+			...acc,
+			{
+				...existing,
+				coingeckoPlatformId: coingeckoId,
+				contractAddresses: [...(existing?.contractAddresses ?? []), { address, coingeckoId }]
+			}
+		];
+	}, []);
 
 	try {
 		const [
@@ -92,10 +116,7 @@ const syncExchange = async ({
 		] = await Promise.all([
 			exchangeRateETHToUsd(),
 			exchangeRateBTCToUsd(),
-			exchangeRateERC20ToUsd({
-				coingeckoPlatformId: 'ethereum',
-				contractAddresses: erc20ContractAddresses
-			}),
+			...erc20PriceParams.map((params) => exchangeRateERC20ToUsd(params)),
 			exchangeRateICPToUsd(),
 			exchangeRateICRCToUsd(icrcLedgerCanisterIds),
 			exchangeRateSOLToUsd(),


### PR DESCRIPTION
# Motivation

We want to track the price for all ERC20 tokens, including the ones for EVM networks. To do so, we need to use the Coingecko platform ID for each respective network, when fetching the prices.

# Changes

- Move derived store `enabledErc20TokensAddresses` (since it is used only for that scope, preferable to have all concentrated there).
- Add additional field `coingeckoId` to all the derived stores used when creating the list of ERC20 addresses to fetch.
- Create new types for the interface that is now provided by the derived stores and by the ERC20 price request params.
- Adapt service `syncExchange` to reduce the address-with-network object to a list of network-and-addresses

# Tests

Deployed:

![Screenshot 2025-04-29 at 16 37 09](https://github.com/user-attachments/assets/34a185f2-0bfd-4456-a725-33bde1978019)

