### PR TITLE
feat(frontend): Add utility to get supported networks for token account id

### DIFF
--- a/src/frontend/src/lib/constants/token-account-id.constants.ts
+++ b/src/frontend/src/lib/constants/token-account-id.constants.ts
@@ -1,0 +1,14 @@
+import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
+import { SUPPORTED_BITCOIN_NETWORKS } from '$env/networks/networks.btc.env';
+import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { SUPPORTED_SOLANA_NETWORKS } from '$env/networks/networks.sol.env';
+import type { Network } from '$lib/types/network';
+import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
+
+export const TOKEN_ACCOUNT_ID_TO_NETWORKS: { [key in TokenAccountIdTypes]: Network[] } = {
+	Icrcv2: [ICP_NETWORK],
+	Btc: SUPPORTED_BITCOIN_NETWORKS,
+	Eth: [...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS],
+	Sol: SUPPORTED_SOLANA_NETWORKS
+};

--- a/src/frontend/src/lib/utils/token-account-id.utils.ts
+++ b/src/frontend/src/lib/utils/token-account-id.utils.ts
@@ -1,6 +1,8 @@
 import { getBtcAddressString } from '$btc/utils/btc-address.utils';
 import type { TokenAccountId } from '$declarations/backend/backend.did';
+import { TOKEN_ACCOUNT_ID_TO_NETWORKS } from '$lib/constants/token-account-id.constants';
 import type { Address } from '$lib/types/address';
+import type { Network } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
 import { assertNever } from '$lib/types/utils';
 
@@ -58,3 +60,6 @@ export const getAddressString = (tokenAccountId: TokenAccountId): Address => {
 
 	return assertNever({ variable: tokenAccountId, typeName: 'TokenAccountId' });
 };
+
+export const getNetworksForTokenAccountIdType = (addressType: TokenAccountIdTypes): Network[] =>
+	TOKEN_ACCOUNT_ID_TO_NETWORKS[addressType];

--- a/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
@@ -1,6 +1,11 @@
 import type { TokenAccountId } from '$declarations/backend/backend.did';
+import { TOKEN_ACCOUNT_ID_TO_NETWORKS } from '$lib/constants/token-account-id.constants';
 import { TokenAccountIdSchema } from '$lib/schema/token-account-id.schema';
-import { getAddressString } from '$lib/utils/token-account-id.utils';
+import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
+import {
+	getAddressString,
+	getNetworksForTokenAccountIdType
+} from '$lib/utils/token-account-id.utils';
 
 describe('token-account-id.utils', () => {
 	describe('getAddressString', () => {
@@ -66,6 +71,23 @@ describe('token-account-id.utils', () => {
 			const result = getAddressString(tokenAccountId);
 
 			expect(result).toEqual(solAddressStr);
+		});
+	});
+
+	describe('getNetworksForAddressType', () => {
+		it('should return networks for all types', () => {
+
+			const TOKEN_ACCOUNT_ID_TYPES = Object.keys(
+				TOKEN_ACCOUNT_ID_TO_NETWORKS
+			) as TokenAccountIdTypes[];
+
+			TOKEN_ACCOUNT_ID_TYPES.forEach((type) => {
+				const networks = getNetworksForTokenAccountIdType(type);
+
+				expect(networks).toBeDefined();
+				expect(Array.isArray(networks)).toBeTruthy();
+				expect(networks.length).toBeGreaterThan(0);
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
@@ -76,7 +76,6 @@ describe('token-account-id.utils', () => {
 
 	describe('getNetworksForAddressType', () => {
 		it('should return networks for all types', () => {
-
 			const TOKEN_ACCOUNT_ID_TYPES = Object.keys(
 				TOKEN_ACCOUNT_ID_TO_NETWORKS
 			) as TokenAccountIdTypes[];


### PR DESCRIPTION
# Motivation

To display the supported networks for a given contact address, this PR adds a utility to get from `TokenAccountIdType` to the supported networks

# Changes

- Adds `getNetworksForTokenAccountIdType`

# Tests

- Add a test to ensure all types returns some networks