### PR TITLE
refactor(frontend): upgrades Header to svelte 5

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -64,13 +64,13 @@
 <Header>
 	{$i18n.transactions.text.title}
 
-	<svelte:fragment slot="end">
+	{#snippet end()}
 		{#if $tokenCkBtcLedger}
 			<IcTransactionsBitcoinStatus />
 		{:else if ckEthereum}
 			<IcTransactionsEthereumStatus />
 		{/if}
-	</svelte:fragment>
+	{/snippet}
 </Header>
 
 <IcTransactionsSkeletons>

--- a/src/frontend/src/lib/components/ui/Header.svelte
+++ b/src/frontend/src/lib/components/ui/Header.svelte
@@ -1,5 +1,16 @@
-<div class="mb-6 flex items-center justify-between pb-1">
-	<h2 class="text-base"><slot /></h2>
+<script lang="ts">
+	import type { Snippet } from 'svelte';
 
-	<slot name="end" />
+	interface Props {
+		children: Snippet;
+		end?: Snippet;
+	}
+
+	let {children, end}: Props = $props();
+</script>
+
+<div class="mb-6 flex items-center justify-between pb-1">
+	<h2 class="text-base">{@render children()}</h2>
+
+	{@render end?.()}
 </div>


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- upgrades `Header`
