### PR TITLE
feat(frontend): Forward mouse event in ButtonIcon

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonIcon.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonIcon.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import type { MouseEventHandler } from 'svelte/elements';
 	import type { ButtonColorStyle } from '$lib/types/style';
 
 	interface Props {
-		onclick: () => void;
+		onclick: MouseEventHandler<HTMLButtonElement>;
 		icon: Snippet;
 		children?: Snippet;
 		button?: HTMLButtonElement;


### PR DESCRIPTION
# Motivation

In order to be able to disable event propagation, this PR exposes the `MouseEvent` to the `onclick` event handler.

# Changes

Expose the event in `ButtonInput`
