### PR TITLE
feat(frontend):  Expose InputAddress parse error

### DIFF
--- a/src/frontend/src/lib/components/address/InputAddress.svelte
+++ b/src/frontend/src/lib/components/address/InputAddress.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { ComponentProps } from 'svelte';
 	import { slide } from 'svelte/transition';
+	import type { ZodError } from 'zod';
 	import QrButton from '$lib/components/common/QrButton.svelte';
 	import Input from '$lib/components/ui/Input.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
@@ -12,7 +13,6 @@
 		getDiscriminatorForTokenAccountId,
 		getNetworksForTokenAccountIdType
 	} from '$lib/utils/token-account-id.utils';
-	import type { ZodError } from 'zod';
 
 	interface InputAddressProps {
 		onQRCodeScan?: () => void;

--- a/src/frontend/src/lib/components/address/InputAddress.svelte
+++ b/src/frontend/src/lib/components/address/InputAddress.svelte
@@ -12,17 +12,20 @@
 		getDiscriminatorForTokenAccountId,
 		getNetworksForTokenAccountIdType
 	} from '$lib/utils/token-account-id.utils';
+	import type { ZodError } from 'zod';
 
 	interface InputAddressProps {
 		onQRCodeScan?: () => void;
 		value?: string;
 		addressType?: TokenAccountIdTypes;
+		parseError?: ZodError;
 	}
 
 	let {
 		onQRCodeScan,
 		value = $bindable(),
 		addressType = $bindable(),
+		parseError = $bindable(),
 		...props
 	}: InputAddressProps & ComponentProps<Input> = $props();
 
@@ -51,6 +54,7 @@
 	$effect(() => {
 		// Because bindable props may not be derrived, set it manually in an effect
 		addressType = currentAddressType;
+		parseError = tokenAccountIdParseResult?.error;
 	});
 </script>
 


### PR DESCRIPTION
# Motivation

To react in the address form to any errors, this PR exposes the error.

# Changes

- Expose the error

# Tests

No tests are added since for testing the `svelte-htm` library would be neede, which we don't have integrated. 