### PR TITLE
feat(frontend): display only valid contacts for ICP/ICRC tokens

### DIFF
--- a/src/frontend/src/icp/derived/ic-contacts.derived.ts
+++ b/src/frontend/src/icp/derived/ic-contacts.derived.ts
@@ -1,8 +1,30 @@
+import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
+import { isIcrcAddress } from '$icp/utils/icrc-account.utils';
+import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { contacts } from '$lib/derived/contacts.derived';
+import { tokenWithFallback } from '$lib/derived/token.derived';
 import type { NetworkContacts } from '$lib/types/contacts';
+import { isIcpAccountIdentifier } from '$lib/utils/account.utils';
 import { getNetworkContacts } from '$lib/utils/contacts.utils';
 import { derived, type Readable } from 'svelte/store';
 
-export const icNetworkContacts: Readable<NetworkContacts> = derived([contacts], ([$contacts]) =>
-	getNetworkContacts({ addressType: 'Icrcv2', contacts: $contacts })
+export const icNetworkContacts: Readable<NetworkContacts> = derived(
+	[contacts, tokenWithFallback],
+	([$contacts, $tokenWithFallback]) => {
+		const isIcpToken = $tokenWithFallback.id === ICP_TOKEN_ID;
+		const isIcrcToken = isTokenIcrc({ standard: $tokenWithFallback.standard });
+
+		const allIcNetworkContacts = getNetworkContacts({ addressType: 'Icrcv2', contacts: $contacts });
+
+		return Object.keys(allIcNetworkContacts).reduce<NetworkContacts>(
+			(acc, address) => ({
+				...acc,
+				...((isIcpToken && isIcpAccountIdentifier(address)) ||
+				(isIcrcToken && isIcrcAddress(address))
+					? { [address]: allIcNetworkContacts[address] }
+					: {})
+			}),
+			{}
+		);
+	}
 );

--- a/src/frontend/src/tests/icp/derived/ic-contacts.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ic-contacts.derived.spec.ts
@@ -1,26 +1,52 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { icNetworkContacts } from '$icp/derived/ic-contacts.derived';
 import { contactsStore } from '$lib/stores/contacts.store';
+import { token } from '$lib/stores/token.store';
 import type { ContactUi } from '$lib/types/contact';
 import { getMockContactsUi, mockContactIcrcAddressUi } from '$tests/mocks/contacts.mock';
+import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockPrincipalText } from '$tests/mocks/identity.mock';
 import { get } from 'svelte/store';
 
 describe('ic-contacts.derived', () => {
 	describe('icNetworkContacts', () => {
-		const contactWithIcAddress = getMockContactsUi({
-			n: 3,
-			name: 'Multiple Addresses Contact',
-			addresses: [mockContactIcrcAddressUi]
-		}) as unknown as ContactUi[];
-
 		beforeEach(() => {
 			contactsStore.reset();
+			token.reset();
 		});
 
-		it('has correct data if there are some IC contacts', () => {
-			contactsStore.set([...contactWithIcAddress]);
+		it('has correct data if there are some IC contacts and current token is ICRC', () => {
+			const contactWithIcrcAddress = getMockContactsUi({
+				n: 3,
+				name: 'Multiple Addresses Contact',
+				addresses: [
+					{
+						...mockContactIcrcAddressUi,
+						address: mockPrincipalText
+					}
+				]
+			}) as unknown as ContactUi[];
+
+			token.set(mockValidIcrcToken);
+			contactsStore.set([...contactWithIcrcAddress]);
 
 			expect(get(icNetworkContacts)).toStrictEqual({
-				[mockContactIcrcAddressUi.address]: contactWithIcAddress[0]
+				[mockPrincipalText]: contactWithIcrcAddress[0]
+			});
+		});
+
+		it('has correct data if there are some IC contacts and current token is ICP', () => {
+			const contactWithIcrcAddress = getMockContactsUi({
+				n: 3,
+				name: 'Multiple Addresses Contact',
+				addresses: [mockContactIcrcAddressUi]
+			}) as unknown as ContactUi[];
+
+			token.set(ICP_TOKEN);
+			contactsStore.set([...contactWithIcrcAddress]);
+
+			expect(get(icNetworkContacts)).toStrictEqual({
+				[mockContactIcrcAddressUi.address]: contactWithIcrcAddress[0]
 			});
 		});
 


### PR DESCRIPTION
# Motivation

We need to separate `icNetworkContacts` for the ICP and ICRC cases in order to display only valid addresses for the selected IC token.