### PR TITLE
feat(frontend): Show owner address instead of ATA for recent Solana recipients

### DIFF
--- a/src/frontend/src/sol/derived/sol-transactions.derived.ts
+++ b/src/frontend/src/sol/derived/sol-transactions.derived.ts
@@ -33,12 +33,16 @@ export const solKnownDestinations: Readable<KnownDestinations> = derived(
 			const token = $tokens.find(({ id }) => id === tokenId);
 
 			if (nonNullish(token)) {
-				($solTransactionsStore?.[tokenId as TokenId] ?? []).forEach(({ data }) => {
-					mappedTransactions.push({
-						...data,
-						token
-					});
-				});
+				($solTransactionsStore?.[tokenId as TokenId] ?? []).forEach(
+					({ data: { from, fromOwner, to, toOwner, ...rest } }) => {
+						mappedTransactions.push({
+							...rest,
+							from: fromOwner ?? from,
+							to: toOwner ?? to,
+							token
+						});
+					}
+				);
 			}
 		});
 

--- a/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
@@ -165,10 +165,10 @@ describe('sol-transactions.derived', () => {
 			const maxTimestamp = Math.max(...mockTransactions.map(({ data }) => Number(data.timestamp)));
 
 			expect(get(solKnownDestinations)).toEqual({
-				[transactions[0].data.to as string]: {
+				[mockTransactions[0].data.toOwner as string]: {
 					amounts: mockTransactions.map(({ data }) => ({ value: data.value, token: SOLANA_TOKEN })),
 					timestamp: maxTimestamp,
-					address: mockTransactions[0].data.to
+					address: mockTransactions[0].data.toOwner
 				}
 			});
 		});

--- a/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/sol/derived/sol-transactions.derived.spec.ts
@@ -147,6 +147,32 @@ describe('sol-transactions.derived', () => {
 			});
 		});
 
+		it('should return known destinations with owner addresses if exists', () => {
+			const mockTransactions = transactions.map((tx) => ({
+				...tx,
+				data: {
+					...tx.data,
+					toOwner: 'ownerAddress',
+					fromOwner: 'fromOwnerAddress'
+				}
+			}));
+
+			solTransactionsStore.append({
+				tokenId: SOLANA_TOKEN_ID,
+				transactions: mockTransactions
+			});
+
+			const maxTimestamp = Math.max(...mockTransactions.map(({ data }) => Number(data.timestamp)));
+
+			expect(get(solKnownDestinations)).toEqual({
+				[transactions[0].data.to as string]: {
+					amounts: mockTransactions.map(({ data }) => ({ value: data.value, token: SOLANA_TOKEN })),
+					timestamp: maxTimestamp,
+					address: mockTransactions[0].data.to
+				}
+			});
+		});
+
 		it('should return empty object if transactions store does not have data', () => {
 			expect(get(solKnownDestinations)).toEqual({});
 		});


### PR DESCRIPTION
# Motivation

The store for known Solana recipient should show the owner address instead of the ATA address. We can do it thanks to the changes of https://github.com/dfinity/oisy-wallet/pull/7100

![Screenshot 2025-06-02 at 13 22 32](https://github.com/user-attachments/assets/df93b57d-814b-4cf0-857a-a0ca2a1bd374)
![Screenshot 2025-06-02 at 13 22 23](https://github.com/user-attachments/assets/b2c89307-7a8e-4a6e-a6e0-a3caf8b8d14d)

