### PR TITLE
fix(frontend): Stop ICRC wallet worker before restarting it with ledger only

### DIFF
--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -25,6 +25,9 @@ export const initIcrcWalletWorker = async ({
 	let restartedWithLedgerOnly = false;
 
 	const restartWorkerWithLedgerOnly = () => {
+		// For good measure, we stop the worker before restarting it with ledger only
+		stop();
+
 		if (restartedWithLedgerOnly) {
 			return;
 		}
@@ -80,6 +83,12 @@ export const initIcrcWalletWorker = async ({
 		}
 	};
 
+	const stop = () => {
+		worker.postMessage({
+			msg: 'stopIcrcWalletTimer'
+		});
+	};
+
 	return {
 		start: () => {
 			worker.postMessage({
@@ -91,11 +100,7 @@ export const initIcrcWalletWorker = async ({
 				}
 			});
 		},
-		stop: () => {
-			worker.postMessage({
-				msg: 'stopIcrcWalletTimer'
-			});
-		},
+		stop,
 		trigger: () => {
 			worker.postMessage({
 				msg: 'triggerIcrcWalletTimer',

--- a/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
@@ -141,8 +141,11 @@ describe('worker.icrc-wallet.services', () => {
 					};
 					workerInstance.onmessage?.({ data: payload } as MessageEvent);
 
-					expect(postMessageSpy).toHaveBeenCalledOnce();
+					expect(postMessageSpy).toHaveBeenCalledTimes(2);
 					expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+						msg: 'stopIcrcWalletTimer'
+					});
+					expect(postMessageSpy).toHaveBeenNthCalledWith(2, {
 						msg: 'startIcrcWalletTimer',
 						data: {
 							ledgerCanisterId,
@@ -161,13 +164,23 @@ describe('worker.icrc-wallet.services', () => {
 						workerInstance.onmessage?.({ data: payload } as MessageEvent);
 					});
 
-					expect(postMessageSpy).toHaveBeenCalledOnce();
+					expect(postMessageSpy).toHaveBeenCalledTimes(10 + 1);
+
 					expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+						msg: 'stopIcrcWalletTimer'
+					});
+					expect(postMessageSpy).toHaveBeenNthCalledWith(2, {
 						msg: 'startIcrcWalletTimer',
 						data: {
 							ledgerCanisterId,
 							env
 						}
+					});
+
+					Array.from({ length: 8 }).forEach((_, index) => {
+						expect(postMessageSpy).toHaveBeenNthCalledWith(index + 3, {
+							msg: 'stopIcrcWalletTimer'
+						});
 					});
 				});
 			});


### PR DESCRIPTION
# Motivation

When we restart an ICRC wallet with ledger only, because of an error in the index canister, we are asking it to stop the previous worker. However, the command is not executed in the correct scheduler.

So, for good measure, we first stop the timer and then restart it with ledger only.
