### PR TITLE
feat(frontend): Cache ERC20 User tokens in IDB

### DIFF
--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -21,6 +21,7 @@ import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import type { EthereumNetwork } from '$eth/types/network';
 import { mapErc20Token, mapErc20UserToken } from '$eth/utils/erc20.utils';
 import { listUserTokens } from '$lib/api/backend.api';
+import { setIdbEthTokens } from '$lib/api/idb-tokens.api';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsErrorNoTrace } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -106,6 +107,11 @@ const loadUserTokens = async (params: {
 			...params,
 			nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 		});
+
+		// Caching the custom tokens in the IDB if update call
+		if (params.certified && contracts.length > 0) {
+			await setIdbEthTokens({ identity: params.identity, tokens: contracts });
+		}
 
 		return contracts
 			.filter(({ chain_id }) =>

--- a/src/frontend/src/lib/api/idb-tokens.api.ts
+++ b/src/frontend/src/lib/api/idb-tokens.api.ts
@@ -1,4 +1,6 @@
 import { browser } from '$app/environment';
+import type { CustomToken, UserToken } from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.sol.env';
 import { nullishSignOut } from '$lib/services/auth.services';
@@ -14,13 +16,14 @@ const idbTokensStore = (key: string): UseStore =>
 		: ({} as unknown as UseStore);
 
 const idbIcTokensStore = idbTokensStore(ICP_NETWORK_SYMBOL.toLowerCase());
+const idbEthTokensStore = idbTokensStore(ETHEREUM_NETWORK_SYMBOL.toLowerCase());
 const idbSolTokensStore = idbTokensStore(SOLANA_MAINNET_NETWORK_SYMBOL.toLowerCase());
 
-export const setIdbTokensStore = async ({
+export const setIdbTokensStore = async <T extends CustomToken | UserToken>({
 	identity,
 	tokens,
 	idbTokensStore
-}: SetIdbTokensParams & {
+}: SetIdbTokensParams<T> & {
 	idbTokensStore: UseStore;
 }) => {
 	if (isNullish(identity)) {
@@ -31,22 +34,30 @@ export const setIdbTokensStore = async ({
 	await idbSet(identity.getPrincipal().toText(), tokens, idbTokensStore);
 };
 
-export const setIdbIcTokens = (params: SetIdbTokensParams): Promise<void> =>
+export const setIdbIcTokens = (params: SetIdbTokensParams<CustomToken>): Promise<void> =>
 	setIdbTokensStore({ ...params, idbTokensStore: idbIcTokensStore });
 
-export const setIdbSolTokens = (params: SetIdbTokensParams): Promise<void> =>
+export const setIdbEthTokens = (params: SetIdbTokensParams<UserToken>): Promise<void> =>
+	setIdbTokensStore({ ...params, idbTokensStore: idbEthTokensStore });
+
+export const setIdbSolTokens = (params: SetIdbTokensParams<CustomToken>): Promise<void> =>
 	setIdbTokensStore({ ...params, idbTokensStore: idbSolTokensStore });
 
 export const getIdbIcTokens = (
 	principal: Principal
-): Promise<SetIdbTokensParams['tokens'] | undefined> => get(principal.toText(), idbIcTokensStore);
+): Promise<SetIdbTokensParams<CustomToken>['tokens'] | undefined> =>
+	get(principal.toText(), idbIcTokensStore);
 
 export const getIdbSolTokens = (
 	principal: Principal
-): Promise<SetIdbTokensParams['tokens'] | undefined> => get(principal.toText(), idbSolTokensStore);
+): Promise<SetIdbTokensParams<CustomToken>['tokens'] | undefined> =>
+	get(principal.toText(), idbSolTokensStore);
 
 export const deleteIdbIcTokens = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbIcTokensStore);
+
+export const deleteIdbEthTokens = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbEthTokensStore);
 
 export const deleteIdbSolTokens = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbSolTokensStore);

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -3,7 +3,7 @@ import {
 	deleteIdbEthAddress,
 	deleteIdbSolAddressMainnet
 } from '$lib/api/idb-addresses.api';
-import { deleteIdbIcTokens, deleteIdbSolTokens } from '$lib/api/idb-tokens.api';
+import { deleteIdbEthTokens, deleteIdbIcTokens, deleteIdbSolTokens } from '$lib/api/idb-tokens.api';
 import {
 	TRACK_COUNT_SIGN_IN_SUCCESS,
 	TRACK_SIGN_IN_CANCELLED_COUNT,
@@ -118,6 +118,8 @@ const emptyIdbSolAddress = (): Promise<void> => emptyIdbStore(deleteIdbSolAddres
 
 const emptyIdbIcTokens = (): Promise<void> => emptyIdbStore(deleteIdbIcTokens);
 
+const emptyIdbEthTokens = (): Promise<void> => emptyIdbStore(deleteIdbEthTokens);
+
 const emptyIdbSolTokens = (): Promise<void> => emptyIdbStore(deleteIdbSolTokens);
 
 // eslint-disable-next-line require-await
@@ -143,6 +145,7 @@ const logout = async ({
 			emptyIdbEthAddress(),
 			emptyIdbSolAddress(),
 			emptyIdbIcTokens(),
+			emptyIdbEthTokens(),
 			emptyIdbSolTokens()
 		]);
 	}

--- a/src/frontend/src/lib/services/custom-tokens.services.ts
+++ b/src/frontend/src/lib/services/custom-tokens.services.ts
@@ -12,7 +12,7 @@ interface LoadCustomTokensFromBackendParams {
 	identity: OptionIdentity;
 	certified: boolean;
 	filterTokens: (token: CustomToken) => boolean;
-	setIdbTokens: (params: SetIdbTokensParams) => Promise<void>;
+	setIdbTokens: (params: SetIdbTokensParams<CustomToken>) => Promise<void>;
 }
 
 type LoadCustomTokensParams = LoadCustomTokensFromBackendParams & {

--- a/src/frontend/src/lib/types/idb-tokens.ts
+++ b/src/frontend/src/lib/types/idb-tokens.ts
@@ -1,7 +1,7 @@
-import type { CustomToken } from '$declarations/backend/backend.did';
+import type { CustomToken, UserToken } from '$declarations/backend/backend.did';
 import type { OptionIdentity } from '$lib/types/identity';
 
-export interface SetIdbTokensParams {
+export interface SetIdbTokensParams<T extends CustomToken | UserToken> {
 	identity: OptionIdentity;
-	tokens: CustomToken[];
+	tokens: T[];
 }

--- a/src/frontend/src/tests/eth/services/erc20.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20.services.spec.ts
@@ -20,8 +20,19 @@ import { mockEthAddress, mockEthAddress2, mockEthAddress3 } from '$tests/mocks/e
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
+import * as idbKeyval from 'idb-keyval';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
+
+vi.mock('idb-keyval', () => ({
+	createStore: vi.fn(() => ({
+		/* mock store implementation */
+	})),
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn(),
+	update: vi.fn()
+}));
 
 vi.mock('$lib/api/backend.api', () => ({
 	listUserTokens: vi.fn()
@@ -420,6 +431,18 @@ describe('erc20.services', () => {
 				msg: { text: en.init.error.erc20_user_tokens },
 				err: mockError
 			});
+		});
+
+		it('should cache the custom tokens in IDB on update call', async () => {
+			await loadErc20UserTokens({ identity: mockIdentity });
+
+			expect(idbKeyval.set).toHaveBeenCalledOnce();
+			expect(idbKeyval.set).toHaveBeenNthCalledWith(
+				1,
+				mockIdentity.getPrincipal().toText(),
+				mockUserTokens,
+				expect.any(Object)
+			);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We are caching custom tokens (ICRC and SPL) in IDB. Now we can use the same flow to cache User tokens (ERC20).

# Changes

- Create IDB functions to save and delete cached ETH tokens.
- Use the functions in the same places that we use it for the Custom Tokens.

# Tests

New tests.
