### PR TITLE
refactor(frontend): Remove unnecessary nullish checks for `children` snippet

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionsCkBTCListeners.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsCkBTCListeners.svelte
@@ -28,6 +28,4 @@
 	{/if}
 {/if}
 
-{#if children}
-	{@render children()}
-{/if}
+{@render children?.()}

--- a/src/frontend/src/icp/components/transactions/IcTransactionsCkEthereumListeners.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsCkEthereumListeners.svelte
@@ -31,6 +31,4 @@
 
 <CkEthereumPendingTransactionsListener {token} {ckEthereumNativeToken} />
 
-{#if children}
-	{@render children()}
-{/if}
+{@render children?.()}

--- a/src/frontend/src/lib/components/ui/DelayedTooltip.svelte
+++ b/src/frontend/src/lib/components/ui/DelayedTooltip.svelte
@@ -39,9 +39,7 @@
 			onfocus={handleEnter}
 			onblur={handleLeave}
 		>
-			{#if children}
-				{@render children()}
-			{/if}
+			{@render children?.()}
 		</span>
 	{/snippet}
 


### PR DESCRIPTION
# Motivation

When we render `children` as snippet, we don't necessarily require to create a nullish check.