### PR TITLE
refactor(frontend): use localized value in SwapProvider

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -93,7 +93,7 @@
 			{#if displayURL}
 				<ModalValue>
 					{#snippet label()}
-						Website
+						{$i18n.swap.text.swap_provider_website}
 					{/snippet}
 
 					{#snippet mainValue()}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -605,6 +605,7 @@
 			"swapping": "Swapping...",
 			"refreshing_ui": "Refreshing UI",
 			"swap_provider": "Swap provider",
+			"swap_provider_website": "Website",
 			"swap_route": "Swap route",
 			"included_network_fees": "Included network fees",
 			"included_liquidity_fees": "Included liquidity pool fees",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -573,6 +573,7 @@ interface I18nSwap {
 		swapping: string;
 		refreshing_ui: string;
 		swap_provider: string;
+		swap_provider_website: string;
 		swap_route: string;
 		included_network_fees: string;
 		included_liquidity_fees: string;


### PR DESCRIPTION
# Motivation

We had an unlocalized value displayed in SwapProvider.
