### PR TITLE
refactor(frontend): Use modaldata address in edit address book step

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
@@ -10,8 +10,12 @@
 		ADDRESS_BOOK_CANCEL_BUTTON,
 		ADDRESS_BOOK_SAVE_BUTTON
 	} from '$lib/constants/test-ids.constants';
+	import { AddressBookSteps } from '$lib/enums/progress-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { AddressBookModalParams } from '$lib/types/address-book';
 	import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
+	import { mapAddressToContactAddressUi } from '$lib/utils/contact.utils';
 
 	interface Props {
 		contact: ContactUi;
@@ -31,9 +35,22 @@
 		isNewAddress
 	}: Props = $props();
 
+	let modalData: AddressBookModalParams = $derived($modalStore?.data as AddressBookModalParams);
+	let modalDataAddress: string | undefined = $derived(
+		modalData?.entrypoint?.type === AddressBookSteps.SAVE_ADDRESS
+			? modalData.entrypoint.address
+			: undefined
+	);
+
+	let addressModel = $derived(
+		nonNullish(modalDataAddress)
+			? (mapAddressToContactAddressUi(modalDataAddress) ?? address)
+			: address
+	);
+
 	const handleSave = () => {
 		if (isNewAddress) {
-			onAddAddress({ ...address } as ContactAddressUi);
+			onAddAddress({ ...addressModel } as ContactAddressUi);
 		} else {
 			onSaveAddress(address as ContactAddressUi);
 		}
@@ -60,7 +77,12 @@
 		class="mt-2 w-full rounded-lg bg-brand-light px-3 py-4 text-sm md:px-5 md:text-base md:font-bold"
 	>
 		<div class="pb-4 text-xl font-bold">{title}</div>
-		<AddressForm {isNewAddress} {address} bind:isInvalid></AddressForm>
+		<AddressForm
+			{isNewAddress}
+			address={addressModel}
+			bind:isInvalid
+			disabled={nonNullish(modalDataAddress)}
+		></AddressForm>
 	</div>
 
 	<ButtonGroup slot="toolbar">


### PR DESCRIPTION
# Motivation

For the upcoming feature #6980 we need the possibility to use an address from modal data and prefill and disable the EditAddress input.

# Changes

Take modal data address if supplied and prefill/disable address input

# Tests

WIth entrypoint & address defined in store data:
![image](https://github.com/user-attachments/assets/00be2b58-c091-4913-b094-79591149f7b0)

Without store data:
![image](https://github.com/user-attachments/assets/b872a127-c48a-46d7-b779-da34d58ac506)
