### PR TITLE
feat(frontend): Add edit contact step

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditContactStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactStep.svelte
@@ -1,10 +1,24 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import AddressListItem from '$lib/components/contact/AddressListItem.svelte';
+	import Avatar from '$lib/components/contact/Avatar.svelte';
+	import IconPencil from '$lib/components/icons/lucide/IconPencil.svelte';
+	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
+	import IconTrash from '$lib/components/icons/lucide/IconTrash.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
-	import { CONTACT_SHOW_CLOSE_BUTTON } from '$lib/constants/test-ids.constants';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import {
+		CONTACT_EDIT_DELETE_CONTACT_BUTTON,
+		CONTACT_SHOW_CLOSE_BUTTON,
+		CONTACT_EDIT_ADD_ADDRESS_BUTTON,
+		CONTACT_HEADER_EDITING_EDIT_BUTTON
+	} from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 
 	interface Props {
@@ -28,34 +42,71 @@
 	}: Props = $props();
 </script>
 
-<ContentWithToolbar styleClass="flex flex-col items-stretch gap-3">
-	<!-- TODO add contact edit header here: https://github.com/dfinity/oisy-wallet/pull/6557 -->
-	<Button on:click={() => onEdit(contact)}>EDIT CONTACT</Button>
+<ContentWithToolbar styleClass="flex flex-col items-stretch gap-1">
+	<LogoButton hover={false} condensed={true}>
+		<span slot="logo">
+			<Avatar name={contact.name} variant="xs" styleClass="md:text-[19.2px]"></Avatar>
+		</span>
 
-	<!--
-		TODO: Render AddressListItems here
-		https://github.com/dfinity/oisy-wallet/pull/6243 
-		-->
-	{#each contact.addresses as address, index (index)}
-		<div class="flex items-center">
-			<div class="grow">ADDRESS: {address.addressType} {address.address} {address.label}</div>
-			<div class="flex gap-2">
-				<Button styleClass="flex-none" on:click={() => onEditAddress(index)}>EDIT</Button>
-				<Button styleClass="flex-none" on:click={() => onDeleteAddress(index)}>DELETE</Button>
-			</div>
-		</div>
-		<Hr />
-	{/each}
+		<span slot="title">
+			{contact.name}
+		</span>
 
-	<!-- TODO Implement proper button here -->
-	<Button ariaLabel="" on:click={onAddAddress}>ADD ADDRESS</Button>
+		<span slot="action">
+			<ButtonIcon
+				styleClass="-m-1 md:m-0 hover:text-primary"
+				ariaLabel={$i18n.core.text.edit}
+				onclick={() => onEdit(contact)}
+				testId={CONTACT_HEADER_EDITING_EDIT_BUTTON}
+			>
+				{#snippet icon()}
+					<IconPencil />
+				{/snippet}
+			</ButtonIcon>
+		</span>
+	</LogoButton>
 
 	<Hr />
 
-	<!-- TODO Implement proper button here -->
-	<Button on:click={() => onDeleteContact(contact.id)}>DELETE CONTACT</Button>
+	{#each contact.addresses as address, index (index)}
+		<AddressListItem
+			{address}
+			hideCopyButton={true}
+			onEdit={() => onEditAddress(index)}
+			onDelete={() => onDeleteAddress(index)}
+		/>
+	{/each}
+
+	<Button
+		styleClass="self-start hover:bg-transparent flex-none px-1"
+		ariaLabel={$i18n.address_book.edit_contact.add_address}
+		colorStyle="tertiary-main-card"
+		disabled={isNullish(onAddAddress)}
+		on:click={() => onAddAddress?.()}
+		testId={CONTACT_EDIT_ADD_ADDRESS_BUTTON}
+	>
+		<span class="flex items-center">
+			<IconPlus />
+		</span>
+		{$i18n.address_book.edit_contact.add_address}
+	</Button>
+
+	<Hr />
+
+	<Button
+		styleClass="self-start text-error-primary hover:bg-transparent flex-none px-1"
+		ariaLabel={$i18n.address_book.edit_contact.delete_contact}
+		colorStyle="tertiary-main-card"
+		on:click={() => onDeleteContact?.(contact.id)}
+		testId={CONTACT_EDIT_DELETE_CONTACT_BUTTON}
+	>
+		<span class="flex items-center">
+			<IconTrash />
+		</span>
+		{$i18n.address_book.edit_contact.delete_contact}
+	</Button>
 
 	<ButtonGroup slot="toolbar">
-		<ButtonCancel onclick={() => onClose()} testId={CONTACT_SHOW_CLOSE_BUTTON}></ButtonCancel>
+		<ButtonCancel onclick={onClose} testId={CONTACT_SHOW_CLOSE_BUTTON}></ButtonCancel>
 	</ButtonGroup>
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/address-book/EditContactStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactStep.svelte
@@ -44,15 +44,15 @@
 
 <ContentWithToolbar styleClass="flex flex-col items-stretch gap-1">
 	<LogoButton hover={false} condensed={true}>
-		<span slot="logo">
+		{#snippet logo()}
 			<Avatar name={contact.name} variant="xs" styleClass="md:text-[19.2px]"></Avatar>
-		</span>
+		{/snippet}
 
-		<span slot="title">
+		{#snippet title()}
 			{contact.name}
-		</span>
+		{/snippet}
 
-		<span slot="action">
+		{#snippet action()}
 			<ButtonIcon
 				styleClass="-m-1 md:m-0 hover:text-primary"
 				ariaLabel={$i18n.core.text.edit}
@@ -63,7 +63,7 @@
 					<IconPencil />
 				{/snippet}
 			</ButtonIcon>
-		</span>
+		{/snippet}
 	</LogoButton>
 
 	<Hr />
@@ -78,31 +78,30 @@
 	{/each}
 
 	<Button
-		styleClass="self-start hover:bg-transparent flex-none px-1"
+		fullWidth
+		alignLeft
 		ariaLabel={$i18n.address_book.edit_contact.add_address}
 		colorStyle="tertiary-main-card"
 		disabled={isNullish(onAddAddress)}
 		on:click={() => onAddAddress?.()}
 		testId={CONTACT_EDIT_ADD_ADDRESS_BUTTON}
 	>
-		<span class="flex items-center">
-			<IconPlus />
-		</span>
+		<IconPlus />
 		{$i18n.address_book.edit_contact.add_address}
 	</Button>
 
 	<Hr />
 
 	<Button
-		styleClass="self-start text-error-primary hover:bg-transparent flex-none px-1"
+		fullWidth
+		alignLeft
+		styleClass="text-error-primary hover:bg-error-light"
 		ariaLabel={$i18n.address_book.edit_contact.delete_contact}
 		colorStyle="tertiary-main-card"
 		on:click={() => onDeleteContact?.(contact.id)}
 		testId={CONTACT_EDIT_DELETE_CONTACT_BUTTON}
 	>
-		<span class="flex items-center">
-			<IconTrash />
-		</span>
+		<IconTrash />
 		{$i18n.address_book.edit_contact.delete_contact}
 	</Button>
 

--- a/src/frontend/src/lib/components/address-book/EditContactStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactStep.svelte
@@ -42,7 +42,7 @@
 	}: Props = $props();
 </script>
 
-<ContentWithToolbar styleClass="flex flex-col items-stretch gap-1">
+<ContentWithToolbar styleClass="flex flex-col gap-1 h-full">
 	<LogoButton hover={false} condensed={true}>
 		{#snippet logo()}
 			<Avatar name={contact.name} variant="xs" styleClass="md:text-[19.2px]"></Avatar>
@@ -71,39 +71,45 @@
 	{#each contact.addresses as address, index (index)}
 		<AddressListItem
 			{address}
-			hideCopyButton={true}
-			onEdit={() => onEditAddress(index)}
-			onDelete={() => onDeleteAddress(index)}
+			addressItemActionsProps={{
+				hideCopyButton: true,
+				onEdit: () => onEditAddress(index),
+				onDelete: () => onDeleteAddress(index)
+			}}
 		/>
 	{/each}
 
-	<Button
-		fullWidth
-		alignLeft
-		ariaLabel={$i18n.address_book.edit_contact.add_address}
-		colorStyle="tertiary-main-card"
-		disabled={isNullish(onAddAddress)}
-		on:click={() => onAddAddress?.()}
-		testId={CONTACT_EDIT_ADD_ADDRESS_BUTTON}
-	>
-		<IconPlus />
-		{$i18n.address_book.edit_contact.add_address}
-	</Button>
+	<div class="flex justify-start">
+		<Button
+			alignLeft
+			ariaLabel={$i18n.address_book.edit_contact.add_address}
+			colorStyle="tertiary-main-card"
+			disabled={isNullish(onAddAddress)}
+			on:click={() => onAddAddress?.()}
+			testId={CONTACT_EDIT_ADD_ADDRESS_BUTTON}
+		>
+			<IconPlus />
+			{$i18n.address_book.edit_contact.add_address}
+		</Button>
+	</div>
 
 	<Hr />
 
-	<Button
-		fullWidth
-		alignLeft
-		styleClass="text-error-primary hover:bg-error-light"
-		ariaLabel={$i18n.address_book.edit_contact.delete_contact}
-		colorStyle="tertiary-main-card"
-		on:click={() => onDeleteContact?.(contact.id)}
-		testId={CONTACT_EDIT_DELETE_CONTACT_BUTTON}
-	>
-		<IconTrash />
-		{$i18n.address_book.edit_contact.delete_contact}
-	</Button>
+	<div class="flex justify-start">
+		<Button
+			alignLeft
+			styleClass="text-error-primary hover:bg-error-light"
+			ariaLabel={$i18n.address_book.edit_contact.delete_contact}
+			colorStyle="tertiary-main-card"
+			on:click={() => onDeleteContact?.(contact.id)}
+			testId={CONTACT_EDIT_DELETE_CONTACT_BUTTON}
+		>
+			<IconTrash />
+			{$i18n.address_book.edit_contact.delete_contact}
+		</Button>
+	</div>
+
+	<div class="flex-grow"></div>
 
 	<ButtonGroup slot="toolbar">
 		<ButtonCancel onclick={onClose} testId={CONTACT_SHOW_CLOSE_BUTTON}></ButtonCancel>

--- a/src/frontend/src/lib/components/contact/AddressListItem.svelte
+++ b/src/frontend/src/lib/components/contact/AddressListItem.svelte
@@ -1,26 +1,27 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
-	import type { ComponentProps } from 'svelte';
 	import IconAddressType from '$lib/components/address/IconAddressType.svelte';
-	import AddressItemActions from '$lib/components/contact/AddressItemActions.svelte';
+	import AddressItemActions, {
+		type Props as AddressItemActionsProps
+	} from '$lib/components/contact/AddressItemActions.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
-	interface AddressListItemProps {
+	interface Props {
 		address: ContactAddressUi;
 		onClick?: () => void;
 		styleClass?: string;
 		showFullAddress?: boolean;
+		addressItemActionsProps?: Omit<AddressItemActionsProps, 'address'>;
 	}
-	type Props = AddressListItemProps & ComponentProps<typeof AddressItemActions>;
 
 	let {
 		address,
 		onClick,
 		styleClass = '',
 		showFullAddress = false,
-		...actionProps
+		addressItemActionsProps
 	}: Props = $props();
 
 	let displayAddress = $derived(
@@ -49,5 +50,5 @@
 			<span>{displayAddress}</span>
 		</div>
 	</div>
-	<AddressItemActions {address} styleClass="ml-auto items-center" {...actionProps} />
+	<AddressItemActions {address} styleClass="ml-auto items-center" {...addressItemActionsProps} />
 </button>

--- a/src/frontend/src/lib/components/contact/AddressListItem.svelte
+++ b/src/frontend/src/lib/components/contact/AddressListItem.svelte
@@ -1,19 +1,27 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
+	import type { ComponentProps } from 'svelte';
 	import IconAddressType from '$lib/components/address/IconAddressType.svelte';
 	import AddressItemActions from '$lib/components/contact/AddressItemActions.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
-	interface Props {
+	interface AddressListItemProps {
 		address: ContactAddressUi;
-		onInfo?: () => void;
 		onClick?: () => void;
 		styleClass?: string;
 		showFullAddress?: boolean;
 	}
-	let { address, onClick, onInfo, styleClass = '', showFullAddress = false }: Props = $props();
+	type Props = AddressListItemProps & ComponentProps<typeof AddressItemActions>;
+
+	let {
+		address,
+		onClick,
+		styleClass = '',
+		showFullAddress = false,
+		...actionProps
+	}: Props = $props();
 
 	let displayAddress = $derived(
 		showFullAddress ? address.address : shortenWithMiddleEllipsis({ text: address.address })
@@ -41,5 +49,5 @@
 			<span>{displayAddress}</span>
 		</div>
 	</div>
-	<AddressItemActions {address} {onInfo} styleClass="ml-auto items-center" />
+	<AddressItemActions {address} styleClass="ml-auto items-center" {...actionProps} />
 </button>

--- a/src/frontend/src/lib/components/contact/ContactCard.svelte
+++ b/src/frontend/src/lib/components/contact/ContactCard.svelte
@@ -106,7 +106,8 @@
 			</div>
 			<div class="flex flex-col gap-1.5 md:pl-20">
 				{#each contact.addresses as address, index (index)}
-					<AddressListItem {address} onInfo={() => onInfo(index)}></AddressListItem>
+					<AddressListItem {address} addressItemActionsProps={{ onInfo: () => onInfo(index) }}
+					></AddressListItem>
 				{/each}
 			</div>
 		</Collapsible>

--- a/src/frontend/src/lib/components/icons/lucide/IconTrash.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconTrash.svelte
@@ -1,0 +1,19 @@
+<!-- source: ISC Lucide - please visit https://lucide.dev/license -->
+<script lang="ts">
+	export const size = '24';
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	><path d="M3 6h18" /><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" /><path
+		d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"
+	/><line x1="10" x2="10" y1="11" y2="17" /><line x1="14" x2="14" y1="11" y2="17" /></svg
+>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -189,11 +189,15 @@ export const ADDRESS_BOOK_CONTACT_NAME_INPUT = 'address-book-contact-name-input'
 export const ADDRESS_BOOK_SAVE_BUTTON = 'address-book-save-button';
 export const ADDRESS_BOOK_CANCEL_BUTTON = 'address-book-cancel-button';
 export const ADDRESS_BOOK_SEARCH_CONTACT_INPUT = 'address-book-search-contact-input';
+export const ADDRESS_EDIT_CANCEL_BUTTON = 'address-edit-cancel-button';
+export const ADDRESS_EDIT_SAVE_BUTTON = 'address-edit-save-button';
 
 export const CONTACT_SHOW_ADD_ADDRESS_BUTTON = 'contact-show-add-address-button';
 export const CONTACT_SHOW_CLOSE_BUTTON = 'contact-show-close-button';
 export const CONTACT_HEADER_EDIT_BUTTON = 'contact-header-edit-button';
 export const CONTACT_HEADER_EDITING_EDIT_BUTTON = 'contact-header-editing-edit-button';
+export const CONTACT_EDIT_ADD_ADDRESS_BUTTON = 'contact-edit-add-address-button';
+export const CONTACT_EDIT_DELETE_CONTACT_BUTTON = 'contact-edit-delete-contact-button';
 
 export const ADDRESS_LIST_ITEM_COPY_BUTTON = 'address-list-item-copy-button';
 export const ADDRESS_LIST_ITEM_INFO_BUTTON = 'address-list-item-info-button';

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1045,6 +1045,10 @@
 			"show_addresses_of_contact": "Show all addresses for contact",
 			"hide_addresses": "Hide addresses of contact"
 		},
+		"edit_contact": {
+			"add_address": "Add address",
+			"delete_contact": "Delete contact"
+		},
 		"show_contact": {
 			"title": "Contact",
 			"add_address": "Add address",
@@ -1054,6 +1058,7 @@
 	},
 	"contact": {
 		"form": {
+			"edit_contact": "Edit contact",
 			"add_new_contact": "Add new contact"
 		},
 		"fields": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -960,6 +960,7 @@ interface I18nAddress_book {
 		no_contact_found: string;
 	};
 	alt: { show_addresses_of_contact: string; hide_addresses: string };
+	edit_contact: { add_address: string; delete_contact: string };
 	show_contact: {
 		title: string;
 		add_address: string;
@@ -969,7 +970,7 @@ interface I18nAddress_book {
 }
 
 interface I18nContact {
-	form: { add_new_contact: string };
+	form: { edit_contact: string; add_new_contact: string };
 	fields: { name: string };
 }
 

--- a/src/frontend/src/tests/lib/components/address-book/EditContactStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditContactStep.spec.ts
@@ -1,0 +1,217 @@
+import EditContactStep from '$lib/components/address-book/EditContactStep.svelte';
+import {
+	CONTACT_EDIT_ADD_ADDRESS_BUTTON,
+	CONTACT_EDIT_DELETE_CONTACT_BUTTON,
+	CONTACT_SHOW_CLOSE_BUTTON
+} from '$lib/constants/test-ids.constants';
+import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
+import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mocks';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render } from '@testing-library/svelte';
+import { vi } from 'vitest';
+
+describe('EditContactStep', () => {
+	const mockAddress1: ContactAddressUi = {
+		address: mockEthAddress,
+		addressType: 'Eth'
+	};
+
+	const mockAddress2: ContactAddressUi = {
+		address: mockEthAddress2,
+		addressType: 'Eth',
+		label: 'My ETH Address'
+	};
+
+	const mockContact: ContactUi = {
+		id: BigInt(1),
+		name: 'Test Contact',
+		addresses: [mockAddress1, mockAddress2],
+		updateTimestampNs: BigInt(Date.now())
+	};
+
+	it('should render the edit contact step with contact information', () => {
+		const onClose = vi.fn();
+		const onEdit = vi.fn();
+		const onEditAddress = vi.fn();
+		const onAddAddress = vi.fn();
+		const onDeleteContact = vi.fn();
+		const onDeleteAddress = vi.fn();
+
+		const { getByText, getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose,
+				onEdit,
+				onEditAddress,
+				onAddAddress,
+				onDeleteContact,
+				onDeleteAddress
+			}
+		});
+
+		// Check that the contact name is displayed
+		expect(getByText('Test Contact')).toBeInTheDocument();
+
+		// Check that the addresses are displayed
+		expect(getByText(`ADDRESS: ${mockEthAddress}`)).toBeInTheDocument();
+		expect(getByText(`ADDRESS: ${mockEthAddress2} My ETH Address`)).toBeInTheDocument();
+
+		// Check that the close button is rendered
+		expect(getByTestId(CONTACT_SHOW_CLOSE_BUTTON)).toBeInTheDocument();
+
+		// Check that the add address button is rendered
+		expect(getByText(en.address_book.edit_contact.add_address)).toBeInTheDocument();
+
+		// Check that the delete contact button is rendered
+		expect(getByText(en.address_book.edit_contact.delete_contact)).toBeInTheDocument();
+	});
+
+	it('should call onClose when close button is clicked', async () => {
+		const onClose = vi.fn();
+		const onEdit = vi.fn();
+
+		const { getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose,
+				onEdit
+			}
+		});
+
+		// Click the close button
+		const closeButton = getByTestId(CONTACT_SHOW_CLOSE_BUTTON);
+		await fireEvent.click(closeButton);
+
+		// Check that onClose was called
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call onEdit when contact header is clicked', async () => {
+		const onEdit = vi.fn();
+
+		const { getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: vi.fn(),
+				onEdit
+			}
+		});
+
+		// Click the contact header edit button
+		const editButton = getByTestId('contact-header-editing-edit-button');
+		await fireEvent.click(editButton);
+
+		// Check that onEdit was called with the contact
+		expect(onEdit).toHaveBeenCalledTimes(1);
+		expect(onEdit).toHaveBeenCalledWith(mockContact);
+	});
+
+	it('should call onEditAddress when edit button for an address is clicked', async () => {
+		const onEditAddress = vi.fn();
+		const onEdit = vi.fn();
+
+		const { getAllByText } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: vi.fn(),
+				onEdit,
+				onEditAddress
+			}
+		});
+
+		// Click the edit button for the first address
+		const editButtons = getAllByText('Edit');
+		await fireEvent.click(editButtons[0]);
+
+		// Check that onEditAddress was called with the address
+		expect(onEditAddress).toHaveBeenCalledTimes(1);
+		expect(onEditAddress).toHaveBeenCalledWith(mockAddress1);
+	});
+
+	it('should call deleteAddress when delete button for an address is clicked', async () => {
+		const onDeleteAddress = vi.fn();
+		const onEdit = vi.fn();
+
+		const { getAllByText } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: vi.fn(),
+				onEdit,
+				onDeleteAddress
+			}
+		});
+
+		// Click the delete button for the first address
+		const deleteButtons = getAllByText('Delete');
+		await fireEvent.click(deleteButtons[0]);
+
+		// Check that deleteAddress was called with the address index
+		expect(onDeleteAddress).toHaveBeenCalledTimes(1);
+		expect(onDeleteAddress).toHaveBeenCalledWith(0);
+	});
+
+	it('should call onAddAddress when add address button is clicked', async () => {
+		const onAddAddress = vi.fn();
+		const onEdit = vi.fn();
+
+		const { getByText } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: vi.fn(),
+				onEdit,
+				onAddAddress
+			}
+		});
+
+		// Click the add address button
+		const addButton = getByText(en.address_book.edit_contact.add_address);
+		await fireEvent.click(addButton);
+
+		// Check that onAddAddress was called
+		expect(onAddAddress).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call onDeleteContact when delete contact button is clicked', async () => {
+		const onDeleteContact = vi.fn();
+		const onEdit = vi.fn();
+
+		const { getByText } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: vi.fn(),
+				onEdit,
+				onDeleteContact
+			}
+		});
+
+		// Click the delete contact button
+		const deleteButton = getByText(en.address_book.edit_contact.delete_contact);
+		await fireEvent.click(deleteButton);
+
+		// Check that onDeleteContact was called with the contact id
+		expect(onDeleteContact).toHaveBeenCalledTimes(1);
+		expect(onDeleteContact).toHaveBeenCalledWith(mockContact.id);
+	});
+
+	it('should disable buttons when corresponding functions are not provided', () => {
+		const onEdit = vi.fn();
+
+		const { getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: vi.fn(),
+				onEdit
+			}
+		});
+
+		// Check that the add address button is disabled
+		const addButton = getByTestId(CONTACT_EDIT_ADD_ADDRESS_BUTTON);
+
+		expect(addButton).toBeDisabled();
+
+		// Check that the delete contact button is disabled
+		const deleteButton = getByTestId(CONTACT_EDIT_DELETE_CONTACT_BUTTON);
+
+		expect(deleteButton).toBeDisabled();
+	});
+});

--- a/src/frontend/src/tests/lib/components/address-book/EditContactStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditContactStep.spec.ts
@@ -1,217 +1,209 @@
 import EditContactStep from '$lib/components/address-book/EditContactStep.svelte';
 import {
+	ADDRESS_LIST_ITEM_DELETE_BUTTON,
+	ADDRESS_LIST_ITEM_EDIT_BUTTON,
 	CONTACT_EDIT_ADD_ADDRESS_BUTTON,
 	CONTACT_EDIT_DELETE_CONTACT_BUTTON,
+	CONTACT_HEADER_EDITING_EDIT_BUTTON,
 	CONTACT_SHOW_CLOSE_BUTTON
 } from '$lib/constants/test-ids.constants';
-import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
-import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mocks';
+import type { ContactUi } from '$lib/types/contact';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 import { vi } from 'vitest';
 
 describe('EditContactStep', () => {
-	const mockAddress1: ContactAddressUi = {
-		address: mockEthAddress,
-		addressType: 'Eth'
-	};
-
-	const mockAddress2: ContactAddressUi = {
-		address: mockEthAddress2,
-		addressType: 'Eth',
-		label: 'My ETH Address'
-	};
-
 	const mockContact: ContactUi = {
-		id: BigInt(1),
+		id: 1n,
 		name: 'Test Contact',
-		addresses: [mockAddress1, mockAddress2],
+		addresses: [
+			{
+				address: mockEthAddress,
+				label: 'My ETH Address',
+				addressType: 'Eth'
+			},
+			{
+				address: mockBtcAddress,
+				label: 'My BTC Address',
+				addressType: 'Btc'
+			}
+		],
 		updateTimestampNs: BigInt(Date.now())
 	};
 
-	it('should render the edit contact step with contact information', () => {
-		const onClose = vi.fn();
-		const onEdit = vi.fn();
-		const onEditAddress = vi.fn();
-		const onAddAddress = vi.fn();
-		const onDeleteContact = vi.fn();
-		const onDeleteAddress = vi.fn();
+	const mockClose = vi.fn();
+	const mockEdit = vi.fn();
+	const mockEditAddress = vi.fn();
+	const mockAddAddress = vi.fn();
+	const mockDeleteContact = vi.fn();
+	const mockDeleteAddress = vi.fn();
 
-		const { getByText, getByTestId } = render(EditContactStep, {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should render the contact name and addresses', () => {
+		const { getByText } = render(EditContactStep, {
 			props: {
 				contact: mockContact,
-				onClose,
-				onEdit,
-				onEditAddress,
-				onAddAddress,
-				onDeleteContact,
-				onDeleteAddress
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
 			}
 		});
 
 		// Check that the contact name is displayed
-		expect(getByText('Test Contact')).toBeInTheDocument();
+		expect(getByText(mockContact.name)).toBeInTheDocument();
 
-		// Check that the addresses are displayed
-		expect(getByText(`ADDRESS: ${mockEthAddress}`)).toBeInTheDocument();
-		expect(getByText(`ADDRESS: ${mockEthAddress2} My ETH Address`)).toBeInTheDocument();
-
-		// Check that the close button is rendered
-		expect(getByTestId(CONTACT_SHOW_CLOSE_BUTTON)).toBeInTheDocument();
-
-		// Check that the add address button is rendered
-		expect(getByText(en.address_book.edit_contact.add_address)).toBeInTheDocument();
-
-		// Check that the delete contact button is rendered
-		expect(getByText(en.address_book.edit_contact.delete_contact)).toBeInTheDocument();
+		// Check that addresses are displayed
+		expect(getByText(en.address.types.Eth)).toBeInTheDocument();
+		expect(getByText('My ETH Address')).toBeInTheDocument();
+		expect(getByText(en.address.types.Btc)).toBeInTheDocument();
+		expect(getByText('My BTC Address')).toBeInTheDocument();
 	});
 
-	it('should call onClose when close button is clicked', async () => {
-		const onClose = vi.fn();
-		const onEdit = vi.fn();
-
+	it('should call edit function when edit button is clicked', async () => {
 		const { getByTestId } = render(EditContactStep, {
 			props: {
 				contact: mockContact,
-				onClose,
-				onEdit
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
 			}
 		});
 
-		// Click the close button
+		const editButton = getByTestId(CONTACT_HEADER_EDITING_EDIT_BUTTON);
+		await fireEvent.click(editButton);
+
+		expect(mockEdit).toHaveBeenCalledTimes(1);
+		expect(mockEdit).toHaveBeenCalledWith(mockContact);
+	});
+
+	it('should call addAddress function when add address button is clicked', async () => {
+		const { getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
+			}
+		});
+
+		const addAddressButton = getByTestId(CONTACT_EDIT_ADD_ADDRESS_BUTTON);
+		await fireEvent.click(addAddressButton);
+
+		expect(mockAddAddress).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call deleteContact function when delete contact button is clicked', async () => {
+		const { getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
+			}
+		});
+
+		const deleteContactButton = getByTestId(CONTACT_EDIT_DELETE_CONTACT_BUTTON);
+		await fireEvent.click(deleteContactButton);
+
+		expect(mockDeleteContact).toHaveBeenCalledTimes(1);
+		expect(mockDeleteContact).toHaveBeenCalledWith(mockContact.id);
+	});
+
+	it('should call close function when close button is clicked', async () => {
+		const { getByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
+			}
+		});
+
 		const closeButton = getByTestId(CONTACT_SHOW_CLOSE_BUTTON);
 		await fireEvent.click(closeButton);
 
-		// Check that onClose was called
-		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(mockClose).toHaveBeenCalledTimes(1);
 	});
 
-	it('should call onEdit when contact header is clicked', async () => {
-		const onEdit = vi.fn();
+	it('should call editAddress function when edit address button is clicked', async () => {
+		const { getAllByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
+			}
+		});
 
+		const editAddressButtons = getAllByTestId(ADDRESS_LIST_ITEM_EDIT_BUTTON);
+
+		// Click the first edit address button
+		await fireEvent.click(editAddressButtons[0]);
+
+		expect(mockEditAddress).toHaveBeenCalledTimes(1);
+		expect(mockEditAddress).toHaveBeenCalledWith(0);
+	});
+
+	it('should call deleteAddress function when delete address button is clicked', async () => {
+		const { getAllByTestId } = render(EditContactStep, {
+			props: {
+				contact: mockContact,
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: mockAddAddress,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
+			}
+		});
+
+		const deleteAddressButtons = getAllByTestId(ADDRESS_LIST_ITEM_DELETE_BUTTON);
+
+		// Click the first delete address button
+		await fireEvent.click(deleteAddressButtons[0]);
+
+		expect(mockDeleteAddress).toHaveBeenCalledTimes(1);
+		expect(mockDeleteAddress).toHaveBeenCalledWith(0);
+	});
+
+	it('should disable add address button when onAddAddress is not provided', () => {
 		const { getByTestId } = render(EditContactStep, {
 			props: {
 				contact: mockContact,
-				onClose: vi.fn(),
-				onEdit
+				onClose: mockClose,
+				onEdit: mockEdit,
+				onEditAddress: mockEditAddress,
+				onAddAddress: null as unknown as () => void,
+				onDeleteContact: mockDeleteContact,
+				onDeleteAddress: mockDeleteAddress
 			}
 		});
 
-		// Click the contact header edit button
-		const editButton = getByTestId('contact-header-editing-edit-button');
-		await fireEvent.click(editButton);
+		const addAddressButton = getByTestId(CONTACT_EDIT_ADD_ADDRESS_BUTTON);
 
-		// Check that onEdit was called with the contact
-		expect(onEdit).toHaveBeenCalledTimes(1);
-		expect(onEdit).toHaveBeenCalledWith(mockContact);
-	});
-
-	it('should call onEditAddress when edit button for an address is clicked', async () => {
-		const onEditAddress = vi.fn();
-		const onEdit = vi.fn();
-
-		const { getAllByText } = render(EditContactStep, {
-			props: {
-				contact: mockContact,
-				onClose: vi.fn(),
-				onEdit,
-				onEditAddress
-			}
-		});
-
-		// Click the edit button for the first address
-		const editButtons = getAllByText('Edit');
-		await fireEvent.click(editButtons[0]);
-
-		// Check that onEditAddress was called with the address
-		expect(onEditAddress).toHaveBeenCalledTimes(1);
-		expect(onEditAddress).toHaveBeenCalledWith(mockAddress1);
-	});
-
-	it('should call deleteAddress when delete button for an address is clicked', async () => {
-		const onDeleteAddress = vi.fn();
-		const onEdit = vi.fn();
-
-		const { getAllByText } = render(EditContactStep, {
-			props: {
-				contact: mockContact,
-				onClose: vi.fn(),
-				onEdit,
-				onDeleteAddress
-			}
-		});
-
-		// Click the delete button for the first address
-		const deleteButtons = getAllByText('Delete');
-		await fireEvent.click(deleteButtons[0]);
-
-		// Check that deleteAddress was called with the address index
-		expect(onDeleteAddress).toHaveBeenCalledTimes(1);
-		expect(onDeleteAddress).toHaveBeenCalledWith(0);
-	});
-
-	it('should call onAddAddress when add address button is clicked', async () => {
-		const onAddAddress = vi.fn();
-		const onEdit = vi.fn();
-
-		const { getByText } = render(EditContactStep, {
-			props: {
-				contact: mockContact,
-				onClose: vi.fn(),
-				onEdit,
-				onAddAddress
-			}
-		});
-
-		// Click the add address button
-		const addButton = getByText(en.address_book.edit_contact.add_address);
-		await fireEvent.click(addButton);
-
-		// Check that onAddAddress was called
-		expect(onAddAddress).toHaveBeenCalledTimes(1);
-	});
-
-	it('should call onDeleteContact when delete contact button is clicked', async () => {
-		const onDeleteContact = vi.fn();
-		const onEdit = vi.fn();
-
-		const { getByText } = render(EditContactStep, {
-			props: {
-				contact: mockContact,
-				onClose: vi.fn(),
-				onEdit,
-				onDeleteContact
-			}
-		});
-
-		// Click the delete contact button
-		const deleteButton = getByText(en.address_book.edit_contact.delete_contact);
-		await fireEvent.click(deleteButton);
-
-		// Check that onDeleteContact was called with the contact id
-		expect(onDeleteContact).toHaveBeenCalledTimes(1);
-		expect(onDeleteContact).toHaveBeenCalledWith(mockContact.id);
-	});
-
-	it('should disable buttons when corresponding functions are not provided', () => {
-		const onEdit = vi.fn();
-
-		const { getByTestId } = render(EditContactStep, {
-			props: {
-				contact: mockContact,
-				onClose: vi.fn(),
-				onEdit
-			}
-		});
-
-		// Check that the add address button is disabled
-		const addButton = getByTestId(CONTACT_EDIT_ADD_ADDRESS_BUTTON);
-
-		expect(addButton).toBeDisabled();
-
-		// Check that the delete contact button is disabled
-		const deleteButton = getByTestId(CONTACT_EDIT_DELETE_CONTACT_BUTTON);
-
-		expect(deleteButton).toBeDisabled();
+		expect(addAddressButton).toBeDisabled();
 	});
 });

--- a/src/frontend/src/tests/lib/components/contact/AddressListItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/contact/AddressListItem.spec.ts
@@ -136,7 +136,7 @@ describe('AddressListItem', () => {
 		const { getByTestId } = render(AddressListItem, {
 			props: {
 				address: icrcAddress,
-				onInfo
+				addressItemActionsProps: { onInfo }
 			},
 			context: mockContext
 		});


### PR DESCRIPTION
# Motivation

Adds the contact edit step where the user will be able to manage addresses, delete the contact and jump to the contact form to modify the name.

# Changes

- Adds contact edit step
- Adds additional tests

# Demo

Note: The delete confirmation is not yet implemented.

[vokoscreenNG-2025-05-26_10-11-41.webm](https://github.com/user-attachments/assets/e7adb884-3d08-42fe-8826-61c0e986d3d3)
