### PR TITLE
feat(frontend): adds privacy mode to NetworkButton

### DIFF
--- a/src/frontend/src/lib/components/icons/IconDots.svelte
+++ b/src/frontend/src/lib/components/icons/IconDots.svelte
@@ -1,36 +1,36 @@
 <!-- source: DFINITY foundation -->
 <script lang="ts">
-    export type DotVariant = 'lg' | 'md' | 'sm' | 'xs';
+	export type DotVariant = 'lg' | 'md' | 'sm' | 'xs';
 
-    interface Props {
-        variant?: DotVariant;
-        times?: number;
-        styleClass?: string;
-    }
+	interface Props {
+		variant?: DotVariant;
+		times?: number;
+		styleClass?: string;
+	}
 
-    let { variant = 'md', times = 5, styleClass = '' }: Props = $props();
+	let { variant = 'md', times = 5, styleClass = '' }: Props = $props();
 
-    const size = $derived(
-        variant === 'lg' ? '14' : variant === 'md' ? '8' : variant === 'sm' ? '6' : '5'
-    );
-    const gap = $derived(variant === 'lg' ? 'gap-2' : 'gap-1');
+	const size = $derived(
+		variant === 'lg' ? '14' : variant === 'md' ? '8' : variant === 'sm' ? '6' : '5'
+	);
+	const gap = $derived(variant === 'lg' ? 'gap-2' : 'gap-1');
 </script>
 
 <div class="flex {gap} {styleClass}">
-    {#each Array(times) as _, i (i)}
-        <svg
-                width={size}
-                height={size}
-                viewBox="0 0 14 14"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-        >
-            <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
-                    d="M9.39024 13.7666C8.30726 14 8.20635 13.9638 7.5122 13.9899C7.34425 13.9963 7.17471 13.9996 7.00382 14C6.84961 13.9996 6.69652 13.9969 6.54472 13.9917C5.5 13.9389 5.5 13.9389 4.66667 13.7779C1.94673 13.2101 -0.0119686 11.4611 5.50531e-05 7.48653L5.50531e-05 6.51348C-0.0119686 2.53104 1.94673 0.786605 4.66667 0.221076C5.5 0.0612176 5.5 0.0612175 6.54472 0.00821954C6.69652 0.00309032 6.84961 0.000395598 7.00382 0C7.17477 0 7.3443 0.00288246 7.5122 0.00882773C8.15369 0.0314817 8.58839 0.0569706 9.39024 0.229165C12.0776 0.806211 13.9999 2.56419 13.9999 6.51348V7.48653C14.0119 11.4351 12.0788 13.1871 9.39024 13.7666Z"
-                    fill="currentColor"
-            />
-        </svg>
-    {/each}
+	{#each Array(times) as _, i (i)}
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 14 14"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+				d="M9.39024 13.7666C8.30726 14 8.20635 13.9638 7.5122 13.9899C7.34425 13.9963 7.17471 13.9996 7.00382 14C6.84961 13.9996 6.69652 13.9969 6.54472 13.9917C5.5 13.9389 5.5 13.9389 4.66667 13.7779C1.94673 13.2101 -0.0119686 11.4611 5.50531e-05 7.48653L5.50531e-05 6.51348C-0.0119686 2.53104 1.94673 0.786605 4.66667 0.221076C5.5 0.0612176 5.5 0.0612175 6.54472 0.00821954C6.69652 0.00309032 6.84961 0.000395598 7.00382 0C7.17477 0 7.3443 0.00288246 7.5122 0.00882773C8.15369 0.0314817 8.58839 0.0569706 9.39024 0.229165C12.0776 0.806211 13.9999 2.56419 13.9999 6.51348V7.48653C14.0119 11.4351 12.0788 13.1871 9.39024 13.7666Z"
+				fill="currentColor"
+			/>
+		</svg>
+	{/each}
 </div>

--- a/src/frontend/src/lib/components/icons/IconDots.svelte
+++ b/src/frontend/src/lib/components/icons/IconDots.svelte
@@ -1,0 +1,36 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+    export type DotVariant = 'lg' | 'md' | 'sm' | 'xs';
+
+    interface Props {
+        variant?: DotVariant;
+        times?: number;
+        styleClass?: string;
+    }
+
+    let { variant = 'md', times = 5, styleClass = '' }: Props = $props();
+
+    const size = $derived(
+        variant === 'lg' ? '14' : variant === 'md' ? '8' : variant === 'sm' ? '6' : '5'
+    );
+    const gap = $derived(variant === 'lg' ? 'gap-2' : 'gap-1');
+</script>
+
+<div class="flex {gap} {styleClass}">
+    {#each Array(times) as _, i (i)}
+        <svg
+                width={size}
+                height={size}
+                viewBox="0 0 14 14"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M9.39024 13.7666C8.30726 14 8.20635 13.9638 7.5122 13.9899C7.34425 13.9963 7.17471 13.9996 7.00382 14C6.84961 13.9996 6.69652 13.9969 6.54472 13.9917C5.5 13.9389 5.5 13.9389 4.66667 13.7779C1.94673 13.2101 -0.0119686 11.4611 5.50531e-05 7.48653L5.50531e-05 6.51348C-0.0119686 2.53104 1.94673 0.786605 4.66667 0.221076C5.5 0.0612176 5.5 0.0612175 6.54472 0.00821954C6.69652 0.00309032 6.84961 0.000395598 7.00382 0C7.17477 0 7.3443 0.00288246 7.5122 0.00882773C8.15369 0.0314817 8.58839 0.0569706 9.39024 0.229165C12.0776 0.806211 13.9999 2.56419 13.9999 6.51348V7.48653C14.0119 11.4351 12.0788 13.1871 9.39024 13.7666Z"
+                    fill="currentColor"
+            />
+        </svg>
+    {/each}
+</div>

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -9,6 +9,8 @@
 	import type { LabelSize } from '$lib/types/components';
 	import type { Network, NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
+	import {isPrivacyMode} from "$lib/derived/settings.derived";
+	import IconDots from "$lib/components/icons/IconDots.svelte";
 
 	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let network: Network | undefined = undefined;
@@ -60,7 +62,11 @@ TODO: Find a way to have the "All networks" not be a fallback for undefined netw
 	<span slot="description-end">
 		<span class:text-sm={labelsSize === 'lg'} class:md:text-base={labelsSize === 'lg'}>
 			{#if nonNullish(usdBalance)}
-				{formatUSD({ value: usdBalance })}
+				{#if $isPrivacyMode}
+					<IconDots variant="xs" />
+				{:else}
+					{formatUSD({ value: usdBalance })}
+				{/if}
 			{/if}
 		</span>
 

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
+	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import AllNetworksLogo from '$lib/components/networks/AllNetworksLogo.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LabelSize } from '$lib/types/components';
 	import type { Network, NetworkId } from '$lib/types/network';
 	import { formatUSD } from '$lib/utils/format.utils';
-	import {isPrivacyMode} from "$lib/derived/settings.derived";
-	import IconDots from "$lib/components/icons/IconDots.svelte";
 
 	export let selectedNetworkId: NetworkId | undefined = undefined;
 	export let network: Network | undefined = undefined;


### PR DESCRIPTION
# Motivation

We want to be able to hide the balances on the `NetworkButton` whether the `privacy mode` is turned on or off.

# Changes

- adds `IconDots`
- adds privacy mode to `NetworkButton`

# Tests

<img width="292" alt="image" src="https://github.com/user-attachments/assets/c907e92b-73df-47f8-b56b-4513cd138623" />

