### PR TITLE
refactor(frontend): opens the RewardModal in the AllRewardsList

### DIFF
--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -6,7 +6,6 @@
 	import DappModalDetails from '$lib/components/dapps/DappModalDetails.svelte';
 	import VipQrCodeModal from '$lib/components/qr/VipQrCodeModal.svelte';
 	import ReferralCodeModal from '$lib/components/referral/ReferralCodeModal.svelte';
-	import RewardModal from '$lib/components/rewards/RewardModal.svelte';
 	import SettingsModal from '$lib/components/settings/SettingsModal.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import {
@@ -14,12 +13,10 @@
 		modalHideToken,
 		modalIcHideToken,
 		modalVipQrCode,
-		modalRewardDetails,
 		modalSettingsState,
 		modalReferralCode,
 		modalAddressBook,
-		modalVipQrCodeData,
-		modalRewardDetailsData
+		modalVipQrCodeData
 	} from '$lib/derived/modal.derived';
 
 	/**
@@ -34,8 +31,6 @@
 		<IcHideTokenModal />
 	{:else if $modalDAppDetails}
 		<DappModalDetails />
-	{:else if $modalRewardDetails && nonNullish($modalRewardDetailsData)}
-		<RewardModal reward={$modalRewardDetailsData} />
 	{:else if $modalVipQrCode && nonNullish($modalVipQrCodeData)}
 		<VipQrCodeModal codeType={$modalVipQrCodeData} />
 	{:else if $modalSettingsState}

--- a/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
+++ b/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import {isNullish, nonNullish} from '@dfinity/utils';
 	import { onMount, setContext } from 'svelte';
 	import { rewardCampaigns } from '$env/reward-campaigns.env';
 	import type { RewardDescription } from '$env/types/env-reward';
@@ -22,6 +22,8 @@
 	} from '$lib/stores/reward.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { isEndedCampaign, isOngoingCampaign, isUpcomingCampaign } from '$lib/utils/rewards.utils';
+	import {modalRewardDetails, modalRewardDetailsData} from "$lib/derived/modal.derived";
+	import RewardModal from "$lib/components/rewards/RewardModal.svelte";
 
 	const store = initRewardEligibilityStore();
 	setContext(REWARD_ELIGIBILITY_CONTEXT_KEY, initRewardEligibilityContext(store));
@@ -69,4 +71,8 @@
 	/>
 {:else if selectedRewardState === RewardStates.ENDED}
 	<RewardsGroup rewards={endedCampaigns} testId={REWARDS_ENDED_CAMPAIGNS_CONTAINER} />
+{/if}
+
+{#if $modalRewardDetails && nonNullish($modalRewardDetailsData)}
+	<RewardModal reward={$modalRewardDetailsData} />
 {/if}


### PR DESCRIPTION
# Motivation

To be able to use the `reward store` and its context from the `AllRewardsList` in the `RewardModal`, we need to open the modal in the `AllRewardsList` instead of the `Modals` component.

# Changes

- opens `RewardModal` in the `AllRewardsList`

