### PR TITLE
refactor(frontend): upgrades ReceiveAddressModal to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
@@ -12,11 +12,14 @@
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
 
-	export let infoCmp:
-		| typeof ReceiveAddresses
-		| typeof IcReceiveInfoCkBTC
-		| typeof IcReceiveInfoICP
-		| typeof IcReceiveInfoIcrc;
+	interface Props {
+		infoCmp:| typeof ReceiveAddresses
+				| typeof IcReceiveInfoCkBTC
+				| typeof IcReceiveInfoICP
+				| typeof IcReceiveInfoIcrc;
+	}
+
+	let {infoCmp}: Props = $props();
 
 	const steps: WizardSteps = [
 		{
@@ -29,13 +32,13 @@
 		}
 	];
 
-	let currentStep: WizardStep | undefined;
-	let modal: WizardModal;
+	let currentStep: WizardStep | undefined = $state();
+	let modal: WizardModal = $state();
 
-	let address: undefined | string;
-	let addressLabel: undefined | string;
-	let addressToken: Token | undefined;
-	let copyAriaLabel: string | undefined;
+	let address: undefined | string = $state();
+	let addressLabel: undefined | string = $state();
+	let addressToken: Token | undefined = $state();
+	let copyAriaLabel: string | undefined = $state();
 
 	const displayQRCode = ({ detail }: CustomEvent<ReceiveQRCode>) => {
 		({ address, addressLabel, addressToken, copyAriaLabel } = detail);


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.



# Changes

- Upgrades `ReceiveAddressModal`

