### PR TITLE
feat(frontend): introduce DIP-20 standard

### DIFF
--- a/src/frontend/src/icp/components/receive/IcReceive.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceive.svelte
@@ -15,7 +15,7 @@
 		isTokenCkErc20Ledger,
 		isTokenCkEthLedger
 	} from '$icp/utils/ic-send.utils';
-	import { isTokenIcrc } from '$icp/utils/icrc.utils';
+	import { isTokenDip20, isTokenIcrc } from '$icp/utils/icrc.utils';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
 
@@ -29,6 +29,9 @@
 
 	let icrc = false;
 	$: icrc = isTokenIcrc(token);
+
+	let dip20 = false;
+	$: dip20 = isTokenDip20(token);
 
 	const open = async (callback: () => Promise<void>) => {
 		await callback();
@@ -52,7 +55,7 @@
 	<IcReceiveCkEthereum />
 {:else if ckBTC}
 	<IcReceiveCkBTC />
-{:else if icrc}
+{:else if icrc || dip20}
 	<IcReceiveIcrc />
 {:else}
 	<IcReceiveIcp />

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -107,8 +107,11 @@ export const isTokenIcp = (token: Partial<IcToken>): token is IcToken => token.s
 
 export const isTokenIcrc = (token: Partial<IcToken>): token is IcToken => token.standard === 'icrc';
 
+export const isTokenDip20 = (token: Partial<IcToken>): token is IcToken =>
+	token.standard === 'dip20';
+
 export const isTokenIc = (token: Partial<IcToken>): token is IcToken =>
-	isTokenIcp(token) || isTokenIcrc(token);
+	isTokenIcp(token) || isTokenIcrc(token) || isTokenDip20(token);
 
 export const icTokenIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
 	isTokenIc(token) && 'enabled' in token;

--- a/src/frontend/src/lib/schema/token.schema.ts
+++ b/src/frontend/src/lib/schema/token.schema.ts
@@ -12,6 +12,7 @@ export const TokenStandardSchema = z.enum([
 	'erc20',
 	'icp',
 	'icrc',
+	'dip20',
 	'bitcoin',
 	'solana',
 	'spl'

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -260,12 +260,32 @@ describe('icrc.utils', () => {
 		);
 	});
 
-	describe('isTokenIc', () => {
-		it.each(['icp', 'icrc'])('should return true for valid token standards: %s', (standard) => {
+	describe('isTokenDip20', () => {
+		it.each(['dip20'])('should return true for valid token standards: %s', (standard) => {
 			expect(
-				isTokenIc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				isTokenIcrc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
 			).toBeTruthy();
 		});
+
+		it.each(['icp', 'icrc', 'ethereum', 'erc20', 'bitcoin', 'solana', 'spl'])(
+			'should return false for invalid token standards: %s',
+			(standard) => {
+				expect(
+					isTokenIcrc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				).toBeFalsy();
+			}
+		);
+	});
+
+	describe('isTokenIc', () => {
+		it.each(['icp', 'icrc', 'dip20'])(
+			'should return true for valid token standards: %s',
+			(standard) => {
+				expect(
+					isTokenIc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				).toBeTruthy();
+			}
+		);
 
 		it.each(['ethereum', 'erc20', 'bitcoin', 'solana', 'spl'])(
 			'should return false for invalid token standards: %s',

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -1,6 +1,7 @@
 import {
 	buildIcrcCustomTokenMetadataPseudoResponse,
 	icTokenIcrcCustomToken,
+	isTokenDip20,
 	isTokenIc,
 	isTokenIcp,
 	isTokenIcrc,
@@ -263,7 +264,7 @@ describe('icrc.utils', () => {
 	describe('isTokenDip20', () => {
 		it.each(['dip20'])('should return true for valid token standards: %s', (standard) => {
 			expect(
-				isTokenIcrc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+				isTokenDip20({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
 			).toBeTruthy();
 		});
 
@@ -271,7 +272,7 @@ describe('icrc.utils', () => {
 			'should return false for invalid token standards: %s',
 			(standard) => {
 				expect(
-					isTokenIcrc({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
+					isTokenDip20({ ...mockIcrcCustomToken, standard: standard as TokenStandard })
 				).toBeFalsy();
 			}
 		);


### PR DESCRIPTION
# Motivation

We want to start supporting [IC DIP-20 tokens](https://github.com/Psychedelic/DIP20), specifically [XTC](https://github.com/Psychedelic/dank/tree/main/xtc). In this PR, we introduce the new standard.

# Changes

- Add `dip20` among the token standard.
- Create util to check the correct new standard.
- Use the util in the receive modal.

# Tests

Add tests.
