### PR TITLE
feat(frontend): Add EthAddressSchema

### DIFF
--- a/src/frontend/src/lib/schema/address.schema.ts
+++ b/src/frontend/src/lib/schema/address.schema.ts
@@ -1,5 +1,6 @@
 import { parseBtcAddress } from '$btc/utils/btc-address.utils';
 import type { BtcAddress } from '$declarations/backend/backend.did';
+import { isEthAddress } from '$lib/utils/account.utils';
 import { isBtcAddress } from '$lib/utils/address.utils';
 import { isSolAddress } from '$sol/utils/sol-address.utils';
 import { nonNullish } from '@dfinity/utils';
@@ -26,3 +27,7 @@ export const BtcAddressObjectSchema = BtcAddressSchema.transform<BtcAddress>((da
 
 	return z.NEVER;
 }).transform<BtcAddress>((v) => v);
+
+export const EthAddressSchema = AddressSchema.refine((val) => isEthAddress(val));
+
+export const EthAddressObjectSchema = EthAddressSchema.transform((v) => ({ Public: v }));

--- a/src/frontend/src/lib/types/address.ts
+++ b/src/frontend/src/lib/types/address.ts
@@ -1,4 +1,9 @@
-import type { AddressSchema, BtcAddressSchema, SolAddressSchema } from '$lib/schema/address.schema';
+import type {
+	AddressSchema,
+	BtcAddressSchema,
+	EthAddressSchema,
+	SolAddressSchema
+} from '$lib/schema/address.schema';
 import type { Option } from '$lib/types/utils';
 import type * as z from 'zod';
 
@@ -6,7 +11,7 @@ export type Address = z.infer<typeof AddressSchema>;
 
 export type BtcAddress = z.infer<typeof BtcAddressSchema>;
 
-export type EthAddress = Address;
+export type EthAddress = z.infer<typeof EthAddressSchema>;
 
 export type SolAddress = z.infer<typeof SolAddressSchema>;
 

--- a/src/frontend/src/tests/lib/schema/address.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/address.schema.spec.ts
@@ -1,6 +1,8 @@
 import {
 	BtcAddressObjectSchema,
 	BtcAddressSchema,
+	EthAddressObjectSchema,
+	EthAddressSchema,
 	SolAddressSchema
 } from '$lib/schema/address.schema';
 
@@ -129,6 +131,61 @@ describe('address.schema', () => {
 			const invalidResult = BtcAddressSchema.safeParse(invalidAddress);
 
 			expect(invalidResult.success).toBeFalsy();
+		});
+	});
+
+	describe('EthAddressSchema', () => {
+		it('should validate a valid Ethereum address', () => {
+			const validAddress = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
+			const result = EthAddressSchema.safeParse(validAddress);
+
+			expect(result.success).toBeTruthy();
+		});
+
+		it('should reject an invalid Ethereum address', () => {
+			const invalidAddress = '0xG1C7656EC7ab88b098defB751B7401B5f6d8976F'; // Invalid character (G)
+			const result = EthAddressSchema.safeParse(invalidAddress);
+
+			expect(result.success).toBeFalsy();
+		});
+
+		it('should validate valid Ethereum addresses', () => {
+			// Valid Ethereum addresses according to ethers isAddress function
+			const validAddresses = [
+				'0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+				'0x1234567890123456789012345678901234567890',
+				'0x0000000000000000000000000000000000000000' // Zero address is valid for ethers
+			];
+
+			validAddresses.forEach((address) => {
+				const result = EthAddressObjectSchema.safeParse(address);
+
+				expect(result.success).toBeTruthy();
+				expect(result.data).toEqual({ Public: address });
+			});
+		});
+
+		it('should fail validation for non-string values', () => {
+			expect(EthAddressObjectSchema.safeParse(123).success).toBeFalsy();
+			expect(EthAddressObjectSchema.safeParse(null).success).toBeFalsy();
+			expect(EthAddressObjectSchema.safeParse(undefined).success).toBeFalsy();
+			expect(EthAddressObjectSchema.safeParse({}).success).toBeFalsy();
+		});
+
+		it('should fail validation for invalid Ethereum addresses', () => {
+			// Invalid Ethereum addresses according to ethers isAddress function
+			const invalidAddresses = [
+				'0x71C7656EC7ab88b098defB751B7401B5f6d897', // Too short
+				'0x71C7656EC7ab88b098defB751B7401B5f6d8976F00', // Too long
+				'0xG1C7656EC7ab88b098defB751B7401B5f6d8976F', // Invalid character (G)
+				'0xinvalid' // Invalid format
+			];
+
+			invalidAddresses.forEach((address) => {
+				const result = EthAddressObjectSchema.safeParse(address);
+
+				expect(result.success).toBeFalsy();
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

In order to be able to parse Eth adresses, this PR adds a `EthAddressSchema`

# Changes

- Adds `EthAddressSchema`
- Use `EthAddressSchema` to infer `EthAddress` type
