### PR TITLE
fix(frontend): Format numbers with precision above the maximum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"alchemy-sdk": "3.6.0",
 				"bitcoinjs-lib": "^6.1.7",
 				"buffer": "^6.0.3",
+				"decimal.js": "^10.6.0",
 				"ethers": "^6.14.4",
 				"idb-keyval": "^6.2.2",
 				"plausible-tracker": "^0.3.9",
@@ -7057,10 +7058,9 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-			"integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-			"dev": true,
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"license": "MIT"
 		},
 		"node_modules/decode-uri-component": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"alchemy-sdk": "3.6.0",
 		"bitcoinjs-lib": "^6.1.7",
 		"buffer": "^6.0.3",
+		"decimal.js": "^10.6.0",
 		"ethers": "^6.14.4",
 		"idb-keyval": "^6.2.2",
 		"plausible-tracker": "^0.3.9",

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -3,6 +3,7 @@ import { MILLISECONDS_IN_DAY, NANO_SECONDS_IN_MILLISECOND } from '$lib/constants
 import type { AmountString } from '$lib/types/amount';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { Utils } from 'alchemy-sdk';
+import Decimal from 'decimal.js';
 import type { BigNumberish } from 'ethers/utils';
 
 const DEFAULT_DISPLAY_DECIMALS = 4;
@@ -35,12 +36,13 @@ export const formatToken = ({
 	const maxFractionDigits = Math.min(leadingZeros + 2, MAX_DEFAULT_DISPLAY_DECIMALS);
 	const minFractionDigits = displayDecimals ?? DEFAULT_DISPLAY_DECIMALS;
 
-	const formatted = (+res).toLocaleString('en-US', {
-		useGrouping: false,
-		maximumFractionDigits:
-			displayDecimals ?? (leadingZeros > 2 ? maxFractionDigits : DEFAULT_DISPLAY_DECIMALS),
-		minimumFractionDigits: trailingZeros ? minFractionDigits : undefined
-	}) as `${number}`;
+	const dec = new Decimal(res);
+	const maxDigits =
+		displayDecimals ?? (leadingZeros > 2 ? maxFractionDigits : DEFAULT_DISPLAY_DECIMALS);
+	const decDP = dec.toDecimalPlaces(maxDigits);
+	const minDigits = trailingZeros ? Math.max(minFractionDigits, maxDigits) : undefined;
+
+	const formatted = decDP.toFixed(minDigits) as `${number}`;
 
 	if (trailingZeros) {
 		return formatted;

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,4 +1,5 @@
-import { ZERO } from '$lib/constants/app.constants';
+import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
+import { DEFAULT_BITCOIN_TOKEN } from '$lib/constants/tokens.constants';
 import {
 	formatNanosecondsToDate,
 	formatSecondsToDate,
@@ -111,7 +112,20 @@ describe('format.utils', () => {
 
 			expect(formatToken({ value: valueD1, showPlusSign: true })).toBe('+1.2');
 
+			expect(formatToken({ value: ZERO, showPlusSign: true })).toBe('0');
+		});
+
+		it('should format negative value with minus sign', () => {
 			expect(formatToken({ value: negativeValue, showPlusSign: true })).toBe('-1');
+
+			expect(
+				formatToken({
+					value: -40827n,
+					displayDecimals: EIGHT_DECIMALS,
+					unitName: DEFAULT_BITCOIN_TOKEN.decimals,
+					showPlusSign: true
+				})
+			).toBe('-0.00040827');
 		});
 
 		it('should format small values', () => {
@@ -145,6 +159,49 @@ describe('format.utils', () => {
 		it('should format too small value with default displayDecimals', () => {
 			expect(formatToken({ value: 1200000000n })).toBe('< 0.00000001');
 			expect(formatToken({ value: 7000000000n })).toBe('< 0.00000001');
+		});
+
+		it('should format correctly for precision above the maximum', () => {
+			expect(formatToken({ value: 999999999999999876n, displayDecimals: 18, unitName: 18 })).toBe(
+				'0.999999999999999876'
+			);
+
+			expect(formatToken({ value: 999999999999999876n, displayDecimals: 17, unitName: 18 })).toBe(
+				'0.99999999999999988'
+			);
+
+			expect(formatToken({ value: 999999999999999871n, displayDecimals: 17, unitName: 18 })).toBe(
+				'0.99999999999999987'
+			);
+
+			expect(
+				formatToken({ value: 9999999999999999999999999876n, displayDecimals: 28, unitName: 28 })
+			).toBe('0.9999999999999999999999999876');
+
+			expect(
+				formatToken({
+					value: 9999999999999999999999999876n,
+					displayDecimals: 4,
+					unitName: 28,
+					trailingZeros: true
+				})
+			).toBe('1.0000');
+
+			expect(formatToken({ value: 9999999999999999999999999876n, unitName: 28 })).toBe('1');
+
+			expect(formatToken({ value: 876n, displayDecimals: 28, unitName: 28 })).toBe(
+				'0.0000000000000000000000000876'
+			);
+
+			expect(formatToken({ value: 876n, unitName: 28 })).toBe('< 0.00000001');
+
+			expect(
+				formatToken({
+					value: 1111119999999999999999999999999876n,
+					displayDecimals: 28,
+					unitName: 28
+				})
+			).toBe('111111.9999999999999999999999999876');
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The util `formatToken` does not properly format big numbers with precision above the 17. That is because transforming a string/bigint to number accepts a precision of 15-17 digits.

For example:

`Number(0.999999999999999876n)` or `(+"0.999999999999999876")` prints `0.9999999999999999`
`Number(0.999999999999999812n)` or `(+"0.999999999999999812")` prints `0.9999999999999998`

Such rounding is causing issues when defining the amounts provided by the user in an input. For example, if the max balance is the first number in the example, and we click the max button, we would try to send more than the balance.

To fix it, we cannot rely on `Number()` nor to `(+...)`. But we can rely on library [decimal.js](https://www.npmjs.com/package/decimal.js?activeTab=readme).

# Changes

- Install `decimal.js`.
- Changed util to create a Decimal object and adapt it to our constraints of min and max digits.

# Tests

Added tests, and practical one too where we know that the account has `999999999999999843n ARB`:

### Before

![Screenshot 2025-07-08 at 13 56 59](https://github.com/user-attachments/assets/6c6c007f-e176-46f8-86da-574063ed2cd3)


### Before

![Screenshot 2025-07-08 at 14 50 46](https://github.com/user-attachments/assets/612e634f-4d50-494b-8ff2-b1dc389f6955)

