### PR TITLE
refactor(frontend): replaces deprecated page from app/store

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -2,7 +2,7 @@
 	import { IconUser, Popover } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { ADDRESS_BOOK_ENABLED } from '$env/address-book.env';
 	import AboutWhyOisy from '$lib/components/about/AboutWhyOisy.svelte';
 	import MenuAddresses from '$lib/components/core/MenuAddresses.svelte';
@@ -58,10 +58,10 @@
 
 	const hidePopover = () => (visible = false);
 
-	const settingsRoute = $derived(isRouteSettings($page));
-	const dAppExplorerRoute = $derived(isRouteDappExplorer($page));
-	const activityRoute = $derived(isRouteActivity($page));
-	const rewardsRoute = $derived(isRouteRewards($page));
+	const settingsRoute = $derived(isRouteSettings(page));
+	const dAppExplorerRoute = $derived(isRouteDappExplorer(page));
+	const activityRoute = $derived(isRouteActivity(page));
+	const rewardsRoute = $derived(isRouteRewards(page));
 	const addressesOption = $derived(
 		!settingsRoute && !dAppExplorerRoute && !activityRoute && !rewardsRoute
 	);


### PR DESCRIPTION
# Motivation

Since `page` from `app/store` is deprecated and we upgraded the `Menu` component to svelte 5, we can use the `page` from `app/state` instead.

# Changes

- uses page from `app/state`

