### PR TITLE
fix(frontend): Empty avatar size inside AddressCard

### DIFF
--- a/src/frontend/src/lib/components/address/AddressCard.svelte
+++ b/src/frontend/src/lib/components/address/AddressCard.svelte
@@ -28,11 +28,15 @@
 	class:bg-brand-subtle-10={variant === 'info'}
 	class:border-brand-subtle-10={variant === 'info'}
 >
-	{@render logo?.()}
+	<div class="flex flex-shrink-0">
+		{@render logo?.()}
+	</div>
 
-	<div class="flex w-full flex-col truncate pl-2 pr-4 text-sm sm:text-base">
+	<div class="flex flex-col truncate pl-2 pr-4 text-sm sm:text-base">
 		{@render content()}
 	</div>
 
-	{@render actions?.()}
+	<div class="flex">
+		{@render actions?.()}
+	</div>
 </div>


### PR DESCRIPTION
# Motivation

Inside the `AddressCard` component, the empty avatar size didnt adjust properly.

# Changes

- Wrap flex elements inside `AddressCard`
- Add `flex-shrink-0` on `<Img>` wrapper

# Tests

Before:
![image](https://github.com/user-attachments/assets/16629d8e-d1d1-441d-91c9-ef9103b90091)

After:
![image](https://github.com/user-attachments/assets/ae883ff8-4dd2-4d81-8750-3b977c05807f)


