### PR TITLE
style(frontend): Use Responsive component for mobile navigation

### DIFF
--- a/src/frontend/src/lib/components/navigation/MobileNavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/MobileNavigationMenu.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import { MOBILE_NAVIGATION_MENU } from '$lib/constants/test-ids.constants';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 </script>
 
+<Responsive down="md">
 <div
 	class="mobile-nav z-2 border-t-1 visible fixed bottom-0 left-0 right-0 flex flex-row border-tertiary bg-primary-inverted-alt md:hidden"
 	data-tid={MOBILE_NAVIGATION_MENU}
 >
 	<slot />
 </div>
+</Responsive>


### PR DESCRIPTION
# Motivation

To improve performance, we should avoid rendering the mobile navigation in DOM, if not needed. Until now we were rendering it, but hiding it too. However, with Responsive component, we can use the Svelte `{#if}` statement and avoid rendering it, until necessary.

Note that we combine both. This ensures:

- It's only in the DOM when it should be
- And it behaves responsively too

### Results

No changes in behaviour:

https://github.com/user-attachments/assets/fb049972-2245-4905-8a52-de8316140a0f


