### PR TITLE
fix(devops): never lower the vitest coverage thresholds

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -35,8 +35,47 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
 
+      - name: Save current thresholds
+        run: cp vitest.config.ts vitest.config.before.ts
+
       - name: Test
         run: npm run test:coverage
+
+      - name: Update thresholds only if increased
+        run: |
+          node -e "
+          const fs = require('fs');
+          
+          const file = 'vitest.config.ts';
+          const current = fs.readFileSync(file, 'utf8');
+          const original = fs.readFileSync('vitest.config.before.ts', 'utf8');
+          
+          const extractThresholds = (text) => {
+            const map = {};
+            for (const match of text.matchAll(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g)) {
+             map[match[1]] = parseFloat(match[2]);
+            }
+            return map;
+          };
+          
+          const originalThresholds = extractThresholds(original);
+          const updatedThresholds = extractThresholds(current);
+          
+          const updated = current.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
+            const oldValue = originalThresholds[key];
+            const newValue = updatedThresholds[key];
+            if (newValue > oldValue) {
+             return \`\${key}: \${newValue.toFixed(2)}\`;
+            } else {
+             return \`\${key}: \${oldValue.toFixed(2)}\`;
+            }
+          });
+          
+          fs.writeFileSync(file, updated);
+          "
+
+      - name: Remove old thresholds file
+        run: rm vitest.config.before.ts
 
       # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
       - name: Reduce coverage thresholds by 0.50%

--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
+      # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
+      - name: Reduce coverage thresholds by 0.50%
+        run: |
+          node -e "
+          const fs = require('fs');
+          const file = 'vitest.config.ts';
+          const text = fs.readFileSync(file, 'utf8');
+          const updated = text.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
+            const reduced = (parseFloat(value) - 0.5).toFixed(2);
+            return \`\${key}: \${reduced}\`;
+          });
+          fs.writeFileSync(file, updated);
+          "
+      # The coverage thresholds should never decrease
       - name: Update thresholds only if increased
         run: |
           node -e "
@@ -76,20 +90,6 @@ jobs:
 
       - name: Remove old thresholds file
         run: rm vitest.config.before.ts
-
-      # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
-      - name: Reduce coverage thresholds by 0.50%
-        run: |
-          node -e "
-          const fs = require('fs');
-          const file = 'vitest.config.ts';
-          const text = fs.readFileSync(file, 'utf8');
-          const updated = text.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
-            const reduced = (parseFloat(value) - 0.5).toFixed(2);
-            return \`\${key}: \${reduced}\`;
-          });
-          fs.writeFileSync(file, updated);
-          "
 
       # To avoid a high frequency of PRs, we remove the decimals from the coverage thresholds
       - name: Floor coverage thresholds (remove decimals)


### PR DESCRIPTION
# Motivation

We want to avoid that the CI workflow decreases the vitest coverage thresholds, so we create a step that compares with the old values and takes the biggest.
