### PR TITLE
style(frontend): styling of the SendInputDestination component

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -23,38 +23,63 @@
 
 	const debounceValidate = debounce(validate);
 
+	let focused: boolean;
+	const onFocus = () => (focused = true);
+	const onBlur = () => (focused = false);
+
 	$: destination, networkId, isInvalidDestination, debounceValidate();
 </script>
 
-<label for="destination" class="font-bold">
-	{$i18n.core.text.to}
-</label>
+<div
+	class="rounded-lg border border-solid p-5 text-left duration-300"
+	class:bg-brand-subtle-10={focused}
+	class:border-brand-subtle-20={focused}
+	class:bg-secondary={!focused}
+	class:border-secondary={!focused}
+>
+	<label for="destination" class="font-bold">
+		{$i18n.core.text.to}
+	</label>
 
-<div class="mb-4">
-	<InputTextWithAction
-		name="destination"
-		bind:value={destination}
-		placeholder={inputPlaceholder}
-		testId={DESTINATION_INPUT}
-		autofocus={isDesktop()}
-		on:nnsInput
-	>
-		<svelte:fragment slot="inner-end">
-			{#if nonNullish(onQRButtonClick)}
-				<QrButton on:click={onQRButtonClick} />
-			{/if}
-		</svelte:fragment>
-	</InputTextWithAction>
+	<div class="send-input-destination" class:error={invalidDestination}>
+		<InputTextWithAction
+			name="destination"
+			bind:value={destination}
+			placeholder={inputPlaceholder}
+			testId={DESTINATION_INPUT}
+			autofocus={isDesktop()}
+			on:focus={onFocus}
+			on:blur={onBlur}
+			on:nnsInput
+		>
+			<svelte:fragment slot="inner-end">
+				{#if nonNullish(onQRButtonClick)}
+					<QrButton on:click={onQRButtonClick} />
+				{/if}
+			</svelte:fragment>
+		</InputTextWithAction>
+
+		{#if invalidDestination}
+			<p transition:slide={SLIDE_DURATION} class="mb-0 mt-4 text-error-primary">
+				{$i18n.send.assertion.invalid_destination_address}
+			</p>
+		{/if}
+	</div>
 </div>
 
-{#if invalidDestination}
-	<p transition:slide={SLIDE_DURATION} class="pb-3 text-error-primary">
-		{$i18n.send.assertion.invalid_destination_address}
-	</p>
-{:else if notEmptyString(destination) && nonNullish(knownDestinations) && isNullish(knownDestinations[destination.toLowerCase()])}
+{#if !invalidDestination && notEmptyString(destination) && nonNullish(knownDestinations) && isNullish(knownDestinations[destination.toLowerCase()])}
 	<div transition:slide={SLIDE_DURATION}>
-		<MessageBox level="warning">
+		<MessageBox level="warning" styleClass="mt-4">
 			{$i18n.send.info.unknown_destination}
 		</MessageBox>
 	</div>
 {/if}
+
+<style lang="scss">
+	:global(.error.send-input-destination div.input-field input) {
+		--input-error-color: var(--color-border-error-solid);
+		--secondary: var(--color-border-error-solid);
+		--focus-background-contrast: var(--color-border-error-solid);
+		--input-background-contrast: var(--color-border-error-solid);
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/InputTextWithAction.svelte
+++ b/src/frontend/src/lib/components/ui/InputTextWithAction.svelte
@@ -28,6 +28,8 @@
 	autocomplete="off"
 	{testId}
 	on:nnsInput
+	on:blur
+	on:focus
 	bind:inputElement
 >
 	<slot name="inner-end" slot="inner-end" />


### PR DESCRIPTION
# Motivation

We need to update styling of the SendInputDestination component. 
<img width="602" alt="Screenshot 2025-05-26 at 10 27 54" src="https://github.com/user-attachments/assets/a3819725-eb1d-4909-ad36-7ec5adbe08a9" />
<img width="616" alt="Screenshot 2025-05-26 at 10 28 00" src="https://github.com/user-attachments/assets/7f605ef7-9bd0-4e26-86ff-378c36e3f84a" />
<img width="623" alt="Screenshot 2025-05-26 at 10 28 08" src="https://github.com/user-attachments/assets/a1354e3d-7f57-494c-bcb5-78bff87df560" />
<img width="608" alt="Screenshot 2025-05-26 at 10 28 25" src="https://github.com/user-attachments/assets/98095322-c770-49c3-9fa1-c353e41d8711" />
