### PR TITLE
feat(frontend): resets filter field after closing

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -36,7 +36,7 @@
 		})
 	);
 
-	const {setFilterQuery} = setContext<ModalTokensListContext>(
+	const { setFilterQuery } = setContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		initModalTokensListContext({
 			tokens: [],

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -36,7 +36,7 @@
 		})
 	);
 
-	setContext<ModalTokensListContext>(
+	const {setFilterQuery} = setContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		initModalTokensListContext({
 			tokens: [],
@@ -65,6 +65,7 @@
 
 	const closeTokenList = () => {
 		selectTokenType = undefined;
+		setFilterQuery('');
 	};
 
 	const selectToken = ({ detail: token }: CustomEvent<IcTokenToggleable>) => {


### PR DESCRIPTION
# Motivation

The filter field during the `swap` process should be reset after `canceling` the process or when `selecting` a token.

# Changes

- resets filter

# Tests

**before:**

https://github.com/user-attachments/assets/4d0b33ad-5bf9-4f1e-8f5c-cf672b74f710


**after:**

https://github.com/user-attachments/assets/c7d64d1e-e427-4203-a5c0-9ac18772c2bd

