### PR TITLE
feat(frontend): remove the group data from BEP20 tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env.ts
@@ -1,5 +1,4 @@
 import { BSC_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
-import { USDC_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
 import usdc from '$eth/assets/usdc.svg';
 import type { RequiredEvmBep20Token } from '$evm/types/bep20';
 import type { TokenId } from '$lib/types/token';
@@ -22,7 +21,8 @@ export const USDC_TOKEN: RequiredEvmBep20Token = {
 	icon: usdc,
 	address: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
 	exchange: 'erc20',
-	groupData: USDC_TOKEN_GROUP,
+	// TODO: reintegrate the groupData when the sum of balances is fixed: the tokens have different decimals, so it cannot work for now
+	// groupData: USDC_TOKEN_GROUP,
 	buy: {
 		onramperId: 'usdc_bsc'
 	}

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env.ts
@@ -1,5 +1,4 @@
 import { BSC_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
-import { USDT_TOKEN_GROUP } from '$env/tokens/groups/groups.usdt.env';
 import usdt from '$eth/assets/usdt.svg';
 import type { RequiredEvmBep20Token } from '$evm/types/bep20';
 import type { TokenId } from '$lib/types/token';
@@ -22,7 +21,8 @@ export const USDT_TOKEN: RequiredEvmBep20Token = {
 	icon: usdt,
 	address: '0x55d398326f99059ff775485246999027b3197955',
 	exchange: 'erc20',
-	groupData: USDT_TOKEN_GROUP,
+	// TODO: reintegrate the groupData when the sum of balances is fixed: the tokens have different decimals, so it cannot work for now
+	// groupData: USDT_TOKEN_GROUP,
 	buy: {
 		onramperId: 'usdt_bsc'
 	}


### PR DESCRIPTION
# Motivation

Since they have different decimals, the sum of the pure balance of the BEP20 tokens with their ERC20 twins will not work when grouping them. So, while working on a fix, we temporary un-group them for the release.