### PR TITLE
refactor(frontend): Extract type for load custom tokens params

### DIFF
--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -4,6 +4,7 @@ import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 import type { SplToken } from '$sol/types/spl';
+import type { QueryAndUpdateRequestParams } from '@dfinity/utils';
 
 type CustomTokenNetworkKeys = BackendToken extends infer T
 	? T extends Record<string, unknown>
@@ -31,3 +32,5 @@ export type SaveCustomTokenWithKey = UserTokenState &
 	);
 
 export type CustomToken<T extends Token> = TokenToggleable<T>;
+
+export type LoadCustomTokenParams = QueryAndUpdateRequestParams & { useCache?: boolean };

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -3,11 +3,11 @@ import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/net
 import { SOLANA_DEFAULT_DECIMALS } from '$env/tokens/tokens.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import { getIdbSolTokens, setIdbSolTokens } from '$lib/api/idb-tokens.api';
-import { nullishSignOut } from '$lib/services/auth.services';
 import { loadNetworkCustomTokens } from '$lib/services/custom-tokens.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { SolAddress } from '$lib/types/address';
+import type { LoadCustomTokenParams } from '$lib/types/custom-token';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { TokenMetadata } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -54,12 +54,9 @@ const loadDefaultSplTokens = (): ResultSuccess => {
 export const loadCustomTokens = ({
 	identity,
 	useCache = false
-}: {
-	identity: OptionIdentity;
-	useCache?: boolean;
-}): Promise<void> =>
+}: Omit<LoadCustomTokenParams, 'certified'>): Promise<void> =>
 	queryAndUpdate<SplCustomToken[]>({
-		request: () => loadCustomTokensWithMetadata({ identity, useCache }),
+		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
 		onUpdateError: ({ error: err }) => {
 			splCustomTokensStore.resetAll();
@@ -73,38 +70,19 @@ export const loadCustomTokens = ({
 		strategy: 'query'
 	});
 
-const loadSplCustomTokens = async ({
-	identity,
-	certified,
-	useCache = false
-}: {
-	identity: OptionIdentity;
-	certified: boolean;
-	useCache?: boolean;
-}): Promise<CustomToken[]> =>
+const loadSplCustomTokens = async (params: LoadCustomTokenParams): Promise<CustomToken[]> =>
 	await loadNetworkCustomTokens({
-		identity,
-		certified,
+		...params,
 		filterTokens: ({ token }) => 'SplMainnet' in token || 'SplDevnet' in token,
 		setIdbTokens: setIdbSolTokens,
-		getIdbTokens: getIdbSolTokens,
-		useCache
+		getIdbTokens: getIdbSolTokens
 	});
 
-const loadCustomTokensWithMetadata = async ({
-	identity,
-	useCache = false
-}: {
-	identity: OptionIdentity;
-	useCache?: boolean;
-}): Promise<SplCustomToken[]> => {
+const loadCustomTokensWithMetadata = async (
+	params: LoadCustomTokenParams
+): Promise<SplCustomToken[]> => {
 	const loadCustomContracts = async (): Promise<SplCustomToken[]> => {
-		if (isNullish(identity)) {
-			await nullishSignOut();
-			return [];
-		}
-
-		const splCustomTokens = await loadSplCustomTokens({ identity, certified: true, useCache });
+		const splCustomTokens = await loadSplCustomTokens(params);
 
 		const [existingTokens, nonExistingTokens] = splCustomTokens.reduce<
 			[SplCustomToken[], SplCustomToken[]]


### PR DESCRIPTION
# Motivation

To simplify the code, we create a specific type for the params of the functions that load custom tokens (and similar for user tokens).
