### PR TITLE
fix(build): Add new WalletConnect endpoint to CSP

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -173,7 +173,7 @@ const updateCSP = (indexHtml) => {
 	const plausibleApiConnectSrc = 'https://plausible.io/api/event';
 
 	const walletConnectSrc =
-		'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org';
+		'wss://relay.walletconnect.com wss://relay.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org https://pulse.walletconnect.org';
 	const walletConnectFrameSrc = 'https://verify.walletconnect.com https://verify.walletconnect.org';
 
 	const onramperConnectFrameSrc = 'https://buy.onramper.dev https://buy.onramper.com';


### PR DESCRIPTION
# Motivation

The CSP is raising a warning for a new WalletConnect endpoint:


![Screenshot 2025-07-07 at 15 21 01](https://github.com/user-attachments/assets/fdb96fed-815e-4f4b-88e6-9f5640519c56)
