### PR TITLE
fix(frontend): Keep selected contact during whole send flow

### DIFF
--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, getContext, onMount } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
 	import { btcNetworkContacts } from '$btc/derived/btc-contacts.derived';
 	import { btcKnownDestinations } from '$btc/derived/btc-transactions.derived';
@@ -50,10 +50,6 @@
 		selectedContact = $bindable(),
 		formCancelAction = 'back'
 	}: Props = $props();
-
-	onMount(() => {
-		selectedContact = undefined;
-	});
 
 	const { sendToken, sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 


### PR DESCRIPTION
# Motivation

In send flow when we select a contact, the contact is displayed correctly on the next form where we can enter the amount to send. When we go back and click next again the contact doesnt show anymore.

We want to persist the selected contect when navigating the send modal wizard, except for when we select another contact.

# Changes

Removed the reset of the contact on mounting the select contact step.

# Tests


https://github.com/user-attachments/assets/a159c60f-fd30-4e0a-9bef-23bb8581b6fc


