### PR TITLE
feat(frontend): Use real contacts backend in address book 

### DIFF
--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -62,3 +62,11 @@ export const TRACK_COUNT_SWAP_ERROR = 'swap_error_count';
 export const TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS = 'manage_tokens_enable_success_count';
 export const TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS = 'manage_tokens_disable_success_count';
 export const TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR = 'manage_tokens_save_error_count';
+
+// Contacts
+export const TRACK_CONTACT_CREATE_SUCCESS = 'contact_create_success_count';
+export const TRACK_CONTACT_CREATE_ERROR = 'contact_create_error_count';
+export const TRACK_CONTACT_UPDATE_SUCCESS = 'contact_update_success_count';
+export const TRACK_CONTACT_UPDATE_ERROR = 'contact_update_error_count';
+export const TRACK_CONTACT_DELETE_SUCCESS = 'contact_delete_success_count';
+export const TRACK_CONTACT_DELETE_ERROR = 'contact_delete_error_count';

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -467,7 +467,7 @@
 			"contacts_tab": "Contacts",
 			"recently_used_empty_state_title": "Recently used addresses will appear here",
 			"recently_used_empty_state_description": "Make your first send now!",
-			"contacts_empty_state_title": "Your contacts will appear here",
+			"contacts_empty_state_title": "Your rontacts will appear here",
 			"contacts_empty_state_description": "It looks like you haven’t added contacts yet"
 		},
 		"placeholder": {
@@ -1042,6 +1042,7 @@
 			"add_new_contact": "Add new contact",
 			"add_contact": "Add contact",
 			"search_contact": "Search contact",
+			"loading_contacts": "Loading contacts...",
 			"no_contact_found": "No contacts found"
 		},
 		"alt": {
@@ -1072,6 +1073,11 @@
 			"title": "Delete $contact contact?",
 			"delete_contact": "Delete contact",
 			"content_text": "This will delete $contact and all associated addresses from your Address Book. This action cannot be undone."
+		},
+		"error": {
+			"create": "Failed to create the contact",
+			"update": "Failed to update the contact",
+			"delete": "Failed to delete the contact"
 		}
 	},
 	"address": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -467,7 +467,7 @@
 			"contacts_tab": "Contacts",
 			"recently_used_empty_state_title": "Recently used addresses will appear here",
 			"recently_used_empty_state_description": "Make your first send now!",
-			"contacts_empty_state_title": "Your rontacts will appear here",
+			"contacts_empty_state_title": "Your contacts will appear here",
 			"contacts_empty_state_description": "It looks like you haven’t added contacts yet"
 		},
 		"placeholder": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -960,6 +960,7 @@ interface I18nAddress_book {
 		add_new_contact: string;
 		add_contact: string;
 		search_contact: string;
+		loading_contacts: string;
 		no_contact_found: string;
 	};
 	alt: { show_addresses_of_contact: string; hide_addresses: string };
@@ -976,6 +977,7 @@ interface I18nContact {
 	form: { edit_contact: string; add_new_contact: string };
 	fields: { name: string };
 	delete: { title: string; delete_contact: string; content_text: string };
+	error: { create: string; update: string; delete: string };
 }
 
 interface I18nAddress {

--- a/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
@@ -12,10 +12,40 @@ import {
 	CONTACT_SHOW_CLOSE_BUTTON,
 	MODAL_TITLE
 } from '$lib/constants/test-ids.constants';
+import { loadContacts } from '$lib/services/manage-contacts.service';
+import { contactsStore } from '$lib/stores/contacts.store';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
 import en from '$tests/mocks/i18n.mock';
-import { fireEvent, render } from '@testing-library/svelte';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockManageContactsService } from '$tests/mocks/manage-contacts.service.mock';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { vi } from 'vitest';
 
 describe('AddressBookModal', () => {
+	let cleanup: { restore: () => void };
+
+	beforeEach(async () => {
+		// Reset the contacts store before each test
+		contactsStore.reset();
+
+		// Mock the auth identity
+		mockAuthStore();
+
+		// Mock the manage-contacts service
+		cleanup = mockManageContactsService();
+
+		// Load contacts (this will set an empty array in the store)
+		await loadContacts(mockIdentity);
+	});
+
+	afterEach(() => {
+		// Restore the original service methods
+		cleanup.restore();
+
+		// Restore the auth mock
+		vi.restoreAllMocks();
+	});
+
 	it('should render the address book step initially', () => {
 		const { getByTestId } = render(AddressBookModal);
 
@@ -47,8 +77,10 @@ describe('AddressBookModal', () => {
 		// Click close button
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_CANCEL_BUTTON));
 
-		// Should be back on address book step
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+		await waitFor(() => {
+			// Should be back on address book step
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+		});
 	});
 
 	it('should add a contact and display it in the address book', async () => {
@@ -67,11 +99,12 @@ describe('AddressBookModal', () => {
 		// Save contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Should be back on address book step
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
-
-		// Contact should be displayed in the list
-		expect(getByText('Test Contact', { exact: false })).toBeInTheDocument();
+		await waitFor(() => {
+			// Should be back on address book step
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			// Contact should be displayed in the list
+			expect(getByText('Test Contact', { exact: false })).toBeInTheDocument();
+		});
 	});
 
 	it('should not add a contact if name is empty', async () => {
@@ -99,7 +132,18 @@ describe('AddressBookModal', () => {
 		await fireEvent.input(getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT), {
 			target: { value: 'Contact 1' }
 		});
+
+		expect(getByTestId(ADDRESS_BOOK_SAVE_BUTTON)).toBeEnabled();
+
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
+
+		// Wait a bit for the store to update and UI to reflect changes
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			expect(getByText('Contact 1', { exact: false })).toBeInTheDocument();
+		});
 
 		// Add second contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -108,13 +152,18 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Both contacts should be displayed
-		expect(getByText('Contact 1', { exact: false })).toBeInTheDocument();
-		expect(getByText('Contact 2', { exact: false })).toBeInTheDocument();
+		// Wait a bit for the store to update and UI to reflect changes
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			expect(getByText('Contact 1', { exact: false })).toBeInTheDocument();
+			expect(getByText('Contact 2', { exact: false })).toBeInTheDocument();
+		});
 	});
 
 	it('should display contacts using ContactCard components', async () => {
-		const { getByTestId, getAllByTestId } = render(AddressBookModal);
+		const { getByTestId, findAllByTestId } = render(AddressBookModal);
 
 		// Add first contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -123,8 +172,8 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Should display the contact using ContactCard
-		const contactCards = getAllByTestId(CONTACT_CARD);
+		// Wait for the contact card to be displayed
+		const contactCards = await findAllByTestId(CONTACT_CARD);
 
 		expect(contactCards).toHaveLength(1);
 		expect(contactCards[0]).toBeInTheDocument();
@@ -139,6 +188,10 @@ describe('AddressBookModal', () => {
 			target: { value: 'Test Contact' }
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+		});
 
 		// Click on the contact card
 		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
@@ -157,6 +210,10 @@ describe('AddressBookModal', () => {
 			target: { value: 'Test Contact' }
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+		});
 
 		// Navigate to show contact step
 		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
@@ -181,9 +238,15 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+		});
+
 		// Navigate to show contact step
 		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
 		await fireEvent.click(contactButtons[0]);
+
+		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 
 		// Navigate to edit contact step
 		await fireEvent.click(getByTestId(CONTACT_HEADER_EDIT_BUTTON));
@@ -198,7 +261,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from edit address step to show contact when close button is clicked', async () => {
-		const { getByTestId, getAllByTestId } = render(AddressBookModal);
+		const { getByTestId, findAllByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -207,19 +270,49 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Navigate to show contact step
-		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
+		// Wait for the contact card button to be displayed
+		const contactButtons = await findAllByTestId(CONTACT_CARD_BUTTON);
 		await fireEvent.click(contactButtons[0]);
+
+		// Wait for navigation to show contact step
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
 
 		// Navigate to add address step
 		await fireEvent.click(getByTestId(CONTACT_SHOW_ADD_ADDRESS_BUTTON));
 
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent('Edit contact');
+		// Wait for navigation to edit address step
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent('Edit contact');
+		});
 
 		// Click close button
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_CANCEL_BUTTON));
 
 		// Should be back on show contact step
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+	});
+
+	it('should display pre-existing contacts from the store', async () => {
+		// Pre-populate the contacts store with contacts
+		const contact = {
+			id: BigInt(1),
+			name: 'Pre-existing Contact',
+			updateTimestampNs: BigInt(Date.now()),
+			addresses: []
+		};
+
+		contactsStore.set([contact]);
+
+		const { getByText } = render(AddressBookModal);
+
+		// Wait for the component to update
+		await waitFor(() => {
+			// The existing contact should be displayed
+			expect(getByText('Pre-existing Contact', { exact: false })).toBeInTheDocument();
+		});
 	});
 });

--- a/src/frontend/src/tests/mocks/manage-contacts.service.mock.ts
+++ b/src/frontend/src/tests/mocks/manage-contacts.service.mock.ts
@@ -1,0 +1,55 @@
+import * as manageContactsService from '$lib/services/manage-contacts.service';
+import { contactsStore } from '$lib/stores/contacts.store';
+import type { ContactUi } from '$lib/types/contact';
+import { vi } from 'vitest';
+
+export const mockManageContactsService = () => {
+	// Mock createContact
+	vi.spyOn(manageContactsService, 'createContact').mockImplementation(
+		async ({ name }: { name: string }) => {
+			const newContact: ContactUi = {
+				id: BigInt(Date.now()),
+				name,
+				updateTimestampNs: BigInt(Date.now()),
+				addresses: []
+			};
+
+			contactsStore.addContact(newContact);
+			// Add a Promise.resolve() to satisfy the async/await requirement
+			await Promise.resolve();
+			return newContact;
+		}
+	);
+
+	// Mock updateContact
+	vi.spyOn(manageContactsService, 'updateContact').mockImplementation(
+		async ({ contact }: { contact: ContactUi }) => {
+			contactsStore.updateContact(contact);
+			// Add a Promise.resolve() to satisfy the async/await requirement
+			await Promise.resolve();
+			return contact;
+		}
+	);
+
+	// Mock deleteContact
+	vi.spyOn(manageContactsService, 'deleteContact').mockImplementation(
+		async ({ id }: { id: ContactUi['id'] }) => {
+			contactsStore.removeContact(id);
+			// Add a Promise.resolve() to satisfy the async/await requirement
+			await Promise.resolve();
+		}
+	);
+
+	// Mock loadContacts
+	vi.spyOn(manageContactsService, 'loadContacts').mockImplementation(async () => {
+		// Set an empty contacts array to simulate loaded contacts
+		contactsStore.set([]);
+		await Promise.resolve();
+	});
+
+	return {
+		restore: () => {
+			vi.restoreAllMocks();
+		}
+	};
+};


### PR DESCRIPTION
# Motivation

In order to really save the contacts in the backend, this PR integrates the contacts store and contacts.service with minimal changes. Further optimization to come.

# Changes

- Use service methods for contacts CRUD
- Use contacts store for address book
