### PR TITLE
feat(frontend): improve ConvertAmountExchange component

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import { EXCHANGE_USD_AMOUNT_THRESHOLD } from '$lib/constants/exchange.constants';
 	import {
 		CONVERT_AMOUNT_EXCHANGE_SKELETON,
 		CONVERT_AMOUNT_EXCHANGE_VALUE
@@ -12,18 +13,24 @@
 	export let amount: OptionAmount = undefined;
 	export let exchangeRate: number | undefined = undefined;
 
-	let usdValue: string | undefined;
+	let usdValue: number | undefined;
 	$: usdValue =
-		nonNullish(amount) && nonNullish(exchangeRate)
-			? formatUSD({
-					value: Number(amount) * exchangeRate
-				})
-			: undefined;
+		nonNullish(amount) && nonNullish(exchangeRate) ? Number(amount) * exchangeRate : undefined;
+
+	let displayValue: string | undefined;
+	$: displayValue = nonNullish(usdValue)
+		? formatUSD({
+				value:
+					usdValue === 0 || usdValue > EXCHANGE_USD_AMOUNT_THRESHOLD
+						? usdValue
+						: EXCHANGE_USD_AMOUNT_THRESHOLD
+			})
+		: undefined;
 </script>
 
 {#if nonNullish(usdValue)}
 	<div in:fade data-tid={CONVERT_AMOUNT_EXCHANGE_VALUE}>
-		{`${nonNullish(amount) && amount === 0 ? '' : '~'}`}{usdValue}
+		{usdValue === 0 ? '' : usdValue < EXCHANGE_USD_AMOUNT_THRESHOLD ? '< ' : '~'}{displayValue}
 	</div>
 {:else if isNullish(amount)}
 	<div in:fade class="w-10 sm:w-8" data-tid={CONVERT_AMOUNT_EXCHANGE_SKELETON}>

--- a/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertAmountExchange.spec.ts
@@ -31,6 +31,14 @@ describe('ConvertAmountExchange', () => {
 		expect(getByTestId(divTestId)).toHaveTextContent('$0.00');
 	});
 
+	it('should display correct value if amount is less than placeholder value', () => {
+		const { getByTestId } = render(ConvertAmountExchange, {
+			props: { ...props, amount: 0.00001 }
+		});
+
+		expect(getByTestId(divTestId)).toHaveTextContent('< $0.01');
+	});
+
 	it('should display skeleton if amount is not provided', () => {
 		const { amount: _, ...newProps } = props;
 		const { getByTestId } = render(ConvertAmountExchange, { props: newProps });


### PR DESCRIPTION
# Motivation

We need to improve the ConvertAmountExchange component so it can handle the following cases:
1. If `usdValue` is 0, we display it as `$0.00`.
2. If `usdValue` is less than 0.01, we display it as `< $0.00`.
3. If `usdValue` is greater than 0.01, we display it as `~$0.03`.