### PR TITLE
refactor(frontend): Move DMAIL token to additional ERC20 tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.dmail.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.dmail.env.ts
@@ -1,0 +1,24 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import dmail from '$eth/assets/dmail.svg';
+import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+const DMAIL_DECIMALS = 18;
+
+const DMAIL_SYMBOL = 'DMAIL';
+
+export const DMAIL_TOKEN_ID: TokenId = parseTokenId(DMAIL_SYMBOL);
+
+export const DMAIL_TOKEN: RequiredAdditionalErc20Token = {
+	id: DMAIL_TOKEN_ID,
+	network: ETHEREUM_NETWORK,
+	standard: 'erc20',
+	category: 'default',
+	name: 'Dmail Network',
+	symbol: DMAIL_SYMBOL,
+	decimals: DMAIL_DECIMALS,
+	icon: dmail,
+	address: '0xcC6f1e1B87cfCbe9221808d2d85C501aab0B5192',
+	exchange: 'erc20'
+};

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -101,7 +101,11 @@ export const ERC20_CONTRACTS: (Erc20Contract & { network: EthereumNetwork })[] =
 	...ERC20_CONTRACTS_SEPOLIA.map((contract) => ({ ...contract, network: SEPOLIA_NETWORK }))
 ];
 
-export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN, DMAIL_TOKEN,JASMY_TOKEN];
+export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [
+	ONEINCH_TOKEN,
+	DMAIL_TOKEN,
+	JASMY_TOKEN
+];
 
 /**
  * ERC20 which have twin tokens counterparts.

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -4,6 +4,7 @@ import {
 	SEPOLIA_NETWORK
 } from '$env/networks/networks.eth.env';
 import { ONEINCH_TOKEN } from '$env/tokens/tokens-erc20/tokens.1inch.env';
+import { DMAIL_TOKEN } from '$env/tokens/tokens-erc20/tokens.dmail.env';
 import { EURC_TOKEN, SEPOLIA_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
@@ -25,12 +26,6 @@ import type { TokenId } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 
 // TODO: remember to remove the ERC20 from here once the ckERC20 is implemented. Following the normal flow, the ERC20 variables should be created on a separate file.
-
-const ERC20_CONTRACT_ADDRESS_DMAIL: Erc20Contract = {
-	// Dmail Network
-	address: '0xcC6f1e1B87cfCbe9221808d2d85C501aab0B5192',
-	exchange: 'erc20'
-};
 
 const ERC20_CONTRACT_ADDRESS_MATIC: Erc20Contract = {
 	// Polygon
@@ -96,7 +91,6 @@ export const ERC20_CONTRACT_ICP: Erc20Contract = {
 
 export const ERC20_CONTRACTS_PRODUCTION: Erc20Contract[] = [
 	ERC20_CONTRACT_ICP,
-	ERC20_CONTRACT_ADDRESS_DMAIL,
 	ERC20_CONTRACT_ADDRESS_MATIC,
 	ERC20_CONTRACT_ADDRESS_JASMY,
 	ERC20_CONTRACT_ADDRESS_DAI,
@@ -113,7 +107,7 @@ export const ERC20_CONTRACTS: (Erc20Contract & { network: EthereumNetwork })[] =
 	...ERC20_CONTRACTS_SEPOLIA.map((contract) => ({ ...contract, network: SEPOLIA_NETWORK }))
 ];
 
-export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN];
+export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN, DMAIL_TOKEN];
 
 /**
  * ERC20 which have twin tokens counterparts.

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -1,5 +1,4 @@
 import dai from '$eth/assets/dai.svg';
-import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
 import jasmy from '$eth/assets/jasmy.svg';
 import matic from '$eth/assets/matic.svg';
@@ -47,8 +46,6 @@ const mapErc20Icon = (symbol: string): string | undefined => {
 	switch (symbol.toLowerCase()) {
 		case 'dai':
 			return dai;
-		case 'dmail':
-			return dmail;
 		case 'floki':
 			return floki;
 		case 'jasmy':

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -7,7 +7,6 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import dai from '$eth/assets/dai.svg';
-import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
 import jasmy from '$eth/assets/jasmy.svg';
 import matic from '$eth/assets/matic.svg';
@@ -29,7 +28,6 @@ import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 describe('erc20.utils', () => {
 	const iconCases = [
 		['dai', dai],
-		['dmail', dmail],
 		['floki', floki],
 		['jasmy', jasmy],
 		['matic', matic],


### PR DESCRIPTION
# Motivation

Similar to others ERC20 tokens, we move the DMAIL token to the list of additional ERC20 tokens.
