### PR TITLE
test(frontend): flaky timestamp for test of `icKnownDestinations`

### DIFF
--- a/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
@@ -171,10 +171,12 @@ describe('ic-transactions.derived', () => {
 				transactions
 			});
 
+			const maxTimestamp = Math.max(...transactions.map(({ data }) => Number(data.timestamp)));
+
 			expect(get(icKnownDestinations)).toEqual({
 				[transactions[0].data.to as string]: {
 					amounts: transactions.map(({ data }) => data.value),
-					timestamp: Number(transactions[0].data.timestamp)
+					timestamp: maxTimestamp
 				}
 			});
 		});


### PR DESCRIPTION
# Motivation

When testing derived store `icKnownDestinations`, the timestamp created for the mock transactions can be higher than the previous one. So, to avoid flakiness (see [failed CI workflow](https://github.com/dfinity/oisy-wallet/actions/runs/14937269291/job/41967527170?pr=6476)), we need to confirm that the store takes the most recent timestamp.
