### PR TITLE
fix(frontend): update ConvertAmountExchange skeleton logic

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDisplay.svelte
@@ -4,6 +4,10 @@
 	import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import {
+		CONVERT_AMOUNT_DISPLAY_SKELETON,
+		CONVERT_AMOUNT_DISPLAY_VALUE
+	} from '$lib/constants/test-ids.constants';
 	import type { OptionAmount } from '$lib/types/send';
 
 	export let amount: OptionAmount = undefined;
@@ -18,13 +22,13 @@
 
 	<svelte:fragment slot="main-value">
 		{#if nonNullish(amount)}
-			<div in:fade data-tid="convert-amount-display-value">
+			<div in:fade data-tid={CONVERT_AMOUNT_DISPLAY_VALUE}>
 				{nonNullish(amount) && Number(amount) === 0 && nonNullish(zeroAmountLabel)
 					? zeroAmountLabel
 					: `${amount} ${symbol}`}
 			</div>
 		{:else}
-			<div class="w-14 sm:w-24" data-tid="convert-amount-display-skeleton">
+			<div class="w-14 sm:w-24" data-tid={CONVERT_AMOUNT_DISPLAY_SKELETON}>
 				<SkeletonText />
 			</div>
 		{/if}

--- a/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import {
+		CONVERT_AMOUNT_EXCHANGE_SKELETON,
+		CONVERT_AMOUNT_EXCHANGE_VALUE
+	} from '$lib/constants/test-ids.constants';
 	import type { OptionAmount } from '$lib/types/send';
 	import { formatUSD } from '$lib/utils/format.utils';
 
@@ -18,11 +22,11 @@
 </script>
 
 {#if nonNullish(usdValue)}
-	<div in:fade data-tid="convert-amount-exchange">
+	<div in:fade data-tid={CONVERT_AMOUNT_EXCHANGE_VALUE}>
 		{`${nonNullish(amount) && amount === 0 ? '' : '~'}`}{usdValue}
 	</div>
-{:else}
-	<div class="w-10 sm:w-8" data-tid="convert-amount-exchange-skeleton">
+{:else if isNullish(amount)}
+	<div in:fade class="w-10 sm:w-8" data-tid={CONVERT_AMOUNT_EXCHANGE_SKELETON}>
 		<SkeletonText />
 	</div>
 {/if}

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -194,3 +194,8 @@ export const CONTACT_HEADER_EDITING_EDIT_BUTTON = 'contact-header-editing-edit-b
 export const SEND_DESTINATION_WIZARD_STEP = 'send-destination-wizard-step';
 
 export const SEND_DESTINATION_SECTION = 'send-destination-section';
+
+export const CONVERT_AMOUNT_DISPLAY_VALUE = 'convert-amount-display-value';
+export const CONVERT_AMOUNT_DISPLAY_SKELETON = 'convert-amount-display-skeleton';
+export const CONVERT_AMOUNT_EXCHANGE_VALUE = 'convert-amount-exchange-value';
+export const CONVERT_AMOUNT_EXCHANGE_SKELETON = 'convert-amount-exchange-skeleton';

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountDisplay.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountDisplay.spec.ts
@@ -1,5 +1,11 @@
 import { BTC_MAINNET_SYMBOL } from '$env/tokens/tokens.btc.env';
 import ConvertAmountDisplay from '$lib/components/convert/ConvertAmountDisplay.svelte';
+import {
+	CONVERT_AMOUNT_DISPLAY_SKELETON,
+	CONVERT_AMOUNT_DISPLAY_VALUE,
+	CONVERT_AMOUNT_EXCHANGE_SKELETON,
+	CONVERT_AMOUNT_EXCHANGE_VALUE
+} from '$lib/constants/test-ids.constants';
 import { render } from '@testing-library/svelte';
 
 describe('ConvertAmountDisplay', () => {
@@ -13,13 +19,16 @@ describe('ConvertAmountDisplay', () => {
 		symbol
 	};
 
-	const valueTestId = 'convert-amount-display-value';
-	const skeletonTestId = 'convert-amount-display-skeleton';
+	const valueTestId = CONVERT_AMOUNT_DISPLAY_VALUE;
+	const skeletonTestId = CONVERT_AMOUNT_DISPLAY_SKELETON;
+	const exchangeSkeleton = CONVERT_AMOUNT_EXCHANGE_SKELETON;
+	const exchangeValue = CONVERT_AMOUNT_EXCHANGE_VALUE;
 
-	it('should display correct value if amount is provided', () => {
+	it('should display correct values if amount is provided', () => {
 		const { getByTestId } = render(ConvertAmountDisplay, { props });
 
 		expect(getByTestId(valueTestId)).toHaveTextContent('20.25 BTC');
+		expect(getByTestId(exchangeValue)).toHaveTextContent('$0.20');
 	});
 
 	it('should display zero label if amount is zero and label is provided', () => {
@@ -28,6 +37,7 @@ describe('ConvertAmountDisplay', () => {
 		});
 
 		expect(getByTestId(valueTestId)).toHaveTextContent('Free');
+		expect(getByTestId(exchangeValue)).toHaveTextContent('$0.00');
 	});
 
 	it('should display zero if amount is zero and label is not provided', () => {
@@ -36,12 +46,14 @@ describe('ConvertAmountDisplay', () => {
 		});
 
 		expect(getByTestId(valueTestId)).toHaveTextContent('0 BTC');
+		expect(getByTestId(exchangeValue)).toHaveTextContent('$0.00');
 	});
 
-	it('should display skeleton if amount is not provided', () => {
+	it('should display skeletons if amount is not provided', () => {
 		const { amount: _, ...newProps } = props;
 		const { getByTestId } = render(ConvertAmountDisplay, { props: newProps });
 
 		expect(getByTestId(skeletonTestId)).toBeInTheDocument();
+		expect(getByTestId(exchangeSkeleton)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
@@ -1,4 +1,8 @@
 import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
+import {
+	CONVERT_AMOUNT_EXCHANGE_SKELETON,
+	CONVERT_AMOUNT_EXCHANGE_VALUE
+} from '$lib/constants/test-ids.constants';
 import { render } from '@testing-library/svelte';
 
 describe('ConvertAmountExchange', () => {
@@ -10,8 +14,8 @@ describe('ConvertAmountExchange', () => {
 		exchangeRate
 	};
 
-	const divTestId = 'convert-amount-exchange';
-	const skeletonTestId = 'convert-amount-exchange-skeleton';
+	const divTestId = CONVERT_AMOUNT_EXCHANGE_VALUE;
+	const skeletonTestId = CONVERT_AMOUNT_EXCHANGE_SKELETON;
 
 	it('should display correct value if amount is provided', () => {
 		const { getByTestId } = render(ConvertAmountExchange, { props });
@@ -34,10 +38,10 @@ describe('ConvertAmountExchange', () => {
 		expect(getByTestId(skeletonTestId)).toBeInTheDocument();
 	});
 
-	it('should display skeleton if exchange rate is not provided', () => {
+	it('should not display skeleton if exchange rate is not provided', () => {
 		const { exchangeRate: _, ...newProps } = props;
 		const { getByTestId } = render(ConvertAmountExchange, { props: newProps });
 
-		expect(getByTestId(skeletonTestId)).toBeInTheDocument();
+		expect(() => getByTestId(skeletonTestId)).toThrow();
 	});
 });


### PR DESCRIPTION
# Motivation

We need to hide skeleton in ConvertAmountExchange if exchange rate is not available for a token.

# Changes

1. `ConvertAmountExchange` update - the exchange skeleton will be shown only while `value` is not available.
2. Replaced hardcoded testIds in the related components.

# Tests

Added new tests.
