### PR TITLE
refactor(frontend): removes unused CampaignCriterion attributes

### DIFF
--- a/src/frontend/src/lib/types/reward.ts
+++ b/src/frontend/src/lib/types/reward.ts
@@ -54,9 +54,6 @@ export interface CampaignEligibility {
 export interface CampaignCriterion {
 	satisfied: boolean;
 	type: RewardCriterionType;
-	days?: bigint;
-	count?: number;
-	usd?: number;
 }
 
 export interface MinLoginsCriterion extends CampaignCriterion {


### PR DESCRIPTION
# Motivation

When the types `MinLoginsCriterion`, `MinTransactionsCriterion` and `MinTotalAssetsUsdCriterion` were added, i forgot to remove the unused attributes from the type `CampaignCriterion`.

# Changes

- removes unused attributes
