### PR TITLE
refactor(frontend): upgrades ButtonAuthenticateWithLicense to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -12,7 +12,7 @@
 		licenseAlignment?: 'inherit' | 'center';
 	}
 
-	let {fullWidth = false, licenseAlignment = 'inherit'}: Props = $props();
+	let { fullWidth = false, licenseAlignment = 'inherit' }: Props = $props();
 
 	const modalId = Symbol();
 

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -7,8 +7,12 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
-	export let fullWidth = false;
-	export let licenseAlignment: 'inherit' | 'center' = 'inherit';
+	interface Props {
+		fullWidth?: boolean;
+		licenseAlignment?: 'inherit' | 'center';
+	}
+
+	let {fullWidth = false, licenseAlignment = 'inherit'}: Props = $props();
 
 	const modalId = Symbol();
 


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- Upgrades `ButtonAuthenticateWithLicense`
