### PR TITLE
style(frontend): Remove address from transaction modal if it is myself

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -92,41 +92,6 @@
 		{/if}
 
 		<List styleClass="mt-5">
-			{#if type === 'receive' && nonNullish(to)}
-				<ListItem>
-					<span>{$i18n.transaction.text.to}</span>
-					<output class="flex max-w-[50%] flex-row">
-						{#each to as address, index (`${address}-${index}`)}
-							<span>
-								<output>{shortenWithMiddleEllipsis({ text: address })}</output>
-
-								<TransactionAddressActions
-									copyAddress={address}
-									copyAddressText={$i18n.transaction.text.to_copied}
-									explorerUrl={`${explorerUrl}/address/${address}`}
-									explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
-								/>
-							</span>
-						{/each}
-					</output>
-				</ListItem>
-			{/if}
-			{#if type === 'send' && nonNullish(from)}
-				<ListItem>
-					<span>{$i18n.transaction.text.from}</span>
-					<output class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: from })}</output>
-
-						<TransactionAddressActions
-							copyAddress={from}
-							copyAddressText={$i18n.transaction.text.from_copied}
-							explorerUrl={fromExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
-						/>
-					</output>
-				</ListItem>
-			{/if}
-
 			{#if nonNullish(id)}
 				<ListItem>
 					<span>

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -116,7 +116,6 @@
 		{/if}
 
 		<List styleClass="mt-5">
-
 			{#if nonNullish(hash)}
 				<ListItem>
 					<span>{$i18n.transaction.text.hash}</span>

--- a/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionModal.svelte
@@ -116,36 +116,6 @@
 		{/if}
 
 		<List styleClass="mt-5">
-			{#if type === 'receive' && nonNullish(to)}
-				<ListItem>
-					<span>{$i18n.transaction.text.to}</span>
-					<span class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: to })}</output>
-
-						<TransactionAddressActions
-							copyAddress={to}
-							copyAddressText={$i18n.transaction.text.to_copied}
-							explorerUrl={toExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
-						/>
-					</span>
-				</ListItem>
-			{/if}
-			{#if type === 'send' && nonNullish(from)}
-				<ListItem>
-					<span>{$i18n.transaction.text.from}</span>
-					<output class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: from })}</output>
-
-						<TransactionAddressActions
-							copyAddress={from}
-							copyAddressText={$i18n.transaction.text.from_copied}
-							explorerUrl={fromExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
-						/>
-					</output>
-				</ListItem>
-			{/if}
 
 			{#if nonNullish(hash)}
 				<ListItem>

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -72,7 +72,6 @@
 		{/if}
 
 		<List styleClass="mt-5">
-
 			{#if nonNullish(timestamp)}
 				<ListItem>
 					<span>{$i18n.transaction.text.timestamp}</span>

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -72,34 +72,6 @@
 		{/if}
 
 		<List styleClass="mt-5">
-			{#if type === 'receive' && nonNullish(to)}
-				<ListItem>
-					<span>{$i18n.transaction.text.to}</span>
-					<output class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: to })}</output>
-						<TransactionAddressActions
-							copyAddress={to}
-							copyAddressText={$i18n.transaction.text.to_copied}
-							explorerUrl={toExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
-						/>
-					</output>
-				</ListItem>
-			{/if}
-			{#if type === 'send' && nonNullish(from)}
-				<ListItem>
-					<span>{$i18n.transaction.text.from}</span>
-					<output class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: from })}</output>
-						<TransactionAddressActions
-							copyAddress={from}
-							copyAddressText={$i18n.transaction.text.from_copied}
-							explorerUrl={fromExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
-						/>
-					</output>
-				</ListItem>
-			{/if}
 
 			{#if nonNullish(timestamp)}
 				<ListItem>

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -14,10 +14,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionToken } from '$lib/types/token';
-	import {
-		formatNanosecondsToDate,
-		formatToken,
-	} from '$lib/utils/format.utils';
+	import { formatNanosecondsToDate, formatToken } from '$lib/utils/format.utils';
 
 	interface Props {
 		transaction: IcTransactionUi;

--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -17,7 +17,6 @@
 	import {
 		formatNanosecondsToDate,
 		formatToken,
-		shortenWithMiddleEllipsis
 	} from '$lib/utils/format.utils';
 
 	interface Props {

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -101,8 +101,6 @@
 		{/if}
 
 		<List styleClass="mt-5">
-
-
 			{#if nonNullish(id)}
 				<ListItem>
 					<span>

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -101,35 +101,7 @@
 		{/if}
 
 		<List styleClass="mt-5">
-			{#if type === 'receive' && nonNullish(to)}
-				<ListItem>
-					<span>{$i18n.transaction.text.to}</span>
-					<output class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: to })}</output>
 
-						<TransactionAddressActions
-							copyAddress={to}
-							copyAddressText={$i18n.transaction.text.to_copied}
-							explorerUrl={toExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_to_block_explorer}
-						/>
-					</output>
-				</ListItem>
-			{/if}
-			{#if type === 'send' && nonNullish(from)}
-				<ListItem>
-					<span>{$i18n.transaction.text.from}</span>
-					<output class="flex max-w-[50%] flex-row">
-						<output>{shortenWithMiddleEllipsis({ text: from })}</output>
-						<TransactionAddressActions
-							copyAddress={from}
-							copyAddressText={$i18n.transaction.text.from_copied}
-							explorerUrl={fromExplorerUrl}
-							explorerUrlAriaLabel={$i18n.transaction.alt.open_from_block_explorer}
-						/>
-					</output>
-				</ListItem>
-			{/if}
 
 			{#if nonNullish(id)}
 				<ListItem>

--- a/src/frontend/src/tests/btc/components/transactions/BtcTransactionModal.spec.ts
+++ b/src/frontend/src/tests/btc/components/transactions/BtcTransactionModal.spec.ts
@@ -37,12 +37,6 @@ describe('BtcTransactionModal', () => {
 		});
 
 		expect(getByText(mockBtcTransactionUi.from)).toBeInTheDocument();
-
-		if (mockBtcTransactionUi.to?.length) {
-			expect(
-				getByText(shortenWithMiddleEllipsis({ text: mockBtcTransactionUi.to[0] }))
-			).toBeInTheDocument();
-		}
 	});
 
 	it('should display transaction status', () => {

--- a/src/frontend/src/tests/eth/components/transactions/EthTransactionModal.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransactionModal.spec.ts
@@ -37,10 +37,6 @@ describe('EthTransactionModal', () => {
 			token: ETHEREUM_TOKEN
 		});
 
-		expect(
-			getByText(shortenWithMiddleEllipsis({ text: mockEthTransactionUi.from as string }))
-		).toBeInTheDocument();
-
 		expect(getByText(mockEthTransactionUi.to as string)).toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/icp/components/transactions/IcTransactionModal.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcTransactionModal.spec.ts
@@ -37,10 +37,6 @@ describe('IcTransactionModal', () => {
 			token: ICP_TOKEN
 		});
 
-		expect(
-			getByText(shortenWithMiddleEllipsis({ text: mockIcTransactionUi.from as string }))
-		).toBeInTheDocument();
-
 		expect(getByText(mockIcTransactionUi.to as string)).toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -40,10 +40,6 @@ describe('SolTransactionModal', () => {
 			token: SOLANA_TOKEN
 		});
 
-		expect(
-			getByText(shortenWithMiddleEllipsis({ text: mockSolTransactionUi.from as string }))
-		).toBeInTheDocument();
-
 		expect(getByText(mockSolTransactionUi.to as string)).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
# Motivation

We decided to remove the information about the user address in the transaction modal. For example, when it is a `receive` transaction, the `To` field will not appear.

### Before

![Screenshot 2025-05-28 at 14 46 56](https://github.com/user-attachments/assets/b38c93a1-3d6d-4c08-94dc-b4bdf203b953)


### After

![Screenshot 2025-05-28 at 14 39 59](https://github.com/user-attachments/assets/091c9cea-3afd-4c25-b9a7-3eece3c23174)
