### PR TITLE
feat(frontend): updates win modal for season 4 wins

### DIFF
--- a/src/frontend/src/env/reward-campaigns.json
+++ b/src/frontend/src/env/reward-campaigns.json
@@ -42,10 +42,10 @@
 		"endDate": "2025-07-09T21:00:00.000Z",
 		"win": {
 			"default": {
-				"title": "Congratulations on earning today’s OISY Sprinkles!",
+				"title": "You got rewarded",
 				"banner": "/images/rewards/reward-received.svg",
-				"description": "Share your victory on Twitter to qualify for another chance to earn.",
-				"shareHref": "https://x.com/intent/post?text=Just%20scored%20free%20Bitcoin%20from%20%40OISY%20Wallet%20%F0%9F%AA%82%0AThey%E2%80%99re%20dropping%20sprinkles%20of%20%24BTC%20non-stop.%0AIf%20you%E2%80%99re%20not%20on%20OISY.com%20yet%2C%20now%E2%80%99s%20the%20time."
+				"description": "Your rewards just landed in your wallet<br>Don't forget to refer and stay active to win more",
+				"shareHref": "https://x.com/intent/post?text=Another%20%40OISY%20Sprinkle%20hit%20my%20wallet.%0AOne%20of%20the%20easiest%20airdrops%20in%20DeFi.%0ACheck%20OISY.com"
 			},
 			"jackpot": {
 				"title": "Congratulations on earning today’s largest OISY Sprinkles!",

--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Modal } from '@dfinity/gix-components';
+	import { Modal, Html } from '@dfinity/gix-components';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import Sprinkles from '$lib/components/sprinkles/Sprinkles.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -35,9 +35,7 @@
 
 		<div class="flex flex-col items-center gap-4 text-center">
 			<h3 class="my-3">{jackpot ? reward.win.jackpot.title : reward.win.default.title}</h3>
-			<span class="block w-full"
-				>{jackpot ? reward.win.jackpot.description : reward.win.default.description}</span
-			>
+			<Html text={jackpot ? reward.win.jackpot.description : reward.win.default.description} />
 
 			<Share
 				testId={REWARDS_STATE_MODAL_SHARE_BUTTON}

--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -5,17 +5,18 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import Share from '$lib/components/ui/Share.svelte';
 	import { TRACK_REWARD_CAMPAIGN_WIN_SHARE } from '$lib/constants/analytics.contants';
+	import { OISY_REWARDS_URL } from '$lib/constants/oisy.constants';
 	import {
-		REWARDS_STATE_MODAL_IMAGE_BANNER, REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR,
+		REWARDS_STATE_MODAL_IMAGE_BANNER,
+		REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR,
 		REWARDS_STATE_MODAL_SHARE_BUTTON
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { OISY_REWARDS_URL } from '$lib/constants/oisy.constants';
-	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 
 	interface Props {
 		reward: RewardCampaignDescription;

--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -9,11 +9,13 @@
 	import Share from '$lib/components/ui/Share.svelte';
 	import { TRACK_REWARD_CAMPAIGN_WIN_SHARE } from '$lib/constants/analytics.contants';
 	import {
-		REWARDS_STATE_MODAL_IMAGE_BANNER,
+		REWARDS_STATE_MODAL_IMAGE_BANNER, REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR,
 		REWARDS_STATE_MODAL_SHARE_BUTTON
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { OISY_REWARDS_URL } from '$lib/constants/oisy.constants';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 
 	interface Props {
 		reward: RewardCampaignDescription;
@@ -37,15 +39,28 @@
 			<h3 class="my-3">{jackpot ? reward.win.jackpot.title : reward.win.default.title}</h3>
 			<Html text={jackpot ? reward.win.jackpot.description : reward.win.default.description} />
 
-			<Share
-				testId={REWARDS_STATE_MODAL_SHARE_BUTTON}
-				text={$i18n.rewards.text.share}
-				href={jackpot ? reward.win.jackpot.shareHref : reward.win.default.shareHref}
-				trackEvent={{
-					name: TRACK_REWARD_CAMPAIGN_WIN_SHARE,
-					metadata: { campaignId: `${reward.id}`, type: `${jackpot ? 'jackpot' : 'airdrop'}` }
-				}}
-			/>
+			<div>
+				<ExternalLink
+					href={OISY_REWARDS_URL}
+					ariaLabel={$i18n.rewards.text.learn_more}
+					iconVisible={false}
+					asButton
+					styleClass="rounded-xl px-3 py-2 secondary-light mb-3"
+					testId={REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR}
+				>
+					{$i18n.rewards.text.learn_more}
+				</ExternalLink>
+
+				<Share
+					testId={REWARDS_STATE_MODAL_SHARE_BUTTON}
+					text={$i18n.rewards.text.share}
+					href={jackpot ? reward.win.jackpot.shareHref : reward.win.default.shareHref}
+					trackEvent={{
+						name: TRACK_REWARD_CAMPAIGN_WIN_SHARE,
+						metadata: { campaignId: `${reward.id}`, type: `${jackpot ? 'jackpot' : 'airdrop'}` }
+					}}
+				/>
+			</div>
 		</div>
 
 		{#snippet toolbar()}

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -138,6 +138,7 @@ export const REWARDS_MODAL = 'rewards-modal';
 export const REWARDS_MODAL_DATE_BADGE = 'rewards-modal-date-badge';
 export const REWARDS_MODAL_IMAGE_BANNER = 'rewards-modal-image-banner';
 export const REWARDS_STATE_MODAL_IMAGE_BANNER = 'reward-state-modal-image-banner';
+export const REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR = 'reward-state-modal-learn-more-anchor';
 export const REWARDS_STATE_MODAL_SHARE_BUTTON = 'reward-state-modal-share-button';
 export const REWARDS_BANNER = 'rewards-banner';
 export const REWARDS_REQUIREMENTS_STATUS = 'reward-requirement-status';

--- a/src/frontend/src/tests/lib/components/rewards/RewardStateModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardStateModal.spec.ts
@@ -1,14 +1,15 @@
 import { SPRINKLES_SEASON_1_EPISODE_3_ID } from '$env/reward-campaigns.env';
 import type { RewardCampaignDescription } from '$env/types/env-reward';
 import RewardStateModal from '$lib/components/rewards/RewardStateModal.svelte';
+import { OISY_REWARDS_URL } from '$lib/constants/oisy.constants';
 import {
-	REWARDS_STATE_MODAL_IMAGE_BANNER, REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR,
+	REWARDS_STATE_MODAL_IMAGE_BANNER,
+	REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR,
 	REWARDS_STATE_MODAL_SHARE_BUTTON
 } from '$lib/constants/test-ids.constants';
 import { mockRewardCampaigns } from '$tests/mocks/reward-campaigns.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
-import { OISY_REWARDS_URL } from '$lib/constants/oisy.constants';
 
 describe('RewardStateModal', () => {
 	const imageBannerSelector = `img[data-tid="${REWARDS_STATE_MODAL_IMAGE_BANNER}"]`;

--- a/src/frontend/src/tests/lib/components/rewards/RewardStateModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardStateModal.spec.ts
@@ -2,15 +2,17 @@ import { SPRINKLES_SEASON_1_EPISODE_3_ID } from '$env/reward-campaigns.env';
 import type { RewardCampaignDescription } from '$env/types/env-reward';
 import RewardStateModal from '$lib/components/rewards/RewardStateModal.svelte';
 import {
-	REWARDS_STATE_MODAL_IMAGE_BANNER,
+	REWARDS_STATE_MODAL_IMAGE_BANNER, REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR,
 	REWARDS_STATE_MODAL_SHARE_BUTTON
 } from '$lib/constants/test-ids.constants';
 import { mockRewardCampaigns } from '$tests/mocks/reward-campaigns.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
+import { OISY_REWARDS_URL } from '$lib/constants/oisy.constants';
 
 describe('RewardStateModal', () => {
 	const imageBannerSelector = `img[data-tid="${REWARDS_STATE_MODAL_IMAGE_BANNER}"]`;
+	const learnMoreSelector = `a[data-tid="${REWARDS_STATE_MODAL_LEARN_MORE_ANCHOR}"]`;
 	const shareSelector = `a[data-tid="${REWARDS_STATE_MODAL_SHARE_BUTTON}"]`;
 
 	it('should render modal content', () => {
@@ -33,6 +35,11 @@ describe('RewardStateModal', () => {
 
 		expect(imageBanner).toBeInTheDocument();
 		expect(imageBanner?.src).toContain(mockedReward.win.default.banner);
+
+		const learnMore: HTMLAnchorElement | null = container.querySelector(learnMoreSelector);
+
+		expect(learnMore).toBeInTheDocument();
+		expect(learnMore?.href).toBe(OISY_REWARDS_URL);
 
 		const share: HTMLAnchorElement | null = container.querySelector(shareSelector);
 
@@ -60,6 +67,11 @@ describe('RewardStateModal', () => {
 
 		expect(imageBanner).toBeInTheDocument();
 		expect(imageBanner?.src).toContain(mockedReward.win.jackpot.banner);
+
+		const learnMore: HTMLAnchorElement | null = container.querySelector(learnMoreSelector);
+
+		expect(learnMore).toBeInTheDocument();
+		expect(learnMore?.href).toBe(OISY_REWARDS_URL);
 
 		const share: HTMLAnchorElement | null = container.querySelector(shareSelector);
 


### PR DESCRIPTION
# Motivation

Every sprinkles season does have a custom win modal configuration. The configuration for season 4 needs some adjustments.

# Changes

- updates win modal for season 4

# Tests

**New:**
<img width="427" alt="image" src="https://github.com/user-attachments/assets/8b8e6400-d4dc-49a6-a21d-4535b88db2e8" />
