### PR TITLE
feat(frontend): Add code from library `ic-pub-key` for BTC address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"@solana/kit": "^2.1.1",
 				"@walletconnect/auth-client": "^2.1.2",
 				"alchemy-sdk": "3.6.0",
+				"bitcoinjs-lib": "^6.1.7",
 				"buffer": "^6.0.3",
 				"ethers": "^6.14.3",
 				"idb-keyval": "^6.2.2",
@@ -6399,7 +6400,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
 			"integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/base58-js": {
@@ -6451,6 +6451,38 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/bip174": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+			"integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/bitcoinjs-lib": {
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
+			"integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "^1.2.0",
+				"bech32": "^2.0.0",
+				"bip174": "^2.1.1",
+				"bs58check": "^3.0.1",
+				"typeforce": "^1.11.3",
+				"varuint-bitcoin": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/bitcoinjs-lib/node_modules/bech32": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+			"license": "MIT"
 		},
 		"node_modules/blakejs": {
 			"version": "1.2.1",
@@ -6573,7 +6605,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
 			"integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"base-x": "^4.0.0"
@@ -6583,7 +6614,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
 			"integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@noble/hashes": "^1.2.0",
@@ -13584,6 +13614,12 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"node_modules/typeforce": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+			"license": "MIT"
+		},
 		"node_modules/typescript": {
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -13811,6 +13847,15 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/varuint-bitcoin": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+			"integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"node_modules/viem": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"@solana/kit": "^2.1.1",
 		"@walletconnect/auth-client": "^2.1.2",
 		"alchemy-sdk": "3.6.0",
+		"bitcoinjs-lib": "^6.1.7",
 		"buffer": "^6.0.3",
 		"ethers": "^6.14.3",
 		"idb-keyval": "^6.2.2",

--- a/src/frontend/src/lib/ic-pub-key/src/cli.ts
+++ b/src/frontend/src/lib/ic-pub-key/src/cli.ts
@@ -2,7 +2,9 @@
 /* istanbul ignore file */
 /* v8 ignore start */
 
+import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import { Principal } from '@dfinity/principal';
+import { networks, payments, type Network } from 'bitcoinjs-lib';
 import { computeAddress } from 'ethers/transaction';
 import {
 	DerivationPath,
@@ -24,6 +26,46 @@ export const deriveEthAddress = async (user: string): Promise<string> => {
 	let eth_pubkey_with_chaincode =
 		await signer_pubkey_with_chain_code.deriveSubkeyWithChainCode(derivation_path);
 	return computeAddress('0x' + eth_pubkey_with_chaincode.public_key.toHex());
+};
+
+/* istanbul ignore next */
+function mapBitcoinNetworkToBitcoinJS(network: BitcoinNetwork): Network {
+	switch (network) {
+		case 'mainnet':
+			return networks.bitcoin;
+		case 'testnet':
+			return networks.testnet;
+		case 'regtest':
+			return networks.regtest;
+		default:
+			throw new Error(`Unsupported Bitcoin network: ${network}`);
+	}
+}
+
+/* istanbul ignore next */
+export const deriveBtcAddress = async (user: string, network: BitcoinNetwork): Promise<string> => {
+	const pubkey = '0259761672ec7ee3bdc5eca95ba5f6a493d1133b86a76163b68af30c06fe3b75c0';
+	const chaincode = 'f666a98c7f70fe281ca8142f14eb4d1e0934a439237da83869e2cfd924b270c0';
+
+	let principal = Principal.fromText(user);
+	let principal_as_bytes = principal.toUint8Array();
+	let derivation_path = new DerivationPath([Uint8Array.from([0x00]), principal_as_bytes]);
+	let signer_pubkey_with_chain_code = Secp256k1PublicKeyWithChainCode.fromString({
+		public_key: pubkey,
+		chain_code: chaincode
+	});
+	let btc_pubkey_with_chaincode =
+		await signer_pubkey_with_chain_code.deriveSubkeyWithChainCode(derivation_path);
+	let btc_pubkey = btc_pubkey_with_chaincode.public_key;
+	let networkJs = mapBitcoinNetworkToBitcoinJS(network);
+	let { address: btc_address } = payments.p2wpkh({
+		pubkey: btc_pubkey.toBuffer(),
+		network: networkJs
+	});
+	if (btc_address === undefined) {
+		throw new Error('Failed to derive Bitcoin address from public key.');
+	}
+	return btc_address;
 };
 
 /* v8 ignore stop */

--- a/src/frontend/src/lib/ic-pub-key/src/ecdsa/secp256k1.ts
+++ b/src/frontend/src/lib/ic-pub-key/src/ecdsa/secp256k1.ts
@@ -150,6 +150,10 @@ export class Sec1EncodedPublicKey {
 		return new PublicKeyWithChainCode(Sec1EncodedPublicKey.fromProjectivePoint(pt), new_chain_code);
 	}
 
+	toBuffer(): Buffer {
+		return Buffer.from(this.bytes);
+	}
+
 	/**
 	 * Creates a new Sec1EncodedPublicKey from a 66 character hex string.
 	 * @param hex The 66 character hex string.


### PR DESCRIPTION
# Motivation

We will start to derive the addresses in the frontend using the library [ic-pub-key](https://github.com/dfinity/ic-pub-key). However the library is not public yet (it is under publication process).

So, in the interest of time, we simply copy the code from it and paste it here, to use it and derive the addresses. In this specific case, the code for BTC address (very similar to the one copied for the ETH address).

NOTE: there is a feature flag that enable/disable this new feature in case something goes awry.
