### PR TITLE
fix(frontend): use styleClass in LogoButton

### DIFF
--- a/src/frontend/src/lib/components/ui/LogoButton.svelte
+++ b/src/frontend/src/lib/components/ui/LogoButton.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <div
-	class="flex"
+	class={`flex ${styleClass ?? ''}`}
 	class:w-full={dividers}
 	class:hover:bg-brand-subtle-10={hover}
 	class:rounded-lg={rounded}


### PR DESCRIPTION
# Motivation

Small fix for the LogoButton component - `styleClass` was added but never used.
