### PR TITLE
feat(dependabot): Enable dependabot for all dependencies of npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: weekly
     allow:
-      - dependency-type: development
+      - dependency-type: all
     ignore:
       - dependency-name: '@dfinity/*'
       - dependency-name: '@types/*'


### PR DESCRIPTION
# Motivation

We want to stay up to date with all the dependencies of the frontend, for example `ethers` or solana kit. In any case, we can analyze the PRs created and decide singularly if we accept the update or not.
