### PR TITLE
feat(frontend): Use network case-sensitiveness in transaction list

### DIFF
--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -68,17 +68,16 @@ export const getCaseSensitiveness = (
 export const areAddressesEqual = <T extends Address>({
 	address1,
 	address2,
-	networkId
-}: {
-	address1: OptionAddress<T>;
-	address2: OptionAddress<T>;
-	networkId: NetworkId;
-}): boolean => {
+	...rest
+}: { address1: OptionAddress<T>; address2: OptionAddress<T> } & (
+	| { networkId: NetworkId }
+	| { addressType: TokenAccountIdTypes }
+)): boolean => {
 	if (isNullish(address1) || isNullish(address2)) {
 		return false;
 	}
 
-	const isCaseSensitive = getCaseSensitiveness({ networkId });
+	const isCaseSensitive = getCaseSensitiveness(rest);
 
 	if (isCaseSensitive) {
 		return address1 === address2;

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -63,7 +63,15 @@ export const getContactForAddress = ({
 	addressString: string;
 	contactList: ContactUi[];
 }): ContactUi | undefined =>
-	contactList.find((c) => c.addresses.find((address) => address.address === addressString));
+	contactList.find((c) =>
+		c.addresses.find((address) =>
+			areAddressesEqual({
+				address1: address.address,
+				address2: addressString,
+				addressType: address.addressType
+			})
+		)
+	);
 
 export const mapAddressToContactAddressUi = (address: Address): ContactAddressUi | undefined => {
 	const tokenAccountIdParseResult = TokenAccountIdSchema.safeParse(address);

--- a/src/frontend/src/tests/lib/utils/address.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/address.utils.spec.ts
@@ -85,6 +85,42 @@ describe('address.utils', () => {
 			).toBeFalsy();
 		});
 
+		describe.each(['Btc', 'Eth', 'Icrcv2', 'unknown'])('for %s address type', (rawAddressType) => {
+			const addressType = rawAddressType as TokenAccountIdTypes;
+
+			it('should return true for equal addresses', () => {
+				expect(areAddressesEqual({ address1, address2: address1, addressType })).toBeTruthy();
+			});
+
+			it('should return false for different addresses', () => {
+				expect(areAddressesEqual({ address1, address2, addressType })).toBeFalsy();
+			});
+
+			it('should return true for case-insensitive equal addresses', () => {
+				expect(
+					areAddressesEqual({ address1, address2: address1.toUpperCase(), addressType })
+				).toBeTruthy();
+			});
+		});
+
+		describe('for Sol address type', () => {
+			const addressType = 'Sol' as TokenAccountIdTypes;
+
+			it('should return true for equal addresses', () => {
+				expect(areAddressesEqual({ address1, address2: address1, addressType })).toBeTruthy();
+			});
+
+			it('should return false for different addresses', () => {
+				expect(areAddressesEqual({ address1, address2, addressType })).toBeFalsy();
+			});
+
+			it('should return true for case-insensitive equal addresses', () => {
+				expect(
+					areAddressesEqual({ address1, address2: address1.toUpperCase(), addressType })
+				).toBeFalsy();
+			});
+		});
+
 		describe.each([
 			ICP_NETWORK,
 			...SUPPORTED_BITCOIN_NETWORKS,

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -169,11 +169,27 @@ describe('contact.utils', () => {
 			expect(result).toBeUndefined();
 		});
 
-		it('should match address only case sensitive', () => {
+		it('should not match address only case-sensitive for a case-insensitive network', () => {
 			const upperCasedAddress = mockEthAddress3.toUpperCase();
 			const result = getContactForAddress({
 				addressString: upperCasedAddress,
 				contactList: mockContacts
+			});
+
+			expect(result?.addresses?.[0]?.address).toEqual(mockEthAddress3);
+		});
+
+		it('should match address only case-sensitive for a case-sensitive network', () => {
+			const upperCasedAddress = mockEthAddress3.toUpperCase();
+			const result = getContactForAddress({
+				addressString: upperCasedAddress,
+				contactList: mockContacts.map((c) => ({
+					...c,
+					addresses: c.addresses.map((a) => ({
+						...a,
+						addressType: 'Sol'
+					}))
+				}))
 			});
 
 			expect(result?.addresses?.[0]?.address).not.toEqual(mockEthAddress3);


### PR DESCRIPTION
# Motivation

We need to match the contacts based on network case-sensitiveness even in the transaction list.

# Changes

- Adapt util `areAddressesEqual` to accept both network ID and address type.
- Use it in util `getContactForAddress` that the transaction list apply to match addresses.

# Tests

Matched transaction with lower case address to a contact with some upper case character.

![Screenshot 2025-06-12 at 08 49 52](https://github.com/user-attachments/assets/43f2a001-00c6-4af9-ac35-dcd2760b4b9d)
![Screenshot 2025-06-12 at 08 50 00](https://github.com/user-attachments/assets/964b3b1d-0146-4992-95c1-f53b6aad9463)
![Screenshot 2025-06-12 at 08 50 12](https://github.com/user-attachments/assets/6388ac52-292c-4bb1-b941-b1355fd1ce9a)

