### PR TITLE
refactor(frontend): remove convert-related code from IcSendAmount

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendAmount.svelte
+++ b/src/frontend/src/icp/components/send/IcSendAmount.svelte
@@ -1,39 +1,19 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext } from 'svelte';
-	import { ethereumFeeTokenCkEth } from '$icp/derived/ethereum-fee.derived';
-	import { tokenCkErc20Ledger, tokenCkEthLedger } from '$icp/derived/ic-token.derived';
-	import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
-	import {
-		ETHEREUM_FEE_CONTEXT_KEY,
-		type EthereumFeeContext
-	} from '$icp/stores/ethereum-fee.store';
 	import { IcAmountAssertionError } from '$icp/types/ic-send';
 	import type { OptionIcToken } from '$icp/types/ic-token';
-	import { assertCkBTCUserInputAmount } from '$icp/utils/ckbtc.utils';
-	import {
-		assertCkETHBalanceEstimatedFee,
-		assertCkETHMinFee,
-		assertCkETHMinWithdrawalAmount
-	} from '$icp/utils/cketh.utils';
-	import { ckEthereumNativeTokenId } from '$icp-eth/derived/cketh.derived';
-	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
-	import { balance } from '$lib/derived/balances.derived';
-	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { NetworkId } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
-	import { isNetworkIdBitcoin, isNetworkIdEthereum } from '$lib/utils/network.utils';
 
 	export let amount: OptionAmount = undefined;
 	export let amountError: IcAmountAssertionError | undefined;
-	export let networkId: NetworkId | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -47,81 +27,20 @@
 	let inputUnit: DisplayUnit;
 	$: inputUnit = exchangeValueUnit === 'token' ? 'usd' : 'token';
 
-	const { store: ethereumFeeStore } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
-
 	const customValidate = (userAmount: bigint): Error | undefined => {
 		if (isNullish(fee) || isNullish($sendToken)) {
 			return;
 		}
 
-		if (isNetworkIdBitcoin(networkId)) {
-			const error = assertCkBTCUserInputAmount({
-				amount: userAmount,
-				minterInfo: $ckBtcMinterInfoStore?.[$sendToken.id],
-				tokenDecimals: $sendToken.decimals,
-				i18n: $i18n
-			});
-
-			if (nonNullish(error)) {
-				return error;
-			}
-		}
-
-		// if CkEth, asset the minimal withdrawal amount is met and the amount should at least be bigger than the fee.
-		if (isNetworkIdEthereum(networkId) && $tokenCkEthLedger) {
-			const error = assertCkETHMinWithdrawalAmount({
-				amount: userAmount,
-				tokenDecimals: $sendToken.decimals,
-				tokenSymbol: $sendToken.symbol,
-				minterInfo: $ckEthMinterInfoStore?.[$ckEthereumNativeTokenId],
-				i18n: $i18n
-			});
-
-			if (nonNullish(error)) {
-				return error;
-			}
-
-			return assertCkETHMinFee({
-				amount: userAmount,
-				tokenSymbol: $sendToken.symbol,
-				fee,
-				i18n: $i18n
-			});
-		}
-
 		const assertBalance = (): IcAmountAssertionError | undefined => {
 			const total = userAmount + (fee ?? ZERO);
 
-			if (total > ($balance ?? ZERO)) {
+			if (total > ($sendBalance ?? ZERO)) {
 				return new IcAmountAssertionError($i18n.send.assertion.insufficient_funds);
 			}
 
 			return undefined;
 		};
-
-		// if CkErc20, the entered amount should be covered by fee + balance and the ckEth balance should cover the estimated fee.
-		if (isNetworkIdEthereum(networkId) && $tokenCkErc20Ledger) {
-			const error = assertBalance();
-
-			if (nonNullish(error)) {
-				return error;
-			}
-
-			const errorEstimatedFee = assertCkETHBalanceEstimatedFee({
-				balance: nonNullish($ethereumFeeTokenCkEth)
-					? $balancesStore?.[$ethereumFeeTokenCkEth.id]?.data
-					: undefined,
-				tokenCkEth: $ethereumFeeTokenCkEth,
-				feeStoreData: $ethereumFeeStore,
-				i18n: $i18n
-			});
-
-			if (nonNullish(errorEstimatedFee)) {
-				return errorEstimatedFee;
-			}
-
-			return undefined;
-		}
 
 		return assertBalance();
 	};

--- a/src/frontend/src/icp/components/send/IcSendForm.svelte
+++ b/src/frontend/src/icp/components/send/IcSendForm.svelte
@@ -44,7 +44,7 @@
 	disabled={invalid}
 	hideSource
 >
-	<IcSendAmount slot="amount" bind:amount bind:amountError {networkId} on:icTokensList />
+	<IcSendAmount slot="amount" bind:amount bind:amountError on:icTokensList />
 
 	<IcTokenFee slot="fee" />
 

--- a/src/frontend/src/tests/icp/components/send/IcSendAmount.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendAmount.spec.ts
@@ -1,0 +1,84 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import IcSendAmount from '$icp/components/send/IcSendAmount.svelte';
+import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
+import { balancesStore } from '$lib/stores/balances.store';
+import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import en from '$tests/mocks/i18n.mock';
+import { assertNonNullish } from '@dfinity/utils';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+describe('IcSendAmount', () => {
+	const mockContext = new Map([]);
+	mockContext.set(
+		SEND_CONTEXT_KEY,
+		initSendContext({
+			token: ICP_TOKEN
+		})
+	);
+
+	const props = {
+		amount: 1,
+		amountError: undefined
+	};
+	const newAmount = 10;
+
+	const amountSelector = `input[data-tid="${TOKEN_INPUT_CURRENCY_TOKEN}"]`;
+
+	it('should render input with the proper value', () => {
+		const { container } = render(IcSendAmount, {
+			props,
+			context: mockContext
+		});
+
+		const input: HTMLInputElement | null = container.querySelector(amountSelector);
+
+		expect(input?.value).toBe(`${props.amount}`);
+	});
+
+	it('should show balance error on input if there is not enough funds', async () => {
+		const { container, getByText } = render(IcSendAmount, {
+			props: {
+				...props,
+				amount: undefined
+			},
+			context: mockContext
+		});
+
+		const input: HTMLInputElement | null = container.querySelector(amountSelector);
+
+		assertNonNullish(input);
+
+		await fireEvent.input(input, { target: { value: `${newAmount}` } });
+
+		await waitFor(() => {
+			expect(input?.value).toBe(`${newAmount}`);
+			expect(getByText(en.send.assertion.insufficient_funds)).toBeInTheDocument();
+		});
+	});
+
+	it('should not show balance error on input if there is enough funds', async () => {
+		balancesStore.set({
+			id: ICP_TOKEN.id,
+			data: { data: 500000000000n, certified: true }
+		});
+
+		const { container, getByText } = render(IcSendAmount, {
+			props: {
+				...props,
+				amount: undefined
+			},
+			context: mockContext
+		});
+
+		const input: HTMLInputElement | null = container.querySelector(amountSelector);
+
+		assertNonNullish(input);
+
+		await fireEvent.input(input, { target: { value: `${newAmount}` } });
+
+		await waitFor(() => {
+			expect(input?.value).toBe(`${newAmount}`);
+			expect(() => getByText(en.send.assertion.insufficient_funds)).toThrow();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

As the next step of the Send flow clean up, we remove convert-related code from IcSendAmount.
