### PR TITLE
feat(frontend): added icp swap service method

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -602,7 +602,11 @@
 			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
 			"unexpected": "Something went wrong while swapping tokens.",
 			"unexpected_missing_data": "Something went wrong while initiating a swap transaction.",
-			"slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again."
+			"slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again.",
+			"pool_not_found": "Swap failed. Pool not found.",
+			"deposit_error": "Swap failed. We couldn’t deposit your tokens into the pool. Please try again.",
+			"withdraw_failed": "Swap failed and withdraw also failed. Please check your unused balance and try manual withdrawal: $url%`",
+			"swap_failed_withdraw_success": "Swap failed. Your tokens were refunded successfully. You can try again or increase the slippage tolerance."
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -2,12 +2,14 @@ import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.d
 import { approve } from '$icp/api/icrc-ledger.api';
 import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
 import { loadCustomTokens } from '$icp/services/icrc.services';
-import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { setCustomToken } from '$lib/api/backend.api';
+import { getPoolCanister } from '$lib/api/icp-swap-factory.api';
+import { deposit, depositFrom, swap as swapIcp, withdraw } from '$lib/api/icp-swap-pool.api';
 import { kongSwap, kongTokens } from '$lib/api/kong_backend.api';
 import { KONG_BACKEND_CANISTER_ID, NANO_SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
+import { ICP_SWAP_POOL_FEE } from '$lib/constants/swap.constants';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { swapProviders } from '$lib/providers/swap.providers';
 import { i18n } from '$lib/stores/i18n.store';
@@ -15,23 +17,23 @@ import {
 	kongSwapTokensStore,
 	type KongSwapTokensStoreData
 } from '$lib/stores/kong-swap-tokens.store';
-import type { OptionIdentity } from '$lib/types/identity';
-import type { Amount } from '$lib/types/send';
 import {
 	SwapProvider,
 	type FetchSwapAmountsParams,
 	type ICPSwapResult,
-	type SwapMappedResult
+	type SwapMappedResult,
+	type SwapParams
 } from '$lib/types/swap';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
 import { parseToken } from '$lib/utils/parse.utils';
+import { calculateSlippage } from '$lib/utils/swap.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export const swap = async ({
+export const fetchKongSwap = async ({
 	identity,
 	progress,
 	sourceToken,
@@ -41,17 +43,7 @@ export const swap = async ({
 	slippageValue,
 	sourceTokenFee,
 	isSourceTokenIcrc2
-}: {
-	identity: OptionIdentity;
-	progress: (step: ProgressStepsSwap) => void;
-	sourceToken: IcTokenToggleable;
-	destinationToken: IcTokenToggleable;
-	swapAmount: Amount;
-	receiveAmount: bigint;
-	slippageValue: Amount;
-	sourceTokenFee: bigint;
-	isSourceTokenIcrc2: boolean;
-}) => {
+}: SwapParams) => {
 	progress(ProgressStepsSwap.SWAP);
 
 	const parsedSwapAmount = parseToken({
@@ -174,4 +166,128 @@ export const fetchSwapAmounts = async ({
 	);
 
 	return mappedProvidersResults.sort((a, b) => Number(b.receiveAmount) - Number(a.receiveAmount));
+};
+
+export const fetchIcpSwap = async ({
+	identity,
+	progress,
+	sourceToken,
+	destinationToken,
+	swapAmount,
+	receiveAmount,
+	slippageValue,
+	sourceTokenFee,
+	isSourceTokenIcrc2
+}: SwapParams): Promise<void> => {
+	progress(ProgressStepsSwap.SWAP);
+
+	const parsedSwapAmount = parseToken({
+		value: `${swapAmount}`,
+		unitName: sourceToken.decimals
+	});
+
+	const pool = await getPoolCanister({
+		identity,
+		token0: { address: sourceToken.ledgerCanisterId, standard: sourceToken.standard },
+		token1: { address: destinationToken.ledgerCanisterId, standard: destinationToken.standard },
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity,
+		fee: ICP_SWAP_POOL_FEE
+	});
+
+	if (isNullish(pool)) {
+		throw new Error(get(i18n).swap.error.pool_not_found);
+	}
+
+	const slippageMinimum = calculateSlippage({
+		quoteAmount: receiveAmount,
+		slippagePercentage: Number(slippageValue)
+	});
+
+	const transferParams = {
+		identity,
+		token: sourceToken,
+		amount: parsedSwapAmount,
+		to: pool.canisterId.toString(),
+		ledgerCanisterId: sourceToken.ledgerCanisterId
+	};
+
+	try {
+		if (!isSourceTokenIcrc2) {
+			await sendIcrc(transferParams);
+			await deposit({
+				identity,
+				canisterId: pool.canisterId.toString(),
+				token: sourceToken.ledgerCanisterId,
+				amount: parsedSwapAmount,
+				fee: sourceTokenFee
+			});
+		} else {
+			await approve({
+				identity,
+				ledgerCanisterId: sourceToken.ledgerCanisterId,
+				amount: parsedSwapAmount + sourceTokenFee * 2n,
+				expiresAt: nowInBigIntNanoSeconds() + 5n * NANO_SECONDS_IN_MINUTE,
+				spender: { owner: pool.canisterId }
+			});
+
+			await depositFrom({
+				identity,
+				canisterId: pool.canisterId.toString(),
+				token: sourceToken.ledgerCanisterId,
+				amount: parsedSwapAmount,
+				fee: sourceTokenFee
+			});
+		}
+	} catch (_: unknown) {
+		throw new Error(get(i18n).swap.error.deposit_error);
+	}
+
+	try {
+		await swapIcp({
+			identity,
+			canisterId: pool.canisterId.toString(),
+			amountIn: parsedSwapAmount.toString(),
+			zeroForOne: pool.token0.address === sourceToken.ledgerCanisterId,
+			amountOutMinimum: slippageMinimum.toString()
+		});
+	} catch (_: unknown) {
+		try {
+			await withdraw({
+				identity,
+				canisterId: pool.canisterId.toString(),
+				token: sourceToken.ledgerCanisterId,
+				amount: parsedSwapAmount,
+				fee: sourceTokenFee
+			});
+		} catch (_: unknown) {
+			throw new Error(get(i18n).swap.error.withdraw_failed);
+		}
+
+		throw new Error(get(i18n).swap.error.swap_failed_withdraw_success);
+	}
+
+	try {
+		await withdraw({
+			identity,
+			canisterId: pool.canisterId.toString(),
+			token: destinationToken.ledgerCanisterId,
+			amount: receiveAmount,
+			fee: destinationToken.fee
+		});
+	} catch (_: unknown) {
+		throw new Error(get(i18n).swap.error.withdraw_failed);
+	}
+
+	progress(ProgressStepsSwap.UPDATE_UI);
+
+	if (!destinationToken.enabled) {
+		await setCustomToken({
+			token: toCustomToken({ ...destinationToken, enabled: true, networkKey: 'Icrc' }),
+			identity,
+			nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+		});
+		await loadCustomTokens({ identity });
+	}
+
+	await waitAndTriggerWallet();
 };

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -570,6 +570,10 @@ interface I18nSwap {
 		unexpected: string;
 		unexpected_missing_data: string;
 		slippage_exceeded: string;
+		pool_not_found: string;
+		deposit_error: string;
+		withdraw_failed: string;
+		swap_failed_withdraw_success: string;
 	};
 }
 

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -1,7 +1,11 @@
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import type { IcToken } from '$icp/types/ic-token';
+import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
+import type { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import type { Token } from '$lib/types/token';
 import type { Identity } from '@dfinity/agent';
+import type { OptionIdentity } from './identity';
+import type { Amount } from './send';
 
 export type SwapSelectTokenType = 'source' | 'destination';
 
@@ -86,3 +90,15 @@ type KongSwapProvider = BaseSwapProvider<SwapProvider.KONG_SWAP, SwapAmountsRepl
 type IcpSwapProvider = BaseSwapProvider<SwapProvider.ICP_SWAP, ICPSwapResult, IcpQuoteParams>;
 
 export type SwapProviderConfig = KongSwapProvider | IcpSwapProvider;
+
+export type SwapParams = {
+	identity: OptionIdentity;
+	progress: (step: ProgressStepsSwap) => void;
+	sourceToken: IcTokenToggleable;
+	destinationToken: IcTokenToggleable;
+	swapAmount: Amount;
+	receiveAmount: bigint;
+	slippageValue: Amount;
+	sourceTokenFee: bigint;
+	isSourceTokenIcrc2: boolean;
+};

--- a/src/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -1,9 +1,22 @@
 import type { IcToken } from '$icp/types/ic-token';
+import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import * as factoryApi from '$lib/api/icp-swap-factory.api';
+import { getPoolCanister } from '$lib/api/icp-swap-factory.api';
 import * as poolApi from '$lib/api/icp-swap-pool.api';
+import { deposit, depositFrom, swap as swapIcp, withdraw } from '$lib/api/icp-swap-pool.api';
 import { icpSwapAmounts } from '$lib/services/icp-swap.services';
+import { fetchIcpSwap } from '$lib/services/swap.services';
+import { mockValidIcToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { Principal } from '@dfinity/principal';
+
+import { approve } from '$icp/api/icrc-ledger.api';
+import { sendIcrc } from '$icp/services/ic-send.services';
+
+import { loadCustomTokens } from '$icp/services/icrc.services';
+import { setCustomToken } from '$lib/api/backend.api';
+import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 
 const mockPool = {
 	canisterId: Principal.fromText('aaaaa-aa'),
@@ -69,5 +82,114 @@ describe('icpSwapAmounts', () => {
 			zeroForOne: false,
 			amountOutMinimum: '0'
 		});
+	});
+});
+
+vi.mock('$lib/api/icp-swap-factory.api');
+vi.mock('$lib/api/icp-swap-pool.api');
+vi.mock('$icp/api/icrc-ledger.api');
+vi.mock('$icp/services/ic-send.services');
+vi.mock('$icp/services/icrc.services');
+vi.mock('$lib/utils/wallet.utils');
+vi.mock('$lib/api/backend.api');
+
+describe('fetchIcpSwap', () => {
+	const swapArgs = {
+		identity: mockIdentity,
+		progress: vi.fn(),
+		sourceToken: mockValidIcToken as IcTokenToggleable,
+		destinationToken: { ...mockValidIcrcToken, enabled: true } as IcTokenToggleable,
+		swapAmount: 1,
+		receiveAmount: 900n,
+		slippageValue: 0.5,
+		sourceTokenFee: 100n,
+		isSourceTokenIcrc2: false
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('Success swap for ICRC1', async () => {
+		vi.mocked(getPoolCanister).mockResolvedValue(mockPool);
+
+		vi.mocked(sendIcrc).mockResolvedValue(1n);
+		vi.mocked(deposit).mockResolvedValue(1n);
+		vi.mocked(swapIcp).mockResolvedValue(1n);
+		vi.mocked(withdraw).mockResolvedValue(1n);
+		vi.mocked(waitAndTriggerWallet).mockResolvedValue();
+		vi.mocked(setCustomToken).mockResolvedValue();
+		vi.mocked(loadCustomTokens).mockResolvedValue();
+
+		await expect(fetchIcpSwap({ ...swapArgs, isSourceTokenIcrc2: false })).resolves.not.toThrow();
+
+		expect(swapArgs.progress).toHaveBeenCalledWith(ProgressStepsSwap.SWAP);
+		expect(swapArgs.progress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+		expect(sendIcrc).toHaveBeenCalled();
+		expect(deposit).toHaveBeenCalled();
+		expect(swapIcp).toHaveBeenCalled();
+		expect(withdraw).toHaveBeenCalled();
+	});
+
+	it('Success swap for ICRC2', async () => {
+		vi.mocked(getPoolCanister).mockResolvedValue(mockPool);
+
+		vi.mocked(approve).mockResolvedValue(1n);
+		vi.mocked(depositFrom).mockResolvedValue(1n);
+		vi.mocked(swapIcp).mockResolvedValue(1n);
+		vi.mocked(withdraw).mockResolvedValue(1n);
+		vi.mocked(waitAndTriggerWallet).mockResolvedValue();
+
+		await expect(fetchIcpSwap({ ...swapArgs, isSourceTokenIcrc2: true })).resolves.not.toThrow();
+
+		expect(approve).toHaveBeenCalled();
+		expect(depositFrom).toHaveBeenCalled();
+		expect(swapIcp).toHaveBeenCalled();
+		expect(withdraw).toHaveBeenCalled();
+	});
+
+	it('Swap failed. Pool not found', async () => {
+		vi.mocked(getPoolCanister).mockRejectedValue(new Error('pool_not_found'));
+
+		await expect(fetchIcpSwap({ ...swapArgs, isSourceTokenIcrc2: false })).rejects.toThrow(
+			'pool_not_found'
+		);
+	});
+
+	it('Swap failed. Deposit failed', async () => {
+		vi.mocked(getPoolCanister).mockResolvedValue(mockPool);
+
+		vi.mocked(sendIcrc).mockResolvedValue(1n);
+		vi.mocked(deposit).mockRejectedValue(new Error('fail'));
+
+		await expect(fetchIcpSwap({ ...swapArgs, isSourceTokenIcrc2: false })).rejects.toThrow(
+			'Swap failed. We couldn’t deposit your tokens into the pool. Please try again.'
+		);
+	});
+
+	it('Swap failed. Withdraw Success', async () => {
+		vi.mocked(getPoolCanister).mockResolvedValue(mockPool);
+
+		vi.mocked(sendIcrc).mockResolvedValue(1n);
+		vi.mocked(deposit).mockResolvedValue(1n);
+		vi.mocked(swapIcp).mockRejectedValue(new Error('swap fail'));
+		vi.mocked(withdraw).mockResolvedValue(1n);
+
+		await expect(fetchIcpSwap({ ...swapArgs, isSourceTokenIcrc2: false })).rejects.toThrow(
+			'Swap failed. Your tokens were refunded successfully. You can try again or increase the slippage tolerance.'
+		);
+	});
+
+	it('Swap and withdraw both failed', async () => {
+		vi.mocked(getPoolCanister).mockResolvedValue(mockPool);
+
+		vi.mocked(sendIcrc).mockResolvedValue(1n);
+		vi.mocked(deposit).mockResolvedValue(1n);
+		vi.mocked(swapIcp).mockRejectedValue(new Error('swap fail'));
+		vi.mocked(withdraw).mockRejectedValue(new Error('withdraw fail'));
+
+		await expect(fetchIcpSwap({ ...swapArgs, isSourceTokenIcrc2: false })).rejects.toThrow(
+			'Swap failed and withdraw also failed. Please check your unused balance and try manual withdrawal: $url%`'
+		);
 	});
 });


### PR DESCRIPTION
# Motivation

Implemented a new service method fetchIcpSwap to handle token swaps, including transfer, deposit, swap, and withdrawal steps.

# Changes

- Created fetchIcpSwap to encapsulate the ICP Swap logic.

- Integrated i18n error messages.

- Handled different token standards (ICRC1 and ICRC2) with branching logic.

- Added fallback and compensation logic for failed swap/withdraw steps.

# Tests

Covered new logic with the tests.