### PR TITLE
fix(frontend): IC and Solana scrollers were not loading next transactions

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -65,11 +65,10 @@
 		icTransactionsData = $icTransactions;
 	}, 1);
 
-	$: {
-		if ($icTransactions.length > 0) {
+	$: if ($icTransactions.length > 0) {
 			debounceIcTransactions();
 		}
-	}
+
 </script>
 
 <Info />

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -66,9 +66,8 @@
 	}, 1);
 
 	$: if ($icTransactions.length > 0) {
-			debounceIcTransactions();
-		}
-
+		debounceIcTransactions();
+	}
 </script>
 
 <Info />

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { debounce, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import TransactionsPlaceholder from '$lib/components/transactions/TransactionsPlaceholder.svelte';
 	import Header from '$lib/components/ui/Header.svelte';
@@ -26,6 +26,19 @@
 			$modalOpen: $modalSolTransaction,
 			$modalStore
 		}));
+
+
+	let solTransactionsData: SolTransactionUi[];
+
+	const debounceIcTransactions = debounce(() => {
+		solTransactionsData = $solTransactions;
+	}, 1);
+
+	$: {
+		if ($solTransactions.length > 0) {
+			debounceIcTransactions();
+		}
+	}
 </script>
 
 <Header>
@@ -35,7 +48,7 @@
 <SolTransactionsSkeletons>
 	{#if $solTransactions.length > 0}
 		<SolTransactionsScroll token={$token ?? DEFAULT_SOLANA_TOKEN}>
-			{#each $solTransactions as transaction, index (`${transaction.id}-${index}`)}
+			{#each (solTransactionsData ?? []) as transaction, index (`${transaction.id}-${index}`)}
 				<li in:slide={SLIDE_DURATION}>
 					<SolTransaction {transaction} token={$token ?? DEFAULT_SOLANA_TOKEN} />
 				</li>

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -34,11 +34,9 @@
 		solTransactionsData = $solTransactions;
 	}, 1);
 
-	$: {
-		if ($solTransactions.length > 0) {
+	$: if ($solTransactions.length > 0) {
 			debounceIcTransactions();
 		}
-	}
 </script>
 
 <Header>

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -27,7 +27,6 @@
 			$modalStore
 		}));
 
-
 	let solTransactionsData: SolTransactionUi[];
 
 	const debounceIcTransactions = debounce(() => {
@@ -35,8 +34,8 @@
 	}, 1);
 
 	$: if ($solTransactions.length > 0) {
-			debounceIcTransactions();
-		}
+		debounceIcTransactions();
+	}
 </script>
 
 <Header>
@@ -46,7 +45,7 @@
 <SolTransactionsSkeletons>
 	{#if $solTransactions.length > 0}
 		<SolTransactionsScroll token={$token ?? DEFAULT_SOLANA_TOKEN}>
-			{#each (solTransactionsData ?? []) as transaction, index (`${transaction.id}-${index}`)}
+			{#each solTransactionsData ?? [] as transaction, index (`${transaction.id}-${index}`)}
 				<li in:slide={SLIDE_DURATION}>
 					<SolTransaction {transaction} token={$token ?? DEFAULT_SOLANA_TOKEN} />
 				</li>


### PR DESCRIPTION
# Motivation

A strange behaviours appear for components `IcTransactionsScroll` and `SolTransactionsScroll`, both a wrapper around component [`InfiniteScroll`](https://gix.design/components/infinite-scroll) of GIX components.

Basically, they don't load the next transactions in OISY. However, a [very similar structure](https://github.com/dfinity/nns-dapp/blob/24bc9b3581548215ced1821871b653d0781bf59b/frontend/src/lib/components/accounts/UiTransactionsList.svelte) is done in NNS dApp and it works smoothly.

# Hypothesis

I couldn't find a rational reason, but I have an hypothesis. After a few tests, it seems that introducing a lag between the rendering of the scroller and the list of its children solves it.

That led me to the conclusion that the observer is not correctly updated if the rendering of the children happens simultaneously to the `afterUpdate` callback of component `InfiniteScroll`.

Note that it can be caused by both element: for example, the transaction store may have N transactions initially and N+M right after a split-second, causing the observer to not be updated.

Furthermore, if we navigate from the transaction list to another page and back to the transaction list, the scroller work correctly. That is because the initial list of transaction to be rendered is already present. However, it works only for one reload. To keep reloading, one must go back and forth.

# Trial & Error

I tested a small component that only loads 2 elements of the list each time it intersects. However, it is loaded only up to the bottom of the page. After that the observer stops.

```svelte
<script lang="ts">
	import { InfiniteScroll } from '@dfinity/gix-components';
	import { onMount } from 'svelte';
	import { slide } from 'svelte/transition';
	import { writable } from 'svelte/store';

	const numbersStore = writable<number[]>([]);

	let disableInfiniteScroll = false;
	
	onMount(() => {
		numbersStore.set(Array.from({ length: 2 }, (_, i) => i))
	});

	const onIntersect = () => {
		const numbers  = $numbersStore;

		numbersStore.set(
			[...numbers, ...Array.from({ length: 10 }, (_, i) => numbers.length + i)]
		);

		if (numbers.length > 100) {
			disableInfiniteScroll = true;
		}
	};
</script>

{#if $numbersStore.length > 0}
	<InfiniteScroll on:nnsIntersect={onIntersect} disabled={disableInfiniteScroll}>
		{#each $numbersStore as n (n)}
			<li in:slide={{ duration: 0 }}>
				Number {n}
			</li>
		{/each}
	</InfiniteScroll>
{/if}

```

The results:

![Screenshot 2025-05-15 at 01 43 19](https://github.com/user-attachments/assets/0e8e1c04-4e6e-4ffd-b80d-919a5c15233e)

# Changes

- Add a lag between transactions store and the data used to create the list of children of the scroller, both in `IcTransactions` and `SolTransactions`.

# Tests

### Before

https://github.com/user-attachments/assets/ca0eafa3-c0eb-4667-8aba-b31520637e73

### After


https://github.com/user-attachments/assets/024d2692-a1e9-45ac-a222-4f23fa47acf0




