### PR TITLE
refactor(frontend): Extract util to retry with delay

### DIFF
--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -7,14 +7,13 @@ import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
 import { TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR } from '$lib/constants/analytics.contants';
 import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { trackEvent } from '$lib/services/analytics.services';
-import { retry } from '$lib/services/rest.services';
+import { retryWithDelay } from '$lib/services/rest.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
-import { randomWait } from '$lib/utils/time.utils';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -158,9 +157,8 @@ const loadErc20Transactions = async ({
 
 	try {
 		const { erc20Transactions } = etherscanProviders(networkId);
-		const transactions = await retry({
-			request: async () => await erc20Transactions({ contract: token, address }),
-			onRetry: async () => await randomWait({})
+		const transactions = await retryWithDelay({
+			request: async () => await erc20Transactions({ contract: token, address })
 		});
 
 		if (updateOnly) {

--- a/src/frontend/src/lib/services/rest.services.ts
+++ b/src/frontend/src/lib/services/rest.services.ts
@@ -1,3 +1,5 @@
+import { randomWait } from '$lib/utils/time.utils';
+
 export interface RetryParams<Response, Error = unknown> {
 	request: () => Promise<Response>;
 	onRetry?: (options: { error: Error; retryCount: number }) => Promise<void>;
@@ -35,3 +37,9 @@ export const retry = async <Response, Error>({
 
 	return await executeRequest(0);
 };
+
+export const retryWithDelay = <Response, Error>({
+	request,
+	maxRetries = 3
+}: RetryParams<Response, Error>): Promise<Response> =>
+	retry({ request, onRetry: async () => await randomWait({}), maxRetries });

--- a/src/frontend/src/tests/lib/services/rest.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/rest.services.spec.ts
@@ -1,4 +1,9 @@
-import { retry } from '$lib/services/rest.services';
+import { retry, retryWithDelay } from '$lib/services/rest.services';
+import { randomWait } from '$lib/utils/time.utils';
+
+vi.mock('$lib/utils/time.utils', () => ({
+	randomWait: vi.fn()
+}));
 
 describe('rest.services', () => {
 	describe('retry', () => {
@@ -144,6 +149,84 @@ describe('rest.services', () => {
 			expect(mockOnRetry).not.toHaveBeenCalled();
 
 			expect(console.error).not.toHaveBeenCalled();
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('retryWithDelay', () => {
+		const mockResult = 'success';
+		const mockError = new Error('Failed');
+
+		const mockSuccessfulRequest = vi.fn().mockResolvedValue(mockResult);
+		const mockFailedRequest = vi.fn().mockRejectedValue(mockError);
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should call the request function when the request succeeds on the first try', async () => {
+			await retryWithDelay({
+				request: mockSuccessfulRequest
+			});
+
+			expect(mockSuccessfulRequest).toHaveBeenCalledOnce();
+		});
+
+		it('should return the result of the request when the request succeeds on the first try', async () => {
+			const result = await retryWithDelay({
+				request: mockSuccessfulRequest
+			});
+
+			expect(result).toEqual(mockResult);
+		});
+
+		it('should retry up to maxRetries and then call raise an error', async () => {
+			const maxRetries = 3;
+
+			await expect(
+				async () =>
+					await retryWithDelay({
+						request: mockFailedRequest,
+						maxRetries
+					})
+			).rejects.toThrow(mockError);
+
+			expect(mockFailedRequest).toHaveBeenCalledTimes(maxRetries + 1);
+
+			expect(console.error).toHaveBeenCalled();
+			expect(console.error).toHaveBeenCalledWith('Max retries reached. Error:', mockError);
+		});
+
+		it('should call randomWait after each failed attempt', async () => {
+			await expect(
+				async () =>
+					await retryWithDelay({
+						request: mockFailedRequest,
+						maxRetries: 2
+					})
+			).rejects.toThrow(mockError);
+
+			expect(mockFailedRequest).toHaveBeenCalledTimes(3);
+			expect(randomWait).toHaveBeenCalledTimes(2);
+
+			expect(console.warn).toHaveBeenCalledTimes(2);
+			expect(console.warn).toHaveBeenCalledWith('Request attempt 1 failed. Retrying...');
+			expect(console.warn).toHaveBeenCalledWith('Request attempt 2 failed. Retrying...');
+		});
+
+		it('should not retry if maxRetries is set to 0', async () => {
+			await expect(
+				async () =>
+					await retryWithDelay({
+						request: mockFailedRequest,
+						maxRetries: 0
+					})
+			).rejects.toThrow(mockError);
+
+			expect(mockFailedRequest).toHaveBeenCalledTimes(1);
+			expect(randomWait).not.toHaveBeenCalled();
+			expect(console.error).toHaveBeenCalled();
+			expect(console.error).toHaveBeenCalledWith('Max retries reached. Error:', mockError);
 			expect(console.warn).not.toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
# Motivation

We need the retry function with a delay for the Solana wallet too. So, as first step, we extract it so a re-usable util.
