### PR TITLE
fix(frontend): Loading metadata shall be case-insensitive

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
@@ -39,7 +39,7 @@
 		loading = false;
 	};
 
-	const debounceLoad = debounce(onLoad, 500);
+	const debounceLoad = debounce(onLoad, 1000);
 
 	$effect(() => {
 		// To trigger the load function when any of the dependencies change.

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -123,7 +123,8 @@ const loadUserTokens = async (params: {
 					// Check it the user token is actually a match in the environment static metadata
 					const existingToken = ALL_DEFAULT_ERC20_TOKENS.find(
 						({ address: tokenAddress, network }) =>
-							tokenAddress === address && (network as EthereumNetwork).chainId === chain_id
+							tokenAddress.toLowerCase() === address.toLowerCase() &&
+							(network as EthereumNetwork).chainId === chain_id
 					);
 
 					if (nonNullish(existingToken)) {

--- a/src/frontend/src/tests/eth/services/erc20.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20.services.spec.ts
@@ -46,7 +46,7 @@ describe('erc20.services', () => {
 			version: toNullable(2n),
 			enabled: toNullable(),
 			chain_id: BASE_NETWORK.chainId,
-			contract_address: mockEthAddress2,
+			contract_address: mockEthAddress2.toUpperCase(),
 			symbol: toNullable('TTK2')
 		},
 		{
@@ -98,7 +98,7 @@ describe('erc20.services', () => {
 				version: 2n,
 				enabled: true,
 				network: BASE_NETWORK,
-				address: mockEthAddress2,
+				address: mockEthAddress2.toUpperCase(),
 				decimals: mockMetadata2.decimals,
 				name: mockMetadata2.name,
 				symbol: mockMetadata2.symbol


### PR DESCRIPTION
# Motivation

When we are loading metadata from existing static tokens, we should compare the addresses without being case-sensitive.
