### PR TITLE
refactor(backend)!: create result type for `top_up_cycles_ledger` method

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -180,7 +180,7 @@ async fn hourly_housekeeping_tasks() {
     // Tops up the account on the cycles ledger
     {
         let result = top_up_cycles_ledger(None).await;
-        if let Err(err) = result {
+        if let TopUpCyclesLedgerResult::Err(err) = result {
             eprintln!("Failed to top up cycles ledger: {err:?}");
         }
         // TODO: Add monitoring for how many cycles have been topped up and whether topping up is

--- a/src/backend/src/signer.rs
+++ b/src/backend/src/signer.rs
@@ -222,7 +222,10 @@ pub async fn btc_principal_to_p2wpkh_address(
 /// # Errors
 /// Errors are enumerated by: `TopUpCyclesLedgerError`
 pub async fn top_up_cycles_ledger(request: TopUpCyclesLedgerRequest) -> TopUpCyclesLedgerResult {
-    request.check()?;
+    match request.check() {
+        Ok(()) => {}
+        Err(err) => return TopUpCyclesLedgerResult::Err(err),
+    }
 
     // Cycles ledger account details:
     let cycles_ledger = CyclesLedgerService(*CYCLES_LEDGER);
@@ -232,10 +235,13 @@ pub async fn top_up_cycles_ledger(request: TopUpCyclesLedgerRequest) -> TopUpCyc
     };
 
     // Backend balance on the cycles ledger:
-    let (ledger_balance,): (Nat,) = cycles_ledger
+    let (ledger_balance,): (Nat,) =match cycles_ledger
         .icrc_1_balance_of(&account)
         .await
-        .map_err(|_| TopUpCyclesLedgerError::CouldNotGetBalanceFromCyclesLedger)?;
+        .map_err(|_| TopUpCyclesLedgerError::CouldNotGetBalanceFromCyclesLedger) {
+        Ok(res) => res,
+        Err(err) => return TopUpCyclesLedgerResult::Err(err),
+    };
 
     // Cycles directly attached to the backend:
     let backend_cycles = Nat::from(ic_cdk::api::canister_balance128());
@@ -255,25 +261,28 @@ pub async fn top_up_cycles_ledger(request: TopUpCyclesLedgerRequest) -> TopUpCyc
             to_send.clone().0.try_into().unwrap_or_else(|err| {
                 unreachable!("Failed to convert cycle amount to u128: {}", err)
             });
-        let (result,): (DepositResult,) =
+        let (result,): (DepositResult,) = match
             call_with_payment128(*CYCLES_LEDGER, "deposit", (arg,), to_send_128)
                 .await
                 .map_err(|_| TopUpCyclesLedgerError::CouldNotTopUpCyclesLedger {
                     available: backend_cycles,
                     tried_to_send: to_send.clone(),
-                })?;
+                }) {
+            Ok(res) => res,
+            Err(err) => return TopUpCyclesLedgerResult::Err(err),
+        };
         let new_ledger_balance = result.balance;
 
         Ok(TopUpCyclesLedgerResponse {
             ledger_balance: new_ledger_balance,
             backend_cycles: to_retain,
             topped_up: to_send,
-        })
+        }).into()
     } else {
         Ok(TopUpCyclesLedgerResponse {
             ledger_balance,
             backend_cycles,
             topped_up: Nat::from(0u32),
-        })
+        }).into()
     }
 }

--- a/src/shared/src/types/signer.rs
+++ b/src/shared/src/types/signer.rs
@@ -40,7 +40,7 @@ pub struct GetAllowedCyclesResponse {
 
 pub mod topup {
     use candid::Nat;
-
+    use serde::Serialize;
     use super::{CandidType, Debug, Deserialize};
     /// A request to top up the cycles ledger.
     #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
@@ -98,14 +98,14 @@ pub mod topup {
     pub const MAX_PERCENTAGE: u8 = 99;
 
     /// Possible error conditions when topping up the cycles ledger.
-    #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
+    #[derive(CandidType, Serialize,Deserialize, Debug, Clone, Eq, PartialEq)]
     pub enum TopUpCyclesLedgerError {
         CouldNotGetBalanceFromCyclesLedger,
         InvalidArgPercentageOutOfRange { percentage: u8, min: u8, max: u8 },
         CouldNotTopUpCyclesLedger { available: Nat, tried_to_send: Nat },
     }
     /// Possible successful responses when topping up the cycles ledger.
-    #[derive(CandidType, Deserialize, Debug, Clone, Eq, PartialEq)]
+    #[derive(CandidType,Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
     pub struct TopUpCyclesLedgerResponse {
         /// The ledger balance after topping up.
         pub ledger_balance: Nat,
@@ -117,5 +117,19 @@ pub mod topup {
         pub topped_up: Nat,
     }
 
-    pub type TopUpCyclesLedgerResult = Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>;
+    #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
+    pub enum TopUpCyclesLedgerResult {
+        /// The cycles ledger was topped up successfully.
+        Ok(TopUpCyclesLedgerResponse),
+        /// The cycles ledger could not be topped up due to an error.
+        Err(TopUpCyclesLedgerError),
+    }
+    impl From<Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>> for TopUpCyclesLedgerResult {
+        fn from(result: Result<TopUpCyclesLedgerResponse, TopUpCyclesLedgerError>) -> Self {
+            match result {
+                Ok(res) => TopUpCyclesLedgerResult::Ok(res),
+                Err(err) => TopUpCyclesLedgerResult::Err(err),
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Motivation

In an effort to make the did file more readable, we create a specific type for the results of method `top_up_cycles_ledger`.

BREAKING CHANGE: the interface will be changed.
