### PR TITLE
refactor(frontend): Get language directly as params in util `formatNanosecondsToDate`

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionModal.svelte
@@ -80,7 +80,7 @@
 			{#if nonNullish(timestamp)}
 				<ListItem>
 					<span>{$i18n.transaction.text.timestamp}</span>
-					<output>{formatNanosecondsToDate({ nanoseconds: timestamp, i18n: $i18n })}</output>
+					<output>{formatNanosecondsToDate({ nanoseconds: timestamp, language: $i18n })}</output>
 				</ListItem>
 			{/if}
 

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -97,13 +97,13 @@ export const formatSecondsToDate = ({
 
 export const formatNanosecondsToDate = ({
 	nanoseconds,
-	i18n
+	language
 }: {
 	nanoseconds: bigint;
-	i18n?: I18n;
+	language?: Languages;
 }): string => {
 	const date = new Date(Number(nanoseconds / NANO_SECONDS_IN_MILLISECOND));
-	return date.toLocaleDateString(i18n?.lang ?? Languages.ENGLISH, DATE_TIME_FORMAT_OPTIONS);
+	return date.toLocaleDateString(language ?? Languages.ENGLISH, DATE_TIME_FORMAT_OPTIONS);
 };
 
 export const formatNanosecondsToTimestamp = (nanoseconds: bigint): number => {

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,5 +1,6 @@
 import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 import { DEFAULT_BITCOIN_TOKEN } from '$lib/constants/tokens.constants';
+import { Languages } from '$lib/enums/languages';
 import {
 	formatNanosecondsToDate,
 	formatSecondsToDate,
@@ -489,7 +490,7 @@ describe('format.utils', () => {
 			const jan1_2023_ns = BigInt(1672531200000000000); // Jan 1, 2023 in nanoseconds
 			const result = formatNanosecondsToDate({
 				nanoseconds: jan1_2023_ns,
-				i18n: { lang: 'de' } as unknown as I18n
+				language: Languages.GERMAN
 			});
 
 			expect(result).toMatch('1. Jan. 2023');
@@ -497,10 +498,7 @@ describe('format.utils', () => {
 
 		it('falls back to en locale when i18n.lang is not provided', () => {
 			const jan1_2023_ns = BigInt(1672531200000000000); // Jan 1, 2023 in nanoseconds
-			const result = formatNanosecondsToDate({
-				nanoseconds: jan1_2023_ns,
-				i18n: {} as unknown as I18n
-			});
+			const result = formatNanosecondsToDate({ nanoseconds: jan1_2023_ns });
 
 			expect(result).toMatch('Jan 1, 2023');
 		});


### PR DESCRIPTION
# Motivation

To simplify the code, we pass directly the language to the util `formatNanosecondsToDate`.
