### PR TITLE
fix(frontend): onclick event in Input

### DIFF
--- a/src/frontend/src/lib/components/ui/Input.svelte
+++ b/src/frontend/src/lib/components/ui/Input.svelte
@@ -27,7 +27,7 @@
 		{#if nonNullish(value) && notEmptyString(value.toString()) && showResetButton}
 			<button
 				class="text-tertiary"
-				on:click={reset}
+				onclick={reset}
 				aria-label={resetButtonAriaLabel ?? $i18n.convert.text.input_reset_button}
 			>
 				<IconClose />


### PR DESCRIPTION
# Motivation

While building the frontend, noticed there is a linter warning in the `Input` component.