### PR TITLE
feat(frontend): add privacy mode indicator in activity

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -40,7 +40,7 @@
 	</output>
 	<span class="flex items-center gap-2 text-xl font-medium text-brand-secondary-alt sm:max-w-none">
 		{#if hideBalance}
-			<IconEyeOff />{$i18n.hero.text.hidden_balance}
+			<IconEyeOff color="white" />{$i18n.hero.text.hidden_balance}
 		{:else}
 			{$allBalancesZero ? $i18n.hero.text.top_up : $i18n.hero.text.available_balance}
 		{/if}

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -55,7 +55,7 @@
 			/>
 		{:else}
 			<span class="flex items-center justify-center gap-2">
-				<IconEyeOff />
+				<IconEyeOff color="white" />
 				{$i18n.hero.text.hidden_balance}
 			</span>
 		{/if}

--- a/src/frontend/src/lib/components/icons/lucide/IconEyeOff.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconEyeOff.svelte
@@ -2,12 +2,13 @@
 <script lang="ts">
 	interface Props {
 		size?: string;
+		color?: string;
 	}
 
-	let { size = '20' }: Props = $props();
+	let { size = '20', color }: Props = $props();
 </script>
 
-<svg width={size} height={size} viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width={size} height={size} viewBox="0 0 22 22" fill="none" style="color: {color || 'black'}" xmlns="http://www.w3.org/2000/svg">
 	<g clip-path="url(#clip0_12507_17697)">
 		<path
 			fill-rule="evenodd"

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -7,10 +7,12 @@
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
+	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenUi } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import { isPrivacyMode } from '$lib/derived/settings.derived';
 
 	$: enabledTokensWithoutTransaction = $enabledNetworkTokens
 		.filter((token) => $icTransactionsStore?.[token.id] === null)
@@ -44,7 +46,14 @@
 </script>
 
 <div class="flex flex-col gap-5">
+	{#if !$isPrivacyMode}
 	<PageTitle>{$i18n.activity.text.title}</PageTitle>
+	{:else}
+		<span class="flex items-center gap-2">
+			<PageTitle>{$i18n.activity.text.title}</PageTitle>
+			<IconEyeOff color="grey" />
+		</span>
+	{/if}
 
 	{#if notEmptyString(tokenListWithoutCanister)}
 		<MessageBox level="warning" closableKey="oisy_ic_hide_transaction_no_canister">


### PR DESCRIPTION
# Motivation

Users should be able to see when Privacy Mode is enabled during Activity. This helps improve transparency and UX by visually indicating that sensitive data is being hidden.

# Changes

Added a Privacy Mode indicator to the Activity view
Hooked into existing Privacy Mode state
Styled icon appropriately using Svelte SVG component
Supported dynamic color prop

# Tests
Manually verified that the Privacy Mode icon appears only when enabled
<img width="1205" alt="Screenshot 2025-06-16 at 19 02 04" src="https://github.com/user-attachments/assets/d227a27a-cfc7-45ca-96a9-18dd19560ed9" />
<img width="1205" alt="Screenshot 2025-06-16 at 19 02 04" src="https://github.com/user-attachments/assets/d227a27a-cfc7-45ca-96a9-18dd19560ed9" />
![Uploading Screenshot 2025-06-16 at 19.02.04.png…]()
