### PR TITLE
fix(frontend): missing chain ID in class `EtherscanProvider` for ERC20

### DIFF
--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -142,6 +142,7 @@ export class EtherscanProvider {
 		contract: Erc20Token;
 	}): Promise<Transaction[]> => {
 		const params = {
+			chainId: this.chainId,
 			action: 'tokentx',
 			contractAddress,
 			address,


### PR DESCRIPTION
# Motivation

There is a missing parameter chainId in method `erc20Transactions` of class `EtherscanProvider`. It was not raised since the method is still unused.