### PR TITLE
refactor(frontend): SOL Transaction details

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -1,71 +1,203 @@
 <script lang="ts">
+	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import type { Commitment } from '@solana/kit';
-	import TransactionModal from '$lib/components/transactions/TransactionModal.svelte';
-	import Value from '$lib/components/ui/Value.svelte';
+	import List from '$lib/components/common/List.svelte';
+	import ListItem from '$lib/components/common/ListItem.svelte';
+	import ModalHero from '$lib/components/common/ModalHero.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import TransactionAddressActions from '$lib/components/transactions/TransactionAddressActions.svelte';
+	import TransactionContactCard from '$lib/components/transactions/TransactionContactCard.svelte';
+	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionToken } from '$lib/types/token';
+	import {
+		formatSecondsToDate,
+		formatToken,
+		shortenWithMiddleEllipsis
+	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkSolana } from '$lib/utils/network.utils';
-	import type { SolTransactionType, SolTransactionUi } from '$sol/types/sol-transaction';
+	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 
-	export let transaction: SolTransactionUi;
-	export let token: OptionToken;
+	interface Props {
+		transaction: SolTransactionUi;
+		token: OptionToken;
+	}
 
-	let from: string;
-	let to: string | undefined;
-	let type: SolTransactionType;
-	let value: bigint | undefined;
-	let timestamp: bigint | undefined;
-	let id: string;
-	let status: Commitment | null;
+	const { transaction, token }: Props = $props();
 
-	let explorerUrl: string | undefined;
-	$: explorerUrl = isNetworkSolana(token?.network) ? token.network.explorerUrl : undefined;
+	let {
+		from,
+		value,
+		timestamp,
+		signature: id,
+		blockNumber,
+		to,
+		type,
+		status
+	} = $derived(transaction);
 
-	$: ({ from, value, timestamp, signature: id, blockNumber, to, type, status } = transaction);
+	let explorerUrl: string | undefined = $derived(
+		isNetworkSolana(token?.network) ? token.network.explorerUrl : undefined
+	);
 
-	let txExplorerUrl: string | undefined;
-	$: txExplorerUrl = nonNullish(explorerUrl)
-		? replacePlaceholders(explorerUrl, { $args: `tx/${id}/` })
-		: undefined;
+	let txExplorerUrl: string | undefined = $derived(
+		nonNullish(explorerUrl) ? replacePlaceholders(explorerUrl, { $args: `tx/${id}/` }) : undefined
+	);
 
-	let toExplorerUrl: string | undefined;
-	$: toExplorerUrl = nonNullish(explorerUrl)
-		? replacePlaceholders(explorerUrl, { $args: `account/${to}/` })
-		: undefined;
+	let toExplorerUrl: string | undefined = $derived(
+		nonNullish(explorerUrl)
+			? replacePlaceholders(explorerUrl, { $args: `account/${to}/` })
+			: undefined
+	);
 
-	let fromExplorerUrl: string | undefined;
-	$: fromExplorerUrl = nonNullish(explorerUrl)
-		? replacePlaceholders(explorerUrl, { $args: `account/${from}/` })
-		: undefined;
+	let fromExplorerUrl: string | undefined = $derived(
+		nonNullish(explorerUrl)
+			? replacePlaceholders(explorerUrl, { $args: `account/${from}/` })
+			: undefined
+	);
 </script>
 
-<TransactionModal
-	commonData={{
-		to,
-		from,
-		timestamp,
-		blockNumber,
-		txExplorerUrl,
-		toExplorerUrl,
-		fromExplorerUrl
-	}}
-	hash={id}
-	{value}
-	{token}
-	sendToLabel={$i18n.transaction.text.to}
-	typeLabel={type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}
->
-	<Value ref="status" slot="transaction-status">
-		{#snippet label()}
-			{$i18n.transaction.text.status}
-		{/snippet}
+<Modal on:nnsClose={modalStore.close}>
+	<svelte:fragment slot="title">{$i18n.transaction.text.details}</svelte:fragment>
 
-		{#snippet content()}
-			{#if nonNullish(status)}
-				{`${$i18n.transaction.status[status]}`}
+	<ContentWithToolbar>
+		<ModalHero variant={type === 'receive' ? 'success' : 'default'}>
+			{#snippet logo()}
+				{#if nonNullish(token)}
+					<TokenLogo logoSize="lg" data={token} badge={{ type: 'network' }} />
+				{/if}
+			{/snippet}
+			{#snippet subtitle()}
+				<span class="capitalize">{type}</span>
+			{/snippet}
+			{#snippet title()}
+				{#if nonNullish(token) && nonNullish(value)}
+					<output class:text-success-primary={type === 'receive'}>
+						{formatToken({
+							value,
+							unitName: token.decimals,
+							displayDecimals: token.decimals,
+							showPlusSign: type === 'receive'
+						})}
+						{token.symbol}
+					</output>
+				{:else}
+					&ZeroWidthSpace;
+				{/if}
+			{/snippet}
+		</ModalHero>
+
+		{#if nonNullish(to) && nonNullish(from)}
+			<TransactionContactCard
+				type={type === 'receive' ? 'receive' : 'send'}
+				{to}
+				{from}
+				{toExplorerUrl}
+				{fromExplorerUrl}
+			/>
+		{/if}
+
+		<List styleClass="mt-5">
+			{#if type === 'receive' && nonNullish(to)}
+				<ListItem>
+					<span>{$i18n.transaction.text.to}</span>
+					<output class="flex max-w-[50%] flex-row">
+						<output>{shortenWithMiddleEllipsis({ text: to })}</output>
+
+						<TransactionAddressActions
+							copyAddress={to}
+							copyAddressText={$i18n.transaction.text.to_copied}
+							explorerUrl={toExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
+						/>
+					</output>
+				</ListItem>
 			{/if}
-		{/snippet}
-	</Value>
-</TransactionModal>
+			{#if type === 'send' && nonNullish(from)}
+				<ListItem>
+					<span>{$i18n.transaction.text.from}</span>
+					<output class="flex max-w-[50%] flex-row">
+						<output>{shortenWithMiddleEllipsis({ text: from })}</output>
+						<TransactionAddressActions
+							copyAddress={from}
+							copyAddressText={$i18n.transaction.text.from_copied}
+							explorerUrl={fromExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
+						/>
+					</output>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(id)}
+				<ListItem>
+					<span>
+						{$i18n.transaction.text.hash}
+					</span>
+
+					<span>
+						<output>{shortenWithMiddleEllipsis({ text: id })}</output>
+						<TransactionAddressActions
+							copyAddress={id}
+							copyAddressText={replacePlaceholders($i18n.transaction.text.hash_copied, {
+								$hash: id
+							})}
+							explorerUrl={txExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_block_explorer}
+						/>
+					</span>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(blockNumber)}
+				<ListItem>
+					<span>
+						{$i18n.transaction.text.block}
+					</span>
+
+					<output>{blockNumber}</output>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(status)}
+				<ListItem>
+					<span>
+						{$i18n.transaction.text.status}
+					</span>
+					<span>
+						{`${$i18n.transaction.status[status]}`}
+					</span>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(timestamp)}
+				<ListItem>
+					<span>
+						{$i18n.transaction.text.timestamp}
+					</span>
+
+					<output>{formatSecondsToDate(Number(timestamp))}</output>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(value) && nonNullish(token)}
+				<ListItem>
+					<span>{$i18n.core.text.amount}</span>
+
+					<output>
+						{formatToken({
+							value,
+							unitName: token.decimals,
+							displayDecimals: token.decimals
+						})}
+						{token.symbol}
+					</output>
+				</ListItem>
+			{/if}
+		</List>
+
+		<ButtonCloseModal slot="toolbar" />
+	</ContentWithToolbar>
+</Modal>

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -1,0 +1,57 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import IcTransactionModal from '$icp/components/transactions/IcTransactionModal.svelte';
+import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
+import { render } from '@testing-library/svelte';
+
+const mockIcTransactionUi = createMockIcTransactionsUi(1)[0];
+
+describe('IcTransactionModal', () => {
+	it('should render the IC transaction modal', () => {
+		const { getByText } = render(IcTransactionModal, {
+			transaction: mockIcTransactionUi,
+			token: ICP_TOKEN
+		});
+
+		expect(getByText('send')).toBeInTheDocument();
+	});
+
+	it('should display correct amount and currency', () => {
+		const { getByText } = render(IcTransactionModal, {
+			transaction: mockIcTransactionUi,
+			token: ICP_TOKEN
+		});
+
+		const formattedAmount = `${formatToken({
+			value: mockIcTransactionUi.value ?? 0n,
+			unitName: ICP_TOKEN.decimals,
+			displayDecimals: ICP_TOKEN.decimals
+		})} ${ICP_TOKEN.symbol}`;
+
+		expect(getByText(formattedAmount)).toBeInTheDocument();
+	});
+
+	it('should display correct to and from addresses for receive', () => {
+		const { getByText } = render(IcTransactionModal, {
+			transaction: mockIcTransactionUi,
+			token: ICP_TOKEN
+		});
+
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockIcTransactionUi.from as string }))
+		).toBeInTheDocument();
+
+		expect(getByText(mockIcTransactionUi.to as string)).toBeInTheDocument();
+	});
+
+	it('should display tx id', () => {
+		const { getByText } = render(IcTransactionModal, {
+			transaction: mockIcTransactionUi,
+			token: ICP_TOKEN
+		});
+
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockIcTransactionUi.id }))
+		).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -1,57 +1,77 @@
-import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import IcTransactionModal from '$icp/components/transactions/IcTransactionModal.svelte';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { i18n } from '$lib/stores/i18n.store';
 import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
+import SolTransactionModal from '$sol/components/transactions/SolTransactionModal.svelte';
+import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
+import { capitalizeFirstLetter } from '$tests/utils/string-utils';
 import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 
-const mockIcTransactionUi = createMockIcTransactionsUi(1)[0];
+const [mockSolTransactionUi] = createMockSolTransactionsUi(1);
 
-describe('IcTransactionModal', () => {
-	it('should render the IC transaction modal', () => {
-		const { getByText } = render(IcTransactionModal, {
-			transaction: mockIcTransactionUi,
-			token: ICP_TOKEN
+describe('SolTransactionModal', () => {
+	it('should render the SOL transaction modal', () => {
+		const { getByText } = render(SolTransactionModal, {
+			transaction: mockSolTransactionUi,
+			token: SOLANA_TOKEN
 		});
 
 		expect(getByText('send')).toBeInTheDocument();
 	});
 
 	it('should display correct amount and currency', () => {
-		const { getByText } = render(IcTransactionModal, {
-			transaction: mockIcTransactionUi,
-			token: ICP_TOKEN
+		const { getAllByText } = render(SolTransactionModal, {
+			transaction: mockSolTransactionUi,
+			token: SOLANA_TOKEN
 		});
 
 		const formattedAmount = `${formatToken({
-			value: mockIcTransactionUi.value ?? 0n,
-			unitName: ICP_TOKEN.decimals,
-			displayDecimals: ICP_TOKEN.decimals
-		})} ${ICP_TOKEN.symbol}`;
+			value: mockSolTransactionUi.value ?? 0n,
+			unitName: SOLANA_TOKEN.decimals,
+			displayDecimals: SOLANA_TOKEN.decimals
+		})} ${SOLANA_TOKEN.symbol}`;
 
-		expect(getByText(formattedAmount)).toBeInTheDocument();
+		expect(getAllByText(formattedAmount)[0]).toBeInTheDocument();
 	});
 
-	it('should display correct to and from addresses for receive', () => {
-		const { getByText } = render(IcTransactionModal, {
-			transaction: mockIcTransactionUi,
-			token: ICP_TOKEN
+	it('should display correct to and from addresses for send', () => {
+		const { getByText } = render(SolTransactionModal, {
+			transaction: mockSolTransactionUi,
+			token: SOLANA_TOKEN
 		});
 
 		expect(
-			getByText(shortenWithMiddleEllipsis({ text: mockIcTransactionUi.from as string }))
+			getByText(shortenWithMiddleEllipsis({ text: mockSolTransactionUi.from as string }))
 		).toBeInTheDocument();
 
-		expect(getByText(mockIcTransactionUi.to as string)).toBeInTheDocument();
+		expect(getByText(mockSolTransactionUi.to as string)).toBeInTheDocument();
 	});
 
-	it('should display tx id', () => {
-		const { getByText } = render(IcTransactionModal, {
-			transaction: mockIcTransactionUi,
-			token: ICP_TOKEN
+	it('should display tx status', () => {
+		const { getByText } = render(SolTransactionModal, {
+			transaction: mockSolTransactionUi,
+			token: SOLANA_TOKEN
+		});
+
+		const statusTranslation = get(i18n).transaction.status;
+
+		expect(
+			getByText(
+				capitalizeFirstLetter(
+					statusTranslation[mockSolTransactionUi.status as keyof typeof statusTranslation]
+				)
+			)
+		).toBeInTheDocument();
+	});
+
+	it('should display tx hash', () => {
+		const { getByText } = render(SolTransactionModal, {
+			transaction: mockSolTransactionUi,
+			token: SOLANA_TOKEN
 		});
 
 		expect(
-			getByText(shortenWithMiddleEllipsis({ text: mockIcTransactionUi.id }))
+			getByText(shortenWithMiddleEllipsis({ text: mockSolTransactionUi.signature }))
 		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

Were refactoring how the transaction details modal look.

# Changes

Adjusted design according to Figma

# Tests
Added tests

SOL receive:
![image](https://github.com/user-attachments/assets/c595b8a2-4179-4f02-a5a3-98847fe01582)

SOL send:
![image](https://github.com/user-attachments/assets/d18a2a29-8714-40b6-8c9f-6ad09414565a)
