### PR TITLE
feat(frontend): use assertIndexCanisterId for Icrc tokens editing

### DIFF
--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -206,7 +206,7 @@ const loadIndexBalance = async ({
 	}
 };
 
-const assertIndexLedgerId = async ({
+export const assertIndexLedgerId = async ({
 	identity,
 	indexCanisterId,
 	ledgerCanisterId

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -54,15 +54,15 @@ const loadDefaultIcrcTokens = async () => {
 export const loadCustomTokens = ({
 	identity,
 	useCache = false,
-	onQuerySuccess
+	onSuccess
 }: {
 	identity: OptionIdentity;
 	useCache?: boolean;
-	onQuerySuccess?: () => void;
+	onSuccess?: () => void;
 }): Promise<void> =>
 	queryAndUpdate<IcrcCustomToken[]>({
 		request: (params) => loadIcrcCustomTokens({ ...params, useCache }),
-		onLoad: (params) => loadIcrcCustomData({ ...params, onQuerySuccess }),
+		onLoad: (params) => loadIcrcCustomData({ ...params, onSuccess }),
 		onUpdateError: ({ error: err }) => {
 			icrcCustomTokensStore.resetAll();
 
@@ -247,13 +247,13 @@ const loadCustomIcrcTokensData = async ({
 const loadIcrcCustomData = ({
 	response: tokens,
 	certified,
-	onQuerySuccess
+	onSuccess
 }: {
 	certified: boolean;
 	response: IcrcCustomToken[];
-	onQuerySuccess?: () => void;
+	onSuccess?: () => void;
 }) => {
-	!certified && onQuerySuccess?.();
+	onSuccess?.();
 
 	icrcCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
 };

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 	import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
@@ -40,7 +40,6 @@
 	import type { OptionToken, Token } from '$lib/types/token';
 	import { toCustomToken } from '$lib/utils/custom-token.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { back, gotoReplaceRoot } from '$lib/utils/nav.utils';
 	import { isNetworkIdSOLDevnet } from '$lib/utils/network.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
@@ -234,7 +233,7 @@
 				gotoStep(TokenModalSteps.EDIT_PROGRESS);
 				progress(ProgressStepsAddToken.SAVE);
 
-				const { valid } = !isNullishOrEmpty(icrcTokenIndexCanisterId)
+				const { valid } = notEmptyString(icrcTokenIndexCanisterId)
 					? await assertIndexLedgerId({
 							identity: $authIdentity,
 							ledgerCanisterId: tokenToEdit.ledgerCanisterId,
@@ -252,7 +251,7 @@
 
 				await setCustomToken({
 					token: toCustomToken({
-						...(!isNullishOrEmpty(icrcTokenIndexCanisterId) && {
+						...(notEmptyString(icrcTokenIndexCanisterId) && {
 							indexCanisterId: icrcTokenIndexCanisterId
 						}),
 						ledgerCanisterId: tokenToEdit.ledgerCanisterId,

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -1,4 +1,5 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import * as icAddCustomTokensService from '$icp/services/ic-add-custom-tokens.service';
 import { loadCustomTokens } from '$icp/services/icrc.services';
 import * as backendApi from '$lib/api/backend.api';
 import * as idbTokensApi from '$lib/api/idb-tokens.api';
@@ -40,6 +41,8 @@ describe('TokenModal', () => {
 		vi.spyOn(backendApi, 'setCustomToken').mockResolvedValue(undefined);
 	const mockIdbTokensApi = () =>
 		vi.spyOn(idbTokensApi, 'deleteIdbEthToken').mockResolvedValue(undefined);
+	const mockIcAddCustomTokensService = (result = true) =>
+		vi.spyOn(icAddCustomTokensService, 'assertIndexLedgerId').mockResolvedValue({ valid: result });
 	const mockToastsShow = () => vi.spyOn(toastsStore, 'toastsShow').mockImplementation(vi.fn());
 	const mockToastsError = () => vi.spyOn(toastsStore, 'toastsError').mockImplementation(vi.fn());
 	const mockGoToRoot = () => vi.spyOn(navUtils, 'gotoReplaceRoot').mockImplementation(vi.fn());
@@ -98,6 +101,7 @@ describe('TokenModal', () => {
 		});
 
 		const setCustomTokenMock = mockSetCustomToken();
+		mockIcAddCustomTokensService();
 		mockAuthStore();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
@@ -137,6 +141,7 @@ describe('TokenModal', () => {
 
 		const setCustomTokenMock = mockSetCustomToken();
 		mockAuthStore();
+		mockIcAddCustomTokensService();
 
 		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
 
@@ -158,6 +163,36 @@ describe('TokenModal', () => {
 			identity: mockIdentity
 		});
 		expect(loadCustomTokens).toHaveBeenCalledOnce();
+	});
+
+	it('does not save token if indexCanisterId assertion failed', async () => {
+		const { getByTestId, getByText } = render(TokenModal, {
+			props: {
+				token: {
+					...mockIcToken,
+					indexCanisterId: 'test',
+					enabled: true
+				} as Token,
+				isEditable: true
+			}
+		});
+
+		const setCustomTokenMock = mockSetCustomToken();
+		mockAuthStore();
+		mockIcAddCustomTokensService(false);
+
+		expect(getByText(en.tokens.details.title)).toBeInTheDocument();
+
+		await fireEvent.click(getByTestId(TOKEN_MODAL_INDEX_CANISTER_ID_EDIT_BUTTON));
+
+		await fireEvent.input(getByTestId(TOKEN_MODAL_INDEX_CANISTER_ID_INPUT), {
+			target: { value: MOCK_CANISTER_ID_1 }
+		});
+
+		await fireEvent.click(getByTestId(TOKEN_MODAL_SAVE_BUTTON));
+
+		expect(setCustomTokenMock).not.toHaveBeenCalledOnce();
+		expect(loadCustomTokens).not.toHaveBeenCalledOnce();
 	});
 
 	it('does not delete token if it is not erc20', async () => {


### PR DESCRIPTION
# Motivation

We need to improve the token editing feature by asserting indexCanisterId before saving it. Mostly, it is needed to check whether an index id matches with the provided ledger id. 

Also, we need to improve the onSuccess callback of `loadCustomTokens` - previously, it was only triggered after query calls, but since we cannot guarantee that they succeed, it's better to call `onSuccess` on both certified and uncertified calls.
