### PR TITLE
feat(frontend): add focus to the input depends on the view

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
@@ -76,6 +76,7 @@
 	);
 
 	let isInvalid = $state(false);
+	const focusField = isNewAddress ? 'address' : 'label';
 </script>
 
 <form onsubmit={handleSubmit} method="POST" class="flex w-full flex-col items-center">
@@ -96,6 +97,7 @@
 				address={addressModel}
 				bind:isInvalid
 				{disabled}
+				{focusField}
 			/>
 		</div>
 		<ButtonGroup slot="toolbar">

--- a/src/frontend/src/lib/components/address/AddressForm.svelte
+++ b/src/frontend/src/lib/components/address/AddressForm.svelte
@@ -13,6 +13,7 @@
 	import { ContactAddressUiSchema } from '$lib/schema/contact.schema';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi } from '$lib/types/contact';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
@@ -20,12 +21,15 @@
 		disableAddressField?: boolean;
 		isInvalid: boolean;
 		disabled?: boolean;
+		focusField?: 'address' | 'label' | null;
 	}
+
 	let {
 		address = $bindable(),
 		disableAddressField = false,
 		isInvalid = $bindable(),
-		disabled = false
+		disabled = false,
+		focusField = null
 	}: Props = $props();
 
 	let addressParseError = $state<ZodError | undefined>();
@@ -49,6 +53,7 @@
 		showPasteButton={!disableAddressField && !disabled}
 		showResetButton={!disableAddressField && !disabled}
 		disabled={disableAddressField || disabled}
+		autofocus={isDesktop() && focusField === 'address'}
 	/>
 
 	<label for="label" class="font-bold">{$i18n.address.fields.label}</label>
@@ -60,7 +65,9 @@
 		{disabled}
 		showResetButton={!disabled}
 		required={false}
+		autofocus={isDesktop() && focusField === 'label'}
 	/>
+
 	{#if nonNullish(labelError)}
 		<p transition:slide={SLIDE_DURATION} class="pt-2 text-error-primary">
 			{replacePlaceholders($i18n.address.form.error.label_too_long, {

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -18,8 +18,10 @@
 	let status: Commitment | null;
 	let to: string | undefined;
 	let from: string | undefined;
+	let toOwner: string | undefined;
+	let fromOwner: string | undefined;
 
-	$: ({ type, value, timestamp, status, to, from } = transaction);
+	$: ({ type, value, timestamp, status, to, from, toOwner, fromOwner } = transaction);
 
 	let label: string;
 	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
@@ -44,8 +46,8 @@
 	status={transactionStatus}
 	{token}
 	{iconType}
-	{to}
-	{from}
+	to={toOwner ?? to}
+	from={fromOwner ?? from}
 >
 	{label}
 </Transaction>

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -18,6 +18,8 @@ describe('EditAddressStep', () => {
 		updateTimestampNs: BigInt(Date.now())
 	};
 
+	const onQRCodeScan = vi.fn(); // ✅ NEW SHARED MOCK
+
 	it('should render the edit address step with form and buttons', () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
@@ -28,20 +30,16 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true
 			}
 		});
 
-		// Check that the form is rendered
 		expect(getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT)).toBeInTheDocument();
 		expect(getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT)).toBeInTheDocument();
-
-		// Check that the buttons are rendered
 		expect(getByTestId(ADDRESS_BOOK_SAVE_BUTTON)).toBeInTheDocument();
 		expect(getByTestId(ADDRESS_BOOK_CANCEL_BUTTON)).toBeInTheDocument();
-
-		// Check that the save button has the correct text
 		expect(getByTestId(ADDRESS_BOOK_SAVE_BUTTON)).toHaveTextContent(en.core.text.save);
 	});
 
@@ -55,12 +53,12 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true
 			}
 		});
 
-		// Check that the contact name is displayed
 		expect(screen.getByText(mockContact.name)).toBeInTheDocument();
 	});
 
@@ -74,12 +72,12 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true
 			}
 		});
 
-		// Check that the save button is disabled initially
 		expect(getByTestId(ADDRESS_BOOK_SAVE_BUTTON)).toBeDisabled();
 	});
 
@@ -94,23 +92,22 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true,
 				address
 			}
 		});
 
-		// Enter a valid Ethereum address to make the form valid
 		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
 		await fireEvent.input(addressInput, {
 			target: { value: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F' }
 		});
 
-		// Check that the save button is enabled
 		expect(getByTestId(ADDRESS_BOOK_SAVE_BUTTON)).not.toBeDisabled();
 	});
 
-	it('should call onAddAddress when save button is clicked with isNewAddress=true', async () => {
+	it('should call onAddAddress when save is clicked with isNewAddress=true', async () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();
@@ -121,28 +118,23 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true,
 				address
 			}
 		});
 
-		// Enter a valid Ethereum address to make the form valid
-		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
-		await fireEvent.input(addressInput, {
+		await fireEvent.input(getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT), {
 			target: { value: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F' }
 		});
 
-		// Enter a label
-		const labelInput = getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT);
-		await fireEvent.input(labelInput, { target: { value: 'Test Address' } });
+		await fireEvent.input(getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT), {
+			target: { value: 'Test Address' }
+		});
 
-		// Click the save button
-		const saveButton = getByTestId(ADDRESS_BOOK_SAVE_BUTTON);
-		await fireEvent.click(saveButton);
+		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Check that onAddAddress was called with the correct address
-		expect(onAddAddress).toHaveBeenCalled();
 		expect(onAddAddress).toHaveBeenCalledWith(
 			expect.objectContaining({
 				address: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
@@ -152,7 +144,7 @@ describe('EditAddressStep', () => {
 		);
 	});
 
-	it('should call onSaveAddress when save button is clicked with isNewAddress=false', async () => {
+	it('should call onSaveAddress when save is clicked with isNewAddress=false', async () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();
@@ -166,22 +158,19 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: false,
 				address
 			}
 		});
 
-		// Click the save button
-		const saveButton = getByTestId(ADDRESS_BOOK_SAVE_BUTTON);
-		await fireEvent.click(saveButton);
+		await fireEvent.click(getByTestId(ADDRESS_BOOK_SAVE_BUTTON));
 
-		// Check that onSaveAddress was called with the correct address
-		expect(onSaveAddress).toHaveBeenCalled();
 		expect(onSaveAddress).toHaveBeenCalledWith(address);
 	});
 
-	it('should call onClose when cancel button is clicked', async () => {
+	it('should call onClose when cancel is clicked', async () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();
@@ -191,20 +180,18 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true
 			}
 		});
 
-		// Click the cancel button
-		const cancelButton = getByTestId(ADDRESS_BOOK_CANCEL_BUTTON);
-		await fireEvent.click(cancelButton);
+		await fireEvent.click(getByTestId(ADDRESS_BOOK_CANCEL_BUTTON));
 
-		// Check that onClose was called
 		expect(onClose).toHaveBeenCalled();
 	});
 
-	it('should display reset buttons for address and label fields when not disabled', async () => {
+	it('should show reset buttons for inputs when filled and not disabled', async () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();
@@ -214,25 +201,26 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true
 			}
 		});
 
-		// Enter values into the address and alias fields to trigger the display of reset buttons
-		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
-		const aliasInput = getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT);
+		await fireEvent.input(getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT), {
+			target: { value: '0x1234567890abcdef' }
+		});
+		await fireEvent.input(getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT), {
+			target: { value: 'My Wallet' }
+		});
 
-		await fireEvent.input(addressInput, { target: { value: '0x1234567890abcdef' } });
-		await fireEvent.input(aliasInput, { target: { value: 'My Wallet' } });
-
-		const resetButtons = screen.getAllByRole('button', { name: 'Reset input value' });
-
-		// Assert that two reset buttons are present
+		const resetButtons = screen.getAllByRole('button', {
+			name: 'Reset input value'
+		});
 		expect(resetButtons).toHaveLength(2);
 	});
 
-	it('should submit the form when Enter is pressed in the address input', async () => {
+	it('should submit form on Enter key', async () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();
@@ -242,23 +230,17 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: true
 			}
 		});
 
-		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
-		await fireEvent.input(addressInput, {
+		await fireEvent.input(getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT), {
 			target: { value: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F' }
 		});
 
-		const form = container.querySelector('form');
-		if (!form) {
-			throw new Error('Form element not found');
-		}
-
-		await fireEvent.submit(form);
-
+		await fireEvent.submit(container.querySelector('form')!);
 		expect(onAddAddress).toHaveBeenCalled();
 	});
 
@@ -277,62 +259,13 @@ describe('EditAddressStep', () => {
 				contact: mockContact,
 				onSaveAddress,
 				onAddAddress,
+				onQRCodeScan,
 				onClose,
 				isNewAddress: false,
 				address: initialAddress
 			}
 		});
 
-		const saveButton = getByTestId(ADDRESS_BOOK_SAVE_BUTTON);
-
-		expect(saveButton).toBeDisabled();
-	});
-
-	it('should autofocus address input when adding a new address on desktop', () => {
-		const onSaveAddress = vi.fn();
-		const onAddAddress = vi.fn();
-		const onClose = vi.fn();
-
-		vi.mock('$lib/utils/device.utils', () => ({
-			isDesktop: () => true
-		}));
-
-		const { getByTestId } = render(EditAddressStep, {
-			props: {
-				contact: mockContact,
-				onSaveAddress,
-				onAddAddress,
-				onClose,
-				isNewAddress: true
-			}
-		});
-
-		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
-
-		expect(document.activeElement).toBe(addressInput);
-	});
-
-	it('should autofocus label input when editing an address on desktop', () => {
-		const onSaveAddress = vi.fn();
-		const onAddAddress = vi.fn();
-		const onClose = vi.fn();
-
-		vi.mock('$lib/utils/device.utils', () => ({
-			isDesktop: () => true
-		}));
-
-		const { getByTestId } = render(EditAddressStep, {
-			props: {
-				contact: mockContact,
-				onSaveAddress,
-				onAddAddress,
-				onClose,
-				isNewAddress: false
-			}
-		});
-
-		const labelInput = getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT);
-
-		expect(document.activeElement).toBe(labelInput);
+		expect(getByTestId(ADDRESS_BOOK_SAVE_BUTTON)).toBeDisabled();
 	});
 });

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -217,6 +217,7 @@ describe('EditAddressStep', () => {
 		const resetButtons = screen.getAllByRole('button', {
 			name: 'Reset input value'
 		});
+
 		expect(resetButtons).toHaveLength(2);
 	});
 
@@ -240,7 +241,12 @@ describe('EditAddressStep', () => {
 			target: { value: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F' }
 		});
 
-		await fireEvent.submit(container.querySelector('form')!);
+		const form = container.querySelector('form');
+		if (!form) {
+			throw new Error('Form element not found');
+		}
+		await fireEvent.submit(form);
+
 		expect(onAddAddress).toHaveBeenCalled();
 	});
 

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -261,4 +261,52 @@ describe('EditAddressStep', () => {
 
 		expect(onAddAddress).toHaveBeenCalled();
 	});
+
+	it('should autofocus address input when adding a new address on desktop', async () => {
+		const onSaveAddress = vi.fn();
+		const onAddAddress = vi.fn();
+		const onClose = vi.fn();
+
+		vi.mock('$lib/utils/device.utils', () => ({
+			isDesktop: () => true
+		}));
+
+		const { getByTestId } = render(EditAddressStep, {
+			props: {
+				contact: mockContact,
+				onSaveAddress,
+				onAddAddress,
+				onClose,
+				isNewAddress: true
+			}
+		});
+
+		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
+
+		expect(document.activeElement).toBe(addressInput);
+	});
+
+	it('should autofocus label input when editing an address on desktop', async () => {
+		const onSaveAddress = vi.fn();
+		const onAddAddress = vi.fn();
+		const onClose = vi.fn();
+
+		vi.mock('$lib/utils/device.utils', () => ({
+			isDesktop: () => true
+		}));
+
+		const { getByTestId } = render(EditAddressStep, {
+			props: {
+				contact: mockContact,
+				onSaveAddress,
+				onAddAddress,
+				onClose,
+				isNewAddress: false
+			}
+		});
+
+		const labelInput = getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT);
+
+		expect(document.activeElement).toBe(labelInput);
+	});
 });

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -262,7 +262,7 @@ describe('EditAddressStep', () => {
 		expect(onAddAddress).toHaveBeenCalled();
 	});
 
-	it('should autofocus address input when adding a new address on desktop', async () => {
+	it('should autofocus address input when adding a new address on desktop', () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();
@@ -286,7 +286,7 @@ describe('EditAddressStep', () => {
 		expect(document.activeElement).toBe(addressInput);
 	});
 
-	it('should autofocus label input when editing an address on desktop', async () => {
+	it('should autofocus label input when editing an address on desktop', () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
 		const onClose = vi.fn();

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -261,6 +261,7 @@ describe('EditAddressStep', () => {
 
 		expect(onAddAddress).toHaveBeenCalled();
 	});
+
 	it('should disable save button when alias is unchanged in edit mode', () => {
 		const onSaveAddress = vi.fn();
 		const onAddAddress = vi.fn();
@@ -283,6 +284,7 @@ describe('EditAddressStep', () => {
 		});
 
 		const saveButton = getByTestId(ADDRESS_BOOK_SAVE_BUTTON);
+
 		expect(saveButton).toBeDisabled();
 	});
 
@@ -306,6 +308,7 @@ describe('EditAddressStep', () => {
 		});
 
 		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
+
 		expect(document.activeElement).toBe(addressInput);
 	});
 
@@ -329,7 +332,7 @@ describe('EditAddressStep', () => {
 		});
 
 		const labelInput = getByTestId(ADDRESS_BOOK_ADDRESS_ALIAS_INPUT);
+
 		expect(document.activeElement).toBe(labelInput);
 	});
-
 });


### PR DESCRIPTION
# Motivation

The primary goal of this PR is to enhance the user experience by implementing context-sensitive autofocus behavior in the address form. Specifically, when adding a new address, the focus should automatically be set to the address input field; when editing an existing address, the focus should shift to the label input field. This behavior is conditioned to activate only on desktop devices to maintain optimal usability across different platforms.

# Changes

Introduced a new prop in the AddressForm component to determine which input field should receive focus upon rendering.
Using the isDesktop() function to ensure autofocus behavior is only applied on desktop devices.
Implemented conditional logic within the AddressForm to set focus.

<img width="694" alt="Screenshot 2025-06-02 at 18 00 25" src="https://github.com/user-attachments/assets/e4ba4b32-5d19-43f1-bbb0-91be7f1aca63" />


# Tests

Add 2 Unit Tests:
Verified that the focusField prop correctly sets focus to the intended input field when the component is rendered on a desktop device.
Ensured that no autofocus behavior is triggered on non-desktop devices, maintaining expected functionality across platforms.

