### PR TITLE
style(frontend): Correct colors for warn toast

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -395,6 +395,9 @@ div.select {
 .toast {
 	--toast-error-background: var(--color-background-error-light);
 	--toast-error-color: var(--color-foreground-error-secondary);
+
+	--toast-warn-background: var(--color-background-error-light);
+	--toast-warn-color: var(--color-foreground-error-secondary);
 }
 
 // Tooltip


### PR DESCRIPTION
# Motivation

After PR #7674, we are defining the colors of a `Toast` message according to their level.

In this PR we fix the colors of the `warn` level, to be the same as `error` level (as it was before the aforementioned PR).

Thanks @DenysKarmazynDFINITY for spotting it!

### Before

<img width="1326" height="202" alt="Screenshot 2025-07-16 at 09 34 56" src="https://github.com/user-attachments/assets/32a9938a-74e3-42b6-ab3d-4b63c1098c47" />

### After

<img width="1324" height="310" alt="Screenshot 2025-07-16 at 09 31 57" src="https://github.com/user-attachments/assets/ec43e95d-da61-4924-a809-2b6261bffd1a" />

