### PR TITLE
feat(frontend): sort known destinations by timestamp

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -14,16 +14,23 @@
 
 	const dispatch = createEventDispatcher();
 
-	let destinations = $derived(
+	let sortedKnownDestinations = $derived(
 		nonNullish(knownDestinations)
-			? Object.keys(knownDestinations).filter((address) =>
-					address.toLowerCase().includes(destination.toLowerCase())
+			? Object.values(knownDestinations).sort(
+					(destinationA, destinationB) =>
+						(destinationB.timestamp ?? 0) - (destinationA.timestamp ?? 0)
 				)
 			: []
 	);
+
+	let filteredKnownDestinations = $derived(
+		sortedKnownDestinations.filter(({ address }) =>
+			address.toLowerCase().includes(destination.toLowerCase())
+		)
+	);
 </script>
 
-{#if nonNullish(knownDestinations) && destinations.length > 0}
+{#if nonNullish(knownDestinations) && filteredKnownDestinations.length > 0}
 	<div class="mb-2 mt-8" in:fade>
 		<div class="mb-2 font-bold">
 			{$i18n.send.text.recently_used}
@@ -31,13 +38,13 @@
 
 		<div class="flex flex-col overflow-y-hidden sm:max-h-[13.5rem]">
 			<ul class="list-none overflow-y-auto overscroll-contain">
-				{#each destinations as recentDestination (recentDestination)}
+				{#each filteredKnownDestinations as { address, ...rest } (address)}
 					<li>
 						<KnownDestination
-							destination={recentDestination}
-							{...knownDestinations[recentDestination]}
+							destination={address}
+							{...rest}
 							on:click={() => {
-								destination = recentDestination;
+								destination = address;
 								dispatch('icNext');
 							}}
 						/>

--- a/src/frontend/src/lib/types/transactions.ts
+++ b/src/frontend/src/lib/types/transactions.ts
@@ -17,6 +17,7 @@ export interface TransactionsStoreCheckParams {
 
 export interface KnownDestination {
 	amounts: { value: bigint; token: Token }[];
+	address: Address;
 	timestamp?: number;
 }
 

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -320,7 +320,8 @@ export const getKnownDestinations = (
 											? Math.max(Number(acc[address].timestamp), Number(timestamp))
 											: nonNullish(timestamp)
 												? Number(timestamp)
-												: acc[address].timestamp
+												: acc[address].timestamp,
+									address
 								}
 							}),
 							{}

--- a/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/btc/derived/btc-transactions.derived.spec.ts
@@ -115,7 +115,8 @@ describe('btc-transactions.derived', () => {
 						value: data.value,
 						token: BTC_MAINNET_TOKEN
 					})),
-					timestamp: maxTimestamp
+					timestamp: maxTimestamp,
+					address: transactions[0].data.to?.[0]
 				}
 			});
 		});

--- a/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
@@ -48,7 +48,8 @@ describe('eth-transactions.derived', () => {
 			expect(get(ethKnownDestinations)).toEqual({
 				[transactions[0].to as string]: {
 					amounts: transactions.map(({ value }) => ({ value, token: ETHEREUM_TOKEN })),
-					timestamp: Number(transactions[0].timestamp)
+					timestamp: Number(transactions[0].timestamp),
+					address: transactions[0].to
 				}
 			});
 		});

--- a/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ic-transactions.derived.spec.ts
@@ -176,7 +176,8 @@ describe('ic-transactions.derived', () => {
 			expect(get(icKnownDestinations)).toEqual({
 				[transactions[0].data.to as string]: {
 					amounts: transactions.map(({ data }) => ({ value: data.value, token: ICP_TOKEN })),
-					timestamp: maxTimestamp
+					timestamp: maxTimestamp,
+					address: transactions[0].data.to
 				}
 			});
 		});

--- a/src/frontend/src/tests/lib/components/send/KnownDestinations.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/KnownDestinations.spec.ts
@@ -14,15 +14,18 @@ describe('KnownDestinations', () => {
 	const knownDestinations = {
 		[mockBtcAddress]: {
 			amounts: [{ value: 10000000n, token: BTC_MAINNET_TOKEN }],
-			timestamp: 1671234567890
+			timestamp: 1671234567890,
+			address: mockBtcAddress
 		},
 		[mockEthAddress]: {
 			amounts: [{ value: 10000000n, token: ETHEREUM_TOKEN }],
-			timestamp: 1671234567890
+			timestamp: 1671234567890,
+			address: mockEthAddress
 		},
 		[mockSolAddress]: {
 			amounts: [{ value: 10000000n, token: SOLANA_TOKEN }],
-			timestamp: 1671234567890
+			timestamp: 1671234567890,
+			address: mockSolAddress
 		}
 	};
 

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1434,7 +1434,8 @@ describe('transactions.utils', () => {
 			const expectedIcKnownDestinations = {
 				[icTransactionsUi[0].to as string]: {
 					amounts: icTransactionsUi.map(({ value, token }) => ({ value, token })),
-					timestamp: Number(icTransactionsUi[0].timestamp)
+					timestamp: Number(icTransactionsUi[0].timestamp),
+					address: icTransactionsUi[0].to
 				}
 			};
 
@@ -1455,11 +1456,13 @@ describe('transactions.utils', () => {
 			expect(getKnownDestinations([icTransactionsUi1, icTransactionsUi2])).toEqual({
 				[icTransactionsUi1.to as string]: {
 					amounts: [{ value: icTransactionsUi1.value, token: icTransactionsUi1.token }],
-					timestamp: Number(icTransactionsUi1.timestamp)
+					timestamp: Number(icTransactionsUi1.timestamp),
+					address: icTransactionsUi1.to
 				},
 				[icTransactionsUi2.to as string]: {
 					amounts: [{ value: icTransactionsUi2.value, token: icTransactionsUi2.token }],
-					timestamp: Number(icTransactionsUi2.timestamp)
+					timestamp: Number(icTransactionsUi2.timestamp),
+					address: icTransactionsUi2.to
 				}
 			});
 		});
@@ -1476,11 +1479,13 @@ describe('transactions.utils', () => {
 			expect(getKnownDestinations([btcTransactionsUi])).toEqual({
 				[btcTransactionsUi.to[0] as string]: {
 					amounts: [{ value: btcTransactionsUi.value, token: btcTransactionsUi.token }],
-					timestamp: Number(btcTransactionsUi.timestamp)
+					timestamp: Number(btcTransactionsUi.timestamp),
+					address: btcTransactionsUi.to[0]
 				},
 				[btcTransactionsUi.to[1] as string]: {
 					amounts: [{ value: btcTransactionsUi.value, token: btcTransactionsUi.token }],
-					timestamp: Number(btcTransactionsUi.timestamp)
+					timestamp: Number(btcTransactionsUi.timestamp),
+					address: btcTransactionsUi.to[1]
 				}
 			});
 		});
@@ -1496,7 +1501,8 @@ describe('transactions.utils', () => {
 			const expectedIcKnownDestinations = {
 				[icTransactionsUi[0].to as string]: {
 					amounts: icTransactionsUi.map(({ value, token }) => ({ value, token })),
-					timestamp: Number(icTransactionsUi[icTransactionsUi.length - 1].timestamp)
+					timestamp: Number(icTransactionsUi[icTransactionsUi.length - 1].timestamp),
+					address: icTransactionsUi[0].to
 				}
 			};
 

--- a/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
@@ -141,7 +141,8 @@ describe('sol-transactions.derived', () => {
 			expect(get(solKnownDestinations)).toEqual({
 				[transactions[0].data.to as string]: {
 					amounts: transactions.map(({ data }) => ({ value: data.value, token: SOLANA_TOKEN })),
-					timestamp: maxTimestamp
+					timestamp: maxTimestamp,
+					address: transactions[0].data.to
 				}
 			});
 		});


### PR DESCRIPTION
# Motivation

We need to sort all known destinations by timestamp. To do that, we add `address` to the `knownDestinations` stores and sort the values before filtering them in the UI component.
