### PR TITLE
fix(frontend): pass networkId to BtcSendDestination

### DIFF
--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -95,6 +95,7 @@
 				bind:invalidDestination
 				on:icQRCodeScan
 				knownDestinations={$btcKnownDestinations}
+				networkId={$sendTokenNetworkId}
 			/>
 			<SendDestinationTabs
 				knownDestinations={$btcKnownDestinations}


### PR DESCRIPTION
# Motivation

We need to pass networkId to BtcSendDestination for the validation to work correctly.
