### PR TITLE
feat(frontend): using getAccountIdentifier() to create IcrcSubaccount

### DIFF
--- a/src/frontend/src/icp/utils/icrc-account.utils.ts
+++ b/src/frontend/src/icp/utils/icrc-account.utils.ts
@@ -1,7 +1,7 @@
-import { decodeIcrcAccount, type IcrcAccount } from '@dfinity/ledger-icrc';
+import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
+import { decodeIcrcAccount, type IcrcAccount, type IcrcSubaccount } from '@dfinity/ledger-icrc';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { sha256 } from '@noble/hashes/sha256';
 
 export const getIcrcAccount = (principal: Principal): IcrcAccount => ({ owner: principal });
 
@@ -10,10 +10,8 @@ export const getIcrcAccount = (principal: Principal): IcrcAccount => ({ owner: p
  * @param principal The principal to derive the subaccount from
  * @returns A 32-byte Uint8Array to be used as an ICRC subaccount
  */
-export const getIcrcSubaccount = (principal: Principal): Uint8Array => {
-	const principalBytes = principal.toUint8Array();
-	return sha256(principalBytes);
-};
+export const getIcrcSubaccount = (principal: Principal): IcrcSubaccount =>
+	getAccountIdentifier(principal).toUint8Array();
 
 export const isIcrcAddress = (address: string | undefined): boolean => {
 	if (isNullish(address)) {


### PR DESCRIPTION
# Motivation

The implementation for getIcrcSubaccount() is currently not correct and has therefore to be fixed.

# Changes
- Refactored getIcrcSubaccount logic to leverage a new getAccountIdentifier utility