### PR TITLE
feat(frontend): Get always the max fee for Ethereum/EVM

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -32,6 +32,7 @@
 	import type { Token, TokenId } from '$lib/types/token';
 	import { isNetworkICP } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
+	import { maxBigInt } from '$lib/utils/bigint.utils';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -79,8 +80,8 @@
 
 			const feeData = {
 				...feeDataRest,
-				maxFeePerGas: maxFeePerGas ?? suggestedMaxFeePerGas,
-				maxPriorityFeePerGas: maxPriorityFeePerGas ?? suggestedMaxPriorityFeePerGas
+				maxFeePerGas:maxBigInt( maxFeePerGas , suggestedMaxFeePerGas),
+				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas , suggestedMaxPriorityFeePerGas)
 			};
 
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {

--- a/src/frontend/src/lib/utils/bigint.utils.ts
+++ b/src/frontend/src/lib/utils/bigint.utils.ts
@@ -1,0 +1,5 @@
+import { nonNullish } from '@dfinity/utils';
+
+// eslint-disable-next-line local-rules/prefer-object-params -- Visually, it is clearer to have two parameters for maxBigInt
+export const maxBigInt = (n1: bigint | null, n2: bigint | null): bigint | null =>
+	nonNullish(n1) && nonNullish(n2) ? (n1 > n2 ? n1 : n2) : (n1 ?? n2);

--- a/src/frontend/src/tests/lib/utils/bigint.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/bigint.utils.spec.ts
@@ -1,0 +1,27 @@
+import { maxBigInt } from '$lib/utils/bigint.utils';
+
+describe('bigint.utils', () => {
+	describe('maxBigInt', () => {
+		it('should return the maximum of two bigint values', () => {
+			expect(maxBigInt(10n, 20n)).toBe(20n);
+			expect(maxBigInt(30n, 20n)).toBe(30n);
+		});
+
+		it('should handle negative bigints', () => {
+			expect(maxBigInt(-10n, -20n)).toBe(-10n);
+			expect(maxBigInt(-30n, -20n)).toBe(-20n);
+		});
+
+		it('should return null if both values are null', () => {
+			expect(maxBigInt(null, null)).toBeNull();
+		});
+
+		it('should return the non-null value if one is null', () => {
+			expect(maxBigInt(10n, null)).toBe(10n);
+			expect(maxBigInt(null, 20n)).toBe(20n);
+
+			expect(maxBigInt(-10n, null)).toBe(-10n);
+			expect(maxBigInt(null, -20n)).toBe(-20n);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

For all tokens in Ethereum and EVM, it is better to always get the max fee as the maximum between our sources: ck-minters, RPC fee data, and Infura fee API.

# Changes

- Create util to get the max between two `bigint` objects.
- Use the util in `FeeContext`.

# Tests

Added tests.
