### PR TITLE
refactor(frontend): make targetNetwork optional in sendIc

### DIFF
--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -35,7 +35,7 @@ export const sendIc = async ({
 	...rest
 }: IcTransferParams & {
 	token: IcToken;
-	targetNetworkId: NetworkId | undefined;
+	targetNetworkId?: NetworkId;
 	sendCompleted: () => void;
 }): Promise<void> => {
 	await send({
@@ -56,7 +56,7 @@ const send = async ({
 	...rest
 }: IcTransferParams & {
 	token: IcToken;
-	targetNetworkId: NetworkId | undefined;
+	targetNetworkId?: NetworkId;
 }): Promise<void> => {
 	if (isNetworkIdBitcoin(targetNetworkId)) {
 		await convertCkBTCToBtc({


### PR DESCRIPTION
# Motivation

We want to clean up the Send flow from the convert-related things. To do that, we need to make targetNetwork optional in sendIc.