### PR TITLE
feat(frontend): add execution for swapService based on selected provider

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -20,7 +20,7 @@
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { nullishSignOut } from '$lib/services/auth.services';
-	import { swap as swapService } from '$lib/services/swap.services';
+	import { swapService } from '$lib/services/swap.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		SWAP_AMOUNTS_CONTEXT_KEY,
@@ -76,7 +76,8 @@
 			isNullish(slippageValue) ||
 			isNullish(swapAmount) ||
 			isNullish(sourceTokenFee) ||
-			isNullish($swapAmountsStore?.selectedProvider?.receiveAmount)
+			isNullish($swapAmountsStore?.selectedProvider?.receiveAmount) ||
+			isNullish($swapAmountsStore?.selectedProvider?.provider)
 		) {
 			toastsError({
 				msg: { text: $i18n.swap.error.unexpected_missing_data }
@@ -89,7 +90,7 @@
 		try {
 			failedSwapError.set(undefined);
 
-			await swapService({
+			await swapService[$swapAmountsStore.selectedProvider.provider]({
 				identity: $authIdentity,
 				progress,
 				sourceToken: $sourceToken,
@@ -108,7 +109,7 @@
 				metadata: {
 					sourceToken: $sourceToken.symbol,
 					destinationToken: $destinationToken.symbol,
-					dApp: 'KONG'
+					dApp: $swapAmountsStore.selectedProvider.provider
 				}
 			});
 
@@ -154,7 +155,7 @@
 				metadata: {
 					sourceToken: $sourceToken.symbol,
 					destinationToken: $destinationToken.symbol,
-					dApp: 'KONG'
+					dApp: $swapAmountsStore.selectedProvider.provider
 				}
 			});
 

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -35,7 +35,7 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 import { autoLoadSingleToken } from './token.services';
 
-export const swap = async ({
+export const fetchKongSwap = async ({
 	identity,
 	progress,
 	sourceToken,
@@ -314,4 +314,9 @@ export const fetchIcpSwap = async ({
 	}
 
 	await waitAndTriggerWallet();
+};
+
+export const swapService = {
+	[SwapProvider.ICP_SWAP]: fetchIcpSwap,
+	[SwapProvider.KONG_SWAP]: fetchKongSwap
 };


### PR DESCRIPTION
# Motivation

Refactored the token swap logic to move the provider-specific method call into a separate function. While calling the swap method dynamically could be risky, using the `SwapProvider` enum ensures that only valid keys are used. This provides type safety and guarantees that the corresponding method exists at compile time. The main goal of this change is to improve readability, structure, and testability of the swap logic.

# Changes

Extracted the dynamic provider call from the swap function into a dedicated helper

