### PR TITLE
fix(frontend): Completely terminate Exchange workers on destroy

### DIFF
--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -18,7 +18,7 @@ let errorMessages: { msg: string; timestamp: number }[] = [];
 
 export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 	const ExchangeWorker = await import('$lib/workers/workers?worker');
-	const exchangeWorker: Worker = new ExchangeWorker.default();
+	let exchangeWorker: Worker | null = new ExchangeWorker.default();
 
 	exchangeWorker.onmessage = ({
 		data: dataMsg
@@ -87,20 +87,29 @@ export const initExchangeWorker = async (): Promise<ExchangeWorker> => {
 	};
 
 	const stopTimer = () =>
-		exchangeWorker.postMessage({
+		exchangeWorker?.postMessage({
 			msg: 'stopExchangeTimer'
 		});
 
+	let isDestroying = false;
+
 	return {
 		startExchangeTimer: (data: PostMessageDataRequestExchangeTimer) => {
-			exchangeWorker.postMessage({
+			exchangeWorker?.postMessage({
 				msg: 'startExchangeTimer',
 				data
 			});
 		},
 		stopExchangeTimer: stopTimer,
 		destroy: () => {
+			if (isDestroying) {
+				return;
+			}
+			isDestroying = true;
 			stopTimer();
+			exchangeWorker?.terminate();
+			exchangeWorker = null;
+			isDestroying = false;
 			errorMessages = [];
 		}
 	};

--- a/src/frontend/src/tests/lib/services/worker.exchange.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/worker.exchange.service.spec.ts
@@ -1,0 +1,114 @@
+import { syncExchange } from '$lib/services/exchange.services';
+import { initExchangeWorker, type ExchangeWorker } from '$lib/services/worker.exchange.services';
+import { toastsError } from '$lib/stores/toasts.store';
+import type {
+	PostMessageDataRequestExchangeTimer,
+	PostMessageDataResponseExchange
+} from '$lib/types/post-message';
+import { mockEthAddress } from '$tests/mocks/eth.mocks';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
+import { mockSplAddress } from '$tests/mocks/sol.mock';
+
+vi.mock('$lib/services/exchange.services', () => ({
+	syncExchange: vi.fn()
+}));
+
+vi.mock('$lib/stores/toasts.store', () => ({
+	toastsError: vi.fn()
+}));
+
+const postMessageSpy = vi.fn();
+
+class MockWorker {
+	postMessage = postMessageSpy;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	terminate: () => void = vi.fn();
+}
+
+vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
+
+let workerInstance: Worker;
+
+vi.mock('$lib/workers/workers?worker', () => ({
+	default: vi.fn().mockImplementation(() => {
+		// @ts-expect-error testing this on purpose with a mock class
+		workerInstance = new Worker();
+		return workerInstance;
+	})
+}));
+
+describe('worker.exchange.services', () => {
+	describe('initExchangeWorker', () => {
+		let worker: ExchangeWorker;
+
+		const mockData: PostMessageDataRequestExchangeTimer = {
+			erc20Addresses: [{ address: mockEthAddress, coingeckoId: 'ethereum' }],
+			icrcCanisterIds: [mockIcrcCustomToken.ledgerCanisterId],
+			splAddresses: [mockSplAddress]
+		};
+
+		beforeEach(async () => {
+			vi.clearAllMocks();
+
+			worker = await initExchangeWorker();
+		});
+
+		it('should start the worker and send the correct start message', () => {
+			worker.startExchangeTimer(mockData);
+
+			expect(postMessageSpy).toHaveBeenCalledExactlyOnceWith({
+				msg: 'startExchangeTimer',
+				data: mockData
+			});
+		});
+
+		it('should stop the worker and send the correct stop message', () => {
+			worker.stopExchangeTimer();
+
+			expect(postMessageSpy).toHaveBeenCalledExactlyOnceWith({ msg: 'stopExchangeTimer' });
+		});
+
+		it('should destroy the worker', () => {
+			worker.destroy();
+
+			expect(postMessageSpy).toHaveBeenCalledExactlyOnceWith({ msg: 'stopExchangeTimer' });
+
+			expect(workerInstance.terminate).toHaveBeenCalledOnce();
+		});
+
+		describe('onmessage', () => {
+			it('should handle syncExchange message', () => {
+				const mockData: PostMessageDataResponseExchange = {
+					currentEthPrice: { ethereum: { usd: 1 } },
+					currentBtcPrice: { bitcoin: { usd: 50000 } },
+					currentErc20Prices: {},
+					currentIcpPrice: { 'internet-computer': { usd: 10 } },
+					currentIcrcPrices: {},
+					currentSolPrice: { solana: { usd: 100 } },
+					currentSplPrices: {},
+					currentBnbPrice: { binancecoin: { usd: 400 } },
+					currentPolPrice: {}
+				};
+				const payload = { msg: 'syncExchange', data: mockData };
+				workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+				expect(syncExchange).toHaveBeenCalledExactlyOnceWith(mockData);
+			});
+
+			it('should handle syncExchangeError message', () => {
+				const payload = {
+					msg: 'syncExchangeError',
+					data: { err: 'Exchange error' }
+				};
+				workerInstance.onmessage?.({ data: payload } as MessageEvent);
+
+				expect(console.error).toHaveBeenCalledExactlyOnceWith(
+					'An error occurred while attempting to retrieve the USD exchange rates.',
+					'Exchange error'
+				);
+
+				expect(toastsError).not.toHaveBeenCalled();
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Credits

This PR is just a split of @DecentAgeCoder 's PR https://github.com/dfinity/oisy-wallet/pull/7797 .

> # Motivation
> 
> Workers are not being properly terminated, causing memory leaks. In this PR we fix the issue of the Exchange worker that isn't properly terminated on destroy.
> 
> `ExchangeWorker.svelte` gets "terminated" when `ExchangeWorker.svelte` gets unmounted or the user navigates to to a page that doesn't include the component `ExchangeWorker.svelte`
> Wallet worker lifecycle is bound to tokens array
> The missing worker termination for exchange or wallet workers could be the primary source of the memory leak
> 
> # Changes
> 
> - Changed worker type: From `const exchangeWorker: Worker` to `let exchangeWorker: Worker | null`.
> - Added optional chaining: Used `?.` for all `postMessage` calls to prevent errors when worker is `null`.
> - Enhanced `destroy` method: Added proper worker termination.

# Tests

Since we are here, we included tests.
