### PR TITLE
feat(frontend): Util to get the case-sensitiveness of a network

### DIFF
--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -1,10 +1,16 @@
+import { SUPPORTED_EVM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
+import { SUPPORTED_BITCOIN_NETWORK_IDS } from '$env/networks/networks.btc.env';
+import { SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { SUPPORTED_SOLANA_NETWORK_IDS } from '$env/networks/networks.sol.env';
 import { TOKEN_ACCOUNT_ID_TYPES_CASE_SENSITIVE } from '$lib/constants/token-account-id.constants';
 import type { StorageAddressData } from '$lib/stores/address.store';
 import type { Address, OptionAddress } from '$lib/types/address';
+import type { NetworkId } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
 import { parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const mapAddress = <T extends Address>(
 	$addressStore: StorageAddressData<T>
@@ -26,6 +32,39 @@ export const isBtcAddress = (address: BtcAddress | undefined): boolean => {
 export const invalidBtcAddress = (address: BtcAddress | undefined): boolean =>
 	!isBtcAddress(address);
 
+const mapNetworkIdToAddressType = (
+	networkId: NetworkId | undefined
+): TokenAccountIdTypes | undefined => {
+	if (isNullish(networkId)) {
+		return;
+	}
+
+	if (networkId === ICP_NETWORK_ID) {
+		return 'Icrcv2';
+	}
+	if (SUPPORTED_BITCOIN_NETWORK_IDS.includes(networkId)) {
+		return 'Btc';
+	}
+	if (
+		SUPPORTED_ETHEREUM_NETWORK_IDS.includes(networkId) ||
+		SUPPORTED_EVM_NETWORK_IDS.includes(networkId)
+	) {
+		return 'Eth';
+	}
+	if (SUPPORTED_SOLANA_NETWORK_IDS.includes(networkId)) {
+		return 'Sol';
+	}
+};
+
+export const getCaseSensitiveness = (
+	params: { addressType: TokenAccountIdTypes } | { networkId: NetworkId | undefined }
+): boolean => {
+	const addressType =
+		'addressType' in params ? params.addressType : mapNetworkIdToAddressType(params.networkId);
+
+	return nonNullish(addressType) ? TOKEN_ACCOUNT_ID_TYPES_CASE_SENSITIVE[addressType] : false;
+};
+
 export const areAddressesEqual = <T extends Address>({
 	address1,
 	address2,
@@ -39,7 +78,7 @@ export const areAddressesEqual = <T extends Address>({
 		return false;
 	}
 
-	const isCaseSensitive = TOKEN_ACCOUNT_ID_TYPES_CASE_SENSITIVE[addressType] ?? false;
+	const isCaseSensitive = getCaseSensitiveness({ addressType });
 
 	if (isCaseSensitive) {
 		return address1 === address2;

--- a/src/frontend/src/tests/lib/utils/address.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/address.utils.spec.ts
@@ -1,7 +1,58 @@
+import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
+import { SUPPORTED_BITCOIN_NETWORKS } from '$env/networks/networks.btc.env';
+import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { SUPPORTED_SOLANA_NETWORKS } from '$env/networks/networks.sol.env';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
-import { areAddressesEqual } from '$lib/utils/address.utils';
+import { areAddressesEqual, getCaseSensitiveness } from '$lib/utils/address.utils';
+import { parseNetworkId } from '$lib/validation/network.validation';
 
 describe('address.utils', () => {
+	describe('getCaseSensitiveness', () => {
+		it.each(['Btc', 'Eth', 'Icrcv2', 'unknown'])(
+			'should return false for %s address type',
+			(rawAddressType) => {
+				const addressType = rawAddressType as TokenAccountIdTypes;
+
+				expect(getCaseSensitiveness({ addressType })).toBeFalsy();
+			}
+		);
+
+		it('should return true for Sol address type', () => {
+			const addressType = 'Sol' as TokenAccountIdTypes;
+
+			expect(getCaseSensitiveness({ addressType })).toBeTruthy();
+		});
+
+		it.each([
+			ICP_NETWORK,
+			...SUPPORTED_BITCOIN_NETWORKS,
+			...SUPPORTED_ETHEREUM_NETWORKS,
+			...SUPPORTED_EVM_NETWORKS
+		])('should return false for network $name', ({ id: networkId }) => {
+			expect(getCaseSensitiveness({ networkId })).toBeFalsy();
+		});
+
+		it.each(SUPPORTED_SOLANA_NETWORKS)(
+			'should return true for network $name',
+			({ id: networkId }) => {
+				expect(getCaseSensitiveness({ networkId })).toBeTruthy();
+			}
+		);
+
+		it('should return false for unknown network', () => {
+			expect(
+				getCaseSensitiveness({
+					networkId: parseNetworkId('mock-network')
+				})
+			).toBeFalsy();
+		});
+
+		it('should return false for undefined network', () => {
+			expect(getCaseSensitiveness({ networkId: undefined })).toBeFalsy();
+		});
+	});
+
 	describe('areAddressesEqual', () => {
 		const address1 = 'address123';
 		const address2 = 'address456';


### PR DESCRIPTION
# Motivation

It is useful to use a generic function to get the case-sensitiveness of a network, either by type of address or by network ID.

It will be used for the known destinations and the contacts too.

# Changes

- Create map of networks to address type.
- Create util `getCaseSensitiveness` that uses either network Id or address type.
- Use it in the code.

# Tests

Added tests.
