### PR TITLE
feat(frontend): Allow button text to be aligned left

### DIFF
--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -7,7 +7,7 @@
 	export let loading = false;
 	export let loadingAsSkeleton = true;
 	export let fullWidth = false;
-	export let alignLeft = false
+	export let alignLeft = false;
 	export let link = false;
 	export let inlineLink = false;
 	export let paddingSmall = false;

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -7,6 +7,7 @@
 	export let loading = false;
 	export let loadingAsSkeleton = true;
 	export let fullWidth = false;
+	export let alignLeft = false
 	export let link = false;
 	export let inlineLink = false;
 	export let paddingSmall = false;
@@ -26,6 +27,7 @@
 	class:w-full={fullWidth}
 	class:link
 	{type}
+	class:justify-start={alignLeft}
 	disabled={disabled || loading}
 	class:loading
 	class:transition={loading}


### PR DESCRIPTION
# Motivation

Allows the button text to be aligned left. Needed in AddressBookEdit step. See: https://github.com/dfinity/oisy-wallet/pull/6557

# Changes

Adds property to set text alignement.