### PR TITLE
fix(frontend): Missing total amount in Solana RPC consensus strategy

### DIFF
--- a/src/frontend/src/sol/canisters/sol-rpc.constants.ts
+++ b/src/frontend/src/sol/canisters/sol-rpc.constants.ts
@@ -6,7 +6,7 @@ import type {
 import { toNullable } from '@dfinity/utils';
 
 const SOL_RPC_CONSENSUS_STRATEGY: ConsensusStrategy = {
-	Threshold: { min: 2, total: toNullable() }
+	Threshold: { min: 2, total: toNullable(3) }
 };
 
 export const SOL_RPC_CONFIG: [] | [RpcConfig] = toNullable({


### PR DESCRIPTION
# Motivation

In PR #7606 , I forgot to add the total number of RPC providers in the consensus strategy.
