### PR TITLE
refactor(frontend): use WizardModal instead of Modal for token details

### DIFF
--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -42,3 +42,8 @@ export enum WizardStepsReceive {
 	RECEIVE = 'Receive',
 	QR_CODE = 'QR Code'
 }
+
+export enum TokenModalSteps {
+	CONTENT = 'content',
+	DELETE_CONFIRMATION = 'delete_confirnation'
+}

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -1,5 +1,6 @@
 import type { AddressBookSteps } from '$lib/enums/progress-steps';
 import type {
+	TokenModalSteps,
 	WizardStepsAuthHelp,
 	WizardStepsConvert,
 	WizardStepsHowToConvert,
@@ -21,7 +22,8 @@ export const goToWizardStep = ({
 		| WizardStepsAuthHelp
 		| WizardStepsHowToConvert
 		| WizardStepsReceive
-		| AddressBookSteps;
+		| AddressBookSteps
+		| TokenModalSteps;
 }) => {
 	const stepNumber = steps.findIndex(({ name }) => name === stepName);
 	modal.set(Math.max(stepNumber, 0));


### PR DESCRIPTION
# Motivation

It makes sense to use WizardModal instead of Modal for token details - this will allow us to use BottomSheet component for the delete confirmation step (similar as in AddressBook wizard).
