### PR TITLE
feat(frontend): remove ERC20 token from IDB on token delete

### DIFF
--- a/src/frontend/src/lib/api/idb-tokens.api.ts
+++ b/src/frontend/src/lib/api/idb-tokens.api.ts
@@ -4,9 +4,9 @@ import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.sol.env';
 import { nullishSignOut } from '$lib/services/auth.services';
-import type { SetIdbTokensParams } from '$lib/types/idb-tokens';
+import type { DeleteIdbTokenParams, SetIdbTokensParams } from '$lib/types/idb-tokens';
 import type { Principal } from '@dfinity/principal';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { createStore, del, get, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
@@ -66,3 +66,24 @@ export const deleteIdbEthTokens = (principal: Principal): Promise<void> =>
 
 export const deleteIdbSolTokens = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbSolTokensStore);
+
+export const deleteIdbEthToken = async ({
+	identity,
+	token
+}: DeleteIdbTokenParams<UserToken>): Promise<void> => {
+	if (isNullish(identity)) {
+		await nullishSignOut();
+		return;
+	}
+
+	const currentTokens = await getIdbEthTokens(identity.getPrincipal());
+
+	if (nonNullish(currentTokens)) {
+		await setIdbEthTokens({
+			identity,
+			tokens: currentTokens.filter(({ contract_address, chain_id }) =>
+				token.chain_id === chain_id ? token.contract_address !== contract_address : true
+			)
+		});
+	}
+};

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -6,6 +6,7 @@
 	import { isTokenErc20UserToken } from '$eth/utils/erc20.utils';
 	import { toUserToken } from '$icp-eth/services/user-token.services';
 	import { removeUserToken } from '$lib/api/backend.api';
+	import { deleteIdbEthToken } from '$lib/api/idb-tokens.api.js';
 	import TokenModalContent from '$lib/components/tokens/TokenModalContent.svelte';
 	import TokenModalDeleteConfirmation from '$lib/components/tokens/TokenModalDeleteConfirmation.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -62,15 +63,16 @@
 			if (isTokenErc20UserToken(tokenToDelete)) {
 				loading = true;
 
-				const { chain_id, contract_address } = toUserToken(tokenToDelete);
+				const userToken = toUserToken(tokenToDelete);
 
 				await removeUserToken({
-					chain_id,
-					contract_address,
+					chain_id: userToken.chain_id,
+					contract_address: userToken.contract_address,
 					identity: $authIdentity
 				});
 
 				erc20UserTokensStore.reset(tokenToDelete.id);
+				await deleteIdbEthToken({ identity: $authIdentity, token: userToken });
 
 				await onTokenDeleteSuccess(tokenToDelete);
 			}

--- a/src/frontend/src/lib/types/idb-tokens.ts
+++ b/src/frontend/src/lib/types/idb-tokens.ts
@@ -5,3 +5,8 @@ export interface SetIdbTokensParams<T extends CustomToken | UserToken> {
 	identity: OptionIdentity;
 	tokens: T[];
 }
+
+export interface DeleteIdbTokenParams<T extends CustomToken | UserToken> {
+	identity: OptionIdentity;
+	token: T;
+}

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -1,5 +1,6 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as backendApi from '$lib/api/backend.api';
+import * as idbTokensApi from '$lib/api/idb-tokens.api';
 import TokenModal from '$lib/components/tokens/TokenModal.svelte';
 import {
 	TOKEN_MODAL_CONTENT_DELETE_BUTTON,
@@ -19,6 +20,8 @@ import { vi } from 'vitest';
 
 describe('TokenModal', () => {
 	const mockBackendApi = () => vi.spyOn(backendApi, 'removeUserToken').mockResolvedValue(undefined);
+	const mockIdbTokensApi = () =>
+		vi.spyOn(idbTokensApi, 'deleteIdbEthToken').mockResolvedValue(undefined);
 	const mockToastsShow = () => vi.spyOn(toastsStore, 'toastsShow').mockImplementation(vi.fn());
 	const mockToastsError = () => vi.spyOn(toastsStore, 'toastsError').mockImplementation(vi.fn());
 	const mockGoToRoot = () => vi.spyOn(navUtils, 'gotoReplaceRoot').mockImplementation(vi.fn());
@@ -43,6 +46,7 @@ describe('TokenModal', () => {
 		const removeUserTokenMock = mockBackendApi();
 		const toasts = mockToastsShow();
 		const gotoReplaceRoot = mockGoToRoot();
+		const idbTokensApi = mockIdbTokensApi();
 		mockAuthStore();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
@@ -55,6 +59,7 @@ describe('TokenModal', () => {
 
 		expect(removeUserTokenMock).toHaveBeenCalledOnce();
 		expect(toasts).toHaveBeenCalledOnce();
+		expect(idbTokensApi).toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).toHaveBeenCalledOnce();
 	});
 
@@ -69,6 +74,7 @@ describe('TokenModal', () => {
 		const removeUserTokenMock = mockBackendApi();
 		const toasts = mockToastsShow();
 		const gotoReplaceRoot = mockGoToRoot();
+		const idbTokensApi = mockIdbTokensApi();
 		mockAuthStore();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
@@ -81,6 +87,7 @@ describe('TokenModal', () => {
 
 		expect(removeUserTokenMock).not.toHaveBeenCalledOnce();
 		expect(toasts).not.toHaveBeenCalledOnce();
+		expect(idbTokensApi).not.toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).not.toHaveBeenCalledOnce();
 	});
 
@@ -99,6 +106,7 @@ describe('TokenModal', () => {
 		const removeUserTokenMock = mockBackendApi();
 		const toasts = mockToastsShow();
 		const gotoReplaceRoot = mockGoToRoot();
+		const idbTokensApi = mockIdbTokensApi();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
 
@@ -111,6 +119,7 @@ describe('TokenModal', () => {
 		expect(removeUserTokenMock).not.toHaveBeenCalledOnce();
 		expect(toasts).not.toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).not.toHaveBeenCalledOnce();
+		expect(idbTokensApi).not.toHaveBeenCalledOnce();
 		expect(signOutSpy).toHaveBeenCalledOnce();
 	});
 
@@ -140,6 +149,7 @@ describe('TokenModal', () => {
 			.mockRejectedValue(new Error('test'));
 		const toastsError = mockToastsError();
 		const gotoReplaceRoot = mockGoToRoot();
+		const idbTokensApi = mockIdbTokensApi();
 		mockAuthStore();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
@@ -153,5 +163,6 @@ describe('TokenModal', () => {
 		expect(removeUserTokenMock).toHaveBeenCalledOnce();
 		expect(toastsError).toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).not.toHaveBeenCalledOnce();
+		expect(idbTokensApi).not.toHaveBeenCalledOnce();
 	});
 });


### PR DESCRIPTION
# Motivation

When user removes an ERC20 token, we should also delete it from IDB.
