### PR TITLE
feat(frontend): Services to load ERC20 Custom Tokens

### DIFF
--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -1,4 +1,4 @@
-import type { UserToken } from '$declarations/backend/backend.did';
+import type { CustomToken, UserToken } from '$declarations/backend/backend.did';
 import {
 	SUPPORTED_EVM_NETWORKS,
 	SUPPORTED_EVM_NETWORKS_CHAIN_IDS
@@ -13,21 +13,32 @@ import {
 	ERC20_CONTRACTS,
 	ERC20_TWIN_TOKENS
 } from '$env/tokens/tokens.erc20.env';
+import { ETHEREUM_DEFAULT_DECIMALS } from '$env/tokens/tokens.eth.env';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
+import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import type { Erc20Contract, Erc20Metadata, Erc20Token } from '$eth/types/erc20';
+import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
 import type { Erc20UserToken } from '$eth/types/erc20-user-token';
 import type { EthereumNetwork } from '$eth/types/network';
-import { mapErc20Token, mapErc20UserToken } from '$eth/utils/erc20.utils';
+import { mapErc20Icon, mapErc20Token, mapErc20UserToken } from '$eth/utils/erc20.utils';
 import { listUserTokens } from '$lib/api/backend.api';
-import { getIdbEthTokensDeprecated, setIdbEthTokensDeprecated } from '$lib/api/idb-tokens.api';
+import {
+	getIdbEthTokens,
+	getIdbEthTokensDeprecated,
+	setIdbEthTokens,
+	setIdbEthTokensDeprecated
+} from '$lib/api/idb-tokens.api';
 import { nullishSignOut } from '$lib/services/auth.services';
+import { loadNetworkCustomTokens } from '$lib/services/custom-tokens.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsErrorNoTrace } from '$lib/stores/toasts.store';
+import { toastsError, toastsErrorNoTrace } from '$lib/stores/toasts.store';
+import type { LoadCustomTokenParams } from '$lib/types/custom-token';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { UserTokenState } from '$lib/types/token-toggleable';
 import type { ResultSuccess } from '$lib/types/utils';
+import { parseTokenId } from '$lib/validation/token.validation';
 import {
 	assertNonNullish,
 	fromNullable,
@@ -42,7 +53,11 @@ export const loadErc20Tokens = async ({
 }: {
 	identity: OptionIdentity;
 }): Promise<void> => {
-	await Promise.all([loadDefaultErc20Tokens(), loadErc20UserTokens({ identity, useCache: true })]);
+	await Promise.all([
+		loadDefaultErc20Tokens(),
+		loadErc20UserTokens({ identity, useCache: true }),
+		loadCustomTokens({ identity, useCache: true })
+	]);
 };
 
 const ALL_DEFAULT_ERC20_TOKENS = [
@@ -84,6 +99,25 @@ const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 	return { success: true };
 };
 
+export const loadCustomTokens = ({
+	identity,
+	useCache = false
+}: Omit<LoadCustomTokenParams, 'certified'>): Promise<void> =>
+	queryAndUpdate<Erc20CustomToken[]>({
+		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
+		onLoad: loadCustomTokenData,
+		onUpdateError: ({ error: err }) => {
+			erc20CustomTokensStore.resetAll();
+
+			toastsError({
+				msg: { text: get(i18n).init.error.erc20_custom_tokens },
+				err
+			});
+		},
+		identity
+	});
+
+// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
 export const loadErc20UserTokens = ({
 	identity,
 	useCache = false
@@ -152,6 +186,103 @@ const loadNetworkUserTokens = async ({
 		identity,
 		certified
 	});
+};
+
+const loadErc20CustomTokens = async (params: LoadCustomTokenParams): Promise<CustomToken[]> =>
+	await loadNetworkCustomTokens({
+		...params,
+		filterTokens: ({ token }) => 'Erc20' in token,
+		setIdbTokens: setIdbEthTokens,
+		getIdbTokens: getIdbEthTokens
+	});
+
+const loadCustomTokensWithMetadata = async (
+	params: LoadCustomTokenParams
+): Promise<Erc20CustomToken[]> => {
+	const loadCustomContracts = async (): Promise<Erc20CustomToken[]> => {
+		const erc20CustomTokens = await loadErc20CustomTokens(params);
+
+		const [existingTokens, nonExistingTokens] = erc20CustomTokens.reduce<
+			[Erc20CustomToken[], Erc20CustomToken[]]
+		>(
+			([accExisting, accNonExisting], { token, enabled, version: versionNullable }) => {
+				if (!('Erc20' in token)) {
+					return [accExisting, accNonExisting];
+				}
+
+				if (
+					![...SUPPORTED_ETHEREUM_NETWORKS_CHAIN_IDS, ...SUPPORTED_EVM_NETWORKS_CHAIN_IDS].includes(
+						token.Erc20.chain_id
+					)
+				) {
+					return [accExisting, accNonExisting];
+				}
+
+				const version = fromNullable(versionNullable);
+
+				const {
+					Erc20: { symbol, decimals, token_address: tokenAddress, chain_id: tokenChainId }
+				} = token;
+
+				const existingToken = ALL_DEFAULT_ERC20_TOKENS.find(
+					({ address, network: { chainId } }) =>
+						tokenAddress.toLowerCase() === address.toLowerCase() && tokenChainId === chainId
+				);
+
+				if (nonNullish(existingToken)) {
+					return [[...accExisting, { ...existingToken, enabled, version }], accNonExisting];
+				}
+
+				const network = [...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS].find(
+					({ chainId }) => tokenChainId === chainId
+				);
+
+				// This should not happen because we filter the chain_id in the previous filter, but we need it to be type safe
+				assertNonNullish(
+					network,
+					`Inconsistency in network data: no network found for chainId ${tokenChainId} in custom token, even though it is in the environment`
+				);
+
+				return [
+					accExisting,
+					[
+						...accNonExisting,
+						{
+							id: parseTokenId(`custom-token#${symbol}#${network.chainId}`),
+							name: tokenAddress,
+							address: tokenAddress,
+							network,
+							symbol: fromNullable(symbol) ?? '',
+							decimals: fromNullable(decimals) ?? ETHEREUM_DEFAULT_DECIMALS,
+							standard: 'erc20' as const,
+							category: 'custom' as const,
+							exchange: 'erc20' as const,
+							enabled,
+							version
+						}
+					]
+				];
+			},
+			[[], []]
+		);
+
+		const customTokens: Erc20CustomToken[] = await nonExistingTokens.reduce<
+			Promise<Erc20CustomToken[]>
+		>(async (acc, token) => {
+			const { network, address } = token;
+
+			// TODO(GIX-2740): check if metadata for address already loaded in store and reuse - using Infura is not a certified call anyway
+			const metadata = await infuraErc20Providers(network.id).metadata({ address });
+
+			const icon = mapErc20Icon(metadata.symbol);
+
+			return nonNullish(metadata) ? [...(await acc), { icon, ...token, ...metadata }] : acc;
+		}, Promise.resolve([]));
+
+		return [...existingTokens, ...customTokens];
+	};
+
+	return await loadCustomContracts();
 };
 
 const loadUserTokens = async (params: {
@@ -227,6 +358,16 @@ const loadUserTokens = async (params: {
 
 	const contracts = await Promise.all(userContracts);
 	return contracts.map(mapErc20UserToken);
+};
+
+const loadCustomTokenData = ({
+	response: tokens,
+	certified
+}: {
+	certified: boolean;
+	response: Erc20CustomToken[];
+}) => {
+	erc20CustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
 };
 
 const loadUserTokenData = ({

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -289,7 +289,6 @@ const loadCustomTokensWithMetadata = async (
 				address
 			} = token;
 
-			// TODO(GIX-2740): check if metadata for address already loaded in store and reuse - using Infura is not a certified call anyway
 			const metadata = await safeLoadMetadata({ networkId, address });
 
 			return nonNullish(metadata)

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -292,7 +292,7 @@ const loadCustomTokensWithMetadata = async (
 			const metadata = await safeLoadMetadata({ networkId, address });
 
 			return nonNullish(metadata)
-				? [...(await acc), { icon: mapErc20Icon(metadata.symbol), ...token, ...metadata }]
+				? [...(await acc), { ...token, icon: mapErc20Icon(metadata.symbol), ...metadata }]
 				: acc;
 		}, Promise.resolve([]));
 

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -292,13 +292,9 @@ const loadCustomTokensWithMetadata = async (
 			// TODO(GIX-2740): check if metadata for address already loaded in store and reuse - using Infura is not a certified call anyway
 			const metadata = await safeLoadMetadata({ networkId, address });
 
-			if (isNullish(metadata)) {
-				return acc;
-			}
-
-			const icon = mapErc20Icon(metadata.symbol);
-
-			return [...(await acc), { icon, ...token, ...metadata }];
+			return nonNullish(metadata)
+				? [...(await acc), { icon: mapErc20Icon(metadata.symbol), ...token, ...metadata }]
+				: acc;
 		}, Promise.resolve([]));
 
 		return [...existingTokens, ...customTokens];

--- a/src/frontend/src/eth/stores/erc20-custom-tokens.store.ts
+++ b/src/frontend/src/eth/stores/erc20-custom-tokens.store.ts
@@ -1,5 +1,5 @@
 import type { Erc20Token } from '$eth/types/erc20';
 import { initCertifiedUserTokensStore } from '$lib/stores/user-tokens.store';
 
-// TODO: use initCertifiedIcrcTokensStore when we deprecate initCertifiedUserTokensStore
+// TODO: UserToken is deprecated - rename this store initCertifiedUserTokensStore
 export const erc20CustomTokensStore = initCertifiedUserTokensStore<Erc20Token>();

--- a/src/frontend/src/eth/stores/erc20-custom-tokens.store.ts
+++ b/src/frontend/src/eth/stores/erc20-custom-tokens.store.ts
@@ -1,5 +1,5 @@
+import type { Erc20Token } from '$eth/types/erc20';
 import { initCertifiedUserTokensStore } from '$lib/stores/user-tokens.store';
-import type { SplToken } from '$sol/types/spl';
 
 // TODO: use initCertifiedIcrcTokensStore when we deprecate initCertifiedUserTokensStore
-export const splCustomTokensStore = initCertifiedUserTokensStore<SplToken>();
+export const erc20CustomTokensStore = initCertifiedUserTokensStore<Erc20Token>();

--- a/src/frontend/src/eth/types/address.ts
+++ b/src/frontend/src/eth/types/address.ts
@@ -1,5 +1,7 @@
 import type { BaseContract } from 'ethers/contract';
 
+export type Erc20ContractAddress = Awaited<ReturnType<BaseContract['getAddress']>>;
+
 export interface ContractAddress {
-	address: Awaited<ReturnType<BaseContract['getAddress']>>;
+	address: Erc20ContractAddress;
 }

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -35,7 +35,7 @@ export const mapErc20UserToken = ({
 	...rest
 });
 
-const mapErc20Icon = (symbol: string): string | undefined => {
+export const mapErc20Icon = (symbol: string): string | undefined => {
 	switch (symbol.toLowerCase()) {
 		// ICP in production. ckICP was used on staging because the definitive name and symbol had not been decided.
 		case 'icp':

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -482,6 +482,7 @@
 			"btc_withdrawal_statuses": "Fehler beim Abrufen der BTC-Auszahlungsstatus.",
 			"transaction_price": "Fehler beim Laden der Schätzung des Transaktionspreises.",
 			"icrc_canisters": "Fehler beim Laden der ICRC-Canisters.",
+			"erc20_custom_tokens": "",
 			"erc20_user_tokens": "Fehler beim Laden der ERC20-Benutzertoken.",
 			"spl_custom_tokens": "Fehler beim Laden der SPL-Benutzertoken.",
 			"erc20_user_token": "Fehler beim Aktivieren des ERC20-Zwillings-Token.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -482,7 +482,7 @@
 			"btc_withdrawal_statuses": "Fehler beim Abrufen der BTC-Auszahlungsstatus.",
 			"transaction_price": "Fehler beim Laden der Schätzung des Transaktionspreises.",
 			"icrc_canisters": "Fehler beim Laden der ICRC-Canisters.",
-			"erc20_custom_tokens": "",
+			"erc20_custom_tokens": "Fehler beim Laden der ERC20-Benutzertoken.",
 			"erc20_user_tokens": "Fehler beim Laden der ERC20-Benutzertoken.",
 			"spl_custom_tokens": "Fehler beim Laden der SPL-Benutzertoken.",
 			"erc20_user_token": "Fehler beim Aktivieren des ERC20-Zwillings-Token.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -482,6 +482,7 @@
 			"btc_withdrawal_statuses": "Error while fetching the BTC withdrawal statuses.",
 			"transaction_price": "Error while loading the estimation of the price of a transaction.",
 			"icrc_canisters": "Error while loading the ICRC canisters.",
+			"erc20_custom_tokens": "Error while loading the ERC20 custom tokens.",
 			"erc20_user_tokens": "Error while loading the ERC20 user tokens.",
 			"spl_custom_tokens": "Error while loading the SPL custom tokens.",
 			"erc20_user_token": "Error while enabling the ERC20 twin token.",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -482,6 +482,7 @@
 			"btc_withdrawal_statuses": "",
 			"transaction_price": "",
 			"icrc_canisters": "",
+			"erc20_custom_tokens": "",
 			"erc20_user_tokens": "",
 			"spl_custom_tokens": "",
 			"erc20_user_token": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -482,7 +482,7 @@
 			"btc_withdrawal_statuses": "获取 BTC 提现状态时出错。",
 			"transaction_price": "加载交易价格预估时出错。",
 			"icrc_canisters": "加载 ICRC 容器时出错。",
-			"erc20_custom_tokens": "",
+			"erc20_custom_tokens": "加载 ERC20 用户代币时出错。",
 			"erc20_user_tokens": "加载 ERC20 用户代币时出错。",
 			"spl_custom_tokens": "加载 SPL 用户代币时出错。",
 			"erc20_user_token": "启用 ERC20 双生代币时出错。",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -482,6 +482,7 @@
 			"btc_withdrawal_statuses": "获取 BTC 提现状态时出错。",
 			"transaction_price": "加载交易价格预估时出错。",
 			"icrc_canisters": "加载 ICRC 容器时出错。",
+			"erc20_custom_tokens": "",
 			"erc20_user_tokens": "加载 ERC20 用户代币时出错。",
 			"spl_custom_tokens": "加载 SPL 用户代币时出错。",
 			"erc20_user_token": "启用 ERC20 双生代币时出错。",

--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -4,6 +4,7 @@ import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
 import type { SplToken } from '$sol/types/spl';
+import type { QueryAndUpdateRequestParams } from '@dfinity/utils';
 
 type CustomTokenNetworkKeys = BackendToken extends infer T
 	? T extends Record<string, unknown>
@@ -31,3 +32,5 @@ export type SaveCustomTokenWithKey = UserTokenState &
 	);
 
 export type CustomToken<T extends Token> = TokenToggleable<T>;
+
+export type LoadCustomTokenParams = QueryAndUpdateRequestParams & { useCache?: boolean };

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -365,6 +365,7 @@ interface I18nInit {
 		btc_withdrawal_statuses: string;
 		transaction_price: string;
 		icrc_canisters: string;
+		erc20_custom_tokens: string;
 		erc20_user_tokens: string;
 		spl_custom_tokens: string;
 		erc20_user_token: string;

--- a/src/frontend/src/sol/stores/spl-custom-tokens.store.ts
+++ b/src/frontend/src/sol/stores/spl-custom-tokens.store.ts
@@ -1,5 +1,5 @@
 import { initCertifiedUserTokensStore } from '$lib/stores/user-tokens.store';
 import type { SplToken } from '$sol/types/spl';
 
-// TODO: use initCertifiedIcrcTokensStore when we deprecate initCertifiedUserTokensStore
+// TODO: UserToken is deprecated - rename this store initCertifiedUserTokensStore
 export const splCustomTokensStore = initCertifiedUserTokensStore<SplToken>();

--- a/src/frontend/src/tests/eth/services/erc20.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20.services.spec.ts
@@ -1,4 +1,4 @@
-import type { UserToken } from '$declarations/backend/backend.did';
+import type { CustomToken, UserToken } from '$declarations/backend/backend.did';
 import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { POLYGON_AMOY_NETWORK } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
@@ -8,13 +8,18 @@ import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { ADDITIONAL_ERC20_TOKENS, ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
 import type { InfuraErc20Provider } from '$eth/providers/infura-erc20.providers';
 import * as infuraProvidersModule from '$eth/providers/infura-erc20.providers';
-import { loadErc20Tokens, loadErc20UserTokens } from '$eth/services/erc20.services';
+import {
+	loadCustomTokens,
+	loadErc20Tokens,
+	loadErc20UserTokens
+} from '$eth/services/erc20.services';
+import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import type { Erc20Metadata } from '$eth/types/erc20';
-import { listUserTokens } from '$lib/api/backend.api';
+import { listCustomTokens, listUserTokens } from '$lib/api/backend.api';
 import * as toastsStore from '$lib/stores/toasts.store';
-import { toastsErrorNoTrace } from '$lib/stores/toasts.store';
+import { toastsError, toastsErrorNoTrace } from '$lib/stores/toasts.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockEthAddress, mockEthAddress2, mockEthAddress3 } from '$tests/mocks/eth.mocks';
 import en from '$tests/mocks/i18n.mock';
@@ -35,7 +40,8 @@ vi.mock('idb-keyval', () => ({
 }));
 
 vi.mock('$lib/api/backend.api', () => ({
-	listUserTokens: vi.fn()
+	listUserTokens: vi.fn(),
+	listCustomTokens: vi.fn()
 }));
 
 vi.mock('$eth/providers/infura-erc20.providers', () => ({
@@ -70,6 +76,45 @@ describe('erc20.services', () => {
 		}
 	];
 
+	const mockCustomTokens: CustomToken[] = [
+		{
+			version: toNullable(1n),
+			enabled: true,
+			token: {
+				Erc20: {
+					decimals: toNullable(18),
+					chain_id: ETHEREUM_NETWORK.chainId,
+					token_address: mockEthAddress,
+					symbol: toNullable('TTK')
+				}
+			}
+		},
+		{
+			version: toNullable(2n),
+			enabled: true,
+			token: {
+				Erc20: {
+					decimals: toNullable(18),
+					chain_id: BASE_NETWORK.chainId,
+					token_address: mockEthAddress2.toUpperCase(),
+					symbol: toNullable('TTK2')
+				}
+			}
+		},
+		{
+			version: toNullable(),
+			enabled: false,
+			token: {
+				Erc20: {
+					decimals: toNullable(18),
+					chain_id: POLYGON_AMOY_NETWORK.chainId,
+					token_address: mockEthAddress3,
+					symbol: toNullable('TTK3')
+				}
+			}
+		}
+	];
+
 	const mockMetadata1: Erc20Metadata = {
 		name: 'Test Token',
 		symbol: 'MetadataTTK',
@@ -84,6 +129,55 @@ describe('erc20.services', () => {
 	};
 
 	const expectedUserTokens = [
+		{
+			certified: true,
+			data: {
+				standard: 'erc20',
+				category: 'custom',
+				exchange: 'erc20',
+				version: 1n,
+				enabled: true,
+				network: ETHEREUM_NETWORK,
+				address: mockEthAddress,
+				decimals: mockMetadata1.decimals,
+				name: mockMetadata1.name,
+				symbol: mockMetadata1.symbol,
+				icon: mockMetadata1.icon
+			}
+		},
+		{
+			certified: true,
+			data: {
+				standard: 'erc20',
+				category: 'custom',
+				exchange: 'erc20',
+				version: 2n,
+				enabled: true,
+				network: BASE_NETWORK,
+				address: mockEthAddress2.toUpperCase(),
+				decimals: mockMetadata2.decimals,
+				name: mockMetadata2.name,
+				symbol: mockMetadata2.symbol
+			}
+		},
+		{
+			certified: true,
+			data: {
+				standard: 'erc20',
+				category: 'custom',
+				exchange: 'erc20',
+				version: undefined,
+				enabled: false,
+				network: POLYGON_AMOY_NETWORK,
+				address: mockEthAddress3,
+				decimals: mockMetadata2.decimals,
+				name: mockMetadata2.name,
+				symbol: mockMetadata2.symbol
+			}
+		}
+	];
+
+	const expectedCustomTokens = [
 		{
 			certified: true,
 			data: {
@@ -150,11 +244,14 @@ describe('erc20.services', () => {
 			mockAuthStore();
 
 			vi.spyOn(toastsStore, 'toastsErrorNoTrace');
+			vi.spyOn(toastsStore, 'toastsError');
 
 			erc20DefaultTokensStore.reset();
 			erc20UserTokensStore.resetAll();
+			erc20CustomTokensStore.resetAll();
 
 			vi.mocked(listUserTokens).mockResolvedValue(mockUserTokens);
+			vi.mocked(listCustomTokens).mockResolvedValue(mockCustomTokens);
 
 			mockMetadata.mockImplementation(({ address }) =>
 				address === mockUserTokens[0].contract_address ? mockMetadata1 : mockMetadata2
@@ -193,6 +290,22 @@ describe('erc20.services', () => {
 			expect(tokens).toEqual(expected);
 		});
 
+		it('should save the custom tokens in the store', async () => {
+			await loadErc20Tokens({ identity: mockIdentity });
+
+			const tokens = get(erc20CustomTokensStore);
+
+			const expected = expectedCustomTokens.map((token, index) => ({
+				...token,
+				data: {
+					...token.data,
+					id: (tokens ?? [])[index].data.id
+				}
+			}));
+
+			expect(tokens).toEqual(expected);
+		});
+
 		it('should not throw error if metadata throws', async () => {
 			const mockError = new Error('Error loading metadata');
 			vi.mocked(mockMetadata).mockRejectedValue(mockError);
@@ -203,6 +316,13 @@ describe('erc20.services', () => {
 		it('should not throw error if list user tokens throws', async () => {
 			const mockError = new Error('Error loading user tokens');
 			vi.mocked(listUserTokens).mockRejectedValue(mockError);
+
+			await expect(loadErc20Tokens({ identity: mockIdentity })).resolves.not.toThrow();
+		});
+
+		it('should not throw error if list custom tokens throws', async () => {
+			const mockError = new Error('Error loading custom tokens');
+			vi.mocked(listCustomTokens).mockRejectedValue(mockError);
 
 			await expect(loadErc20Tokens({ identity: mockIdentity })).resolves.not.toThrow();
 		});
@@ -447,6 +567,262 @@ describe('erc20.services', () => {
 
 		it('should fetch the cached custom tokens in IDB on query call', async () => {
 			await loadErc20UserTokens({ identity: mockIdentity, useCache: true });
+
+			expect(idbKeyval.get).toHaveBeenCalledOnce();
+			expect(idbKeyval.get).toHaveBeenNthCalledWith(
+				1,
+				mockIdentity.getPrincipal().toText(),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('loadCustomTokens', () => {
+		let infuraProvidersSpy: MockInstance;
+
+		const mockMetadata = vi.fn();
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			mockAuthStore();
+
+			vi.spyOn(toastsStore, 'toastsErrorNoTrace');
+
+			erc20CustomTokensStore.resetAll();
+
+			vi.mocked(listCustomTokens).mockResolvedValue(mockCustomTokens);
+
+			mockMetadata.mockImplementation(({ address }) => {
+				assert('Erc20' in mockCustomTokens[0].token);
+
+				return address === mockCustomTokens[0].token.Erc20.token_address
+					? mockMetadata1
+					: mockMetadata2;
+			});
+
+			infuraProvidersSpy = vi.spyOn(infuraProvidersModule, 'infuraErc20Providers');
+
+			infuraProvidersSpy.mockReturnValue({
+				metadata: mockMetadata
+			} as unknown as InfuraErc20Provider);
+		});
+
+		it('should load custom ERC20 tokens', async () => {
+			await loadCustomTokens({ identity: mockIdentity });
+
+			// query + update
+			expect(listCustomTokens).toHaveBeenCalledTimes(2);
+			expect(listCustomTokens).toHaveBeenNthCalledWith(1, {
+				identity: mockIdentity,
+				certified: false,
+				nullishIdentityErrorMessage: en.auth.error.no_internet_identity
+			});
+			expect(listCustomTokens).toHaveBeenNthCalledWith(2, {
+				identity: mockIdentity,
+				certified: true,
+				nullishIdentityErrorMessage: en.auth.error.no_internet_identity
+			});
+		});
+
+		it('should query metadata for the tokens that are not in the default list', async () => {
+			await loadCustomTokens({ identity: mockIdentity });
+
+			// query + update
+			expect(mockMetadata).toHaveBeenCalledTimes(mockCustomTokens.length * 2);
+
+			// query
+			mockCustomTokens.forEach(({ token }, index) => {
+				assert('Erc20' in token);
+
+				const {
+					Erc20: { token_address }
+				} = token;
+
+				expect(infuraProvidersSpy).toHaveBeenNthCalledWith(
+					index + 1,
+					expectedCustomTokens[index].data.network.id
+				);
+				expect(mockMetadata).toHaveBeenNthCalledWith(index + 1, {
+					address: token_address
+				});
+			});
+
+			// update
+			mockCustomTokens.forEach(({ token }, index) => {
+				assert('Erc20' in token);
+
+				const {
+					Erc20: { token_address }
+				} = token;
+
+				expect(infuraProvidersSpy).toHaveBeenNthCalledWith(
+					index + 1 + mockCustomTokens.length,
+					expectedCustomTokens[index].data.network.id
+				);
+				expect(mockMetadata).toHaveBeenNthCalledWith(index + 1 + mockCustomTokens.length, {
+					address: token_address
+				});
+			});
+		});
+
+		it('should not query metadata for the tokens that are in the default list', async () => {
+			const additionalCustomToken: CustomToken = {
+				version: toNullable(),
+				enabled: true,
+				token: {
+					Erc20: {
+						decimals: toNullable(3),
+						chain_id: ETHEREUM_NETWORK.chainId,
+						token_address: EURC_TOKEN.address,
+						symbol: toNullable(EURC_TOKEN.symbol)
+					}
+				}
+			};
+			assert('Erc20' in additionalCustomToken.token);
+
+			vi.mocked(listCustomTokens).mockResolvedValue([...mockCustomTokens, additionalCustomToken]);
+
+			await loadCustomTokens({ identity: mockIdentity });
+
+			expect(mockMetadata).not.toHaveBeenCalledWith({
+				address: additionalCustomToken.token.Erc20.token_address
+			});
+
+			// query + update
+			expect(mockMetadata).toHaveBeenCalledTimes(mockCustomTokens.length * 2);
+
+			// query
+			mockCustomTokens.forEach(({ token }, index) => {
+				assert('Erc20' in token);
+
+				const {
+					Erc20: { token_address }
+				} = token;
+
+				expect(infuraProvidersSpy).toHaveBeenNthCalledWith(
+					index + 1,
+					expectedCustomTokens[index].data.network.id
+				);
+				expect(mockMetadata).toHaveBeenNthCalledWith(index + 1, {
+					address: token_address
+				});
+			});
+
+			// update
+			mockCustomTokens.forEach(({ token }, index) => {
+				assert('Erc20' in token);
+
+				const {
+					Erc20: { token_address }
+				} = token;
+
+				expect(infuraProvidersSpy).toHaveBeenNthCalledWith(
+					index + 1 + mockCustomTokens.length,
+					expectedCustomTokens[index].data.network.id
+				);
+				expect(mockMetadata).toHaveBeenNthCalledWith(index + 1 + mockCustomTokens.length, {
+					address: token_address
+				});
+			});
+		});
+
+		it('should save custom ERC20 tokens to store', async () => {
+			await loadCustomTokens({ identity: mockIdentity });
+
+			const tokens = get(erc20CustomTokensStore);
+
+			expect(tokens).toEqual(
+				expectedCustomTokens.map((token, index) => ({
+					...token,
+					data: {
+						...token.data,
+						id: (tokens ?? [])[index].data.id
+					}
+				}))
+			);
+		});
+
+		it('should use the static metadata for the custom tokens that are already among the default tokens', async () => {
+			const additionalCustomToken: CustomToken = {
+				version: toNullable(17n),
+				enabled: true,
+				token: {
+					Erc20: {
+						decimals: toNullable(3),
+						chain_id: ETHEREUM_NETWORK.chainId,
+						token_address: EURC_TOKEN.address,
+						symbol: toNullable('Not-EURC')
+					}
+				}
+			};
+
+			vi.mocked(listCustomTokens).mockResolvedValue([...mockCustomTokens, additionalCustomToken]);
+
+			await loadCustomTokens({ identity: mockIdentity });
+
+			const tokens = get(erc20CustomTokensStore);
+
+			const expected = [
+				{
+					certified: true,
+					data: {
+						...EURC_TOKEN,
+						version: 17n,
+						enabled: true
+					}
+				},
+				...expectedCustomTokens.map((token, index) => ({
+					...token,
+					data: {
+						...token.data,
+						id: (tokens ?? [])[index + 1].data.id
+					}
+				}))
+			];
+
+			expect(tokens).toEqual(expected);
+		});
+
+		it('should reset token store on error', async () => {
+			erc20CustomTokensStore.setAll([
+				{ data: { ...SEPOLIA_PEPE_TOKEN, enabled: true }, certified: false }
+			]);
+
+			vi.mocked(listCustomTokens).mockRejectedValue(new Error('Error loading custom tokens'));
+
+			await loadCustomTokens({ identity: mockIdentity });
+
+			expect(get(erc20CustomTokensStore)).toBeNull();
+		});
+
+		it('should display the toast on error', async () => {
+			const mockError = new Error('Error loading custom tokens');
+			vi.mocked(listCustomTokens).mockRejectedValue(mockError);
+
+			await loadCustomTokens({ identity: mockIdentity });
+
+			expect(toastsError).toHaveBeenCalledOnce();
+			expect(toastsError).toHaveBeenNthCalledWith(1, {
+				msg: { text: en.init.error.erc20_custom_tokens },
+				err: mockError
+			});
+		});
+
+		it('should cache the custom tokens in IDB on update call', async () => {
+			await loadCustomTokens({ identity: mockIdentity });
+
+			expect(idbKeyval.set).toHaveBeenCalledOnce();
+			expect(idbKeyval.set).toHaveBeenNthCalledWith(
+				1,
+				mockIdentity.getPrincipal().toText(),
+				mockCustomTokens,
+				expect.any(Object)
+			);
+		});
+
+		it('should fetch the cached custom tokens in IDB on query call', async () => {
+			await loadCustomTokens({ identity: mockIdentity, useCache: true });
 
 			expect(idbKeyval.get).toHaveBeenCalledOnce();
 			expect(idbKeyval.get).toHaveBeenNthCalledWith(


### PR DESCRIPTION
# Motivation

We are going to deprecate `UserToken` in favour of `CustomToken`, to have a single type normalized among all networks.

However, we are going to have them in parallel for a certain amount of time, so that the migration is smoother.

In this PR, we create the mirror service to load ERC20 custom tokens from the backend: it is a mix of the existing services for ERC20 `UserToken` and SPL `CustomToken`.

# Changes

- Create ERC20 custom token store: this is identical to SPL custom tokens store. Note that the store initialization function has still not the proper name.
- Create service to load ERC20 custom tokens (and its sub-functions): this has the same basic structure of what we do for SPL custom tokens, but obviously using the filters and the metadata services that already exists for ERC20 `UserToken`.
- Add the new service in the existing generic service that loads both default and user/custom tokens.

# Tests

Included more tests.
