### PR TITLE
feat(frontend): Map owner address in Solana transaction services

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -16,7 +16,7 @@ import {
 	isNetworkIdSOLTestnet
 } from '$lib/utils/network.utils';
 import { findOldestTransaction } from '$lib/utils/transactions.utils';
-import { fetchTransactionDetailForSignature } from '$sol/api/solana.api';
+import { fetchTransactionDetailForSignature, getAccountOwner } from '$sol/api/solana.api';
 import { getSolTransactions } from '$sol/services/sol-signatures.services';
 import {
 	solTransactionsStore,
@@ -169,6 +169,15 @@ export const fetchSolTransactionsForSignature = async ({
 				return { parsedTransactions, cumulativeBalances, addressToToken };
 			}
 
+			const fromOwner: SolTransactionUi['from'] | undefined = await getAccountOwner({
+				address: from,
+				network
+			});
+
+			const toOwner: SolTransactionUi['to'] | undefined = nonNullish(to)
+				? await getAccountOwner({ address: to, network })
+				: undefined;
+
 			const newTransaction: SolTransactionUi = {
 				id: `${signature.signature}-${idx}-${instruction.programId}`,
 				signature: signature.signature,
@@ -176,7 +185,9 @@ export const fetchSolTransactionsForSignature = async ({
 				value,
 				type: address === from || ataAddress === from ? 'send' : 'receive',
 				from,
+				...(nonNullish(fromOwner) && { fromOwner }),
 				to,
+				...(nonNullish(toOwner) && { toOwner }),
 				status,
 				// Since the fee is assigned to a single signature, it is not entirely correct to assign it to each transaction.
 				// Particularly, we are repeating the same fee for each instruction in the transaction.

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -23,7 +23,7 @@ export interface SolTransactionUi extends TransactionUiCommon {
 	status: Commitment | null;
 	value?: bigint;
 	fee?: bigint;
-	// For Solana transactions, we want to show the owner instead of the ATA address, if it refers to a token
+	// For Solana transactions, we want to show the owner instead of the ATA address
 	fromOwner?: SolAddress;
 	toOwner?: SolAddress;
 }

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -23,6 +23,9 @@ export interface SolTransactionUi extends TransactionUiCommon {
 	status: Commitment | null;
 	value?: bigint;
 	fee?: bigint;
+	// For Solana transactions, we want to show the owner instead of the ATA address, if it refers to a token
+	fromOwner?: SolAddress;
+	toOwner?: SolAddress;
 }
 
 export type SolRpcTransactionRaw = NonNullable<Awaited<ReturnType<typeof getRpcTransaction>>>;


### PR DESCRIPTION
# Motivation

We are going to show the owner address instead of the ATA address for Solana transactions. This will happen in multiple places: modal and recent addresses, for example.

So, it is better to map it directly during the fetching service of the transactions. In a follow-up PR, we will use it.

# Changes

- Expand type `SolTransactionUi` to have the `fromOwner` and the `toOwner`.
- Query the owner address both for from and to address. This can happen to be even for non token transactions, so we are forced to do it always.

# Tests

Added tests.
