### PR TITLE
feat(frontend): ERC20 fee is max between `approve` and `transfer`

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -4,6 +4,7 @@ import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { ERC20_ABI } from '$eth/constants/erc20.constants';
 import type { Erc20Provider } from '$eth/types/contracts-providers';
 import type { Erc20ContractAddress, Erc20Metadata } from '$eth/types/erc20';
+import { ZERO } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
@@ -47,7 +48,7 @@ export class InfuraErc20Provider implements Erc20Provider {
 		return erc20Contract.balanceOf(address);
 	};
 
-	getFeeData = ({
+	getFeeData = async ({
 		contract: { address: contractAddress },
 		to,
 		from,
@@ -59,7 +60,18 @@ export class InfuraErc20Provider implements Erc20Provider {
 		amount: bigint;
 	}): Promise<bigint> => {
 		const erc20Contract = new Contract(contractAddress, ERC20_ABI, this.provider);
-		return erc20Contract.approve.estimateGas(to, amount, { from });
+
+		const results = await Promise.allSettled([
+			erc20Contract.approve.estimateGas(to, amount, { from }),
+			erc20Contract.transfer.estimateGas(to, amount, { from })
+		]);
+
+		return results.reduce((max, result) => {
+			if (result.status === 'fulfilled' && result.value > max) {
+				return result.value;
+			}
+			return max;
+		}, ZERO);
 	};
 
 	// Transaction send: https://ethereum.stackexchange.com/a/131944

--- a/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
@@ -268,26 +268,26 @@ describe('etherscan.providers', () => {
 				});
 			});
 		});
+	});
 
-		describe('etherscanProviders', () => {
-			networks.forEach(({ id, name }) => {
-				it(`should return the correct provider for ${name} network`, () => {
-					const provider = etherscanProviders(id);
+	describe('etherscanProviders', () => {
+		networks.forEach(({ id, name }) => {
+			it(`should return the correct provider for ${name} network`, () => {
+				const provider = etherscanProviders(id);
 
-					expect(provider).toBeInstanceOf(EtherscanProvider);
+				expect(provider).toBeInstanceOf(EtherscanProvider);
 
-					expect(provider).toHaveProperty('network');
-					expect(provider).toHaveProperty('chainId');
-				});
+				expect(provider).toHaveProperty('network');
+				expect(provider).toHaveProperty('chainId');
 			});
+		});
 
-			it('should throw an error for an unsupported network ID', () => {
-				expect(() => etherscanProviders(ICP_NETWORK_ID)).toThrow(
-					replacePlaceholders(en.init.error.no_etherscan_provider, {
-						$network: ICP_NETWORK_ID.toString()
-					})
-				);
-			});
+		it('should throw an error for an unsupported network ID', () => {
+			expect(() => etherscanProviders(ICP_NETWORK_ID)).toThrow(
+				replacePlaceholders(en.init.error.no_etherscan_provider, {
+					$network: ICP_NETWORK_ID.toString()
+				})
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/providers/infura-erc20.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/infura-erc20.providers.spec.ts
@@ -1,0 +1,495 @@
+import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
+import { ETHEREUM_NETWORK, SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
+import { ERC20_ABI } from '$eth/constants/erc20.constants';
+import { InfuraErc20Provider, infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
+import type { EthereumNetwork } from '$eth/types/network';
+import { ZERO } from '$lib/constants/app.constants';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mocks';
+import en from '$tests/mocks/i18n.mock';
+import { Contract, type ContractTransaction } from 'ethers/contract';
+import { InfuraProvider as InfuraProviderLib } from 'ethers/providers';
+import type { MockedClass } from 'vitest';
+
+vi.mock('$env/rest/infura.env', () => ({
+	INFURA_API_KEY: 'test-api-key'
+}));
+
+vi.mock('ethers/contract', () => ({
+	Contract: vi.fn()
+}));
+
+describe('infura-erc20.providers', () => {
+	const INFURA_API_KEY = 'test-api-key';
+
+	const networks: EthereumNetwork[] = [...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS];
+
+	it('should create the correct map of providers', () => {
+		expect(InfuraProviderLib).toHaveBeenCalledTimes(networks.length);
+
+		networks.forEach(({ providers: { infura } }, index) => {
+			expect(InfuraProviderLib).toHaveBeenNthCalledWith(index + 1, infura, INFURA_API_KEY);
+		});
+	});
+
+	describe('InfuraErc20Provider', () => {
+		const {
+			providers: { infura }
+		} = ETHEREUM_NETWORK;
+		const { address: contractAddress } = PEPE_TOKEN;
+
+		const mockProvider = InfuraProviderLib as MockedClass<typeof InfuraProviderLib>;
+		const expectedContractParams = [contractAddress, ERC20_ABI];
+
+		const mockContract = Contract as MockedClass<typeof Contract>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should initialise the provider with the correct network and API key', () => {
+			const provider = new InfuraErc20Provider(infura);
+
+			expect(provider).toBeDefined();
+			expect(InfuraProviderLib).toHaveBeenCalledWith(infura, INFURA_API_KEY);
+		});
+
+		describe('metadata method', () => {
+			const mockName = vi.fn() as unknown as typeof mockContract.prototype.name;
+			const mockSymbol = vi.fn() as unknown as typeof mockContract.prototype.symbol;
+			const mockDecimals = vi.fn() as unknown as typeof mockContract.prototype.decimals;
+
+			const mockParams = {
+				address: contractAddress
+			};
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				mockName.mockResolvedValue('mock-name');
+				mockSymbol.mockResolvedValue('mock-symbol');
+				mockDecimals.mockResolvedValue('18');
+
+				mockContract.prototype.name = mockName;
+				mockContract.prototype.symbol = mockSymbol;
+				mockContract.prototype.decimals = mockDecimals;
+			});
+
+			it('should return the fetched metadata', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.metadata(mockParams);
+
+				expect(result).toStrictEqual({
+					name: 'mock-name',
+					symbol: 'mock-symbol',
+					decimals: 18
+				});
+			});
+
+			it('should call the metadata methods of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.metadata(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockName).toHaveBeenCalledOnce();
+				expect(mockSymbol).toHaveBeenCalledOnce();
+				expect(mockDecimals).toHaveBeenCalledOnce();
+			});
+
+			it('should handle errors gracefully', async () => {
+				const errorMessage = 'Error fetching metadata';
+				mockName.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				await expect(provider.metadata(mockParams)).rejects.toThrow(errorMessage);
+			});
+		});
+
+		describe('balance method', () => {
+			const mockBalanceOf = vi.fn() as unknown as typeof mockContract.prototype.balanceOf;
+
+			const mockParams = {
+				contract: { address: contractAddress },
+				address: mockEthAddress
+			};
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				mockBalanceOf.mockResolvedValue(123456n);
+
+				mockContract.prototype.balanceOf = mockBalanceOf;
+			});
+
+			it('should return the fetched balance', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.balance(mockParams);
+
+				expect(result).toBe(123456n);
+			});
+
+			it('should call the balance method of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.balance(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockBalanceOf).toHaveBeenCalledOnce();
+			});
+
+			it('should handle errors gracefully', async () => {
+				const errorMessage = 'Error fetching balance';
+				mockBalanceOf.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				await expect(provider.balance(mockParams)).rejects.toThrow(errorMessage);
+			});
+		});
+
+		describe('getFeeData method', () => {
+			const mockApproveEstimateGas = vi.fn();
+			const mockTransferEstimateGas = vi.fn();
+			const mockApprove = vi.fn() as unknown as typeof mockContract.prototype.approve;
+			const mockTransfer = vi.fn() as unknown as typeof mockContract.prototype.transfer;
+
+			const mockApproveGas = 100n;
+			const mockTransferGas = 200n;
+
+			const mockAmount = 123456n;
+
+			const mockParams = {
+				contract: { address: contractAddress },
+				to: mockEthAddress,
+				from: mockEthAddress2,
+				amount: mockAmount
+			};
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				mockApproveEstimateGas.mockResolvedValue(mockApproveGas);
+				mockTransferEstimateGas.mockResolvedValue(mockTransferGas);
+
+				mockApprove.estimateGas = mockApproveEstimateGas;
+				mockTransfer.estimateGas = mockTransferEstimateGas;
+
+				mockContract.prototype.approve = mockApprove;
+				mockContract.prototype.transfer = mockTransfer;
+			});
+
+			it('should return the highest estimated fee', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.getFeeData(mockParams);
+
+				expect(result).toStrictEqual(mockTransferGas);
+			});
+
+			it('should call the approve method of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.getFeeData(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockApprove.estimateGas).toHaveBeenCalledOnce();
+				expect(mockApprove.estimateGas).toHaveBeenNthCalledWith(1, mockEthAddress, mockAmount, {
+					from: mockEthAddress2
+				});
+			});
+
+			it('should call the transfer method of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.getFeeData(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockTransfer.estimateGas).toHaveBeenCalledOnce();
+				expect(mockTransfer.estimateGas).toHaveBeenNthCalledWith(1, mockEthAddress, mockAmount, {
+					from: mockEthAddress2
+				});
+			});
+
+			it('should ignore errors raised by the approve method', async () => {
+				const errorMessage = 'Error fetching approve fee data';
+				mockApproveEstimateGas.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.getFeeData(mockParams);
+
+				expect(result).toStrictEqual(mockTransferGas);
+			});
+
+			it('should ignore errors raised by the transfer method', async () => {
+				const errorMessage = 'Error fetching transfer fee data';
+				mockTransferEstimateGas.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.getFeeData(mockParams);
+
+				expect(result).toStrictEqual(mockApproveGas);
+			});
+
+			it('should handle all errors gracefully', async () => {
+				const errorMessage = 'Error fetching fee data';
+				mockApproveEstimateGas.mockRejectedValue(new Error(errorMessage));
+				mockTransferEstimateGas.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.getFeeData(mockParams);
+
+				expect(result).toStrictEqual(ZERO);
+			});
+		});
+
+		describe('populateTransaction method', () => {
+			const mockPopulateTransaction = vi.fn();
+			const mockTransfer = vi.fn() as unknown as typeof mockContract.prototype.transfer;
+
+			const mockContractTransaction: ContractTransaction = {
+				to: mockEthAddress,
+				data: '0x',
+				from: mockEthAddress2
+			};
+
+			const mockAmount = 123456n;
+
+			const mockParams = {
+				contract: { address: contractAddress },
+				to: mockEthAddress,
+				amount: mockAmount
+			};
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				mockPopulateTransaction.mockResolvedValue(mockContractTransaction);
+
+				mockTransfer.populateTransaction = mockPopulateTransaction;
+
+				mockContract.prototype.transfer = mockTransfer;
+			});
+
+			it('should return a populated transfer transaction', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.populateTransaction(mockParams);
+
+				expect(result).toStrictEqual(mockContractTransaction);
+			});
+
+			it('should call the transfer method of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.populateTransaction(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockTransfer.populateTransaction).toHaveBeenCalledOnce();
+				expect(mockTransfer.populateTransaction).toHaveBeenNthCalledWith(
+					1,
+					mockEthAddress,
+					mockAmount
+				);
+			});
+
+			it('should handle errors gracefully', async () => {
+				const errorMessage = 'Error populating transfer transaction';
+				mockPopulateTransaction.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				await expect(provider.populateTransaction(mockParams)).rejects.toThrow(errorMessage);
+			});
+		});
+
+		describe('populateApprove method', () => {
+			const mockPopulateTransaction = vi.fn();
+			const mockApprove = vi.fn() as unknown as typeof mockContract.prototype.approve;
+
+			const mockContractTransaction: ContractTransaction = {
+				to: mockEthAddress,
+				data: '0x',
+				from: mockEthAddress2
+			};
+
+			const mockAmount = 123456n;
+
+			const mockParams = {
+				contract: { address: contractAddress },
+				spender: mockEthAddress2,
+				amount: mockAmount
+			};
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				mockPopulateTransaction.mockResolvedValue(mockContractTransaction);
+
+				mockApprove.populateTransaction = mockPopulateTransaction;
+
+				mockContract.prototype.approve = mockApprove;
+			});
+
+			it('should return a populated approve transaction', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.populateApprove(mockParams);
+
+				expect(result).toStrictEqual(mockContractTransaction);
+			});
+
+			it('should call the approve method of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.populateApprove(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockApprove.populateTransaction).toHaveBeenCalledOnce();
+				expect(mockApprove.populateTransaction).toHaveBeenNthCalledWith(
+					1,
+					mockEthAddress2,
+					mockAmount
+				);
+			});
+
+			it('should handle errors gracefully', async () => {
+				const errorMessage = 'Error populating approve transaction';
+				mockPopulateTransaction.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				await expect(provider.populateApprove(mockParams)).rejects.toThrow(errorMessage);
+			});
+		});
+
+		describe('allowance method', () => {
+			const mockAllowance = vi.fn() as unknown as typeof mockContract.prototype.allowance;
+
+			const mockParams = {
+				contract: { address: contractAddress },
+				owner: mockEthAddress,
+				spender: mockEthAddress2
+			};
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				mockAllowance.mockResolvedValue(123456n);
+
+				mockContract.prototype.allowance = mockAllowance;
+			});
+
+			it('should return the fetched allowance', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				const result = await provider.allowance(mockParams);
+
+				expect(result).toBe(123456n);
+			});
+
+			it('should call the allowance method of the contract', async () => {
+				const provider = new InfuraErc20Provider(infura);
+
+				await provider.allowance(mockParams);
+
+				expect(provider).toBeDefined();
+
+				expect(mockContract).toHaveBeenCalledOnce();
+				expect(mockContract).toHaveBeenNthCalledWith(
+					1,
+					...expectedContractParams,
+					new mockProvider()
+				);
+
+				expect(mockAllowance).toHaveBeenCalledOnce();
+				expect(mockAllowance).toHaveBeenNthCalledWith(1, mockEthAddress, mockEthAddress2);
+			});
+
+			it('should handle errors gracefully', async () => {
+				const errorMessage = 'Error fetching balance';
+				mockAllowance.mockRejectedValue(new Error(errorMessage));
+
+				const provider = new InfuraErc20Provider(infura);
+
+				await expect(provider.allowance(mockParams)).rejects.toThrow(errorMessage);
+			});
+		});
+	});
+
+	describe('infuraErc20Providers', () => {
+		networks.forEach(({ id, name }) => {
+			it(`should return the correct provider for ${name} network`, () => {
+				const provider = infuraErc20Providers(id);
+
+				expect(provider).toBeInstanceOf(InfuraErc20Provider);
+
+				expect(provider).toHaveProperty('network');
+			});
+		});
+
+		it('should throw an error for an unsupported network ID', () => {
+			expect(() => infuraErc20Providers(ICP_NETWORK_ID)).toThrow(
+				replacePlaceholders(en.init.error.no_infura_erc20_provider, {
+					$network: ICP_NETWORK_ID.toString()
+				})
+			);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We are having some situations where the Base transactions are failing due to too little gas provided. After analyzing the code, we are calculating the fee for ERC20 based on the estimate gas of the `approve` method of ERC20, plus a buffer of 50%. However, it seems it is not enough for Base `transfer` method.

To solve it at top-tier level, we modify the calculation of the fee to get the max value between the estimated gas for `approve` method and the one for `transfer` method.

# Changes

- Modify class `InfuraErc20Provider` to have method `getFeeData` fetch estimated fees both for approve and transfer.
- Return the max between them.

# Tests

Since we are here, we create tests for the entire module. Plus test in a test canister, before and after and it worked.

- Wallet: https://basescan.org/address/0x4309bd5566796FFf8621133EBc52e437a9d822af
- Failed transaction: https://basescan.org/tx/0x94cb5ec8980be7ed1cebb3da0894fc9d5b0c72916273b7f4796cd38c0dc86c09
- Successful transaction: https://basescan.org/tx/0x7b40277f8f51a033c7125e4c3366a083836f8f6314e0a5b5bdd9438a33fbacf6

![Screenshot 2025-05-12 at 12 50 25](https://github.com/user-attachments/assets/210d0f69-557e-4f33-8e97-db5c7b7187a9)



