### PR TITLE
refactor(frontend): upgrades HeroButtonGroup to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
+++ b/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
@@ -5,7 +5,7 @@
 		children: Snippet;
 	}
 
-	let {children}: Props = $props();
+	let { children }: Props = $props();
 </script>
 
 <div role="toolbar" class="flex flex-1 flex-row justify-between gap-2">

--- a/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
+++ b/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
@@ -1,3 +1,13 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let {children}: Props = $props();
+</script>
+
 <div role="toolbar" class="flex flex-1 flex-row justify-between gap-2">
-	<slot />
+	{@render children()}
 </div>


### PR DESCRIPTION
# Motivation

Since we upgraded svelte from V4 to V5 we also want to upgrade the components step by step to V5.


# Changes

- upgrades `HeroButtonGroup`
