### PR TITLE
feat(frontend): Cache custom tokens

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -109,24 +109,31 @@ const loadIcrcData = ({
 /**
  * @todo Add missing document and test for this function.
  */
-const loadIcrcCustomTokens = async (params: {
+const loadIcrcCustomTokens = async ({
+	identity,
+	certified
+}: {
 	identity: OptionIdentity;
 	certified: boolean;
 }): Promise<IcrcCustomToken[]> => {
 	const tokens = await listCustomTokens({
-		...params,
+		identity,
+		certified,
 		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 	});
 
 	// We filter the custom tokens that are Icrc (the backend "Custom Token" potentially supports other types).
 	const icrcTokens = tokens.filter(({ token }) => 'Icrc' in token);
 
-	// Caching the custom tokens in the IDB
-	await setIdbIcTokens({ identity: params.identity, tokens: icrcTokens });
+	// Caching the custom tokens in the IDB if update call
+	if (certified) {
+		await setIdbIcTokens({ identity, tokens: icrcTokens });
+	}
 
 	return await loadCustomIcrcTokensData({
 		tokens: icrcTokens,
-		...params
+		identity,
+		certified
 	});
 };
 

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -16,6 +16,7 @@ import {
 	type IcrcLoadData
 } from '$icp/utils/icrc.utils';
 import { listCustomTokens } from '$lib/api/backend.api';
+import { setIdbIcTokens } from '$lib/api/idb-tokens.api';
 import { exchangeRateERC20ToUsd, exchangeRateICRCToUsd } from '$lib/services/exchange.services';
 import { balancesStore } from '$lib/stores/balances.store';
 import { exchangeStore } from '$lib/stores/exchange.store';
@@ -119,6 +120,9 @@ const loadIcrcCustomTokens = async (params: {
 
 	// We filter the custom tokens that are Icrc (the backend "Custom Token" potentially supports other types).
 	const icrcTokens = tokens.filter(({ token }) => 'Icrc' in token);
+
+	// Caching the custom tokens in the IDB
+	await setIdbIcTokens({ identity: params.identity, tokens: icrcTokens });
 
 	return await loadCustomIcrcTokensData({
 		tokens: icrcTokens,

--- a/src/frontend/src/lib/api/idb-tokens.api.ts
+++ b/src/frontend/src/lib/api/idb-tokens.api.ts
@@ -1,0 +1,37 @@
+import { browser } from '$app/environment';
+import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
+import { SOLANA_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.sol.env';
+import { nullishSignOut } from '$lib/services/auth.services';
+import type { SetIdbTokensParams } from '$lib/types/idb-tokens';
+import { isNullish } from '@dfinity/utils';
+import { createStore, set as idbSet, type UseStore } from 'idb-keyval';
+
+// There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
+const idbTokensStore = (key: string): UseStore =>
+	browser
+		? createStore(`oisy-${key}-custom-tokens`, `${key}-custom-tokens`)
+		: ({} as unknown as UseStore);
+
+const idbIcTokensStore = idbTokensStore(ICP_NETWORK_SYMBOL.toLowerCase());
+const idbSolTokensStore = idbTokensStore(SOLANA_MAINNET_NETWORK_SYMBOL.toLowerCase());
+
+export const setIdbTokensStore = async ({
+	identity,
+	tokens,
+	idbTokensStore
+}: SetIdbTokensParams & {
+	idbTokensStore: UseStore;
+}) => {
+	if (isNullish(identity)) {
+		await nullishSignOut();
+		return;
+	}
+
+	await idbSet(identity.getPrincipal().toText(), tokens, idbTokensStore);
+};
+
+export const setIdbIcTokens = (params: SetIdbTokensParams): Promise<void> =>
+	setIdbTokensStore({ ...params, idbTokensStore: idbIcTokensStore });
+
+export const setIdbSolTokens = (params: SetIdbTokensParams): Promise<void> =>
+	setIdbTokensStore({ ...params, idbTokensStore: idbSolTokensStore });

--- a/src/frontend/src/lib/types/idb-tokens.ts
+++ b/src/frontend/src/lib/types/idb-tokens.ts
@@ -1,0 +1,7 @@
+import type { CustomToken } from '$declarations/backend/backend.did';
+import type { OptionIdentity } from '$lib/types/identity';
+
+export interface SetIdbTokensParams {
+	identity: OptionIdentity;
+	tokens: CustomToken[];
+}

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -67,20 +67,26 @@ export const loadCustomTokens = ({ identity }: { identity: OptionIdentity }): Pr
 		strategy: 'query'
 	});
 
-const loadSplCustomTokens = async (params: {
+const loadSplCustomTokens = async ({
+	identity,
+	certified
+}: {
 	identity: OptionIdentity;
 	certified: boolean;
 }): Promise<CustomToken[]> => {
 	const tokens = await listCustomTokens({
-		...params,
+		identity,
+		certified,
 		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 	});
 
 	// We filter the custom tokens that are Spl (the backend "Custom Token" potentially supports other types).
 	const splTokens = tokens.filter(({ token }) => 'SplMainnet' in token || 'SplDevnet' in token);
 
-	// Caching the custom tokens in the IDB
-	await setIdbSolTokens({ identity: params.identity, tokens: splTokens });
+	// Caching the custom tokens in the IDB if update call
+	if (certified) {
+		await setIdbSolTokens({ identity, tokens: splTokens });
+	}
 
 	return splTokens;
 };
@@ -198,8 +204,6 @@ const loadCustomTokenData = ({
 	response: SplCustomToken[];
 }) => {
 	splCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
-
-	setIdbSolTokens;
 };
 
 export const getSplMetadata = async ({

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -3,6 +3,7 @@ import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/net
 import { SOLANA_DEFAULT_DECIMALS } from '$env/tokens/tokens.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import { listCustomTokens } from '$lib/api/backend.api';
+import { setIdbSolTokens } from '$lib/api/idb-tokens.api';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -76,7 +77,12 @@ const loadSplCustomTokens = async (params: {
 	});
 
 	// We filter the custom tokens that are Spl (the backend "Custom Token" potentially supports other types).
-	return tokens.filter(({ token }) => 'SplMainnet' in token || 'SplDevnet' in token);
+	const splTokens = tokens.filter(({ token }) => 'SplMainnet' in token || 'SplDevnet' in token);
+
+	// Caching the custom tokens in the IDB
+	await setIdbSolTokens({ identity: params.identity, tokens: splTokens });
+
+	return splTokens;
 };
 
 export const loadCustomTokensWithMetadata = async ({
@@ -192,6 +198,8 @@ const loadCustomTokenData = ({
 	response: SplCustomToken[];
 }) => {
 	splCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+
+	setIdbSolTokens;
 };
 
 export const getSplMetadata = async ({

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -233,21 +233,14 @@ describe('icrc.services', () => {
 				});
 			});
 
-			it('should cache the custom tokens in IDB', async () => {
+			it('should cache the custom tokens in IDB on update call', async () => {
 				backendCanisterMock.listCustomTokens.mockResolvedValue([mockCustomToken]);
 
 				await testLoadCustomTokens({ mockCustomToken, ledgerCanisterId: mockLedgerCanisterId });
 
-				// query + update
-				expect(idbKeyval.set).toHaveBeenCalledTimes(2);
+				expect(idbKeyval.set).toHaveBeenCalledOnce();
 				expect(idbKeyval.set).toHaveBeenNthCalledWith(
 					1,
-					mockIdentity.getPrincipal().toText(),
-					[mockCustomToken],
-					expect.any(Object)
-				);
-				expect(idbKeyval.set).toHaveBeenNthCalledWith(
-					2,
 					mockIdentity.getPrincipal().toText(),
 					[mockCustomToken],
 					expect.any(Object)

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -21,9 +21,24 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 import { IcrcLedgerCanister } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
 import { fromNullable, nonNullish } from '@dfinity/utils';
+import * as idbKeyval from 'idb-keyval';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
+
+vi.mock('idb-keyval', () => ({
+	createStore: vi.fn(() => ({
+		/* mock store implementation */
+	})),
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn(),
+	update: vi.fn()
+}));
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
 
 describe('icrc.services', () => {
 	const mockLedgerCanisterId = 'bw4dl-smaaa-aaaaa-qaacq-cai';
@@ -216,6 +231,27 @@ describe('icrc.services', () => {
 				expect(spyListCustomTokens).toHaveBeenCalledWith({
 					certified: true
 				});
+			});
+
+			it('should cache the custom tokens in IDB', async () => {
+				backendCanisterMock.listCustomTokens.mockResolvedValue([mockCustomToken]);
+
+				await testLoadCustomTokens({ mockCustomToken, ledgerCanisterId: mockLedgerCanisterId });
+
+				// query + update
+				expect(idbKeyval.set).toHaveBeenCalledTimes(2);
+				expect(idbKeyval.set).toHaveBeenNthCalledWith(
+					1,
+					mockIdentity.getPrincipal().toText(),
+					[mockCustomToken],
+					expect.any(Object)
+				);
+				expect(idbKeyval.set).toHaveBeenNthCalledWith(
+					2,
+					mockIdentity.getPrincipal().toText(),
+					[mockCustomToken],
+					expect.any(Object)
+				);
 			});
 		});
 

--- a/src/frontend/src/tests/lib/api/idb-tokens.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-tokens.api.spec.ts
@@ -1,0 +1,116 @@
+import type { CustomToken } from '$declarations/backend/backend.did';
+import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
+import { setIdbTokensStore } from '$lib/api/idb-tokens.api';
+import { mockIndexCanisterId, mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { Principal } from '@dfinity/principal';
+import { toNullable } from '@dfinity/utils';
+import * as idbKeyval from 'idb-keyval';
+import { createStore } from 'idb-keyval';
+
+vi.mock('idb-keyval', () => ({
+	createStore: vi.fn(() => ({
+		/* mock store implementation */
+	})),
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn(),
+	update: vi.fn()
+}));
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('idb-tokens.api', () => {
+	const mockIdbTokensStore = createStore('mock-store', 'mock-store');
+
+	const mockTokens: CustomToken[] = [
+		{
+			token: {
+				Icrc: {
+					ledger_id: Principal.fromText(mockLedgerCanisterId),
+					index_id: toNullable(Principal.fromText(mockIndexCanisterId))
+				}
+			},
+			version: toNullable(2n),
+			enabled: true
+		},
+		{
+			token: {
+				Icrc: { ledger_id: Principal.fromText(IC_CKETH_LEDGER_CANISTER_ID), index_id: toNullable() }
+			},
+			version: toNullable(1n),
+			enabled: false
+		},
+		{
+			token: {
+				SplDevnet: {
+					decimals: toNullable(18),
+					symbol: toNullable(),
+					token_address: BONK_TOKEN.address
+				}
+			},
+			version: toNullable(),
+			enabled: true
+		}
+	];
+
+	const mockParams = {
+		identity: mockIdentity,
+		idbTokensStore: mockIdbTokensStore,
+		tokens: mockTokens
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('setIdbTokensStore', () => {
+		it('should not set the tokens in the IDB if the identity is nullish', async () => {
+			await setIdbTokensStore({
+				...mockParams,
+				identity: null
+			});
+
+			expect(idbKeyval.set).not.toHaveBeenCalled();
+
+			await setIdbTokensStore({
+				...mockParams,
+				identity: undefined
+			});
+
+			expect(idbKeyval.set).not.toHaveBeenCalled();
+		});
+
+		it('should set the transactions in the IDB', async () => {
+			await setIdbTokensStore({
+				...mockParams
+			});
+
+			expect(idbKeyval.set).toHaveBeenCalledOnce();
+			expect(idbKeyval.set).toHaveBeenNthCalledWith(
+				1,
+				mockIdentity.getPrincipal().toText(),
+				mockTokens,
+				mockIdbTokensStore
+			);
+		});
+
+		it('should handle emtpy tokens list', async () => {
+			await setIdbTokensStore({
+				...mockParams,
+				tokens: []
+			});
+
+			expect(idbKeyval.set).toHaveBeenCalledOnce();
+			expect(idbKeyval.set).toHaveBeenNthCalledWith(
+				1,
+				mockIdentity.getPrincipal().toText(),
+				[],
+				mockIdbTokensStore
+			);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We want to start caching custom tokens, to increase the login speed. First, we save the cache for each update call to the backend canister.

# Changes

- Create IDB functions to store `CustomTokens` lists to the IDB cache.
- Use the set IDB functions in ICRC services and SPL services.

# Tests

Included more tests and a practical one:

![Screenshot 2025-05-22 at 11 48 17](https://github.com/user-attachments/assets/b8c1296d-bf8a-4c10-a1b3-b7fd1df52aea)

