### PR TITLE
feat(frontend): network contacts util

### DIFF
--- a/src/frontend/src/lib/types/contacts.ts
+++ b/src/frontend/src/lib/types/contacts.ts
@@ -1,0 +1,4 @@
+import type { Address } from '$lib/types/address';
+import type { ContactUi } from '$lib/types/contact';
+
+export type NetworkContacts = Record<Address, ContactUi>;

--- a/src/frontend/src/lib/utils/contacts.utils.ts
+++ b/src/frontend/src/lib/utils/contacts.utils.ts
@@ -1,0 +1,23 @@
+import type { ContactUi } from '$lib/types/contact';
+import type { NetworkContacts } from '$lib/types/contacts';
+import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
+import { isNullish } from '@dfinity/utils';
+
+export const getNetworkContacts = ({
+	addressType,
+	contacts
+}: {
+	addressType: TokenAccountIdTypes;
+	contacts: ContactUi[];
+}): NetworkContacts =>
+	isNullish(contacts)
+		? {}
+		: contacts.reduce<NetworkContacts>((acc, contact) => {
+				contact.addresses.forEach((addressUi) => {
+					if (addressUi.addressType === addressType && isNullish(acc[addressUi.address])) {
+						acc[addressUi.address] = contact;
+					}
+				});
+
+				return acc;
+			}, {});

--- a/src/frontend/src/tests/lib/utils/contacts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contacts.utils.spec.ts
@@ -1,0 +1,42 @@
+import type { ContactUi } from '$lib/types/contact';
+import { getNetworkContacts } from '$lib/utils/contacts.utils';
+import {
+	getMockContactsUi,
+	mockContactBtcAddressUi,
+	mockContactIcrcAddressUi
+} from '$tests/mocks/contacts.mock';
+
+describe('contacts.utils', () => {
+	describe('getNetworkContacts', () => {
+		const contactWithIcrcAddress = getMockContactsUi({
+			n: 3,
+			name: 'Multiple Addresses Contact',
+			addresses: [mockContactIcrcAddressUi]
+		}) as unknown as ContactUi[];
+		const contactWithBtcAddress = getMockContactsUi({
+			n: 3,
+			name: 'Multiple Addresses Contact',
+			addresses: [mockContactBtcAddressUi]
+		}) as unknown as ContactUi[];
+
+		it('returns one contact per address for the provided addressType', () => {
+			expect(
+				getNetworkContacts({
+					addressType: 'Btc',
+					contacts: [...contactWithIcrcAddress, ...contactWithBtcAddress]
+				})
+			).toStrictEqual({
+				[mockContactBtcAddressUi.address]: contactWithBtcAddress[0]
+			});
+		});
+
+		it('returns empty object if no contacts available for the provided addressType', () => {
+			expect(
+				getNetworkContacts({
+					addressType: 'Sol',
+					contacts: [...contactWithIcrcAddress, ...contactWithBtcAddress]
+				})
+			).toStrictEqual({});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Before creating stores for each network, we need to implement a util for parsing `contacts` and returning a dictionary with contacts by address type. It will be used in the Address Picker step in the Send flow.
