### PR TITLE
feat(frontend): use Avatar component in SendDestination

### DIFF
--- a/src/frontend/src/lib/components/send/SendDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendDestination.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 	import AddressCard from '$lib/components/address/AddressCard.svelte';
+	import AvatarWithBadge from '$lib/components/contact/AvatarWithBadge.svelte';
 	import IconPenLine from '$lib/components/icons/IconPenLine.svelte';
-	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import { SEND_DESTINATION_SECTION } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
 	interface Props {
 		destination: string;
@@ -15,8 +15,6 @@
 
 	const dispatch = createEventDispatcher();
 
-	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
-
 	const onIcSendDestinationStep = () => dispatch('icSendDestinationStep');
 </script>
 
@@ -25,11 +23,11 @@
 
 	<AddressCard hasError={invalidDestination} items="center">
 		{#snippet logo()}
-			<NetworkLogo network={$sendToken.network} />
+			<div class="mr-2"><AvatarWithBadge address={destination} /></div>
 		{/snippet}
 
 		{#snippet content()}
-			{destination}
+			{shortenWithMiddleEllipsis({ text: destination })}
 		{/snippet}
 
 		{#snippet actions()}

--- a/src/frontend/src/tests/lib/components/send/SendDestination.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendDestination.spec.ts
@@ -1,6 +1,7 @@
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import SendDestination from '$lib/components/send/SendDestination.svelte';
 import { initSendContext, SEND_CONTEXT_KEY } from '$lib/stores/send.store';
+import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import { render } from '@testing-library/svelte';
 
@@ -19,6 +20,6 @@ describe('SendDestination', () => {
 			context: mockContext
 		});
 
-		expect(getByText(mockEthAddress)).toBeInTheDocument();
+		expect(getByText(shortenWithMiddleEllipsis({ text: mockEthAddress }))).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

We want to use Avatar component in SendDestination.

<img width="589" alt="Screenshot 2025-05-28 at 11 42 42" src="https://github.com/user-attachments/assets/c2ee08ed-c7bb-4d3d-9518-423a282b55ad" />
