### PR TITLE
feat(frontend): added env varaible to constant for ICP Swap

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -76,6 +76,14 @@ export const KONG_BACKEND_CANISTER_ID = LOCAL
 			? import.meta.env.VITE_BETA_KONG_BACKEND_CANISTER_ID
 			: import.meta.env.VITE_IC_KONG_BACKEND_CANISTER_ID;
 
+export const ICP_SWAP_CANISTER_ID = LOCAL
+	? import.meta.env.VITE_LOCAL_ICP_SWAP_CANISTER_ID
+	: STAGING
+		? import.meta.env.VITE_STAGING_ICP_SWAP_CANISTER_ID
+		: BETA
+			? import.meta.env.VITE_BETA_ICP_SWAP_CANISTER_ID
+			: import.meta.env.VITE_IC_ICP_SWAP_CANISTER_ID;
+
 // How long the delegation identity should remain valid?
 // e.g. BigInt(60 * 60 * 1000 * 1000 * 1000) = 1 hour in nanoseconds
 export const AUTH_MAX_TIME_TO_LIVE = BigInt(60 * 60 * 1000 * 1000 * 1000);


### PR DESCRIPTION
# Motivation

We aim to integrate with ICP Swap and in this PR is provided config to get ICP_SWAP_CANISTER_ID depends on env.

# Changes

Added new ICP_SWAP_CANISTER_ID to constant env file

