### PR TITLE
feat(frontend): Add missing implementation for Icrcv2 token account id to address string

### DIFF
--- a/src/frontend/src/lib/utils/token-account-id.utils.ts
+++ b/src/frontend/src/lib/utils/token-account-id.utils.ts
@@ -1,5 +1,6 @@
 import { getBtcAddressString } from '$btc/utils/btc-address.utils';
 import type { TokenAccountId } from '$declarations/backend/backend.did';
+import { getIcrcv2AccountIdString } from '$icp/utils/icp-account.utils';
 import { TOKEN_ACCOUNT_ID_TO_NETWORKS } from '$lib/constants/token-account-id.constants';
 import type { Network } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
@@ -13,8 +14,7 @@ export const getTokenAccountIdAddressString = (tokenAccountId: TokenAccountId): 
 		return tokenAccountId.Eth.Public;
 	}
 	if ('Icrcv2' in tokenAccountId) {
-		// TODO PR: https://github.com/dfinity/oisy-wallet/pull/6716
-		throw new Error('Not implemented yet');
+		return getIcrcv2AccountIdString(tokenAccountId.Icrcv2);
 	}
 	if ('Sol' in tokenAccountId) {
 		return tokenAccountId.Sol;

--- a/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-account-id.utils.spec.ts
@@ -37,6 +37,34 @@ describe('token-account-id.utils', () => {
 			expect(result).toEqual(solAddressStr);
 		});
 
+		it('should extract address string from Icrcv2 token account ID with ICP account identifier', () => {
+			const icpAccountId = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+			const tokenAccountId = TokenAccountIdSchema.parse(icpAccountId);
+
+			const result = getTokenAccountIdAddressString(tokenAccountId);
+
+			expect(result).toEqual(icpAccountId);
+		});
+
+		it('should extract address string from Icrcv2 token account ID with principal only', () => {
+			const principal = 'rrkah-fqaaa-aaaaa-aaaaq-cai';
+			const tokenAccountId = TokenAccountIdSchema.parse(principal);
+
+			const result = getTokenAccountIdAddressString(tokenAccountId);
+
+			expect(result).toEqual(principal);
+		});
+
+		it('should extract address string from Icrcv2 token account ID with principal and subaccount', () => {
+			const icrcAccount =
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1';
+			const tokenAccountId = TokenAccountIdSchema.parse(icrcAccount);
+
+			const result = getTokenAccountIdAddressString(tokenAccountId);
+
+			expect(result).toEqual(icrcAccount);
+		});
+
 		it('should throw an error for invalid token account ID types', () => {
 			// Create an empty object that doesn't match any valid TokenAccountId type
 			const invalidTokenAccountId = {} as TokenAccountId;
@@ -71,6 +99,34 @@ describe('token-account-id.utils', () => {
 			const result = getTokenAccountIdAddressString(tokenAccountId);
 
 			expect(result).toEqual(solAddressStr);
+		});
+
+		it('should handle Icrcv2 token account ID with ICP account identifier in a roundtrip conversion', () => {
+			const icpAccountId = '6c04faf793b42b156206f805d13ba1b3b697ec18f519e6a11484eed091859d5a';
+			const tokenAccountId = TokenAccountIdSchema.parse(icpAccountId);
+
+			const result = getTokenAccountIdAddressString(tokenAccountId);
+
+			expect(result).toEqual(icpAccountId);
+		});
+
+		it('should handle Icrcv2 token account ID with principal only in a roundtrip conversion', () => {
+			const principal = 'rrkah-fqaaa-aaaaa-aaaaq-cai';
+			const tokenAccountId = TokenAccountIdSchema.parse(principal);
+
+			const result = getTokenAccountIdAddressString(tokenAccountId);
+
+			expect(result).toEqual(principal);
+		});
+
+		it('should handle Icrcv2 token account ID with principal and subaccount in a roundtrip conversion', () => {
+			const icrcAccount =
+				'k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1';
+			const tokenAccountId = TokenAccountIdSchema.parse(icrcAccount);
+
+			const result = getTokenAccountIdAddressString(tokenAccountId);
+
+			expect(result).toEqual(icrcAccount);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

In order to serialize Icrcv2 Addresses to strings, this PR adds the missing functionality to the `getTokenAccountIdAddressString` method.


# Changes

- Completes getTokenAccountIdAddressString implementation

# Tests

- Adds test to verify serialization to string
- Adds test to ensure parsing and serialization leads to original string