### PR TITLE
refactor(frontend): Correct utils to verify Standard Ethereum tokens

### DIFF
--- a/src/frontend/src/eth/utils/eth.utils.ts
+++ b/src/frontend/src/eth/utils/eth.utils.ts
@@ -5,6 +5,12 @@ import {
 import type { OptionToken, TokenId } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
 
+export const isStandardEthereumToken = (token: OptionToken): boolean =>
+	nonNullish(token) && token.category === 'default' && token.standard === 'ethereum';
+
+export const isNotStandardEthereumToken = (token: OptionToken): boolean =>
+	!isStandardEthereumToken(token);
+
 export const isSupportedEthTokenId = (tokenId: TokenId): boolean =>
 	SUPPORTED_ETHEREUM_TOKEN_IDS.includes(tokenId);
 

--- a/src/frontend/src/eth/utils/eth.utils.ts
+++ b/src/frontend/src/eth/utils/eth.utils.ts
@@ -5,11 +5,11 @@ import {
 import type { OptionToken, TokenId } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
 
-export const isStandardEthereumToken = (token: OptionToken): boolean =>
+export const isDefaultEthereumToken = (token: OptionToken): boolean =>
 	nonNullish(token) && token.category === 'default' && token.standard === 'ethereum';
 
-export const isNotStandardEthereumToken = (token: OptionToken): boolean =>
-	!isStandardEthereumToken(token);
+export const isNotDefaultEthereumToken = (token: OptionToken): boolean =>
+	!isDefaultEthereumToken(token);
 
 export const isSupportedEthTokenId = (tokenId: TokenId): boolean =>
 	SUPPORTED_ETHEREUM_TOKEN_IDS.includes(tokenId);

--- a/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
@@ -2,7 +2,7 @@
 	import { Toggle } from '@dfinity/gix-components';
 	import { createEventDispatcher } from 'svelte';
 	import type { EthereumUserToken } from '$eth/types/erc20-user-token';
-	import { isStandardEthereumToken } from '$eth/utils/eth.utils';
+	import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 	import { MANAGE_TOKENS_MODAL_TOKEN_TOGGLE } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
@@ -11,7 +11,7 @@
 	export let testIdPrefix = MANAGE_TOKENS_MODAL_TOKEN_TOGGLE;
 
 	let disabled = false;
-	$: disabled = isStandardEthereumToken(token);
+	$: disabled = isDefaultEthereumToken(token);
 
 	let checked: boolean;
 	$: checked = token.enabled ?? false;

--- a/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
@@ -2,10 +2,10 @@
 	import { Toggle } from '@dfinity/gix-components';
 	import { createEventDispatcher } from 'svelte';
 	import type { EthereumUserToken } from '$eth/types/erc20-user-token';
+	import { isStandardEthereumToken } from '$eth/utils/eth.utils';
 	import { MANAGE_TOKENS_MODAL_TOKEN_TOGGLE } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
-	import { isStandardEthereumToken } from '$eth/utils/eth.utils';
 
 	export let token: EthereumUserToken | SplTokenToggleable;
 	export let testIdPrefix = MANAGE_TOKENS_MODAL_TOKEN_TOGGLE;

--- a/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokenToggle.svelte
@@ -4,14 +4,14 @@
 	import type { EthereumUserToken } from '$eth/types/erc20-user-token';
 	import { MANAGE_TOKENS_MODAL_TOKEN_TOGGLE } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { isEthereumTokenToggleDisabled } from '$lib/utils/token-toggle.utils';
 	import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
+	import { isStandardEthereumToken } from '$eth/utils/eth.utils';
 
 	export let token: EthereumUserToken | SplTokenToggleable;
 	export let testIdPrefix = MANAGE_TOKENS_MODAL_TOKEN_TOGGLE;
 
 	let disabled = false;
-	$: disabled = isEthereumTokenToggleDisabled(token);
+	$: disabled = isStandardEthereumToken(token);
 
 	let checked: boolean;
 	$: checked = token.enabled ?? false;

--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -1,5 +1,5 @@
 import { isTokenEthereumUserToken } from '$eth/utils/erc20.utils';
-import { isNotStandardEthereumToken } from '$eth/utils/eth.utils';
+import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 import {
 	DEFAULT_BASE_TOKEN,
@@ -76,7 +76,7 @@ export const tokenToggleable: Readable<boolean> = derived([token], ([$token]) =>
 		return icTokenIcrcCustomToken($token)
 			? isIcrcTokenToggleEnabled($token)
 			: isTokenEthereumUserToken($token)
-				? isNotStandardEthereumToken($token)
+				? isNotDefaultEthereumToken($token)
 				: false;
 	}
 

--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -1,4 +1,5 @@
 import { isTokenEthereumUserToken } from '$eth/utils/erc20.utils';
+import { isNotStandardEthereumToken } from '$eth/utils/eth.utils';
 import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 import {
 	DEFAULT_BASE_TOKEN,
@@ -18,10 +19,7 @@ import {
 } from '$lib/derived/network.derived';
 import { token } from '$lib/stores/token.store';
 import type { OptionTokenId, OptionTokenStandard, Token } from '$lib/types/token';
-import {
-	isEthereumTokenToggleEnabled,
-	isIcrcTokenToggleEnabled
-} from '$lib/utils/token-toggle.utils';
+import { isIcrcTokenToggleEnabled } from '$lib/utils/token-toggle.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -78,7 +76,7 @@ export const tokenToggleable: Readable<boolean> = derived([token], ([$token]) =>
 		return icTokenIcrcCustomToken($token)
 			? isIcrcTokenToggleEnabled($token)
 			: isTokenEthereumUserToken($token)
-				? isEthereumTokenToggleEnabled($token)
+				? isNotStandardEthereumToken($token)
 				: false;
 	}
 

--- a/src/frontend/src/lib/utils/token-toggle.utils.ts
+++ b/src/frontend/src/lib/utils/token-toggle.utils.ts
@@ -1,15 +1,6 @@
 import { ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
-import type { EthereumUserToken } from '$eth/types/erc20-user-token';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { isTokenIcp } from '$icp/utils/icrc.utils';
-import { nonNullish } from '@dfinity/utils';
-
-// TODO: Check why this functionality is used instead of eth.utils.ts -> isSupportedEthToken.
-export const isEthereumTokenToggleDisabled = (token: EthereumUserToken): boolean =>
-	nonNullish(token) && token.category === 'default' && token.standard === 'ethereum';
-
-export const isEthereumTokenToggleEnabled = (token: EthereumUserToken): boolean =>
-	!isEthereumTokenToggleDisabled(token);
 
 // TODO: Like above - check why this functionality is used.
 export const isIcrcTokenToggleDisabled = (token: IcrcCustomToken): boolean =>

--- a/src/frontend/src/tests/eth/utils/eth.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/eth.utils.spec.ts
@@ -1,0 +1,179 @@
+import { WBTC_TOKEN } from '$env/tokens/tokens-erc20/tokens.wbtc.env';
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
+import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
+import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
+import { ADDITIONAL_ERC20_TOKENS, ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
+import { ETHEREUM_TOKEN, SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
+import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
+import {
+	isNotStandardEthereumToken,
+	isNotSupportedEthTokenId,
+	isStandardEthereumToken,
+	isSupportedEthToken,
+	isSupportedEthTokenId
+} from '$eth/utils/eth.utils';
+
+describe('eth.utils', () => {
+	describe('isStandardEthereumToken', () => {
+		it.each([...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS])(
+			'should return true for standard Ethereum token $symbol',
+			(token) => {
+				expect(isStandardEthereumToken(token)).toBeTruthy();
+			}
+		);
+
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS])(
+			'should return false for non-standard Ethereum token $symbol',
+			(token) => {
+				expect(isStandardEthereumToken(token)).toBeFalsy();
+			}
+		);
+
+		it('should return false for a custom Ethereum user token', () => {
+			const token = { ...ETHEREUM_TOKEN, category: 'custom' as const };
+
+			expect(isStandardEthereumToken(token)).toBeFalsy();
+		});
+
+		it('should return false for a non-standard Ethereum user token', () => {
+			const token = { ...ETHEREUM_TOKEN, standard: 'erc20' as const };
+
+			expect(isStandardEthereumToken(token)).toBeFalsy();
+		});
+
+		it('should return true for a default standard Ethereum token', () => {
+			const token = {
+				...WBTC_TOKEN,
+				standard: 'ethereum' as const,
+				category: 'default' as const
+			};
+
+			expect(isStandardEthereumToken(token)).toBeTruthy();
+		});
+
+		it('should return false for a nullish token', () => {
+			expect(isStandardEthereumToken(null)).toBeFalsy();
+
+			expect(isStandardEthereumToken(undefined)).toBeFalsy();
+		});
+	});
+
+	describe('isNotStandardEthereumToken', () => {
+		it.each([...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS])(
+			'should return false for standard Ethereum token $symbol',
+			(token) => {
+				expect(isNotStandardEthereumToken(token)).toBeFalsy();
+			}
+		);
+
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS])(
+			'should return true for non-standard Ethereum token $symbol',
+			(token) => {
+				expect(isNotStandardEthereumToken(token)).toBeTruthy();
+			}
+		);
+
+		it('should return true for a custom Ethereum user token', () => {
+			const token = { ...ETHEREUM_TOKEN, category: 'custom' as const };
+
+			expect(isNotStandardEthereumToken(token)).toBeTruthy();
+		});
+
+		it('should return true for a non-standard Ethereum user token', () => {
+			const token = { ...ETHEREUM_TOKEN, standard: 'erc20' as const };
+
+			expect(isNotStandardEthereumToken(token)).toBeTruthy();
+		});
+
+		it('should return false for a default standard Ethereum token', () => {
+			const token = {
+				...WBTC_TOKEN,
+				standard: 'ethereum' as const,
+				category: 'default' as const
+			};
+
+			expect(isNotStandardEthereumToken(token)).toBeFalsy();
+		});
+
+		it('should return true for a nullish token', () => {
+			expect(isNotStandardEthereumToken(null)).toBeTruthy();
+
+			expect(isNotStandardEthereumToken(undefined)).toBeTruthy();
+		});
+	});
+
+	describe('isSupportedEthTokenId', () => {
+		it.each(SUPPORTED_ETHEREUM_TOKENS)(
+			'should return true for supported token $symbol',
+			({ id }) => {
+				expect(isSupportedEthTokenId(id)).toBeTruthy();
+			}
+		);
+
+		it.each([...SUPPORTED_EVM_TOKENS, ...SUPPORTED_BITCOIN_TOKENS])(
+			'should return false for unsupported token $symbol',
+			({ id }) => {
+				expect(isSupportedEthTokenId(id)).toBeFalsy();
+			}
+		);
+
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS, ...SPL_TOKENS])(
+			'should return false for unsupported token $symbol',
+			({ id }) => {
+				expect(isSupportedEthTokenId(id)).toBeFalsy();
+			}
+		);
+	});
+
+	describe('isSupportedEthToken', () => {
+		it.each(SUPPORTED_ETHEREUM_TOKENS)(
+			'should return true for supported token $symbol',
+			(token) => {
+				expect(isSupportedEthToken(token)).toBeTruthy();
+			}
+		);
+
+		it.each([...SUPPORTED_EVM_TOKENS, ...SUPPORTED_BITCOIN_TOKENS])(
+			'should return false for unsupported token $symbol',
+			(token) => {
+				expect(isSupportedEthToken(token)).toBeFalsy();
+			}
+		);
+
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS, ...SPL_TOKENS])(
+			'should return false for unsupported token $symbol',
+			(token) => {
+				expect(isSupportedEthToken(token)).toBeFalsy();
+			}
+		);
+
+		it('should return false for a nullish token', () => {
+			expect(isSupportedEthToken(null)).toBeFalsy();
+
+			expect(isSupportedEthToken(undefined)).toBeFalsy();
+		});
+	});
+
+	describe('isNotSupportedEthTokenId', () => {
+		it.each(SUPPORTED_ETHEREUM_TOKENS)(
+			'should return false for supported token $symbol',
+			({ id }) => {
+				expect(isNotSupportedEthTokenId(id)).toBeFalsy();
+			}
+		);
+
+		it.each([...SUPPORTED_EVM_TOKENS, ...SUPPORTED_BITCOIN_TOKENS])(
+			'should return true for unsupported token $symbol',
+			({ id }) => {
+				expect(isNotSupportedEthTokenId(id)).toBeTruthy();
+			}
+		);
+
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS, ...SPL_TOKENS])(
+			'should return true for unsupported token $symbol',
+			({ id }) => {
+				expect(isNotSupportedEthTokenId(id)).toBeTruthy();
+			}
+		);
+	});
+});

--- a/src/frontend/src/tests/eth/utils/eth.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/eth.utils.spec.ts
@@ -6,39 +6,39 @@ import { ADDITIONAL_ERC20_TOKENS, ERC20_TWIN_TOKENS } from '$env/tokens/tokens.e
 import { ETHEREUM_TOKEN, SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import {
-	isNotStandardEthereumToken,
+	isDefaultEthereumToken,
+	isNotDefaultEthereumToken,
 	isNotSupportedEthTokenId,
-	isStandardEthereumToken,
 	isSupportedEthToken,
 	isSupportedEthTokenId
 } from '$eth/utils/eth.utils';
 
 describe('eth.utils', () => {
-	describe('isStandardEthereumToken', () => {
+	describe('isDefaultEthereumToken', () => {
 		it.each([...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS])(
 			'should return true for standard Ethereum token $symbol',
 			(token) => {
-				expect(isStandardEthereumToken(token)).toBeTruthy();
+				expect(isDefaultEthereumToken(token)).toBeTruthy();
 			}
 		);
 
 		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS])(
 			'should return false for non-standard Ethereum token $symbol',
 			(token) => {
-				expect(isStandardEthereumToken(token)).toBeFalsy();
+				expect(isDefaultEthereumToken(token)).toBeFalsy();
 			}
 		);
 
 		it('should return false for a custom Ethereum user token', () => {
 			const token = { ...ETHEREUM_TOKEN, category: 'custom' as const };
 
-			expect(isStandardEthereumToken(token)).toBeFalsy();
+			expect(isDefaultEthereumToken(token)).toBeFalsy();
 		});
 
 		it('should return false for a non-standard Ethereum user token', () => {
 			const token = { ...ETHEREUM_TOKEN, standard: 'erc20' as const };
 
-			expect(isStandardEthereumToken(token)).toBeFalsy();
+			expect(isDefaultEthereumToken(token)).toBeFalsy();
 		});
 
 		it('should return true for a default standard Ethereum token', () => {
@@ -48,41 +48,41 @@ describe('eth.utils', () => {
 				category: 'default' as const
 			};
 
-			expect(isStandardEthereumToken(token)).toBeTruthy();
+			expect(isDefaultEthereumToken(token)).toBeTruthy();
 		});
 
 		it('should return false for a nullish token', () => {
-			expect(isStandardEthereumToken(null)).toBeFalsy();
+			expect(isDefaultEthereumToken(null)).toBeFalsy();
 
-			expect(isStandardEthereumToken(undefined)).toBeFalsy();
+			expect(isDefaultEthereumToken(undefined)).toBeFalsy();
 		});
 	});
 
-	describe('isNotStandardEthereumToken', () => {
+	describe('isNotDefaultEthereumToken', () => {
 		it.each([...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS])(
 			'should return false for standard Ethereum token $symbol',
 			(token) => {
-				expect(isNotStandardEthereumToken(token)).toBeFalsy();
+				expect(isNotDefaultEthereumToken(token)).toBeFalsy();
 			}
 		);
 
 		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS, ...ADDITIONAL_ERC20_TOKENS])(
 			'should return true for non-standard Ethereum token $symbol',
 			(token) => {
-				expect(isNotStandardEthereumToken(token)).toBeTruthy();
+				expect(isNotDefaultEthereumToken(token)).toBeTruthy();
 			}
 		);
 
 		it('should return true for a custom Ethereum user token', () => {
 			const token = { ...ETHEREUM_TOKEN, category: 'custom' as const };
 
-			expect(isNotStandardEthereumToken(token)).toBeTruthy();
+			expect(isNotDefaultEthereumToken(token)).toBeTruthy();
 		});
 
 		it('should return true for a non-standard Ethereum user token', () => {
 			const token = { ...ETHEREUM_TOKEN, standard: 'erc20' as const };
 
-			expect(isNotStandardEthereumToken(token)).toBeTruthy();
+			expect(isNotDefaultEthereumToken(token)).toBeTruthy();
 		});
 
 		it('should return false for a default standard Ethereum token', () => {
@@ -92,13 +92,13 @@ describe('eth.utils', () => {
 				category: 'default' as const
 			};
 
-			expect(isNotStandardEthereumToken(token)).toBeFalsy();
+			expect(isNotDefaultEthereumToken(token)).toBeFalsy();
 		});
 
 		it('should return true for a nullish token', () => {
-			expect(isNotStandardEthereumToken(null)).toBeTruthy();
+			expect(isNotDefaultEthereumToken(null)).toBeTruthy();
 
-			expect(isNotStandardEthereumToken(undefined)).toBeTruthy();
+			expect(isNotDefaultEthereumToken(undefined)).toBeTruthy();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/token-toggle.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-toggle.utils.spec.ts
@@ -1,39 +1,6 @@
-import { EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
-import { WBTC_TOKEN } from '$env/tokens/tokens-erc20/tokens.wbtc.env';
-import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import type { EthereumUserToken } from '$eth/types/erc20-user-token';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import {
-	isEthereumTokenToggleDisabled,
-	isIcrcTokenToggleDisabled
-} from '$lib/utils/token-toggle.utils';
-
-describe('isEthereumUserTokenDisabled', () => {
-	it('should check if default ethereum user token is disabled for token toggle', () => {
-		const token: EthereumUserToken = { ...ETHEREUM_TOKEN, enabled: false };
-
-		expect(isEthereumTokenToggleDisabled(token)).toBeTruthy();
-	});
-
-	it('should check if custom ethereum user token is disabled for token toggle', () => {
-		const token: EthereumUserToken = { ...ETHEREUM_TOKEN, enabled: false, category: 'custom' };
-
-		expect(isEthereumTokenToggleDisabled(token)).toBeFalsy();
-	});
-
-	it('should check if default erc20 token is disabled for token toggle', () => {
-		const token: EthereumUserToken = { ...EURC_TOKEN, enabled: false };
-
-		expect(isEthereumTokenToggleDisabled(token)).toBeFalsy();
-	});
-
-	it('should check if custom erc20 token is disabled for token toggle', () => {
-		const token: EthereumUserToken = { ...WBTC_TOKEN, enabled: false, category: 'custom' };
-
-		expect(isEthereumTokenToggleDisabled(token)).toBeFalsy();
-	});
-});
+import { isIcrcTokenToggleDisabled } from '$lib/utils/token-toggle.utils';
 
 describe('isIcrcCustomTokenDisabled', () => {
 	it('should check if icp default token is disabled for token toggle', () => {


### PR DESCRIPTION
# Motivation

The utils `isEthereumTokenToggleDisabled` and `isEthereumTokenToggleEnabled` are not exactly doing what the name suggests.

Basically, they should define whether an Ethereum or EVM native token can be toggled or not. For example, we don't want to give the choice to disable the ETH token in specific cases.

To that scope we refactor a bit the utils to understand better their scope.

# Changes

- Move utils to proper module `eth.utils.ts`.
- Rename them to `isStandardEthereumToken` and `isNotStandardEthereumToken`.
- Adapt usage.

# Tests

We created new tests, and since we are here, for all the ETH utils.
