### PR TITLE
feat(frontend): extract network dropdown from AddTokenByNetwork

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-	import { Dropdown, DropdownItem } from '@dfinity/gix-components';
 	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import EthAddTokenForm from '$eth/components/tokens/EthAddTokenForm.svelte';
 	import IcAddTokenForm from '$icp/components/tokens/IcAddTokenForm.svelte';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
+	import AddTokenByNetworkDropdown from '$lib/components/manage/AddTokenByNetworkDropdown.svelte';
 	import AddTokenByNetworkToolbar from '$lib/components/manage/AddTokenByNetworkToolbar.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Value from '$lib/components/ui/Value.svelte';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { networks, networksMainnets } from '$lib/derived/networks.derived';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -95,24 +94,7 @@
 <form on:submit={() => dispatch('icNext')} method="POST" in:fade class="min-h-auto">
 	<ContentWithToolbar>
 		{#if enabledNetworkSelector}
-			<Value ref="network" element="div">
-				{#snippet label()}
-					{$i18n.tokens.manage.text.network}
-				{/snippet}
-
-				{#snippet content()}
-					<div id="network" class="network mt-1 pt-0.5">
-						<Dropdown name="network" bind:selectedValue={networkName}>
-							<option disabled selected value={undefined} class:hidden={nonNullish(networkName)}
-								>{$i18n.tokens.manage.placeholder.select_network}</option
-							>
-							{#each availableNetworks as network (network.id)}
-								<DropdownItem value={network.name}>{network.name}</DropdownItem>
-							{/each}
-						</Dropdown>
-					</div>
-				{/snippet}
-			</Value>
+			<AddTokenByNetworkDropdown bind:networkName {availableNetworks} />
 		{/if}
 
 		{#if isIcpNetwork}
@@ -130,13 +112,3 @@
 		{/snippet}
 	</ContentWithToolbar>
 </form>
-
-<style lang="scss">
-	.hidden {
-		display: none;
-	}
-
-	.network {
-		--disable-contrast: rgba(0, 0, 0, 0.5);
-	}
-</style>

--- a/src/frontend/src/lib/components/manage/AddTokenByNetworkDropdown.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetworkDropdown.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Dropdown, DropdownItem } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Network } from '$lib/types/network';
+
+	interface Props {
+		availableNetworks: Network[];
+		disabled?: boolean;
+		networkName?: string;
+	}
+	let { networkName = $bindable(), availableNetworks, disabled = false }: Props = $props();
+</script>
+
+<Value ref="network" element="div">
+	{#snippet label()}
+		{$i18n.tokens.manage.text.network}:
+	{/snippet}
+
+	{#snippet content()}
+		<div id="network" class="mt-1 pt-0.5" class:disabled>
+			<Dropdown name="network" bind:selectedValue={networkName} {disabled}>
+				<option disabled selected value={undefined} class:hidden={nonNullish(networkName)}
+					>{$i18n.tokens.manage.placeholder.select_network}</option
+				>
+				{#each availableNetworks as network (network.id)}
+					<DropdownItem value={network.name}>{network.name}</DropdownItem>
+				{/each}
+			</Dropdown>
+		</div>
+	{/snippet}
+</Value>
+
+<style lang="scss">
+	:global(.disabled div.select) {
+		--input-border-size: 0;
+	}
+</style>

--- a/src/frontend/src/tests/lib/components/manage/AddTokenByNetworkDropdown.spec.ts
+++ b/src/frontend/src/tests/lib/components/manage/AddTokenByNetworkDropdown.spec.ts
@@ -1,0 +1,30 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import AddTokenByNetworkDropdown from '$lib/components/manage/AddTokenByNetworkDropdown.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('AddTokenByNetworkDropdown', () => {
+	const props = {
+		availableNetworks: [ICP_NETWORK, ETHEREUM_NETWORK]
+	};
+
+	it('should render all expected values when networkName is not provided', () => {
+		const { container } = render(AddTokenByNetworkDropdown, { props });
+
+		expect(container).toHaveTextContent(en.tokens.manage.text.network);
+		expect(container).toHaveTextContent(en.tokens.manage.placeholder.select_network);
+	});
+
+	it('should render all expected values when networkName is provided', () => {
+		const { container } = render(AddTokenByNetworkDropdown, {
+			props: {
+				...props,
+				networkName: ICP_NETWORK.name
+			}
+		});
+
+		expect(container).toHaveTextContent(en.tokens.manage.text.network);
+		expect(container).toHaveTextContent(ICP_NETWORK.name);
+	});
+});


### PR DESCRIPTION
# Motivation

We need to extract the dropdown code from `AddTokenByNetwork` so it can be re-used in the Edit ICRC token modal.
