### PR TITLE
feat(frontend): Use cached tokens for Ethereum and EVM networks

### DIFF
--- a/src/frontend/src/lib/api/idb-tokens.api.ts
+++ b/src/frontend/src/lib/api/idb-tokens.api.ts
@@ -48,6 +48,11 @@ export const getIdbIcTokens = (
 ): Promise<SetIdbTokensParams<CustomToken>['tokens'] | undefined> =>
 	get(principal.toText(), idbIcTokensStore);
 
+export const getIdbEthTokens = (
+	principal: Principal
+): Promise<SetIdbTokensParams<UserToken>['tokens'] | undefined> =>
+	get(principal.toText(), idbEthTokensStore);
+
 export const getIdbSolTokens = (
 	principal: Principal
 ): Promise<SetIdbTokensParams<CustomToken>['tokens'] | undefined> =>

--- a/src/frontend/src/tests/eth/services/erc20.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20.services.spec.ts
@@ -444,5 +444,16 @@ describe('erc20.services', () => {
 				expect.any(Object)
 			);
 		});
+
+		it('should fetch the cached custom tokens in IDB on query call', async () => {
+			await loadErc20UserTokens({ identity: mockIdentity, useCache: true });
+
+			expect(idbKeyval.get).toHaveBeenCalledOnce();
+			expect(idbKeyval.get).toHaveBeenNthCalledWith(
+				1,
+				mockIdentity.getPrincipal().toText(),
+				expect.any(Object)
+			);
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/api/idb-tokens.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-tokens.api.spec.ts
@@ -2,8 +2,10 @@ import type { CustomToken } from '$declarations/backend/backend.did';
 import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import {
+	deleteIdbEthTokens,
 	deleteIdbIcTokens,
 	deleteIdbSolTokens,
+	getIdbEthTokens,
 	getIdbIcTokens,
 	getIdbSolTokens,
 	setIdbTokensStore
@@ -131,6 +133,17 @@ describe('idb-tokens.api', () => {
 		});
 	});
 
+	describe('getIdbEthTokens', () => {
+		it('should get ETH tokens', async () => {
+			vi.mocked(idbKeyval.get).mockResolvedValue(mockTokens);
+
+			const result = await getIdbEthTokens(mockPrincipal);
+
+			expect(result).toEqual(mockTokens);
+			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+	});
+
 	describe('getIdbSolTokens', () => {
 		it('should get SOL tokens', async () => {
 			vi.mocked(idbKeyval.get).mockResolvedValue(mockTokens);
@@ -145,6 +158,15 @@ describe('idb-tokens.api', () => {
 	describe('deleteIdbIcTokens', () => {
 		it('should delete IC tokens', async () => {
 			await deleteIdbIcTokens(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledOnce();
+			expect(idbKeyval.del).toHaveBeenNthCalledWith(1, mockPrincipal.toText(), expect.any(Object));
+		});
+	});
+
+	describe('deleteIdbEthTokens', () => {
+		it('should delete ETH tokens', async () => {
+			await deleteIdbEthTokens(mockPrincipal);
 
 			expect(idbKeyval.del).toHaveBeenCalledOnce();
 			expect(idbKeyval.del).toHaveBeenNthCalledWith(1, mockPrincipal.toText(), expect.any(Object));


### PR DESCRIPTION
# Motivation

We can use the cached tokens for the Ethereum and EVM networks like we do for the other networks.

# Changes

- Create function to get the tokens from IDB cache.
- Extract sub-service of `loadUserTokens` that will use the cache ONLY for query calls and if required (defaults to not using the cache).
- Adapt the rest of the code to use the cache ONLY during the initial loader.

# Tests

Added tests.
