### PR TITLE
feat(frontend): add token id store to the sol-fee context

### DIFF
--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -34,7 +34,7 @@
 	import type { OptionSolAddress } from '$lib/types/address';
 	import type { Network, NetworkId } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
-	import type { Token } from '$lib/types/token';
+	import type { Token, TokenId } from '$lib/types/token';
 	import { invalidAmount, isNullishOrEmpty } from '$lib/utils/input.utils';
 	import {
 		isNetworkIdSolana,
@@ -89,6 +89,9 @@
 	let feeSymbolStore = writable<string | undefined>(undefined);
 	$: feeSymbolStore.set(solanaNativeToken.symbol);
 
+	let feeTokenIdStore = writable<TokenId | undefined>(undefined);
+	$: feeTokenIdStore.set(solanaNativeToken.id);
+
 	let feeDecimalsStore = writable<number | undefined>(undefined);
 	$: feeDecimalsStore.set(solanaNativeToken.decimals);
 
@@ -99,7 +102,8 @@
 			prioritizationFeeStore,
 			ataFeeStore,
 			feeSymbolStore,
-			feeDecimalsStore
+			feeDecimalsStore,
+			feeTokenIdStore
 		})
 	);
 

--- a/src/frontend/src/sol/stores/sol-fee.store.ts
+++ b/src/frontend/src/sol/stores/sol-fee.store.ts
@@ -1,3 +1,4 @@
+import type { TokenId } from '$lib/types/token';
 import { writable, type Readable, type Writable } from 'svelte/store';
 
 export type FeeStoreData = bigint | undefined;
@@ -23,6 +24,7 @@ export interface FeeContext {
 	ataFeeStore: FeeStore;
 	feeSymbolStore: Writable<string | undefined>;
 	feeDecimalsStore: Writable<number | undefined>;
+	feeTokenIdStore: Writable<TokenId | undefined>;
 }
 
 export const initFeeContext = (params: FeeContext): FeeContext => params;

--- a/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendForm.spec.ts
@@ -47,7 +47,8 @@ describe('SolSendForm', () => {
 				prioritizationFeeStore: mockPrioritizationFeeStore,
 				ataFeeStore: mockAtaFeeStore,
 				feeSymbolStore: writable(SOLANA_TOKEN.symbol),
-				feeDecimalsStore: writable(SOLANA_TOKEN.decimals)
+				feeDecimalsStore: writable(SOLANA_TOKEN.decimals),
+				feeTokenIdStore: writable(SOLANA_TOKEN.id)
 			})
 		);
 	});

--- a/src/frontend/src/tests/sol/components/send/SolSendReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendReview.spec.ts
@@ -41,7 +41,8 @@ describe('SolSendReview', () => {
 				prioritizationFeeStore: mockPrioritizationFeeStore,
 				ataFeeStore: mockAtaFeeStore,
 				feeSymbolStore: writable(SOLANA_TOKEN.symbol),
-				feeDecimalsStore: writable(SOLANA_TOKEN.decimals)
+				feeDecimalsStore: writable(SOLANA_TOKEN.decimals),
+				feeTokenIdStore: writable(SOLANA_TOKEN.id)
 			})
 		);
 	});


### PR DESCRIPTION
# Motivation

We need to extend the sol-fee context with additional store for the token id in which the fee will be paid (similar as in the eth-fee context).