### PR TITLE
fix(frontend): Correctly parse `Principal` from cached tokens

### DIFF
--- a/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
@@ -69,6 +69,8 @@ describe('custom-tokens.services', () => {
 			vi.clearAllMocks();
 
 			vi.mocked(listCustomTokens).mockResolvedValue(mockCustomTokens);
+
+			mockGetIdbTokens.mockImplementation(vi.fn());
 		});
 
 		it('should load the custom tokens from the backend', async () => {
@@ -90,9 +92,7 @@ describe('custom-tokens.services', () => {
 				filterTokens: ({ token }) => 'Icrc' in token
 			});
 
-			const expectedTokens = mockCustomTokens.splice(0, 2);
-
-			expect(result).toStrictEqual(expectedTokens);
+			expect(result).toStrictEqual(mockCustomTokens.slice(0, 2));
 		});
 
 		it('should handle empty token list from the backend', async () => {

--- a/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
@@ -210,5 +210,33 @@ describe('custom-tokens.services', () => {
 				nullishIdentityErrorMessage: en.auth.error.no_internet_identity
 			});
 		});
+
+		it('should parse correctly the cached ledger and index canister IDs from the custom tokens', async () => {
+			mockGetIdbTokens.mockResolvedValue([
+				{
+					token: {
+						Icrc: {
+							ledger_id: Principal.fromText(mockLedgerCanisterId).toUint8Array(),
+							index_id: toNullable(Principal.fromText(mockIndexCanisterId).toUint8Array())
+						}
+					},
+					version: toNullable(2n),
+					enabled: true
+				}
+			]);
+
+			const result = await loadNetworkCustomTokens({
+				...mockParams,
+				certified: false,
+				useCache: true
+			});
+
+			expect(result).toStrictEqual(mockCustomTokens.slice(0, 1));
+
+			expect(mockGetIdbTokens).toHaveBeenCalledOnce();
+			expect(mockGetIdbTokens).toHaveBeenNthCalledWith(1, mockIdentity.getPrincipal());
+
+			expect(listCustomTokens).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The `Principal` objects of the Ledger and Index canister IDs of custom tokens are saved in the cached as `Uint8Array` objects. So we need to parse them correctly when we re-fetch them form the cache.

# Changes

Add mapper for Icrc tokens in service `loadNetworkCustomTokens`.

# Tests

Included tests.
