### PR TITLE
refactor(frontend): Address form

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import AddressForm from '$lib/components/address/AddressForm.svelte';
+	import InputAddressAlias from '$lib/components/address/InputAddressAlias.svelte';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -96,7 +96,7 @@
 		<div class="mt-2 w-full rounded-lg bg-brand-subtle-10 px-3 py-4 text-sm md:px-5 md:text-base">
 			<div class="pb-4 text-xl font-bold">{title}</div>
 
-			<AddressForm
+			<InputAddressAlias
 				{onQRCodeScan}
 				disableAddressField={!isNewAddress || nonNullish(modalDataAddress)}
 				address={addressModel}

--- a/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import InputAddressAlias from '$lib/components/address/InputAddressAlias.svelte';
+	import AddressForm from '$lib/components/address/InputAddressAlias.svelte';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -64,7 +64,7 @@
 
 	const handleSubmit = (event: Event) => {
 		event.preventDefault();
-		if (!isInvalid) {
+		if (isFormValid && !disabled) {
 			handleSave();
 		}
 	};
@@ -77,7 +77,7 @@
 				: ''
 	);
 
-	let isInvalid = $state(false);
+	let isFormValid = $state(true);
 
 	const focusField = isNewAddress ? 'address' : 'label';
 
@@ -96,11 +96,11 @@
 		<div class="mt-2 w-full rounded-lg bg-brand-subtle-10 px-3 py-4 text-sm md:px-5 md:text-base">
 			<div class="pb-4 text-xl font-bold">{title}</div>
 
-			<InputAddressAlias
+			<AddressForm
 				{onQRCodeScan}
 				disableAddressField={!isNewAddress || nonNullish(modalDataAddress)}
 				address={addressModel}
-				bind:isInvalid
+				bind:isValid={isFormValid}
 				{disabled}
 				{focusField}
 			/>
@@ -112,7 +112,7 @@
 				></ButtonCancel>
 				<Button
 					colorStyle="primary"
-					disabled={isInvalid || (!isNewAddress && !labelChanged)}
+					disabled={!isFormValid || (!isNewAddress && !labelChanged)}
 					onclick={handleSave}
 					testId={ADDRESS_BOOK_SAVE_BUTTON}
 					loading={disabled}

--- a/src/frontend/src/lib/components/address/InputAddressAlias.svelte
+++ b/src/frontend/src/lib/components/address/InputAddressAlias.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import type { ZodError } from 'zod';
 	import InputAddress from '$lib/components/address/InputAddress.svelte';
@@ -17,10 +17,10 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
-		onQRCodeScan: () => void;
+		onQRCodeScan?: () => void;
 		address: Partial<ContactAddressUi>;
 		disableAddressField?: boolean;
-		isInvalid: boolean;
+		isValid: boolean;
 		disabled?: boolean;
 		focusField?: 'address' | 'label' | null;
 	}
@@ -29,7 +29,7 @@
 		onQRCodeScan,
 		address = $bindable(),
 		disableAddressField = false,
-		isInvalid = $bindable(),
+		isValid = $bindable(),
 		disabled = false,
 		focusField = null
 	}: Props = $props();
@@ -47,7 +47,7 @@
 	});
 
 	$effect(() => {
-		isInvalid = nonNullish(addressParseError) || nonNullish(labelError);
+		isValid = isNullish(addressParseError) && isNullish(labelError);
 	});
 </script>
 

--- a/src/frontend/src/tests/lib/components/address/InputAddressAlias.spec.ts
+++ b/src/frontend/src/tests/lib/components/address/InputAddressAlias.spec.ts
@@ -1,21 +1,21 @@
-import AddressForm from '$lib/components/address/AddressForm.svelte';
+import InputAddressAlias from '$lib/components/address/InputAddressAlias.svelte';
 import { CONTACT_MAX_LABEL_LENGTH } from '$lib/constants/app.constants';
 import {
 	ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT,
 	ADDRESS_BOOK_ADDRESS_ALIAS_INPUT
 } from '$lib/constants/test-ids.constants';
 import type { ContactAddressUi } from '$lib/types/contact';
-import AddressFormTestHost from '$tests/lib/components/address/AddressFormTestHost.svelte';
+import InputAddressAliasTestHost from '$tests/lib/components/address/InputAddressAliasTestHost.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 
-describe('AddressForm', () => {
+describe('InputAddressAlias', () => {
 	it('should render the form with address and label fields', () => {
 		const address: Partial<ContactAddressUi> = {};
-		const { getByTestId, getByText } = render(AddressForm, {
+		const { getByTestId, getByText } = render(InputAddressAlias, {
 			props: {
 				address,
-				isInvalid: false,
+				isValid: true,
 				onQRCodeScan: () => {}
 			}
 		});
@@ -35,11 +35,11 @@ describe('AddressForm', () => {
 			addressType: 'Eth'
 		};
 
-		const { getByTestId } = render(AddressForm, {
+		const { getByTestId } = render(InputAddressAlias, {
 			props: {
 				address,
 				disableAddressField: true,
-				isInvalid: false,
+				isValid: true,
 				onQRCodeScan: () => {}
 			}
 		});
@@ -52,11 +52,11 @@ describe('AddressForm', () => {
 	it('should enable address input when disableAddressField is false', () => {
 		const address: Partial<ContactAddressUi> = {};
 
-		const { getByTestId } = render(AddressForm, {
+		const { getByTestId } = render(InputAddressAlias, {
 			props: {
 				address,
 				disableAddressField: false,
-				isInvalid: false,
+				isValid: true,
 				onQRCodeScan: () => {}
 			}
 		});
@@ -70,10 +70,10 @@ describe('AddressForm', () => {
 describe('AddressFormTestHost', () => {
 	it('should bind address object between host and form', async () => {
 		const address: Partial<ContactAddressUi> = {};
-		const { getByTestId, component } = render(AddressFormTestHost, {
+		const { getByTestId, component } = render(InputAddressAliasTestHost, {
 			props: {
 				address,
-				isInvalid: false
+				isValid: true
 			}
 		});
 
@@ -91,10 +91,10 @@ describe('AddressFormTestHost', () => {
 
 	it('should trim whitespace from label input', async () => {
 		const address: Partial<ContactAddressUi> = {};
-		const { getByTestId, component } = render(AddressFormTestHost, {
+		const { getByTestId, component } = render(InputAddressAliasTestHost, {
 			props: {
 				address,
-				isInvalid: false
+				isValid: true
 			}
 		});
 
@@ -118,10 +118,10 @@ describe('AddressFormTestHost', () => {
 
 	it('should handle empty string label', async () => {
 		const address: Partial<ContactAddressUi> = { label: 'initial' };
-		const { getByTestId, component } = render(AddressFormTestHost, {
+		const { getByTestId, component } = render(InputAddressAliasTestHost, {
 			props: {
 				address,
-				isInvalid: false
+				isValid: true
 			}
 		});
 
@@ -138,13 +138,13 @@ describe('AddressFormTestHost', () => {
 		expect(component.getAddress().label).toBe('');
 	});
 
-	it('should update isInvalid when address is invalid or valid', async () => {
+	it('should update isValid when address is invalid or valid', async () => {
 		const address: Partial<ContactAddressUi> = {};
 
-		const { getByTestId, component } = render(AddressFormTestHost, {
+		const { getByTestId, component } = render(InputAddressAliasTestHost, {
 			props: {
 				address,
-				isInvalid: false
+				isValid: true
 			}
 		});
 
@@ -152,14 +152,14 @@ describe('AddressFormTestHost', () => {
 		const addressInput = getByTestId(ADDRESS_BOOK_ADDRESS_ADDRESS_INPUT);
 		await fireEvent.input(addressInput, { target: { value: 'invalid-address' } });
 
-		// Check that isInvalid is now true
-		expect(component.getIsInvalid()).toBeTruthy();
+		// Check that isValid is now false
+		expect(component.getIsValid()).toBeFalsy();
 
 		const validAddress = '0x1234567890abcdef1234567890abcdef12345678';
 		await fireEvent.input(addressInput, { target: { value: validAddress } });
 
-		// Check that isInvalid is now true
-		expect(component.getIsInvalid()).toBeFalsy();
+		// Check that isValid is now true
+		expect(component.getIsValid()).toBeTruthy();
 	});
 
 	it('should maintain address type when address is updated', async () => {
@@ -167,10 +167,10 @@ describe('AddressFormTestHost', () => {
 			addressType: 'Btc'
 		};
 
-		const { component, getByTestId } = render(AddressFormTestHost, {
+		const { component, getByTestId } = render(InputAddressAliasTestHost, {
 			props: {
 				address,
-				isInvalid: false
+				isValid: true
 			}
 		});
 
@@ -187,10 +187,10 @@ describe('AddressFormTestHost', () => {
 
 	it('should show error when label exceeds 50 characters', async () => {
 		const address: Partial<ContactAddressUi> = {};
-		const { getByTestId, getByText, component } = render(AddressFormTestHost, {
+		const { getByTestId, getByText, component } = render(InputAddressAliasTestHost, {
 			props: {
 				address,
-				isInvalid: false
+				isValid: true
 			}
 		});
 
@@ -202,6 +202,6 @@ describe('AddressFormTestHost', () => {
 		expect(
 			getByText(`Label may not exceed ${CONTACT_MAX_LABEL_LENGTH} characters`)
 		).toBeInTheDocument();
-		expect(component.getIsInvalid).toBeTruthy();
+		expect(component.getIsValid()).toBeFalsy();
 	});
 });

--- a/src/frontend/src/tests/lib/components/address/InputAddressAliasTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/address/InputAddressAliasTestHost.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import AddressForm from '$lib/components/address/AddressForm.svelte';
+	import InputAddressAlias from '$lib/components/address/InputAddressAlias.svelte';
 	import type { ContactAddressUi } from '$lib/types/contact';
 
 	let {
 		address = $bindable(),
 		disableAddressField,
-		isInvalid = $bindable()
+		isValid = $bindable()
 	}: {
 		address: Partial<ContactAddressUi>;
 		disableAddressField?: boolean;
-		isInvalid: boolean;
+		isValid: boolean;
 	} = $props();
 
-	// Expose the isInvalid value for testing
-	export const getIsInvalid = () => isInvalid;
+	// Expose the isValid value for testing
+	export const getIsValid = () => isValid;
 	export const getAddress = () => address;
 </script>
 
-<AddressForm bind:address bind:isInvalid {disableAddressField} />
+<InputAddressAlias bind:address bind:isValid {disableAddressField} />


### PR DESCRIPTION
# Motivation

In order for a future feature where we want to have a create contact page in the address book, we clean up the current forms as they have been built differently.

# Changes

- Renamed to input because the form inside the component makes compositions difficult and moved the form to the page where the submit happens and the input is used
- Cleaned up usage of form
- Cleaned up isValid vars
- Added a condition to not submit when disabled (it was possible to submit multiple times when hitting enter multiple times)

# Tests

Adjusted the tests accordingly
