### PR TITLE
feat(frontend): added new formatReceiveOutMinimun util

### DIFF
--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -5,7 +5,7 @@ import type { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import type { Token } from '$lib/types/token';
 import type { Identity } from '@dfinity/agent';
 import type { OptionIdentity } from './identity';
-import type { Amount } from './send';
+import type { Amount, OptionAmount } from './send';
 
 export type SwapSelectTokenType = 'source' | 'destination';
 
@@ -101,4 +101,10 @@ export interface SwapParams {
 	slippageValue: Amount;
 	sourceTokenFee: bigint;
 	isSourceTokenIcrc2: boolean;
+}
+
+export interface FormatSlippageParams {
+	slippageValue: OptionAmount;
+	receiveAmount: bigint;
+	decimals: number;
 }

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -141,7 +141,7 @@ export const formatReceiveOutMinimum = ({
 	decimals
 }: FormatSlippageParams): AmountString | undefined => {
 	if (isNullishOrEmpty(slippageValue?.toString())) {
-		return undefined;
+		return;
 	}
 	const receiveOutMinimum = calculateSlippage({
 		quoteAmount: receiveAmount,

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -5,8 +5,10 @@ import type {
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import { ZERO } from '$lib/constants/app.constants';
 import { SWAP_DEFAULT_SLIPPAGE_VALUE } from '$lib/constants/swap.constants';
+import type { AmountString } from '$lib/types/amount';
 import {
 	SwapProvider,
+	type FormatSlippageParams,
 	type ICPSwapResult,
 	type ProviderFee,
 	type Slippage,
@@ -15,6 +17,8 @@ import {
 import type { Token } from '$lib/types/token';
 import { findToken } from '$lib/utils/tokens.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { formatToken } from './format.utils';
+import { isNullishOrEmpty } from './input.utils';
 
 export const getSwapRoute = (transactions: SwapAmountsTxReply[]): string[] =>
 	transactions.length === 0
@@ -119,4 +123,34 @@ export const calculateSlippage = ({
 }): bigint => {
 	const factor = 1 - slippagePercentage / 100;
 	return BigInt(Math.floor(Number(quoteAmount) * factor));
+};
+
+/**
+ * Formats the minimum expected receive amount after applying slippage.
+ *
+ * @param {OptionAmount} params.slippageValue - The slippage percentage (as string or number or undefined).
+ * @param {number} params.receiveAmount - The original quoted amount to receive.
+ * @param {number} params.decimals - The number of decimal places for the token.
+ * @returns {AmountString | null} A formatted string representing the minimum amount the user can expect to receive,
+ * formatted with the token's decimals, or `null` if any required value is missing.
+ *
+ */
+export const formatReceiveOutMinimum = ({
+	slippageValue,
+	receiveAmount,
+	decimals
+}: FormatSlippageParams): AmountString | undefined => {
+	if (isNullishOrEmpty(slippageValue?.toString())) {
+		return undefined;
+	}
+	const receiveOutMinimum = calculateSlippage({
+		quoteAmount: receiveAmount,
+		slippagePercentage: Number(slippageValue)
+	});
+
+	return formatToken({
+		value: receiveOutMinimum,
+		unitName: decimals,
+		displayDecimals: decimals
+	});
 };

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -12,8 +12,10 @@ import {
 	SWAP_DEFAULT_SLIPPAGE_VALUE
 } from '$lib/constants/swap.constants';
 import type { ICPSwapResult } from '$lib/types/swap';
+import { formatToken } from '$lib/utils/format.utils';
 import {
 	calculateSlippage,
+	formatReceiveOutMinimum,
 	getKongIcTokenIdentifier,
 	getLiquidityFees,
 	getNetworkFee,
@@ -245,6 +247,70 @@ describe('swap utils', () => {
 
 		it('returns 0 for full slippage (100%)', () => {
 			expect(calculateSlippage({ quoteAmount: 12345n, slippagePercentage: 100 })).toBe(0n);
+		});
+	});
+
+	describe('formatReceiveOutMinimum', () => {
+		it('formats valid number slippage', () => {
+			const result = formatReceiveOutMinimum({
+				slippageValue: 5,
+				receiveAmount: 1000n,
+				decimals: 2
+			});
+
+			const expectedMinimum = calculateSlippage({
+				quoteAmount: 1000n,
+				slippagePercentage: 5
+			});
+
+			const expectedFormatted = formatToken({
+				value: expectedMinimum,
+				unitName: 2,
+				displayDecimals: 2
+			});
+
+			expect(result).toBe(expectedFormatted);
+		});
+
+		it('formats valid string slippage', () => {
+			const result = formatReceiveOutMinimum({
+				slippageValue: '1',
+				receiveAmount: 1000n,
+				decimals: 2
+			});
+
+			const expectedMinimum = calculateSlippage({
+				quoteAmount: 1000n,
+				slippagePercentage: 1
+			});
+
+			const expectedFormatted = formatToken({
+				value: expectedMinimum,
+				unitName: 2,
+				displayDecimals: 2
+			});
+
+			expect(result).toBe(expectedFormatted);
+		});
+
+		it('returns null for empty slippage string', () => {
+			const result = formatReceiveOutMinimum({
+				slippageValue: '',
+				receiveAmount: 1000n,
+				decimals: 2
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns null for undefined slippage', () => {
+			const result = formatReceiveOutMinimum({
+				slippageValue: undefined,
+				receiveAmount: 1000n,
+				decimals: 2
+			});
+
+			expect(result).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The logic for calculating and formatting the minimum expected receive amount after applying slippage was previously duplicated and embedded inside components. This PR introduces a dedicated utility function to centralize that logic, improve code reuse, and increase overall clarity and maintainability.

# Changes

- Added `formatReceiveOutMinimum` utility:
  - Accepts `slippageValue`, `receiveAmount`, and `decimals`
  - Calculates slippage-adjusted amount
  - Formats the result based on token precision
- Simplified related component logic by delegating formatting to the new utility

# Tests

- Added unit tests for `formatReceiveOutMinimum`
  - Covers valid numeric and string input
  - Handles edge cases like empty, null, and undefined slippage
  - Validates formatting and calculation behavior
