### PR TITLE
style(frontend): Address group enhancements

### DIFF
--- a/src/frontend/src/lib/components/contact/ContactCard.svelte
+++ b/src/frontend/src/lib/components/contact/ContactCard.svelte
@@ -115,7 +115,6 @@
 
 <div
 	class="flex w-full flex-col rounded-xl p-2 hover:bg-brand-subtle-10"
-	class:bg-primary-alt={!expanded}
 	class:bg-brand-subtle-10={expanded}
 	data-tid={CONTACT_CARD}
 >

--- a/src/frontend/src/lib/components/contact/ContactCard.svelte
+++ b/src/frontend/src/lib/components/contact/ContactCard.svelte
@@ -48,7 +48,9 @@
 {#snippet header()}
 	<LogoButton {onClick} hover={false} condensed testId={CONTACT_CARD_BUTTON} styleClass="group">
 		{#snippet logo()}
-			<AvatarWithBadge {contact} badge={{ type: 'addressTypeOrCount' }} variant="sm" />
+			<span class="pr-2">
+				<AvatarWithBadge {contact} badge={{ type: 'addressTypeOrCount' }} variant="sm" />
+			</span>
 		{/snippet}
 
 		{#snippet title()}
@@ -88,7 +90,9 @@
 				/>
 			{:else if multipleAddresses}
 				<ButtonIcon
-					styleClass="text-primary"
+					styleClass="text-primary hover:bg-brand-subtle-20 rounded-md"
+					width="w-6"
+					height="h-6"
 					onclick={(e) => {
 						e.preventDefault();
 						e.stopPropagation();
@@ -110,14 +114,16 @@
 {/snippet}
 
 <div
-	class="flex w-full flex-col rounded-xl bg-primary p-2 hover:bg-brand-subtle-20"
+	class="flex w-full flex-col rounded-xl p-2 hover:bg-brand-subtle-10"
+	class:bg-primary={!expanded}
+	class:bg-brand-subtle-10={expanded}
 	data-tid={CONTACT_CARD}
 >
 	{#if multipleAddresses}
 		{@render header()}
 		{#if expanded}
 			<div
-				class="mt-1 flex flex-col gap-1.5 md:pl-20"
+				class="mt-1 flex flex-col gap-1.5 md:pl-16"
 				transition:slide={SLIDE_DURATION}
 				data-tid="collapsible-content"
 			>

--- a/src/frontend/src/lib/components/contact/ContactCard.svelte
+++ b/src/frontend/src/lib/components/contact/ContactCard.svelte
@@ -115,7 +115,7 @@
 
 <div
 	class="flex w-full flex-col rounded-xl p-2 hover:bg-brand-subtle-10"
-	class:bg-primary={!expanded}
+	class:bg-primary-alt={!expanded}
 	class:bg-brand-subtle-10={expanded}
 	data-tid={CONTACT_CARD}
 >

--- a/src/frontend/src/lib/components/ui/ButtonIcon.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonIcon.svelte
@@ -15,6 +15,7 @@
 		link?: boolean;
 		styleClass?: string;
 		width?: 'w-6' | 'w-8' | 'w-10';
+		height?: 'h-6' | 'h-8' | 'h-10';
 	}
 
 	let {
@@ -28,13 +29,14 @@
 		disabled = false,
 		link = true,
 		styleClass = '',
-		width = 'w-10'
+		width = 'w-10',
+		height = 'h-10'
 	}: Props = $props();
 </script>
 
 <button
 	type="button"
-	class={`${colorStyle} icon flex h-10 flex-col text-center text-xs font-normal ${styleClass} ${width}`}
+	class={`${colorStyle} icon flex flex-col text-center text-xs font-normal ${styleClass} ${width} ${height}`}
 	class:link
 	bind:this={button}
 	{onclick}


### PR DESCRIPTION
# Motivation

We enhance the styling of the contact addresses group cards.

# Changes

- Adjusted ButtonIcon to allow to set height prop as well
- Adjusted padding between Avatar and Name as well as the address list left padding
- Adjusted hover state colors
- Adjusted card bg

# Tests

Hover on first address:
![image](https://github.com/user-attachments/assets/8b54293f-87b7-437a-b921-9677899dd770)

Hover on caret icon:
![image](https://github.com/user-attachments/assets/1e3c5e50-9165-425e-8cb8-a43735881d0b)

Hover on last contact:
![image](https://github.com/user-attachments/assets/fbc26416-6ec8-4f05-b796-8bb081c5ef65)

Mobile:
![image](https://github.com/user-attachments/assets/4c7d4165-3b83-489e-bf79-687b0f63038e)
