### PR TITLE
refactor(frontend): collect all EVM ERC20 tokens in a single list

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens.erc20.env.ts
@@ -1,0 +1,10 @@
+import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
+import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
+import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import type { RequiredEvmErc20Token } from '$evm/types/erc20';
+
+export const EVM_ERC20_TOKENS: RequiredEvmErc20Token[] = [
+	...BASE_ERC20_TOKENS,
+	...BSC_BEP20_TOKENS,
+	...POLYGON_ERC20_TOKENS
+];

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -7,9 +7,7 @@ import {
 	SUPPORTED_ETHEREUM_NETWORKS,
 	SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS
 } from '$env/networks/networks.eth.env';
-import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
-import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
-import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { ERC20_CONTRACTS, ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
@@ -55,9 +53,7 @@ const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 		const contracts = await Promise.all(loadKnownContracts());
 		erc20DefaultTokensStore.set([
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS,
+			...EVM_ERC20_TOKENS,
 			...contracts.map(mapErc20Token)
 		]);
 	} catch (err: unknown) {

--- a/src/frontend/src/tests/btc/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/token.utils.spec.ts
@@ -1,7 +1,5 @@
 import { isBitcoinToken } from '$btc/utils/token.utils';
-import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
-import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
-import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
 import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
@@ -22,9 +20,7 @@ describe('token.utils', () => {
 			...SUPPORTED_EVM_TOKENS,
 			...SUPPORTED_SOLANA_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS,
+			...EVM_ERC20_TOKENS,
 			...SPL_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isBitcoinToken(token)).toBeFalsy();

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -1,6 +1,4 @@
-import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
-import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
-import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
 import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
@@ -159,9 +157,7 @@ describe('erc20.utils', () => {
 			...SUPPORTED_ETHEREUM_TOKENS,
 			...SUPPORTED_EVM_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS
+			...EVM_ERC20_TOKENS
 		];
 
 		it.each(
@@ -189,12 +185,7 @@ describe('erc20.utils', () => {
 	});
 
 	describe('isTokenErc20UserToken', () => {
-		const tokens = [
-			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS
-		];
+		const tokens = [...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS];
 
 		it.each(
 			tokens.map((token) => ({
@@ -243,14 +234,12 @@ describe('erc20.utils', () => {
 	});
 
 	describe('isTokenErc20', () => {
-		it.each([
-			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS
-		])('should return true for token $name', (token) => {
-			expect(isTokenErc20(token)).toBeTruthy();
-		});
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS])(
+			'should return true for token $name',
+			(token) => {
+				expect(isTokenErc20(token)).toBeTruthy();
+			}
+		);
 
 		it.each([
 			ICP_TOKEN,

--- a/src/frontend/src/tests/icp-eth/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/icp-eth/utils/token.utils.spec.ts
@@ -1,6 +1,4 @@
-import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
-import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
-import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
 import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
@@ -36,9 +34,7 @@ describe('token.utils', () => {
 			...SUPPORTED_EVM_TOKENS,
 			...SUPPORTED_SOLANA_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS,
+			...EVM_ERC20_TOKENS,
 			...SPL_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isGLDTToken(token)).toBeFalsy();
@@ -69,9 +65,7 @@ describe('token.utils', () => {
 			...SUPPORTED_EVM_TOKENS,
 			...SUPPORTED_SOLANA_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS,
+			...EVM_ERC20_TOKENS,
 			...SPL_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isVCHFToken(token)).toBeFalsy();
@@ -102,9 +96,7 @@ describe('token.utils', () => {
 			...SUPPORTED_EVM_TOKENS,
 			...SUPPORTED_SOLANA_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS,
+			...EVM_ERC20_TOKENS,
 			...SPL_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isVEURToken(token)).toBeFalsy();

--- a/src/frontend/src/tests/sol/utils/spl.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/spl.utils.spec.ts
@@ -1,6 +1,4 @@
-import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
-import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
-import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
 import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
@@ -23,9 +21,7 @@ describe('spl.utils', () => {
 			...SUPPORTED_EVM_TOKENS,
 			...SUPPORTED_SOLANA_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS
+			...EVM_ERC20_TOKENS
 		])('should return false for token $id', (token) => {
 			expect(isTokenSpl(token)).toBeFalsy();
 		});
@@ -44,9 +40,7 @@ describe('spl.utils', () => {
 				...SUPPORTED_EVM_TOKENS,
 				...SUPPORTED_SOLANA_TOKENS,
 				...ERC20_TWIN_TOKENS,
-				...BASE_ERC20_TOKENS,
-				...BSC_BEP20_TOKENS,
-				...POLYGON_ERC20_TOKENS
+				...EVM_ERC20_TOKENS
 			])('should return false for token $id', (token) => {
 				expect(isTokenSplToggleable(token)).toBeFalsy();
 			});
@@ -70,9 +64,7 @@ describe('spl.utils', () => {
 					...SUPPORTED_EVM_TOKENS,
 					...SUPPORTED_SOLANA_TOKENS,
 					...ERC20_TWIN_TOKENS,
-					...BASE_ERC20_TOKENS,
-					...BSC_BEP20_TOKENS,
-					...POLYGON_ERC20_TOKENS
+					...EVM_ERC20_TOKENS
 				].map((token) => ({
 					...token,
 					enabled: Math.random() < 0.5

--- a/src/frontend/src/tests/sol/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/token.utils.spec.ts
@@ -1,6 +1,4 @@
-import { BASE_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc20.env';
-import { BSC_BEP20_TOKENS } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bep20.env';
-import { POLYGON_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import { TRUMP_TOKEN, TRUMP_TOKEN_ID } from '$env/tokens/tokens-spl/tokens.trump.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
@@ -26,9 +24,7 @@ describe('token.utils', () => {
 			...SUPPORTED_ETHEREUM_TOKENS,
 			...SUPPORTED_EVM_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS
+			...EVM_ERC20_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isSolanaToken(token)).toBeFalsy();
 		});
@@ -52,9 +48,7 @@ describe('token.utils', () => {
 			...SUPPORTED_ETHEREUM_TOKENS,
 			...SUPPORTED_EVM_TOKENS,
 			...ERC20_TWIN_TOKENS,
-			...BASE_ERC20_TOKENS,
-			...BSC_BEP20_TOKENS,
-			...POLYGON_ERC20_TOKENS
+			...EVM_ERC20_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isTrumpToken(token)).toBeFalsy();
 		});


### PR DESCRIPTION
# Motivation

All the current ERC20 tokens for EVM networks (and their wrapped standard like BEP20) are treated the same way. So, to improve manageability, we can collect them in a single list that can be updated accordingly.
