### PR TITLE
fix(frontend): BSC USDC and USDT digits

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env.ts
@@ -5,7 +5,7 @@ import type { RequiredEvmBep20Token } from '$evm/types/bep20';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
 
-export const USDC_DECIMALS = 6;
+export const USDC_DECIMALS = 18;
 
 export const USDC_SYMBOL = 'USDC';
 

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env.ts
@@ -5,7 +5,7 @@ import type { RequiredEvmBep20Token } from '$evm/types/bep20';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
 
-export const USDT_DECIMALS = 6;
+export const USDT_DECIMALS = 18;
 
 export const USDT_SYMBOL = 'USDT';
 


### PR DESCRIPTION
# Motivation

BSC USDC and USDT use 18 digits and not 6.
