### PR TITLE
refactor(frontend): Correctly simplify component `SendContacts`

### DIFF
--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isEmptyString, isNullish, nonNullish } from '@dfinity/utils';
+	import { isEmptyString, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import SendContact from '$lib/components/send/SendContact.svelte';
@@ -27,24 +27,16 @@
 		nonNullish(networkContacts)
 			? isEmptyString(destination)
 				? networkContacts
-				: Object.keys(networkContacts).reduce<NetworkContacts>((acc, address) => {
-						const networkContact = networkContacts[address];
-
-						if (isNullish(networkContact)) {
-							return acc;
-						}
-
-						return {
+				: Object.entries(networkContacts).reduce<NetworkContacts>((acc, [address, contact]) => ({
 							...acc,
 							...(isContactMatchingFilter({
 								filterValue: destination,
-								contact: networkContact,
+								contact,
 								address
 							})
-								? { [address]: networkContact }
+								? { [address]: contact }
 								: {})
-						};
-					}, {})
+						}), {})
 			: {}
 	);
 </script>

--- a/src/frontend/src/lib/components/send/SendContacts.svelte
+++ b/src/frontend/src/lib/components/send/SendContacts.svelte
@@ -27,7 +27,8 @@
 		nonNullish(networkContacts)
 			? isEmptyString(destination)
 				? networkContacts
-				: Object.entries(networkContacts).reduce<NetworkContacts>((acc, [address, contact]) => ({
+				: Object.entries(networkContacts).reduce<NetworkContacts>(
+						(acc, [address, contact]) => ({
 							...acc,
 							...(isContactMatchingFilter({
 								filterValue: destination,
@@ -36,7 +37,9 @@
 							})
 								? { [address]: contact }
 								: {})
-						}), {})
+						}),
+						{}
+					)
 			: {}
 	);
 </script>


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/7242 I simplified the component `SendContacts` in the wrong way: I should have used `Object.entries`, so that there is no need to use the util to get the value from the record.
