### PR TITLE
feat(frontend): validate contact name

### DIFF
--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { notEmptyString } from '@dfinity/utils';
+	import { slide } from 'svelte/transition';
 	import InputText from '$lib/components/ui/InputText.svelte';
 	import { ADDRESS_BOOK_CONTACT_NAME_INPUT } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
+	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 
 	let {
 		contact = $bindable(),
@@ -11,10 +13,12 @@
 		onSubmit = () => {}
 	}: { contact: Partial<ContactUi>; disabled?: boolean; onSubmit?: () => void } = $props();
 
-	let isValid = $derived(notEmptyString(contact?.name?.trim?.()));
+	const trimmedName = $derived(contact?.name?.trim?.() ?? '');
+	const isNameTooLong = $derived(trimmedName.length > 100);
+	const isValid = $derived(notEmptyString(trimmedName) && !isNameTooLong);
 
 	const handleKeydown = (event: KeyboardEvent): void => {
-		if (event.key === 'Enter') {
+		if (event.key === 'Enter' && isValid) {
 			event.preventDefault();
 			onSubmit();
 		}
@@ -37,5 +41,10 @@
 			autofocus={true}
 			{disabled}
 		/>
+		{#if isNameTooLong}
+			<p transition:slide={SLIDE_DURATION} class="pt-2 text-error-primary">
+				{$i18n.contact.error.name_too_long}</p
+			>
+		{/if}
 	</div>
 </form>

--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -17,10 +17,13 @@
 
 	const trimmedName = $derived((contact.name ?? '').trim());
 	const isNameTooLong = $derived(trimmedName.length > CONTACT_MAX_NAME_LENGTH);
-	const isValid = $derived(notEmptyString(trimmedName) && !isNameTooLong);
+
+	const assertValid = (): boolean => notEmptyString(trimmedName) && !isNameTooLong;
+
+	const isValid = $derived(assertValid());
 
 	const handleKeydown = (event: KeyboardEvent): void => {
-		if (event.key === 'Enter' && isValid) {
+		if (event.key === 'Enter' && assertValid()) {
 			event.preventDefault();
 			onSubmit();
 		}

--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -15,12 +15,12 @@
 		onSubmit = () => {}
 	}: { contact: Partial<ContactUi>; disabled?: boolean; onSubmit?: () => void } = $props();
 
-	const trimmedName = $derived(contact?.name?.trim?.() ?? '');
-	const isNameTooLong = $derived(trimmedName.length > 100);
+	const trimmedName = $derived((contact.name ?? '').trim());
+	const isNameTooLong = $derived(trimmedName.length > CONTACT_MAX_NAME_LENGTH);
 	const isValid = $derived(notEmptyString(trimmedName) && !isNameTooLong);
 
 	const handleKeydown = (event: KeyboardEvent): void => {
-		if (event.key === 'Enter' && isValid) {
+		if (event.key === 'Enter') {
 			event.preventDefault();
 			onSubmit();
 		}
@@ -31,7 +31,7 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<form class="w-full" method="POST">
+<form class="w-full">
 	<div class="rounded-lg bg-brand-subtle-10 p-4 pb-6 pt-4 text-sm md:p-6 md:text-base md:font-bold">
 		{$i18n.contact.fields.name}
 		<InputText

--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -2,10 +2,12 @@
 	import { notEmptyString } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import InputText from '$lib/components/ui/InputText.svelte';
+	import { CONTACT_MAX_NAME_LENGTH } from '$lib/constants/app.constants';
 	import { ADDRESS_BOOK_CONTACT_NAME_INPUT } from '$lib/constants/test-ids.constants';
+	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
-	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	let {
 		contact = $bindable(),
@@ -43,7 +45,9 @@
 		/>
 		{#if isNameTooLong}
 			<p transition:slide={SLIDE_DURATION} class="pt-2 text-error-primary">
-				{$i18n.contact.error.name_too_long}</p
+				{replacePlaceholders($i18n.contact.error.name_too_long, {
+					$maxCharacters: `${CONTACT_MAX_NAME_LENGTH}`
+				})}</p
 			>
 		{/if}
 	</div>

--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -31,7 +31,7 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<form class="w-full">
+<form class="w-full" method="POST">
 	<div class="rounded-lg bg-brand-subtle-10 p-4 pb-6 pt-4 text-sm md:p-6 md:text-base md:font-bold">
 		{$i18n.contact.fields.name}
 		<InputText

--- a/src/frontend/src/lib/components/address-book/ContactForm.svelte
+++ b/src/frontend/src/lib/components/address-book/ContactForm.svelte
@@ -20,7 +20,7 @@
 	const isValid = $derived(notEmptyString(trimmedName) && !isNameTooLong);
 
 	const handleKeydown = (event: KeyboardEvent): void => {
-		if (event.key === 'Enter') {
+		if (event.key === 'Enter' && isValid) {
 			event.preventDefault();
 			onSubmit();
 		}

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -173,3 +173,6 @@ export const MIN_DESTINATION_LENGTH_FOR_ERROR_STATE = 10;
 
 // Contact validation
 export const CONTACT_MAX_LABEL_LENGTH = 50;
+
+// Contact validation
+export const CONTACT_MAX_NAME_LENGTH = 100;

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1089,7 +1089,8 @@
 		"error": {
 			"create": "Failed to create the contact",
 			"update": "Failed to update the contact",
-			"delete": "Failed to delete the contact"
+			"delete": "Failed to delete the contact",
+			"name_too_long": "Name must be 100 characters or fewer."
 		}
 	},
 	"address": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1090,7 +1090,7 @@
 			"create": "Failed to create the contact",
 			"update": "Failed to update the contact",
 			"delete": "Failed to delete the contact",
-			"name_too_long": "Name must be 100 characters or fewer."
+			"name_too_long": "Name must be $maxCharacters characters or fewer."
 		}
 	},
 	"address": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1090,7 +1090,7 @@
 			"create": "Failed to create the contact",
 			"update": "Failed to update the contact",
 			"delete": "Failed to delete the contact",
-			"name_too_long": "Name must be $maxCharacters characters or fewer."
+			"name_too_long": "Please keep the name to $maxCharacters characters or fewer."
 		}
 	},
 	"address": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -986,7 +986,7 @@ interface I18nContact {
 	form: { edit_contact: string; add_new_contact: string };
 	fields: { name: string };
 	delete: { title: string; delete_contact: string; content_text: string };
-	error: { create: string; update: string; delete: string };
+	error: { create: string; update: string; delete: string; name_too_long: string };
 }
 
 interface I18nAddress {

--- a/src/frontend/src/tests/lib/components/address-book/ContactForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/ContactForm.spec.ts
@@ -2,7 +2,7 @@ import ContactForm from '$lib/components/address-book/ContactForm.svelte';
 import { ADDRESS_BOOK_CONTACT_NAME_INPUT } from '$lib/constants/test-ids.constants';
 import type { ContactUi } from '$lib/types/contact';
 import en from '$tests/mocks/i18n.mock';
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 
 describe('ContactForm', () => {
 	it('should render the contact form with name field', () => {
@@ -53,5 +53,52 @@ describe('ContactForm', () => {
 		expect(
 			getByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
 		).toBeInTheDocument();
+	});
+
+	it('should not show error message on load', () => {
+		const contact: Partial<ContactUi> = {};
+		const { queryByText } = render(ContactForm, { props: { contact } });
+
+		expect(
+			queryByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
+		).not.toBeInTheDocument();
+	});
+
+	it('should not show error when name is valid and within max length', async () => {
+		const contact: Partial<ContactUi> = {};
+		const { getByTestId, queryByText } = render(ContactForm, { props: { contact } });
+
+		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
+		await fireEvent.input(nameInput, { target: { value: 'Valid Name' } });
+
+		expect(
+			queryByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
+		).not.toBeInTheDocument();
+	});
+
+	it('should show and then hide error when name is corrected', async () => {
+		const contact: Partial<ContactUi> = {};
+		const { getByTestId, queryByText, getByText } = render(ContactForm, { props: { contact } });
+
+		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
+		const longName = 'A'.repeat(101);
+		const shortName = 'Valid';
+
+		// Trigger error
+		fireEvent.input(nameInput, { target: { value: longName } });
+
+		expect(
+			getByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
+		).toBeInTheDocument();
+
+		// Correct name
+		await fireEvent.input(nameInput, { target: { value: shortName } });
+
+		// Wait for error message to be removed after input becomes valid
+		await waitFor(() =>
+			expect(
+				queryByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
+			).not.toBeInTheDocument()
+		);
 	});
 });

--- a/src/frontend/src/tests/lib/components/address-book/ContactForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/ContactForm.spec.ts
@@ -40,4 +40,18 @@ describe('ContactForm', () => {
 		// Check that validation failed
 		expect(component.isValid).toBeFalsy();
 	});
+
+	it('should show error when name exceeds max length', async () => {
+		const contact: Partial<ContactUi> = {};
+		const { getByTestId, getByText } = render(ContactForm, { props: { contact } });
+
+		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
+		const longName = 'A'.repeat(101);
+
+		await fireEvent.input(nameInput, { target: { value: longName } });
+
+		expect(
+			getByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
+		).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
# Motivation

We introduced a maximum character limit of 100 for the contact name.

# Changes

Added a derived reactive value isNameTooLong to check if the contact name exceeds 100 characters.
Rendered an animated error message using slide transition when the name exceeds the limit.
Updated the error message to use replacePlaceholders with the correct max length from a constant.

# Tests
Added a new unit test to ensure the error message is displayed when the name exceeds 100 characters.

Manual testing:
Snapshot and visual check for the slide transition animation of the error message.
<img width="651" alt="Screenshot 2025-06-04 at 20 21 55" src="https://github.com/user-attachments/assets/f128a3ca-89c5-4915-ba25-b579164edf53" />


