### PR TITLE
fix(frontend): add aria-label and role to avatar element

### DIFF
--- a/src/frontend/src/lib/components/contact/Avatar.svelte
+++ b/src/frontend/src/lib/components/contact/Avatar.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import IconAvatar from '$lib/components/icons/IconAvatar.svelte';
 	import { CONTACT_BACKGROUND_COLORS } from '$lib/constants/contact.constants';
+	import { i18n } from '$lib/stores/i18n.store';
 	import type { AvatarVariants } from '$lib/types/style';
 	import { selectColorForName } from '$lib/utils/contact.utils';
 
@@ -9,10 +10,9 @@
 		name?: string;
 		variant?: AvatarVariants;
 		styleClass?: string;
-		alt?: string;
 	}
 
-	const { name, variant = 'md', styleClass, alt = 'Default avatar' }: AvatarProps = $props();
+	const { name, variant = 'md', styleClass }: AvatarProps = $props();
 
 	const font = $derived(
 		{
@@ -27,7 +27,9 @@
 	let size = $derived(variant === 'xl' ? 'size-25' : 'size-[2.5em]');
 	let bgColor = $derived(selectColorForName({ name, colors: CONTACT_BACKGROUND_COLORS }));
 	let commonClasses = $derived(`${font} ${size} ${bgColor} relative z-0 rounded-full`);
-	let ariaLabel = $derived(name ? `Avatar for ${name}` : alt);
+	let ariaLabel = $derived(
+		name ? `${$i18n.address_book.avatar.avatar_for} ${name}` : $i18n.address_book.avatar.default
+	);
 
 	const initials = $derived(
 		(nonNullish(name) ? name : '')

--- a/src/frontend/src/lib/components/contact/Avatar.svelte
+++ b/src/frontend/src/lib/components/contact/Avatar.svelte
@@ -9,8 +9,10 @@
 		name?: string;
 		variant?: AvatarVariants;
 		styleClass?: string;
+		alt?: string;
 	}
-	const { name, variant = 'md', styleClass }: AvatarProps = $props();
+
+	const { name, variant = 'md', styleClass, alt = 'Default avatar' }: AvatarProps = $props();
 
 	const font = $derived(
 		{
@@ -21,11 +23,11 @@
 			xs: 'text-[12.8px]' // size: 32px
 		}[variant]
 	);
+
 	let size = $derived(variant === 'xl' ? 'size-25' : 'size-[2.5em]');
-
 	let bgColor = $derived(selectColorForName({ name, colors: CONTACT_BACKGROUND_COLORS }));
-
 	let commonClasses = $derived(`${font} ${size} ${bgColor} relative z-0 rounded-full`);
+	let ariaLabel = $derived(name ? `Avatar for ${name}` : alt);
 
 	const initials = $derived(
 		(nonNullish(name) ? name : '')
@@ -38,12 +40,19 @@
 </script>
 
 {#if !initials}
-	<div class={`${commonClasses} text-brand-primary ${styleClass}`}>
-		<IconAvatar size={`${size}`}></IconAvatar>
+	<div
+		class={`${commonClasses} text-brand-primary ${styleClass}`}
+		role="img"
+		aria-label={ariaLabel}
+	>
+		<IconAvatar {size} />
 	</div>
 {:else}
 	<span
 		class={`${commonClasses} inline-block inline-flex items-center justify-center font-bold text-white transition-colors duration-1000 ${styleClass}`}
-		>{initials}</span
+		role="img"
+		aria-label={ariaLabel}
 	>
+		{initials}
+	</span>
 {/if}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1058,6 +1058,10 @@
 			"add_address": "Add address",
 			"delete_contact": "Delete contact"
 		},
+		"avatar": {
+			"default": "Default avatar",
+			"avatar_for": "Avatar for"
+		},
 		"show_contact": {
 			"title": "Contact",
 			"add_address": "Add address",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -969,6 +969,7 @@ interface I18nAddress_book {
 	};
 	alt: { show_addresses_of_contact: string; hide_addresses: string };
 	edit_contact: { title: string; add_address: string; delete_contact: string };
+	avatar: { default: string; avatar_for: string };
 	show_contact: {
 		title: string;
 		add_address: string;


### PR DESCRIPTION
# Motivation

The primary goal is to make the Avatar component more accessible, aligning with best practices for web accessibility.

# Changes

Updated the Avatar component to include role="img" and aria-label attributes.

# Tests

Manual Testing: 
   Verified that screen readers announce the avatar correctly with both name and alt props.
    Ensured that the IconAvatar component renders without issues.
