### PR TITLE
test(frontend): add simple tests for message switch in simple workers

### DIFF
--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -20,7 +20,7 @@ import type { SplTokenAddress } from '$sol/types/spl';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import * as z from 'zod';
 
-export const PostMessageRequestSchema = z.enum([
+export const POST_MESSAGE_REQUESTS = [
 	'startIdleTimer',
 	'stopIdleTimer',
 	'startCodeTimer',
@@ -53,7 +53,9 @@ export const PostMessageRequestSchema = z.enum([
 	'stopCkBtcMinterInfoTimer',
 	'startCkBtcMinterInfoTimer',
 	'triggerCkBtcMinterInfoTimer'
-]);
+] as const;
+
+export const PostMessageRequestSchema = z.enum(POST_MESSAGE_REQUESTS);
 
 export const PostMessageDataRequestSchema = z.never();
 export const PostMessageDataResponseSchema = z.object({}).strict();

--- a/src/frontend/src/tests/icp/workers/btc-statuses.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/btc-statuses.worker.spec.ts
@@ -1,0 +1,89 @@
+import { BtcStatusesScheduler } from '$icp/schedulers/btc-statuses.scheduler';
+import { onBtcStatusesMessage } from '$icp/workers/btc-statuses.worker';
+import type { PostMessage, PostMessageDataRequestIcCk } from '$lib/types/post-message';
+import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+
+vi.mock(import('$icp/schedulers/btc-statuses.scheduler'), async (importOriginal) => {
+	const actual = await importOriginal();
+	const scheduler = actual.BtcStatusesScheduler;
+	scheduler.prototype.start = vi.fn();
+	scheduler.prototype.stop = vi.fn();
+	scheduler.prototype.trigger = vi.fn();
+	return {
+		...actual,
+		BtcStatusesScheduler: scheduler
+	};
+});
+
+describe('btc-statuses.worker', () => {
+	describe('onBtcStatusesMessage', () => {
+		const invalidMessages = excludeValidMessageEvents([
+			'stopBtcStatusesTimer',
+			'startBtcStatusesTimer',
+			'triggerBtcStatusesTimer'
+		]);
+
+		const mockStart = vi.fn();
+		const mockStop = vi.fn();
+		const mockTrigger = vi.fn();
+
+		const createEvent = (msg: string) =>
+			createMockEvent(msg) as unknown as MessageEvent<PostMessage<PostMessageDataRequestIcCk>>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			BtcStatusesScheduler.prototype.start = mockStart;
+			BtcStatusesScheduler.prototype.stop = mockStop;
+			BtcStatusesScheduler.prototype.trigger = mockTrigger;
+		});
+
+		it('should stop the scheduler when message is stopBtcStatusesTimer', async () => {
+			const event = createEvent('stopBtcStatusesTimer');
+
+			await onBtcStatusesMessage(event);
+
+			expect(mockStop).toHaveBeenCalledOnce();
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should start the scheduler when message is startBtcStatusesTimer', async () => {
+			const event = createEvent('startBtcStatusesTimer');
+
+			await onBtcStatusesMessage(event);
+
+			expect(mockStart).toHaveBeenCalledOnce();
+			expect(mockStart).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStop).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should trigger the scheduler when message is triggerBtcStatusesTimer', async () => {
+			const event = createEvent('triggerBtcStatusesTimer');
+
+			await onBtcStatusesMessage(event);
+
+			expect(mockTrigger).toHaveBeenCalledOnce();
+			expect(mockTrigger).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockStop).not.toHaveBeenCalled();
+		});
+
+		it.each(invalidMessages)(
+			'should not call any scheduler method when message is %s',
+			async (msg) => {
+				const event = createEvent(msg);
+
+				await onBtcStatusesMessage(event);
+
+				expect(mockStart).not.toHaveBeenCalled();
+				expect(mockStop).not.toHaveBeenCalled();
+				expect(mockTrigger).not.toHaveBeenCalled();
+			}
+		);
+	});
+});

--- a/src/frontend/src/tests/icp/workers/ckbtc-minter-info.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ckbtc-minter-info.worker.spec.ts
@@ -1,0 +1,89 @@
+import { CkMinterInfoScheduler } from '$icp/schedulers/ck-minter-info.scheduler';
+import { onCkBtcMinterInfoMessage } from '$icp/workers/ckbtc-minter-info.worker';
+import type { PostMessage, PostMessageDataRequestIcCk } from '$lib/types/post-message';
+import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+
+vi.mock(import('$icp/schedulers/ck-minter-info.scheduler'), async (importOriginal) => {
+	const actual = await importOriginal();
+	const scheduler = actual.CkMinterInfoScheduler;
+	scheduler.prototype.start = vi.fn();
+	scheduler.prototype.stop = vi.fn();
+	scheduler.prototype.trigger = vi.fn();
+	return {
+		...actual,
+		CkMinterInfoScheduler: scheduler
+	};
+});
+
+describe('ckbtc-minter-info.worker', () => {
+	describe('onCkBtcMinterInfoMessage', () => {
+		const invalidMessages = excludeValidMessageEvents([
+			'stopCkBtcMinterInfoTimer',
+			'startCkBtcMinterInfoTimer',
+			'triggerCkBtcMinterInfoTimer'
+		]);
+
+		const mockStart = vi.fn();
+		const mockStop = vi.fn();
+		const mockTrigger = vi.fn();
+
+		const createEvent = (msg: string) =>
+			createMockEvent(msg) as unknown as MessageEvent<PostMessage<PostMessageDataRequestIcCk>>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			CkMinterInfoScheduler.prototype.start = mockStart;
+			CkMinterInfoScheduler.prototype.stop = mockStop;
+			CkMinterInfoScheduler.prototype.trigger = mockTrigger;
+		});
+
+		it('should stop the scheduler when message is stopCkBtcMinterInfoTimer', async () => {
+			const event = createEvent('stopCkBtcMinterInfoTimer');
+
+			await onCkBtcMinterInfoMessage(event);
+
+			expect(mockStop).toHaveBeenCalledOnce();
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should start the scheduler when message is startCkBtcMinterInfoTimer', async () => {
+			const event = createEvent('startCkBtcMinterInfoTimer');
+
+			await onCkBtcMinterInfoMessage(event);
+
+			expect(mockStart).toHaveBeenCalledOnce();
+			expect(mockStart).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStop).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should trigger the scheduler when message is triggerCkBtcMinterInfoTimer', async () => {
+			const event = createEvent('triggerCkBtcMinterInfoTimer');
+
+			await onCkBtcMinterInfoMessage(event);
+
+			expect(mockTrigger).toHaveBeenCalledOnce();
+			expect(mockTrigger).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockStop).not.toHaveBeenCalled();
+		});
+
+		it.each(invalidMessages)(
+			'should not call any scheduler method when message is %s',
+			async (msg) => {
+				const event = createEvent(msg);
+
+				await onCkBtcMinterInfoMessage(event);
+
+				expect(mockStart).not.toHaveBeenCalled();
+				expect(mockStop).not.toHaveBeenCalled();
+				expect(mockTrigger).not.toHaveBeenCalled();
+			}
+		);
+	});
+});

--- a/src/frontend/src/tests/icp/workers/ckbtc-update-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ckbtc-update-balance.worker.spec.ts
@@ -1,0 +1,75 @@
+import { CkBTCUpdateBalanceScheduler } from '$icp/schedulers/ckbtc-update-balance.scheduler';
+import { onCkBtcUpdateBalanceMessage } from '$icp/workers/ckbtc-update-balance.worker';
+import type {
+	PostMessage,
+	PostMessageDataRequestIcCkBTCUpdateBalance
+} from '$lib/types/post-message';
+import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+
+vi.mock(import('$icp/schedulers/ckbtc-update-balance.scheduler'), async (importOriginal) => {
+	const actual = await importOriginal();
+	const scheduler = actual.CkBTCUpdateBalanceScheduler;
+	scheduler.prototype.start = vi.fn();
+	scheduler.prototype.stop = vi.fn();
+	return {
+		...actual,
+		CkBTCUpdateBalanceScheduler: scheduler
+	};
+});
+
+describe('ckbtc-update-balance.worker', () => {
+	describe('onCkBtcUpdateBalanceMessage', () => {
+		const invalidMessages = excludeValidMessageEvents([
+			'stopCkBTCUpdateBalanceTimer',
+			'startCkBTCUpdateBalanceTimer'
+		]);
+
+		const mockStart = vi.fn();
+		const mockStop = vi.fn();
+
+		const createEvent = (msg: string) =>
+			createMockEvent(msg) as unknown as MessageEvent<
+				PostMessage<PostMessageDataRequestIcCkBTCUpdateBalance>
+			>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			CkBTCUpdateBalanceScheduler.prototype.start = mockStart;
+			CkBTCUpdateBalanceScheduler.prototype.stop = mockStop;
+		});
+
+		it('should stop the scheduler when message is stopCkBTCUpdateBalanceTimer', async () => {
+			const event = createEvent('stopCkBTCUpdateBalanceTimer');
+
+			await onCkBtcUpdateBalanceMessage(event);
+
+			expect(mockStop).toHaveBeenCalledOnce();
+
+			expect(mockStart).not.toHaveBeenCalled();
+		});
+
+		it('should start the scheduler when message is startCkBTCUpdateBalanceTimer', async () => {
+			const event = createEvent('startCkBTCUpdateBalanceTimer');
+
+			await onCkBtcUpdateBalanceMessage(event);
+
+			expect(mockStart).toHaveBeenCalledOnce();
+			expect(mockStart).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStop).not.toHaveBeenCalled();
+		});
+
+		it.each(invalidMessages)(
+			'should not call any scheduler method when message is %s',
+			async (msg) => {
+				const event = createEvent(msg);
+
+				await onCkBtcUpdateBalanceMessage(event);
+
+				expect(mockStart).not.toHaveBeenCalled();
+				expect(mockStop).not.toHaveBeenCalled();
+			}
+		);
+	});
+});

--- a/src/frontend/src/tests/icp/workers/cketh-minter-info.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/cketh-minter-info.worker.spec.ts
@@ -15,7 +15,7 @@ vi.mock(import('$icp/schedulers/ck-minter-info.scheduler'), async (importOrigina
 	};
 });
 
-describe('ck-minter-info.worker', () => {
+describe('cketh-minter-info.worker', () => {
 	describe('onCkEthMinterInfoMessage', () => {
 		const invalidMessages = excludeValidMessageEvents([
 			'stopCkEthMinterInfoTimer',

--- a/src/frontend/src/tests/icp/workers/cketh-minter-info.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/cketh-minter-info.worker.spec.ts
@@ -1,0 +1,89 @@
+import { CkMinterInfoScheduler } from '$icp/schedulers/ck-minter-info.scheduler';
+import { onCkEthMinterInfoMessage } from '$icp/workers/cketh-minter-info.worker';
+import type { PostMessage, PostMessageDataRequestIcCk } from '$lib/types/post-message';
+import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+
+vi.mock(import('$icp/schedulers/ck-minter-info.scheduler'), async (importOriginal) => {
+	const actual = await importOriginal();
+	const scheduler = actual.CkMinterInfoScheduler;
+	scheduler.prototype.start = vi.fn();
+	scheduler.prototype.stop = vi.fn();
+	scheduler.prototype.trigger = vi.fn();
+	return {
+		...actual,
+		CkMinterInfoScheduler: scheduler
+	};
+});
+
+describe('sol-wallet.worker', () => {
+	describe('onSolWalletMessage', () => {
+		const invalidMessages = excludeValidMessageEvents([
+			'stopCkEthMinterInfoTimer',
+			'startCkEthMinterInfoTimer',
+			'triggerCkEthMinterInfoTimer'
+		]);
+
+		const mockStart = vi.fn();
+		const mockStop = vi.fn();
+		const mockTrigger = vi.fn();
+
+		const createEvent = (msg: string) =>
+			createMockEvent(msg) as unknown as MessageEvent<PostMessage<PostMessageDataRequestIcCk>>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			CkMinterInfoScheduler.prototype.start = mockStart;
+			CkMinterInfoScheduler.prototype.stop = mockStop;
+			CkMinterInfoScheduler.prototype.trigger = mockTrigger;
+		});
+
+		it('should stop the scheduler when message is stopCkEthMinterInfoTimer', async () => {
+			const event = createEvent('stopCkEthMinterInfoTimer');
+
+			await onCkEthMinterInfoMessage(event);
+
+			expect(mockStop).toHaveBeenCalledOnce();
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should start the scheduler when message is startCkEthMinterInfoTimer', async () => {
+			const event = createEvent('startCkEthMinterInfoTimer');
+
+			await onCkEthMinterInfoMessage(event);
+
+			expect(mockStart).toHaveBeenCalledOnce();
+			expect(mockStart).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStop).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should trigger the scheduler when message is triggerCkEthMinterInfoTimer', async () => {
+			const event = createEvent('triggerCkEthMinterInfoTimer');
+
+			await onCkEthMinterInfoMessage(event);
+
+			expect(mockTrigger).toHaveBeenCalledOnce();
+			expect(mockTrigger).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockStop).not.toHaveBeenCalled();
+		});
+
+		it.each(invalidMessages)(
+			'should not call any scheduler method when message is %s',
+			async (msg) => {
+				const event = createEvent(msg);
+
+				await onCkEthMinterInfoMessage(event);
+
+				expect(mockStart).not.toHaveBeenCalled();
+				expect(mockStop).not.toHaveBeenCalled();
+				expect(mockTrigger).not.toHaveBeenCalled();
+			}
+		);
+	});
+});

--- a/src/frontend/src/tests/icp/workers/cketh-minter-info.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/cketh-minter-info.worker.spec.ts
@@ -15,8 +15,8 @@ vi.mock(import('$icp/schedulers/ck-minter-info.scheduler'), async (importOrigina
 	};
 });
 
-describe('sol-wallet.worker', () => {
-	describe('onSolWalletMessage', () => {
+describe('ck-minter-info.worker', () => {
+	describe('onCkEthMinterInfoMessage', () => {
 		const invalidMessages = excludeValidMessageEvents([
 			'stopCkEthMinterInfoTimer',
 			'startCkEthMinterInfoTimer',

--- a/src/frontend/src/tests/mocks/workers.mock.ts
+++ b/src/frontend/src/tests/mocks/workers.mock.ts
@@ -1,0 +1,10 @@
+import { POST_MESSAGE_REQUESTS } from '$lib/schema/post-message.schema';
+
+export const mockEventData = { value: 'mockData' };
+
+export const createMockEvent = (msg: string) => ({
+	data: { msg, data: mockEventData }
+});
+
+export const excludeValidMessageEvents = (validMessages: string[]) =>
+	POST_MESSAGE_REQUESTS.filter((message) => !validMessages.includes(message));

--- a/src/frontend/src/tests/mocks/workers.mock.ts
+++ b/src/frontend/src/tests/mocks/workers.mock.ts
@@ -8,4 +8,3 @@ export const createMockEvent = (msg: string) => ({
 
 export const excludeValidMessageEvents = (validMessages: string[]) =>
 	POST_MESSAGE_REQUESTS.filter((message) => !validMessages.includes(message));
-

--- a/src/frontend/src/tests/sol/workers/sol-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/sol/workers/sol-wallet.worker.spec.ts
@@ -1,0 +1,89 @@
+import type { PostMessage, PostMessageDataRequestSol } from '$lib/types/post-message';
+import { SolWalletScheduler } from '$sol/schedulers/sol-wallet.scheduler';
+import { onSolWalletMessage } from '$sol/workers/sol-wallet.worker';
+import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+
+vi.mock(import('$sol/schedulers/sol-wallet.scheduler'), async (importOriginal) => {
+	const actual = await importOriginal();
+	const scheduler = actual.SolWalletScheduler;
+	scheduler.prototype.start = vi.fn();
+	scheduler.prototype.stop = vi.fn();
+	scheduler.prototype.trigger = vi.fn();
+	return {
+		...actual,
+		SolWalletScheduler: scheduler
+	};
+});
+
+describe('sol-wallet.worker', () => {
+	describe('onSolWalletMessage', () => {
+		const invalidMessages = excludeValidMessageEvents([
+			'stopSolWalletTimer',
+			'startSolWalletTimer',
+			'triggerSolWalletTimer'
+		]);
+
+		const mockStart = vi.fn();
+		const mockStop = vi.fn();
+		const mockTrigger = vi.fn();
+
+		const createEvent = (msg: string) =>
+			createMockEvent(msg) as unknown as MessageEvent<PostMessage<PostMessageDataRequestSol>>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			SolWalletScheduler.prototype.start = mockStart;
+			SolWalletScheduler.prototype.stop = mockStop;
+			SolWalletScheduler.prototype.trigger = mockTrigger;
+		});
+
+		it('should stop the scheduler when message is stopSolWalletTimer', async () => {
+			const event = createEvent('stopSolWalletTimer');
+
+			await onSolWalletMessage(event);
+
+			expect(mockStop).toHaveBeenCalledOnce();
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should start the scheduler when message is startSolWalletTimer', async () => {
+			const event = createEvent('startSolWalletTimer');
+
+			await onSolWalletMessage(event);
+
+			expect(mockStart).toHaveBeenCalledOnce();
+			expect(mockStart).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStop).not.toHaveBeenCalled();
+			expect(mockTrigger).not.toHaveBeenCalled();
+		});
+
+		it('should trigger the scheduler when message is triggerSolWalletTimer', async () => {
+			const event = createEvent('triggerSolWalletTimer');
+
+			await onSolWalletMessage(event);
+
+			expect(mockTrigger).toHaveBeenCalledOnce();
+			expect(mockTrigger).toHaveBeenNthCalledWith(1, event.data.data);
+
+			expect(mockStart).not.toHaveBeenCalled();
+			expect(mockStop).not.toHaveBeenCalled();
+		});
+
+		it.each(invalidMessages)(
+			'should not call any scheduler method when message is %s',
+			async (msg) => {
+				const event = createEvent(msg);
+
+				await onSolWalletMessage(event);
+
+				expect(mockStart).not.toHaveBeenCalled();
+				expect(mockStop).not.toHaveBeenCalled();
+				expect(mockTrigger).not.toHaveBeenCalled();
+			}
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

We create simple tests to verify the correct scheduler calls for the workers that switch the messages that are posted.
