### PR TITLE
feat(frontend): Use Solana transaction data for owner address

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -19,9 +19,7 @@
 	} from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkSolana } from '$lib/utils/network.utils';
-	import { getAccountOwner } from '$sol/api/solana.api';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
-	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 
 	interface Props {
 		transaction: SolTransactionUi;
@@ -32,44 +30,19 @@
 
 	let {
 		from: fromAddress,
+		fromOwner,
 		value,
 		timestamp,
 		signature: id,
 		blockNumber,
 		to: toAddress,
+		toOwner,
 		type,
 		status
 	} = $derived(transaction);
 
-	let solanaNetwork = $derived(
-		nonNullish(token?.network.id) ? mapNetworkIdToNetwork(token?.network.id) : undefined
-	);
-
-	let from = $derived<SolTransactionUi['from'] | undefined>(undefined);
-	let to = $derived<SolTransactionUi['to'] | undefined>(undefined);
-
-	const updateFromAddress = async () => {
-		from = nonNullish(solanaNetwork)
-			? ((await getAccountOwner({ address: fromAddress, network: solanaNetwork })) ?? fromAddress)
-			: fromAddress;
-	};
-
-	const updateToAddress = async () => {
-		to =
-			nonNullish(solanaNetwork) && nonNullish(toAddress)
-				? ((await getAccountOwner({ address: toAddress, network: solanaNetwork })) ?? toAddress)
-				: toAddress;
-	};
-
-	$effect(() => {
-		[fromAddress];
-		updateFromAddress();
-	});
-
-	$effect(() => {
-		[toAddress];
-		updateToAddress();
-	});
+	let from = $derived<SolTransactionUi['from'] | undefined>(fromOwner ?? fromAddress);
+	let to = $derived<SolTransactionUi['to'] | undefined>(toOwner ?? toAddress);
 
 	let explorerUrl: string | undefined = $derived(
 		isNetworkSolana(token?.network) ? token.network.explorerUrl : undefined

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -41,8 +41,8 @@
 		status
 	} = $derived(transaction);
 
-	let from = $derived<SolTransactionUi['from'] | undefined>(fromOwner ?? fromAddress);
-	let to = $derived<SolTransactionUi['to'] | undefined>(toOwner ?? toAddress);
+	let from = $derived<SolTransactionUi['from'] | SolTransactionUi['fromOwner'] |undefined>(fromOwner ?? fromAddress);
+	let to = $derived<SolTransactionUi['to'] | SolTransactionUi['toOwner'] | undefined>(toOwner ?? toAddress);
 
 	let explorerUrl: string | undefined = $derived(
 		isNetworkSolana(token?.network) ? token.network.explorerUrl : undefined

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -41,8 +41,12 @@
 		status
 	} = $derived(transaction);
 
-	let from = $derived<SolTransactionUi['from'] | SolTransactionUi['fromOwner'] |undefined>(fromOwner ?? fromAddress);
-	let to = $derived<SolTransactionUi['to'] | SolTransactionUi['toOwner'] | undefined>(toOwner ?? toAddress);
+	let from = $derived<SolTransactionUi['from'] | SolTransactionUi['fromOwner'] | undefined>(
+		fromOwner ?? fromAddress
+	);
+	let to = $derived<SolTransactionUi['to'] | SolTransactionUi['toOwner'] | undefined>(
+		toOwner ?? toAddress
+	);
 
 	let explorerUrl: string | undefined = $derived(
 		isNetworkSolana(token?.network) ? token.network.explorerUrl : undefined

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -2,7 +2,6 @@ import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { i18n } from '$lib/stores/i18n.store';
 import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-import { getAccountOwner } from '$sol/api/solana.api';
 import SolTransactionModal from '$sol/components/transactions/SolTransactionModal.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
@@ -11,18 +10,8 @@ import { capitalizeFirstLetter } from '$tests/utils/string-utils';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-vi.mock('$sol/api/solana.api', () => ({
-	getAccountOwner: vi.fn()
-}));
-
 describe('SolTransactionModal', () => {
 	const [mockSolTransactionUi] = createMockSolTransactionsUi(1);
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-
-		vi.mocked(getAccountOwner).mockResolvedValue(undefined);
-	});
 
 	it('should render the SOL transaction modal', () => {
 		const { getByText } = render(SolTransactionModal, {
@@ -88,10 +77,8 @@ describe('SolTransactionModal', () => {
 	});
 
 	it('should not display ATA address if is not SPL token', () => {
-		vi.mocked(getAccountOwner).mockResolvedValue('mock-owner-address');
-
 		const { queryByText } = render(SolTransactionModal, {
-			transaction: mockSolTransactionUi,
+			transaction: { ...mockSolTransactionUi, to: 'mock-owner-address' },
 			token: SOLANA_TOKEN
 		});
 
@@ -102,10 +89,8 @@ describe('SolTransactionModal', () => {
 	});
 
 	it('should display ATA address if is SPL token', async () => {
-		vi.mocked(getAccountOwner).mockResolvedValue(mockSolAddress2);
-
 		const { getByText } = render(SolTransactionModal, {
-			transaction: mockSolTransactionUi,
+			transaction: { ...mockSolTransactionUi, to: 'mock-owner-address' },
 			token: BONK_TOKEN
 		});
 

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -76,9 +76,9 @@ describe('SolTransactionModal', () => {
 		).toBeInTheDocument();
 	});
 
-	it('should not display ATA address if is not SPL token', () => {
+	it('should not display ATA address if there is no owner address', () => {
 		const { queryByText } = render(SolTransactionModal, {
-			transaction: { ...mockSolTransactionUi, to: 'mock-owner-address' },
+			transaction: { ...mockSolTransactionUi, fromOwner: undefined, toOwner: undefined },
 			token: SOLANA_TOKEN
 		});
 
@@ -88,9 +88,22 @@ describe('SolTransactionModal', () => {
 		expect(queryByText('mock-owner-address')).not.toBeInTheDocument();
 	});
 
+	it('should display ATA address if there is the owner address even if it is not SPL token', () => {
+		const { queryByText } = render(SolTransactionModal, {
+			transaction: { ...mockSolTransactionUi, toOwner: 'mock-owner-address' },
+			token: SOLANA_TOKEN
+		});
+
+		expect(queryByText(en.transaction.text.from_ata)).not.toBeInTheDocument();
+
+		expect(queryByText(en.transaction.text.to_ata)).toBeInTheDocument();
+
+		expect(queryByText('mock-owner-address')).toBeInTheDocument();
+	});
+
 	it('should display ATA address if is SPL token', async () => {
 		const { getByText } = render(SolTransactionModal, {
-			transaction: { ...mockSolTransactionUi, to: 'mock-owner-address' },
+			transaction: { ...mockSolTransactionUi, toOwner: mockSolAddress2 },
 			token: BONK_TOKEN
 		});
 


### PR DESCRIPTION
# Motivation

After PR #7100 , we can use directly the props fromOwner and toOwner of the Solana transaction, instead of calculating the owner addresses in the component.