### PR TITLE
test(frontend): additional test for `IcTransactionsScroll`

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionsScroll.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsScroll.svelte
@@ -25,6 +25,10 @@
 			return;
 		}
 
+		if (disableInfiniteScroll) {
+			return;
+		}
+
 		const lastId = last($icTransactions)?.data.id;
 
 		if (isNullish(lastId)) {

--- a/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
+++ b/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
@@ -33,3 +33,52 @@ export class IntersectionObserverActive implements IntersectionObserver {
 	disconnect = () => null;
 	unobserve = () => null;
 }
+
+export const INTERSECTION_OBSERVER_ACTIVE_INTERVAL = 5000;
+
+export class IntersectionObserverActiveInterval implements IntersectionObserver {
+	public readonly root: Element | Document | null = null;
+	public readonly rootMargin: string = '';
+	public readonly thresholds: ReadonlyArray<number> = [];
+	public takeRecords: () => IntersectionObserverEntry[] = () => [];
+
+	constructor(
+		private callback: (
+			entries: IntersectionObserverEntry[],
+			observer: IntersectionObserver
+		) => void,
+		private options?: IntersectionObserverInit
+	) {}
+
+	observe(element: HTMLElement) {
+		let isIntersecting = false;
+
+		// Immediately call once
+		this.callback(
+			[
+				{
+					isIntersecting,
+					target: element
+				} as unknown as IntersectionObserverEntry
+			],
+			this
+		);
+
+		// Start toggling every 5 seconds
+		setInterval(() => {
+			isIntersecting = !isIntersecting;
+
+			this.callback(
+				[
+					{
+						isIntersecting,
+						target: element
+					} as unknown as IntersectionObserverEntry
+				],
+				this
+			);
+		}, INTERSECTION_OBSERVER_ACTIVE_INTERVAL);
+	}
+	disconnect = () => null;
+	unobserve = () => null;
+}

--- a/src/frontend/src/tests/utils/transactions-stores.test-utils.ts
+++ b/src/frontend/src/tests/utils/transactions-stores.test-utils.ts
@@ -2,7 +2,7 @@ import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import type { CertifiedData } from '$lib/types/store';
 
-export const createIcTransactionUiMock = (id: string): IcTransactionUi => ({
+const createIcTransactionUiMock = (id: string): IcTransactionUi => ({
 	id,
 	timestamp: nowInBigIntNanoSeconds(),
 	type: 'send',
@@ -16,3 +16,6 @@ export const createCertifiedIcTransactionUiMock = (id: string): CertifiedData<Ic
 	certified: true,
 	data: createIcTransactionUiMock(id)
 });
+
+export const createIcTransactionUiMockList = (n: number): IcTransactionUi[] =>
+	Array.from({ length: n }, (_, i) => createIcTransactionUiMock(`tx${i}`));


### PR DESCRIPTION
# Motivation

For component `IcTransactionsScroll`, we should test if the transactions are not loaded anymore once they are finished.
