### PR TITLE
feat(frontend): implements isEligible reward canister function

### DIFF
--- a/src/frontend/src/lib/api/reward.api.ts
+++ b/src/frontend/src/lib/api/reward.api.ts
@@ -1,5 +1,5 @@
 import type {
-	ClaimedVipReward,
+	ClaimedVipReward, EligibilityResponse,
 	NewVipRewardResponse,
 	ReferrerInfo,
 	SetReferrerResponse,
@@ -15,6 +15,15 @@ import { Principal } from '@dfinity/principal';
 import { assertNonNullish, isNullish, type QueryParams } from '@dfinity/utils';
 
 let canister: RewardCanister | undefined = undefined;
+
+export const isEligible = async ({
+	 identity,
+	 certified
+ }: CanisterApiFunctionParams<QueryParams>): Promise<EligibilityResponse> => {
+	const { isEligible } = await rewardCanister({ identity });
+
+	return isEligible({ certified });
+};
 
 export const getUserInfo = async ({
 	identity,


### PR DESCRIPTION
# Motivation

The `isEligible` api function needs to be implemented to be able to use the canister implementation.

# Changes

- implements `isEligible` function

