### PR TITLE
feat(frontend): Remove toast error during ETH loading transactions

### DIFF
--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -4,10 +4,12 @@ import { etherscanProviders } from '$eth/providers/etherscan.providers';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
+import { TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR } from '$lib/constants/analytics.contants';
 import { ethAddress as addressStore } from '$lib/derived/address.derived';
+import { trackEvent } from '$lib/services/analytics.services';
 import { retry } from '$lib/services/rest.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsError, toastsErrorNoTrace } from '$lib/stores/toasts.store';
+import { toastsError } from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -88,14 +90,22 @@ const loadEthTransactions = async ({
 				}
 			} = get(i18n);
 
-			toastsErrorNoTrace({
-				msg: {
-					text: replacePlaceholders(loading_transactions_symbol, {
-						$symbol: ETHEREUM_NETWORK_SYMBOL
-					})
-				},
-				err
+			trackEvent({
+				name: TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR,
+				metadata: {
+					tokenId: `${tokenId.description}`,
+					networkId: `${networkId.description}`,
+					error: `${err}`
+				}
 			});
+
+			// We print the error to console just for debugging purposes
+			console.warn(
+				replacePlaceholders(loading_transactions_symbol, {
+					$symbol: ETHEREUM_NETWORK_SYMBOL
+				}),
+				err
+			);
 		}
 
 		return { success: false };
@@ -167,14 +177,23 @@ const loadErc20Transactions = async ({
 			}
 		} = get(i18n);
 
-		toastsErrorNoTrace({
-			msg: {
-				text: replacePlaceholders(loading_transactions_symbol, {
-					$symbol: token.symbol
-				})
-			},
-			err
+		trackEvent({
+			name: TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR,
+			metadata: {
+				tokenId: `${tokenId.description}`,
+				networkId: `${networkId.description}`,
+				error: `${err}`
+			}
 		});
+
+		// We print the error to console just for debugging purposes
+		console.warn(
+			replacePlaceholders(loading_transactions_symbol, {
+				$symbol: token.symbol
+			}),
+			err
+		);
+
 		return { success: false };
 	}
 

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -19,6 +19,7 @@ export const TRACK_COUNT_WC_ETH_SEND_ERROR = 'wc_eth_send_error_count';
 export const TRACK_COUNT_CONVERT_ETH_TO_CKETH_SUCCESS = 'eth_to_cketh_convert_success_count';
 export const TRACK_COUNT_CONVERT_ETH_TO_CKETH_ERROR = 'eth_to_cketh_convert_error_count';
 export const TRACK_COUNT_ETH_LOADING_BALANCE_ERROR = 'eth_loading_balance_error_count';
+export const TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR = 'eth_loading_transactions_error_count';
 
 // Internet Computer
 export const TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS = 'ic_ckbtc_to_btc_success_count';

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -11,6 +11,8 @@ import {
 } from '$eth/services/eth-transactions.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+import { TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR } from '$lib/constants/analytics.contants';
+import { trackEvent } from '$lib/services/analytics.services';
 import { ethAddressStore } from '$lib/stores/address.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -24,9 +26,12 @@ vi.mock('$eth/providers/etherscan.providers', () => ({
 	etherscanProviders: vi.fn()
 }));
 
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: vi.fn()
+}));
+
 describe('eth-transactions.services', () => {
 	let spyToastsError: MockInstance;
-	let spyToastsErrorNoTrace: MockInstance;
 
 	const mockErc20UserTokens = [USDC_TOKEN, LINK_TOKEN, PEPE_TOKEN].map((token) => ({
 		data: { ...token, enabled: true },
@@ -37,7 +42,6 @@ describe('eth-transactions.services', () => {
 		vi.clearAllMocks();
 
 		spyToastsError = vi.spyOn(toastsStore, 'toastsError');
-		spyToastsErrorNoTrace = vi.spyOn(toastsStore, 'toastsErrorNoTrace');
 
 		ethAddressStore.set({ data: mockEthAddress, certified: false });
 		erc20UserTokensStore.setAll(mockErc20UserTokens);
@@ -151,14 +155,22 @@ describe('eth-transactions.services', () => {
 
 				expect(result).toEqual({ success: false });
 				expect(get(ethTransactionsStore)).toEqual({ [mockTokenId]: null });
-				expect(spyToastsErrorNoTrace).toHaveBeenCalledWith({
-					err: mockError,
-					msg: {
-						text: replacePlaceholders(en.transactions.error.loading_transactions_symbol, {
-							$symbol: mockSymbol
-						})
+
+				expect(trackEvent).toHaveBeenCalledWith({
+					name: TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR,
+					metadata: {
+						tokenId: mockTokenId.description,
+						networkId: mockNetworkId.description,
+						error: mockError.toString()
 					}
 				});
+
+				expect(console.warn).toHaveBeenCalledWith(
+					replacePlaceholders(en.transactions.error.loading_transactions_symbol, {
+						$symbol: mockSymbol
+					}),
+					mockError
+				);
 			});
 		}, 60000);
 	});


### PR DESCRIPTION
# Motivation

We don't want to show anymore the toast error about the loading ETH transactions failing. However, we want to keep track of it.

# Changes

- Removing the toast error from services `loadEthTransactions` and `loadErc20Transactions`.
- Add track event for errors during loading.
- Add console warn for the error.

# Tests

Adapted tests.
