### PR TITLE
feat(frontend): Completely terminate ck-related workers on destroy

### DIFF
--- a/src/frontend/src/icp/components/core/IcCkListener.svelte
+++ b/src/frontend/src/icp/components/core/IcCkListener.svelte
@@ -21,7 +21,7 @@
 			}))
 	);
 
-	onDestroy(() => worker?.stop());
+	onDestroy(() => {worker?.destroy()});
 
 	const syncTimer = () => {
 		worker?.stop();

--- a/src/frontend/src/icp/components/core/IcCkListener.svelte
+++ b/src/frontend/src/icp/components/core/IcCkListener.svelte
@@ -21,7 +21,7 @@
 			}))
 	);
 
-	onDestroy(() => {worker?.destroy()});
+	onDestroy(() => worker?.destroy());
 
 	const syncTimer = () => {
 		worker?.stop();

--- a/src/frontend/src/icp/services/worker.btc-statuses.services.ts
+++ b/src/frontend/src/icp/services/worker.btc-statuses.services.ts
@@ -37,6 +37,12 @@ export const initBtcStatusesWorker: IcCkWorker = async ({
 		}
 	};
 
+	const stop = () => {
+		worker.postMessage({
+			msg: 'stopBtcStatusesTimer'
+		});
+	};
+
 	return {
 		start: () => {
 			worker.postMessage({
@@ -46,11 +52,7 @@ export const initBtcStatusesWorker: IcCkWorker = async ({
 				}
 			});
 		},
-		stop: () => {
-			worker.postMessage({
-				msg: 'stopBtcStatusesTimer'
-			});
-		},
+		stop,
 		trigger: () => {
 			worker.postMessage({
 				msg: 'triggerBtcStatusesTimer',
@@ -58,6 +60,10 @@ export const initBtcStatusesWorker: IcCkWorker = async ({
 					minterCanisterId
 				}
 			});
+		},
+		destroy: () => {
+			stop();
+			worker.terminate();
 		}
 	};
 };

--- a/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
+++ b/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
@@ -80,6 +80,12 @@ const initCkMinterInfoWorker = async ({
 		}
 	};
 
+	const stop = () => {
+		worker.postMessage({
+			msg: `stop${postMessageKey}MinterInfoTimer`
+		});
+	};
+
 	return {
 		start: () => {
 			worker.postMessage({
@@ -89,11 +95,7 @@ const initCkMinterInfoWorker = async ({
 				}
 			});
 		},
-		stop: () => {
-			worker.postMessage({
-				msg: `stop${postMessageKey}MinterInfoTimer`
-			});
-		},
+		stop,
 		trigger: () => {
 			worker.postMessage({
 				msg: `trigger${postMessageKey}MinterInfoTimer`,
@@ -101,6 +103,10 @@ const initCkMinterInfoWorker = async ({
 					minterCanisterId
 				}
 			});
+		},
+		destroy: () => {
+			stop();
+			worker.terminate();
 		}
 	};
 };

--- a/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
+++ b/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
@@ -60,6 +60,12 @@ export const initCkBTCUpdateBalanceWorker: IcCkWorker = async ({
 		}
 	};
 
+	const stop = () => {
+		worker.postMessage({
+			msg: 'stopCkBTCUpdateBalanceTimer'
+		});
+	};
+
 	return {
 		start: () => {
 			// We can imperatively get the address because the worker fetches it, and we only provide it to reduce the number of calls. By doing so, we can adhere to our standard component abstraction for interacting with workers.
@@ -74,14 +80,14 @@ export const initCkBTCUpdateBalanceWorker: IcCkWorker = async ({
 				}
 			});
 		},
-		stop: () => {
-			worker.postMessage({
-				msg: 'stopCkBTCUpdateBalanceTimer'
-			});
-		},
+		stop,
 		trigger: () => {
 			// Do nothing, we do not restart the ckBtc update balance worker for any particular events.
-			// When user execute it manually on the UI side, we display a progression in a modal therefore we do not have to execute it in the background.
+			// When a user executes it manually on the UI side, we display a progression in a modal therefore we do not have to execute it in the background.
+		},
+		destroy: () => {
+			stop();
+			worker.terminate();
 		}
 	};
 };

--- a/src/frontend/src/icp/types/ck-listener.ts
+++ b/src/frontend/src/icp/types/ck-listener.ts
@@ -10,6 +10,7 @@ export interface IcCkWorkerInitResult {
 	start: () => void;
 	stop: () => void;
 	trigger: () => void;
+	destroy: () => void;
 }
 
 export type IcCkWorker = (params: IcCkWorkerParams) => Promise<IcCkWorkerInitResult>;

--- a/src/frontend/src/tests/btc/components/convert/ConvertToCkBTC.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/ConvertToCkBTC.spec.ts
@@ -37,7 +37,8 @@ describe('ConvertToCkBTC', () => {
 		vi.spyOn(ckMinterInfoWorkerServices, 'initCkBTCMinterInfoWorker').mockResolvedValue({
 			start: () => {},
 			stop: () => {},
-			trigger: () => {}
+			trigger: () => {},
+			destroy: () => {}
 		});
 	const mockIsBusyStore = (isBusy = false) =>
 		vi.spyOn(isBusyStore, 'isBusy', 'get').mockImplementation(() => readable(isBusy));


### PR DESCRIPTION
# Motivation

When we destroy a component that initiate a worker, we stop such worker. However, we do not destroy it.

To fix it, we create a new function called `destroy`.

In this PR, we tackle the ck-related workers.

# Changes

- Refactor a sub-function for `stop` in the workers.
- Create `destroy` method, using `worker.terminate`.

# Tests

Existing and new tests suffice.
