### PR TITLE
fix(frontend): Race condition in ICRC wallet worker with index canister

### DIFF
--- a/src/frontend/src/lib/schedulers/scheduler.ts
+++ b/src/frontend/src/lib/schedulers/scheduler.ts
@@ -51,7 +51,10 @@ export class SchedulerTimer {
 		const execute = async () => await this.executeJob<T>({ identity, ...rest });
 
 		// We sync the cycles now but also schedule the update after wards
-		await execute();
+		// We don't wait for the execution to finish before scheduling the next one, because, in case of error, there could be a race condition:
+		// the error would trigger another execution that first try and stop the timer, but the timer is still not set, so it would not stop it.
+		// TODO: If this doesn't really fix it, another solution is to loop the function that stops the timer, so that it will run until it is triggered at least once (or until a max number of attempts).
+		execute();
 
 		// Support for features that implement the exact same pattern of a repetitive task but, are currently not scheduled for being refreshed automatically.
 		if (interval === 'disabled') {

--- a/src/frontend/src/tests/lib/schedulers/scheduler.spec.ts
+++ b/src/frontend/src/tests/lib/schedulers/scheduler.spec.ts
@@ -1,0 +1,307 @@
+import { SchedulerTimer } from '$lib/schedulers/scheduler';
+import * as authUtils from '$lib/utils/auth.utils';
+import { loadIdentity } from '$lib/utils/auth.utils';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { expect, vi, type MockInstance } from 'vitest';
+
+describe('scheduler', () => {
+	describe('SchedulerTimer', () => {
+		let originalPostmessage: unknown;
+
+		let scheduler: SchedulerTimer;
+
+		const mockInterval = 10000;
+		const mockJob = vi.fn();
+		const mockData = { value: 'mock-data' };
+
+		const mockParams = {
+			interval: mockInterval,
+			job: mockJob,
+			data: mockData
+		};
+
+		const statusMsg = 'syncIcWalletStatus';
+
+		const postMessageMock = vi.fn();
+
+		beforeAll(() => {
+			originalPostmessage = window.postMessage;
+			window.postMessage = postMessageMock;
+		});
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			vi.useFakeTimers();
+
+			scheduler = new SchedulerTimer(statusMsg);
+
+			vi.spyOn(authUtils, 'loadIdentity').mockResolvedValue(mockIdentity);
+		});
+
+		afterEach(() => {
+			scheduler.stop();
+
+			vi.useRealTimers();
+		});
+
+		afterAll(() => {
+			// @ts-expect-error redo original
+			window.postMessage = originalPostmessage;
+		});
+
+		describe('start', () => {
+			it('should not start if identity is nullish', async () => {
+				vi.spyOn(authUtils, 'loadIdentity').mockResolvedValueOnce(undefined);
+
+				await scheduler.start(mockParams);
+
+				expect(loadIdentity).toHaveBeenCalledOnce();
+
+				expect(console.error).toHaveBeenCalledOnce();
+				expect(console.error).toHaveBeenNthCalledWith(
+					1,
+					'Attempted to initiate a worker without an authenticated identity.'
+				);
+
+				expect(mockJob).not.toHaveBeenCalled();
+			});
+
+			it('should post initial and final status messages', async () => {
+				await scheduler.start(mockParams);
+
+				expect(postMessageMock).toHaveBeenCalledTimes(2);
+				expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+					msg: statusMsg,
+					data: { state: 'in_progress' }
+				});
+				expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+					msg: statusMsg,
+					data: { state: 'idle' }
+				});
+			});
+
+			it('should execute job once immediately', async () => {
+				await scheduler.start(mockParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+				expect(mockJob).toHaveBeenNthCalledWith(1, { identity: mockIdentity, data: mockData });
+			});
+
+			it('should set interval for the job', async () => {
+				await scheduler.start(mockParams);
+
+				vi.advanceTimersByTime(mockInterval);
+
+				expect(mockJob).toHaveBeenCalledTimes(2);
+				expect(mockJob).toHaveBeenNthCalledWith(1, { identity: mockIdentity, data: mockData });
+				expect(mockJob).toHaveBeenNthCalledWith(2, { identity: mockIdentity, data: mockData });
+			});
+
+			it('should not start a second timer if one exists', async () => {
+				vi.useRealTimers();
+
+				await scheduler.start(mockParams);
+				await scheduler.start(mockParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+			});
+
+			it('should not execute the job twice if one is in progress', async () => {
+				vi.useRealTimers();
+
+				mockJob.mockImplementationOnce(() => new Promise((resolve) => setTimeout(resolve, 1000)));
+
+				setTimeout(async () => await scheduler.start(mockParams), 500);
+
+				await scheduler.start(mockParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+			});
+
+			it('should not set timer if interval is not provided', async () => {
+				await scheduler.start({ ...mockParams, interval: 'disabled' });
+
+				expect(mockJob).toHaveBeenCalledOnce();
+
+				vi.advanceTimersByTime(mockInterval * 10);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+			});
+
+			it('should handle job errors', async () => {
+				mockJob.mockRejectedValueOnce(new Error('Job failed'));
+
+				await scheduler.start(mockParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+
+				expect(console.error).toHaveBeenCalledOnce();
+				expect(console.error).toHaveBeenNthCalledWith(1, new Error('Job failed'));
+
+				expect(postMessageMock).toHaveBeenCalledTimes(3);
+				expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+					msg: statusMsg,
+					data: { state: 'in_progress' }
+				});
+				expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+					msg: statusMsg,
+					data: { state: 'error' }
+				});
+				expect(postMessageMock).toHaveBeenNthCalledWith(3, {
+					msg: statusMsg,
+					data: { state: 'idle' }
+				});
+			});
+
+			it('should stop the timer if job throws error', async () => {
+				mockJob.mockRejectedValueOnce(new Error('Job failed'));
+
+				await scheduler.start(mockParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+
+				vi.advanceTimersByTime(mockInterval * 10);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+			});
+		});
+
+		describe('trigger', () => {
+			const { interval: _, ...mockTriggerParams } = mockParams;
+
+			it('should not trigger if identity is nullish', async () => {
+				vi.spyOn(authUtils, 'loadIdentity').mockResolvedValueOnce(undefined);
+
+				await scheduler.trigger(mockTriggerParams);
+
+				expect(loadIdentity).toHaveBeenCalledOnce();
+
+				expect(console.error).toHaveBeenCalledOnce();
+				expect(console.error).toHaveBeenNthCalledWith(
+					1,
+					'Attempted to execute a worker without an authenticated identity.'
+				);
+
+				expect(mockJob).not.toHaveBeenCalled();
+			});
+
+			it('should post initial and final status messages', async () => {
+				await scheduler.trigger(mockTriggerParams);
+
+				expect(postMessageMock).toHaveBeenCalledTimes(2);
+				expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+					msg: statusMsg,
+					data: { state: 'in_progress' }
+				});
+				expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+					msg: statusMsg,
+					data: { state: 'idle' }
+				});
+			});
+
+			it('should execute job', async () => {
+				await scheduler.trigger(mockTriggerParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+				expect(mockJob).toHaveBeenNthCalledWith(1, { identity: mockIdentity, data: mockData });
+			});
+
+			it('should not set interval for the job', async () => {
+				await scheduler.trigger(mockTriggerParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+
+				vi.advanceTimersByTime(mockInterval * 10);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+			});
+
+			it('should not execute the job twice if one is in progress', async () => {
+				vi.useRealTimers();
+
+				mockJob.mockImplementationOnce(() => new Promise((resolve) => setTimeout(resolve, 1000)));
+
+				setTimeout(async () => await scheduler.trigger(mockTriggerParams), 500);
+
+				await scheduler.trigger(mockTriggerParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+			});
+
+			it('should handle job errors', async () => {
+				mockJob.mockRejectedValueOnce(new Error('Job failed'));
+
+				await scheduler.trigger(mockTriggerParams);
+
+				expect(mockJob).toHaveBeenCalledOnce();
+
+				expect(console.error).toHaveBeenCalledOnce();
+				expect(console.error).toHaveBeenNthCalledWith(1, new Error('Job failed'));
+
+				expect(postMessageMock).toHaveBeenCalledTimes(3);
+				expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+					msg: statusMsg,
+					data: { state: 'in_progress' }
+				});
+				expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+					msg: statusMsg,
+					data: { state: 'error' }
+				});
+				expect(postMessageMock).toHaveBeenNthCalledWith(3, {
+					msg: statusMsg,
+					data: { state: 'idle' }
+				});
+			});
+		});
+
+		describe('stop', () => {
+			let spyClearInterval: MockInstance;
+
+			beforeEach(async () => {
+				await scheduler.start(mockParams);
+
+				spyClearInterval = vi.spyOn(global, 'clearInterval');
+			});
+
+			it('should stop the timer', () => {
+				vi.clearAllMocks();
+
+				scheduler.stop();
+
+				expect(spyClearInterval).toHaveBeenCalledOnce();
+
+				expect(postMessageMock).toHaveBeenCalledTimes(1);
+				expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+					msg: statusMsg,
+					data: { state: 'idle' }
+				});
+			});
+
+			it('should not throw if stop is called when timer is not running', () => {
+				scheduler.stop();
+
+				vi.clearAllMocks();
+
+				scheduler.stop();
+
+				expect(spyClearInterval).not.toHaveBeenCalled();
+
+				expect(postMessageMock).toHaveBeenCalledTimes(1);
+				expect(postMessageMock).toHaveBeenNthCalledWith(1, {
+					msg: statusMsg,
+					data: { state: 'idle' }
+				});
+			});
+		});
+
+		describe('postMsg', () => {
+			const msg = 'syncExchange';
+
+			it('should not post message if it is idle', () => {
+				scheduler.postMsg({ msg, data: mockData });
+
+				expect(postMessageMock).not.toHaveBeenCalled();
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We have a curious race condition: the wallet worker for a typical ICRC token with Index canister starts normally and raises an error if the index canister raises an error.
In this case, we decide to restart the worker without index canister (only ledger canister), to guarantee that at least the balance is being fetched.

However, the error is raised right before the interval of the first worker is set. That means that the first worker is not stopped before starting the new one, since the timer is `undefined`: we send a message to stop the worker before starting the new one, but this message find the interval still not set.

There are a few solutions for it. The one coded in this PR simply does not `await` the execution of the sync-wallet function (that one that would raise the error): doing so, makes it so with the utmost probability, the interval is already set when the function raise the error.

# Alternative Solution

Another solution would be to modify the stopTimer function so that it runs in loop until it is executed at least once (and max to a certain number of try).

# Tests

Added tests.
