### PR TITLE
refactor(frontend): use util `defineSupportedTokens` to create the lists of contract-tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.erc20.env.ts
@@ -8,12 +8,14 @@ import {
 	USDC_TOKEN
 } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
 import type { RequiredEvmErc20Token } from '$evm/types/erc20';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 
 const BASE_ERC20_TOKENS_SEPOLIA: RequiredEvmErc20Token[] = [SEPOLIA_USDC_TOKEN, SEPOLIA_EURC_TOKEN];
 
 const BASE_ERC20_TOKENS_MAINNET: RequiredEvmErc20Token[] = [USDC_TOKEN, EURC_TOKEN];
 
-export const BASE_ERC20_TOKENS: RequiredEvmErc20Token[] = [
-	...(BASE_MAINNET_ENABLED ? BASE_ERC20_TOKENS_MAINNET : []),
-	...BASE_ERC20_TOKENS_SEPOLIA
-];
+export const BASE_ERC20_TOKENS: RequiredEvmErc20Token[] = defineSupportedTokens({
+	mainnetFlag: BASE_MAINNET_ENABLED,
+	mainnetTokens: BASE_ERC20_TOKENS_MAINNET,
+	testnetTokens: BASE_ERC20_TOKENS_SEPOLIA
+});

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env.ts
@@ -2,9 +2,11 @@ import { BSC_MAINNET_ENABLED } from '$env/networks/networks-evm/networks.evm.bsc
 import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdc.env';
 import { USDT_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/tokens-bep20/tokens.usdt.env';
 import type { RequiredEvmBep20Token } from '$evm/types/bep20';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 
 const BSC_BEP20_TOKENS_MAINNET: RequiredEvmBep20Token[] = [USDC_TOKEN, USDT_TOKEN];
 
-export const BSC_BEP20_TOKENS: RequiredEvmBep20Token[] = [
-	...(BSC_MAINNET_ENABLED ? BSC_BEP20_TOKENS_MAINNET : [])
-];
+export const BSC_BEP20_TOKENS: RequiredEvmBep20Token[] = defineSupportedTokens({
+	mainnetFlag: BSC_MAINNET_ENABLED,
+	mainnetTokens: BSC_BEP20_TOKENS_MAINNET
+});

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -17,6 +17,7 @@ import { XAUT_TOKEN } from '$env/tokens/tokens-erc20/tokens.xaut.env';
 import type { Erc20Contract, RequiredErc20Token } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { TokenId } from '$lib/types/token';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 
 // TODO: remember to remove the ERC20 from here once the ckERC20 is implemented. Following the normal flow, the ERC20 variables should be created on a separate file.
 
@@ -141,10 +142,11 @@ export const ERC20_TWIN_TOKENS_MAINNET: RequiredErc20Token[] = [
 	XAUT_TOKEN
 ];
 
-export const ERC20_TWIN_TOKENS: RequiredErc20Token[] = [
-	...(ETH_MAINNET_ENABLED ? ERC20_TWIN_TOKENS_MAINNET : []),
-	...ERC20_TWIN_TOKENS_SEPOLIA
-];
+export const ERC20_TWIN_TOKENS: RequiredErc20Token[] = defineSupportedTokens({
+	mainnetFlag: ETH_MAINNET_ENABLED,
+	mainnetTokens: ERC20_TWIN_TOKENS_MAINNET,
+	testnetTokens: ERC20_TWIN_TOKENS_SEPOLIA
+});
 
 export const ERC20_TWIN_TOKENS_IDS: TokenId[] = ERC20_TWIN_TOKENS.map(({ id }) => id);
 

--- a/src/frontend/src/env/tokens/tokens.spl.env.ts
+++ b/src/frontend/src/env/tokens/tokens.spl.env.ts
@@ -9,6 +9,7 @@ import { TRUMP_TOKEN } from '$env/tokens/tokens-spl/tokens.trump.env';
 import { DEVNET_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-spl/tokens.usdc.env';
 import { USDT_TOKEN } from '$env/tokens/tokens-spl/tokens.usdt.env';
 import { WSOL_TOKEN } from '$env/tokens/tokens-spl/tokens.wsol.env';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import type { RequiredSplToken } from '$sol/types/spl';
 
 const SPL_TOKENS_MAINNET: RequiredSplToken[] = [
@@ -26,7 +27,8 @@ const SPL_TOKENS_MAINNET: RequiredSplToken[] = [
 
 const SPL_TOKENS_DEVNET: RequiredSplToken[] = [DEVNET_USDC_TOKEN, DEVNET_EURC_TOKEN];
 
-export const SPL_TOKENS: RequiredSplToken[] = [
-	...(SOL_MAINNET_ENABLED ? SPL_TOKENS_MAINNET : []),
-	...SPL_TOKENS_DEVNET
-];
+export const SPL_TOKENS: RequiredSplToken[] = defineSupportedTokens({
+	mainnetFlag: SOL_MAINNET_ENABLED,
+	mainnetTokens: SPL_TOKENS_MAINNET,
+	testnetTokens: SPL_TOKENS_DEVNET
+});


### PR DESCRIPTION
# Motivation

For tokens like ERC20 and SPL, we can reuse the util `defineSupportedTokens` to create the list variables.
