### PR TITLE
feat(frontend): adds privacy mode to Balance

### DIFF
--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -8,6 +8,8 @@
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionTokenUi } from '$lib/types/token';
+	import IconDots from "$lib/components/icons/IconDots.svelte";
+	import {isPrivacyMode} from "$lib/derived/settings.derived";
 
 	export let token: OptionTokenUi;
 
@@ -20,17 +22,29 @@
 		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"
 	>
 		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !(token.balance === ZERO)}
-			<Amount amount={token.balance} decimals={token.decimals} symbol={token.symbol} />
+			{#if $isPrivacyMode}
+				<IconDots variant="lg" times={6} styleClass="h-17 mt-4" />
+			{:else}
+				<Amount amount={token.balance} decimals={token.decimals} symbol={token.symbol} />
+			{/if}
 		{:else}
-			<span class:animate-pulse={$loading}>0.00</span>
+			<span class:animate-pulse={$loading}>
+				{#if $isPrivacyMode}
+					<IconDots variant="lg" times={6} styleClass="h-17 mt-4" />
+				{:else}
+					0.00
+				{/if}
+			</span>
 		{/if}
 	</output>
 
-	<span class="text-xl font-bold opacity-50">
-		<TokenExchangeBalance
-			balance={token?.balance}
-			usdBalance={token?.usdBalance}
-			nullishBalanceMessage={$i18n.hero.text.unavailable_balance}
-		/>
-	</span>
+	{#if !$isPrivacyMode}
+		<span class="text-xl font-bold opacity-50">
+			<TokenExchangeBalance
+					balance={token?.balance}
+					usdBalance={token?.usdBalance}
+					nullishBalanceMessage={$i18n.hero.text.unavailable_balance}
+			/>
+		</span>
+	{/if}
 </span>

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { AMOUNT_DATA } from '$lib/constants/test-ids.constants';
+	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionTokenUi } from '$lib/types/token';
-	import IconDots from "$lib/components/icons/IconDots.svelte";
-	import {isPrivacyMode} from "$lib/derived/settings.derived";
 
 	export let token: OptionTokenUi;
 
@@ -41,9 +41,9 @@
 	{#if !$isPrivacyMode}
 		<span class="text-xl font-bold opacity-50">
 			<TokenExchangeBalance
-					balance={token?.balance}
-					usdBalance={token?.usdBalance}
-					nullishBalanceMessage={$i18n.hero.text.unavailable_balance}
+				balance={token?.balance}
+				usdBalance={token?.usdBalance}
+				nullishBalanceMessage={$i18n.hero.text.unavailable_balance}
 			/>
 		</span>
 	{/if}


### PR DESCRIPTION
# Motivation

We want to be able to hide the balance on the transaction page Hero component if privacy mode is on.


# Changes

- adds privacy mode to `Balance`

# Tests

**on:**
<img width="875" alt="image" src="https://github.com/user-attachments/assets/d25cb8da-13ca-47e9-814e-d5ed6827392f" />

**off:**
<img width="890" alt="image" src="https://github.com/user-attachments/assets/ad877a6d-1152-4da9-b07a-4a6d9ddfff3b" />
