### PR TITLE
style(): Hero buttons truncate and adjust for longer labels

### DIFF
--- a/src/frontend/src/lib/components/hero/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/hero/ButtonHero.svelte
@@ -24,11 +24,12 @@
 	{testId}
 	colorStyle="tertiary-main-card"
 	paddingSmall
+	styleClass="py-1 min-w-0"
 >
-	<div class="flex flex-col items-center justify-center gap-2 lg:flex-row">
+	<div class="flex min-w-0 flex-col items-center justify-center">
 		{@render icon()}
-		<div class="min-w-12 max-w-[72px] break-words text-sm lg:text-base">
-			{@render label()}
-		</div>
+		<span class="block w-full truncate text-sm lg:text-base">
+			{@render label()} very long label
+		</span>
 	</div>
 </Button>

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -69,7 +69,7 @@
 	aria-label={ariaLabel}
 >
 	<span
-		class="flex gap-2"
+		class="flex min-w-0 gap-2"
 		class:transition={loading}
 		class:duration-500={loading}
 		class:ease-in-out={loading}

--- a/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
+++ b/src/frontend/src/lib/components/ui/HeroButtonGroup.svelte
@@ -8,6 +8,6 @@
 	let { children }: Props = $props();
 </script>
 
-<div role="toolbar" class="flex flex-1 flex-row justify-between gap-2">
+<div role="toolbar" class="flex w-full justify-between gap-2">
 	{@render children()}
 </div>


### PR DESCRIPTION
# Motivation

In preparation of possibly much longer texts in other languages, we need to adjust the hero buttons.

# Changes

Adjusted some styling and always make them `flex-col` to render text below icon at all times.

# Tests

![image](https://github.com/user-attachments/assets/cab4261b-1763-4e85-beac-9421e165d13d)
![image](https://github.com/user-attachments/assets/55080ae2-0ec6-49d5-a2f0-7624e68cdc42)
![image](https://github.com/user-attachments/assets/acc506be-cc60-443c-a8f8-965c2f1c432b)
