### PR TITLE
refactor(frontend): Make address line item actions reusable

### DIFF
--- a/src/frontend/src/lib/components/contact/AddressItemActions.svelte
+++ b/src/frontend/src/lib/components/contact/AddressItemActions.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import Copy from '$lib/components/ui/Copy.svelte';
+	import {
+		ADDRESS_LIST_ITEM_COPY_BUTTON,
+		ADDRESS_LIST_ITEM_INFO_BUTTON
+	} from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { ContactAddressUi } from '$lib/types/contact';
+
+	interface Props {
+		address: ContactAddressUi;
+		onInfo?: () => void;
+		styleClass?: string;
+	}
+	let { address, onInfo, styleClass = '' }: Props = $props();
+</script>
+
+<div class={`flex ${styleClass}`}>
+	<Copy
+		testId={ADDRESS_LIST_ITEM_COPY_BUTTON}
+		text={$i18n.wallet.text.address_copied}
+		value={address.address}
+	/>
+	{#if nonNullish(onInfo)}
+		<ButtonIcon
+			styleClass="-m-1 md:m-0 hover:text-inherit"
+			ariaLabel={$i18n.core.text.view}
+			testId={ADDRESS_LIST_ITEM_INFO_BUTTON}
+			onclick={onInfo}
+		>
+			{#snippet icon()}
+				<IconInfo />
+			{/snippet}
+		</ButtonIcon>
+	{/if}
+</div>

--- a/src/frontend/src/lib/components/contact/AddressListItem.svelte
+++ b/src/frontend/src/lib/components/contact/AddressListItem.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import IconAddressType from '$lib/components/address/IconAddressType.svelte';
-	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
-	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
-	import Copy from '$lib/components/ui/Copy.svelte';
-	import {
-		ADDRESS_LIST_ITEM_COPY_BUTTON,
-		ADDRESS_LIST_ITEM_INFO_BUTTON
-	} from '$lib/constants/test-ids.constants';
+	import AddressItemActions from '$lib/components/contact/AddressItemActions.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
@@ -47,23 +41,5 @@
 			<span>{displayAddress}</span>
 		</div>
 	</div>
-	<div class="ml-auto flex items-center">
-		<Copy
-			testId={ADDRESS_LIST_ITEM_COPY_BUTTON}
-			text={$i18n.wallet.text.address_copied}
-			value={address.address}
-		/>
-		{#if nonNullish(onInfo)}
-			<ButtonIcon
-				styleClass="-m-1 md:m-0 hover:text-inherit"
-				ariaLabel={$i18n.core.text.view}
-				testId={ADDRESS_LIST_ITEM_INFO_BUTTON}
-				onclick={onInfo}
-			>
-				{#snippet icon()}
-					<IconInfo />
-				{/snippet}
-			</ButtonIcon>
-		{/if}
-	</div>
+	<AddressItemActions {address} {onInfo} styleClass="ml-auto items-center" />
 </button>

--- a/src/frontend/src/tests/lib/components/contact/AddressItemActions.spec.ts
+++ b/src/frontend/src/tests/lib/components/contact/AddressItemActions.spec.ts
@@ -1,0 +1,120 @@
+import AddressItemActions from '$lib/components/contact/AddressItemActions.svelte';
+import {
+	ADDRESS_LIST_ITEM_COPY_BUTTON,
+	ADDRESS_LIST_ITEM_INFO_BUTTON
+} from '$lib/constants/test-ids.constants';
+import type { ContactAddressUi } from '$lib/types/contact';
+import * as clipboardUtils from '$lib/utils/clipboard.utils';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+import { vi } from 'vitest';
+
+describe('AddressItemActions', () => {
+	// Mock the i18n store
+	const mockI18n = readable(en);
+
+	// Mock the clipboard utils
+	vi.spyOn(clipboardUtils, 'copyToClipboard').mockResolvedValue(undefined);
+
+	// Setup the context with the mocked i18n store
+	const mockContext = new Map([['i18n', mockI18n]]);
+
+	const mockAddress: ContactAddressUi = {
+		addressType: 'Btc',
+		address: mockBtcAddress
+	};
+
+	it('should render copy button', () => {
+		const { getByTestId } = render(AddressItemActions, {
+			props: { address: mockAddress },
+			context: mockContext
+		});
+
+		// Check that the copy button is rendered
+		expect(getByTestId(ADDRESS_LIST_ITEM_COPY_BUTTON)).toBeInTheDocument();
+	});
+
+	it('should render info button when onInfo is provided', () => {
+		const onInfo = vi.fn();
+
+		const { getByTestId } = render(AddressItemActions, {
+			props: {
+				address: mockAddress,
+				onInfo
+			},
+			context: mockContext
+		});
+
+		// Check that the info button is rendered
+		expect(getByTestId(ADDRESS_LIST_ITEM_INFO_BUTTON)).toBeInTheDocument();
+	});
+
+	it('should not render info button when onInfo is not provided', () => {
+		const { queryByTestId } = render(AddressItemActions, {
+			props: { address: mockAddress },
+			context: mockContext
+		});
+
+		// Check that the info button is not rendered
+		expect(queryByTestId(ADDRESS_LIST_ITEM_INFO_BUTTON)).toBeNull();
+	});
+
+	it('should copy address to clipboard when copy button is clicked', async () => {
+		const { getByTestId } = render(AddressItemActions, {
+			props: { address: mockAddress },
+			context: mockContext
+		});
+
+		// Find the copy button using test ID
+		const copyButton = getByTestId(ADDRESS_LIST_ITEM_COPY_BUTTON);
+
+		// Click the copy button
+		await fireEvent.click(copyButton);
+
+		// Check that copyToClipboard was called with the correct arguments
+		expect(clipboardUtils.copyToClipboard).toHaveBeenCalledWith({
+			text: en.wallet.text.address_copied,
+			value: mockAddress.address
+		});
+	});
+
+	it('should call onInfo when info button is clicked', async () => {
+		const onInfo = vi.fn();
+
+		const { getByTestId } = render(AddressItemActions, {
+			props: {
+				address: mockAddress,
+				onInfo
+			},
+			context: mockContext
+		});
+
+		// Find the info button using test ID
+		const infoButton = getByTestId(ADDRESS_LIST_ITEM_INFO_BUTTON);
+
+		// Click the info button
+		await fireEvent.click(infoButton);
+
+		// Check that onInfo was called
+		expect(onInfo).toHaveBeenCalled();
+	});
+
+	it('should apply custom style class', () => {
+		const customClass = 'custom-style-class';
+
+		const { container } = render(AddressItemActions, {
+			props: {
+				address: mockAddress,
+				styleClass: customClass
+			},
+			context: mockContext
+		});
+
+		// Check that the custom class is applied to the div
+		const div = container.querySelector('div');
+
+		expect(div?.classList.contains(customClass)).toBeTruthy();
+	});
+});


### PR DESCRIPTION
# Motivation

The actions for addresses will be reused in contact card

# Changes

- Created new component for address actions
