### PR TITLE
fix(frontend): ethKnownDestinations when txs failed to load

### DIFF
--- a/src/frontend/src/eth/derived/eth-transactions.derived.ts
+++ b/src/frontend/src/eth/derived/eth-transactions.derived.ts
@@ -82,7 +82,7 @@ export const ethKnownDestinations: Readable<KnownDestinations> = derived(
 			const token = $tokens.find(({ id }) => id === tokenId);
 
 			if (nonNullish(token) && token.network.id === $tokenWithFallback.network.id) {
-				$ethTransactionsStore[tokenId as TokenId].forEach((transaction) => {
+				($ethTransactionsStore[tokenId as TokenId] ?? []).forEach((transaction) => {
 					mappedTransactions.push({
 						...mapEthTransactionUi({
 							transaction,

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -307,25 +307,26 @@ export const getKnownDestinations = (
 			nonNullish(to) && type === 'send' && nonNullish(value) && value > ZERO
 				? {
 						...acc,
-						...(Array.isArray(to) ? to : [to]).reduce(
-							(innerAcc, address) => ({
+						...(Array.isArray(to) ? to : [to]).reduce((innerAcc, address) => {
+							const parsedAddress = address.toLowerCase();
+
+							return {
 								...innerAcc,
-								[address]: {
+								[parsedAddress]: {
 									amounts: [
-										...(nonNullish(acc[address]) ? acc[address].amounts : []),
+										...(nonNullish(acc[parsedAddress]) ? acc[parsedAddress].amounts : []),
 										{ value, token }
 									],
 									timestamp:
-										nonNullish(acc[address]?.timestamp) && nonNullish(timestamp)
-											? Math.max(Number(acc[address].timestamp), Number(timestamp))
+										nonNullish(acc[parsedAddress]?.timestamp) && nonNullish(timestamp)
+											? Math.max(Number(acc[parsedAddress].timestamp), Number(timestamp))
 											: nonNullish(timestamp)
 												? Number(timestamp)
-												: acc[address].timestamp,
-									address
+												: acc[parsedAddress].timestamp,
+									address: parsedAddress
 								}
-							}),
-							{}
-						)
+							};
+						}, {})
 					}
 				: acc,
 		{}

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1472,7 +1472,7 @@ describe('transactions.utils', () => {
 			const btcTransactionsUi = {
 				...mockTransaction,
 				type: 'send' as BtcTransactionType,
-				to: [mockTransaction.to, mockTransaction.from] as string[],
+				to: [...(mockTransaction.to as string[]), mockTransaction.from] as string[],
 				token: BTC_MAINNET_TOKEN
 			};
 


### PR DESCRIPTION
# Motivation

Similar as with other networks, we need to fallback to `[]` if eth transactions failed to load. Also, we need to lowercase addresses before adding them to the map.