### PR TITLE
feat(frontend): API function for method `getAccountInfo` of SOL RPC canister

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -92,6 +92,14 @@ export const XTC_LEDGER_CANISTER_ID = LOCAL
 			? import.meta.env.VITE_BETA_XTC_LEDGER_CANISTER_ID
 			: import.meta.env.VITE_IC_XTC_LEDGER_CANISTER_ID;
 
+export const SOL_RPC_CANISTER_ID = LOCAL
+	? import.meta.env.VITE_LOCAL_SOL_RPC_CANISTER_ID
+	: STAGING
+		? import.meta.env.VITE_STAGING_SOL_RPC_CANISTER_ID
+		: BETA
+			? import.meta.env.VITE_BETA_SOL_RPC_CANISTER_ID
+			: import.meta.env.VITE_IC_SOL_RPC_CANISTER_ID;
+
 // How long the delegation identity should remain valid?
 // e.g. BigInt(60 * 60 * 1000 * 1000 * 1000) = 1 hour in nanoseconds
 export const AUTH_MAX_TIME_TO_LIVE = BigInt(60 * 60 * 1000 * 1000 * 1000);

--- a/src/frontend/src/sol/api/sol-rpc.api.ts
+++ b/src/frontend/src/sol/api/sol-rpc.api.ts
@@ -1,0 +1,58 @@
+import type { AccountInfo } from '$declarations/sol_rpc/sol_rpc.did';
+import { SOL_RPC_CANISTER_ID } from '$lib/constants/app.constants';
+import type { SolAddress } from '$lib/types/address';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
+import { SolRpcCanister } from '$sol/canisters/sol-rpc.canister';
+import type { SolanaNetworkType } from '$sol/types/network';
+import { Principal } from '@dfinity/principal';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
+
+let canister: SolRpcCanister | undefined = undefined;
+
+export const getAccountInfo = async ({
+	identity,
+	...rest
+}: CanisterApiFunctionParams<{
+	address: SolAddress;
+	network: SolanaNetworkType;
+}>): Promise<AccountInfo | undefined> => {
+	const { getAccountInfo } = await solRpcCanister({ identity });
+
+	const accountInfo = await getAccountInfo(rest);
+
+	if (isNullish(accountInfo)) {
+		return accountInfo;
+	}
+
+	if (!('json' in accountInfo.data)) {
+		return accountInfo;
+	}
+
+	return {
+		...accountInfo,
+		data: {
+			...accountInfo.data,
+			json: {
+				...accountInfo.data.json,
+				parsed: JSON.parse(accountInfo.data.json.parsed)
+			}
+		}
+	};
+};
+
+const solRpcCanister = async ({
+	identity,
+	nullishIdentityErrorMessage,
+	canisterId = SOL_RPC_CANISTER_ID
+}: CanisterApiFunctionParams): Promise<SolRpcCanister> => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	if (isNullish(canister)) {
+		canister = await SolRpcCanister.create({
+			identity,
+			canisterId: Principal.fromText(canisterId)
+		});
+	}
+
+	return canister;
+};

--- a/src/frontend/src/tests/mocks/sol-rpc.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-rpc.mock.ts
@@ -1,0 +1,28 @@
+import type { AccountInfo } from '$declarations/sol_rpc/sol_rpc.did';
+import { SYSTEM_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+
+export const mockParsedAccountInfoAsString =
+	'{"info":{"decimals":5,"freezeAuthority":null,"isInitialized":true,"mintAuthority":null,"supply":"8879703657698256210"},"type":"mint"}';
+
+export const mockParsedAccountInfo = {
+	info: {
+		decimals: 5,
+		freezeAuthority: null,
+		isInitialized: true,
+		mintAuthority: null,
+		supply: '8879703657698256210'
+	},
+	type: 'mint'
+};
+
+export const mockAccountInfo: AccountInfo = {
+	executable: false,
+	owner: mockSolAddress,
+	lamports: 1000n,
+	data: {
+		json: { space: 1n, parsed: mockParsedAccountInfoAsString, program: SYSTEM_PROGRAM_ADDRESS }
+	},
+	space: 1n,
+	rentEpoch: 123n
+};

--- a/src/frontend/src/tests/sol/api/sol-rpc.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/sol-rpc.api.spec.ts
@@ -1,0 +1,80 @@
+import { getAccountInfo } from '$sol/api/sol-rpc.api';
+import { SolRpcCanister } from '$sol/canisters/sol-rpc.canister';
+import { SYSTEM_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockAccountInfo, mockParsedAccountInfo } from '$tests/mocks/sol-rpc.mock';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+import { mock } from 'vitest-mock-extended';
+
+describe('icp-ledger.api', () => {
+	const solRpcCanisterMock = mock<SolRpcCanister>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(SolRpcCanister, 'create').mockResolvedValue(solRpcCanisterMock);
+	});
+
+	describe('getAccountInfo', () => {
+		const address = mockSolAddress;
+
+		const params = {
+			address,
+			network: 'mainnet' as const,
+			identity: mockIdentity
+		};
+
+		const expectedParsedAccountInfo = {
+			...mockAccountInfo,
+			data: {
+				...mockAccountInfo.data,
+				json: {
+					space: 1n,
+					parsed: mockParsedAccountInfo,
+					program: SYSTEM_PROGRAM_ADDRESS
+				}
+			}
+		};
+
+		beforeEach(() => {
+			solRpcCanisterMock.getAccountInfo.mockResolvedValue(mockAccountInfo);
+		});
+
+		it('should successfully call getAccountInfo endpoint', async () => {
+			const result = await getAccountInfo(params);
+
+			expect(result).toEqual(expectedParsedAccountInfo);
+
+			expect(solRpcCanisterMock.getAccountInfo).toHaveBeenCalledExactlyOnceWith({
+				address,
+				network: 'mainnet'
+			});
+		});
+
+		it('should returned unparsed account info', async () => {
+			solRpcCanisterMock.getAccountInfo.mockResolvedValue({
+				...mockAccountInfo,
+				data: { legacyBinary: 'binary-string' }
+			});
+
+			const result = await getAccountInfo(params);
+
+			expect(result).toEqual({
+				...mockAccountInfo,
+				data: { legacyBinary: 'binary-string' }
+			});
+		});
+
+		it('should handle undefined account info', async () => {
+			solRpcCanisterMock.getAccountInfo.mockResolvedValue(undefined);
+
+			const result = await getAccountInfo(params);
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(getAccountInfo({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+});

--- a/src/frontend/src/tests/sol/canisters/sol-rpc.canister.spec.ts
+++ b/src/frontend/src/tests/sol/canisters/sol-rpc.canister.spec.ts
@@ -1,5 +1,4 @@
 import type {
-	AccountInfo,
 	GetAccountInfoResult,
 	MultiGetAccountInfoResult,
 	RpcError,
@@ -11,9 +10,9 @@ import type { CreateCanisterOptions } from '$lib/types/canister';
 import { SolRpcCanister, networkToCluster } from '$sol/canisters/sol-rpc.canister';
 import { JSON_PARSED, SOL_RPC_CONFIG } from '$sol/canisters/sol-rpc.constants';
 import { SolRpcCanisterError } from '$sol/canisters/sol-rpc.errors';
-import { SYSTEM_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import { SOLANA_NETWORK_TYPES } from '$sol/schema/network.schema';
 import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockAccountInfo } from '$tests/mocks/sol-rpc.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import type { ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
@@ -68,14 +67,6 @@ describe('sol-rpc.canister', () => {
 			const networkCluster = networkToCluster(network);
 			const mockParams = { address, network };
 
-			const mockAccountInfo: AccountInfo = {
-				executable: false,
-				owner: address,
-				lamports: 1000n,
-				data: { json: { space: 1n, parsed: 'parsed', program: SYSTEM_PROGRAM_ADDRESS } },
-				space: 1n,
-				rentEpoch: 123n
-			};
 			const mockResult: GetAccountInfoResult = { Ok: toNullable(mockAccountInfo) };
 			const mockResponse: MultiGetAccountInfoResult = { Consistent: mockResult };
 


### PR DESCRIPTION
# Motivation

We now expose the `getAccountInfo` of the Solana RPC Canister as explicit function, as we usually do.