### PR TITLE
feat(frontend): update appearance of SOL fees in the Send form

### DIFF
--- a/src/frontend/src/sol/components/fee/SolFeeDisplay.svelte
+++ b/src/frontend/src/sol/components/fee/SolFeeDisplay.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { slide } from 'svelte/transition';
-	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
-	import Value from '$lib/components/ui/Value.svelte';
-	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { type FeeContext, SOL_FEE_CONTEXT_KEY } from '$sol/stores/sol-fee.store';
@@ -21,37 +18,24 @@
 
 {#if nonNullish($symbol) && nonNullish($sendTokenId) && nonNullish($decimals)}
 	{#if nonNullish($fee)}
-		<Value ref="fee">
-			{#snippet label()}
-				{$i18n.fee.text.fee}
-			{/snippet}
-
-			{#snippet content()}
-				<ExchangeAmountDisplay
-					amount={$fee}
-					decimals={$decimals}
-					symbol={$symbol}
-					exchangeRate={$sendTokenExchangeRate}
-				/>
-			{/snippet}
-		</Value>
+		<FeeDisplay
+			feeAmount={$fee}
+			decimals={$decimals}
+			symbol={$symbol}
+			exchangeRate={$sendTokenExchangeRate}
+		>
+			<span slot="label">{$i18n.fee.text.fee}</span>
+		</FeeDisplay>
 	{/if}
-	{#if nonNullish($ataFee)}
-		<div transition:slide={SLIDE_DURATION}>
-			<Value ref="ataFee">
-				{#snippet label()}
-					{$i18n.fee.text.ata_fee}
-				{/snippet}
 
-				{#snippet content()}
-					<ExchangeAmountDisplay
-						amount={$ataFee}
-						decimals={$decimals}
-						symbol={$symbol}
-						exchangeRate={$sendTokenExchangeRate}
-					/>
-				{/snippet}
-			</Value>
-		</div>
+	{#if nonNullish($ataFee)}
+		<FeeDisplay
+			feeAmount={$ataFee}
+			decimals={$decimals}
+			symbol={$symbol}
+			exchangeRate={$sendTokenExchangeRate}
+		>
+			<span slot="label">{$i18n.fee.text.ata_fee}</span>
+		</FeeDisplay>
 	{/if}
 {/if}

--- a/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
@@ -9,6 +9,7 @@ import * as solanaApi from '$sol/api/solana.api';
 import SolSendForm from '$sol/components/send/SolSendForm.svelte';
 import { SOL_FEE_CONTEXT_KEY, initFeeContext, initFeeStore } from '$sol/stores/sol-fee.store';
 import * as solAddressUtils from '$sol/utils/sol-address.utils';
+import en from '$tests/mocks/i18n.mock';
 import { mockAtaAddress, mockSolAddress } from '$tests/mocks/sol.mock';
 import { render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
@@ -27,8 +28,6 @@ describe('SolSendForm', () => {
 	};
 
 	const amountSelector = `input[data-tid="${TOKEN_INPUT_CURRENCY_TOKEN}"]`;
-	const feeSelector = 'p[id="fee"]';
-	const ataFeeSelector = 'p[id="ataFee"]';
 	const toolbarSelector = 'div[data-tid="toolbar"]';
 
 	beforeEach(() => {
@@ -61,7 +60,7 @@ describe('SolSendForm', () => {
 			})
 		);
 
-		const { container, getByTestId } = render(SolSendForm, {
+		const { container, getByTestId, getByText } = render(SolSendForm, {
 			props,
 			context: mockContext
 		});
@@ -72,9 +71,7 @@ describe('SolSendForm', () => {
 
 		expect(getByTestId(SEND_DESTINATION_SECTION)).toBeInTheDocument();
 
-		const fee: HTMLParagraphElement | null = container.querySelector(feeSelector);
-
-		expect(fee).not.toBeNull();
+		expect(getByText(en.fee.text.fee)).toBeInTheDocument();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
 
@@ -97,18 +94,16 @@ describe('SolSendForm', () => {
 		});
 
 		it('should not render ATA creation fee if the destination is empty', () => {
-			const { container } = render(SolSendForm, {
+			const { getByText } = render(SolSendForm, {
 				props: { ...props, destination: '' },
 				context: mockContext
 			});
 
-			const ataFee: HTMLParagraphElement | null = container.querySelector(ataFeeSelector);
-
-			expect(ataFee).toBeNull();
+			expect(() => getByText(en.fee.text.ata_fee)).toThrow();
 		});
 
 		it('should render ATA creation fee if it is not nullish', async () => {
-			const { container } = render(SolSendForm, {
+			const { getByText } = render(SolSendForm, {
 				props,
 				context: mockContext
 			});
@@ -118,15 +113,13 @@ describe('SolSendForm', () => {
 			// Wait for the fee to be loaded
 			await new Promise((resolve) => setTimeout(resolve, 100));
 
-			const ataFee: HTMLParagraphElement | null = container.querySelector(ataFeeSelector);
-
-			expect(ataFee).not.toBeNull();
+			expect(getByText(en.fee.text.ata_fee)).toBeInTheDocument();
 		});
 
 		it('should not render ATA creation fee if it is nullish', async () => {
 			mockAtaFeeStore.setFee(123n);
 
-			const { container } = render(SolSendForm, {
+			const { getByText } = render(SolSendForm, {
 				props,
 				context: mockContext
 			});
@@ -136,9 +129,7 @@ describe('SolSendForm', () => {
 			// Wait for the fee to be loaded
 			await new Promise((resolve) => setTimeout(resolve, 5000));
 
-			const ataFee: HTMLParagraphElement | null = container.querySelector(ataFeeSelector);
-
-			expect(ataFee).toBeNull();
+			expect(() => getByText(en.fee.text.ata_fee)).toThrow();
 		}, 60000);
 	});
 });


### PR DESCRIPTION
# Motivation

We need to update the way we display SOL fees in the Send form. Note: displaying `< 0.01$` instead of `~ 0.00$` will be tackled separately.

<img width="601" alt="Screenshot 2025-05-09 at 12 29 29" src="https://github.com/user-attachments/assets/23036e07-476d-4296-96ea-ffc7477092c0" />
