### PR TITLE
feat(frontend): Create IDB methods for ERC20 custom tokens

### DIFF
--- a/src/frontend/src/lib/api/idb-tokens.api.ts
+++ b/src/frontend/src/lib/api/idb-tokens.api.ts
@@ -16,6 +16,10 @@ const idbTokensStore = (key: string): UseStore =>
 		: ({} as unknown as UseStore);
 
 const idbIcTokensStore = idbTokensStore(ICP_NETWORK_SYMBOL.toLowerCase());
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
+const idbEthTokensStoreDeprecated = idbTokensStore(
+	`${ETHEREUM_NETWORK_SYMBOL.toLowerCase()}-deprecated`
+);
 const idbEthTokensStore = idbTokensStore(ETHEREUM_NETWORK_SYMBOL.toLowerCase());
 const idbSolTokensStore = idbTokensStore(SOLANA_MAINNET_NETWORK_SYMBOL.toLowerCase());
 
@@ -37,7 +41,11 @@ export const setIdbTokensStore = async <T extends CustomToken | UserToken>({
 export const setIdbIcTokens = (params: SetIdbTokensParams<CustomToken>): Promise<void> =>
 	setIdbTokensStore({ ...params, idbTokensStore: idbIcTokensStore });
 
-export const setIdbEthTokens = (params: SetIdbTokensParams<UserToken>): Promise<void> =>
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
+export const setIdbEthTokensDeprecated = (params: SetIdbTokensParams<UserToken>): Promise<void> =>
+	setIdbTokensStore({ ...params, idbTokensStore: idbEthTokensStoreDeprecated });
+
+export const setIdbEthTokens = (params: SetIdbTokensParams<CustomToken>): Promise<void> =>
 	setIdbTokensStore({ ...params, idbTokensStore: idbEthTokensStore });
 
 export const setIdbSolTokens = (params: SetIdbTokensParams<CustomToken>): Promise<void> =>
@@ -48,9 +56,15 @@ export const getIdbIcTokens = (
 ): Promise<SetIdbTokensParams<CustomToken>['tokens'] | undefined> =>
 	get(principal.toText(), idbIcTokensStore);
 
-export const getIdbEthTokens = (
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
+export const getIdbEthTokensDeprecated = (
 	principal: Principal
 ): Promise<SetIdbTokensParams<UserToken>['tokens'] | undefined> =>
+	get(principal.toText(), idbEthTokensStoreDeprecated);
+
+export const getIdbEthTokens = (
+	principal: Principal
+): Promise<SetIdbTokensParams<CustomToken>['tokens'] | undefined> =>
 	get(principal.toText(), idbEthTokensStore);
 
 export const getIdbSolTokens = (
@@ -61,13 +75,18 @@ export const getIdbSolTokens = (
 export const deleteIdbIcTokens = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbIcTokensStore);
 
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
+export const deleteIdbEthTokensDeprecated = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbEthTokensStoreDeprecated);
+
 export const deleteIdbEthTokens = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbEthTokensStore);
 
 export const deleteIdbSolTokens = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbSolTokensStore);
 
-export const deleteIdbEthToken = async ({
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
+export const deleteIdbEthTokenDeprecated = async ({
 	identity,
 	token
 }: DeleteIdbTokenParams<UserToken>): Promise<void> => {
@@ -76,13 +95,47 @@ export const deleteIdbEthToken = async ({
 		return;
 	}
 
+	const currentTokens = await getIdbEthTokensDeprecated(identity.getPrincipal());
+
+	if (nonNullish(currentTokens)) {
+		await setIdbEthTokensDeprecated({
+			identity,
+			tokens: currentTokens.filter(({ contract_address, chain_id }) =>
+				token.chain_id === chain_id ? token.contract_address !== contract_address : true
+			)
+		});
+	}
+};
+
+export const deleteIdbEthToken = async ({
+	identity,
+	token
+}: DeleteIdbTokenParams<CustomToken>): Promise<void> => {
+	if (isNullish(identity)) {
+		await nullishSignOut();
+		return;
+	}
+
+	const { token: tokenToDelete } = token;
+
+	if (!('Erc20' in tokenToDelete)) {
+		return;
+	}
+
+	const {
+		Erc20: { token_address: tokenToDeleteAddress, chain_id: tokenToDeleteChainId }
+	} = tokenToDelete;
+
 	const currentTokens = await getIdbEthTokens(identity.getPrincipal());
 
 	if (nonNullish(currentTokens)) {
 		await setIdbEthTokens({
 			identity,
-			tokens: currentTokens.filter(({ contract_address, chain_id }) =>
-				token.chain_id === chain_id ? token.contract_address !== contract_address : true
+			tokens: currentTokens.filter(({ token: savedToken }) =>
+				'Erc20' in savedToken
+					? savedToken.Erc20.token_address !== tokenToDeleteAddress &&
+						savedToken.Erc20.chain_id !== tokenToDeleteChainId
+					: true
 			)
 		});
 	}

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -11,7 +11,7 @@
 	import { icTokenIcrcCustomToken, isTokenIcrc } from '$icp/utils/icrc.utils';
 	import { toUserToken } from '$icp-eth/services/user-token.services';
 	import { removeCustomToken, removeUserToken, setCustomToken } from '$lib/api/backend.api';
-	import { deleteIdbEthToken, deleteIdbIcToken, deleteIdbSolToken } from '$lib/api/idb-tokens.api';
+	import { deleteIdbEthTokenDeprecated, deleteIdbIcToken, deleteIdbSolToken } from '$lib/api/idb-tokens.api';
 	import AddTokenByNetworkDropdown from '$lib/components/manage/AddTokenByNetworkDropdown.svelte';
 	import TokenModalContent from '$lib/components/tokens/TokenModalContent.svelte';
 	import TokenModalDeleteConfirmation from '$lib/components/tokens/TokenModalDeleteConfirmation.svelte';
@@ -165,7 +165,7 @@
 				});
 
 				erc20UserTokensStore.reset(tokenToDelete.id);
-				await deleteIdbEthToken({ identity: $authIdentity, token: userToken });
+				await deleteIdbEthTokenDeprecated({ identity: $authIdentity, token: userToken });
 
 				await onTokenDeleteSuccess(tokenToDelete);
 			} else if (isTokenIcrc(tokenToDelete)) {

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -3,7 +3,12 @@ import {
 	deleteIdbEthAddress,
 	deleteIdbSolAddressMainnet
 } from '$lib/api/idb-addresses.api';
-import { deleteIdbEthTokens, deleteIdbIcTokens, deleteIdbSolTokens } from '$lib/api/idb-tokens.api';
+import {
+	deleteIdbEthTokens,
+	deleteIdbEthTokensDeprecated,
+	deleteIdbIcTokens,
+	deleteIdbSolTokens
+} from '$lib/api/idb-tokens.api';
 import {
 	TRACK_COUNT_SIGN_IN_SUCCESS,
 	TRACK_SIGN_IN_CANCELLED_COUNT,
@@ -118,6 +123,10 @@ const emptyIdbSolAddress = (): Promise<void> => emptyIdbStore(deleteIdbSolAddres
 
 const emptyIdbIcTokens = (): Promise<void> => emptyIdbStore(deleteIdbIcTokens);
 
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
+const emptyIdbEthTokensDeprecated = (): Promise<void> =>
+	emptyIdbStore(deleteIdbEthTokensDeprecated);
+
 const emptyIdbEthTokens = (): Promise<void> => emptyIdbStore(deleteIdbEthTokens);
 
 const emptyIdbSolTokens = (): Promise<void> => emptyIdbStore(deleteIdbSolTokens);
@@ -145,6 +154,7 @@ const logout = async ({
 			emptyIdbEthAddress(),
 			emptyIdbSolAddress(),
 			emptyIdbIcTokens(),
+			emptyIdbEthTokensDeprecated(),
 			emptyIdbEthTokens(),
 			emptyIdbSolTokens()
 		]);

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -82,7 +82,7 @@ describe('auth.services', () => {
 			await signOut({});
 
 			// addresses + tokens
-			expect(idbKeyval.del).toHaveBeenCalledTimes(6);
+			expect(idbKeyval.del).toHaveBeenCalledTimes(7);
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/erc20-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/erc20-tokens.mock.ts
@@ -1,5 +1,6 @@
 import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import type { Erc20Token } from '$eth/types/erc20';
+import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import type { NetworkEnvironment } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
@@ -46,6 +47,20 @@ export const createMockErc20UserTokens = ({
 	networkEnv: NetworkEnvironment;
 	start?: number;
 }): CertifiedData<Erc20UserToken>[] =>
+	createMockErc20Tokens({ n, networkEnv, start }).map((token) => ({
+		data: { ...token, enabled: true },
+		certified: false
+	}));
+
+export const createMockErc20CustomTokens = ({
+	n,
+	networkEnv,
+	start = 0
+}: {
+	n: number;
+	networkEnv: NetworkEnvironment;
+	start?: number;
+}): CertifiedData<Erc20CustomToken>[] =>
 	createMockErc20Tokens({ n, networkEnv, start }).map((token) => ({
 		data: { ...token, enabled: true },
 		certified: false


### PR DESCRIPTION
# Motivation

We are going to deprecate `UserToken` in favour of `CustomToken`, to have a single type normalized among all networks.

In this PR, we create the IDB methods to save/get/delete ERC20 custom tokens in IDB.

However we also need to differentiate between the deprecated methods and the new ones, since they will run in parallel for some time.

# Changes

- Rename all existing ERC20 user tokens IDB methods as "deprecated".
- Create new IDB methods based on existing ones.

# Tests

New tests.
