### PR TITLE
feat(frontend): TokenModal component

### DIFF
--- a/src/frontend/src/lib/components/common/ModalListItem.svelte
+++ b/src/frontend/src/lib/components/common/ModalListItem.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import ListItem from '$lib/components/common/ListItem.svelte';
+
+	interface Props {
+		label: Snippet;
+		content: Snippet;
+	}
+
+	let { label, content }: Props = $props();
+</script>
+
+<ListItem>
+	<span class="text-tertiary">{@render label()}</span>
+
+	<span class="flex items-center gap-1">
+		{@render content()}
+	</span>
+</ListItem>

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -2,6 +2,8 @@
 	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
+	import { isTokenErc20 } from '$eth/utils/erc20.utils';
+	import { isTokenIcrc, isTokenDip20 } from '$icp/utils/icrc.utils';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
@@ -58,7 +60,7 @@
 
 			{@render children?.()}
 
-			{#if ['icrc', 'erc20'].includes(token.standard)}
+			{#if isTokenIcrc(token) || isTokenErc20(token) || isTokenDip20(token)}
 				<ModalValue ref="symbol">
 					{#snippet label()}
 						{$i18n.tokens.details.standard}

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { Modal } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
+	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionToken } from '$lib/types/token';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	interface BaseTokenModalProps {
+		children?: Snippet;
+		token: OptionToken;
+	}
+
+	let { children, token }: BaseTokenModalProps = $props();
+</script>
+
+<Modal on:nnsClose={modalStore.close}>
+	<svelte:fragment slot="title">{$i18n.tokens.details.title}</svelte:fragment>
+
+	<ContentWithToolbar>
+		{#if nonNullish(token)}
+			<ModalValue ref="network">
+				{#snippet label()}
+					{$i18n.tokens.details.network}
+				{/snippet}
+
+				{#snippet mainValue()}
+					<span class="flex items-center gap-1">
+						<output>{token.network.name}</output>
+						<NetworkLogo network={token.network} />
+					</span>
+				{/snippet}
+			</ModalValue>
+
+			<ModalValue ref="name">
+				{#snippet label()}
+					{$i18n.tokens.details.token}
+				{/snippet}
+
+				{#snippet mainValue()}
+					<span class="flex items-center gap-1">
+						<output>{token.name}</output>
+						<Logo
+							src={token.icon}
+							alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
+							color="white"
+						/>
+					</span>
+				{/snippet}
+			</ModalValue>
+
+			{@render children?.()}
+
+			{#if ['icrc', 'erc20'].includes(token.standard)}
+				<ModalValue ref="symbol">
+					{#snippet label()}
+						{$i18n.tokens.details.standard}
+					{/snippet}
+
+					{#snippet mainValue()}
+						<output class="inline-block first-letter:capitalize">{token.standard}</output>
+					{/snippet}
+				</ModalValue>
+			{/if}
+
+			<ModalValue ref="symbol">
+				{#snippet label()}
+					{$i18n.core.text.symbol}
+				{/snippet}
+
+				{#snippet mainValue()}
+					<output>
+						{`${getTokenDisplaySymbol(token)}${nonNullish(token.oisySymbol) ? ` (${token.symbol})` : ''}`}
+					</output>
+				{/snippet}
+			</ModalValue>
+
+			<ModalValue ref="decimals">
+				{#snippet label()}
+					{$i18n.core.text.decimals}
+				{/snippet}
+
+				{#snippet mainValue()}
+					<output>{token.decimals}</output>
+				{/snippet}
+			</ModalValue>
+		{/if}
+
+		<ButtonDone onclick={modalStore.close} slot="toolbar" />
+	</ContentWithToolbar>
+</Modal>

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -4,11 +4,12 @@
 	import type { Snippet } from 'svelte';
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import { isTokenIcrc, isTokenDip20 } from '$icp/utils/icrc.utils';
+	import List from '$lib/components/common/List.svelte';
+	import ModalListItem from '$lib/components/common/ModalListItem.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
-	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionToken } from '$lib/types/token';
@@ -28,73 +29,67 @@
 
 	<ContentWithToolbar>
 		{#if nonNullish(token)}
-			<ModalValue ref="network">
-				{#snippet label()}
-					{$i18n.tokens.details.network}
-				{/snippet}
-
-				{#snippet mainValue()}
-					<output>{token.network.name}</output>
-				{/snippet}
-
-				{#snippet secondaryValue()}
-					<NetworkLogo network={token.network} />
-				{/snippet}
-			</ModalValue>
-
-			<ModalValue ref="name">
-				{#snippet label()}
-					{$i18n.tokens.details.token}
-				{/snippet}
-
-				{#snippet mainValue()}
-					<output>{token.name}</output>
-				{/snippet}
-
-				{#snippet secondaryValue()}
-					<Logo
-						src={token.icon}
-						alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
-						color="white"
-					/>
-				{/snippet}
-			</ModalValue>
-
-			{@render children?.()}
-
-			{#if isTokenIcrc(token) || isTokenErc20(token) || isTokenDip20(token)}
-				<ModalValue ref="symbol">
+			<List styleClass="text-sm" condensed={false}>
+				<ModalListItem>
 					{#snippet label()}
-						{$i18n.tokens.details.standard}
+						{$i18n.tokens.details.network}
 					{/snippet}
 
-					{#snippet mainValue()}
-						<output>{token.standard}</output>
+					{#snippet content()}
+						<output>{token.network.name}</output>
+						<NetworkLogo network={token.network} />
 					{/snippet}
-				</ModalValue>
-			{/if}
+				</ModalListItem>
 
-			<ModalValue ref="symbol">
-				{#snippet label()}
-					{$i18n.core.text.symbol}
-				{/snippet}
+				<ModalListItem>
+					{#snippet label()}
+						{$i18n.tokens.details.token}
+					{/snippet}
 
-				{#snippet mainValue()}
-					<output>
+					{#snippet content()}
+						<output>{token.name}</output>
+						<Logo
+							src={token.icon}
+							alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
+							color="white"
+						/>
+					{/snippet}
+				</ModalListItem>
+
+				{@render children?.()}
+
+				{#if isTokenIcrc(token) || isTokenErc20(token) || isTokenDip20(token)}
+					<ModalListItem>
+						{#snippet label()}
+							{$i18n.tokens.details.standard}
+						{/snippet}
+
+						{#snippet content()}
+							{token.standard}
+						{/snippet}
+					</ModalListItem>
+				{/if}
+
+				<ModalListItem>
+					{#snippet label()}
+						{$i18n.core.text.symbol}
+					{/snippet}
+
+					{#snippet content()}
 						{`${getTokenDisplaySymbol(token)}${nonNullish(token.oisySymbol) ? ` (${token.symbol})` : ''}`}
-					</output>
-				{/snippet}
-			</ModalValue>
+					{/snippet}
+				</ModalListItem>
 
-			<ModalValue ref="decimals">
-				{#snippet label()}
-					{$i18n.core.text.decimals}
-				{/snippet}
+				<ModalListItem>
+					{#snippet label()}
+						{$i18n.core.text.decimals}
+					{/snippet}
 
-				{#snippet mainValue()}
-					<output>{token.decimals}</output>
-				{/snippet}
-			</ModalValue>
+					{#snippet content()}
+						{token.decimals}
+					{/snippet}
+				</ModalListItem>
+			</List>
 		{/if}
 
 		<ButtonDone onclick={modalStore.close} slot="toolbar" />

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -34,10 +34,11 @@
 				{/snippet}
 
 				{#snippet mainValue()}
-					<span class="flex items-center gap-1">
-						<output>{token.network.name}</output>
-						<NetworkLogo network={token.network} />
-					</span>
+					<output>{token.network.name}</output>
+				{/snippet}
+
+				{#snippet secondaryValue()}
+					<NetworkLogo network={token.network} />
 				{/snippet}
 			</ModalValue>
 
@@ -47,14 +48,15 @@
 				{/snippet}
 
 				{#snippet mainValue()}
-					<span class="flex items-center gap-1">
-						<output>{token.name}</output>
-						<Logo
-							src={token.icon}
-							alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
-							color="white"
-						/>
-					</span>
+					<output>{token.name}</output>
+				{/snippet}
+
+				{#snippet secondaryValue()}
+					<Logo
+						src={token.icon}
+						alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
+						color="white"
+					/>
 				{/snippet}
 			</ModalValue>
 
@@ -67,7 +69,7 @@
 					{/snippet}
 
 					{#snippet mainValue()}
-						<output class="inline-block first-letter:capitalize">{token.standard}</output>
+						<output>{token.standard}</output>
 					{/snippet}
 				</ModalValue>
 			{/if}

--- a/src/frontend/src/tests/lib/components/common/ModalListItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/ModalListItem.spec.ts
@@ -1,0 +1,29 @@
+import ModalListItem from '$lib/components/common/ModalListItem.svelte';
+import { render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+describe('ModalListItem', () => {
+	const mockContext = new Map([]);
+	mockContext.set('list-context', {
+		variant: 'styled'
+	});
+
+	it('renders correctly', () => {
+		const label = 'label';
+		const content = 'content';
+		const { getByText } = render(ModalListItem, {
+			context: mockContext,
+			props: {
+				label: createRawSnippet(() => ({
+					render: () => label
+				})),
+				content: createRawSnippet(() => ({
+					render: () => content
+				}))
+			}
+		});
+
+		expect(getByText(label)).toBeInTheDocument();
+		expect(getByText(content)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -1,0 +1,52 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import TokenModal from '$lib/components/tokens/TokenModal.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { render } from '@testing-library/svelte';
+
+describe('TokenModal', () => {
+	it('renders all values correctly for ICP token', () => {
+		const { getByText, getAllByText } = render(TokenModal, {
+			props: {
+				token: ICP_TOKEN
+			}
+		});
+
+		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.network)).toBeInTheDocument();
+		expect(getAllByText(ICP_TOKEN.network.name)[0]).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.token)).toBeInTheDocument();
+		expect(getAllByText(ICP_TOKEN.name)[1]).toBeInTheDocument();
+
+		expect(getByText(en.core.text.symbol)).toBeInTheDocument();
+
+		expect(getByText(en.core.text.decimals)).toBeInTheDocument();
+		expect(getByText(ICP_TOKEN.decimals)).toBeInTheDocument();
+	});
+
+	it('renders all values correctly for ICRC token', () => {
+		const { getByText } = render(TokenModal, {
+			props: {
+				token: mockValidIcrcToken
+			}
+		});
+
+		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.network)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.network.name)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.token)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.name)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.standard)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.standard)).toBeInTheDocument();
+
+		expect(getByText(en.core.text.symbol)).toBeInTheDocument();
+
+		expect(getByText(en.core.text.decimals)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.decimals)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to create a re-usable TokenModal component. It is based on the existing `Token` component, but now includes the Modal-related usage. Also, instead of `Value`, `ModalValue` is now used for displaying the data.

UPD: the design is now a bit different

<img width="592" alt="Screenshot 2025-06-05 at 11 48 29" src="https://github.com/user-attachments/assets/0f8392d0-3982-4e65-a79e-d7349973be64" />

