### PR TITLE
feat(frontend): Derived store for current language

### DIFF
--- a/src/frontend/src/lib/derived/i18n.derived.ts
+++ b/src/frontend/src/lib/derived/i18n.derived.ts
@@ -1,0 +1,5 @@
+import { i18n } from '$lib/stores/i18n.store';
+import type { Languages } from '$lib/types/languages';
+import { derived, type Readable } from 'svelte/store';
+
+export const currentLanguage: Readable<Languages> = derived([i18n], ([{ lang }]) => lang);

--- a/src/frontend/src/tests/lib/derived/i18n.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/i18n.derived.spec.ts
@@ -1,0 +1,38 @@
+import { currentLanguage } from '$lib/derived/i18n.derived';
+import { i18n } from '$lib/stores/i18n.store';
+import { Languages } from '$lib/types/languages';
+import { get } from 'svelte/store';
+
+vi.mock('idb-keyval', () => ({
+	createStore: vi.fn(() => ({
+		/* mock store implementation */
+	})),
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn(),
+	update: vi.fn()
+}));
+
+describe('i18n.derived', () => {
+	describe('currentLanguage', () => {
+		beforeEach(() => {
+			i18n.init();
+		});
+
+		it('should initialize with the default language', () => {
+			expect(get(currentLanguage)).toEqual(Languages.ENGLISH);
+		});
+
+		it('should return the current language from the i18n store', () => {
+			expect(get(currentLanguage)).toEqual(Languages.ENGLISH);
+
+			i18n.switchLang(Languages.GERMAN);
+
+			expect(get(currentLanguage)).toEqual(Languages.GERMAN);
+
+			i18n.switchLang(Languages.ITALIAN);
+
+			expect(get(currentLanguage)).toEqual(Languages.ITALIAN);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Just to simplify the code, we create a derived store that returns the selected `Language` object. it will be used throughout the next PRs, to select the current locale for the new currencies.
