### PR TITLE
fix(frontend): Fix Hangover sprinkles criteria 

### DIFF
--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -150,7 +150,7 @@ const mapCriterion = (criterion: CriterionEligibility): CampaignCriterion => {
 		} as MinTotalAssetsUsdCriterion;
 	}
 	if ('Hangover' in criterion.criterion) {
-		const duration = criterion.criterion.Hangover;
+		const { duration } = criterion.criterion.Hangover;
 		if ('Days' in duration) {
 			const days = duration.Days;
 			return {


### PR DESCRIPTION
# Motivation

The 4th criteria, Hangover, is not showing on the Sprinkles Episode 4 card.

# Changes

- add { } into the Util to correctly handle the datatype

# Tests

**Before**
<img width="583" alt="image" src="https://github.com/user-attachments/assets/d027ab7b-4374-413d-a933-3390b9632012" />

**After**
<img width="585" alt="image" src="https://github.com/user-attachments/assets/1b8cd35b-baaa-40e4-884c-84e4af428d11" />

