### PR TITLE
feat(frontend): Use network ID instead of address type in util `areAddressesEqual`

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
@@ -45,8 +45,11 @@
 		if (
 			$erc20Tokens?.find(
 				({ address, network: tokenNetwork }) =>
-					areAddressesEqual({ address1: address, address2: contractAddress, networkId: network.id }) &&
-					tokenNetwork.chainId === (network as EthereumNetwork).chainId
+					areAddressesEqual({
+						address1: address,
+						address2: contractAddress,
+						networkId: network.id
+					}) && tokenNetwork.chainId === (network as EthereumNetwork).chainId
 			) !== undefined
 		) {
 			toastsError({

--- a/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
@@ -45,7 +45,7 @@
 		if (
 			$erc20Tokens?.find(
 				({ address, network: tokenNetwork }) =>
-					areAddressesEqual({ address1: address, address2: contractAddress, addressType: 'Eth' }) &&
+					areAddressesEqual({ address1: address, address2: contractAddress, networkId: network.id }) &&
 					tokenNetwork.chainId === (network as EthereumNetwork).chainId
 			) !== undefined
 		) {

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -68,17 +68,17 @@ export const getCaseSensitiveness = (
 export const areAddressesEqual = <T extends Address>({
 	address1,
 	address2,
-	addressType
+	networkId
 }: {
 	address1: OptionAddress<T>;
 	address2: OptionAddress<T>;
-	addressType: TokenAccountIdTypes;
+	networkId: NetworkId;
 }): boolean => {
 	if (isNullish(address1) || isNullish(address2)) {
 		return false;
 	}
 
-	const isCaseSensitive = getCaseSensitiveness({ addressType });
+	const isCaseSensitive = getCaseSensitiveness({ networkId });
 
 	if (isCaseSensitive) {
 		return address1 === address2;

--- a/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
+++ b/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
@@ -46,7 +46,7 @@
 
 		if (
 			$splTokens?.find(({ address }) =>
-				areAddressesEqual({ address1: address, address2: tokenAddress, addressType: 'Sol' })
+				areAddressesEqual({ address1: address, address2: tokenAddress, networkId: network.id })
 			) !== undefined
 		) {
 			toastsError({

--- a/src/frontend/src/tests/lib/utils/address.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/address.utils.spec.ts
@@ -58,69 +58,62 @@ describe('address.utils', () => {
 		const address2 = 'address456';
 
 		it('should return false for nullish addresses', () => {
-			const mockAddressType = 'mock-address-type' as TokenAccountIdTypes;
+			const mockNetworkId = parseNetworkId('mock-network-id');
+
+			expect(areAddressesEqual({ address1: null, address2, networkId: mockNetworkId })).toBeFalsy();
+
+			expect(areAddressesEqual({ address1, address2: null, networkId: mockNetworkId })).toBeFalsy();
 
 			expect(
-				areAddressesEqual({ address1: null, address2, addressType: mockAddressType })
+				areAddressesEqual({ address1: null, address2: null, networkId: mockNetworkId })
 			).toBeFalsy();
 
 			expect(
-				areAddressesEqual({ address1, address2: null, addressType: mockAddressType })
+				areAddressesEqual({ address1: undefined, address2, networkId: mockNetworkId })
 			).toBeFalsy();
 
 			expect(
-				areAddressesEqual({ address1: null, address2: null, addressType: mockAddressType })
+				areAddressesEqual({ address1, address2: undefined, networkId: mockNetworkId })
 			).toBeFalsy();
 
 			expect(
-				areAddressesEqual({ address1: undefined, address2, addressType: mockAddressType })
-			).toBeFalsy();
-
-			expect(
-				areAddressesEqual({ address1, address2: undefined, addressType: mockAddressType })
-			).toBeFalsy();
-
-			expect(
-				areAddressesEqual({
-					address1: undefined,
-					address2: undefined,
-					addressType: mockAddressType
-				})
+				areAddressesEqual({ address1: undefined, address2: undefined, networkId: mockNetworkId })
 			).toBeFalsy();
 		});
 
-		describe.each(['Btc', 'Eth', 'Icrcv2', 'unknown'])('for %s address type', (rawAddressType) => {
-			const addressType = rawAddressType as TokenAccountIdTypes;
-
+		describe.each([
+			ICP_NETWORK,
+			...SUPPORTED_BITCOIN_NETWORKS,
+			...SUPPORTED_ETHEREUM_NETWORKS,
+			...SUPPORTED_EVM_NETWORKS
+		])('for network $name', ({ id: networkId }) => {
 			it('should return true for equal addresses', () => {
-				expect(areAddressesEqual({ address1, address2: address1, addressType })).toBeTruthy();
+				expect(areAddressesEqual({ address1, address2: address1, networkId })).toBeTruthy();
 			});
 
 			it('should return false for different addresses', () => {
-				expect(areAddressesEqual({ address1, address2, addressType })).toBeFalsy();
+				expect(areAddressesEqual({ address1, address2, networkId })).toBeFalsy();
 			});
 
 			it('should return true for case-insensitive equal addresses', () => {
 				expect(
-					areAddressesEqual({ address1, address2: address1.toUpperCase(), addressType })
+					areAddressesEqual({ address1, address2: address1.toUpperCase(), networkId })
 				).toBeTruthy();
 			});
 		});
 
-		describe('for Sol address type', () => {
-			const addressType = 'Sol' as TokenAccountIdTypes;
-
+		describe.each(SUPPORTED_SOLANA_NETWORKS)('for network $name', ({ id: networkId }) => {
 			it('should return true for equal addresses', () => {
-				expect(areAddressesEqual({ address1, address2: address1, addressType })).toBeTruthy();
+				expect(areAddressesEqual({ address1, address2: address1, networkId })).toBeTruthy();
 			});
 
 			it('should return false for different addresses', () => {
-				expect(areAddressesEqual({ address1, address2, addressType })).toBeFalsy();
+				expect(areAddressesEqual({ address1, address2, networkId })).toBeFalsy();
 			});
 
-			it('should return true for case-insensitive equal addresses', () => {
+			it('should return false for case-insensitive equal addresses', () => {
 				expect(
-					areAddressesEqual({ address1, address2: address1.toUpperCase(), addressType })
+					areAddressesEqual({ address1, address2: address1.toUpperCase(), networkId })
 				).toBeFalsy();
 			});
 		});


### PR DESCRIPTION
# Motivation

For util `areAddressesEqual` it is more versatile if we use the network ID.
