### PR TITLE
feat(frontend): Add property to always show a token in a group

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.eurc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.eurc.env.ts
@@ -23,7 +23,8 @@ export const EURC_TOKEN: RequiredErc20Token = {
 	address: '0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c',
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckEURC',
-	groupData: EURC_TOKEN_GROUP
+	groupData: EURC_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true
 };
 
 export const SEPOLIA_EURC_SYMBOL = 'SepoliaEURC';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.link.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.link.env.ts
@@ -24,6 +24,7 @@ export const LINK_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckLINK',
 	groupData: LINK_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'link_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.oct.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.oct.env.ts
@@ -24,6 +24,7 @@ export const OCT_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckOCT',
 	groupData: OCT_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'oct_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.pepe.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.pepe.env.ts
@@ -24,6 +24,7 @@ export const PEPE_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckPEPE',
 	groupData: PEPE_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'pepe_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.shib.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.shib.env.ts
@@ -24,6 +24,7 @@ export const SHIB_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckSHIB',
 	groupData: SHIB_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'shib_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.uni.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.uni.env.ts
@@ -23,5 +23,6 @@ export const UNI_TOKEN: RequiredErc20Token = {
 	address: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckUNI',
-	groupData: UNI_TOKEN_GROUP
+	groupData: UNI_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.usdc.env.ts
@@ -24,6 +24,7 @@ export const USDC_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckUSDC',
 	groupData: USDC_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'usdc_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.usdt.env.ts
@@ -24,6 +24,7 @@ export const USDT_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckUSDT',
 	groupData: USDT_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'usdt_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.wbtc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.wbtc.env.ts
@@ -24,6 +24,7 @@ export const WBTC_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckWBTC',
 	groupData: WBTC_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: {
 		onramperId: 'wbtc_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.wsteth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.wsteth.env.ts
@@ -23,5 +23,6 @@ export const WSTETH_TOKEN: RequiredErc20Token = {
 	address: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckWSTETH',
-	groupData: WSTETH_TOKEN_GROUP
+	groupData: WSTETH_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
@@ -23,5 +23,6 @@ export const XAUT_TOKEN: RequiredErc20Token = {
 	address: '0x68749665FF8D2d112Fa859AA293F07A622782F38',
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckXAUT',
-	groupData: XAUT_TOKEN_GROUP
+	groupData: XAUT_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true
 };

--- a/src/frontend/src/env/tokens/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens.btc.env.ts
@@ -28,6 +28,7 @@ export const BTC_MAINNET_TOKEN: TokenWithLinkedData = {
 	icon: bitcoin,
 	twinTokenSymbol: 'ckBTC',
 	groupData: BTC_TOKEN_GROUP,
+	alwaysShowInTokenGroup: true,
 	buy: { onramperId: 'btc' }
 };
 


### PR DESCRIPTION
# Motivation

A few times, we want to show only CK tokens or "native" tokens, for example when a token group has zero balance. For this, instead on relying on a propriety of the group, we can rely on the specific tokens. This gives us more flexibility to add more if we want.

# Changes

- Add new optional prop `alwaysShowInTokenGroup` to `TokenAppearanceSchema`.
- Set it to true for the "native" tokens.
- Adapt component `TokenGroupCard`.

# Tests

No changes in local replica.
