### PR TITLE
style(frontend): Use `Responsive` component for `SplitPane`

### DIFF
--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-import Responsive from '$lib/components/ui/Responsive.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 </script>
 
 <main class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto">
 	<Responsive up="md">
-	<div
-		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:mt-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"
-	>
-		<slot name="menu" />
-	</div>
+		<div
+			class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:mt-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"
+		>
+			<slot name="menu" />
+		</div>
 	</Responsive>
 
 	<div

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,9 +1,15 @@
+<script lang="ts">
+import Responsive from '$lib/components/ui/Responsive.svelte';
+</script>
+
 <main class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto">
+	<Responsive up="md">
 	<div
 		class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:mt-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"
 	>
 		<slot name="menu" />
 	</div>
+	</Responsive>
 
 	<div
 		class="mx-auto max-w-xl overflow-hidden px-3 transition-all duration-500 ease-linear md:ml-64 md:box-content md:w-sm md:max-w-none md:px-4 xl:ml-auto"


### PR DESCRIPTION
# Motivation

To improve performance, we should avoid rendering the mobile navigation in DOM, if not needed. Until now we were rendering it, but hiding it too. However, with Responsive component, we can use the Svelte `{#if}` statement and avoid rendering it, until necessary.

Note that we combine both. This ensures:

- It's only in the DOM when it should be
- And it behaves responsively too

### Results

No changes in behaviour:


https://github.com/user-attachments/assets/4f4ef257-cd71-4af7-b1b8-2e1614c548c9




