### PR TITLE
feat(frontend): implements new hangover campaign requirement

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
@@ -4,7 +4,7 @@
 	import { RewardCriterionType } from '$lib/enums/reward-criterion-type';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type {
-		CampaignCriterion,
+		CampaignCriterion, HangoverCriterion,
 		MinLoginsCriterion,
 		MinTotalAssetsUsdCriterion,
 		MinTransactionsCriterion
@@ -40,6 +40,13 @@
 
 			return replacePlaceholders($i18n.rewards.requirements.min_total_assets_usd, {
 				$usd: minTotalAssetsUsdCriterion.usd.toString()
+			});
+		}
+		if (RewardCriterionType.HANGOVER === criterion.type) {
+			const hangoverCriterion = criterion as HangoverCriterion;
+
+			return replacePlaceholders($i18n.rewards.requirements.hangover, {
+				$days: hangoverCriterion.days.toString()
 			});
 		}
 	};

--- a/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
@@ -4,7 +4,8 @@
 	import { RewardCriterionType } from '$lib/enums/reward-criterion-type';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type {
-		CampaignCriterion, HangoverCriterion,
+		CampaignCriterion,
+		HangoverCriterion,
 		MinLoginsCriterion,
 		MinTotalAssetsUsdCriterion,
 		MinTransactionsCriterion

--- a/src/frontend/src/lib/enums/reward-criterion-type.ts
+++ b/src/frontend/src/lib/enums/reward-criterion-type.ts
@@ -4,5 +4,6 @@ export enum RewardCriterionType {
 	MIN_REFERRALS = 'min_referrals',
 	MIN_LOGINS = 'min_logins',
 	MIN_TOTAL_ASSETS_USD = 'min_total_assets_usd',
-	MIN_TOKENS = 'min_tokens'
+	MIN_TOKENS = 'min_tokens',
+	HANGOVER = 'hangover'
 }

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -207,7 +207,8 @@
 			"requirements_title": "Eligibility criteria",
 			"min_logins": "Login $loginsx in last $days days",
 			"min_transactions": "Complete $transactions transactions in last $days days",
-			"min_total_assets_usd": "Hold $$usd worth of tokens at the time of issuance"
+			"min_total_assets_usd": "Hold $$usd worth of tokens at the time of issuance",
+			"hangover": "No recent win (last $days days)"
 		},
 		"alt": {
 			"upcoming_campaigns": "Keep an eye out for upcoming token drops! <a href=\"https://x.com/oisy\" target=\"_blank\">Follow us on X</a>, join our <a href=\"https://www.reddit.com/r/OISY/\" target=\"_blank\">Reddit</a>, or hop into <a href=\"https://discord.com/invite/ejBT7dQneK\" target=\"_blank\">Discord</a> to stay in the loop.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -204,6 +204,7 @@ interface I18nRewards {
 		min_logins: string;
 		min_transactions: string;
 		min_total_assets_usd: string;
+		hangover: string;
 	};
 	alt: { upcoming_campaigns: string; coming_soon: string; reward_banner: string };
 }

--- a/src/frontend/src/lib/types/reward.ts
+++ b/src/frontend/src/lib/types/reward.ts
@@ -77,3 +77,7 @@ export interface MinTransactionsCriterion extends CampaignCriterion {
 export interface MinTotalAssetsUsdCriterion extends CampaignCriterion {
 	usd: number;
 }
+
+export interface HangoverCriterion extends CampaignCriterion {
+	days: bigint;
+}

--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -4,7 +4,7 @@ import { RewardCriterionType } from '$lib/enums/reward-criterion-type';
 import { getRewards } from '$lib/services/reward.services';
 import type {
 	CampaignCriterion,
-	CampaignEligibility,
+	CampaignEligibility, HangoverCriterion,
 	MinLoginsCriterion,
 	MinTotalAssetsUsdCriterion,
 	MinTransactionsCriterion,
@@ -147,6 +147,18 @@ const mapCriterion = (criterion: CriterionEligibility): CampaignCriterion => {
 			type: RewardCriterionType.MIN_TOTAL_ASSETS_USD,
 			usd
 		} as MinTotalAssetsUsdCriterion;
+	}
+	if ('Hangover' in criterion.criterion) {
+		const duration = criterion.criterion.Hangover;
+		if ('Days' in duration) {
+			const days = duration.Days;
+			return {
+				satisfied: criterion.satisfied,
+				type: RewardCriterionType.HANGOVER,
+				days
+			} as HangoverCriterion;
+		}
+		return { satisfied: criterion.satisfied, type: RewardCriterionType.UNKNOWN };
 	}
 
 	return { satisfied: criterion.satisfied, type: RewardCriterionType.UNKNOWN };

--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -4,7 +4,8 @@ import { RewardCriterionType } from '$lib/enums/reward-criterion-type';
 import { getRewards } from '$lib/services/reward.services';
 import type {
 	CampaignCriterion,
-	CampaignEligibility, HangoverCriterion,
+	CampaignEligibility,
+	HangoverCriterion,
 	MinLoginsCriterion,
 	MinTotalAssetsUsdCriterion,
 	MinTransactionsCriterion,


### PR DESCRIPTION
# Motivation

We want to support the new `Hangover` requirement for the campaigns. With this requirement we show for how many days in a row you didn't win a reward.

# Changes

- supports `hangover` requirement

# Tests

**New:**

<img width="443" alt="image" src="https://github.com/user-attachments/assets/9b818cb5-9b4a-47ff-aec3-ee7078151cc1" />
