### PR TITLE
feat(frontend): Estimate gas for Ethereum/EVM instead of hard-coded values

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -30,9 +30,9 @@
 	import type { Network } from '$lib/types/network';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Token, TokenId } from '$lib/types/token';
+	import { maxBigInt } from '$lib/utils/bigint.utils';
 	import { isNetworkICP } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
-	import { maxBigInt } from '$lib/utils/bigint.utils';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -80,8 +80,8 @@
 
 			const feeData = {
 				...feeDataRest,
-				maxFeePerGas:maxBigInt( maxFeePerGas , suggestedMaxFeePerGas) ?? null,
-				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas , suggestedMaxPriorityFeePerGas) ?? null
+				maxFeePerGas: maxBigInt(maxFeePerGas, suggestedMaxFeePerGas) ?? null,
+				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas, suggestedMaxPriorityFeePerGas) ?? null
 			};
 
 			const feeDataGas = getEthFeeData({
@@ -89,9 +89,9 @@
 				helperContractAddress: toCkEthHelperContractAddress(
 					$ckEthMinterInfoStore?.[nativeEthereumToken.id]
 				)
-			})
+			});
 
-			const estimatedGas = await estimateGas(params)
+			const estimatedGas = await estimateGas(params);
 
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {
 				feeStore.setFee({

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -65,7 +65,7 @@
 				from: mapAddressStartsWith0x($ethAddress)
 			};
 
-			const { getFeeData } = infuraProviders(sendToken.network.id);
+			const { getFeeData, estimateGas } = infuraProviders(sendToken.network.id);
 
 			const { maxFeePerGas, maxPriorityFeePerGas, ...feeDataRest } = await getFeeData();
 
@@ -84,15 +84,19 @@
 				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas , suggestedMaxPriorityFeePerGas) ?? null
 			};
 
+			const feeDataGas = getEthFeeData({
+				...params,
+				helperContractAddress: toCkEthHelperContractAddress(
+					$ckEthMinterInfoStore?.[nativeEthereumToken.id]
+				)
+			})
+
+			const estimatedGas = await estimateGas(params)
+
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {
 				feeStore.setFee({
 					...feeData,
-					gas: getEthFeeData({
-						...params,
-						helperContractAddress: toCkEthHelperContractAddress(
-							$ckEthMinterInfoStore?.[nativeEthereumToken.id]
-						)
-					})
+					gas: maxBigInt(feeDataGas, estimatedGas)
 				});
 				return;
 			}

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -80,8 +80,8 @@
 
 			const feeData = {
 				...feeDataRest,
-				maxFeePerGas:maxBigInt( maxFeePerGas , suggestedMaxFeePerGas),
-				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas , suggestedMaxPriorityFeePerGas)
+				maxFeePerGas:maxBigInt( maxFeePerGas , suggestedMaxFeePerGas) ?? null,
+				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas , suggestedMaxPriorityFeePerGas) ?? null
 			};
 
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {

--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -32,6 +32,7 @@
 	import type { Token, TokenId } from '$lib/types/token';
 	import { isNetworkICP } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
+	import { maxBigInt } from '$lib/utils/bigint.utils';
 
 	export let observe: boolean;
 	export let destination = '';
@@ -79,8 +80,8 @@
 
 			const feeData = {
 				...feeDataRest,
-				maxFeePerGas: maxFeePerGas ?? suggestedMaxFeePerGas,
-				maxPriorityFeePerGas: maxPriorityFeePerGas ?? suggestedMaxPriorityFeePerGas
+				maxFeePerGas:maxBigInt( maxFeePerGas , suggestedMaxFeePerGas),
+				maxPriorityFeePerGas: maxBigInt(maxPriorityFeePerGas , suggestedMaxPriorityFeePerGas)
 			};
 
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {

--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -26,8 +26,7 @@ export class InfuraProvider {
 
 	getFeeData = (): Promise<FeeData> => this.provider.getFeeData();
 
-	estimateGas = ({ to, from }: GetFeeData): Promise<bigint> =>
-		this.provider.estimateGas({ to, from });
+	estimateGas = (params: GetFeeData): Promise<bigint> => this.provider.estimateGas(params);
 
 	sendTransaction = (signedTransaction: string): Promise<TransactionResponse> =>
 		this.provider.broadcastTransaction(signedTransaction);

--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -1,6 +1,7 @@
 import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
+import type { GetFeeData } from '$eth/services/fee.services';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
@@ -25,7 +26,7 @@ export class InfuraProvider {
 
 	getFeeData = (): Promise<FeeData> => this.provider.getFeeData();
 
-	estimateGas = ({ to, from }: { from: EthAddress; to: EthAddress }) =>
+	estimateGas = ({ to, from }: GetFeeData): Promise<bigint> =>
 		this.provider.estimateGas({ to, from });
 
 	sendTransaction = (signedTransaction: string): Promise<TransactionResponse> =>

--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -25,6 +25,9 @@ export class InfuraProvider {
 
 	getFeeData = (): Promise<FeeData> => this.provider.getFeeData();
 
+	estimateGas = ({ to, from }: { from: EthAddress; to: EthAddress }) =>
+		this.provider.estimateGas({ to, from });
+
 	sendTransaction = (signedTransaction: string): Promise<TransactionResponse> =>
 		this.provider.broadcastTransaction(signedTransaction);
 

--- a/src/frontend/src/lib/utils/bigint.utils.ts
+++ b/src/frontend/src/lib/utils/bigint.utils.ts
@@ -1,6 +1,12 @@
 import type { Option } from '$lib/types/utils';
 import { nonNullish } from '@dfinity/utils';
 
-// eslint-disable-next-line local-rules/prefer-object-params -- Visually, it is clearer to have two parameters for maxBigInt
-export const maxBigInt = (n1: Option<bigint>, n2: Option<bigint>): Option<bigint> =>
-	nonNullish(n1) && nonNullish(n2) ? (n1 > n2 ? n1 : n2) : (n1 ?? n2);
+export function maxBigInt(n1: bigint, n2: bigint): bigint;
+export function maxBigInt(n1: bigint, n2: Option<bigint>): bigint;
+export function maxBigInt(n1: Option<bigint>, n2: bigint): bigint;
+export function maxBigInt(n1: Option<bigint>, n2: Option<bigint>): Option<bigint>;
+
+// eslint-disable-next-line local-rules/prefer-object-params, prefer-arrow/prefer-arrow-functions, func-style -- Visually, it is clearer to have two parameters for maxBigInt and to have the overloads for the types
+export function maxBigInt(n1: Option<bigint>, n2: Option<bigint>): Option<bigint> {
+	return nonNullish(n1) && nonNullish(n2) ? (n1 > n2 ? n1 : n2) : (n1 ?? n2);
+}

--- a/src/frontend/src/lib/utils/bigint.utils.ts
+++ b/src/frontend/src/lib/utils/bigint.utils.ts
@@ -1,5 +1,6 @@
+import type { Option } from '$lib/types/utils';
 import { nonNullish } from '@dfinity/utils';
 
 // eslint-disable-next-line local-rules/prefer-object-params -- Visually, it is clearer to have two parameters for maxBigInt
-export const maxBigInt = (n1: bigint | null, n2: bigint | null): bigint | null =>
+export const maxBigInt = (n1: Option<bigint>, n2: Option<bigint>): Option<bigint> =>
 	nonNullish(n1) && nonNullish(n2) ? (n1 > n2 ? n1 : n2) : (n1 ?? n2);

--- a/src/frontend/src/lib/utils/bigint.utils.ts
+++ b/src/frontend/src/lib/utils/bigint.utils.ts
@@ -1,0 +1,5 @@
+import { nonNullish } from '@dfinity/utils';
+
+// eslint-disable-next-line local-rules/prefer-object-params -- Visually, it is clearer to have two parameters for maxBigInt
+export const maxBigInt = (n1: bigint | null, n2: bigint | null): bigint | null =>
+	nonNullish(n1) && nonNullish(n2) ? (n1 > n2 ? n1 : n2) : (n1 ?? n2);

--- a/src/frontend/src/tests/lib/utils/bigint.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/bigint.utils.spec.ts
@@ -1,0 +1,27 @@
+import { maxBigInt } from '$lib/utils/bigint.utils';
+
+describe('bigint.utils', () => {
+	describe('maxBigInt', () => {
+		it('should return the maximum of two bigint values', () => {
+			expect(maxBigInt(10n, 20n)).toBe(20n);
+			expect(maxBigInt(30n, 20n)).toBe(30n);
+		});
+
+		it('should handle negative bigints', () => {
+			expect(maxBigInt(-10n, -20n)).toBe(-10n);
+			expect(maxBigInt(-30n, -20n)).toBe(-20n);
+		});
+
+		it('should return null if both values are null', () => {
+			expect(maxBigInt(null, null)).toBeNull();
+		});
+
+		it('should return the non-null value if one is null', () => {
+			expect(maxBigInt(10n, null)).toBe(10n);
+			expect(maxBigInt(null, 20n)).toBe(20n);
+
+			expect(maxBigInt(-10n, null)).toBe(-10n);
+			expect(maxBigInt(null, -20n)).toBe(-20n);
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/bigint.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/bigint.utils.spec.ts
@@ -16,12 +16,30 @@ describe('bigint.utils', () => {
 			expect(maxBigInt(null, null)).toBeNull();
 		});
 
+		it('should return undefined if both values are undefined', () => {
+			expect(maxBigInt(undefined, undefined)).toBeUndefined();
+		});
+
 		it('should return the non-null value if one is null', () => {
 			expect(maxBigInt(10n, null)).toBe(10n);
 			expect(maxBigInt(null, 20n)).toBe(20n);
 
 			expect(maxBigInt(-10n, null)).toBe(-10n);
 			expect(maxBigInt(null, -20n)).toBe(-20n);
+		});
+
+		it('should return the non-undefined value if one is undefined', () => {
+			expect(maxBigInt(10n, undefined)).toBe(10n);
+			expect(maxBigInt(undefined, 20n)).toBe(20n);
+
+			expect(maxBigInt(-10n, undefined)).toBe(-10n);
+			expect(maxBigInt(undefined, -20n)).toBe(-20n);
+		});
+
+		it('should return the second value if both are nullish', () => {
+			expect(maxBigInt(null, undefined)).toBeUndefined();
+
+			expect(maxBigInt(undefined, null)).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We are integrating more EVM networks. However, not all of them have the gas limit defined the same as Ethereum.

They don't necessarily all use 21k for `transfer` transactions. In fact, for Arbitrum, the normal transfers are failing, since we don't provide enough gas limit.

# Changes

- Change util maxBigInt to have overloads, so that the type is guaranteed if one of the two inputs is non-nullish.
- Create method to estimate gas from provider in class `InfuraProvider`.
- Take the max between the current hard-coded values and the estimated ones.

# Tests

Tested manually in FE test canister 2, and the transaction wen through:


https://github.com/user-attachments/assets/13f98a23-8ee4-4b71-8b29-bd024d36af37


