### PR TITLE
feat(frontend): Util to filter an address inside a contact

### DIFF
--- a/src/frontend/src/lib/components/send/SendContactName.svelte
+++ b/src/frontend/src/lib/components/send/SendContactName.svelte
@@ -4,6 +4,7 @@
 	import Divider from '$lib/components/common/Divider.svelte';
 	import type { Address } from '$lib/types/address';
 	import type { ContactUi } from '$lib/types/contact';
+	import { filterAddressFromContact } from '$lib/utils/contact.utils';
 
 	interface Props {
 		address: Address;
@@ -13,9 +14,7 @@
 
 	let { contact, address, children }: Props = $props();
 
-	let contactLabel = $derived(
-		contact?.addresses.find(({ address: innerAddress }) => address === innerAddress)?.label
-	);
+	let contactLabel = $derived(filterAddressFromContact({contact,address})?.label);
 </script>
 
 <span class="font-bold">

--- a/src/frontend/src/lib/components/send/SendContactName.svelte
+++ b/src/frontend/src/lib/components/send/SendContactName.svelte
@@ -14,7 +14,7 @@
 
 	let { contact, address, children }: Props = $props();
 
-	let contactLabel = $derived(filterAddressFromContact({contact,address})?.label);
+	let contactLabel = $derived(filterAddressFromContact({ contact, address })?.label);
 </script>
 
 <span class="font-bold">

--- a/src/frontend/src/lib/components/send/SendContactName.svelte
+++ b/src/frontend/src/lib/components/send/SendContactName.svelte
@@ -4,7 +4,6 @@
 	import Divider from '$lib/components/common/Divider.svelte';
 	import type { Address } from '$lib/types/address';
 	import type { ContactUi } from '$lib/types/contact';
-	import { areAddressesEqual } from '$lib/utils/address.utils';
 	import { filterAddressFromContact } from '$lib/utils/contact.utils';
 
 	interface Props {

--- a/src/frontend/src/lib/components/send/SendContactName.svelte
+++ b/src/frontend/src/lib/components/send/SendContactName.svelte
@@ -4,8 +4,8 @@
 	import Divider from '$lib/components/common/Divider.svelte';
 	import type { Address } from '$lib/types/address';
 	import type { ContactUi } from '$lib/types/contact';
-	import { filterAddressFromContact } from '$lib/utils/contact.utils';
 	import { areAddressesEqual } from '$lib/utils/address.utils';
+	import { filterAddressFromContact } from '$lib/utils/contact.utils';
 
 	interface Props {
 		address: Address;

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -15,7 +15,7 @@
 	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus, TransactionType } from '$lib/types/transaction';
 	import { areAddressesEqual } from '$lib/utils/address.utils';
-	import { getContactForAddress } from '$lib/utils/contact.utils';
+	import { filterAddressFromContact, getContactForAddress } from '$lib/utils/contact.utils';
 	import { formatSecondsToDate } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
@@ -64,13 +64,7 @@
 	);
 
 	let addressAlias: string | undefined = $derived(
-		contact?.addresses.find((a) =>
-			areAddressesEqual({
-				address1: a.address,
-				address2: contactAddress,
-				addressType: a.addressType
-			})
-		)?.label
+		filterAddressFromContact({contact,address:contactAddress})?.label
 	);
 </script>
 

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -14,7 +14,6 @@
 	import type { ContactUi } from '$lib/types/contact';
 	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus, TransactionType } from '$lib/types/transaction';
-	import { areAddressesEqual } from '$lib/utils/address.utils';
 	import { filterAddressFromContact, getContactForAddress } from '$lib/utils/contact.utils';
 	import { formatSecondsToDate } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -64,7 +64,7 @@
 	);
 
 	let addressAlias: string | undefined = $derived(
-		filterAddressFromContact({contact,address:contactAddress})?.label
+		filterAddressFromContact({ contact, address: contactAddress })?.label
 	);
 </script>
 

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -1,6 +1,6 @@
 import type { Contact } from '$declarations/backend/backend.did';
 import { TokenAccountIdSchema } from '$lib/schema/token-account-id.schema';
-import type { Address } from '$lib/types/address';
+import type { Address, OptionAddress } from '$lib/types/address';
 import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
 import type { NetworkId } from '$lib/types/network';
 import type { NonEmptyArray } from '$lib/types/utils';
@@ -63,15 +63,7 @@ export const getContactForAddress = ({
 	addressString: string;
 	contactList: ContactUi[];
 }): ContactUi | undefined =>
-	contactList.find((c) =>
-		c.addresses.find((address) =>
-			areAddressesEqual({
-				address1: address.address,
-				address2: addressString,
-				addressType: address.addressType
-			})
-		)
-	);
+	contactList.find((c) => filterAddressFromContact({ contact: c, address: addressString }));
 
 export const mapAddressToContactAddressUi = (address: Address): ContactAddressUi | undefined => {
 	const tokenAccountIdParseResult = TokenAccountIdSchema.safeParse(address);
@@ -115,3 +107,18 @@ export const isContactMatchingFilter = ({
 					networkId
 				}) && label?.toLowerCase().includes(filterValue.toLowerCase())
 		));
+
+export const filterAddressFromContact = <T extends Address>({
+	contact,
+	address: filterAddress
+}: {
+	contact: ContactUi | undefined;
+	address: OptionAddress<T>;
+}): ContactAddressUi | undefined =>
+	contact?.addresses.find(({ address, addressType }) =>
+		areAddressesEqual({
+			address1: address,
+			address2: filterAddress,
+			addressType
+		})
+	);


### PR DESCRIPTION
# Motivation

To avoid repetition of code we create an util to filter the address inside a contact. 

# Changes

- Util `filterAddressFromContact` will filter among the addresses of a contact, based on network case-sensitiveness (it uses existing code).
- Use the util in the code.

# Tests

Added tests.
