### PR TITLE
refactor(frontend): Selectable contact card

### DIFF
--- a/src/frontend/src/lib/components/contact/ContactCard.svelte
+++ b/src/frontend/src/lib/components/contact/ContactCard.svelte
@@ -14,15 +14,18 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+	import { nonNullish } from '@dfinity/utils';
+	import Button from '$lib/components/ui/Button.svelte';
 
 	interface Props {
 		contact: ContactUi;
 		onClick: () => void;
 		onInfo: (addressIndex: number) => void;
+		onSelect?: () => void;
 		initiallyExpanded?: boolean;
 	}
 
-	let { contact, onInfo, onClick, initiallyExpanded = false }: Props = $props();
+	let { contact, onInfo, onClick, onSelect, initiallyExpanded = false }: Props = $props();
 
 	let toggleContent = $state<() => void | undefined>();
 
@@ -83,6 +86,9 @@
 						<IconExpand {expanded} />
 					{/snippet}
 				</ButtonIcon>
+			{/if}
+			{#if nonNullish(onSelect)}
+				<Button link on:click={onSelect}>{$i18n.core.text.select}</Button>
 			{/if}
 		{/snippet}
 	</LogoButton>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -29,7 +29,8 @@
 			"paste": "Paste",
 			"to": "To",
 			"add": "Add",
-			"more_items": "+$items more"
+			"more_items": "+$items more",
+			"select": "Select"
 		},
 		"info": {
 			"test_banner": "For testing purposes only!"


### PR DESCRIPTION
# Motivation

For an upcoming feature, we need to be able to select a contact, for this we add a callback prop to the contact card.

# Changes

Added `onSelect` callback to `ContactCard`

# Tests

onSelect passed:
![image](https://github.com/user-attachments/assets/9a0cea6b-717e-4494-8e38-7dcf06a2b84b)

onSelect not passed:
![image](https://github.com/user-attachments/assets/efbd32aa-b3c9-416c-a533-b2bfd0df868d)

