### PR TITLE
feat(frontend): TokenAccountId and Address mappings and schemas

### DIFF
--- a/src/frontend/src/btc/utils/btc-address.utils.ts
+++ b/src/frontend/src/btc/utils/btc-address.utils.ts
@@ -1,0 +1,54 @@
+import type { BtcAddress } from '$declarations/backend/backend.did';
+import { assertNever } from '$lib/types/utils';
+import {
+	BtcAddressType,
+	parseBtcAddress as parseBtcAddressCkbtc,
+	type BtcAddressInfo
+} from '@dfinity/ckbtc';
+
+const createBtcAddressFromAddressInfo = (info: BtcAddressInfo): BtcAddress => {
+	switch (info.type) {
+		case BtcAddressType.P2wpkhV0:
+			return { P2WPKH: info.address };
+		case BtcAddressType.P2pkh:
+			return { P2PKH: info.address };
+		case BtcAddressType.P2sh:
+			return { P2SH: info.address };
+		case BtcAddressType.P2wsh:
+			return { P2WSH: info.address };
+		case BtcAddressType.P2tr:
+			return { P2TR: info.address };
+		default:
+			// This should never happen if the BtcAddressType enum is exhaustive
+			throw new Error(`Unsupported Bitcoin address type: ${info.type}`);
+	}
+};
+
+export const parseBtcAddress = (address: string): BtcAddress | undefined => {
+	try {
+		const info = parseBtcAddressCkbtc({ address });
+		return createBtcAddressFromAddressInfo(info);
+	} catch (_: unknown) {
+		return undefined;
+	}
+};
+
+export const getBtcAddressString = (address: BtcAddress): string => {
+	if ('P2WPKH' in address) {
+		return address.P2WPKH;
+	}
+	if ('P2PKH' in address) {
+		return address.P2PKH;
+	}
+	if ('P2SH' in address) {
+		return address.P2SH;
+	}
+	if ('P2WSH' in address) {
+		return address.P2WSH;
+	}
+	if ('P2TR' in address) {
+		return address.P2TR;
+	}
+
+	return assertNever({ variable: address, typeName: 'BtcAddress' });
+};

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -1,5 +1,57 @@
-import { AccountIdentifier } from '@dfinity/ledger-icp';
+import type { Icrcv2AccountId } from '$declarations/backend/backend.did';
+import { assertNever } from '$lib/types/utils';
+import { AccountIdentifier, isIcpAccountIdentifier } from '@dfinity/ledger-icp';
+import { decodeIcrcAccount, encodeIcrcAccount } from '@dfinity/ledger-icrc';
 import type { Principal } from '@dfinity/principal';
 
 export const getAccountIdentifier = (principal: Principal): AccountIdentifier =>
 	AccountIdentifier.fromPrincipal({ principal, subAccount: undefined });
+
+/**
+ * Parses a string into an Icrcv2AccountId object
+ * @param address The address string to parse
+ * @returns The parsed Icrcv2AccountId or undefined if parsing fails
+ */
+export const parseIcpAccountId = (address: string): Icrcv2AccountId | undefined => {
+	if (isIcpAccountIdentifier(address)) {
+		return {
+			Account: new TextEncoder().encode(address)
+		};
+	}
+
+	try {
+		const decoded = decodeIcrcAccount(address);
+		return {
+			WithPrincipal: {
+				owner: decoded.owner,
+				subaccount: decoded.subaccount ? [decoded.subaccount] : []
+			}
+		};
+	} catch (_: unknown) {
+		return undefined;
+	}
+};
+
+/**
+ * Extracts the address string from an Icrcv2AccountId object
+ * @param accountId The Icrcv2AccountId object
+ * @returns The address string or undefined if extraction fails
+ */
+export const getIcpAccountIdString = (accountId: Icrcv2AccountId): string => {
+	if ('Account' in accountId) {
+		return new TextDecoder().decode(new Uint8Array(accountId.Account));
+	}
+
+	if ('WithPrincipal' in accountId) {
+		const { owner, subaccount } = accountId.WithPrincipal;
+		const subaccountArray = subaccount.length > 0 ? subaccount[0] : undefined;
+
+		// Use the encodeIcrcAccount function to get the correct textual representation
+		return encodeIcrcAccount({
+			owner,
+			subaccount: subaccountArray
+		});
+	}
+
+	return assertNever({ variable: accountId, typeName: 'Icrcv2AccountId' });
+};

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -46,7 +46,6 @@ export const getIcpAccountIdString = (accountId: Icrcv2AccountId): string => {
 		const { owner, subaccount } = accountId.WithPrincipal;
 		const subaccountArray = subaccount.length > 0 ? subaccount[0] : undefined;
 
-		// Use the encodeIcrcAccount function to get the correct textual representation
 		return encodeIcrcAccount({
 			owner,
 			subaccount: subaccountArray

--- a/src/frontend/src/lib/schema/address.schema.ts
+++ b/src/frontend/src/lib/schema/address.schema.ts
@@ -1,0 +1,55 @@
+import { parseBtcAddress } from '$btc/utils/btc-address.utils';
+import type { BtcAddress, EthAddress, Icrcv2AccountId } from '$declarations/backend/backend.did';
+import { parseIcpAccountId } from '$icp/utils/icp-account.utils';
+import type { SolAddress } from '$lib/types/address';
+import { isEthAddress } from '$lib/utils/account.utils';
+import { isSolAddress } from '$sol/utils/sol-address.utils';
+import { z } from 'zod';
+
+const BaseAddressSchema = z.string().nonempty();
+
+// eslint-disable-next-line local-rules/prefer-object-params
+export const BtcAddressSchema = BaseAddressSchema.transform<BtcAddress>((data, context) => {
+	const btcAddress = parseBtcAddress(data);
+
+	if (btcAddress) {
+		return btcAddress;
+	}
+
+	context.addIssue({
+		code: z.ZodIssueCode.custom,
+		message: 'Could not parse Bitcoin address'
+	});
+
+	return z.NEVER;
+}).transform<BtcAddress>((v) => v);
+
+export const Icrcv2AccountIdSchema = BaseAddressSchema.transform<Icrcv2AccountId>(
+	// eslint-disable-next-line local-rules/prefer-object-params
+	(data, context): Icrcv2AccountId => {
+		const accountId = parseIcpAccountId(data);
+
+		if (accountId) {
+			return accountId;
+		}
+
+		context.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: 'Could not parse Icrcv2 account address'
+		});
+
+		return z.NEVER;
+	}
+)
+	// Ensures that the type matches the backend type
+	.transform<Icrcv2AccountId>((v) => v);
+
+export const EthAddressString = z.custom<string>(
+	(val) => typeof val === 'string' && isEthAddress(val)
+);
+export const EthAddressSchema = EthAddressString.transform<EthAddress>((v) => ({ Public: v }));
+
+export const SolAddressSchema = z
+	.custom<string>((val) => typeof val === 'string' && isSolAddress(val))
+	// Ensures that the type matches the backend type
+	.transform<SolAddress>((v) => v);

--- a/src/frontend/src/lib/schema/token-account-id.schema.ts
+++ b/src/frontend/src/lib/schema/token-account-id.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import {
+	BtcAddressSchema,
+	EthAddressSchema,
+	Icrcv2AccountIdSchema,
+	SolAddressSchema
+} from './address.schema';
+
+export const TokenAccountIdSchema = z.union([
+	Icrcv2AccountIdSchema.transform((data) => ({ Icrcv2: data })),
+	BtcAddressSchema.transform((data) => ({ Btc: data })),
+	EthAddressSchema.transform((data) => ({ Eth: data })),
+	SolAddressSchema.transform((data) => ({ Sol: data }))
+]);

--- a/src/frontend/src/lib/types/token-account-id.ts
+++ b/src/frontend/src/lib/types/token-account-id.ts
@@ -1,0 +1,4 @@
+import type { TokenAccountId } from '$declarations/backend/backend.did';
+import type { KeysOfUnion } from '$lib/types/utils';
+
+export type TokenAccountIdTypes = KeysOfUnion<TokenAccountId>;

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -17,3 +17,31 @@ export type AtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
 export type PartialSpecific<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export type NonEmptyArray<T> = [T, ...T[]];
+
+/**
+ * Returns all keys of a union type. For example:
+ *   KeyOfUnion<{ a: number } | { b: string } | { d: { ... } }>
+ * will result in: 'a' | 'b' | 'd'
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type KeysOfUnion<T> = T extends any ? keyof T : never;
+
+/**
+ * Utility function for exhaustive type checking in TypeScript.
+ *
+ * This function is used to ensure all possible cases in a discriminated union or enum
+ * are handled. When TypeScript narrows a variable to type `never`, it means all possible
+ * types have been handled.
+ *
+ * @param params.variable - The value that should be of type `never` if all cases are handled
+ * @param params.typeName - A string describing the type being checked (for error message)
+ */
+export const assertNever = ({
+	variable,
+	typeName
+}: {
+	variable: never;
+	typeName: string;
+}): never => {
+	throw new Error(`Unexpected ${typeName}: ${variable}`);
+};

--- a/src/frontend/src/lib/utils/token-account-id.utils.ts
+++ b/src/frontend/src/lib/utils/token-account-id.utils.ts
@@ -1,0 +1,59 @@
+import { getBtcAddressString } from '$btc/utils/btc-address.utils';
+import type { TokenAccountId } from '$declarations/backend/backend.did';
+import { getIcpAccountIdString } from '$icp/utils/icp-account.utils';
+import type { Address } from '$lib/types/address';
+import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
+import { assertNever } from '$lib/types/utils';
+
+export const tokenAccountIdToAddressString = (tokenAccountId: TokenAccountId): string => {
+	if ('Btc' in tokenAccountId) {
+		return getBtcAddressString(tokenAccountId.Btc);
+	}
+	if ('Eth' in tokenAccountId) {
+		return tokenAccountId.Eth.Public;
+	}
+	if ('Icrcv2' in tokenAccountId) {
+		return getIcpAccountIdString(tokenAccountId.Icrcv2);
+	}
+	if ('Sol' in tokenAccountId) {
+		return tokenAccountId.Sol;
+	}
+
+	return assertNever({ variable: tokenAccountId, typeName: 'TokenAccountId' });
+};
+
+export const getDiscriminatorForTokenAccountId = (
+	tokenAccountId: TokenAccountId
+): TokenAccountIdTypes => {
+	if ('Btc' in tokenAccountId) {
+		return 'Btc';
+	}
+	if ('Eth' in tokenAccountId) {
+		return 'Eth';
+	}
+	if ('Icrcv2' in tokenAccountId) {
+		return 'Icrcv2';
+	}
+	if ('Sol' in tokenAccountId) {
+		return 'Sol';
+	}
+
+	return assertNever({ variable: tokenAccountId, typeName: 'TokenAccountId' });
+};
+
+export const getAddressString = (tokenAccountId: TokenAccountId): Address => {
+	if ('Btc' in tokenAccountId) {
+		return getBtcAddressString(tokenAccountId.Btc);
+	}
+	if ('Eth' in tokenAccountId) {
+		return tokenAccountId.Eth.Public;
+	}
+	if ('Icrcv2' in tokenAccountId) {
+		return getIcpAccountIdString(tokenAccountId.Icrcv2);
+	}
+	if ('Sol' in tokenAccountId) {
+		return tokenAccountId.Sol;
+	}
+
+	return assertNever({ variable: tokenAccountId, typeName: 'TokenAccountId' });
+};

--- a/src/frontend/src/tests/btc/utils/btc-address.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-address.utils.spec.ts
@@ -1,0 +1,150 @@
+import { getBtcAddressString, parseBtcAddress } from '$btc/utils/btc-address.utils';
+import type { BtcAddress } from '$declarations/backend/backend.did';
+
+describe('btc-address.utils', () => {
+	describe('parseBtcAddress', () => {
+		it('should parse P2PKH addresses (legacy addresses starting with 1)', () => {
+			const p2pkhAddress = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+
+			const result = parseBtcAddress(p2pkhAddress);
+
+			expect(result).toEqual({ P2PKH: p2pkhAddress });
+		});
+
+		it('should parse P2SH addresses (legacy addresses starting with 3)', () => {
+			const p2shAddress = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+
+			const result = parseBtcAddress(p2shAddress);
+
+			expect(result).toEqual({ P2SH: p2shAddress });
+		});
+
+		it('should parse P2WPKH addresses (segwit addresses starting with bc1q)', () => {
+			const p2wpkhAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+
+			const result = parseBtcAddress(p2wpkhAddress);
+
+			expect(result).toEqual({ P2WPKH: p2wpkhAddress });
+		});
+
+		it('should parse P2WSH addresses (segwit script addresses)', () => {
+			const p2wshAddress = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+
+			const result = parseBtcAddress(p2wshAddress);
+
+			expect(result).toEqual({ P2WSH: p2wshAddress });
+		});
+
+		it('should parse P2TR addresses (taproot addresses starting with bc1p)', () => {
+			const p2trAddress = 'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0';
+
+			const result = parseBtcAddress(p2trAddress);
+
+			expect(result).toEqual({ P2TR: p2trAddress });
+		});
+
+		it('should return undefined for invalid BTC addresses', () => {
+			// Invalid BTC addresses (wrong checksums or formats)
+			const invalidAddresses = [
+				'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlx', // Invalid checksum
+				'1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN3', // Invalid P2PKH
+				'3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLz', // Invalid P2SH
+				'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mda', // Invalid P2WPKH
+				'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj1', // Invalid P2TR
+				'', // Empty string
+				'not-a-bitcoin-address', // Completely invalid format
+				'0x71C7656EC7ab88b098defB751B7401B5f6d8976F' // Ethereum address
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = parseBtcAddress(address);
+
+				expect(result).toBeUndefined();
+			});
+		});
+
+		it('should return undefined for non-string inputs', () => {
+			// @ts-expect-error Testing invalid input types
+			expect(parseBtcAddress(123)).toBeUndefined();
+			// @ts-expect-error Testing invalid input types
+			expect(parseBtcAddress(null)).toBeUndefined();
+			// @ts-expect-error Testing invalid input types
+			expect(parseBtcAddress(undefined)).toBeUndefined();
+			// @ts-expect-error Testing invalid input types
+			expect(parseBtcAddress({})).toBeUndefined();
+		});
+	});
+
+	describe('getBtcAddressString', () => {
+		it('should extract address string from P2PKH address object', () => {
+			const addressStr = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+			const addressObj: BtcAddress = { P2PKH: addressStr };
+
+			const result = getBtcAddressString(addressObj);
+
+			expect(result).toEqual(addressStr);
+		});
+
+		it('should extract address string from P2SH address object', () => {
+			const addressStr = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+			const addressObj: BtcAddress = { P2SH: addressStr };
+
+			const result = getBtcAddressString(addressObj);
+
+			expect(result).toEqual(addressStr);
+		});
+
+		it('should extract address string from P2WPKH address object', () => {
+			const addressStr = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+			const addressObj: BtcAddress = { P2WPKH: addressStr };
+
+			const result = getBtcAddressString(addressObj);
+
+			expect(result).toEqual(addressStr);
+		});
+
+		it('should extract address string from P2WSH address object', () => {
+			const addressStr = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+			const addressObj: BtcAddress = { P2WSH: addressStr };
+
+			const result = getBtcAddressString(addressObj);
+
+			expect(result).toEqual(addressStr);
+		});
+
+		it('should extract address string from P2TR address object', () => {
+			const addressStr = 'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0';
+			const addressObj: BtcAddress = { P2TR: addressStr };
+
+			const result = getBtcAddressString(addressObj);
+
+			expect(result).toEqual(addressStr);
+		});
+
+		it('should return undefined for invalid BtcAddress objects', () => {
+			// @ts-expect-error Testing invalid input
+			expect(() => getBtcAddressString({})).toThrow();
+			// @ts-expect-error Testing invalid input
+			expect(() => getBtcAddressString({ InvalidType: 'address' })).toThrow();
+		});
+	});
+
+	describe('roundtrip conversion', () => {
+		it('should handle all valid BTC address types in a roundtrip conversion', () => {
+			const validAddresses = [
+				'1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', // P2PKH
+				'3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy', // P2SH
+				'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq', // P2WPKH
+				'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3', // P2WSH
+				'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0' // P2TR
+			];
+
+			validAddresses.forEach((address) => {
+				const parsedAddress = parseBtcAddress(address);
+				const recoveredAddress = getBtcAddressString(parsedAddress!);
+
+				expect(recoveredAddress).toEqual(address);
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/icp/utils/icp-account.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icp-account.utils.spec.ts
@@ -1,0 +1,199 @@
+import type { Icrcv2AccountId } from '$declarations/backend/backend.did';
+import { getIcpAccountIdString, parseIcpAccountId } from '$icp/utils/icp-account.utils';
+import { Principal } from '@dfinity/principal';
+
+describe('icp-account.utils', () => {
+	describe('parseIcpAccountId', () => {
+		it('should parse ICP account identifiers', () => {
+			// Valid ICP account identifier (example)
+			const icpAccountId = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+
+			const result = parseIcpAccountId(icpAccountId);
+
+			expect(result).toEqual({
+				Account: new TextEncoder().encode(icpAccountId)
+			});
+		});
+
+		it('should parse ICRC account addresses with principal and no subaccount', () => {
+			// Valid ICRC account address with principal and no subaccount
+			const principal = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+			const icrcAccount = `${principal.toText()}`;
+
+			const result = parseIcpAccountId(icrcAccount);
+
+			expect(result).toEqual({
+				WithPrincipal: {
+					owner: principal,
+					subaccount: []
+				}
+			});
+		});
+
+		it('should parse ICRC account addresses with subaccount', () => {
+			// Valid ICRC account address with principal and subaccount
+			// Compare: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md
+			const icrcAccount =
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1';
+
+			const result = parseIcpAccountId(icrcAccount);
+
+			expect(result).toBeDefined();
+
+			if (!result || !('WithPrincipal' in result)) {
+				throw new Error('Missing key in data');
+			}
+
+			expect(result.WithPrincipal.owner.toString()).toEqual(
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae'
+			);
+			expect(result.WithPrincipal.subaccount).toHaveLength(1);
+
+			// Check that the subaccount is a Uint8Array with the last byte set to 1
+			const [subaccount] = result.WithPrincipal.subaccount;
+
+			expect(subaccount).toBeDefined();
+
+			if (!subaccount) {
+				throw new Error('Subaccount is undefined');
+			}
+
+			expect(subaccount).toBeInstanceOf(Uint8Array);
+
+			expect(subaccount).toHaveLength(32);
+
+			expect(subaccount[31]).toBe(1);
+
+			// All other bytes should be 0
+			for (let i = 0; i < 31; i++) {
+				expect(subaccount[i]).toBe(0);
+			}
+		});
+
+		it('should return undefined for invalid ICP or ICRC addresses', () => {
+			// Invalid addresses
+			const invalidAddresses = [
+				'not-a-valid-principal', // Invalid principal format
+				'rrkah-fqaaa-aaaaa-aaaaq-cai-invalidsubaccount', // Invalid subaccount format
+				'a4c0c0d2b51d33f0e5a2b1e3e0f91e8e7d54609c5af5fa04e5c7c49e3ce8de9', // Too short for ICP account ID
+				'a4c0c0d2b51d33f0e5a2b1e3e0f91e8e7d54609c5af5fa04e5c7c49e3ce8de9ez' // Invalid hex for ICP account ID
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = parseIcpAccountId(address);
+
+				expect(result).toBeUndefined();
+			});
+		});
+
+		it('should return undefined for non-string inputs', () => {
+			// @ts-expect-error Testing invalid input types
+			expect(parseIcpAccountId(123)).toBeUndefined();
+			// @ts-expect-error Testing invalid input types
+			expect(parseIcpAccountId(null)).toBeUndefined();
+			// @ts-expect-error Testing invalid input types
+			expect(parseIcpAccountId(undefined)).toBeUndefined();
+			// @ts-expect-error Testing invalid input types
+			expect(parseIcpAccountId({})).toBeUndefined();
+		});
+	});
+
+	describe('getIcpAccountIdString', () => {
+		it('should extract string from Account type', () => {
+			const accountIdStr = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+			const accountIdObj: Icrcv2AccountId = {
+				Account: new TextEncoder().encode(accountIdStr)
+			};
+
+			const result = getIcpAccountIdString(accountIdObj);
+
+			expect(result).toEqual(accountIdStr);
+		});
+
+		it('should extract string from WithPrincipal type with no subaccount', () => {
+			const principal = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+			const accountIdObj: Icrcv2AccountId = {
+				WithPrincipal: {
+					owner: principal,
+					subaccount: []
+				}
+			};
+
+			const result = getIcpAccountIdString(accountIdObj);
+
+			expect(result).toEqual(principal.toString());
+		});
+
+		it('should extract string from WithPrincipal type with subaccount', () => {
+			const principal = Principal.fromText(
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae'
+			);
+			const subaccount = new Uint8Array(32);
+			subaccount[31] = 1; // Set the last byte to 1
+
+			const accountIdObj: Icrcv2AccountId = {
+				WithPrincipal: {
+					owner: principal,
+					subaccount: [subaccount]
+				}
+			};
+
+			const result = getIcpAccountIdString(accountIdObj);
+
+			expect(result).toEqual(`${principal.toString()}-6cc627i.1`);
+		});
+
+		it('should return undefined for invalid Icrcv2AccountId objects', () => {
+			// @ts-expect-error Testing invalid input
+			expect(() => getIcpAccountIdString({})).toThrow();
+			// @ts-expect-error Testing invalid input
+			expect(() => getIcpAccountIdString({ InvalidType: 'address' })).toThrow();
+		});
+	});
+
+	describe('roundtrip conversion', () => {
+		it('should preserve ICP account identifiers when parsing and then getting the string', () => {
+			const originalAddress = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+
+			const parsedAddress = parseIcpAccountId(originalAddress);
+			const recoveredAddress = getIcpAccountIdString(parsedAddress!);
+
+			expect(recoveredAddress).toEqual(originalAddress);
+		});
+
+		it('should preserve ICRC account addresses with principal when parsing and then getting the string', () => {
+			const principal = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+			const originalAddress = principal.toString();
+
+			const parsedAddress = parseIcpAccountId(originalAddress);
+			const recoveredAddress = getIcpAccountIdString(parsedAddress!);
+
+			expect(recoveredAddress).toEqual(originalAddress);
+		});
+
+		it('should preserve ICRC account addresses with subaccount when parsing and then getting the string', () => {
+			const originalAddress =
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1';
+
+			const parsedAddress = parseIcpAccountId(originalAddress);
+			const recoveredAddress = getIcpAccountIdString(parsedAddress!);
+
+			expect(recoveredAddress).toEqual(originalAddress);
+		});
+
+		it('should handle all valid ICP address types in a roundtrip conversion', () => {
+			const validAddresses = [
+				'6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a', // ICP account ID
+				'rrkah-fqaaa-aaaaa-aaaaq-cai', // Principal only
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1' // Principal with subaccount
+			];
+
+			validAddresses.forEach((address) => {
+				const parsedAddress = parseIcpAccountId(address);
+				const recoveredAddress = getIcpAccountIdString(parsedAddress!);
+
+				expect(recoveredAddress).toEqual(address);
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/schema/address.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/address.schema.spec.ts
@@ -1,0 +1,242 @@
+import {
+	BtcAddressSchema,
+	EthAddressSchema,
+	Icrcv2AccountIdSchema,
+	SolAddressSchema
+} from '$lib/schema/address.schema';
+import { Principal } from '@dfinity/principal';
+
+describe('address.schema', () => {
+	describe('BtcAddressSchema', () => {
+		it('should validate P2PKH addresses (legacy addresses starting with 1)', () => {
+			const p2pkhAddress = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+
+			const result = BtcAddressSchema.safeParse(p2pkhAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ P2PKH: p2pkhAddress });
+		});
+
+		it('should validate P2SH addresses (legacy addresses starting with 3)', () => {
+			const p2shAddress = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+
+			const result = BtcAddressSchema.safeParse(p2shAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ P2SH: p2shAddress });
+		});
+
+		it('should validate P2WPKH addresses (segwit addresses starting with bc1q)', () => {
+			const p2wpkhAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+
+			const result = BtcAddressSchema.safeParse(p2wpkhAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ P2WPKH: p2wpkhAddress });
+		});
+
+		it('should validate P2WSH addresses (segwit script addresses)', () => {
+			const p2wshAddress = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+
+			const result = BtcAddressSchema.safeParse(p2wshAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ P2WSH: p2wshAddress });
+		});
+
+		it('should validate P2TR addresses (taproot addresses starting with bc1p)', () => {
+			const p2trAddress = 'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0';
+
+			const result = BtcAddressSchema.safeParse(p2trAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ P2TR: p2trAddress });
+		});
+
+		it('should fail validation for non-string values', () => {
+			expect(BtcAddressSchema.safeParse(123).success).toBeFalsy();
+			expect(BtcAddressSchema.safeParse(null).success).toBeFalsy();
+			expect(BtcAddressSchema.safeParse(undefined).success).toBeFalsy();
+			expect(BtcAddressSchema.safeParse({}).success).toBeFalsy();
+		});
+
+		it('should fail validation for invalid BTC addresses', () => {
+			// Invalid BTC addresses (wrong checksums or formats)
+			const invalidAddresses = [
+				'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlx', // Invalid checksum
+				'1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN3', // Invalid P2PKH
+				'3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLz', // Invalid P2SH
+				'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mda', // Invalid P2WPKH
+				'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj1' // Invalid P2TR
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = BtcAddressSchema.safeParse(address);
+
+				expect(result.success).toBeFalsy();
+			});
+		});
+	});
+
+	describe('Icrcv2AccountIdSchema', () => {
+		it('should validate ICP account identifiers', () => {
+			// Valid ICP account identifier (example)
+			const icpAccountId = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+
+			const result = Icrcv2AccountIdSchema.safeParse(icpAccountId);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({
+				Account: new TextEncoder().encode(icpAccountId)
+			});
+		});
+
+		it('should validate ICRC account addresses', () => {
+			// Valid ICRC account address with principal and no subaccount
+			const principal = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+			const icrcAccount = `${principal.toText()}`;
+
+			const result = Icrcv2AccountIdSchema.safeParse(icrcAccount);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({
+				WithPrincipal: {
+					owner: principal,
+					subaccount: []
+				}
+			});
+		});
+
+		it('should validate ICRC account addresses with subaccount', () => {
+			// Valid ICRC account address with principal and subaccount
+			// Compare: https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/TextualEncoding.md
+			const icrcAccount =
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1';
+
+			const result = Icrcv2AccountIdSchema.safeParse(icrcAccount);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toBeDefined();
+
+			if (!('WithPrincipal' in result.data!)) {
+				throw new Error('Missing key in data');
+			}
+
+			expect(result.data.WithPrincipal.owner.toString()).toEqual(
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae'
+			);
+			expect(result.data.WithPrincipal.subaccount).toEqual([
+				Uint8Array.from([
+					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 1
+				])
+			]);
+		});
+
+		it('should fail validation for non-string values', () => {
+			expect(Icrcv2AccountIdSchema.safeParse(123).success).toBeFalsy();
+			expect(Icrcv2AccountIdSchema.safeParse(null).success).toBeFalsy();
+			expect(Icrcv2AccountIdSchema.safeParse(undefined).success).toBeFalsy();
+			expect(Icrcv2AccountIdSchema.safeParse({}).success).toBeFalsy();
+		});
+
+		it('should fail validation for invalid ICRC or ICP addresses', () => {
+			// Invalid addresses
+			const invalidAddresses = [
+				'not-a-valid-principal', // Invalid principal format
+				'rrkah-fqaaa-aaaaa-aaaaq-cai-invalidsubaccount', // Invalid subaccount format
+				'a4c0c0d2b51d33f0e5a2b1e3e0f91e8e7d54609c5af5fa04e5c7c49e3ce8de9', // Too short for ICP account ID
+				'a4c0c0d2b51d33f0e5a2b1e3e0f91e8e7d54609c5af5fa04e5c7c49e3ce8de9ez' // Invalid hex for ICP account ID
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = Icrcv2AccountIdSchema.safeParse(address);
+
+				expect(result.success).toBeFalsy();
+			});
+		});
+	});
+
+	describe('EthAddressSchema', () => {
+		it('should validate valid Ethereum addresses', () => {
+			// Valid Ethereum addresses according to ethers isAddress function
+			const validAddresses = [
+				'0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+				'0x1234567890123456789012345678901234567890',
+				'0x0000000000000000000000000000000000000000' // Zero address is valid for ethers
+			];
+
+			validAddresses.forEach((address) => {
+				const result = EthAddressSchema.safeParse(address);
+
+				expect(result.success).toBeTruthy();
+				expect(result.data).toEqual({ Public: address });
+			});
+		});
+
+		it('should fail validation for non-string values', () => {
+			expect(EthAddressSchema.safeParse(123).success).toBeFalsy();
+			expect(EthAddressSchema.safeParse(null).success).toBeFalsy();
+			expect(EthAddressSchema.safeParse(undefined).success).toBeFalsy();
+			expect(EthAddressSchema.safeParse({}).success).toBeFalsy();
+		});
+
+		it('should fail validation for invalid Ethereum addresses', () => {
+			// Invalid Ethereum addresses according to ethers isAddress function
+			const invalidAddresses = [
+				'0x71C7656EC7ab88b098defB751B7401B5f6d897', // Too short
+				'0x71C7656EC7ab88b098defB751B7401B5f6d8976F00', // Too long
+				'0xG1C7656EC7ab88b098defB751B7401B5f6d8976F', // Invalid character (G)
+				'0xinvalid' // Invalid format
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = EthAddressSchema.safeParse(address);
+
+				expect(result.success).toBeFalsy();
+			});
+		});
+	});
+
+	describe('SolAddressSchema', () => {
+		it('should validate valid Solana addresses', () => {
+			// Valid Solana addresses (base58 encoded, 32-44 characters)
+			const validAddresses = [
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGD',
+				'5vfCbYFSP5GcFhKQz11DXvxiwjwEUyXRYmP7W7HS2wJk',
+				'3h1zGmCwsRJnVk5BuRNnHaE2HNhB5Z8oEo8kvwXBvrzD'
+			];
+
+			validAddresses.forEach((address) => {
+				const result = SolAddressSchema.safeParse(address);
+
+				expect(result.success).toBeTruthy();
+				expect(result.data).toEqual(address);
+			});
+		});
+
+		it('should fail validation for non-string values', () => {
+			expect(SolAddressSchema.safeParse(123).success).toBeFalsy();
+			expect(SolAddressSchema.safeParse(null).success).toBeFalsy();
+			expect(SolAddressSchema.safeParse(undefined).success).toBeFalsy();
+			expect(SolAddressSchema.safeParse({}).success).toBeFalsy();
+		});
+
+		it('should fail validation for invalid Solana addresses', () => {
+			// Invalid Solana addresses
+			const invalidAddresses = [
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRc', // Too short
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGDD', // Too long
+				'0xDRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGD', // Wrong format (with 0x)
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRG!', // Invalid character (!)
+				'OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO' // Invalid base58 characters
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = SolAddressSchema.safeParse(address);
+
+				expect(result.success).toBeFalsy();
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/schema/token-account-id.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/token-account-id.schema.spec.ts
@@ -1,0 +1,52 @@
+import { TokenAccountIdSchema } from '$lib/schema/token-account-id.schema';
+import { Principal } from '@dfinity/principal';
+
+describe('token-account-id.schema', () => {
+	describe('TokenAccountIdSchema', () => {
+		it('should validate Icrcv2 account addresses', () => {
+			// Valid ICRC account address with principal and no subaccount
+			const principal = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+			const icrcAccount = `${principal.toText()}`;
+
+			const result = TokenAccountIdSchema.safeParse(icrcAccount);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({
+				Icrcv2: {
+					WithPrincipal: {
+						owner: principal,
+						subaccount: []
+					}
+				}
+			});
+		});
+
+		it('should validate Btc P2PKH addresses', () => {
+			const p2pkhAddress = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+
+			// const result = TokenAccountIdSchema.safeParse({ Btc: p2pkhAddress });
+			const result = TokenAccountIdSchema.safeParse(p2pkhAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ Btc: { P2PKH: p2pkhAddress } });
+		});
+
+		it('should validate Eth addresses', () => {
+			const ethAddress = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
+
+			const result = TokenAccountIdSchema.safeParse(ethAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ Eth: { Public: ethAddress } });
+		});
+
+		it('should validate Sol addresses', () => {
+			const solAddress = 'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGD';
+
+			const result = TokenAccountIdSchema.safeParse(solAddress);
+
+			expect(result.success).toBeTruthy();
+			expect(result.data).toEqual({ Sol: solAddress });
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
@@ -1,0 +1,100 @@
+import type { TokenAccountId } from '$declarations/backend/backend.did';
+import { TokenAccountIdSchema } from '$lib/schema/token-account-id.schema';
+import { getAddressString } from '$lib/utils/token-account-id.utils';
+import { Principal } from '@dfinity/principal';
+
+describe('token-account-id.utils', () => {
+	describe('getAddressString', () => {
+		it('should extract address string from BTC token account ID', () => {
+			// Test for P2PKH BTC address
+			const btcAddressStr = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+			const tokenAccountId = TokenAccountIdSchema.parse(btcAddressStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(btcAddressStr);
+		});
+
+		it('should extract address string from ETH token account ID', () => {
+			const ethAddressStr = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
+			const tokenAccountId = TokenAccountIdSchema.parse(ethAddressStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(ethAddressStr);
+		});
+
+		it('should extract address string from ICRCV2 token account ID with Account type', () => {
+			const icpAccountIdStr = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+			const tokenAccountId = TokenAccountIdSchema.parse(icpAccountIdStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(icpAccountIdStr);
+		});
+
+		it('should extract address string from ICRCV2 token account ID with WithPrincipal type', () => {
+			const principalStr = 'rrkah-fqaaa-aaaaa-aaaaq-cai';
+			const tokenAccountId = TokenAccountIdSchema.parse(principalStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(principalStr);
+		});
+
+		it('should extract address string from SOL token account ID', () => {
+			const solAddressStr = 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH';
+			const tokenAccountId = TokenAccountIdSchema.parse(solAddressStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(solAddressStr);
+		});
+
+		it('should throw an error for invalid token account ID types', () => {
+			// Create an empty object that doesn't match any valid TokenAccountId type
+			const invalidTokenAccountId = {} as TokenAccountId;
+
+			expect(() => getAddressString(invalidTokenAccountId)).toThrow();
+		});
+	});
+
+	describe('roundtrip conversion', () => {
+		it('should handle BTC token account ID in a roundtrip conversion', () => {
+			const btcAddressStr = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+			const tokenAccountId = TokenAccountIdSchema.parse(btcAddressStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(btcAddressStr);
+		});
+
+		it('should handle ETH token account ID in a roundtrip conversion', () => {
+			const ethAddressStr = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
+			const tokenAccountId = TokenAccountIdSchema.parse(ethAddressStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(ethAddressStr);
+		});
+
+		it('should handle SOL token account ID in a roundtrip conversion', () => {
+			const solAddressStr = 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH';
+			const tokenAccountId = TokenAccountIdSchema.parse(solAddressStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(solAddressStr);
+		});
+
+		it('should handle ICRCV2 token account ID in a roundtrip conversion', () => {
+			const principal = Principal.fromText('rrkah-fqaaa-aaaaa-aaaaq-cai');
+			const principalStr = principal.toString();
+			const tokenAccountId = TokenAccountIdSchema.parse(principalStr);
+
+			const result = getAddressString(tokenAccountId);
+
+			expect(result).toEqual(principalStr);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Addresses in the address book will be stored as `TokenAccountId`s. Since the user provides the addresses as strings we need code that does the mapping between `string`s and `TokenAccountId`s. This PR adds parsing and methods to get the string representation back from `TokenAccountId`s.

# Changes

- Add some utils to work with discriminative unions
- Adds parsing/serialization for all supported address types
- Adds parsing/serialization for all `TokenAccountId`
