### PR TITLE
style(frontend): Correct background for toasts

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -173,7 +173,7 @@ const updateCSP = (indexHtml) => {
 	const plausibleApiConnectSrc = 'https://plausible.io/api/event';
 
 	const walletConnectSrc =
-		'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org';
+		'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org https://pulse.walletconnect.org';
 	const walletConnectFrameSrc = 'https://verify.walletconnect.com https://verify.walletconnect.org';
 
 	const onramperConnectFrameSrc = 'https://buy.onramper.dev https://buy.onramper.com';

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -1,14 +1,14 @@
 @use '../mixins/media';
 
-/************* USE OF !IMPORTANT ********************
-**   Only in this file the use of !important       **
-**   CAN be warranted. As this file is the last    **
-**   instance where the gix components can be      **
-**   styled, !important can be used to override    **
-**   certain styles. However, it still is a last   **
-**   resort solution and if possible, a proper     **
-**   solution must be tried and still is prefered. **
-****************************************************/
+/************* USE OF !IMPORTANT *********************
+**   Only in this file the use of !important        **
+**   CAN be warranted. As this file is the last     **
+**   instance where the gix components can be       **
+**   styled, !important can be used to override     **
+**   certain styles. However, it still is a last    **
+**   resort solution and if possible, a proper      **
+**   solution must be tried and still is preferred. **
+*****************************************************/
 
 :root {
 	--toggle-disabled-opacity: 1;
@@ -394,7 +394,7 @@ div.select {
 // TOASTS
 // Toasts other than error are not used
 // Also, it seems that gix components dont apply the success and warn classes correctly
-div.error .toast {
+.toast:has(> .icon.error) {
 	--overlay-background: var(--color-background-error-light);
 	--overlay-background-contrast: var(--color-foreground-error-secondary);
 }

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -391,9 +391,7 @@ div.select {
 	}
 }
 
-// TOASTS
-// Toasts other than error are not used
-// Also, it seems that gix components dont apply the success and warn classes correctly
+// Toasts
 .toast:has(> .icon.error) {
 	--overlay-background: var(--color-background-error-light);
 	--overlay-background-contrast: var(--color-foreground-error-secondary);


### PR DESCRIPTION
# Motivation

If there is at least an error-styled toast in the list of toasts, all of them will be error-styled. We correct this with a specific CSS selector.

### Before

![Screenshot 2025-07-07 at 15 58 56](https://github.com/user-attachments/assets/81ce447b-1355-4981-bd64-7f8da57f252a)


### After

![Screenshot 2025-07-07 at 15 45 50](https://github.com/user-attachments/assets/b3a9c13b-b290-4b2a-b3dc-83f74e129442)
