### PR TITLE
feat(frontend): Remove IC wallet pagination in all transactions list

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
@@ -4,7 +4,6 @@
 	import { loadNextIcTransactionsByOldest } from '$icp/services/ic-transactions.services';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
-	import { ALL_TRANSACTIONS_WALLET_PAGINATION, WALLET_PAGINATION } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { transactionsStoreWithTokens } from '$lib/derived/transactions.derived';

--- a/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
@@ -4,7 +4,7 @@
 	import { loadNextIcTransactionsByOldest } from '$icp/services/ic-transactions.services';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
-	import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+	import { ALL_TRANSACTIONS_WALLET_PAGINATION, WALLET_PAGINATION } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { transactionsStoreWithTokens } from '$lib/derived/transactions.derived';
@@ -67,7 +67,7 @@
 					transactions: ($icTransactionsStore?.[tokenId] ?? []).map(({ data }) => data),
 					owner: $authIdentity.getPrincipal(),
 					identity: $authIdentity,
-					maxResults: WALLET_PAGINATION,
+					maxResults: ALL_TRANSACTIONS_WALLET_PAGINATION,
 					token,
 					signalEnd: () => (disableLoader[tokenId] = true)
 				});

--- a/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
@@ -67,7 +67,6 @@
 					transactions: ($icTransactionsStore?.[tokenId] ?? []).map(({ data }) => data),
 					owner: $authIdentity.getPrincipal(),
 					identity: $authIdentity,
-					maxResults: ALL_TRANSACTIONS_WALLET_PAGINATION,
 					token,
 					signalEnd: () => (disableLoader[tokenId] = true)
 				});

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -141,6 +141,7 @@ export const ZERO = 0n;
 // Wallets
 export const WALLET_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 2) * 1000; // 30 seconds in milliseconds
 export const WALLET_PAGINATION = 10n;
+export const ALL_TRANSACTIONS_WALLET_PAGINATION = 100n; // For the "All transactions" wallet, we want to load more transactions at once.
 // Solana wallets
 // Until we find a way to reduce the number of calls (that we pay proportionally) done to the Solana RPC, we delay them more than the other wallets.
 // TODO: Use the normal one when we have a better way to handle the Solana wallets, for example when we have the internal Solana RPC canister, or when we don't load again the transactions that are already loaded.

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -141,7 +141,6 @@ export const ZERO = 0n;
 // Wallets
 export const WALLET_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 2) * 1000; // 30 seconds in milliseconds
 export const WALLET_PAGINATION = 10n;
-export const ALL_TRANSACTIONS_WALLET_PAGINATION = 100n; // For the "All transactions" wallet, we want to load more transactions at once.
 // Solana wallets
 // Until we find a way to reduce the number of calls (that we pay proportionally) done to the Solana RPC, we delay them more than the other wallets.
 // TODO: Use the normal one when we have a better way to handle the Solana wallets, for example when we have the internal Solana RPC canister, or when we don't load again the transactions that are already loaded.

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsLoader.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsLoader.spec.ts
@@ -14,7 +14,6 @@ import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
 import AllTransactionsLoader from '$lib/components/transactions/AllTransactionsLoader.svelte';
-import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import type { Token } from '$lib/types/token';
 import type { AllTransactionUiWithCmp, Transaction } from '$lib/types/transaction';
 import * as transactionsUtils from '$lib/utils/transactions.utils';
@@ -271,7 +270,6 @@ describe('AllTransactionsLoader', () => {
 					transactions,
 					owner: mockIdentity.getPrincipal(),
 					identity: mockIdentity,
-					maxResults: WALLET_PAGINATION,
 					token,
 					signalEnd: expect.any(Function)
 				});
@@ -297,7 +295,6 @@ describe('AllTransactionsLoader', () => {
 					transactions,
 					owner: mockIdentity.getPrincipal(),
 					identity: mockIdentity,
-					maxResults: WALLET_PAGINATION,
 					token,
 					signalEnd: expect.any(Function)
 				});
@@ -321,7 +318,6 @@ describe('AllTransactionsLoader', () => {
 					transactions,
 					owner: mockIdentity.getPrincipal(),
 					identity: mockIdentity,
-					maxResults: WALLET_PAGINATION,
 					token,
 					signalEnd: expect.any(Function)
 				});
@@ -529,7 +525,6 @@ describe('AllTransactionsLoader', () => {
 				transactions,
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
-				maxResults: WALLET_PAGINATION,
 				token,
 				signalEnd: expect.any(Function)
 			});


### PR DESCRIPTION
# Motivation

For the activity page, it does not really make sense to paginate the loading of the missing transactions. pagination is useful for the scroller, but not when we first load the component.
