### PR TITLE
fix(script): Check for i18n shall consider deconstruct

### DIFF
--- a/scripts/check.i18n.mjs
+++ b/scripts/check.i18n.mjs
@@ -16,10 +16,22 @@ const extractKeys = ({ obj, prefix = '' }) =>
 		return [...res, `${prefix}${el}`];
 	}, []);
 
-// It checks if the key is used in the content or if the key is used in a dynamic way
-const checkKeyUsage = ({ key, content }) =>
-	content.includes(key) ??
-	(content.includes(`get(i18n)`) && key.split('.').every((k) => content.includes(k)));
+// It checks if the key is used in the content or if the key is used dynamically
+const checkKeyUsage = ({ key, content }) => {
+	if (content.includes(`"${key}"`) || content.includes(`'${key}'`) || content.includes(key)) {
+		return true;
+	}
+
+	const parts = key.split('.');
+	const lastKey = parts[parts.length - 1];
+
+	const destructureRegex = new RegExp(`[{,]\\s*${lastKey}\\s*[:}]`);
+	if (destructureRegex.test(content)) {
+		return true;
+	}
+
+	return content.includes('get(i18n)') && parts.every((p) => content.includes(p));
+};
 
 const main = () => {
 	const en = JSON.parse(readFileSync(PATH_TO_EN_JSON, 'utf8'));
@@ -39,10 +51,11 @@ const main = () => {
 	});
 
 	if (potentialUnusedKeys.length === 0) {
-		console.log('All keys are used.');
+		console.log('✅ All keys are used.');
 		process.exit(0);
 	} else {
-		console.error('Unused keys:', potentialUnusedKeys);
+		console.error(`❌ ${potentialUnusedKeys.length} unused keys:`);
+		potentialUnusedKeys.forEach((key) => console.error(' -', key));
 		process.exit(1);
 	}
 };


### PR DESCRIPTION
# Motivation

The script that checks if keys are used from the `i18n` file was not considering deconstruction. For example, in the code we had:

```ts
const {
	transactions: {
		error: { unexpected_transaction_for_hash }
	}
} = get(i18n);
```
		
but key `transactions.error.unexpected_transaction_for_hash` being flagged as unused.

# Changes

- Adapt script to other possible usage of `i18n` keys.

# Tests

Running it locally, the correct list of keys were raised as unused. We remove them in this PR as tests for everything working.
