### PR TITLE
chore(frontend): remove unnecessary check in util `isIcrcTokenToggleDisabled`

### DIFF
--- a/src/frontend/src/lib/utils/token-toggle.utils.ts
+++ b/src/frontend/src/lib/utils/token-toggle.utils.ts
@@ -13,10 +13,8 @@ export const isEthereumTokenToggleEnabled = (token: EthereumUserToken): boolean 
 
 // TODO: Like above - check why this functionality is used.
 export const isIcrcTokenToggleDisabled = (token: IcrcCustomToken): boolean =>
-	nonNullish(token)
-		? (token.category === 'default' && isTokenIcp(token)) ||
-			ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS.includes(token.ledgerCanisterId)
-		: false;
+	(token.category === 'default' && isTokenIcp(token)) ||
+	ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS.includes(token.ledgerCanisterId);
 
 export const isIcrcTokenToggleEnabled = (token: IcrcCustomToken): boolean =>
 	!isIcrcTokenToggleDisabled(token);


### PR DESCRIPTION
# Motivation

Since the input of util `isIcrcTokenToggleDisabled` is always a defined token, we don't need to check for nullish values.