### PR TITLE
fix(frontend): fixes TokenInputCurrency and TokenInputCurrencyUsd field padding

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
@@ -49,6 +49,6 @@
 		height: 100%;
 		border: none;
 		border-radius: 0;
-		padding: 0 4rem 0 0.75rem;
+		padding: 0 0.75rem 0 0.75rem;
 	}
 </style>

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
@@ -74,6 +74,6 @@
 
 <style lang="scss">
 	:global(.token-input-currency.no-padding div.input-field input[id]) {
-		padding: 0;
+		padding: 0 0.75rem 0 0;
 	}
 </style>


### PR DESCRIPTION
# Motivation

The `InputField` in the `swap` and `send` form do have a bad padding which cuts off the visible digits too early,

# Changes

- fixes padding

# Tests

**before:**
<img width="437" alt="image" src="https://github.com/user-attachments/assets/0b98a95b-c255-472c-ae33-9749209108cc" />


**after:**
<img width="425" alt="image" src="https://github.com/user-attachments/assets/c3ed6a24-b9da-43bb-9feb-266a0cc73d95" />
