### PR TITLE
fix(frontend): use suggested fee data for ERC20 tokens too

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { debounce, isNullish } from '@dfinity/utils';
+	import { debounce } from '@dfinity/utils';
 	import { getContext, onDestroy, onMount } from 'svelte';
 	import { infuraProviders } from '$eth/providers/infura.providers';
 	import { InfuraGasRest } from '$eth/rest/infura.rest';

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -31,7 +31,6 @@
 	import type { Token, TokenId } from '$lib/types/token';
 	import { isNetworkICP } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
-	import type { FeeData } from 'ethers/providers';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -64,7 +63,6 @@
 
 			const feeData = await getFeeData();
 
-
 			const { getSuggestedFeeData } = new InfuraGasRest(
 				(sendToken.network as EthereumNetwork).chainId
 			);
@@ -82,9 +80,7 @@
 				})
 			};
 
-
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {
-
 				feeStore.setFee({
 					...adjustedFeeData,
 					gas: getEthFeeData({
@@ -96,7 +92,6 @@
 				});
 				return;
 			}
-
 
 			const erc20GasFeeParams = {
 				contract: sendToken as Erc20Token,


### PR DESCRIPTION
# Motivation

When we introduced the usage of Infura Gas API in PR https://github.com/dfinity/oisy-wallet/pull/6158 for fee data calculation, we should have included for all tokens.


![Screenshot 2025-04-30 at 09 03 34](https://github.com/user-attachments/assets/d9ba830d-a11e-4636-9600-acc6b4aa1e5a)
