### PR TITLE
fix(frontend): Localize labels for IC transactions

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionLabel.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionLabel.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import type { OptionIcCkToken } from '$icp/types/ic-token';
+	import type { IcTransactionType } from '$icp/types/ic-transaction';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionToken, Token } from '$lib/types/token';
 	import { replacePlaceholders, resolveText } from '$lib/utils/i18n.utils';
 
 	interface Props {
 		label: string | undefined;
-		fallback: string;
+		fallback: IcTransactionType | undefined;
 		token: OptionToken;
 	}
 
-	const { label, fallback = '', token }: Props = $props();
+	const { label, fallback, token }: Props = $props();
 
-	let fallbackLabel: string = $derived(fallback.charAt(0).toUpperCase() + fallback.slice(1));
+	const fallbackLabel: string = nonNullish(fallback) ? $i18n.transaction.type[fallback] : '';
 
 	let twinToken: Token | undefined = $derived((token as OptionIcCkToken)?.twinToken);
 

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1100,6 +1100,15 @@
 			"safe": "Sicher",
 			"unconfirmed": "Unbestätigt"
 		},
+		"type": {
+			"send": "",
+			"receive": "",
+			"withdraw": "",
+			"deposit": "",
+			"approve": "",
+			"burn": "",
+			"mint": ""
+		},
 		"label": {
 			"reimbursement": "Rückerstattung",
 			"twin_token_sent": "$twinToken gesendet",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1100,6 +1100,15 @@
 			"safe": "Safe",
 			"unconfirmed": "Unconfirmed"
 		},
+		"type": {
+			"send": "Send",
+			"receive": "Receive",
+			"withdraw": "Withdraw",
+			"deposit": "Deposit",
+			"approve": "Approve",
+			"burn": "Burn",
+			"mint": "Mint"
+		},
 		"label": {
 			"reimbursement": "Reimbursement",
 			"twin_token_sent": "$twinToken sent",


### PR DESCRIPTION
# Motivation

Send and receive transactions labels are not localized for IC transactions.

# Changes

- Use i18n store to fetch the labels in `IcTransactionLabel` component.

# Tests

### Before

![Screenshot 2025-07-03 at 17 31 18](https://github.com/user-attachments/assets/5e3ddead-c743-46cb-a5d8-2ddd6389b1ed)

### After

![Screenshot 2025-07-03 at 17 31 11](https://github.com/user-attachments/assets/cff8cdca-6eff-4b41-8e29-cc678fd52b24)

