### PR TITLE
fix(frontend): improve contact search to also include the Alias and the Address

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookStep.svelte
@@ -33,10 +33,15 @@
 	let searchTerm = $state('');
 
 	let filteredContacts = $derived(
-		contacts.filter(({ name: contactName }) => {
+		contacts.filter(({ name: contactName, addresses }) => {
 			const name = contactName.toLowerCase();
+			const addressText = addresses
+				.map(({ address, label }) => `${address.toLowerCase()} ${label?.toLowerCase() ?? ''}`)
+				.join(' ');
+
+			const searchableText = `${name} ${addressText}`;
 			const terms = searchTerm.toLowerCase().split(/\s+/).filter(Boolean);
-			return terms.every((term) => name.includes(term));
+			return terms.every((term) => searchableText.includes(term));
 		})
 	);
 </script>


### PR DESCRIPTION
# Motivation

The contact search functionality was previously limited to matching only the contact's name. To improve user experience and search accuracy, we needed to extend the filtering to also include labels and addresses associated with each contact.

# Changes

Updated the filteredContacts derived state to include:
Matching against contact name
Matching against all address
Matching against all Alias
Flattened and normalized address and label data for case-insensitive, multi-term searching.
Maintained existing support for splitting and matching multiple search terms.

# Tests

Manually tested search functionality in the address book:
✅ Search by name returns expected contacts.
✅ Search by address returns matching contacts.
✅ Search by label (where present) returns correct results.
