### PR TITLE
refactor(frontend): Contact name form

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactNameStep.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
-	import ContactForm from '$lib/components/address-book/ContactForm.svelte';
+	import InputContactName from '$lib/components/address-book/InputContactName.svelte';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -33,10 +33,10 @@
 
 	let editingContact = $state(contact ? { ...contact } : {});
 
-	let form: ContactForm | undefined = $state();
+	const handleSave = (event: Event) => {
+		event.preventDefault();
 
-	const handleSave = () => {
-		if (!form?.isValid) {
+		if (!isFormValid || disabled) {
 			return;
 		}
 		if (nonNullish(editingContact.name)) {
@@ -49,6 +49,8 @@
 		}
 	};
 
+	let isFormValid = $state(true);
+
 	let title = $derived(
 		notEmptyString(editingContact?.name?.trim?.())
 			? editingContact?.name
@@ -58,26 +60,27 @@
 	export { title };
 </script>
 
-<ContentWithToolbar styleClass="flex flex-col gap-6 items-center">
-	<Avatar name={editingContact?.name} variant="xl"></Avatar>
-	<ContactForm bind:contact={editingContact} bind:this={form} {disabled} onSubmit={handleSave}
-	></ContactForm>
+<form onsubmit={handleSave} method="POST" class="flex w-full flex-col items-center">
+	<ContentWithToolbar styleClass="flex flex-col gap-6 items-center w-full">
+		<Avatar name={editingContact?.name} variant="xl"></Avatar>
+		<InputContactName bind:contact={editingContact} bind:isValid={isFormValid} {disabled} />
 
-	<!-- TODO Add address list here -->
+		<!-- TODO Add address list here -->
 
-	{#snippet toolbar()}
-		<ButtonGroup>
-			<ButtonCancel {disabled} onclick={() => onClose()} testId={ADDRESS_BOOK_CANCEL_BUTTON}
-			></ButtonCancel>
-			<Button
-				colorStyle="primary"
-				onclick={handleSave}
-				disabled={!form?.isValid}
-				loading={disabled}
-				testId={ADDRESS_BOOK_SAVE_BUTTON}
-			>
-				{$i18n.core.text.save}
-			</Button>
-		</ButtonGroup>
-	{/snippet}
-</ContentWithToolbar>
+		{#snippet toolbar()}
+			<ButtonGroup>
+				<ButtonCancel {disabled} onclick={() => onClose()} testId={ADDRESS_BOOK_CANCEL_BUTTON}
+				></ButtonCancel>
+				<Button
+					type="submit"
+					colorStyle="primary"
+					disabled={!isFormValid}
+					loading={disabled}
+					testId={ADDRESS_BOOK_SAVE_BUTTON}
+				>
+					{$i18n.core.text.save}
+				</Button>
+			</ButtonGroup>
+		{/snippet}
+	</ContentWithToolbar>
+</form>

--- a/src/frontend/src/lib/components/address-book/InputContactName.svelte
+++ b/src/frontend/src/lib/components/address-book/InputContactName.svelte
@@ -9,33 +9,25 @@
 	import type { ContactUi } from '$lib/types/contact';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	let {
-		contact = $bindable(),
-		disabled = false,
-		onSubmit = () => {}
-	}: { contact: Partial<ContactUi>; disabled?: boolean; onSubmit?: () => void } = $props();
+	interface Props {
+		contact: Partial<ContactUi>;
+		disabled?: boolean;
+		isValid: boolean;
+	}
+	let { contact = $bindable(), disabled = false, isValid = $bindable() }: Props = $props();
 
 	const trimmedName = $derived((contact.name ?? '').trim());
 	const isNameTooLong = $derived(trimmedName.length > CONTACT_MAX_NAME_LENGTH);
 
-	const assertValid = (): boolean => notEmptyString(trimmedName) && !isNameTooLong;
-
-	const isValid = $derived(assertValid());
-
-	const handleKeydown = (event: KeyboardEvent): void => {
-		if (event.key === 'Enter' && assertValid()) {
-			event.preventDefault();
-			onSubmit();
-		}
-	};
-
-	export { isValid };
+	$effect(() => {
+		isValid = notEmptyString(trimmedName) && !isNameTooLong;
+	});
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
-
-<form class="w-full" style="--input-font-size: var(--text-base)">
-	<div class="rounded-lg bg-brand-subtle-10 p-4 pb-6 pt-4 text-sm md:p-6 md:text-base md:font-bold">
+<div class="w-full" style="--input-font-size: var(--text-base)">
+	<div
+		class="w-full rounded-lg bg-brand-subtle-10 p-4 pb-6 pt-4 text-sm md:p-6 md:text-base md:font-bold"
+	>
 		{$i18n.contact.fields.name}
 		<InputText
 			name="name"
@@ -54,4 +46,4 @@
 			>
 		{/if}
 	</div>
-</form>
+</div>

--- a/src/frontend/src/tests/lib/components/address-book/InputContactName.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/InputContactName.spec.ts
@@ -1,12 +1,15 @@
-import ContactForm from '$lib/components/address-book/ContactForm.svelte';
+import InputContactName from '$lib/components/address-book/InputContactName.svelte';
 import { ADDRESS_BOOK_CONTACT_NAME_INPUT } from '$lib/constants/test-ids.constants';
 import type { ContactUi } from '$lib/types/contact';
+import InputContactNameTestHost from '$tests/lib/components/address-book/InputContactNameTestHost.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 
-describe('ContactForm', () => {
+describe('InputContactName', () => {
 	it('should render the contact form with name field', () => {
-		const { getByTestId, getByText } = render(ContactForm, { props: { contact: {} } });
+		const { getByTestId, getByText } = render(InputContactName, {
+			props: { contact: {}, isValid: true }
+		});
 
 		// Check that the name field is rendered
 		expect(getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT)).toBeInTheDocument();
@@ -15,35 +18,39 @@ describe('ContactForm', () => {
 
 	it('should validate successfully when name is provided', async () => {
 		const contact: Partial<ContactUi> = {};
-		const { component, getByTestId } = render(ContactForm, { props: { contact } });
+		const { component, getByTestId } = render(InputContactNameTestHost, {
+			props: { contact, isValid: true }
+		});
 
 		// Enter a name
 		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
 		await fireEvent.input(nameInput, { target: { value: 'Test Contact' } });
 
 		// Check that validation passed
-		expect(component.isValid).toBeTruthy();
+		expect(component.getIsValid()).toBeTruthy();
 	});
 
 	it('should fail validation when name is empty', () => {
 		const contact: Partial<ContactUi> = {};
-		const { component } = render(ContactForm, { props: { contact } });
+		const { component } = render(InputContactNameTestHost, { props: { contact, isValid: true } });
 
 		// Check that validation failed
-		expect(component.isValid).toBeFalsy();
+		expect(component.getIsValid()).toBeFalsy();
 	});
 
 	it('should fail validation when name is only spaces', () => {
 		const contact: Partial<ContactUi> = { name: '   ' };
-		const { component } = render(ContactForm, { props: { contact } });
+		const { component } = render(InputContactNameTestHost, { props: { contact, isValid: true } });
 
 		// Check that validation failed
-		expect(component.isValid).toBeFalsy();
+		expect(component.getIsValid()).toBeFalsy();
 	});
 
 	it('should show error when name exceeds max length', async () => {
 		const contact: Partial<ContactUi> = {};
-		const { getByTestId, getByText } = render(ContactForm, { props: { contact } });
+		const { getByTestId, getByText } = render(InputContactName, {
+			props: { contact, isValid: true }
+		});
 
 		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
 		const longName = 'A'.repeat(101);
@@ -57,7 +64,7 @@ describe('ContactForm', () => {
 
 	it('should not show error message on load', () => {
 		const contact: Partial<ContactUi> = {};
-		const { queryByText } = render(ContactForm, { props: { contact } });
+		const { queryByText } = render(InputContactName, { props: { contact, isValid: true } });
 
 		expect(
 			queryByText(en.contact.error.name_too_long.replace('$maxCharacters', '100'))
@@ -66,7 +73,9 @@ describe('ContactForm', () => {
 
 	it('should not show error when name is valid and within max length', async () => {
 		const contact: Partial<ContactUi> = {};
-		const { getByTestId, queryByText } = render(ContactForm, { props: { contact } });
+		const { getByTestId, queryByText } = render(InputContactName, {
+			props: { contact, isValid: true }
+		});
 
 		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
 		await fireEvent.input(nameInput, { target: { value: 'Valid Name' } });
@@ -78,7 +87,9 @@ describe('ContactForm', () => {
 
 	it('should show and then hide error when name is corrected', async () => {
 		const contact: Partial<ContactUi> = {};
-		const { getByTestId, queryByText, getByText } = render(ContactForm, { props: { contact } });
+		const { getByTestId, queryByText, getByText } = render(InputContactName, {
+			props: { contact, isValid: true }
+		});
 
 		const nameInput = getByTestId(ADDRESS_BOOK_CONTACT_NAME_INPUT);
 		const longName = 'A'.repeat(101);

--- a/src/frontend/src/tests/lib/components/address-book/InputContactNameTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/address-book/InputContactNameTestHost.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import type { ContactUi } from '$lib/types/contact';
+	import InputContactName from '$lib/components/address-book/InputContactName.svelte';
+
+	let {
+		contact = $bindable(),
+		disabled,
+		isValid = $bindable()
+	}: {
+		contact: Partial<ContactUi>;
+		disabled?: boolean;
+		isValid: boolean;
+	} = $props();
+
+	// Expose the isValid value for testing
+	export const getIsValid = () => isValid;
+</script>
+
+<InputContactName bind:contact bind:isValid {disabled} />

--- a/src/frontend/src/tests/lib/components/address-book/InputContactNameTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/address-book/InputContactNameTestHost.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { ContactUi } from '$lib/types/contact';
 	import InputContactName from '$lib/components/address-book/InputContactName.svelte';
+	import type { ContactUi } from '$lib/types/contact';
 
 	let {
 		contact = $bindable(),


### PR DESCRIPTION
# Motivation

In order for a future feature where we want to have a create contact page in the address book, we clean up the current forms as they have been built differently.

# Changes

- Renamed to input because the form inside the component makes compositions difficult and moved the form to the page where the submit happens and the input is used
- No exported variables in the component anymore
- Cleaned up usage of form
- Removed manually event handler for key presses (submit on enter - now down with form submit)
- Cleaned up isValid vars
- Added a condition to not submit when disabled (it was possible to submit multiple times when hitting enter multiple times)

# Tests

Added a test host component and adjusted the tests accordingly
