### PR TITLE
feat(frontend): update ETH fees logic

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeDisplay.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeDisplay.svelte
@@ -1,48 +1,16 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { getContext, onDestroy } from 'svelte';
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
 	import { FEE_CONTEXT_KEY, type FeeContext } from '$eth/stores/fee.store';
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 
 	const { maxGasFee, feeSymbolStore, feeDecimalsStore, feeExchangeRateStore }: FeeContext =
 		getContext<FeeContext>(FEE_CONTEXT_KEY);
-
-	let fee: bigint | undefined = undefined;
-
-	let timer: NodeJS.Timeout | undefined;
-
-	// The time is used to animate the UI - i.e. displays a fade animation each time the fee is updated
-	$: $maxGasFee,
-		(() => {
-			fee = undefined;
-
-			if (isNullish($maxGasFee)) {
-				return;
-			}
-
-			const calculateFee = () => {
-				if (isNullish($maxGasFee)) {
-					return;
-				}
-
-				fee = $maxGasFee;
-			};
-
-			timer = setTimeout(calculateFee, 500);
-		})();
-
-	onDestroy(() => {
-		if (isNullish(timer)) {
-			return;
-		}
-
-		clearTimeout(timer);
-	});
 </script>
 
 {#if nonNullish($feeSymbolStore) && nonNullish($feeDecimalsStore)}
 	<FeeDisplay
-		feeAmount={fee}
+		feeAmount={$maxGasFee}
 		decimals={$feeDecimalsStore}
 		symbol={$feeSymbolStore}
 		exchangeRate={$feeExchangeRateStore}

--- a/src/frontend/src/eth/constants/eth.constants.ts
+++ b/src/frontend/src/eth/constants/eth.constants.ts
@@ -1,1 +1,3 @@
 export const ETH_BASE_FEE = 21_000n;
+
+export const ETH_FEE_DATA_LISTENER_DELAY = 10000;

--- a/src/frontend/src/tests/eth/components/fee/EthFeeDisplay.spec.ts
+++ b/src/frontend/src/tests/eth/components/fee/EthFeeDisplay.spec.ts
@@ -1,0 +1,44 @@
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
+import { FEE_CONTEXT_KEY, initFeeContext, initFeeStore } from '$eth/stores/fee.store';
+import { maxGasFee as maxGasFeeUtils } from '$eth/utils/fee.utils';
+import { ZERO } from '$lib/constants/app.constants';
+import { formatToken } from '$lib/utils/format.utils';
+import { render } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+
+describe('EthFeeDisplay', () => {
+	const mockStoreValues = {
+		maxFeePerGas: 1000n,
+		maxGasFee: 1000n,
+		gas: 1000n,
+		maxPriorityFeePerGas: 1000n
+	};
+	const store = initFeeStore();
+	store.setFee(mockStoreValues);
+
+	const mockContext = new Map([]);
+	mockContext.set(
+		FEE_CONTEXT_KEY,
+		initFeeContext({
+			feeStore: store,
+			feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
+			feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
+			feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals)
+		})
+	);
+
+	it('renders provided fee', () => {
+		const { container } = render(EthFeeDisplay, {
+			context: mockContext
+		});
+
+		expect(container).toHaveTextContent(
+			`${formatToken({
+				value: maxGasFeeUtils(mockStoreValues) ?? ZERO,
+				displayDecimals: ETHEREUM_TOKEN.decimals,
+				unitName: ETHEREUM_TOKEN.decimals
+			})} ${ETHEREUM_TOKEN.symbol}`
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

We want to update the ETH fees appearance logic:
1. To make sure we don't update UI too often, we throttle the `maxGasFee` update by 10s. On practice, It only affects Base tokens where the fees are being changed every ~1s. 
2. We now display skeleton only on initial fee fetch. The idea is to add some indicator (e.g. loader) that provides user a visual feedback when the fee values changes. It will be done separately. 
