### PR TITLE
refactor(frontend): apply lint rule `consistent-type-definitions`

### DIFF
--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -22,11 +22,11 @@ import {
 } from 'ethers/providers';
 import { get } from 'svelte/store';
 
-type TransactionsParams = {
+interface TransactionsParams {
 	address: EthAddress;
 	startBlock?: BlockTag;
 	endBlock?: BlockTag;
-};
+}
 
 export class EtherscanProvider {
 	private readonly provider: EtherscanProviderLib;

--- a/src/frontend/src/icp/workers/dip20-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/dip20-wallet.worker.ts
@@ -17,10 +17,10 @@ import type {
 import { isNullish } from '@dfinity/utils';
 
 // TODO: add query for transactions - for now we mock with empty transactions
-type GetTransactions = {
+interface GetTransactions {
 	transactions: Dip20TransactionWithId[];
 	oldest_tx_id: [] | [bigint];
-};
+}
 
 type GetBalance = bigint;
 

--- a/src/frontend/src/lib/components/ui/Input.svelte
+++ b/src/frontend/src/lib/components/ui/Input.svelte
@@ -7,12 +7,12 @@
 	import ButtonReset from '$lib/components/ui/ButtonReset.svelte';
 
 	type GixInputProps = ComponentProps<GixInput>;
-	type InputProps = {
+	interface InputProps {
 		showResetButton?: boolean;
 		resetButtonAriaLabel?: string;
 		showPasteButton?: boolean;
 		innerEnd?: Snippet;
-	};
+	}
 
 	let endWidth: number = $state(0);
 

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -64,10 +64,10 @@ export interface Modal<T> {
 
 export type ModalData<T> = Option<Modal<T>>;
 
-type SetWithDataParams<D> = { id: symbol; data: D };
-type SetWithOptionalDataParams<D> = { id: symbol; data?: D };
+interface SetWithDataParams<D> { id: symbol; data: D }
+interface SetWithOptionalDataParams<D> { id: symbol; data?: D }
 
-type OpenTransactionParams<T extends AnyTransactionUi> = { transaction: T; token: Token };
+interface OpenTransactionParams<T extends AnyTransactionUi> { transaction: T; token: Token }
 
 export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openEthReceive: (id: symbol) => void;

--- a/src/frontend/src/lib/stores/reward.store.ts
+++ b/src/frontend/src/lib/stores/reward.store.ts
@@ -1,9 +1,9 @@
 import type { CampaignEligibility } from '$lib/types/reward';
 import { derived, writable, type Readable } from 'svelte/store';
 
-export type RewardEligibilityData = {
+export interface RewardEligibilityData {
 	campaignEligibilities?: CampaignEligibility[] | undefined;
-};
+}
 
 export interface RewardEligibilityStore extends Readable<RewardEligibilityData> {
 	setCampaignEligibilities: (campaignEligibilities: CampaignEligibility[]) => void;

--- a/src/frontend/src/lib/stores/transactions.store.ts
+++ b/src/frontend/src/lib/stores/transactions.store.ts
@@ -10,10 +10,10 @@ type TransactionTypes = IcTransactionUi | BtcTransactionUi | SolTransactionUi;
 
 export type CertifiedTransaction<T extends TransactionTypes> = CertifiedData<T>;
 
-export type TransactionsStoreParams<T extends TransactionTypes> = {
+export interface TransactionsStoreParams<T extends TransactionTypes> {
 	tokenId: TokenId;
 	transactions: CertifiedTransaction<T>[];
-};
+}
 
 export type TransactionsStoreIdParams<T extends TransactionTypes> = Omit<
 	TransactionsStoreParams<T>,

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -77,7 +77,7 @@ export type CoingeckoPriceResponse =
 	| CoingeckoSimplePriceResponse
 	| CoingeckoSimpleTokenPriceResponse;
 
-export type CoingeckoErc20PriceParams = {
+export interface CoingeckoErc20PriceParams {
 	coingeckoPlatformId: CoingeckoPlatformId;
 	contractAddresses: Erc20ContractAddress[];
-};
+}

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -48,32 +48,32 @@ export type SwapMappedResult =
 			swapDetails: SwapAmountsReply;
 	  };
 
-export type KongQuoteResult = {
+export interface KongQuoteResult {
 	swap: SwapAmountsReply;
 	tokens: IcToken[];
-};
+}
 
-export type IcpQuoteResult = {
+export interface IcpQuoteResult {
 	swap: ICPSwapResult;
 	slippage: Slippage;
-};
+}
 
-type KongQuoteParams = {
+interface KongQuoteParams {
 	swap: SwapAmountsReply;
 	tokens: Token[];
-};
+}
 
-type IcpQuoteParams = {
+interface IcpQuoteParams {
 	swap: ICPSwapResult;
 	slippage: Slippage;
-};
+}
 
-type SwapQuoteParams = {
+interface SwapQuoteParams {
 	identity: Identity;
 	sourceToken: IcToken;
 	destinationToken: IcToken;
 	sourceAmount: bigint;
-};
+}
 interface BaseSwapProvider<T extends SwapProvider, QuoteResult, QuoteMapParams> {
 	key: T;
 	getQuote: (params: SwapQuoteParams) => Promise<QuoteResult>;

--- a/src/frontend/src/lib/types/transactions.ts
+++ b/src/frontend/src/lib/types/transactions.ts
@@ -15,6 +15,6 @@ export interface TransactionsStoreCheckParams {
 	tokens: Token[];
 }
 
-export type KnownDestination = { amounts: { value: bigint; token: Token }[]; timestamp?: number };
+export interface KnownDestination { amounts: { value: bigint; token: Token }[]; timestamp?: number }
 
 export type KnownDestinations = Record<Address, KnownDestination>;

--- a/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
@@ -18,12 +18,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const fakeSnippet: Snippet = (() => {}) as Snippet;
 
-type SwapAmountsContextProps = {
+interface SwapAmountsContextProps {
 	amount: OptionAmount;
 	sourceToken: IcToken | undefined;
 	destinationToken: IcToken | undefined;
 	slippageValue: OptionAmount;
-};
+}
 
 describe('SwapAmountsContext.svelte', () => {
 	const [sourceToken, destinationToken] = [mockValidIcToken, mockValidIcCkToken] as IcToken[];

--- a/src/frontend/src/tests/lib/utils/clipboard.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/clipboard.utils.spec.ts
@@ -21,7 +21,7 @@ describe('clipboard.utils', () => {
 
 			spyToastsShow = vi.spyOn(toastsStore, 'toastsShow');
 
-			mockCopyText.mockImplementation(() => Promise.resolve());
+			mockCopyText.mockResolvedValue(undefined);
 		});
 
 		it('should copy text to clipboard', async () => {

--- a/src/frontend/src/tests/lib/utils/clipboard.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/clipboard.utils.spec.ts
@@ -21,7 +21,7 @@ describe('clipboard.utils', () => {
 
 			spyToastsShow = vi.spyOn(toastsStore, 'toastsShow');
 
-			mockCopyText.mockResolvedValue(undefined);
+			mockCopyText.mockImplementation(() => Promise.resolve());
 		});
 
 		it('should copy text to clipboard', async () => {


### PR DESCRIPTION
# Motivation

Before bumping the lint library in PR https://github.com/dfinity/oisy-wallet/pull/6637, we need to manually solve lint rule [consistent-type-definitions](https://typescript-eslint.io/rules/consistent-type-definitions/).