### PR TITLE
feat(frontend): advanced contacts filtering in the send flow

### DIFF
--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -26,7 +26,14 @@
 			? Object.keys(networkContacts).reduce<NetworkContacts>(
 					(acc, address) => ({
 						...acc,
-						...(address.includes(destination) ? { [address]: networkContacts[address] } : {})
+						...(address.includes(destination) ||
+						networkContacts[address].name.toLowerCase().includes(destination.toLowerCase()) ||
+						networkContacts[address].addresses.some(
+							({ label, address: innerAddress }) =>
+								address === innerAddress && label?.toLowerCase().includes(destination.toLowerCase())
+						)
+							? { [address]: networkContacts[address] }
+							: {})
 					}),
 					{}
 				)

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -4,6 +4,7 @@
 	import QrButton from '$lib/components/common/QrButton.svelte';
 	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { MIN_DESTINATION_LENGTH_FOR_ERROR_STATE } from '$lib/constants/app.constants';
 	import { DESTINATION_INPUT } from '$lib/constants/test-ids.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -30,6 +31,10 @@
 	const onBlur = () => (focused = false);
 
 	$: destination, networkId, isInvalidDestination, debounceValidate();
+
+	let isErrorState = false;
+	$: isErrorState =
+		invalidDestination && destination.length > MIN_DESTINATION_LENGTH_FOR_ERROR_STATE;
 </script>
 
 <div
@@ -43,7 +48,7 @@
 		{$i18n.core.text.to}
 	</label>
 
-	<div class="send-input-destination" class:error={invalidDestination}>
+	<div class="send-input-destination" class:error={isErrorState}>
 		<InputTextWithAction
 			name="destination"
 			bind:value={destination}
@@ -61,7 +66,7 @@
 			</svelte:fragment>
 		</InputTextWithAction>
 
-		{#if invalidDestination}
+		{#if isErrorState}
 			<p transition:slide={SLIDE_DURATION} class="mb-0 mt-4 text-error-primary">
 				{$i18n.send.assertion.invalid_destination_address}
 			</p>

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -167,3 +167,6 @@ export const MICRO_TRANSACTION_USD_THRESHOLD = 0.01;
 
 // Known destinations
 export const MAX_DISPLAYED_KNOWN_DESTINATION_AMOUNTS = 3;
+
+// Send destination
+export const MIN_DESTINATION_LENGTH_FOR_ERROR_STATE = 10;

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -472,9 +472,9 @@
 			"contacts_empty_state_description": "It looks like you haven’t added contacts yet"
 		},
 		"placeholder": {
-			"enter_eth_address": "Enter public address (0x)",
-			"enter_recipient_address": "Enter recipient address",
-			"enter_wallet_address": "Enter wallet address",
+			"enter_eth_address": "Enter public address (0x), name or alias",
+			"enter_recipient_address": "Enter recipient address, name or alias",
+			"enter_wallet_address": "Enter wallet address, name or alias",
 			"select_network": "Select network"
 		},
 		"info": {

--- a/src/frontend/src/tests/lib/components/send/SendContacts.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendContacts.spec.ts
@@ -37,13 +37,61 @@ describe('SendContacts', () => {
 		).toBeInTheDocument();
 	});
 
-	it('renders filtered content if data is provided', () => {
+	it('renders filtered by address content if data is provided', () => {
 		const { getByText } = render(SendContacts, {
 			props: {
 				destination: mockContactEthAddressUi.address,
 				networkContacts: {
 					[mockContactBtcAddressUi.address]: contact1,
 					[mockContactEthAddressUi.address]: contact2
+				}
+			}
+		});
+
+		expect(() =>
+			getByText(shortenWithMiddleEllipsis({ text: mockContactBtcAddressUi.address }))
+		).toThrow();
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockContactEthAddressUi.address }))
+		).toBeInTheDocument();
+	});
+
+	it('renders filtered by contact name content if data is provided', () => {
+		const { getByText } = render(SendContacts, {
+			props: {
+				destination: contact2.name.toUpperCase(),
+				networkContacts: {
+					[mockContactBtcAddressUi.address]: contact1,
+					[mockContactEthAddressUi.address]: contact2
+				}
+			}
+		});
+
+		expect(() =>
+			getByText(shortenWithMiddleEllipsis({ text: mockContactBtcAddressUi.address }))
+		).toThrow();
+		expect(
+			getByText(shortenWithMiddleEllipsis({ text: mockContactEthAddressUi.address }))
+		).toBeInTheDocument();
+	});
+
+	it('renders filtered by contact address label content if data is provided', () => {
+		const contactWithLabel = {
+			...contact2,
+			addresses: [
+				{
+					...contact2.addresses[0],
+					label: 'LABEL'
+				}
+			]
+		};
+
+		const { getByText } = render(SendContacts, {
+			props: {
+				destination: contactWithLabel.addresses[0].label,
+				networkContacts: {
+					[mockContactBtcAddressUi.address]: contact1,
+					[mockContactEthAddressUi.address]: contactWithLabel
 				}
 			}
 		});

--- a/src/frontend/src/tests/lib/components/send/SendInputDestination.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendInputDestination.spec.ts
@@ -43,6 +43,18 @@ describe('SendInputDestination', () => {
 		expect(getByText(en.send.assertion.invalid_destination_address)).toBeInTheDocument();
 	});
 
+	it('does not render invalid destination error message if destination length is less than required limit', () => {
+		const { getByText } = render(SendInputDestination, {
+			props: {
+				...props,
+				destination: 'Test',
+				invalidDestination: true
+			}
+		});
+
+		expect(() => getByText(en.send.assertion.invalid_destination_address)).toThrow();
+	});
+
 	it('does not render unknown destination warning message if there is a contact with the provided address', () => {
 		const [contact] = getMockContactsUi({
 			n: 1,


### PR DESCRIPTION
# Motivation

We should allow users typing contact name or label in the destination input. The contacts should be filtered accordingly based on this information. Also, we decided to display the input error state only if the value length exceeds 10 characters.
