### PR TITLE
feat(frontend): Partially match addresses but using case-sensitiveness

### DIFF
--- a/src/frontend/src/lib/components/send/KnownDestinations.svelte
+++ b/src/frontend/src/lib/components/send/KnownDestinations.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { isEmptyString, nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import KnownDestination from '$lib/components/send/KnownDestination.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -9,6 +9,7 @@
 	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { isContactMatchingFilter } from '$lib/utils/contact.utils';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 
 	interface Props {
 		destination: string;
@@ -24,6 +25,8 @@
 	}: Props = $props();
 
 	const dispatch = createEventDispatcher();
+
+	const { sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let sortedKnownDestinations = $derived(
 		nonNullish(knownDestinations)
@@ -44,7 +47,8 @@
 						return isContactMatchingFilter({
 							address,
 							contact: networkContact,
-							filterValue: destination
+							filterValue: destination,
+							networkId: $sendTokenNetworkId
 						});
 					}
 

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -68,21 +68,46 @@ export const getCaseSensitiveness = (
 export const areAddressesEqual = <T extends Address>({
 	address1,
 	address2,
-	addressType
+	networkId
 }: {
 	address1: OptionAddress<T>;
 	address2: OptionAddress<T>;
-	addressType: TokenAccountIdTypes;
+	networkId: NetworkId;
 }): boolean => {
 	if (isNullish(address1) || isNullish(address2)) {
 		return false;
 	}
 
-	const isCaseSensitive = getCaseSensitiveness({ addressType });
+	const isCaseSensitive = getCaseSensitiveness({ networkId });
 
 	if (isCaseSensitive) {
 		return address1 === address2;
 	}
 
 	return address1.toLowerCase() === address2.toLowerCase();
+};
+
+export const areAddressesPartiallyEqual = <T extends Address>({
+	address1,
+	address2,
+	networkId
+}: {
+	address1: OptionAddress<T>;
+	address2: OptionAddress<T>;
+	networkId: NetworkId;
+}): boolean => {
+	if (isNullish(address1) || isNullish(address2)) {
+		return false;
+	}
+
+	const isCaseSensitive = getCaseSensitiveness({ networkId });
+
+	if (isCaseSensitive) {
+		return address1.includes(address2) || address2.includes(address1);
+	}
+
+	return (
+		address1.toLowerCase().includes(address2.toLowerCase()) ||
+		address2.toLowerCase().includes(address1.toLowerCase())
+	);
 };

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -2,7 +2,9 @@ import type { Contact } from '$declarations/backend/backend.did';
 import { TokenAccountIdSchema } from '$lib/schema/token-account-id.schema';
 import type { Address } from '$lib/types/address';
 import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
+import type { NetworkId } from '$lib/types/network';
 import type { NonEmptyArray } from '$lib/types/utils';
+import { areAddressesPartiallyEqual } from '$lib/utils/address.utils';
 import {
 	getDiscriminatorForTokenAccountId,
 	getTokenAccountIdAddressString
@@ -82,14 +84,20 @@ export const mapAddressToContactAddressUi = (address: Address): ContactAddressUi
 export const isContactMatchingFilter = ({
 	address,
 	contact,
-	filterValue
+	filterValue,
+	networkId
 }: {
 	address: Address;
 	contact: ContactUi;
 	filterValue: string;
+	networkId: NetworkId;
 }): boolean =>
 	notEmptyString(filterValue) &&
-	(address.includes(filterValue) ||
+	(areAddressesPartiallyEqual({
+		address1: address,
+		address2: filterValue,
+		networkId
+	}) ||
 		contact.name.toLowerCase().includes(filterValue.toLowerCase()) ||
 		contact.addresses.some(
 			({ label, address: innerAddress }) =>

--- a/src/frontend/src/tests/lib/components/send/SendContacts.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendContacts.spec.ts
@@ -1,5 +1,9 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import SendContacts from '$lib/components/send/SendContacts.svelte';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import type { ContactUi } from '$lib/types/contact';
+import type { Token } from '$lib/types/token';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import {
@@ -22,6 +26,16 @@ describe('SendContacts', () => {
 		addresses: [mockContactEthAddressUi]
 	}) as unknown as ContactUi[];
 
+	const mockContext = (sendToken: Token) =>
+		new Map<symbol, SendContext>([
+			[
+				SEND_CONTEXT_KEY,
+				initSendContext({
+					token: sendToken
+				})
+			]
+		]);
+
 	it('renders content if data is provided', () => {
 		const { getByText } = render(SendContacts, {
 			props: {
@@ -29,7 +43,8 @@ describe('SendContacts', () => {
 				networkContacts: {
 					[mockContactBtcAddressUi.address]: contact1
 				}
-			}
+			},
+			context: mockContext(BTC_MAINNET_TOKEN)
 		});
 
 		expect(
@@ -45,7 +60,8 @@ describe('SendContacts', () => {
 					[mockContactBtcAddressUi.address]: contact1,
 					[mockContactEthAddressUi.address]: contact2
 				}
-			}
+			},
+			context: mockContext(ETHEREUM_TOKEN)
 		});
 
 		expect(() =>
@@ -64,7 +80,8 @@ describe('SendContacts', () => {
 					[mockContactBtcAddressUi.address]: contact1,
 					[mockContactEthAddressUi.address]: contact2
 				}
-			}
+			},
+			context: mockContext(ETHEREUM_TOKEN)
 		});
 
 		expect(() =>
@@ -93,7 +110,8 @@ describe('SendContacts', () => {
 					[mockContactBtcAddressUi.address]: contact1,
 					[mockContactEthAddressUi.address]: contactWithLabel
 				}
-			}
+			},
+			context: mockContext(BTC_MAINNET_TOKEN)
 		});
 
 		expect(() =>
@@ -108,7 +126,8 @@ describe('SendContacts', () => {
 		const { getByText } = render(SendContacts, {
 			props: {
 				destination: mockBtcAddress
-			}
+			},
+			context: mockContext(BTC_MAINNET_TOKEN)
 		});
 
 		expect(getByText(en.send.text.contacts_empty_state_title)).toBeInTheDocument();

--- a/src/frontend/src/tests/lib/utils/address.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/address.utils.spec.ts
@@ -4,7 +4,11 @@ import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { SUPPORTED_SOLANA_NETWORKS } from '$env/networks/networks.sol.env';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
-import { areAddressesEqual, getCaseSensitiveness } from '$lib/utils/address.utils';
+import {
+	areAddressesEqual,
+	areAddressesPartiallyEqual,
+	getCaseSensitiveness
+} from '$lib/utils/address.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 
 describe('address.utils', () => {
@@ -121,6 +125,116 @@ describe('address.utils', () => {
 			it('should return true for case-insensitive equal addresses', () => {
 				expect(
 					areAddressesEqual({ address1, address2: address1.toUpperCase(), addressType })
+				).toBeFalsy();
+			});
+		});
+	});
+
+	describe('areAddressesPartiallyEqual', () => {
+		const address1 = 'address123';
+		const address2 = 'address456';
+
+		it('should return false for nullish addresses', () => {
+			const mockNetworkId = parseNetworkId('mock-network-id');
+
+			expect(
+				areAddressesPartiallyEqual({ address1: null, address2, networkId: mockNetworkId })
+			).toBeFalsy();
+
+			expect(
+				areAddressesPartiallyEqual({ address1, address2: null, networkId: mockNetworkId })
+			).toBeFalsy();
+
+			expect(
+				areAddressesPartiallyEqual({ address1: null, address2: null, networkId: mockNetworkId })
+			).toBeFalsy();
+
+			expect(
+				areAddressesPartiallyEqual({ address1: undefined, address2, networkId: mockNetworkId })
+			).toBeFalsy();
+
+			expect(
+				areAddressesPartiallyEqual({ address1, address2: undefined, networkId: mockNetworkId })
+			).toBeFalsy();
+
+			expect(
+				areAddressesPartiallyEqual({
+					address1: undefined,
+					address2: undefined,
+					networkId: mockNetworkId
+				})
+			).toBeFalsy();
+		});
+
+		describe.each([
+			ICP_NETWORK,
+			...SUPPORTED_BITCOIN_NETWORKS,
+			...SUPPORTED_ETHEREUM_NETWORKS,
+			...SUPPORTED_EVM_NETWORKS
+		])('for network $name', ({ id: networkId }) => {
+			it('should return true for equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({ address1, address2: address1, networkId })
+				).toBeTruthy();
+			});
+
+			it('should return true for partially equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({ address1, address2: address1.slice(0, 3), networkId })
+				).toBeTruthy();
+			});
+
+			it('should return false for different addresses', () => {
+				expect(areAddressesPartiallyEqual({ address1, address2, networkId })).toBeFalsy();
+			});
+
+			it('should return true for case-insensitive equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({ address1, address2: address1.toUpperCase(), networkId })
+				).toBeTruthy();
+			});
+
+			it('should return true for case-insensitive partially equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({
+						address1,
+						address2: address1.toUpperCase().slice(0, 3),
+						networkId
+					})
+				).toBeTruthy();
+			});
+		});
+
+		describe.each(SUPPORTED_SOLANA_NETWORKS)('for network $name', ({ id: networkId }) => {
+			it('should return true for equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({ address1, address2: address1, networkId })
+				).toBeTruthy();
+			});
+
+			it('should return true for partially equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({ address1, address2: address1.slice(0, 3), networkId })
+				).toBeTruthy();
+			});
+
+			it('should return false for different addresses', () => {
+				expect(areAddressesPartiallyEqual({ address1, address2, networkId })).toBeFalsy();
+			});
+
+			it('should return false for case-insensitive equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({ address1, address2: address1.toUpperCase(), networkId })
+				).toBeFalsy();
+			});
+
+			it('should return false for case-insensitive partially equal addresses', () => {
+				expect(
+					areAddressesPartiallyEqual({
+						address1,
+						address2: address1.toUpperCase().slice(0, 3),
+						networkId
+					})
 				).toBeFalsy();
 			});
 		});

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -1,3 +1,4 @@
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import type { ContactUi } from '$lib/types/contact';
 import {
 	getContactForAddress,
@@ -221,7 +222,8 @@ describe('contact.utils', () => {
 				isContactMatchingFilter({
 					address: mockContactBtcAddressUi.address,
 					contact,
-					filterValue: 'Joh'
+					filterValue: 'Joh',
+					networkId: ICP_NETWORK_ID
 				})
 			).toBeTruthy();
 		});
@@ -231,7 +233,8 @@ describe('contact.utils', () => {
 				isContactMatchingFilter({
 					address: mockContactBtcAddressUi.address,
 					contact,
-					filterValue: 'Bitcoin'
+					filterValue: 'Bitcoin',
+					networkId: ICP_NETWORK_ID
 				})
 			).toBeTruthy();
 		});
@@ -241,7 +244,8 @@ describe('contact.utils', () => {
 				isContactMatchingFilter({
 					address: mockContactBtcAddressUi.address,
 					contact,
-					filterValue: mockContactBtcAddressUi.address
+					filterValue: mockContactBtcAddressUi.address,
+					networkId: ICP_NETWORK_ID
 				})
 			).toBeTruthy();
 		});
@@ -251,7 +255,8 @@ describe('contact.utils', () => {
 				isContactMatchingFilter({
 					address: mockContactBtcAddressUi.address,
 					contact,
-					filterValue: mockContactBtcAddressUi.address.slice(0, 6)
+					filterValue: mockContactBtcAddressUi.address.slice(0, 6),
+					networkId: ICP_NETWORK_ID
 				})
 			).toBeTruthy();
 		});
@@ -261,7 +266,8 @@ describe('contact.utils', () => {
 				isContactMatchingFilter({
 					address: mockContactBtcAddressUi.address,
 					contact,
-					filterValue: ''
+					filterValue: '',
+					networkId: ICP_NETWORK_ID
 				})
 			).toBeFalsy();
 		});
@@ -271,7 +277,8 @@ describe('contact.utils', () => {
 				isContactMatchingFilter({
 					address: mockContactBtcAddressUi.address,
 					contact,
-					filterValue: 'Test1'
+					filterValue: 'Test1',
+					networkId: ICP_NETWORK_ID
 				})
 			).toBeFalsy();
 		});


### PR DESCRIPTION
# Motivation

We need to use the network case-sensitiveness when partially matching a filtered address.

# Changes

- Create util `areAddressesPartiallyEqual` to partially match two addresses, based on network case-sensitiveness (similar to `areAddressesEqual`).
- Use it in util `isContactMatchingFilter` (more use-cases to come in next PRs).
- Adapt the code.

# Tests

Created new tests.
