### PR TITLE
fix(frontend): Pass data from WalletConnect to fee context

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeContext.svelte
@@ -37,6 +37,7 @@
 	export let observe: boolean;
 	export let destination = '';
 	export let amount: OptionAmount = undefined;
+	export let data: string | undefined = undefined;
 	export let sourceNetwork: EthereumNetwork;
 	export let targetNetwork: Network | undefined = undefined;
 	export let nativeEthereumToken: Token;
@@ -93,7 +94,7 @@
 
 			// We estimate gas only when it is not a ck-conversion (i.e. target network is not ICP).
 			// Otherwise, we would need to emulate the data that are provided to the minter contract address.
-			const estimatedGas = isNetworkICP(targetNetwork) ? undefined : await estimateGas(params);
+			const estimatedGas = isNetworkICP(targetNetwork) ? undefined : await estimateGas({ ...params, data });
 
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {
 				feeStore.setFee({

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -37,6 +37,7 @@
 	import type { Network } from '$lib/types/network';
 	import type { TokenId } from '$lib/types/token';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
+	import { isNullish } from '@dfinity/utils';
 
 	export let request: WalletKitTypes.SessionRequest;
 	export let firstTransaction: WalletConnectEthSendTransactionParams;
@@ -141,6 +142,9 @@
 	let amount: bigint;
 	$: amount = BigInt(firstTransaction?.value ?? ZERO);
 
+	let data: string | undefined
+	$: data = firstTransaction?.data
+
 	const send = async () => {
 		const { success } = await sendServices({
 			request,
@@ -170,6 +174,7 @@
 
 	<EthFeeContext
 		amount={amount.toString()}
+		{data}
 		sendToken={$sendToken}
 		sendTokenId={$sendTokenId}
 		{destination}

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -14,6 +14,7 @@ import { isNetworkIdICP } from '$lib/utils/network.utils';
 export interface GetFeeData {
 	from: EthAddress;
 	to: EthAddress;
+	data?: string;
 }
 
 export const getEthFeeData = ({


### PR DESCRIPTION
# Motivation

When WalletConnect send the requests, for ERC20, it may happen that the first transaction is an approval. In that case, to estimate the gas (the one that we show in the frontend review UI), we need to pass the data of the transaction.

# Changes

- Allow `EthFeeContext` component to receive optional `data` params.
- Extract data from the transaction in WalletConnect flow.
- Pass it through to calculate the estimated gas.

# Tests

### Before

![Screenshot 2025-07-07 at 13 45 29](https://github.com/user-attachments/assets/e7e36306-f24c-4690-879a-6e514f6e3776)


### After

![Screenshot 2025-07-07 at 13 43 12](https://github.com/user-attachments/assets/feff7507-51ef-406a-ab40-802e288ac491)

