### PR TITLE
feat(frontend): removes the rewards navigation menu item tag

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -105,8 +105,6 @@
 	ariaLabel={$i18n.navigation.alt.airdrops}
 	selected={isRouteRewards(pageData)}
 	testId={addTestIdPrefix(NAVIGATION_ITEM_REWARDS)}
-	tag={$i18n.core.text.new}
-	tagVariant="emphasis"
 >
 	<IconGift />
 	{$i18n.navigation.text.airdrops}


### PR DESCRIPTION
# Motivation

The `New` tag for the `rewards` navigation menu item is not needed anymore.

# Changes

- removes tag

# Tests

**before:**

**after:**
<img width="166" alt="image" src="https://github.com/user-attachments/assets/386c665a-6e7f-4460-914f-9fd475a12bfd" />
