### PR TITLE
refactor(frontend): Simplify component `SendContacts`

### DIFF
--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -43,19 +43,18 @@
 			: {}
 	);
 
-	let filteredNetworkContactsKeys = $derived(Object.keys(filteredNetworkContacts));
 </script>
 
 <div in:fade>
-	{#if nonNullish(networkContacts) && filteredNetworkContactsKeys.length > 0}
+	{#if nonNullish(networkContacts) && Object.keys(filteredNetworkContacts).length > 0}
 		<div in:fade class="flex flex-col overflow-y-hidden sm:max-h-[13.5rem]">
 			<ul class="list-none overflow-y-auto overscroll-contain">
-				{#each filteredNetworkContactsKeys as address, index (index)}
+				{#each Object.entries(filteredNetworkContacts) as [address, contact], index (index)}
 					<SendContact
-						contact={networkContacts[address]}
+						{contact}
 						{address}
 						onClick={() => {
-							selectedContact = networkContacts[address];
+							selectedContact = contact;
 							destination = address;
 							dispatch('icNext');
 						}}


### PR DESCRIPTION
# Motivation

We will start selecting the values of a contacts record by case-sensitive keys. That means to use a specific utils. However, before that, we simplify a little the possible instances where it could be used.

For example in component `SendContacts`, we can use directly list `filteredNetworkContacts`, instead of iterating in it.