### PR TITLE
refactor(frontend): upgrades Logo to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -5,24 +5,27 @@
 	import { logoSizes } from '$lib/constants/components.constants';
 	import type { LogoSize } from '$lib/types/components';
 
-	export let src: string | undefined;
-	export let alt = '';
-	export let size: LogoSize = 'xxs';
-	export let color: 'off-white' | 'white' = 'off-white';
-	export let ring = false;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		src?: string;
+		alt?: string;
+		size?: LogoSize;
+		color?: 'off-white' | 'white';
+		ring?: boolean;
+		testId?: string;
+	}
 
-	let sizePx = logoSizes[size];
+	let {src, alt = '', size = 'xxs', color = 'off-white', ring = false, testId}: Props = $props();
 
-	let loaded = false;
+	let sizePx = $state(logoSizes[size]);
 
-	$: src,
-		(() => {
-			loaded = isNullish(src);
-			loadingError = false;
-		})();
+	let loaded = $state(false);
 
-	let loadingError = false;
+	$effect(() => {
+		loaded = isNullish(src);
+		loadingError = false;
+	});
+
+	let loadingError = $state(false);
 	const onError = () => {
 		loadingError = true;
 		loaded = true;

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -14,7 +14,7 @@
 		testId?: string;
 	}
 
-	let {src, alt = '', size = 'xxs', color = 'off-white', ring = false, testId}: Props = $props();
+	let { src, alt = '', size = 'xxs', color = 'off-white', ring = false, testId }: Props = $props();
 
 	let sizePx = $state(logoSizes[size]);
 


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- Upgrades `Logo`

