### PR TITLE
fix(frontend): Use convert context in component `SendInputDestination`

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -37,11 +37,9 @@
 
 	const convertContext = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
-	let sendTokenNetworkId: Readable<NetworkId> | undefined;
-	$: sendTokenNetworkId = nonNullish(sendContext) ? sendContext.sendTokenNetworkId : undefined;
+	const sendTokenNetworkId = nonNullish(sendContext) ? sendContext.sendTokenNetworkId : undefined;
 
-	let destinationToken: Readable<Token> | undefined;
-	$: destinationToken = nonNullish(convertContext) ? convertContext.destinationToken : undefined;
+	const destinationToken = nonNullish(convertContext) ? convertContext.destinationToken : undefined;
 
 	let destinationNetworkId: NetworkId | undefined;
 	$: destinationNetworkId = nonNullish(sendTokenNetworkId)

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -16,6 +16,7 @@
 	import { getNetworkContact } from '$lib/utils/contacts.utils';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { getKnownDestination } from '$lib/utils/known-destinations.utils';
+	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 
 	export let destination = '';
 	export let networkId: NetworkId | undefined = undefined;
@@ -31,6 +32,8 @@
 	const debounceValidate = debounce(validate);
 
 	const { sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const { destinationToken } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
 	let focused: boolean;
 	const onFocus = () => (focused = true);
@@ -49,7 +52,7 @@
 			getKnownDestination({
 				knownDestinations,
 				address: destination,
-				networkId: $sendTokenNetworkId
+				networkId: $sendTokenNetworkId ?? $destinationToken?.network.id
 			})
 		);
 
@@ -60,7 +63,7 @@
 			getNetworkContact({
 				networkContacts,
 				address: destination,
-				networkId: $sendTokenNetworkId
+				networkId: $sendTokenNetworkId ?? $destinationToken?.network.id
 			})
 		);
 </script>

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import type { Readable } from 'svelte/store';
 	import { slide } from 'svelte/transition';
 	import QrButton from '$lib/components/common/QrButton.svelte';
 	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
@@ -14,7 +13,6 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { NetworkId } from '$lib/types/network';
-	import type { Token } from '$lib/types/token';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { getNetworkContact } from '$lib/utils/contacts.utils';
 	import { isDesktop } from '$lib/utils/device.utils';

--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import type { Readable } from 'svelte/store';
 	import { slide } from 'svelte/transition';
 	import QrButton from '$lib/components/common/QrButton.svelte';
 	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
@@ -8,17 +9,16 @@
 	import { MIN_DESTINATION_LENGTH_FOR_ERROR_STATE } from '$lib/constants/app.constants';
 	import { DESTINATION_INPUT } from '$lib/constants/test-ids.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { NetworkContacts } from '$lib/types/contacts';
 	import type { NetworkId } from '$lib/types/network';
+	import type { Token } from '$lib/types/token';
 	import type { KnownDestinations } from '$lib/types/transactions';
 	import { getNetworkContact } from '$lib/utils/contacts.utils';
 	import { isDesktop } from '$lib/utils/device.utils';
 	import { getKnownDestination } from '$lib/utils/known-destinations.utils';
-	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
-	import type { Readable } from 'svelte/store';
-	import type { Token } from '$lib/types/token';
 
 	export let destination = '';
 	export let networkId: NetworkId | undefined = undefined;
@@ -37,15 +37,18 @@
 
 	const convertContext = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
 
-	let sendTokenNetworkId: Readable<NetworkId> | undefined
-	$: sendTokenNetworkId = nonNullish(sendContext) ? sendContext.sendTokenNetworkId : undefined
+	let sendTokenNetworkId: Readable<NetworkId> | undefined;
+	$: sendTokenNetworkId = nonNullish(sendContext) ? sendContext.sendTokenNetworkId : undefined;
 
-	let destinationToken :  Readable<Token> | undefined
+	let destinationToken: Readable<Token> | undefined;
 	$: destinationToken = nonNullish(convertContext) ? convertContext.destinationToken : undefined;
 
-	let destinationNetworkId: NetworkId | undefined
-	$: destinationNetworkId = nonNullish(sendTokenNetworkId) ? $sendTokenNetworkId :  nonNullish(destinationToken) ? $destinationToken?.network.id : undefined
-
+	let destinationNetworkId: NetworkId | undefined;
+	$: destinationNetworkId = nonNullish(sendTokenNetworkId)
+		? $sendTokenNetworkId
+		: nonNullish(destinationToken)
+			? $destinationToken?.network.id
+			: undefined;
 
 	let focused: boolean;
 	const onFocus = () => (focused = true);
@@ -59,7 +62,8 @@
 
 	let isNotKnownDestination = false;
 	$: isNotKnownDestination =
-		nonNullish(knownDestinations) && nonNullish(destinationNetworkId) &&
+		nonNullish(knownDestinations) &&
+		nonNullish(destinationNetworkId) &&
 		isNullish(
 			getKnownDestination({
 				knownDestinations,
@@ -70,12 +74,13 @@
 
 	let isNotNetworkContact = false;
 	$: isNotNetworkContact =
-		nonNullish(networkContacts) && nonNullish(destinationNetworkId) &&
+		nonNullish(networkContacts) &&
+		nonNullish(destinationNetworkId) &&
 		isNullish(
 			getNetworkContact({
 				networkContacts,
 				address: destination,
-				networkId:destinationNetworkId
+				networkId: destinationNetworkId
 			})
 		);
 </script>


### PR DESCRIPTION
# Motivation

The component `SendInputDestination` is used both in the send flow and in the convert flow. That means that, since we use the send context to define the destination network, we need to add the convert context for the same tasks too.