### PR TITLE
fix(frontend): Make search and add contact button responsive

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
@@ -61,7 +61,8 @@
 				ariaLabel={$i18n.address_book.text.add_contact}
 			>
 				<IconPlus />
-				<span class="hidden whitespace-nowrap xs:block">{$i18n.address_book.text.add_contact}</span></Button
+				<span class="hidden whitespace-nowrap xs:block">{$i18n.address_book.text.add_contact}</span
+				></Button
 			>
 		</div>
 

--- a/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
@@ -45,27 +45,24 @@
 	{#if contacts.length === 0}
 		<EmptyAddressBook {onAddContact}></EmptyAddressBook>
 	{:else}
-		<div class="flex w-full gap-2">
-			<div class="w-3/5">
-				<InputSearch
-					bind:filter={searchTerm}
-					showResetButton={notEmptyString(searchTerm)}
-					placeholder={$i18n.address_book.text.search_contact}
-					autofocus={true}
-					testId={ADDRESS_BOOK_SEARCH_CONTACT_INPUT}
-				/>
-			</div>
-			<div class="flex w-2/5 justify-end pt-[var(--padding)]">
-				<Button
-					colorStyle="secondary-light"
-					on:click={onAddContact}
-					testId={ADDRESS_BOOK_ADD_CONTACT_BUTTON}
-					styleClass="rounded-[12px]"
-				>
-					<IconPlus />
-					{$i18n.address_book.text.add_contact}
-				</Button>
-			</div>
+		<div class="flex w-full items-end gap-2">
+			<InputSearch
+				bind:filter={searchTerm}
+				showResetButton={notEmptyString(searchTerm)}
+				placeholder={$i18n.address_book.text.search_contact}
+				autofocus={true}
+				testId={ADDRESS_BOOK_SEARCH_CONTACT_INPUT}
+			/>
+			<Button
+				colorStyle="secondary-light"
+				on:click={onAddContact}
+				testId={ADDRESS_BOOK_ADD_CONTACT_BUTTON}
+				styleClass="rounded-xl"
+				ariaLabel={$i18n.address_book.text.add_contact}
+			>
+				<IconPlus />
+				<span class="hidden whitespace-nowrap xs:block">{$i18n.address_book.text.add_contact}</span></Button
+			>
 		</div>
 
 		<div class="flex flex-col gap-0.5 py-6">


### PR DESCRIPTION
# Motivation

Text of add contact input breaks into two lines on small screen. Makes input and button responsive.

# Changes

- Hide button text on small scerens
- Use flex to resize search input and button

# Tests

[vokoscreenNG-2025-05-30_10-14-43.webm](https://github.com/user-attachments/assets/265382cf-ced4-41db-82f4-27b892516fc0)
