### PR TITLE
fix(frontend): HOTFIX: Disable reactivity for CK Ethereum pending transactions

### DIFF
--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import {
-		isNullish,
-		nonNullish,
-		isEmptyString,
-		fromNullishNullable
-	} from '@dfinity/utils';
+	import { isNullish, nonNullish, isEmptyString, fromNullishNullable } from '@dfinity/utils';
 	import type { TransactionResponse } from 'ethers/providers';
 	import { onDestroy } from 'svelte';
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import { isNullish, nonNullish, isEmptyString, fromNullishNullable, debounce } from '@dfinity/utils';
+	import {
+		isNullish,
+		nonNullish,
+		isEmptyString,
+		fromNullishNullable,
+		debounce
+	} from '@dfinity/utils';
 	import type { TransactionResponse } from 'ethers/providers';
 	import { onDestroy } from 'svelte';
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
@@ -124,14 +130,16 @@
 
 	$: (async () => await init({ toAddress: toContractAddress, twinToken }))();
 
-	const debounceLoadPendingTransactions = debounce(async () => await loadPendingTransactions({ toAddress: toContractAddress }), 2000);
+	const debounceLoadPendingTransactions = debounce(
+		async () => await loadPendingTransactions({ toAddress: toContractAddress }),
+		2000
+	);
 
 	// Update pending transactions:
 	// - When the balance updates, i.e., when new transactions are detected, it's possible that the pending ETH -> ckETH transactions have been minted.
 	// - The scheduled minter info updates are important because we use the information it provides to query the Ethereum network starting from a specific block index.
 	// TODO: re-set the reactivity (and remove the onMount) when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
 	// $:  $balance,toContractAddress, debounceLoadPendingTransactions();
-
 
 	onDestroy(async () => await listener?.disconnect());
 </script>

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -3,8 +3,7 @@
 		isNullish,
 		nonNullish,
 		isEmptyString,
-		fromNullishNullable,
-		debounce
+		fromNullishNullable
 	} from '@dfinity/utils';
 	import type { TransactionResponse } from 'ethers/providers';
 	import { onDestroy } from 'svelte';
@@ -40,7 +39,8 @@
 	$: twinToken = nonNullish(token) && isIcCkToken(token) ? token.twinToken : undefined;
 
 	// TODO: this is way too much work for a component and for the UI. Defer all that mumbo jumbo to a worker.
-
+	// TODO: re-set the reactivity (and remove the onMount) when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
+	// tslint-disable-next-line @typescript-eslint/no-unused-vars
 	const loadPendingTransactions = async ({ toAddress }: { toAddress: OptionEthAddress }) => {
 		if (isNullish(token)) {
 			return;
@@ -130,16 +130,11 @@
 
 	$: (async () => await init({ toAddress: toContractAddress, twinToken }))();
 
-	const debounceLoadPendingTransactions = debounce(
-		async () => await loadPendingTransactions({ toAddress: toContractAddress }),
-		2000
-	);
-
 	// Update pending transactions:
 	// - When the balance updates, i.e., when new transactions are detected, it's possible that the pending ETH -> ckETH transactions have been minted.
 	// - The scheduled minter info updates are important because we use the information it provides to query the Ethereum network starting from a specific block index.
 	// TODO: re-set the reactivity (and remove the onMount) when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
-	// $:  $balance,toContractAddress, debounceLoadPendingTransactions();
+	// $:  $balance,toContractAddress, (async () => await loadPendingTransactions({ toAddress: toContractAddress }))();
 
 	onDestroy(async () => await listener?.disconnect());
 </script>

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish, isEmptyString, fromNullishNullable, debounce } from '@dfinity/utils';
 	import type { TransactionResponse } from 'ethers/providers';
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import { initPendingTransactionsListener as initEthPendingTransactionsListenerProvider } from '$eth/providers/alchemy.providers';
 	import { icPendingTransactionsStore } from '$icp/stores/ic-pending-transactions.store';
 	import type { IcToken } from '$icp/types/ic-token';

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -35,7 +35,7 @@
 
 	// TODO: this is way too much work for a component and for the UI. Defer all that mumbo jumbo to a worker.
 	// TODO: re-set the reactivity (and remove the onMount) when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
-	// tslint-disable-next-line @typescript-eslint/no-unused-vars
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const loadPendingTransactions = async ({ toAddress }: { toAddress: OptionEthAddress }) => {
 		if (isNullish(token)) {
 			return;

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -34,7 +34,6 @@
 	$: twinToken = nonNullish(token) && isIcCkToken(token) ? token.twinToken : undefined;
 
 	// TODO: this is way too much work for a component and for the UI. Defer all that mumbo jumbo to a worker.
-	// TODO: re-set the reactivity (and remove the onMount) when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const loadPendingTransactions = async ({ toAddress }: { toAddress: OptionEthAddress }) => {
 		if (isNullish(token)) {
@@ -128,7 +127,7 @@
 	// Update pending transactions:
 	// - When the balance updates, i.e., when new transactions are detected, it's possible that the pending ETH -> ckETH transactions have been minted.
 	// - The scheduled minter info updates are important because we use the information it provides to query the Ethereum network starting from a specific block index.
-	// TODO: re-set the reactivity (and remove the onMount) when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
+	// TODO: re-set the reactivity when we find out why it is too frequent to request (most probably because the balances store is frequently refreshed and the minter info store too).
 	// $:  $balance,toContractAddress, (async () => await loadPendingTransactions({ toAddress: toContractAddress }))();
 
 	onDestroy(async () => await listener?.disconnect());


### PR DESCRIPTION
# Motivation

We included the CK Ethereum pending transactions listener in the main page. However, this triggers too many calls. Just as HOTFIX, we disable the reactivity of the component for now. In the meanwhile we investigate.

NOTE: we simplified the reactivity too, since it had redundant elements.
