### PR TITLE
feat(frontend): migrated links to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/about/AboutWhyOisy.svelte
+++ b/src/frontend/src/lib/components/about/AboutWhyOisy.svelte
@@ -6,9 +6,14 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { trackEvent } from '$lib/services/analytics.services';
 
-	export let asMenuItem = false;
-	export let asMenuItemCondensed = false;
+	interface Props {
+		asMenuItem?: boolean;
+		asMenuItemCondensed?: boolean;
+	}
+
+	let { asMenuItem = false, asMenuItemCondensed = false }: Props = $props();
 
 	const dispatch = createEventDispatcher();
 
@@ -17,6 +22,12 @@
 	const openModal = () => {
 		dispatch('icOpenAboutModal');
 		modalStore.openAboutWhyOisy(modalId);
+		trackEvent({
+			name: 'about_why_oisy',
+			metadata: {
+				source: 'landing_page'
+			}
+		});
 	};
 </script>
 

--- a/src/frontend/src/lib/components/navigation/ChangelogLink.svelte
+++ b/src/frontend/src/lib/components/navigation/ChangelogLink.svelte
@@ -4,8 +4,12 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	export let asMenuItem = false;
-	export let asMenuItemCondensed = false;
+	interface Props {
+		asMenuItem?: boolean;
+		asMenuItemCondensed?: boolean;
+	}
+
+	let { asMenuItem = false, asMenuItemCondensed = false }: Props = $props();
 </script>
 
 <ExternalLink

--- a/src/frontend/src/lib/components/navigation/DocumentationLink.svelte
+++ b/src/frontend/src/lib/components/navigation/DocumentationLink.svelte
@@ -5,11 +5,18 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	export let asMenuItem = false;
-	export let asMenuItemCondensed = false;
+	interface Props {
+		asMenuItem?: boolean;
+		asMenuItemCondensed?: boolean;
+		shortTextOnMobile?: boolean;
+	}
 
 	// We display an alternative "Docs" text instead of "Documentation" to avoid design breaks on small screens
-	export let shortTextOnMobile = false;
+	let {
+		asMenuItem = false,
+		asMenuItemCondensed = false,
+		shortTextOnMobile = false
+	}: Props = $props();
 </script>
 
 <ExternalLink


### PR DESCRIPTION
# Motivation

Migrated WhyOisy, DocumentationLink, and ChangelogLink components to Svelte 5 in order to enable Plausible event tracking and begin the transition of the codebase to Svelte 5.

# Changes

Migrated the following components to Svelte 5:

- AboutWhyOisy component

- ChangelogLink component

- DocumentationLink component
