### PR TITLE
fix(frontend): User cannot add ICP token

### DIFF
--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -1,3 +1,4 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { getLedgerId, getTransactions as getTransactionsIcrc } from '$icp/api/icrc-index-ng.api';
 import { balance, metadata } from '$icp/api/icrc-ledger.api';
 import type { IcCanisters, IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
@@ -42,7 +43,7 @@ export const loadAndAssertAddCustomToken = async ({
 	const canisterIds = { ledgerCanisterId, indexCanisterId };
 
 	const { alreadyAvailable } = assertAlreadyAvailable({
-		icrcTokens,
+		icrcTokens: [ICP_TOKEN, ...icrcTokens],
 		...canisterIds
 	});
 

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -1,4 +1,8 @@
-import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import {
+	ICP_INDEX_CANISTER_ID,
+	ICP_LEDGER_CANISTER_ID,
+	ICP_NETWORK
+} from '$env/networks/networks.icp.env';
 import { loadAndAssertAddCustomToken } from '$icp/services/ic-add-custom-tokens.service';
 import type { IcCanisters, IcToken } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
@@ -93,6 +97,21 @@ describe('ic-add-custom-tokens.service', () => {
 
 				expect(spyToastsError).toHaveBeenNthCalledWith(1, {
 					msg: { text: get(i18n).tokens.import.error.missing_ledger_id }
+				});
+			});
+
+			it('should return error if the ledger canister is the ICP token ledger', async () => {
+				const result = await loadAndAssertAddCustomToken({
+					identity: mockIdentity,
+					icrcTokens: [],
+					ledgerCanisterId: ICP_LEDGER_CANISTER_ID,
+					indexCanisterId: ICP_INDEX_CANISTER_ID
+				});
+
+				expect(result).toEqual({ result: 'error' });
+
+				expect(spyToastsError).toHaveBeenNthCalledWith(1, {
+					msg: { text: get(i18n).tokens.error.already_available }
 				});
 			});
 

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -105,7 +105,6 @@ describe('ic-add-custom-tokens.service', () => {
 					identity: mockIdentity,
 					icrcTokens: [],
 					ledgerCanisterId: ICP_LEDGER_CANISTER_ID,
-					indexCanisterId: ICP_INDEX_CANISTER_ID
 				});
 
 				expect(result).toEqual({ result: 'error' });

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -1,8 +1,4 @@
-import {
-	ICP_INDEX_CANISTER_ID,
-	ICP_LEDGER_CANISTER_ID,
-	ICP_NETWORK
-} from '$env/networks/networks.icp.env';
+import { ICP_LEDGER_CANISTER_ID, ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { loadAndAssertAddCustomToken } from '$icp/services/ic-add-custom-tokens.service';
 import type { IcCanisters, IcToken } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
@@ -104,7 +100,7 @@ describe('ic-add-custom-tokens.service', () => {
 				const result = await loadAndAssertAddCustomToken({
 					identity: mockIdentity,
 					icrcTokens: [],
-					ledgerCanisterId: ICP_LEDGER_CANISTER_ID,
+					ledgerCanisterId: ICP_LEDGER_CANISTER_ID
 				});
 
 				expect(result).toEqual({ result: 'error' });


### PR DESCRIPTION
# Motivation

The user should not be able to add the ICp token, since it is always present.

# Changes

Adjust assertion of already-available tokens, passing ICP tokens together with ICRC tokens.

# Tests

Adjusted tests and tested manually in local replica:

![Screenshot 2025-06-27 at 11 10 55](https://github.com/user-attachments/assets/66d18933-4ec7-4eab-9bf3-45c55744d312)

