### PR TITLE
style(frontend): disabled background to inputs in Token edit modal

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -14,12 +14,14 @@
 	>{$i18n.tokens.import.text.ledger_canister_id}:
 	<span class="text-brand-primary-alt">*</span></label
 >
-<InputText
-	name="ledgerCanisterId"
-	bind:value={ledgerCanisterId}
-	disabled={editMode}
-	placeholder="_____-_____-_____-_____-cai"
-/>
+<div style={`${editMode ? '--input-background: var(--color-background-disabled);' : ''}`}>
+	<InputText
+		name="ledgerCanisterId"
+		bind:value={ledgerCanisterId}
+		disabled={editMode}
+		placeholder="_____-_____-_____-_____-cai"
+	/>
+</div>
 
 <label for="indexCanisterId" class="mt-6 block font-bold"
 	>{$i18n.tokens.import.text.index_canister_id}:</label

--- a/src/frontend/src/lib/components/manage/AddTokenByNetworkDropdown.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetworkDropdown.svelte
@@ -19,7 +19,12 @@
 	{/snippet}
 
 	{#snippet content()}
-		<div id="network" class="mt-1 pt-0.5" class:disabled>
+		<div
+			id="network"
+			class="network mt-1 pt-0.5"
+			class:disabled
+			style={`${disabled ? '--input-background: var(--color-background-disabled);' : ''}`}
+		>
 			<Dropdown name="network" bind:selectedValue={networkName} {disabled}>
 				<option disabled selected value={undefined} class:hidden={nonNullish(networkName)}
 					>{$i18n.tokens.manage.placeholder.select_network}</option


### PR DESCRIPTION
# Motivation

We need to improve the appearance of disabled inputs/selects in Token edit modal.

![Screenshot 2025-06-25 at 11 23 55](https://github.com/user-attachments/assets/dd43bde3-a629-4b0a-8d0a-f33f8aecdb36)
