### PR TITLE
feat(frontend): Make contact color computation reusable

### DIFF
--- a/src/frontend/src/lib/components/contact/Avatar.svelte
+++ b/src/frontend/src/lib/components/contact/Avatar.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-	import { isEmptyString, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import IconAvatar from '$lib/components/icons/IconAvatar.svelte';
+	import { CONTACT_BACKGROUND_COLORS } from '$lib/constants/contact.constants';
 	import type { AvatarVariants } from '$lib/types/style';
+	import { selectColorForName } from '$lib/utils/contact.utils';
 
 	interface AvatarProps {
 		name?: string;
@@ -9,20 +11,6 @@
 		styleClass?: string;
 	}
 	const { name, variant = 'md', styleClass }: AvatarProps = $props();
-	// This constant is needed because all classes need to be somewhere in the
-	// sourcecode. Otherwise tailwind will not include the classes in the css.
-	// Compare: https://v3.tailwindcss.com/docs/content-configuration#class-detection-in-depth
-	const COLORS = [
-		`bg-contact-1`,
-		`bg-contact-2`,
-		`bg-contact-3`,
-		`bg-contact-4`,
-		`bg-contact-5`,
-		`bg-contact-6`,
-		`bg-contact-7`,
-		`bg-contact-8`,
-		`bg-contact-9`
-	];
 
 	const font = $derived(
 		{
@@ -35,20 +23,7 @@
 	);
 	let size = $derived(variant === 'xl' ? 'size-25' : 'size-[2.5em]');
 
-	const computeContactColor = (contactName?: string) => {
-		const trimmedName = contactName?.trim?.();
-		if (isEmptyString(trimmedName)) {
-			return '';
-		}
-
-		let hash = 0;
-		for (let i = 0; i < trimmedName.length; i++) {
-			hash = (hash + trimmedName.charCodeAt(i)) % 9;
-		}
-
-		return COLORS[hash];
-	};
-	let bgColor = $derived(computeContactColor(name));
+	let bgColor = $derived(selectColorForName({ name, colors: CONTACT_BACKGROUND_COLORS }));
 
 	let commonClasses = $derived(`${font} ${size} ${bgColor} rounded-full`);
 

--- a/src/frontend/src/lib/constants/contact.constants.ts
+++ b/src/frontend/src/lib/constants/contact.constants.ts
@@ -1,0 +1,12 @@
+// Available contact background colors
+export const CONTACT_BACKGROUND_COLORS = [
+	`bg-contact-1`,
+	`bg-contact-2`,
+	`bg-contact-3`,
+	`bg-contact-4`,
+	`bg-contact-5`,
+	`bg-contact-6`,
+	`bg-contact-7`,
+	`bg-contact-8`,
+	`bg-contact-9`
+];

--- a/src/frontend/src/lib/constants/contact.constants.ts
+++ b/src/frontend/src/lib/constants/contact.constants.ts
@@ -1,5 +1,7 @@
+import type { NonEmptyArray } from '$lib/types/utils';
+
 // Available contact background colors
-export const CONTACT_BACKGROUND_COLORS = [
+export const CONTACT_BACKGROUND_COLORS: NonEmptyArray<string> = [
 	`bg-contact-1`,
 	`bg-contact-2`,
 	`bg-contact-3`,

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -15,3 +15,5 @@ export type AtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
 	{ [K in Keys]-?: Required<Pick<T, K>> & Partial<Omit<T, K>> }[Keys];
 
 export type PartialSpecific<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -1,0 +1,25 @@
+import { isEmptyString } from '@dfinity/utils';
+
+export const selectColorForName = <T>({
+	colors,
+	name
+}: {
+	colors: T[];
+	name?: string;
+}): T | undefined => {
+	if (colors.length === 0) {
+		throw new Error('Colors array cannot be empty');
+	}
+
+	const trimmedName = name?.trim?.();
+	if (isEmptyString(trimmedName)) {
+		return undefined;
+	}
+
+	const hash = [...trimmedName].reduce<number>(
+		(acc, char) => (acc + char.charCodeAt(0)) % colors.length,
+		0
+	);
+
+	return colors[hash];
+};

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -1,16 +1,13 @@
+import type { NonEmptyArray } from '$lib/types/utils';
 import { isEmptyString } from '@dfinity/utils';
 
 export const selectColorForName = <T>({
 	colors,
 	name
 }: {
-	colors: T[];
-	name?: string;
+	colors: NonEmptyArray<T>;
+	name: string | undefined;
 }): T | undefined => {
-	if (colors.length === 0) {
-		throw new Error('Colors array cannot be empty');
-	}
-
 	const trimmedName = name?.trim?.();
 	if (isEmptyString(trimmedName)) {
 		return undefined;

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -1,0 +1,39 @@
+import { selectColorForName } from '$lib/utils/contact.utils';
+
+describe('contact.utils', () => {
+	describe('selectColorForName', () => {
+		it('should return a color from the array based on the name', () => {
+			const colors = ['red', 'green', 'blue'];
+
+			expect(selectColorForName({ colors, name: 'John 1' })).toEqual('red');
+			expect(selectColorForName({ colors, name: 'John 2' })).toEqual('green');
+			expect(selectColorForName({ colors, name: 'John 3' })).toEqual('blue');
+			expect(selectColorForName({ colors, name: 'John 4' })).toEqual('red');
+			expect(selectColorForName({ colors, name: 'John 4 ' })).toEqual('red');
+		});
+
+		it('should return the same color for the same name', () => {
+			const colors = ['red', 'green', 'blue'];
+			const name = 'John Doe';
+
+			const result1 = selectColorForName({ colors, name });
+			const result2 = selectColorForName({ colors, name });
+
+			expect(result1).toBe(result2);
+		});
+
+		it('should return undefined if name is empty', () => {
+			const colors = ['red', 'green', 'blue'];
+
+			expect(selectColorForName({ colors, name: '' })).toBeUndefined();
+			expect(selectColorForName({ colors, name: '   ' })).toBeUndefined();
+			expect(selectColorForName({ colors, name: undefined })).toBeUndefined();
+		});
+
+		it('should throw an error if colors array is empty', () => {
+			expect(() => selectColorForName({ colors: [], name: 'John Doe' })).toThrow(
+				'Colors array cannot be empty'
+			);
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -1,9 +1,10 @@
 import { selectColorForName } from '$lib/utils/contact.utils';
+import type { NonEmptyArray } from 'alchemy-sdk';
 
 describe('contact.utils', () => {
 	describe('selectColorForName', () => {
 		it('should return a color from the array based on the name', () => {
-			const colors = ['red', 'green', 'blue'];
+			const colors: NonEmptyArray<string> = ['red', 'green', 'blue'];
 
 			expect(selectColorForName({ colors, name: 'John 1' })).toEqual('red');
 			expect(selectColorForName({ colors, name: 'John 2' })).toEqual('green');
@@ -13,7 +14,7 @@ describe('contact.utils', () => {
 		});
 
 		it('should return the same color for the same name', () => {
-			const colors = ['red', 'green', 'blue'];
+			const colors: NonEmptyArray<string> = ['red', 'green', 'blue'];
 			const name = 'John Doe';
 
 			const result1 = selectColorForName({ colors, name });
@@ -23,17 +24,11 @@ describe('contact.utils', () => {
 		});
 
 		it('should return undefined if name is empty', () => {
-			const colors = ['red', 'green', 'blue'];
+			const colors: NonEmptyArray<string> = ['red', 'green', 'blue'];
 
 			expect(selectColorForName({ colors, name: '' })).toBeUndefined();
 			expect(selectColorForName({ colors, name: '   ' })).toBeUndefined();
 			expect(selectColorForName({ colors, name: undefined })).toBeUndefined();
-		});
-
-		it('should throw an error if colors array is empty', () => {
-			expect(() => selectColorForName({ colors: [], name: 'John Doe' })).toThrow(
-				'Colors array cannot be empty'
-			);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Move the color selection in a utils file in order to reuse the functionality for the contact header later.

# Changes

- Move computation into a separate file
- Enhancement: Make the hash computation functional

# Tests

Added tests