### PR TITLE
fix(frontend): Avoid disconnected form when sending or adding tokens

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -91,7 +91,7 @@
 	).filter(({ id }) => !isNetworkIdBitcoin(id));
 </script>
 
-<form on:submit={() => dispatch('icNext')} method="POST" in:fade class="min-h-auto">
+<form on:submit|preventDefault={() => dispatch('icNext')} method="POST" in:fade class="min-h-auto">
 	<ContentWithToolbar>
 		{#if enabledNetworkSelector}
 			<AddTokenByNetworkDropdown bind:networkName {availableNetworks} />

--- a/src/frontend/src/lib/components/send/SendForm.svelte
+++ b/src/frontend/src/lib/components/send/SendForm.svelte
@@ -17,7 +17,7 @@
 	const back = () => dispatch('icBack');
 </script>
 
-<form on:submit={() => dispatch('icNext')} method="POST">
+<form on:submit|preventDefault={() => dispatch('icNext')} method="POST">
 	<ContentWithToolbar>
 		<slot name="amount" />
 


### PR DESCRIPTION
# Motivation

When we submit the forms in both the Sending flow or when adding a new token, we dispatch `icNext` in the form's `on:submit`, and the parent reacts by removing (destroying) the form component and showing another one before the browser finishes submitting the form, which triggers the warning:

"Form submission canceled because the form is not connected"

<img width="758" alt="image-20250629-090550" src="https://github.com/user-attachments/assets/cefe1563-f9e9-415b-90eb-7e274061b062" />

This happens because the browser thinks the form is being submitted (default behavior of method="POST"), but the DOM element is gone by the time the actual submission would happen.

To fix it, since we are not using the actual POST submission (we are dispatching an event instead and the validation happens with functions), we prevent the default browser behavior.


