### PR TITLE
refactor(frontend): move `result_types` to shared folder

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -38,6 +38,7 @@ use shared::{
             AllowSigningStatus, ChallengeCompletion, CreateChallengeError, CreateChallengeResponse,
             CYCLES_PER_DIFFICULTY, POW_ENABLED,
         },
+        result_types::AddUserCredentialResult,
         signer::{
             topup::{TopUpCyclesLedgerRequest, TopUpCyclesLedgerResult},
             AllowSigningRequest, AllowSigningResponse, GetAllowedCyclesError,
@@ -52,7 +53,6 @@ use shared::{
         Stats, Timestamp,
     },
 };
-use shared::types::result_types::AddUserCredentialResult;
 use signer::{btc_principal_to_p2wpkh_address, AllowSigningError};
 use types::{
     Candid, ConfigCell, CustomTokenMap, StoredPrincipal, UserProfileMap, UserProfileUpdatedMap,

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -525,7 +525,7 @@ pub fn add_user_credential(request: AddUserCredentialRequest) -> AddUserCredenti
                 &credential_type,
                 vc_flow_signers.issuer_origin,
                 &mut user_profile_model,
-            )
+            ).into()
         }),
         Err(_) => AddUserCredentialResult::Err(AddUserCredentialError::InvalidCredential),
     }

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -525,7 +525,8 @@ pub fn add_user_credential(request: AddUserCredentialRequest) -> AddUserCredenti
                 &credential_type,
                 vc_flow_signers.issuer_origin,
                 &mut user_profile_model,
-            ).into()
+            )
+            .into()
         }),
         Err(_) => AddUserCredentialResult::Err(AddUserCredentialError::InvalidCredential),
     }

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -52,6 +52,7 @@ use shared::{
         Stats, Timestamp,
     },
 };
+use shared::types::result_types::AddUserCredentialResult;
 use signer::{btc_principal_to_p2wpkh_address, AllowSigningError};
 use types::{
     Candid, ConfigCell, CustomTokenMap, StoredPrincipal, UserProfileMap, UserProfileUpdatedMap,
@@ -63,7 +64,6 @@ use user_profile_model::UserProfileModel;
 use crate::{
     assertions::{assert_token_enabled_is_some, assert_token_symbol_length},
     guards::{caller_is_allowed, caller_is_controller, caller_is_not_anonymous},
-    result_types::AddUserCredentialResult,
     token::{add_to_user_token, remove_from_user_token},
     types::PowChallengeMap,
     user_profile::{add_hidden_dapp_id, set_show_testnets, update_network_settings},
@@ -84,7 +84,6 @@ mod types;
 mod user_profile;
 mod user_profile_model;
 
-mod result_types;
 #[cfg(test)]
 mod tests;
 

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -527,9 +527,8 @@ pub fn add_user_credential(request: AddUserCredentialRequest) -> AddUserCredenti
                 &mut user_profile_model,
             )
         }),
-        Err(_) => Err(AddUserCredentialError::InvalidCredential),
+        Err(_) => AddUserCredentialResult::Err(AddUserCredentialError::InvalidCredential),
     }
-    .into()
 }
 
 /// Updates the user's preference to enable (or disable) networks in the interface, merging with any

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -47,7 +47,7 @@ pub fn add_credential(
     credential_type: &CredentialType,
     issuer: String,
     user_profile_model: &mut UserProfileModel,
-) -> AddUserCredentialResult {
+) -> Result<(), AddUserCredentialError>  {
     if let Ok(user_profile) = find_profile(principal, user_profile_model) {
         let now = time();
         if let Ok(new_profile) =
@@ -61,7 +61,6 @@ pub fn add_credential(
     } else {
         Err(AddUserCredentialError::UserNotFound)
     }
-    .into()
 }
 
 /// Updates the user's network settings, merging with any existing settings.

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -4,7 +4,6 @@ use ic_cdk::api::time;
 use shared::types::{
     dapp::AddDappSettingsError,
     network::{NetworkSettingsMap, SaveNetworksSettingsError, SaveTestnetsSettingsError},
-    result_types::AddUserCredentialResult,
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
     verifiable_credential::CredentialType,
     Version,

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -47,7 +47,7 @@ pub fn add_credential(
     credential_type: &CredentialType,
     issuer: String,
     user_profile_model: &mut UserProfileModel,
-) -> Result<(), AddUserCredentialError>  {
+) -> Result<(), AddUserCredentialError> {
     if let Ok(user_profile) = find_profile(principal, user_profile_model) {
         let now = time();
         if let Ok(new_profile) =

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -46,7 +46,7 @@ pub fn add_credential(
     credential_type: &CredentialType,
     issuer: String,
     user_profile_model: &mut UserProfileModel,
-) -> Result<(), AddUserCredentialError> {
+) -> AddUserCredentialResult {
     if let Ok(user_profile) = find_profile(principal, user_profile_model) {
         let now = time();
         if let Ok(new_profile) =

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -8,7 +8,7 @@ use shared::types::{
     verifiable_credential::CredentialType,
     Version,
 };
-
+use shared::types::result_types::AddUserCredentialResult;
 use crate::{read_state, user_profile_model::UserProfileModel, State, StoredPrincipal};
 
 pub fn find_profile(
@@ -59,7 +59,7 @@ pub fn add_credential(
         }
     } else {
         Err(AddUserCredentialError::UserNotFound)
-    }
+    }.into()
 }
 
 /// Updates the user's network settings, merging with any existing settings.

--- a/src/backend/src/user_profile.rs
+++ b/src/backend/src/user_profile.rs
@@ -4,11 +4,12 @@ use ic_cdk::api::time;
 use shared::types::{
     dapp::AddDappSettingsError,
     network::{NetworkSettingsMap, SaveNetworksSettingsError, SaveTestnetsSettingsError},
+    result_types::AddUserCredentialResult,
     user_profile::{AddUserCredentialError, GetUserProfileError, StoredUserProfile},
     verifiable_credential::CredentialType,
     Version,
 };
-use shared::types::result_types::AddUserCredentialResult;
+
 use crate::{read_state, user_profile_model::UserProfileModel, State, StoredPrincipal};
 
 pub fn find_profile(
@@ -59,7 +60,8 @@ pub fn add_credential(
         }
     } else {
         Err(AddUserCredentialError::UserNotFound)
-    }.into()
+    }
+    .into()
 }
 
 /// Updates the user's network settings, merging with any existing settings.

--- a/src/backend/tests/it/user_credentials.rs
+++ b/src/backend/tests/it/user_credentials.rs
@@ -2,9 +2,11 @@ use std::time::Duration;
 
 use candid::Principal;
 use ic_verifiable_credentials::issuer_api::CredentialSpec;
+use shared::types::result_types::AddUserCredentialResult;
 use shared::types::user_profile::{
     AddUserCredentialError, AddUserCredentialRequest, GetUserProfileError, UserProfile,
 };
+
 
 use crate::utils::{
     mock::{ISSUER_CANISTER_ID, VC_HOLDER, VP_JWT},
@@ -34,7 +36,7 @@ fn test_add_user_credential_adds_credential() {
             .expect("VC Holder principal is invalid"),
     };
 
-    let add_user_credential_response = pic_setup.update::<Result<(), AddUserCredentialError>>(
+    let add_user_credential_response = pic_setup.update::<AddUserCredentialResult>(
         vc_holder,
         "add_user_credential",
         add_user_cred_arg,
@@ -82,7 +84,7 @@ fn test_add_user_credential_cannot_updated_wrong_version() {
             .expect("VC Holder principal is invalid"),
     };
 
-    let add_user_credential_response = pic_setup.update::<Result<(), AddUserCredentialError>>(
+    let add_user_credential_response = pic_setup.update::<AddUserCredentialResult>(
         vc_holder,
         "add_user_credential",
         add_user_cred_arg,
@@ -120,7 +122,7 @@ fn test_add_user_credential_replaces_credential_same_type() {
             .expect("VC Holder principal is invalid"),
     };
 
-    let add_user_credential_response = pic_setup.update::<Result<(), AddUserCredentialError>>(
+    let add_user_credential_response = pic_setup.update::<AddUserCredentialResult>(
         vc_holder,
         "add_user_credential",
         add_user_cred_arg.clone(),
@@ -146,7 +148,7 @@ fn test_add_user_credential_replaces_credential_same_type() {
     let mut add_user_cred_arg_2 = add_user_cred_arg.clone();
     add_user_cred_arg_2.current_user_version = first_profile.version;
 
-    let add_user_credential_response = pic_setup.update::<Result<(), AddUserCredentialError>>(
+    let add_user_credential_response = pic_setup.update::<AddUserCredentialResult>(
         vc_holder,
         "add_user_credential",
         add_user_cred_arg_2.clone(),

--- a/src/backend/tests/it/user_credentials.rs
+++ b/src/backend/tests/it/user_credentials.rs
@@ -2,11 +2,12 @@ use std::time::Duration;
 
 use candid::Principal;
 use ic_verifiable_credentials::issuer_api::CredentialSpec;
-use shared::types::result_types::AddUserCredentialResult;
-use shared::types::user_profile::{
-    AddUserCredentialError, AddUserCredentialRequest, GetUserProfileError, UserProfile,
+use shared::types::{
+    result_types::AddUserCredentialResult,
+    user_profile::{
+        AddUserCredentialError, AddUserCredentialRequest, GetUserProfileError, UserProfile,
+    },
 };
-
 
 use crate::utils::{
     mock::{ISSUER_CANISTER_ID, VC_HOLDER, VP_JWT},

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -22,6 +22,7 @@ pub mod token_standard;
 pub mod transaction;
 pub mod user_profile;
 pub mod verifiable_credential;
+pub mod result_types;
 
 #[cfg(test)]
 mod tests;

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -13,6 +13,7 @@ pub mod dapp;
 pub mod network;
 pub mod number;
 pub mod pow;
+pub mod result_types;
 pub mod settings;
 pub mod signer;
 pub mod snapshot;
@@ -22,7 +23,6 @@ pub mod token_standard;
 pub mod transaction;
 pub mod user_profile;
 pub mod verifiable_credential;
-pub mod result_types;
 
 #[cfg(test)]
 mod tests;

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -1,5 +1,6 @@
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
+
 use crate::types::user_profile::AddUserCredentialError;
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -10,6 +10,18 @@ pub enum AddUserCredentialResult {
     /// The user's credential was not added due to an error.
     Err(AddUserCredentialError),
 }
+impl AddUserCredentialResult {
+    pub fn is_err(&self) -> bool {
+        matches!(self, Self::Err(_))
+    }
+
+    pub fn unwrap_err(self) -> AddUserCredentialError {
+        match self {
+            Self::Err(e) => e,
+            Self::Ok(_) => panic!("called `unwrap_err()` on an `Ok` value"),
+        }
+    }
+}
 impl From<Result<(), AddUserCredentialError>> for AddUserCredentialResult {
     fn from(result: Result<(), AddUserCredentialError>) -> Self {
         match result {

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
-use shared::types::user_profile::AddUserCredentialError;
+use crate::types::user_profile::AddUserCredentialError;
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub enum AddUserCredentialResult {

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -11,14 +11,20 @@ pub enum AddUserCredentialResult {
     Err(AddUserCredentialError),
 }
 impl AddUserCredentialResult {
+    #[must_use]
     pub fn is_err(&self) -> bool {
         matches!(self, Self::Err(_))
     }
 
-    pub fn unwrap_err(self) -> AddUserCredentialError {
+    /// Returns the contained `AddUserCredentialError` if the result is an `Err`.
+    ///
+    /// # Panics
+    /// - If the result is `Ok`.
+    #[must_use]
+     pub fn unwrap_err(self) -> AddUserCredentialError {
         match self {
-            Self::Err(e) => e,
-            Self::Ok(_) => panic!("called `unwrap_err()` on an `Ok` value"),
+            Self::Err(err) => err,
+            Self::Ok(()) => panic!("Called `AddUserCredentialResult.unwrap_err()` on an `Ok` value"),
         }
     }
 }

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -21,10 +21,12 @@ impl AddUserCredentialResult {
     /// # Panics
     /// - If the result is `Ok`.
     #[must_use]
-     pub fn unwrap_err(self) -> AddUserCredentialError {
+    pub fn unwrap_err(self) -> AddUserCredentialError {
         match self {
             Self::Err(err) => err,
-            Self::Ok(()) => panic!("Called `AddUserCredentialResult.unwrap_err()` on an `Ok` value"),
+            Self::Ok(()) => {
+                panic!("Called `AddUserCredentialResult.unwrap_err()` on an `Ok` value")
+            }
         }
     }
 }


### PR DESCRIPTION
# Motivation

We want to use the result types in the tests too. So we need to move them to the shared folder.
