### PR TITLE
refactor(frontend): Move JASMY token to additional ERC20 tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.jasmy.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.jasmy.env.ts
@@ -1,0 +1,24 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import jasmy from '$eth/assets/jasmy.svg';
+import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+const JASMY_DECIMALS = 18;
+
+const JASMY_SYMBOL = 'JASMY';
+
+export const JASMY_TOKEN_ID: TokenId = parseTokenId(JASMY_SYMBOL);
+
+export const JASMY_TOKEN: RequiredAdditionalErc20Token = {
+	id: JASMY_TOKEN_ID,
+	network: ETHEREUM_NETWORK,
+	standard: 'erc20',
+	category: 'default',
+	name: 'JasmyCoin',
+	symbol: JASMY_SYMBOL,
+	decimals: JASMY_DECIMALS,
+	icon: jasmy,
+	address: '0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC',
+	exchange: 'erc20'
+};

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -5,6 +5,7 @@ import {
 } from '$env/networks/networks.eth.env';
 import { ONEINCH_TOKEN } from '$env/tokens/tokens-erc20/tokens.1inch.env';
 import { EURC_TOKEN, SEPOLIA_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
+import { JASMY_TOKEN } from '$env/tokens/tokens-erc20/tokens.jasmy.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
 import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
@@ -35,12 +36,6 @@ const ERC20_CONTRACT_ADDRESS_DMAIL: Erc20Contract = {
 const ERC20_CONTRACT_ADDRESS_MATIC: Erc20Contract = {
 	// Polygon
 	address: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
-	exchange: 'erc20'
-};
-
-const ERC20_CONTRACT_ADDRESS_JASMY: Erc20Contract = {
-	// Jasmy
-	address: '0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC',
 	exchange: 'erc20'
 };
 
@@ -98,7 +93,6 @@ export const ERC20_CONTRACTS_PRODUCTION: Erc20Contract[] = [
 	ERC20_CONTRACT_ICP,
 	ERC20_CONTRACT_ADDRESS_DMAIL,
 	ERC20_CONTRACT_ADDRESS_MATIC,
-	ERC20_CONTRACT_ADDRESS_JASMY,
 	ERC20_CONTRACT_ADDRESS_DAI,
 	ERC20_CONTRACT_ADDRESS_FLOKI,
 	ERC20_CONTRACT_ADDRESS_RNDR,
@@ -113,7 +107,7 @@ export const ERC20_CONTRACTS: (Erc20Contract & { network: EthereumNetwork })[] =
 	...ERC20_CONTRACTS_SEPOLIA.map((contract) => ({ ...contract, network: SEPOLIA_NETWORK }))
 ];
 
-export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN];
+export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [ONEINCH_TOKEN, JASMY_TOKEN];
 
 /**
  * ERC20 which have twin tokens counterparts.

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -1,7 +1,6 @@
 import dai from '$eth/assets/dai.svg';
 import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
-import jasmy from '$eth/assets/jasmy.svg';
 import matic from '$eth/assets/matic.svg';
 import rndr from '$eth/assets/rndr.svg';
 import weeth from '$eth/assets/weeth.svg';
@@ -51,8 +50,6 @@ const mapErc20Icon = (symbol: string): string | undefined => {
 			return dmail;
 		case 'floki':
 			return floki;
-		case 'jasmy':
-			return jasmy;
 		case 'matic':
 			return matic;
 		case 'rndr':

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -9,7 +9,6 @@ import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import dai from '$eth/assets/dai.svg';
 import dmail from '$eth/assets/dmail.svg';
 import floki from '$eth/assets/floki.svg';
-import jasmy from '$eth/assets/jasmy.svg';
 import matic from '$eth/assets/matic.svg';
 import rndr from '$eth/assets/rndr.svg';
 import weeth from '$eth/assets/weeth.svg';
@@ -31,7 +30,6 @@ describe('erc20.utils', () => {
 		['dai', dai],
 		['dmail', dmail],
 		['floki', floki],
-		['jasmy', jasmy],
 		['matic', matic],
 		['rndr', rndr],
 		['weeth', weeth],


### PR DESCRIPTION
# Motivation

Similar to others ERC20 tokens, we move the JASMY token to the list of additional ERC20 tokens.
