### PR TITLE
feat(frontend): implements isEndedCampaign function

### DIFF
--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -46,5 +46,12 @@ export const isUpcomingCampaign = (startDate: Date) => {
 	return startDiff > 0;
 };
 
+export const isEndedCampaign = (endDate: Date) => {
+	const currentDate = new Date(Date.now());
+	const endDiff = endDate.getTime() - currentDate.getTime();
+
+	return endDiff <= 0;
+};
+
 export const getRewardsBalance = (rewards: RewardResponseInfo[]): bigint =>
 	rewards.reduce<bigint>((total, { amount }) => total + amount, ZERO);

--- a/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
@@ -5,9 +5,10 @@ import type { RewardResponseInfo } from '$lib/types/reward';
 import {
 	INITIAL_REWARD_RESULT,
 	getRewardsBalance,
+	isEndedCampaign,
 	isOngoingCampaign,
 	isUpcomingCampaign,
-	loadRewardResult, isEndedCampaign
+	loadRewardResult
 } from '$lib/utils/rewards.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 

--- a/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
@@ -7,7 +7,7 @@ import {
 	getRewardsBalance,
 	isOngoingCampaign,
 	isUpcomingCampaign,
-	loadRewardResult
+	loadRewardResult, isEndedCampaign
 } from '$lib/utils/rewards.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 
@@ -200,6 +200,24 @@ describe('rewards.utils', () => {
 			const result = isUpcomingCampaign(startDate);
 
 			expect(result).toBeFalsy();
+		});
+	});
+
+	describe('isEndedCampaign', () => {
+		it('should return false if the current date is before the end date of the campaign', () => {
+			const endDate = new Date(Date.now() + 86400000);
+
+			const result = isEndedCampaign(endDate);
+
+			expect(result).toBeFalsy();
+		});
+
+		it('should return true if the current date is after the end date of the campaign', () => {
+			const endDate = new Date(Date.now() - 86400000);
+
+			const result = isEndedCampaign(endDate);
+
+			expect(result).toBeTruthy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

We want to be able to find out if a campaign has ended exactly like we already check if a campaign is upcoming or ongoing.

# Changes

- implements `isEndedCampaign`

