### PR TITLE
test(frontend): Tests for ckbtc-minter API

### DIFF
--- a/src/frontend/src/icp/api/ckbtc-minter.api.ts
+++ b/src/frontend/src/icp/api/ckbtc-minter.api.ts
@@ -133,7 +133,7 @@ const minterCanister = async ({
 };
 
 const minterAccountParams = ({ identity }: { identity: Identity }): { owner: Principal } =>
-	// We use the identity to follow NNS-dapp's scheme but, if it would not be provided, it would be the same result.
+	// We use the identity to follow NNS-dapp's scheme but, if it was not provided, it would be the same result.
 	// If "owner" is not provided, the minter canister uses the "caller" as a fallback.
 	({
 		owner: identity.getPrincipal()

--- a/src/frontend/src/tests/icp/api/ckbtc-minter.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/ckbtc-minter.api.spec.ts
@@ -55,7 +55,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.retrieveBtcWithApproval).toHaveBeenCalledTimes(1);
+			expect(canisterMock.retrieveBtcWithApproval).toHaveBeenCalledOnce();
 			expect(canisterMock.retrieveBtcWithApproval).toHaveBeenCalledWith({
 				amount,
 				address: mockBtcAddress
@@ -84,7 +84,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.updateBalance).toHaveBeenCalledTimes(1);
+			expect(canisterMock.updateBalance).toHaveBeenCalledOnce();
 			expect(canisterMock.updateBalance).toHaveBeenCalledWith({
 				owner: mockIdentity.getPrincipal()
 			});
@@ -117,7 +117,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.getMinterInfo).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getMinterInfo).toHaveBeenCalledOnce();
 			expect(canisterMock.getMinterInfo).toHaveBeenCalledWith({ certified: true });
 		});
 
@@ -126,7 +126,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.getMinterInfo).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getMinterInfo).toHaveBeenCalledOnce();
 			expect(canisterMock.getMinterInfo).toHaveBeenCalledWith({ certified: false });
 		});
 
@@ -150,7 +150,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(mockBtcAddress);
 
-			expect(canisterMock.getBtcAddress).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getBtcAddress).toHaveBeenCalledOnce();
 			expect(canisterMock.getBtcAddress).toHaveBeenCalledWith({
 				owner: mockIdentity.getPrincipal()
 			});
@@ -185,7 +185,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledTimes(1);
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledOnce();
 			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledWith({ amount, certified: true });
 		});
 
@@ -194,7 +194,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledTimes(1);
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledOnce();
 			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledWith({ certified: true });
 		});
 
@@ -203,7 +203,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledTimes(1);
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledOnce();
 			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledWith({ amount, certified: false });
 		});
 
@@ -233,7 +233,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledTimes(1);
+			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledOnce();
 			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledWith({ certified: true });
 		});
 
@@ -242,7 +242,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledTimes(1);
+			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledOnce();
 			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledWith({ certified: false });
 		});
 
@@ -268,7 +268,7 @@ describe('ckbtc-minter.api', () => {
 
 			expect(result).toEqual(expected);
 
-			expect(canisterMock.getKnownUtxos).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getKnownUtxos).toHaveBeenCalledOnce();
 			expect(canisterMock.getKnownUtxos).toHaveBeenCalledWith({
 				owner: mockIdentity.getPrincipal()
 			});

--- a/src/frontend/src/tests/icp/api/ckbtc-minter.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/ckbtc-minter.api.spec.ts
@@ -1,0 +1,281 @@
+import { IC_CKBTC_MINTER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import {
+	estimateFee,
+	getBtcAddress,
+	getKnownUtxos,
+	minterInfo,
+	retrieveBtc,
+	updateBalance,
+	withdrawalStatuses
+} from '$icp/api/ckbtc-minter.api';
+import { mockBtcAddress, mockUtxo } from '$tests/mocks/btc.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import {
+	CkBTCMinterCanister,
+	type EstimateWithdrawalFee,
+	type MinterInfo,
+	type RetrieveBtcOk,
+	type RetrieveBtcStatusV2WithId,
+	type Utxo
+} from '@dfinity/ckbtc';
+import type { UpdateBalanceOk } from '@dfinity/ckbtc/dist/types/types/minter.responses';
+import { mock } from 'vitest-mock-extended';
+
+vi.mock('$icp/utils/date.utils', () => ({
+	nowInBigIntNanoSeconds: vi.fn()
+}));
+
+describe('ckbtc-minter.api', () => {
+	const canisterMock = mock<CkBTCMinterCanister>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(CkBTCMinterCanister, 'create').mockImplementation(() => canisterMock);
+	});
+
+	describe('retrieveBtc', () => {
+		const amount = 123_456_789n;
+
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID,
+			amount,
+			address: mockBtcAddress
+		};
+
+		const expected: RetrieveBtcOk = { block_index: 123n };
+
+		beforeEach(() => {
+			canisterMock.retrieveBtcWithApproval.mockResolvedValue(expected);
+		});
+
+		it('successfully calls retrieveBtcWithApproval endpoint', async () => {
+			const result = await retrieveBtc(params);
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.retrieveBtcWithApproval).toHaveBeenCalledTimes(1);
+			expect(canisterMock.retrieveBtcWithApproval).toHaveBeenCalledWith({
+				amount,
+				address: mockBtcAddress
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(retrieveBtc({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('updateBalance', () => {
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID
+		};
+
+		const expected: UpdateBalanceOk = [{ ValueTooSmall: mockUtxo }, { Tainted: mockUtxo }];
+
+		beforeEach(() => {
+			canisterMock.updateBalance.mockResolvedValue(expected);
+		});
+
+		it('successfully calls updateBalance endpoint', async () => {
+			const result = await updateBalance(params);
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.updateBalance).toHaveBeenCalledTimes(1);
+			expect(canisterMock.updateBalance).toHaveBeenCalledWith({
+				owner: mockIdentity.getPrincipal()
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(updateBalance({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('minterInfo', () => {
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID,
+			certified: true
+		};
+
+		const expected: MinterInfo = {
+			retrieve_btc_min_amount: 123n,
+			min_confirmations: 111,
+			kyt_fee: 456n
+		};
+
+		beforeEach(() => {
+			canisterMock.getMinterInfo.mockResolvedValue(expected);
+		});
+
+		it('successfully calls getMinterInfo endpoint', async () => {
+			const result = await minterInfo(params);
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.getMinterInfo).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getMinterInfo).toHaveBeenCalledWith({ certified: true });
+		});
+
+		it('successfully calls getMinterInfo endpoint as query', async () => {
+			const result = await minterInfo({ ...params, certified: false });
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.getMinterInfo).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getMinterInfo).toHaveBeenCalledWith({ certified: false });
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(minterInfo({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('getBtcAddress', () => {
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID
+		};
+
+		beforeEach(() => {
+			canisterMock.getBtcAddress.mockResolvedValue(mockBtcAddress);
+		});
+
+		it('successfully calls getBtcAddress endpoint', async () => {
+			const result = await getBtcAddress(params);
+
+			expect(result).toEqual(mockBtcAddress);
+
+			expect(canisterMock.getBtcAddress).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getBtcAddress).toHaveBeenCalledWith({
+				owner: mockIdentity.getPrincipal()
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(getBtcAddress({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('estimateFee', () => {
+		const amount = 123_456_789n;
+
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID,
+			amount,
+			certified: true
+		};
+
+		const expected: EstimateWithdrawalFee = {
+			minter_fee: 123n,
+			bitcoin_fee: 456n
+		};
+
+		beforeEach(() => {
+			canisterMock.estimateWithdrawalFee.mockResolvedValue(expected);
+		});
+
+		it('successfully calls estimateWithdrawalFee endpoint', async () => {
+			const result = await estimateFee(params);
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledTimes(1);
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledWith({ amount, certified: true });
+		});
+
+		it('successfully calls estimateWithdrawalFee endpoint with no amount', async () => {
+			const result = await estimateFee({ ...params, amount: undefined });
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledTimes(1);
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledWith({ certified: true });
+		});
+
+		it('successfully calls estimateWithdrawalFee endpoint as query', async () => {
+			const result = await estimateFee({ ...params, certified: false });
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledTimes(1);
+			expect(canisterMock.estimateWithdrawalFee).toHaveBeenCalledWith({ amount, certified: false });
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(estimateFee({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('withdrawalStatuses', () => {
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID,
+			certified: true
+		};
+
+		const expected: RetrieveBtcStatusV2WithId[] = [
+			{ id: 1n, status: undefined },
+			{ id: 2n, status: { AmountTooLow: null } }
+		];
+
+		beforeEach(() => {
+			canisterMock.retrieveBtcStatusV2ByAccount.mockResolvedValue(expected);
+		});
+
+		it('successfully calls retrieveBtcStatusV2ByAccount endpoint', async () => {
+			const result = await withdrawalStatuses(params);
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledTimes(1);
+			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledWith({ certified: true });
+		});
+
+		it('successfully calls retrieveBtcStatusV2ByAccount endpoint as query', async () => {
+			const result = await withdrawalStatuses({ ...params, certified: false });
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledTimes(1);
+			expect(canisterMock.retrieveBtcStatusV2ByAccount).toHaveBeenCalledWith({ certified: false });
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(withdrawalStatuses({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('getKnownUtxos', () => {
+		const params = {
+			identity: mockIdentity,
+			minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID
+		};
+
+		const expected: Utxo[] = [mockUtxo, mockUtxo];
+
+		beforeEach(() => {
+			canisterMock.getKnownUtxos.mockResolvedValue(expected);
+		});
+
+		it('successfully calls getKnownUtxos endpoint', async () => {
+			const result = await getKnownUtxos(params);
+
+			expect(result).toEqual(expected);
+
+			expect(canisterMock.getKnownUtxos).toHaveBeenCalledTimes(1);
+			expect(canisterMock.getKnownUtxos).toHaveBeenCalledWith({
+				owner: mockIdentity.getPrincipal()
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(getKnownUtxos({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+});

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -98,7 +98,7 @@ describe('icrc-ledger.api', () => {
 
 			expect(result).toEqual(fee);
 
-			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledTimes(1);
+			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledOnce();
 			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledWith({
 				certified: true
 			});

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -97,8 +97,8 @@ describe('icrc-ledger.api', () => {
 			const result = await transactionFee(params);
 
 			expect(result).toEqual(fee);
-			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledWith({
 				certified: true
 			});
@@ -108,8 +108,8 @@ describe('icrc-ledger.api', () => {
 			const result = await transactionFee({ ...params, certified: false });
 
 			expect(result).toEqual(fee);
-			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.transactionFee).toHaveBeenCalledWith({ certified: false });
 		});
 
@@ -140,8 +140,8 @@ describe('icrc-ledger.api', () => {
 			const tokens = await balance(params);
 
 			expect(tokens).toEqual(balanceE8s);
-			expect(ledgerCanisterMock.balance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.balance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.balance).toHaveBeenCalledWith({
 				certified: true,
 				...account
@@ -152,8 +152,8 @@ describe('icrc-ledger.api', () => {
 			const tokens = await balance({ ...params, certified: false });
 
 			expect(tokens).toEqual(balanceE8s);
-			expect(ledgerCanisterMock.balance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.balance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.balance).toHaveBeenCalledWith({ certified: false, ...account });
 		});
 
@@ -326,8 +326,8 @@ describe('icrc-ledger.api', () => {
 			const result = await allowance(params);
 
 			expect(result).toEqual(allowanceResponse);
-			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.allowance).toHaveBeenCalledWith({
 				certified: true,
 				account: {
@@ -352,8 +352,8 @@ describe('icrc-ledger.api', () => {
 			const result = await allowance(params);
 
 			expect(result).toEqual(allowanceResponse);
-			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.allowance).toHaveBeenCalledWith({
 				certified: false,
 				account: {
@@ -377,8 +377,8 @@ describe('icrc-ledger.api', () => {
 			const result = await allowance(params);
 
 			expect(result).toEqual(allowanceResponse);
-			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.allowance).toHaveBeenCalledWith({
 				certified: true,
 				account: {
@@ -402,8 +402,8 @@ describe('icrc-ledger.api', () => {
 			const result = await allowance(params);
 
 			expect(result).toEqual(allowanceResponse);
-			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.allowance).toHaveBeenCalledWith({
 				certified: true,
 				account: {
@@ -427,8 +427,8 @@ describe('icrc-ledger.api', () => {
 			const result = await allowance(params);
 
 			expect(result).toEqual(allowanceResponse);
-			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.allowance).toHaveBeenCalledWith({
 				certified: true,
 				account: {
@@ -455,8 +455,8 @@ describe('icrc-ledger.api', () => {
 			const result = await allowance(params);
 
 			expect(result).toEqual(allowanceResponse);
-			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 
+			expect(ledgerCanisterMock.allowance).toHaveBeenCalledTimes(1);
 			expect(ledgerCanisterMock.allowance).toHaveBeenCalledWith({
 				certified: true,
 				account: {

--- a/src/frontend/src/tests/mocks/btc.mock.ts
+++ b/src/frontend/src/tests/mocks/btc.mock.ts
@@ -1,19 +1,20 @@
 import type { UtxosFee } from '$btc/types/btc-send';
+import type { Utxo } from '@dfinity/ckbtc/dist/candid/minter';
 
 export const mockBtcAddress = 'bc1qt0nkp96r7p95xfacyp98pww2eu64yzuf78l4a2wy0sttt83hux4q6u2nl7';
 
 export const mockBtcP2SHAddress = '3AdD7ZaJQw9m1maN39CeJ1zVyXQLn2MEHR';
 
+export const mockUtxo: Utxo = {
+	height: 1000,
+	value: 1n,
+	outpoint: {
+		txid: [1, 2, 3],
+		vout: 1
+	}
+};
+
 export const mockUtxosFee: UtxosFee = {
 	feeSatoshis: 1000n,
-	utxos: [
-		{
-			height: 1000,
-			value: 1n,
-			outpoint: {
-				txid: [1, 2, 3],
-				vout: 1
-			}
-		}
-	]
+	utxos: [mockUtxo]
 };


### PR DESCRIPTION
# Motivation

For coverage, some tests for ckbtc-minter API methods.
