### PR TITLE
feat(devops): Reduce coverage thresholds by 0.50%

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -38,9 +38,18 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
-      - name: Floor coverage thresholds (remove decimals)
+      - name: Reduce coverage thresholds by 0.50%
         run: |
-          sed -i -E 's/(lines|functions|branches|statements):[[:space:]]*([0-9]+)\.[0-9]+/\1: \2/g' vitest.config.ts
+          node -e "
+          const fs = require('fs');
+          const file = 'vitest.config.ts';
+          const text = fs.readFileSync(file, 'utf8');
+          const updated = text.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
+            const reduced = (parseFloat(value) - 0.5).toFixed(2);
+            return \`\${key}: \${reduced}\`;
+          });
+          fs.writeFileSync(file, updated);
+          "
 
       - name: Check for Coverage Thresholds Changes
         id: check_changes

--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -52,6 +52,10 @@ jobs:
           fs.writeFileSync(file, updated);
           "
 
+      - name: Floor coverage thresholds (remove decimals)
+        run: |
+          sed -i -E 's/(lines|functions|branches|statements):[[:space:]]*([0-9]+)\.[0-9]+/\1: \2/g' vitest.config.ts
+
       - name: Check for Coverage Thresholds Changes
         id: check_changes
         run: |

--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -52,6 +52,7 @@ jobs:
           fs.writeFileSync(file, updated);
           "
 
+      # To avoid a high frequency of PRs, we remove the decimals from the coverage thresholds
       - name: Floor coverage thresholds (remove decimals)
         run: |
           sed -i -E 's/(lines|functions|branches|statements):[[:space:]]*([0-9]+)\.[0-9]+/\1: \2/g' vitest.config.ts

--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
+      # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
       - name: Reduce coverage thresholds by 0.50%
         run: |
           node -e "

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,10 +77,10 @@ export default defineConfig(
 				// TODO: increase the thresholds slowly up to an acceptable 80% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 65.58,
-					branches: 83.51,
-					functions: 74.34,
-					lines: 65.58
+					statements: 65,
+					branches: 83,
+					functions: 74,
+					lines: 65
 				}
 			}
 		}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,10 +77,10 @@ export default defineConfig(
 				// TODO: increase the thresholds slowly up to an acceptable 80% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 66,
-					branches: 84,
-					functions: 74,
-					lines: 66
+					statements: 65.58,
+					branches: 83.51,
+					functions: 74.34,
+					lines: 65.58
 				}
 			}
 		}


### PR DESCRIPTION
# Motivation

The checks for tests coverage are a bit flaky, since the calculation can change for a few basis points: we round the thresholds to the lowest integers; so, if we are close to it, the checks keep failing.

Example: threshold is set at 84%, real coverage is at 84.01%, but the flaky calculation returns sometimes 83.98%.

To avoid this, we change the workflow that changes the thresholds to reduce them by 0.50% instead of flooring them. That should be enough margin for flakiness in the calculation.
