### PR TITLE
refactor(frontend): Remove unnecessary worker stop in `initIcrcWalletWorker`

### DIFF
--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -25,9 +25,6 @@ export const initIcrcWalletWorker = async ({
 	let restartedWithLedgerOnly = false;
 
 	const restartWorkerWithLedgerOnly = () => {
-		// For good measure, we stop the worker before restarting it with ledger only
-		stop();
-
 		if (restartedWithLedgerOnly) {
 			return;
 		}
@@ -83,12 +80,6 @@ export const initIcrcWalletWorker = async ({
 		}
 	};
 
-	const stop = () => {
-		worker.postMessage({
-			msg: 'stopIcrcWalletTimer'
-		});
-	};
-
 	return {
 		start: () => {
 			worker.postMessage({
@@ -100,7 +91,11 @@ export const initIcrcWalletWorker = async ({
 				}
 			});
 		},
-		stop,
+		stop: () => {
+			worker.postMessage({
+				msg: 'stopIcrcWalletTimer'
+			});
+		},
 		trigger: () => {
 			worker.postMessage({
 				msg: 'triggerIcrcWalletTimer',

--- a/src/frontend/src/lib/schedulers/scheduler.ts
+++ b/src/frontend/src/lib/schedulers/scheduler.ts
@@ -100,31 +100,8 @@ export class SchedulerTimer {
 	}
 
 	stop() {
-		const stopFn = () => {
-			this.stopTimer();
-			this.setStatus('idle');
-		};
-
-		stopFn();
-
-		let attempts = 0;
-
-		const tryStop = () => {
-			if (attempts >= 100) {
-				return;
-			}
-
-			if (nonNullish(this.timer)) {
-				stopFn();
-				return;
-			}
-
-			attempts++;
-
-			setTimeout(tryStop, 0);
-		};
-
-		tryStop();
+		this.stopTimer();
+		this.setStatus('idle');
 	}
 
 	postMsg<T>(data: { msg: PostMessageResponse; data?: T }) {

--- a/src/frontend/src/lib/schedulers/scheduler.ts
+++ b/src/frontend/src/lib/schedulers/scheduler.ts
@@ -100,8 +100,31 @@ export class SchedulerTimer {
 	}
 
 	stop() {
-		this.stopTimer();
-		this.setStatus('idle');
+		const stopFn = () => {
+			this.stopTimer();
+			this.setStatus('idle');
+		};
+
+		stopFn();
+
+		let attempts = 0;
+
+		const tryStop = () => {
+			if (attempts >= 100) {
+				return;
+			}
+
+			if (nonNullish(this.timer)) {
+				stopFn();
+				return;
+			}
+
+			attempts++;
+
+			setTimeout(tryStop, 0);
+		};
+
+		tryStop();
 	}
 
 	postMsg<T>(data: { msg: PostMessageResponse; data?: T }) {

--- a/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
@@ -141,11 +141,8 @@ describe('worker.icrc-wallet.services', () => {
 					};
 					workerInstance.onmessage?.({ data: payload } as MessageEvent);
 
-					expect(postMessageSpy).toHaveBeenCalledTimes(2);
+					expect(postMessageSpy).toHaveBeenCalledTimes(1);
 					expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
-						msg: 'stopIcrcWalletTimer'
-					});
-					expect(postMessageSpy).toHaveBeenNthCalledWith(2, {
 						msg: 'startIcrcWalletTimer',
 						data: {
 							ledgerCanisterId,
@@ -164,23 +161,13 @@ describe('worker.icrc-wallet.services', () => {
 						workerInstance.onmessage?.({ data: payload } as MessageEvent);
 					});
 
-					expect(postMessageSpy).toHaveBeenCalledTimes(10 + 1);
-
+					expect(postMessageSpy).toHaveBeenCalledTimes(1);
 					expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
-						msg: 'stopIcrcWalletTimer'
-					});
-					expect(postMessageSpy).toHaveBeenNthCalledWith(2, {
 						msg: 'startIcrcWalletTimer',
 						data: {
 							ledgerCanisterId,
 							env
 						}
-					});
-
-					Array.from({ length: 8 }).forEach((_, index) => {
-						expect(postMessageSpy).toHaveBeenNthCalledWith(index + 3, {
-							msg: 'stopIcrcWalletTimer'
-						});
 					});
 				});
 			});


### PR DESCRIPTION
# Motivation

After PR #7337, we don't really need to call the worker stop, since it is correctly done when re-starting it.