### PR TITLE
feat(frontend): added new icp swap utils methods

### DIFF
--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -4,7 +4,26 @@ export type SwapSelectTokenType = 'source' | 'destination';
 
 export type DisplayUnit = 'token' | 'usd';
 
+export type SwapProvider = 'kongSwap' | 'icpSwap';
+
 export interface ProviderFee {
 	fee: bigint;
 	token: Token;
+}
+
+export interface ICPSwapResult {
+	receiveAmount: bigint;
+}
+
+export type Slippage = string | number;
+
+export interface SwapMappedResult {
+	provider: SwapProvider;
+	receiveAmount: bigint;
+	slippage?: number;
+	route?: string[];
+	liquidityFees?: ProviderFee[];
+	receiveOutMinimum?: bigint;
+	networkFee?: ProviderFee;
+	swapDetails: unknown;
 }

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -1,7 +1,15 @@
-import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
+import type {
+	SwapAmountsReply,
+	SwapAmountsTxReply
+} from '$declarations/kong_backend/kong_backend.did';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import { ZERO } from '$lib/constants/app.constants';
-import type { ProviderFee } from '$lib/types/swap';
+import {
+	ICP_SWAP_PROVIDER,
+	KONG_SWAP_PROVIDER,
+	SWAP_DEFAULT_SLIPPAGE_VALUE
+} from '$lib/constants/swap.constants';
+import type { ICPSwapResult, ProviderFee, Slippage, SwapMappedResult } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { findToken } from '$lib/utils/tokens.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -51,3 +59,62 @@ export const getNetworkFee = ({
 
 export const getKongIcTokenIdentifier = (token: Token): string =>
 	isIcToken(token) ? `IC.${token.ledgerCanisterId}` : '';
+
+export const mapIcpSwapResult = ({
+	swap,
+	slippage
+}: {
+	swap: ICPSwapResult;
+	slippage: Slippage;
+}): SwapMappedResult => {
+	const parsedSlippage = Number(slippage);
+	const slippagePercentage = parsedSlippage > 0 ? parsedSlippage : SWAP_DEFAULT_SLIPPAGE_VALUE;
+	return {
+		provider: ICP_SWAP_PROVIDER,
+		receiveAmount: swap.receiveAmount,
+		receiveOutMinimum: calculateSlippage({
+			quoteAmount: swap.receiveAmount,
+			slippagePercentage
+		}),
+		swapDetails: swap
+	};
+};
+
+export const mapKongSwapResult = ({
+	swap,
+	tokens
+}: {
+	swap: SwapAmountsReply;
+	tokens: Token[];
+}): SwapMappedResult => ({
+	provider: KONG_SWAP_PROVIDER,
+	slippage: swap.slippage,
+	receiveAmount: swap.receive_amount,
+	route: getSwapRoute(swap.txs ?? []),
+	liquidityFees: getLiquidityFees({ transactions: swap.txs ?? [], tokens }),
+	networkFee: getNetworkFee({ transactions: swap.txs ?? [], tokens }),
+	swapDetails: swap
+});
+
+/**
+ * Calculates the minimum acceptable amount after applying slippage tolerance.
+ *
+ * This is typically used when performing swaps to ensure that
+ * the received amount doesn't fall below the expected slippage tolerance.
+ *
+ * @param params - Parameters to calculate slippage
+ * @param params.quoteAmount - The quoted amount without slippage (in smallest token units, e.g., wei)
+ * @param params.slippagePercentage - The allowed slippage percentage (e.g., 0.5 for 0.5%)
+ * @returns The minimum amount after slippage, as bigint
+ *
+ */
+export const calculateSlippage = ({
+	quoteAmount,
+	slippagePercentage
+}: {
+	quoteAmount: bigint;
+	slippagePercentage: number;
+}): bigint => {
+	const slippageFactor = BigInt(10000 - Math.floor(slippagePercentage * 100));
+	return (quoteAmount * slippageFactor) / 10000n;
+};

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -1,13 +1,25 @@
-import type { SwapAmountsTxReply } from '$declarations/kong_backend/kong_backend.did';
+import type {
+	SwapAmountsReply,
+	SwapAmountsTxReply
+} from '$declarations/kong_backend/kong_backend.did';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_SYMBOL, ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { ZERO } from '$lib/constants/app.constants';
 import {
+	ICP_SWAP_PROVIDER,
+	KONG_SWAP_PROVIDER,
+	SWAP_DEFAULT_SLIPPAGE_VALUE
+} from '$lib/constants/swap.constants';
+import type { ICPSwapResult } from '$lib/types/swap';
+import {
+	calculateSlippage,
 	getKongIcTokenIdentifier,
 	getLiquidityFees,
 	getNetworkFee,
-	getSwapRoute
+	getSwapRoute,
+	mapIcpSwapResult,
+	mapKongSwapResult
 } from '$lib/utils/swap.utils';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockTokens } from '$tests/mocks/tokens.mock';
@@ -125,6 +137,80 @@ describe('swap utils', () => {
 
 		it('returns empty string for non-IC token', () => {
 			expect(getKongIcTokenIdentifier(BTC_MAINNET_TOKEN)).toBe('');
+		});
+	});
+
+	describe('mapIcpSwapResult', () => {
+		const baseSwap: ICPSwapResult = {
+			receiveAmount: 1000n
+		};
+
+		it('should return mapped result with valid numeric slippage as string', () => {
+			const result = mapIcpSwapResult({ swap: baseSwap, slippage: '0.5' });
+
+			expect(result.provider).toBe(ICP_SWAP_PROVIDER);
+			expect(result.receiveAmount).toBe(1000n);
+			expect(result.receiveOutMinimum).toBe(
+				calculateSlippage({ quoteAmount: 1000n, slippagePercentage: 0.5 })
+			);
+			expect(result.swapDetails).toBe(baseSwap);
+		});
+
+		it('should return mapped result with numeric slippage', () => {
+			const result = mapIcpSwapResult({ swap: baseSwap, slippage: 0.3 });
+
+			expect(result.receiveOutMinimum).toBe(
+				calculateSlippage({ quoteAmount: 1000n, slippagePercentage: 0.3 })
+			);
+		});
+
+		it('should fallback to default slippage if value is NaN', () => {
+			const result = mapIcpSwapResult({ swap: baseSwap, slippage: 'string' });
+
+			expect(result.receiveOutMinimum).toBe(
+				calculateSlippage({
+					quoteAmount: 1000n,
+					slippagePercentage: SWAP_DEFAULT_SLIPPAGE_VALUE
+				})
+			);
+		});
+
+		it('should fallback to default slippage if empty string is passed', () => {
+			const result = mapIcpSwapResult({ swap: baseSwap, slippage: '' });
+
+			expect(result.receiveOutMinimum).toBe(
+				calculateSlippage({
+					quoteAmount: 1000n,
+					slippagePercentage: SWAP_DEFAULT_SLIPPAGE_VALUE
+				})
+			);
+		});
+	});
+
+	describe('mapKongSwapResult', () => {
+		const tokens = mockTokens;
+		const swap: SwapAmountsReply = {
+			slippage: 0.3,
+			receive_amount: 2000n,
+			txs: [],
+			receive_chain: 'icp',
+			mid_price: 1.0,
+			pay_amount: 1000n,
+			receive_symbol: 'BBB',
+			pay_symbol: 'AAA',
+			receive_address: 'address1',
+			pay_address: 'address2',
+			price: 1.0,
+			pay_chain: 'icp'
+		};
+
+		it('should return mapped kong swap result', () => {
+			const result = mapKongSwapResult({ swap, tokens });
+
+			expect(result.provider).toBe(KONG_SWAP_PROVIDER);
+			expect(result.slippage).toBe(0.3);
+			expect(result.receiveAmount).toBe(2000n);
+			expect(result.swapDetails).toBe(swap);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Added new icp swap utils methods to calculate slippage and map swap responses to common interface

# Changes

Added new icp swap utils methods: 
- mapIcpSwapResult
- mapKongSwapResult
- calculateSlippage


# Tests

Covered new logic with tests
