### PR TITLE
refactor(frontend): upgrades TokenInputCurrency

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapSlippage.svelte
+++ b/src/frontend/src/lib/components/swap/SwapSlippage.svelte
@@ -86,7 +86,9 @@
 						on:focus={onFocus}
 						on:blur={onBlur}
 					>
-						<span class="text-tertiary" slot="inner-end">%</span>
+						{#snippet innerEnd()}
+							<span class="text-tertiary">%</span>
+						{/snippet}
 					</TokenInputCurrency>
 				</TokenInputContainer>
 

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
 	import type { OptionAmount } from '$lib/types/send';
-	import type {Snippet} from "svelte";
 
 	interface Props {
 		innerEnd: Snippet;

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
@@ -19,7 +19,7 @@
 	}
 
 	let {
-		innerEnd: _innerEnd,
+		innerEnd,
 		prefix,
 		value = $bindable(),
 		decimals,
@@ -51,11 +51,8 @@
 		on:focus
 		on:blur
 		on:nnsInput
-	>
-		{#snippet innerEnd()}
-			{@render _innerEnd()}
-		{/snippet}
-	</InputCurrency>
+		{innerEnd}
+	/>
 </div>
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrency.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import InputCurrency from '$lib/components/ui/InputCurrency.svelte';
 	import type { OptionAmount } from '$lib/types/send';
+	import type {Snippet} from "svelte";
 
 	interface Props {
+		innerEnd: Snippet;
+		prefix?: Snippet;
 		value: OptionAmount;
 		decimals: number;
 		name?: string;
@@ -16,6 +19,8 @@
 	}
 
 	let {
+		innerEnd: _innerEnd,
+		prefix,
 		value = $bindable(),
 		decimals,
 		name = 'token-input-currency',
@@ -34,7 +39,7 @@
 	class:text-error-primary={error}
 	class:animate-pulse={loading}
 >
-	<slot name="prefix"></slot>
+	{@render prefix?.()}
 	<InputCurrency
 		{testId}
 		bind:value
@@ -47,7 +52,9 @@
 		on:blur
 		on:nnsInput
 	>
-		<slot name="inner-end" slot="inner-end" />
+		{#snippet innerEnd()}
+			{@render _innerEnd()}
+		{/snippet}
 	</InputCurrency>
 </div>
 

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrencyToken.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrencyToken.svelte
@@ -27,5 +27,7 @@
 	on:blur
 	on:nnsInput
 >
-	<slot name="inner-end" slot="inner-end" />
+	{#snippet innerEnd()}
+		<slot name="inner-end" />
+	{/snippet}
 </TokenInputCurrency>

--- a/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputCurrencyUsd.svelte
@@ -60,7 +60,7 @@
 	testId={TOKEN_INPUT_CURRENCY_USD}
 	styleClass="no-padding"
 >
-	<svelte:fragment slot="prefix">
+	{#snippet prefix()}
 		<span
 			class="duration=[var(--animation-time-short)] pl-3 transition-colors"
 			class:text-tertiary={isNullish(displayValue)}
@@ -68,8 +68,10 @@
 		>
 			$
 		</span>
-	</svelte:fragment>
-	<slot name="inner-end" slot="inner-end" />
+	{/snippet}
+	{#snippet innerEnd()}
+		<slot name="inner-end" />
+	{/snippet}
 </TokenInputCurrency>
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/ui/InputCurrency.svelte
+++ b/src/frontend/src/lib/components/ui/InputCurrency.svelte
@@ -53,8 +53,8 @@
 		on:focus
 		bind:inputElement
 	>
-		{#snippet innerEnd()}
-			<slot name="inner-end" />
-		{/snippet}
+		<svelte:fragment slot="inner-end">
+			{@render innerEnd()}
+		</svelte:fragment>
 	</Input>
 </div>

--- a/src/frontend/src/lib/components/ui/InputCurrency.svelte
+++ b/src/frontend/src/lib/components/ui/InputCurrency.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { Input } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import { onMount } from 'svelte';
+	import {onMount, type Snippet} from 'svelte';
 
 	interface Props {
+		innerEnd: Snippet;
 		value?: string | number;
 		disabled?: boolean;
 		name: string;
@@ -15,6 +16,7 @@
 	}
 
 	let {
+		innerEnd,
 		value = $bindable(),
 		disabled,
 		name,
@@ -51,6 +53,8 @@
 		on:focus
 		bind:inputElement
 	>
-		<slot name="inner-end" slot="inner-end" />
+		{#snippet innerEnd()}
+			<slot name="inner-end" />
+		{/snippet}
 	</Input>
 </div>

--- a/src/frontend/src/lib/components/ui/InputCurrency.svelte
+++ b/src/frontend/src/lib/components/ui/InputCurrency.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Input } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import {onMount, type Snippet} from 'svelte';
+	import { onMount, type Snippet } from 'svelte';
 
 	interface Props {
 		innerEnd: Snippet;


### PR DESCRIPTION
# Motivation

Since we upgraded the component to svelte 5 we also need to use the new `snippets` instead of `slots`.

# Changes

- replaces `slots` with `snippets`
