### PR TITLE
feat(frontend): Disable edit contact name form when backend call is in progress

### DIFF
--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -5,7 +5,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 
-	let { contact = $bindable() }: { contact: Partial<ContactUi> } = $props();
+	interface Props {
+		contact: Partial<ContactUi>;
+		disabled?: boolean;
+	}
+	let { contact = $bindable(), disabled = false }: Props = $props();
 
 	let isValid = $derived(notEmptyString(contact?.name?.trim?.()));
 
@@ -22,6 +26,7 @@
 			showResetButton
 			testId={ADDRESS_BOOK_CONTACT_NAME_INPUT}
 			autofocus={true}
+			{disabled}
 		/>
 	</div>
 </form>

--- a/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
@@ -57,7 +57,11 @@
 	<!-- TODO Add address list here -->
 
 	<ButtonGroup slot="toolbar">
-		<ButtonCancel onclick={() => onClose()} testId={ADDRESS_BOOK_CANCEL_BUTTON} disabled={loading} />
+		<ButtonCancel
+			onclick={() => onClose()}
+			testId={ADDRESS_BOOK_CANCEL_BUTTON}
+			disabled={loading}
+		/>
 		<Button
 			colorStyle="primary"
 			on:click={handleSave}

--- a/src/frontend/src/lib/components/ui/InputText.svelte
+++ b/src/frontend/src/lib/components/ui/InputText.svelte
@@ -8,6 +8,7 @@
 	export let required = true;
 	export let testId: string | undefined = undefined;
 	export let autofocus = false;
+	export let disabled: boolean | undefined = undefined;
 </script>
 
 <Input
@@ -21,4 +22,5 @@
 	autocomplete="off"
 	{autofocus}
 	{testId}
+	{disabled}
 />

--- a/src/frontend/src/tests/lib/components/address-book/EditContactNameStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditContactNameStep.spec.ts
@@ -118,28 +118,42 @@ describe('EditContactNameStep', () => {
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
 
-	it('should update title when contact name changes', async () => {
-		const onAddContact = vi.fn();
+	it('should disable form when loading', async () => {
+		let resolveCall = () => {};
+		const onAddContact = vi.fn().mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCall = resolve;
+				})
+		);
+
 		const onSaveContact = vi.fn();
 		const onClose = vi.fn();
 
-		const { getByTestId, component } = render(EditContactNameStep, {
+		const { getByTestId } = render(EditContactNameStep, {
 			props: { onAddContact, onSaveContact, onClose, isNewContact: true }
 		});
 
-		// Initially, the title should be the default
-		expect(component.title).toBe(en.contact.form.add_new_contact);
-
-		// Enter a name
+		// Enter a name to make the form valid
 		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
 		await fireEvent.input(nameInput, { target: { value: 'Test Contact' } });
 
-		// Check that the title has been updated
-		expect(component.title).toBe('Test Contact');
+		// Click the save button to trigger loading state
+		const saveButton = getByTestId(ADDRESS_BOOK_SAVE_BUTTON);
+		await fireEvent.click(saveButton);
 
-		// Empty name should reset to default title
-		await fireEvent.input(nameInput, { target: { value: '  ' } });
+		// Check that the form input is disabled during loading
+		expect(getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT)).toBeDisabled();
 
-		expect(component.title).toBe(en.contact.form.add_new_contact);
+		// Check that the cancel button is disabled during loading
+		expect(getByTestId(ADDRESS_BOOK_CANCEL_BUTTON)).toBeDisabled();
+
+		// Check that the save button is disabled during loading
+		expect(saveButton).toBeDisabled();
+
+		resolveCall();
+
+		// Button should be enabled again
+		expect(saveButton).toBeDisabled();
 	});
 });


### PR DESCRIPTION
# Motivation

To prevent sending a backend call multiple times, the form should be disabled during backend calls.

# Changes

- Disabled form during backend call

# Tests

- Added test
