### PR TITLE
feat(frontend): define default token for Polygon networks

### DIFF
--- a/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
@@ -1,11 +1,13 @@
 import { SUPPORTED_BASE_NETWORKS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORKS } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { SUPPORTED_POLYGON_NETWORKS } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
 import type { Network, NetworkId } from '$lib/types/network';
 
 export const SUPPORTED_EVM_NETWORKS: EthereumNetwork[] = [
 	...SUPPORTED_BASE_NETWORKS,
-	...SUPPORTED_BSC_NETWORKS
+	...SUPPORTED_BSC_NETWORKS,
+	...SUPPORTED_POLYGON_NETWORKS
 ];
 
 export const SUPPORTED_EVM_NETWORK_IDS: NetworkId[] = SUPPORTED_EVM_NETWORKS.map(({ id }) => id);

--- a/src/frontend/src/env/networks/networks-evm/networks.evm.polygon.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.polygon.env.ts
@@ -35,7 +35,7 @@ export const POLYGON_MAINNET_NETWORK: EthereumNetwork = {
 	buy: { onramperId: 'polygon' }
 };
 
-export const POLYGON_AMOY_NETWORK_SYMBOL = 'BSC (Amoy Testnet)';
+export const POLYGON_AMOY_NETWORK_SYMBOL = 'POL (Amoy Testnet)';
 
 export const POLYGON_AMOY_NETWORK_ID: NetworkId = parseNetworkId(POLYGON_AMOY_NETWORK_SYMBOL);
 

--- a/src/frontend/src/env/tokens/tokens-evm/tokens.evm.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens.evm.env.ts
@@ -1,10 +1,12 @@
 import { SUPPORTED_BASE_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { SUPPORTED_BSC_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import { SUPPORTED_POLYGON_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import type { RequiredToken, TokenId } from '$lib/types/token';
 
 export const SUPPORTED_EVM_TOKENS: RequiredToken[] = [
 	...SUPPORTED_BASE_TOKENS,
-	...SUPPORTED_BSC_TOKENS
+	...SUPPORTED_BSC_TOKENS,
+	...SUPPORTED_POLYGON_TOKENS
 ];
 
 export const SUPPORTED_EVM_TOKEN_IDS: TokenId[] = SUPPORTED_EVM_TOKENS.map(({ id }) => id);

--- a/src/frontend/src/lib/constants/tokens.constants.ts
+++ b/src/frontend/src/lib/constants/tokens.constants.ts
@@ -1,5 +1,6 @@
 import { SUPPORTED_BASE_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { SUPPORTED_BSC_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import { SUPPORTED_POLYGON_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
 import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
 import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
@@ -13,3 +14,5 @@ export const [DEFAULT_SOLANA_TOKEN] = SUPPORTED_SOLANA_TOKENS;
 export const [DEFAULT_BSC_TOKEN] = SUPPORTED_BSC_TOKENS;
 
 export const [DEFAULT_BASE_TOKEN] = SUPPORTED_BASE_TOKENS;
+
+export const [DEFAULT_POLYGON_TOKEN] = SUPPORTED_POLYGON_TOKENS;

--- a/src/frontend/src/lib/derived/network.derived.ts
+++ b/src/frontend/src/lib/derived/network.derived.ts
@@ -11,6 +11,7 @@ import {
 	isNetworkIdEthereum,
 	isNetworkIdEvm,
 	isNetworkIdICP,
+	isNetworkIdPolygon,
 	isNetworkIdSolana
 } from '$lib/utils/network.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -51,6 +52,10 @@ export const networkBase: Readable<boolean> = derived([networkId], ([$networkId]
 
 export const networkBsc: Readable<boolean> = derived([networkId], ([$networkId]) =>
 	isNetworkIdBsc($networkId)
+);
+
+export const networkPolygon: Readable<boolean> = derived([networkId], ([$networkId]) =>
+	isNetworkIdPolygon($networkId)
 );
 
 export const networkSolana: Readable<boolean> = derived([networkId], ([$networkId]) =>

--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -5,6 +5,7 @@ import {
 	DEFAULT_BITCOIN_TOKEN,
 	DEFAULT_BSC_TOKEN,
 	DEFAULT_ETHEREUM_TOKEN,
+	DEFAULT_POLYGON_TOKEN,
 	DEFAULT_SOLANA_TOKEN
 } from '$lib/constants/tokens.constants';
 import {
@@ -12,6 +13,7 @@ import {
 	networkBitcoin,
 	networkBsc,
 	networkEthereum,
+	networkPolygon,
 	networkSolana
 } from '$lib/derived/network.derived';
 import { token } from '$lib/stores/token.store';
@@ -24,8 +26,15 @@ import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const defaultFallbackToken: Readable<Token> = derived(
-	[networkBitcoin, networkEthereum, networkBase, networkBsc, networkSolana],
-	([$networkBitcoin, $networkEthereum, $networkBase, $networkBsc, $networkSolana]) => {
+	[networkBitcoin, networkEthereum, networkBase, networkBsc, networkPolygon, networkSolana],
+	([
+		$networkBitcoin,
+		$networkEthereum,
+		$networkBase,
+		$networkBsc,
+		$networkPolygon,
+		$networkSolana
+	]) => {
 		if ($networkBitcoin) {
 			return DEFAULT_BITCOIN_TOKEN;
 		}
@@ -40,6 +49,9 @@ export const defaultFallbackToken: Readable<Token> = derived(
 		}
 		if ($networkBsc) {
 			return DEFAULT_BSC_TOKEN;
+		}
+		if ($networkPolygon) {
+			return DEFAULT_POLYGON_TOKEN;
 		}
 
 		return DEFAULT_ETHEREUM_TOKEN;

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -2,6 +2,7 @@ import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signe
 import { SUPPORTED_BASE_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import { SUPPORTED_EVM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
+import { SUPPORTED_POLYGON_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
@@ -44,6 +45,9 @@ export const isNetworkIdBase: IsNetworkIdUtil = (id) =>
 
 export const isNetworkIdBsc: IsNetworkIdUtil = (id) =>
 	nonNullish(id) && SUPPORTED_BSC_NETWORK_IDS.includes(id);
+
+export const isNetworkIdPolygon: IsNetworkIdUtil = (id) =>
+	nonNullish(id) && SUPPORTED_POLYGON_NETWORK_IDS.includes(id);
 
 export const isNetworkIdBitcoin: IsNetworkIdUtil = (id) =>
 	nonNullish(id) && SUPPORTED_BITCOIN_NETWORK_IDS.includes(id);

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
@@ -1,12 +1,5 @@
-import {
-	BASE_ETH_TOKEN,
-	BASE_SEPOLIA_ETH_TOKEN
-} from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
-import {
-	BNB_MAINNET_TOKEN,
-	BNB_TESTNET_TOKEN
-} from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
-import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
+import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
 import LoaderEthBalances from '$eth/components/loaders/LoaderEthBalances.svelte';
 import { loadErc20Balances, loadEthBalances } from '$eth/services/eth-balance.services';
 import type { Erc20Token } from '$eth/types/erc20';
@@ -32,16 +25,9 @@ describe('LoaderEthBalances', () => {
 		networkEnv: 'testnet'
 	});
 
-	const mainnetTokens: Token[] = [ETHEREUM_TOKEN, BASE_ETH_TOKEN, BNB_MAINNET_TOKEN];
+	const allTokens: Token[] = [...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS];
 
-	const allTokens: Token[] = [
-		ETHEREUM_TOKEN,
-		SEPOLIA_TOKEN,
-		BASE_ETH_TOKEN,
-		BASE_SEPOLIA_ETH_TOKEN,
-		BNB_MAINNET_TOKEN,
-		BNB_TESTNET_TOKEN
-	];
+	const mainnetTokens: Token[] = allTokens.filter(({ network: { env } }) => env === 'mainnet');
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -44,14 +44,6 @@ describe('LoaderMultipleEthTransactions', () => {
 		start: 2
 	});
 
-	const mockMainnetErc20UserTokens = mockMainnetErc20CertifiedUserTokens.map(
-		({ data: token }) => token
-	);
-
-	const mockSepoliaErc20UserTokens = mockSepoliaErc20CertifiedUserTokens.map(
-		({ data: token }) => token
-	);
-
 	const mockErc20UserTokens = mockErc20CertifiedUserTokens.map(({ data: token }) => token);
 
 	const mockAdditionalTokens = mockAdditionalCertifiedTokens.map(({ data: token }) => token);

--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -1,17 +1,10 @@
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
-import {
-	BASE_ETH_TOKEN,
-	BASE_SEPOLIA_ETH_TOKEN
-} from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
-import {
-	BNB_MAINNET_TOKEN,
-	BNB_TESTNET_TOKEN
-} from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import {
 	ETHEREUM_TOKEN,
 	ETHEREUM_TOKEN_ID,
-	SEPOLIA_TOKEN,
-	SEPOLIA_TOKEN_ID
+	SEPOLIA_TOKEN_ID,
+	SUPPORTED_ETHEREUM_TOKENS
 } from '$env/tokens/tokens.eth.env';
 import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
 import { loadEthereumTransactions } from '$eth/services/eth-transactions.services';
@@ -63,14 +56,10 @@ describe('LoaderMultipleEthTransactions', () => {
 
 	const mockAdditionalTokens = mockAdditionalCertifiedTokens.map(({ data: token }) => token);
 
-	const expectedTokens = [
-		ETHEREUM_TOKEN,
-		SEPOLIA_TOKEN,
+	const allExpectedTokens = [
+		...SUPPORTED_ETHEREUM_TOKENS,
 		...mockErc20UserTokens,
-		BASE_ETH_TOKEN,
-		BASE_SEPOLIA_ETH_TOKEN,
-		BNB_MAINNET_TOKEN,
-		BNB_TESTNET_TOKEN
+		...SUPPORTED_EVM_TOKENS
 	];
 
 	beforeEach(() => {
@@ -102,9 +91,9 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(allExpectedTokens.length);
 
-		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
+		allExpectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
 	});
@@ -116,18 +105,18 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(allExpectedTokens.length);
 
-		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
+		allExpectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		// same number of calls as before
-		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(allExpectedTokens.length);
 
-		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
+		allExpectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
 	});
@@ -139,12 +128,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		const expectedTokens = [
-			ETHEREUM_TOKEN,
-			...mockMainnetErc20UserTokens,
-			BASE_ETH_TOKEN,
-			BNB_MAINNET_TOKEN
-		];
+		const expectedTokens = allExpectedTokens.filter(({ network: { env } }) => env === 'mainnet');
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
 
@@ -166,12 +150,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		const expectedTokens = [
-			SEPOLIA_TOKEN,
-			...mockSepoliaErc20UserTokens,
-			BASE_SEPOLIA_ETH_TOKEN,
-			BNB_TESTNET_TOKEN
-		];
+		const expectedTokens = allExpectedTokens.filter(({ network: { env } }) => env === 'testnet');
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
 
@@ -201,9 +180,9 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(allExpectedTokens.length);
 
-		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
+		allExpectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
 
@@ -214,7 +193,7 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		// the number of calls as before + mockAdditionalTokens.length
 		const expectedNewTokens = [
-			...expectedTokens,
+			...allExpectedTokens,
 			...mockAdditionalTokens.map(({ data: token }) => token)
 		];
 
@@ -239,9 +218,9 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(allExpectedTokens.length);
 
-		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
+		allExpectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
 
@@ -254,7 +233,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		// the number of calls as before + mockAdditionalTokens.length
-		const expectedNewTokens = [...expectedTokens, ...mockAdditionalTokens];
+		const expectedNewTokens = [...allExpectedTokens, ...mockAdditionalTokens];
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedNewTokens.length);
 
@@ -302,9 +281,9 @@ describe('LoaderMultipleEthTransactions', () => {
 
 		await vi.advanceTimersByTimeAsync(timeout);
 
-		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedTokens.length);
+		expect(loadEthereumTransactions).toHaveBeenCalledTimes(allExpectedTokens.length);
 
-		expectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
+		allExpectedTokens.forEach(({ id: tokenId, network: { id: networkId } }, index) => {
 			expect(loadEthereumTransactions).toHaveBeenNthCalledWith(index + 1, { tokenId, networkId });
 		});
 
@@ -317,7 +296,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		await vi.advanceTimersByTimeAsync(timeout);
 
 		// the number of calls as before + the failed call + mockAdditionalTokens.length
-		const expectedNewTokens = [...expectedTokens, ETHEREUM_TOKEN, ...mockAdditionalTokens];
+		const expectedNewTokens = [...allExpectedTokens, ETHEREUM_TOKEN, ...mockAdditionalTokens];
 
 		expect(loadEthereumTransactions).toHaveBeenCalledTimes(expectedNewTokens.length);
 

--- a/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
@@ -186,6 +186,7 @@ describe('AddressGuard', () => {
 									[{ EthereumMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ BaseMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ BscMainnet: null }, { enabled: false, is_testnet: false }],
+									[{ PolygonMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ SolanaMainnet: null }, { enabled: true, is_testnet: false }]
 								]
 							}

--- a/src/frontend/src/tests/lib/derived/all-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/all-tokens.derived.spec.ts
@@ -9,6 +9,10 @@ import {
 	BNB_TESTNET_TOKEN
 } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import {
+	POL_AMOY_TOKEN,
+	POL_MAINNET_TOKEN
+} from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
+import {
 	BTC_MAINNET_TOKEN,
 	BTC_REGTEST_TOKEN,
 	BTC_TESTNET_TOKEN
@@ -138,6 +142,7 @@ describe('all-tokens.derived', () => {
 				SOLANA_TOKEN.id.description,
 				BASE_ETH_TOKEN.id.description,
 				BNB_MAINNET_TOKEN.id.description,
+				POL_MAINNET_TOKEN.id.description,
 				mockErc20Token.id.description,
 				mockDip20Token.id.description,
 				mockIcrcToken2.id.description,
@@ -215,7 +220,9 @@ describe('all-tokens.derived', () => {
 				BASE_ETH_TOKEN.id.description,
 				BASE_SEPOLIA_ETH_TOKEN.id.description,
 				BNB_MAINNET_TOKEN.id.description,
-				BNB_TESTNET_TOKEN.id.description
+				BNB_TESTNET_TOKEN.id.description,
+				POL_MAINNET_TOKEN.id.description,
+				POL_AMOY_TOKEN.id.description
 			]);
 		});
 
@@ -242,7 +249,9 @@ describe('all-tokens.derived', () => {
 				BASE_ETH_TOKEN.id.description,
 				BASE_SEPOLIA_ETH_TOKEN.id.description,
 				BNB_MAINNET_TOKEN.id.description,
-				BNB_TESTNET_TOKEN.id.description
+				BNB_TESTNET_TOKEN.id.description,
+				POL_MAINNET_TOKEN.id.description,
+				POL_AMOY_TOKEN.id.description
 			]);
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/network-tokens.derived.spec.ts
@@ -6,6 +6,10 @@ import {
 	BSC_MAINNET_NETWORK,
 	BSC_TESTNET_NETWORK
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import {
+	POLYGON_AMOY_NETWORK,
+	POLYGON_MAINNET_NETWORK
+} from '$env/networks/networks-evm/networks.evm.polygon.env';
 import * as btcEnv from '$env/networks/networks.btc.env';
 import { BTC_MAINNET_NETWORK } from '$env/networks/networks.btc.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
@@ -27,6 +31,10 @@ import {
 	BNB_MAINNET_TOKEN,
 	BNB_TESTNET_TOKEN
 } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import {
+	POL_AMOY_TOKEN,
+	POL_MAINNET_TOKEN
+} from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { DEVNET_EURC_TOKEN } from '$env/tokens/tokens-spl/tokens.eurc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
@@ -43,6 +51,8 @@ import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
+import type { Network } from '$lib/types/network';
+import type { Token } from '$lib/types/token';
 import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
 import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
 import type { SplCustomToken } from '$sol/types/spl-custom-token';
@@ -85,7 +95,8 @@ describe('network-tokens.derived', () => {
 				ETHEREUM_TOKEN,
 				SOLANA_TOKEN,
 				BASE_ETH_TOKEN,
-				BNB_MAINNET_TOKEN
+				BNB_MAINNET_TOKEN,
+				POL_MAINNET_TOKEN
 			]);
 		});
 
@@ -110,7 +121,7 @@ describe('network-tokens.derived', () => {
 				...toggleProps
 			};
 
-			const networkMap = [
+			const networkMap: { network: Network; tokens: Token[] }[] = [
 				{
 					network: ICP_NETWORK,
 					tokens: [ICP_TOKEN]
@@ -154,6 +165,14 @@ describe('network-tokens.derived', () => {
 				{
 					network: BSC_TESTNET_NETWORK,
 					tokens: [BNB_TESTNET_TOKEN]
+				},
+				{
+					network: POLYGON_MAINNET_NETWORK,
+					tokens: [POL_MAINNET_TOKEN]
+				},
+				{
+					network: POLYGON_AMOY_NETWORK,
+					tokens: [POL_AMOY_TOKEN]
 				}
 			];
 
@@ -178,6 +197,7 @@ describe('network-tokens.derived', () => {
 					SOLANA_TOKEN,
 					BASE_ETH_TOKEN,
 					BNB_MAINNET_TOKEN,
+					POL_MAINNET_TOKEN,
 					mockErc20UserToken,
 					mockSplCustomToken
 				]);

--- a/src/frontend/src/tests/lib/derived/token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/token.derived.spec.ts
@@ -1,5 +1,6 @@
 import { SUPPORTED_BASE_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { SUPPORTED_POLYGON_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { SUPPORTED_BITCOIN_NETWORK_IDS } from '$env/networks/networks.btc.env';
 import { SUPPORTED_NETWORK_IDS, SUPPORTED_TESTNET_NETWORK_IDS } from '$env/networks/networks.env';
 import { SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
@@ -7,6 +8,7 @@ import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { SUPPORTED_SOLANA_NETWORK_IDS } from '$env/networks/networks.sol.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { BNB_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import { POL_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
@@ -97,6 +99,15 @@ describe('token.derived', () => {
 				mockPage.mock({ network: networkId.description });
 
 				expect(get(defaultFallbackToken)).toEqual(BNB_MAINNET_TOKEN);
+			}
+		);
+
+		it.each(SUPPORTED_POLYGON_NETWORK_IDS)(
+			`should return default token for BSC network %s`,
+			(networkId) => {
+				mockPage.mock({ network: networkId.description });
+
+				expect(get(defaultFallbackToken)).toEqual(POL_MAINNET_TOKEN);
 			}
 		);
 

--- a/src/frontend/src/tests/lib/derived/token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/token.derived.spec.ts
@@ -103,7 +103,7 @@ describe('token.derived', () => {
 		);
 
 		it.each(SUPPORTED_POLYGON_NETWORK_IDS)(
-			`should return default token for BSC network %s`,
+			`should return default token for Polygon network %s`,
 			(networkId) => {
 				mockPage.mock({ network: networkId.description });
 

--- a/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -1,8 +1,6 @@
-import * as baseEnv from '$env/networks/networks-evm/networks.evm.base.env';
 import * as bscEnv from '$env/networks/networks-evm/networks.evm.bsc.env';
 import * as btcEnv from '$env/networks/networks.btc.env';
 import * as ethEnv from '$env/networks/networks.eth.env';
-import * as solEnv from '$env/networks/networks.sol.env';
 import {
 	BASE_ETH_TOKEN,
 	BASE_SEPOLIA_ETH_TOKEN
@@ -11,6 +9,10 @@ import {
 	BNB_MAINNET_TOKEN,
 	BNB_TESTNET_TOKEN
 } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import {
+	POL_AMOY_TOKEN,
+	POL_MAINNET_TOKEN
+} from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import {
 	BTC_MAINNET_TOKEN,
 	BTC_REGTEST_TOKEN,
@@ -94,11 +96,6 @@ describe('tokens.derived', () => {
 			setupTestnetsStore('reset');
 			setupUserNetworksStore('allEnabled');
 
-			vi.spyOn(btcEnv, 'BTC_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-			vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-			vi.spyOn(solEnv, 'SOL_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-			vi.spyOn(baseEnv, 'BASE_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-			vi.spyOn(bscEnv, 'BSC_MAINNET_ENABLED', 'get').mockImplementation(() => true);
 			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => false);
 		});
 
@@ -119,10 +116,11 @@ describe('tokens.derived', () => {
 				SOLANA_TOKEN,
 				BASE_ETH_TOKEN,
 				BNB_MAINNET_TOKEN,
+				POL_MAINNET_TOKEN,
 				{ ...mockErc20DefaultToken, enabled: false, version: undefined },
 				mockEr20UserToken,
-				{ ...mockIcrcDefaultToken, enabled: false, version: undefined, id: result[8].id },
-				{ ...mockIcrcCustomToken, id: result[9].id },
+				{ ...mockIcrcDefaultToken, enabled: false, version: undefined, id: result[9].id },
+				{ ...mockIcrcCustomToken, id: result[10].id },
 				{ ...mockSplDefaultToken, enabled: false, version: undefined },
 				mockSplCustomToken
 			]);
@@ -135,7 +133,8 @@ describe('tokens.derived', () => {
 				ETHEREUM_TOKEN,
 				SOLANA_TOKEN,
 				BASE_ETH_TOKEN,
-				BNB_MAINNET_TOKEN
+				BNB_MAINNET_TOKEN,
+				POL_MAINNET_TOKEN
 			]);
 		});
 
@@ -144,7 +143,7 @@ describe('tokens.derived', () => {
 			vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => false);
 			vi.spyOn(bscEnv, 'BSC_MAINNET_ENABLED', 'get').mockImplementation(() => false);
 
-			expect(get(tokens)).toEqual([ICP_TOKEN, SOLANA_TOKEN, BASE_ETH_TOKEN]);
+			expect(get(tokens)).toEqual([ICP_TOKEN, SOLANA_TOKEN, BASE_ETH_TOKEN, POL_MAINNET_TOKEN]);
 		});
 
 		it('should return testnet tokens too when testnets are enabled', () => {
@@ -162,7 +161,9 @@ describe('tokens.derived', () => {
 				BASE_ETH_TOKEN,
 				BASE_SEPOLIA_ETH_TOKEN,
 				BNB_MAINNET_TOKEN,
-				BNB_TESTNET_TOKEN
+				BNB_TESTNET_TOKEN,
+				POL_MAINNET_TOKEN,
+				POL_AMOY_TOKEN
 			]);
 		});
 
@@ -184,7 +185,9 @@ describe('tokens.derived', () => {
 				BASE_ETH_TOKEN,
 				BASE_SEPOLIA_ETH_TOKEN,
 				BNB_MAINNET_TOKEN,
-				BNB_TESTNET_TOKEN
+				BNB_TESTNET_TOKEN,
+				POL_MAINNET_TOKEN,
+				POL_AMOY_TOKEN
 			]);
 		});
 	});

--- a/src/frontend/src/tests/lib/services/loader.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/loader.services.spec.ts
@@ -195,6 +195,7 @@ describe('loader.services', () => {
 									[{ EthereumMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ BaseMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ BscMainnet: null }, { enabled: false, is_testnet: false }],
+									[{ PolygonMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ SolanaMainnet: null }, { enabled: true, is_testnet: false }]
 								]
 							}

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -6,6 +6,10 @@ import {
 	BSC_MAINNET_NETWORK_ID,
 	BSC_TESTNET_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import {
+	POLYGON_AMOY_NETWORK_ID,
+	POLYGON_MAINNET_NETWORK_ID
+} from '$env/networks/networks-evm/networks.evm.polygon.env';
 import * as btcNetworkEnv from '$env/networks/networks.btc.env';
 import {
 	BTC_MAINNET_NETWORK,
@@ -50,6 +54,7 @@ import {
 	isNetworkIdEthereum,
 	isNetworkIdEvm,
 	isNetworkIdICP,
+	isNetworkIdPolygon,
 	isNetworkIdSOLDevnet,
 	isNetworkIdSOLLocal,
 	isNetworkIdSOLMainnet,
@@ -138,7 +143,7 @@ describe('network utils', () => {
 			expect(isNetworkIdBase(id as NetworkId)).toBeTruthy();
 		});
 
-		it('should return false for non-EVM network IDs', () => {
+		it('should return false for non-Base network IDs', () => {
 			expect(isNetworkIdBase(BTC_MAINNET_NETWORK_ID)).toBeFalsy();
 
 			expect(isNetworkIdBase(ETHEREUM_NETWORK_ID)).toBeFalsy();
@@ -150,16 +155,32 @@ describe('network utils', () => {
 	describe('isNetworkIdBsc', () => {
 		const allBscNetworkIds = [BSC_MAINNET_NETWORK_ID, BSC_TESTNET_NETWORK_ID];
 
-		it.each(allBscNetworkIds)('should return true for Base network ID %s', (id) => {
+		it.each(allBscNetworkIds)('should return true for BSC network ID %s', (id) => {
 			expect(isNetworkIdBsc(id as NetworkId)).toBeTruthy();
 		});
 
-		it('should return false for non-EVM network IDs', () => {
+		it('should return false for non-BSC network IDs', () => {
 			expect(isNetworkIdBsc(BTC_MAINNET_NETWORK_ID)).toBeFalsy();
 
 			expect(isNetworkIdBsc(ETHEREUM_NETWORK_ID)).toBeFalsy();
 
 			expect(isNetworkIdBsc(BASE_NETWORK_ID)).toBeFalsy();
+		});
+	});
+
+	describe('isNetworkIdPolygon', () => {
+		const allPolygonNetworkIds = [POLYGON_MAINNET_NETWORK_ID, POLYGON_AMOY_NETWORK_ID];
+
+		it.each(allPolygonNetworkIds)('should return true for Polygon network ID %s', (id) => {
+			expect(isNetworkIdPolygon(id as NetworkId)).toBeTruthy();
+		});
+
+		it('should return false for non-Polygon network IDs', () => {
+			expect(isNetworkIdPolygon(BTC_MAINNET_NETWORK_ID)).toBeFalsy();
+
+			expect(isNetworkIdPolygon(ETHEREUM_NETWORK_ID)).toBeFalsy();
+
+			expect(isNetworkIdPolygon(BASE_NETWORK_ID)).toBeFalsy();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -1,15 +1,13 @@
 import {
 	BASE_NETWORK_ID,
-	BASE_SEPOLIA_NETWORK_ID
+	SUPPORTED_BASE_NETWORK_IDS
 } from '$env/networks/networks-evm/networks.evm.base.env';
 import {
 	BSC_MAINNET_NETWORK_ID,
-	BSC_TESTNET_NETWORK_ID
+	SUPPORTED_BSC_NETWORK_IDS
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
-import {
-	POLYGON_AMOY_NETWORK_ID,
-	POLYGON_MAINNET_NETWORK_ID
-} from '$env/networks/networks-evm/networks.evm.polygon.env';
+import { SUPPORTED_EVM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
+import { SUPPORTED_POLYGON_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import * as btcNetworkEnv from '$env/networks/networks.btc.env';
 import {
 	BTC_MAINNET_NETWORK,
@@ -17,12 +15,12 @@ import {
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
-import * as ethEnv from '$env/networks/networks.eth.env';
 import {
 	ETHEREUM_NETWORK,
 	ETHEREUM_NETWORK_ID,
 	SEPOLIA_NETWORK,
-	SEPOLIA_NETWORK_ID
+	SEPOLIA_NETWORK_ID,
+	SUPPORTED_ETHEREUM_NETWORK_IDS
 } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { CKBTC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
@@ -98,19 +96,12 @@ describe('network utils', () => {
 	});
 
 	describe('isNetworkIdEthereum', () => {
-		const allEthereumNetworkIds = [ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID];
-
-		beforeEach(() => {
-			vi.clearAllMocks();
-
-			vi.spyOn(ethEnv, 'SUPPORTED_ETHEREUM_NETWORK_IDS', 'get').mockImplementation(
-				() => allEthereumNetworkIds
-			);
-		});
-
-		it.each(allEthereumNetworkIds)('should return true for Ethereum network ID %s', (id) => {
-			expect(isNetworkIdEthereum(id as NetworkId)).toBeTruthy();
-		});
+		it.each(SUPPORTED_ETHEREUM_NETWORK_IDS)(
+			'should return true for Ethereum network ID %s',
+			(id) => {
+				expect(isNetworkIdEthereum(id as NetworkId)).toBeTruthy();
+			}
+		);
 
 		it('should return false for non-Ethereum network IDs', () => {
 			expect(isNetworkIdEthereum(BTC_MAINNET_NETWORK_ID)).toBeFalsy();
@@ -118,14 +109,7 @@ describe('network utils', () => {
 	});
 
 	describe('isNetworkIdEvm', () => {
-		const allEvmNetworkIds = [
-			BASE_NETWORK_ID,
-			BASE_SEPOLIA_NETWORK_ID,
-			BSC_MAINNET_NETWORK_ID,
-			BSC_TESTNET_NETWORK_ID
-		];
-
-		it.each(allEvmNetworkIds)('should return true for EVM network ID %s', (id) => {
+		it.each(SUPPORTED_EVM_NETWORK_IDS)('should return true for EVM network ID %s', (id) => {
 			expect(isNetworkIdEvm(id as NetworkId)).toBeTruthy();
 		});
 
@@ -137,9 +121,7 @@ describe('network utils', () => {
 	});
 
 	describe('isNetworkIdBase', () => {
-		const allBaseNetworkIds = [BASE_NETWORK_ID, BASE_SEPOLIA_NETWORK_ID];
-
-		it.each(allBaseNetworkIds)('should return true for Base network ID %s', (id) => {
+		it.each(SUPPORTED_BASE_NETWORK_IDS)('should return true for Base network ID %s', (id) => {
 			expect(isNetworkIdBase(id as NetworkId)).toBeTruthy();
 		});
 
@@ -153,9 +135,7 @@ describe('network utils', () => {
 	});
 
 	describe('isNetworkIdBsc', () => {
-		const allBscNetworkIds = [BSC_MAINNET_NETWORK_ID, BSC_TESTNET_NETWORK_ID];
-
-		it.each(allBscNetworkIds)('should return true for BSC network ID %s', (id) => {
+		it.each(SUPPORTED_BSC_NETWORK_IDS)('should return true for BSC network ID %s', (id) => {
 			expect(isNetworkIdBsc(id as NetworkId)).toBeTruthy();
 		});
 
@@ -169,9 +149,7 @@ describe('network utils', () => {
 	});
 
 	describe('isNetworkIdPolygon', () => {
-		const allPolygonNetworkIds = [POLYGON_MAINNET_NETWORK_ID, POLYGON_AMOY_NETWORK_ID];
-
-		it.each(allPolygonNetworkIds)('should return true for Polygon network ID %s', (id) => {
+		it.each(SUPPORTED_POLYGON_NETWORK_IDS)('should return true for Polygon network ID %s', (id) => {
 			expect(isNetworkIdPolygon(id as NetworkId)).toBeTruthy();
 		});
 


### PR DESCRIPTION
# Motivation

As for the other networks, we need to define the default token of Polygon networks.

# Changes

- Create util to check id a network ID is Polygon.
- Create derived store to verify the current network if it's Polygon.
- Map the current network to POL default token if it's Polygon network.

# Tests

More test and current tests will be sufficient.
