### PR TITLE
feat(frontend): Remove event dispatcher from `ModalTokensListItem` component

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -26,7 +26,7 @@
 	networkSelectorViewOnly={nonNullish($selectedNetwork)}
 >
 	{#snippet tokenListItem(token, onClick)}
-		<ModalTokensListItem data={token} on:click={onClick} />
+		<ModalTokensListItem {token} {onClick} />
 	{/snippet}
 	{#snippet noResults()}
 		<p class="text-primary">

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -51,7 +51,7 @@
 	on:icTokenButtonClick={onIcTokenButtonClick}
 >
 	{#snippet tokenListItem(token, onClick)}
-		<ModalTokensListItem data={token} on:click={onClick} />
+		<ModalTokensListItem {token} {onClick} />
 	{/snippet}
 	{#snippet noResults()}
 		<p class="text-primary">

--- a/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
@@ -7,21 +7,22 @@
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LogoSize } from '$lib/types/components';
+	import type { Token } from '$lib/types/token';
 	import type { CardData } from '$lib/types/token-card';
 
 	interface Props {
-		data: CardData;
+		token: Token;
 		logoSize?: LogoSize;
+		onClick: () => void;
 	}
 
-	let { data, logoSize = 'lg' }: Props = $props();
 
-	const { oisyName, oisySymbol, symbol, name, network } = data;
+	let { token, logoSize = 'lg', onClick }: Props = $props();
 
-	const dispatch = createEventDispatcher();
+	const { oisyName, oisySymbol, symbol, name, network } = token;
 </script>
 
-<LogoButton onClick={() => dispatch('click')} dividers={true}>
+<LogoButton {onClick} dividers={true}>
 	{#snippet title()}
 		{nonNullish(oisySymbol) ? oisySymbol.oisySymbol : symbol}
 	{/snippet}
@@ -40,15 +41,15 @@
 
 	{#snippet logo()}
 		<div class="mr-2">
-			<TokenLogo {data} color="white" badge={{ type: 'network' }} {logoSize} />
+			<TokenLogo data={token} color="white" badge={{ type: 'network' }} {logoSize} />
 		</div>
 	{/snippet}
 
 	{#snippet titleEnd()}
-		<TokenBalance {data} />
+		<TokenBalance data={token} />
 	{/snippet}
 
 	{#snippet descriptionEnd()}
-		<ExchangeTokenValue {data} />
+		<ExchangeTokenValue data={token} />
 	{/snippet}
 </LogoButton>

--- a/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
 	import TokenBalance from '$lib/components/tokens/TokenBalance.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
@@ -8,7 +7,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LogoSize } from '$lib/types/components';
 	import type { Token } from '$lib/types/token';
-	import type { CardData } from '$lib/types/token-card';
 
 	interface Props {
 		token: Token;

--- a/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
@@ -14,7 +14,6 @@
 		onClick: () => void;
 	}
 
-
 	let { token, logoSize = 'lg', onClick }: Props = $props();
 
 	const { oisyName, oisySymbol, symbol, name, network } = token;


### PR DESCRIPTION
# Motivation

In Svelte 5 event dispatchers are deprecated. So we can remove it from `ModalTokensListItem`.
