### PR TITLE
feat(frontend): case-sensitive displaying/filtering of send addresses

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -25,9 +25,7 @@
 	);
 
 	let filteredKnownDestinations = $derived(
-		sortedKnownDestinations.filter(({ address }) =>
-			address.toLowerCase().includes(destination.toLowerCase())
-		)
+		sortedKnownDestinations.filter(({ address }) => address.includes(destination))
 	);
 </script>
 

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -67,7 +67,7 @@
 	</div>
 </div>
 
-{#if !invalidDestination && notEmptyString(destination) && nonNullish(knownDestinations) && isNullish(knownDestinations[destination.toLowerCase()])}
+{#if !invalidDestination && notEmptyString(destination) && nonNullish(knownDestinations) && isNullish(knownDestinations[destination])}
 	<div transition:slide={SLIDE_DURATION}>
 		<MessageBox level="warning" styleClass="mt-4">
 			{$i18n.send.info.unknown_destination}

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -307,26 +307,25 @@ export const getKnownDestinations = (
 			nonNullish(to) && type === 'send' && nonNullish(value) && value > ZERO
 				? {
 						...acc,
-						...(Array.isArray(to) ? to : [to]).reduce((innerAcc, address) => {
-							const parsedAddress = address.toLowerCase();
-
-							return {
+						...(Array.isArray(to) ? to : [to]).reduce(
+							(innerAcc, address) => ({
 								...innerAcc,
-								[parsedAddress]: {
+								[address]: {
 									amounts: [
-										...(nonNullish(acc[parsedAddress]) ? acc[parsedAddress].amounts : []),
+										...(nonNullish(acc[address]) ? acc[address].amounts : []),
 										{ value, token }
 									],
 									timestamp:
-										nonNullish(acc[parsedAddress]?.timestamp) && nonNullish(timestamp)
-											? Math.max(Number(acc[parsedAddress].timestamp), Number(timestamp))
+										nonNullish(acc[address]?.timestamp) && nonNullish(timestamp)
+											? Math.max(Number(acc[address].timestamp), Number(timestamp))
 											: nonNullish(timestamp)
 												? Number(timestamp)
-												: acc[parsedAddress].timestamp,
-									address: parsedAddress
+												: acc[address].timestamp,
+									address
 								}
-							};
-						}, {})
+							}),
+							{}
+						)
 					}
 				: acc,
 		{}


### PR DESCRIPTION
# Motivation

When displaying and filtering destinations in the Address Picker step, we should work with raw (non-lowercased) values because e.g. Solana addresses are case-sensitive. 
