### PR TITLE
feat(frontend): `To` and `From` are optional in `TransactionContactCard`

### DIFF
--- a/src/frontend/src/lib/components/address/SkeletonAddressCard.svelte
+++ b/src/frontend/src/lib/components/address/SkeletonAddressCard.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import AddressCard from '$lib/components/address/AddressCard.svelte';
+	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+</script>
+
+<AddressCard>
+	{#snippet logo()}
+		<SkeletonLogo size="small" />
+	{/snippet}
+	{#snippet content()}
+		<span class="mx-1 inline-block flex w-[120px] max-w-full items-center text-left sm:w-[200px]"
+			><SkeletonText /></span
+		>
+	{/snippet}
+</AddressCard>

--- a/src/frontend/src/lib/components/address/SkeletonAddressCard.svelte
+++ b/src/frontend/src/lib/components/address/SkeletonAddressCard.svelte
@@ -9,7 +9,7 @@
 		<SkeletonLogo size="small" />
 	{/snippet}
 	{#snippet content()}
-		<span class="mx-1 inline-block flex w-[120px] max-w-full items-center text-left sm:w-[200px]"
+		<span class="mx-1 inline-block w-[120px] max-w-full items-center sm:w-[200px]"
 			><SkeletonText /></span
 		>
 	{/snippet}

--- a/src/frontend/src/lib/components/transactions/TransactionContactCard.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionContactCard.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import AddressCard from '$lib/components/address/AddressCard.svelte';
+	import SkeletonAddressCard from '$lib/components/address/SkeletonAddressCard.svelte';
 	import AvatarWithBadge from '$lib/components/contact/AvatarWithBadge.svelte';
 	import TransactionAddressActions from '$lib/components/transactions/TransactionAddressActions.svelte';
 	import { contacts } from '$lib/derived/contacts.derived';
@@ -9,50 +11,56 @@
 
 	interface Props {
 		type: 'send' | 'receive';
-		to: string;
+		to: string | undefined;
 		toExplorerUrl?: string;
-		from: string;
+		from: string | undefined;
 		fromExplorerUrl?: string;
 	}
 
 	const { type, to, from, toExplorerUrl, fromExplorerUrl }: Props = $props();
 
 	let contact: ContactUi | undefined = $derived(
-		getContactForAddress({
-			contactList: $contacts,
-			addressString: type === 'send' ? to : from
-		})
+		nonNullish(to) && nonNullish(from)
+			? getContactForAddress({
+					contactList: $contacts,
+					addressString: type === 'send' ? to : from
+				})
+			: undefined
 	);
 </script>
 
-<AddressCard>
-	{#snippet logo()}
-		<AvatarWithBadge
-			{contact}
-			badge={{ type: 'addressType', address: type === 'send' ? to : from }}
-		/>
-	{/snippet}
-	{#snippet content()}
-		<span class="mx-1 flex flex-col items-start text-left">
-			<span class="font-bold"
-				>{type === 'send' ? $i18n.transaction.text.to : $i18n.transaction.text.from}: {contact?.name}</span
-			>
-			<span class="w-full truncate">{type === 'send' ? to : from}</span>
-			<!-- Todo: enable button once the save flow is implemented
+{#if nonNullish(from) && nonNullish(to)}
+	<AddressCard>
+		{#snippet logo()}
+			<AvatarWithBadge
+				{contact}
+				badge={{ type: 'addressType', address: type === 'send' ? to : from }}
+			/>
+		{/snippet}
+		{#snippet content()}
+			<span class="mx-1 flex flex-col items-start text-left">
+				<span class="font-bold"
+					>{type === 'send' ? $i18n.transaction.text.to : $i18n.transaction.text.from}: {contact?.name}</span
+				>
+				<span class="w-full truncate">{type === 'send' ? to : from}</span>
+				<!-- Todo: enable button once the save flow is implemented
 			<Button link styleClass="mt-3 text-sm"><IconUserSquare size="20px" /> Save address</Button>
 			-->
-		</span>
-	{/snippet}
-	{#snippet actions()}
-		<TransactionAddressActions
-			copyAddress={type === 'send' ? to : from}
-			copyAddressText={type === 'send'
-				? $i18n.transaction.text.to_copied
-				: $i18n.transaction.text.from_copied}
-			explorerUrl={type === 'send' ? toExplorerUrl : fromExplorerUrl}
-			explorerUrlAriaLabel={type === 'send'
-				? $i18n.transaction.alt.open_to_block_explorer
-				: $i18n.transaction.alt.open_from_block_explorer}
-		/>
-	{/snippet}
-</AddressCard>
+			</span>
+		{/snippet}
+		{#snippet actions()}
+			<TransactionAddressActions
+				copyAddress={type === 'send' ? to : from}
+				copyAddressText={type === 'send'
+					? $i18n.transaction.text.to_copied
+					: $i18n.transaction.text.from_copied}
+				explorerUrl={type === 'send' ? toExplorerUrl : fromExplorerUrl}
+				explorerUrlAriaLabel={type === 'send'
+					? $i18n.transaction.alt.open_to_block_explorer
+					: $i18n.transaction.alt.open_from_block_explorer}
+			/>
+		{/snippet}
+	</AddressCard>
+{:else}
+	<SkeletonAddressCard />
+{/if}


### PR DESCRIPTION
# Motivation

We are going to provide possibly undefined addresses to the component TransactionContactCard. That is because we will be showing the owner address in a Solana transaction, that is derived from the ATA address, and that takes a bit of time (async function).

While it is loading, we will show a skeleton.

![Screenshot 2025-05-28 at 15 26 00](https://github.com/user-attachments/assets/f293efc3-15fb-4214-936e-48df7e8684d7)
