### PR TITLE
refactor(frontend): Make `burnStatus` util type-safe

### DIFF
--- a/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
@@ -175,11 +175,11 @@ const burnStatus = (
 				status: 'pending'
 			};
 		}
-
-		if (!('Confirmed' in retrieveBtcStatus)) {
-			console.error('Unknown retrieveBtcStatusV2:', retrieveBtcStatus);
-		}
 	}
+
+	// Force compiler error on unhandled cases based on leftover types
+	const _: { Confirmed: { txid: Uint8Array | number[] } } | { Unknown: null } | undefined | never =
+		retrieveBtcStatus;
 
 	return {
 		typeLabel: 'transaction.label.twin_token_sent',


### PR DESCRIPTION
# Motivation

When we map a ckBTC transaction, instead of raising a console error for unknown statuses, it is better to make it type-safe with the expected leftover types. In fact, we don't really act upon an unknown variant of the status.
