### PR TITLE
fix(frontend): issue with Reward modal not being openable via Carousel

### DIFF
--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -5,6 +5,8 @@
 	import AddressBookModal from '$lib/components/address-book/AddressBookModal.svelte';
 	import DappModalDetails from '$lib/components/dapps/DappModalDetails.svelte';
 	import ReferralCodeModal from '$lib/components/referral/ReferralCodeModal.svelte';
+	import RewardModal from '$lib/components/rewards/RewardModal.svelte';
+	import RewardsEligibilityContext from '$lib/components/rewards/RewardsEligibilityContext.svelte';
 	import SettingsModal from '$lib/components/settings/SettingsModal.svelte';
 	import VipQrCodeModal from '$lib/components/vip/VipQrCodeModal.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
@@ -18,7 +20,9 @@
 		modalAddressBook,
 		modalVipQrCodeData,
 		modalIcHideTokenData,
-		modalHideTokenData
+		modalHideTokenData,
+		modalRewardDetails,
+		modalRewardDetailsData
 	} from '$lib/derived/modal.derived';
 
 	/**
@@ -41,5 +45,9 @@
 		<ReferralCodeModal />
 	{:else if $modalAddressBook}
 		<AddressBookModal />
+	{:else if $modalRewardDetails && nonNullish($modalRewardDetailsData)}
+		<RewardsEligibilityContext>
+			<RewardModal reward={$modalRewardDetailsData} />
+		</RewardsEligibilityContext>
 	{/if}
 {/if}

--- a/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
+++ b/src/frontend/src/lib/components/rewards/AllRewardsList.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { onMount, setContext } from 'svelte';
 	import { rewardCampaigns } from '$env/reward-campaigns.env';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import oisyEpisodeFour from '$lib/assets/oisy-episode-four-coming.svg';
-	import RewardModal from '$lib/components/rewards/RewardModal.svelte';
+	import RewardsEligibilityContext from '$lib/components/rewards/RewardsEligibilityContext.svelte';
 	import RewardsFilter from '$lib/components/rewards/RewardsFilter.svelte';
 	import RewardsGroup from '$lib/components/rewards/RewardsGroup.svelte';
 	import {
@@ -12,34 +10,10 @@
 		REWARDS_ENDED_CAMPAIGNS_CONTAINER,
 		REWARDS_UPCOMING_CAMPAIGNS_CONTAINER
 	} from '$lib/constants/test-ids.constants';
-	import { authIdentity } from '$lib/derived/auth.derived';
-	import { modalRewardDetails, modalRewardDetailsData } from '$lib/derived/modal.derived';
 	import { RewardStates } from '$lib/enums/reward-states';
-	import { nullishSignOut } from '$lib/services/auth.services';
-	import { getCampaignEligibilities } from '$lib/services/reward.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import {
-		initRewardEligibilityContext,
-		initRewardEligibilityStore,
-		REWARD_ELIGIBILITY_CONTEXT_KEY
-	} from '$lib/stores/reward.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { isEndedCampaign, isOngoingCampaign, isUpcomingCampaign } from '$lib/utils/rewards.utils';
-
-	const store = initRewardEligibilityStore();
-	setContext(REWARD_ELIGIBILITY_CONTEXT_KEY, initRewardEligibilityContext(store));
-
-	const loadEligibilityReport = async () => {
-		if (isNullish($authIdentity)) {
-			await nullishSignOut();
-			return;
-		}
-
-		const campaignEligibilities = await getCampaignEligibilities({ identity: $authIdentity });
-		store.setCampaignEligibilities(campaignEligibilities);
-	};
-
-	onMount(loadEligibilityReport);
 
 	let selectedRewardState = $state(RewardStates.ONGOING);
 
@@ -56,29 +30,27 @@
 	);
 </script>
 
-<RewardsFilter
-	bind:rewardState={selectedRewardState}
-	endedCampaignsAmount={endedCampaigns.length}
-/>
-
-{#if selectedRewardState === RewardStates.ONGOING}
-	<RewardsGroup
-		rewards={ongoingCampaigns}
-		testId={REWARDS_ACTIVE_CAMPAIGNS_CONTAINER}
-		altImg={oisyEpisodeFour}
-		altText={replaceOisyPlaceholders($i18n.rewards.alt.coming_soon)}
+<RewardsEligibilityContext>
+	<RewardsFilter
+		bind:rewardState={selectedRewardState}
+		endedCampaignsAmount={endedCampaigns.length}
 	/>
 
-	<RewardsGroup
-		title={replaceOisyPlaceholders($i18n.rewards.text.upcoming_campaigns)}
-		rewards={upcomingCampaigns}
-		altText={replaceOisyPlaceholders($i18n.rewards.alt.upcoming_campaigns)}
-		testId={REWARDS_UPCOMING_CAMPAIGNS_CONTAINER}
-	/>
-{:else if selectedRewardState === RewardStates.ENDED}
-	<RewardsGroup rewards={endedCampaigns} testId={REWARDS_ENDED_CAMPAIGNS_CONTAINER} />
-{/if}
+	{#if selectedRewardState === RewardStates.ONGOING}
+		<RewardsGroup
+			rewards={ongoingCampaigns}
+			testId={REWARDS_ACTIVE_CAMPAIGNS_CONTAINER}
+			altImg={oisyEpisodeFour}
+			altText={replaceOisyPlaceholders($i18n.rewards.alt.coming_soon)}
+		/>
 
-{#if $modalRewardDetails && nonNullish($modalRewardDetailsData)}
-	<RewardModal reward={$modalRewardDetailsData} />
-{/if}
+		<RewardsGroup
+			title={replaceOisyPlaceholders($i18n.rewards.text.upcoming_campaigns)}
+			rewards={upcomingCampaigns}
+			altText={replaceOisyPlaceholders($i18n.rewards.alt.upcoming_campaigns)}
+			testId={REWARDS_UPCOMING_CAMPAIGNS_CONTAINER}
+		/>
+	{:else if selectedRewardState === RewardStates.ENDED}
+		<RewardsGroup rewards={endedCampaigns} testId={REWARDS_ENDED_CAMPAIGNS_CONTAINER} />
+	{/if}
+</RewardsEligibilityContext>

--- a/src/frontend/src/lib/components/rewards/RewardsEligibilityContext.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsEligibilityContext.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { onMount, setContext, type Snippet } from 'svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { nullishSignOut } from '$lib/services/auth.services';
+	import { getCampaignEligibilities } from '$lib/services/reward.services';
+	import {
+		initRewardEligibilityContext,
+		initRewardEligibilityStore,
+		REWARD_ELIGIBILITY_CONTEXT_KEY
+	} from '$lib/stores/reward.store';
+
+	interface Props {
+		children?: Snippet;
+	}
+	let { children }: Props = $props();
+
+	const store = initRewardEligibilityStore();
+	setContext(REWARD_ELIGIBILITY_CONTEXT_KEY, initRewardEligibilityContext(store));
+
+	const loadEligibilityReport = async () => {
+		if (isNullish($authIdentity)) {
+			await nullishSignOut();
+			return;
+		}
+
+		const campaignEligibilities = await getCampaignEligibilities({ identity: $authIdentity });
+		store.setCampaignEligibilities(campaignEligibilities);
+	};
+
+	onMount(loadEligibilityReport);
+</script>
+
+{@render children?.()}

--- a/src/frontend/src/tests/lib/components/rewards/AllRewardsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/AllRewardsList.spec.ts
@@ -6,7 +6,6 @@ import {
 	REWARDS_FILTER,
 	REWARDS_UPCOMING_CAMPAIGNS_CONTAINER
 } from '$lib/constants/test-ids.constants';
-import * as rewardStore from '$lib/stores/reward.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockRewardCampaigns } from '$tests/mocks/reward-campaigns.mock';
 import { render, waitFor } from '@testing-library/svelte';
@@ -26,14 +25,6 @@ describe('AllRewardsList', () => {
 		);
 
 		mockAuthStore();
-	});
-
-	it('should initialize reward store while rendering component', () => {
-		const initStoreSpy = vi.spyOn(rewardStore, 'initRewardEligibilityStore');
-
-		render(AllRewardsList);
-
-		expect(initStoreSpy).toHaveBeenCalledOnce();
 	});
 
 	it('should render reward filter and ongoing campaigns', () => {

--- a/src/frontend/src/tests/lib/components/rewards/RewardsEligibilityContext.spec.ts
+++ b/src/frontend/src/tests/lib/components/rewards/RewardsEligibilityContext.spec.ts
@@ -1,0 +1,44 @@
+import RewardsEligibilityContext from '$lib/components/rewards/RewardsEligibilityContext.svelte';
+import * as authServices from '$lib/services/auth.services';
+import * as rewardServices from '$lib/services/reward.services';
+import * as rewardStore from '$lib/stores/reward.store';
+import type { CampaignEligibility } from '$lib/types/reward';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { render } from '@testing-library/svelte';
+import { expect, vi } from 'vitest';
+
+describe('RewardsEligibilityContext', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should call nullishSignOut when authIdentity is not set', () => {
+		const signOutSpy = vi.spyOn(authServices, 'nullishSignOut').mockResolvedValue();
+
+		render(RewardsEligibilityContext);
+
+		expect(signOutSpy).toHaveBeenCalled();
+	});
+
+	it('should initialize reward store while rendering component', () => {
+		mockAuthStore();
+
+		const campaignEligibilities: CampaignEligibility[] = [
+			{
+				campaignId: 'test',
+				eligible: true,
+				available: true,
+				criteria: []
+			}
+		];
+		const getCampaignEligibilitiesSpy = vi
+			.spyOn(rewardServices, 'getCampaignEligibilities')
+			.mockResolvedValueOnce(campaignEligibilities);
+		const initStoreSpy = vi.spyOn(rewardStore, 'initRewardEligibilityStore');
+
+		render(RewardsEligibilityContext);
+
+		expect(getCampaignEligibilitiesSpy).toHaveBeenCalledOnce();
+		expect(initStoreSpy).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
# Motivation

It is currently not possible to open a Reward modal via Carousel. This started to be the case after some refactorings made for the airdrops feature a few months ago. To fix that, we need to do a few steps:

1. Move `RewardModal` to the global `Modals` component so it can be opened within any part of the app.
2. Extract the context initialisation into a separate component and re-use it in `Modals` and `AllRewardsList`. 
