### PR TITLE
feat(devops): remove script folder from vitest coverage analysis

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,7 +73,7 @@ export default defineConfig(
 			setupFiles: ['./vitest.setup.ts'],
 			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
 			coverage: {
-				include: ['src/frontend', 'scripts'],
+				include: ['src/frontend'],
 				// TODO: increase the thresholds slowly up to an acceptable 80% at least
 				thresholds: {
 					autoUpdate: true,


### PR DESCRIPTION
# Motivation

We don't have unittests for the scripts: run them in the workflows, or manually. Plus some of them are tested in the workflows too.

So, I think it makes sense to remove them from vitest coverage analysis.
