### PR TITLE
feat(frontend): REVERT: reset selected contact when going back in send flow

### DIFF
--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
 	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
 	import { btcNetworkContacts } from '$btc/derived/btc-contacts.derived';
 	import { btcKnownDestinations } from '$btc/derived/btc-transactions.derived';
@@ -50,6 +50,10 @@
 		selectedContact = $bindable(),
 		formCancelAction = 'back'
 	}: Props = $props();
+
+	onMount(() => {
+		selectedContact = undefined;
+	});
 
 	const { sendToken, sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
 


### PR DESCRIPTION
# Motivation

In PR #7205, we wanted to avoid resetting the selected contact when moving back and forth between steps in the send flow. However, this causes inconsistencies if the user modify the address in the input:


https://github.com/user-attachments/assets/429d41bb-cddf-47c6-87a0-a798b905ba67

So, we re-instate resetting the selected contact:


https://github.com/user-attachments/assets/57f84af8-1a00-42fa-a2c8-ade6851b499d




