### PR TITLE
fix(frontend): do not use lower case for contract addresses in Coingecko requests

### DIFF
--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -21,7 +21,7 @@ const fetchIcrcPricesFromCoingecko = (
 	simpleTokenPrice({
 		id: 'internet-computer',
 		vs_currencies: 'usd',
-		contract_addresses: ledgerCanisterIds.map((id) => id.toLowerCase()),
+		contract_addresses: ledgerCanisterIds,
 		include_market_cap: true
 	});
 

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -103,7 +103,7 @@ export const exchangeRateSPLToUsd = (
 	simpleTokenPrice({
 		id: 'solana',
 		vs_currencies: 'usd',
-		contract_addresses: tokenAddresses.map((tokenAddresses) => tokenAddresses),
+		contract_addresses: tokenAddresses,
 		include_market_cap: true
 	});
 

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -70,7 +70,7 @@ export const exchangeRateERC20ToUsd = ({
 	simpleTokenPrice({
 		id,
 		vs_currencies: 'usd',
-		contract_addresses: contractAddresses.map(({ address }) => address.toLowerCase()),
+		contract_addresses: contractAddresses.map(({ address }) => address),
 		include_market_cap: true
 	});
 
@@ -103,7 +103,7 @@ export const exchangeRateSPLToUsd = (
 	simpleTokenPrice({
 		id: 'solana',
 		vs_currencies: 'usd',
-		contract_addresses: tokenAddresses.map((tokenAddresses) => tokenAddresses.toLowerCase()),
+		contract_addresses: tokenAddresses.map((tokenAddresses) => tokenAddresses),
 		include_market_cap: true
 	});
 


### PR DESCRIPTION
# Motivation

Coingecko requests are actually case-sensitive when treating contract addresses, so we need to adjust the functions.

### Before

![Screenshot 2025-04-30 at 16 24 25](https://github.com/user-attachments/assets/abff52c7-41fa-48eb-85bc-29bf776b34ee)

### After

![Screenshot 2025-04-30 at 16 23 32](https://github.com/user-attachments/assets/85fbbd78-68bf-4961-ab26-705e246019b7)

