### PR TITLE
feat(frontend): improve getUsdBalance to safely handle undefined values

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapProviderListItem.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProviderListItem.svelte
@@ -77,7 +77,7 @@
 				<SwapBestRateBadge />
 			{/if}
 			<span class="mt-1">
-				{usdBalance}
+				{usdBalance ?? $i18n.tokens.text.exchange_is_not_available_short}
 			</span>
 		</div>
 	</LogoButton>

--- a/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
@@ -33,7 +33,7 @@
 		token: IcTokenToggleable | undefined;
 		exchangeRate?: number;
 	}): string | undefined => {
-		if (isNullish(amount) || isNullish(token?.decimals) || isNullish(exchangeRate)) {
+		if (isNullish(amount) || isNullish(token) || isNullish(exchangeRate)) {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
 	import SwapProviderListItem from './SwapProviderListItem.svelte';
 	import { dAppDescriptions } from '$env/dapp-descriptions.env';
@@ -32,17 +32,20 @@
 		amount: bigint;
 		token: IcTokenToggleable | undefined;
 		exchangeRate?: number;
-	}): string =>
-		formatUSD({
-			value:
-				nonNullish(amount) && nonNullish(token) && nonNullish(exchangeRate)
-					? formatTokenBigintToNumber({
-							value: amount,
-							unitName: token.decimals,
-							displayDecimals: token.decimals
-						}) * exchangeRate
-					: 0
-		});
+	}): string | undefined => {
+		if (isNullish(amount) || isNullish(token?.decimals) || isNullish(exchangeRate)) {
+			return;
+		}
+
+		const usdValue =
+			formatTokenBigintToNumber({
+				value: amount,
+				unitName: token.decimals,
+				displayDecimals: token.decimals
+			}) * exchangeRate;
+
+		return formatUSD({ value: usdValue });
+	};
 </script>
 
 <div class=" mb-4 overflow-y-auto overscroll-contain">

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -639,6 +639,7 @@
 			"hide_token": "Hide token",
 			"select_token": "Select token",
 			"exchange_is_not_available": "USD value is currently not available.",
+			"exchange_is_not_available_short": "USD value not available",
 			"source_token_title": "You pay",
 			"destination_token_title": "You receive",
 			"chain_key": "Chain Key",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -603,6 +603,7 @@ interface I18nTokens {
 		hide_token: string;
 		select_token: string;
 		exchange_is_not_available: string;
+		exchange_is_not_available_short: string;
 		source_token_title: string;
 		destination_token_title: string;
 		chain_key: string;

--- a/src/frontend/src/tests/lib/components/swap/SwapProviderListItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapProviderListItem.spec.ts
@@ -1,5 +1,6 @@
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import SwapProviderListItem from '$lib/components/swap/SwapProviderListItem.svelte';
+import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
@@ -95,5 +96,19 @@ describe('SwapProviderListItem', () => {
 		});
 
 		expect(getByText('$12.34')).toBeInTheDocument();
+	});
+
+	it('renders fallback text if usdBalance is undefined', () => {
+		const dapp = createDapp();
+
+		const { getByText } = render(SwapProviderListItem, {
+			props: {
+				...baseProps,
+				usdBalance: undefined,
+				dapp
+			}
+		});
+
+		expect(getByText(en.tokens.text.exchange_is_not_available_short)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

The previous logic for displaying the USD balance in swap providers showed $0.00. This changes would show USD value not available instead

# Changes

- Refactored `getUsdBalance` utility
- Ensured it returns `undefined` gracefully when data is incomplete
- Updated swap provider UI to handle missing USD values with shorter fallback text

# Tests

- Added unit tests for `getUsdBalance`
