### PR TITLE
refactor(frontend): rename service to load the next IC transactions

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionsScroll.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsScroll.svelte
@@ -3,7 +3,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { icTransactions } from '$icp/derived/ic-transactions.derived';
-	import { loadNextTransactions } from '$icp/services/ic-transactions.services';
+	import { loadNextIcTransactions } from '$icp/services/ic-transactions.services';
 	import { isNotIcToken, isNotIcTokenCanistersStrict } from '$icp/validation/ic-token.validation';
 	import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -52,7 +52,7 @@
 			return;
 		}
 
-		await loadNextTransactions({
+		await loadNextIcTransactions({
 			owner: $authIdentity.getPrincipal(),
 			identity: $authIdentity,
 			maxResults: WALLET_PAGINATION,

--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -40,7 +40,7 @@ const getTransactions = async ({
 	return transactions.flatMap(mapTransactionIcpToSelf);
 };
 
-export const loadNextTransactions = ({
+export const loadNextIcTransactions = ({
 	token,
 	identity,
 	signalEnd,


### PR DESCRIPTION
# Motivation

It seems more consistent to rename the function `loadNextTransactions` to `loadNextIcTransactions` since we already have `loadNextSolTransactions` too.
