### PR TITLE
feat(frontend): updated swap components to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
-	import { getContext } from 'svelte';
+	import { getContext, type Snippet } from 'svelte';
 	import { kongSwapAmounts } from '$lib/api/kong_backend.api';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
@@ -14,9 +14,14 @@
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { getLiquidityFees, getNetworkFee, getSwapRoute } from '$lib/utils/swap.utils';
 
-	export let amount: OptionAmount = undefined;
-	export let sourceToken: Token | undefined;
-	export let destinationToken: Token | undefined;
+	interface Props {
+		amount: OptionAmount;
+		sourceToken: Token | undefined;
+		destinationToken: Token | undefined;
+		children: Snippet;
+	}
+
+	let { amount, sourceToken, destinationToken, children }: Props = $props();
 
 	const { store } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
@@ -76,7 +81,10 @@
 	};
 	const debounceLoadSwapAmounts = debounce(loadSwapAmounts);
 
-	$: amount, sourceToken, destinationToken, debounceLoadSwapAmounts();
+	$effect(() => {
+		[amount, sourceToken, destinationToken];
+		debounceLoadSwapAmounts();
+	});
 </script>
 
-<slot />
+{@render children()}

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -33,9 +33,16 @@
 	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
 
-	export let swapAmount: OptionAmount;
-	export let receiveAmount: number | undefined;
-	export let slippageValue: OptionAmount;
+	interface Props {
+		swapAmount: OptionAmount;
+		receiveAmount: number | undefined;
+		slippageValue: OptionAmount;
+	}
+	let {
+		swapAmount = $bindable<OptionAmount>(),
+		receiveAmount = $bindable<number | undefined>(),
+		slippageValue = $bindable<OptionAmount>()
+	}: Props = $props();
 
 	const {
 		sourceToken,
@@ -52,51 +59,58 @@
 
 	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
 
-	let errorType: TokenActionErrorType = undefined;
-	let amountSetToMax = false;
-	let exchangeValueUnit: DisplayUnit = 'usd';
-	let inputUnit: DisplayUnit;
-	$: inputUnit = exchangeValueUnit === 'token' ? 'usd' : 'token';
+	let errorType: TokenActionErrorType = $state<TokenActionErrorType | undefined>(undefined);
+	let amountSetToMax = $state(false);
+	let exchangeValueUnit: DisplayUnit = $state<'token' | 'usd'>('usd');
 
-	$: receiveAmount =
-		nonNullish($destinationToken) && $swapAmountsStore?.swapAmounts?.receiveAmount
-			? formatTokenBigintToNumber({
-					value: $swapAmountsStore?.swapAmounts.receiveAmount,
-					unitName: $destinationToken.decimals,
-					displayDecimals: $destinationToken.decimals
-				})
-			: undefined;
+	let inputUnit: DisplayUnit = $derived(exchangeValueUnit === 'token' ? 'usd' : 'token');
 
-	let sourceTokenFee: bigint | undefined;
-	$: sourceTokenFee = nonNullish($sourceToken)
-		? $icTokenFeeStore?.[$sourceToken.symbol]
-		: undefined;
+	let sourceTokenFee: bigint | undefined = $derived(
+		nonNullish($sourceToken) && nonNullish($icTokenFeeStore)
+			? $icTokenFeeStore[$sourceToken.symbol]
+			: undefined
+	);
 
-	let totalFee: bigint | undefined;
-	// multiply sourceTokenFee by two if it's an icrc2 token to cover transfer and approval fees
-	$: totalFee = (sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n);
+	let totalFee: bigint | undefined = $derived(
+		sourceTokenFee ?? ZERO * ($isSourceTokenIcrc2 ? 2n : 1n)
+	);
 
-	let swapAmountsLoading = false;
-	$: swapAmountsLoading =
+	let swapAmountsLoading = $derived(
 		nonNullish(swapAmount) && nonNullish($swapAmountsStore?.amountForSwap)
 			? Number(swapAmount) !== Number($swapAmountsStore.amountForSwap)
-			: false;
+			: false
+	);
 
-	let disableSwitchTokens = false;
-	$: disableSwitchTokens =
-		(nonNullish(swapAmount) && isNullish(receiveAmount)) || swapAmountsLoading;
+	let disableSwitchTokens = $derived(
+		(nonNullish(swapAmount) && isNullish(receiveAmount)) || swapAmountsLoading
+	);
+
+	let invalid: boolean = $derived(
+		nonNullish(errorType) ||
+			isNullish(swapAmount) ||
+			Number(swapAmount) <= 0 ||
+			isNullish(receiveAmount) ||
+			isNullish(sourceTokenFee) ||
+			swapAmountsLoading ||
+			Number(slippageValue!) >= SWAP_SLIPPAGE_INVALID_VALUE
+	);
+
+	$effect(() => {
+		if (
+			nonNullish($destinationToken) &&
+			nonNullish($swapAmountsStore?.swapAmounts?.receiveAmount)
+		) {
+			receiveAmount = formatTokenBigintToNumber({
+				value: $swapAmountsStore?.swapAmounts.receiveAmount,
+				unitName: $destinationToken.decimals,
+				displayDecimals: $destinationToken.decimals
+			});
+		} else {
+			receiveAmount = undefined;
+		}
+	});
 
 	const dispatch = createEventDispatcher();
-
-	let invalid: boolean;
-	$: invalid =
-		nonNullish(errorType) ||
-		isNullish(swapAmount) ||
-		Number(swapAmount) <= 0 ||
-		isNullish(receiveAmount) ||
-		isNullish(sourceTokenFee) ||
-		swapAmountsLoading ||
-		Number(slippageValue) >= SWAP_SLIPPAGE_INVALID_VALUE;
 
 	const onTokensSwitch = () => {
 		const tempAmount = receiveAmount;

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -32,11 +32,20 @@
 	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let swapAmount: OptionAmount;
-	export let receiveAmount: number | undefined;
-	export let slippageValue: OptionAmount;
-	export let swapProgressStep: string;
-	export let currentStep: WizardStep | undefined;
+	interface Props {
+		swapAmount: OptionAmount;
+		receiveAmount: number | undefined;
+		slippageValue: OptionAmount;
+		swapProgressStep: string;
+		currentStep: WizardStep | undefined;
+	}
+	let {
+		swapAmount = $bindable<OptionAmount>(),
+		receiveAmount = $bindable<number | undefined>(),
+		slippageValue = $bindable<OptionAmount>(),
+		swapProgressStep = $bindable<string>(),
+		currentStep
+	}: Props = $props();
 
 	const { sourceToken, destinationToken, isSourceTokenIcrc2, failedSwapError } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
@@ -49,11 +58,14 @@
 
 	const dispatch = createEventDispatcher();
 
-	let sourceTokenFee: bigint | undefined;
-	$: sourceTokenFee =
-		nonNullish($sourceToken) && nonNullish($icTokenFeeStore)
-			? $icTokenFeeStore[$sourceToken.symbol]
-			: undefined;
+	let sourceTokenFee: bigint | undefined = $state();
+
+	$effect(() => {
+		sourceTokenFee =
+			nonNullish($sourceToken) && nonNullish($icTokenFeeStore)
+				? $icTokenFeeStore[$sourceToken.symbol]
+				: undefined;
+	});
 
 	const swap = async () => {
 		if (isNullish($authIdentity)) {
@@ -158,8 +170,6 @@
 			<SwapReview on:icSwap={swap} on:icBack {slippageValue} {swapAmount} {receiveAmount} />
 		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
 			<SwapProgress bind:swapProgressStep />
-		{:else}
-			<slot />
 		{/if}
 	</SwapAmountsContext>
 </IcTokenFeeContext>


### PR DESCRIPTION
# Motivation

Before updating the logic of the swap flow and store, this PR migrates several components to Svelte 5.
These components will be refactored and extended in upcoming PRs.

# Changes

Migrated the following components to Svelte 5:
 - SwapAmountContext
 - SwapForm
 - SwapProvider
 - SwapWizard

# Tests

These components will be covered with tests in the next PRs, once the swap logic is fully updated.
