### PR TITLE
feat(frontend): handle subaccounts in icNetworkContacts

### DIFF
--- a/src/frontend/src/icp/derived/ic-contacts.derived.ts
+++ b/src/frontend/src/icp/derived/ic-contacts.derived.ts
@@ -1,5 +1,5 @@
 import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
-import { parseIcrcAccountToAccountIdentifierText } from '$icp/utils/icp-account.utils';
+import { tryToParseIcrcAccountStringToAccountIdentifierText } from '$icp/utils/icp-account.utils';
 import { isIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import { contacts } from '$lib/derived/contacts.derived';
@@ -23,7 +23,7 @@ export const icNetworkContacts: Readable<NetworkContacts> = derived(
 			const { address, contact } = allIcNetworkContacts[key];
 
 			if (isIcrcAddress(address)) {
-				const accountIdentifierText = parseIcrcAccountToAccountIdentifierText(address);
+				const accountIdentifierText = tryToParseIcrcAccountStringToAccountIdentifierText(address);
 
 				return {
 					...acc,

--- a/src/frontend/src/icp/derived/ic-contacts.derived.ts
+++ b/src/frontend/src/icp/derived/ic-contacts.derived.ts
@@ -1,14 +1,12 @@
 import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
-import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
+import { parseIcrcAccountToAccountIdentifierText } from '$icp/utils/icp-account.utils';
 import { isIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { isTokenIcrc } from '$icp/utils/icrc.utils';
-import { TRACK_IC_NETWORK_CONTACTS_GENERATION_ISSUE } from '$lib/constants/analytics.contants';
 import { contacts } from '$lib/derived/contacts.derived';
 import { tokenWithFallback } from '$lib/derived/token.derived';
-import { trackEvent } from '$lib/services/analytics.services';
 import type { NetworkContacts } from '$lib/types/contacts';
 import { getNetworkContacts } from '$lib/utils/contacts.utils';
-import { Principal } from '@dfinity/principal';
+import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const icNetworkContacts: Readable<NetworkContacts> = derived(
@@ -25,21 +23,14 @@ export const icNetworkContacts: Readable<NetworkContacts> = derived(
 			const { address, contact } = allIcNetworkContacts[key];
 
 			if (isIcrcAddress(address)) {
-				try {
-					return {
-						...acc,
-						[contact.id.toString()]: [
-							...(acc[contact.id.toString()] ?? []),
-							getAccountIdentifier(Principal.fromText(address)).toHex()
-						]
-					};
-				} catch (_: unknown) {
-					trackEvent({ name: TRACK_IC_NETWORK_CONTACTS_GENERATION_ISSUE });
+				const accountIdentifierText = parseIcrcAccountToAccountIdentifierText(address);
 
-					// Principal.fromText does not support sub-accounts and therefore throws an error.
-					// As a temporary patch, we ignore such addresses and proceed with the generation further.
-					return acc;
-				}
+				return {
+					...acc,
+					...(nonNullish(accountIdentifierText) && {
+						[contact.id.toString()]: [...(acc[contact.id.toString()] ?? []), accountIdentifierText]
+					})
+				};
 			}
 
 			return acc;

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -70,6 +70,7 @@ export const tryToParseIcrcAccountStringToAccountIdentifierText = (
 			? SubAccount.fromBytes(new Uint8Array(icrcSubaccount))
 			: undefined;
 
+		// TODO: remove this check after we use the latest ic-js packages (where this error is thrown internally)
 		if (!(subAccount instanceof Error)) {
 			return AccountIdentifier.fromPrincipal({
 				principal,

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -57,6 +57,8 @@ export const getIcrcv2AccountIdString = (accountId: Icrcv2AccountId): string => 
 
 /**
  * Tries to parse an Icrc-1 account string to AccountIdentifier text.
+ * Used for generating account ID from a principal when opening "Contacts" tab in the send flow.
+ * The goal - we to filter out account IDs from the list if the same contact has the matching Principal saved.
  * @param accountString A string that will be decoded into an Icrc-1 compatible account
  * @returns AccountIdentifier text equivalent of the provided accountString or undefined if parsing fails
  */

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -1,5 +1,4 @@
 import type { Icrcv2AccountId } from '$declarations/backend/backend.did';
-import type { Address } from '$lib/types/address';
 import { assertNever } from '$lib/types/utils';
 import { AccountIdentifier, isIcpAccountIdentifier, SubAccount } from '@dfinity/ledger-icp';
 import { decodeIcrcAccount, encodeIcrcAccount } from '@dfinity/ledger-icrc';
@@ -56,20 +55,25 @@ export const getIcrcv2AccountIdString = (accountId: Icrcv2AccountId): string => 
 	return assertNever({ variable: accountId, typeName: 'Icrcv2AccountId' });
 };
 
-export const parseIcrcAccountToAccountIdentifierText = (address: Address): string | undefined => {
+/**
+ * Tries to parse an Icrc-1 account string to AccountIdentifier text.
+ * @param accountString A string that will be decoded into an Icrc-1 compatible account
+ * @returns AccountIdentifier text equivalent of the provided accountString or undefined if parsing fails
+ */
+export const tryToParseIcrcAccountStringToAccountIdentifierText = (
+	accountString: string
+): string | undefined => {
 	try {
-		const { owner: principal, subaccount: unparsedSubAccount } = decodeIcrcAccount(address);
+		const { owner: principal, subaccount: icrcSubaccount } = decodeIcrcAccount(accountString);
 
-		const subAccount = nonNullish(unparsedSubAccount)
-			? SubAccount.fromBytes(new Uint8Array(unparsedSubAccount))
+		const subAccount = nonNullish(icrcSubaccount)
+			? SubAccount.fromBytes(new Uint8Array(icrcSubaccount))
 			: undefined;
 
 		if (!(subAccount instanceof Error)) {
 			return AccountIdentifier.fromPrincipal({
 				principal,
-				...(nonNullish(subAccount) && {
-					subAccount
-				})
+				subAccount
 			}).toHex();
 		}
 	} catch (_: unknown) {

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -119,5 +119,3 @@ export const MANAGE_TOKENS_MODAL_ROUTE = 'manage-tokens-modal';
 // This event is used to track the number of calls to Infura's getLogs endpoint.
 // TODO: Remove these events once the issue is resolved.
 export const TRACK_INFURA_GET_LOGS_CALL = 'infura_get_logs_call';
-export const TRACK_IC_NETWORK_CONTACTS_GENERATION_ISSUE =
-	'track-ic-network-contacts-generation-issue';

--- a/src/frontend/src/tests/icp/utils/icp-account.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icp-account.utils.spec.ts
@@ -1,5 +1,11 @@
 import type { Icrcv2AccountId } from '$declarations/backend/backend.did';
-import { getIcrcv2AccountIdString, parseIcrcv2AccountId } from '$icp/utils/icp-account.utils';
+import {
+	getIcrcv2AccountIdString,
+	parseIcrcAccountToAccountIdentifierText,
+	parseIcrcv2AccountId
+} from '$icp/utils/icp-account.utils';
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+import { encodeIcrcAccount } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
 
@@ -208,6 +214,32 @@ describe('icp-account.utils', () => {
 
 				expect(recoveredAddress).toEqual(address);
 			});
+		});
+	});
+
+	describe('parseAddressToAccountIdentifierText', () => {
+		it('should return a correct account identifier text for account without subaccount', () => {
+			expect(
+				parseIcrcAccountToAccountIdentifierText(encodeIcrcAccount({ owner: mockPrincipal }))
+			).toEqual('97783b7f0f34634c06ced774bd1bd27d2c76e80b0dd88f56ad55b3ecab292f68');
+		});
+
+		it('should return a correct account identifier text for account with subaccount', () => {
+			const subaccount = new Uint8Array(32);
+			subaccount[31] = 1; // Set the last byte to 1
+
+			expect(
+				parseIcrcAccountToAccountIdentifierText(
+					encodeIcrcAccount({
+						owner: mockPrincipal,
+						subaccount
+					})
+				)
+			).toEqual('453705c03b4faebe09d6f9b1f5bad842f6006cd75650ef83aa3adc8a09a63547');
+		});
+
+		it('should return undefined if the provided address failed to be parsed', () => {
+			expect(parseIcrcAccountToAccountIdentifierText('test')).toEqual(undefined);
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/utils/icp-account.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icp-account.utils.spec.ts
@@ -1,8 +1,8 @@
 import type { Icrcv2AccountId } from '$declarations/backend/backend.did';
 import {
 	getIcrcv2AccountIdString,
-	parseIcrcAccountToAccountIdentifierText,
-	parseIcrcv2AccountId
+	parseIcrcv2AccountId,
+	tryToParseIcrcAccountStringToAccountIdentifierText
 } from '$icp/utils/icp-account.utils';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import { encodeIcrcAccount } from '@dfinity/ledger-icrc';
@@ -217,10 +217,12 @@ describe('icp-account.utils', () => {
 		});
 	});
 
-	describe('parseAddressToAccountIdentifierText', () => {
+	describe('tryToParseIcrcAccountStringToAccountIdentifierText', () => {
 		it('should return a correct account identifier text for account without subaccount', () => {
 			expect(
-				parseIcrcAccountToAccountIdentifierText(encodeIcrcAccount({ owner: mockPrincipal }))
+				tryToParseIcrcAccountStringToAccountIdentifierText(
+					encodeIcrcAccount({ owner: mockPrincipal })
+				)
 			).toEqual('97783b7f0f34634c06ced774bd1bd27d2c76e80b0dd88f56ad55b3ecab292f68');
 		});
 
@@ -229,7 +231,7 @@ describe('icp-account.utils', () => {
 			subaccount[31] = 1; // Set the last byte to 1
 
 			expect(
-				parseIcrcAccountToAccountIdentifierText(
+				tryToParseIcrcAccountStringToAccountIdentifierText(
 					encodeIcrcAccount({
 						owner: mockPrincipal,
 						subaccount
@@ -239,7 +241,7 @@ describe('icp-account.utils', () => {
 		});
 
 		it('should return undefined if the provided address failed to be parsed', () => {
-			expect(parseIcrcAccountToAccountIdentifierText('test')).toEqual(undefined);
+			expect(tryToParseIcrcAccountStringToAccountIdentifierText('test')).toEqual(undefined);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Instead of just skipping principal addresses with subaccounts, we need to correctly handle such a case. To do that, we move the address parsing logic to a separate util `parseIcrcAccountToAccountIdentifierText`. Also, the temporary plausible event can now be removed.
