### PR TITLE
refactor(frontend): Expand logic of component `KnownDestinations`

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -38,9 +38,7 @@
 		isEmptyString(destination)
 			? sortedKnownDestinations
 			: sortedKnownDestinations.filter(({ address }) => {
-					const networkContact = nonNullish(networkContacts)
-						? networkContacts[address]
-						: undefined;
+					const networkContact = nonNullish(networkContacts) ? networkContacts[address] : undefined;
 
 					if (nonNullish(networkContact)) {
 						return isContactMatchingFilter({

--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -7,15 +7,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 	import type { NetworkContacts } from '$lib/types/contacts';
-	import type { NetworkId } from '$lib/types/network';
-	import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isContactMatchingFilter } from '$lib/utils/contact.utils';
-	import { getNetworkContact } from '$lib/utils/contacts.utils';
 
 	interface Props {
 		destination: string;
-		networkId: NetworkId;
 		knownDestinations?: KnownDestinations;
 		networkContacts?: NetworkContacts;
 		selectedContact?: ContactUi;
@@ -23,7 +19,6 @@
 	let {
 		knownDestinations,
 		destination = $bindable(),
-		networkId,
 		selectedContact = $bindable(),
 		networkContacts
 	}: Props = $props();

--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -7,11 +7,15 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 	import type { NetworkContacts } from '$lib/types/contacts';
+	import type { NetworkId } from '$lib/types/network';
+	import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isContactMatchingFilter } from '$lib/utils/contact.utils';
+	import { getNetworkContact } from '$lib/utils/contacts.utils';
 
 	interface Props {
 		destination: string;
+		networkId: NetworkId;
 		knownDestinations?: KnownDestinations;
 		networkContacts?: NetworkContacts;
 		selectedContact?: ContactUi;
@@ -19,6 +23,7 @@
 	let {
 		knownDestinations,
 		destination = $bindable(),
+		networkId,
 		selectedContact = $bindable(),
 		networkContacts
 	}: Props = $props();
@@ -37,15 +42,21 @@
 	let filteredKnownDestinations = $derived(
 		isEmptyString(destination)
 			? sortedKnownDestinations
-			: sortedKnownDestinations.filter(({ address }) =>
-					nonNullish(networkContacts?.[address])
-						? isContactMatchingFilter({
-								address,
-								contact: networkContacts[address],
-								filterValue: destination
-							})
-						: address.includes(destination)
-				)
+			: sortedKnownDestinations.filter(({ address }) => {
+					const networkContact = nonNullish(networkContacts)
+						? networkContacts[address]
+						: undefined;
+
+					if (nonNullish(networkContact)) {
+						return isContactMatchingFilter({
+							address,
+							contact: networkContact,
+							filterValue: destination
+						});
+					}
+
+					return address.includes(destination);
+				})
 	);
 </script>
 


### PR DESCRIPTION
# Motivation

In component `KnownDestinations` we will change the logic of how the addresses are filtered, using case-sensitive logic. So, before that, we expand the logic maintaining the same flow, to be easier to modify after.