### PR TITLE
feat(frontend): SendDestinationsTabs component and related updates

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -31,12 +31,8 @@
 	);
 </script>
 
-{#if nonNullish(knownDestinations) && filteredKnownDestinations.length > 0}
-	<div class="mb-2 mt-8" in:fade>
-		<div class="mb-2 font-bold">
-			{$i18n.send.text.recently_used}
-		</div>
-
+<div in:fade>
+	{#if nonNullish(knownDestinations) && filteredKnownDestinations.length > 0}
 		<div class="flex flex-col overflow-y-hidden sm:max-h-[13.5rem]">
 			<ul class="list-none overflow-y-auto overscroll-contain">
 				{#each filteredKnownDestinations as { address, ...rest } (address)}
@@ -53,10 +49,10 @@
 				{/each}
 			</ul>
 		</div>
-	</div>
-{:else}
-	<EmptyState
-		title={$i18n.send.text.recently_used_empty_state_title}
-		description={$i18n.send.text.recently_used_empty_state_description}
-	/>
-{/if}
+	{:else}
+		<EmptyState
+			title={$i18n.send.text.recently_used_empty_state_title}
+			description={$i18n.send.text.recently_used_empty_state_description}
+		/>
+	{/if}
+</div>

--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	// TODO: display filtered contacts in this component
+</script>
+
+<EmptyState
+	title={$i18n.send.text.contacts_empty_state_title}
+	description={$i18n.send.text.contacts_empty_state_description}
+/>

--- a/src/frontend/src/lib/components/send/SendDestinationTabs.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationTabs.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import KnownDestinationsComponent from '$lib/components/send/KnownDestinations.svelte';
+	import SendContacts from '$lib/components/send/SendContacts.svelte';
+	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { KnownDestinations } from '$lib/types/transactions';
+
+	interface Props {
+		knownDestinations?: KnownDestinations;
+		destination: string;
+	}
+
+	let { knownDestinations, destination = $bindable() }: Props = $props();
+
+	let activeTab = $derived<'recentlyUsed' | 'contacts'>('recentlyUsed');
+</script>
+
+<div class="my-6">
+	<Tabs
+		bind:activeTab
+		tabs={[
+			{ label: $i18n.send.text.recently_used_tab, id: 'recentlyUsed' },
+			{ label: $i18n.send.text.contacts_tab, id: 'contacts' }
+		]}
+	>
+		{#if activeTab === 'recentlyUsed'}
+			<KnownDestinationsComponent {knownDestinations} bind:destination on:icNext />
+		{:else if activeTab === 'contacts'}
+			<SendContacts />
+		{/if}
+	</Tabs>
+</div>

--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -9,7 +9,7 @@
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
 	import { icKnownDestinations } from '$icp/derived/ic-transactions.derived';
 	import CkEthLoader from '$icp-eth/components/core/CkEthLoader.svelte';
-	import KnownDestinationsComponent from '$lib/components/send/KnownDestinations.svelte';
+	import SendDestinationTabs from '$lib/components/send/SendDestinationTabs.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -65,7 +65,7 @@
 						bind:invalidDestination
 						on:icQRCodeScan
 					/>
-					<KnownDestinationsComponent
+					<SendDestinationTabs
 						knownDestinations={$ethKnownDestinations}
 						bind:destination
 						on:icNext={next}
@@ -82,7 +82,7 @@
 				bind:invalidDestination
 				on:icQRCodeScan
 			/>
-			<KnownDestinationsComponent
+			<SendDestinationTabs
 				knownDestinations={$icKnownDestinations}
 				bind:destination
 				on:icNext={next}
@@ -96,7 +96,7 @@
 				on:icQRCodeScan
 				knownDestinations={$btcKnownDestinations}
 			/>
-			<KnownDestinationsComponent
+			<SendDestinationTabs
 				knownDestinations={$btcKnownDestinations}
 				bind:destination
 				on:icNext={next}
@@ -110,7 +110,7 @@
 				on:icQRCodeScan
 				knownDestinations={$solKnownDestinations}
 			/>
-			<KnownDestinationsComponent
+			<SendDestinationTabs
 				knownDestinations={$solKnownDestinations}
 				bind:destination
 				on:icNext={next}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -463,9 +463,12 @@
 			"select_token": "Select token to send",
 			"select_network_filter": "Select network filter",
 			"send_again": "Send again",
-			"recently_used": "Recently used",
+			"recently_used_tab": "Recently Used",
+			"contacts_tab": "Contacts",
 			"recently_used_empty_state_title": "Recently used addresses will appear here",
-			"recently_used_empty_state_description": "Make your first send now!"
+			"recently_used_empty_state_description": "Make your first send now!",
+			"contacts_empty_state_title": "Your contacts will appear here",
+			"contacts_empty_state_description": "It looks like you haven’t added contacts yet"
 		},
 		"placeholder": {
 			"enter_eth_address": "Enter public address (0x)",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -435,9 +435,12 @@ interface I18nSend {
 		select_token: string;
 		select_network_filter: string;
 		send_again: string;
-		recently_used: string;
+		recently_used_tab: string;
+		contacts_tab: string;
 		recently_used_empty_state_title: string;
 		recently_used_empty_state_description: string;
+		contacts_empty_state_title: string;
+		contacts_empty_state_description: string;
 	};
 	placeholder: {
 		enter_eth_address: string;

--- a/src/frontend/src/tests/lib/components/send/KnownDestinations.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/KnownDestinations.spec.ts
@@ -1,34 +1,13 @@
-import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
-import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
-import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import KnownDestinations from '$lib/components/send/KnownDestinations.svelte';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
+import { knownDestinations } from '$tests/mocks/transactions.mock';
 import { render } from '@testing-library/svelte';
-import { expect } from 'vitest';
 
 describe('KnownDestinations', () => {
-	const knownDestinations = {
-		[mockBtcAddress]: {
-			amounts: [{ value: 10000000n, token: BTC_MAINNET_TOKEN }],
-			timestamp: 1671234567890,
-			address: mockBtcAddress
-		},
-		[mockEthAddress]: {
-			amounts: [{ value: 10000000n, token: ETHEREUM_TOKEN }],
-			timestamp: 1671234567890,
-			address: mockEthAddress
-		},
-		[mockSolAddress]: {
-			amounts: [{ value: 10000000n, token: SOLANA_TOKEN }],
-			timestamp: 1671234567890,
-			address: mockSolAddress
-		}
-	};
-
 	it('renders content if data is provided', () => {
 		const { getByText } = render(KnownDestinations, {
 			props: {
@@ -36,8 +15,6 @@ describe('KnownDestinations', () => {
 				knownDestinations
 			}
 		});
-
-		expect(getByText(en.send.text.recently_used)).toBeInTheDocument();
 
 		expect(getByText(shortenWithMiddleEllipsis({ text: mockBtcAddress }))).toBeInTheDocument();
 		expect(getByText(shortenWithMiddleEllipsis({ text: mockEthAddress }))).toBeInTheDocument();
@@ -52,8 +29,6 @@ describe('KnownDestinations', () => {
 			}
 		});
 
-		expect(getByText(en.send.text.recently_used)).toBeInTheDocument();
-
 		expect(getByText(shortenWithMiddleEllipsis({ text: mockBtcAddress }))).toBeInTheDocument();
 		expect(() => getByText(shortenWithMiddleEllipsis({ text: mockEthAddress }))).toThrow();
 		expect(() => getByText(shortenWithMiddleEllipsis({ text: mockSolAddress }))).toThrow();
@@ -66,7 +41,6 @@ describe('KnownDestinations', () => {
 			}
 		});
 
-		expect(() => getByText(en.send.text.recently_used)).toThrow();
 		expect(getByText(en.send.text.recently_used_empty_state_title)).toBeInTheDocument();
 		expect(getByText(en.send.text.recently_used_empty_state_description)).toBeInTheDocument();
 	});

--- a/src/frontend/src/tests/lib/components/send/SendDestinationTabs.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendDestinationTabs.spec.ts
@@ -1,0 +1,21 @@
+import SendDestinationTabs from '$lib/components/send/SendDestinationTabs.svelte';
+import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+import { knownDestinations } from '$tests/mocks/transactions.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SendDestinationTabs', () => {
+	it('renders known destinations tab by default', () => {
+		const { getByText } = render(SendDestinationTabs, {
+			props: {
+				destination: '',
+				knownDestinations
+			}
+		});
+
+		Object.keys(knownDestinations).forEach((address) => {
+			expect(getByText(shortenWithMiddleEllipsis({ text: address }))).toBeInTheDocument();
+		});
+	});
+
+	// TODO: add test for contacts tab when it's implemented
+});

--- a/src/frontend/src/tests/mocks/transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/transactions.mock.ts
@@ -1,4 +1,10 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import type { AnyTransactionUiWithCmp } from '$lib/types/transaction';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
 
 export const createTransactionsUiWithCmp = (n: number): AnyTransactionUiWithCmp[] =>
 	Array.from({ length: n }, (_, i) => ({
@@ -13,3 +19,21 @@ export const createTransactionsUiWithCmp = (n: number): AnyTransactionUiWithCmp[
 		},
 		component: 'ic'
 	}));
+
+export const knownDestinations = {
+	[mockBtcAddress]: {
+		amounts: [{ value: 10000000n, token: BTC_MAINNET_TOKEN }],
+		timestamp: 1671234567890,
+		address: mockBtcAddress
+	},
+	[mockEthAddress]: {
+		amounts: [{ value: 10000000n, token: ETHEREUM_TOKEN }],
+		timestamp: 1671234567890,
+		address: mockEthAddress
+	},
+	[mockSolAddress]: {
+		amounts: [{ value: 10000000n, token: SOLANA_TOKEN }],
+		timestamp: 1671234567890,
+		address: mockSolAddress
+	}
+};


### PR DESCRIPTION
# Motivation

We continue extending the SendDestinationWizardStep by introducing `SendDestinationsTabs`.
<img width="575" alt="Screenshot 2025-05-27 at 12 45 03" src="https://github.com/user-attachments/assets/5ee479c3-3c97-4a29-8db9-83e24c823713" />
<img width="592" alt="Screenshot 2025-05-27 at 12 45 08" src="https://github.com/user-attachments/assets/b1332ce7-ade3-4365-90e9-92174fa372a7" />
