### PR TITLE
refactor(frontend): remove networkId usage from IC Send review

### DIFF
--- a/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
+++ b/src/frontend/src/icp/components/send/IcReviewNetwork.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
-	import type { NetworkId } from '$lib/types/network';
-
-	export let networkId: NetworkId | undefined = undefined;
 </script>
 
-<ReviewNetwork sourceNetwork={ICP_NETWORK} destinationNetworkId={networkId} />
+<ReviewNetwork sourceNetwork={ICP_NETWORK} />

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -6,13 +6,11 @@
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import SendReview from '$lib/components/send/SendReview.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { NetworkId } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
 	export let destination = '';
 	export let amount: OptionAmount = undefined;
-	export let networkId: NetworkId | undefined = undefined;
 
 	const { sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
@@ -22,8 +20,7 @@
 		isNullish($sendTokenStandard) ||
 		isInvalidDestinationIc({
 			destination,
-			tokenStandard: $sendTokenStandard,
-			networkId
+			tokenStandard: $sendTokenStandard
 		}) ||
 		invalidAmount(amount);
 </script>
@@ -31,5 +28,5 @@
 <SendReview on:icBack on:icSend {amount} {destination} disabled={invalid}>
 	<IcTokenFee slot="fee" />
 
-	<IcReviewNetwork {networkId} slot="network" />
+	<IcReviewNetwork slot="network" />
 </SendReview>

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -190,7 +190,7 @@
 <EthereumFeeContext {networkId}>
 	<BitcoinFeeContext {amount} {networkId} token={$tokenWithFallbackAsIcToken}>
 		{#if currentStep?.name === WizardStepsSend.REVIEW}
-			<IcSendReview on:icBack on:icSend={send} {destination} {amount} {networkId} />
+			<IcSendReview on:icBack on:icSend={send} {destination} {amount} />
 		{:else if currentStep?.name === WizardStepsSend.SENDING}
 			<IcSendProgress bind:sendProgressStep {networkId} />
 		{:else if currentStep?.name === WizardStepsSend.SEND}

--- a/src/frontend/src/tests/icp/components/send/IcSendReview.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendReview.spec.ts
@@ -15,8 +15,7 @@ describe('IcSendReview', () => {
 
 	const props = {
 		destination: '0xF2777205439a8c7be0425cbb21D8DB7426Df5DE9',
-		amount: 22_000_000,
-		networkId: ICP_TOKEN
+		amount: 22_000_000
 	};
 
 	const toolbarSelector = 'div[data-tid="toolbar"]';


### PR DESCRIPTION
# Motivation

As the next step of the Send flow clean up, we remove `networkId` from IC send review form and related components.
