### PR TITLE
refactor(frontend): Address Card variant

### DIFF
--- a/src/frontend/src/lib/components/address/AddressCard.svelte
+++ b/src/frontend/src/lib/components/address/AddressCard.svelte
@@ -5,16 +5,28 @@
 		logo?: Snippet;
 		content: Snippet;
 		actions?: Snippet;
+		variant?: 'default' | 'info';
 		hasError?: boolean;
 		items?: 'start' | 'center' | 'end';
 	}
 
-	const { logo, content, actions, hasError = false, items = 'start' }: Props = $props();
+	const {
+		logo,
+		content,
+		actions,
+		variant = 'default',
+		hasError = false,
+		items = 'start'
+	}: Props = $props();
 </script>
 
 <div
 	class={`flex rounded-lg border border-disabled bg-secondary px-2 py-3 items-${items}`}
 	class:border-error-solid={hasError}
+	class:bg-secondary={variant === 'default'}
+	class:border-disabled={variant === 'default'}
+	class:bg-brand-subtle-10={variant === 'info'}
+	class:border-brand-subtle-10={variant === 'info'}
 >
 	{@render logo?.()}
 


### PR DESCRIPTION
# Motivation

For an upcoming feature we need an info variant on the AddressCard component.

# Changes

- Added variant to component

# Tests

Default variant:
![image](https://github.com/user-attachments/assets/d2f26f80-c63d-41be-a0bb-c18b5cbe14ff)

Info variant:
![image](https://github.com/user-attachments/assets/c07a3120-8cb1-4f21-92ac-551117af2d51)

