### PR TITLE
feat(frontend): enable deletion of custom ERC20 tokens

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -13,7 +13,7 @@ import { derived, type Readable } from 'svelte/store';
 /**
  * The list of ERC20 default tokens - i.e. the statically configured ERC20 tokens of Oisy + their metadata, unique ids etc. fetched at runtime.
  */
-const erc20DefaultTokens: Readable<Erc20Token[]> = derived(
+export const erc20DefaultTokens: Readable<Erc20Token[]> = derived(
 	[erc20DefaultTokensStore, enabledEthereumNetworksIds, enabledEvmNetworksIds],
 	([$erc20TokensStore, $enabledEthereumNetworksIds, $enabledEvmNetworksIds]) =>
 		($erc20TokensStore ?? []).filter(({ network: { id: networkId } }) =>

--- a/src/frontend/src/tests/eth/components/tokens/EthTokenModal.spec.ts
+++ b/src/frontend/src/tests/eth/components/tokens/EthTokenModal.spec.ts
@@ -1,18 +1,18 @@
 import EthTokenModal from '$eth/components/tokens/EthTokenModal.svelte';
-import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
+import { enabledErc20Tokens, erc20DefaultTokens } from '$eth/derived/erc20.derived';
 import { modalStore } from '$lib/stores/modal.store';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import en from '$tests/mocks/i18n.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockSplCustomToken } from '$tests/mocks/spl-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('EthTokenModal', () => {
 	beforeEach(() => {
+		vi.resetAllMocks();
 		mockPage.reset();
-	});
 
-	it('displays all required values', () => {
 		vi.spyOn(enabledErc20Tokens, 'subscribe').mockImplementation((fn) => {
 			fn([{ ...mockValidErc20Token, enabled: true }]);
 			return () => {};
@@ -21,6 +21,29 @@ describe('EthTokenModal', () => {
 		mockPage.mock({
 			token: mockValidErc20Token.name,
 			network: mockValidErc20Token.network.id.description
+		});
+	});
+
+	it('displays all required values including the delete button', () => {
+		const { container } = render(EthTokenModal);
+
+		modalStore.openBtcToken(mockValidErc20Token.id);
+
+		expect(container).toHaveTextContent(mockValidErc20Token.network.name);
+		expect(container).toHaveTextContent(mockValidErc20Token.name);
+		expect(container).toHaveTextContent(mockValidErc20Token.symbol);
+		expect(container).toHaveTextContent(
+			shortenWithMiddleEllipsis({ text: mockValidErc20Token.address })
+		);
+		expect(container).toHaveTextContent(`${mockSplCustomToken.decimals}`);
+
+		expect(container).toHaveTextContent(en.tokens.text.delete_token);
+	});
+
+	it('displays all required values without the delete button for a default token', () => {
+		vi.spyOn(erc20DefaultTokens, 'subscribe').mockImplementation((fn) => {
+			fn([mockValidErc20Token]);
+			return () => {};
 		});
 
 		const { container } = render(EthTokenModal);
@@ -34,5 +57,7 @@ describe('EthTokenModal', () => {
 			shortenWithMiddleEllipsis({ text: mockValidErc20Token.address })
 		);
 		expect(container).toHaveTextContent(`${mockSplCustomToken.decimals}`);
+
+		expect(container).not.toHaveTextContent(en.tokens.text.delete_token);
 	});
 });


### PR DESCRIPTION
# Motivation

The last step of enabling the deletion of custom ERC20 tokens is to check whether a token is a non-default ERC20 and pass `isDeletable` prop to TokenModal accordingly.
