### PR TITLE
feat(frontend): Create pseudo-network for ICRC test tokens

### DIFF
--- a/src/frontend/src/env/networks/networks.env.ts
+++ b/src/frontend/src/env/networks/networks.env.ts
@@ -3,12 +3,13 @@
 import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_BITCOIN_NETWORKS } from '$env/networks/networks.btc.env';
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK, ICP_PSEUDO_TESTNET_NETWORK } from '$env/networks/networks.icp.env';
 import { SUPPORTED_SOLANA_NETWORKS } from '$env/networks/networks.sol.env';
 import type { Network, NetworkId } from '$lib/types/network';
 
 export const SUPPORTED_NETWORKS: Network[] = [
 	ICP_NETWORK,
+	ICP_PSEUDO_TESTNET_NETWORK,
 	...SUPPORTED_BITCOIN_NETWORKS,
 	...SUPPORTED_ETHEREUM_NETWORKS,
 	...SUPPORTED_SOLANA_NETWORKS,

--- a/src/frontend/src/env/networks/networks.icp.env.ts
+++ b/src/frontend/src/env/networks/networks.icp.env.ts
@@ -37,7 +37,7 @@ export const ICP_NETWORK: Network = {
  * ICP Pseudo Testnet Network
  *
  * This is a pseudo testnet network for ICP, used for testing/developing purposes.
- * It will be associated with what we call ck-testnet-tokens.
+ * It will be associated with what we call "testnet" tokens.
  * This allows us to simplify the filters of the token list and avoid polluting "real" ICP balance with the balances of the testnet tokens.
  */
 const ICP_PSEUDO_TESTNET_NETWORK_SYMBOL = 'ICP-PSEUDO-TESTNET';

--- a/src/frontend/src/env/networks/networks.icp.env.ts
+++ b/src/frontend/src/env/networks/networks.icp.env.ts
@@ -32,3 +32,24 @@ export const ICP_NETWORK: Network = {
 	iconDark: icpIconDark,
 	buy: { onramperId: 'icp' }
 };
+
+/**
+ * ICP Pseudo Testnet Network
+ *
+ * This is a pseudo testnet network for ICP, used for testing/developing purposes.
+ * It will be associated with what we call ck-testnet-tokens.
+ * This allows us to simplify the filters of the token list and avoid polluting "real" ICP balance with the balances of the testnet tokens.
+ */
+const ICP_PSEUDO_TESTNET_NETWORK_SYMBOL = 'ICP-PSEUDO-TESTNET';
+
+export const ICP_PSEUDO_TESTNET_NETWORK_ID: NetworkId = parseNetworkId(
+	ICP_PSEUDO_TESTNET_NETWORK_SYMBOL
+);
+
+export const ICP_PSEUDO_TESTNET_NETWORK: Network = {
+	id: ICP_PSEUDO_TESTNET_NETWORK_ID,
+	env: 'testnet',
+	name: 'IC (testnet tokens)',
+	iconLight: icpIconLight,
+	iconDark: icpIconDark
+};

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -34,6 +34,32 @@ const CUSTOM_SYMBOLS_BY_LEDGER_CANISTER_ID: Record<LedgerCanisterIdText, string>
 	[ICONFUCIUS_LEDGER_CANISTER_ID]: 'ICONFUCIUS'
 };
 
+/**
+ * Determines which network a given ICRC token belongs to based on its ledger canister ID.
+ *
+ * Some tokens (e.g., `ckSepoliaETH`, `ckSepoliaUSDC`) are considered "testnet" tokens.
+ * These are tied to testnets of external chains (like Sepolia for Ethereum), but since the
+ * Internet Computer (IC) does not have a native testnet environment, we fake one.
+ *
+ * Originally, testnet tokens were shown as part of the IC network, but that led to confusion
+ * — especially when aggregating balances — as their balances would mix with mainnet tokens.
+ *
+ * To avoid this, we now separate these testnet tokens into a pseudo-test network:
+ * `ICP_PSEUDO_TESTNET_NETWORK`, which mirrors the IC network in behavior but is visually
+ * and logically distinct.
+ *
+ * This ensures:
+ * - Production tokens only show in the "real" IC network (`ICP_NETWORK`)
+ * - Testnet tokens only show in the pseudo-network when testnet mode is enabled
+ *
+ * @param ledgerCanisterId - The ledger canister ID of the token.
+ * @returns The appropriate network identifier for the token:
+ *          - `ICP_NETWORK` for "mainnet" tokens
+ *          - `ICP_PSEUDO_TESTNET_NETWORK` for known "testnet" tokens
+ */
+const mapIcNetwork = (ledgerCanisterId: LedgerCanisterIdText) =>
+	isTokenIcrcTestnet({ ledgerCanisterId }) ? ICP_PSEUDO_TESTNET_NETWORK : ICP_NETWORK;
+
 export const mapIcrcToken = ({
 	metadata,
 	icrcCustomTokens,
@@ -59,7 +85,7 @@ export const mapIcrcToken = ({
 
 	return {
 		id: parseTokenId(symbol),
-		network: isTokenIcrcTestnet({ ledgerCanisterId }) ? ICP_PSEUDO_TESTNET_NETWORK : ICP_NETWORK,
+		network: mapIcNetwork(ledgerCanisterId),
 		standard: icrcCustomTokens?.[ledgerCanisterId]?.standard ?? 'icrc',
 		symbol,
 		...(notEmptyString(icon) && { icon }),

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK, ICP_PSEUDO_TESTNET_NETWORK } from '$env/networks/networks.icp.env';
 import {
 	GHOSTNODE_LEDGER_CANISTER_ID,
 	ICONFUCIUS_LEDGER_CANISTER_ID
@@ -10,6 +10,7 @@ import type {
 	IcTokenWithoutIdExtended,
 	IcrcCustomToken
 } from '$icp/types/icrc-custom-token';
+import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { TokenCategory, TokenMetadata } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -58,7 +59,7 @@ export const mapIcrcToken = ({
 
 	return {
 		id: parseTokenId(symbol),
-		network: ICP_NETWORK,
+		network: isTokenIcrcTestnet({ ledgerCanisterId }) ? ICP_PSEUDO_TESTNET_NETWORK : ICP_NETWORK,
 		standard: icrcCustomTokens?.[ledgerCanisterId]?.standard ?? 'icrc',
 		symbol,
 		...(notEmptyString(icon) && { icon }),

--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -34,6 +34,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { UserNetworks } from '$lib/types/user-networks';
 	import { emit } from '$lib/utils/events.utils';
+	import { isNetworkIdICP } from '$lib/utils/network.utils.js';
 
 	const enabledNetworks = { ...$userNetworks };
 	const enabledNetworksInitial = { ...enabledNetworks };
@@ -134,7 +135,7 @@
 				<ManageNetworkToggle
 					checked={enabledNetworks[network.id]?.enabled ?? false}
 					on:nnsToggle={() => toggleNetwork(network)}
-					disabled={network.id === ICP_NETWORK_ID}
+					disabled={isNetworkIdICP(network.id)}
 				/>
 			</ListItem>
 		{/each}
@@ -156,6 +157,7 @@
 						checked={enabledNetworks[network.id]?.enabled ?? false}
 						on:nnsToggle={() => toggleNetwork(network)}
 						testId={`${SETTINGS_NETWORKS_MODAL_TESTNET_TOGGLE}-${network.id.description}`}
+						disabled={isNetworkIdICP(network.id)}
 					/>
 				</ListItem>
 			{/each}

--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -6,7 +6,6 @@
 		SUPPORTED_NETWORKS,
 		SUPPORTED_TESTNET_NETWORKS
 	} from '$env/networks/networks.env';
-	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 	import { setUserShowTestnets, updateUserNetworkSettings } from '$lib/api/backend.api';
 	import List from '$lib/components/common/List.svelte';
 	import ListItem from '$lib/components/common/ListItem.svelte';

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -9,7 +9,7 @@ import {
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK, ICP_PSEUDO_TESTNET_NETWORK } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,
@@ -32,6 +32,7 @@ export const networks: Readable<Network[]> = derived(
 		...$enabledBitcoinNetworks,
 		...$enabledEthereumNetworks,
 		ICP_NETWORK,
+		ICP_PSEUDO_TESTNET_NETWORK,
 		...$enabledSolanaNetworks,
 		...$enabledEvmNetworks
 	]

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -25,7 +25,7 @@ import {
 	SUPPORTED_TESTNET_NETWORK_IDS
 } from '$env/networks/networks.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,
@@ -126,7 +126,8 @@ export const userNetworks: Readable<UserNetworks> = derived(
 				return { ...acc, [networkId]: { enabled, isTestnet } };
 			}, {}),
 			// We always enable ICP network.
-			[ICP_NETWORK_ID]: { enabled: true, isTestnet: false }
+			[ICP_NETWORK_ID]: { enabled: true, isTestnet: false },
+			[ICP_PSEUDO_TESTNET_NETWORK_ID]: { enabled: true, isTestnet: true }
 		};
 	}
 );

--- a/src/frontend/src/lib/schema/network.schema.ts
+++ b/src/frontend/src/lib/schema/network.schema.ts
@@ -29,6 +29,17 @@ const IconSchema = z
 		message: 'Must be an SVG file'
 	});
 
+/**
+ * Zod schema defining the shape of a network-like object.
+ *
+ * This schema represents both actual networks (e.g., the Internet Computer, Ethereum, Bitcoin mainnet)
+ * and "pseudo-networks" used for development or simulation purposes. For example, the
+ * `ICP_PSEUDO_TESTNET_NETWORK` mimics the structure of the IC network but is used to
+ * isolate testnet tokens such as `ckSepoliaETH` from production data.
+ *
+ * This flexible schema supports both actual networks and internally defined groupings used
+ * for development, testing, or UX separation.
+ */
 export const NetworkSchema = z.object({
 	id: NetworkIdSchema,
 	env: NetworkEnvironmentSchema,

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -1,7 +1,6 @@
 import { SUPPORTED_EVM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_BITCOIN_NETWORK_IDS } from '$env/networks/networks.btc.env';
 import { SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { SUPPORTED_SOLANA_NETWORK_IDS } from '$env/networks/networks.sol.env';
 import { TOKEN_ACCOUNT_ID_TYPES_CASE_SENSITIVE } from '$lib/constants/token-account-id.constants';
 import type { StorageAddressData } from '$lib/stores/address.store';
@@ -9,6 +8,7 @@ import type { Address, OptionAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
+import { isNetworkIdICP } from '$lib/utils/network.utils';
 import { parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
@@ -39,7 +39,7 @@ const mapNetworkIdToAddressType = (
 		return;
 	}
 
-	if (networkId === ICP_NETWORK_ID) {
+	if (isNetworkIdICP(networkId)) {
 		return 'Icrcv2';
 	}
 	if (SUPPORTED_BITCOIN_NETWORK_IDS.includes(networkId)) {

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -11,7 +11,7 @@ import {
 	SUPPORTED_BITCOIN_NETWORK_IDS
 } from '$env/networks/networks.btc.env';
 import { SEPOLIA_NETWORK_ID, SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,
@@ -32,7 +32,8 @@ export const isNetworkICP = (network: Network | undefined): boolean => isNetwork
 export const isNetworkSolana = (network: Network | undefined): network is SolanaNetwork =>
 	isNetworkIdSolana(network?.id);
 
-export const isNetworkIdICP: IsNetworkIdUtil = (id) => nonNullish(id) && ICP_NETWORK_ID === id;
+export const isNetworkIdICP: IsNetworkIdUtil = (id) =>
+	nonNullish(id) && (ICP_NETWORK_ID === id || ICP_PSEUDO_TESTNET_NETWORK_ID === id);
 
 export const isNetworkIdEthereum: IsNetworkIdUtil = (id) =>
 	nonNullish(id) && SUPPORTED_ETHEREUM_NETWORK_IDS.includes(id);

--- a/src/frontend/src/lib/utils/user-networks.utils.ts
+++ b/src/frontend/src/lib/utils/user-networks.utils.ts
@@ -34,7 +34,6 @@ import { isNullish } from '@dfinity/utils';
 const networkIdToKey = (networkId: NetworkId): NetworkSettingsFor | undefined => {
 	switch (networkId) {
 		case ICP_NETWORK_ID:
-			return { InternetComputer: null };
 		case ICP_PSEUDO_TESTNET_NETWORK_ID:
 			return { InternetComputer: null };
 		case ETHEREUM_NETWORK_ID:

--- a/src/frontend/src/lib/utils/user-networks.utils.ts
+++ b/src/frontend/src/lib/utils/user-networks.utils.ts
@@ -33,7 +33,9 @@ import { isNullish } from '@dfinity/utils';
 
 const networkIdToKey = (networkId: NetworkId): NetworkSettingsFor | undefined => {
 	switch (networkId) {
-		case ICP_NETWORK_ID || ICP_PSEUDO_TESTNET_NETWORK_ID:
+		case ICP_NETWORK_ID:
+			return { InternetComputer: null };
+		case ICP_PSEUDO_TESTNET_NETWORK_ID:
 			return { InternetComputer: null };
 		case ETHEREUM_NETWORK_ID:
 			return { EthereumMainnet: null };

--- a/src/frontend/src/lib/utils/user-networks.utils.ts
+++ b/src/frontend/src/lib/utils/user-networks.utils.ts
@@ -21,7 +21,7 @@ import {
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_LOCAL_NETWORK_ID,
@@ -33,7 +33,7 @@ import { isNullish } from '@dfinity/utils';
 
 const networkIdToKey = (networkId: NetworkId): NetworkSettingsFor | undefined => {
 	switch (networkId) {
-		case ICP_NETWORK_ID:
+		case ICP_NETWORK_ID || ICP_PSEUDO_TESTNET_NETWORK_ID:
 			return { InternetComputer: null };
 		case ETHEREUM_NETWORK_ID:
 			return { EthereumMainnet: null };

--- a/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-networks.derived.spec.ts
@@ -2,7 +2,7 @@ import {
 	SUPPORTED_MAINNET_NETWORKS_IDS,
 	SUPPORTED_TESTNET_NETWORK_IDS
 } from '$env/networks/networks.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 import { userNetworks } from '$lib/derived/user-networks.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
@@ -105,7 +105,8 @@ describe('user-networks.derived', () => {
 			expect(get(userNetworks)).toEqual({
 				...mockUserNetworksOnlyMainnetsComplete,
 				[SOLANA_MAINNET_NETWORK_ID]: { enabled: true, isTestnet: false },
-				[ICP_NETWORK_ID]: { enabled: true, isTestnet: false }
+				[ICP_NETWORK_ID]: { enabled: true, isTestnet: false },
+				[ICP_PSEUDO_TESTNET_NETWORK_ID]: { enabled: true, isTestnet: true }
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/network.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/network.utils.spec.ts
@@ -23,7 +23,11 @@ import {
 	SEPOLIA_NETWORK_ID,
 	SUPPORTED_ETHEREUM_NETWORK_IDS
 } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import {
+	ICP_NETWORK,
+	ICP_NETWORK_ID,
+	ICP_PSEUDO_TESTNET_NETWORK_ID
+} from '$env/networks/networks.icp.env';
 import { CKBTC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
 import {
 	SOLANA_DEVNET_NETWORK,
@@ -88,6 +92,10 @@ describe('network utils', () => {
 	describe('isNetworkIdICP', () => {
 		it('should return true for ICP network ID', () => {
 			expect(isNetworkIdICP(ICP_NETWORK_ID)).toBeTruthy();
+		});
+
+		it('should return true for ICP pseud-network ID', () => {
+			expect(isNetworkIdICP(ICP_PSEUDO_TESTNET_NETWORK_ID)).toBeTruthy();
 		});
 
 		it('should return false for non-ICP network ID', () => {

--- a/src/frontend/src/tests/mocks/user-networks.mock.ts
+++ b/src/frontend/src/tests/mocks/user-networks.mock.ts
@@ -1,7 +1,7 @@
 import { BTC_MAINNET_NETWORK_ID, BTC_TESTNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { SUPPORTED_NETWORKS } from '$env/networks/networks.env';
 import { ETHEREUM_NETWORK_ID, SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_MAINNET_NETWORK_ID
@@ -14,6 +14,7 @@ export const mockUserNetworks: UserNetworks = {
 	[ETHEREUM_NETWORK_ID]: { enabled: true, isTestnet: false },
 	[SEPOLIA_NETWORK_ID]: { enabled: false, isTestnet: false },
 	[ICP_NETWORK_ID]: { enabled: true, isTestnet: false },
+	[ICP_PSEUDO_TESTNET_NETWORK_ID]: { enabled: true, isTestnet: true },
 	[SOLANA_MAINNET_NETWORK_ID]: { enabled: true, isTestnet: false },
 	[SOLANA_DEVNET_NETWORK_ID]: { enabled: true, isTestnet: true }
 };

--- a/src/frontend/src/tests/mocks/user-profile.mock.ts
+++ b/src/frontend/src/tests/mocks/user-profile.mock.ts
@@ -14,6 +14,7 @@ export const mockUserNetworksMap: Array<[NetworkSettingsFor, NetworkSettings]> =
 	[{ EthereumMainnet: null }, { enabled: true, is_testnet: false }],
 	[{ EthereumSepolia: null }, { enabled: false, is_testnet: false }],
 	[{ InternetComputer: null }, { enabled: true, is_testnet: false }],
+	[{ InternetComputer: null }, { enabled: true, is_testnet: true }],
 	[{ SolanaMainnet: null }, { enabled: true, is_testnet: false }],
 	[{ SolanaDevnet: null }, { enabled: true, is_testnet: true }]
 ];


### PR DESCRIPTION
# Motivation

There are a few ICRC tokens that we define as "testnet" tokens, for example ckSepoliaETH or ckSepoliaUSDC. They are linked to their respective twin tokens but on testnets.

Since there is no test network for IC network, we first decided to show them in the IC network AND only if testnets are enabled. However, that is a bit confusing since we show a wrong balance (the sum of "normal" tokens and "testnet" tokens).

Since these tokens are really just for testing and developing purposes, the new proposal is to separate them from IC network and put them in a pseudo-test-network, that is simply a replica of IC network.

# Changes

- Create pseudo-network for ICRC "testnet" tokens: it is a copy of the existing IC network.
- Add it to the respective lists of networks.
- Expand util isNetworkIdICP (the pseudo-network should be treated exactly as the IC network).
- Map ICRC "testnet" tokens with the new pseudo-network.

# Tests

In local replica and test canister everything works as usual:

![Screenshot 2025-06-27 at 12 26 32](https://github.com/user-attachments/assets/767576c5-0c46-4b4c-88c9-c98b09c93253)
![Screenshot 2025-06-27 at 12 26 39](https://github.com/user-attachments/assets/0d8c9391-2fdd-4d95-8079-48ee53944ff7)
![Screenshot 2025-06-27 at 12 26 47](https://github.com/user-attachments/assets/eee0e13c-97c4-4bec-ba2c-8ba78098be7f)
![Screenshot 2025-06-27 at 12 26 54](https://github.com/user-attachments/assets/5436e45d-ce23-4d6a-970c-5db4773d63f0)
![Screenshot 2025-06-27 at 12 33 55](https://github.com/user-attachments/assets/ec6e514e-8c65-4f15-b02d-d525a4ace3c3)
![Screenshot 2025-06-27 at 12 34 24](https://github.com/user-attachments/assets/731d7520-a97c-416f-9405-cd219d03d012)
![Screenshot 2025-06-27 at 13 30 39](https://github.com/user-attachments/assets/104c7eeb-3d42-423d-82f8-7cf8db7be49f)

