### PR TITLE
refactor(frontend): upgrades ShareButton to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/share/ShareButton.svelte
+++ b/src/frontend/src/lib/components/share/ShareButton.svelte
@@ -8,7 +8,7 @@
 		testId?: string;
 	}
 
-	let {shareAriaLabel, testId}: Props = $props();
+	let { shareAriaLabel, testId }: Props = $props();
 </script>
 
 {#if canShare()}

--- a/src/frontend/src/lib/components/share/ShareButton.svelte
+++ b/src/frontend/src/lib/components/share/ShareButton.svelte
@@ -3,8 +3,12 @@
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { canShare, shareText } from '$lib/utils/share.utils';
 
-	export let shareAriaLabel: string;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		shareAriaLabel: string;
+		testId?: string;
+	}
+
+	let {shareAriaLabel, testId}: Props = $props();
 </script>
 
 {#if canShare()}


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- upgrades `ShareButton`
