### PR TITLE
feat(frontend): Remove address store for Solana Testnet

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -23,7 +23,6 @@
 		solAddressDevnet,
 		solAddressLocal,
 		solAddressMainnet,
-		solAddressTestnet
 	} from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
@@ -37,7 +36,6 @@
 		networkSolanaDevnetEnabled,
 		networkSolanaLocalEnabled,
 		networkSolanaMainnetEnabled,
-		networkSolanaTestnetEnabled
 	} from '$lib/derived/networks.derived';
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
 	import { ProgressStepsLoader } from '$lib/enums/progress-steps';
@@ -111,7 +109,6 @@
 	const debounceLoadBtcAddressRegtest = debounce(loadBtcAddressRegtest);
 
 	const debounceLoadSolAddressMainnet = debounce(loadSolAddressMainnet);
-	const debounceLoadSolAddressTestnet = debounce(loadSolAddressTestnet);
 	const debounceLoadSolAddressDevnet = debounce(loadSolAddressDevnet);
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
@@ -137,9 +134,7 @@
 				debounceLoadBtcAddressTestnet();
 			}
 
-			if ($networkSolanaTestnetEnabled && isNullish($solAddressTestnet)) {
-				debounceLoadSolAddressTestnet();
-			}
+
 
 			if ($networkSolanaDevnetEnabled && isNullish($solAddressDevnet)) {
 				debounceLoadSolAddressDevnet();

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -17,7 +17,6 @@
 		ethAddressNotLoaded,
 		btcAddressRegtestNotLoaded,
 		btcAddressTestnetNotLoaded,
-		solAddressTestnetNotLoaded,
 		solAddressLocalnetNotLoaded,
 		solAddressDevnetNotLoaded,
 		solAddressMainnetNotLoaded
@@ -114,9 +113,7 @@
 								? $solAddressDevnetNotLoaded
 								: isNetworkIdSOLLocal(id)
 									? $solAddressLocalnetNotLoaded
-									: isNetworkIdSOLTestnet(id)
-										? $solAddressTestnetNotLoaded
-										: false;
+									: false;
 
 	const onIcSendToken = async ({ detail: token }: CustomEvent<Token>) => {
 		if (isDisabled(token)) {

--- a/src/frontend/src/lib/derived/address.derived.ts
+++ b/src/frontend/src/lib/derived/address.derived.ts
@@ -5,8 +5,7 @@ import {
 	ethAddressStore,
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
-	solAddressMainnetStore,
-	solAddressTestnetStore
+	solAddressMainnetStore
 } from '$lib/stores/address.store';
 import type {
 	BtcAddress,
@@ -43,11 +42,6 @@ export const ethAddressNotLoaded: Readable<boolean> = derived(
 export const solAddressMainnetNotLoaded: Readable<boolean> = derived(
 	[solAddressMainnetStore],
 	([$solAddressMainnetStore]) => isNullish($solAddressMainnetStore)
-);
-
-export const solAddressTestnetNotLoaded: Readable<boolean> = derived(
-	[solAddressTestnetStore],
-	([$solAddressTestnetStore]) => isNullish($solAddressTestnetStore)
 );
 
 export const solAddressDevnetNotLoaded: Readable<boolean> = derived(
@@ -93,11 +87,6 @@ export const ethAddressNotCertified: Readable<boolean> = derived(
 export const solAddressMainnet: Readable<OptionSolAddress> = derived(
 	[solAddressMainnetStore],
 	([$solAddressMainnetStore]) => mapAddress<SolAddress>($solAddressMainnetStore)
-);
-
-export const solAddressTestnet: Readable<OptionSolAddress> = derived(
-	[solAddressTestnetStore],
-	([$solAddressTestnetStore]) => mapAddress<SolAddress>($solAddressTestnetStore)
 );
 
 export const solAddressDevnet: Readable<OptionSolAddress> = derived(

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -29,6 +29,5 @@ export const btcAddressMainnetStore = initAddressStore<BtcAddress>();
 export const ethAddressStore = initAddressStore<EthAddress>();
 
 export const solAddressMainnetStore = initAddressStore<SolAddress>();
-export const solAddressTestnetStore = initAddressStore<SolAddress>();
 export const solAddressDevnetStore = initAddressStore<SolAddress>();
 export const solAddressLocalnetStore = initAddressStore<SolAddress>();

--- a/src/frontend/src/sol/components/receive/SolReceive.svelte
+++ b/src/frontend/src/sol/components/receive/SolReceive.svelte
@@ -9,7 +9,6 @@
 		solAddressDevnetStore,
 		solAddressLocalnetStore,
 		solAddressMainnetStore,
-		solAddressTestnetStore,
 		type StorageAddressData
 	} from '$lib/stores/address.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -19,16 +18,13 @@
 	import {
 		isNetworkIdSOLDevnet,
 		isNetworkIdSOLLocal,
-		isNetworkIdSOLTestnet
 	} from '$lib/utils/network.utils';
 
 	export let token: Token;
 
 	let addressData: StorageAddressData<SolAddress>;
 	//TODO consolidate this logic together with btc into $networkAddress like it's done for ICP and ETH
-	$: addressData = isNetworkIdSOLTestnet($networkId)
-		? $solAddressTestnetStore
-		: isNetworkIdSOLDevnet($networkId)
+	$: addressData =  isNetworkIdSOLDevnet($networkId)
 			? $solAddressDevnetStore
 			: isNetworkIdSOLLocal($networkId)
 				? $solAddressLocalnetStore

--- a/src/frontend/src/sol/schema/network.schema.ts
+++ b/src/frontend/src/sol/schema/network.schema.ts
@@ -6,7 +6,7 @@ export const SolRpcConnectionConfigSchema = z.object({
 	websocketUrl: UrlSchema
 });
 
-export const SolanaNetworkSchema = z.enum(['mainnet', 'testnet', 'devnet', 'local']);
+export const SolanaNetworkSchema = z.enum(['mainnet', 'devnet', 'local']);
 
 export const SolanaChainIdSchema = z.object({
 	chainId: z.string().optional()

--- a/src/frontend/src/sol/services/sol-address.services.ts
+++ b/src/frontend/src/sol/services/sol-address.services.ts
@@ -2,15 +2,13 @@ import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_KEY_ID,
 	SOLANA_LOCAL_NETWORK_ID,
-	SOLANA_MAINNET_NETWORK_ID,
-	SOLANA_TESTNET_NETWORK_ID
+	SOLANA_MAINNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
 import {
 	getIdbSolAddressMainnet,
 	setIdbSolAddressDevnet,
 	setIdbSolAddressLocal,
 	setIdbSolAddressMainnet,
-	setIdbSolAddressTestnet,
 	updateIdbSolAddressMainnetLastUsage
 } from '$lib/api/idb-addresses.api';
 import { getSchnorrPublicKey } from '$lib/api/signer.api';
@@ -25,7 +23,6 @@ import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
 	solAddressMainnetStore,
-	solAddressTestnetStore,
 	type StorageAddressData
 } from '$lib/stores/address.store';
 import type { SolAddress } from '$lib/types/address';
@@ -62,9 +59,6 @@ const getSolAddress = async ({
 export const getSolAddressMainnet = async (identity: OptionIdentity): Promise<SolAddress> =>
 	await getSolAddress({ identity, derivationPath: [SolanaNetworks.mainnet] });
 
-export const getSolAddressTestnet = async (identity: OptionIdentity): Promise<SolAddress> =>
-	await getSolAddress({ identity, derivationPath: [SolanaNetworks.testnet] });
-
 export const getSolAddressDevnet = async (identity: OptionIdentity): Promise<SolAddress> =>
 	await getSolAddress({ identity, derivationPath: [SolanaNetworks.devnet] });
 
@@ -79,11 +73,6 @@ const solanaMapper: Record<
 		addressStore: solAddressMainnetStore,
 		getAddress: getSolAddressMainnet,
 		setIdbAddress: setIdbSolAddressMainnet
-	},
-	testnet: {
-		addressStore: solAddressTestnetStore,
-		getAddress: getSolAddressTestnet,
-		setIdbAddress: setIdbSolAddressTestnet
 	},
 	devnet: {
 		addressStore: solAddressDevnetStore,
@@ -113,12 +102,6 @@ export const loadSolAddressMainnet = (): Promise<ResultSuccess> =>
 	loadSolAddress({
 		networkId: SOLANA_MAINNET_NETWORK_ID,
 		network: SolanaNetworks.mainnet
-	});
-
-export const loadSolAddressTestnet = (): Promise<ResultSuccess> =>
-	loadSolAddress({
-		networkId: SOLANA_TESTNET_NETWORK_ID,
-		network: SolanaNetworks.testnet
 	});
 
 export const loadSolAddressDevnet = (): Promise<ResultSuccess> =>

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -1,8 +1,7 @@
 import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
-	solAddressMainnetStore,
-	solAddressTestnetStore
+	solAddressMainnetStore
 } from '$lib/stores/address.store';
 import type { WalletWorker } from '$lib/types/listener';
 import type {
@@ -11,11 +10,7 @@ import type {
 	PostMessageDataResponseError
 } from '$lib/types/post-message';
 import type { Token } from '$lib/types/token';
-import {
-	isNetworkIdSOLDevnet,
-	isNetworkIdSOLLocal,
-	isNetworkIdSOLTestnet
-} from '$lib/utils/network.utils';
+import { isNetworkIdSOLDevnet, isNetworkIdSOLLocal } from '$lib/utils/network.utils';
 import { syncWallet, syncWalletError } from '$sol/services/sol-listener.services';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
@@ -32,7 +27,6 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
-	const isTestnetNetwork = isNetworkIdSOLTestnet(networkId);
 	const isDevnetNetwork = isNetworkIdSOLDevnet(networkId);
 	const isLocalNetwork = isNetworkIdSOLLocal(networkId);
 
@@ -59,13 +53,11 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 
 	// TODO: stop/start the worker on address change (same as for worker.btc-wallet.services.ts)
 	const address = get(
-		isTestnetNetwork
-			? solAddressTestnetStore
-			: isDevnetNetwork
-				? solAddressDevnetStore
-				: isLocalNetwork
-					? solAddressLocalnetStore
-					: solAddressMainnetStore
+		isDevnetNetwork
+			? solAddressDevnetStore
+			: isLocalNetwork
+				? solAddressLocalnetStore
+				: solAddressMainnetStore
 	);
 	assertNonNullish(address, 'No Solana address provided to start Solana wallet worker.');
 

--- a/src/frontend/src/tests/lib/derived/address.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/address.derived.spec.ts
@@ -5,8 +5,7 @@ import {
 	ethAddressNotLoaded,
 	solAddressDevnetNotLoaded,
 	solAddressLocalnetNotLoaded,
-	solAddressMainnetNotLoaded,
-	solAddressTestnetNotLoaded
+	solAddressMainnetNotLoaded
 } from '$lib/derived/address.derived';
 import {
 	btcAddressMainnetStore,
@@ -16,7 +15,6 @@ import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
 	solAddressMainnetStore,
-	solAddressTestnetStore,
 	type AddressStore
 } from '$lib/stores/address.store';
 import type { BtcAddress, EthAddress, SolAddress } from '$lib/types/address';
@@ -33,7 +31,6 @@ describe('address.derived', () => {
 		['btcAddressRegtestNotLoaded', btcAddressRegtestStore, btcAddressRegtestNotLoaded],
 		['ethAddressNotLoaded', ethAddressStore, ethAddressNotLoaded],
 		['solAddressMainnetNotLoaded', solAddressMainnetStore, solAddressMainnetNotLoaded],
-		['solAddressTestnetNotLoaded', solAddressTestnetStore, solAddressTestnetNotLoaded],
 		['solAddressDevnetNotLoaded', solAddressDevnetStore, solAddressDevnetNotLoaded],
 		['solAddressLocalnetNotLoaded', solAddressLocalnetStore, solAddressLocalnetNotLoaded]
 	];

--- a/src/frontend/src/tests/sol/components/core/SolLoaderWallets.spec.ts
+++ b/src/frontend/src/tests/sol/components/core/SolLoaderWallets.spec.ts
@@ -3,8 +3,7 @@ import * as appConstants from '$lib/constants/app.constants';
 import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
-	solAddressMainnetStore,
-	solAddressTestnetStore
+	solAddressMainnetStore
 } from '$lib/stores/address.store';
 import SolLoaderWallets from '$sol/components/core/SolLoaderWallets.svelte';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
@@ -24,7 +23,6 @@ describe('SolLoaderWallets', () => {
 
 		// Reset all address stores
 		solAddressLocalnetStore.reset();
-		solAddressTestnetStore.reset();
 		solAddressDevnetStore.reset();
 		solAddressMainnetStore.reset();
 
@@ -80,7 +78,6 @@ describe('SolLoaderWallets', () => {
 
 	it('should handle all networks having addresses', () => {
 		solAddressLocalnetStore.set({ data: 'local-address', certified: true });
-		solAddressTestnetStore.set({ data: 'testnet-address', certified: true });
 		solAddressDevnetStore.set({ data: 'devnet-address', certified: true });
 		solAddressMainnetStore.set({ data: 'mainnet-address', certified: true });
 

--- a/src/frontend/src/tests/sol/components/tokens/SolTokenMenu.spec.ts
+++ b/src/frontend/src/tests/sol/components/tokens/SolTokenMenu.spec.ts
@@ -7,11 +7,7 @@ import {
 	TOKEN_MENU_SOL_BUTTON,
 	TOKEN_MENU_SOL_EXPLORER_LINK
 } from '$lib/constants/test-ids.constants';
-import {
-	solAddressDevnetStore,
-	solAddressMainnetStore,
-	solAddressTestnetStore
-} from '$lib/stores/address.store';
+import { solAddressDevnetStore, solAddressMainnetStore } from '$lib/stores/address.store';
 import { token as tokenStore } from '$lib/stores/token.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import SolTokenMenu from '$sol/components/tokens/SolTokenMenu.svelte';
@@ -32,7 +28,6 @@ describe('SolTokenMenu', () => {
 		mockPage.reset();
 
 		solAddressMainnetStore.reset();
-		solAddressTestnetStore.reset();
 		solAddressDevnetStore.reset();
 
 		// In component TokenMenu there is a dependency to the store erc20UserTokensStore that impedes the correct rendering of the component

--- a/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-address.services.spec.ts
@@ -5,8 +5,7 @@ import * as signerApi from '$lib/api/signer.api';
 import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
-	solAddressMainnetStore,
-	solAddressTestnetStore
+	solAddressMainnetStore
 } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
 import * as toastsStore from '$lib/stores/toasts.store';
@@ -22,7 +21,6 @@ import {
 	loadSolAddressDevnet,
 	loadSolAddressLocal,
 	loadSolAddressMainnet,
-	loadSolAddressTestnet,
 	validateSolAddressMainnet
 } from '$sol/services/sol-address.services';
 import { SolanaNetworks } from '$sol/types/network';
@@ -98,7 +96,6 @@ describe('sol-address.services', () => {
 
 		const loadCases = [
 			['mainnet', loadSolAddressMainnet, solAddressMainnetStore],
-			['testnet', loadSolAddressTestnet, solAddressTestnetStore],
 			['devnet', loadSolAddressDevnet, solAddressDevnetStore],
 			['local', loadSolAddressLocal, solAddressLocalnetStore]
 		] as const;


### PR DESCRIPTION
# Motivation

We want to start integrating the [Solana RPC canister](https://github.com/dfinity/sol-rpc-canister). However, it still does not support Solana Testnet (not Devnet). After a small analysis, we decided to remove the support on OISY side too.

In this PR, we remove the address store, its derived and any other usage related to it (for example IDB).
