### PR TITLE
test(frontend): Use `TokenId` type in mock for IC transactions

### DIFF
--- a/src/frontend/src/tests/icp/utils/ic-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/ic-transactions.utils.spec.ts
@@ -7,6 +7,7 @@ import { getCkBtcPendingUtxoTransactions } from '$icp/utils/ckbtc-transactions.u
 import { getCkEthPendingTransactions } from '$icp/utils/cketh-transactions.utils';
 import { getAllIcTransactions, getIcExtendedTransactions } from '$icp/utils/ic-transactions.utils';
 import type { Token } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
 import {
 	MOCK_CKBTC_TOKEN,
 	MOCK_CKETH_TOKEN,
@@ -19,7 +20,6 @@ import {
 } from '$tests/mocks/ic-transactions.mock';
 import { get } from 'svelte/store';
 import { expect } from 'vitest';
-import type { BRAND } from 'zod/v4';
 
 describe('getIcExtendedTransactions', () => {
 	it('should return no transactions if the stores are empty', () => {
@@ -34,7 +34,7 @@ describe('getIcExtendedTransactions', () => {
 
 	it('should return 3 transactions', () => {
 		setupIcTransactionsStore({
-			tokenId: MOCK_CKETH_TOKEN.id as unknown as symbol & BRAND<'TokenId'>
+			tokenId: MOCK_CKETH_TOKEN.id ?? parseTokenId('')
 		});
 
 		const result = getIcExtendedTransactions({
@@ -46,7 +46,7 @@ describe('getIcExtendedTransactions', () => {
 		expect(result).toHaveLength(3);
 
 		cleanupIcTransactionsStore({
-			tokenId: MOCK_CKETH_TOKEN.id as unknown as symbol & BRAND<'TokenId'>
+			tokenId: MOCK_CKETH_TOKEN.id ?? parseTokenId('')
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/ic-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/ic-transactions.mock.ts
@@ -11,12 +11,11 @@ import { icPendingTransactionsStore } from '$icp/stores/ic-pending-transactions.
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import type { IcCkToken } from '$icp/types/ic-token';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
-import type { Token } from '$lib/types/token';
+import type { Token, TokenId } from '$lib/types/token';
 import { bn1Bi } from '$tests/mocks/balances.mock';
 import { mockCkBtcMinterInfo, mockCkBtcPendingUtxoTransaction } from '$tests/mocks/ckbtc.mock';
 import { createCertifiedIcTransactionUiMock } from '$tests/utils/transactions-stores.test-utils';
 import type { PendingUtxo } from '@dfinity/ckbtc';
-import type { BRAND } from 'zod/v4';
 
 export const createMockIcTransactionsUi = (n: number): IcTransactionUi[] =>
 	Array.from({ length: n }, () => ({
@@ -29,7 +28,7 @@ export const createMockIcTransactionsUi = (n: number): IcTransactionUi[] =>
 		timestamp: 1_747_732_396_194_882_329n
 	}));
 
-export const setupIcTransactionsStore = ({ tokenId }: { tokenId: symbol & BRAND<'TokenId'> }) => {
+export const setupIcTransactionsStore = ({ tokenId }: { tokenId: TokenId }) => {
 	const transactions = [
 		createCertifiedIcTransactionUiMock('tx1'),
 		createCertifiedIcTransactionUiMock('tx2'),
@@ -42,7 +41,7 @@ export const setupIcTransactionsStore = ({ tokenId }: { tokenId: symbol & BRAND<
 	});
 };
 
-export const cleanupIcTransactionsStore = ({ tokenId }: { tokenId: symbol & BRAND<'TokenId'> }) => {
+export const cleanupIcTransactionsStore = ({ tokenId }: { tokenId: TokenId }) => {
 	icTransactionsStore.reset(tokenId);
 };
 


### PR DESCRIPTION
# Motivation

For consistency, we can use directly the `TokenId` type in the mocks.