### PR TITLE
feat(frontend): improves create contact flow

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -290,7 +290,7 @@
 	{:else if currentStep?.name === AddressBookSteps.SHOW_CONTACT && nonNullish(currentContact)}
 		<ShowContactStep
 			onClose={() => {
-				navigateToEntrypointOrCallback(handleClose);
+				navigateToEntrypointOrCallback(() => gotoStep(AddressBookSteps.ADDRESS_BOOK));
 			}}
 			contact={currentContact}
 			onEdit={(contact) => {
@@ -366,7 +366,12 @@
 					gotoStep(AddressBookSteps.EDIT_ADDRESS);
 					previousStepName = AddressBookSteps.SAVE_ADDRESS;
 				} else {
-					gotoStep(AddressBookSteps.ADDRESS_BOOK);
+					if (nonNullish(createdContact)) {
+						currentContactId = createdContact.id;
+						gotoStep(AddressBookSteps.SHOW_CONTACT);
+					} else {
+						gotoStep(AddressBookSteps.ADDRESS_BOOK);
+					}
 				}
 			}}
 			onSaveContact={async (contact: ContactUi) => {

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -262,7 +262,7 @@
 		/>
 	{:else if currentStep?.name === AddressBookSteps.SHOW_CONTACT && nonNullish(currentContact)}
 		<ShowContactStep
-			onClose={handleClose}
+			onClose={() => gotoStep(AddressBookSteps.ADDRESS_BOOK)}
 			contact={currentContact}
 			onEdit={(contact) => {
 				currentContactId = contact.id;
@@ -330,8 +330,9 @@
 			bind:this={editContactNameStep}
 			contact={currentContact}
 			onAddContact={async (contact: Pick<ContactUi, 'name'>) => {
-				await callCreateContact({ name: contact.name });
-				gotoStep(AddressBookSteps.ADDRESS_BOOK);
+				const newContact = await callCreateContact({ name: contact.name });
+				currentContactId = newContact.id;
+				gotoStep(AddressBookSteps.SHOW_CONTACT);
 			}}
 			onSaveContact={async (contact: ContactUi) => {
 				await callUpdateContact({ contact });

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -331,8 +331,12 @@
 			contact={currentContact}
 			onAddContact={async (contact: Pick<ContactUi, 'name'>) => {
 				const newContact = await callCreateContact({ name: contact.name });
-				currentContactId = newContact.id;
-				gotoStep(AddressBookSteps.SHOW_CONTACT);
+				if (nonNullish(newContact)) {
+					currentContactId = newContact.id;
+					gotoStep(AddressBookSteps.SHOW_CONTACT);
+				} else {
+					gotoStep(AddressBookSteps.ADDRESS_BOOK);
+				}
 			}}
 			onSaveContact={async (contact: ContactUi) => {
 				await callUpdateContact({ contact });

--- a/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
@@ -100,6 +100,12 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
+
+		await waitFor(() => {
 			// Should be back on address book step
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
 			// Contact should be displayed in the list
@@ -137,8 +143,11 @@ describe('AddressBookModal', () => {
 
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Wait a bit for the store to update and UI to reflect changes
-		await new Promise((resolve) => setTimeout(resolve, 100));
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
 
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
@@ -152,8 +161,11 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Wait a bit for the store to update and UI to reflect changes
-		await new Promise((resolve) => setTimeout(resolve, 100));
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
 
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
@@ -172,6 +184,12 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
+
 		// Wait for the contact card to be displayed
 		const contactCards = await findAllByTestId(CONTACT_CARD);
 
@@ -188,6 +206,12 @@ describe('AddressBookModal', () => {
 			target: { value: 'Test Contact' }
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
 
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
@@ -212,14 +236,8 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
-			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 		});
-
-		// Navigate to show contact step
-		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
-		await fireEvent.click(contactButtons[0]);
-
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 
 		// Click close button
 		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
@@ -239,19 +257,13 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
-			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 		});
-
-		// Navigate to show contact step
-		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
-		await fireEvent.click(contactButtons[0]);
-
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 
 		// Navigate to edit contact step
 		await fireEvent.click(getByTestId(CONTACT_HEADER_EDIT_BUTTON));
 
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent('Edit contact');
+		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.edit_contact.title);
 
 		// Click close button
 		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
@@ -270,10 +282,6 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Wait for the contact card button to be displayed
-		const contactButtons = await findAllByTestId(CONTACT_CARD_BUTTON);
-		await fireEvent.click(contactButtons[0]);
-
 		// Wait for navigation to show contact step
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
@@ -284,7 +292,7 @@ describe('AddressBookModal', () => {
 
 		// Wait for navigation to edit address step
 		await waitFor(() => {
-			expect(getByTestId(MODAL_TITLE)).toHaveTextContent('Edit contact');
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.edit_contact.title);
 		});
 
 		// Click close button

--- a/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
@@ -226,7 +226,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from show contact step to address book when close button is clicked', async () => {
-		const { getByTestId, getAllByTestId } = render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -247,7 +247,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from edit contact step to show contact when close button is clicked', async () => {
-		const { getByTestId, getAllByTestId } = render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -273,7 +273,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from edit address step to show contact when close button is clicked', async () => {
-		const { getByTestId, findAllByTestId } = render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));


### PR DESCRIPTION
# Motivation

After creating a new contact the user should land on the `contact card` instead of the `contact list`.

# Changes

- improves flow

# Tests

**before:**

https://github.com/user-attachments/assets/5c4b96e5-af14-4695-aa0a-bf0f94e3d52b



**after:**

https://github.com/user-attachments/assets/aff5fec2-3daa-45a3-a587-ceaa82a821f6

