### PR TITLE
refactor(frontend): refactored icp swap logic

### DIFF
--- a/src/frontend/src/lib/api/icp-swap-factory.api.ts
+++ b/src/frontend/src/lib/api/icp-swap-factory.api.ts
@@ -8,6 +8,21 @@ import { assertNonNullish, isNullish } from '@dfinity/utils';
 
 let canister: ICPSwapFactoryCanister | undefined = undefined;
 
+export const getPoolCanister = async ({
+	identity,
+	nullishIdentityErrorMessage,
+	canisterId,
+	...restParams
+}: CanisterApiFunctionParams<ICPSwapGetPoolParams>): Promise<PoolData> => {
+	const { getPool } = await icpSwapFactoryCanister({
+		identity,
+		canisterId,
+		nullishIdentityErrorMessage
+	});
+
+	return getPool(restParams);
+};
+
 const icpSwapFactoryCanister = async ({
 	identity,
 	nullishIdentityErrorMessage,
@@ -23,19 +38,4 @@ const icpSwapFactoryCanister = async ({
 	}
 
 	return canister;
-};
-
-export const getPool = async ({
-	identity,
-	nullishIdentityErrorMessage,
-	canisterId,
-	...restParams
-}: CanisterApiFunctionParams<ICPSwapGetPoolParams>): Promise<PoolData> => {
-	const { getPool } = await icpSwapFactoryCanister({
-		identity,
-		canisterId,
-		nullishIdentityErrorMessage
-	});
-
-	return getPool(restParams);
 };

--- a/src/frontend/src/lib/services/icp-swap.services.ts
+++ b/src/frontend/src/lib/services/icp-swap.services.ts
@@ -1,4 +1,4 @@
-import { getPool } from '$lib/api/icp-swap-factory.api';
+import { getPoolCanister } from '$lib/api/icp-swap-factory.api';
 import { getQuote } from '$lib/api/icp-swap-pool.api';
 import { ICP_SWAP_POOL_FEE } from '$lib/constants/swap.constants';
 import type { ICPSwapAmountReply, ICPSwapQuoteParams } from '$lib/types/api';
@@ -10,7 +10,7 @@ export const icpSwapAmounts = async ({
 	sourceAmount,
 	fee = ICP_SWAP_POOL_FEE // The only supported pool fee on ICPSwap at the moment (0.3%)
 }: ICPSwapQuoteParams): Promise<ICPSwapAmountReply> => {
-	const pool = await getPool({
+	const pool = await getPoolCanister({
 		identity,
 		token0: { address: sourceToken.ledgerCanisterId, standard: sourceToken.standard },
 		token1: { address: destinationToken.ledgerCanisterId, standard: destinationToken.standard },

--- a/src/frontend/src/tests/lib/canisters/icp-swap-factory.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/icp-swap-factory.spec.ts
@@ -15,10 +15,7 @@ import { mock } from 'vitest-mock-extended';
 describe('icp_swap_factory.canister', () => {
 	const createFactory = ({
 		serviceOverride
-	}: Pick<
-		CreateCanisterOptions<SwapFactoryService>,
-		'serviceOverride'
-	>): Promise<ICPSwapFactoryCanister> =>
+	}: Pick<CreateCanisterOptions<SwapFactoryService>, 'serviceOverride'>) =>
 		ICPSwapFactoryCanister.create({
 			canisterId: Principal.fromText('4mmnk-kiaaa-aaaag-qbllq-cai'),
 			identity: mockIdentity,

--- a/src/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -27,7 +27,7 @@ describe('icpSwapAmounts', () => {
 	});
 
 	it('returns receiveAmount when everything succeeds', async () => {
-		vi.spyOn(factoryApi, 'getPool').mockResolvedValue(mockPool);
+		vi.spyOn(factoryApi, 'getPoolCanister').mockResolvedValue(mockPool);
 		vi.spyOn(poolApi, 'getQuote').mockResolvedValue(999n);
 
 		const result = await icpSwapAmounts(params);
@@ -37,7 +37,7 @@ describe('icpSwapAmounts', () => {
 
 	it('uses correct zeroForOne = true when source is token0', async () => {
 		const getQuoteSpy = vi.spyOn(poolApi, 'getQuote').mockResolvedValue(888n);
-		vi.spyOn(factoryApi, 'getPool').mockResolvedValue(mockPool);
+		vi.spyOn(factoryApi, 'getPoolCanister').mockResolvedValue(mockPool);
 
 		await icpSwapAmounts(params);
 
@@ -58,7 +58,7 @@ describe('icpSwapAmounts', () => {
 		};
 
 		const getQuoteSpy = vi.spyOn(poolApi, 'getQuote').mockResolvedValue(888n);
-		vi.spyOn(factoryApi, 'getPool').mockResolvedValue(flippedPool);
+		vi.spyOn(factoryApi, 'getPoolCanister').mockResolvedValue(flippedPool);
 
 		await icpSwapAmounts(params);
 


### PR DESCRIPTION
# Motivation

Refactored the ICP Swap logic for consistency with other files and updated the test to properly mock the canister method.

# Changes

- Refactored ICP Swap logic
- Aligned structure with other modules
- Updated test to mock canister method correctly
