### PR TITLE
feat(backend): Remove Solana Testnet (not Devnet) from backend

### DIFF
--- a/src/backend/tests/it/settings/networks_settings.rs
+++ b/src/backend/tests/it/settings/networks_settings.rs
@@ -44,7 +44,7 @@ lazy_static! {
             },
         );
         map.insert(
-            NetworkSettingsFor::SolanaTestnet,
+            NetworkSettingsFor::SolanaDevnet,
             NetworkSettings {
                 enabled: true,
                 is_testnet: true,
@@ -83,7 +83,7 @@ lazy_static! {
             },
         );
         map.insert(
-            NetworkSettingsFor::SolanaTestnet,
+            NetworkSettingsFor::SolanaDevnet,
             NetworkSettings {
                 enabled: true,
                 is_testnet: true,

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -25,8 +25,7 @@ import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,
-	SOLANA_MAINNET_NETWORK_ID,
-	SOLANA_TESTNET_NETWORK_ID
+	SOLANA_MAINNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
@@ -78,9 +77,6 @@ export const userNetworks: Readable<UserNetworks> = derived(
 			}
 			if ('SolanaMainnet' in key) {
 				return SOLANA_MAINNET_NETWORK_ID;
-			}
-			if ('SolanaTestnet' in key) {
-				return SOLANA_TESTNET_NETWORK_ID;
 			}
 			if ('SolanaDevnet' in key) {
 				return SOLANA_DEVNET_NETWORK_ID;

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -308,7 +308,6 @@ describe('Loader', () => {
 								networks: [
 									[{ BitcoinMainnet: null }, { enabled: false, is_testnet: false }],
 									[{ SolanaMainnet: null }, { enabled: true, is_testnet: false }],
-									[{ SolanaTestnet: null }, { enabled: true, is_testnet: true }],
 									[{ SolanaDevnet: null }, { enabled: false, is_testnet: true }]
 								]
 							}

--- a/src/shared/src/types/account.rs
+++ b/src/shared/src/types/account.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use super::token_id::TokenId;
 use crate::types::network::marker_trait::{
     BitcoinMainnet, BitcoinRegtest, BitcoinTestnet, EthereumMainnet, EthereumSepolia,
-    InternetComputer, Network, SolanaDevnet, SolanaLocal, SolanaMainnet, SolanaTestnet,
+    InternetComputer, Network, SolanaDevnet, SolanaLocal, SolanaMainnet,
 };
 
 pub mod conversion;
@@ -59,11 +59,9 @@ pub struct IcrcSubaccountId(pub [u8; 32]);
 pub struct SolPrincipal(pub String);
 impl AccountId<SolanaMainnet> for SolPrincipal {}
 impl AccountId<SolanaDevnet> for SolPrincipal {}
-impl AccountId<SolanaTestnet> for SolPrincipal {}
 impl AccountId<SolanaLocal> for SolPrincipal {}
 impl TokenId<SolanaMainnet> for SolPrincipal {}
 impl TokenId<SolanaDevnet> for SolPrincipal {}
-impl TokenId<SolanaTestnet> for SolPrincipal {}
 impl TokenId<SolanaLocal> for SolPrincipal {}
 
 /// A bitcoin address

--- a/src/shared/src/types/network.rs
+++ b/src/shared/src/types/network.rs
@@ -157,11 +157,6 @@ pub mod marker_trait {
     pub struct SolanaDevnet {}
     impl Network for SolanaDevnet {}
 
-    /// A marker trait, used to indicate that a type is to be used with the Solana testnet.
-    #[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-    pub struct SolanaTestnet {}
-    impl Network for SolanaTestnet {}
-
     #[derive(CandidType, Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
     pub struct SolanaLocal {}
     impl Network for SolanaLocal {}

--- a/src/shared/src/types/snapshot.rs
+++ b/src/shared/src/types/snapshot.rs
@@ -9,7 +9,7 @@ use crate::types::{
     account::{AccountId, BtcAddress, EthAddress, Icrcv2AccountId, SolPrincipal},
     network::marker_trait::{
         BitcoinMainnet, BitcoinRegtest, BitcoinTestnet, EthereumMainnet, EthereumSepolia,
-        InternetComputer, Network, SolanaDevnet, SolanaLocal, SolanaMainnet, SolanaTestnet,
+        InternetComputer, Network, SolanaDevnet, SolanaLocal, SolanaMainnet,
     },
     number::ComparableFloat,
     token_id::{BtcTokenId, EthTokenId, IcrcTokenId, SolTokenId, TokenId},
@@ -43,11 +43,9 @@ pub enum AccountSnapshotFor {
     Icrcv2(AccountSnapshot<InternetComputer, Icrcv2AccountId, IcrcTokenId>),
     SolDevnet(AccountSnapshot<SolanaDevnet, SolPrincipal, SolTokenId>),
     SolMainnet(AccountSnapshot<SolanaMainnet, SolPrincipal, SolTokenId>),
-    SolTestnet(AccountSnapshot<SolanaTestnet, SolPrincipal, SolTokenId>),
     SolLocal(AccountSnapshot<SolanaLocal, SolPrincipal, SolTokenId>),
     SplMainnet(AccountSnapshot<SolanaMainnet, SolPrincipal, SolTokenId>),
     SplDevnet(AccountSnapshot<SolanaDevnet, SolPrincipal, SolTokenId>),
-    SplTestnet(AccountSnapshot<SolanaTestnet, SolPrincipal, SolTokenId>),
     SplLocal(AccountSnapshot<SolanaLocal, SolPrincipal, SolTokenId>),
     BtcMainnet(AccountSnapshot<BitcoinMainnet, BtcAddress, BtcTokenId>),
     BtcTestnet(AccountSnapshot<BitcoinTestnet, BtcAddress, BtcTokenId>),
@@ -68,9 +66,6 @@ impl AccountSnapshotFor {
                 snapshot.timestamp
             }
             AccountSnapshotFor::SolMainnet(snapshot) | AccountSnapshotFor::SplMainnet(snapshot) => {
-                snapshot.timestamp
-            }
-            AccountSnapshotFor::SolTestnet(snapshot) | AccountSnapshotFor::SplTestnet(snapshot) => {
                 snapshot.timestamp
             }
             AccountSnapshotFor::SolLocal(snapshot) | AccountSnapshotFor::SplLocal(snapshot) => {
@@ -96,9 +91,6 @@ impl AccountSnapshotFor {
             AccountSnapshotFor::SolMainnet(snapshot) | AccountSnapshotFor::SplMainnet(snapshot) => {
                 snapshot.decimals
             }
-            AccountSnapshotFor::SolTestnet(snapshot) | AccountSnapshotFor::SplTestnet(snapshot) => {
-                snapshot.decimals
-            }
             AccountSnapshotFor::SolLocal(snapshot) | AccountSnapshotFor::SplLocal(snapshot) => {
                 snapshot.decimals
             }
@@ -122,9 +114,6 @@ impl AccountSnapshotFor {
             AccountSnapshotFor::SolMainnet(snapshot) | AccountSnapshotFor::SplMainnet(snapshot) => {
                 snapshot.approx_usd_per_token
             }
-            AccountSnapshotFor::SolTestnet(snapshot) | AccountSnapshotFor::SplTestnet(snapshot) => {
-                snapshot.approx_usd_per_token
-            }
             AccountSnapshotFor::SolLocal(snapshot) | AccountSnapshotFor::SplLocal(snapshot) => {
                 snapshot.approx_usd_per_token
             }
@@ -146,9 +135,6 @@ impl AccountSnapshotFor {
                 snapshot.amount
             }
             AccountSnapshotFor::SolMainnet(snapshot) | AccountSnapshotFor::SplMainnet(snapshot) => {
-                snapshot.amount
-            }
-            AccountSnapshotFor::SolTestnet(snapshot) | AccountSnapshotFor::SplTestnet(snapshot) => {
                 snapshot.amount
             }
             AccountSnapshotFor::SolLocal(snapshot) | AccountSnapshotFor::SplLocal(snapshot) => {
@@ -191,11 +177,6 @@ impl AccountSnapshotFor {
                 .iter()
                 .map(|t| t.timestamp)
                 .collect(),
-            AccountSnapshotFor::SolTestnet(snapshot) => snapshot
-                .last_transactions
-                .iter()
-                .map(|t| t.timestamp)
-                .collect(),
             AccountSnapshotFor::SolLocal(snapshot) => snapshot
                 .last_transactions
                 .iter()
@@ -207,11 +188,6 @@ impl AccountSnapshotFor {
                 .map(|t| t.timestamp)
                 .collect(),
             AccountSnapshotFor::SplDevnet(snapshot) => snapshot
-                .last_transactions
-                .iter()
-                .map(|t| t.timestamp)
-                .collect(),
-            AccountSnapshotFor::SplTestnet(snapshot) => snapshot
                 .last_transactions
                 .iter()
                 .map(|t| t.timestamp)


### PR DESCRIPTION
# Motivation

We want to start integrating the [Solana RPC canister](https://github.com/dfinity/sol-rpc-canister). However, it still does not support Solana Testnet (not Devnet). After a small analysis, we decided to remove the support on OISY side too.

In this PR, we remove Solana Testnet from the backend.
