### PR TITLE
feat(frontend): SendFeeInfo component

### DIFF
--- a/src/frontend/src/lib/components/send/SendFeeInfo.svelte
+++ b/src/frontend/src/lib/components/send/SendFeeInfo.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { Html } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { SEND_FEE_INFO } from '$lib/constants/test-ids.constants';
+	import { balancesStore } from '$lib/stores/balances.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { OptionString } from '$lib/types/string';
+	import type { OptionTokenId } from '$lib/types/token';
+	import { formatToken } from '$lib/utils/format.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		decimals?: number;
+		feeTokenId?: OptionTokenId;
+		feeSymbol?: OptionString;
+	}
+	let { decimals, feeSymbol, feeTokenId }: Props = $props();
+
+	const { sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const balanceForFee = nonNullish(feeTokenId)
+		? ($balancesStore?.[feeTokenId]?.data ?? ZERO)
+		: ZERO;
+</script>
+
+{#if nonNullish(feeSymbol) && $sendTokenSymbol !== feeSymbol}
+	<MessageBox styleClass="mt-6 sm:text-sm" testId={SEND_FEE_INFO}>
+		<Html
+			text={replacePlaceholders($i18n.send.info.fee_info, {
+				$feeSymbol: feeSymbol,
+				$feeBalance: formatToken({
+					value: balanceForFee,
+					displayDecimals: decimals,
+					unitName: decimals
+				})
+			})}
+		/>
+	</MessageBox>
+{/if}

--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -9,6 +9,7 @@
 
 	export let level: 'plain' | 'info' | 'warning' | 'error' | 'success' = 'info';
 	export let closableKey: HideInfoKey | undefined = undefined;
+	export let styleClass: string | undefined = undefined;
 	export let testId: string | undefined = undefined;
 
 	let closable = false;
@@ -30,7 +31,7 @@
 
 {#if visible}
 	<div
-		class="mb-4 flex items-start gap-4 rounded-xl px-4 py-3 text-sm font-medium sm:text-base"
+		class={`mb-4 flex items-start gap-4 rounded-xl px-4 py-3 text-sm font-medium sm:text-base ${styleClass ?? ''}`}
 		class:bg-primary={level === 'plain'}
 		class:bg-brand-light={level === 'info'}
 		class:bg-warning-light={level === 'warning'}

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -199,3 +199,5 @@ export const CONVERT_AMOUNT_DISPLAY_VALUE = 'convert-amount-display-value';
 export const CONVERT_AMOUNT_DISPLAY_SKELETON = 'convert-amount-display-skeleton';
 export const CONVERT_AMOUNT_EXCHANGE_VALUE = 'convert-amount-exchange-value';
 export const CONVERT_AMOUNT_EXCHANGE_SKELETON = 'convert-amount-exchange-skeleton';
+
+export const SEND_FEE_INFO = 'send-fee-info';

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -468,7 +468,8 @@
 			"cketh_certified": "Please wait until the ckETH parameters have been certified.",
 			"pending_bitcoin_transaction": "You can send another Bitcoin transaction once the pending one is complete.",
 			"no_available_utxos": "You won't have available utxos to perform this transaction.",
-			"unknown_destination": "You haven't interacted with this address before. Please ensure you know the recipient."
+			"unknown_destination": "You haven't interacted with this address before. Please ensure you know the recipient.",
+			"fee_info": "Fee will be paid in $feeSymbol. Available: <strong>$feeBalance $feeSymbol</strong>"
 		},
 		"assertion": {
 			"invalid_destination_address": "Invalid destination address",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -440,6 +440,7 @@ interface I18nSend {
 		pending_bitcoin_transaction: string;
 		no_available_utxos: string;
 		unknown_destination: string;
+		fee_info: string;
 	};
 	assertion: {
 		invalid_destination_address: string;

--- a/src/frontend/src/tests/lib/components/send/SendFeeInfo.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendFeeInfo.spec.ts
@@ -1,0 +1,45 @@
+import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
+import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
+import SendFeeInfo from '$lib/components/send/SendFeeInfo.svelte';
+import { SEND_FEE_INFO } from '$lib/constants/test-ids.constants';
+import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import type { Token } from '$lib/types/token';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SendFeeInfo', () => {
+	const mockContext = (token: Token) => {
+		const mockContext = new Map([]);
+		mockContext.set(
+			SEND_CONTEXT_KEY,
+			initSendContext({
+				token
+			})
+		);
+		return mockContext;
+	};
+
+	const props = {
+		decimals: 8,
+		feeSymbol: ETHEREUM_NETWORK_SYMBOL,
+		feeTokenId: ETHEREUM_TOKEN_ID
+	};
+
+	it('does not render the info message if fee symbol is the same as send token symbol', () => {
+		const { getByTestId } = render(SendFeeInfo, {
+			props,
+			context: mockContext(ETHEREUM_TOKEN)
+		});
+
+		expect(() => getByTestId(SEND_FEE_INFO)).toThrow();
+	});
+
+	it('renders the info message if fee symbol is not the same as send token symbol', () => {
+		const { getByTestId } = render(SendFeeInfo, {
+			props,
+			context: mockContext(mockValidErc20Token)
+		});
+
+		expect(getByTestId(SEND_FEE_INFO)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

In order to display an info banner when a fee symbol does not match with a send token symbol, we need to have a new reusable component.

<img width="541" alt="Screenshot 2025-05-16 at 11 49 16" src="https://github.com/user-attachments/assets/b632772c-9794-4f7f-8b37-dfc00413cc52" />

