### PR TITLE
feat(frontend): Service to calculate FX rates USDXXX

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -590,7 +590,7 @@ if (
 export const exchangeRateBNBToUsd = (): Promise<CoingeckoSimplePriceResponse | null> =>
 	simplePrice({
 		ids: 'binancecoin',
-		vs_currencies: 'usd'
+		vs_currencies: Currencies.USD
 	});
 ```
 

--- a/src/frontend/src/lib/rest/coingecko.rest.ts
+++ b/src/frontend/src/lib/rest/coingecko.rest.ts
@@ -31,7 +31,7 @@ export const simplePrice = ({
 	});
 
 /**
- * Get current price of tokens (using contract addresses) for a given platform in any other currency that you need.
+ * Get the current price of tokens (using contract addresses) for a given platform in any other currency that you need.
  *
  * Documentation:
  * - https://www.coingecko.com/api/documentation

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -4,6 +4,7 @@
 // *refers to curl -l https://api.coingecko.com/api/v3/coins/list
 import type { Erc20ContractAddress } from '$eth/types/erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
+import type { Currencies } from '$lib/enums/currencies';
 import type { EthAddress } from '$lib/types/address';
 import type { CoingeckoCoinsIdSchema } from '$lib/validation/coingecko.validation';
 import type * as z from 'zod/v4';
@@ -21,13 +22,13 @@ export type CoingeckoPlatformId =
 	| 'polygon-pos'
 	| 'arbitrum-one';
 
-// We only support conversion in USD for now, therefore not an exhaustive list.
+// Please, cross-reference the OISY supported currencies with the Coingecko API for supported currencies.
 // *refers to curl -l https://api.coingecko.com/api/v3/simple/supported_vs_currencies
-export type CoingeckoCurrency = 'usd';
+export type CoingeckoCurrency = `${Currencies}`;
 
 export interface CoingeckoSimpleParams {
 	// vs_currency of coins, comma-separated if querying more than 1 vs_currency
-	vs_currencies: CoingeckoCurrency;
+	vs_currencies: CoingeckoCurrency | `${CoingeckoCurrency},${CoingeckoCurrency}`;
 
 	// true/false to include market_cap, default: false
 	include_market_cap?: boolean;
@@ -57,13 +58,15 @@ export interface CoingeckoSimpleTokenPriceParams extends CoingeckoSimpleParams {
 	contract_addresses: string | string[];
 }
 
-export interface CoingeckoSimplePrice {
+export type CoingeckoSimplePrice = {
 	usd: number;
 	usd_market_cap?: number;
 	usd_24h_vol?: number;
 	usd_24h_change?: number;
 	last_updated_at?: number;
-}
+} & {
+	[K in Exclude<`${Currencies}`, 'usd'>]?: number;
+};
 
 export type CoingeckoSimpleTokenPrice = Omit<CoingeckoSimplePrice, 'usd_market_cap'> &
 	Required<Pick<CoingeckoSimplePrice, 'usd_market_cap'>>;

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -1,6 +1,7 @@
 import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { SYNC_EXCHANGE_TIMER_INTERVAL } from '$lib/constants/exchange.constants';
+import { Currencies } from '$lib/enums/currencies';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
 import type {
 	CoingeckoSimplePriceParams,
@@ -102,20 +103,29 @@ describe('exchange.worker', () => {
 				await onExchangeMessage(event);
 
 				expect(simplePrice).toHaveBeenCalledTimes(6);
-				expect(simplePrice).toHaveBeenNthCalledWith(1, { ids: 'ethereum', vs_currencies: 'usd' });
-				expect(simplePrice).toHaveBeenNthCalledWith(2, { ids: 'bitcoin', vs_currencies: 'usd' });
+				expect(simplePrice).toHaveBeenNthCalledWith(1, {
+					ids: 'ethereum',
+					vs_currencies: Currencies.USD
+				});
+				expect(simplePrice).toHaveBeenNthCalledWith(2, {
+					ids: 'bitcoin',
+					vs_currencies: Currencies.USD
+				});
 				expect(simplePrice).toHaveBeenNthCalledWith(3, {
 					ids: 'internet-computer',
-					vs_currencies: 'usd'
+					vs_currencies: Currencies.USD
 				});
-				expect(simplePrice).toHaveBeenNthCalledWith(4, { ids: 'solana', vs_currencies: 'usd' });
+				expect(simplePrice).toHaveBeenNthCalledWith(4, {
+					ids: 'solana',
+					vs_currencies: Currencies.USD
+				});
 				expect(simplePrice).toHaveBeenNthCalledWith(5, {
 					ids: 'binancecoin',
-					vs_currencies: 'usd'
+					vs_currencies: Currencies.USD
 				});
 				expect(simplePrice).toHaveBeenNthCalledWith(6, {
 					ids: 'polygon-ecosystem-token',
-					vs_currencies: 'usd'
+					vs_currencies: Currencies.USD
 				});
 			});
 
@@ -227,19 +237,19 @@ describe('exchange.worker', () => {
 					expect(simpleTokenPrice).toHaveBeenCalledTimes(3);
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(1, {
 						id: 'ethereum',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: ['0x123', '0xabc'],
 						include_market_cap: true
 					});
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(2, {
 						id: 'polygon-pos',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: ['0x456'],
 						include_market_cap: true
 					});
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(3, {
 						id: 'binance-smart-chain',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: ['0x789'],
 						include_market_cap: true
 					});
@@ -264,7 +274,7 @@ describe('exchange.worker', () => {
 					expect(simpleTokenPrice).toHaveBeenCalledOnce();
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(1, {
 						id: 'internet-computer',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: mockIcrcLedgerCanisterIds,
 						include_market_cap: true
 					});
@@ -291,7 +301,7 @@ describe('exchange.worker', () => {
 					expect(simpleTokenPrice).toHaveBeenCalledOnce();
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(1, {
 						id: 'solana',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: mockSplTokenAddresses,
 						include_market_cap: true
 					});
@@ -307,33 +317,33 @@ describe('exchange.worker', () => {
 
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(1, {
 						id: 'ethereum',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: ['0x123', '0xabc'],
 						include_market_cap: true
 					});
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(2, {
 						id: 'polygon-pos',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: ['0x456'],
 						include_market_cap: true
 					});
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(3, {
 						id: 'binance-smart-chain',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: ['0x789'],
 						include_market_cap: true
 					});
 
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(4, {
 						id: 'internet-computer',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: mockIcrcLedgerCanisterIds,
 						include_market_cap: true
 					});
 
 					expect(simpleTokenPrice).toHaveBeenNthCalledWith(5, {
 						id: 'solana',
-						vs_currencies: 'usd',
+						vs_currencies: Currencies.USD,
 						contract_addresses: mockSplTokenAddresses,
 						include_market_cap: true
 					});


### PR DESCRIPTION
# Motivation

We want to display the FIAT amounts in more currencies than USD. So, as _escamotage_, we leave all amounts in USD and multiply by the USDXXX FX rate of the user's selected currency.

This should work well, since we do not expect to have multiple FIAT currencies at the same time. So, we can use the unique FX rate for all the amounts.

However, to use existing services, we will derive this rate by cross-referencing the prices of a very liquid asset (BTC in our case) against the two currencies (USD and XXX). Then we obtain the USDXXX rate by BTCUSD / BTCXXX.

# Changes

- Adapt Coingecko `simplePrice` service to accept multiple currencies as request (see [documentation](https://docs.coingecko.com/reference/simple-price)) by having them as comma-separated list.
- Create service to fetch the prices of USD and a generic currency XXX.
- Cross those prices to obtain the final FX rate.

# Tests

Added unitests.
