### PR TITLE
fix(frontend): Close address book modal if addres has been added in SAVE_ADDRESS flow

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -290,7 +290,7 @@
 	{:else if currentStep?.name === AddressBookSteps.SHOW_CONTACT && nonNullish(currentContact)}
 		<ShowContactStep
 			onClose={() => {
-				navigateToEntrypointOrCallback(handleClose);
+				navigateToEntrypointOrCallback(() => gotoStep(AddressBookSteps.ADDRESS_BOOK));
 			}}
 			contact={currentContact}
 			onEdit={(contact) => {
@@ -366,7 +366,12 @@
 					gotoStep(AddressBookSteps.EDIT_ADDRESS);
 					previousStepName = AddressBookSteps.SAVE_ADDRESS;
 				} else {
-					gotoStep(AddressBookSteps.ADDRESS_BOOK);
+					if (nonNullish(createdContact)) {
+						currentContactId = createdContact.id;
+						gotoStep(AddressBookSteps.SHOW_CONTACT);
+					} else {
+						gotoStep(AddressBookSteps.ADDRESS_BOOK);
+					}
 				}
 			}}
 			onSaveContact={async (contact: ContactUi) => {

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -189,7 +189,7 @@
 			addresses
 		};
 		await callUpdateContact({ contact });
-		// if the entrypoint was SAVE_ADDRESS this is the last step of the flow, so we close the address book
+		// if the entrypoint was SAVE_ADDRESS this is the last step of the flow, so we close the address book modal
 		if (
 			nonNullish(modalData?.entrypoint) &&
 			modalData.entrypoint.type === AddressBookSteps.SAVE_ADDRESS

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -189,6 +189,14 @@
 			addresses
 		};
 		await callUpdateContact({ contact });
+		// if the entrypoint was SAVE_ADDRESS this is the last step of the flow, so we close the address book
+		if (
+			nonNullish(modalData?.entrypoint) &&
+			modalData.entrypoint.type === AddressBookSteps.SAVE_ADDRESS
+		) {
+			modalStore.close();
+			return;
+		}
 		gotoStep(AddressBookSteps.SHOW_CONTACT);
 	};
 

--- a/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/AddressBookModal.spec.ts
@@ -100,6 +100,12 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
+
+		await waitFor(() => {
 			// Should be back on address book step
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
 			// Contact should be displayed in the list
@@ -137,8 +143,11 @@ describe('AddressBookModal', () => {
 
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Wait a bit for the store to update and UI to reflect changes
-		await new Promise((resolve) => setTimeout(resolve, 100));
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
 
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
@@ -152,8 +161,11 @@ describe('AddressBookModal', () => {
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Wait a bit for the store to update and UI to reflect changes
-		await new Promise((resolve) => setTimeout(resolve, 100));
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
 
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
@@ -171,6 +183,12 @@ describe('AddressBookModal', () => {
 			target: { value: 'Contact 1' }
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
 
 		// Wait for the contact card to be displayed
 		const contactCards = await findAllByTestId(CONTACT_CARD);
@@ -190,6 +208,12 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
+		});
+
+		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
+
+		await waitFor(() => {
 			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
 		});
 
@@ -202,7 +226,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from show contact step to address book when close button is clicked', async () => {
-		const { getByTestId, getAllByTestId } = render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -212,14 +236,8 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
-			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 		});
-
-		// Navigate to show contact step
-		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
-		await fireEvent.click(contactButtons[0]);
-
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 
 		// Click close button
 		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
@@ -229,7 +247,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from edit contact step to show contact when close button is clicked', async () => {
-		const { getByTestId, getAllByTestId } = render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -239,19 +257,13 @@ describe('AddressBookModal', () => {
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
 		await waitFor(() => {
-			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.text.title);
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 		});
-
-		// Navigate to show contact step
-		const contactButtons = getAllByTestId(CONTACT_CARD_BUTTON);
-		await fireEvent.click(contactButtons[0]);
-
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.show_contact.title);
 
 		// Navigate to edit contact step
 		await fireEvent.click(getByTestId(CONTACT_HEADER_EDIT_BUTTON));
 
-		expect(getByTestId(MODAL_TITLE)).toHaveTextContent('Edit contact');
+		expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.edit_contact.title);
 
 		// Click close button
 		await fireEvent.click(getByTestId(CONTACT_SHOW_CLOSE_BUTTON));
@@ -261,7 +273,7 @@ describe('AddressBookModal', () => {
 	});
 
 	it('should navigate from edit address step to show contact when close button is clicked', async () => {
-		const { getByTestId, findAllByTestId } = render(AddressBookModal);
+		const { getByTestId } = render(AddressBookModal);
 
 		// Add a contact
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_ADD_CONTACT_BUTTON));
@@ -269,10 +281,6 @@ describe('AddressBookModal', () => {
 			target: { value: 'Test Contact' }
 		});
 		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
-
-		// Wait for the contact card button to be displayed
-		const contactButtons = await findAllByTestId(CONTACT_CARD_BUTTON);
-		await fireEvent.click(contactButtons[0]);
 
 		// Wait for navigation to show contact step
 		await waitFor(() => {
@@ -284,7 +292,7 @@ describe('AddressBookModal', () => {
 
 		// Wait for navigation to edit address step
 		await waitFor(() => {
-			expect(getByTestId(MODAL_TITLE)).toHaveTextContent('Edit contact');
+			expect(getByTestId(MODAL_TITLE)).toHaveTextContent(en.address_book.edit_contact.title);
 		});
 
 		// Click close button


### PR DESCRIPTION
# Motivation

In the SAVE_ADDRESS flow we should close the modal once the address has been added.

# Changes

- added condition with close modal call
- added comment explaining this is end of the flow

# Tests


https://github.com/user-attachments/assets/459379fa-7c3f-4010-937e-7fc95f801a73


