### PR TITLE
refactor(frontend): Single string for WalletConnect executed transaction

### DIFF
--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -25,6 +25,7 @@ import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { ResultSuccess } from '$lib/types/utils';
 import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -185,7 +186,9 @@ export const send = ({
 				throw err;
 			}
 		},
-		toastMsg: get(i18n).wallet_connect.info.eth_transaction_executed
+		toastMsg: replacePlaceholders(get(i18n).wallet_connect.info.transaction_executed, {
+			$method: params.request.params.request.method
+		})
 	});
 
 export const signMessage = ({

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1044,8 +1044,7 @@
 			"disconnected": "WalletConnect getrennt.",
 			"session_ended": "WalletConnect-Sitzung wurde beendet.",
 			"connected": "WalletConnect verbunden.",
-			"eth_transaction_executed": "WalletConnect eth_sendTransaction-Anfrage ausgeführt.",
-			"sol_transaction_executed": "WalletConnect \"$method\"-Anfrage ausgeführt.",
+			"transaction_executed": "WalletConnect \"$method\"-Anfrage ausgeführt.",
 			"sign_executed": "WalletConnect-Signaturanfrage ausgeführt."
 		},
 		"error": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1044,8 +1044,7 @@
 			"disconnected": "WalletConnect disconnected.",
 			"session_ended": "WalletConnect session was ended.",
 			"connected": "WalletConnect connected.",
-			"eth_transaction_executed": "WalletConnect eth_sendTransaction request executed.",
-			"sol_transaction_executed": "WalletConnect \"$method\" request executed.",
+			"transaction_executed": "WalletConnect \"$method\" request executed.",
 			"sign_executed": "WalletConnect sign request executed."
 		},
 		"error": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1044,8 +1044,7 @@
 			"disconnected": "WalletConnect disconnesso.",
 			"session_ended": "La sessione WalletConnect è terminata.",
 			"connected": "WalletConnect connesso.",
-			"eth_transaction_executed": "Richiesta WalletConnect eth_sendTransaction eseguita.",
-			"sol_transaction_executed": "Richiesta WalletConnect \"$method\" eseguita.",
+			"transaction_executed": "Richiesta WalletConnect \"$method\" eseguita.",
 			"sign_executed": "Richiesta di firma WalletConnect eseguita."
 		},
 		"error": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1044,8 +1044,7 @@
 			"disconnected": "WalletConnect desconectado.",
 			"session_ended": "A sessão WalletConnect foi encerrada.",
 			"connected": "WalletConnect conectado.",
-			"eth_transaction_executed": "Solicitação WalletConnect eth_sendTransaction executada.",
-			"sol_transaction_executed": "Solicitação WalletConnect \"$method\" executada.",
+			"transaction_executed": "Solicitação WalletConnect \"$method\" executada.",
 			"sign_executed": "Solicitação de assinatura WalletConnect executada."
 		},
 		"error": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1044,8 +1044,7 @@
 			"disconnected": "WalletConnect 已断开连接。",
 			"session_ended": "WalletConnect 会话已结束。",
 			"connected": "WalletConnect 已连接。",
-			"eth_transaction_executed": "WalletConnect eth_sendTransaction 请求已执行。",
-			"sol_transaction_executed": "WalletConnect “$method” 请求已执行。",
+			"transaction_executed": "WalletConnect “$method” 请求已执行。",
 			"sign_executed": "WalletConnect 签名请求已执行。"
 		},
 		"error": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1045,7 +1045,7 @@
 			"disconnected": "WalletConnect 已断开连接。",
 			"session_ended": "WalletConnect 会话已结束。",
 			"connected": "WalletConnect 已连接。",
-			"transaction_executed": "WalletConnect \“$method\” 请求已执行。",
+			"transaction_executed": "WalletConnect “$method” 请求已执行。",
 			"sign_executed": "WalletConnect 签名请求已执行。"
 		},
 		"error": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1045,7 +1045,7 @@
 			"disconnected": "WalletConnect 已断开连接。",
 			"session_ended": "WalletConnect 会话已结束。",
 			"connected": "WalletConnect 已连接。",
-			"transaction_executed": "WalletConnect “$method” 请求已执行。",
+			"transaction_executed": "WalletConnect \“$method\” 请求已执行。",
 			"sign_executed": "WalletConnect 签名请求已执行。"
 		},
 		"error": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -884,8 +884,7 @@ interface I18nWallet_connect {
 		disconnected: string;
 		session_ended: string;
 		connected: string;
-		eth_transaction_executed: string;
-		sol_transaction_executed: string;
+		transaction_executed: string;
 		sign_executed: string;
 	};
 	error: {

--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -236,7 +236,7 @@ export const sign = ({
 				throw err;
 			}
 		},
-		toastMsg: replacePlaceholders(get(i18n).wallet_connect.info.sol_transaction_executed, {
+		toastMsg: replacePlaceholders(get(i18n).wallet_connect.info.transaction_executed, {
 			$method: params.request.params.request.method
 		})
 	});


### PR DESCRIPTION
# Motivation

As suggested by @ilbertt , we unify the strings that represent an executed transaction on WalletConnect.
