### PR TITLE
feat(frontend): update SendModal component

### DIFF
--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -8,6 +8,10 @@ interface SendWizardStepsParams extends WizardStepsParams {
 
 export const sendWizardSteps = ({ i18n, converting }: SendWizardStepsParams): WizardSteps => [
 	{
+		name: WizardStepsSend.DESTINATION,
+		title: i18n.send.text.send
+	},
+	{
 		name: WizardStepsSend.SEND,
 		title: i18n.send.text.send
 	},

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -1,5 +1,6 @@
 export enum WizardStepsSend {
 	TOKENS_LIST = 'Tokens List',
+	DESTINATION = 'Destination',
 	FILTER_NETWORKS = 'Filter Networks',
 	SEND = 'Send',
 	REVIEW = 'Review',

--- a/src/frontend/src/tests/lib/config/send.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/send.config.spec.ts
@@ -10,6 +10,10 @@ import type { WizardSteps } from '@dfinity/gix-components';
 describe('send.config', () => {
 	const expectedBaseConfig: WizardSteps = [
 		{
+			name: WizardStepsSend.DESTINATION,
+			title: en.send.text.send
+		},
+		{
 			name: WizardStepsSend.SEND,
 			title: en.send.text.send
 		},


### PR DESCRIPTION
# Motivation

The last step is to add SendDestinationWizard step to the Modal and update all related events. Additionally, we fetch ETH transactions in case selected token standard is ETH in order to generate known destinations derived. 
