### PR TITLE
chore(frontend): Fix Portuguese dapp category names

### DIFF
--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -183,7 +183,7 @@
 		},
 		"categories": {
 			"defi": "DeFi",
-			"social_media": "Mídias Sociais",
+			"social_media": "Mídias sociais",
 			"verifiable_credentials": "Credentiais verificáveis",
 			"staking": "Staking",
 			"walletconnect": "WalletConnect",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -183,10 +183,10 @@
 		},
 		"categories": {
 			"defi": "DeFi",
-			"social_media": "Meios de comunicação social",
+			"social_media": "Mídias Sociais",
 			"verifiable_credentials": "Credentiais verificáveis",
-			"staking": "Participar no stake de ativos",
-			"walletconnect": "Conexão de carteira",
+			"staking": "Staking",
+			"walletconnect": "WalletConnect",
 			"game": "Jogo"
 		},
 		"descriptions": {


### PR DESCRIPTION
# Motivation

Tags in the Dapp Explorer are too long in Portuguese.

<img width="449" height="466" alt="image" src="https://github.com/user-attachments/assets/f3182226-1a46-422c-b598-34a710e9d016" />

# Changes

- Shorten them. Also don't translate idioms.

Sources:
-  https://pt.wikipedia.org/wiki/M%C3%ADdias_sociais
- <img width="434" height="262" alt="image" src="https://github.com/user-attachments/assets/9cd6c2b6-9529-4a99-abeb-a27e268674ab" />


# Tests

<img width="449" height="554" alt="image" src="https://github.com/user-attachments/assets/713229e0-b14a-420f-9862-2f9ed4ac3da1" />
