### PR TITLE
feat(frontend): SendDestinationWizardStep component

### DIFF
--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -14,12 +14,7 @@
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import {
-		SEND_DESTINATION_WIZARD_STEP_BTC,
-		SEND_DESTINATION_WIZARD_STEP_ETH,
-		SEND_DESTINATION_WIZARD_STEP_IC,
-		SEND_DESTINATION_WIZARD_STEP_SOL
-	} from '$lib/constants/test-ids.constants';
+	import { SEND_DESTINATION_WIZARD_STEP } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
@@ -39,7 +34,7 @@
 	}
 	let { destination = $bindable(), formCancelAction = 'back' }: Props = $props();
 
-	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendToken, sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
@@ -50,11 +45,13 @@
 	let invalidDestination = $state(false);
 
 	let disabled = $derived(invalidDestination || isNullishOrEmpty(destination));
+
+	let testId = $derived(`${SEND_DESTINATION_WIZARD_STEP}-${$sendToken.network.name}`);
 </script>
 
 <ContentWithToolbar>
-	{#if isNetworkIdEthereum($sendToken?.network.id) || isNetworkIdEvm($sendToken.network.id)}
-		<div data-tid={SEND_DESTINATION_WIZARD_STEP_ETH}>
+	{#if isNetworkIdEthereum($sendTokenNetworkId) || isNetworkIdEvm($sendTokenNetworkId)}
+		<div data-tid={testId}>
 			<CkEthLoader nativeTokenId={$ethereumTokenId} isSendFlow={true}>
 				<EthSendDestination
 					token={$sendToken}
@@ -70,8 +67,8 @@
 				/>
 			</CkEthLoader>
 		</div>
-	{:else if isNetworkIdICP($sendToken?.network.id)}
-		<div data-tid={SEND_DESTINATION_WIZARD_STEP_IC}>
+	{:else if isNetworkIdICP($sendTokenNetworkId)}
+		<div data-tid={testId}>
 			<IcSendDestination
 				tokenStandard={$sendToken.standard}
 				knownDestinations={$icKnownDestinations}
@@ -85,8 +82,8 @@
 				on:icNext={next}
 			/>
 		</div>
-	{:else if isNetworkIdBitcoin($sendToken?.network.id)}
-		<div data-tid={SEND_DESTINATION_WIZARD_STEP_BTC}>
+	{:else if isNetworkIdBitcoin($sendTokenNetworkId)}
+		<div data-tid={testId}>
 			<BtcSendDestination
 				bind:destination
 				bind:invalidDestination
@@ -99,8 +96,8 @@
 				on:icNext={next}
 			/>
 		</div>
-	{:else if isNetworkIdSolana($sendToken?.network.id)}
-		<div data-tid={SEND_DESTINATION_WIZARD_STEP_SOL}>
+	{:else if isNetworkIdSolana($sendTokenNetworkId)}
+		<div data-tid={testId}>
 			<SolSendDestination
 				bind:destination
 				bind:invalidDestination

--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { createEventDispatcher, getContext } from 'svelte';
+	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
+	import { btcKnownDestinations } from '$btc/derived/btc-transactions.derived';
+	import EthSendDestination from '$eth/components/send/EthSendDestination.svelte';
+	import { ethKnownDestinations } from '$eth/derived/eth-transactions.derived';
+	import { ethereumTokenId } from '$eth/derived/token.derived';
+	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
+	import { icKnownDestinations } from '$icp/derived/ic-transactions.derived';
+	import CkEthLoader from '$icp-eth/components/core/CkEthLoader.svelte';
+	import KnownDestinationsComponent from '$lib/components/send/KnownDestinations.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import {
+		SEND_DESTINATION_WIZARD_STEP_BTC,
+		SEND_DESTINATION_WIZARD_STEP_ETH,
+		SEND_DESTINATION_WIZARD_STEP_IC,
+		SEND_DESTINATION_WIZARD_STEP_SOL
+	} from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { isNullishOrEmpty } from '$lib/utils/input.utils';
+	import {
+		isNetworkIdBitcoin,
+		isNetworkIdEthereum,
+		isNetworkIdEvm,
+		isNetworkIdICP,
+		isNetworkIdSolana
+	} from '$lib/utils/network.utils';
+	import SolSendDestination from '$sol/components/send/SolSendDestination.svelte';
+	import { solKnownDestinations } from '$sol/derived/sol-transactions.derived';
+
+	interface Props {
+		destination: string;
+		formCancelAction?: 'back' | 'close';
+	}
+	let { destination = $bindable(), formCancelAction = 'back' }: Props = $props();
+
+	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const dispatch = createEventDispatcher();
+
+	const back = () => dispatch('icBack');
+	const next = () => dispatch('icNext');
+	const close = () => dispatch('icClose');
+
+	let invalidDestination = $state(false);
+
+	let disabled = $derived(invalidDestination || isNullishOrEmpty(destination));
+</script>
+
+<ContentWithToolbar>
+	{#if isNetworkIdEthereum($sendToken?.network.id) || isNetworkIdEvm($sendToken.network.id)}
+		<div data-tid={SEND_DESTINATION_WIZARD_STEP_ETH}>
+			<CkEthLoader nativeTokenId={$ethereumTokenId} isSendFlow={true}>
+				<EthSendDestination
+					token={$sendToken}
+					knownDestinations={$ethKnownDestinations}
+					bind:destination
+					bind:invalidDestination
+					on:icQRCodeScan
+				/>
+				<KnownDestinationsComponent
+					knownDestinations={$ethKnownDestinations}
+					bind:destination
+					on:icNext={next}
+				/>
+			</CkEthLoader>
+		</div>
+	{:else if isNetworkIdICP($sendToken?.network.id)}
+		<div data-tid={SEND_DESTINATION_WIZARD_STEP_IC}>
+			<IcSendDestination
+				tokenStandard={$sendToken.standard}
+				knownDestinations={$icKnownDestinations}
+				bind:destination
+				bind:invalidDestination
+				on:icQRCodeScan
+			/>
+			<KnownDestinationsComponent
+				knownDestinations={$icKnownDestinations}
+				bind:destination
+				on:icNext={next}
+			/>
+		</div>
+	{:else if isNetworkIdBitcoin($sendToken?.network.id)}
+		<div data-tid={SEND_DESTINATION_WIZARD_STEP_BTC}>
+			<BtcSendDestination
+				bind:destination
+				bind:invalidDestination
+				on:icQRCodeScan
+				knownDestinations={$btcKnownDestinations}
+			/>
+			<KnownDestinationsComponent
+				knownDestinations={$btcKnownDestinations}
+				bind:destination
+				on:icNext={next}
+			/>
+		</div>
+	{:else if isNetworkIdSolana($sendToken?.network.id)}
+		<div data-tid={SEND_DESTINATION_WIZARD_STEP_SOL}>
+			<SolSendDestination
+				bind:destination
+				bind:invalidDestination
+				on:icQRCodeScan
+				knownDestinations={$solKnownDestinations}
+			/>
+			<KnownDestinationsComponent
+				knownDestinations={$solKnownDestinations}
+				bind:destination
+				on:icNext={next}
+			/>
+		</div>
+	{/if}
+
+	<ButtonGroup slot="toolbar">
+		{#if formCancelAction === 'back'}
+			<ButtonBack onclick={back} />
+		{:else}
+			<ButtonCancel onclick={close} />
+		{/if}
+
+		<Button on:click={next} {disabled}>
+			{$i18n.core.text.next}
+		</Button>
+	</ButtonGroup>
+</ContentWithToolbar>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -184,7 +184,4 @@ export const ADDRESS_BOOK_CONTACT_NAME_INPUT = 'address-book-contact-name-input'
 export const ADDRESS_BOOK_SAVE_BUTTON = 'address-book-save-button';
 export const ADDRESS_BOOK_CANCEL_BUTTON = 'address-book-cancel-button';
 
-export const SEND_DESTINATION_WIZARD_STEP_ETH = 'send-destination-wizard-step-eth';
-export const SEND_DESTINATION_WIZARD_STEP_BTC = 'send-destination-wizard-step-btc';
-export const SEND_DESTINATION_WIZARD_STEP_SOL = 'send-destination-wizard-step-sol';
-export const SEND_DESTINATION_WIZARD_STEP_IC = 'send-destination-wizard-step-ic';
+export const SEND_DESTINATION_WIZARD_STEP = 'send-destination-wizard-step';

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -183,3 +183,8 @@ export const ADDRESS_BOOK_CONTACT_FORM = 'address-book-contact-form';
 export const ADDRESS_BOOK_CONTACT_NAME_INPUT = 'address-book-contact-name-input';
 export const ADDRESS_BOOK_SAVE_BUTTON = 'address-book-save-button';
 export const ADDRESS_BOOK_CANCEL_BUTTON = 'address-book-cancel-button';
+
+export const SEND_DESTINATION_WIZARD_STEP_ETH = 'send-destination-wizard-step-eth';
+export const SEND_DESTINATION_WIZARD_STEP_BTC = 'send-destination-wizard-step-btc';
+export const SEND_DESTINATION_WIZARD_STEP_SOL = 'send-destination-wizard-step-sol';
+export const SEND_DESTINATION_WIZARD_STEP_IC = 'send-destination-wizard-step-ic';

--- a/src/frontend/src/tests/lib/components/send/SendDestinationWizardStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendDestinationWizardStep.spec.ts
@@ -1,0 +1,87 @@
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import { SOLANA_DEVNET_TOKEN } from '$env/tokens/tokens.sol.env';
+import SendDestinationWizardStep from '$lib/components/send/SendDestinationWizardStep.svelte';
+import {
+	SEND_DESTINATION_WIZARD_STEP_BTC,
+	SEND_DESTINATION_WIZARD_STEP_ETH,
+	SEND_DESTINATION_WIZARD_STEP_IC,
+	SEND_DESTINATION_WIZARD_STEP_SOL
+} from '$lib/constants/test-ids.constants';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import type { Token } from '$lib/types/token';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SendDestinationWizardStep', () => {
+	const props = {
+		destination: mockEthAddress
+	};
+
+	const mockContext = (sendToken: Token) =>
+		new Map<symbol, SendContext>([
+			[
+				SEND_CONTEXT_KEY,
+				initSendContext({
+					token: sendToken
+				})
+			]
+		]);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockPage.reset();
+	});
+
+	it('should display BTC send destination components if sendToken network is BTC', () => {
+		const { getByTestId } = render(SendDestinationWizardStep, {
+			props,
+			context: mockContext(BTC_MAINNET_TOKEN)
+		});
+
+		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_BTC)).toBeInTheDocument();
+	});
+
+	it('should display ETH send destination components if sendToken network is ETH', () => {
+		mockPage.mock({ network: ETHEREUM_NETWORK_ID.description });
+
+		const { getByTestId } = render(SendDestinationWizardStep, {
+			props,
+			context: mockContext(SEPOLIA_TOKEN)
+		});
+
+		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_ETH)).toBeInTheDocument();
+	});
+
+	it('should display IC send destination components if sendToken network is IC', () => {
+		const { getByTestId } = render(SendDestinationWizardStep, {
+			props,
+			context: mockContext(mockValidIcCkToken)
+		});
+
+		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_IC)).toBeInTheDocument();
+	});
+
+	it('should display SOL send destination components if sendToken network is SOL', () => {
+		const { getByTestId } = render(SendDestinationWizardStep, {
+			props,
+			context: mockContext(SOLANA_DEVNET_TOKEN)
+		});
+
+		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_SOL)).toBeInTheDocument();
+	});
+
+	it('should display ETH send destination components if sendToken network is EVM', () => {
+		const { getByTestId } = render(SendDestinationWizardStep, {
+			props,
+			context: mockContext(BASE_ETH_TOKEN)
+		});
+
+		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_ETH)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/send/SendDestinationWizardStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendDestinationWizardStep.spec.ts
@@ -1,20 +1,13 @@
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { SOLANA_DEVNET_TOKEN } from '$env/tokens/tokens.sol.env';
 import SendDestinationWizardStep from '$lib/components/send/SendDestinationWizardStep.svelte';
-import {
-	SEND_DESTINATION_WIZARD_STEP_BTC,
-	SEND_DESTINATION_WIZARD_STEP_ETH,
-	SEND_DESTINATION_WIZARD_STEP_IC,
-	SEND_DESTINATION_WIZARD_STEP_SOL
-} from '$lib/constants/test-ids.constants';
+import { SEND_DESTINATION_WIZARD_STEP } from '$lib/constants/test-ids.constants';
 import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import type { Token } from '$lib/types/token';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
-import { mockPage } from '$tests/mocks/page.store.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SendDestinationWizardStep', () => {
@@ -34,8 +27,6 @@ describe('SendDestinationWizardStep', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-
-		mockPage.reset();
 	});
 
 	it('should display BTC send destination components if sendToken network is BTC', () => {
@@ -44,18 +35,20 @@ describe('SendDestinationWizardStep', () => {
 			context: mockContext(BTC_MAINNET_TOKEN)
 		});
 
-		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_BTC)).toBeInTheDocument();
+		expect(
+			getByTestId(`${SEND_DESTINATION_WIZARD_STEP}-${BTC_MAINNET_TOKEN.network.name}`)
+		).toBeInTheDocument();
 	});
 
 	it('should display ETH send destination components if sendToken network is ETH', () => {
-		mockPage.mock({ network: ETHEREUM_NETWORK_ID.description });
-
 		const { getByTestId } = render(SendDestinationWizardStep, {
 			props,
 			context: mockContext(SEPOLIA_TOKEN)
 		});
 
-		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_ETH)).toBeInTheDocument();
+		expect(
+			getByTestId(`${SEND_DESTINATION_WIZARD_STEP}-${SEPOLIA_TOKEN.network.name}`)
+		).toBeInTheDocument();
 	});
 
 	it('should display IC send destination components if sendToken network is IC', () => {
@@ -64,7 +57,9 @@ describe('SendDestinationWizardStep', () => {
 			context: mockContext(mockValidIcCkToken)
 		});
 
-		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_IC)).toBeInTheDocument();
+		expect(
+			getByTestId(`${SEND_DESTINATION_WIZARD_STEP}-${mockValidIcCkToken.network.name}`)
+		).toBeInTheDocument();
 	});
 
 	it('should display SOL send destination components if sendToken network is SOL', () => {
@@ -73,7 +68,9 @@ describe('SendDestinationWizardStep', () => {
 			context: mockContext(SOLANA_DEVNET_TOKEN)
 		});
 
-		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_SOL)).toBeInTheDocument();
+		expect(
+			getByTestId(`${SEND_DESTINATION_WIZARD_STEP}-${SOLANA_DEVNET_TOKEN.network.name}`)
+		).toBeInTheDocument();
 	});
 
 	it('should display ETH send destination components if sendToken network is EVM', () => {
@@ -82,6 +79,8 @@ describe('SendDestinationWizardStep', () => {
 			context: mockContext(BASE_ETH_TOKEN)
 		});
 
-		expect(getByTestId(SEND_DESTINATION_WIZARD_STEP_ETH)).toBeInTheDocument();
+		expect(
+			getByTestId(`${SEND_DESTINATION_WIZARD_STEP}-${BASE_ETH_TOKEN.network.name}`)
+		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

We need to have a component for the Send Destination step. Base on `sendToken`, it decides which components should be rendered.

<img width="580" alt="Screenshot 2025-05-08 at 10 22 14" src="https://github.com/user-attachments/assets/50f0d6b6-81cf-405e-bf64-1c87a790a3e7" />
