### PR TITLE
feat(frontend): filter network contacts

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendDestination.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendDestination.svelte
@@ -2,6 +2,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { NetworkId } from '$lib/types/network';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isInvalidDestinationBtc } from '$lib/utils/send.utils';
@@ -10,6 +11,7 @@
 	export let networkId: NetworkId | undefined = undefined;
 	export let invalidDestination = false;
 	export let knownDestinations: KnownDestinations | undefined = undefined;
+	export let networkContacts: NetworkContacts | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -24,6 +26,7 @@
 	bind:destination
 	bind:invalidDestination
 	{knownDestinations}
+	{networkContacts}
 	{isInvalidDestination}
 	inputPlaceholder={$i18n.send.placeholder.enter_recipient_address}
 	on:icQRCodeScan

--- a/src/frontend/src/eth/components/send/EthSendDestination.svelte
+++ b/src/frontend/src/eth/components/send/EthSendDestination.svelte
@@ -4,6 +4,7 @@
 	import { isErc20Icp } from '$eth/utils/token.utils';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { Network } from '$lib/types/network';
 	import type { OptionToken } from '$lib/types/token';
 	import type { KnownDestinations } from '$lib/types/transactions';
@@ -16,6 +17,7 @@
 	export let destination = '';
 	export let invalidDestination = false;
 	export let knownDestinations: KnownDestinations | undefined = undefined;
+	export let networkContacts: NetworkContacts | undefined = undefined;
 
 	let networkICP = false;
 	$: networkICP = isNetworkICP(network);
@@ -49,6 +51,7 @@
 	bind:destination
 	bind:invalidDestination
 	{knownDestinations}
+	{networkContacts}
 	{isInvalidDestination}
 	inputPlaceholder={$i18n.send.placeholder.enter_eth_address}
 	on:icQRCodeScan

--- a/src/frontend/src/icp/components/send/IcSendDestination.svelte
+++ b/src/frontend/src/icp/components/send/IcSendDestination.svelte
@@ -4,6 +4,7 @@
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { NetworkId } from '$lib/types/network';
 	import type { TokenStandard } from '$lib/types/token';
 	import type { KnownDestinations } from '$lib/types/transactions';
@@ -14,6 +15,7 @@
 	export let tokenStandard: TokenStandard;
 	export let invalidDestination = false;
 	export let knownDestinations: KnownDestinations | undefined = undefined;
+	export let networkContacts: NetworkContacts | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -44,6 +46,7 @@
 	bind:destination
 	bind:invalidDestination
 	{knownDestinations}
+	{networkContacts}
 	{isInvalidDestination}
 	{inputPlaceholder}
 	on:icQRCodeScan

--- a/src/frontend/src/lib/components/send/SendContact.svelte
+++ b/src/frontend/src/lib/components/send/SendContact.svelte
@@ -17,7 +17,9 @@
 
 <LogoButton styleClass="group" {onClick}>
 	{#snippet logo()}
-		<AvatarWithBadge {contact} badge={{ type: 'addressType', address }} variant="sm" />
+		<div class="mr-2">
+			<AvatarWithBadge {contact} badge={{ type: 'addressType', address }} variant="sm" />
+		</div>
 	{/snippet}
 
 	{#snippet title()}

--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -20,12 +20,26 @@
 	}: Props = $props();
 
 	const dispatch = createEventDispatcher();
+
+	let filteredNetworkContacts = $derived(
+		nonNullish(networkContacts)
+			? Object.keys(networkContacts).reduce<NetworkContacts>(
+					(acc, address) => ({
+						...acc,
+						...(address.includes(destination) ? { [address]: networkContacts[address] } : {})
+					}),
+					{}
+				)
+			: {}
+	);
+
+	let filteredNetworkContactsKeys = $derived(Object.keys(filteredNetworkContacts));
 </script>
 
-{#if nonNullish(networkContacts) && Object.keys(networkContacts).length > 0}
+{#if nonNullish(networkContacts) && filteredNetworkContactsKeys.length > 0}
 	<div class="flex flex-col overflow-y-hidden sm:max-h-[13.5rem]">
 		<ul class="list-none overflow-y-auto overscroll-contain">
-			{#each Object.keys(networkContacts) as address, index (index)}
+			{#each filteredNetworkContactsKeys as address, index (index)}
 				<SendContact
 					contact={networkContacts[address]}
 					{address}

--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -74,6 +74,7 @@
 					<EthSendDestination
 						token={$sendToken}
 						knownDestinations={$ethKnownDestinations}
+						networkContacts={$ethNetworkContacts}
 						bind:destination
 						bind:invalidDestination
 						on:icQRCodeScan
@@ -94,6 +95,7 @@
 			<IcSendDestination
 				tokenStandard={$sendToken.standard}
 				knownDestinations={$icKnownDestinations}
+				networkContacts={$ethNetworkContacts}
 				bind:destination
 				bind:invalidDestination
 				on:icQRCodeScan
@@ -114,6 +116,7 @@
 				bind:invalidDestination
 				on:icQRCodeScan
 				knownDestinations={$btcKnownDestinations}
+				networkContacts={$ethNetworkContacts}
 				networkId={$sendTokenNetworkId}
 			/>
 			<SendDestinationTabs
@@ -132,6 +135,7 @@
 				bind:invalidDestination
 				on:icQRCodeScan
 				knownDestinations={$solKnownDestinations}
+				networkContacts={$ethNetworkContacts}
 			/>
 			<SendDestinationTabs
 				knownDestinations={$solKnownDestinations}

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -7,6 +7,7 @@
 	import { DESTINATION_INPUT } from '$lib/constants/test-ids.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { NetworkId } from '$lib/types/network';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isDesktop } from '$lib/utils/device.utils';
@@ -18,6 +19,7 @@
 	export let isInvalidDestination: (() => boolean) | undefined;
 	export let onQRButtonClick: (() => void) | undefined = undefined;
 	export let knownDestinations: KnownDestinations | undefined = undefined;
+	export let networkContacts: NetworkContacts | undefined = undefined;
 
 	const validate = () => (invalidDestination = isInvalidDestination?.() ?? false);
 
@@ -67,7 +69,7 @@
 	</div>
 </div>
 
-{#if !invalidDestination && notEmptyString(destination) && nonNullish(knownDestinations) && isNullish(knownDestinations[destination])}
+{#if !invalidDestination && notEmptyString(destination) && nonNullish(knownDestinations) && isNullish(knownDestinations[destination]) && nonNullish(networkContacts) && isNullish(networkContacts[destination])}
 	<div transition:slide={SLIDE_DURATION}>
 		<MessageBox level="warning" styleClass="mt-4">
 			{$i18n.send.info.unknown_destination}

--- a/src/frontend/src/sol/components/send/SolSendDestination.svelte
+++ b/src/frontend/src/sol/components/send/SolSendDestination.svelte
@@ -2,12 +2,14 @@
 	import { createEventDispatcher } from 'svelte';
 	import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isInvalidDestinationSol } from '$sol/utils/sol-send.utils';
 
 	export let destination = '';
 	export let invalidDestination = false;
 	export let knownDestinations: KnownDestinations | undefined = undefined;
+	export let networkContacts: NetworkContacts | undefined = undefined;
 
 	const dispatch = createEventDispatcher();
 
@@ -18,6 +20,7 @@
 	bind:destination
 	bind:invalidDestination
 	{knownDestinations}
+	{networkContacts}
 	{isInvalidDestination}
 	inputPlaceholder={$i18n.send.placeholder.enter_recipient_address}
 	on:icQRCodeScan

--- a/src/frontend/src/tests/lib/components/send/SendContacts.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendContacts.spec.ts
@@ -2,15 +2,24 @@ import SendContacts from '$lib/components/send/SendContacts.svelte';
 import type { ContactUi } from '$lib/types/contact';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
-import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
+import {
+	getMockContactsUi,
+	mockContactBtcAddressUi,
+	mockContactEthAddressUi
+} from '$tests/mocks/contacts.mock';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SendContacts', () => {
-	const [contact] = getMockContactsUi({
+	const [contact1] = getMockContactsUi({
 		n: 1,
-		name: 'Multiple Addresses Contact',
+		name: 'Test 1',
 		addresses: [mockContactBtcAddressUi]
+	}) as unknown as ContactUi[];
+	const [contact2] = getMockContactsUi({
+		n: 1,
+		name: 'Test 2',
+		addresses: [mockContactEthAddressUi]
 	}) as unknown as ContactUi[];
 
 	it('renders content if data is provided', () => {
@@ -18,13 +27,32 @@ describe('SendContacts', () => {
 			props: {
 				destination: '',
 				networkContacts: {
-					[mockContactBtcAddressUi.address]: contact
+					[mockContactBtcAddressUi.address]: contact1
 				}
 			}
 		});
 
 		expect(
 			getByText(shortenWithMiddleEllipsis({ text: mockContactBtcAddressUi.address }))
+		).toBeInTheDocument();
+	});
+
+	it('renders filtered content if data is provided', () => {
+		const { getByText } = render(SendContacts, {
+			props: {
+				destination: mockContactEthAddressUi.address,
+				networkContacts: {
+					[mockContactBtcAddressUi.address]: contact1,
+					[mockContactEthAddressUi.address]: contact2
+				}
+			}
+		});
+
+		expect(() =>
+			getByText(shortenWithMiddleEllipsis({ text: mockContactBtcAddressUi.address }))
+		).toThrow();
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockContactEthAddressUi.address }))
 		).toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/lib/components/send/SendInputDestination.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendInputDestination.spec.ts
@@ -1,4 +1,6 @@
 import SendInputDestination from '$lib/components/send/SendInputDestination.svelte';
+import type { ContactUi } from '$lib/types/contact';
+import { getMockContactsUi, mockContactEthAddressUi } from '$tests/mocks/contacts.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
@@ -6,6 +8,7 @@ import { render } from '@testing-library/svelte';
 describe('SendInputDestination', () => {
 	const props = {
 		destination: mockEthAddress,
+		networkContacts: {},
 		inputPlaceholder: 'test',
 		isInvalidDestination: undefined
 	};
@@ -38,6 +41,27 @@ describe('SendInputDestination', () => {
 		});
 
 		expect(getByText(en.send.assertion.invalid_destination_address)).toBeInTheDocument();
+	});
+
+	it('does not render unknown destination warning message if there is a contact with the provided address', () => {
+		const [contact] = getMockContactsUi({
+			n: 1,
+			name: 'Multiple Addresses Contact',
+			addresses: [mockContactEthAddressUi]
+		}) as unknown as ContactUi[];
+
+		const { getByText } = render(SendInputDestination, {
+			props: {
+				...props,
+				invalidDestination: false,
+				knownDestinations: {},
+				networkContacts: {
+					[props.destination]: contact
+				}
+			}
+		});
+
+		expect(() => getByText(en.send.info.unknown_destination)).toThrow();
 	});
 
 	it('renders unknown destination warning message', () => {


### PR DESCRIPTION
# Motivation

Similar to what we do with the "recent destinations", we should filter use contacts based on the inputted address. Also, the "unknown destination" message should be only displayed if the address is not available in any of the categories.
