### PR TITLE
refactor(frontend): upgrades NetworkLogo to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworkLogo.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkLogo.svelte
@@ -12,7 +12,7 @@
 		testId?: string;
 	}
 
-	let {network, size = 'xxs', color = 'off-white', testId}: Props = $props();
+	let { network, size = 'xxs', color = 'off-white', testId }: Props = $props();
 </script>
 
 <div class="dark-hidden block" data-tid={`${testId}-light-container`}>

--- a/src/frontend/src/lib/components/networks/NetworkLogo.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkLogo.svelte
@@ -5,10 +5,14 @@
 	import type { Network } from '$lib/types/network';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let network: Network;
-	export let size: LogoSize = 'xxs';
-	export let color: 'off-white' | 'white' = 'off-white';
-	export let testId: string | undefined = undefined;
+	interface Props {
+		network: Network;
+		size?: LogoSize;
+		color?: 'off-white' | 'white';
+		testId?: string;
+	}
+
+	let {network, size = 'xxs', color = 'off-white', testId}: Props = $props();
 </script>
 
 <div class="dark-hidden block" data-tid={`${testId}-light-container`}>


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- Upgrades `NetworkLogo`

