### PR TITLE
feat(frontend): Add label validation

### DIFF
--- a/src/frontend/src/lib/components/address/AddressForm.svelte
+++ b/src/frontend/src/lib/components/address/AddressForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { slide } from 'svelte/transition';
 	import type { ZodError } from 'zod';
 	import InputAddress from '$lib/components/address/InputAddress.svelte';
 	import InputText from '$lib/components/ui/InputText.svelte';
@@ -7,6 +8,8 @@
 		ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT,
 		ADDRESS_BOOK_ADDRESS_ALIAS_INPUT
 	} from '$lib/constants/test-ids.constants';
+	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import { ContactAddressUiSchema } from '$lib/schema/contact.schema';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
 
@@ -24,9 +27,10 @@
 	}: Props = $props();
 
 	let addressParseError = $state<ZodError | undefined>();
+	let labelError = $derived(ContactAddressUiSchema.shape.label.safeParse(address.label)?.error);
 
 	$effect(() => {
-		isInvalid = nonNullish(addressParseError);
+		isInvalid = nonNullish(addressParseError) || nonNullish(labelError);
 	});
 </script>
 
@@ -53,4 +57,9 @@
 		testId={ADDRESS_BOOK_ADDRESS_ALIAS_INPUT}
 		{disabled}
 	/>
+	{#if nonNullish(labelError)}
+		<p transition:slide={SLIDE_DURATION} class="pt-2 text-error-primary">
+			{$i18n.address.form.error.label_too_long}
+		</p>
+	{/if}
 </form>

--- a/src/frontend/src/lib/components/address/AddressForm.svelte
+++ b/src/frontend/src/lib/components/address/AddressForm.svelte
@@ -4,6 +4,7 @@
 	import type { ZodError } from 'zod';
 	import InputAddress from '$lib/components/address/InputAddress.svelte';
 	import InputText from '$lib/components/ui/InputText.svelte';
+	import { CONTACT_MAX_LABEL_LENGTH } from '$lib/constants/app.constants';
 	import {
 		ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT,
 		ADDRESS_BOOK_ADDRESS_ALIAS_INPUT
@@ -13,7 +14,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { CONTACT_MAX_LABEL_LENGTH } from '$lib/constants/app.constants';
 
 	interface Props {
 		address: Partial<ContactAddressUi>;

--- a/src/frontend/src/lib/components/address/AddressForm.svelte
+++ b/src/frontend/src/lib/components/address/AddressForm.svelte
@@ -12,6 +12,8 @@
 	import { ContactAddressUiSchema } from '$lib/schema/contact.schema';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { CONTACT_MAX_LABEL_LENGTH } from '$lib/constants/app.constants';
 
 	interface Props {
 		address: Partial<ContactAddressUi>;
@@ -59,7 +61,9 @@
 	/>
 	{#if nonNullish(labelError)}
 		<p transition:slide={SLIDE_DURATION} class="pt-2 text-error-primary">
-			{$i18n.address.form.error.label_too_long}
+			{replacePlaceholders($i18n.address.form.error.label_too_long, {
+				$maxCharacters: `${CONTACT_MAX_LABEL_LENGTH}`
+			})}
 		</p>
 	{/if}
 </form>

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -170,3 +170,6 @@ export const MAX_DISPLAYED_KNOWN_DESTINATION_AMOUNTS = 3;
 
 // Send destination
 export const MIN_DESTINATION_LENGTH_FOR_ERROR_STATE = 10;
+
+// Contact validation
+export const CONTACT_MAX_LABEL_LENGTH = 50;

--- a/src/frontend/src/lib/constants/token-account-id.constants.ts
+++ b/src/frontend/src/lib/constants/token-account-id.constants.ts
@@ -5,6 +5,7 @@ import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { SUPPORTED_SOLANA_MAINNET_NETWORKS } from '$env/networks/networks.sol.env';
 import type { Network } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
+import type { NonEmptyArray } from '$lib/types/utils';
 
 export const TOKEN_ACCOUNT_ID_TO_NETWORKS: { [key in TokenAccountIdTypes]: Network[] } = {
 	Icrcv2: [ICP_NETWORK],
@@ -12,6 +13,12 @@ export const TOKEN_ACCOUNT_ID_TO_NETWORKS: { [key in TokenAccountIdTypes]: Netwo
 	Eth: [...SUPPORTED_ETHEREUM_MAINNET_NETWORKS, ...SUPPORTED_EVM_MAINNET_NETWORKS],
 	Sol: SUPPORTED_SOLANA_MAINNET_NETWORKS
 };
+
+// The type definition '[key in ToeknAccountIdType]' of TOKEN_ACCOUNT_ID_TO_NETWORKS ensures
+// that this array contains all possible values of TokenAccountIdType
+export const TOKEN_ACCOUNT_ID_TYPES = Object.keys(
+	TOKEN_ACCOUNT_ID_TO_NETWORKS
+) as NonEmptyArray<TokenAccountIdTypes>;
 
 export const TOKEN_ACCOUNT_ID_TYPES_SORT_ORDER: { [key in TokenAccountIdTypes]: number } = {
 	Btc: 1,

--- a/src/frontend/src/lib/constants/token-account-id.constants.ts
+++ b/src/frontend/src/lib/constants/token-account-id.constants.ts
@@ -14,7 +14,7 @@ export const TOKEN_ACCOUNT_ID_TO_NETWORKS: { [key in TokenAccountIdTypes]: Netwo
 	Sol: SUPPORTED_SOLANA_MAINNET_NETWORKS
 };
 
-// The type definition '[key in ToeknAccountIdType]' of TOKEN_ACCOUNT_ID_TO_NETWORKS ensures
+// The type definition '[key in TokenAccountIdType]' of TOKEN_ACCOUNT_ID_TO_NETWORKS ensures
 // that this array contains all possible values of TokenAccountIdType
 export const TOKEN_ACCOUNT_ID_TYPES = Object.keys(
 	TOKEN_ACCOUNT_ID_TO_NETWORKS

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1102,7 +1102,7 @@
 			"invalid_address": "Invalid address",
 			"valid_for_networks": "Valid for networks:",
 			"error": {
-				"label_too_long": "Label may not exceed 50 characters"
+				"label_too_long": "Label may not exceed $maxCharacters characters"
 			}
 		},
 		"fields": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1100,7 +1100,10 @@
 			"address_placeholder": "Enter or paste address",
 			"label_placeholder": "E.g., “Mom’s wallet“",
 			"invalid_address": "Invalid address",
-			"valid_for_networks": "Valid for networks:"
+			"valid_for_networks": "Valid for networks:",
+			"error": {
+				"label_too_long": "Label may not exceed 50 characters"
+			}
 		},
 		"fields": {
 			"label": "Alias",

--- a/src/frontend/src/lib/schema/contact.schema.ts
+++ b/src/frontend/src/lib/schema/contact.schema.ts
@@ -1,10 +1,11 @@
+import { CONTACT_MAX_LABEL_LENGTH } from '$lib/constants/app.constants';
 import { AddressSchema } from '$lib/schema/address.schema';
 import { TokenAccountIdTypesSchema } from '$lib/schema/token-account-id.schema';
 import * as z from 'zod';
 
 export const ContactAddressUiSchema = z.object({
 	address: AddressSchema,
-	label: z.string().max(50).optional(),
+	label: z.string().max(CONTACT_MAX_LABEL_LENGTH).optional(),
 	addressType: TokenAccountIdTypesSchema
 });
 

--- a/src/frontend/src/lib/schema/contact.schema.ts
+++ b/src/frontend/src/lib/schema/contact.schema.ts
@@ -1,0 +1,11 @@
+import { AddressSchema } from '$lib/schema/address.schema';
+import { TokenAccountIdTypesSchema } from '$lib/schema/token-account-id.schema';
+import * as z from 'zod';
+
+export const ContactAddressUiSchema = z.object({
+	address: AddressSchema,
+	label: z.string().max(50).optional(),
+	addressType: TokenAccountIdTypesSchema
+});
+
+export type ContactAddressUiSchemaType = z.infer<typeof ContactAddressUiSchema>;

--- a/src/frontend/src/lib/schema/token-account-id.schema.ts
+++ b/src/frontend/src/lib/schema/token-account-id.schema.ts
@@ -1,3 +1,4 @@
+import { TOKEN_ACCOUNT_ID_TYPES } from '$lib/constants/token-account-id.constants';
 import {
 	BtcAddressObjectSchema,
 	EthAddressObjectSchema,
@@ -12,3 +13,5 @@ export const TokenAccountIdSchema = z.union([
 	EthAddressObjectSchema.transform((data) => ({ Eth: data })),
 	SolAddressSchema.transform((data) => ({ Sol: data }))
 ]);
+
+export const TokenAccountIdTypesSchema = z.enum(TOKEN_ACCOUNT_ID_TYPES);

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -993,6 +993,7 @@ interface I18nAddress {
 		label_placeholder: string;
 		invalid_address: string;
 		valid_for_networks: string;
+		error: { label_too_long: string };
 	};
 	fields: { label: string; address: string };
 	delete: { title: string; delete_address: string; content_text: string };

--- a/src/frontend/src/tests/lib/components/address/AddressForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/address/AddressForm.spec.ts
@@ -1,4 +1,5 @@
 import AddressForm from '$lib/components/address/AddressForm.svelte';
+import { CONTACT_MAX_LABEL_LENGTH } from '$lib/constants/app.constants';
 import {
 	ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT,
 	ADDRESS_BOOK_ADDRESS_ALIAS_INPUT
@@ -134,10 +135,9 @@ describe('AddressFormTestHost', () => {
 
 	it('should show error when label exceeds 50 characters', async () => {
 		const address: Partial<ContactAddressUi> = {};
-		const { getByTestId, getByText } = render(AddressFormTestHost, {
+		const { getByTestId, getByText, component } = render(AddressFormTestHost, {
 			props: {
 				address,
-				isNewAddress: true,
 				isInvalid: false
 			}
 		});
@@ -147,9 +147,9 @@ describe('AddressFormTestHost', () => {
 
 		await fireEvent.input(labelInput, { target: { value: longLabel } });
 
-		waitFor(() => {
-			// Check that isInvalid is now true
-			expect(getByText(en.address.form.error.label_too_long)).toBeInTheDocument();
-		});
+		expect(
+			getByText(`Label may not exceed ${CONTACT_MAX_LABEL_LENGTH} characters`)
+		).toBeInTheDocument();
+		expect(component.getIsInvalid).toBeTruthy();
 	});
 });

--- a/src/frontend/src/tests/lib/components/address/AddressForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/address/AddressForm.spec.ts
@@ -131,4 +131,25 @@ describe('AddressFormTestHost', () => {
 		expect(component.getAddress().address).toBe(validEthAddress);
 		expect(component.getAddress().addressType).toBe('Eth');
 	});
+
+	it('should show error when label exceeds 50 characters', async () => {
+		const address: Partial<ContactAddressUi> = {};
+		const { getByTestId, getByText } = render(AddressFormTestHost, {
+			props: {
+				address,
+				isNewAddress: true,
+				isInvalid: false
+			}
+		});
+
+		const labelInput = getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT);
+		const longLabel = 'This is a very long label that exceeds fifty characters limit';
+
+		await fireEvent.input(labelInput, { target: { value: longLabel } });
+
+		waitFor(() => {
+			// Check that isInvalid is now true
+			expect(getByText(en.address.form.error.label_too_long)).toBeInTheDocument();
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

There are validation errors in the backend when an address with an alias more than 50 characters is saved. This PR adds FE validation for this.

# Changes

- Adds a ContactAddressUi schema
- Adds validation to the address form

# Tests

![Screenshot_2025-05-30_15-16-44](https://github.com/user-attachments/assets/c137ce5f-85c9-498d-9dcf-a5a5a1f41a55)
