### PR TITLE
feat(frontend): removes defined sprinkles carousel card

### DIFF
--- a/src/frontend/src/env/reward-campaigns.env.ts
+++ b/src/frontend/src/env/reward-campaigns.env.ts
@@ -6,4 +6,4 @@ import * as z from 'zod';
 const parseResult = z.array(RewardEventsSchema).safeParse(rewardCampaignsJson);
 export const rewardCampaigns: RewardDescription[] = parseResult.success ? parseResult.data : [];
 
-export const FEATURED_REWARD_CAROUSEL_SLIDE_ID = 'OISY Airdrop #1';
+export const FEATURED_REWARD_CAROUSEL_SLIDE_ID = undefined;


### PR DESCRIPTION
# Motivation

The `Season 3 Episode 1 sprinkles` are no longer new, so we don't want to show them in the carousel anymore. They will be added back once `Season 4` is released.

# Changes

- removes `sprinkles` carousel card.

