### PR TITLE
feat(frontend): display contact label if available in SendContact

### DIFF
--- a/src/frontend/src/lib/components/send/SendContact.svelte
+++ b/src/frontend/src/lib/components/send/SendContact.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import Divider from '$lib/components/common/Divider.svelte';
 	import AvatarWithBadge from '$lib/components/contact/AvatarWithBadge.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -13,6 +15,12 @@
 	}
 
 	let { contact, address, onClick }: Props = $props();
+
+	let contactLabel = $derived(
+		nonNullish(contact)
+			? contact.addresses.find(({ address }) => address === address)?.label
+			: undefined
+	);
 </script>
 
 <LogoButton styleClass="group" {onClick}>
@@ -24,6 +32,11 @@
 
 	{#snippet title()}
 		{contact.name}
+
+		{#if nonNullish(contactLabel)}
+			<Divider />
+			{contactLabel}
+		{/if}
 	{/snippet}
 
 	{#snippet description()}

--- a/src/frontend/src/tests/lib/components/send/SendContact.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendContact.spec.ts
@@ -17,11 +17,12 @@ describe('SendContact', () => {
 	};
 
 	it('renders expected data', () => {
-		const { getByText } = render(SendContact, {
+		const { getByText, container } = render(SendContact, {
 			props
 		});
 
-		expect(getByText(contact.name)).toBeInTheDocument();
+		expect(container).toHaveTextContent(contact.name);
+		expect(container).toHaveTextContent(mockContactBtcAddressUi.label as string);
 		expect(getByText(shortenWithMiddleEllipsis({ text: props.address }))).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/send/SendDestinationTabs.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendDestinationTabs.spec.ts
@@ -27,7 +27,7 @@ describe('SendDestinationTabs', () => {
 	});
 
 	it('renders contacts tab', () => {
-		const { getByText } = render(SendDestinationTabs, {
+		const { getByText, container } = render(SendDestinationTabs, {
 			props: {
 				destination: '',
 				knownDestinations,
@@ -41,6 +41,7 @@ describe('SendDestinationTabs', () => {
 		expect(
 			getByText(shortenWithMiddleEllipsis({ text: mockContactBtcAddressUi.address }))
 		).toBeInTheDocument();
-		expect(getByText(contact.name)).toBeInTheDocument();
+		expect(container).toHaveTextContent(contact.name);
+		expect(container).toHaveTextContent(mockContactBtcAddressUi.label as string);
 	});
 });


### PR DESCRIPTION
# Motivation

We need to display contact label if available in SendContact.