### PR TITLE
fix(frontend): Tokenlist enabled tokens reset

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -91,6 +91,15 @@
 		const { id: networkId } = network;
 		const { [`${networkId.description}-${id.description}`]: current, ...tokens } = modifiedTokens;
 
+		// we need to set the tokenlist for the ModalTokenListContext manually when we change the enabled prop,
+		// because the exposed prop from the context is a derived and on update of the data the "enabled" gets reset
+		const tokensList = [...allTokensSorted];
+		const token = tokensList.find((t) => t.id === id);
+		if (token && 'enabled' in token) {
+			token.enabled = !token.enabled;
+			setTokens(tokensList);
+		}
+
 		if (nonNullish(current)) {
 			modifiedTokens = { ...tokens };
 			return;


### PR DESCRIPTION
# Motivation

When enabling/disabling tokens in the manage tokens modal, sometimes the changes made to the enabled/disabled state got lost.

# Changes

We manually need to set the enabled prop in the tokenlist of the ModalTokenListContext to avoid it being reset. Added a comment for clarity.

# Tests


https://github.com/user-attachments/assets/6a596ac4-53f9-404e-a301-8bab6221cc4a

