### PR TITLE
fix(frontend): Available balance -> Your balance label change 

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -300,7 +300,7 @@
 	},
 	"hero": {
 		"text": {
-			"available_balance": "Available balance",
+			"available_balance": "Your balance",
 			"unavailable_balance": "$ value is not available",
 			"top_up": "Top up your wallet to start using it!",
 			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum."


### PR DESCRIPTION
# Motivation

We'd like to make the hero a bit more personalised: 

<img width="473" alt="image" src="https://github.com/user-attachments/assets/d901bd04-b3ae-4d9f-affd-6cdc21b1a3dc" />


# Changes

Changed title from "Available balance" to "Your balance"

# Tests

I can not test it locally unfortunately as I don't have api keys to display the balance from staging 
