### PR TITLE
style(frontent): Fix BTC send review warnings

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
@@ -2,45 +2,45 @@
 	import { fade } from 'svelte/transition';
 	import { BtcPendingSentTransactionsStatus } from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
-	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 
 	export let pendingTransactionsStatus: BtcPendingSentTransactionsStatus;
 	export let utxosFee: UtxosFee | undefined = undefined;
 </script>
 
 {#if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.SOME}
-	<div in:fade>
-		<WarningBanner>
+	<div class="w-full" in:fade>
+		<MessageBox level="warning">
 			<span>{$i18n.send.info.pending_bitcoin_transaction}</span>
-		</WarningBanner>
+		</MessageBox>
 	</div>
 {:else if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.ERROR}
-	<div in:fade>
-		<WarningBanner>
+	<div class="w-full" in:fade>
+		<MessageBox level="warning">
 			<span>{$i18n.send.error.no_pending_bitcoin_transaction}</span>
-		</WarningBanner>
+		</MessageBox>
 	</div>
 {/if}
 
 {#if utxosFee?.error === BtcPrepareSendError.InsufficientBalance}
-	<div in:fade>
-		<WarningBanner>
+	<div class="w-full" in:fade>
+		<MessageBox level="warning">
 			<span>{$i18n.send.assertion.insufficient_funds}</span>
-		</WarningBanner>
+		</MessageBox>
 	</div>
 {:else if utxosFee?.error === BtcPrepareSendError.InsufficientBalanceForFee}
-	<div in:fade>
-		<WarningBanner>
+	<div class="w-full" in:fade>
+		<MessageBox level="warning">
 			<span data-tid="btc-send-form-insufficient-funds-for-fee"
 				>{$i18n.fee.assertion.insufficient_funds_for_fee}</span
 			>
-		</WarningBanner>
+		</MessageBox>
 	</div>
 {:else if utxosFee?.utxos.length === 0}
-	<div in:fade>
-		<WarningBanner>
+	<div class="w-full" in:fade>
+		<MessageBox level="warning">
 			<span>{$i18n.send.info.no_available_utxos}</span>
-		</WarningBanner>
+		</MessageBox>
 	</div>
 {/if}


### PR DESCRIPTION
# Motivation

The warnings for example "Insufficient balance to cover fees" are not correctly styled.

# Changes

- Used MessageBox component instead of warning banner
- Adjusted width so it takes full space horizontally

# Tests

<img width="577" height="672" alt="image" src="https://github.com/user-attachments/assets/53da0fa0-4e91-4ae7-873b-279a69f92b5b" />