### PR TITLE
fix(frontend): getNetworkContactKey util

### DIFF
--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -122,3 +122,11 @@ export const filterAddressFromContact = <T extends Address>({
 			addressType
 		})
 	);
+
+export const getNetworkContactKey = ({
+	contact,
+	address
+}: {
+	contact: ContactUi;
+	address: Address;
+}) => `${address}-${contact.id.toString()}`;

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -3,6 +3,7 @@ import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
 import {
 	filterAddressFromContact,
 	getContactForAddress,
+	getNetworkContactKey,
 	isContactMatchingFilter,
 	mapAddressToContactAddressUi,
 	mapToBackendContact,
@@ -378,6 +379,20 @@ describe('contact.utils', () => {
 			expect(
 				filterAddressFromContact({ contact: mockContact, address: mockSolAddress.toUpperCase() })
 			).toBeUndefined();
+		});
+	});
+
+	describe('getNetworkContactKey', () => {
+		it('returns correct key', () => {
+			const [contact] = getMockContactsUi({
+				n: 1,
+				name: 'Multiple Addresses Contact',
+				addresses: [mockContactBtcAddressUi]
+			}) as unknown as ContactUi[];
+
+			expect(getNetworkContactKey({ address: mockContactBtcAddressUi.address, contact })).toBe(
+				`${mockContactBtcAddressUi.address}-${contact.id.toString()}`
+			);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

To make `networkContacts` identifiers really unique, we are going to extend the keys with contact ids. It is going to be used in plenty of tests, therefore for convenience we need to create a separate util.