### PR TITLE
refactor(frontend): ETH Transaction details

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -9,11 +9,14 @@
 	import { mapAddressToName } from '$eth/utils/transactions.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
+	import List from '$lib/components/common/List.svelte';
+	import ListItem from '$lib/components/common/ListItem.svelte';
+	import ModalHero from '$lib/components/common/ModalHero.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import TransactionAddressActions from '$lib/components/transactions/TransactionAddressActions.svelte';
+	import TransactionContactCard from '$lib/components/transactions/TransactionContactCard.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Copy from '$lib/components/ui/Copy.svelte';
-	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
-	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionString } from '$lib/types/string';
@@ -26,45 +29,43 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkIdSepolia } from '$lib/utils/network.utils';
 
-	export let transaction: EthTransactionUi;
-	export let token: OptionToken;
+	interface Props {
+		transaction: EthTransactionUi;
+		token: OptionToken;
+	}
 
-	let from: string;
-	let to: string | undefined;
-	let value: bigint;
-	let timestamp: number | undefined;
-	let hash: string | undefined;
-	let blockNumber: number | undefined;
+	const { transaction, token }: Props = $props();
 
-	$: ({ from, value, timestamp, hash, blockNumber, to, type } = transaction);
+	let { from, value, timestamp, hash, blockNumber, to, type } = $derived(transaction);
 
-	let explorerUrl: string | undefined;
-	$: explorerUrl = notEmptyString(hash) ? `${$explorerUrlStore}/tx/${hash}` : undefined;
+	let explorerUrl: string | undefined = $derived(
+		notEmptyString(hash) ? `${$explorerUrlStore}/tx/${hash}` : undefined
+	);
 
-	let fromExplorerUrl: string;
-	$: fromExplorerUrl = `${$explorerUrlStore}/address/${from}`;
+	let fromExplorerUrl: string = $derived(`${$explorerUrlStore}/address/${from}`);
 
-	let toExplorerUrl: string | undefined;
-	$: toExplorerUrl = notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined;
+	let toExplorerUrl: string | undefined = $derived(
+		notEmptyString(to) ? `${$explorerUrlStore}/address/${to}` : undefined
+	);
 
-	let ckMinterInfo: OptionCertifiedMinterInfo;
-	$: ckMinterInfo =
+	let ckMinterInfo: OptionCertifiedMinterInfo = $derived(
 		$ckEthMinterInfoStore?.[
 			isNetworkIdSepolia(token?.network.id) ? SEPOLIA_TOKEN_ID : ETHEREUM_TOKEN_ID
-		];
+		]
+	);
 
-	let fromDisplay: OptionString;
-	$: fromDisplay = nonNullish(token)
-		? (mapAddressToName({
-				address: from,
-				networkId: token.network.id,
-				erc20Tokens: $erc20Tokens,
-				ckMinterInfo
-			}) ?? from)
-		: from;
+	let fromDisplay: OptionString = $derived(
+		nonNullish(token)
+			? (mapAddressToName({
+					address: from,
+					networkId: token.network.id,
+					erc20Tokens: $erc20Tokens,
+					ckMinterInfo
+				}) ?? from)
+			: from
+	);
 
-	let toDisplay: OptionString;
-	$: toDisplay = nonNullish(token)
+	let toDisplay: OptionString = nonNullish(token)
 		? (mapAddressToName({
 				address: to,
 				networkId: token.network.id,
@@ -78,112 +79,148 @@
 	<svelte:fragment slot="title">{$i18n.transaction.text.details}</svelte:fragment>
 
 	<ContentWithToolbar>
-		{#if nonNullish(hash)}
-			<Value ref="hash">
-				{#snippet label()}
-					{$i18n.transaction.text.hash}
-				{/snippet}
-				{#snippet content()}
-					<output>{shortenWithMiddleEllipsis({ text: hash })}</output>
-					<Copy
-						value={hash}
-						text={replacePlaceholders($i18n.transaction.text.hash_copied, {
-							$hash: hash
-						})}
-						inline
-					/>
-					{#if nonNullish(explorerUrl)}
-						<ExternalLink
-							iconSize="18"
-							href={explorerUrl}
-							ariaLabel={$i18n.transaction.alt.open_block_explorer}
-							inline
-							color="blue"
-						/>
-					{/if}
-				{/snippet}
-			</Value>
-		{/if}
-
-		{#if nonNullish(blockNumber)}
-			<Value ref="blockNumber">
-				{#snippet label()}
-					{$i18n.transaction.text.block}
-				{/snippet}
-				{#snippet content()}
-					<output>{blockNumber}</output>
-				{/snippet}
-			</Value>
-
-			<EthTransactionStatus {blockNumber} />
-		{/if}
-
-		{#if nonNullish(timestamp)}
-			<Value ref="timestamp">
-				{#snippet label()}
-					{$i18n.transaction.text.timestamp}
-				{/snippet}
-				{#snippet content()}
-					<output>{formatSecondsToDate(timestamp)}</output>
-				{/snippet}
-			</Value>
-		{/if}
-
-		<Value ref="type">
-			{#snippet label()}
-				{$i18n.transaction.text.type}
-			{/snippet}
-			{#snippet content()}
-				{`${type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive}`}
-			{/snippet}
-		</Value>
-
-		<Value ref="from">
-			{#snippet label()}
-				{$i18n.transaction.text.from}
-			{/snippet}
-			{#snippet content()}
-				<output>{fromDisplay}</output>
-				<Copy value={from} text={$i18n.transaction.text.from_copied} inline />
-				{#if nonNullish(fromExplorerUrl)}
-					<ExternalLink
-						iconSize="18"
-						href={fromExplorerUrl}
-						ariaLabel={$i18n.transaction.alt.open_from_block_explorer}
-						inline
-						color="blue"
-					/>
+		<ModalHero variant={type === 'receive' ? 'success' : 'default'}>
+			{#snippet logo()}
+				{#if nonNullish(token)}
+					<TokenLogo logoSize="lg" data={token} badge={{ type: 'network' }} />
 				{/if}
 			{/snippet}
-		</Value>
+			{#snippet subtitle()}
+				<span class="capitalize">{type}</span>
+			{/snippet}
+			{#snippet title()}
+				{#if nonNullish(token) && nonNullish(value)}
+					<output class:text-success-primary={type === 'receive'}>
+						{formatToken({
+							value,
+							unitName: token.decimals,
+							displayDecimals: token.decimals,
+							showPlusSign: type === 'receive'
+						})}
+						{token.symbol}
+					</output>
+				{:else}
+					&ZeroWidthSpace;
+				{/if}
+			{/snippet}
+		</ModalHero>
 
-		{#if nonNullish(to) && nonNullish(toDisplay)}
-			<Value ref="to">
-				{#snippet label()}
-					{$i18n.transaction.text.interacted_with}
-				{/snippet}
-				{#snippet content()}
-					<output>{toDisplay}</output>
-					<Copy value={to} text={$i18n.transaction.text.to_copied} inline />
-					{#if nonNullish(toExplorerUrl)}
-						<ExternalLink
-							iconSize="18"
-							href={toExplorerUrl}
-							ariaLabel={$i18n.transaction.alt.open_to_block_explorer}
-							inline
-							color="blue"
-						/>
-					{/if}
-				{/snippet}
-			</Value>
+		{#if nonNullish(to) && nonNullish(from)}
+			<TransactionContactCard
+				type={type === 'receive' ? 'receive' : 'send'}
+				{to}
+				{from}
+				{toExplorerUrl}
+				{fromExplorerUrl}
+			/>
 		{/if}
 
-		{#if nonNullish(token)}
-			<Value ref="amount">
-				{#snippet label()}
-					{$i18n.core.text.amount}
-				{/snippet}
-				{#snippet content()}
+		<List styleClass="mt-5">
+			{#if type === 'receive' && nonNullish(to)}
+				<ListItem>
+					<span>{$i18n.transaction.text.to}</span>
+					<span class="flex max-w-[50%] flex-row">
+						<output>{shortenWithMiddleEllipsis({ text: to })}</output>
+
+						<TransactionAddressActions
+							copyAddress={to}
+							copyAddressText={$i18n.transaction.text.to_copied}
+							explorerUrl={toExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
+						/>
+					</span>
+				</ListItem>
+			{/if}
+			{#if type === 'send' && nonNullish(from)}
+				<ListItem>
+					<span>{$i18n.transaction.text.from}</span>
+					<output class="flex max-w-[50%] flex-row">
+						<output>{shortenWithMiddleEllipsis({ text: from })}</output>
+
+						<TransactionAddressActions
+							copyAddress={from}
+							copyAddressText={$i18n.transaction.text.from_copied}
+							explorerUrl={fromExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
+						/>
+					</output>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(hash)}
+				<ListItem>
+					<span>{$i18n.transaction.text.hash}</span>
+					<span>
+						<output>{shortenWithMiddleEllipsis({ text: hash })}</output>
+
+						<TransactionAddressActions
+							copyAddress={hash}
+							copyAddressText={replacePlaceholders($i18n.transaction.text.hash_copied, {
+								$hash: hash
+							})}
+							{explorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_block_explorer}
+						/>
+					</span>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(blockNumber)}
+				<ListItem>
+					<span>{$i18n.transaction.text.block}</span>
+					<span>
+						<output>{blockNumber}</output>
+					</span>
+				</ListItem>
+
+				<ListItem>
+					<EthTransactionStatus {blockNumber} />
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(timestamp)}
+				<ListItem>
+					<span>{$i18n.transaction.text.timestamp}</span>
+					<output>{formatSecondsToDate(timestamp)}</output>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(from) && nonNullish(fromDisplay) && from !== fromDisplay}
+				<ListItem>
+					<span>{$i18n.transaction.text.from}</span>
+					<span class="flex max-w-[50%] flex-row break-all">
+						<output>{fromDisplay}</output>
+
+						<TransactionAddressActions
+							copyAddress={fromDisplay}
+							copyAddressText={$i18n.transaction.text.from_copied}
+							explorerUrl={fromExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
+						/>
+					</span>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(to) && nonNullish(toDisplay) && to !== toDisplay}
+				<ListItem>
+					<span>{$i18n.transaction.text.interacted_with}</span>
+
+					<span class="flex max-w-[50%] flex-row break-all">
+						<output>{toDisplay}</output>
+
+						<TransactionAddressActions
+							copyAddress={toDisplay}
+							copyAddressText={$i18n.transaction.text.to_copied}
+							explorerUrl={toExplorerUrl}
+							explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
+						/>
+					</span>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(token)}
+				<ListItem>
+					<span>{$i18n.core.text.amount}</span>
 					<output>
 						{formatToken({
 							value,
@@ -192,9 +229,9 @@
 						})}
 						{token.symbol}
 					</output>
-				{/snippet}
-			</Value>
-		{/if}
+				</ListItem>
+			{/if}
+		</List>
 
 		<ButtonCloseModal slot="toolbar" />
 	</ContentWithToolbar>

--- a/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
@@ -75,12 +75,12 @@
 	})();
 </script>
 
-<label for="to" class="font-bold">{$i18n.transaction.text.status}:</label>
+<label for="to">{$i18n.transaction.text.status}</label>
 
-<p id="to" class="mb-4 break-all font-normal first-letter:capitalize">
+<span id="to" class="break-all font-normal first-letter:capitalize">
 	{#if nonNullish(status)}
 		<span in:fade>{$i18n.transaction.status[status]}</span>
 	{:else}
 		<span style="visibility: hidden; opacity: 0">&nbsp;</span>
 	{/if}
-</p>
+</span>

--- a/src/frontend/src/tests/eth/components/transactions/EthTransactionModal.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransactionModal.spec.ts
@@ -1,0 +1,66 @@
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import EthTransactionModal from '$eth/components/transactions/EthTransactionModal.svelte';
+import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+import { createMockEthTransactionsUi } from '$tests/mocks/eth-transactions.mock';
+import { render } from '@testing-library/svelte';
+
+const [mockEthTransactionUi] = createMockEthTransactionsUi(1);
+
+describe('EthTransactionModal', () => {
+	it('should render the SOL transaction modal', () => {
+		const { getByText } = render(EthTransactionModal, {
+			transaction: mockEthTransactionUi,
+			token: ETHEREUM_TOKEN
+		});
+
+		expect(getByText('send')).toBeInTheDocument();
+	});
+
+	it('should display correct amount and currency', () => {
+		const { getAllByText } = render(EthTransactionModal, {
+			transaction: mockEthTransactionUi,
+			token: ETHEREUM_TOKEN
+		});
+
+		const formattedAmount = `${formatToken({
+			value: mockEthTransactionUi.value ?? 0n,
+			unitName: ETHEREUM_TOKEN.decimals,
+			displayDecimals: ETHEREUM_TOKEN.decimals
+		})} ${ETHEREUM_TOKEN.symbol}`;
+
+		expect(getAllByText(formattedAmount)[0]).toBeInTheDocument();
+	});
+
+	it('should display correct to and from addresses for send', () => {
+		const { getByText } = render(EthTransactionModal, {
+			transaction: mockEthTransactionUi,
+			token: ETHEREUM_TOKEN
+		});
+
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockEthTransactionUi.from as string }))
+		).toBeInTheDocument();
+
+		expect(getByText(mockEthTransactionUi.to as string)).toBeInTheDocument();
+	});
+
+	it('should display tx block number', () => {
+		const { getByText } = render(EthTransactionModal, {
+			transaction: mockEthTransactionUi,
+			token: ETHEREUM_TOKEN
+		});
+
+		expect(getByText(mockEthTransactionUi.blockNumber as number)).toBeInTheDocument();
+	});
+
+	it('should display tx hash', () => {
+		const { getByText } = render(EthTransactionModal, {
+			transaction: mockEthTransactionUi,
+			token: ETHEREUM_TOKEN
+		});
+
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockEthTransactionUi.hash as string }))
+		).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/eth/components/transactions/EthTransactionModal.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransactionModal.spec.ts
@@ -7,7 +7,7 @@ import { render } from '@testing-library/svelte';
 const [mockEthTransactionUi] = createMockEthTransactionsUi(1);
 
 describe('EthTransactionModal', () => {
-	it('should render the SOL transaction modal', () => {
+	it('should render the ETH transaction modal', () => {
 		const { getByText } = render(EthTransactionModal, {
 			transaction: mockEthTransactionUi,
 			token: ETHEREUM_TOKEN


### PR DESCRIPTION
# Motivation

Were refactoring how the transaction details modal look.

# Changes

Adjusted design according to Figma

# Tests
Added tests

ETH receive:
![image](https://github.com/user-attachments/assets/2983a229-1b40-47d3-ab4b-fd6a8b96dcd0)

ETH send:
![image](https://github.com/user-attachments/assets/a77a18d3-754b-420b-9660-cfac7f717c65)
