### PR TITLE
feat(frontend): Allow closing address book with cross

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -268,7 +268,7 @@
 	{steps}
 	bind:currentStep
 	bind:this={modal}
-	disablePointerEvents={true}
+	disablePointerEvents={loading}
 	testId={ADDRESS_BOOK_MODAL}
 	on:nnsClose={close}
 >


### PR DESCRIPTION
# Motivation

Allow always to close address book wizard with the cross on top right.

# Changes

- Allow pointer events in address book

# Test

![Screenshot_2025-05-28_14-12-43](https://github.com/user-attachments/assets/8621385c-041e-4d14-9883-1208c3bc3370)
