### PR TITLE
test(e2e): Disable CIs for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,15 @@
 name: E2E Tests
 
 on:
-# TODO: Re-enable the E2E test CIs when the E2E tests are stable and not failing frequently.
-#  push:
-#    branches:
-#      - main
+  # TODO: Re-enable the E2E test CIs when the E2E tests are stable and not failing frequently.
+  #  push:
+  #    branches:
+  #      - main
   pull_request:
     types: [opened, synchronize, labeled]
   merge_group:
-#  schedule:
-#    - cron: '30 3 * * *'
+  #  schedule:
+  #    - cron: '30 3 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,14 +1,15 @@
 name: E2E Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, labeled]
-  merge_group:
-  schedule:
-    - cron: '30 3 * * *'
+# TODO: Re-enable the E2E test CIs when the E2E tests are stable and not failing frequently.
+#  push:
+#    branches:
+#      - main
+#  pull_request:
+#    types: [opened, synchronize, labeled]
+#  merge_group:
+#  schedule:
+#    - cron: '30 3 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,9 +5,9 @@ on:
 #  push:
 #    branches:
 #      - main
-#  pull_request:
-#    types: [opened, synchronize, labeled]
-#  merge_group:
+  pull_request:
+    types: [opened, synchronize, labeled]
+  merge_group:
 #  schedule:
 #    - cron: '30 3 * * *'
   workflow_dispatch:


### PR DESCRIPTION
# Motivation

We temporarily disable the E2E tests from automatically run: they are currently failing and costing too much in workflow force.
