### PR TITLE
refactor(frontend): remove non-null assertion from `CAIP10_CHAINS`

### DIFF
--- a/src/frontend/src/env/caip10-chains.env.ts
+++ b/src/frontend/src/env/caip10-chains.env.ts
@@ -4,24 +4,31 @@ import {
 	SOLANA_TESTNET_NETWORK
 } from '$env/networks/networks.sol.env';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
+import { nonNullish } from '@dfinity/utils';
 
 export const CAIP10_CHAINS: Record<
 	string,
 	{ chainId: string; name: string; network: SolanaNetworkType }
 > = {
-	[`solana:${SOLANA_MAINNET_NETWORK.chainId}`]: {
-		chainId: SOLANA_MAINNET_NETWORK.chainId!,
-		name: SOLANA_MAINNET_NETWORK.name,
-		network: SolanaNetworks.mainnet
-	},
-	[`solana:${SOLANA_TESTNET_NETWORK.chainId}`]: {
-		chainId: SOLANA_TESTNET_NETWORK.chainId!,
-		name: SOLANA_TESTNET_NETWORK.name,
-		network: SolanaNetworks.testnet
-	},
-	[`solana:${SOLANA_DEVNET_NETWORK.chainId}`]: {
-		chainId: SOLANA_DEVNET_NETWORK.chainId!,
-		name: SOLANA_DEVNET_NETWORK.name,
-		network: SolanaNetworks.devnet
-	}
+	...(nonNullish(SOLANA_MAINNET_NETWORK.chainId) && {
+		[`solana:${SOLANA_MAINNET_NETWORK.chainId}`]: {
+			chainId: SOLANA_MAINNET_NETWORK.chainId,
+			name: SOLANA_MAINNET_NETWORK.name,
+			network: SolanaNetworks.mainnet
+		}
+	}),
+	...(nonNullish(SOLANA_TESTNET_NETWORK.chainId) && {
+		[`solana:${SOLANA_TESTNET_NETWORK.chainId}`]: {
+			chainId: SOLANA_TESTNET_NETWORK.chainId,
+			name: SOLANA_TESTNET_NETWORK.name,
+			network: SolanaNetworks.testnet
+		}
+	}),
+	...(nonNullish(SOLANA_DEVNET_NETWORK.chainId) && {
+		[`solana:${SOLANA_DEVNET_NETWORK.chainId}`]: {
+			chainId: SOLANA_DEVNET_NETWORK.chainId,
+			name: SOLANA_DEVNET_NETWORK.name,
+			network: SolanaNetworks.devnet
+		}
+	})
 };


### PR DESCRIPTION
# Motivation

One more step towards removing non-null assertions: refactoring `CAIP10_CHAINS` to adapt to nullish chain IDs.
