### PR TITLE
refactor(frontend): upgrades NavigationMenuMainItems to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -45,7 +45,7 @@
 
 	const isTransactionsRoute = $derived(isRouteTransactions($page));
 
-	let fromRoute = $state<NavigationTarget | null>();
+	let fromRoute = $state<NavigationTarget | null>(null);
 
 	afterNavigate(({ from }) => {
 		fromRoute = from;

--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -33,7 +33,7 @@
 		testIdPrefix?: string;
 	}
 
-	let {testIdPrefix}: Props = $props();
+	let { testIdPrefix }: Props = $props();
 
 	const addTestIdPrefix = (testId: string): string =>
 		nonNullish(testIdPrefix) ? `${testIdPrefix}-${testId}` : testId;

--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -29,7 +29,11 @@
 		networkUrl
 	} from '$lib/utils/nav.utils';
 
-	export let testIdPrefix: string | undefined = undefined;
+	interface Props {
+		testIdPrefix?: string;
+	}
+
+	let {testIdPrefix}: Props = $props();
 
 	const addTestIdPrefix = (testId: string): string =>
 		nonNullish(testIdPrefix) ? `${testIdPrefix}-${testId}` : testId;
@@ -37,13 +41,11 @@
 	// If we pass $page directly, we get a type error: for some reason (I cannot find any
 	// documentation on it), the type of $page is not `Page`, but `unknown`. So we need to manually
 	// cast it to `Page`.
-	let pageData: Page;
-	$: pageData = $page;
+	const pageData = $derived($page);
 
-	let isTransactionsRoute = false;
-	$: isTransactionsRoute = isRouteTransactions($page);
+	const isTransactionsRoute = $derived(isRouteTransactions($page));
 
-	let fromRoute: NavigationTarget | null;
+	let fromRoute = $state<NavigationTarget | null>();
 
 	afterNavigate(({ from }) => {
 		fromRoute = from;

--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -41,7 +41,7 @@
 	// If we pass $page directly, we get a type error: for some reason (I cannot find any
 	// documentation on it), the type of $page is not `Page`, but `unknown`. So we need to manually
 	// cast it to `Page`.
-	const pageData = $derived($page);
+	const pageData: Page = $derived($page);
 
 	const isTransactionsRoute = $derived(isRouteTransactions($page));
 


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- Upgrades `NavigationMenuMainItems`

