### PR TITLE
feat(frontend): SendReviewDestination component

### DIFF
--- a/src/frontend/src/lib/components/send/SendReviewDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendReviewDestination.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { nonNullish, notEmptyString } from '@dfinity/utils';
+	import AddressCard from '$lib/components/address/AddressCard.svelte';
+	import Divider from '$lib/components/common/Divider.svelte';
+	import AvatarWithBadge from '$lib/components/contact/AvatarWithBadge.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { ContactUi } from '$lib/types/contact';
+
+	interface Props {
+		destination: string;
+		selectedContact?: ContactUi;
+	}
+
+	const { destination, selectedContact }: Props = $props();
+
+	let selectedContactLabel = $derived(
+		nonNullish(selectedContact)
+			? selectedContact.addresses.find(({ address }) => address === destination)?.label
+			: undefined
+	);
+</script>
+
+<AddressCard>
+	{#snippet logo()}
+		<div class="mr-2">
+			<AvatarWithBadge
+				contact={selectedContact}
+				address={destination}
+				badge={{ type: 'addressType', address: destination }}
+			/>
+		</div>
+	{/snippet}
+
+	{#snippet content()}
+		<span>
+			<span class="font-bold">
+				{$i18n.transaction.text.to}{nonNullish(selectedContact) ? `: ${selectedContact?.name}` : ''}
+			</span>
+
+			{#if notEmptyString(selectedContactLabel)}
+				<Divider />
+				{selectedContactLabel}
+			{/if}
+		</span>
+
+		<span class="w-full whitespace-normal break-all">{destination}</span>
+	{/snippet}
+</AddressCard>

--- a/src/frontend/src/tests/lib/components/send/SendReviewDestination.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendReviewDestination.spec.ts
@@ -1,0 +1,26 @@
+import SendReviewDestination from '$lib/components/send/SendReviewDestination.svelte';
+import type { ContactUi } from '$lib/types/contact';
+import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SendReviewDestination', () => {
+	const [contact] = getMockContactsUi({
+		n: 1,
+		name: 'Multiple Addresses Contact',
+		addresses: [mockContactBtcAddressUi]
+	}) as unknown as ContactUi[];
+	const props = {
+		selectedContact: contact,
+		destination: mockContactBtcAddressUi.address
+	};
+
+	it('renders expected data', () => {
+		const { getByText, container } = render(SendReviewDestination, {
+			props
+		});
+
+		expect(container).toHaveTextContent(contact.name);
+		expect(container).toHaveTextContent(mockContactBtcAddressUi.label as string);
+		expect(getByText(props.destination)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to implement a component for reviewing selected contact or recently used address in the Send Review form. Potentially, we can combine it later with the one from TransactionModal, but due to design specs differences (subject to discuss), for now it's easier to keep them separate.

<img width="537" alt="Screenshot 2025-06-02 at 10 25 10" src="https://github.com/user-attachments/assets/b6053a4b-dd41-43b5-a91f-5131d40af1e2" />
