### PR TITLE
refactor(frontend): remove convert-related code from BTC send components

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -6,27 +6,24 @@
 	import type { BtcAmountAssertionError } from '$btc/types/btc-send';
 	import SendForm from '$lib/components/send/SendForm.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { balance } from '$lib/derived/balances.derived';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { NetworkId } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
 
-	export let networkId: NetworkId | undefined = undefined;
 	export let amount: OptionAmount = undefined;
 	export let destination = '';
 	export let source: string;
 
 	let amountError: BtcAmountAssertionError | undefined;
 
-	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let invalidDestination = false;
 	$: invalidDestination =
 		isInvalidDestinationBtc({
 			destination,
-			networkId
+			networkId: $sendTokenNetworkId
 		}) || isNullishOrEmpty(destination);
 
 	// TODO: check if we can align this validation flag with other SendForm components (e.g IcSendForm)
@@ -38,23 +35,13 @@
 		// This data will then be used in the review step. That's why we don't wait here.
 		loadBtcPendingSentTransactions({
 			identity: $authIdentity,
-			networkId,
+			networkId: $sendTokenNetworkId,
 			address: source
 		});
 	});
 </script>
 
-<SendForm
-	on:icNext
-	on:icBack
-	{source}
-	{destination}
-	{invalidDestination}
-	token={$sendToken}
-	balance={$balance}
-	disabled={invalid}
-	hideSource
->
+<SendForm on:icNext on:icBack {destination} {invalidDestination} disabled={invalid}>
 	<BtcSendAmount slot="amount" bind:amount bind:amountError on:icTokensList />
 
 	<!--	TODO: calculate and display transaction fee	-->

--- a/src/frontend/src/btc/components/send/BtcSendReview.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendReview.svelte
@@ -13,7 +13,6 @@
 	import InsufficientFundsForFee from '$lib/components/fee/InsufficientFundsForFee.svelte';
 	import SendReview from '$lib/components/send/SendReview.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { NetworkId } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
@@ -21,11 +20,11 @@
 
 	export let destination = '';
 	export let amount: OptionAmount = undefined;
-	export let networkId: NetworkId | undefined = undefined;
 	export let source: string;
 	export let utxosFee: UtxosFee | undefined = undefined;
 
-	const { sendBalance, sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendBalance, sendTokenDecimals, sendTokenNetworkId } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let hasPendingTransactionsStore: Readable<BtcPendingSentTransactionsStatus>;
 	$: hasPendingTransactionsStore = initPendingSentTransactionsStatus(source);
@@ -56,14 +55,14 @@
 	$: invalid =
 		isInvalidDestinationBtc({
 			destination,
-			networkId
+			networkId: $sendTokenNetworkId
 		}) || invalidAmount(amount);
 </script>
 
 <SendReview on:icBack on:icSend {amount} {destination} disabled={disableSend}>
-	<BtcReviewNetwork {networkId} slot="network" />
+	<BtcReviewNetwork networkId={$sendTokenNetworkId} slot="network" />
 
-	<BtcUtxosFee slot="fee" bind:utxosFee {networkId} {amount} />
+	<BtcUtxosFee slot="fee" bind:utxosFee networkId={$sendTokenNetworkId} {amount} />
 
 	<div class="mt-8" slot="info">
 		{#if insufficientFundsForFee}

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -134,28 +134,11 @@
 </script>
 
 {#if currentStep?.name === WizardStepsSend.REVIEW}
-	<BtcSendReview
-		on:icBack
-		on:icSend={send}
-		bind:utxosFee
-		{destination}
-		{amount}
-		{networkId}
-		{source}
-	/>
+	<BtcSendReview on:icBack on:icSend={send} bind:utxosFee {destination} {amount} {source} />
 {:else if currentStep?.name === WizardStepsSend.SENDING}
 	<BtcSendProgress bind:sendProgressStep />
 {:else if currentStep?.name === WizardStepsSend.SEND}
-	<BtcSendForm
-		on:icNext
-		on:icClose
-		on:icBack
-		on:icTokensList
-		bind:destination
-		bind:amount
-		{source}
-		{networkId}
-	>
+	<BtcSendForm {source} on:icNext on:icClose on:icBack on:icTokensList bind:destination bind:amount>
 		<ButtonBack onclick={back} slot="cancel" />
 	</BtcSendForm>
 {:else}


### PR DESCRIPTION
# Motivation

We want to remove convert-related code from BTC send components.
