### PR TITLE
feat(frontend): display network contacts in the send flow

### DIFF
--- a/src/frontend/src/lib/components/send/SendDestinationTabs.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationTabs.svelte
@@ -4,6 +4,7 @@
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
+	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { SendDestinationTab } from '$lib/types/send';
 	import type { KnownDestinations } from '$lib/types/transactions';
 
@@ -11,6 +12,7 @@
 		destination: string;
 		activeSendDestinationTab: SendDestinationTab;
 		knownDestinations?: KnownDestinations;
+		networkContacts?: NetworkContacts;
 		selectedContact?: ContactUi;
 	}
 
@@ -18,7 +20,8 @@
 		knownDestinations,
 		destination = $bindable(),
 		activeSendDestinationTab = $bindable(),
-		selectedContact = $bindable()
+		selectedContact = $bindable(),
+		networkContacts
 	}: Props = $props();
 </script>
 
@@ -33,7 +36,7 @@
 		{#if activeSendDestinationTab === 'recentlyUsed'}
 			<KnownDestinationsComponent {knownDestinations} bind:destination on:icNext />
 		{:else if activeSendDestinationTab === 'contacts'}
-			<SendContacts bind:destination bind:selectedContact on:icNext />
+			<SendContacts {networkContacts} bind:destination bind:selectedContact on:icNext />
 		{/if}
 	</Tabs>
 </div>

--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
 	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
+	import { btcNetworkContacts } from '$btc/derived/btc-contacts.derived';
 	import { btcKnownDestinations } from '$btc/derived/btc-transactions.derived';
 	import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
 	import EthSendDestination from '$eth/components/send/EthSendDestination.svelte';
+	import { ethNetworkContacts } from '$eth/derived/eth-contacts.derived';
 	import { ethKnownDestinations } from '$eth/derived/eth-transactions.derived';
 	import { ethereumTokenId } from '$eth/derived/token.derived';
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
+	import { icNetworkContacts } from '$icp/derived/ic-contacts.derived';
 	import { icKnownDestinations } from '$icp/derived/ic-transactions.derived';
 	import CkEthLoader from '$icp-eth/components/core/CkEthLoader.svelte';
 	import SendDestinationTabs from '$lib/components/send/SendDestinationTabs.svelte';
@@ -32,6 +35,7 @@
 		isNetworkIdSolana
 	} from '$lib/utils/network.utils';
 	import SolSendDestination from '$sol/components/send/SolSendDestination.svelte';
+	import { solNetworkContacts } from '$sol/derived/sol-contacts.derived';
 	import { solKnownDestinations } from '$sol/derived/sol-transactions.derived';
 
 	interface Props {
@@ -76,6 +80,7 @@
 					/>
 					<SendDestinationTabs
 						knownDestinations={$ethKnownDestinations}
+						networkContacts={$ethNetworkContacts}
 						bind:destination
 						bind:activeSendDestinationTab
 						bind:selectedContact
@@ -95,6 +100,7 @@
 			/>
 			<SendDestinationTabs
 				knownDestinations={$icKnownDestinations}
+				networkContacts={$icNetworkContacts}
 				bind:destination
 				bind:activeSendDestinationTab
 				bind:selectedContact
@@ -112,6 +118,7 @@
 			/>
 			<SendDestinationTabs
 				knownDestinations={$btcKnownDestinations}
+				networkContacts={$btcNetworkContacts}
 				bind:destination
 				bind:activeSendDestinationTab
 				bind:selectedContact
@@ -128,6 +135,7 @@
 			/>
 			<SendDestinationTabs
 				knownDestinations={$solKnownDestinations}
+				networkContacts={$solNetworkContacts}
 				bind:destination
 				bind:activeSendDestinationTab
 				bind:selectedContact

--- a/src/frontend/src/tests/lib/components/send/SendDestinationTabs.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendDestinationTabs.spec.ts
@@ -1,10 +1,18 @@
 import SendDestinationTabs from '$lib/components/send/SendDestinationTabs.svelte';
+import type { ContactUi } from '$lib/types/contact';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
 import { knownDestinations } from '$tests/mocks/transactions.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SendDestinationTabs', () => {
-	it('renders known destinations tab by default', () => {
+	const [contact] = getMockContactsUi({
+		n: 1,
+		name: 'Multiple Addresses Contact',
+		addresses: [mockContactBtcAddressUi]
+	}) as unknown as ContactUi[];
+
+	it('renders known destinations tab', () => {
 		const { getByText } = render(SendDestinationTabs, {
 			props: {
 				destination: '',
@@ -18,5 +26,21 @@ describe('SendDestinationTabs', () => {
 		});
 	});
 
-	// TODO: add test for contacts tab when it's implemented
+	it('renders contacts tab', () => {
+		const { getByText } = render(SendDestinationTabs, {
+			props: {
+				destination: '',
+				knownDestinations,
+				networkContacts: {
+					[mockContactBtcAddressUi.address]: contact
+				},
+				activeSendDestinationTab: 'contacts'
+			}
+		});
+
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockContactBtcAddressUi.address }))
+		).toBeInTheDocument();
+		expect(getByText(contact.name)).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
# Motivation

We now can connect the recently added network contacts stores with the UI components.

Note: the parent PR (https://github.com/dfinity/oisy-wallet/pull/7046) should be merged first.

<img width="596" alt="Screenshot 2025-05-29 at 14 47 12" src="https://github.com/user-attachments/assets/d5f493d6-0c24-4cd1-bed2-1b2cc418fc00" />
