### PR TITLE
fix(devops): correct cron expression for CI to remove components

### DIFF
--- a/.github/workflows/frontend-remove-unused-components.yml
+++ b/.github/workflows/frontend-remove-unused-components.yml
@@ -2,7 +2,7 @@ name: Remove Unused Svelte Files
 
 on:
   schedule:
-    - cron: '30 3 1-7 * 1'
+    - cron: '30 3 1 * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
# Motivation

According to [POSIX cron documentation](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07), the day-of-week and day-of-month are linked by OR logic and not AND logic:

> The specification of days can be made by two fields (day of the month and day of the week). If month, day of month, and day of week are all <asterisk> characters, every day shall be matched. If either the month or day of month is specified as an element or list, but the day of week is an <asterisk>, the month and day of month fields shall specify the days that match. If both month and day of month are specified as an <asterisk>, but day of week is an element or list, then only the specified days of the week match. Finally, if either the month or day of month is specified as an element or list, and the day of week is also specified as an element or list, then any day matching either the month and day of month, or the day of week, shall be matched.

That means that the current cron expression of Action frontend-remove-unused-components will run everyday in the first week of the month AND on Mondays.

To fix this, we make it run ONLY on the first day of the month: we just wont it to run monthly.



