### PR TITLE
fix: update font size and colors

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressInfoCard.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressInfoCard.svelte
@@ -15,7 +15,7 @@
 
 <Value ref="address-info" element="div">
 	{#snippet label()}
-		<div class="mb-3 text-sm font-bold text-primary">
+		<div class="mb-3 text-md font-bold text-primary">
 			{$i18n.address.types[address.addressType]}
 		</div>
 	{/snippet}
@@ -32,7 +32,7 @@
 						{address.label}
 					</div>
 				{/if}
-				<div class="break-all text-sm text-tertiary">
+				<div class="break-all text-sm text-primary">
 					{address.address}
 				</div>
 			</div>


### PR DESCRIPTION
# Motivation

The Address Info section had visual issues impacting readability and design consistency:

The font appeared too light, especially in light mode, making it harder to read 

# Changes

Change the font to the main color and size by design

# Tests
Manual test the view
<img width="634" alt="Screenshot 2025-05-30 at 12 36 19" src="https://github.com/user-attachments/assets/6c52c832-3db1-4a30-94ee-2ebcd8d480b0" />

