### PR TITLE
feat(frontend): save contact if selected in the known destinations list

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -5,6 +5,7 @@
 	import KnownDestination from '$lib/components/send/KnownDestination.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { ContactUi } from '$lib/types/contact';
 	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isContactMatchingFilter } from '$lib/utils/contact.utils';
@@ -13,8 +14,14 @@
 		destination: string;
 		knownDestinations?: KnownDestinations;
 		networkContacts?: NetworkContacts;
+		selectedContact?: ContactUi;
 	}
-	let { knownDestinations, destination = $bindable(), networkContacts }: Props = $props();
+	let {
+		knownDestinations,
+		destination = $bindable(),
+		selectedContact = $bindable(),
+		networkContacts
+	}: Props = $props();
 
 	const dispatch = createEventDispatcher();
 
@@ -52,6 +59,11 @@
 							{...rest}
 							onClick={() => {
 								destination = address;
+
+								if (nonNullish(networkContacts?.[address])) {
+									selectedContact = networkContacts[address];
+								}
+
 								dispatch('icNext');
 							}}
 						/>

--- a/src/frontend/src/lib/components/send/SendDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendDestination.svelte
@@ -35,14 +35,20 @@
 
 	<AddressCard hasError={invalidDestination} items="center">
 		{#snippet logo()}
-			<div class="mr-2"><AvatarWithBadge contact={selectedContact} address={destination} /></div>
+			<div class="mr-2">
+				<AvatarWithBadge
+					contact={selectedContact}
+					address={destination}
+					badge={{ type: 'addressType', address: destination }}
+				/>
+			</div>
 		{/snippet}
 
 		{#snippet content()}
 			{#if isNullish(selectedContact)}
 				{addressToDisplay}
 			{:else}
-				<span>
+				<span class="font-bold">
 					{selectedContact.name}
 
 					{#if notEmptyString(selectedContactLabel)}

--- a/src/frontend/src/lib/components/send/SendDestinationTabs.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationTabs.svelte
@@ -37,6 +37,7 @@
 			<KnownDestinationsComponent
 				{knownDestinations}
 				{networkContacts}
+				bind:selectedContact
 				bind:destination
 				on:icNext
 			/>


### PR DESCRIPTION
# Motivation

We also need to save contact for the next steps if selected in the known destinations list. Also, we should display it correctly with the badge and font-bold on the Send Form screen.
