### PR TITLE
fix(frontend): displays token symbol even balance is ZERO

### DIFF
--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -4,7 +4,6 @@
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import Amount from '$lib/components/ui/Amount.svelte';
-	import { ZERO } from '$lib/constants/app.constants';
 	import { AMOUNT_DATA } from '$lib/constants/test-ids.constants';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
@@ -21,7 +20,7 @@
 		data-tid={AMOUNT_DATA}
 		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"
 	>
-		{#if nonNullish(token?.balance) && nonNullish(token?.symbol) && !(token.balance === ZERO)}
+		{#if nonNullish(token?.balance) && nonNullish(token?.symbol)}
 			{#if $isPrivacyMode}
 				<IconDots variant="lg" times={6} styleClass="h-12.5 my-4.25" />
 			{:else}


### PR DESCRIPTION
# Motivation

On the `token view` the symbol of the token should be displayed even if the token balance is ZERO.

# Changes

- displays token symbol

# Tests

**before:**

**after:**
