### PR TITLE
feat(frontend): update KnownDestinations utils

### DIFF
--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -72,6 +72,10 @@ export type AnyTransactionUi =
 	| IcTransactionUi
 	| SolTransactionUi;
 
+export type AnyTransactionUiWithToken = AnyTransactionUi & {
+	token: Token;
+};
+
 export type AnyTransactionUiWithCmp =
 	| { component: 'bitcoin'; transaction: BtcTransactionUi }
 	| { component: 'ethereum'; transaction: EthTransactionUi }

--- a/src/frontend/src/lib/types/transactions.ts
+++ b/src/frontend/src/lib/types/transactions.ts
@@ -15,4 +15,6 @@ export interface TransactionsStoreCheckParams {
 	tokens: Token[];
 }
 
-export type KnownDestinations = Record<Address, { amounts: bigint[]; timestamp?: number }>;
+export type KnownDestination = { amounts: { value: bigint; token: Token }[]; timestamp?: number };
+
+export type KnownDestinations = Record<Address, KnownDestination>;

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -24,7 +24,11 @@ import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';
-import type { AllTransactionUiWithCmp, AnyTransactionUi } from '$lib/types/transaction';
+import type {
+	AllTransactionUiWithCmp,
+	AnyTransactionUi,
+	AnyTransactionUiWithToken
+} from '$lib/types/transaction';
 import type { KnownDestinations, TransactionsStoreCheckParams } from '$lib/types/transactions';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
@@ -287,9 +291,11 @@ export const areTransactionsStoresLoading = (
 	return (someNullish || someNotInitialized) && allEmpty;
 };
 
-export const getKnownDestinations = (transactions: AnyTransactionUi[]): KnownDestinations =>
+export const getKnownDestinations = (
+	transactions: AnyTransactionUiWithToken[]
+): KnownDestinations =>
 	transactions.reduce<KnownDestinations>(
-		(acc, { timestamp, value, to, type }) =>
+		(acc, { timestamp, value, to, type, token }) =>
 			nonNullish(to) && type === 'send' && nonNullish(value) && value > ZERO
 				? {
 						...acc,
@@ -297,7 +303,10 @@ export const getKnownDestinations = (transactions: AnyTransactionUi[]): KnownDes
 							(innerAcc, address) => ({
 								...innerAcc,
 								[address]: {
-									amounts: [...(nonNullish(acc[address]) ? acc[address].amounts : []), value],
+									amounts: [
+										...(nonNullish(acc[address]) ? acc[address].amounts : []),
+										{ value, token }
+									],
 									timestamp:
 										nonNullish(acc[address]?.timestamp) && nonNullish(timestamp)
 											? Math.max(Number(acc[address].timestamp), Number(timestamp))

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1088,10 +1088,13 @@ describe('transactions.utils', () => {
 
 	describe('getKnownDestinations', () => {
 		it('should correctly return a single known destinations', () => {
-			const icTransactionsUi = createMockIcTransactionsUi(7);
+			const icTransactionsUi = createMockIcTransactionsUi(7).map((transaction) => ({
+				...transaction,
+				token: ICP_TOKEN
+			}));
 			const expectedIcKnownDestinations = {
 				[icTransactionsUi[0].to as string]: {
-					amounts: icTransactionsUi.map(({ value }) => value),
+					amounts: icTransactionsUi.map(({ value, token }) => ({ value, token })),
 					timestamp: Number(icTransactionsUi[0].timestamp)
 				}
 			};
@@ -1100,19 +1103,23 @@ describe('transactions.utils', () => {
 		});
 
 		it('should correctly return multiple known destinations', () => {
-			const [icTransactionsUi1] = createMockIcTransactionsUi(1);
+			const icTransactionsUi1 = {
+				...createMockIcTransactionsUi(1)[0],
+				token: ICP_TOKEN
+			};
 			const icTransactionsUi2 = {
 				...createMockIcTransactionsUi(1)[0],
+				token: ICP_TOKEN,
 				to: icTransactionsUi1.from
 			};
 
 			expect(getKnownDestinations([icTransactionsUi1, icTransactionsUi2])).toEqual({
 				[icTransactionsUi1.to as string]: {
-					amounts: [icTransactionsUi1.value],
+					amounts: [{ value: icTransactionsUi1.value, token: icTransactionsUi1.token }],
 					timestamp: Number(icTransactionsUi1.timestamp)
 				},
 				[icTransactionsUi2.to as string]: {
-					amounts: [icTransactionsUi2.value],
+					amounts: [{ value: icTransactionsUi2.value, token: icTransactionsUi2.token }],
 					timestamp: Number(icTransactionsUi2.timestamp)
 				}
 			});
@@ -1123,16 +1130,17 @@ describe('transactions.utils', () => {
 			const btcTransactionsUi = {
 				...mockTransaction,
 				type: 'send' as BtcTransactionType,
-				to: [mockTransaction.to, mockTransaction.from] as string[]
+				to: [mockTransaction.to, mockTransaction.from] as string[],
+				token: BTC_MAINNET_TOKEN
 			};
 
 			expect(getKnownDestinations([btcTransactionsUi])).toEqual({
 				[btcTransactionsUi.to[0] as string]: {
-					amounts: [btcTransactionsUi.value],
+					amounts: [{ value: btcTransactionsUi.value, token: btcTransactionsUi.token }],
 					timestamp: Number(btcTransactionsUi.timestamp)
 				},
 				[btcTransactionsUi.to[1] as string]: {
-					amounts: [btcTransactionsUi.value],
+					amounts: [{ value: btcTransactionsUi.value, token: btcTransactionsUi.token }],
 					timestamp: Number(btcTransactionsUi.timestamp)
 				}
 			});
@@ -1142,12 +1150,13 @@ describe('transactions.utils', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(
 				({ timestamp, ...rest }, index) => ({
 					...rest,
-					timestamp: (timestamp ?? ZERO) + BigInt(index)
+					timestamp: (timestamp ?? ZERO) + BigInt(index),
+					token: ICP_TOKEN
 				})
 			);
 			const expectedIcKnownDestinations = {
 				[icTransactionsUi[0].to as string]: {
-					amounts: icTransactionsUi.map(({ value }) => value),
+					amounts: icTransactionsUi.map(({ value, token }) => ({ value, token })),
 					timestamp: Number(icTransactionsUi[icTransactionsUi.length - 1].timestamp)
 				}
 			};
@@ -1158,6 +1167,7 @@ describe('transactions.utils', () => {
 		it('should correctly return an empty array if all txs do not have values', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(({ value: _, ...rest }) => ({
 				...rest,
+				token: ICP_TOKEN,
 				value: undefined
 			}));
 
@@ -1167,6 +1177,7 @@ describe('transactions.utils', () => {
 		it('should correctly return an empty array if all txs have zero values', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(({ value: _, ...rest }) => ({
 				...rest,
+				token: ICP_TOKEN,
 				value: ZERO
 			}));
 
@@ -1176,6 +1187,7 @@ describe('transactions.utils', () => {
 		it('should correctly return an empty array if all txs are receive', () => {
 			const icTransactionsUi = createMockIcTransactionsUi(7).map(({ type: _, ...rest }) => ({
 				...rest,
+				token: ICP_TOKEN,
 				type: 'receive' as IcTransactionType
 			}));
 


### PR DESCRIPTION
# Motivation

We need to update the KnownDestinations utils according to the new specs - the addresses should be grouped based on networks, and not only based on a single token.

<img width="603" alt="Screenshot 2025-05-13 at 16 53 25" src="https://github.com/user-attachments/assets/0cf5ccca-6614-479d-99b1-9e493f7668a7" />
