### PR TITLE
feat(frontend): Revert bumping of ethers from 6.14.3 to 6.13.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"@walletconnect/auth-client": "^2.1.2",
 				"alchemy-sdk": "3.4.1",
 				"buffer": "^6.0.3",
-				"ethers": "^6.14.3",
+				"ethers": "^6.13.7",
 				"idb-keyval": "^6.2.2",
 				"plausible-tracker": "^0.3.9",
 				"svelte-confetti": "^2.3.1",
@@ -7941,9 +7941,9 @@
 			}
 		},
 		"node_modules/ethers": {
-			"version": "6.14.3",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.14.3.tgz",
-			"integrity": "sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA==",
+			"version": "6.13.7",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.7.tgz",
+			"integrity": "sha512-qbaJ0uIrjh+huP1Lad2f2QtzW5dcqSVjIzVH6yWB4dKoMuj2WqYz5aMeeQTCNpAKgTJBM5J9vcc2cYJ23UAimQ==",
 			"funding": [
 				{
 					"type": "individual",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"@walletconnect/auth-client": "^2.1.2",
 		"alchemy-sdk": "3.4.1",
 		"buffer": "^6.0.3",
-		"ethers": "^6.14.3",
+		"ethers": "^6.13.7",
 		"idb-keyval": "^6.2.2",
 		"plausible-tracker": "^0.3.9",
 		"svelte-confetti": "^2.3.1",


### PR DESCRIPTION
# Motivation

Ideally we should bump ethers and already adapt the code in the same PR, since there was a quasi-breaking change (at least for our code, see https://github.com/ethers-io/ethers.js/issues/4975#issuecomment-2910714249). To monitor the correct code execution, we will tackle this with PR:

- https://github.com/dfinity/oisy-wallet/pull/7013

For now, we revert it to the previous version.