### PR TITLE
fix(frontend): normalize decimals for grouped tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env.ts
@@ -1,4 +1,5 @@
 import { BSC_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { USDC_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
 import usdc from '$eth/assets/usdc.svg';
 import type { RequiredEvmBep20Token } from '$evm/types/bep20';
 import type { TokenId } from '$lib/types/token';
@@ -21,8 +22,7 @@ export const USDC_TOKEN: RequiredEvmBep20Token = {
 	icon: usdc,
 	address: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
 	exchange: 'erc20',
-	// TODO: reintegrate the groupData when the sum of balances is fixed: the tokens have different decimals, so it cannot work for now
-	// groupData: USDC_TOKEN_GROUP,
+	groupData: USDC_TOKEN_GROUP,
 	buy: {
 		onramperId: 'usdc_bsc'
 	}

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env.ts
@@ -1,4 +1,5 @@
 import { BSC_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { USDT_TOKEN_GROUP } from '$env/tokens/groups/groups.usdt.env';
 import usdt from '$eth/assets/usdt.svg';
 import type { RequiredEvmBep20Token } from '$evm/types/bep20';
 import type { TokenId } from '$lib/types/token';
@@ -21,8 +22,7 @@ export const USDT_TOKEN: RequiredEvmBep20Token = {
 	icon: usdt,
 	address: '0x55d398326f99059ff775485246999027b3197955',
 	exchange: 'erc20',
-	// TODO: reintegrate the groupData when the sum of balances is fixed: the tokens have different decimals, so it cannot work for now
-	// groupData: USDT_TOKEN_GROUP,
+	groupData: USDT_TOKEN_GROUP,
 	buy: {
 		onramperId: 'usdt_bsc'
 	}

--- a/src/frontend/src/lib/types/token-group.ts
+++ b/src/frontend/src/lib/types/token-group.ts
@@ -14,6 +14,7 @@ export type TokenGroup = z.infer<typeof TokenGroupPropSchema>;
 
 export type TokenUiGroup = {
 	id: TokenGroupId;
+	decimals: number;
 	// TODO: remove deprecated field when groupData is completely integrated
 	nativeToken: TokenUi;
 	groupData: TokenGroupData;

--- a/src/frontend/src/lib/utils/parse.utils.ts
+++ b/src/frontend/src/lib/utils/parse.utils.ts
@@ -1,9 +1,23 @@
-import { parseUnits, type BigNumberish } from 'ethers/utils';
+import { formatUnits, parseUnits, type BigNumberish } from 'ethers/utils';
 
 export const parseToken = ({
 	value,
 	unitName = 18
 }: {
 	value: string;
-	unitName?: string | BigNumberish;
+	unitName?: BigNumberish;
 }): bigint => parseUnits(value, unitName);
+
+export const parseTokenToDecimals = ({
+	value,
+	oldUnitName,
+	newUnitName
+}: {
+	value: bigint;
+	oldUnitName: BigNumberish;
+	newUnitName: BigNumberish;
+}): bigint =>
+	parseToken({
+		value: formatUnits(value, oldUnitName),
+		unitName: newUnitName
+	});

--- a/src/frontend/src/lib/utils/token-card.utils.ts
+++ b/src/frontend/src/lib/utils/token-card.utils.ts
@@ -8,8 +8,10 @@ import type { TokenUiGroup } from '$lib/types/token-group';
  */
 export const mapHeaderData = ({
 	groupData: { name, symbol, icon },
-	nativeToken: { decimals, network },
+	// TODO: check if we still need network prop
+	nativeToken: { network },
 	tokens,
+	decimals,
 	balance,
 	usdBalance
 }: TokenUiGroup): CardData => ({

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -168,10 +168,7 @@ export const mapTokenUi = <T extends Token>({
 	})
 });
 
-export const sumBalances = ([balance1, balance2]: [
-	TokenUi['balance'],
-	TokenUi['balance']
-]): TokenUi['balance'] =>
+export const sumBalances = ([balance1, balance2]: TokenUi['balance'][]): TokenUi['balance'] =>
 	nonNullish(balance1) && nonNullish(balance2)
 		? balance1 + balance2
 		: balance1 === undefined || balance2 === undefined

--- a/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
@@ -14,6 +14,7 @@ describe('mapHeaderData', () => {
 	// We mock the token group with a mix of data just to verify that the function works correctly
 	const tokenGroup: TokenUiGroup = {
 		id: mockGroup.id,
+		decimals: mockToken.decimals,
 		nativeToken: mockToken,
 		groupData: mockGroup,
 		tokens: [mockToken, ICP_TOKEN],

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -14,6 +14,7 @@ import { ZERO } from '$lib/constants/app.constants';
 import type { TokenUi } from '$lib/types/token';
 import type { TokenUiGroup } from '$lib/types/token-group';
 import { last } from '$lib/utils/array.utils';
+import { parseTokenToDecimals } from '$lib/utils/parse.utils';
 import {
 	filterTokenGroups,
 	groupSecondaryToken,
@@ -289,6 +290,7 @@ describe('token-group.utils', () => {
 
 		const tokenGroup: TokenUiGroup = {
 			id: anotherToken.groupData.id,
+			decimals: anotherToken.decimals,
 			nativeToken: anotherToken,
 			groupData: anotherToken.groupData,
 			tokens: [anotherToken],
@@ -296,10 +298,25 @@ describe('token-group.utils', () => {
 			usdBalance: anotherToken.usdBalance
 		};
 
+		const expectedDecimals = Math.max(anotherToken.decimals, token.decimals);
+
+		const expectedBalance =
+			parseTokenToDecimals({
+				value: anotherToken.balance,
+				oldUnitName: anotherToken.decimals,
+				newUnitName: expectedDecimals
+			}) +
+			parseTokenToDecimals({
+				value: token.balance,
+				oldUnitName: token.decimals,
+				newUnitName: expectedDecimals
+			});
+
 		const expectedGroup: TokenUiGroup = {
 			...tokenGroup,
+			decimals: expectedDecimals,
 			tokens: [anotherToken, token],
-			balance: anotherToken.balance + token.balance,
+			balance: expectedBalance,
 			usdBalance: anotherToken.usdBalance + token.usdBalance
 		};
 
@@ -310,6 +327,7 @@ describe('token-group.utils', () => {
 		it('should add a token to a token group with multiple tokens successfully', () => {
 			const thirdToken = {
 				...BTC_TESTNET_TOKEN,
+				decimals: expectedDecimals,
 				groupData: ETH_TOKEN_GROUP,
 				balance: bn3Bi,
 				usdBalance: 300
@@ -322,7 +340,7 @@ describe('token-group.utils', () => {
 			expect(updatedGroup).toStrictEqual({
 				...tokenGroup,
 				tokens: [anotherToken, thirdToken, token],
-				balance: anotherToken.balance + thirdToken.balance + token.balance,
+				balance: expectedBalance + thirdToken.balance,
 				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
 			});
 		});
@@ -384,15 +402,72 @@ describe('token-group.utils', () => {
 				usdBalance: tokenGroup.usdBalance
 			});
 		});
+
+		it('should handle tokens with different decimals', () => {
+			assertNonNullish(tokenGroup.usdBalance);
+
+			const newDecimals = expectedGroup.decimals * 2;
+
+			const newToken = { ...token, decimals: newDecimals };
+
+			const initialGroup = updateTokenGroup({
+				token: newToken,
+				tokenGroup
+			});
+
+			const expectedBalance =
+				parseTokenToDecimals({
+					value: anotherToken.balance,
+					oldUnitName: anotherToken.decimals,
+					newUnitName: newDecimals
+				}) + newToken.balance;
+
+			expect(initialGroup).toStrictEqual({
+				...tokenGroup,
+				decimals: newDecimals,
+				tokens: [...tokenGroup.tokens, newToken],
+				balance: expectedBalance,
+				usdBalance: tokenGroup.usdBalance + newToken.usdBalance
+			});
+
+			const thirdToken = {
+				...BTC_TESTNET_TOKEN,
+				decimals: newDecimals * 2,
+				groupData: ETH_TOKEN_GROUP,
+				balance: bn3Bi,
+				usdBalance: 300
+			};
+
+			const updatedGroup = updateTokenGroup({ token: thirdToken, tokenGroup: initialGroup });
+
+			assertNonNullish(initialGroup.balance);
+
+			expect(updatedGroup).toStrictEqual({
+				...initialGroup,
+				decimals: newDecimals * 2,
+				tokens: [...initialGroup.tokens, thirdToken],
+				balance:
+					parseTokenToDecimals({
+						value: initialGroup.balance,
+						oldUnitName: initialGroup.decimals,
+						newUnitName: newDecimals * 2
+					}) + thirdToken.balance,
+				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
+			});
+		});
 	});
 
 	describe('groupSecondaryToken', () => {
-		const token = { ...ETHEREUM_TOKEN, balance: bn1Bi, usdBalance: 100 };
-		const anotherToken = { ...BTC_REGTEST_TOKEN, balance: bn2Bi, usdBalance: 200 };
+		// We normalize the decimals, to avoid having to mock the normalizing of balances
+		const decimals = ETHEREUM_TOKEN.decimals;
 
-		// We mock the tokens to have the same "main token"
+		const token = { ...ETHEREUM_TOKEN, decimals, balance: bn1Bi, usdBalance: 100 };
+		const anotherToken = { ...BTC_REGTEST_TOKEN, decimals, balance: bn2Bi, usdBalance: 200 };
+
+		// We mock the tokens to have the same group data
 		const twinToken = {
 			...SOLANA_TOKEN,
+			decimals,
 			balance: bn2Bi,
 			usdBalance: 250,
 			groupData: ETH_TOKEN_GROUP
@@ -401,6 +476,7 @@ describe('token-group.utils', () => {
 		it('should create a new group when no tokenGroup exists', () => {
 			expect(groupSecondaryToken({ token: twinToken, tokenGroup: undefined })).toEqual({
 				id: ETH_TOKEN_GROUP_ID,
+				decimals,
 				nativeToken: twinToken,
 				groupData: ETH_TOKEN_GROUP,
 				tokens: [twinToken],
@@ -412,6 +488,7 @@ describe('token-group.utils', () => {
 		it('should add token to existing group and update balances', () => {
 			const tokenGroup: TokenUiGroup = {
 				id: ETH_TOKEN_GROUP_ID,
+				decimals,
 				nativeToken: token,
 				groupData: ETH_TOKEN_GROUP,
 				tokens: [token],
@@ -419,11 +496,14 @@ describe('token-group.utils', () => {
 				usdBalance: 300
 			};
 
+			assertNonNullish(tokenGroup.balance);
+			assertNonNullish(tokenGroup.usdBalance);
+
 			expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
 				...tokenGroup,
 				tokens: [...tokenGroup.tokens, twinToken],
-				balance: tokenGroup.balance! + twinToken.balance,
-				usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
+				balance: tokenGroup.balance + twinToken.balance,
+				usdBalance: tokenGroup.usdBalance + twinToken.usdBalance
 			});
 		});
 
@@ -432,6 +512,7 @@ describe('token-group.utils', () => {
 
 			const tokenGroup: TokenUiGroup = {
 				id: token.groupData.id,
+				decimals,
 				nativeToken: token,
 				groupData: token.groupData,
 				tokens: [token, anotherToken],
@@ -439,29 +520,37 @@ describe('token-group.utils', () => {
 				usdBalance: 300
 			};
 
+			assertNonNullish(tokenGroup.balance);
+			assertNonNullish(tokenGroup.usdBalance);
+
 			expect(groupSecondaryToken({ token: twinToken, tokenGroup })).toEqual({
 				...tokenGroup,
 				tokens: [...tokenGroup.tokens, twinToken],
-				balance: tokenGroup.balance! + twinToken.balance,
-				usdBalance: tokenGroup.usdBalance! + twinToken.usdBalance
+				balance: tokenGroup.balance + twinToken.balance,
+				usdBalance: tokenGroup.usdBalance + twinToken.usdBalance
 			});
 		});
 	});
 
 	describe('groupTokens', () => {
-		const mockToken = { ...ETHEREUM_TOKEN, balance: bn1Bi, usdBalance: 100 };
-		const mockSecondToken = { ...BTC_MAINNET_TOKEN, balance: bn3Bi, usdBalance: 300 };
-		const mockThirdToken = { ...ICP_TOKEN, balance: bn2Bi, usdBalance: 200 };
+		// We normalize the decimals, to avoid having to mock the normalizing of balances
+		const decimals = ETHEREUM_TOKEN.decimals;
+
+		const mockToken = { ...ETHEREUM_TOKEN, decimals, balance: bn1Bi, usdBalance: 100 };
+		const mockSecondToken = { ...BTC_MAINNET_TOKEN, decimals, balance: bn3Bi, usdBalance: 300 };
+		const mockThirdToken = { ...ICP_TOKEN, decimals, balance: bn2Bi, usdBalance: 200 };
 
 		// We mock the tokens to have the same "main token"
 		const mockTwinToken1 = {
 			...mockValidIcToken,
+			decimals,
 			balance: bn2Bi,
 			usdBalance: 250,
 			groupData: mockToken.groupData
 		};
 		const mockTwinToken2 = {
 			...mockValidIcToken,
+			decimals,
 			balance: bn1Bi,
 			usdBalance: 450,
 			groupData: mockToken.groupData
@@ -509,6 +598,7 @@ describe('token-group.utils', () => {
 
 				expect(group).toEqual({
 					id: currentToken.groupData?.id,
+					decimals: currentToken.decimals,
 					nativeToken: currentToken,
 					groupData: currentToken.groupData,
 					tokens: [currentToken],
@@ -538,6 +628,7 @@ describe('token-group.utils', () => {
 
 			expect(group0).toStrictEqual({
 				id: mockToken.groupData?.id,
+				decimals,
 				nativeToken: mockToken,
 				groupData: mockToken.groupData,
 				tokens: [mockToken, mockTwinToken1, mockTwinToken2],
@@ -547,6 +638,7 @@ describe('token-group.utils', () => {
 
 			expect(group1).toStrictEqual({
 				id: mockSecondToken.groupData?.id,
+				decimals: mockSecondToken.decimals,
 				nativeToken: mockSecondToken,
 				groupData: mockSecondToken.groupData,
 				tokens: [mockSecondToken],
@@ -573,6 +665,7 @@ describe('token-group.utils', () => {
 
 			expect(group0).toStrictEqual({
 				id: mockTwinToken1.groupData?.id,
+				decimals,
 				nativeToken: mockTwinToken1,
 				groupData: mockTwinToken1.groupData,
 				tokens: [mockTwinToken1, mockToken, mockTwinToken2],
@@ -582,6 +675,7 @@ describe('token-group.utils', () => {
 
 			expect(group1).toStrictEqual({
 				id: mockSecondToken.groupData?.id,
+				decimals,
 				nativeToken: mockSecondToken,
 				groupData: mockSecondToken.groupData,
 				tokens: [mockSecondToken],
@@ -609,6 +703,7 @@ describe('token-group.utils', () => {
 
 			expect(group0).toStrictEqual({
 				id: mockSecondToken.groupData?.id,
+				decimals,
 				nativeToken: mockSecondToken,
 				groupData: mockSecondToken.groupData,
 				tokens: [mockSecondToken],
@@ -618,6 +713,7 @@ describe('token-group.utils', () => {
 
 			expect(group1).toStrictEqual({
 				id: mockToken.groupData?.id,
+				decimals,
 				nativeToken: mockToken,
 				groupData: mockToken.groupData,
 				tokens: [mockToken, mockTwinToken1, mockTwinToken2],
@@ -645,6 +741,7 @@ describe('token-group.utils', () => {
 
 			expect(group).toStrictEqual({
 				id: mockToken.groupData?.id,
+				decimals,
 				nativeToken: mockToken,
 				groupData: mockToken.groupData,
 				tokens: [mockToken, mockTwinToken, mockTwinToken2],

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -16,6 +16,7 @@ const token3: TokenUi = SOLANA_TOKEN;
 
 const tokenGroup: TokenUiGroup = {
 	id: ETH_TOKEN_GROUP_ID,
+	decimals: token1.decimals,
 	nativeToken: token1,
 	groupData: ETH_TOKEN_GROUP,
 	tokens: [token2, token3]


### PR DESCRIPTION
# Motivation

<!-- Describe the motivation that lead to the PR -->

# Changes

- Create util `parseTokenToDecimals` that parse a `BigInt` to a number of decimals to another: it uses pre-existing `ethers` utils `parseUnits` and `formatUnits`.
- Add field `decimals` to `TokenGroupUi` type type.
- Change util `updateTokenGroup` to always normalize the tokens balances the highest decimal (to avoid losing units). 
- Re-instate the group data for BSC tokens.

# Tests

Added tests and adapted the rest. Replica:


