### PR TITLE
feat(frontend): adds privacy mode to TokenCard

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import TokenBalanceSkeleton from '$lib/components/tokens/TokenBalanceSkeleton.svelte';
 	import { TOKEN_BALANCE } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CardData } from '$lib/types/token-card';
 	import { formatToken } from '$lib/utils/format.utils';
-	import type {Snippet} from "svelte";
 
 	interface Props {
 		privacyBalance?: Snippet;

--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -5,8 +5,15 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CardData } from '$lib/types/token-card';
 	import { formatToken } from '$lib/utils/format.utils';
+	import type {Snippet} from "svelte";
 
-	export let data: CardData;
+	interface Props {
+		privacyBalance?: Snippet;
+		data: CardData;
+		hideBalance?: boolean;
+	}
+
+	let { privacyBalance, data, hideBalance = false }: Props = $props();
 </script>
 
 <TokenBalanceSkeleton {data}>
@@ -15,10 +22,14 @@
 		data-tid={`${TOKEN_BALANCE}-${data.symbol}-${data.network.id.description}`}
 	>
 		{#if nonNullish(data.balance)}
-			{formatToken({
-				value: data.balance,
-				unitName: data.decimals
-			})}
+			{#if hideBalance}
+				{@render privacyBalance?.()}
+			{:else}
+				{formatToken({
+					value: data.balance,
+					unitName: data.decimals
+				})}
+			{/if}
 		{:else}
 			<span>{$i18n.tokens.balance.error.not_applicable}</span>
 		{/if}

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
+	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { TOKEN_CARD, type TOKEN_GROUP } from '$lib/constants/test-ids.constants';
+	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CardData } from '$lib/types/token-card';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
-	import {isPrivacyMode} from "$lib/derived/settings.derived";
-	import IconDots from "$lib/components/icons/IconDots.svelte";
 
 	let {
 		data,

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -8,6 +8,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CardData } from '$lib/types/token-card';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
+	import {isPrivacyMode} from "$lib/derived/settings.derived";
+	import IconDots from "$lib/components/icons/IconDots.svelte";
 
 	let {
 		data,
@@ -58,7 +60,11 @@
 		</span>
 
 		<span class:text-sm={asNetwork} class="block min-w-12 text-nowrap" slot="title-end">
-			<TokenBalance {data} />
+			<TokenBalance {data} hideBalance={$isPrivacyMode}>
+				{#snippet privacyBalance()}
+					<IconDots variant={asNetwork ? 'sm' : 'md'} styleClass={asNetwork ? 'my-4.25' : 'pb-4'} />
+				{/snippet}
+			</TokenBalance>
 		</span>
 
 		<span class:text-sm={asNetwork} slot="description">
@@ -75,7 +81,9 @@
 		</span>
 
 		<span class:text-sm={asNetwork} class="block min-w-12 text-nowrap" slot="description-end">
-			<ExchangeTokenValue {data} />
+			{#if !$isPrivacyMode}
+				<ExchangeTokenValue {data} />
+			{/if}
 		</span>
 	</LogoButton>
 </div>


### PR DESCRIPTION
# Motivation

We want to be able to hide the balances on the displayed tokens if privacy mode is on.

# Changes

- add privacy mode to `TokenCard`

# Tests

**on:**
<img width="497" alt="image" src="https://github.com/user-attachments/assets/40209d75-d634-49af-9226-454fe4117f12" />

**off:**
<img width="464" alt="image" src="https://github.com/user-attachments/assets/61e9d004-ef14-4943-b6a7-877d426d6cc8" />
