### PR TITLE
feat(frontend): change title of the Token Modal delete confirmation

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -90,9 +90,7 @@
 
 <Modal on:nnsClose={modalStore.close} disablePointerEvents={loading}>
 	<svelte:fragment slot="title">
-		{showDeleteConfirmation
-			? $i18n.tokens.details.confirm_deletion_title
-			: $i18n.tokens.details.title}
+		{showDeleteConfirmation ? $i18n.tokens.text.delete_token : $i18n.tokens.details.title}
 	</svelte:fragment>
 
 	{#if showDeleteConfirmation}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -675,7 +675,6 @@
 			"token_address_copied": "Token address copied to clipboard.",
 			"twin_token": "Twin token",
 			"standard": "Standard",
-			"confirm_deletion_title": "Delete from the list of your tokens?",
 			"confirm_deletion_description": "This will remove <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your funds will remain untouched — you can re-add the token at any time.",
 			"deletion_confirmation": "$token has been successfully removed from your $oisy_short token list."
 		},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -640,7 +640,6 @@ interface I18nTokens {
 		token_address_copied: string;
 		twin_token: string;
 		standard: string;
-		confirm_deletion_title: string;
 		confirm_deletion_description: string;
 		deletion_confirmation: string;
 	};

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -53,7 +53,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_CONTENT_DELETE_BUTTON));
 
-		expect(getByText(en.tokens.details.confirm_deletion_title)).toBeInTheDocument();
+		expect(getByText(en.tokens.text.delete_token)).toBeInTheDocument();
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
@@ -81,7 +81,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_CONTENT_DELETE_BUTTON));
 
-		expect(getByText(en.tokens.details.confirm_deletion_title)).toBeInTheDocument();
+		expect(getByText(en.tokens.text.delete_token)).toBeInTheDocument();
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
@@ -112,7 +112,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_CONTENT_DELETE_BUTTON));
 
-		expect(getByText(en.tokens.details.confirm_deletion_title)).toBeInTheDocument();
+		expect(getByText(en.tokens.text.delete_token)).toBeInTheDocument();
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
@@ -156,7 +156,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_CONTENT_DELETE_BUTTON));
 
-		expect(getByText(en.tokens.details.confirm_deletion_title)).toBeInTheDocument();
+		expect(getByText(en.tokens.text.delete_token)).toBeInTheDocument();
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 


### PR DESCRIPTION
# Motivation

We need to make the title of TokenModalDeleteConfirmation shorter - `Delete token`.
