### PR TITLE
feat(e2e): Remove test for Solana Testnet (not Devnet) QR

### DIFF
--- a/e2e/receive-tokens-modal.spec.ts
+++ b/e2e/receive-tokens-modal.spec.ts
@@ -8,8 +8,7 @@ import {
 	RECEIVE_TOKENS_MODAL_ICRC_SECTION,
 	RECEIVE_TOKENS_MODAL_OPEN_BUTTON,
 	RECEIVE_TOKENS_MODAL_SOL_DEVNET_SECTION,
-	RECEIVE_TOKENS_MODAL_SOL_MAINNET_SECTION,
-	RECEIVE_TOKENS_MODAL_SOL_TESTNET_SECTION
+	RECEIVE_TOKENS_MODAL_SOL_MAINNET_SECTION
 } from '$lib/constants/test-ids.constants';
 import { testWithII } from '@dfinity/internet-identity-playwright';
 import { MODALS_VIEWPORT_WIDTH } from './utils/constants/e2e.constants';
@@ -48,7 +47,6 @@ testWithII('should display receive-tokens modal', async () => {
 			RECEIVE_TOKENS_MODAL_BTC_TESTNET_SECTION,
 			RECEIVE_TOKENS_MODAL_BTC_REGTEST_SECTION,
 			RECEIVE_TOKENS_MODAL_SOL_MAINNET_SECTION,
-			RECEIVE_TOKENS_MODAL_SOL_TESTNET_SECTION,
 			RECEIVE_TOKENS_MODAL_SOL_DEVNET_SECTION
 		])
 	});
@@ -75,12 +73,6 @@ testWithII('should display correct QR codes for receiving ETH tokens', async () 
 testWithII('should display correct QR codes for receiving SOL mainnet tokens', async () => {
 	await homepageLoggedIn.testReceiveModalQrCode({
 		receiveModalSectionSelector: RECEIVE_TOKENS_MODAL_SOL_MAINNET_SECTION
-	});
-});
-
-testWithII('should display correct QR codes for receiving SOL testnet tokens', async () => {
-	await homepageLoggedIn.testReceiveModalQrCode({
-		receiveModalSectionSelector: RECEIVE_TOKENS_MODAL_SOL_TESTNET_SECTION
 	});
 });
 


### PR DESCRIPTION
# Motivation

We are going to remove the support for Solana Testnet (not Solana Devnet), since the new [Solana RPC Canister](https://github.com/dfinity/sol-rpc-canister) (that we are going to integrate) will not support it.

So, we start with the E2E tests, in this case, the QR code.