### PR TITLE
test(backend): Check that the backend returns custom Result types

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -39,8 +39,10 @@ jobs:
           key: ${{ runner.os }}-cargo-backend-tests-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
       - name: Install rust
         run: ./scripts/setup rust
-      - name: Lint
+      - name: Lint rust
         run: ./scripts/lint.rust.sh
+      - name: Lint candid
+        run: ./scripts/lint.did.sh
 
   workspace-dependencies:
     runs-on: ubuntu-24.04

--- a/scripts/lint.did.sh
+++ b/scripts/lint.did.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_CANDID_FILE="$(jq -re .canisters.backend.candid dfx.json)"
+
+has_result_types() {
+  git grep -w Result "$BACKEND_CANDID_FILE" || git grep -E 'Result_[0-9]' "$BACKEND_CANDID_FILE"
+}
+
+check_result_types() {
+  ! has_result_types || {
+    echo "ERROR: $BACKEND_CANDID_FILE should not contain Result or Result_[0-9]."
+    echo "       Please define custom Resut types with specific names."
+    exit 1
+  }
+}
+
+check() {
+  check_result_types
+}
+
+check


### PR DESCRIPTION
# Motivation
The candid generator doesn't do a nice job of encoding Result types.  To address this, we define custom result types that we use in the canister API.

# Changes
- Add a  CI check that verifies that there are no generic Results in the backend .did file.

# Tests
- If I change a response type to Result or Result_1 locally, `./scripts/lint.did.sh` fails.