### PR TITLE
fix(frontend): incorrect address labels in SendContact

### DIFF
--- a/src/frontend/src/lib/components/send/SendContact.svelte
+++ b/src/frontend/src/lib/components/send/SendContact.svelte
@@ -18,7 +18,7 @@
 
 	let contactLabel = $derived(
 		nonNullish(contact)
-			? contact.addresses.find(({ address }) => address === address)?.label
+			? contact.addresses.find(({ address: innerAddress }) => address === innerAddress)?.label
 			: undefined
 	);
 </script>


### PR DESCRIPTION
# Motivation

There was an issue with the address label extraction in SendContact.
