### PR TITLE
refactor(frontend): upgrades Controls to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/carousel/Controls.svelte
+++ b/src/frontend/src/lib/components/carousel/Controls.svelte
@@ -3,8 +3,12 @@
 	import ButtonControl from '$lib/components/ui/ButtonControl.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	export let onNext: () => void;
-	export let onPrevious: () => void;
+	interface Props {
+		onNext: () => void;
+		onPrevious: () => void;
+	}
+
+	let {onNext, onPrevious}: Props = $props();
 </script>
 
 <div class="mr-3 flex items-center">

--- a/src/frontend/src/lib/components/carousel/Controls.svelte
+++ b/src/frontend/src/lib/components/carousel/Controls.svelte
@@ -8,7 +8,7 @@
 		onPrevious: () => void;
 	}
 
-	let {onNext, onPrevious}: Props = $props();
+	let { onNext, onPrevious }: Props = $props();
 </script>
 
 <div class="mr-3 flex items-center">


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- Upgrades `Controls`

