### PR TITLE
feat(frontend): update BtcSendReview component

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -60,16 +60,16 @@
 		}) || invalidAmount(amount);
 </script>
 
-<SendReview on:icBack on:icSend {source} {amount} {destination} disabled={disableSend}>
+<SendReview on:icBack on:icSend {amount} {destination} disabled={disableSend}>
 	<BtcReviewNetwork {networkId} slot="network" />
 
 	<BtcUtxosFee slot="fee" bind:utxosFee {networkId} {amount} />
 
-	<svelte:fragment slot="info">
+	<div class="mt-8" slot="info">
 		{#if insufficientFundsForFee}
 			<InsufficientFundsForFee testId="btc-send-form-insufficient-funds-for-fee" />
 		{:else}
 			<BtcSendWarnings {utxosFee} pendingTransactionsStatus={$hasPendingTransactionsStore} />
 		{/if}
-	</svelte:fragment>
+	</div>
 </SendReview>

--- a/src/frontend/src/lib/components/send/SendReview.svelte
+++ b/src/frontend/src/lib/components/send/SendReview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
-	import SendData from '$lib/components/send/SendData.svelte';
+	import SendDataDestination from '$lib/components/send/SendDataDestination.svelte';
+	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
@@ -13,34 +13,27 @@
 
 	export let destination = '';
 	export let amount: OptionAmount = undefined;
-	export let source: string;
 	export let disabled: boolean | undefined = false;
+	// TODO: remove when all send review forms are updated
+	export let source: string | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
-	const { sendToken, sendBalance, sendTokenExchangeRate } =
-		getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendToken, sendTokenExchangeRate } = getContext<SendContext>(SEND_CONTEXT_KEY);
 </script>
 
 <ContentWithToolbar>
-	{#if nonNullish($sendToken)}
-		<SendData
-			{amount}
-			{destination}
-			token={$sendToken}
-			balance={$sendBalance}
-			exchangeRate={$sendTokenExchangeRate}
-			{source}
-		>
-			<slot name="fee" slot="fee" />
+	<SendTokenReview sendAmount={amount} token={$sendToken} exchangeRate={$sendTokenExchangeRate} />
 
-			<slot name="network" slot="network" />
-		</SendData>
-	{/if}
+	<SendDataDestination {destination} />
+
+	<slot name="network" />
+
+	<slot name="fee" />
 
 	<slot name="info" />
 
-	<ButtonGroup slot="toolbar">
+	<ButtonGroup slot="toolbar" testId="toolbar">
 		<ButtonBack onclick={() => dispatch('icBack')} />
 		<Button {disabled} on:click={() => dispatch('icSend')} testId={REVIEW_FORM_SEND_BUTTON}>
 			{$i18n.send.text.send}


### PR DESCRIPTION
# Motivation

The design update of the BtcSendReview component. This PR also includes related `SendReview` changes. 

Note: in order not to update all the network forms at once, I left an unused `source` prop which allows us to introduce changes gradually.

<img width="615" alt="Screenshot 2025-05-12 at 14 31 49" src="https://github.com/user-attachments/assets/af54daa0-35e2-4a0c-a665-96fbfadc2fc4" />
