### PR TITLE
fix(frontend): Title for Edit contact Name step

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -165,6 +165,7 @@
 	let currentStepName = $derived(currentStep?.name as AddressBookSteps | undefined);
 	let previousStepName = $state<AddressBookSteps | undefined>();
 	let editContactNameStep = $state<EditContactNameStep>();
+	let editContactNameTitle = $state<string>($i18n.contact.form.add_new_contact);
 
 	let isDeletingContact = $state<boolean>(false);
 
@@ -301,7 +302,7 @@
 		{:else if currentStepName === AddressBookSteps.DELETE_CONTACT && nonNullish(currentContact)}
 			{replacePlaceholders($i18n.contact.delete.title, { $contact: currentContact.name })}
 		{:else if currentStepName === AddressBookSteps.EDIT_CONTACT_NAME && nonNullish(editContactNameStep)}
-			{editContactNameStep.title}
+			{editContactNameTitle}
 		{:else}
 			{currentStep?.title}
 		{/if}
@@ -397,6 +398,7 @@
 	{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT_NAME}
 		<EditContactNameStep
 			bind:this={editContactNameStep}
+			bind:title={editContactNameTitle}
 			contact={currentContact}
 			onAddContact={async (contact: Pick<ContactUi, 'name'>) => {
 				const createdContact = await callCreateContact({ name: contact.name });

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -165,7 +165,7 @@
 	let currentStepName = $derived(currentStep?.name as AddressBookSteps | undefined);
 	let previousStepName = $state<AddressBookSteps | undefined>();
 	let editContactNameStep = $state<EditContactNameStep>();
-	let editContactNameTitle = $state<string>($i18n.contact.form.add_new_contact);
+	let editContactNameTitle = $state($i18n.contact.form.add_new_contact);
 
 	let isDeletingContact = $state<boolean>(false);
 

--- a/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
@@ -50,13 +50,12 @@
 			onSaveContact(editingContact as ContactUi);
 		}
 	};
-	
+
 	const trimedTitle = $derived(
 		notEmptyString(editingContact.name?.trim())
 			? editingContact.name
 			: $i18n.contact.form.add_new_contact
-		);
-
+	);
 
 	let isFormValid = $state(true);
 

--- a/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
@@ -50,11 +50,14 @@
 			onSaveContact(editingContact as ContactUi);
 		}
 	};
+	const trimedTitle = $derived(
+		notEmptyString(editingContact.name?.trim())
+			? editingContact.name
+			: $i18n.contact.form.add_new_contact
+	);
 
 	$effect(() => {
-		title = notEmptyString(editingContact.name?.trim())
-			? editingContact.name
-			: $i18n.contact.form.add_new_contact;
+		title = trimedTitle;
 	});
 </script>
 

--- a/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
@@ -20,15 +20,17 @@
 		onClose: () => void;
 		isNewContact: boolean;
 		disabled?: boolean;
+		title?: string;
 	}
 
 	let {
+		contact = {},
+		isNewContact,
+		disabled = false,
 		onAddContact,
 		onSaveContact,
 		onClose,
-		isNewContact,
-		contact = {},
-		disabled = false
+		title = $bindable<string>()
 	}: Props = $props();
 
 	let editingContact = $state(contact ? { ...contact } : {});
@@ -49,13 +51,11 @@
 		}
 	};
 
-	let title = $derived(
-		notEmptyString(editingContact?.name?.trim?.())
-			? editingContact?.name
-			: $i18n.contact.form.add_new_contact
-	);
-
-	export { title };
+	$effect(() => {
+		title = notEmptyString(editingContact.name?.trim())
+			? editingContact.name
+			: $i18n.contact.form.add_new_contact;
+	});
 </script>
 
 <ContentWithToolbar styleClass="flex flex-col gap-6 items-center">

--- a/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
@@ -24,13 +24,13 @@
 	}
 
 	let {
-		contact = {},
-		isNewContact,
-		disabled = false,
 		onAddContact,
 		onSaveContact,
 		onClose,
-		title = $bindable<string>()
+		isNewContact,
+		contact = {},
+		disabled = false,
+		title = $bindable<string | undefined>()
 	}: Props = $props();
 
 	let editingContact = $state(contact ? { ...contact } : {});

--- a/src/frontend/src/tests/lib/components/address-book/EditContactNameStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditContactNameStep.spec.ts
@@ -128,6 +128,7 @@ describe('EditContactNameStep', () => {
 		});
 
 		const defaultLabel = en.address_book.avatar.default;
+
 		expect(getByLabelText(defaultLabel)).toBeInTheDocument();
 
 		// Type name
@@ -140,7 +141,7 @@ describe('EditContactNameStep', () => {
 				getByLabelText(`${en.address_book.avatar.avatar_for} Test Contact`)
 			).toBeInTheDocument();
 		});
-		
+
 		// Clear the name by actually removing all characters
 		await fireEvent.input(nameInput, { target: { value: '' } });
 

--- a/src/frontend/src/tests/lib/components/address-book/EditContactNameStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditContactNameStep.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '$lib/constants/test-ids.constants';
 import type { ContactUi } from '$lib/types/contact';
 import en from '$tests/mocks/i18n.mock';
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { vi } from 'vitest';
 
 describe('EditContactNameStep', () => {
@@ -123,24 +123,30 @@ describe('EditContactNameStep', () => {
 		const onSaveContact = vi.fn();
 		const onClose = vi.fn();
 
-		const { getByTestId, component } = render(EditContactNameStep, {
+		const { getByTestId, getByLabelText } = render(EditContactNameStep, {
 			props: { onAddContact, onSaveContact, onClose, isNewContact: true }
 		});
 
-		// Initially, the title should be the default
-		expect(component.title).toBe(en.contact.form.add_new_contact);
+		const defaultLabel = en.address_book.avatar.default;
+		expect(getByLabelText(defaultLabel)).toBeInTheDocument();
 
-		// Enter a name
+		// Type name
 		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
 		await fireEvent.input(nameInput, { target: { value: 'Test Contact' } });
 
-		// Check that the title has been updated
-		expect(component.title).toBe('Test Contact');
+		// Expect aria-label to update
+		await waitFor(() => {
+			expect(
+				getByLabelText(`${en.address_book.avatar.avatar_for} Test Contact`)
+			).toBeInTheDocument();
+		});
+		
+		// Clear the name by actually removing all characters
+		await fireEvent.input(nameInput, { target: { value: '' } });
 
-		// Empty name should reset to default title
-		await fireEvent.input(nameInput, { target: { value: '  ' } });
-
-		expect(component.title).toBe(en.contact.form.add_new_contact);
+		await waitFor(() => {
+			expect(getByLabelText(defaultLabel)).toBeInTheDocument();
+		});
 	});
 
 	it('should trim leading spaces before calling onAddContact', async () => {


### PR DESCRIPTION
# Motivation

Svelte components should not export derived state. For example:
<script>
   let title = $derived(...);
   export { title };
</script>
This pattern is non-standard and unsupported. The goal of this PR is to proactively refactor components to avoid such usage and ensure long-term stability with Svelte.

# Changes

Replaced export $derived(...) with $bindable<string>() in $props().
Used $effect to update title reactively based on editingContact.name.
In the parent, bound title as editContactNameTitle and displayed it in the modal's title slot.

# Tests

Verified modal title updates dynamically when editing contact names.
Confirmed no regressions via manual testing.
