### PR TITLE
fix(frontend): worker memory leak fixes

### DIFF
--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -18,7 +18,7 @@ let errorMessages: { msg: string; timestamp: number }[] = [];
 
 export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 	const ExchangeWorker = await import('$lib/workers/workers?worker');
-	const exchangeWorker: Worker = new ExchangeWorker.default();
+	let exchangeWorker: Worker | null = new ExchangeWorker.default();
 
 	exchangeWorker.onmessage = ({
 		data: dataMsg
@@ -87,13 +87,13 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 	};
 
 	const stopTimer = () =>
-		exchangeWorker.postMessage({
+		exchangeWorker?.postMessage({
 			msg: 'stopExchangeTimer'
 		});
 
 	return {
 		startExchangeTimer: (data: PostMessageDataRequestExchangeTimer) => {
-			exchangeWorker.postMessage({
+			exchangeWorker?.postMessage({
 				msg: 'startExchangeTimer',
 				data
 			});
@@ -101,6 +101,10 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 		stopExchangeTimer: stopTimer,
 		destroy: () => {
 			stopTimer();
+			if (exchangeWorker) {
+				exchangeWorker.terminate();
+				exchangeWorker = null;
+			}
 			errorMessages = [];
 		}
 	};


### PR DESCRIPTION
# Motivation
Workers are not being properly terminated, causing memory leaks. The main issues are:
1. Exchange worker isn't properly terminated on destroy
2. Worker cleanup in `cleanWorkers` only called stop but not `destroy()`

If I understand correctly the `ExchangeWorker.svelte` gets "terminated" when `ExchangeWorker.svelte` gets unmounted or the user navigates to to a page that doesn't include the component `ExchangeWorker.svelte`


**The missing exchange worker termination could be the primary source of the memory leak**


# Changes

**Fixed Exchange Worker (`worker.exchange.services.ts`)**
- Changed worker type:  From `const exchangeWorker: Worker` to `let exchangeWorker: Worker | null` 
- Added optional chaining: Used `?.` for all `postMessage` calls to prevent errors when worker is null
- Enhanced destroy method: Added proper worker termination:

**Improved Worker Cleanup Utility (`wallet.utils.ts`)**
