### PR TITLE
fix(frontend): Allow ERC20 tokens with same address and different networks

### DIFF
--- a/src/frontend/src/lib/stores/user-tokens.store.ts
+++ b/src/frontend/src/lib/stores/user-tokens.store.ts
@@ -23,7 +23,11 @@ export const initCertifiedUserTokensStore = <T extends Token>(): CertifiedUserTo
 	const getIdentifier = <T extends Token>(
 		token: T
 	): TokenId | Erc20ContractAddress['address'] | SplTokenAddress =>
-		isTokenSpl(token) ? token.address : isTokenErc20(token) ? token.address : token.id;
+		isTokenSpl(token)
+			? token.address
+			: isTokenErc20(token)
+				? `${token.address}#${token.network.chainId}`
+				: token.id;
 
 	return {
 		setAll: (tokens: CertifiedData<UserToken<T>>[]) =>

--- a/src/frontend/src/tests/lib/stores/user-tokens.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/user-tokens.store.spec.ts
@@ -1,3 +1,5 @@
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
@@ -14,6 +16,7 @@ import type { CertifiedData } from '$lib/types/store';
 import type { Token } from '$lib/types/token';
 import type { UserToken } from '$lib/types/user-token';
 import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { get } from 'svelte/store';
 
 describe('user-token.store', () => {
@@ -118,6 +121,43 @@ describe('user-token.store', () => {
 
 				const expectedResults = [
 					{ data: { ...erc20Token2, enabled, id: BONK_TOKEN.id }, certified }
+				];
+
+				expect(get(mockStore)).toEqual(expectedResults);
+			});
+
+			it('should not save ERC20 tokens with same address and same networks as different tokens', () => {
+				mockStore.setAll([
+					{ data: { ...mockValidErc20Token, network: BASE_NETWORK, enabled }, certified }
+				]);
+				mockStore.setAll([
+					{ data: { ...mockValidErc20Token, network: BASE_NETWORK, enabled }, certified }
+				]);
+
+				const expectedResults = [
+					{ data: { ...mockValidErc20Token, network: BASE_NETWORK, enabled }, certified }
+				];
+
+				expect(get(mockStore)).toEqual(expectedResults);
+			});
+
+			it('should save ERC20 tokens with same address but different networks as different tokens', () => {
+				mockStore.setAll([
+					{ data: { ...mockValidErc20Token, network: BASE_NETWORK, enabled }, certified }
+				]);
+				mockStore.setAll([
+					{
+						data: { ...mockValidErc20Token, network: ARBITRUM_MAINNET_NETWORK, enabled },
+						certified
+					}
+				]);
+
+				const expectedResults = [
+					{ data: { ...mockValidErc20Token, network: BASE_NETWORK, enabled }, certified },
+					{
+						data: { ...mockValidErc20Token, network: ARBITRUM_MAINNET_NETWORK, enabled },
+						certified
+					}
 				];
 
 				expect(get(mockStore)).toEqual(expectedResults);


### PR DESCRIPTION
# Motivation

It may happen that some ERC20 share the same address thorough different networks. However, OISY was consider them duplicates. We fix that.

# Changes

- Change method setAll of user token store to identify ERC20 tokens both by address and chain ID.

# Tests

Added tests and practical example:

### Before

![Screenshot 2025-06-27 at 11 35 03](https://github.com/user-attachments/assets/0b1cc2a6-9a7c-4e38-97fb-d60aa06ef5f4)

### After

![Screenshot 2025-06-27 at 11 34 46](https://github.com/user-attachments/assets/05374f87-6599-43e3-bc02-97fa6229bf78)

