### PR TITLE
feat(frontend): added methods to open SwapProviderListModal

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -230,7 +230,7 @@
 			<Hr spacing="md" />
 
 			<div class="flex flex-col gap-3">
-				<SwapProvider />
+				<SwapProvider on:icShowProviderList />
 				<SwapFees />
 			</div>
 		{/if}

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -24,8 +24,9 @@
 	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext, initSwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
-	import type { SwapSelectTokenType } from '$lib/types/swap';
+	import type { SwapMappedResult, SwapSelectTokenType } from '$lib/types/swap';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import SwapProviderListModal from '$lib/components/swap/SwapProviderListModal.svelte';
 
 	const { setSourceToken, setDestinationToken } = setContext<SwapContext>(
 		SWAP_CONTEXT_KEY,
@@ -55,6 +56,7 @@
 	let swapProgressStep = $state(ProgressStepsSwap.INITIALIZATION);
 	let currentStep = $state<WizardStep | undefined>();
 	let selectTokenType = $state<SwapSelectTokenType | undefined>();
+	let showSelectProviderModal = $state<boolean>(false);
 
 	const showTokensList = ({ detail: type }: CustomEvent<SwapSelectTokenType>) => {
 		swapAmountsStore.reset();
@@ -79,7 +81,9 @@
 			? $i18n.swap.text.select_source_token
 			: selectTokenType === 'destination'
 				? $i18n.swap.text.select_destination_token
-				: (currentStep?.title ?? '')
+				: showSelectProviderModal
+					? $i18n.swap.text.select_swap_provider
+					: (currentStep?.title ?? '')
 	);
 
 	const dispatch = createEventDispatcher();
@@ -88,8 +92,20 @@
 		closeModal(() => {
 			currentStep = undefined;
 			selectTokenType = undefined;
+			showSelectProviderModal = false;
 			dispatch('nnsClose');
 		});
+
+	const openSelectProviderModal = () => {
+		showSelectProviderModal = true;
+	};
+	const closeSelectProviderModal = () => {
+		showSelectProviderModal = false;
+	};
+	const selectProvider = ({ detail }: CustomEvent<SwapMappedResult>) => {
+		swapAmountsStore.setSelectedProvider(detail);
+		closeSelectProviderModal();
+	};
 
 	// TODO: Migrate to Svelte 5, remove legacy slot usage and use render composition instead
 </script>
@@ -100,12 +116,17 @@
 	bind:this={modal}
 	bind:currentStep
 	on:nnsClose={close}
-	disablePointerEvents={currentStep?.name === WizardStepsSwap.SWAPPING}
+	disablePointerEvents={currentStep?.name === WizardStepsSwap.SWAPPING || showSelectProviderModal}
 >
 	<svelte:fragment slot="title">{title}</svelte:fragment>
 
 	{#if nonNullish(selectTokenType)}
 		<SwapTokensList on:icSelectToken={selectToken} on:icCloseTokensList={closeTokenList} />
+	{:else if showSelectProviderModal}
+		<SwapProviderListModal
+			on:icSelectProvider={selectProvider}
+			on:icCloseProviderList={closeSelectProviderModal}
+		/>
 	{:else}
 		<SwapWizard
 			{currentStep}
@@ -117,6 +138,7 @@
 			on:icNext={modal.next}
 			on:icClose={close}
 			on:icShowTokensList={showTokensList}
+			on:icShowProviderList={openSelectProviderModal}
 		/>
 	{/if}
 </WizardModal>

--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { getContext } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import SwapBestRateBadge from './SwapBestRateBadge.svelte';
 	import { dAppDescriptions } from '$env/dapp-descriptions.env';
 	import SwapDetailsIcp from '$lib/components/swap/SwapDetailsIcp.svelte';
@@ -42,15 +42,22 @@
 			displayURL = null;
 		}
 	});
+
+	const dispatch = createEventDispatcher();
 </script>
 
 {#if nonNullish(swapDApp) && nonNullish(selectedProvider) && nonNullish($swapAmountsStore)}
 	<CollapsibleBottomSheet showContentHeader>
-		{#snippet contentHeader()}
+		{#snippet contentHeader({ isInBottomSheet })}
 			<ModalValue>
 				<svelte:fragment slot="label">
 					<div class="flex justify-center gap-2">
 						{$i18n.swap.text.swap_provider}
+						{#if nonNullish($swapAmountsStore) && $swapAmountsStore?.swaps.length > 1 && !isInBottomSheet}
+							<Button link on:click={() => dispatch('icShowProviderList')}
+								>{$i18n.swap.text.select}</Button
+							>
+						{/if}
 					</div>
 				</svelte:fragment>
 

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -160,6 +160,7 @@
 				on:icClose
 				on:icNext
 				on:icShowTokensList
+				on:icShowProviderList
 				bind:swapAmount
 				bind:receiveAmount
 				bind:slippageValue

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -594,7 +594,9 @@
 			"included_liquidity_fees": "Included liquidity pool fees",
 			"best_rate": "Best Rate",
 			"expected_minimum": "Expected minimum",
-			"you_receive": "You receive"
+			"you_receive": "You receive",
+			"select": "Select >",
+			"select_swap_provider": "Select swap provider"
 		},
 		"error": {
 			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -562,6 +562,8 @@ interface I18nSwap {
 		best_rate: string;
 		expected_minimum: string;
 		you_receive: string;
+		select: string;
+		select_swap_provider: string;
 	};
 	error: {
 		kong_not_available: string;


### PR DESCRIPTION
# Motivation

Enable the ability to open the SwapProviderListModal from the swap UI using new event methods.

# Changes

- Added methods to open the SwapProviderListModal.

- Introduced a button that triggers the modal via event listeners.