### PR TITLE
refactor(frontend): Hide network selector on token pages

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -28,8 +28,11 @@
 	</div>
 
 	<div class="pointer-events-auto flex justify-end gap-2 md:gap-5">
+		{#if $authSignedIn && !isRouteTransactions($page)}
+			<NetworksSwitcher />
+		{/if}
+
 		{#if $authSignedIn}
-			<NetworksSwitcher disabled={isRouteTransactions($page)} />
 			<WalletConnect />
 		{/if}
 


### PR DESCRIPTION
# Motivation

Currently it was just disabled on the token pages, we want it removed completely in that case.

# Changes

Moved disabled condition to the if rendering the component

# Tests

Homepage
![image](https://github.com/user-attachments/assets/337a26f3-869c-469d-acaf-01ff5a54e522)

On token page
![image](https://github.com/user-attachments/assets/e1fb939b-a658-4b55-8c72-d1aad0d9d1a2)

