### PR TITLE
test(frontend): more error-testing of signer canister interface

### DIFF
--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -16,6 +16,7 @@ import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import type { ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
+import { jsonReplacer } from '@dfinity/utils';
 import { mock } from 'vitest-mock-extended';
 
 vi.mock(import('$lib/constants/app.constants'), async (importOriginal) => {
@@ -84,6 +85,8 @@ describe('signer.canister', () => {
 	// TODO: We should test the SignerCanisterPaymentError as currently there is no test that covers how all possible payment errors are parsed
 	const paymentErrorResponse = { Err: { PaymentError: { UnsupportedPaymentType: null } } };
 
+	const genericErrorResponse = { Err: { CanisterError: null } };
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -132,6 +135,21 @@ describe('signer.canister', () => {
 
 			await expect(res).rejects.toThrow(
 				new SignerCanisterPaymentError(paymentErrorResponse.Err.PaymentError)
+			);
+		});
+
+		it('should throw an error if btc_caller_address returns a generic canister error', async () => {
+			// @ts-expect-error we test this in purposes
+			service.btc_caller_address.mockResolvedValue(genericErrorResponse);
+
+			const { getBtcAddress } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			const res = getBtcAddress(btcParams);
+
+			await expect(res).rejects.toThrow(
+				new CanisterInternalError('Unknown SignerCanisterBtcError')
 			);
 		});
 
@@ -230,6 +248,21 @@ describe('signer.canister', () => {
 
 			await expect(res).rejects.toThrow(
 				new SignerCanisterPaymentError(paymentErrorResponse.Err.PaymentError)
+			);
+		});
+
+		it('should throw an error if btc_caller_balance returns a generic canister error', async () => {
+			// @ts-expect-error we test this in purposes
+			service.btc_caller_balance.mockResolvedValue(genericErrorResponse);
+
+			const { getBtcBalance } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			const res = getBtcBalance(btcParams);
+
+			await expect(res).rejects.toThrow(
+				new CanisterInternalError('Unknown SignerCanisterBtcError')
 			);
 		});
 
@@ -544,6 +577,44 @@ describe('signer.canister', () => {
 
 			await expect(res).rejects.toThrow(
 				new SignerCanisterPaymentError(paymentErrorResponse.Err.PaymentError)
+			);
+		});
+
+		it.each([
+			['NotEnoughFunds', { NotEnoughFunds: { available: 1000n, required: 2000n } }],
+			['WrongBitcoinNetwork', { WrongBitcoinNetwork: null }],
+			['NotP2WPKHSourceAddress', { NotP2WPKHSourceAddress: null }],
+			['InvalidDestinationAddress', { InvalidDestinationAddress: { address: 'mock-destination' } }],
+			['InvalidSourceAddress', { InvalidSourceAddress: { address: 'mock-source' } }]
+			// eslint-disable-next-line local-rules/prefer-object-params -- It is a simple list of cases
+		])(`should throw an error if btc_caller_send returns a build error %s`, async (_, error) => {
+			const errorResponse = { Err: { BuildP2wpkhError: error } };
+
+			service.btc_caller_send.mockResolvedValue(errorResponse);
+
+			const { sendBtc } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			const res = sendBtc(sendBtcParams);
+
+			await expect(res).rejects.toThrow(
+				new CanisterInternalError(JSON.stringify(error, jsonReplacer))
+			);
+		});
+
+		it('should throw an error if btc_caller_send returns a generic canister error', async () => {
+			// @ts-expect-error we test this in purposes
+			service.btc_caller_send.mockResolvedValue(genericErrorResponse);
+
+			const { sendBtc } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			const res = sendBtc(sendBtcParams);
+
+			await expect(res).rejects.toThrow(
+				new CanisterInternalError('Unknown SignerCanisterSendBtcError')
 			);
 		});
 


### PR DESCRIPTION
# Motivation

We add a few test cases when mocking the signer canister interface to run the unittests.
