### PR TITLE
refactor(devops): No repeat downloads

### DIFF
--- a/scripts/build.cycles_depositor.sh
+++ b/scripts/build.cycles_depositor.sh
@@ -29,22 +29,12 @@ WASM_FILE="$(jq -r .canisters.cycles_depositor.wasm dfx.json)"
 ARG_FILE="$(jq -r .canisters.cycles_depositor.init_arg_file dfx.json)"
 
 ####
-# Downloads the candid file, if it does not exist already.
-if test -e "$CANDID_FILE"; then
-  echo "Using existing cycles_depositor candid file"
-else
-  mkdir -p "$(dirname "$CANDID_FILE")"
-  curl -sSL "$CANDID_URL" >"$CANDID_FILE"
-fi
+# Downloads the candid file
+scripts/download-immutable.sh "$CANDID_URL" "$CANDID_FILE"
 
 ####
-# Downloads the Wasm file, if it does not exist already.
-if test -e "$WASM_FILE"; then
-  echo "Using existing cycles_depositor Wasm file"
-else
-  mkdir -p "$(dirname "$WASM_FILE")"
-  curl -sSL "$WASM_URL" >"$WASM_FILE"
-fi
+# Downloads the Wasm file
+scripts/download-immutable.sh "$WASM_URL" "$WASM_FILE"
 
 ####
 # Computes the install args, overwriting any existing args file.

--- a/scripts/download.ckbtc.sh
+++ b/scripts/download.ckbtc.sh
@@ -11,16 +11,16 @@ fi
 IC_COMMIT="03dd6ee6de80c2202f66948692c69c61eb6af54d"
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz" /ckbtc_minter.wasm.gz
-gunzip "$DIR"/ckbtc_minter.wasm.gz
+gunzip --keep --force "$DIR"/ckbtc_minter.wasm.gz
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger.wasm.gz" "$DIR"/ckbtc_ledger.wasm.gz
-gunzip -k "$DIR"/ckbtc_ledger.wasm.gz
+gunzip --keep --force "$DIR"/ckbtc_ledger.wasm.gz
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index-ng.wasm.gz" "$DIR"/ckbtc_index.wasm.gz
-gunzip -k "$DIR"/ckbtc_index.wasm.gz
+gunzip --keep --force "$DIR"/ckbtc_index.wasm.gz
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-kyt.wasm.gz" "$DIR"/ckbtc_kyt.wasm.gz
-gunzip "$DIR"/ckbtc_kyt.wasm.gz
+gunzip --keep --force "$DIR"/ckbtc_kyt.wasm.gz
 
 scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/minter/ckbtc_minter.did" "$DIR"/ckbtc_minter.did
 

--- a/scripts/download.ckbtc.sh
+++ b/scripts/download.ckbtc.sh
@@ -10,22 +10,22 @@ fi
 
 IC_COMMIT="03dd6ee6de80c2202f66948692c69c61eb6af54d"
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz -o "$DIR"/ckbtc_minter.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz" /ckbtc_minter.wasm.gz
 gunzip "$DIR"/ckbtc_minter.wasm.gz
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger.wasm.gz -o "$DIR"/ckbtc_ledger.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger.wasm.gz" "$DIR"/ckbtc_ledger.wasm.gz
 gunzip -k "$DIR"/ckbtc_ledger.wasm.gz
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index-ng.wasm.gz -o "$DIR"/ckbtc_index.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index-ng.wasm.gz" "$DIR"/ckbtc_index.wasm.gz
 gunzip -k "$DIR"/ckbtc_index.wasm.gz
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-kyt.wasm.gz -o "$DIR"/ckbtc_kyt.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-kyt.wasm.gz" "$DIR"/ckbtc_kyt.wasm.gz
 gunzip "$DIR"/ckbtc_kyt.wasm.gz
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/minter/ckbtc_minter.did -o "$DIR"/ckbtc_minter.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/minter/ckbtc_minter.did" "$DIR"/ckbtc_minter.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/ledger/ledger.did -o "$DIR"/ckbtc_ledger.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/ledger/ledger.did" "$DIR"/ckbtc_ledger.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did -o "$DIR"/ckbtc_index.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did" "$DIR"/ckbtc_index.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/kyt/kyt.did -o "$DIR"/ckbtc_kyt.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/bitcoin/ckbtc/kyt/kyt.did" "$DIR"/ckbtc_kyt.did

--- a/scripts/download.cketh.sh
+++ b/scripts/download.cketh.sh
@@ -8,18 +8,18 @@ mkdir -p "$DIR"
 
 IC_COMMIT="03dd6ee6de80c2202f66948692c69c61eb6af54d"
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-cketh-minter.wasm.gz -o "$DIR"/cketh_minter.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-cketh-minter.wasm.gz" "$DIR"/cketh_minter.wasm.gz
 gunzip -f "$DIR"/cketh_minter.wasm.gz
 
 # ckETH requires special ledger and index to handle 18 decimals, therefore the special wasm
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger-u256.wasm.gz -o "$DIR"/cketh_ledger.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger-u256.wasm.gz" "$DIR"/cketh_ledger.wasm.gz
 gunzip -f "$DIR"/cketh_ledger.wasm.gz
 
-curl -sSL https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index-ng-u256.wasm.gz -o "$DIR"/cketh_index.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-index-ng-u256.wasm.gz" "$DIR"/cketh_index.wasm.gz
 gunzip -f "$DIR"/cketh_index.wasm.gz
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ethereum/cketh/minter/cketh_minter.did -o "$DIR"/cketh_minter.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ethereum/cketh/minter/cketh_minter.did" "$DIR"/cketh_minter.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/ledger/ledger.did -o "$DIR"/cketh_ledger.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/ledger/ledger.did" "$DIR"/cketh_ledger.did
 
-curl -sSL https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did -o "$DIR"/cketh_index.did
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_COMMIT/rs/ledger_suite/icrc1/index-ng/index-ng.did" "$DIR"/cketh_index.did

--- a/scripts/download.icp.sh
+++ b/scripts/download.icp.sh
@@ -11,9 +11,9 @@ fi
 IC_VERSION=6dcfafb491092704d374317d9a72a7ad2475d7c9
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ic-icp-index-canister.wasm.gz" "$DIR"/icp_index.wasm.gz
-gunzip "$DIR"/icp_index.wasm.gz
+gunzip --force "$DIR"/icp_index.wasm.gz
 scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/index/index.did" "$DIR"/icp_index.did
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister.wasm.gz" "$DIR"/icp_ledger.wasm.gz
-gunzip "$DIR"/icp_ledger.wasm.gz
+gunzip --force "$DIR"/icp_ledger.wasm.gz
 scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/ledger.did" "$DIR"/icp_ledger.did

--- a/scripts/download.icp.sh
+++ b/scripts/download.icp.sh
@@ -10,10 +10,10 @@ fi
 
 IC_VERSION=6dcfafb491092704d374317d9a72a7ad2475d7c9
 
-curl -o "$DIR"/icp_index.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ic-icp-index-canister.wasm.gz"
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ic-icp-index-canister.wasm.gz" "$DIR"/icp_index.wasm.gz
 gunzip "$DIR"/icp_index.wasm.gz
-curl -o "$DIR"/icp_index.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/index/index.did"
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/index/index.did" "$DIR"/icp_index.did
 
-curl -o "$DIR"/icp_ledger.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister.wasm.gz"
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister.wasm.gz" "$DIR"/icp_ledger.wasm.gz
 gunzip "$DIR"/icp_ledger.wasm.gz
-curl -o "$DIR"/icp_ledger.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/ledger.did"
+scripts/download-immutable.sh "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/ledger_suite/icp/ledger.did" "$DIR"/icp_ledger.did

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -36,7 +36,7 @@ function install_did_files() {
       destination=".dfx/local/canisters/${array[0]}/${filename}"
       mkdir -p "$(dirname "$destination")"
       case "$source" in
-      http*) curl -sSL "$source" >"$destination" ;;
+      http*) scripts/download-immutable.sh "$source" "$destination" ;;
       *) if test -e "$source"; then cp "$source" "$destination"; else echo "WARNING: $canister_name did file not found at $source"; fi ;;
       esac
     done

--- a/scripts/setup.bitcoin-node.sh
+++ b/scripts/setup.bitcoin-node.sh
@@ -56,14 +56,16 @@ if [ ! -d $BITCOIN_DIR ]; then
   case "$OS_TYPE" in
   linux)
     echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for Linux..."
-    curl -O "$BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz"
-    tar -xzf "bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz"
+    TARFILE="bitcoin-$BITCOIN_CORE_VERSION-x86_64-linux-gnu.tar.gz"
+    scripts/download-immutable.sh "$BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/$TARFILE" "$TARFILE"
+    tar -xzf "$TARFILE"
     mv "bitcoin-$BITCOIN_CORE_VERSION" "$BITCOIN_DIR"
     ;;
   darwin)
     echo "Downloading Bitcoin Core $BITCOIN_CORE_VERSION for macOS..."
-    curl -O "$BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz"
-    tar -xzf "bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz"
+    TARFILE="bitcoin-$BITCOIN_CORE_VERSION-$(uname -m)-apple-darwin.tar.gz"
+    scripts/download-immutable.sh "$BITCOIN_URL/bitcoin-core-$BITCOIN_CORE_VERSION/$TARFILE" "$TARFILE"
+    tar -xzf "$TARFILE"
     mv "bitcoin-$BITCOIN_CORE_VERSION" "$BITCOIN_DIR"
     # Reference:
     if [ "$(uname -m)" = "arm64" ]; then

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -33,7 +33,7 @@ IFS=',' read -r -a versions <<<"$OISY_UPGRADE_VERSIONS"
 for version in "${versions[@]}"; do
   OISY_UPGRADE_PATH="./backend-${version}.wasm.gz"
 
-  scripts/download-immutable.sh "https://github.com/dfinity/oisy-wallet/releases/download/${version}/backend.wasm.gz" $OISY_UPGRADE_PATH"
+  scripts/download-immutable.sh "https://github.com/dfinity/oisy-wallet/releases/download/${version}/backend.wasm.gz" "$OISY_UPGRADE_PATH"
 done
 
 # Download PocketIC server

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -18,21 +18,11 @@ else
   cargo build --locked --target wasm32-unknown-unknown --release -p backend
 fi
 
-if [ -f "./$BITCON_CANISTER_WASM" ]; then
-  echo "Use existing $BITCON_CANISTER_WASM canister."
-else
-  echo "Downloading bitcoin_canister canister."
-  curl -sSL "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F$BITCOIN_CANISTER_RELEASE/ic-btc-canister.wasm.gz" -o $BITCON_CANISTER_WASM
-fi
+scripts/download-immutable.sh "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F$BITCOIN_CANISTER_RELEASE/ic-btc-canister.wasm.gz" "$BITCON_CANISTER_WASM"
 # Setting the environment variable that will be used in the test to load that particular file relative to the cargo workspace.
 export BITCOIN_CANISTER_WASM_FILE="../../$BITCON_CANISTER_WASM"
 
-if [ -f "./${CYCLES_LEDGER_CANISTER_WASM}" ]; then
-  echo "Use existing ${CYCLES_LEDGER_CANISTER_WASM} canister."
-else
-  echo "Downloading cycles_ledger canister."
-  curl -sSL "${CYCLES_LEDGER_CANISTER_URL}" -o "${CYCLES_LEDGER_CANISTER_WASM}"
-fi
+scripts/download-immutable.sh "${CYCLES_LEDGER_CANISTER_URL}" "${CYCLES_LEDGER_CANISTER_WASM}"
 
 # Setting the environment variable that will be used in the test to load that particular file relative to the cargo workspace.
 export CYCLES_LEDGER_CANISTER_WASM_FILE="../../${CYCLES_LEDGER_CANISTER_WASM}"
@@ -43,9 +33,7 @@ IFS=',' read -r -a versions <<<"$OISY_UPGRADE_VERSIONS"
 for version in "${versions[@]}"; do
   OISY_UPGRADE_PATH="./backend-${version}.wasm.gz"
 
-  if [ ! -f "$OISY_UPGRADE_PATH" ]; then
-    curl -sSL "https://github.com/dfinity/oisy-wallet/releases/download/${version}/backend.wasm.gz" -o "$OISY_UPGRADE_PATH"
-  fi
+  scripts/download-immutable.sh "https://github.com/dfinity/oisy-wallet/releases/download/${version}/backend.wasm.gz" $OISY_UPGRADE_PATH"
 done
 
 # Download PocketIC server
@@ -65,14 +53,7 @@ else
   exit 1
 fi
 
-if [ ! -f "$POCKET_IC_SERVER_PATH" ]; then
-  echo "Downloading PocketIC."
-  curl -sSL https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_SERVER_VERSION}/pocket-ic-x86_64-${PLATFORM}.gz -o ${POCKET_IC_SERVER_PATH}.gz
-  gunzip ${POCKET_IC_SERVER_PATH}.gz
-  chmod +x ${POCKET_IC_SERVER_PATH}
-else
-  echo "PocketIC server already exists, skipping download."
-fi
+scripts/download-immutable.sh "https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_SERVER_VERSION}/pocket-ic-x86_64-${PLATFORM}.gz" "${POCKET_IC_SERVER_PATH}.gz"
 
 export POCKET_IC_BIN="../../${POCKET_IC_SERVER_PATH}"
 export POCKET_IC_MUTE_SERVER=""


### PR DESCRIPTION
# Motivation
We download a lot of data with curl.  In some places we try to make this more efficient by not downloading a file if it already exists, however that breaks if the URL changes, giving strange results.  We have a script now that does this properly, so we can roll it out everywhere.

# Changes
- Use  `download-immutable` in most places where we used to curl.

# Tests
Existing tests should verify that existing functionality still works.