### PR TITLE
refactor(frontend): use `ProgressSteps` instead of `ProgressStep` array

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertProgress.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertProgress.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import type { ProgressStep } from '@dfinity/gix-components';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { ProgressStepsConvert } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressSteps } from '$lib/types/progress-steps';
 
 	export let convertProgressStep: string = ProgressStepsConvert.INITIALIZATION;
 
-	let steps: [ProgressStep, ...ProgressStep[]];
+	let steps: ProgressSteps;
 	$: steps = [
 		{
 			step: ProgressStepsConvert.INITIALIZATION,

--- a/src/frontend/src/lib/components/swap/SwapProgress.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProgress.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import type { ProgressStep } from '@dfinity/gix-components';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressSteps } from '$lib/types/progress-steps';
 
 	export let swapProgressStep: string = ProgressStepsSwap.INITIALIZATION;
 
-	let steps: [ProgressStep, ...ProgressStep[]];
+	let steps: ProgressSteps;
 	$: steps = [
 		{
 			step: ProgressStepsSwap.INITIALIZATION,

--- a/src/frontend/src/lib/components/ui/InProgress.svelte
+++ b/src/frontend/src/lib/components/ui/InProgress.svelte
@@ -11,9 +11,9 @@
 	let cmp: typeof StaticSteps | typeof ProgressStepsCmp;
 	$: cmp = type === 'static' ? StaticSteps : ProgressStepsCmp;
 
-	let dynamicSteps: [ProgressStep, ...ProgressStep[]] = [
+	let dynamicSteps: ProgressSteps = [
 		// TODO: have a look if there is a better solution than casting
-		...(steps as [ProgressStep, ...ProgressStep[]])
+		...(steps as ProgressSteps)
 	];
 
 	const updateSteps = () => {


### PR DESCRIPTION
# Motivation

To avoid repetition of code we substitute `[ProgressStep, ...ProgressStep[]]` with existing `ProgressSteps`.