### PR TITLE
feat(frontend): loads campaign eligibilities with reward service

### DIFF
--- a/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
+++ b/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
@@ -21,6 +21,7 @@
 	} from '$lib/stores/reward.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { isEndedCampaign, isOngoingCampaign, isUpcomingCampaign } from '$lib/utils/rewards.utils';
+	import {getCampaignEligibilities} from "$lib/services/reward.services";
 
 	const { store } = setContext<RewardEligibilityContext>(REWARD_ELIGIBILITY_CONTEXT_KEY, {
 		store: initRewardEligibilityStore()
@@ -32,8 +33,8 @@
 			return;
 		}
 
-		// TODO load campaign eligibilities from reward service
-		store.setCampaignEligibilities([]);
+		const campaignEligibilities = await getCampaignEligibilities({ identity: $authIdentity });
+		store.setCampaignEligibilities(campaignEligibilities);
 	};
 
 	onMount(loadEligibilityReport);

--- a/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
+++ b/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
@@ -13,6 +13,7 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { RewardStates } from '$lib/enums/reward-states';
 	import { nullishSignOut } from '$lib/services/auth.services';
+	import { getCampaignEligibilities } from '$lib/services/reward.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		initRewardEligibilityStore,
@@ -21,7 +22,6 @@
 	} from '$lib/stores/reward.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { isEndedCampaign, isOngoingCampaign, isUpcomingCampaign } from '$lib/utils/rewards.utils';
-	import {getCampaignEligibilities} from "$lib/services/reward.services";
 
 	const { store } = setContext<RewardEligibilityContext>(REWARD_ELIGIBILITY_CONTEXT_KEY, {
 		store: initRewardEligibilityStore()


### PR DESCRIPTION
# Motivation

Now the `reward service` does provide a function to load the campaign eligibility data and we want to use it to write the data to our reward store.

# Changes

- loads eligibility data

