### PR TITLE
fix(frontend): Add `polling` for Alchemy providers

### DIFF
--- a/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy-erc20.providers.ts
@@ -19,7 +19,10 @@ export class AlchemyErc20Provider {
 
 	// AlchemyProvider of ether.js does not support Sepolia
 	constructor(private readonly providerUrl: string) {
-		this.provider = new JsonRpcProvider(`${this.providerUrl}/${ALCHEMY_API_KEY}`);
+		this.provider = new JsonRpcProvider(`${this.providerUrl}/${ALCHEMY_API_KEY}`, undefined, {
+			// See: https://github.com/ethers-io/ethers.js/issues/4784#issuecomment-2820177791
+			polling: true
+		});
 	}
 
 	initMinedTransactionsListener = ({

--- a/src/frontend/src/tests/eth/providers/alchemy-erc20.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/alchemy-erc20.providers.spec.ts
@@ -25,7 +25,11 @@ describe('alchemy-erc20.providers', () => {
 		networks.forEach(({ providers: { alchemyJsonRpcUrl } }, index) => {
 			expect(JsonRpcProvider).toHaveBeenNthCalledWith(
 				index + 1,
-				`${alchemyJsonRpcUrl}/${ALCHEMY_API_KEY}`
+				`${alchemyJsonRpcUrl}/${ALCHEMY_API_KEY}`,
+				undefined,
+				{
+					polling: true
+				}
 			);
 		});
 	});


### PR DESCRIPTION
# Motivation

As per thread https://github.com/ethers-io/ethers.js/issues/4784#issuecomment-2820177791:

> By default, etherjs uses RPC Filter and turns off polling. Filter relies on `eth_newFilter` / `eth_getFilterChanges`, both of which are state interfaces and need to store `filterId` status on the node. For service providers with distributed architectures such as Infura and QuickNode, each request may hit a different backend node, and these nodes do not share `filter` status. Therefore, they choose to disable `eth_newFilter` and `eth_getFilterChanges` and only support stateless requests (such as `eth_getLogs`) to ensure system stability and scalability.

This causes an extreme amount of console logs. Not errors, since it is expected according to https://github.com/ethers-io/ethers.js/issues/4796.



<img width="748" alt="image-20250520-062407 (1)" src="https://github.com/user-attachments/assets/2cf03750-0f5d-478d-8e70-5c3b290ad27e" />




So, as [suggested in the same thread](https://github.com/ethers-io/ethers.js/issues/4784#issuecomment-2273652405), we turn on `polling` for Alchemy JSON RPC providers.
