### PR TITLE
feat(frontend): disable save button if alias is not changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6317,11 +6317,10 @@
 			}
 		},
 		"node_modules/bufferutil": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
-			"integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+			"integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"node-gyp-build": "^4.3.0"
 			},

--- a/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
@@ -76,6 +76,9 @@
 	);
 
 	let isInvalid = $state(false);
+
+	let originalLabel = $derived(!isNewAddress && nonNullish(address?.label) ? address.label : '');
+	let labelChanged = $derived(isNewAddress ? true : editingAddress.label !== originalLabel);
 </script>
 
 <form onsubmit={handleSubmit} method="POST" class="flex w-full flex-col items-center">
@@ -102,7 +105,7 @@
 			<ButtonCancel {disabled} onclick={onClose} testId={ADDRESS_BOOK_CANCEL_BUTTON}></ButtonCancel>
 			<Button
 				colorStyle="primary"
-				disabled={isInvalid}
+				disabled={isInvalid || (!isNewAddress && !labelChanged)}
 				on:click={handleSave}
 				testId={ADDRESS_BOOK_SAVE_BUTTON}
 				loading={disabled}

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -261,4 +261,30 @@ describe('EditAddressStep', () => {
 
 		expect(onAddAddress).toHaveBeenCalled();
 	});
+
+	it('should disable save button when alias is unchanged in edit mode', () => {
+		const onSaveAddress = vi.fn();
+		const onAddAddress = vi.fn();
+		const onClose = vi.fn();
+
+		const initialAddress: Partial<ContactAddressUi> = {
+			address: 'icp:abcdefghijklmnopqrstuvwxyz',
+			label: 'Original Label'
+		};
+
+		const { getByTestId } = render(EditAddressStep, {
+			props: {
+				contact: mockContact,
+				onSaveAddress,
+				onAddAddress,
+				onClose,
+				isNewAddress: false,
+				address: initialAddress
+			}
+		});
+
+		const saveButton = getByTestId(ADDRESS_BOOK_SAVE_BUTTON);
+
+		expect(saveButton).toBeDisabled();
+	});
 });


### PR DESCRIPTION
# Motivation

The motivation behind this PR is to enhance user experience by ensuring that the Save button is only enabled when alias is  changed during the edit process.

# Changes

Introduced originalLabel and labelChanged Derived States.
Updated Save Button Logic - Modified the disabled property of the Save button to consider both the form's validity (isInvalid) and whether the alias has been altered (labelChanged).

# Tests

Unit test
Verifies that the Save button remains disabled if the alias field is not modified during editing.
