### PR TITLE
feat(frontend): implement Tabs component

### DIFF
--- a/src/frontend/src/lib/components/ui/Tabs.svelte
+++ b/src/frontend/src/lib/components/ui/Tabs.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { NonEmptyArray } from '$lib/types/utils';
+
+	interface Props {
+		tabs: NonEmptyArray<{ label: string; id: string }>;
+		activeTab: string;
+		children: Snippet;
+		styleClass?: string;
+	}
+
+	let { children, activeTab = $bindable(), tabs, styleClass }: Props = $props();
+</script>
+
+<div class={`flex ${styleClass ?? ''}`}>
+	{#each tabs as { label, id }, index (id)}
+		<button
+			onclick={() => (activeTab = id)}
+			aria-label={label}
+			class="w-full justify-center rounded-none border-0 border-b-2 p-2 text-sm font-semibold transition hover:border-brand-primary hover:text-brand-primary sm:text-base"
+			class:ml-4={index !== 0}
+			class:text-tertiary-inverted={activeTab !== id}
+			class:border-primary={activeTab !== id}
+			class:text-brand-primary={activeTab === id}
+			class:border-brand-primary={activeTab === id}
+		>
+			{label}
+		</button>
+	{/each}
+</div>
+
+<div class="mt-6">
+	{@render children()}
+</div>

--- a/src/frontend/src/tests/lib/components/ui/Tabs.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Tabs.spec.ts
@@ -1,0 +1,22 @@
+import Tabs from '$lib/components/ui/Tabs.svelte';
+import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { render } from '@testing-library/svelte';
+
+describe('Tabs', () => {
+	const props = {
+		activeTab: 'test1',
+		tabs: [
+			{ label: 'Test 1', id: 'test1' },
+			{ label: 'Test 2', id: 'test2' }
+		],
+		children: createMockSnippet('snippet')
+	};
+
+	it('renders component correctly', () => {
+		const { getByText, getByTestId } = render(Tabs, { props });
+
+		expect(getByText(props.tabs[0].label)).toBeInTheDocument();
+		expect(getByText(props.tabs[1].label)).toBeInTheDocument();
+		expect(getByTestId('snippet')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

To implement the update design for the SendDestinationWizardStep, we need to create a new component - `Tabs`.

<img width="550" alt="Screenshot 2025-05-27 at 10 43 24" src="https://github.com/user-attachments/assets/6be6fd5b-d1a3-4ee4-8060-ee5de69804ab" />

<img width="555" alt="Screenshot 2025-05-27 at 10 43 18" src="https://github.com/user-attachments/assets/4ebde97a-4c50-4577-b421-8f928b0261ed" />
