### PR TITLE
fix(frontend): avoid looping of restarting IC Wallet Workers

### DIFF
--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -11,6 +11,7 @@ import type {
 	PostMessageDataResponseWallet,
 	PostMessageDataResponseWalletCleanUp
 } from '$lib/types/post-message';
+import { nonNullish } from '@dfinity/utils';
 
 export const initIcrcWalletWorker = async ({
 	indexCanisterId,
@@ -21,7 +22,15 @@ export const initIcrcWalletWorker = async ({
 	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
-	const restartWorkerWithLedgerOnly = () =>
+	let restartedWithLedgerOnly = false;
+
+	const restartWorkerWithLedgerOnly = () => {
+		if (restartedWithLedgerOnly) {
+			return;
+		}
+
+		restartedWithLedgerOnly = true;
+
 		worker.postMessage({
 			msg: 'startIcrcWalletTimer',
 			data: {
@@ -29,6 +38,7 @@ export const initIcrcWalletWorker = async ({
 				env
 			}
 		});
+	};
 
 	worker.onmessage = ({
 		data
@@ -57,7 +67,9 @@ export const initIcrcWalletWorker = async ({
 
 				// In case of error, we start the listener again, but only with the ledgerCanisterId,
 				// to make it request only the balance and not the transactions
-				restartWorkerWithLedgerOnly();
+				if (nonNullish(indexCanisterId)) {
+					restartWorkerWithLedgerOnly();
+				}
 
 				return;
 			case 'syncIcrcWalletCleanUp':

--- a/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
@@ -1,0 +1,282 @@
+import { syncWallet } from '$icp/services/ic-listener.services';
+import {
+	onLoadTransactionsError,
+	onTransactionsCleanUp
+} from '$icp/services/ic-transactions.services';
+import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
+import type { WalletWorker } from '$lib/types/listener';
+import { mockIndexCanisterId, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+
+vi.mock('$icp/services/ic-listener.services', () => ({
+	syncWallet: vi.fn()
+}));
+
+vi.mock('$icp/services/ic-transactions.services', () => ({
+	onLoadTransactionsError: vi.fn(),
+	onTransactionsCleanUp: vi.fn()
+}));
+
+const postMessageSpy = vi.fn();
+
+class MockWorker {
+	postMessage = postMessageSpy;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+}
+
+vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
+
+let workerInstance: Worker;
+
+vi.mock('$lib/workers/workers?worker', () => ({
+	default: vi.fn().mockImplementation(() => {
+		// @ts-expect-error testing this on purpose with a mock class
+		workerInstance = new Worker();
+		return workerInstance;
+	})
+}));
+
+describe('worker.icrc-wallet.services', () => {
+	describe('initIcrcWalletWorker', () => {
+		let worker: WalletWorker;
+
+		describe('with index canister id', () => {
+			const mockToken = { ...mockValidIcToken, indexCanisterId: mockIndexCanisterId };
+
+			const {
+				ledgerCanisterId,
+				indexCanisterId,
+				network: { env }
+			} = mockToken;
+
+			beforeEach(async () => {
+				vi.clearAllMocks();
+
+				worker = await initIcrcWalletWorker(mockToken);
+			});
+
+			it('should start the worker and send the correct start message', () => {
+				worker.start();
+
+				expect(postMessageSpy).toHaveBeenCalledOnce();
+				expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+					msg: 'startIcrcWalletTimer',
+					data: {
+						indexCanisterId,
+						ledgerCanisterId,
+						env
+					}
+				});
+			});
+
+			it('should stop the worker and send the correct stop message', () => {
+				worker.stop();
+
+				expect(postMessageSpy).toHaveBeenCalledOnce();
+				expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+					msg: 'stopIcrcWalletTimer'
+				});
+			});
+
+			it('should trigger the worker and send the correct trigger message', () => {
+				worker.trigger();
+
+				expect(postMessageSpy).toHaveBeenCalledOnce();
+				expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+					msg: 'triggerIcrcWalletTimer',
+					data: {
+						indexCanisterId,
+						ledgerCanisterId,
+						env
+					}
+				});
+			});
+
+			describe('onmessage', () => {
+				it('should handle syncIcrcWallet message', () => {
+					const payload = {
+						msg: 'syncIcrcWallet',
+						data: { balance: 1000 }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(syncWallet).toHaveBeenCalledOnce();
+					expect(syncWallet).toHaveBeenCalledWith({
+						tokenId: mockToken.id,
+						data: payload.data
+					});
+				});
+
+				it('should handle syncIcrcWalletError message', () => {
+					const payload = {
+						msg: 'syncIcrcWalletError',
+						data: { error: 'error' }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(onLoadTransactionsError).toHaveBeenCalledOnce();
+					expect(onLoadTransactionsError).toHaveBeenNthCalledWith(1, {
+						tokenId: mockToken.id,
+						error: payload.data.error,
+						silent: true
+					});
+				});
+
+				it('should handle syncIcrcWalletCleanUp message', () => {
+					const payload = {
+						msg: 'syncIcrcWalletCleanUp',
+						data: { transactionIds: ['id1', 'id2'] }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(onTransactionsCleanUp).toHaveBeenCalledOnce();
+					expect(onTransactionsCleanUp).toHaveBeenNthCalledWith(1, {
+						tokenId: mockToken.id,
+						transactionIds: payload.data.transactionIds
+					});
+				});
+
+				it('should restart the worker with ledger only on error', () => {
+					const payload = {
+						msg: 'syncIcrcWalletError',
+						data: { error: 'error' }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(postMessageSpy).toHaveBeenCalledOnce();
+					expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+						msg: 'startIcrcWalletTimer',
+						data: {
+							ledgerCanisterId,
+							env
+						}
+					});
+				});
+
+				it('should restart the worker with ledger only on error but only once', () => {
+					const payload = {
+						msg: 'syncIcrcWalletError',
+						data: { error: 'error' }
+					};
+
+					Array.from({ length: 10 }).forEach(() => {
+						workerInstance.onmessage?.({ data: payload } as MessageEvent);
+					});
+
+					expect(postMessageSpy).toHaveBeenCalledOnce();
+					expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+						msg: 'startIcrcWalletTimer',
+						data: {
+							ledgerCanisterId,
+							env
+						}
+					});
+				});
+			});
+		});
+
+		describe('without index canister id', () => {
+			const { indexCanisterId: _, ...mockToken } = mockValidIcToken;
+
+			const {
+				ledgerCanisterId,
+				network: { env }
+			} = mockToken;
+
+			beforeEach(async () => {
+				vi.clearAllMocks();
+
+				worker = await initIcrcWalletWorker(mockToken);
+			});
+
+			it('should start the worker and send the correct start message', () => {
+				worker.start();
+
+				expect(postMessageSpy).toHaveBeenCalledOnce();
+				expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+					msg: 'startIcrcWalletTimer',
+					data: {
+						ledgerCanisterId,
+						env
+					}
+				});
+			});
+
+			it('should stop the worker and send the correct stop message', () => {
+				worker.stop();
+
+				expect(postMessageSpy).toHaveBeenCalledOnce();
+				expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+					msg: 'stopIcrcWalletTimer'
+				});
+			});
+
+			it('should trigger the worker and send the correct trigger message', () => {
+				worker.trigger();
+
+				expect(postMessageSpy).toHaveBeenCalledOnce();
+				expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+					msg: 'triggerIcrcWalletTimer',
+					data: {
+						ledgerCanisterId,
+						env
+					}
+				});
+			});
+
+			describe('onmessage', () => {
+				it('should handle syncIcrcWallet message', () => {
+					const payload = {
+						msg: 'syncIcrcWallet',
+						data: { balance: 1000 }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(syncWallet).toHaveBeenCalledOnce();
+					expect(syncWallet).toHaveBeenCalledWith({
+						tokenId: mockToken.id,
+						data: payload.data
+					});
+				});
+
+				it('should handle syncIcrcWalletError message', () => {
+					const payload = {
+						msg: 'syncIcrcWalletError',
+						data: { error: 'error' }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(onLoadTransactionsError).toHaveBeenCalledOnce();
+					expect(onLoadTransactionsError).toHaveBeenNthCalledWith(1, {
+						tokenId: mockToken.id,
+						error: payload.data.error,
+						silent: true
+					});
+				});
+
+				it('should handle syncIcrcWalletCleanUp message', () => {
+					const payload = {
+						msg: 'syncIcrcWalletCleanUp',
+						data: { transactionIds: ['id1', 'id2'] }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(onTransactionsCleanUp).toHaveBeenCalledOnce();
+					expect(onTransactionsCleanUp).toHaveBeenNthCalledWith(1, {
+						tokenId: mockToken.id,
+						transactionIds: payload.data.transactionIds
+					});
+				});
+
+				it('should not restart the worker with ledger only on error', () => {
+					const payload = {
+						msg: 'syncIcrcWalletError',
+						data: { error: 'error' }
+					};
+					workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+					expect(postMessageSpy).not.toHaveBeenCalled();
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

The IC wallet worker restarts itself if there is an error with the index canister, to restart it with ledger balance only. However, this should happen only once. Otherwise it will keep going in loops to restart itself.

# Changes

- Restart the worker `initIcrcWalletWorker` only if there was an index canister before (it does not make sense to restart it for tokens that already have only the ledger).
- Add a check to verify if it was already restarted once.

# Tests

Created a few tests. Plus, mocking a ledger canister error, we can check that it would have gone in infinite loops before this PR.

### Before

![Screenshot 2025-05-15 at 16 15 51](https://github.com/user-attachments/assets/90b1f058-625b-4e8f-afd5-7f8559cad391)

### After

![Screenshot 2025-05-15 at 16 15 16](https://github.com/user-attachments/assets/1ff3c24e-416a-465c-a8c9-ea2613726003)

