### PR TITLE
feat(frontend): use SendFeeInfo in SOL/ETH send

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendForm.svelte
+++ b/src/frontend/src/eth/components/send/EthSendForm.svelte
@@ -4,6 +4,8 @@
 	import { getContext } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
 	import EthSendAmount from '$eth/components/send/EthSendAmount.svelte';
+	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
+	import SendFeeInfo from '$lib/components/send/SendFeeInfo.svelte';
 	import SendForm from '$lib/components/send/SendForm.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -25,6 +27,9 @@
 	$: invalid = invalidDestination || insufficientFunds || isNullish(amount);
 
 	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const { feeSymbolStore, feeDecimalsStore, feeTokenIdStore }: FeeContext =
+		getContext<FeeContext>(FEE_CONTEXT_KEY);
 </script>
 
 <SendForm
@@ -48,6 +53,13 @@
 	<EthFeeDisplay slot="fee">
 		<Html slot="label" text={$i18n.fee.text.max_fee_eth} />
 	</EthFeeDisplay>
+
+	<SendFeeInfo
+		slot="info"
+		feeSymbol={$feeSymbolStore}
+		decimals={$feeDecimalsStore}
+		feeTokenId={$feeTokenIdStore}
+	/>
 
 	<slot name="cancel" slot="cancel" />
 </SendForm>

--- a/src/frontend/src/sol/components/send/SolSendForm.svelte
+++ b/src/frontend/src/sol/components/send/SolSendForm.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import SendFeeInfo from '$lib/components/send/SendFeeInfo.svelte';
 	import SendForm from '$lib/components/send/SendForm.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import SolFeeDisplay from '$sol/components/fee/SolFeeDisplay.svelte';
 	import SolSendAmount from '$sol/components/send/SolSendAmount.svelte';
+	import { type FeeContext, SOL_FEE_CONTEXT_KEY } from '$sol/stores/sol-fee.store';
 	import type { SolAmountAssertionError } from '$sol/types/sol-send';
 	import { invalidSolAddress } from '$sol/utils/sol-address.utils';
 
@@ -15,6 +17,9 @@
 	export let source: string;
 
 	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const { feeDecimalsStore, feeSymbolStore, feeTokenIdStore }: FeeContext =
+		getContext<FeeContext>(SOL_FEE_CONTEXT_KEY);
 
 	let amountError: SolAmountAssertionError | undefined;
 
@@ -39,6 +44,13 @@
 	<SolSendAmount slot="amount" bind:amount bind:amountError on:icTokensList />
 
 	<SolFeeDisplay slot="fee" />
+
+	<SendFeeInfo
+		slot="info"
+		feeSymbol={$feeSymbolStore}
+		decimals={$feeDecimalsStore}
+		feeTokenId={$feeTokenIdStore}
+	/>
 
 	<slot name="cancel" slot="cancel" />
 </SendForm>


### PR DESCRIPTION
# Motivation

We can now start using the `SendFeeInfo` component in ETH and SOL send flows.

<img width="644" alt="Screenshot 2025-05-16 at 12 42 58" src="https://github.com/user-attachments/assets/63f167e3-615f-46bf-a1f4-7c610319e0cd" />
