### PR TITLE
feat(frontend): New type for ERC20 Custom tokens

### DIFF
--- a/src/frontend/src/eth/types/erc20-custom-token.ts
+++ b/src/frontend/src/eth/types/erc20-custom-token.ts
@@ -1,0 +1,4 @@
+import type { Erc20Token } from '$eth/types/erc20';
+import type { UserToken } from '$lib/types/user-token';
+
+export type Erc20CustomToken = UserToken<Erc20Token>;

--- a/src/frontend/src/icp/types/icrc-custom-token.ts
+++ b/src/frontend/src/icp/types/icrc-custom-token.ts
@@ -1,6 +1,6 @@
 import type { EnvIcrcTokenMetadata } from '$env/types/env-icrc-token';
 import type { IcToken, IcTokenWithoutId } from '$icp/types/ic-token';
-import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { CustomToken } from '$lib/types/custom-token';
 import type { Option } from '$lib/types/utils';
 
 export type IcrcCustomTokenExtra = Pick<EnvIcrcTokenMetadata, 'alternativeName'>;
@@ -9,6 +9,6 @@ export type IcTokenExtended = IcToken & IcrcCustomTokenExtra;
 
 export type IcTokenWithoutIdExtended = IcTokenWithoutId & IcrcCustomTokenExtra;
 
-export type IcrcCustomToken = TokenToggleable<IcToken> & IcrcCustomTokenExtra;
+export type IcrcCustomToken = CustomToken<IcToken> & IcrcCustomTokenExtra;
 
 export type OptionIcrcCustomToken = Option<IcrcCustomToken>;

--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -1,10 +1,11 @@
-import type { Token } from '$declarations/backend/backend.did';
+import type { Token as BackendToken } from '$declarations/backend/backend.did';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import type { UserTokenState } from '$lib/types/token-toggleable';
+import type { Token } from '$lib/types/token';
+import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 import type { SplToken } from '$sol/types/spl';
 
-type CustomTokenNetworkKeys = Token extends infer T
+type CustomTokenNetworkKeys = BackendToken extends infer T
 	? T extends Record<string, unknown>
 		? keyof T
 		: never
@@ -28,3 +29,5 @@ export type SaveCustomTokenWithKey = UserTokenState &
 		| TokenVariant<'Erc20', Erc20SaveCustomToken>
 		| TokenVariant<'SplDevnet' | 'SplMainnet', SplSaveCustomToken>
 	);
+
+export type CustomToken<T extends Token> = TokenToggleable<T>;

--- a/src/frontend/src/sol/types/spl-custom-token.ts
+++ b/src/frontend/src/sol/types/spl-custom-token.ts
@@ -1,7 +1,7 @@
-import type { UserToken } from '$lib/types/user-token';
+import type { CustomToken } from '$lib/types/custom-token';
 import type { SplToken } from '$sol/types/spl';
 
-export type SplCustomToken = UserToken<SplToken>;
+export type SplCustomToken = CustomToken<SplToken>;
 
 export type SaveSplCustomToken = Pick<
 	SplCustomToken,


### PR DESCRIPTION
# Motivation

Starting to normalize the Custom tokens among the network, we first create a type for ERC20 custom tokens. It should be the same as the ICRC and SPL ones.
