### PR TITLE
feat(frontend): Parse IC errors into objects for track-event metadata

### DIFF
--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -17,7 +17,7 @@ import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Token, TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
-import { replaceIcErrorFields } from '$lib/utils/error.utils';
+import { mapIcErrorMetadata } from '$lib/utils/error.utils';
 import { findOldestTransaction } from '$lib/utils/transactions.utils';
 import type { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish, queryAndUpdate } from '@dfinity/utils';
@@ -109,7 +109,7 @@ export const onLoadTransactionsError = ({
 		name: TRACK_COUNT_IC_LOADING_TRANSACTIONS_ERROR,
 		metadata: {
 			tokenId: tokenId.description ?? '',
-			error: replaceIcErrorFields(err) ?? `${err}`
+			...(mapIcErrorMetadata(err) ?? {})
 		}
 	});
 

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -27,7 +27,7 @@ import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenCategory } from '$lib/types/token';
-import { replaceIcErrorFields } from '$lib/utils/error.utils';
+import { mapIcErrorMetadata } from '$lib/utils/error.utils';
 import { AnonymousIdentity, type Identity } from '@dfinity/agent';
 import {
 	fromNullable,
@@ -66,9 +66,7 @@ export const loadCustomTokens = ({
 
 			trackEvent({
 				name: TRACK_COUNT_IC_LOADING_ICRC_CANISTER_ERROR,
-				metadata: {
-					error: replaceIcErrorFields(err) ?? `${err}`
-				}
+				metadata: mapIcErrorMetadata(err)
 			});
 
 			toastsError({
@@ -94,9 +92,7 @@ const loadDefaultIcrc = ({
 
 			trackEvent({
 				name: TRACK_COUNT_IC_LOADING_ICRC_CANISTER_ERROR,
-				metadata: {
-					error: replaceIcErrorFields(err) ?? `${err}`
-				}
+				metadata: mapIcErrorMetadata(err)
 			});
 
 			toastsError({

--- a/src/frontend/src/lib/utils/error.utils.ts
+++ b/src/frontend/src/lib/utils/error.utils.ts
@@ -1,4 +1,4 @@
-import { isNullish, jsonReplacer } from '@dfinity/utils';
+import { isEmptyString, isNullish, jsonReplacer, nonNullish, notEmptyString } from '@dfinity/utils';
 
 export const errorDetailToString = (err: unknown): string | undefined =>
 	typeof err === 'string'
@@ -35,6 +35,7 @@ const buildTextPattern = (key: string): RegExp => {
 	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	return new RegExp(`"?${escapedKey}"?\\s*:\\s*("?[^"\\n,]+"?)`, 'gi');
 };
+
 const cleanTrailingCommasAndLines = (text: string): string =>
 	text
 		.replace(/,\s*,/g, ',') // ", ,"
@@ -98,3 +99,68 @@ export const replaceErrorFields = ({
 
 export const replaceIcErrorFields = (err: unknown): string | undefined =>
 	replaceErrorFields({ err, keysToRemove: ['Request ID'] });
+
+export const parseIcErrorMessage = (err: unknown): Record<string, string> | undefined => {
+	if (isNullish(err)) {
+		return;
+	}
+
+	if (!(err instanceof Error)) {
+		return;
+	}
+
+	const { message } = err;
+
+	if (isEmptyString(message)) {
+		return;
+	}
+
+	try {
+		const messageParts = message
+			.replace(/\\n/g, '\n')
+			.replace(/\\'/g, "'")
+			.replace(/\\"/g, '"')
+			.split('\n')
+			// The first part is just the "Call failed" initial text, we skip it
+			.slice(1);
+
+		const cleanRegex = /^\s*['"]?([^'":]+)['"]?\s*:\s*['"]?(.+?)['"]?\s*$/;
+
+		const errObj: Record<string, string> = messageParts.reduce<Record<string, string>>(
+			(acc, part) => {
+				const match = part.match(cleanRegex);
+				if (nonNullish(match)) {
+					const [, rawKey, rawValue] = match;
+
+					return {
+						...acc,
+						...(notEmptyString(rawKey?.trim()) && nonNullish(rawValue)
+							? {
+									[rawKey.trim()]: rawValue.trim()
+								}
+							: {})
+					};
+				}
+
+				return acc;
+			},
+			{}
+		);
+
+		// Remove the "Request ID" key if it exists, since it is unique per request, so not useful for general error handling
+		const { ['Request ID']: _, ...rest } = errObj;
+
+		return rest;
+	} catch (_: unknown) {
+		// If parsing fails, we return undefined. We do not need to throw an error here.
+		return;
+	}
+};
+
+export const mapIcErrorMetadata = (err: unknown): Record<string, string> | undefined => {
+	if (isNullish(err)) {
+		return;
+	}
+
+	return parseIcErrorMessage(err) ?? { error: replaceIcErrorFields(err) ?? `${err}` };
+};

--- a/src/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -1,4 +1,9 @@
-import { replaceErrorFields, replaceIcErrorFields } from '$lib/utils/error.utils';
+import {
+	mapIcErrorMetadata,
+	parseIcErrorMessage,
+	replaceErrorFields,
+	replaceIcErrorFields
+} from '$lib/utils/error.utils';
 
 describe('error.utils', () => {
 	describe('replaceErrorFields', () => {
@@ -204,6 +209,147 @@ describe('error.utils', () => {
 			const result = replaceIcErrorFields(error);
 
 			expect(result).toBe('Some unknown issue');
+		});
+	});
+
+	describe('parseIcErrorMessage', () => {
+		it('should return undefined if input is nullish', () => {
+			expect(parseIcErrorMessage(null)).toBeUndefined();
+			expect(parseIcErrorMessage(undefined)).toBeUndefined();
+		});
+
+		it('should return undefined if the input is not an error object', () => {
+			expect(
+				parseIcErrorMessage({
+					message: 'fail',
+					requestId: 'abc123',
+					token: 'secret',
+					code: 500
+				})
+			).toBeUndefined();
+
+			expect(parseIcErrorMessage('Some string error')).toBeUndefined();
+
+			expect(parseIcErrorMessage(123)).toBeUndefined();
+
+			expect(parseIcErrorMessage(true)).toBeUndefined();
+
+			expect(parseIcErrorMessage(false)).toBeUndefined();
+
+			expect(parseIcErrorMessage({})).toBeUndefined();
+
+			expect(parseIcErrorMessage([])).toBeUndefined();
+
+			expect(parseIcErrorMessage(new Date())).toBeUndefined();
+		});
+
+		it('should return undefined if the error message is empty', () => {
+			expect(parseIcErrorMessage(new Error(''))).toBeUndefined();
+		});
+
+		it('should return a parsed object with a correct error message', () => {
+			const errorMsg = `Call failed: \n message: fail\n 'Error code': abc123\n token: secret\n "Reject message": "This is a reject message"\n code: 500`;
+			const expected = {
+				message: 'fail',
+				'Error code': 'abc123',
+				token: 'secret',
+				'Reject message': 'This is a reject message',
+				code: '500'
+			};
+			const error = new Error(JSON.stringify(errorMsg));
+
+			const result = parseIcErrorMessage(error);
+
+			expect(result).toEqual(expected);
+		});
+
+		it('should return a parsed object removing the unnecessary keys', () => {
+			const errorMsg = `Call failed: \n message: fail\n 'Error code': abc123\n token: secret\n "Request ID": "abc123"\n "Reject message": "This is a reject message"\n code: 500`;
+			const expected = {
+				message: 'fail',
+				'Error code': 'abc123',
+				token: 'secret',
+				'Reject message': 'This is a reject message',
+				code: '500'
+			};
+			const error = new Error(JSON.stringify(errorMsg));
+
+			const result = parseIcErrorMessage(error);
+
+			expect(result).toEqual(expected);
+		});
+
+		it('should handle missing error details', () => {
+			const errorMsg = `Call failed:`;
+			const error = new Error(JSON.stringify(errorMsg));
+
+			const result = parseIcErrorMessage(error);
+
+			expect(result).toEqual({});
+		});
+
+		it('should ignore empty error details', () => {
+			const errorMsg = `Call failed: \n message: fail\n 'Error code':\n token: secret\n "Reject message": "This is a reject message"\n code: 500`;
+			const expected = {
+				message: 'fail',
+				token: 'secret',
+				'Reject message': 'This is a reject message',
+				code: '500'
+			};
+			const error = new Error(JSON.stringify(errorMsg));
+
+			const result = parseIcErrorMessage(error);
+
+			expect(result).toEqual(expected);
+		});
+
+		it('should ignore empty error keys', () => {
+			const errorMsg = `Call failed: \n message: fail\n  : abc123\n token: secret\n "Reject message": "This is a reject message"\n code: 500`;
+			const expected = {
+				message: 'fail',
+				token: 'secret',
+				'Reject message': 'This is a reject message',
+				code: '500'
+			};
+			const error = new Error(JSON.stringify(errorMsg));
+
+			const result = parseIcErrorMessage(error);
+
+			expect(result).toEqual(expected);
+		});
+	});
+
+	describe('mapIcErrorMetadata', () => {
+		it('should return an empty object if input is nullish', () => {
+			expect(mapIcErrorMetadata(null)).toBeUndefined();
+			expect(mapIcErrorMetadata(undefined)).toBeUndefined();
+		});
+
+		it('should return a parsed object if the input is an error object', () => {
+			const errorMsg = `Call failed: \n message: fail\n 'Error code': abc123\n token: secret\n "Reject message": "This is a reject message"\n code: 500`;
+			const expected = {
+				message: 'fail',
+				'Error code': 'abc123',
+				token: 'secret',
+				'Reject message': 'This is a reject message',
+				code: '500'
+			};
+			const error = new Error(JSON.stringify(errorMsg));
+
+			const result = parseIcErrorMessage(error);
+
+			expect(result).toEqual(expected);
+		});
+
+		it('removes keys from object error', () => {
+			const result = replaceIcErrorFields({
+				message: 'fail',
+				'Request ID': 'abc123',
+				token: 'secret',
+				code: 500
+			});
+
+			expect(result).toBe(JSON.stringify({ message: 'fail', token: 'secret', code: 500 }));
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We want to break the IC errors down to more granular parameters, so that we can analyze it better. Up until now we are just transmitting the error as string, but the same string has parseable details.

Note that if any error appears during parsing, we want to fallback to the "old" flow.

# Changes

- Create util to parse an IC error into an object with keys and values.
- Create generic mapper for IC errors metadata (it uses the new utils and fallback to the old code).
- Use the new mapper in the code.

# Tests

Added new tests.
