### PR TITLE
fix(frontend): service `loadNextSolTransactions` assigns to correct token ID

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolTransactionsScroll.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionsScroll.svelte
@@ -62,6 +62,7 @@
 			address,
 			tokenAddress,
 			tokenOwnerAddress,
+			token,
 			before: lastSignature,
 			signalEnd: () => (disableInfiniteScroll = true)
 		});

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -1,10 +1,4 @@
 import { WSOL_TOKEN } from '$env/tokens/tokens-spl/tokens.wsol.env';
-import {
-	SOLANA_DEVNET_TOKEN_ID,
-	SOLANA_LOCAL_TOKEN_ID,
-	SOLANA_TESTNET_TOKEN_ID,
-	SOLANA_TOKEN_ID
-} from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
@@ -13,8 +7,8 @@ import {
 	solTransactionsStore,
 	type SolCertifiedTransaction
 } from '$sol/stores/sol-transactions.store';
-import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
-import type { GetSolTransactionsParams, LoadNextSolTransactionsParams } from '$sol/types/sol-api';
+import type { SolanaNetworkType } from '$sol/types/network';
+import type { LoadNextSolTransactionsParams, LoadSolTransactionsParams } from '$sol/types/sol-api';
 import type {
 	ParsedAccount,
 	SolMappedTransaction,
@@ -210,22 +204,15 @@ export const loadNextSolTransactions = async ({
 
 	if (transactions.length === 0) {
 		signalEnd();
+		return;
 	}
 };
 
-const networkToSolTokenIdMap = {
-	[SolanaNetworks.mainnet]: SOLANA_TOKEN_ID,
-	[SolanaNetworks.testnet]: SOLANA_TESTNET_TOKEN_ID,
-	[SolanaNetworks.devnet]: SOLANA_DEVNET_TOKEN_ID,
-	[SolanaNetworks.local]: SOLANA_LOCAL_TOKEN_ID
-};
-
 const loadSolTransactions = async ({
+	token: { id: tokenId },
 	network,
 	...rest
-}: GetSolTransactionsParams): Promise<SolCertifiedTransaction[]> => {
-	const solTokenIdForNetwork = networkToSolTokenIdMap[network];
-
+}: LoadSolTransactionsParams): Promise<SolCertifiedTransaction[]> => {
 	try {
 		const transactions = await getSolTransactions({
 			network,
@@ -238,15 +225,15 @@ const loadSolTransactions = async ({
 		}));
 
 		solTransactionsStore.append({
-			tokenId: solTokenIdForNetwork,
+			tokenId,
 			transactions: certifiedTransactions
 		});
 
 		return certifiedTransactions;
 	} catch (error: unknown) {
-		solTransactionsStore.reset(solTokenIdForNetwork);
+		solTransactionsStore.reset(tokenId);
 
-		console.error(`Failed to load transactions for ${solTokenIdForNetwork.description}:`, error);
+		console.error(`Failed to load transactions for ${tokenId.description}:`, error);
 		return [];
 	}
 };

--- a/src/frontend/src/sol/types/sol-api.ts
+++ b/src/frontend/src/sol/types/sol-api.ts
@@ -1,4 +1,5 @@
 import type { SolAddress } from '$lib/types/address';
+import type { Token } from '$lib/types/token';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SplTokenAddress } from '$sol/types/spl';
 
@@ -11,6 +12,11 @@ export interface GetSolTransactionsParams {
 	limit?: number;
 }
 
+export type LoadSolTransactionsParams = GetSolTransactionsParams & {
+	token: Token;
+};
+
 export type LoadNextSolTransactionsParams = GetSolTransactionsParams & {
+	token: Token;
 	signalEnd: () => void;
 };

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -1,4 +1,5 @@
-import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
+import { BONK_TOKEN, BONK_TOKEN_ID } from '$env/tokens/tokens-spl/tokens.bonk.env';
+import { SOLANA_TOKEN, SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
 import * as solanaApi from '$sol/api/solana.api';
 import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
@@ -361,14 +362,17 @@ describe('sol-transactions.services', () => {
 	});
 
 	describe('loadNextSolTransactions', () => {
+		const mockToken = SOLANA_TOKEN;
+
 		const mockParams: LoadNextSolTransactionsParams = {
 			address: mockSolAddress,
 			network: SolanaNetworks.mainnet,
+			token: mockToken,
 			signalEnd
 		};
 
 		beforeEach(() => {
-			solTransactionsStore.reset(SOLANA_TOKEN_ID);
+			solTransactionsStore.reset(mockToken.id);
 
 			spyGetTransactions.mockResolvedValue(mockTransactions);
 		});
@@ -415,7 +419,11 @@ describe('sol-transactions.services', () => {
 		it('should append transactions to the store', async () => {
 			await loadNextSolTransactions(mockParams);
 
-			expect(get(solTransactionsStore)?.[SOLANA_TOKEN_ID]).toEqual(mockCertifiedTransactions);
+			expect(get(solTransactionsStore)?.[mockToken.id]).toEqual(mockCertifiedTransactions);
+
+			await loadNextSolTransactions({ ...mockParams, token: BONK_TOKEN });
+
+			expect(get(solTransactionsStore)?.[BONK_TOKEN_ID]).toEqual(mockCertifiedTransactions);
 		});
 
 		it('should handle errors and reset store', async () => {
@@ -424,7 +432,7 @@ describe('sol-transactions.services', () => {
 
 			await loadNextSolTransactions(mockParams);
 
-			expect(get(solTransactionsStore)?.[SOLANA_TOKEN_ID]).toBeNull();
+			expect(get(solTransactionsStore)?.[mockToken.id]).toBeNull();
 		});
 
 		it('should work with different networks', async () => {


### PR DESCRIPTION
# Motivation

Service `loadNextSolTransactions` was not correctly assigning the next transactions to the respective token. It was mapping all of them to the network-specific native token.

# Changes

- Add token as input to `loadNextSolTransactions`.
- Use it instead of mapping to native Solana tokens.

# Tests

Added tests to verify that it works correctly (same tests would have failed before).
