### PR TITLE
chore(frontend): Remove usage of `any` in `KeysOfUnion`

### DIFF
--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -43,5 +43,4 @@ export const assertNever = ({
  *   KeyOfUnion<{ a: number } | { b: string } | { d: { ... } }>
  * will result in: 'a' | 'b' | 'd'
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type KeysOfUnion<T> = T extends any ? keyof T : never;
+export type KeysOfUnion<T> = T extends unknown ? keyof T : never;


### PR DESCRIPTION
# Motivation

No need to use `any` in type util `KeysOfUnion`. We can replace it with `unknown`.