### PR TITLE
feat(backend): correct incorrect guards used for the contact endpoints

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -881,7 +881,7 @@ pub fn get_snapshot() -> Option<UserSnapshot> {
 ///
 /// # Test
 /// This endpoint is currently a placeholder and will be fully implemented in a future PR.
-#[update(guard = "caller_is_allowed")]
+#[update(guard = "caller_is_not_anonymous")]
 #[must_use]
 pub async fn create_contact(request: CreateContactRequest) -> CreateContactResult {
     let result = contacts::create_contact(request).await;
@@ -892,7 +892,7 @@ pub async fn create_contact(request: CreateContactRequest) -> CreateContactResul
 ///
 /// # Errors
 /// Errors are enumerated by: `ContactError`.
-#[update(guard = "caller_is_allowed")]
+#[update(guard = "caller_is_not_anonymous")]
 #[must_use]
 pub fn update_contact(request: UpdateContactRequest) -> UpdateContactResult {
     // TODO replace mock data with data from contact service
@@ -910,7 +910,7 @@ pub fn update_contact(request: UpdateContactRequest) -> UpdateContactResult {
 ///
 /// # Errors
 /// Errors are enumerated by: `ContactError`.
-#[update(guard = "caller_is_allowed")]
+#[update(guard = "caller_is_not_anonymous")]
 #[must_use]
 pub fn delete_contact(contact_id: u64) -> DeleteContactResult {
     // TODO integrate delete contact service

--- a/src/backend/tests/it/contacts.rs
+++ b/src/backend/tests/it/contacts.rs
@@ -1,6 +1,8 @@
 use candid::Principal;
-use shared::types::contact::{Contact, ContactError, CreateContactRequest};
-use shared::types::user_profile::OisyUser;
+use shared::types::{
+    contact::{Contact, ContactError, CreateContactRequest},
+    user_profile::OisyUser,
+};
 
 use crate::utils::{
     mock::CALLER,

--- a/src/backend/tests/it/contacts.rs
+++ b/src/backend/tests/it/contacts.rs
@@ -1,5 +1,6 @@
 use candid::Principal;
 use shared::types::contact::{Contact, ContactError, CreateContactRequest};
+use shared::types::user_profile::OisyUser;
 
 use crate::utils::{
     mock::CALLER,
@@ -153,8 +154,6 @@ fn test_create_multiple_contacts() {
     assert_ne!(id2, id3);
 }
 
-/*
-TODO Uncommment this test as soon as we can register a caller address dynamically
 #[test]
 fn test_contacts_are_isolated_between_users() {
     let pic_setup = setup();
@@ -162,7 +161,6 @@ fn test_contacts_are_isolated_between_users() {
     // Initialize multiple test users
     let test_users: Vec<OisyUser> = pic_setup.create_users(1..=3);
 
-    // TODO add a function that allows the users to call the backewnd canister here
     // Create a contact for each user with a dynamically generated name
     for (index, test_user) in test_users.iter().enumerate() {
         let user_number = index + 1;
@@ -201,4 +199,3 @@ fn test_contacts_are_isolated_between_users() {
         );
     }
 }
-*/


### PR DESCRIPTION
# Motivation

We must allow non-anonymous users to call the address book endpoints. The guard `caller_is_allowed` currently used  only allows controllers and allowed principles (which must be registered on canister level) to call the endpoint.
# Changes

- Updated the create_contact function to use the caller_is_not_anonymous guard.
- Updated the delete_contact function to use the caller_is_not_anonymous guard.

# Tests
- Uncommenting test_contacts_are_isolated_between_users since the all valid principles are allowed to call the create_contact endpoint
