### PR TITLE
chore(frontend): Correct key name for SPL custom tokens in i18n file

### DIFF
--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -483,7 +483,7 @@
 			"transaction_price": "Fehler beim Laden der Schätzung des Transaktionspreises.",
 			"icrc_canisters": "Fehler beim Laden der ICRC-Canisters.",
 			"erc20_user_tokens": "Fehler beim Laden der ERC20-Benutzertoken.",
-			"spl_user_tokens": "Fehler beim Laden der SPL-Benutzertoken.",
+			"spl_custom_tokens": "Fehler beim Laden der SPL-Benutzertoken.",
 			"erc20_user_token": "Fehler beim Aktivieren des ERC20-Zwillings-Token.",
 			"icrc_custom_token": "Fehler beim Laden des benutzerdefinierten ICRC-Token.",
 			"loading_wallet_timeout": "Deine Wallet benötigt einige Anfangsdaten, die noch nicht geladen wurden. Bitte versuche es erneut.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -483,7 +483,7 @@
 			"transaction_price": "Error while loading the estimation of the price of a transaction.",
 			"icrc_canisters": "Error while loading the ICRC canisters.",
 			"erc20_user_tokens": "Error while loading the ERC20 user tokens.",
-			"spl_user_tokens": "Error while loading the SPL user tokens.",
+			"spl_custom_tokens": "Error while loading the SPL custom tokens.",
 			"erc20_user_token": "Error while enabling the ERC20 twin token.",
 			"icrc_custom_token": "Error while loading the ICRC custom token.",
 			"loading_wallet_timeout": "Your wallet requires some initial data which has not been loaded yet. Please try again.",

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -65,7 +65,7 @@ export const loadCustomTokens = ({
 			splCustomTokensStore.resetAll();
 
 			toastsError({
-				msg: { text: get(i18n).init.error.spl_user_tokens },
+				msg: { text: get(i18n).init.error.spl_custom_tokens },
 				err
 			});
 		},
@@ -180,16 +180,7 @@ const loadCustomTokensWithMetadata = async ({
 
 			const metadata = await getSplMetadata({ address, network: solNetwork });
 
-			return nonNullish(metadata)
-				? [
-						...(await acc),
-						{
-							...token,
-							owner,
-							...metadata
-						}
-					]
-				: acc;
+			return nonNullish(metadata) ? [...(await acc), { ...token, owner, ...metadata }] : acc;
 		}, Promise.resolve([]));
 
 		return [...existingTokens, ...customTokens];


### PR DESCRIPTION
# Motivation

Small consistency adaptation in the i18n keys: the SPL tokens saved in the backend are `CustomToken` and not `UserToken`.