### PR TITLE
feat(frontend): enables to set Tags to ButtonMenu

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import {nonNullish} from "@dfinity/utils";
-	import Tag from "$lib/components/ui/Tag.svelte";
-	import type {TagVariant} from "$lib/types/style";
+	import { nonNullish } from '@dfinity/utils';
+	import Tag from '$lib/components/ui/Tag.svelte';
+	import type { TagVariant } from '$lib/types/style';
 
 	export let disabled = false;
 	export let ariaLabel: string;

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+	import {nonNullish} from "@dfinity/utils";
+	import Tag from "$lib/components/ui/Tag.svelte";
+
 	export let disabled = false;
 	export let ariaLabel: string;
 	export let testId: string | undefined = undefined;
+	export let tag: string | undefined = undefined;
+	export let tagVariant: TagVariant | undefined = undefined;
 </script>
 
 <button
@@ -13,4 +18,9 @@
 	class:opacity-50={disabled}
 >
 	<slot />
+	{#if nonNullish(tag)}
+		<span class="ml-auto">
+			<Tag variant={tagVariant}>{tag}</Tag>
+		</span>
+	{/if}
 </button>

--- a/src/frontend/src/lib/components/ui/ButtonMenu.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {nonNullish} from "@dfinity/utils";
 	import Tag from "$lib/components/ui/Tag.svelte";
+	import type {TagVariant} from "$lib/types/style";
 
 	export let disabled = false;
 	export let ariaLabel: string;


### PR DESCRIPTION
# Motivation

We want to be able to set `Tags` to the Menu items.

# Changes

- supports `Tags`

# Tests

<img width="204" alt="image" src="https://github.com/user-attachments/assets/ce843c90-2f28-4edd-bb33-10c50525ac79" />

