### PR TITLE
feat(frontend): expose remove_custom_token

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -83,6 +83,15 @@ export const removeUserToken = async ({
 	return removeUserToken(restParams);
 };
 
+export const removeCustomToken = async ({
+	identity,
+	...restParams
+}: CanisterApiFunctionParams<{ token: CustomToken }>): Promise<void> => {
+	const { removeCustomToken } = await backendCanister({ identity });
+
+	return removeCustomToken(restParams);
+};
+
 export const setManyUserTokens = async ({
 	identity,
 	tokens

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -98,6 +98,12 @@ export class BackendCanister extends Canister<BackendService> {
 		return remove_user_token(params);
 	};
 
+	removeCustomToken = ({ token }: { token: CustomToken }): Promise<void> => {
+		const { remove_custom_token } = this.caller({ certified: true });
+
+		return remove_custom_token(token);
+	};
+
 	createUserProfile = (): Promise<UserProfile> => {
 		const { create_user_profile } = this.caller({ certified: true });
 

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -1290,4 +1290,41 @@ describe('backend.canister', () => {
 			await expect(res).rejects.toThrow(mockResponseError);
 		});
 	});
+
+	describe('removeCustomToken', () => {
+		it('should call remove_custom_token method', async () => {
+			const params = {
+				token: mockedCustomToken
+			};
+			const response = undefined;
+
+			service.remove_custom_token.mockResolvedValue(response);
+
+			const { removeCustomToken } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await removeCustomToken(params);
+
+			expect(service.remove_custom_token).toHaveBeenCalledWith(params.token);
+			expect(res).toEqual(response);
+		});
+
+		it('should throw an error if remove_custom_token throws', async () => {
+			service.remove_custom_token.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { removeCustomToken } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = removeCustomToken({
+				token: mockedCustomToken
+			});
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

In this PR, the new `remove_custom_token` endpoint is made available for the client.