### PR TITLE
refactor(frontend): Rename method that resets in Ethereum transactions store

### DIFF
--- a/src/frontend/src/eth/stores/eth-transactions.store.ts
+++ b/src/frontend/src/eth/stores/eth-transactions.store.ts
@@ -10,7 +10,7 @@ export interface EthTransactionsStore extends Readable<EthTransactionsData> {
 	add: (params: { tokenId: TokenId; transactions: Transaction[] }) => void;
 	update: (params: { tokenId: TokenId; transaction: Transaction }) => void;
 	nullify: (tokenId: TokenId) => void;
-	reset: () => void;
+	resetAll: () => void;
 }
 
 const initEthTransactionsStore = (): EthTransactionsStore => {
@@ -42,7 +42,7 @@ const initEthTransactionsStore = (): EthTransactionsStore => {
 				...(nonNullish(state) && state),
 				[tokenId]: null
 			})),
-		reset: () => set(INITIAL),
+		resetAll: () => set(INITIAL),
 		subscribe
 	};
 };

--- a/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/eth-transactions.derived.spec.ts
@@ -36,7 +36,7 @@ describe('eth-transactions.derived', () => {
 
 	describe('ethKnownDestinations', () => {
 		beforeEach(() => {
-			ethTransactionsStore.reset();
+			ethTransactionsStore.resetAll();
 			token.reset();
 			ethAddressStore.set({ certified: true, data: mockEthAddress });
 		});

--- a/src/frontend/src/tests/eth/stores/eth-transactions.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/eth-transactions.store.spec.ts
@@ -14,7 +14,7 @@ describe('eth-transactions.store', () => {
 	const store = ethTransactionsStore;
 
 	beforeEach(() => {
-		store.reset();
+		store.resetAll();
 	});
 
 	describe('set', () => {
@@ -56,7 +56,7 @@ describe('eth-transactions.store', () => {
 		});
 
 		it('should add transactions even if the list is empty', () => {
-			store.reset();
+			store.resetAll();
 			store.add({ tokenId, transactions: mockOtherTransactions });
 
 			const state = get(store);
@@ -145,7 +145,7 @@ describe('eth-transactions.store', () => {
 				[SEPOLIA_TOKEN_ID]: mockOtherTransactions
 			});
 
-			store.reset();
+			store.resetAll();
 
 			expect(get(store)).toEqual({});
 		});

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -61,7 +61,7 @@ describe('idb-transactions.api', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
-		ethTransactionsStore.reset();
+		ethTransactionsStore.resetAll();
 
 		ethTransactionsStore.set({
 			tokenId: mockToken1.id,


### PR DESCRIPTION
# Motivation

It makes more sense to rename method `reset()` to `resetAll()` in the Ethereum transactions store.
