### PR TITLE
feat(frontend): updated logic and store for swap Amount

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
-	import { getContext } from 'svelte';
-	import { kongSwapAmounts } from '$lib/api/kong_backend.api';
+	import { getContext, type Snippet } from 'svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
@@ -10,17 +9,22 @@
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
 	import type { OptionAmount } from '$lib/types/send';
-	import type { Token } from '$lib/types/token';
-	import { parseToken } from '$lib/utils/parse.utils';
-	import { getLiquidityFees, getNetworkFee, getSwapRoute } from '$lib/utils/swap.utils';
+	import type { IcToken } from '$icp/types/ic-token';
+	import { fetchSwapAmounts } from '$lib/services/swap.services';
+	import { SWAP_DEFAULT_SLIPPAGE_VALUE } from '$lib/constants/swap.constants';
 
-	export let amount: OptionAmount = undefined;
-	export let sourceToken: Token | undefined;
-	export let destinationToken: Token | undefined;
+	interface Props {
+		amount: OptionAmount;
+		sourceToken: IcToken | undefined;
+		destinationToken: IcToken | undefined;
+		slippageValue: OptionAmount;
+		children: Snippet;
+	}
 
 	const { store } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
-	// TODO: add tests for this context
+	let { amount, sourceToken, destinationToken, slippageValue, children }: Props = $props();
+
 	const loadSwapAmounts = async () => {
 		if (isNullish($authIdentity)) {
 			await nullishSignOut();
@@ -41,42 +45,41 @@
 		}
 
 		try {
-			const swapAmounts = await kongSwapAmounts({
+			const swapAmounts = await fetchSwapAmounts({
 				identity: $authIdentity,
 				sourceToken,
 				destinationToken,
-				sourceAmount: parseToken({
-					value: `${amount}`,
-					unitName: sourceToken.decimals
-				})
+				amount,
+				tokens: $tokens,
+				slippage: slippageValue || SWAP_DEFAULT_SLIPPAGE_VALUE
 			});
 
-			if (isNullish(swapAmounts)) {
+			if (swapAmounts.length === 0) {
 				store.reset();
 				return;
 			}
 
-			store.setSwapAmounts({
-				swapAmounts: {
-					slippage: swapAmounts.slippage,
-					receiveAmount: swapAmounts.receive_amount,
-					route: getSwapRoute(swapAmounts.txs ?? []),
-					liquidityFees: getLiquidityFees({ transactions: swapAmounts.txs ?? [], tokens: $tokens }),
-					networkFee: getNetworkFee({ transactions: swapAmounts.txs ?? [], tokens: $tokens })
-				},
-				amountForSwap: parsedAmount
+			store.setSwaps({
+				swaps: swapAmounts,
+				amountForSwap: parsedAmount,
+				selectedProvider: swapAmounts[0]
 			});
 		} catch (_err: unknown) {
-			// if kongSwapAmounts fails, it means no pool is currently available for the provided tokens
-			store.setSwapAmounts({
-				swapAmounts: null,
-				amountForSwap: parsedAmount
+			store.setSwaps({
+				swaps: [],
+				amountForSwap: parsedAmount,
+				selectedProvider: undefined
 			});
 		}
 	};
+
 	const debounceLoadSwapAmounts = debounce(loadSwapAmounts);
 
-	$: amount, sourceToken, destinationToken, debounceLoadSwapAmounts();
+	$effect(() => {
+		[amount, sourceToken, destinationToken, slippageValue];
+
+		debounceLoadSwapAmounts();
+	});
 </script>
 
-<slot />
+{@render children()}

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -4,7 +4,6 @@
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
-	import type SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
 	import SwapWizard from '$lib/components/swap/SwapWizard.svelte';
 	import { swapWizardSteps } from '$lib/config/swap.config';
@@ -19,7 +18,10 @@
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
-	import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
+	import {
+		SWAP_AMOUNTS_CONTEXT_KEY,
+		type SwapAmountsContext
+	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext, initSwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapSelectTokenType } from '$lib/types/swap';

--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -1,96 +1,101 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { getContext } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import { dAppDescriptions } from '$env/dapp-descriptions.env';
-	import SwapLiquidityFees from '$lib/components/swap/SwapLiquidityFees.svelte';
-	import SwapNetworkFee from '$lib/components/swap/SwapNetworkFee.svelte';
-	import SwapRoute from '$lib/components/swap/SwapRoute.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
-	import ModalExpandableValues from '$lib/components/ui/ModalExpandableValues.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		SWAP_AMOUNTS_CONTEXT_KEY,
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
-	import type { OisyDappDescription } from '$lib/types/dapp-description';
-	import type { OptionString } from '$lib/types/string';
-	import type { ProviderFee } from '$lib/types/swap';
-	import type { Option } from '$lib/types/utils';
+	import { SwapProvider } from '$lib/types/swap';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { UrlSchema } from '$lib/validation/url.validation';
-	import { safeParse } from '$lib/validation/utils.validation';
+	import SwapDetailsKong from '$lib/components/swap/SwapDetailsKongSwap.svelte';
+	import SwapDetailsIcp from '$lib/components/swap/SwapDetailsIcp.svelte';
+	import CollapsibleBottomSheet from '$lib/components/ui/CollapsibleBottomSheet.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import SwapBestRateBadge from './SwapBestRateBadge.svelte';
 
 	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
-	let route: string[] | undefined;
-	$: route = $swapAmountsStore?.swapAmounts?.route;
-
-	let networkFee: ProviderFee | undefined;
-	$: networkFee = $swapAmountsStore?.swapAmounts?.networkFee;
-
-	let liquidityFees: ProviderFee[] | undefined;
-	$: liquidityFees = $swapAmountsStore?.swapAmounts?.liquidityFees;
-
-	const kongSwapDApp: OisyDappDescription | undefined = dAppDescriptions.find(
-		({ id }) => id === 'kongswap'
+	let displayURL: string | null = $state(null);
+	const selectedProvider = $derived($swapAmountsStore?.selectedProvider);
+	const isBestRate = $derived(selectedProvider?.provider === $swapAmountsStore?.swaps[0]?.provider);
+	const swapDApp = $derived(
+		dAppDescriptions.find(
+			({ id }) => id === $swapAmountsStore?.selectedProvider?.provider.toLowerCase()
+		)
 	);
 
-	// TODO: this state - websiteURL - isn't one and should become a local variable
-	let websiteURL: Option<URL>;
-	let displayURL: OptionString;
-	$: if (nonNullish(kongSwapDApp)) {
-		try {
-			const validatedWebsiteUrl = safeParse({
-				schema: UrlSchema,
-				value: kongSwapDApp?.website
-			});
-			if (nonNullish(validatedWebsiteUrl)) {
-				websiteURL = new URL(validatedWebsiteUrl);
-				displayURL = websiteURL.hostname.startsWith('www.')
-					? websiteURL.hostname.substring(4)
-					: websiteURL.hostname;
+	$effect(() => {
+		if (nonNullish(swapDApp)) {
+			const parsed = UrlSchema.safeParse(swapDApp.website);
+			if (parsed.success) {
+				const url = new URL(parsed.data);
+				displayURL = url.hostname.startsWith('www.') ? url.hostname.slice(4) : url.hostname;
+				return;
 			}
-		} catch (_err: unknown) {
-			websiteURL = null;
 			displayURL = null;
 		}
-	}
+	});
+	const dispatch = createEventDispatcher();
 </script>
 
-{#if nonNullish(kongSwapDApp)}
-	<ModalExpandableValues>
-		<ModalValue slot="list-header">
-			<svelte:fragment slot="label">{$i18n.swap.text.swap_provider}</svelte:fragment>
-
-			<svelte:fragment slot="main-value">
-				<div class="flex gap-2">
-					<div class="mt-1">
-						<Logo
-							src={kongSwapDApp.logo}
-							alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: kongSwapDApp.name })}
-						/>
-					</div>
-					<div class="mr-auto">
-						<div class="text-lg font-bold">{kongSwapDApp.name}</div>
-						{#if nonNullish(displayURL)}
-							<div class="text-sm text-tertiary">{displayURL}</div>
+{#if nonNullish(swapDApp) && nonNullish(selectedProvider) && nonNullish($swapAmountsStore)}
+	<CollapsibleBottomSheet showContentHeader>
+		{#snippet contentHeader({ isInBottomSheet })}
+			<ModalValue wrapperStyleClass="items-center">
+				<svelte:fragment slot="label">
+					<div class="flex justify-center gap-2">
+						{$i18n.swap.text.swap_provider}
+						{#if $swapAmountsStore?.swaps.length > 1 && !isInBottomSheet}
+							<Button link on:click={() => dispatch('icShowProviderList')}
+								>{$i18n.swap.text.select}</Button
+							>
 						{/if}
 					</div>
-				</div>
-			</svelte:fragment>
-		</ModalValue>
+				</svelte:fragment>
 
-		<svelte:fragment slot="list-items">
-			{#if nonNullish(route) && route.length > 0}
-				<SwapRoute {route} />
+				<svelte:fragment slot="main-value">
+					<div class="flex items-start gap-3">
+						{#if isBestRate && $swapAmountsStore?.swaps.length > 1}
+							<SwapBestRateBadge />
+						{/if}
+						<div class="flex gap-2">
+							<div class="mt-1">
+								<Logo
+									src={swapDApp.logo}
+									alt={replacePlaceholders($i18n.dapps.alt.logo, { $dAppName: swapDApp.name })}
+								/>
+							</div>
+							<div class="mr-auto">
+								<div class="text-lg font-bold">{swapDApp.name}</div>
+							</div>
+						</div>
+					</div>
+				</svelte:fragment>
+			</ModalValue>
+		{/snippet}
+		{#snippet content()}
+			{#if displayURL}
+				<ModalValue>
+					<svelte:fragment slot="label">Website</svelte:fragment>
+
+					<svelte:fragment slot="main-value">
+						<div class="text-sm">{displayURL}</div>
+					</svelte:fragment>
+				</ModalValue>
 			{/if}
-			{#if nonNullish(networkFee)}
-				<SwapNetworkFee {networkFee} />
+			{#if selectedProvider.provider === SwapProvider.KONG_SWAP}
+				<SwapDetailsKong provider={selectedProvider} />
+			{:else if selectedProvider.provider === SwapProvider.ICP_SWAP}
+				<SwapDetailsIcp provider={selectedProvider} />
 			{/if}
-			{#if nonNullish(liquidityFees) && liquidityFees.length > 0}
-				<SwapLiquidityFees {liquidityFees} />
-			{/if}
-		</svelte:fragment>
-	</ModalExpandableValues>
+		{/snippet}
+		{#snippet contentFooter(closeFn)}
+			<Button fullWidth on:click={closeFn}>Done</Button>
+		{/snippet}
+	</CollapsibleBottomSheet>
 {/if}

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -2,9 +2,10 @@
 	import type { WizardStep } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
-	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
-	import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
-	import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
+	import {
+		IC_TOKEN_FEE_CONTEXT_KEY,
+		type IcTokenFeeContext as IcTokenFeeContextType
+	} from '$icp/stores/ic-token-fee.store';
 	import SwapForm from '$lib/components/swap/SwapForm.svelte';
 	import SwapProgress from '$lib/components/swap/SwapProgress.svelte';
 	import SwapReview from '$lib/components/swap/SwapReview.svelte';
@@ -19,34 +20,49 @@
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { swap as swapService } from '$lib/services/swap.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
+	import {
+		SWAP_AMOUNTS_CONTEXT_KEY,
+		type SwapAmountsContext as SwapAmountsContextType
+	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
+	import SwapAmountsContext from './SwapAmountsContext.svelte';
+	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
+	interface Props {
+		swapAmount: OptionAmount;
+		receiveAmount: number | undefined;
+		slippageValue: OptionAmount;
+		swapProgressStep: string;
+		currentStep: WizardStep | undefined;
+	}
 
-	export let swapAmount: OptionAmount;
-	export let receiveAmount: number | undefined;
-	export let slippageValue: OptionAmount;
-	export let swapProgressStep: string;
-	export let currentStep: WizardStep | undefined;
+	let {
+		swapAmount = $bindable<OptionAmount>(),
+		receiveAmount = $bindable<number | undefined>(),
+		slippageValue = $bindable<OptionAmount>(),
+		swapProgressStep = $bindable<string>(),
+		currentStep
+	}: Props = $props();
 
 	const { sourceToken, destinationToken, isSourceTokenIcrc2, failedSwapError } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
+	const { store: swapAmountsStore } = getContext<SwapAmountsContextType>(SWAP_AMOUNTS_CONTEXT_KEY);
 
-	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
+	const { store: icTokenFeeStore } = getContext<IcTokenFeeContextType>(IC_TOKEN_FEE_CONTEXT_KEY);
 
 	const progress = (step: ProgressStepsSwap) => (swapProgressStep = step);
 
 	const dispatch = createEventDispatcher();
 
-	let sourceTokenFee: bigint | undefined;
-	$: sourceTokenFee = nonNullish($sourceToken)
-		? $icTokenFeeStore?.[$sourceToken.symbol]
-		: undefined;
+	let sourceTokenFee: bigint | undefined = $state();
+
+	$effect(() => {
+		sourceTokenFee = nonNullish($sourceToken) ? $icTokenFeeStore?.[$sourceToken.symbol] : undefined;
+	});
 
 	const swap = async () => {
 		if (isNullish($authIdentity)) {
@@ -60,7 +76,7 @@
 			isNullish(slippageValue) ||
 			isNullish(swapAmount) ||
 			isNullish(sourceTokenFee) ||
-			isNullish($swapAmountsStore?.swapAmounts?.receiveAmount)
+			isNullish($swapAmountsStore?.selectedProvider?.receiveAmount)
 		) {
 			toastsError({
 				msg: { text: $i18n.swap.error.unexpected_missing_data }
@@ -79,7 +95,7 @@
 				sourceToken: $sourceToken,
 				destinationToken: $destinationToken,
 				swapAmount,
-				receiveAmount: $swapAmountsStore.swapAmounts.receiveAmount,
+				receiveAmount: $swapAmountsStore.selectedProvider?.receiveAmount,
 				slippageValue,
 				sourceTokenFee,
 				isSourceTokenIcrc2: $isSourceTokenIcrc2
@@ -137,22 +153,23 @@
 		amount={swapAmount}
 		sourceToken={$sourceToken}
 		destinationToken={$destinationToken}
+		{slippageValue}
 	>
-		{#if currentStep?.name === WizardStepsSwap.SWAP}
-			<SwapForm
-				on:icClose
-				on:icNext
-				on:icShowTokensList
-				bind:swapAmount
-				bind:receiveAmount
-				bind:slippageValue
-			/>
-		{:else if currentStep?.name === WizardStepsSwap.REVIEW}
-			<SwapReview on:icSwap={swap} on:icBack {slippageValue} {swapAmount} {receiveAmount} />
-		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
-			<SwapProgress bind:swapProgressStep />
-		{:else}
-			<slot />
-		{/if}
+		{#snippet children()}
+			{#if currentStep?.name === WizardStepsSwap.SWAP}
+				<SwapForm
+					on:icClose
+					on:icNext
+					on:icShowTokensList
+					bind:swapAmount
+					bind:receiveAmount
+					bind:slippageValue
+				/>
+			{:else if currentStep?.name === WizardStepsSwap.REVIEW}
+				<SwapReview on:icSwap={swap} on:icBack {slippageValue} {swapAmount} {receiveAmount} />
+			{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
+				<SwapProgress bind:swapProgressStep />
+			{/if}
+		{/snippet}
 	</SwapAmountsContext>
 </IcTokenFeeContext>

--- a/src/frontend/src/lib/components/ui/ModalValue.svelte
+++ b/src/frontend/src/lib/components/ui/ModalValue.svelte
@@ -3,9 +3,13 @@
 
 	export let ref: undefined | string = undefined;
 	export let labelStyleClass: string | undefined = undefined;
+	export let wrapperStyleClass: string | undefined = undefined;
 </script>
 
-<div in:fade class="mb-2 flex w-full justify-between last:mb-0 md:items-center">
+<div
+	in:fade
+	class={`mb-2 flex w-full justify-between last:mb-0 md:items-center ${wrapperStyleClass}`}
+>
 	<label for={ref} class={`mr-1 text-sm text-tertiary sm:mr-2 ${labelStyleClass}`}
 		><slot name="label" /></label
 	>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -592,7 +592,8 @@
 			"included_network_fees": "Included network fees",
 			"included_liquidity_fees": "Included liquidity pool fees",
 			"best_rate": "Best Rate",
-			"expected_minimum": "Expected minimum"
+			"expected_minimum": "Expected minimum",
+			"select": "Select >"
 		},
 		"error": {
 			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",

--- a/src/frontend/src/lib/stores/swap-amounts.store.ts
+++ b/src/frontend/src/lib/stores/swap-amounts.store.ts
@@ -1,29 +1,26 @@
-import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import type { OptionAmount } from '$lib/types/send';
-import type { ProviderFee } from '$lib/types/swap';
+import type { SwapMappedResult } from '$lib/types/swap';
 import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
-export type SwapAmountsStoreData = Option<{
-	swapAmounts?: {
-		slippage: SwapAmountsReply['slippage'];
-		receiveAmount: SwapAmountsReply['receive_amount'];
-		route: string[];
-		liquidityFees: ProviderFee[];
-		networkFee: ProviderFee | undefined;
-	} | null;
-	// We need to save the inputted amount for which swap-amounts have been already fetched.
-	// It allows us to compare it with the new value to prevent a re-fetch on consumer component re-render.
-	amountForSwap?: OptionAmount;
-}>;
+export interface SwapAmountsStoreData {
+	swaps: SwapMappedResult[];
+	amountForSwap: OptionAmount;
+	selectedProvider?: SwapMappedResult;
+}
 
-export interface SwapAmountsStore extends Readable<SwapAmountsStoreData> {
-	setSwapAmounts: (data: SwapAmountsStoreData) => void;
+export interface SwapAmountsStore extends Readable<Option<SwapAmountsStoreData>> {
+	setSwaps: (params: {
+		swaps: SwapMappedResult[];
+		amountForSwap: OptionAmount;
+		selectedProvider?: SwapMappedResult;
+	}) => void;
 	reset: () => void;
+	setSelectedProvider: (provider: SwapMappedResult | undefined) => void;
 }
 
 export const initSwapAmountsStore = (): SwapAmountsStore => {
-	const { subscribe, set } = writable<SwapAmountsStoreData>(undefined);
+	const { subscribe, set, update } = writable<Option<SwapAmountsStoreData>>(undefined);
 
 	return {
 		subscribe,
@@ -32,8 +29,21 @@ export const initSwapAmountsStore = (): SwapAmountsStore => {
 			set(null);
 		},
 
-		setSwapAmounts: (data: SwapAmountsStoreData) => {
-			set(data);
+		setSwaps: ({ swaps, amountForSwap, selectedProvider }) => {
+			set({
+				swaps,
+				amountForSwap,
+				selectedProvider
+			});
+		},
+
+		setSelectedProvider: (provider) => {
+			update((data) => {
+				if (!data) {
+					return data;
+				}
+				return { ...data, selectedProvider: provider };
+			});
 		}
 	};
 };

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -561,6 +561,7 @@ interface I18nSwap {
 		included_liquidity_fees: string;
 		best_rate: string;
 		expected_minimum: string;
+		select: string;
 	};
 	error: {
 		kong_not_available: string;

--- a/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
@@ -1,0 +1,158 @@
+import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
+import type { IcToken } from '$icp/types/ic-token';
+import SwapAmountsContext from '$lib/components/swap/SwapAmountsContext.svelte';
+import * as authStore from '$lib/derived/auth.derived';
+import * as tokensStore from '$lib/derived/tokens.derived';
+import * as authServices from '$lib/services/auth.services';
+import * as swapService from '$lib/services/swap.services';
+import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
+import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
+import type { OptionAmount } from '$lib/types/send';
+import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { MOCK_SWAP_PROVIDERS } from '$tests/mocks/swap.mocks';
+import { act, render } from '@testing-library/svelte';
+import { tick, type Snippet } from 'svelte';
+import { get, readable, writable } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fakeSnippet: Snippet = (() => {}) as Snippet;
+
+type SwapAmountsContextProps = {
+	amount: OptionAmount;
+	sourceToken: IcToken | undefined;
+	destinationToken: IcToken | undefined;
+	slippageValue: OptionAmount;
+};
+
+describe('SwapAmountsContext.svelte', () => {
+	const [sourceToken, destinationToken] = [mockValidIcToken, mockValidIcCkToken] as IcToken[];
+
+	let context: Map<symbol, unknown>;
+	let store: ReturnType<typeof initSwapAmountsStore>;
+
+	const renderWithContext = async (componentProps: SwapAmountsContextProps) => {
+		await act(() =>
+			render(SwapAmountsContext, {
+				props: {
+					...componentProps,
+					children: fakeSnippet
+				},
+				context
+			})
+		);
+
+		await tick();
+		await new Promise((resolve) => setTimeout(resolve, 350));
+	};
+
+	beforeEach(() => {
+		store = initSwapAmountsStore();
+
+		context = new Map([
+			[
+				SWAP_CONTEXT_KEY,
+				{
+					sourceToken: readable(sourceToken),
+					destinationToken: readable(destinationToken),
+					isSourceTokenIcrc2: readable(true),
+					failedSwapError: writable(undefined)
+				}
+			],
+			[SWAP_AMOUNTS_CONTEXT_KEY, { store }],
+			[
+				IC_TOKEN_FEE_CONTEXT_KEY,
+				{
+					store: readable({
+						[sourceToken.symbol]: 1000n
+					})
+				}
+			]
+		]);
+
+		vi.spyOn(authStore, 'authIdentity', 'get').mockImplementation(() => readable(mockIdentity));
+		vi.spyOn(tokensStore, 'tokens', 'get').mockImplementation(() =>
+			readable([sourceToken, destinationToken])
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('calls nullishSignOut when authIdentity is null', async () => {
+		const signOutSpy = vi.spyOn(authServices, 'nullishSignOut').mockResolvedValue();
+		vi.spyOn(authStore, 'authIdentity', 'get').mockImplementation(() => readable(null));
+
+		await renderWithContext({
+			amount: '100',
+			sourceToken,
+			destinationToken,
+			slippageValue: '0.5'
+		});
+
+		expect(signOutSpy).toHaveBeenCalled();
+	});
+
+	it('resets store when amount is undefined', async () => {
+		await renderWithContext({
+			amount: undefined,
+			sourceToken,
+			destinationToken,
+			slippageValue: '0.3'
+		});
+
+		expect(get(store)).toBeNull();
+	});
+
+	it('resets store when fetchSwapAmounts returns empty', async () => {
+		vi.spyOn(swapService, 'fetchSwapAmounts').mockResolvedValue([]);
+
+		await renderWithContext({
+			amount: '15',
+			sourceToken,
+			destinationToken,
+			slippageValue: '0.1'
+		});
+
+		expect(get(store)).toBeNull();
+	});
+
+	it('sets swaps when fetchSwapAmounts succeeds', async () => {
+		const fetchMock = vi
+			.spyOn(swapService, 'fetchSwapAmounts')
+			.mockResolvedValue(MOCK_SWAP_PROVIDERS);
+
+		await renderWithContext({
+			amount: '10',
+			sourceToken,
+			destinationToken,
+			slippageValue: '0.3'
+		});
+
+		expect(fetchMock).toHaveBeenCalled();
+
+		const value = get(store);
+
+		expect(value?.swaps).toEqual(MOCK_SWAP_PROVIDERS);
+		expect(value?.selectedProvider).toEqual(MOCK_SWAP_PROVIDERS[0]);
+		expect(value?.amountForSwap).toBe(10);
+	});
+
+	it('sets empty swaps if fetchSwapAmounts throws', async () => {
+		vi.spyOn(swapService, 'fetchSwapAmounts').mockRejectedValue(new Error('fail'));
+
+		await renderWithContext({
+			amount: '20',
+			sourceToken,
+			destinationToken,
+			slippageValue: '0.2'
+		});
+
+		const value = get(store);
+
+		expect(value?.swaps).toEqual([]);
+		expect(value?.selectedProvider).toBeUndefined();
+		expect(value?.amountForSwap).toBe(20);
+	});
+});

--- a/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
@@ -13,20 +13,17 @@ import {
 } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { MOCK_SWAP_PROVIDERS } from '$tests/mocks/swap.mocks';
 import { fireEvent, render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('SwapForm', () => {
 	const mockContext = new Map();
+
 	const mockSwapAmounts: SwapAmountsStoreData = {
 		amountForSwap: 1,
-		swapAmounts: {
-			slippage: 0,
-			receiveAmount: 2000000n,
-			route: [],
-			liquidityFees: [],
-			networkFee: undefined
-		}
+		swaps: MOCK_SWAP_PROVIDERS,
+		selectedProvider: MOCK_SWAP_PROVIDERS[0]
 	};
 
 	beforeEach(() => {
@@ -49,11 +46,12 @@ describe('SwapForm', () => {
 	const setupSwapAmountsStore = (swapAmounts?: SwapAmountsStoreData) => {
 		const swapAmountsStore = initSwapAmountsStore();
 		if (swapAmounts) {
-			swapAmountsStore.setSwapAmounts(swapAmounts);
+			swapAmountsStore.setSwaps(swapAmounts);
 		}
 		mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: swapAmountsStore });
 		return swapAmountsStore;
 	};
+
 	const setupIcTokenFeeStore = () => {
 		icTokenFeeStore.setIcTokenFee({
 			tokenSymbol: mockValidIcToken.symbol,
@@ -78,7 +76,7 @@ describe('SwapForm', () => {
 			},
 			{
 				description: 'swap amount exists but receive amount is null',
-				swapAmounts: { amountForSwap: 1, swapAmounts: undefined },
+				swapAmounts: { amountForSwap: 1, swaps: [], selectedProvider: undefined },
 				props: { swapAmount: '1', receiveAmount: undefined },
 				expected: true
 			},

--- a/src/frontend/src/tests/lib/components/swap/SwapWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapWizard.spec.ts
@@ -1,0 +1,82 @@
+import { render } from '@testing-library/svelte';
+import { readable, writable } from 'svelte/store';
+import SwapWizard from '$lib/components/swap/SwapWizard.svelte';
+import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
+import { initSwapAmountsStore, SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
+import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
+import type { IcToken } from '$icp/types/ic-token';
+import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import { WizardStepsSwap } from '$lib/enums/wizard-steps';
+import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { MOCK_SWAP_PROVIDERS } from '$tests/mocks/swap.mocks';
+
+const mockToken = { ...mockValidIcToken, enabled: true } as IcToken;
+const mockDestToken = { ...mockValidIcCkToken, enabled: true } as IcToken;
+
+const BASE_PROPS = {
+	swapAmount: '1',
+	receiveAmount: 2,
+	slippageValue: '0.5',
+	swapProgressStep: ProgressStepsSwap.INITIALIZATION
+};
+
+describe('SwapWizard', () => {
+	let mockContext: Map<symbol, unknown>;
+
+	const createContext = (): Map<symbol, unknown> => {
+		const swapContext = {
+			sourceToken: readable(mockToken),
+			destinationToken: readable(mockDestToken),
+			isSourceTokenIcrc2: readable(true),
+			failedSwapError: writable(undefined)
+		};
+
+		const swapAmountsStore = initSwapAmountsStore();
+		swapAmountsStore.setSwaps({
+			swaps: [],
+			amountForSwap: '1',
+			selectedProvider: MOCK_SWAP_PROVIDERS[1]
+		});
+
+		const feeStore = readable({
+			[mockToken.symbol]: 1000n
+		});
+
+		return new Map<symbol, unknown>([
+			[SWAP_CONTEXT_KEY, swapContext],
+			[SWAP_AMOUNTS_CONTEXT_KEY, { store: swapAmountsStore }],
+			[IC_TOKEN_FEE_CONTEXT_KEY, { store: feeStore }]
+		]);
+	};
+
+	beforeEach(() => {
+		mockContext = createContext();
+	});
+
+	const renderWithStep = (step: WizardStepsSwap) =>
+		render(SwapWizard, {
+			props: {
+				...BASE_PROPS,
+				currentStep: { name: step, title: 'Swap' }
+			},
+			context: mockContext
+		});
+
+	it('renders SwapForm on SWAP step', () => {
+		const { getByText } = renderWithStep(WizardStepsSwap.SWAP);
+
+		expect(getByText(/review/i)).toBeInTheDocument();
+	});
+
+	it('renders SwapReview on REVIEW step', () => {
+		const { getByText } = renderWithStep(WizardStepsSwap.REVIEW);
+
+		expect(getByText(/swap provider/i)).toBeInTheDocument();
+	});
+
+	it('renders SwapProgress on SWAPPING step', () => {
+		const { getByText } = renderWithStep(WizardStepsSwap.SWAPPING);
+
+		expect(getByText(/swapping/i)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/stores/swap-amounts.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap-amounts.spec.ts
@@ -1,0 +1,62 @@
+import { initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
+import type { OptionAmount } from '$lib/types/send';
+import { MOCK_SWAP_PROVIDERS } from '$tests/mocks/swap.mocks';
+import { get } from 'svelte/store';
+
+const mockAmount: OptionAmount = '100';
+
+describe('swapAmountsStore', () => {
+	const mockSwaps = MOCK_SWAP_PROVIDERS;
+
+	it('should initialize with undefined', () => {
+		const store = initSwapAmountsStore();
+
+		expect(get(store)).toBeUndefined();
+	});
+
+	it('should set swaps with amount and selected provider', () => {
+		const store = initSwapAmountsStore();
+		store.setSwaps({
+			swaps: mockSwaps,
+			amountForSwap: mockAmount,
+			selectedProvider: mockSwaps[0]
+		});
+
+		expect(get(store)).toEqual({
+			swaps: mockSwaps,
+			amountForSwap: mockAmount,
+			selectedProvider: mockSwaps[0]
+		});
+	});
+
+	it('should reset store to null', () => {
+		const store = initSwapAmountsStore();
+		store.setSwaps({
+			swaps: mockSwaps,
+			amountForSwap: mockAmount,
+			selectedProvider: mockSwaps[0]
+		});
+		store.reset();
+
+		expect(get(store)).toBeNull();
+	});
+
+	it('should update selected provider', () => {
+		const store = initSwapAmountsStore();
+		store.setSwaps({
+			swaps: mockSwaps,
+			amountForSwap: mockAmount,
+			selectedProvider: mockSwaps[0]
+		});
+		store.setSelectedProvider(mockSwaps[1]);
+
+		expect(get(store)?.selectedProvider).toEqual(mockSwaps[1]);
+	});
+
+	it('should do nothing when setSelectedProvider is called and store is null', () => {
+		const store = initSwapAmountsStore();
+		store.setSelectedProvider(mockSwaps[0]);
+
+		expect(get(store)).toBeUndefined();
+	});
+});

--- a/src/frontend/src/tests/mocks/swap.mocks.ts
+++ b/src/frontend/src/tests/mocks/swap.mocks.ts
@@ -1,0 +1,29 @@
+import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
+import type { IcToken } from '$icp/types/ic-token';
+import { SwapProvider, type SwapMappedResult } from '$lib/types/swap';
+
+export const MOCK_SWAP_PROVIDERS: SwapMappedResult[] = [
+	{
+		provider: SwapProvider.ICP_SWAP,
+		receiveAmount: 1000000000n,
+		receiveOutMinimum: 990000000n,
+		swapDetails: {} as SwapMappedResult
+	},
+	{
+		provider: SwapProvider.KONG_SWAP,
+		receiveAmount: 2000000000n,
+		slippage: 0.5,
+		route: ['TokenA', 'TokenB'],
+		liquidityFees: [
+			{
+				fee: 3000n,
+				token: { symbol: 'ICP', decimals: 8 } as IcToken
+			}
+		],
+		networkFee: {
+			fee: 3000n,
+			token: { symbol: 'ICP', decimals: 8 } as IcToken
+		},
+		swapDetails: {} as SwapAmountsReply
+	}
+];


### PR DESCRIPTION
# Motivation

As part of integrating ICP Swap in this PR, I've restructured how swap amount data is stored. The updated store logic enables us to persist and manage swap data for multiple tokens simultaneously, improving flexibility and control.

# Changes

- Migrated components to Svelte 5
- Refactored SwapAmountsStore to support multi-swap state management
- Updated component logic to align with the new store structure

# Tests

- Added new unit tests for existing components
- Covered new swap amount logic with tests