### PR TITLE
fix(frontend): Do not estimate gas for ck-conversions

### DIFF
--- a/src/frontend/src/eth/components/fee/FeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/FeeContext.svelte
@@ -91,7 +91,9 @@
 				)
 			});
 
-			const estimatedGas = await estimateGas(params);
+			// We estimate gas only when it is not a ck-conversion (i.e. target network is not ICP).
+			// Otherwise, we would need to emulate the data that are provided to the minter contract address.
+			const estimatedGas = isNetworkICP(targetNetwork) ? undefined : await estimateGas(params);
 
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {
 				feeStore.setFee({


### PR DESCRIPTION
# Motivation

The `estimateGas` method requires data simulation when the destination is not a wallet, but a contract address.

So, in case of ck-conversions, we don't need to estimate gas, since we already use the fee coming directly from the minters.
