### PR TITLE
feat(frontend): Remove Solana Testnet from WalletConnect

### DIFF
--- a/src/frontend/src/env/caip10-chains.env.ts
+++ b/src/frontend/src/env/caip10-chains.env.ts
@@ -1,8 +1,4 @@
-import {
-	SOLANA_DEVNET_NETWORK,
-	SOLANA_MAINNET_NETWORK,
-	SOLANA_TESTNET_NETWORK
-} from '$env/networks/networks.sol.env';
+import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import { nonNullish } from '@dfinity/utils';
 
@@ -15,13 +11,6 @@ export const CAIP10_CHAINS: Record<
 			chainId: SOLANA_MAINNET_NETWORK.chainId,
 			name: SOLANA_MAINNET_NETWORK.name,
 			network: SolanaNetworks.mainnet
-		}
-	}),
-	...(nonNullish(SOLANA_TESTNET_NETWORK.chainId) && {
-		[`solana:${SOLANA_TESTNET_NETWORK.chainId}`]: {
-			chainId: SOLANA_TESTNET_NETWORK.chainId,
-			name: SOLANA_TESTNET_NETWORK.name,
-			network: SolanaNetworks.testnet
 		}
 	}),
 	...(nonNullish(SOLANA_DEVNET_NETWORK.chainId) && {

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -5,7 +5,6 @@
 	import {
 		SOLANA_DEVNET_TOKEN,
 		SOLANA_LOCAL_TOKEN,
-		SOLANA_TESTNET_TOKEN,
 		SOLANA_TOKEN
 	} from '$env/tokens/tokens.sol.env';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
@@ -14,7 +13,6 @@
 		solAddressDevnet,
 		solAddressLocal,
 		solAddressMainnet,
-		solAddressTestnet
 	} from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { type ProgressStepsSendSol, ProgressStepsSign } from '$lib/enums/progress-steps';
@@ -29,7 +27,6 @@
 	import {
 		isNetworkIdSOLDevnet,
 		isNetworkIdSOLLocal,
-		isNetworkIdSOLTestnet
 	} from '$lib/utils/network.utils';
 	import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$sol/constants/steps.constants';
@@ -53,9 +50,7 @@
 
 	let address: OptionSolAddress;
 	let token: Token;
-	$: [address, token] = isNetworkIdSOLTestnet(networkId)
-		? [$solAddressTestnet, SOLANA_TESTNET_TOKEN]
-		: isNetworkIdSOLDevnet(networkId)
+	$: [address, token] = isNetworkIdSOLDevnet(networkId)
 			? [$solAddressDevnet, SOLANA_DEVNET_TOKEN]
 			: isNetworkIdSOLLocal(networkId)
 				? [$solAddressLocal, SOLANA_LOCAL_TOKEN]


### PR DESCRIPTION
# Motivation

We want to start integrating the [Solana RPC canister](https://github.com/dfinity/sol-rpc-canister). However, it still does not support Solana Testnet (not Devnet). After a small analysis, we decided to remove the support on OISY side too.

In this PR, we remove the support from WalletConnect.
