### PR TITLE
feat(frontend): TokenModalContent updates

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModalContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModalContent.svelte
@@ -6,27 +6,33 @@
 	import List from '$lib/components/common/List.svelte';
 	import ModalHero from '$lib/components/common/ModalHero.svelte';
 	import ModalListItem from '$lib/components/common/ModalListItem.svelte';
+	import IconPencil from '$lib/components/icons/lucide/IconPencil.svelte';
 	import IconTrash from '$lib/components/icons/lucide/IconTrash.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Copy from '$lib/components/ui/Copy.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
+	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { TOKEN_MODAL_CONTENT_DELETE_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionToken } from '$lib/types/token';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface BaseTokenModalProps {
 		children?: Snippet;
 		token: OptionToken;
 		onDeleteClick?: () => void;
+		onEditClick?: () => void;
 	}
 
-	let { children, token, onDeleteClick }: BaseTokenModalProps = $props();
+	let { children, token, onDeleteClick, onEditClick }: BaseTokenModalProps = $props();
 </script>
 
 <ContentWithToolbar>
@@ -69,6 +75,62 @@
 			</ModalListItem>
 
 			{@render children?.()}
+
+			{#if isTokenIcrc(token) && (!isNullishOrEmpty(token.indexCanisterId) || nonNullish(onEditClick))}
+				<ModalListItem styleClass="flex-wrap">
+					{#snippet label()}
+						{$i18n.tokens.import.text.index_canister_id}
+					{/snippet}
+
+					{#snippet content()}
+						{#if !isNullishOrEmpty(token.indexCanisterId)}
+							<output>{token.indexCanisterId}</output>
+
+							<Copy
+								value={token.indexCanisterId}
+								text={$i18n.tokens.import.text.index_canister_id_copied}
+								inline
+							/>
+						{:else if nonNullish(onEditClick)}
+							<output class="text-warning-primary">
+								{$i18n.tokens.details.missing_index_canister_id_label}
+							</output>
+
+							<ButtonIcon
+								styleClass="inline-block align-sub"
+								onclick={onEditClick}
+								ariaLabel={$i18n.core.text.edit}
+								width="w-6"
+								height="h-6"
+							>
+								{#snippet icon()}
+									<IconPencil />
+								{/snippet}
+							</ButtonIcon>
+						{/if}
+					{/snippet}
+
+					{#snippet banner()}
+						{#if isNullishOrEmpty(token.indexCanisterId) && nonNullish(onEditClick)}
+							<WarningBanner styleClass="font-normal mt-2.5">
+								<div class="max-w-[60%]">
+									{replaceOisyPlaceholders($i18n.tokens.details.missing_index_canister_id_warning)}
+								</div>
+
+								<Button
+									ariaLabel={$i18n.tokens.details.missing_index_canister_id_button}
+									link
+									transparent
+									onclick={onEditClick}
+									type="button"
+								>
+									{$i18n.tokens.details.missing_index_canister_id_button}
+								</Button>
+							</WarningBanner>
+						{/if}
+					{/snippet}
+				</ModalListItem>
+			{/if}
 
 			{#if isTokenIcrc(token) || isTokenErc20(token) || isTokenDip20(token)}
 				<ModalListItem>

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -842,7 +842,8 @@
 			"show_more_networks": "Zeige $number weitere Netzwerke",
 			"hide_more_networks": "Weitere Netzwerke verbergen",
 			"on_network": " auf $network",
-			"delete_token": "Token löschen"
+			"delete_token": "Token löschen",
+			"edit_token": ""
 		},
 		"details": {
 			"title": "Token-Details",
@@ -853,7 +854,11 @@
 			"twin_token": "Twin-Token",
 			"standard": "Standard",
 			"confirm_deletion_description": "Dies entfernt <span class=\"font-bold\">$token</span> aus deiner $oisy_short-Tokenliste. Deine Gelder bleiben unberührt – Du kannst das Token jederzeit wieder hinzufügen.",
-			"deletion_confirmation": "$token wurde erfolgreich aus deiner $oisy_short Tokenliste entfernt."
+			"deletion_confirmation": "$token wurde erfolgreich aus deiner $oisy_short Tokenliste entfernt.",
+			"update_confirmation": "",
+			"missing_index_canister_id_label": "",
+			"missing_index_canister_id_warning": "",
+			"missing_index_canister_id_button": ""
 		},
 		"balance": {
 			"error": {
@@ -952,7 +957,8 @@
 			"incomplete_metadata": "Kein Name oder Symbol in den Metadaten vorhanden.",
 			"duplicate_metadata": "Ein Token mit einem ähnlichen Namen oder Symbol existiert bereits.",
 			"unexpected_undefined": "Token ist undefiniert. Das ist unerwartet.",
-			"unexpected_error_on_token_delete": "Beim Löschen des Tokens ist etwas schiefgelaufen."
+			"unexpected_error_on_token_delete": "Beim Löschen des Tokens ist etwas schiefgelaufen.",
+			"unexpected_error_on_token_update": ""
 		}
 	},
 	"fee": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -842,7 +842,8 @@
 			"show_more_networks": "Show $number more networks",
 			"hide_more_networks": "Hide more networks",
 			"on_network": " on $network",
-			"delete_token": "Delete token"
+			"delete_token": "Delete token",
+			"edit_token": "Edit token"
 		},
 		"details": {
 			"title": "Token details",
@@ -853,7 +854,11 @@
 			"twin_token": "Twin token",
 			"standard": "Standard",
 			"confirm_deletion_description": "This will remove <span class=\"font-bold\">$token</span> from your $oisy_short token list. Your funds will remain untouched — you can re-add the token at any time.",
-			"deletion_confirmation": "$token has been successfully removed from your $oisy_short token list."
+			"deletion_confirmation": "$token has been successfully removed from your $oisy_short token list.",
+			"update_confirmation": "$token has been successfully updated.",
+			"missing_index_canister_id_label": "Not assigned",
+			"missing_index_canister_id_warning": "Index canister is missing, so $oisy_short can’t fetch a list of transactions",
+			"missing_index_canister_id_button": "Set Index Canister"
 		},
 		"balance": {
 			"error": {
@@ -952,7 +957,8 @@
 			"incomplete_metadata": "No name or symbol is provided in the metadata.",
 			"duplicate_metadata": "A token with a similar name or symbol already exists.",
 			"unexpected_undefined": "Token is undefined. This is unexpected.",
-			"unexpected_error_on_token_delete": "Something went wrong while removing the token."
+			"unexpected_error_on_token_delete": "Something went wrong while removing the token.",
+			"unexpected_error_on_token_update": "Something went wrong while updating the token."
 		}
 	},
 	"fee": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -842,7 +842,8 @@
 			"show_more_networks": "",
 			"hide_more_networks": "",
 			"on_network": "",
-			"delete_token": ""
+			"delete_token": "",
+			"edit_token": ""
 		},
 		"details": {
 			"title": "",
@@ -853,7 +854,11 @@
 			"twin_token": "",
 			"standard": "",
 			"confirm_deletion_description": "",
-			"deletion_confirmation": ""
+			"deletion_confirmation": "",
+			"update_confirmation": "",
+			"missing_index_canister_id_label": "",
+			"missing_index_canister_id_warning": "",
+			"missing_index_canister_id_button": ""
 		},
 		"balance": {
 			"error": {
@@ -952,7 +957,8 @@
 			"incomplete_metadata": "",
 			"duplicate_metadata": "",
 			"unexpected_undefined": "",
-			"unexpected_error_on_token_delete": ""
+			"unexpected_error_on_token_delete": "",
+			"unexpected_error_on_token_update": ""
 		}
 	},
 	"fee": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -705,6 +705,7 @@ interface I18nTokens {
 		hide_more_networks: string;
 		on_network: string;
 		delete_token: string;
+		edit_token: string;
 	};
 	details: {
 		title: string;
@@ -716,6 +717,10 @@ interface I18nTokens {
 		standard: string;
 		confirm_deletion_description: string;
 		deletion_confirmation: string;
+		update_confirmation: string;
+		missing_index_canister_id_label: string;
+		missing_index_canister_id_warning: string;
+		missing_index_canister_id_button: string;
 	};
 	balance: { error: { not_applicable: string } };
 	import: {
@@ -794,6 +799,7 @@ interface I18nTokens {
 		duplicate_metadata: string;
 		unexpected_undefined: string;
 		unexpected_error_on_token_delete: string;
+		unexpected_error_on_token_update: string;
 	};
 }
 

--- a/src/frontend/src/tests/lib/components/tokens/TokenModalContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModalContent.spec.ts
@@ -1,8 +1,9 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import TokenModalContent from '$lib/components/tokens/TokenModalContent.svelte';
+import type { Token } from '$lib/types/token';
 import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import en from '$tests/mocks/i18n.mock';
-import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockIndexCanisterId, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('TokenModalContent', () => {
@@ -27,10 +28,10 @@ describe('TokenModalContent', () => {
 		expect(getByText(ICP_TOKEN.decimals)).toBeInTheDocument();
 	});
 
-	it('renders all values correctly for ICRC token', () => {
+	it('renders all values correctly for ICRC token with index canister', () => {
 		const { getByText, container } = render(TokenModalContent, {
 			props: {
-				token: mockValidIcrcToken
+				token: { ...mockValidIcrcToken, indexCanisterId: mockIndexCanisterId } as Token
 			}
 		});
 
@@ -44,6 +45,38 @@ describe('TokenModalContent', () => {
 
 		expect(getByText(en.tokens.details.standard)).toBeInTheDocument();
 		expect(getByText(mockValidIcrcToken.standard)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.import.text.index_canister_id)).toBeInTheDocument();
+		expect(getByText(mockIndexCanisterId)).toBeInTheDocument();
+
+		expect(getByText(en.core.text.symbol)).toBeInTheDocument();
+
+		expect(getByText(en.core.text.decimals)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.decimals)).toBeInTheDocument();
+	});
+
+	it('renders all values correctly for ICRC token without index canister', () => {
+		const { getByText, container } = render(TokenModalContent, {
+			props: {
+				token: mockValidIcrcToken,
+				onEditClick: () => {}
+			}
+		});
+
+		expect(container).toHaveTextContent(getTokenDisplaySymbol(mockValidIcrcToken));
+
+		expect(getByText(en.tokens.details.network)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.network.name)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.token)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.name)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.details.standard)).toBeInTheDocument();
+		expect(getByText(mockValidIcrcToken.standard)).toBeInTheDocument();
+
+		expect(getByText(en.tokens.import.text.index_canister_id)).toBeInTheDocument();
+		expect(getByText(en.tokens.details.missing_index_canister_id_label)).toBeInTheDocument();
+		expect(getByText(en.tokens.details.missing_index_canister_id_button)).toBeInTheDocument();
 
 		expect(getByText(en.core.text.symbol)).toBeInTheDocument();
 


### PR DESCRIPTION
# Motivation

We need to update TokenModalContect in order to handle the custom icrc token edit functionality. The changes include:

# Changes
1. For better code structure, the index canister modal item was moved from `IcTokenModal` to `TokenModalContent`.
2. If a token is ICRC, and it has an indexCanisterId - we display the value, if no id available AND we pass `onEditClick` from parent (same as with the delete functionality) - we display an edit button as well as warning banner.

# Tests
Updated.

![Screenshot 2025-06-25 at 12 58 08](https://github.com/user-attachments/assets/5a95b3c4-b618-41bc-a009-e0268023cc72)
