### PR TITLE
feat(backend)!: Add ERC20 variant to Custom tokens

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -230,6 +230,12 @@ type DefiniteCanisterSettingsArgs = record {
 	compute_allocation : nat
 };
 type DeleteContactResult = variant { Ok : nat64; Err : ContactError };
+type Erc20Token = record {
+	decimals : opt nat8;
+	token_address : text;
+	chain_id : nat64;
+	symbol : opt text
+};
 type EthAddress = variant { Public : text };
 type GetAllowedCyclesError = variant {
 	Other : text;
@@ -349,6 +355,7 @@ type SupportedCredential = record {
 };
 type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {
+	Erc20 : Erc20Token;
 	Icrc : IcrcToken;
 	SplDevnet : SplToken;
 	SplMainnet : SplToken

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -54,12 +54,15 @@ static ERC20_TOKEN_ID: LazyLock<Erc20TokenId> =
     LazyLock::new(|| Erc20TokenId("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string()));
 static ERC20_CHAIN_ID: LazyLock<ChainId> = LazyLock::new(|| 8453);
 static ERC20_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
-    token: Token::Erc20(Erc20Token {
-        token_address: ERC20_TOKEN_ID.clone(),
-        chain_id: ERC20_CHAIN_ID.clone(),
-        symbol: Some("USDC".to_string()),
-        decimals: Some(u8::MAX),
-    }, ERC20_CHAIN_ID.clone()),
+    token: Token::Erc20(
+        Erc20Token {
+            token_address: ERC20_TOKEN_ID.clone(),
+            chain_id: ERC20_CHAIN_ID.clone(),
+            symbol: Some("USDC".to_string()),
+            decimals: Some(u8::MAX),
+        },
+        ERC20_CHAIN_ID.clone(),
+    ),
     enabled: true,
     version: None,
 });

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -59,7 +59,7 @@ static ERC20_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
         chain_id: ERC20_CHAIN_ID.clone(),
         symbol: Some("USDC".to_string()),
         decimals: Some(u8::MAX),
-    }),
+    }, ERC20_CHAIN_ID.clone()),
     enabled: true,
     version: None,
 });

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -54,15 +54,12 @@ static ERC20_TOKEN_ID: LazyLock<Erc20TokenId> =
     LazyLock::new(|| Erc20TokenId("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string()));
 static ERC20_CHAIN_ID: LazyLock<ChainId> = LazyLock::new(|| 8453);
 static ERC20_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
-    token: Token::Erc20(
-        Erc20Token {
-            token_address: ERC20_TOKEN_ID.clone(),
-            chain_id: ERC20_CHAIN_ID.clone(),
-            symbol: Some("USDC".to_string()),
-            decimals: Some(u8::MAX),
-        },
-        ERC20_CHAIN_ID.clone(),
-    ),
+    token: Token::Erc20(Erc20Token {
+        token_address: ERC20_TOKEN_ID.clone(),
+        chain_id: ERC20_CHAIN_ID.clone(),
+        symbol: Some("USDC".to_string()),
+        decimals: Some(u8::MAX),
+    }),
     enabled: true,
     version: None,
 });

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -2,10 +2,12 @@ use std::sync::LazyLock;
 
 use candid::Principal;
 use shared::types::{
-    custom_token::{CustomToken, IcrcToken, SplToken, SplTokenId, Token},
+    custom_token::{
+        ChainId, CustomToken, Erc20Token, Erc20TokenId, IcrcToken, SplToken, SplTokenId, Token,
+    },
     TokenVersion,
 };
-use shared::types::custom_token::{ChainId, Erc20Token, Erc20TokenId};
+
 use crate::utils::{
     assertion::{assert_custom_tokens_eq, assert_tokens_data_eq},
     mock::CALLER,

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -5,7 +5,7 @@ use shared::types::{
     custom_token::{CustomToken, IcrcToken, SplToken, SplTokenId, Token},
     TokenVersion,
 };
-
+use shared::types::custom_token::{ChainId, Erc20Token, Erc20TokenId};
 use crate::utils::{
     assertion::{assert_custom_tokens_eq, assert_tokens_data_eq},
     mock::CALLER,
@@ -48,11 +48,25 @@ static SPL_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
     enabled: true,
     version: None,
 });
+static ERC20_TOKEN_ID: LazyLock<Erc20TokenId> =
+    LazyLock::new(|| Erc20TokenId("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string()));
+static ERC20_CHAIN_ID: LazyLock<ChainId> = LazyLock::new(|| 8453);
+static ERC20_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
+    token: Token::Erc20(Erc20Token {
+        token_address: ERC20_TOKEN_ID.clone(),
+        chain_id: ERC20_CHAIN_ID.clone(),
+        symbol: Some("USDC".to_string()),
+        decimals: Some(u8::MAX),
+    }),
+    enabled: true,
+    version: None,
+});
 static LOTS_OF_CUSTOM_TOKENS: LazyLock<Vec<CustomToken>> = LazyLock::new(|| {
     vec![
         USER_TOKEN.clone(),
         ANOTHER_USER_TOKEN.clone(),
         SPL_TOKEN.clone(),
+        ERC20_TOKEN.clone(),
     ]
 });
 
@@ -85,6 +99,11 @@ fn test_add_custom_token(user_token: &CustomToken) {
 #[test]
 fn test_remove_custom_spl_token() {
     test_remove_custom_token(&SPL_TOKEN)
+}
+
+#[test]
+fn test_remove_custom_erc20_token() {
+    test_remove_custom_token(&ERC20_TOKEN)
 }
 
 #[test]

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -230,6 +230,12 @@ type DefiniteCanisterSettingsArgs = record {
 	compute_allocation : nat
 };
 type DeleteContactResult = variant { Ok : nat64; Err : ContactError };
+type Erc20Token = record {
+	decimals : opt nat8;
+	token_address : text;
+	chain_id : nat64;
+	symbol : opt text
+};
 type EthAddress = variant { Public : text };
 type GetAllowedCyclesError = variant {
 	Other : text;
@@ -349,6 +355,7 @@ type SupportedCredential = record {
 };
 type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {
+	Erc20 : Erc20Token;
 	Icrc : IcrcToken;
 	SplDevnet : SplToken;
 	SplMainnet : SplToken

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -228,6 +228,12 @@ export interface DefiniteCanisterSettingsArgs {
 	compute_allocation: bigint;
 }
 export type DeleteContactResult = { Ok: bigint } | { Err: ContactError };
+export interface Erc20Token {
+	decimals: [] | [number];
+	token_address: string;
+	chain_id: bigint;
+	symbol: [] | [string];
+}
 export type EthAddress = { Public: string };
 export type GetAllowedCyclesError = { Other: string } | { FailedToContactCyclesLedger: null };
 export interface GetAllowedCyclesResponse {
@@ -360,7 +366,11 @@ export interface SupportedCredential {
 export interface TestnetsSettings {
 	show_testnets: boolean;
 }
-export type Token = { Icrc: IcrcToken } | { SplDevnet: SplToken } | { SplMainnet: SplToken };
+export type Token =
+	| { Erc20: Erc20Token }
+	| { Icrc: IcrcToken }
+	| { SplDevnet: SplToken }
+	| { SplMainnet: SplToken };
 export type TokenAccountId =
 	| { Btc: BtcAddress }
 	| { Eth: EthAddress }

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -432,6 +432,12 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
+	const Erc20Token = IDL.Record({
+		decimals: IDL.Opt(IDL.Nat8),
+		token_address: IDL.Text,
+		chain_id: IDL.Nat64,
+		symbol: IDL.Opt(IDL.Text)
+	});
 	const IcrcToken = IDL.Record({
 		ledger_id: IDL.Principal,
 		index_id: IDL.Opt(IDL.Principal)
@@ -442,6 +448,7 @@ export const idlFactory = ({ IDL }) => {
 		symbol: IDL.Opt(IDL.Text)
 	});
 	const Token = IDL.Variant({
+		Erc20: Erc20Token,
 		Icrc: IcrcToken,
 		SplDevnet: SplToken,
 		SplMainnet: SplToken

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -432,6 +432,12 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
+	const Erc20Token = IDL.Record({
+		decimals: IDL.Opt(IDL.Nat8),
+		token_address: IDL.Text,
+		chain_id: IDL.Nat64,
+		symbol: IDL.Opt(IDL.Text)
+	});
 	const IcrcToken = IDL.Record({
 		ledger_id: IDL.Principal,
 		index_id: IDL.Opt(IDL.Principal)
@@ -442,6 +448,7 @@ export const idlFactory = ({ IDL }) => {
 		symbol: IDL.Opt(IDL.Text)
 	});
 	const Token = IDL.Variant({
+		Erc20: Erc20Token,
 		Icrc: IcrcToken,
 		SplDevnet: SplToken,
 		SplMainnet: SplToken

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -82,6 +82,9 @@ impl From<&Token> for CustomTokenId {
             Token::SplDevnet(SplToken { token_address, .. }) => {
                 CustomTokenId::SolDevnet(token_address.clone())
             }
+            Token::Erc20(Erc20Token { token_address, .. }, chain_id) => {
+                CustomTokenId::Ethereum(token_address.clone(), *chain_id)
+            }
         }
     }
 }
@@ -436,7 +439,7 @@ impl Validate for CustomTokenId {
             CustomTokenId::SolMainnet(token_address) | CustomTokenId::SolDevnet(token_address) => {
                 token_address.validate()
             }
-            CustomTokenId::Erc20(token_address) => token_address.validate(),
+            CustomTokenId::Ethereum(token_address, _) => token_address.validate(),
         }
     }
 }
@@ -452,7 +455,7 @@ impl Validate for Token {
         match self {
             Token::Icrc(token) => token.validate(),
             Token::SplMainnet(token) | Token::SplDevnet(token) => token.validate(),
-            Token::Erc20(token) => token.validate(),
+            Token::Erc20(token, _) => token.validate(),
         }
     }
 }
@@ -612,4 +615,6 @@ validate_on_deserialize!(CustomTokenId);
 validate_on_deserialize!(IcrcToken);
 validate_on_deserialize!(SplToken);
 validate_on_deserialize!(SplTokenId);
+validate_on_deserialize!(Erc20Token);
+validate_on_deserialize!(Erc20TokenId);
 validate_on_deserialize!(UserToken);

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -84,7 +84,7 @@ impl From<&Token> for CustomTokenId {
                 token_address,
                 chain_id,
                 ..
-            }) => CustomTokenId::Ethereum(token_address.clone(), chain_id.clone()),
+            }) => CustomTokenId::Ethereum(token_address.clone(), *chain_id),
         }
     }
 }

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -76,12 +76,10 @@ impl From<&Token> for CustomTokenId {
     fn from(token: &Token) -> Self {
         match token {
             Token::Icrc(token) => CustomTokenId::Icrc(token.ledger_id),
-            Token::SplMainnet(SplToken { token_address, .. }) => {
-                CustomTokenId::SolMainnet(token_address.clone())
-            }
-            Token::SplDevnet(SplToken { token_address, .. }) => {
-                CustomTokenId::SolDevnet(token_address.clone())
-            }
+            Token::SplMainnet(SplToken { token_address, .. }) =>
+                CustomTokenId::SolMainnet(token_address.clone()),
+            Token::SplDevnet(SplToken { token_address, .. }) =>
+                CustomTokenId::SolDevnet(token_address.clone()),
             Token::Erc20(Erc20Token {
                 token_address,
                 chain_id,

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -76,10 +76,12 @@ impl From<&Token> for CustomTokenId {
     fn from(token: &Token) -> Self {
         match token {
             Token::Icrc(token) => CustomTokenId::Icrc(token.ledger_id),
-            Token::SplMainnet(SplToken { token_address, .. }) =>
-                CustomTokenId::SolMainnet(token_address.clone()),
-            Token::SplDevnet(SplToken { token_address, .. }) =>
-                CustomTokenId::SolDevnet(token_address.clone()),
+            Token::SplMainnet(SplToken { token_address, .. }) => {
+                CustomTokenId::SolMainnet(token_address.clone())
+            }
+            Token::SplDevnet(SplToken { token_address, .. }) => {
+                CustomTokenId::SolDevnet(token_address.clone())
+            }
             Token::Erc20(Erc20Token {
                 token_address,
                 chain_id,

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -82,9 +82,11 @@ impl From<&Token> for CustomTokenId {
             Token::SplDevnet(SplToken { token_address, .. }) => {
                 CustomTokenId::SolDevnet(token_address.clone())
             }
-            Token::Erc20(Erc20Token { token_address, .. }, chain_id) => {
-                CustomTokenId::Ethereum(token_address.clone(), *chain_id)
-            }
+            Token::Erc20(Erc20Token {
+                token_address,
+                chain_id,
+                ..
+            }) => CustomTokenId::Ethereum(token_address.clone(), chain_id.clone()),
         }
     }
 }
@@ -455,7 +457,7 @@ impl Validate for Token {
         match self {
             Token::Icrc(token) => token.validate(),
             Token::SplMainnet(token) | Token::SplDevnet(token) => token.validate(),
-            Token::Erc20(token, _) => token.validate(),
+            Token::Erc20(token) => token.validate(),
         }
     }
 }

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -8,7 +8,10 @@ use crate::{
     types::{
         backend_config::{Config, InitArg},
         contact::{Contact, ContactAddressData, CreateContactRequest, UpdateContactRequest},
-        custom_token::{CustomToken, CustomTokenId, IcrcToken, SplToken, SplTokenId, Token},
+        custom_token::{
+            CustomToken, CustomTokenId, Erc20Token, Erc20TokenId, IcrcToken, SplToken, SplTokenId,
+            Token,
+        },
         dapp::{AddDappSettingsError, DappCarouselSettings, DappSettings, MAX_DAPP_ID_LIST_LENGTH},
         network::{
             NetworkSettingsMap, NetworksSettings, SaveNetworksSettingsError,
@@ -24,7 +27,6 @@ use crate::{
     },
     validate::{validate_on_deserialize, Validate},
 };
-use crate::types::custom_token::{Erc20Token, Erc20TokenId};
 
 // Constants for validation limits
 const CONTACT_MAX_NAME_LENGTH: usize = 100;
@@ -374,7 +376,6 @@ impl OisyUser {
     }
 }
 
-
 impl SplTokenId {
     pub const MAX_LENGTH: usize = 44;
     pub const MIN_LENGTH: usize = 32;
@@ -415,18 +416,17 @@ impl Erc20TokenId {
     pub const MIN_LENGTH: usize = 42;
 }
 
-
 impl Validate for Erc20TokenId {
     /// Verifies that an Ethereum/EVM address is valid.
     fn validate(&self) -> Result<(), candid::Error> {
         if self.0.len() != 42 {
-            return Err(candid::Error::msg("Invalid Ethereum/EVM contract address length"));
+            return Err(candid::Error::msg(
+                "Invalid Ethereum/EVM contract address length",
+            ));
         }
         Ok(())
     }
 }
-
-
 
 impl Validate for CustomTokenId {
     fn validate(&self) -> Result<(), candid::Error> {
@@ -435,8 +435,8 @@ impl Validate for CustomTokenId {
             // check the exact type of principal.
             CustomTokenId::SolMainnet(token_address) | CustomTokenId::SolDevnet(token_address) => {
                 token_address.validate()
-            },
-            CustomTokenId::Erc20(token_address) => { token_address.validate() },
+            }
+            CustomTokenId::Erc20(token_address) => token_address.validate(),
         }
     }
 }

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -55,7 +55,7 @@ pub enum Token {
     Icrc(IcrcToken) = 0,
     SplMainnet(SplToken) = 1,
     SplDevnet(SplToken) = 2,
-    Erc20(Erc20Token, ChainId) = 3,
+    Erc20(Erc20Token) = 3,
 }
 
 /// User preferences for any token

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -14,6 +14,11 @@ pub struct IcrcToken {
     pub index_id: Option<IndexId>,
 }
 
+/// A network-specific unique Solana token identifier.
+#[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
+#[serde(remote = "Self")]
+pub struct SplTokenId(pub String);
+
 /// A Solana token
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 #[serde(remote = "Self")]
@@ -23,15 +28,17 @@ pub struct SplToken {
     pub decimals: Option<u8>,
 }
 
-/// A network-specific unique Solana token identifier.
+
+/// A network-specific unique ERC20 token identifier.
 #[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
 #[serde(remote = "Self")]
-pub struct SplTokenId(pub String);
+pub struct Erc20TokenId(pub String);
 
 /// EVM chain ID
 ///
 /// IDs may be found on: <https://chainlist.org/>
 pub type ChainId = u64;
+
 
 /// An ERC20 compliant token on the Ethereum or EVM-compatible networks.
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
@@ -43,10 +50,6 @@ pub struct Erc20Token {
     pub decimals: Option<u8>,
 }
 
-/// A network-specific unique ERC20 token identifier.
-#[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
-#[serde(remote = "Self")]
-pub struct Erc20TokenId(pub String);
 
 /// A variant describing any token
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
@@ -55,7 +58,7 @@ pub enum Token {
     Icrc(IcrcToken) = 0,
     SplMainnet(SplToken) = 1,
     SplDevnet(SplToken) = 2,
-    Erc20(Erc20Token) = 3,
+    Erc20(Erc20Token, ChainId) = 3,
 }
 
 /// User preferences for any token
@@ -78,6 +81,6 @@ pub enum CustomTokenId {
     SolMainnet(SplTokenId) = 1,
     /// A Solana token on the Solana devnet.
     SolDevnet(SplTokenId) = 2,
-    /// An ERC20 token on an EVM-compatible network.
-    Erc20(Erc20TokenId) = 3,
+    /// An Ethereum/EVM token on an EVM-compatible network.
+    Ethereum(Erc20TokenId, ChainId) = 3,
 }

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -28,6 +28,26 @@ pub struct SplToken {
 #[serde(remote = "Self")]
 pub struct SplTokenId(pub String);
 
+/// EVM chain ID
+///
+/// IDs may be found on: <https://chainlist.org/>
+pub type ChainId = u64;
+
+/// An ERC20 compliant token on the Ethereum or EVM-compatible networks.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[serde(remote = "Self")]
+pub struct Erc20Token {
+    pub token_address: Erc20TokenId,
+    pub chain_id: ChainId,
+    pub symbol: Option<String>,
+    pub decimals: Option<u8>,
+}
+
+/// A network-specific unique ERC20 token identifier.
+#[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
+#[serde(remote = "Self")]
+pub struct Erc20TokenId(pub String);
+
 /// A variant describing any token
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 #[repr(u8)]
@@ -35,6 +55,7 @@ pub enum Token {
     Icrc(IcrcToken) = 0,
     SplMainnet(SplToken) = 1,
     SplDevnet(SplToken) = 2,
+    Erc20(Erc20Token) = 3,
 }
 
 /// User preferences for any token
@@ -57,4 +78,6 @@ pub enum CustomTokenId {
     SolMainnet(SplTokenId) = 1,
     /// A Solana token on the Solana devnet.
     SolDevnet(SplTokenId) = 2,
+    /// An ERC20 token on an EVM-compatible network.
+    Erc20(Erc20TokenId) = 3,
 }

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -28,7 +28,6 @@ pub struct SplToken {
     pub decimals: Option<u8>,
 }
 
-
 /// A network-specific unique ERC20 token identifier.
 #[derive(CandidType, Clone, Eq, PartialEq, Deserialize, Debug)]
 #[serde(remote = "Self")]
@@ -39,7 +38,6 @@ pub struct Erc20TokenId(pub String);
 /// IDs may be found on: <https://chainlist.org/>
 pub type ChainId = u64;
 
-
 /// An ERC20 compliant token on the Ethereum or EVM-compatible networks.
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 #[serde(remote = "Self")]
@@ -49,7 +47,6 @@ pub struct Erc20Token {
     pub symbol: Option<String>,
     pub decimals: Option<u8>,
 }
-
 
 /// A variant describing any token
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -246,6 +246,111 @@ mod custom_token {
         );
     }
 
+    mod erc20 {
+        //! Tests for the erc20 module.
+        use super::*;
+        use crate::{
+            types::MAX_SYMBOL_LENGTH,
+            validate::{test_validate_on_deserialize, TestVector, Validate},
+        };
+
+        test_validate_on_deserialize!(
+            Erc20Token,
+            vec![
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 1,
+                        symbol: Some("☃☃☃ ☃ ☃☃☃".to_string()),
+                        decimals: Some(6),
+                    },
+                    valid: true,
+                    description: "Valid Erc20Token",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 1,
+                        symbol: None,
+                        decimals: None,
+                    },
+                    valid: true,
+                    description: "Erc20Token without a symbol or decimals",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(40)),
+                        chain_id: 1,
+                        symbol: Some("Bouncy Castle".to_string()),
+                        decimals: Some(6),
+                    },
+                    valid: false,
+                    description: "Erc20Token with a token address that is too short",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(99)),
+                        chain_id: 1,
+                        symbol: Some("Bouncy Castle".to_string()),
+                        decimals: Some(6),
+                    },
+                    valid: false,
+                    description: "Erc20Token with a token address that is too long",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 1,
+                        symbol: Some("B".repeat(MAX_SYMBOL_LENGTH + 1)),
+                        decimals: Some(6),
+                    },
+                    valid: false,
+                    description: "Too long symbol",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 1,
+                        symbol: Some("Bouncy Castle".to_string()),
+                        decimals: Some(255),
+                    },
+                    valid: true,
+                    description: "Maximum decimals",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 1,
+                        symbol: Some("Bouncy Castle".to_string()),
+                        decimals: Some(0),
+                    },
+                    valid: true,
+                    description: "Minimum decimals",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 255,
+                        symbol: Some("Bouncy Castle".to_string()),
+                        decimals: Some(6),
+                    },
+                    valid: true,
+                    description: "Maximum chain ID",
+                },
+                TestVector {
+                    input: Erc20Token {
+                        token_address: Erc20TokenId("1".repeat(42)),
+                        chain_id: 0,
+                        symbol: Some("Bouncy Castle".to_string()),
+                        decimals: Some(6),
+                    },
+                    valid: true,
+                    description: "Minimum chain ID",
+                },
+            ]
+        );
+    }
+
     mod icrc {
         //! Tests for the icrc module.
         use candid::Principal;

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -330,7 +330,7 @@ mod custom_token {
                 TestVector {
                     input: Erc20Token {
                         token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
-                        chain_id: 255,
+                        chain_id: 2^64 - 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),
                     },

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -259,7 +259,7 @@ mod custom_token {
             vec![
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 1,
                         symbol: Some("☃☃☃ ☃ ☃☃☃".to_string()),
                         decimals: Some(6),
@@ -269,7 +269,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 1,
                         symbol: None,
                         decimals: None,
@@ -279,7 +279,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(40)),
+                        token_address: Erc20TokenId("0x12345678901234567890123456789012345678".to_string()),
                         chain_id: 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),
@@ -299,7 +299,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 1,
                         symbol: Some("B".repeat(MAX_SYMBOL_LENGTH + 1)),
                         decimals: Some(6),
@@ -309,7 +309,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(255),
@@ -319,7 +319,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(0),
@@ -329,7 +329,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 255,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),
@@ -339,7 +339,7 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("1".repeat(42)),
+                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
                         chain_id: 0,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -259,7 +259,9 @@ mod custom_token {
             vec![
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
                         chain_id: 1,
                         symbol: Some("☃☃☃ ☃ ☃☃☃".to_string()),
                         decimals: Some(6),
@@ -269,7 +271,9 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
                         chain_id: 1,
                         symbol: None,
                         decimals: None,
@@ -279,7 +283,9 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x12345678901234567890123456789012345678".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x12345678901234567890123456789012345678".to_string()
+                        ),
                         chain_id: 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),
@@ -299,7 +305,9 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
                         chain_id: 1,
                         symbol: Some("B".repeat(MAX_SYMBOL_LENGTH + 1)),
                         decimals: Some(6),
@@ -309,7 +317,9 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
                         chain_id: 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(255),
@@ -319,7 +329,9 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
                         chain_id: 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(0),
@@ -329,8 +341,10 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
-                        chain_id: 2^64 - 1,
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
+                        chain_id: 2 ^ 64 - 1,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),
                     },
@@ -339,7 +353,9 @@ mod custom_token {
                 },
                 TestVector {
                     input: Erc20Token {
-                        token_address: Erc20TokenId("0x1234567890123456789012345678901234567890".to_string()),
+                        token_address: Erc20TokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
                         chain_id: 0,
                         symbol: Some("Bouncy Castle".to_string()),
                         decimals: Some(6),


### PR DESCRIPTION
# Motivation

We need to deprecate `UserToken` in favour of `CustomToken`: the latter are adapted to be multi-chain, and having a single type extremely simplifies the code.

As first step, we add a variant in the backend to the `CustomToken` type.

Note that the new types are a copy of the existing types used already in `UserToken` type.

BREAKING CHANGE: the interface of the backend changes a bit, adding the new variants.

# Changes

- Create variant for ERC20 tokens, similar to SPL tokens, but with the addition of chain IDs.

# Tests

Added tests.
