### PR TITLE
feat(frontend): Optional network in type `CardData`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -14,13 +14,14 @@
 	}
 
 	let { privacyBalance, data, hideBalance = false }: Props = $props();
+
+	let testId = $derived(
+		`${TOKEN_BALANCE}-${data.symbol}${nonNullish(data.network) ? `-${data.network.id.description}` : ''}`
+	);
 </script>
 
 <TokenBalanceSkeleton {data}>
-	<output
-		class="break-all"
-		data-tid={`${TOKEN_BALANCE}-${data.symbol}-${data.network.id.description}`}
-	>
+	<output class="break-all" data-tid={testId}>
 		{#if nonNullish(data.balance)}
 			{#if hideBalance}
 				{@render privacyBalance?.()}

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -27,13 +27,17 @@
 	} = $props();
 
 	const dispatch = createEventDispatcher();
+
+	let testId = $derived(
+		`${testIdPrefix}-${data.symbol}${nonNullish(data.network) ? `-${data.network.id.description}` : ''}`
+	);
 </script>
 
 <div class="flex w-full flex-col">
 	<LogoButton
 		dividers={false}
 		rounded={false}
-		testId={`${testIdPrefix}-${data.symbol}-${data.network.id.description}`}
+		{testId}
 		onClick={() => dispatch('click')}
 		condensed={asNetwork}
 		{hover}
@@ -54,7 +58,7 @@
 		{#snippet title()}
 			<span class:text-sm={asNetwork}>
 				{getTokenDisplaySymbol(data)}
-				{#if asNetwork}
+				{#if asNetwork && nonNullish(data.network)}
 					<span class="font-normal">
 						{replacePlaceholders($i18n.tokens.text.on_network, { $network: data.network.name })}
 					</span>
@@ -91,7 +95,7 @@
 							<Divider />
 						{/if}{network}
 					{/each}
-				{:else if !asNetwork}
+				{:else if !asNetwork && nonNullish(data.network)}
 					{data.network.name}
 				{/if}
 			</span>

--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import type { Component } from 'svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
@@ -43,7 +44,7 @@
 		>
 			{badge.count}
 		</span>
-	{:else if badge?.type === 'network'}
+	{:else if badge?.type === 'network' && nonNullish(network)}
 		<div
 			class="absolute"
 			class:scale-60={logoSize === 'xs'}

--- a/src/frontend/src/lib/types/token-card.ts
+++ b/src/frontend/src/lib/types/token-card.ts
@@ -3,16 +3,9 @@ import type { TokenUi } from '$lib/types/token';
 
 export type CardData = Pick<
 	TokenUi,
-	| 'name'
-	| 'symbol'
-	| 'decimals'
-	| 'icon'
-	| 'network'
-	| 'oisyName'
-	| 'oisySymbol'
-	| 'balance'
-	| 'usdBalance'
-> & {
-	tokenCount?: number;
-	networks?: Network[];
-};
+	'name' | 'symbol' | 'decimals' | 'icon' | 'oisyName' | 'oisySymbol' | 'balance' | 'usdBalance'
+> &
+	Partial<Pick<TokenUi, 'network'>> & {
+		tokenCount?: number;
+		networks?: Network[];
+	};


### PR DESCRIPTION
# Motivation

Since `CardData` type can refer both to `Token` and `TokenGroup`, it does not make sense that the `network` prop is defined as non-nullish. In fact, a token group does not have any specific network, but a bunch of them.
