### PR TITLE
feat(frontend): extract checks from `IcTransactionsScroll` component

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionsScroll.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsScroll.svelte
@@ -4,7 +4,6 @@
 	import type { Snippet } from 'svelte';
 	import { icTransactions } from '$icp/derived/ic-transactions.derived';
 	import { loadNextIcTransactions } from '$icp/services/ic-transactions.services';
-	import { isNotIcToken, isNotIcTokenCanistersStrict } from '$icp/validation/ic-token.validation';
 	import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
@@ -13,7 +12,7 @@
 
 	interface Props {
 		token: Token;
-		children: Snippet;
+		children?: Snippet;
 	}
 
 	let { token, children }: Props = $props();
@@ -33,30 +32,11 @@
 			return;
 		}
 
-		try {
-			BigInt(lastId.replace('-self', ''));
-		} catch {
-			// Pseudo transactions are displayed at the end of the list. There is not such use case in Oisy.
-			// Additionally, if it would be the case, that would mean that we display pseudo transactions at the end of the list and therefore we could assume all valid transactions have been fetched
-			return;
-		}
-
-		if (isNullish(token)) {
-			// Prevent unlikely events. UI wise if we are about to load the next transactions, it's probably because transactions for a loaded token have been fetched.
-			return;
-		}
-
-		if (isNotIcToken(token) || isNotIcTokenCanistersStrict(token)) {
-			// On one hand, we assume that the parent component does not mount this component if no transactions can be fetched; on the other hand, we want to avoid displaying an error toast that could potentially appear multiple times.
-			// Therefore, we do not particularly display a visual error. In any case, we cannot load transactions without an Index canister.
-			return;
-		}
-
 		await loadNextIcTransactions({
+			lastId,
 			owner: $authIdentity.getPrincipal(),
 			identity: $authIdentity,
 			maxResults: WALLET_PAGINATION,
-			start: BigInt(lastId.replace('-self', '')),
 			token,
 			signalEnd: () => (disableInfiniteScroll = true)
 		});
@@ -64,5 +44,5 @@
 </script>
 
 <InfiniteScroll on:nnsIntersect={onIntersect} disabled={disableInfiniteScroll}>
-	{@render children()}
+	{@render children?.()}
 </InfiniteScroll>

--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -2,18 +2,19 @@ import { getTransactions as getTransactionsIcp } from '$icp/api/icp-index.api';
 import { getTransactions as getTransactionsIcrc } from '$icp/api/icrc-index-ng.api';
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import type { IcCanistersStrict, IcToken } from '$icp/types/ic-token';
-import type { IcTransaction } from '$icp/types/ic-transaction';
+import type { IcTransaction, IcTransactionUi } from '$icp/types/ic-transaction';
 import { mapIcTransaction } from '$icp/utils/ic-transactions.utils';
 import { mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
 import { mapTransactionIcrcToSelf } from '$icp/utils/icrc-transactions.utils';
 import { isTokenIcrc } from '$icp/utils/icrc.utils';
+import { isNotIcToken, isNotIcTokenCanistersStrict } from '$icp/validation/ic-token.validation';
 import { balancesStore } from '$lib/stores/balances.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
-import type { TokenId } from '$lib/types/token';
+import type { Token, TokenId } from '$lib/types/token';
 import type { Principal } from '@dfinity/principal';
-import { queryAndUpdate } from '@dfinity/utils';
+import { isNullish, nonNullish, queryAndUpdate } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 const getTransactions = async ({
@@ -40,7 +41,7 @@ const getTransactions = async ({
 	return transactions.flatMap(mapTransactionIcpToSelf);
 };
 
-export const loadNextIcTransactions = ({
+const loadNextIcTransactionsRequest = ({
 	token,
 	identity,
 	signalEnd,
@@ -119,5 +120,45 @@ export const onTransactionsCleanUp = (data: { tokenId: TokenId; transactionIds: 
 		msg: {
 			text: get(i18n).transactions.error.uncertified_transactions_removed
 		}
+	});
+};
+
+export const loadNextIcTransactions = async ({
+	lastId,
+	token,
+	...rest
+}: {
+	lastId: IcTransactionUi['id'] | undefined;
+	owner: Principal;
+	identity: OptionIdentity;
+	maxResults?: bigint;
+	token: Token;
+	signalEnd: () => void;
+}): Promise<void> => {
+	try {
+		if (nonNullish(lastId)) {
+			BigInt(lastId.replace('-self', ''));
+		}
+	} catch {
+		// Pseudo transactions are displayed at the end of the list. There is not such use case in Oisy.
+		// Additionally, if it would be the case, that would mean that we display pseudo transactions at the end of the list and therefore we could assume all valid transactions have been fetched
+		return;
+	}
+
+	if (isNullish(token)) {
+		// Prevent unlikely events. UI wise if we are about to load the next transactions, it's probably because transactions for a loaded token have been fetched.
+		return;
+	}
+
+	if (isNotIcToken(token) || isNotIcTokenCanistersStrict(token)) {
+		// On one hand, we assume that the parent component does not mount this component if no transactions can be fetched; on the other hand, we want to avoid displaying an error toast that could potentially appear multiple times.
+		// Therefore, we do not particularly display a visual error. In any case, we cannot load transactions without an Index canister.
+		return;
+	}
+
+	await loadNextIcTransactionsRequest({
+		start: nonNullish(lastId) ? BigInt(lastId.replace('-self', '')) : undefined,
+		token,
+		...rest
 	});
 };

--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -135,9 +135,11 @@ export const loadNextIcTransactions = async ({
 	token: Token;
 	signalEnd: () => void;
 }): Promise<void> => {
+	const lastIdCleaned = lastId?.replace('-self', '');
+
 	try {
-		if (nonNullish(lastId)) {
-			BigInt(lastId.replace('-self', ''));
+		if (nonNullish(lastIdCleaned)) {
+			BigInt(lastIdCleaned);
 		}
 	} catch {
 		// Pseudo transactions are displayed at the end of the list. There is not such use case in Oisy.
@@ -157,7 +159,7 @@ export const loadNextIcTransactions = async ({
 	}
 
 	await loadNextIcTransactionsRequest({
-		start: nonNullish(lastId) ? BigInt(lastId.replace('-self', '')) : undefined,
+		start: nonNullish(lastIdCleaned) ? BigInt(lastIdCleaned) : undefined,
 		token,
 		...rest
 	});

--- a/src/frontend/src/tests/icp/components/transactions/IcTransactionsScroll.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcTransactionsScroll.spec.ts
@@ -1,0 +1,114 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import IcTransactionsScroll from '$icp/components/transactions/IcTransactionsScroll.svelte';
+import { loadNextIcTransactions } from '$icp/services/ic-transactions.services';
+import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
+import type { IcTransactionUi } from '$icp/types/ic-transaction';
+import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { nullishSignOut } from '$lib/services/auth.services';
+import { token } from '$lib/stores/token.store';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import {
+	IntersectionObserverActive,
+	IntersectionObserverPassive
+} from '$tests/mocks/infinite-scroll.mock';
+import { createIcTransactionUiMock } from '$tests/utils/transactions-stores.test-utils';
+import { render } from '@testing-library/svelte';
+
+vi.mock('$lib/services/auth.services', () => ({
+	nullishSignOut: vi.fn()
+}));
+
+vi.mock('$icp/services/ic-transactions.services', () => ({
+	loadNextIcTransactions: vi.fn()
+}));
+
+describe('IcTransactionsScroll', () => {
+	const mockToken = ICP_TOKEN;
+
+	const mockTransactions: IcTransactionUi[] = [
+		createIcTransactionUiMock('tx1'),
+		createIcTransactionUiMock('tx2')
+	];
+
+	const mockLastId = mockTransactions[mockTransactions.length - 1].id;
+
+	beforeAll(() => {
+		Object.defineProperty(window, 'IntersectionObserver', {
+			writable: true,
+			configurable: true,
+			value: IntersectionObserverActive
+		});
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockAuthStore();
+
+		token.set(mockToken);
+
+		icTransactionsStore.reset(mockToken.id);
+
+		icTransactionsStore.append({
+			tokenId: mockToken.id,
+			transactions: mockTransactions.map((transaction) => ({
+				data: transaction,
+				certified: false
+			}))
+		});
+	});
+
+	afterAll(() => (global.IntersectionObserver = IntersectionObserverPassive));
+
+	describe('when the infinite scroll is triggered', () => {
+		it('should load next transactions', () => {
+			render(IcTransactionsScroll, { token: mockToken });
+
+			expect(loadNextIcTransactions).toHaveBeenCalledOnce();
+			expect(loadNextIcTransactions).toHaveBeenNthCalledWith(1, {
+				lastId: mockLastId,
+				owner: mockIdentity.getPrincipal(),
+				identity: mockIdentity,
+				maxResults: WALLET_PAGINATION,
+				token: mockToken,
+				signalEnd: expect.any(Function)
+			});
+		});
+
+		it('should not load next transactions if identity is nullish', () => {
+			mockAuthStore(null);
+
+			render(IcTransactionsScroll, { token: mockToken });
+
+			expect(loadNextIcTransactions).not.toHaveBeenCalled();
+
+			expect(nullishSignOut).toHaveBeenCalledOnce();
+		});
+
+		it('should not load next transactions if the token is nullish', () => {
+			token.reset();
+
+			render(IcTransactionsScroll, { token: mockToken });
+
+			expect(loadNextIcTransactions).not.toHaveBeenCalled();
+		});
+
+		it('should not load next transactions if the transactions store is nullish', () => {
+			icTransactionsStore.reset(mockToken.id);
+
+			render(IcTransactionsScroll, { token: mockToken });
+
+			expect(loadNextIcTransactions).not.toHaveBeenCalled();
+		});
+
+		it('should not load next transactions if the transactions store is empty', () => {
+			icTransactionsStore.reset(mockToken.id);
+			icTransactionsStore.prepend({ tokenId: mockToken.id, transactions: [] });
+
+			render(IcTransactionsScroll, { token: mockToken });
+
+			expect(loadNextIcTransactions).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
+++ b/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
@@ -1,0 +1,35 @@
+export const IntersectionObserverPassive = vi.fn();
+IntersectionObserverPassive.mockReturnValue({
+	observe: () => null,
+	unobserve: () => null,
+	disconnect: () => null
+});
+
+export class IntersectionObserverActive implements IntersectionObserver {
+	public readonly root: Element | Document | null = null;
+	public readonly rootMargin: string = '';
+	public readonly thresholds: ReadonlyArray<number> = [];
+	public takeRecords: () => IntersectionObserverEntry[] = () => [];
+
+	constructor(
+		private callback: (
+			entries: IntersectionObserverEntry[],
+			observer: IntersectionObserver
+		) => void,
+		private options?: IntersectionObserverInit
+	) {}
+
+	observe(element: HTMLElement) {
+		this.callback(
+			[
+				{
+					isIntersecting: true,
+					target: element
+				} as unknown as IntersectionObserverEntry
+			],
+			this
+		);
+	}
+	disconnect = () => null;
+	unobserve = () => null;
+}

--- a/src/frontend/src/tests/utils/transactions-stores.test-utils.ts
+++ b/src/frontend/src/tests/utils/transactions-stores.test-utils.ts
@@ -2,7 +2,7 @@ import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import type { CertifiedData } from '$lib/types/store';
 
-const createIcTransactionUiMock = (id: string): IcTransactionUi => ({
+export const createIcTransactionUiMock = (id: string): IcTransactionUi => ({
 	id,
 	timestamp: nowInBigIntNanoSeconds(),
 	type: 'send',


### PR DESCRIPTION
# Motivation

In the coming PR https://github.com/dfinity/oisy-wallet/pull/6438, we want to re-use the logic of `IcTransactionsScroll` to loads the next transactions (that are missing) in the Activity page.

To avoid repetition of code, we extract the checks done in the component to the service `loadNextIcTransactions`.

# Changes

- Rename service loadNextIcTransactions to loadNextIcTransactionsRequest.
- Create new function service loadNextIcTransactions that is a wrapper of the old one plus the checks from `IcTransactionsScroll` component.
- Remove the checks from `IcTransactionsScroll`.
- NOTE: we leave the nullish check for lastId in the component, because we will not need them in the Activity page.

# Tests

Created new tests both for the component and the service. To mock the `InfiniteScroll` component to dispatch the intersection event, I re-used the code developed in [GIX Component tests](https://github.com/dfinity/gix-components/blob/310688d90d3b3692d1f08e2f6323da0a73635302/src/tests/lib/components/InfiniteScroll.spec.ts#L11).
