### PR TITLE
feat(frontend): refactored swapFailedStore

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -9,12 +9,12 @@
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
-	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 
 	export let swapAmount: OptionAmount;
 	export let receiveAmount: number | undefined;

--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -14,6 +14,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
+	import ExternalLink from '../ui/ExternalLink.svelte';
 
 	export let swapAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
@@ -65,8 +66,13 @@
 
 	{#if nonNullish($failedSwapError)}
 		<div class="mt-4">
-			<MessageBox>
-				{$failedSwapError}
+			<MessageBox level={$failedSwapError.variant}>
+				{$failedSwapError.message}
+				{#if nonNullish($failedSwapError?.url)}
+					<ExternalLink href={$failedSwapError.url.url} ariaLabel={$i18n.swap.text.open_icp_swap}
+						>{$failedSwapError.url.text}</ExternalLink
+					>
+				{/if}
 			</MessageBox>
 		</div>
 	{/if}

--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -14,7 +14,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
-	import ExternalLink from '../ui/ExternalLink.svelte';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 
 	export let swapAmount: OptionAmount;
 	export let receiveAmount: number | undefined;

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -115,7 +115,7 @@
 			setTimeout(() => close(), 750);
 		} catch (err: unknown) {
 			const errorDetail = errorDetailToString(err);
-
+			// TODO: Add unit tests to cover failed swap error scenarios
 			if (nonNullish(errorDetail) && errorDetail.startsWith('Slippage exceeded.')) {
 				failedSwapError.set({
 					message: replacePlaceholders(

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -117,11 +117,29 @@
 			const errorDetail = errorDetailToString(err);
 
 			if (nonNullish(errorDetail) && errorDetail.startsWith('Slippage exceeded.')) {
-				failedSwapError.set(
-					replacePlaceholders(replaceOisyPlaceholders($i18n.swap.error.slippage_exceeded), {
-						$maxSlippage: slippageValue.toString()
-					})
-				);
+				failedSwapError.set({
+					message: replacePlaceholders(
+						replaceOisyPlaceholders($i18n.swap.error.slippage_exceeded),
+						{
+							$maxSlippage: slippageValue.toString()
+						}
+					),
+					variant: 'info'
+				});
+			} else if (
+				nonNullish(errorDetail) &&
+				errorDetail.startsWith('Swap failed and withdraw also failed')
+			) {
+				failedSwapError.set({
+					message: errorDetail,
+					variant: 'error',
+					url: {
+						url: `https://app.icpswap.com/swap?input=${$sourceToken.ledgerCanisterId}&output=${$destinationToken.ledgerCanisterId}`,
+						text: 'icpswap.com'
+					}
+				});
+			} else if (errorDetail && errorDetail.startsWith('Swap failed.')) {
+				failedSwapError.set({ message: errorDetail, variant: 'error' });
 			} else {
 				failedSwapError.set(undefined);
 

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -597,7 +597,8 @@
 			"expected_minimum": "Expected minimum",
 			"you_receive": "You receive",
 			"select": "Select >",
-			"select_swap_provider": "Select swap provider"
+			"select_swap_provider": "Select swap provider",
+			"open_icp_swap": "Open ICP Swap website"
 		},
 		"error": {
 			"kong_not_available": "There is currently no exchange available to swap tokens. Please try again later.",
@@ -606,7 +607,7 @@
 			"slippage_exceeded": "$oisy_short protects you: The trade is outside of your slippage tolerance of $maxSlippage%. Please adjust the max slippage and try again.",
 			"pool_not_found": "Swap failed. Pool not found.",
 			"deposit_error": "Swap failed. We couldn’t deposit your tokens into the pool. Please try again.",
-			"withdraw_failed": "Swap failed and withdraw also failed. Please check your unused balance and try manual withdrawal: $url",
+			"withdraw_failed": "Swap failed and withdraw also failed. Please check your unused balance and try manual withdrawal: ",
 			"swap_failed_withdraw_success": "Swap failed. Your tokens were refunded successfully. You can try again or increase the slippage tolerance."
 		}
 	},

--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -6,6 +6,12 @@ import type { Balance } from '$lib/types/balance';
 import { nonNullish } from '@dfinity/utils';
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 
+export interface SwapError {
+	variant: 'error' | 'warning' | 'info';
+	message: string;
+	url?: { url: string; text: string };
+}
+
 export interface SwapData {
 	sourceToken?: IcTokenToggleable;
 	destinationToken?: IcTokenToggleable;
@@ -55,7 +61,7 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		sourceTokenExchangeRate,
 		destinationTokenExchangeRate,
 		isSourceTokenIcrc2,
-		failedSwapError: writable<string | undefined>(undefined),
+		failedSwapError: writable<SwapError | undefined>(undefined),
 		setSourceToken: (token: IcTokenToggleable) =>
 			update((state) => ({
 				...state,
@@ -82,7 +88,7 @@ export interface SwapContext {
 	sourceTokenExchangeRate: Readable<number | undefined>;
 	destinationTokenExchangeRate: Readable<number | undefined>;
 	isSourceTokenIcrc2: Readable<boolean>;
-	failedSwapError: Writable<string | undefined>;
+	failedSwapError: Writable<SwapError | undefined>;
 	setSourceToken: (token: IcTokenToggleable) => void;
 	setDestinationToken: (token: IcTokenToggleable) => void;
 	switchTokens: () => void;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -565,6 +565,7 @@ interface I18nSwap {
 		you_receive: string;
 		select: string;
 		select_swap_provider: string;
+		open_icp_swap: string;
 	};
 	error: {
 		kong_not_available: string;

--- a/src/frontend/src/tests/lib/stores/swap.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap.store.spec.ts
@@ -3,7 +3,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcToken } from '$icp/types/ic-token';
 import * as exchanges from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
-import { initSwapContext, type SwapError } from '$lib/stores/swap.store';
+import { initSwapContext } from '$lib/stores/swap.store';
 import { bn1Bi, bn2Bi } from '$tests/mocks/balances.mock';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -104,41 +104,5 @@ describe('swapStore', () => {
 
 		expect(get(sourceToken)).toBe(mockToken1);
 		expect(get(destinationToken)).toBe(mockToken2);
-	});
-
-	it('should handle failedSwapError correctly', () => {
-		const { failedSwapError } = initSwapContext();
-
-		expect(get(failedSwapError)).toBeUndefined();
-
-		const error: SwapError = {
-			variant: 'error',
-			message: 'Something went wrong',
-			url: { url: 'https://example.com', text: 'More info' }
-		};
-
-		failedSwapError.set(error);
-
-		expect(get(failedSwapError)).toStrictEqual(error);
-
-		failedSwapError.set(undefined);
-
-		expect(get(failedSwapError)).toBeUndefined();
-	});
-
-	it('should handle failedSwapError correctly with just message', () => {
-		const { failedSwapError } = initSwapContext();
-
-		expect(get(failedSwapError)).toBeUndefined();
-
-		const error: SwapError = {
-			variant: 'error',
-			message: 'Something went wrong',
-		};
-
-		failedSwapError.set(error);
-
-		expect(get(failedSwapError)).toStrictEqual(error);
-
 	});
 });

--- a/src/frontend/src/tests/lib/stores/swap.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap.store.spec.ts
@@ -3,7 +3,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcToken } from '$icp/types/ic-token';
 import * as exchanges from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
-import { initSwapContext } from '$lib/stores/swap.store';
+import { initSwapContext, type SwapError } from '$lib/stores/swap.store';
 import { bn1Bi, bn2Bi } from '$tests/mocks/balances.mock';
 import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -104,5 +104,41 @@ describe('swapStore', () => {
 
 		expect(get(sourceToken)).toBe(mockToken1);
 		expect(get(destinationToken)).toBe(mockToken2);
+	});
+
+	it('should handle failedSwapError correctly', () => {
+		const { failedSwapError } = initSwapContext();
+
+		expect(get(failedSwapError)).toBeUndefined();
+
+		const error: SwapError = {
+			variant: 'error',
+			message: 'Something went wrong',
+			url: { url: 'https://example.com', text: 'More info' }
+		};
+
+		failedSwapError.set(error);
+
+		expect(get(failedSwapError)).toStrictEqual(error);
+
+		failedSwapError.set(undefined);
+
+		expect(get(failedSwapError)).toBeUndefined();
+	});
+
+	it('should handle failedSwapError correctly with just message', () => {
+		const { failedSwapError } = initSwapContext();
+
+		expect(get(failedSwapError)).toBeUndefined();
+
+		const error: SwapError = {
+			variant: 'error',
+			message: 'Something went wrong',
+		};
+
+		failedSwapError.set(error);
+
+		expect(get(failedSwapError)).toStrictEqual(error);
+
 	});
 });


### PR DESCRIPTION
# Motivation

Refactored failedSwapStore to support storing error messages with their variant type and optional url.

# Changes

- Updated failedSwapStore to support structured error data: { message, variant, url? }

- Adjusted usage across components to match the new structure

# Tests

Added unit tests to cover the new structure and ensure correct behavior