### PR TITLE
fix(frontend): issue with SendWizard

### DIFF
--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { type WizardStep } from '@dfinity/gix-components';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';


### PR DESCRIPTION
# Motivation

The PR fixes issue with the SendWizard - we should fallback to DEFAULT_ETHEREUM_NETWORK if $selectedEthereumNetwork is not available when sending ETH.
