### PR TITLE
feat(frontend): Services to clear IDB transactions stores

### DIFF
--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -14,7 +14,7 @@ import type {
 	SetIdbTransactionsParams
 } from '$lib/types/idb-transactions';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
-import { Principal } from '@dfinity/principal';
+import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
 import { createStore, del, set as idbSet, type UseStore } from 'idb-keyval';
 

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -14,8 +14,9 @@ import type {
 	SetIdbTransactionsParams
 } from '$lib/types/idb-transactions';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
+import { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, set as idbSet, type UseStore } from 'idb-keyval';
+import { createStore, del, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const idbTransactionsStore = (key: string): UseStore =>
@@ -80,3 +81,15 @@ export const setIdbSolTransactions = (
 	params: SetIdbTransactionsParams<CertifiedStoreData<TransactionsData<SolTransactionUi>>>
 ): Promise<void> =>
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbSolTransactionsStore });
+
+export const deleteIdbBtcTransactions = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbBtcTransactionsStore);
+
+export const deleteIdbEthTransactions = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbEthTransactionsStore);
+
+export const deleteIdbIcTransactions = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbIcTransactionsStore);
+
+export const deleteIdbSolTransactions = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbSolTransactionsStore);

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -10,6 +10,12 @@ import {
 	deleteIdbSolTokens
 } from '$lib/api/idb-tokens.api';
 import {
+	deleteIdbBtcTransactions,
+	deleteIdbEthTransactions,
+	deleteIdbIcTransactions,
+	deleteIdbSolTransactions
+} from '$lib/api/idb-transactions.api';
+import {
 	TRACK_COUNT_SIGN_IN_SUCCESS,
 	TRACK_SIGN_IN_CANCELLED_COUNT,
 	TRACK_SIGN_IN_ERROR_COUNT
@@ -131,6 +137,14 @@ const emptyIdbEthTokens = (): Promise<void> => emptyIdbStore(deleteIdbEthTokens)
 
 const emptyIdbSolTokens = (): Promise<void> => emptyIdbStore(deleteIdbSolTokens);
 
+const emptyIdbBtcTransactions = (): Promise<void> => emptyIdbStore(deleteIdbBtcTransactions);
+
+const emptyIdbEthTransactions = (): Promise<void> => emptyIdbStore(deleteIdbEthTransactions);
+
+const emptyIdbIcTransactions = (): Promise<void> => emptyIdbStore(deleteIdbIcTransactions);
+
+const emptyIdbSolTransactions = (): Promise<void> => emptyIdbStore(deleteIdbSolTransactions);
+
 // eslint-disable-next-line require-await
 const clearSessionStorage = async () => {
 	sessionStorage.clear();
@@ -156,7 +170,11 @@ const logout = async ({
 			emptyIdbIcTokens(),
 			emptyIdbEthTokensDeprecated(),
 			emptyIdbEthTokens(),
-			emptyIdbSolTokens()
+			emptyIdbSolTokens(),
+			emptyIdbBtcTransactions(),
+			emptyIdbEthTransactions(),
+			emptyIdbIcTransactions(),
+			emptyIdbSolTransactions()
 		]);
 	}
 

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -2,10 +2,16 @@ import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
-import { setIdbTransactionsStore } from '$lib/api/idb-transactions.api';
+import {
+	deleteIdbBtcTransactions,
+	deleteIdbEthTransactions,
+	deleteIdbIcTransactions,
+	deleteIdbSolTransactions,
+	setIdbTransactionsStore
+} from '$lib/api/idb-transactions.api';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc-transactions.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
-import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
 import { createStore } from 'idb-keyval';
 import { get } from 'svelte/store';
@@ -147,6 +153,50 @@ describe('idb-transactions.api', () => {
 			});
 
 			expect(idbKeyval.set).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('deleteIdbBtcTransactions', () => {
+		it('should delete IC tokens', async () => {
+			await deleteIdbBtcTransactions(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
+				mockPrincipal.toText(),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('deleteIdbEthTransactions', () => {
+		it('should delete ETH transactions', async () => {
+			await deleteIdbEthTransactions(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
+				mockPrincipal.toText(),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('deleteIdbIcTransactions', () => {
+		it('should delete IC transactions', async () => {
+			await deleteIdbIcTransactions(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
+				mockPrincipal.toText(),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('deleteIdbSolTransactions', () => {
+		it('should delete BTC transactions', async () => {
+			await deleteIdbSolTransactions(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
+				mockPrincipal.toText(),
+				expect.any(Object)
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -81,8 +81,8 @@ describe('auth.services', () => {
 
 			await signOut({});
 
-			// addresses + tokens
-			expect(idbKeyval.del).toHaveBeenCalledTimes(7);
+			// 4 addresses + 3 tokens + 4 transactions
+			expect(idbKeyval.del).toHaveBeenCalledTimes(11);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -81,7 +81,7 @@ describe('auth.services', () => {
 
 			await signOut({});
 
-			// 4 addresses + 3 tokens + 4 transactions
+			// 3 addresses + 3(+1) tokens + 4 transactions
 			expect(idbKeyval.del).toHaveBeenCalledTimes(11);
 		});
 	});


### PR DESCRIPTION
# Motivation

When the user logs out, we need to clean the IDB stores that cached the transactions.
