### PR TITLE
feat(frontend): Add Solana address schema

### DIFF
--- a/src/frontend/src/lib/schema/address.schema.ts
+++ b/src/frontend/src/lib/schema/address.schema.ts
@@ -1,3 +1,6 @@
+import { isSolAddress } from '$sol/utils/sol-address.utils';
 import { z } from 'zod';
 
 export const AddressSchema = z.string().nonempty();
+
+export const SolAddressSchema = AddressSchema.refine((val) => isSolAddress(val));

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -1,4 +1,4 @@
-import type { AddressSchema } from '$lib/schema/address.schema';
+import type { AddressSchema, SolAddressSchema } from '$lib/schema/address.schema';
 import type { Option } from '$lib/types/utils';
 import type { z } from 'zod';
 
@@ -8,7 +8,7 @@ export type BtcAddress = Address;
 
 export type EthAddress = Address;
 
-export type SolAddress = Address;
+export type SolAddress = z.infer<typeof SolAddressSchema>;
 
 export type OptionAddress<T extends Address> = Option<T>;
 

--- a/src/frontend/src/sol/utils/sol-address.utils.ts
+++ b/src/frontend/src/sol/utils/sol-address.utils.ts
@@ -1,10 +1,10 @@
-import type { SolAddress } from '$lib/types/address';
+import type { Address, SolAddress } from '$lib/types/address';
 import { getAccountOwner } from '$sol/api/solana.api';
 import type { SolanaNetworkType } from '$sol/types/network';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { assertIsAddress } from '@solana/kit';
 
-export const isSolAddress = (address: SolAddress | undefined): boolean => {
+export const isSolAddress = (address: Address | undefined): boolean => {
 	if (isNullish(address)) {
 		return false;
 	}
@@ -17,8 +17,7 @@ export const isSolAddress = (address: SolAddress | undefined): boolean => {
 	}
 };
 
-export const invalidSolAddress = (address: SolAddress | undefined): boolean =>
-	!isSolAddress(address);
+export const invalidSolAddress = (address: Address | undefined): boolean => !isSolAddress(address);
 
 export const isAtaAddress = async ({
 	address,

--- a/src/frontend/src/tests/lib/schema/address.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/address.schema.spec.ts
@@ -1,0 +1,45 @@
+import { SolAddressSchema } from '$lib/schema/address.schema';
+
+describe('address.schema', () => {
+	describe('SolAddressSchema', () => {
+		it('should validate valid Solana addresses', () => {
+			// Valid Solana addresses (base58 encoded, 32-44 characters)
+			const validAddresses = [
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGD',
+				'5vfCbYFSP5GcFhKQz11DXvxiwjwEUyXRYmP7W7HS2wJk',
+				'3h1zGmCwsRJnVk5BuRNnHaE2HNhB5Z8oEo8kvwXBvrzD'
+			];
+
+			validAddresses.forEach((address) => {
+				const result = SolAddressSchema.safeParse(address);
+
+				expect(result.success).toBeTruthy();
+				expect(result.data).toEqual(address);
+			});
+		});
+
+		it('should fail validation for non-string values', () => {
+			expect(SolAddressSchema.safeParse(123).success).toBeFalsy();
+			expect(SolAddressSchema.safeParse(null).success).toBeFalsy();
+			expect(SolAddressSchema.safeParse(undefined).success).toBeFalsy();
+			expect(SolAddressSchema.safeParse({}).success).toBeFalsy();
+		});
+
+		it('should fail validation for invalid Solana addresses', () => {
+			// Invalid Solana addresses
+			const invalidAddresses = [
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRc', // Too short
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGDD', // Too long
+				'0xDRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRGD', // Wrong format (with 0x)
+				'DRpbCBMxVnDK7maPM5tGv6MvB3v1TuAeJvzNg9pRcRG!', // Invalid character (!)
+				'OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO' // Invalid base58 characters
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = SolAddressSchema.safeParse(address);
+
+				expect(result.success).toBeFalsy();
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

In order to be able to parse solana adresses, this PR adds a `SolAddressSchema`

# Changes

- Adds `SolAddressSchema`
- Use `SolAddressSchema` to infer `SolAddress` type


# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
