### PR TITLE
fix(frontend): issue with SettingsModalEnabledNetworks

### DIFF
--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -35,8 +35,7 @@
 	import type { UserNetworks } from '$lib/types/user-networks';
 	import { emit } from '$lib/utils/events.utils';
 
-	let enabledNetworks: UserNetworks;
-	$: enabledNetworks = { ...$userNetworks };
+	const enabledNetworks = { ...$userNetworks };
 	const enabledNetworksInitial = { ...enabledNetworks };
 
 	let enabledTestnet = $testnetsEnabled;


### PR DESCRIPTION
# Motivation

This is the fix for the issue that was introduced after making `enabledNetworks` reactive. As a part of the migration to Svelte 5, the further refactorings need to be done to this component.