### PR TITLE
test(frontend): Exclude `+page` modules from coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -74,7 +74,8 @@ export default defineConfig(
 			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
 			coverage: {
 				include: ['src/frontend'],
-				// TODO: increase the thresholds slowly up to an acceptable 80% at least
+				exclude: ['src/frontend/src/routes/**/+page.ts'],
+				// TODO: increase the thresholds slowly up to an acceptable 90% at least
 				thresholds: {
 					autoUpdate: true,
 					statements: 74,


### PR DESCRIPTION
# Motivation

It does not really make sense to have the test coverage for `+page` modules in routes folder: there is no practical way of testing it correctly.
