### PR TITLE
feat(frontend): TokenModalDeleteConfirmation component

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModalDeleteConfirmation.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModalDeleteConfirmation.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Html } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionToken } from '$lib/types/token';
+	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
+	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	interface Props {
+		token: OptionToken;
+		onCancel: () => void;
+		onConfirm: () => void;
+	}
+
+	let { token, onCancel, onConfirm }: Props = $props();
+</script>
+
+<ContentWithToolbar>
+	{#if nonNullish(token)}
+		<div class="my-5 text-center">
+			<Html
+				text={replacePlaceholders(
+					replaceOisyPlaceholders($i18n.tokens.details.confirm_deletion_description),
+					{
+						$token: getTokenDisplaySymbol(token)
+					}
+				)}
+			/>
+		</div>
+	{/if}
+
+	<ButtonGroup slot="toolbar">
+		<ButtonCancel onclick={onCancel} />
+
+		<Button colorStyle="error" onclick={onConfirm}>
+			{$i18n.core.text.delete}
+		</Button>
+	</ButtonGroup>
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/tokens/TokenModalDeleteConfirmation.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModalDeleteConfirmation.svelte
@@ -34,11 +34,13 @@
 		</div>
 	{/if}
 
-	<ButtonGroup slot="toolbar">
-		<ButtonCancel onclick={onCancel} />
+	{#snippet toolbar()}
+		<ButtonGroup>
+			<ButtonCancel onclick={onCancel} />
 
-		<Button colorStyle="error" onclick={onConfirm}>
-			{$i18n.core.text.delete}
-		</Button>
-	</ButtonGroup>
+			<Button colorStyle="error" onclick={onConfirm}>
+				{$i18n.core.text.delete}
+			</Button>
+		</ButtonGroup>
+	{/snippet}
 </ContentWithToolbar>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -673,7 +673,7 @@
 			"twin_token": "Twin token",
 			"standard": "Standard",
 			"confirm_deletion_title": "Delete from the list of your tokens?",
-			"confirm_deletion_description": "This will remove the <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your finds will remain untouched — you can re-add the token at any time."
+			"confirm_deletion_description": "This will remove the <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your funds will remain untouched — you can re-add the token at any time."
 		},
 		"balance": {
 			"error": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -671,7 +671,9 @@
 			"contract_address_copied": "Contract address copied to clipboard.",
 			"token_address_copied": "Token address copied to clipboard.",
 			"twin_token": "Twin token",
-			"standard": "Standard"
+			"standard": "Standard",
+			"confirm_deletion_title": "Delete from the list of your tokens?",
+			"confirm_deletion_description": "This will remove the <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your finds will remain untouched — you can re-add the token at any time."
 		},
 		"balance": {
 			"error": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -637,6 +637,8 @@ interface I18nTokens {
 		token_address_copied: string;
 		twin_token: string;
 		standard: string;
+		confirm_deletion_title: string;
+		confirm_deletion_description: string;
 	};
 	balance: { error: { not_applicable: string } };
 	import: {

--- a/src/frontend/src/tests/lib/components/tokens/TokenModalDeleteConfirmation.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModalDeleteConfirmation.spec.ts
@@ -1,0 +1,18 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import TokenModalDeleteConfirmation from '$lib/components/tokens/TokenModalDeleteConfirmation.svelte';
+import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+import { render } from '@testing-library/svelte';
+
+describe('TokenModalDeleteConfirmation', () => {
+	it('renders correct token symbol', () => {
+		const { container } = render(TokenModalDeleteConfirmation, {
+			props: {
+				token: ICP_TOKEN,
+				onCancel: () => {},
+				onConfirm: () => {}
+			}
+		});
+
+		expect(container).toHaveTextContent(getTokenDisplaySymbol(ICP_TOKEN));
+	});
+});


### PR DESCRIPTION
# Motivation

We need to implement a component for confirming token deletion. 

![Screenshot 2025-06-10 at 11 34 20](https://github.com/user-attachments/assets/e97a5109-2496-4b3f-86eb-7906fd9b9e0b)
