### PR TITLE
feat(frontend): add delete functionality to TokenModal

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -1,111 +1,103 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
-	import { isTokenErc20 } from '$eth/utils/erc20.utils';
-	import { isTokenIcrc, isTokenDip20 } from '$icp/utils/icrc.utils';
-	import List from '$lib/components/common/List.svelte';
-	import ModalHero from '$lib/components/common/ModalHero.svelte';
-	import ModalListItem from '$lib/components/common/ModalListItem.svelte';
-	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
-	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
-	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
-	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Logo from '$lib/components/ui/Logo.svelte';
+	import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
+	import { isTokenErc20UserToken } from '$eth/utils/erc20.utils';
+	import { toUserToken } from '$icp-eth/services/user-token.services';
+	import { removeUserToken } from '$lib/api/backend.api';
+	import TokenModalContent from '$lib/components/tokens/TokenModalContent.svelte';
+	import TokenModalDeleteConfirmation from '$lib/components/tokens/TokenModalDeleteConfirmation.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { nullishSignOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { toastsShow } from '$lib/stores/toasts.store';
 	import type { OptionToken } from '$lib/types/token';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { gotoReplaceRoot } from '$lib/utils/nav.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface BaseTokenModalProps {
-		children?: Snippet;
 		token: OptionToken;
+		children?: Snippet;
+		isDeletable?: boolean;
 	}
 
-	let { children, token }: BaseTokenModalProps = $props();
+	let { children, token, isDeletable = false }: BaseTokenModalProps = $props();
+
+	let showDeleteConfirmation = $state(false);
+	let loading = $state(false);
+
+	const onTokenDeleteSuccess = async () => {
+		loading = false;
+
+		modalStore.close();
+
+		await gotoReplaceRoot();
+
+		if (nonNullish(token)) {
+			toastsShow({
+				text: replacePlaceholders(
+					replaceOisyPlaceholders($i18n.tokens.details.deletion_confirmation),
+					{
+						$token: getTokenDisplaySymbol(token)
+					}
+				),
+				level: 'success'
+			});
+		}
+	};
+
+	const onTokenDelete = async () => {
+		if (isNullish($authIdentity)) {
+			await nullishSignOut();
+			return;
+		}
+
+		if (isNullish(token)) {
+			return;
+		}
+
+		// TODO: update this function to handle ICRC/SPL when BE supports removing custom tokens
+		if (isTokenErc20UserToken(token)) {
+			loading = true;
+
+			const { chain_id, contract_address } = toUserToken(token);
+
+			await removeUserToken({
+				chain_id,
+				contract_address,
+				identity: $authIdentity
+			});
+
+			erc20UserTokensStore.reset(token.id);
+
+			await onTokenDeleteSuccess();
+		}
+	};
 </script>
 
-<Modal on:nnsClose={modalStore.close}>
-	<svelte:fragment slot="title">{$i18n.tokens.details.title}</svelte:fragment>
+<Modal on:nnsClose={modalStore.close} disablePointerEvents={loading}>
+	<svelte:fragment slot="title">
+		{showDeleteConfirmation
+			? $i18n.tokens.details.confirm_deletion_title
+			: $i18n.tokens.details.title}
+	</svelte:fragment>
 
-	<ContentWithToolbar>
-		{#if nonNullish(token)}
-			<ModalHero>
-				{#snippet logo()}
-					<TokenLogo logoSize="lg" data={token} badge={{ type: 'network' }} />
-				{/snippet}
-
-				{#snippet title()}
-					{getTokenDisplaySymbol(token)}
-				{/snippet}
-			</ModalHero>
-
-			<List styleClass="text-sm" condensed={false}>
-				<ModalListItem>
-					{#snippet label()}
-						{$i18n.tokens.details.network}
-					{/snippet}
-
-					{#snippet content()}
-						<output>{token.network.name}</output>
-						<NetworkLogo network={token.network} />
-					{/snippet}
-				</ModalListItem>
-
-				<ModalListItem>
-					{#snippet label()}
-						{$i18n.tokens.details.token}
-					{/snippet}
-
-					{#snippet content()}
-						<output>{token.name}</output>
-						<Logo
-							src={token.icon}
-							alt={replacePlaceholders($i18n.core.alt.logo, { $name: token.name })}
-							color="white"
-						/>
-					{/snippet}
-				</ModalListItem>
-
-				{@render children?.()}
-
-				{#if isTokenIcrc(token) || isTokenErc20(token) || isTokenDip20(token)}
-					<ModalListItem>
-						{#snippet label()}
-							{$i18n.tokens.details.standard}
-						{/snippet}
-
-						{#snippet content()}
-							{token.standard}
-						{/snippet}
-					</ModalListItem>
-				{/if}
-
-				<ModalListItem>
-					{#snippet label()}
-						{$i18n.core.text.symbol}
-					{/snippet}
-
-					{#snippet content()}
-						{`${getTokenDisplaySymbol(token)}${nonNullish(token.oisySymbol) ? ` (${token.symbol})` : ''}`}
-					{/snippet}
-				</ModalListItem>
-
-				<ModalListItem>
-					{#snippet label()}
-						{$i18n.core.text.decimals}
-					{/snippet}
-
-					{#snippet content()}
-						{token.decimals}
-					{/snippet}
-				</ModalListItem>
-			</List>
-		{/if}
-
-		{#snippet toolbar()}
-			<ButtonDone onclick={modalStore.close} />
-		{/snippet}
-	</ContentWithToolbar>
+	{#if showDeleteConfirmation}
+		<TokenModalDeleteConfirmation
+			{token}
+			{loading}
+			onCancel={() => (showDeleteConfirmation = false)}
+			onConfirm={onTokenDelete}
+		/>
+	{:else}
+		<TokenModalContent
+			{token}
+			{...isDeletable && { onDeleteClick: () => (showDeleteConfirmation = true) }}
+		>
+			{@render children?.()}
+		</TokenModalContent>
+	{/if}
 </Modal>

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -12,7 +12,7 @@
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { toastsShow } from '$lib/stores/toasts.store';
+	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import type { OptionToken } from '$lib/types/token';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { gotoReplaceRoot } from '$lib/utils/nav.utils';
@@ -65,15 +65,25 @@
 
 			const { chain_id, contract_address } = toUserToken(token);
 
-			await removeUserToken({
-				chain_id,
-				contract_address,
-				identity: $authIdentity
-			});
+			try {
+				await removeUserToken({
+					chain_id,
+					contract_address,
+					identity: $authIdentity
+				});
 
-			erc20UserTokensStore.reset(token.id);
+				erc20UserTokensStore.reset(token.id);
 
-			await onTokenDeleteSuccess();
+				await onTokenDeleteSuccess();
+			} catch (err: unknown) {
+				toastsError({
+					msg: { text: $i18n.tokens.error.unexpected_error_on_token_delete },
+					err
+				});
+
+				loading = false;
+				showDeleteConfirmation = false;
+			}
 		}
 	};
 </script>

--- a/src/frontend/src/lib/components/tokens/TokenModalContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModalContent.svelte
@@ -13,6 +13,7 @@
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
+	import { TOKEN_MODAL_CONTENT_DELETE_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionToken } from '$lib/types/token';
@@ -110,6 +111,7 @@
 					styleClass="mx-auto"
 					colorStyle="error"
 					onclick={onDeleteClick}
+					testId={TOKEN_MODAL_CONTENT_DELETE_BUTTON}
 				>
 					<IconTrash />
 					{$i18n.tokens.text.delete_token}

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -228,4 +228,5 @@ export const CONTACT_CARD_BUTTON = 'contact-card-button';
 export const CONTACT_CARD_EXPAND_BUTTON = 'contact-card-expand-button';
 
 // token modal
+export const TOKEN_MODAL_CONTENT_DELETE_BUTTON = 'token-modal-content-delete-button';
 export const TOKEN_MODAL_DELETE_BUTTON = 'token-modal-delete-button';

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -675,7 +675,7 @@
 			"twin_token": "Twin token",
 			"standard": "Standard",
 			"confirm_deletion_title": "Delete from the list of your tokens?",
-			"confirm_deletion_description": "This will remove the <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your funds will remain untouched — you can re-add the token at any time.",
+			"confirm_deletion_description": "This will remove <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your funds will remain untouched — you can re-add the token at any time.",
 			"deletion_confirmation": "$token has been successfully removed from your $oisy_short token list."
 		},
 		"balance": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -777,7 +777,8 @@
 			"not_toggleable": "Token is not toggleable, it can not be hidden.",
 			"incomplete_metadata": "No name or symbol is provided in the metadata.",
 			"duplicate_metadata": "A token with a similar name or symbol already exists.",
-			"unexpected_undefined": "Token is undefined. This is unexpected."
+			"unexpected_undefined": "Token is undefined. This is unexpected.",
+			"unexpected_error_on_token_delete": "Something went wrong while removing the token."
 		}
 	},
 	"fee": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -722,6 +722,7 @@ interface I18nTokens {
 		incomplete_metadata: string;
 		duplicate_metadata: string;
 		unexpected_undefined: string;
+		unexpected_error_on_token_delete: string;
 	};
 }
 


### PR DESCRIPTION
# Motivation

We can now introduce the token delete functionality to the TokenModal component. For now, it will only work for "user tokens" (erc20), but later will be extended with ICRC/SPL deletions (BE needs to have a new endpoint for that).

![Screenshot 2025-06-11 at 11 21 26](https://github.com/user-attachments/assets/3bebe210-539a-4c05-9db3-0ffe9a46cd93)
![Screenshot 2025-06-11 at 11 21 33](https://github.com/user-attachments/assets/68ccb129-f281-4e79-8117-ec4a2f7a95c4)
