### PR TITLE
feat(frontend): expose backend's remove_user_token method

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -73,6 +73,17 @@ export const setCustomToken = async ({
 	return setCustomToken({ token });
 };
 
+export const removeUserToken = async ({
+	token,
+	identity
+}: CanisterApiFunctionParams<{
+	token: UserToken;
+}>): Promise<void> => {
+	const { removeUserToken } = await backendCanister({ identity });
+
+	return removeUserToken({ token });
+};
+
 export const setManyUserTokens = async ({
 	identity,
 	tokens

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -91,6 +91,12 @@ export class BackendCanister extends Canister<BackendService> {
 		return set_user_token(token);
 	};
 
+	removeUserToken = ({ token }: { token: UserToken }): Promise<void> => {
+		const { remove_user_token } = this.caller({ certified: true });
+
+		return remove_user_token(token);
+	};
+
 	createUserProfile = (): Promise<UserProfile> => {
 		const { create_user_profile } = this.caller({ certified: true });
 

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -1251,4 +1251,37 @@ describe('backend.canister', () => {
 			await expect(res).rejects.toThrow(mockResponseError);
 		});
 	});
+
+	describe('removeUserToken', () => {
+		it('should call remove_user_token method', async () => {
+			const params = { token: mockedUserToken };
+			const response = undefined;
+
+			service.remove_user_token.mockResolvedValue(response);
+
+			const { removeUserToken } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await removeUserToken(params);
+
+			expect(service.remove_user_token).toHaveBeenCalledWith(params.token);
+			expect(res).toEqual(response);
+		});
+
+		it('should throw an error if remove_user_token throws', async () => {
+			service.remove_user_token.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { removeUserToken } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = removeUserToken({ token: mockedUserToken });
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

For deleting user tokens, we need to expose the related method of the backend canister.
