### PR TITLE
feat(frontend): update KnownDestinations stores

### DIFF
--- a/src/frontend/src/eth/derived/eth-transactions.derived.ts
+++ b/src/frontend/src/eth/derived/eth-transactions.derived.ts
@@ -5,7 +5,9 @@ import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import { toCkMinterInfoAddresses } from '$icp-eth/utils/cketh.utils';
 import { ethAddress } from '$lib/derived/address.derived';
 import { tokenWithFallback } from '$lib/derived/token.derived';
-import type { Transaction } from '$lib/types/transaction';
+import { tokens } from '$lib/derived/tokens.derived';
+import type { TokenId } from '$lib/types/token';
+import type { AnyTransactionUiWithToken, Transaction } from '$lib/types/transaction';
 import type { KnownDestinations } from '$lib/types/transactions';
 import { getKnownDestinations } from '$lib/utils/transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -51,8 +53,8 @@ export const ethTransactionsNotInitialized: Readable<boolean> = derived(
 );
 
 export const ethKnownDestinations: Readable<KnownDestinations> = derived(
-	[sortedEthTransactions, ckEthMinterInfoStore, ethereumTokenId, ethAddress],
-	([$sortedEthTransactions, $ckEthMinterInfoStore, $ethereumTokenId, $ethAddress]) => {
+	[ethTransactionsStore, ckEthMinterInfoStore, ethereumTokenId, ethAddress, tokens],
+	([$ethTransactionsStore, $ckEthMinterInfoStore, $ethereumTokenId, $ethAddress, $tokens]) => {
 		const ckMinterInfoAddresses = toCkMinterInfoAddresses(
 			$ckEthMinterInfoStore?.[$ethereumTokenId]
 		);
@@ -61,13 +63,23 @@ export const ethKnownDestinations: Readable<KnownDestinations> = derived(
 			return {};
 		}
 
-		const mappedTransactions = $sortedEthTransactions.map((transaction) =>
-			mapEthTransactionUi({
-				transaction,
-				ckMinterInfoAddresses,
-				$ethAddress
-			})
-		);
+		const mappedTransactions: AnyTransactionUiWithToken[] = [];
+		Object.getOwnPropertySymbols($ethTransactionsStore ?? {}).forEach((tokenId) => {
+			const token = $tokens.find(({ id }) => id === tokenId);
+
+			if (nonNullish(token)) {
+				$ethTransactionsStore[tokenId as TokenId].forEach((transaction) => {
+					mappedTransactions.push({
+						...mapEthTransactionUi({
+							transaction,
+							ckMinterInfoAddresses,
+							$ethAddress
+						}),
+						token
+					});
+				});
+			}
+		});
 
 		return getKnownDestinations(mappedTransactions);
 	}

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -72,6 +72,10 @@ export type AnyTransactionUi =
 	| IcTransactionUi
 	| SolTransactionUi;
 
+export type AnyTransactionUiWithToken = AnyTransactionUi & {
+	token: Token;
+};
+
 export type AnyTransactionUiWithCmp =
 	| { component: 'bitcoin'; transaction: BtcTransactionUi }
 	| { component: 'ethereum'; transaction: EthTransactionUi }

--- a/src/frontend/src/lib/types/transactions.ts
+++ b/src/frontend/src/lib/types/transactions.ts
@@ -15,4 +15,6 @@ export interface TransactionsStoreCheckParams {
 	tokens: Token[];
 }
 
-export type KnownDestinations = Record<Address, { amounts: bigint[]; timestamp?: number }>;
+export type KnownDestination = { amounts: { value: bigint; token: Token }[]; timestamp?: number };
+
+export type KnownDestinations = Record<Address, KnownDestination>;

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -24,7 +24,11 @@ import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';
-import type { AllTransactionUiWithCmp, AnyTransactionUi } from '$lib/types/transaction';
+import type {
+	AllTransactionUiWithCmp,
+	AnyTransactionUi,
+	AnyTransactionUiWithToken
+} from '$lib/types/transaction';
 import type { KnownDestinations, TransactionsStoreCheckParams } from '$lib/types/transactions';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
@@ -287,9 +291,11 @@ export const areTransactionsStoresLoading = (
 	return (someNullish || someNotInitialized) && allEmpty;
 };
 
-export const getKnownDestinations = (transactions: AnyTransactionUi[]): KnownDestinations =>
+export const getKnownDestinations = (
+	transactions: AnyTransactionUiWithToken[]
+): KnownDestinations =>
 	transactions.reduce<KnownDestinations>(
-		(acc, { timestamp, value, to, type }) =>
+		(acc, { timestamp, value, to, type, token }) =>
 			nonNullish(to) && type === 'send' && nonNullish(value) && value > ZERO
 				? {
 						...acc,
@@ -297,7 +303,10 @@ export const getKnownDestinations = (transactions: AnyTransactionUi[]): KnownDes
 							(innerAcc, address) => ({
 								...innerAcc,
 								[address]: {
-									amounts: [...(nonNullish(acc[address]) ? acc[address].amounts : []), value],
+									amounts: [
+										...(nonNullish(acc[address]) ? acc[address].amounts : []),
+										{ value, token }
+									],
 									timestamp:
 										nonNullish(acc[address]?.timestamp) && nonNullish(timestamp)
 											? Math.max(Number(acc[address].timestamp), Number(timestamp))

--- a/src/frontend/src/sol/derived/sol-transactions.derived.ts
+++ b/src/frontend/src/sol/derived/sol-transactions.derived.ts
@@ -1,4 +1,7 @@
 import { tokenWithFallback } from '$lib/derived/token.derived';
+import { tokens } from '$lib/derived/tokens.derived';
+import type { TokenId } from '$lib/types/token';
+import type { AnyTransactionUiWithToken } from '$lib/types/transaction';
 import type { KnownDestinations } from '$lib/types/transactions';
 import { getKnownDestinations } from '$lib/utils/transactions.utils';
 import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
@@ -23,6 +26,22 @@ export const solTransactionsNotInitialized: Readable<boolean> = derived(
 );
 
 export const solKnownDestinations: Readable<KnownDestinations> = derived(
-	[solTransactions],
-	([$solTransactions]) => getKnownDestinations($solTransactions)
+	[solTransactionsStore, tokens],
+	([$solTransactionsStore, $tokens]) => {
+		const mappedTransactions: AnyTransactionUiWithToken[] = [];
+		Object.getOwnPropertySymbols($solTransactionsStore ?? {}).forEach((tokenId) => {
+			const token = $tokens.find(({ id }) => id === tokenId);
+
+			if (nonNullish(token)) {
+				($solTransactionsStore?.[tokenId as TokenId] ?? []).forEach(({ data }) => {
+					mappedTransactions.push({
+						...data,
+						token
+					});
+				});
+			}
+		});
+
+		return getKnownDestinations(mappedTransactions);
+	}
 );

--- a/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
@@ -84,7 +84,7 @@ describe('btc-transactions.derived', () => {
 		});
 	});
 
-	describe('solKnownDestinations', () => {
+	describe('btcKnownDestinations', () => {
 		const transactions = [
 			{
 				certified: true,
@@ -109,7 +109,10 @@ describe('btc-transactions.derived', () => {
 
 			expect(get(btcKnownDestinations)).toEqual({
 				[transactions[0].data.to?.[0] ?? '']: {
-					amounts: transactions.map(({ data }) => data.value),
+					amounts: transactions.map(({ data }) => ({
+						value: data.value,
+						token: BTC_MAINNET_TOKEN
+					})),
 					timestamp: Number(transactions[0].data.timestamp)
 				}
 			});

--- a/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
+import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ethKnownDestinations } from '$eth/derived/eth-transactions.derived';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
@@ -39,7 +39,7 @@ describe('eth-transactions.derived', () => {
 
 			expect(get(ethKnownDestinations)).toEqual({
 				[transactions[0].to as string]: {
-					amounts: transactions.map(({ value }) => value),
+					amounts: transactions.map(({ value }) => ({ value, token: ETHEREUM_TOKEN })),
 					timestamp: Number(transactions[0].timestamp)
 				}
 			});

--- a/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
@@ -164,7 +164,7 @@ describe('ic-transactions.derived', () => {
 			icTransactionsStore.reset(ICP_TOKEN_ID);
 		});
 
-		it('should return known destinations if transactions store has some data', () => {
+		it('should return known destinations for ICP if transactions store has some data', () => {
 			token.set(ICP_TOKEN);
 			icTransactionsStore.append({
 				tokenId: ICP_TOKEN_ID,
@@ -175,7 +175,7 @@ describe('ic-transactions.derived', () => {
 
 			expect(get(icKnownDestinations)).toEqual({
 				[transactions[0].data.to as string]: {
-					amounts: transactions.map(({ data }) => data.value),
+					amounts: transactions.map(({ data }) => ({ value: data.value, token: ICP_TOKEN })),
 					timestamp: maxTimestamp
 				}
 			});

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1088,10 +1088,13 @@ describe('transactions.utils', () => {
 
 	describe('getKnownDestinations', () => {
 		it('should correctly return a single known destinations', () => {
-			const icTransactionsUi = createMockIcTransactionsUi(7);
+			const icTransactionsUi = createMockIcTransactionsUi(7).map((transaction) => ({
+				...transaction,
+				token: ICP_TOKEN
+			}));
 			const expectedIcKnownDestinations = {
 				[icTransactionsUi[0].to as string]: {
-					amounts: icTransactionsUi.map(({ value }) => value),
+					amounts: icTransactionsUi.map(({ value, token }) => ({ value, token })),
 					timestamp: Number(icTransactionsUi[0].timestamp)
 				}
 			};
@@ -1100,19 +1103,23 @@ describe('transactions.utils', () => {
 		});
 
 		it('should correctly return multiple known destinations', () => {
-			const [icTransactionsUi1] = createMockIcTransactionsUi(1);
+			const icTransactionsUi1 = {
+				...createMockIcTransactionsUi(1)[0],
+				token: ICP_TOKEN
+			};
 			const icTransactionsUi2 = {
 				...createMockIcTransactionsUi(1)[0],
+				token: ICP_TOKEN,
 				to: icTransactionsUi1.from
 			};
 
 			expect(getKnownDestinations([icTransactionsUi1, icTransactionsUi2])).toEqual({
 				[icTransactionsUi1.to as string]: {
-					amounts: [icTransactionsUi1.value],
+					amounts: [{ value: icTransactionsUi1.value, token: icTransactionsUi1.token }],
 					timestamp: Number(icTransactionsUi1.timestamp)
 				},
 				[icTransactionsUi2.to as string]: {
-					amounts: [icTransactionsUi2.value],
+					amounts: [{ value: icTransactionsUi2.value, token: icTransactionsUi2.token }],
 					timestamp: Number(icTransactionsUi2.timestamp)
 				}
 			});
@@ -1123,16 +1130,17 @@ describe('transactions.utils', () => {
 			const btcTransactionsUi = {
 				...mockTransaction,
 				type: 'send' as BtcTransactionType,
-				to: [mockTransaction.to, mockTransaction.from] as string[]
+				to: [mockTransaction.to, mockTransaction.from] as string[],
+				token: BTC_MAINNET_TOKEN
 			};
 
 			expect(getKnownDestinations([btcTransactionsUi])).toEqual({
 				[btcTransactionsUi.to[0] as string]: {
-					amounts: [btcTransactionsUi.value],
+					amounts: [{ value: btcTransactionsUi.value, token: btcTransactionsUi.token }],
 					timestamp: Number(btcTransactionsUi.timestamp)
 				},
 				[btcTransactionsUi.to[1] as string]: {
-					amounts: [btcTransactionsUi.value],
+					amounts: [{ value: btcTransactionsUi.value, token: btcTransactionsUi.token }],
 					timestamp: Number(btcTransactionsUi.timestamp)
 				}
 			});
@@ -1142,12 +1150,13 @@ describe('transactions.utils', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(
 				({ timestamp, ...rest }, index) => ({
 					...rest,
-					timestamp: (timestamp ?? ZERO) + BigInt(index)
+					timestamp: (timestamp ?? ZERO) + BigInt(index),
+					token: ICP_TOKEN
 				})
 			);
 			const expectedIcKnownDestinations = {
 				[icTransactionsUi[0].to as string]: {
-					amounts: icTransactionsUi.map(({ value }) => value),
+					amounts: icTransactionsUi.map(({ value, token }) => ({ value, token })),
 					timestamp: Number(icTransactionsUi[icTransactionsUi.length - 1].timestamp)
 				}
 			};
@@ -1158,6 +1167,7 @@ describe('transactions.utils', () => {
 		it('should correctly return an empty array if all txs do not have values', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(({ value: _, ...rest }) => ({
 				...rest,
+				token: ICP_TOKEN,
 				value: undefined
 			}));
 
@@ -1167,6 +1177,7 @@ describe('transactions.utils', () => {
 		it('should correctly return an empty array if all txs have zero values', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(({ value: _, ...rest }) => ({
 				...rest,
+				token: ICP_TOKEN,
 				value: ZERO
 			}));
 
@@ -1176,6 +1187,7 @@ describe('transactions.utils', () => {
 		it('should correctly return an empty array if all txs are receive', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(({ type: _, ...rest }) => ({
 				...rest,
+				token: ICP_TOKEN,
 				type: 'receive' as IcTransactionType
 			}));
 

--- a/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
@@ -138,7 +138,7 @@ describe('sol-transactions.derived', () => {
 
 			expect(get(solKnownDestinations)).toEqual({
 				[transactions[0].data.to as string]: {
-					amounts: transactions.map(({ data }) => data.value),
+					amounts: transactions.map(({ data }) => ({ value: data.value, token: SOLANA_TOKEN })),
 					timestamp: Number(transactions[0].data.timestamp)
 				}
 			});


### PR DESCRIPTION
# Motivation

We need to update the KnownDestinations stores according to the new specs. ]

Note: there are a few differences in txs stores that do not allow us to easily re-use the code inside `knownDestinations` derived.
