### PR TITLE
feat(frontend): utils to check IC token standards

### DIFF
--- a/src/frontend/src/icp-eth/utils/token.utils.ts
+++ b/src/frontend/src/icp-eth/utils/token.utils.ts
@@ -1,7 +1,6 @@
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import type { Token } from '$lib/types/token';
 
-export const isGLDTToken = (token: Token): boolean =>
-	token.standard === 'icrc' && token.symbol === 'GLDT';
+export const isGLDTToken = (token: Token): boolean => isTokenIcrc(token) && token.symbol === 'GLDT';
 
-export const isVCHFToken = (token: Token): boolean =>
-	token.standard === 'icrc' && token.symbol === 'VCHF';
+export const isVCHFToken = (token: Token): boolean => isTokenIcrc(token) && token.symbol === 'VCHF';

--- a/src/frontend/src/icp/components/receive/IcReceive.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceive.svelte
@@ -20,6 +20,7 @@
 	import { loadTokenAndRun } from '$lib/services/token.services';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
+	import { isTokenIcrc } from '$icp/utils/icrc.utils';
 
 	export let token: Token;
 
@@ -30,7 +31,7 @@
 	$: ckBTC = isTokenCkBtcLedger(token);
 
 	let icrc = false;
-	$: icrc = token.standard === 'icrc';
+	$: icrc =isTokenIcrc(token)
 
 	const open: LoadTokenAndOpenModal = async (callback: () => Promise<void>) => {
 		await loadTokenAndRun({ token, callback });

--- a/src/frontend/src/icp/components/receive/IcReceiveICP.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveICP.svelte
@@ -11,11 +11,12 @@
 	import { modalIcpReceive } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { isRouteTokens } from '$lib/utils/nav.utils';
+	import { isTokenIcp } from '$icp/utils/icrc.utils';
 
 	const { tokenStandard, open, close } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 
 	const openReceive = (modalId: symbol) => {
-		if ($tokenStandard === 'icp' || isRouteTokens($page)) {
+		if (isTokenIcp({standard:$tokenStandard}) || isRouteTokens($page)) {
 			modalStore.openIcpReceive(modalId);
 			return;
 		}

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -15,6 +15,7 @@ import {
 import type { IcTransferParams } from '$icp/types/ic-send';
 import type { IcToken } from '$icp/types/ic-token';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
@@ -79,9 +80,9 @@ const send = async ({
 		return;
 	}
 
-	const { standard, ledgerCanisterId } = token;
+	const { ledgerCanisterId } = token;
 
-	if (standard === 'icrc') {
+	if (isTokenIcrc(token)) {
 		await sendIcrc({
 			...rest,
 			ledgerCanisterId

--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -6,6 +6,7 @@ import type { IcTransaction } from '$icp/types/ic-transaction';
 import { mapIcTransaction } from '$icp/utils/ic-transactions.utils';
 import { mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
 import { mapTransactionIcrcToSelf } from '$icp/utils/icrc-transactions.utils';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { balancesStore } from '$lib/stores/balances.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -25,7 +26,7 @@ const getTransactions = async ({
 	maxResults?: bigint;
 	token: IcToken & IcCanistersStrict;
 }): Promise<IcTransaction[]> => {
-	if (standard === 'icrc') {
+	if (isTokenIcrc({ standard })) {
 		const { transactions } = await getTransactionsIcrc({
 			indexCanisterId,
 			...rest

--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -6,6 +6,7 @@ import {
 } from '$env/networks/networks.icrc.env';
 import type { IcToken } from '$icp/types/ic-token';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenStandard } from '$lib/types/token';
@@ -59,7 +60,7 @@ export const isInvalidDestinationIc = ({
 		return !isEthAddress(destination);
 	}
 
-	if (tokenStandard === 'icrc') {
+	if (isTokenIcrc({ standard: tokenStandard })) {
 		return invalidIcrcAddress(destination);
 	}
 

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -97,8 +97,15 @@ export const buildIcrcCustomTokenMetadataPseudoResponse = ({
 	];
 };
 
+export const isTokenIcp = (token: Partial<IcToken>): token is IcToken => token.standard === 'icp';
+
+export const isTokenIcrc = (token: Partial<IcToken>): token is IcToken => token.standard === 'icrc';
+
+export const isTokenIc = (token: Partial<IcToken>): token is IcToken =>
+	isTokenIcp(token) || isTokenIcrc(token);
+
 export const icTokenIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
-	(token.standard === 'icp' || token.standard === 'icrc') && 'enabled' in token;
+	isTokenIc(token) && 'enabled' in token;
 
 const isIcCkInterface = (token: IcInterface): token is IcCkInterface =>
 	'minterCanisterId' in token && 'twinToken' in token;

--- a/src/frontend/src/icp/utils/wallet.utils.ts
+++ b/src/frontend/src/icp/utils/wallet.utils.ts
@@ -1,7 +1,7 @@
 import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
 import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
-import type { IcToken } from '$icp/types/ic-token';
 import type { InitWalletWorkerFn } from '$lib/types/listener';
+import { isTokenIcrc } from './icrc.utils';
 
 export const initWalletWorker: InitWalletWorkerFn = ({ token }) =>
-	token.standard === 'icrc' ? initIcrcWalletWorker(token as IcToken) : initIcpWalletWorker();
+	isTokenIcrc(token) ? initIcrcWalletWorker(token) : initIcpWalletWorker();

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -8,7 +8,7 @@
 	import { icTokenErc20UserToken, icTokenEthereumUserToken } from '$eth/utils/erc20.utils';
 	import IcManageTokenToggle from '$icp/components/tokens/IcManageTokenToggle.svelte';
 	import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-	import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
+	import { icTokenIcrcCustomToken, isTokenIcrc } from '$icp/utils/icrc.utils';
 	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
 	import ModalNetworksFilter from '$lib/components/tokens/ModalNetworksFilter.svelte';
@@ -111,7 +111,7 @@
 			spl: SplTokenToggleable[];
 		}>(
 			({ icrc, erc20, spl }, token) => ({
-				icrc: [...icrc, ...(token.standard === 'icrc' ? [token as IcrcCustomToken] : [])],
+				icrc: [...icrc, ...(isTokenIcrc(token) ? [token as IcrcCustomToken] : [])],
 				erc20: [
 					...erc20,
 					...(token.standard === 'erc20' && icTokenErc20UserToken(token) ? [token] : [])

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -9,6 +9,7 @@ import type { Erc20Token } from '$eth/types/erc20';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcToken } from '$icp/types/ic-token';
+import { isTokenIc } from '$icp/utils/icrc.utils';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Token, TokenToPin } from '$lib/types/token';
@@ -81,10 +82,8 @@ export const enabledErc20Tokens: Readable<Erc20Token[]> = derived(
  */
 // TODO: The several dependencies of enabledIcTokens are not strictly only IC tokens, but other tokens too.
 //  We should find a better way to handle this, improving the store.
-export const enabledIcTokens: Readable<IcToken[]> = derived(
-	[enabledTokens],
-	([$enabledTokens]) =>
-		$enabledTokens.filter(({ standard }) => standard === 'icp' || standard === 'icrc') as IcToken[]
+export const enabledIcTokens: Readable<IcToken[]> = derived([enabledTokens], ([$enabledTokens]) =>
+	$enabledTokens.filter(isTokenIc)
 );
 
 /**

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -3,6 +3,7 @@ import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
 import { loadCustomTokens } from '$icp/services/icrc.services';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { setCustomToken } from '$lib/api/backend.api';
 import { kongSwap, kongTokens } from '$lib/api/kong_backend.api';
 import { KONG_BACKEND_CANISTER_ID, NANO_SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
@@ -49,7 +50,7 @@ export const swap = async ({
 		value: `${swapAmount}`,
 		unitName: sourceToken.decimals
 	});
-	const { standard, ledgerCanisterId } = sourceToken;
+	const { ledgerCanisterId } = sourceToken;
 	const transferParams = {
 		identity,
 		token: sourceToken,
@@ -58,7 +59,7 @@ export const swap = async ({
 	};
 
 	const txBlockIndex = !isSourceTokenIcrc2
-		? standard === 'icrc'
+		? isTokenIcrc(sourceToken)
 			? await sendIcrc({
 					...transferParams,
 					ledgerCanisterId

--- a/src/frontend/src/lib/utils/token-toggle.utils.ts
+++ b/src/frontend/src/lib/utils/token-toggle.utils.ts
@@ -1,6 +1,7 @@
 import { ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
 import type { EthereumUserToken } from '$eth/types/erc20-user-token';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
+import { isTokenIcp } from '$icp/utils/icrc.utils';
 import { nonNullish } from '@dfinity/utils';
 
 // TODO: Check why this functionality is used instead of eth.utils.ts -> isSupportedEthToken.
@@ -13,7 +14,7 @@ export const isEthereumTokenToggleEnabled = (token: EthereumUserToken): boolean 
 // TODO: Like above - check why this functionality is used.
 export const isIcrcTokenToggleDisabled = (token: IcrcCustomToken): boolean =>
 	nonNullish(token)
-		? (token.category === 'default' && token.standard === 'icp') ||
+		? (token.category === 'default' && isTokenIcp(token)) ||
 			ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS.includes(token.ledgerCanisterId)
 		: false;
 

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -1,8 +1,59 @@
-import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
+import { icTokenIcrcCustomToken, isTokenIc, isTokenIcp, isTokenIcrc } from '$icp/utils/icrc.utils';
 import type { TokenStandard } from '$lib/types/token';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
 
 describe('icrc.utils', () => {
+	describe('isTokenIcp', () => {
+		it.each(['icp'])('should return true for valid token standards: %s', (standard) => {
+			expect(
+				isTokenIcp({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+			).toBeTruthy();
+		});
+
+		it.each(['icrc', 'ethereum', 'erc20', 'bitcoin', 'solana', 'spl'])(
+			'should return false for invalid token standards: %s',
+			(standard) => {
+				expect(
+					isTokenIcp({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				).toBeFalsy();
+			}
+		);
+	});
+
+	describe('isTokenIcrc', () => {
+		it.each(['icrc'])('should return true for valid token standards: %s', (standard) => {
+			expect(
+				isTokenIcrc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+			).toBeTruthy();
+		});
+
+		it.each(['icp', 'ethereum', 'erc20', 'bitcoin', 'solana', 'spl'])(
+			'should return false for invalid token standards: %s',
+			(standard) => {
+				expect(
+					isTokenIcrc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				).toBeFalsy();
+			}
+		);
+	});
+
+	describe('isTokenIc', () => {
+		it.each(['icp', 'icrc'])('should return true for valid token standards: %s', (standard) => {
+			expect(
+				isTokenIc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+			).toBeTruthy();
+		});
+
+		it.each(['ethereum', 'erc20', 'bitcoin', 'solana', 'spl'])(
+			'should return false for invalid token standards: %s',
+			(standard) => {
+				expect(
+					isTokenIc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				).toBeFalsy();
+			}
+		);
+	});
+
 	describe('icTokenIcrcCustomToken', () => {
 		it.each(['icp', 'icrc'])('should return true for valid token standards: %s', (standard) => {
 			expect(

--- a/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/qr-code.utils.spec.ts
@@ -1,5 +1,6 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { EthereumNetwork } from '$eth/types/network';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { DecodedUrn } from '$lib/types/qr-code';
 import { decodeQrCode, decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
@@ -36,7 +37,7 @@ describe('decodeUrn', () => {
 			const expectedPrefix =
 				standard === 'erc20'
 					? 'ethereum'
-					: standard === 'icrc'
+					: isTokenIcrc(token)
 						? token.name.toLowerCase()
 						: standard;
 			const expectedResult: DecodedUrn = {

--- a/src/frontend/src/tests/mocks/qr-generator.mock.ts
+++ b/src/frontend/src/tests/mocks/qr-generator.mock.ts
@@ -1,4 +1,5 @@
 import type { EthereumNetwork } from '$eth/types/network';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import type { Token } from '$lib/types/token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
@@ -26,7 +27,7 @@ export const generateUrn = ({
 	}
 
 	const prefix =
-		standard === 'erc20' ? 'ethereum' : standard === 'icrc' ? name.toLowerCase() : standard;
+		standard === 'erc20' ? 'ethereum' : isTokenIcrc(token) ? name.toLowerCase() : standard;
 
 	urn = `${prefix}:${destination}`;
 


### PR DESCRIPTION
# Motivation

For better manageability, we create utils functions to check the standards for `icp` and `icrc`, and combine them for IC tokens in general.

# Changes

- Create util for standard `icp`.
- Create util for standard `icrc`.
- Merge the utils into a single one to check if the token is an IC token.
- Use all three above in the code.

# Tests

New tests created.
