### PR TITLE
feat(frontend): Completely terminate PoW workers on destroy

### DIFF
--- a/src/frontend/src/icp/services/worker.pow-protection.services.ts
+++ b/src/frontend/src/icp/services/worker.pow-protection.services.ts
@@ -47,21 +47,27 @@ export const initPowProtectorWorker: PowProtectorWorker =
 			}
 		};
 
+		const stop = () => {
+			worker.postMessage({
+				msg: 'stopPowProtectionTimer'
+			});
+		};
+
 		return {
 			start: () => {
 				worker.postMessage({
 					msg: 'startPowProtectionTimer'
 				});
 			},
-			stop: () => {
-				worker.postMessage({
-					msg: 'stopPowProtectionTimer'
-				});
-			},
+			stop,
 			trigger: () => {
 				worker.postMessage({
 					msg: 'triggerPowProtectionTimer'
 				});
+			},
+			destroy: () => {
+				stop();
+				worker.terminate();
 			}
 		};
 	};

--- a/src/frontend/src/icp/types/pow-protector-listener.ts
+++ b/src/frontend/src/icp/types/pow-protector-listener.ts
@@ -2,6 +2,7 @@ export interface PowProtectorWorkerInitResult {
 	start: () => void;
 	stop: () => void;
 	trigger: () => void;
+	destroy: () => void;
 }
 
 export type PowProtectorWorker = () => Promise<PowProtectorWorkerInitResult>;

--- a/src/frontend/src/lib/components/pow/PowProtector.svelte
+++ b/src/frontend/src/lib/components/pow/PowProtector.svelte
@@ -20,7 +20,7 @@
 			powWorker.start();
 		});
 
-		onDestroy(() => powWorker?.stop());
+		onDestroy(() => powWorker?.destroy());
 	}
 </script>
 

--- a/src/frontend/src/tests/icp/services/worker.pow-protector.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.pow-protector.services.spec.ts
@@ -20,6 +20,7 @@ const postMessageSpy = vi.fn();
 class MockWorker {
 	postMessage = postMessageSpy;
 	onmessage: ((event: MessageEvent) => void) | null = null;
+	terminate: () => void = vi.fn();
 }
 
 vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
@@ -69,6 +70,17 @@ describe('worker.pow-protection.services', () => {
 			expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
 				msg: 'triggerPowProtectionTimer'
 			});
+		});
+
+		it('should destroy the worker', () => {
+			worker.destroy();
+
+			expect(postMessageSpy).toHaveBeenCalledOnce();
+			expect(postMessageSpy).toHaveBeenNthCalledWith(1, {
+				msg: 'stopPowProtectionTimer'
+			});
+
+			expect(workerInstance.terminate).toHaveBeenCalledOnce();
 		});
 
 		describe('onmessage', () => {


### PR DESCRIPTION
# Motivation

When we destroy a component that initiate a worker, we stop such worker. However, we do not destroy it.

To fix it, we create a new function called `destroy`.

In this PR, we tackle the PoW worker.

# Changes

- Refactor a sub-function for `stop` in the workers.
- Create `destroy` method, using `worker.terminate`.

# Tests

Existing and new tests suffice.
