### PR TITLE
feat(frontend): Remove Solana Testnet from supported networks

### DIFF
--- a/src/frontend/src/env/networks/networks.sol.env.ts
+++ b/src/frontend/src/env/networks/networks.sol.env.ts
@@ -102,7 +102,7 @@ export const SOLANA_LOCAL_NETWORK: SolanaNetwork = {
 export const SUPPORTED_SOLANA_NETWORKS: Network[] = defineSupportedNetworks({
 	mainnetFlag: SOL_MAINNET_ENABLED,
 	mainnetNetworks: [SOLANA_MAINNET_NETWORK],
-	testnetNetworks: [SOLANA_TESTNET_NETWORK, SOLANA_DEVNET_NETWORK],
+	testnetNetworks: [SOLANA_DEVNET_NETWORK],
 	localNetworks: [SOLANA_LOCAL_NETWORK]
 });
 

--- a/src/frontend/src/sol/derived/networks.derived.ts
+++ b/src/frontend/src/sol/derived/networks.derived.ts
@@ -2,8 +2,7 @@ import {
 	SOL_MAINNET_ENABLED,
 	SOLANA_DEVNET_NETWORK,
 	SOLANA_LOCAL_NETWORK,
-	SOLANA_MAINNET_NETWORK,
-	SOLANA_TESTNET_NETWORK
+	SOLANA_MAINNET_NETWORK
 } from '$env/networks/networks.sol.env';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { userNetworks } from '$lib/derived/user-networks.derived';
@@ -20,7 +19,7 @@ export const enabledSolanaNetworks: Readable<SolanaNetwork[]> = derived(
 			$userNetworks,
 			mainnetFlag: SOL_MAINNET_ENABLED,
 			mainnetNetworks: [SOLANA_MAINNET_NETWORK],
-			testnetNetworks: [SOLANA_TESTNET_NETWORK, SOLANA_DEVNET_NETWORK],
+			testnetNetworks: [SOLANA_DEVNET_NETWORK],
 			localNetworks: [SOLANA_LOCAL_NETWORK]
 		})
 );


### PR DESCRIPTION
# Motivation

We want to start integrating the [Solana RPC canister](https://github.com/dfinity/sol-rpc-canister). However, it still does not support Solana Testnet (not Devnet). After a small analysis, we decided to remove the support on OISY side too.

In this PR, we remove it from the list of supported networks.
