### PR TITLE
fix(devops): Fix dfx settings for staging

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -129,7 +129,7 @@ concurrency:
 permissions: {}
 
 env:
-  DFX_WARNING=-mainnet_plaintext_identity
+  DFX_WARNING: '-mainnet_plaintext_identity'
 
 jobs:
   deployment:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -128,6 +128,9 @@ concurrency:
 
 permissions: {}
 
+env:
+  DFX_WARNING=-mainnet_plaintext_identity
+
 jobs:
   deployment:
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -334,7 +334,7 @@ jobs:
         run: |
           key_pem=$(mktemp)
           printenv "DFX_DEPLOY_KEY" > "$key_pem"
-          dfx identity import --disable-encryption --force default "$key_pem"
+          dfx identity import --storage-mode=plaintext --force default "$key_pem"
           rm "$key_pem"
           dfx identity use default
           dfx identity get-principal


### PR DESCRIPTION
# Motivation
The updated dfx does not deploy to staging.  There is one env var that is now required to use a plaintext key, and one of the flags we use is now deprecated.

# Changes
- Update the dfx configuration.

# Tests
Deployment to fe5: https://github.com/dfinity/oisy-wallet/actions/runs/14998375156