### PR TITLE
style(frontend): Hero adjustments

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -23,7 +23,7 @@
 	const totalUsd = $derived(sumTokensUiUsdBalance($combinedDerivedSortedNetworkTokensUi));
 </script>
 
-<span class="flex flex-col items-center gap-4">
+<span class="flex flex-col items-center gap-1">
 	<output class="mt-7 inline-block break-all text-5xl font-bold">
 		{#if $loaded}
 			{#if hideBalance}

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -24,7 +24,7 @@
 	const { loading } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
-<span class="flex flex-col gap-2">
+<span class="flex flex-col gap-1">
 	<output
 		data-tid={AMOUNT_DATA}
 		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -54,7 +54,7 @@
 			transparent
 			fullWidth
 			ariaLabel="Set privacy mode on and off"
-			styleClass="bg-transparent p-0 text-xl font-bold"
+			styleClass="bg-transparent p-0 text-xl font-medium"
 			ondblclick={() =>
 				setPrivacyMode({
 					enabled: !$isPrivacyMode,

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -91,7 +91,7 @@
 </script>
 
 <div
-	class="flex h-full w-full flex-col content-center items-center justify-center rounded-[28px] bg-brand-primary bg-pos-0 p-5 text-center text-primary-inverted transition-all duration-500 ease-in-out"
+	class="flex h-full w-full flex-col content-center items-center justify-center rounded-[24px] bg-brand-primary bg-pos-0 p-3 text-center text-primary-inverted transition-all duration-500 ease-in-out md:rounded-[28px] md:p-5"
 	class:from-default-0={$pseudoNetworkChainFusion}
 	class:to-default-100={$pseudoNetworkChainFusion}
 	class:bg-pos-100={!$pseudoNetworkChainFusion}


### PR DESCRIPTION
# Motivation

Final round of hero adjustments proposed by Dan.

# Changes

- Font medium for balance like "Top up your wallet" text
- Reduced border radius and padding on mobile
- Reduced spacing between balance and Token name / total balance and "Top up your wallet" text

# Tests

Token Mobile:
![image](https://github.com/user-attachments/assets/9c13fbc5-21e8-4206-8315-2df6b18557f1)

Token Tablet:
![image](https://github.com/user-attachments/assets/e002e299-8c8d-4d9f-81ba-36ff73fb4cdf)

Token Desktop:
![image](https://github.com/user-attachments/assets/c8780762-ba28-414c-a63e-349076a3c32a)

Homepage Mobile:
![image](https://github.com/user-attachments/assets/8b25f278-27ab-4951-984c-d4704f2b19da)

Homepage Tablet:
![image](https://github.com/user-attachments/assets/c17a0a6f-68c1-46c3-9459-5141646b5881)

Homepage Desktop:
![image](https://github.com/user-attachments/assets/0137efce-b693-4bfe-a957-1a698fb76753)
