### PR TITLE
feat(frontend): Keep To address during send flow

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -125,8 +125,6 @@
 
 		// eslint-disable-next-line require-await
 		const callback = async () => {
-			reset();
-
 			goToStep(WizardStepsSend.DESTINATION);
 		};
 


### PR DESCRIPTION
# Motivation

We want to keep the destination address during the send flow, once entered. So selecting a token where the address would be invalid just results in the validation error showing.

It should only reset on modal close.

# Changes

-  Removed reset in callback when navigating the send wizard

# Tests


https://github.com/user-attachments/assets/a4045c10-ea7d-4e04-a49c-375c8f784880

