### PR TITLE
feat(frontend): enable deletion of custom SPL tokens

### DIFF
--- a/src/frontend/src/sol/components/tokens/SolTokenModal.svelte
+++ b/src/frontend/src/sol/components/tokens/SolTokenModal.svelte
@@ -10,21 +10,30 @@
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkSolana } from '$lib/utils/network.utils';
+	import { splDefaultTokens } from '$sol/derived/spl.derived';
 	import { isTokenSpl } from '$sol/utils/spl.utils';
 
-	export let fromRoute: NavigationTarget | undefined;
+	interface Props {
+		fromRoute: NavigationTarget | undefined;
+	}
+	let { fromRoute }: Props = $props();
 
-	let explorerUrl: string | undefined;
-	$: explorerUrl = isNetworkSolana($pageToken?.network)
-		? $pageToken.network.explorerUrl
-		: undefined;
+	let explorerUrl = $derived(
+		isNetworkSolana($pageToken?.network) ? $pageToken.network.explorerUrl : undefined
+	);
 
-	let tokenAddress: string | undefined;
-	$: tokenAddress =
-		nonNullish($pageToken) && isTokenSpl($pageToken) ? $pageToken.address : undefined;
+	let tokenAddress = $derived(
+		nonNullish($pageToken) && isTokenSpl($pageToken) ? $pageToken.address : undefined
+	);
+
+	let undeletableToken = $derived(
+		nonNullish($pageToken) && isTokenSpl($pageToken)
+			? $splDefaultTokens.some(({ address }) => $pageToken.address === address)
+			: true
+	);
 </script>
 
-<TokenModal token={$pageToken} {fromRoute}>
+<TokenModal token={$pageToken} isDeletable={!undeletableToken} {fromRoute}>
 	{#if nonNullish(tokenAddress)}
 		<ModalListItem>
 			{#snippet label()}

--- a/src/frontend/src/sol/derived/spl.derived.ts
+++ b/src/frontend/src/sol/derived/spl.derived.ts
@@ -8,7 +8,7 @@ import type { SplCustomToken } from '$sol/types/spl-custom-token';
 import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
 import { derived, type Readable } from 'svelte/store';
 
-const splDefaultTokens: Readable<SplToken[]> = derived(
+export const splDefaultTokens: Readable<SplToken[]> = derived(
 	[splDefaultTokensStore, enabledSolanaNetworksIds],
 	([$splTokensStore, $enabledSolanaNetworksIds]) =>
 		($splTokensStore ?? []).filter(({ network: { id: networkId } }) =>

--- a/src/frontend/src/tests/sol/components/tokens/SolTokenModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/tokens/SolTokenModal.spec.ts
@@ -1,7 +1,9 @@
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { modalStore } from '$lib/stores/modal.store';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import SplTokenModal from '$sol/components/tokens/SolTokenModal.svelte';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
+import en from '$tests/mocks/i18n.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockSplCustomToken } from '$tests/mocks/spl-tokens.mock';
 import { render } from '@testing-library/svelte';
@@ -11,7 +13,7 @@ describe('SolTokenModal', () => {
 		mockPage.reset();
 	});
 
-	it('displays all required values', () => {
+	it('displays all required values including the delete button', () => {
 		vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
 			fn([mockSplCustomToken]);
 			return () => {};
@@ -33,5 +35,23 @@ describe('SolTokenModal', () => {
 			shortenWithMiddleEllipsis({ text: mockSplCustomToken.address })
 		);
 		expect(container).toHaveTextContent(`${mockSplCustomToken.decimals}`);
+		expect(container).toHaveTextContent(en.tokens.text.delete_token);
+	});
+
+	it('displays all required values without the delete button for a default SPL token', () => {
+		mockPage.mock({
+			token: SOLANA_TOKEN.name,
+			network: SOLANA_TOKEN.network.id.description
+		});
+
+		const { container } = render(SplTokenModal);
+
+		modalStore.openSolToken({ id: SOLANA_TOKEN.id, data: undefined });
+
+		expect(container).toHaveTextContent(SOLANA_TOKEN.network.name);
+		expect(container).toHaveTextContent(SOLANA_TOKEN.name);
+		expect(container).toHaveTextContent(SOLANA_TOKEN.symbol);
+		expect(container).toHaveTextContent(`${SOLANA_TOKEN.decimals}`);
+		expect(container).not.toHaveTextContent(en.tokens.text.delete_token);
 	});
 });


### PR DESCRIPTION
# Motivation

We can now enable deletion of non-default SPL tokens.
