### PR TITLE
fix(frontend): check for an empty string before showing contacts label

### DIFF
--- a/src/frontend/src/lib/components/send/SendContact.svelte
+++ b/src/frontend/src/lib/components/send/SendContact.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import Divider from '$lib/components/common/Divider.svelte';
 	import AvatarWithBadge from '$lib/components/contact/AvatarWithBadge.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
@@ -33,7 +33,7 @@
 	{#snippet title()}
 		{contact.name}
 
-		{#if nonNullish(contactLabel)}
+		{#if notEmptyString(contactLabel)}
 			<Divider />
 			{contactLabel}
 		{/if}

--- a/src/frontend/src/lib/components/send/SendDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendDestination.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import AddressCard from '$lib/components/address/AddressCard.svelte';
 	import Divider from '$lib/components/common/Divider.svelte';
@@ -45,7 +45,7 @@
 				<span>
 					{selectedContact.name}
 
-					{#if nonNullish(selectedContactLabel)}
+					{#if notEmptyString(selectedContactLabel)}
 						<Divider />
 						{selectedContactLabel}
 					{/if}


### PR DESCRIPTION
# Motivation

We should also check if label is an empty in SendContact and SendDestination.
