### PR TITLE
feat(frontend): Load cached custom tokens for SPL and ICRC

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -37,7 +37,7 @@ import {
 import { get } from 'svelte/store';
 
 export const loadIcrcTokens = async ({ identity }: { identity: OptionIdentity }): Promise<void> => {
-	await Promise.all([loadDefaultIcrcTokens(), loadCustomTokens({ identity })]);
+	await Promise.all([loadDefaultIcrcTokens(), loadCustomTokens({ identity, useCache: true })]);
 };
 
 const loadDefaultIcrcTokens = async () => {
@@ -48,9 +48,15 @@ const loadDefaultIcrcTokens = async () => {
 	);
 };
 
-export const loadCustomTokens = ({ identity }: { identity: OptionIdentity }): Promise<void> =>
+export const loadCustomTokens = ({
+	identity,
+	useCache = false
+}: {
+	identity: OptionIdentity;
+	useCache?: boolean;
+}): Promise<void> =>
 	queryAndUpdate<IcrcCustomToken[]>({
-		request: (params) => loadIcrcCustomTokens(params),
+		request: (params) => loadIcrcCustomTokens({ ...params, useCache }),
 		onLoad: loadIcrcCustomData,
 		onUpdateError: ({ error: err }) => {
 			icrcCustomTokensStore.resetAll();
@@ -111,17 +117,20 @@ const loadIcrcData = ({
 
 const loadIcrcCustomTokens = async ({
 	identity,
-	certified
+	certified,
+	useCache = false
 }: {
 	identity: OptionIdentity;
 	certified: boolean;
+	useCache?: boolean;
 }): Promise<IcrcCustomToken[]> => {
 	const tokens = await loadNetworkCustomTokens({
 		identity,
 		certified,
 		filterTokens: ({ token }) => 'Icrc' in token,
 		setIdbTokens: setIdbIcTokens,
-		getIdbTokens: getIdbIcTokens
+		getIdbTokens: getIdbIcTokens,
+		useCache
 	});
 
 	return await loadCustomIcrcTokensData({

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -88,15 +88,9 @@
 	const loadData = async () => {
 		// Load Erc20 contracts and ICRC metadata before loading balances and transactions
 		await Promise.all([
-			loadErc20Tokens({
-				identity: $authIdentity
-			}),
-			loadIcrcTokens({
-				identity: $authIdentity
-			}),
-			loadSplTokens({
-				identity: $authIdentity
-			})
+			loadErc20Tokens({ identity: $authIdentity }),
+			loadIcrcTokens({ identity: $authIdentity }),
+			loadSplTokens({ identity: $authIdentity })
 		]);
 	};
 

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -246,6 +246,17 @@ describe('icrc.services', () => {
 					expect.any(Object)
 				);
 			});
+
+			it('should fetch the cached custom tokens in IDB on query call', async () => {
+				await loadCustomTokens({ identity: mockIdentity, useCache: true });
+
+				expect(idbKeyval.get).toHaveBeenCalledOnce();
+				expect(idbKeyval.get).toHaveBeenNthCalledWith(
+					1,
+					mockIdentity.getPrincipal().toText(),
+					expect.any(Object)
+				);
+			});
 		});
 
 		describe('error', () => {
@@ -339,6 +350,19 @@ describe('icrc.services', () => {
 				expect(console.error).toHaveBeenCalledTimes(2);
 				expect(console.error).toHaveBeenNthCalledWith(1, err);
 				expect(console.error).toHaveBeenNthCalledWith(2, err);
+			});
+
+			it('should not cache the custom tokens in IDB', async () => {
+				const tokens = get(icrcCustomTokensStore);
+
+				expect(tokens).toHaveLength(1);
+
+				const err = new Error('test');
+				backendCanisterMock.listCustomTokens.mockRejectedValue(err);
+
+				await loadCustomTokens({ identity: mockIdentity });
+
+				expect(idbKeyval.set).not.toHaveBeenCalled();
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

We can now enable the cache-fetching for the ICRC and SPL tokens.
