### PR TITLE
refactor(frontend): MessageBox was not fully upgraded to svelte 5

### DIFF
--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -62,7 +62,7 @@
 		{#if closable}
 			<button
 				class="ml-auto p-0.5 text-tertiary"
-				on:click={close}
+				onclick={close}
 				aria-label={$i18n.core.text.close}
 			>
 				<IconClose />


### PR DESCRIPTION


# Motivation

When upgrading `MessageBox` to svelte 5 the buttons `on:click` was not upgraded to `onclick`.

# Changes

- fixes buttons functions

