### PR TITLE
feat(frontend): Track errors while loading pending Ethereum transactions

### DIFF
--- a/src/frontend/src/icp-eth/services/eth.services.ts
+++ b/src/frontend/src/icp-eth/services/eth.services.ts
@@ -147,8 +147,8 @@ const loadPendingTransactions = async ({
 
 		const { id: tokenId } = token;
 
-		// There are no pending ETH -> ckETH or Erc20 -> ckErc20, therefore we reset the store.
-		// This can be useful if there was a previous pending transactions displayed and the transaction has now been processed.
+		// There are no pending ETH -> ckETH or Erc20 -> ckErc20, therefore, we reset the store.
+		// This can be useful if there were previous pending transactions displayed and the transaction has now been processed.
 		if (pendingLogs.length === 0) {
 			icPendingTransactionsStore.reset(tokenId);
 			return;

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -20,6 +20,7 @@ export const TRACK_COUNT_CONVERT_ETH_TO_CKETH_SUCCESS = 'eth_to_cketh_convert_su
 export const TRACK_COUNT_CONVERT_ETH_TO_CKETH_ERROR = 'eth_to_cketh_convert_error_count';
 export const TRACK_COUNT_ETH_LOADING_BALANCE_ERROR = 'eth_loading_balance_error_count';
 export const TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR = 'eth_loading_transactions_error_count';
+export const TRACK_COUNT_ETH_PENDING_TRANSACTIONS_ERROR = 'eth_pending_transactions_error_count';
 
 // Internet Computer
 export const TRACK_COUNT_CONVERT_CKBTC_TO_BTC_SUCCESS = 'ic_ckbtc_to_btc_success_count';


### PR DESCRIPTION
# Motivation

We want to track errors that concerns loading pending Ethereum transactions (and hide the toast, that is not useful to the user).
