### PR TITLE
feat(frontend): added optional warning log to plausible

### DIFF
--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -24,7 +24,7 @@ export const initPlausibleAnalytics = () => {
 	}
 };
 
-export const trackEvent = ({ name, metadata }: TrackEventParams) => {
+export const trackEvent = ({ name, metadata, warning }: TrackEventParams) => {
 	/**
 	 * We use the `PLAUSIBLE_ENABLED` feature flag to allow flexibility in enabling or disabling
 	 * analytics in specific builds. This ensures that analytics
@@ -35,5 +35,10 @@ export const trackEvent = ({ name, metadata }: TrackEventParams) => {
 	 */
 	if (PLAUSIBLE_ENABLED && nonNullish(plausibleTracker)) {
 		plausibleTracker.trackEvent(name, { props: metadata });
+
+		if (nonNullish(warning)) {
+			// We print the error to console just for debugging purposes
+			console.warn(warning);
+		}
 	}
 };

--- a/src/frontend/src/lib/types/analytics.ts
+++ b/src/frontend/src/lib/types/analytics.ts
@@ -1,4 +1,5 @@
 export interface TrackEventParams {
 	name: string;
 	metadata?: Record<string, string>;
+	warning?: string;
 }

--- a/src/frontend/src/tests/lib/services/analytics.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/analytics.service.spec.ts
@@ -37,6 +37,28 @@ describe('plausible analytics service', () => {
 			hashMode: false,
 			trackLocalhost: false
 		});
+
+		expect(console.warn).not.toHaveBeenCalledWith('Warning message');
+	});
+
+	it('should call console.warn if value is provided', async () => {
+		const { trackEvent, initPlausibleAnalytics } = await import('$lib/services/analytics.services');
+
+		initPlausibleAnalytics();
+
+		const params: TrackEventParams = {
+			name: 'test_event_name',
+			metadata: { eventName: 'eventValue' },
+			warning: 'Warning message'
+		};
+
+		trackEvent(params);
+
+		expect(trackEventMock).toHaveBeenCalledWith('test_event_name', {
+			props: { eventName: 'eventValue' }
+		});
+
+		expect(console.warn).toHaveBeenCalledWith('Warning message');
 	});
 
 	it('should enable auto pageviews', async () => {


### PR DESCRIPTION
# Motivation

We want to log error in console.log for debug peposes, so in scope of this PR is added optional field warning that would call console.warn from trackEvent.

# Changes

Added new console.warn for debug purposes

# Tests

Covered new logic with the tests.