### PR TITLE
feat(frontend): reset all values on sendToken change

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -85,15 +85,19 @@
 		})
 	);
 
+	const reset = () => {
+		destination = '';
+		amount = undefined;
+		targetNetwork = undefined;
+
+		sendProgressStep = ProgressStepsSend.INITIALIZATION;
+
+		currentStep = undefined;
+	};
+
 	const close = () =>
 		closeModal(() => {
-			destination = '';
-			amount = undefined;
-			targetNetwork = undefined;
-
-			sendProgressStep = ProgressStepsSend.INITIALIZATION;
-
-			currentStep = undefined;
+			reset();
 
 			dispatch('nnsClose');
 		});
@@ -127,7 +131,7 @@
 		}
 
 		const callback = async () => {
-			destination = '';
+			reset();
 
 			goToStep(WizardStepsSend.DESTINATION);
 


### PR DESCRIPTION
# Motivation

We need to reset all values (not only `destination`) when user updates a token to send.
