### PR TITLE
feat(frontend): Completely migrate `Img` component to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/ui/Img.svelte
+++ b/src/frontend/src/lib/components/ui/Img.svelte
@@ -11,6 +11,8 @@
 		grayscale?: boolean;
 		styleClass?: string;
 		testId?: string;
+		onLoad?: () => void;
+		onError?: () => void;
 	}
 
 	let {
@@ -24,7 +26,9 @@
 		fitHeight = false,
 		grayscale = false,
 		styleClass,
-		testId
+		testId,
+		onLoad,
+		onError
 	}: Props = $props();
 </script>
 
@@ -37,8 +41,8 @@
 	{height}
 	data-tid={testId}
 	decoding="async"
-	on:load
-	on:error
+	onload={onLoad}
+	onerror={onError}
 	class:rounded-full={rounded}
 	class:grayscale
 	class={styleClass}

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -37,8 +37,8 @@
 			{alt}
 			fitHeight
 			height={sizePx}
-			on:load={() => (loadingError = false)}
-			on:error={() => (loadingError = true)}
+			onLoad={() => (loadingError = false)}
+			onError={() => (loadingError = true)}
 			rounded
 		/>
 	{:else}


### PR DESCRIPTION
# Motivation

In component `Img` we were missing the migration of the events to Svelte 5.
