### PR TITLE
feat(build): Diverse domain in Plausible for test canisters

### DIFF
--- a/src/frontend/src/env/plausible.env.ts
+++ b/src/frontend/src/env/plausible.env.ts
@@ -1,14 +1,16 @@
-import { BETA, PROD, STAGING, TEST_FE } from '$lib/constants/app.constants';
+import { AUDIT, BETA, MODE, PROD, STAGING, TEST_FE } from '$lib/constants/app.constants';
 import { parseBoolEnvVar } from '$lib/utils/env.utils';
 
 export const PLAUSIBLE_DOMAIN = PROD
 	? 'oisy.com'
 	: BETA
 		? 'beta.oisy.com'
-		: TEST_FE // Currently using 'fe1.oisy.com' for TEST_FE env, but can be adjusted to 'fe#.oisy.com' if needed.
-			? 'fe1.oisy.com'
-			: STAGING
-				? 'staging.oisy.com'
-				: null;
+		: TEST_FE
+			? `${MODE.replace('test_', '').replace('_', '')}.oisy.com`
+			: AUDIT
+				? 'audit.oisy.com'
+				: STAGING
+					? 'staging.oisy.com'
+					: null;
 
 export const PLAUSIBLE_ENABLED = parseBoolEnvVar(import.meta.env.VITE_PLAUSIBLE_ENABLED);


### PR DESCRIPTION
# Motivation

We want to track the plausible events for each test canister.
