### PR TITLE
feat(frontend): relaunch ICRC worker on indexCanisterId being added

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -53,14 +53,16 @@ const loadDefaultIcrcTokens = async () => {
 
 export const loadCustomTokens = ({
 	identity,
-	useCache = false
+	useCache = false,
+	onSuccess
 }: {
 	identity: OptionIdentity;
 	useCache?: boolean;
+	onSuccess?: () => void;
 }): Promise<void> =>
 	queryAndUpdate<IcrcCustomToken[]>({
 		request: (params) => loadIcrcCustomTokens({ ...params, useCache }),
-		onLoad: loadIcrcCustomData,
+		onLoad: (params) => loadIcrcCustomData({ ...params, onSuccess }),
 		onUpdateError: ({ error: err }) => {
 			icrcCustomTokensStore.resetAll();
 
@@ -244,11 +246,15 @@ const loadCustomIcrcTokensData = async ({
 
 const loadIcrcCustomData = ({
 	response: tokens,
-	certified
+	certified,
+	onSuccess
 }: {
 	certified: boolean;
 	response: IcrcCustomToken[];
+	onSuccess?: () => void;
 }) => {
+	onSuccess?.();
+
 	icrcCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
 };
 

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -242,17 +242,23 @@
 
 				progress(ProgressStepsAddToken.UPDATE_UI);
 				// Similar as on token "save", we reload all custom tokens for simplicity reason.
-				await loadCustomTokens({ identity: $authIdentity });
+				await loadCustomTokens({
+					identity: $authIdentity,
+					onSuccess: () => {
+						progress(ProgressStepsAddToken.DONE);
+						close();
 
-				progress(ProgressStepsAddToken.DONE);
-				modalStore.close();
+						// the token needs to be reset to restart the worker with indexCanisterId
+						icrcCustomTokensStore.reset(tokenToEdit.ledgerCanisterId);
 
-				toastsShow({
-					text: replacePlaceholders($i18n.tokens.details.update_confirmation, {
-						$token: getTokenDisplaySymbol(tokenToEdit)
-					}),
-					level: 'success',
-					duration: 2000
+						toastsShow({
+							text: replacePlaceholders($i18n.tokens.details.update_confirmation, {
+								$token: getTokenDisplaySymbol(tokenToEdit)
+							}),
+							level: 'success',
+							duration: 2000
+						});
+					}
 				});
 			}
 		} catch (err) {
@@ -339,7 +345,7 @@
 	{/if}
 </WizardModal>
 
-{#if currentStep?.name === TokenModalSteps.CONTENT && showBottomSheetDeleteConfirmation}
+{#if currentStepName === TokenModalSteps.CONTENT && showBottomSheetDeleteConfirmation}
 	<BottomSheetConfirmationPopup
 		onCancel={() => (showBottomSheetDeleteConfirmation = false)}
 		disabled={loading}

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -95,7 +95,6 @@ describe('TokenModal', () => {
 		});
 
 		const setCustomTokenMock = mockSetCustomToken();
-		const toasts = mockToastsShow();
 		mockAuthStore();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
@@ -110,7 +109,6 @@ describe('TokenModal', () => {
 
 		expect(setCustomTokenMock).toHaveBeenCalledOnce();
 		expect(loadCustomTokens).toHaveBeenCalledOnce();
-		expect(toasts).toHaveBeenCalledOnce();
 	});
 
 	it('does not delete token if it is not erc20', async () => {


### PR DESCRIPTION
# Motivation

To make a newly added indexCanisterId being used by the ICRC wallet worker, we need to reset the related token store before updating it with the new data from BE (which will include indexCanisterId).
