### PR TITLE
feat(frontend): allow resetting indexCanisterId for custom ICRC tokens

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -54,15 +54,15 @@ const loadDefaultIcrcTokens = async () => {
 export const loadCustomTokens = ({
 	identity,
 	useCache = false,
-	onSuccess
+	onQuerySuccess
 }: {
 	identity: OptionIdentity;
 	useCache?: boolean;
-	onSuccess?: () => void;
+	onQuerySuccess?: () => void;
 }): Promise<void> =>
 	queryAndUpdate<IcrcCustomToken[]>({
 		request: (params) => loadIcrcCustomTokens({ ...params, useCache }),
-		onLoad: (params) => loadIcrcCustomData({ ...params, onSuccess }),
+		onLoad: (params) => loadIcrcCustomData({ ...params, onQuerySuccess }),
 		onUpdateError: ({ error: err }) => {
 			icrcCustomTokensStore.resetAll();
 
@@ -247,13 +247,13 @@ const loadCustomIcrcTokensData = async ({
 const loadIcrcCustomData = ({
 	response: tokens,
 	certified,
-	onSuccess
+	onQuerySuccess
 }: {
 	certified: boolean;
 	response: IcrcCustomToken[];
-	onSuccess?: () => void;
+	onQuerySuccess?: () => void;
 }) => {
-	onSuccess?.();
+	!certified && onQuerySuccess?.();
 
 	icrcCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
 };

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -220,7 +220,7 @@
 			return;
 		}
 
-		if (isNullish(tokenToEdit) || isNullishOrEmpty(icrcTokenIndexCanisterId)) {
+		if (isNullish(tokenToEdit)) {
 			return;
 		}
 
@@ -231,7 +231,9 @@
 
 				await setCustomToken({
 					token: toCustomToken({
-						indexCanisterId: icrcTokenIndexCanisterId,
+						...(!isNullishOrEmpty(icrcTokenIndexCanisterId) && {
+							indexCanisterId: icrcTokenIndexCanisterId
+						}),
 						ledgerCanisterId: tokenToEdit.ledgerCanisterId,
 						version: tokenToEdit.version,
 						enabled: true,
@@ -244,7 +246,7 @@
 				// Similar as on token "save", we reload all custom tokens for simplicity reason.
 				await loadCustomTokens({
 					identity: $authIdentity,
-					onSuccess: () => {
+					onQuerySuccess: () => {
 						progress(ProgressStepsAddToken.DONE);
 						close();
 
@@ -331,7 +333,7 @@
 					<ButtonBack onclick={() => gotoStep(TokenModalSteps.CONTENT)} />
 
 					<Button
-						disabled={isNullishOrEmpty(icrcTokenIndexCanisterId)}
+						disabled={icrcTokenIndexCanisterId === (token.indexCanisterId ?? '')}
 						onclick={() => onTokenEdit(token)}
 						testId={TOKEN_MODAL_SAVE_BUTTON}
 					>

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -14,12 +14,14 @@ import * as authServices from '$lib/services/auth.services';
 import { modalStore } from '$lib/stores/modal.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import type { Token } from '$lib/types/token';
+import { toCustomToken } from '$lib/utils/custom-token.utils';
 import * as navUtils from '$lib/utils/nav.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { MOCK_CANISTER_ID_1 } from '$tests/mocks/exchanges.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 
@@ -109,6 +111,15 @@ describe('TokenModal', () => {
 		await fireEvent.click(getByTestId(TOKEN_MODAL_SAVE_BUTTON));
 
 		expect(setCustomTokenMock).toHaveBeenCalledOnce();
+		expect(setCustomTokenMock).toHaveBeenCalledWith({
+			token: toCustomToken({
+				indexCanisterId: MOCK_CANISTER_ID_1,
+				ledgerCanisterId: mockIcToken.ledgerCanisterId,
+				enabled: true,
+				networkKey: 'Icrc'
+			}),
+			identity: mockIdentity
+		});
 		expect(loadCustomTokens).toHaveBeenCalledOnce();
 	});
 
@@ -132,12 +143,20 @@ describe('TokenModal', () => {
 		await fireEvent.click(getByTestId(TOKEN_MODAL_INDEX_CANISTER_ID_EDIT_BUTTON));
 
 		await fireEvent.input(getByTestId(TOKEN_MODAL_INDEX_CANISTER_ID_INPUT), {
-			target: { value: MOCK_CANISTER_ID_1 }
+			target: { value: '' }
 		});
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_SAVE_BUTTON));
 
 		expect(setCustomTokenMock).toHaveBeenCalledOnce();
+		expect(setCustomTokenMock).toHaveBeenCalledWith({
+			token: toCustomToken({
+				ledgerCanisterId: mockIcToken.ledgerCanisterId,
+				enabled: true,
+				networkKey: 'Icrc'
+			}),
+			identity: mockIdentity
+		});
 		expect(loadCustomTokens).toHaveBeenCalledOnce();
 	});
 


### PR DESCRIPTION
# Motivation

The last missing piece - we now allow resetting indexCanisterId for custom ICRC tokens. Also, I adjusted the `onSuccess` callback so we only call it once after the query request succeeds.
