### PR TITLE
refactor(frontend): upgrades NavigationItem to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationItem.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationItem.svelte
@@ -2,17 +2,23 @@
 	import { nonNullish } from '@dfinity/utils';
 	import Tag from '$lib/components/ui/Tag.svelte';
 	import type { TagVariant } from '$lib/types/style';
+	import type {Snippet} from "svelte";
 
-	export let href: string;
-	export let selected = false;
-	export let ariaLabel: string;
-	export let testId: string | undefined = undefined;
-	export let tag: string | undefined = undefined;
-	export let tagVariant: TagVariant | undefined = undefined;
+	interface Props {
+		children?: Snippet;
+		href: string;
+		selected?: boolean;
+		ariaLabel: string;
+		testId?: string;
+		tag?: string;
+		tagVariant?: TagVariant;
+	}
+
+	let {children, href, selected = false, ariaLabel, testId, tag, tagVariant}: Props = $props();
 </script>
 
 <a {href} class="nav-item" class:selected aria-label={ariaLabel} data-tid={testId}>
-	<slot />
+	{@render children?.()}
 	{#if nonNullish(tag)}
 		<div
 			class="text-xs/4.5 md:mt-0.75 absolute -mt-1.5 ml-10 scale-75 font-bold uppercase md:relative md:ml-1 md:scale-100"

--- a/src/frontend/src/lib/components/navigation/NavigationItem.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationItem.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import Tag from '$lib/components/ui/Tag.svelte';
 	import type { TagVariant } from '$lib/types/style';
-	import type {Snippet} from "svelte";
 
 	interface Props {
 		children?: Snippet;
@@ -14,7 +14,7 @@
 		tagVariant?: TagVariant;
 	}
 
-	let {children, href, selected = false, ariaLabel, testId, tag, tagVariant}: Props = $props();
+	let { children, href, selected = false, ariaLabel, testId, tag, tagVariant }: Props = $props();
 </script>
 
 <a {href} class="nav-item" class:selected aria-label={ariaLabel} data-tid={testId}>


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- Upgrades `NavigationItem`

