### PR TITLE
feat(frontend): Create services to get IDB cached transactions

### DIFF
--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -16,7 +16,7 @@ import type {
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, del, set as idbSet, type UseStore } from 'idb-keyval';
+import { createStore, del, get, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const idbTransactionsStore = (key: string): UseStore =>
@@ -83,6 +83,38 @@ export const setIdbSolTransactions = (
 	params: SetIdbTransactionsParams<CertifiedStoreData<TransactionsData<SolTransactionUi>>>
 ): Promise<void> =>
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbSolTransactionsStore });
+
+export const getIdbBtcTransactions = (
+	principal: Principal
+): Promise<
+	| SetIdbTransactionsParams<
+			CertifiedStoreData<TransactionsData<BtcTransactionUi>>
+	  >['transactionsStoreData']
+	| undefined
+> => get(principal.toText(), idbBtcTransactionsStore);
+
+export const getIdbEthTransactions = (
+	principal: Principal
+): Promise<SetIdbTransactionsParams<EthTransactionsData>['transactionsStoreData'] | undefined> =>
+	get(principal.toText(), idbEthTransactionsStore);
+
+export const getIdbIcTransactions = (
+	principal: Principal
+): Promise<
+	| SetIdbTransactionsParams<
+			CertifiedStoreData<TransactionsData<IcTransactionUi>>
+	  >['transactionsStoreData']
+	| undefined
+> => get(principal.toText(), idbIcTransactionsStore);
+
+export const getIdbSolTransactions = (
+	principal: Principal
+): Promise<
+	| SetIdbTransactionsParams<
+			CertifiedStoreData<TransactionsData<SolTransactionUi>>
+	  >['transactionsStoreData']
+	| undefined
+> => get(principal.toText(), idbSolTransactionsStore);
 
 export const deleteIdbBtcTransactions = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbBtcTransactionsStore);

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -8,6 +8,10 @@ import {
 	deleteIdbEthTransactions,
 	deleteIdbIcTransactions,
 	deleteIdbSolTransactions,
+	getIdbBtcTransactions,
+	getIdbEthTransactions,
+	getIdbIcTransactions,
+	getIdbSolTransactions,
 	setIdbTransactionsStore
 } from '$lib/api/idb-transactions.api';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc-transactions.mock';
@@ -16,6 +20,7 @@ import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
 import { createStore } from 'idb-keyval';
 import { get } from 'svelte/store';
+import { expect, vi } from 'vitest';
 
 vi.mock('idb-keyval', () => ({
 	createStore: vi.fn(() => ({
@@ -194,8 +199,52 @@ describe('idb-transactions.api', () => {
 		});
 	});
 
+	describe('getIdbBtcTransactions', () => {
+		it('should get BTC transactions', async () => {
+			vi.mocked(idbKeyval.get).mockResolvedValue(mockTokens);
+
+			const result = await getIdbBtcTransactions(mockPrincipal);
+
+			expect(result).toEqual(mockTokens);
+			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+	});
+
+	describe('getIdbEthTransactions', () => {
+		it('should get ETH transactions', async () => {
+			vi.mocked(idbKeyval.get).mockResolvedValue(mockTokens);
+
+			const result = await getIdbEthTransactions(mockPrincipal);
+
+			expect(result).toEqual(mockTokens);
+			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+	});
+
+	describe('getIdbIcTransactions', () => {
+		it('should get IC transactions', async () => {
+			vi.mocked(idbKeyval.get).mockResolvedValue(mockTokens);
+
+			const result = await getIdbIcTransactions(mockPrincipal);
+
+			expect(result).toEqual(mockTokens);
+			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+	});
+
+	describe('getIdbSolTransactions', () => {
+		it('should get SOL transactions', async () => {
+			vi.mocked(idbKeyval.get).mockResolvedValue(mockTokens);
+
+			const result = await getIdbSolTransactions(mockPrincipal);
+
+			expect(result).toEqual(mockTokens);
+			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+	});
+
 	describe('deleteIdbBtcTransactions', () => {
-		it('should delete IC tokens', async () => {
+		it('should delete BTC tokens', async () => {
 			await deleteIdbBtcTransactions(mockPrincipal);
 
 			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
@@ -228,7 +277,7 @@ describe('idb-transactions.api', () => {
 	});
 
 	describe('deleteIdbSolTransactions', () => {
-		it('should delete BTC transactions', async () => {
+		it('should delete SOL transactions', async () => {
 			await deleteIdbSolTransactions(mockPrincipal);
 
 			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(


### PR DESCRIPTION
# Motivation

All services to get the transactions that are cached in IDB.
