### PR TITLE
feat(frontend): Create event for enabled and disabled tokens

### DIFF
--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -57,3 +57,8 @@ export const TRACK_COUNT_CAROUSEL_OPEN = 'carousel_open_count';
 // Swap
 export const TRACK_COUNT_SWAP_SUCCESS = 'swap_success_count';
 export const TRACK_COUNT_SWAP_ERROR = 'swap_error_count';
+
+// Manage Tokens
+export const TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS = 'manage_tokens_enable_success_count';
+export const TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS = 'manage_tokens_disable_success_count';
+export const TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR = 'manage_tokens_save_error_count';

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -1,11 +1,22 @@
+import type { SaveUserToken } from '$eth/services/erc20-user-tokens.services';
+import {
+	TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS,
+	TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS,
+	TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR
+} from '$lib/constants/analytics.contants';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import { trackEvent } from '$lib/services/analytics.services';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
+import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
 import type { OptionIdentity } from '$lib/types/identity';
+import type { Token } from '$lib/types/token';
+import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { NonEmptyArray } from '$lib/types/utils';
+import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 import type { Identity } from '@dfinity/agent';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 export interface ManageTokensSaveParams {
@@ -22,7 +33,9 @@ export interface SaveTokensParams<T> {
 	tokens: NonEmptyArray<T>;
 }
 
-export const saveTokens = async <T>({
+export const saveTokens = async <
+	T extends SaveUserToken | SaveCustomTokenWithKey | SaveSplCustomToken | TokenToggleable<Token>
+>({
 	tokens,
 	save,
 	progress,
@@ -60,6 +73,30 @@ export const saveTokens = async <T>({
 		progress(ProgressStepsAddToken.DONE);
 
 		setTimeout(() => onSuccess(), 750);
+
+		tokens.forEach((token) => {
+			const { enabled } = token;
+			const address = 'address' in token ? token.address : undefined;
+			const ledgerCanisterId = 'ledgerCanisterId' in token ? token.ledgerCanisterId : undefined;
+			const indexCanisterId = 'indexCanisterId' in token ? token.indexCanisterId : undefined;
+			const tokenId = 'id' in token ? token.id : undefined;
+			const tokenSymbol = 'symbol' in token ? token.symbol : undefined;
+			const network = 'network' in token ? token.network : undefined;
+
+			trackEvent({
+				name: enabled
+					? TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS
+					: TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS,
+				metadata: {
+					...(nonNullish(address) && { address }),
+					...(nonNullish(ledgerCanisterId) && { ledgerCanisterId }),
+					...(nonNullish(indexCanisterId) && { indexCanisterId }),
+					...(nonNullish(tokenId) && { tokenId: `${tokenId.description}` }),
+					...(nonNullish(tokenSymbol) && { tokenSymbol }),
+					...(nonNullish(network) && { networkId: `${network.id.description}` })
+				}
+			});
+		});
 	} catch (err: unknown) {
 		toastsError({
 			msg: { text: $i18n.tokens.error.unexpected },
@@ -67,5 +104,12 @@ export const saveTokens = async <T>({
 		});
 
 		onError();
+
+		trackEvent({
+			name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
+			metadata: {
+				error: `${err}`
+			}
+		});
 	}
 };

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -1,8 +1,16 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
+import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import {
+	TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS,
+	TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS,
+	TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR
+} from '$lib/constants/analytics.contants';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import { trackEvent } from '$lib/services/analytics.services';
 import { nullishSignOut } from '$lib/services/auth.services';
 import { saveTokens } from '$lib/services/manage-tokens.services';
 import * as toastsStore from '$lib/stores/toasts.store';
@@ -14,6 +22,10 @@ vi.mock('$lib/services/auth.services', () => ({
 	nullishSignOut: vi.fn()
 }));
 
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: vi.fn()
+}));
+
 describe('manage-tokens.services', () => {
 	describe('saveTokens', () => {
 		const mockProgress = vi.fn();
@@ -22,7 +34,17 @@ describe('manage-tokens.services', () => {
 		const mockOnError = vi.fn();
 		const mockSave = vi.fn();
 
-		const tokens = [BTC_MAINNET_TOKEN, ETHEREUM_TOKEN, ICP_TOKEN, SOLANA_TOKEN];
+		const tokens = [
+			BTC_MAINNET_TOKEN,
+			ETHEREUM_TOKEN,
+			ICP_TOKEN,
+			SOLANA_TOKEN,
+			USDC_TOKEN,
+			BONK_TOKEN
+		].map((token) => ({
+			...token,
+			enabled: Math.random() > 0.5
+		}));
 
 		const params = {
 			tokens,
@@ -72,6 +94,24 @@ describe('manage-tokens.services', () => {
 			await new Promise((resolve) => setTimeout(resolve, 750));
 
 			expect(mockOnSuccess).toHaveBeenCalledOnce();
+
+			expect(trackEvent).toHaveBeenCalledTimes(tokens.length);
+
+			tokens.forEach((token, index) => {
+				expect(trackEvent).toHaveBeenNthCalledWith(index + 1, {
+					name: token.enabled
+						? TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS
+						: TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS,
+					metadata: {
+						address: 'address' in token ? token.address : undefined,
+						ledgerCanisterId: 'ledgerCanisterId' in token ? token.ledgerCanisterId : undefined,
+						indexCanisterId: 'indexCanisterId' in token ? token.indexCanisterId : undefined,
+						tokenId: token.id?.description,
+						tokenSymbol: token.symbol,
+						networkId: token.network?.id.description
+					}
+				});
+			});
 		});
 
 		it('should handle errors from save', async () => {
@@ -86,6 +126,12 @@ describe('manage-tokens.services', () => {
 				err: new Error('Save failed')
 			});
 			expect(mockOnError).toHaveBeenCalledOnce();
+
+			expect(trackEvent).toHaveBeenCalledOnce();
+			expect(trackEvent).toHaveBeenNthCalledWith(1, {
+				name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
+				metadata: { error: 'Error: Save failed' }
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

It is useful to know which tokens are included and which ones are disabled by the users. So that we can have static metadata for them (or remove them) and improve performance.
