### PR TITLE
refactor(frontend): Move MATIC token to additional ERC20 tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.matic.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.matic.env.ts
@@ -1,0 +1,24 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import matic from '$eth/assets/matic.svg';
+import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+const MATIC_DECIMALS = 18;
+
+const MATIC_SYMBOL = 'MATIC';
+
+export const MATIC_TOKEN_ID: TokenId = parseTokenId(MATIC_SYMBOL);
+
+export const MATIC_TOKEN: RequiredAdditionalErc20Token = {
+	id: MATIC_TOKEN_ID,
+	network: ETHEREUM_NETWORK,
+	standard: 'erc20',
+	category: 'default',
+	name: 'Matic Token',
+	symbol: MATIC_SYMBOL,
+	decimals: MATIC_DECIMALS,
+	icon: matic,
+	address: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
+	exchange: 'erc20'
+};

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -99,7 +99,7 @@ export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [
 	ONEINCH_TOKEN,
 	DMAIL_TOKEN,
 	JASMY_TOKEN,
-  MATIC_TOKEN
+	MATIC_TOKEN
 ];
 
 /**

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -6,6 +6,7 @@ import {
 import { ONEINCH_TOKEN } from '$env/tokens/tokens-erc20/tokens.1inch.env';
 import { EURC_TOKEN, SEPOLIA_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
+import { MATIC_TOKEN } from '$env/tokens/tokens-erc20/tokens.matic.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
 import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { SHIB_TOKEN } from '$env/tokens/tokens-erc20/tokens.shib.env';
@@ -29,12 +30,6 @@ import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 const ERC20_CONTRACT_ADDRESS_DMAIL: Erc20Contract = {
 	// Dmail Network
 	address: '0xcC6f1e1B87cfCbe9221808d2d85C501aab0B5192',
-	exchange: 'erc20'
-};
-
-const ERC20_CONTRACT_ADDRESS_MATIC: Erc20Contract = {
-	// Polygon
-	address: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
 	exchange: 'erc20'
 };
 
@@ -97,7 +92,6 @@ export const ERC20_CONTRACT_ICP: Erc20Contract = {
 export const ERC20_CONTRACTS_PRODUCTION: Erc20Contract[] = [
 	ERC20_CONTRACT_ICP,
 	ERC20_CONTRACT_ADDRESS_DMAIL,
-	ERC20_CONTRACT_ADDRESS_MATIC,
 	ERC20_CONTRACT_ADDRESS_JASMY,
 	ERC20_CONTRACT_ADDRESS_DAI,
 	ERC20_CONTRACT_ADDRESS_FLOKI,
@@ -113,7 +107,7 @@ export const ERC20_CONTRACTS: (Erc20Contract & { network: EthereumNetwork })[] =
 	...ERC20_CONTRACTS_SEPOLIA.map((contract) => ({ ...contract, network: SEPOLIA_NETWORK }))
 ];
 
-export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN];
+export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN, MATIC_TOKEN];
 
 /**
  * ERC20 which have twin tokens counterparts.

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -2,7 +2,6 @@ import dai from '$eth/assets/dai.svg';
 import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
 import jasmy from '$eth/assets/jasmy.svg';
-import matic from '$eth/assets/matic.svg';
 import rndr from '$eth/assets/rndr.svg';
 import weeth from '$eth/assets/weeth.svg';
 import weth from '$eth/assets/weth.svg';
@@ -53,8 +52,6 @@ const mapErc20Icon = (symbol: string): string | undefined => {
 			return floki;
 		case 'jasmy':
 			return jasmy;
-		case 'matic':
-			return matic;
 		case 'rndr':
 			return rndr;
 		case 'weeth':

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -1,7 +1,5 @@
 import dai from '$eth/assets/dai.svg';
 import floki from '$eth/assets/floki.svg';
-import jasmy from '$eth/assets/jasmy.svg';
-import matic from '$eth/assets/matic.svg';
 import rndr from '$eth/assets/rndr.svg';
 import weeth from '$eth/assets/weeth.svg';
 import weth from '$eth/assets/weth.svg';

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -10,7 +10,6 @@ import dai from '$eth/assets/dai.svg';
 import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
 import jasmy from '$eth/assets/jasmy.svg';
-import matic from '$eth/assets/matic.svg';
 import rndr from '$eth/assets/rndr.svg';
 import weeth from '$eth/assets/weeth.svg';
 import weth from '$eth/assets/weth.svg';
@@ -32,7 +31,6 @@ describe('erc20.utils', () => {
 		['dmail', dmail],
 		['floki', floki],
 		['jasmy', jasmy],
-		['matic', matic],
 		['rndr', rndr],
 		['weeth', weeth],
 		['weth', weth],

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -8,8 +8,6 @@ import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import dai from '$eth/assets/dai.svg';
 import floki from '$eth/assets/floki.svg';
-import jasmy from '$eth/assets/jasmy.svg';
-import matic from '$eth/assets/matic.svg';
 import rndr from '$eth/assets/rndr.svg';
 import weeth from '$eth/assets/weeth.svg';
 import weth from '$eth/assets/weth.svg';


### PR DESCRIPTION
# Motivation

Similar to others ERC20 tokens, we move the MATIC token to the list of additional ERC20 tokens.
