### PR TITLE
feat(frontend): Increase the number of Solana wallet sync retries

### DIFF
--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -123,7 +123,10 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 		assertNonNullish(data, 'No data provided to get Solana balance.');
 
 		try {
-			await retryWithDelay({ request: async () => await this.loadAndSyncWalletData(data) });
+			await retryWithDelay({
+				request: async () => await this.loadAndSyncWalletData(data),
+				maxRetries: 10
+			});
 		} catch (error: unknown) {
 			this.postMessageWalletError({ error });
 		}

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -202,9 +202,9 @@ describe('sol-wallet.scheduler', () => {
 
 					await scheduler.start(startData);
 
-					// first time + 3 retries
-					expect(spyLoadBalance).toHaveBeenCalledTimes(4);
-					expect(spyLoadTransactions).toHaveBeenCalledTimes(4);
+					// first time + 10 retries
+					expect(spyLoadBalance).toHaveBeenCalledTimes(11);
+					expect(spyLoadTransactions).toHaveBeenCalledTimes(11);
 
 					// idle and in_progress
 					// error


### PR DESCRIPTION
# Motivation

The Solana services request quite an high number of queries, especially for multiple tokens and transactions. To try and amend at least a bit more for the limit of request per seconds, we increase the number of retries for the Solana wallet worker.
