### PR TITLE
feat(frontend): improves hide token flow

### DIFF
--- a/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Identity } from '@dfinity/agent';
 	import { assertNonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onMount } from 'svelte';
 	import { loadErc20UserTokens } from '$eth/services/erc20.services';
 	import type { OptionErc20UserToken } from '$eth/types/erc20-user-token';
@@ -10,7 +11,6 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	export let from: NavigationTarget;
 

--- a/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
@@ -10,6 +10,9 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+
+	export let from: NavigationTarget;
 
 	let selectedToken: OptionErc20UserToken;
 
@@ -39,4 +42,4 @@
 	const updateUi = (params: { identity: Identity }): Promise<void> => loadErc20UserTokens(params);
 </script>
 
-<HideTokenModal {assertHide} {hideToken} {updateUi} />
+<HideTokenModal {assertHide} {hideToken} {updateUi} {from} />

--- a/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
@@ -12,7 +12,7 @@
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
-	export let from: NavigationTarget | undefined;
+	export let fromRoute: NavigationTarget | undefined;
 
 	let selectedToken: OptionErc20UserToken;
 
@@ -42,4 +42,4 @@
 	const updateUi = (params: { identity: Identity }): Promise<void> => loadErc20UserTokens(params);
 </script>
 
-<HideTokenModal {assertHide} {hideToken} {updateUi} {from} />
+<HideTokenModal {assertHide} {hideToken} {updateUi} {fromRoute} />

--- a/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/HideTokenModal.svelte
@@ -12,7 +12,7 @@
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
-	export let from: NavigationTarget;
+	export let from: NavigationTarget | undefined;
 
 	let selectedToken: OptionErc20UserToken;
 

--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -12,6 +12,9 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+
+	export let from: NavigationTarget;
 
 	let selectedToken: OptionIcrcCustomToken;
 
@@ -62,4 +65,4 @@
 	const updateUi = (params: { identity: Identity }): Promise<void> => loadCustomTokens(params);
 </script>
 
-<HideTokenModal {assertHide} {hideToken} {updateUi} />
+<HideTokenModal {assertHide} {hideToken} {updateUi} {from} />

--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -14,7 +14,7 @@
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
-	export let from: NavigationTarget;
+	export let from: NavigationTarget | undefined;
 
 	let selectedToken: OptionIcrcCustomToken;
 

--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -14,7 +14,7 @@
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
-	export let from: NavigationTarget | undefined;
+	export let fromRoute: NavigationTarget | undefined;
 
 	let selectedToken: OptionIcrcCustomToken;
 
@@ -65,4 +65,4 @@
 	const updateUi = (params: { identity: Identity }): Promise<void> => loadCustomTokens(params);
 </script>
 
-<HideTokenModal {assertHide} {hideToken} {updateUi} {from} />
+<HideTokenModal {assertHide} {hideToken} {updateUi} {fromRoute} />

--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -2,6 +2,7 @@
 	import type { Identity } from '@dfinity/agent';
 	import { Principal } from '@dfinity/principal';
 	import { assertNonNullish, nonNullish, toNullable } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onMount } from 'svelte';
 	import { loadCustomTokens } from '$icp/services/icrc.services';
 	import type { LedgerCanisterIdText } from '$icp/types/canister';
@@ -12,7 +13,6 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { token } from '$lib/stores/token.store';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	export let from: NavigationTarget;
 

--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -16,7 +16,9 @@
 		modalSettingsState,
 		modalReferralCode,
 		modalAddressBook,
-		modalVipQrCodeData, modalIcHideTokenData, modalHideTokenData
+		modalVipQrCodeData,
+		modalIcHideTokenData,
+		modalHideTokenData
 	} from '$lib/derived/modal.derived';
 
 	/**

--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -16,7 +16,7 @@
 		modalSettingsState,
 		modalReferralCode,
 		modalAddressBook,
-		modalVipQrCodeData
+		modalVipQrCodeData, modalIcHideTokenData, modalHideTokenData
 	} from '$lib/derived/modal.derived';
 
 	/**
@@ -25,10 +25,10 @@
 </script>
 
 {#if $authSignedIn}
-	{#if $modalHideToken}
-		<HideTokenModal />
-	{:else if $modalIcHideToken}
-		<IcHideTokenModal />
+	{#if $modalHideToken && nonNullish($modalHideTokenData)}
+		<HideTokenModal from={$modalHideTokenData} />
+	{:else if $modalIcHideToken && nonNullish($modalIcHideTokenData)}
+		<IcHideTokenModal from={$modalIcHideTokenData} />
 	{:else if $modalDAppDetails}
 		<DappModalDetails />
 	{:else if $modalVipQrCode && nonNullish($modalVipQrCodeData)}

--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -27,9 +27,9 @@
 </script>
 
 {#if $authSignedIn}
-	{#if $modalHideToken && nonNullish($modalHideTokenData)}
+	{#if $modalHideToken}
 		<HideTokenModal from={$modalHideTokenData} />
-	{:else if $modalIcHideToken && nonNullish($modalIcHideTokenData)}
+	{:else if $modalIcHideToken}
 		<IcHideTokenModal from={$modalIcHideTokenData} />
 	{:else if $modalDAppDetails}
 		<DappModalDetails />

--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -28,9 +28,9 @@
 
 {#if $authSignedIn}
 	{#if $modalHideToken}
-		<HideTokenModal from={$modalHideTokenData} />
+		<HideTokenModal fromRoute={$modalHideTokenData} />
 	{:else if $modalIcHideToken}
-		<IcHideTokenModal from={$modalIcHideTokenData} />
+		<IcHideTokenModal fromRoute={$modalIcHideTokenData} />
 	{:else if $modalDAppDetails}
 		<DappModalDetails />
 	{:else if $modalVipQrCode && nonNullish($modalVipQrCodeData)}

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -19,12 +19,12 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { ProgressSteps } from '$lib/types/progress-steps';
-	import { back } from '$lib/utils/nav.utils';
+	import { back, gotoReplaceRoot } from '$lib/utils/nav.utils';
 
 	export let assertHide: () => { valid: boolean };
 	export let hideToken: (params: { identity: Identity }) => Promise<void>;
 	export let updateUi: (params: { identity: Identity }) => Promise<void>;
-	export let from: NavigationTarget | null;
+	export let from: NavigationTarget | undefined;
 
 	const hide = async () => {
 		const { valid } = assertHide();
@@ -113,7 +113,7 @@
 		hideProgressStep = ProgressStepsHideToken.INITIALIZATION;
 	};
 
-	onDestroy(async () => await back({ pop: nonNullish(from) }));
+	onDestroy(async () => nonNullish(from) ? await back({ pop: nonNullish(from) }) : await gotoReplaceRoot());
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -7,6 +7,7 @@
 		type WizardSteps
 	} from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onDestroy } from 'svelte';
 	import HideTokenReview from '$lib/components/tokens/HideTokenReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
@@ -19,7 +20,6 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { ProgressSteps } from '$lib/types/progress-steps';
 	import { back } from '$lib/utils/nav.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	export let assertHide: () => { valid: boolean };
 	export let hideToken: (params: { identity: Identity }) => Promise<void>;
@@ -113,7 +113,7 @@
 		hideProgressStep = ProgressStepsHideToken.INITIALIZATION;
 	};
 
-	onDestroy(async () => await back({pop: nonNullish(from)}));
+	onDestroy(async () => await back({ pop: nonNullish(from) }));
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -113,7 +113,9 @@
 		hideProgressStep = ProgressStepsHideToken.INITIALIZATION;
 	};
 
-	onDestroy(async () => nonNullish(from) ? await back({ pop: nonNullish(from) }) : await gotoReplaceRoot());
+	onDestroy(async () =>
+		nonNullish(from) ? await back({ pop: nonNullish(from) }) : await gotoReplaceRoot()
+	);
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -24,7 +24,7 @@
 	export let assertHide: () => { valid: boolean };
 	export let hideToken: (params: { identity: Identity }) => Promise<void>;
 	export let updateUi: (params: { identity: Identity }) => Promise<void>;
-	export let from: NavigationTarget | undefined;
+	export let fromRoute: NavigationTarget | undefined;
 
 	const hide = async () => {
 		const { valid } = assertHide();
@@ -114,7 +114,7 @@
 	};
 
 	onDestroy(async () =>
-		nonNullish(from) ? await back({ pop: nonNullish(from) }) : await gotoReplaceRoot()
+		nonNullish(fromRoute) ? await back({ pop: nonNullish(fromRoute) }) : await gotoReplaceRoot()
 	);
 </script>
 

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -6,7 +6,7 @@
 		type WizardStep,
 		type WizardSteps
 	} from '@dfinity/gix-components';
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onDestroy } from 'svelte';
 	import HideTokenReview from '$lib/components/tokens/HideTokenReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
@@ -18,11 +18,13 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { ProgressSteps } from '$lib/types/progress-steps';
-	import { gotoReplaceRoot } from '$lib/utils/nav.utils';
+	import { back } from '$lib/utils/nav.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	export let assertHide: () => { valid: boolean };
 	export let hideToken: (params: { identity: Identity }) => Promise<void>;
 	export let updateUi: (params: { identity: Identity }) => Promise<void>;
+	export let from: NavigationTarget | null;
 
 	const hide = async () => {
 		const { valid } = assertHide();
@@ -111,7 +113,7 @@
 		hideProgressStep = ProgressStepsHideToken.INITIALIZATION;
 	};
 
-	onDestroy(async () => await gotoReplaceRoot());
+	onDestroy(async () => await back({pop: nonNullish(from)}));
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { Popover } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate } from '$app/navigation';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import IconMoreVertical from '$lib/components/icons/lucide/IconMoreVertical.svelte';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
@@ -17,8 +19,6 @@
 	import { token } from '$lib/stores/token.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
-	import { afterNavigate } from '$app/navigation';
 
 	export let testId: string | undefined = undefined;
 

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -17,18 +17,28 @@
 	import { token } from '$lib/stores/token.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate } from '$app/navigation';
 
 	export let testId: string | undefined = undefined;
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
+	let fromRoute: NavigationTarget | null;
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
 
 	const hideModalId = Symbol();
 	const openModalId = Symbol();
 
 	const hideToken = () => {
 		const fn = $networkICP ? modalStore.openIcHideToken : modalStore.openHideToken;
-		fn(hideModalId);
+		fn({
+			id: hideModalId,
+			data: fromRoute
+		});
 
 		visible = false;
 	};

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -34,15 +34,13 @@
 	const openModalId = Symbol();
 
 	const hideToken = () => {
-		if (nonNullish(fromRoute)) {
-			const fn = $networkICP ? modalStore.openIcHideToken : modalStore.openHideToken;
-			fn({
-				id: hideModalId,
-				data: fromRoute
-			});
+		const fn = $networkICP ? modalStore.openIcHideToken : modalStore.openHideToken;
+		fn({
+			id: hideModalId,
+			data: fromRoute
+		});
 
-			visible = false;
-		}
+		visible = false;
 	};
 
 	const openToken = () => {

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -24,10 +24,10 @@
 
 	let visible = false;
 	let button: HTMLButtonElement | undefined;
-	let fromRoute: NavigationTarget | null;
+	let fromRoute: NavigationTarget | undefined;
 
 	afterNavigate(({ from }) => {
-		fromRoute = from;
+		fromRoute = from ?? undefined;
 	});
 
 	const hideModalId = Symbol();

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -34,13 +34,15 @@
 	const openModalId = Symbol();
 
 	const hideToken = () => {
-		const fn = $networkICP ? modalStore.openIcHideToken : modalStore.openHideToken;
-		fn({
-			id: hideModalId,
-			data: fromRoute
-		});
+		if (nonNullish(fromRoute)) {
+			const fn = $networkICP ? modalStore.openIcHideToken : modalStore.openHideToken;
+			fn({
+				id: hideModalId,
+				data: fromRoute
+			});
 
-		visible = false;
+			visible = false;
+		}
 	};
 
 	const openToken = () => {

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -5,6 +5,7 @@ import { modalStore } from '$lib/stores/modal.store';
 import type { ManageTokensData } from '$lib/types/manage-tokens';
 import type { RewardStateData, VipRewardStateData } from '$lib/types/reward';
 import { derived, type Readable } from 'svelte/store';
+import type { NavigationTarget } from '@sveltejs/kit';
 
 export const modalEthReceive: Readable<boolean> = derived(
 	modalStore,
@@ -103,9 +104,17 @@ export const modalHideToken: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'hide-token'
 );
+export const modalHideTokenData: Readable<NavigationTarget> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
+);
 export const modalIcHideToken: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'ic-hide-token'
+);
+export const modalIcHideTokenData: Readable<NavigationTarget> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'ic-hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
 );
 export const modalBtcTransaction: Readable<boolean> = derived(
 	modalStore,

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -104,7 +104,7 @@ export const modalHideToken: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'hide-token'
 );
-export const modalHideTokenData: Readable<NavigationTarget> = derived(
+export const modalHideTokenData: Readable<NavigationTarget | undefined> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
 );
@@ -112,7 +112,7 @@ export const modalIcHideToken: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'ic-hide-token'
 );
-export const modalIcHideTokenData: Readable<NavigationTarget> = derived(
+export const modalIcHideTokenData: Readable<NavigationTarget | undefined> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'ic-hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
 );

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -4,8 +4,8 @@ import type { SettingsModalType } from '$lib/enums/settings-modal-types';
 import { modalStore } from '$lib/stores/modal.store';
 import type { ManageTokensData } from '$lib/types/manage-tokens';
 import type { RewardStateData, VipRewardStateData } from '$lib/types/reward';
-import { derived, type Readable } from 'svelte/store';
 import type { NavigationTarget } from '@sveltejs/kit';
+import { derived, type Readable } from 'svelte/store';
 
 export const modalEthReceive: Readable<boolean> = derived(
 	modalStore,
@@ -106,7 +106,8 @@ export const modalHideToken: Readable<boolean> = derived(
 );
 export const modalHideTokenData: Readable<NavigationTarget | undefined> = derived(
 	modalStore,
-	($modalStore) => $modalStore?.type === 'hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
+	($modalStore) =>
+		$modalStore?.type === 'hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
 );
 export const modalIcHideToken: Readable<boolean> = derived(
 	modalStore,
@@ -114,7 +115,8 @@ export const modalIcHideToken: Readable<boolean> = derived(
 );
 export const modalIcHideTokenData: Readable<NavigationTarget | undefined> = derived(
 	modalStore,
-	($modalStore) => $modalStore?.type === 'ic-hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
+	($modalStore) =>
+		$modalStore?.type === 'ic-hide-token' ? ($modalStore?.data as NavigationTarget) : undefined
 );
 export const modalBtcTransaction: Readable<boolean> = derived(
 	modalStore,

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -13,8 +13,8 @@ import type { AnyTransactionUi } from '$lib/types/transaction';
 import type { Option } from '$lib/types/utils';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { WalletKitTypes } from '@reown/walletkit';
-import { writable, type Readable } from 'svelte/store';
 import type { NavigationTarget } from '@sveltejs/kit';
+import { writable, type Readable } from 'svelte/store';
 
 export interface Modal<T> {
 	type:

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -106,8 +106,8 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openBtcTransaction: (params: SetWithDataParams<OpenTransactionParams<BtcTransactionUi>>) => void;
 	openSolTransaction: (params: SetWithDataParams<OpenTransactionParams<SolTransactionUi>>) => void;
 	openManageTokens: (params: SetWithOptionalDataParams<ManageTokensData>) => void;
-	openHideToken: (params: SetWithDataParams<NavigationTarget>) => void;
-	openIcHideToken: (params: SetWithDataParams<NavigationTarget>) => void;
+	openHideToken: (params: SetWithDataParams<NavigationTarget | undefined>) => void;
+	openIcHideToken: (params: SetWithDataParams<NavigationTarget | undefined>) => void;
 	openEthToken: (id: symbol) => void;
 	openBtcToken: (id: symbol) => void;
 	openIcToken: (id: symbol) => void;
@@ -176,10 +176,10 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openManageTokens: <(params: SetWithOptionalDataParams<ManageTokensData>) => void>(
 			setTypeWithData('manage-tokens')
 		),
-		openHideToken: <(params: SetWithDataParams<NavigationTarget>) => void>(
+		openHideToken: <(params: SetWithDataParams<NavigationTarget | undefined>) => void>(
 			setTypeWithData('hide-token')
 		),
-		openIcHideToken: <(params: SetWithDataParams<NavigationTarget>) => void>(
+		openIcHideToken: <(params: SetWithDataParams<NavigationTarget | undefined>) => void>(
 			setTypeWithData('ic-hide-token')
 		),
 		openEthToken: setType('eth-token'),

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -14,6 +14,7 @@ import type { Option } from '$lib/types/utils';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { WalletKitTypes } from '@reown/walletkit';
 import { writable, type Readable } from 'svelte/store';
+import type { NavigationTarget } from '@sveltejs/kit';
 
 export interface Modal<T> {
 	type:
@@ -105,8 +106,8 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openBtcTransaction: (params: SetWithDataParams<OpenTransactionParams<BtcTransactionUi>>) => void;
 	openSolTransaction: (params: SetWithDataParams<OpenTransactionParams<SolTransactionUi>>) => void;
 	openManageTokens: (params: SetWithOptionalDataParams<ManageTokensData>) => void;
-	openHideToken: (id: symbol) => void;
-	openIcHideToken: (id: symbol) => void;
+	openHideToken: (params: SetWithDataParams<NavigationTarget>) => void;
+	openIcHideToken: (params: SetWithDataParams<NavigationTarget>) => void;
 	openEthToken: (id: symbol) => void;
 	openBtcToken: (id: symbol) => void;
 	openIcToken: (id: symbol) => void;
@@ -175,8 +176,12 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openManageTokens: <(params: SetWithOptionalDataParams<ManageTokensData>) => void>(
 			setTypeWithData('manage-tokens')
 		),
-		openHideToken: setType('hide-token'),
-		openIcHideToken: setType('ic-hide-token'),
+		openHideToken: <(params: SetWithDataParams<NavigationTarget>) => void>(
+			setTypeWithData('hide-token')
+		),
+		openIcHideToken: <(params: SetWithDataParams<NavigationTarget>) => void>(
+			setTypeWithData('ic-hide-token')
+		),
 		openEthToken: setType('eth-token'),
 		openBtcToken: setType('btc-token'),
 		openIcToken: setType('ic-token'),


### PR DESCRIPTION
# Motivation

When a user applys a `network filter` and then disabled a token, the `network filter` is also removed. Even after hiding a token, the filter should still be active.

# Changes

- fixes hide token flow

# Tests

**before:**

https://github.com/user-attachments/assets/3a0f1bb2-f5cf-4f96-afb7-567389031f96


**after:**

https://github.com/user-attachments/assets/f7d23cec-6782-49bd-ac82-225b6d5393e2

