### PR TITLE
feat(frontend): filter util for SendContacts and KnownDestinations

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -7,6 +7,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { KnownDestinations } from '$lib/types/transactions';
+	import { isContactMatchingFilter } from '$lib/utils/contact.utils';
 
 	interface Props {
 		destination: string;
@@ -27,7 +28,15 @@
 	);
 
 	let filteredKnownDestinations = $derived(
-		sortedKnownDestinations.filter(({ address }) => address.includes(destination))
+		sortedKnownDestinations.filter(({ address }) =>
+			nonNullish(networkContacts?.[address])
+				? isContactMatchingFilter({
+						address,
+						contact: networkContacts[address],
+						filterValue: destination
+					})
+				: address.includes(destination)
+		)
 	);
 </script>
 

--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -7,6 +7,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 	import type { NetworkContacts } from '$lib/types/contacts';
+	import { isContactMatchingFilter } from '$lib/utils/contact.utils';
 
 	interface Props {
 		destination: string;
@@ -27,12 +28,11 @@
 			? Object.keys(networkContacts).reduce<NetworkContacts>(
 					(acc, address) => ({
 						...acc,
-						...(address.includes(destination) ||
-						networkContacts[address].name.toLowerCase().includes(destination.toLowerCase()) ||
-						networkContacts[address].addresses.some(
-							({ label, address: innerAddress }) =>
-								address === innerAddress && label?.toLowerCase().includes(destination.toLowerCase())
-						)
+						...(isContactMatchingFilter({
+							filterValue: destination,
+							contact: networkContacts[address],
+							address
+						})
 							? { [address]: networkContacts[address] }
 							: {})
 					}),

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -78,3 +78,19 @@ export const mapAddressToContactAddressUi = (address: Address): ContactAddressUi
 		addressType: currentAddressType
 	};
 };
+
+export const isContactMatchingFilter = ({
+	address,
+	contact,
+	filterValue
+}: {
+	address: Address;
+	contact: ContactUi;
+	filterValue: string;
+}): boolean =>
+	address.includes(filterValue) ||
+	contact.name.toLowerCase().includes(filterValue.toLowerCase()) ||
+	contact.addresses.some(
+		({ label, address: innerAddress }) =>
+			address === innerAddress && label?.toLowerCase().includes(filterValue.toLowerCase())
+	);

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -1,6 +1,7 @@
 import type { ContactUi } from '$lib/types/contact';
 import {
 	getContactForAddress,
+	isContactMatchingFilter,
 	mapAddressToContactAddressUi,
 	mapToBackendContact,
 	mapToFrontendContact,
@@ -9,9 +10,11 @@ import {
 import { mockBtcAddress, mockBtcP2SHAddress } from '$tests/mocks/btc.mock';
 import {
 	getMockContacts,
+	getMockContactsUi,
 	mockBackendContactAddressBtc,
 	mockBackendContactAddressEth,
-	mockBackendContactAddressSol
+	mockBackendContactAddressSol,
+	mockContactBtcAddressUi
 } from '$tests/mocks/contacts.mock';
 import { mockEthAddress3 } from '$tests/mocks/eth.mocks';
 import { mockPrincipalText } from '$tests/mocks/identity.mock';
@@ -203,6 +206,54 @@ describe('contact.utils', () => {
 				address: mockPrincipalText,
 				addressType: 'Icrcv2'
 			});
+		});
+	});
+
+	describe('isContactMatchingFilter', () => {
+		const [contact] = getMockContactsUi({
+			n: 1,
+			name: 'Johny',
+			addresses: [mockContactBtcAddressUi]
+		}) as unknown as ContactUi[];
+
+		it('should return true if contact name matches filter', () => {
+			expect(
+				isContactMatchingFilter({
+					address: mockContactBtcAddressUi.address,
+					contact,
+					filterValue: 'Joh'
+				})
+			).toBeTruthy();
+		});
+
+		it('should return true if contact label matches filter', () => {
+			expect(
+				isContactMatchingFilter({
+					address: mockContactBtcAddressUi.address,
+					contact,
+					filterValue: 'Bitcoin'
+				})
+			).toBeTruthy();
+		});
+
+		it('should return true if contact address matches filter', () => {
+			expect(
+				isContactMatchingFilter({
+					address: mockContactBtcAddressUi.address,
+					contact,
+					filterValue: 'bc1qt0nkp9'
+				})
+			).toBeTruthy();
+		});
+
+		it('should return false if contact address does not match filter', () => {
+			expect(
+				isContactMatchingFilter({
+					address: mockContactBtcAddressUi.address,
+					contact,
+					filterValue: 'Test1'
+				})
+			).toBeFalsy();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We now need to apply a similar filter mechanism to both SendContacts and KnownDestinations.
