### PR TITLE
feat(frontend): replace manual slippage formatting with formatReceiveOutMinimum

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapDetailsIcp.svelte
+++ b/src/frontend/src/lib/components/swap/SwapDetailsIcp.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/lib/components/swap/SwapDetailsIcp.svelte
+++ b/src/frontend/src/lib/components/swap/SwapDetailsIcp.svelte
@@ -1,31 +1,39 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
+	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapMappedResult, SwapProvider } from '$lib/types/swap';
-	import { formatToken } from '$lib/utils/format.utils';
+	import { formatReceiveOutMinimum } from '$lib/utils/swap.utils';
 
-	const { provider } = $props<{
+	interface Props {
 		provider: Extract<SwapMappedResult, { provider: SwapProvider.ICP_SWAP }>;
-	}>();
+		slippageValue: OptionAmount;
+	}
+
+	const { provider, slippageValue }: Props = $props();
 	const { destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const formattedMinimum = $derived(
-		nonNullish(provider.receiveOutMinimum) && nonNullish($destinationToken)
-			? `${formatToken({
-					value: provider.receiveOutMinimum,
-					unitName: $destinationToken.decimals,
-					displayDecimals: $destinationToken.decimals
-				})} ${$destinationToken.symbol}`
-			: null
+		nonNullish($destinationToken?.decimals) &&
+			nonNullish(slippageValue) &&
+			nonNullish(provider.receiveAmount)
+			? formatReceiveOutMinimum({
+					slippageValue,
+					receiveAmount: provider.receiveAmount,
+					decimals: $destinationToken.decimals
+				})
+			: undefined
 	);
 </script>
 
-{#if nonNullish(formattedMinimum)}
+{#if nonNullish(formattedMinimum) && nonNullish($destinationToken?.symbol)}
 	<ModalValue>
 		<svelte:fragment slot="label">{$i18n.swap.text.expected_minimum}</svelte:fragment>
-		<svelte:fragment slot="main-value">{formattedMinimum}</svelte:fragment>
+		<svelte:fragment slot="main-value"
+			>{formattedMinimum} {$destinationToken.symbol}</svelte:fragment
+		>
 	</ModalValue>
 {/if}

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -230,7 +230,7 @@
 			<Hr spacing="md" />
 
 			<div class="flex flex-col gap-3">
-				<SwapProvider on:icShowProviderList showSelectButton />
+				<SwapProvider on:icShowProviderList showSelectButton {slippageValue} />
 				<SwapFees />
 			</div>
 		{/if}

--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -14,18 +14,20 @@
 		SWAP_AMOUNTS_CONTEXT_KEY,
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
+	import type { OptionAmount } from '$lib/types/send';
 	import type { OptionString } from '$lib/types/string';
 	import { SwapProvider } from '$lib/types/swap';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { UrlSchema } from '$lib/validation/url.validation';
 
 	interface Props {
+		slippageValue: OptionAmount;
 		showSelectButton?: boolean;
 	}
 
 	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
-	let { showSelectButton = false }: Props = $props();
+	let { showSelectButton = false, slippageValue }: Props = $props();
 
 	let displayURL = $state<OptionString>(null);
 
@@ -100,7 +102,7 @@
 			{#if selectedProvider.provider === SwapProvider.KONG_SWAP}
 				<SwapDetailsKong provider={selectedProvider} />
 			{:else if selectedProvider.provider === SwapProvider.ICP_SWAP}
-				<SwapDetailsIcp provider={selectedProvider} />
+				<SwapDetailsIcp provider={selectedProvider} {slippageValue} />
 			{/if}
 		{/snippet}
 		{#snippet contentFooter(closeFn)}

--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -60,7 +60,7 @@
 	</ModalValue>
 
 	<div class="flex flex-col gap-3">
-		<SwapProvider />
+		<SwapProvider {slippageValue} />
 		<SwapFees />
 	</div>
 

--- a/src/frontend/src/tests/lib/components/swap/SwapDetailsIcp.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapDetailsIcp.spec.ts
@@ -4,6 +4,7 @@ import SwapDetailsIcp from '$lib/components/swap/SwapDetailsIcp.svelte';
 import { initSwapContext, SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
 import type { ICPSwapAmountReply } from '$lib/types/api';
 import { SwapProvider } from '$lib/types/swap';
+import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SwapDetailsIcp', () => {
@@ -26,12 +27,33 @@ describe('SwapDetailsIcp', () => {
 
 		const { getByText } = render(SwapDetailsIcp, {
 			props: {
-				provider: providerMock
+				provider: providerMock,
+				slippageValue: 5
 			},
 			context: mockContext
 		});
 
-		expect(getByText('Expected minimum')).toBeInTheDocument();
+		expect(getByText(en.swap.text.expected_minimum)).toBeInTheDocument();
 		expect(getByText('0.95 ICP')).toBeInTheDocument();
+	});
+
+	it('doesnt renders expected minimum if slippage is undefined', () => {
+		const providerMock = {
+			provider: SwapProvider.ICP_SWAP,
+			receiveAmount: 100_000_000n,
+			receiveOutMinimum: 95_000_000n,
+			swapDetails: {} as ICPSwapAmountReply
+		} as const;
+
+		const { queryByText } = render(SwapDetailsIcp, {
+			props: {
+				provider: providerMock,
+				slippageValue: undefined
+			},
+			context: mockContext
+		});
+
+		expect(queryByText(en.swap.text.expected_minimum)).not.toBeInTheDocument();
+		expect(queryByText('0.95 ICP')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

The logic for calculating and formatting the minimum receive amount with slippage was previously handled inline within components. This led to code duplication and reduced clarity. The goal of this change is to centralize that logic using a utility function (`formatReceiveOutMinimum`) to improve readability, reusability, and testability.

# Changes

- Replaced inline slippage calculation and formatting in ICP swap view with `formatReceiveOutMinimum` utility
- Reduced duplication and improved separation of concerns between logic and UI


