### PR TITLE
refactor(frontend): upgrades LandingPage to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -8,8 +8,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	let ariaLabel: string;
-	$: ariaLabel = replaceOisyPlaceholders($i18n.auth.alt.preview);
+	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));
 </script>
 
 <div


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.

# Changes

- Upgrades `LandingPage`
