### PR TITLE
feat(frontend): Use network case-sensitiveness for send flow alias

### DIFF
--- a/src/frontend/src/lib/components/send/SendContactName.svelte
+++ b/src/frontend/src/lib/components/send/SendContactName.svelte
@@ -4,6 +4,7 @@
 	import Divider from '$lib/components/common/Divider.svelte';
 	import type { Address } from '$lib/types/address';
 	import type { ContactUi } from '$lib/types/contact';
+	import { areAddressesEqual } from '$lib/utils/address.utils';
 
 	interface Props {
 		address: Address;
@@ -14,7 +15,11 @@
 	let { contact, address, children }: Props = $props();
 
 	let contactLabel = $derived(
-		contact?.addresses.find(({ address: innerAddress }) => address === innerAddress)?.label
+		contact?.addresses.find(({ address: innerAddress, addressType }) => areAddressesEqual({
+			address1: innerAddress,
+			address2: address,
+			addressType
+		}))?.label
 	);
 </script>
 


### PR DESCRIPTION
# Motivation

We need to match the alias in the send flow based on network case-sensitiveness.
