### PR TITLE
refactor(frontend): Cleanup classes in contact card

### DIFF
--- a/src/frontend/src/lib/components/contact/ContactCard.svelte
+++ b/src/frontend/src/lib/components/contact/ContactCard.svelte
@@ -48,7 +48,7 @@
 		{/snippet}
 
 		{#snippet description()}
-			<span class="block w-full items-center truncate">
+			<span class="block w-full truncate">
 				{#each contact.addresses as address, index (index)}
 					{#if index !== 0}
 						<Divider />


### PR DESCRIPTION
# Motivation

According to comment https://github.com/dfinity/oisy-wallet/pull/7039#discussion_r2114015180 we need to remove a class because the element is not flex anymore.

# Changes

Removed `items-center` class

