### PR TITLE
refactor(frontend): Move 1INCH token to additional ERC20 tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.1inch.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.1inch.env.ts
@@ -1,0 +1,24 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import oneInch from '$eth/assets/1inch.svg';
+import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+const ONEINCH_DECIMALS = 18;
+
+const ONEINCH_SYMBOL = '1INCH';
+
+export const ONEINCH_TOKEN_ID: TokenId = parseTokenId(ONEINCH_SYMBOL);
+
+export const ONEINCH_TOKEN: RequiredAdditionalErc20Token = {
+	id: ONEINCH_TOKEN_ID,
+	network: ETHEREUM_NETWORK,
+	standard: 'erc20',
+	category: 'default',
+	name: '1INCH Token',
+	symbol: ONEINCH_SYMBOL,
+	decimals: ONEINCH_DECIMALS,
+	icon: oneInch,
+	address: '0x111111111117dc0aa78b770fa6a738034120c302',
+	exchange: 'erc20'
+};

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -3,6 +3,7 @@ import {
 	ETHEREUM_NETWORK,
 	SEPOLIA_NETWORK
 } from '$env/networks/networks.eth.env';
+import { ONEINCH_TOKEN } from '$env/tokens/tokens-erc20/tokens.1inch.env';
 import { EURC_TOKEN, SEPOLIA_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
@@ -14,18 +15,16 @@ import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
 import { WBTC_TOKEN } from '$env/tokens/tokens-erc20/tokens.wbtc.env';
 import { WSTETH_TOKEN } from '$env/tokens/tokens-erc20/tokens.wsteth.env';
 import { XAUT_TOKEN } from '$env/tokens/tokens-erc20/tokens.xaut.env';
-import type { Erc20Contract, RequiredErc20Token } from '$eth/types/erc20';
+import type {
+	Erc20Contract,
+	RequiredAdditionalErc20Token,
+	RequiredErc20Token
+} from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { TokenId } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 
 // TODO: remember to remove the ERC20 from here once the ckERC20 is implemented. Following the normal flow, the ERC20 variables should be created on a separate file.
-
-const ERC20_CONTRACT_ADDRESS_1INCH: Erc20Contract = {
-	// 1INCH
-	address: '0x111111111117dc0aa78b770fa6a738034120c302',
-	exchange: 'erc20'
-};
 
 const ERC20_CONTRACT_ADDRESS_DMAIL: Erc20Contract = {
 	// Dmail Network
@@ -97,7 +96,6 @@ export const ERC20_CONTRACT_ICP: Erc20Contract = {
 
 export const ERC20_CONTRACTS_PRODUCTION: Erc20Contract[] = [
 	ERC20_CONTRACT_ICP,
-	ERC20_CONTRACT_ADDRESS_1INCH,
 	ERC20_CONTRACT_ADDRESS_DMAIL,
 	ERC20_CONTRACT_ADDRESS_MATIC,
 	ERC20_CONTRACT_ADDRESS_JASMY,
@@ -114,6 +112,8 @@ export const ERC20_CONTRACTS: (Erc20Contract & { network: EthereumNetwork })[] =
 		: []),
 	...ERC20_CONTRACTS_SEPOLIA.map((contract) => ({ ...contract, network: SEPOLIA_NETWORK }))
 ];
+
+export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN];
 
 /**
  * ERC20 which have twin tokens counterparts.

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -58,8 +58,8 @@ const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 		erc20DefaultTokensStore.set([
 			...ERC20_TWIN_TOKENS,
 			...EVM_ERC20_TOKENS,
-			...contracts.map(mapErc20Token),
-			...ADDITIONAL_ERC20_TOKENS
+			...ADDITIONAL_ERC20_TOKENS,
+			...contracts.map(mapErc20Token)
 		]);
 	} catch (err: unknown) {
 		erc20DefaultTokensStore.reset();

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -8,7 +8,11 @@ import {
 	SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS
 } from '$env/networks/networks.eth.env';
 import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
-import { ERC20_CONTRACTS, ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
+import {
+	ADDITIONAL_ERC20_TOKENS,
+	ERC20_CONTRACTS,
+	ERC20_TWIN_TOKENS
+} from '$env/tokens/tokens.erc20.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
@@ -54,7 +58,8 @@ const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 		erc20DefaultTokensStore.set([
 			...ERC20_TWIN_TOKENS,
 			...EVM_ERC20_TOKENS,
-			...contracts.map(mapErc20Token)
+			...contracts.map(mapErc20Token),
+			...ADDITIONAL_ERC20_TOKENS
 		]);
 	} catch (err: unknown) {
 		erc20DefaultTokensStore.reset();

--- a/src/frontend/src/eth/types/erc20.ts
+++ b/src/frontend/src/eth/types/erc20.ts
@@ -6,6 +6,7 @@ import type { Option } from '$lib/types/utils';
 export type Erc20Token = Erc20Contract & Token;
 
 export type RequiredErc20Token = RequiredToken<Erc20Token>;
+export type RequiredAdditionalErc20Token = Omit<RequiredErc20Token, keyof TokenLinkedData>;
 
 export type Erc20ContractAddress = ContractAddress;
 export type Erc20Contract = Erc20ContractAddress & { exchange: Exchange } & TokenLinkedData;

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -1,4 +1,3 @@
-import oneInch from '$eth/assets/1inch.svg';
 import dai from '$eth/assets/dai.svg';
 import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
@@ -62,8 +61,6 @@ const mapErc20Icon = (symbol: string): string | undefined => {
 			return weeth;
 		case 'weth':
 			return weth;
-		case '1inch':
-			return oneInch;
 		// ICP in production. ckICP was used on staging because the definitive name and symbol had not been decided.
 		case 'icp':
 		case 'ckicp':


### PR DESCRIPTION
# Motivation

To start reducing the calls for metadata of ERC20 tokens, we can hard-code the remaining tokens, as we do for the ones that have CK twins. We start with 1INCH token.
