### PR TITLE
style(frontend): Use `Responsive` component for dApp carousel

### DIFF
--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -18,6 +18,7 @@
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
 	import { isRouteTokens, isRouteTransactions } from '$lib/utils/nav.utils';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 
 	let tokensRoute: boolean;
 	$: tokensRoute = isRouteTokens($page);
@@ -62,9 +63,11 @@
 			<SplitPane>
 				<NavigationMenu slot="menu">
 					{#if tokensRoute}
+						<Responsive up="xl">
 						<div transition:fade class="hidden xl:block">
 							<DappsCarousel />
 						</div>
+						</Responsive>
 					{/if}
 				</NavigationMenu>
 

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -13,12 +13,12 @@
 	import MobileNavigationMenu from '$lib/components/navigation/MobileNavigationMenu.svelte';
 	import NavigationMenu from '$lib/components/navigation/NavigationMenu.svelte';
 	import NavigationMenuMainItems from '$lib/components/navigation/NavigationMenuMainItems.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import SplitPane from '$lib/components/ui/SplitPane.svelte';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
 	import { isRouteTokens, isRouteTransactions } from '$lib/utils/nav.utils';
-	import Responsive from '$lib/components/ui/Responsive.svelte';
 
 	let tokensRoute: boolean;
 	$: tokensRoute = isRouteTokens($page);
@@ -64,9 +64,9 @@
 				<NavigationMenu slot="menu">
 					{#if tokensRoute}
 						<Responsive up="xl">
-						<div transition:fade class="hidden xl:block">
-							<DappsCarousel />
-						</div>
+							<div transition:fade class="hidden xl:block">
+								<DappsCarousel />
+							</div>
 						</Responsive>
 					{/if}
 				</NavigationMenu>

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Tokens from '$lib/components/tokens/Tokens.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 </script>
 
+<Responsive down="xl">
 <div class="mb-6 flex justify-center xl:hidden">
 	<DappsCarousel />
 </div>
+</Responsive>
 
 <Tokens />

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <Responsive down="xl">
-<div class="mb-6 flex justify-center xl:hidden">
-	<DappsCarousel />
-</div>
+	<div class="mb-6 flex justify-center xl:hidden">
+		<DappsCarousel />
+	</div>
 </Responsive>
 
 <Tokens />


### PR DESCRIPTION
# Motivation

To improve performance, we should avoid rendering the mobile navigation in DOM, if not needed. Until now we were rendering it, but hiding it too. However, with Responsive component, we can use the Svelte `{#if}` statement and avoid rendering it, until necessary.

Note that we combine both. This ensures:

- It's only in the DOM when it should be
- And it behaves responsively too
