### PR TITLE
feat(frontend): implement getKnownDestinations util

### DIFF
--- a/src/frontend/src/lib/types/transactions.ts
+++ b/src/frontend/src/lib/types/transactions.ts
@@ -3,6 +3,7 @@ import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
+import type { Address } from '$lib/types/address';
 import type { Token } from '$lib/types/token';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 
@@ -13,3 +14,5 @@ export interface TransactionsStoreCheckParams {
 		| EthTransactionsData;
 	tokens: Token[];
 }
+
+export type KnownDestinations = Record<Address, { amounts: bigint[]; timestamp?: number }>;

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -302,7 +302,7 @@ export const getKnownDestinations = (transactions: AnyTransactionUi[]): KnownDes
 											? Math.max(Number(acc[address].timestamp), Number(timestamp))
 											: nonNullish(timestamp)
 												? Number(timestamp)
-												: undefined
+												: acc[address].timestamp
 								}
 							}),
 							{}

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -17,14 +17,14 @@ import {
 	getAllIcTransactions,
 	getIcExtendedTransactions
 } from '$icp/utils/ic-transactions.utils';
-import { MICRO_TRANSACTION_USD_THRESHOLD } from '$lib/constants/app.constants';
+import { MICRO_TRANSACTION_USD_THRESHOLD, ZERO } from '$lib/constants/app.constants';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';
 import type { AllTransactionUiWithCmp, AnyTransactionUi } from '$lib/types/transaction';
-import type { TransactionsStoreCheckParams } from '$lib/types/transactions';
+import type { KnownDestinations, TransactionsStoreCheckParams } from '$lib/types/transactions';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
 	isNetworkIdBTCMainnet,
@@ -285,3 +285,29 @@ export const areTransactionsStoresLoading = (
 
 	return (someNullish || someNotInitialized) && allEmpty;
 };
+
+export const getKnownDestinations = (transactions: AnyTransactionUi[]): KnownDestinations =>
+	transactions.reduce<KnownDestinations>(
+		(acc, { timestamp, value, to, type }) =>
+			nonNullish(to) && type === 'send' && nonNullish(value) && value > ZERO
+				? {
+						...acc,
+						...(Array.isArray(to) ? to : [to]).reduce(
+							(innerAcc, address) => ({
+								...innerAcc,
+								[address]: {
+									amounts: [...(nonNullish(acc[address]) ? acc[address].amounts : []), value],
+									timestamp:
+										nonNullish(acc[address]?.timestamp) && nonNullish(timestamp)
+											? Math.max(Number(acc[address].timestamp), Number(timestamp))
+											: nonNullish(timestamp)
+												? Number(timestamp)
+												: undefined
+								}
+							}),
+							{}
+						)
+					}
+				: acc,
+		{}
+	);

--- a/src/frontend/src/tests/mocks/ic-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/ic-transactions.mock.ts
@@ -25,7 +25,8 @@ export const createMockIcTransactionsUi = (n: number): IcTransactionUi[] =>
 		status: 'executed',
 		value: bn1Bi,
 		from: 'dndtm-gk4kn-ssvos-asuit-2q33x-lgtpj-5bnoi-v5ync-m4iza-xclem-mae',
-		to: 'cmpd6-ywgum-ofyfa-masyv-v3gba-il2hu-upwxw-xhdq3-mzkhx-zfhpb-7ae'
+		to: 'cmpd6-ywgum-ofyfa-masyv-v3gba-il2hu-upwxw-xhdq3-mzkhx-zfhpb-7ae',
+		timestamp: BigInt(1746536120801n)
 	}));
 
 export const setupIcTransactionsStore = ({ tokenId }: { tokenId: symbol & BRAND<'TokenId'> }) => {


### PR DESCRIPTION
# Motivation

In order to get all the needed info about known destinations from transactions list, we need to implement a new util.
