### PR TITLE
refactor(frontend): Normalize input names for workers

### DIFF
--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -34,21 +34,23 @@ export const initBtcWalletWorker = async ({
 	const isRegtestNetwork = isNetworkIdBTCRegtest(networkId);
 	const isMainnetNetwork = isNetworkIdBTCMainnet(networkId);
 
-	worker.onmessage = ({ data }: MessageEvent<PostMessage<BtcPostMessageDataResponseWallet>>) => {
-		const { msg } = data;
+	worker.onmessage = ({
+		data: dataMsg
+	}: MessageEvent<PostMessage<BtcPostMessageDataResponseWallet>>) => {
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncBtcWallet':
 				syncWallet({
 					tokenId,
-					data: data.data as BtcPostMessageDataResponseWallet
+					data: data as BtcPostMessageDataResponseWallet
 				});
 				return;
 
 			case 'syncBtcWalletError':
 				syncWalletError({
 					tokenId,
-					error: (data.data as PostMessageDataResponseError).error,
+					error: (data as PostMessageDataResponseError).error,
 					/**
 					 * TODO: Do not launch worker locally if BTC canister is not deployed, and remove "isRegtestNetwork" afterwards.
 					 * TODO: Wait for testnet BTC canister to be fixed on the IC side, and remove "isTestnetNetwork" afterwards.

--- a/src/frontend/src/icp/services/worker.btc-statuses.services.ts
+++ b/src/frontend/src/icp/services/worker.btc-statuses.services.ts
@@ -15,23 +15,23 @@ export const initBtcStatusesWorker: IcCkWorker = async ({
 	const worker: Worker = new BtcStatusesWorker.default();
 
 	worker.onmessage = ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<PostMessageJsonDataResponse | PostMessageSyncState | PostMessageDataResponseError>
 	>) => {
-		const { msg } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncBtcStatuses':
 				syncBtcStatuses({
 					tokenId,
-					data: data.data as PostMessageJsonDataResponse
+					data: data as PostMessageJsonDataResponse
 				});
 				return;
 			case 'syncBtcStatusesError':
 				onLoadBtcStatusesError({
 					tokenId,
-					error: (data.data as PostMessageDataResponseError).error
+					error: (data as PostMessageDataResponseError).error
 				});
 				return;
 		}

--- a/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
+++ b/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
@@ -55,27 +55,27 @@ const initCkMinterInfoWorker = async ({
 	const worker: Worker = new CkMinterInfoWorker.default();
 
 	worker.onmessage = ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<PostMessageJsonDataResponse | PostMessageDataResponseError | PostMessageSyncState>
 	>) => {
-		const { msg } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncCkMinterInfo':
 				onSyncSuccess({
 					tokenId,
-					data: data.data as PostMessageJsonDataResponse
+					data: data as PostMessageJsonDataResponse
 				});
 				return;
 			case 'syncCkMinterInfoError':
 				onSyncError({
 					tokenId,
-					error: (data.data as PostMessageDataResponseError).error
+					error: (data as PostMessageDataResponseError).error
 				});
 				return;
 			case 'syncCkMinterInfoStatus':
-				onSyncStatus((data.data as PostMessageSyncState).state);
+				onSyncStatus((data as PostMessageSyncState).state);
 				return;
 		}
 	};

--- a/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
+++ b/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
@@ -24,37 +24,37 @@ export const initCkBTCUpdateBalanceWorker: IcCkWorker = async ({
 	const worker: Worker = new CkBTCUpdateBalanceWorker.default();
 
 	worker.onmessage = async ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<
 			PostMessageJsonDataResponse | PostMessageSyncState | PostMessageDataResponseBTCAddress
 		>
 	>) => {
-		const { msg } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncBtcPendingUtxos':
 				syncBtcPendingUtxos({
 					tokenId,
-					data: data.data as PostMessageJsonDataResponse
+					data: data as PostMessageJsonDataResponse
 				});
 				return;
 			case 'syncCkBTCUpdateBalanceStatus':
 				emit({
 					message: 'oisyCkBtcUpdateBalance',
-					detail: (data.data as PostMessageSyncState).state
+					detail: (data as PostMessageSyncState).state
 				});
 				return;
 			case 'syncBtcAddress':
 				syncBtcAddress({
 					tokenId,
-					data: data.data as PostMessageDataResponseBTCAddress
+					data: data as PostMessageDataResponseBTCAddress
 				});
 				return;
 			case 'syncCkBTCUpdateOk':
 				await syncCkBTCUpdateOk({
 					tokenId,
-					data: data.data as PostMessageJsonDataResponse
+					data: data as PostMessageJsonDataResponse
 				});
 				return;
 		}

--- a/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
@@ -21,7 +21,7 @@ export const initDip20WalletWorker = async ({
 	const worker: Worker = new WalletWorker.default();
 
 	worker.onmessage = ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<
 			| PostMessageDataResponseWallet
@@ -29,26 +29,26 @@ export const initDip20WalletWorker = async ({
 			| PostMessageDataResponseWalletCleanUp
 		>
 	>) => {
-		const { msg } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncDip20Wallet':
 				syncWallet({
 					tokenId,
-					data: data.data as PostMessageDataResponseWallet
+					data: data as PostMessageDataResponseWallet
 				});
 				return;
 			case 'syncDip20WalletError':
 				onLoadTransactionsError({
 					tokenId,
-					error: (data.data as PostMessageDataResponseError).error
+					error: (data as PostMessageDataResponseError).error
 				});
 
 				return;
 			case 'syncDip20WalletCleanUp':
 				onTransactionsCleanUp({
 					tokenId,
-					transactionIds: (data.data as PostMessageDataResponseWalletCleanUp).transactionIds
+					transactionIds: (data as PostMessageDataResponseWalletCleanUp).transactionIds
 				});
 				return;
 		}

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -17,7 +17,7 @@ export const initIcpWalletWorker = async (): Promise<WalletWorker> => {
 	const worker: Worker = new WalletWorker.default();
 
 	worker.onmessage = ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<
 			| PostMessageDataResponseWallet
@@ -25,25 +25,25 @@ export const initIcpWalletWorker = async (): Promise<WalletWorker> => {
 			| PostMessageDataResponseWalletCleanUp
 		>
 	>) => {
-		const { msg } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncIcpWallet':
 				syncWallet({
 					tokenId: ICP_TOKEN_ID,
-					data: data.data as PostMessageDataResponseWallet
+					data: data as PostMessageDataResponseWallet
 				});
 				return;
 			case 'syncIcpWalletError':
 				onLoadTransactionsError({
 					tokenId: ICP_TOKEN_ID,
-					error: (data.data as PostMessageDataResponseError).error
+					error: (data as PostMessageDataResponseError).error
 				});
 				return;
 			case 'syncIcpWalletCleanUp':
 				onTransactionsCleanUp({
 					tokenId: ICP_TOKEN_ID,
-					transactionIds: (data.data as PostMessageDataResponseWalletCleanUp).transactionIds
+					transactionIds: (data as PostMessageDataResponseWalletCleanUp).transactionIds
 				});
 				return;
 		}

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -41,7 +41,7 @@ export const initIcrcWalletWorker = async ({
 	};
 
 	worker.onmessage = ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<
 			| PostMessageDataResponseWallet
@@ -49,19 +49,19 @@ export const initIcrcWalletWorker = async ({
 			| PostMessageDataResponseWalletCleanUp
 		>
 	>) => {
-		const { msg } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncIcrcWallet':
 				syncWallet({
 					tokenId,
-					data: data.data as PostMessageDataResponseWallet
+					data: data as PostMessageDataResponseWallet
 				});
 				return;
 			case 'syncIcrcWalletError':
 				onLoadTransactionsError({
 					tokenId,
-					error: (data.data as PostMessageDataResponseError).error
+					error: (data as PostMessageDataResponseError).error
 				});
 
 				// In case of error, we start the listener again, but only with the ledgerCanisterId,
@@ -74,7 +74,7 @@ export const initIcrcWalletWorker = async ({
 			case 'syncIcrcWalletCleanUp':
 				onTransactionsCleanUp({
 					tokenId,
-					transactionIds: (data.data as PostMessageDataResponseWalletCleanUp).transactionIds
+					transactionIds: (data as PostMessageDataResponseWalletCleanUp).transactionIds
 				});
 				return;
 		}

--- a/src/frontend/src/icp/services/worker.pow-protection.services.ts
+++ b/src/frontend/src/icp/services/worker.pow-protection.services.ts
@@ -20,7 +20,7 @@ export const initPowProtectorWorker: PowProtectorWorker =
 		const worker: Worker = new PowWorker.default();
 
 		worker.onmessage = ({
-			data
+			data: dataMsg
 		}: MessageEvent<
 			PostMessage<
 				| PostMessageDataResponsePowProtectorProgress
@@ -28,19 +28,19 @@ export const initPowProtectorWorker: PowProtectorWorker =
 				| PostMessageDataResponseError
 			>
 		>) => {
-			const { msg } = data;
+			const { msg, data } = dataMsg;
 
 			switch (msg) {
 				case 'syncPowProgress': {
 					syncPowProgress({
-						data: data.data as PostMessageDataResponsePowProtectorProgress
+						data: data as PostMessageDataResponsePowProtectorProgress
 					});
 					return;
 				}
 				case 'syncPowNextAllowance': {
 					// Check if data.data exists and has proper structure
 					syncPowNextAllowance({
-						data: data.data as PostMessageDataResponsePowProtectorNextAllowance
+						data: data as PostMessageDataResponsePowProtectorNextAllowance
 					});
 					return;
 				}

--- a/src/frontend/src/lib/services/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/worker.auth.services.ts
@@ -7,16 +7,16 @@ export const initAuthWorker = async () => {
 	const authWorker: Worker = new AuthWorker.default();
 
 	authWorker.onmessage = async ({
-		data
+		data: dataMsg
 	}: MessageEvent<PostMessage<PostMessageDataResponseAuth>>) => {
-		const { msg, data: value } = data;
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'signOutIdleTimer':
 				await idleSignOut();
 				return;
 			case 'delegationRemainingTime':
-				authRemainingTimeStore.set(value?.authRemainingTime);
+				authRemainingTimeStore.set(data?.authRemainingTime);
 				return;
 		}
 	};

--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -21,11 +21,11 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 	const exchangeWorker: Worker = new ExchangeWorker.default();
 
 	exchangeWorker.onmessage = ({
-		data
+		data: dataMsg
 	}: MessageEvent<
 		PostMessage<PostMessageDataResponseExchange | PostMessageDataResponseExchangeError>
 	>) => {
-		const { msg, data: value } = data;
+		const { msg, data } = dataMsg;
 
 		// If Coingecko throws an error, for instance, if too many requests are queried within the same minute, it is possible that the window may receive the same error twice because we start and stop the worker based on certain store changes.
 		// To prevent the same issue from being displayed multiple times, which would not be user-friendly, the following function keeps track of errors and only displays those that have occurred with a time span of one minute or more.
@@ -73,13 +73,13 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 
 		switch (msg) {
 			case 'syncExchange':
-				syncExchange(value as PostMessageDataResponseExchange | undefined);
+				syncExchange(data as PostMessageDataResponseExchange | undefined);
 				return;
 			case 'syncExchangeError':
 				// TODO: error appears to often currently and is super annoying. So until we figure out a way to solve this, hide the error to the console.
 				console.error(
 					'An error occurred while attempting to retrieve the USD exchange rates.',
-					(value as PostMessageDataResponseExchangeError | undefined)?.err
+					(data as PostMessageDataResponseExchangeError | undefined)?.err
 				);
 				// toastError(value as PostMessageDataResponseExchangeError | undefined);
 				return;

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -30,21 +30,23 @@ export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<
 	const isDevnetNetwork = isNetworkIdSOLDevnet(networkId);
 	const isLocalNetwork = isNetworkIdSOLLocal(networkId);
 
-	worker.onmessage = ({ data }: MessageEvent<PostMessage<SolPostMessageDataResponseWallet>>) => {
-		const { msg } = data;
+	worker.onmessage = ({
+		data: dataMsg
+	}: MessageEvent<PostMessage<SolPostMessageDataResponseWallet>>) => {
+		const { msg, data } = dataMsg;
 
 		switch (msg) {
 			case 'syncSolWallet':
 				syncWallet({
 					tokenId,
-					data: data.data as SolPostMessageDataResponseWallet
+					data: data as SolPostMessageDataResponseWallet
 				});
 				return;
 
 			case 'syncSolWalletError':
 				syncWalletError({
 					tokenId,
-					error: (data.data as PostMessageDataResponseError).error,
+					error: (data as PostMessageDataResponseError).error,
 					hideToast: true
 				});
 				return;


### PR DESCRIPTION
# Motivation

Just to be consistent and improve readability, we rename the inputs of the workers as `dataMsg` instead of `data` and deconstruct it as `const { msg, data } = dataMsg`
