### PR TITLE
chore(frontend): Change descriptions for address types

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -565,9 +565,9 @@
 			"text": {
 				"account_id": "ICP Account ID",
 				"use_for_all_tokens": "Use for all tokens when receiving from wallets, users, or other apps that support this address format.",
-				"use_for_icrc_deposit": "Use for receiving ICRC-1 tokens in the ICP network, such as SNS, ck tokens, etc.",
+				"use_for_icrc_deposit": "Your address for all tokens on the Internet Computer network.",
 				"use_for_icp_deposit": "Use for ICP deposits from exchanges or other wallets that only support Account IDs.",
-				"your_private_eth_address": "Your private address for all ERC20 tokens.",
+				"your_private_eth_address": "Your address for all tokens on Ethereum and its related networks (Base, Polygon, ...)",
 				"display_account_id_qr": "Display ICP Account ID as a QR code",
 				"account_id_copied": "ICP Account ID copied to clipboard.",
 				"principal": "ICP Principal",


### PR DESCRIPTION
# Motivation

- we called the Ethereum address the `private address`
- and for the ICP principal, we used `icrc-1 tokens`

# Changes

Improved the texts

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
