### PR TITLE
feat(frontend): known destinations only for the current ETH network

### DIFF
--- a/src/frontend/src/eth/derived/eth-transactions.derived.ts
+++ b/src/frontend/src/eth/derived/eth-transactions.derived.ts
@@ -53,8 +53,22 @@ export const ethTransactionsNotInitialized: Readable<boolean> = derived(
 );
 
 export const ethKnownDestinations: Readable<KnownDestinations> = derived(
-	[ethTransactionsStore, ckEthMinterInfoStore, ethereumTokenId, ethAddress, tokens],
-	([$ethTransactionsStore, $ckEthMinterInfoStore, $ethereumTokenId, $ethAddress, $tokens]) => {
+	[
+		ethTransactionsStore,
+		ckEthMinterInfoStore,
+		ethereumTokenId,
+		ethAddress,
+		tokens,
+		tokenWithFallback
+	],
+	([
+		$ethTransactionsStore,
+		$ckEthMinterInfoStore,
+		$ethereumTokenId,
+		$ethAddress,
+		$tokens,
+		$tokenWithFallback
+	]) => {
 		const ckMinterInfoAddresses = toCkMinterInfoAddresses(
 			$ckEthMinterInfoStore?.[$ethereumTokenId]
 		);
@@ -67,7 +81,7 @@ export const ethKnownDestinations: Readable<KnownDestinations> = derived(
 		Object.getOwnPropertySymbols($ethTransactionsStore ?? {}).forEach((tokenId) => {
 			const token = $tokens.find(({ id }) => id === tokenId);
 
-			if (nonNullish(token)) {
+			if (nonNullish(token) && token.network.id === $tokenWithFallback.network.id) {
 				$ethTransactionsStore[tokenId as TokenId].forEach((transaction) => {
 					mappedTransactions.push({
 						...mapEthTransactionUi({

--- a/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
@@ -1,8 +1,10 @@
+import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ethKnownDestinations } from '$eth/derived/eth-transactions.derived';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import { ethAddressStore } from '$lib/stores/address.store';
+import { token } from '$lib/stores/token.store';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import type { MinterInfo as CkEthMinterInfo } from '@dfinity/cketh/dist/candid/minter';
@@ -15,27 +17,33 @@ describe('eth-transactions.derived', () => {
 	};
 	const transactions = createMockEthTransactions(5);
 
+	const setupStores = () => {
+		ckEthMinterInfoStore.set({
+			id: ETHEREUM_TOKEN_ID,
+			data: {
+				...mockCkEthMinterInfo,
+				data: {
+					...mockCkEthMinterInfo.data,
+					eth_helper_contract_address: ['test']
+				}
+			}
+		});
+		ethTransactionsStore.add({
+			tokenId: ETHEREUM_TOKEN_ID,
+			transactions
+		});
+	};
+
 	describe('ethKnownDestinations', () => {
 		beforeEach(() => {
 			ethTransactionsStore.reset();
+			token.reset();
 			ethAddressStore.set({ certified: true, data: mockEthAddress });
 		});
 
-		it('should return known destinations if transactions store has some data and helper addresses available', () => {
-			ckEthMinterInfoStore.set({
-				id: ETHEREUM_TOKEN_ID,
-				data: {
-					...mockCkEthMinterInfo,
-					data: {
-						...mockCkEthMinterInfo.data,
-						eth_helper_contract_address: ['test']
-					}
-				}
-			});
-			ethTransactionsStore.add({
-				tokenId: ETHEREUM_TOKEN_ID,
-				transactions
-			});
+		it('should return known destinations if transactions store has some data and helper addresses available and network matches', () => {
+			token.set(ETHEREUM_TOKEN);
+			setupStores();
 
 			expect(get(ethKnownDestinations)).toEqual({
 				[transactions[0].to as string]: {
@@ -45,7 +53,14 @@ describe('eth-transactions.derived', () => {
 			});
 		});
 
-		it('should return empty object if transactions store does not have data', () => {
+		it('should return empty object if transactions store has data but network does not match', () => {
+			token.set(BASE_ETH_TOKEN);
+			setupStores();
+
+			expect(get(ethKnownDestinations)).toEqual({});
+		});
+
+		it('should return empty object if transactions store does not have data at all', () => {
 			expect(get(ethKnownDestinations)).toEqual({});
 		});
 


### PR DESCRIPTION
# Motivation

For ETH network tokens, we want to display known destinations that only belongs to the selected token network. 
