### PR TITLE
feat(frontend): Derive SOL address in the frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"@dfinity/verifiable-credentials": "^0.0.4",
 				"@dfinity/zod-schemas": "^1.0.0",
 				"@metamask/detect-provider": "^2.0.0",
+				"@noble/ed25519": "^2.3.0",
 				"@noble/hashes": "^1.8.0",
 				"@noble/secp256k1": "^2.3.0",
 				"@reown/walletkit": "^1.2.7",
@@ -2627,6 +2628,15 @@
 			"engines": {
 				"node": "^14.21.3 || >=16"
 			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@noble/ed25519": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+			"integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"@dfinity/verifiable-credentials": "^0.0.4",
 		"@dfinity/zod-schemas": "^1.0.0",
 		"@metamask/detect-provider": "^2.0.0",
+		"@noble/ed25519": "^2.3.0",
 		"@noble/hashes": "^1.8.0",
 		"@noble/secp256k1": "^2.3.0",
 		"@reown/walletkit": "^1.2.7",

--- a/src/frontend/src/lib/ic-pub-key/src/chain_code.ts
+++ b/src/frontend/src/lib/ic-pub-key/src/chain_code.ts
@@ -1,0 +1,79 @@
+/* istanbul ignore file */
+/* v8 ignore start */
+
+import { blobDecode, blobEncode } from './encoding.js';
+
+/**
+ * A chain code is a 32 byte array
+ */
+export class ChainCode {
+	static readonly LENGTH = 32;
+
+	constructor(public readonly bytes: Uint8Array) {
+		if (bytes.length !== ChainCode.LENGTH) {
+			throw new Error(
+				`Invalid ChainCode length: expected ${ChainCode.LENGTH} bytes, got ${bytes.length}`
+			);
+		}
+	}
+
+	/**
+	 * Creates a new ChainCode from a 64 character hex string.
+	 * @param hex_str The 64 character hex string.
+	 * @returns A new ChainCode.
+	 */
+	static fromHex(hex_str: string): ChainCode {
+		if (hex_str.length !== ChainCode.LENGTH * 2) {
+			throw new Error(
+				`Invalid ChainCode length: expected ${ChainCode.LENGTH * 2} characters, got ${hex_str.length}`
+			);
+		}
+		const bytes = Buffer.from(hex_str, 'hex');
+		return new ChainCode(new Uint8Array(bytes));
+	}
+
+	static fromArray(array: number[]): ChainCode {
+		return new ChainCode(new Uint8Array(array));
+	}
+
+	/**
+	 * @returns The chain code as a 64 character hex string.
+	 */
+	toHex(): string {
+		return Buffer.from(this.bytes).toString('hex');
+	}
+
+	/**
+	 * Creates a new ChainCode from a Candid blob.
+	 * @param blob The blob to create the chain code from.
+	 * @returns A new ChainCode.
+	 */
+	static fromBlob(blob: string): ChainCode {
+		return new ChainCode(blobDecode(blob));
+	}
+
+	/**
+	 * @returns The chain code as a Candid blob.
+	 */
+	toBlob(): string {
+		return blobEncode(this.bytes);
+	}
+
+	/**
+	 * Creates a new ChainCode from a string.
+	 * @param str The chain code as a hex string or Candid blob.
+	 * @returns A new ChainCode.
+	 */
+	static fromString(str: string): ChainCode {
+		if (str.length === ChainCode.LENGTH * 2 && str.match(/^[0-9A-Fa-f]+$/)) {
+			return ChainCode.fromHex(str);
+		}
+		return ChainCode.fromBlob(str);
+	}
+
+	toJSON(): string {
+		return this.toHex();
+	}
+}
+
+/* v8 ignore stop */

--- a/src/frontend/src/lib/ic-pub-key/src/cli.ts
+++ b/src/frontend/src/lib/ic-pub-key/src/cli.ts
@@ -2,6 +2,10 @@
 /* istanbul ignore file */
 /* v8 ignore start */
 
+import { schnorr_ed25519_derive } from '$lib/ic-pub-key/src/schnorr/ed25519';
+import { mapDerivationPath } from '$lib/utils/signer.utils';
+import { SOLANA_DERIVATION_PATH_PREFIX } from '$sol/constants/sol.constants';
+import type { SolanaNetworkType } from '$sol/types/network';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import { Principal } from '@dfinity/principal';
 import { networks, payments, type Network } from 'bitcoinjs-lib';
@@ -66,6 +70,28 @@ export const deriveBtcAddress = async (user: string, network: BitcoinNetwork): P
 		throw new Error('Failed to derive Bitcoin address from public key.');
 	}
 	return btc_address;
+};
+
+/* istanbul ignore next */
+export const deriveSolAddress = async (
+	user: string,
+	network: SolanaNetworkType
+): Promise<string> => {
+	const pubkey = 'da38b16641af7626e372070ff9f844b7c89d1012850d2198393849d79d3d2d5d';
+	const chaincode = '985be5283a68fc22540930ca02680f86c771419ece571eb838b33eb5604cfbc0';
+
+	const principal = Principal.fromText(user);
+
+	let derivationPath = new DerivationPath([
+		principal.toUint8Array(),
+		...mapDerivationPath([SOLANA_DERIVATION_PATH_PREFIX, network])
+	]);
+
+	const blobString = derivationPath.toBlob();
+
+	let schnorr_address = schnorr_ed25519_derive(pubkey, chaincode, blobString);
+
+	return schnorr_address;
 };
 
 /* v8 ignore stop */

--- a/src/frontend/src/lib/ic-pub-key/src/encoding.ts
+++ b/src/frontend/src/lib/ic-pub-key/src/encoding.ts
@@ -68,4 +68,41 @@ function blobEncodeU8(u8: number): string {
 	return `\\${u8.toString(16).padStart(2, '0')}`;
 }
 
+/**
+ * Convert bytes arranged most significant first to a bigint.
+ * @param bytes The bytes to convert.
+ * @returns The converted number.
+ */
+export function bigintFromBigEndianBytes(bytes: Uint8Array): bigint {
+	if (bytes.length === 0) {
+		return BigInt(0);
+	}
+	const bigEndianHex = '0x' + Buffer.from(bytes).toString('hex');
+	return BigInt(bigEndianHex);
+}
+
+/**
+ * Convert little endian hex to a bigint.
+ * @param hex The hex to convert.
+ * @returns The converted number.
+ */
+export function bigintFromLittleEndianHex(hex: string): bigint {
+	if (hex.length === 0) {
+		return BigInt(0);
+	}
+	const leBytes = Buffer.from(hex, 'hex');
+	const beBytes = leBytes.reverse();
+	const beHex = beBytes.toString('hex');
+	return BigInt('0x' + beHex);
+}
+
+/**
+ * Convert an array of bytes to a hex string.
+ * @param array The array to convert.
+ * @returns The converted string.
+ */
+export function bytesAsHex(array: Uint8Array): string {
+	return Buffer.from(array).toString('hex');
+}
+
 /* v8 ignore stop */

--- a/src/frontend/src/lib/ic-pub-key/src/schnorr/ed25519.ts
+++ b/src/frontend/src/lib/ic-pub-key/src/schnorr/ed25519.ts
@@ -1,0 +1,228 @@
+/* eslint-disable */
+/* istanbul ignore file */
+/* v8 ignore start */
+
+import { ExtendedPoint } from '@noble/ed25519';
+import { hkdf as nobleHkdf } from '@noble/hashes/hkdf.js';
+import { sha512 } from '@noble/hashes/sha2';
+import { ChainCode } from '../chain_code.js';
+import { bigintFromBigEndianBytes, blobDecode, blobEncode } from '../encoding.js';
+export { ChainCode };
+
+/**
+ * The order of ed25519.
+ */
+const ORDER = 2n ** 252n + 27742317777372353535851937790883648493n;
+
+/**
+ * One part of a derivation path.
+ */
+export type PathComponent = Uint8Array;
+
+export class PublicKey {
+	/**
+	 * The length of a public key in bytes.  As hex it is twice this.
+	 */
+	static readonly LENGTH = 32;
+
+	constructor(public readonly key: ExtendedPoint) {
+		if (key.is0()) {
+			throw new Error('Invalid public key');
+		}
+	}
+
+	/**
+	 * Parses a public key from a string in any supported format.
+	 */
+	static fromString(public_key_string: string): PublicKey {
+		// At present only hex is supported, so this is easy:
+		return PublicKey.fromHex(public_key_string);
+	}
+
+	/**
+	 * Creates a new PublicKey from a hex string.
+	 * @param hex The hex string to create the public key from.
+	 * @throws If the hex string has the wrong length for a public key.
+	 * @throws If the public key is the point at infinity.
+	 * @returns A new PublicKey.
+	 */
+	static fromHex(hex: string): PublicKey {
+		return new PublicKey(ExtendedPoint.fromHex(hex, true));
+	}
+
+	/**
+	 * Returns the public key as a hex string.
+	 * @returns A 64 character hex string.
+	 */
+	toHex(): string {
+		return this.key.toHex();
+	}
+
+	/**
+	 * Returns the preferred JSON encoding of the public key.
+	 * @returns A 64 character hex string.
+	 */
+	toJSON(): string {
+		return this.toHex();
+	}
+}
+
+/**
+ * A public key with its chain code.
+ */
+export class PublicKeyWithChainCode {
+	/**
+	 * @param public_key The public key.
+	 * @param chain_code A hash of the derivation path.
+	 */
+	constructor(
+		public readonly public_key: PublicKey,
+		public readonly chain_code: ChainCode
+	) {}
+
+	/**
+	 * Creates a new PublicKeyWithChainCode from two hex strings.
+	 * @param public_key_hex The public key in hex format.
+	 * @param chain_code_hex The chain code in hex format.
+	 * @returns A new PublicKeyWithChainCode.
+	 */
+	static fromHex(public_key_hex: string, chain_code_hex: string): PublicKeyWithChainCode {
+		const public_key = PublicKey.fromHex(public_key_hex);
+		const chain_key = ChainCode.fromHex(chain_code_hex);
+		return new PublicKeyWithChainCode(public_key, chain_key);
+	}
+
+	/**
+	 * Creates a new PublicKeyWithChainCode from two strings.
+	 * @param public_key_string The public key in any format supported by PublicKey.fromString.
+	 * @param chain_code_string The chain code in any format supported by ChainCode.fromString.
+	 * @returns A new PublicKeyWithChainCode.
+	 */
+	static fromString(public_key_string: string, chain_code_string: string): PublicKeyWithChainCode {
+		const public_key = PublicKey.fromString(public_key_string);
+		const chain_code = ChainCode.fromString(chain_code_string);
+		return new PublicKeyWithChainCode(public_key, chain_code);
+	}
+
+	/**
+	 * Applies the given derivation path to obtain a new public key and chain code.
+	 *
+	 * Corresponds to rust: [`ic_ed25519::PublicKey::derive_public_key_with_chain_code()`](https://github.com/dfinity/ic/blob/e915efecc8af90993ccfc499721ebe826aadba60/packages/ic-ed25519/src/lib.rs#L774C1-L793C6)
+	 */
+	deriveSubkeyWithChainCode(derivationPath: DerivationPath): PublicKeyWithChainCode {
+		const [pt, _sum, chainCode] = derivationPath.deriveOffset(this.public_key.key, this.chain_code);
+		return new PublicKeyWithChainCode(new PublicKey(pt), chainCode);
+	}
+}
+
+export class DerivationPath {
+	constructor(public readonly path: PathComponent[]) {}
+
+	/**
+	 * Creates a new DerivationPath from / separated candid blobs.
+	 * @param blob The / separated blobs to create the derivation path from.
+	 * @returns A new DerivationPath.
+	 */
+	static fromBlob(blob: string | undefined | null): DerivationPath {
+		if (blob === undefined || blob === null) {
+			return new DerivationPath([]);
+		}
+		return new DerivationPath(blob.split('/').map((p) => blobDecode(p)));
+	}
+
+	/**
+	 * @returns A string representation of the derivation path: Candid blob encoded with a '/' between each path component.  Or `null` for a derivation path with no components.
+	 */
+	toBlob(): string | null {
+		if (this.path.length === 0) {
+			return null;
+		}
+		return this.path.map((p) => blobEncode(p)).join('/');
+	}
+
+	/**
+	 * Returns the preferred JSON encoding of the public key.
+	 * @returns A 64 character hex string.
+	 */
+	toJSON(): string | null {
+		return this.toBlob();
+	}
+
+	/**
+	 * A typescript translation of [ic_ed25519::DerivationPath::derive_offset](https://github.com/dfinity/ic/blob/e915efecc8af90993ccfc499721ebe826aadba60/packages/ic-ed25519/src/lib.rs#L849).
+	 * @param pt The public key to derive the offset from.
+	 * @param chainCode The chain code to derive the offset from.
+	 * @returns A tuple containing the derived public key, the offset, and the chain code.
+	 */
+	deriveOffset(pt: ExtendedPoint, chainCode: ChainCode): [ExtendedPoint, bigint, ChainCode] {
+		return this.path.reduce(deriveOneOffset, [pt, 0n, chainCode]);
+	}
+}
+
+/**
+ * One iteration of the main loop of `DerivationPath.derive_offset`.
+ *
+ * This should also correspond to the main loop of [ic_ed25519::DerivationPath::derive_offset](https://github.com/dfinity/ic/blob/e915efecc8af90993ccfc499721ebe826aadba60/packages/ic-ed25519/src/lib.rs#L849).
+ * @param pt The public key to derive the offset from.
+ * @param sum The sum of the offsets of the previous iterations.
+ * @param chainCode The chain code to derive the offset from.
+ * @param idx The next component or index of the derivation path.
+ * @returns A tuple containing the derived public key, the offset, and the chain code.
+ */
+export function deriveOneOffset(
+	[pt, sum, chainCode]: [ExtendedPoint, bigint, ChainCode],
+	idx: PathComponent
+): [ExtendedPoint, bigint, ChainCode] {
+	// Concatenate idx and pt:
+	const ptBytes = pt.toRawBytes();
+	const ikm = new Uint8Array(ptBytes.length + idx.length);
+	ikm.set(ptBytes, 0);
+	ikm.set(idx, ptBytes.length);
+
+	// Hash
+	const okm = nobleHkdf(sha512, ikm, chainCode.bytes, 'Ed25519', 96);
+
+	// Interpret the first 64 bytes of the okm as an ed25519 scalar.
+	const offset = offsetFromOkm(okm);
+
+	// Get the outputs
+	pt = pt.add(ExtendedPoint.BASE.multiply(offset));
+	sum = (sum + offset) % ORDER;
+	chainCode = new ChainCode(okm.subarray(64, 96));
+
+	return [pt, sum, chainCode];
+}
+
+/**
+ * Interpret the first 64 bytes of the okm as an ed25519 scalar.
+ * @param okm The okm to interpret.
+ * @returns The interpreted number.
+ */
+export function offsetFromOkm(okm: Uint8Array): bigint {
+	const offsetBytes = new Uint8Array(okm.subarray(0, 64));
+	const offset = bigintFromBigEndianBytes(offsetBytes);
+	const reduced = offset % ORDER;
+	return reduced;
+}
+
+/**
+ * Derives a public key, using only string arguments and responses.
+ *
+ * @param pubkey
+ * @param chaincode
+ * @param derivationpath
+ * @returns
+ */
+export function schnorr_ed25519_derive(
+	pubkey: string,
+	chaincode: string,
+	derivationpath: string | null
+): string {
+	const pubkey_with_chain_code = PublicKeyWithChainCode.fromString(pubkey, chaincode);
+	const parsed_derivationpath = DerivationPath.fromBlob(derivationpath);
+	const derived_pubkey = pubkey_with_chain_code.deriveSubkeyWithChainCode(parsed_derivationpath);
+
+	return derived_pubkey.public_key.toHex();
+}
+
+/* v8 ignore stop */


### PR DESCRIPTION
# Motivation

We will derive the SOL address in the frontend, using the library [ic-pub-key](https://github.com/dfinity/ic-pub-key) (that for now it is just copied code, see PR #7464).

However, since we are aware of the public key ONLY for the `production Chain Fusion Signer`, we can make it work ONLY for the environments that use such canister, that means `Beta` and `Prod`.

For the other environments, that use `staging Chain Fusion Signer`, we will have to find a better solution, once we discover the correct root key and the correct public key.

# Changes

- When the feature flag is turned on, use the function form the library to derive the address.

# Tests

Manually tested deploying this branch in Beta, and the SOL address was the same as Prod:





