### PR TITLE
fix(frontend): Save manage tokens modal

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -69,11 +69,9 @@
 	let currentStep: WizardStep<WizardStepsManageTokens> | undefined = $state();
 	let modal: WizardModal | undefined = $state();
 
-	const saveTokens = async ({
-		detail: { modifiedTokens }
-	}: CustomEvent<{ modifiedTokens: Record<string, Token> }>) => {
+	const saveTokens = async ({ detail: tokens }: CustomEvent<Record<string, Token>>) => {
 		await saveAllCustomTokens({
-			tokens: modifiedTokens,
+			tokens,
 			progress,
 			modalNext: () => modal?.set(3),
 			onSuccess: close,


### PR DESCRIPTION
# Motivation

On splitting and moving logic out for saving tokens a bug snuck in which breaks the saving in the manage tokens modal. This was due to the change in how the event data is propagated between the `ManageTokens` and `ManageTokensModal` components.

# Changes

Fixed the param which was wrongly read

# Tests

Manually tested, works like before
