### PR TITLE
chore(frontend): Disable 2 xStock Solana tokens that don't have a price (yet)

### DIFF
--- a/src/frontend/src/env/tokens/tokens.spl.env.ts
+++ b/src/frontend/src/env/tokens/tokens.spl.env.ts
@@ -1,7 +1,5 @@
 import { SOL_MAINNET_ENABLED } from '$env/networks/networks.sol.env';
 import { AAPLX_TOKEN } from '$env/tokens/tokens-spl/tokens.aaplx.env';
-import { ABBVX_TOKEN } from '$env/tokens/tokens-spl/tokens.abbvx.env';
-import { ABTX_TOKEN } from '$env/tokens/tokens-spl/tokens.abtx.env';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { COINX_TOKEN } from '$env/tokens/tokens-spl/tokens.coinx.env';
 import { CRCLX_TOKEN } from '$env/tokens/tokens-spl/tokens.crclx.env';
@@ -26,8 +24,9 @@ import type { RequiredSplToken } from '$sol/types/spl';
 
 const SPL_TOKENS_MAINNET: RequiredSplToken[] = [
 	AAPLX_TOKEN,
-	ABBVX_TOKEN,
-	ABTX_TOKEN,
+	// TODO: temporarily disable these 2 tokens, because we don't have a price for them yet. We can enable them once they get traded and habe a price.
+	// ABBVX_TOKEN,
+	// ABTX_TOKEN,
 	BONK_TOKEN,
 	COINX_TOKEN,
 	CRCLX_TOKEN,


### PR DESCRIPTION
# Motivation

These 2 tokens don't have a price on coingecko yet.

# Changes

For now disable them, and add them back once they are traded and have a price.

# Tests
<img width="652" alt="image" src="https://github.com/user-attachments/assets/95a86493-41ab-4099-a8b4-fc333968dda6" />
