### PR TITLE
style(frontend): KnownDestinations styling

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestination.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestination.svelte
@@ -34,7 +34,9 @@
 <LogoButton styleClass="group" on:click>
 	<div class="mr-2" slot="logo"><RoundedIcon icon={IconConvertTo} /></div>
 
-	<svelte:fragment slot="title">{shortenWithMiddleEllipsis({ text: destination })}</svelte:fragment>
+	<svelte:fragment slot="title">
+		<span class="text-base">{shortenWithMiddleEllipsis({ text: destination })}</span>
+	</svelte:fragment>
 
 	<svelte:fragment slot="description">
 		{#each amountsToDisplay as amount, index (index)}

--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -21,25 +21,27 @@
 </script>
 
 {#if nonNullish(knownDestinations) && destinations.length > 0}
-	<div class="my-10" in:fade>
+	<div class="mb-2 mt-8" in:fade>
 		<div class="mb-2 font-bold">
 			{$i18n.send.text.recently_used}
 		</div>
 
-		<ul class="list-none">
-			{#each destinations as recentDestination (recentDestination)}
-				<li>
-					<KnownDestination
-						token={$sendToken}
-						destination={recentDestination}
-						{...knownDestinations[recentDestination]}
-						on:click={() => {
-							destination = recentDestination;
-							dispatch('icNext');
-						}}
-					/>
-				</li>
-			{/each}
-		</ul>
+		<div class="flex flex-col overflow-y-hidden sm:max-h-[13.5rem]">
+			<ul class="list-none overflow-y-auto overscroll-contain">
+				{#each destinations as recentDestination (recentDestination)}
+					<li>
+						<KnownDestination
+							token={$sendToken}
+							destination={recentDestination}
+							{...knownDestinations[recentDestination]}
+							on:click={() => {
+								destination = recentDestination;
+								dispatch('icNext');
+							}}
+						/>
+					</li>
+				{/each}
+			</ul>
+		</div>
 	</div>
 {/if}


### PR DESCRIPTION
# Motivation

The idea is to make only the Known destinations section scrollable, so the input stays always on top (same as with the Tokens screen). Also, we need to decrease destination font size.

<img width="631" alt="Screenshot 2025-05-09 at 11 43 20" src="https://github.com/user-attachments/assets/308d1429-fc30-4998-8e34-e2d0a9ad936a" />

