### PR TITLE
feat(frontend): add ModalHero to TokenModal

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -5,8 +5,10 @@
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import { isTokenIcrc, isTokenDip20 } from '$icp/utils/icrc.utils';
 	import List from '$lib/components/common/List.svelte';
+	import ModalHero from '$lib/components/common/ModalHero.svelte';
 	import ModalListItem from '$lib/components/common/ModalListItem.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
@@ -29,6 +31,16 @@
 
 	<ContentWithToolbar>
 		{#if nonNullish(token)}
+			<ModalHero>
+				{#snippet logo()}
+					<TokenLogo logoSize="lg" data={token} badge={{ type: 'network' }} />
+				{/snippet}
+
+				{#snippet title()}
+					{getTokenDisplaySymbol(token)}
+				{/snippet}
+			</ModalHero>
+
 			<List styleClass="text-sm" condensed={false}>
 				<ModalListItem>
 					{#snippet label()}

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -1,16 +1,19 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import TokenModal from '$lib/components/tokens/TokenModal.svelte';
+import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('TokenModal', () => {
 	it('renders all values correctly for ICP token', () => {
-		const { getByText, getAllByText } = render(TokenModal, {
+		const { getByText, getAllByText, container } = render(TokenModal, {
 			props: {
 				token: ICP_TOKEN
 			}
 		});
+
+		expect(container).toHaveTextContent(getTokenDisplaySymbol(ICP_TOKEN));
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
 
@@ -27,11 +30,13 @@ describe('TokenModal', () => {
 	});
 
 	it('renders all values correctly for ICRC token', () => {
-		const { getByText } = render(TokenModal, {
+		const { getByText, container } = render(TokenModal, {
 			props: {
 				token: mockValidIcrcToken
 			}
 		});
+
+		expect(container).toHaveTextContent(getTokenDisplaySymbol(mockValidIcrcToken));
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
 


### PR DESCRIPTION
# Motivation

As the next step of improving TokenModal, we need to add ModalHero on top of the content.

<img width="579" alt="Screenshot 2025-06-06 at 09 47 06" src="https://github.com/user-attachments/assets/acc9e141-1e7d-4470-a284-96f88b2ce109" />
