### PR TITLE
refactor(frontend): remove networkId usage from IC Send progress

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendProgress.svelte
+++ b/src/frontend/src/icp/components/send/IcSendProgress.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
 	import { sendSteps } from '$icp/constants/steps.constants';
-	import { tokenCkErc20Ledger } from '$icp/derived/ic-token.derived';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { NetworkId } from '$lib/types/network';
 
 	export let sendProgressStep: string = ProgressStepsSendIc.INITIALIZATION;
-	export let networkId: NetworkId | undefined = undefined;
 </script>
 
-<InProgressWizard
-	progressStep={sendProgressStep}
-	steps={sendSteps({ i18n: $i18n, networkId, tokenCkErc20Ledger: $tokenCkErc20Ledger })}
-/>
+<InProgressWizard progressStep={sendProgressStep} steps={sendSteps({ i18n: $i18n })} />

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -192,7 +192,7 @@
 		{#if currentStep?.name === WizardStepsSend.REVIEW}
 			<IcSendReview on:icBack on:icSend={send} {destination} {amount} {networkId} />
 		{:else if currentStep?.name === WizardStepsSend.SENDING}
-			<IcSendProgress bind:sendProgressStep {networkId} />
+			<IcSendProgress bind:sendProgressStep />
 		{:else if currentStep?.name === WizardStepsSend.SEND}
 			<IcSendForm
 				on:icNext

--- a/src/frontend/src/icp/constants/steps.constants.ts
+++ b/src/frontend/src/icp/constants/steps.constants.ts
@@ -10,8 +10,8 @@ export const sendSteps = ({
 	tokenCkErc20Ledger
 }: {
 	i18n: I18n;
-	networkId: NetworkId | undefined;
-	tokenCkErc20Ledger: boolean;
+	networkId?: NetworkId;
+	tokenCkErc20Ledger?: boolean;
 }): ProgressSteps =>
 	[
 		{


### PR DESCRIPTION
# Motivation

As the next step of the Send flow clean up, we remove networkId from IC send progress form and related components.
