### PR TITLE
style(frontend): Add address button

### DIFF
--- a/src/frontend/src/lib/components/address-book/ShowContactStep.svelte
+++ b/src/frontend/src/lib/components/address-book/ShowContactStep.svelte
@@ -77,9 +77,9 @@
 			</div>
 
 			<Button
-				styleClass="py-0"
+				styleClass="py-1.5"
 				ariaLabel={$i18n.address_book.show_contact.add_address}
-				colorStyle="tertiary-main-card"
+				colorStyle="secondary-light"
 				testId={CONTACT_SHOW_ADD_ADDRESS_BUTTON}
 				on:click={onAddAddress}
 			>


### PR DESCRIPTION
# Motivation

The add address button is not correctly styled.

# Changes

Adjusted to `secondary-light` and added more vertical padding as defined by Dan

# Tests

![image](https://github.com/user-attachments/assets/73ad2ee0-518c-47bf-9ce4-0c6907126f4d)
