### PR TITLE
refactor(frontend): remove non-null assertion from `SwapForm`

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -92,7 +92,7 @@
 			isNullish(receiveAmount) ||
 			isNullish(sourceTokenFee) ||
 			swapAmountsLoading ||
-		(nonNullish(slippageValue) && Number(slippageValue) >= SWAP_SLIPPAGE_INVALID_VALUE)
+			(nonNullish(slippageValue) && Number(slippageValue) >= SWAP_SLIPPAGE_INVALID_VALUE)
 	);
 
 	$effect(() => {

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -92,7 +92,7 @@
 			isNullish(receiveAmount) ||
 			isNullish(sourceTokenFee) ||
 			swapAmountsLoading ||
-			Number(slippageValue!) >= SWAP_SLIPPAGE_INVALID_VALUE
+		(nonNullish(slippageValue) && Number(slippageValue) >= SWAP_SLIPPAGE_INVALID_VALUE)
 	);
 
 	$effect(() => {


### PR DESCRIPTION
# Motivation

One more step towards removing non-null assertions: refactoring `SwapForm` to adapt to nullish values of slippage.
