### PR TITLE
feat(frontend): change labels and alts from dapp to app

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -70,7 +70,7 @@
 		"alt": {
 			"tokens": "Go to the assets view",
 			"settings": "Open your settings",
-			"dapp_explorer": "Open dapp explorer",
+			"dapp_explorer": "Open app explorer",
 			"activity": "Open the activity view",
 			"airdrops": "Open the Rewards view",
 			"more_settings": "More settings",
@@ -155,24 +155,24 @@
 	},
 	"dapps": {
 		"text": {
-			"all_dapps": "All dapps",
+			"all_dapps": "All apps",
 			"featured": "Featured",
 			"sign_in": "Sign-in to explore the ecosystem.",
 			"title": "Explore Apps",
 			"open_dapp": "Open $dAppName",
-			"submit_your_dapp": "Submit your dapp"
+			"submit_your_dapp": "Submit your app"
 		},
 		"alt": {
 			"learn_more": "Learn more about $dAppName",
 			"logo": "Logo of $dAppName",
-			"show_all": "Show all decentralised applications",
-			"show_tag": "Show decentralised applications with the tag $tag",
+			"show_all": "Show all applications",
+			"show_tag": "Show applications with the tag $tag",
 			"open_dapp": "Open the app $dAppName",
 			"open_telegram": "Open $dAppName on Telegram",
 			"open_open_chat": "Open $dAppName on OpenChat",
 			"open_twitter": "Open the $dAppName X/Twitter feed",
 			"source_code_on_github": "View source code of $dAppName on github",
-			"submit_your_dapp": "Submit your dapp to be shown in the dapp-explorer",
+			"submit_your_dapp": "Submit your app to be shown in the app-explorer",
 			"tags": "Tags related to $dAppName",
 			"website": "Image of $dAppName"
 		}


### PR DESCRIPTION
# Motivation

Since also show apps in the explorer, we should correctly name them apps and not dapps.
Note: The page header was already set to "Explore Apps"

# Changes

Labels and alts texts for buttons change from dapp to app
