### PR TITLE
refactor(frontend): Use `OisySymbol` for custom symbols

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -13,6 +13,7 @@ import {
 	buildIcrcCustomTokenMetadataPseudoResponse,
 	mapIcrcToken,
 	mapTokenOisyName,
+	mapTokenOisySymbol,
 	type IcrcLoadData
 } from '$icp/utils/icrc.utils';
 import { listCustomTokens } from '$lib/api/backend.api';
@@ -40,7 +41,9 @@ export const loadIcrcTokens = async ({ identity }: { identity: OptionIdentity })
 
 const loadDefaultIcrcTokens = async () => {
 	await Promise.all(
-		ICRC_TOKENS.map(mapTokenOisyName).map((token) => loadDefaultIcrc({ data: token }))
+		ICRC_TOKENS.map(mapTokenOisyName)
+			.map(mapTokenOisySymbol)
+			.map((token) => loadDefaultIcrc({ data: token }))
 	);
 };
 

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -56,7 +56,7 @@ export const mapIcrcToken = ({
 		id: parseTokenId(symbol),
 		network: ICP_NETWORK,
 		standard: icrcCustomTokens?.[ledgerCanisterId]?.standard ?? 'icrc',
-		symbol: CUSTOM_SYMBOLS_BY_LEDGER_CANISTER_ID[ledgerCanisterId] ?? symbol,
+		symbol,
 		...(notEmptyString(icon) && { icon }),
 		...(nonNullish(icrcCustomTokens?.[ledgerCanisterId]?.explorerUrl) && {
 			explorerUrl: icrcCustomTokens[ledgerCanisterId].explorerUrl
@@ -132,6 +132,7 @@ export const icTokenIcrcCustomToken = (token: Partial<IcrcCustomToken>): token i
 const isIcCkInterface = (token: IcInterface): token is IcCkInterface =>
 	'minterCanisterId' in token && 'twinToken' in token;
 
+// TODO: create tests
 export const mapTokenOisyName = (token: IcInterface): IcInterface => ({
 	...token,
 	...(isIcCkInterface(token) && nonNullish(token.twinToken)
@@ -142,4 +143,14 @@ export const mapTokenOisyName = (token: IcInterface): IcInterface => ({
 				}
 			}
 		: {})
+});
+
+// TODO: create tests
+export const mapTokenOisySymbol = (token: IcInterface): IcInterface => ({
+	...token,
+	...{
+		oisySymbol: {
+			oisySymbol: CUSTOM_SYMBOLS_BY_LEDGER_CANISTER_ID[token.ledgerCanisterId]
+		}
+	}
 });

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -1,4 +1,3 @@
-import { GHOSTNODE_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import {
 	buildIcrcCustomTokenMetadataPseudoResponse,
 	icTokenIcrcCustomToken,
@@ -194,25 +193,6 @@ describe('icrc.utils', () => {
 				...mockToken,
 				id: token?.id,
 				standard: 'icrc'
-			});
-		});
-
-		it('should map a token with custom symbol', () => {
-			const token = mapIcrcToken({
-				...mockParams,
-				icrcCustomTokens: {
-					[GHOSTNODE_LEDGER_CANISTER_ID]: {
-						...mockToken
-					}
-				},
-				ledgerCanisterId: GHOSTNODE_LEDGER_CANISTER_ID
-			});
-
-			expect(token).toStrictEqual({
-				...mockToken,
-				ledgerCanisterId: GHOSTNODE_LEDGER_CANISTER_ID,
-				symbol: 'GHOSTNODE',
-				id: token?.id
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

We can use the `oisySymbol` prop for the custom symbols of ICRC tokens.
