### PR TITLE
feat(frontend): Additional ICRC tokens without index canister ID

### DIFF
--- a/scripts/build.tokens.icrc.ts
+++ b/scripts/build.tokens.icrc.ts
@@ -38,10 +38,6 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 				throw new Error(`Ledger canister ID is missing for token symbol ${key}.`);
 			}
 
-			if (isNullish(savedIndexCanisterId)) {
-				throw new Error(`Index canister ID is missing for token symbol ${key}.`);
-			}
-
 			const { tokens: accTokens, icons: accIcons } = await acc;
 
 			const { ledgerCanisterId, ...rest } = token;

--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -495,6 +495,15 @@ const VEUR_IC_DATA: IcInterface | undefined = nonNullish(ADDITIONAL_ICRC_PRODUCT
 		}
 	: undefined;
 
+const GHOSTNODE_IC_DATA: IcInterface | undefined = nonNullish(
+	ADDITIONAL_ICRC_PRODUCTION_DATA?.GHOSTNODE
+)
+	? {
+			...ADDITIONAL_ICRC_PRODUCTION_DATA.GHOSTNODE,
+			position: 23
+		}
+	: undefined;
+
 export const CKERC20_LEDGER_CANISTER_TESTNET_IDS: CanisterIdText[] = [
 	...(nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) ? [LOCAL_CKUSDC_LEDGER_CANISTER_ID] : []),
 	...(nonNullish(CKUSDC_STAGING_DATA?.ledgerCanisterId)
@@ -570,7 +579,8 @@ const ADDITIONAL_ICRC_TOKENS: IcInterface[] = [
 	...(nonNullish(RUGGY_IC_DATA) ? [RUGGY_IC_DATA] : []),
 	...(nonNullish(NAK_IC_DATA) ? [NAK_IC_DATA] : []),
 	...(nonNullish(VCHF_IC_DATA) ? [VCHF_IC_DATA] : []),
-	...(nonNullish(VEUR_IC_DATA) ? [VEUR_IC_DATA] : [])
+	...(nonNullish(VEUR_IC_DATA) ? [VEUR_IC_DATA] : []),
+	...(nonNullish(GHOSTNODE_IC_DATA) ? [GHOSTNODE_IC_DATA] : [])
 ];
 
 export const ICRC_TOKENS: IcInterface[] = [

--- a/src/frontend/src/env/schema/env-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-icrc-token.schema.ts
@@ -18,5 +18,5 @@ export const EnvIcrcTokenMetadataWithIconSchema =
 
 export const EnvIcTokenSchema = z.object({
 	ledgerCanisterId: z.string(),
-	indexCanisterId: z.string()
+	indexCanisterId: z.string().optional()
 });

--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -98,5 +98,8 @@
 		"fee": {
 			"__bigint__": "10000"
 		}
+	},
+	"GHOSTNODE": {
+		"ledgerCanisterId": "sx3gz-hqaaa-aaaar-qaoca-cai"
 	}
 }


### PR DESCRIPTION
# Motivation

We will start to have static ICRC tokens without index canister ID. For example, we will add `GHOSTNODE` (ledger canister ID `sx3gz-hqaaa-aaaar-qaoca-cai`).

# Changes

- Make index canister ID optional in the additional ICRC tokens.
- Add GHOSTNODE data to JSON file.
- Adapt scripts that updates tokens.

# Tests

In a test canister:

![Screenshot 2025-05-23 at 09 45 57](https://github.com/user-attachments/assets/e3478beb-f521-4763-a43b-715b14ec0be5)

![Screenshot 2025-05-23 at 09 45 46](https://github.com/user-attachments/assets/1b3085cc-b5ea-4ad5-9551-ffdb71d33e82)

