### PR TITLE
refactor(frontend): simplify types in `initAddressStore`

### DIFF
--- a/src/frontend/src/btc/components/receive/BtcReceive.svelte
+++ b/src/frontend/src/btc/components/receive/BtcReceive.svelte
@@ -14,7 +14,7 @@
 		btcAddressMainnetStore,
 		btcAddressRegtestStore,
 		btcAddressTestnetStore,
-		type StorageAddressData
+		type AddressStoreData
 	} from '$lib/stores/address.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -22,7 +22,7 @@
 	import type { Token } from '$lib/types/token';
 	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
 
-	let addressData: StorageAddressData<BtcAddress>;
+	let addressData: AddressStoreData<BtcAddress>;
 	$: addressData = isNetworkIdBTCTestnet($networkId)
 		? $btcAddressTestnetStore
 		: isNetworkIdBTCRegtest($networkId)

--- a/src/frontend/src/btc/services/btc-address.services.ts
+++ b/src/frontend/src/btc/services/btc-address.services.ts
@@ -23,7 +23,7 @@ import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
 	btcAddressTestnetStore,
-	type StorageAddressData
+	type AddressStoreData
 } from '$lib/stores/address.store';
 import { i18n } from '$lib/stores/i18n.store';
 import type { BtcAddress } from '$lib/types/address';
@@ -125,7 +125,7 @@ const certifyBtcAddressMainnet = (address: BtcAddress): Promise<ResultSuccess<st
 		addressStore: btcAddressMainnetStore
 	});
 
-export const validateBtcAddressMainnet = async ($addressStore: StorageAddressData<BtcAddress>) =>
+export const validateBtcAddressMainnet = async ($addressStore: AddressStoreData<BtcAddress>) =>
 	await validateAddress<BtcAddress>({
 		$addressStore,
 		certifyAddress: certifyBtcAddressMainnet

--- a/src/frontend/src/eth/services/eth-address.services.ts
+++ b/src/frontend/src/eth/services/eth-address.services.ts
@@ -13,7 +13,7 @@ import {
 	loadTokenAddress,
 	validateAddress
 } from '$lib/services/address.services';
-import { ethAddressStore, type StorageAddressData } from '$lib/stores/address.store';
+import { ethAddressStore, type AddressStoreData } from '$lib/stores/address.store';
 import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';
 import type { LoadIdbAddressError } from '$lib/types/errors';
@@ -62,7 +62,7 @@ const certifyEthAddress = (address: EthAddress): Promise<ResultSuccess<string>> 
 		addressStore: ethAddressStore
 	});
 
-export const validateEthAddress = async ($addressStore: StorageAddressData<EthAddress>) =>
+export const validateEthAddress = async ($addressStore: AddressStoreData<EthAddress>) =>
 	await validateAddress<EthAddress>({
 		$addressStore,
 		certifyAddress: certifyEthAddress

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -1,5 +1,5 @@
 import { warnSignOut } from '$lib/services/auth.services';
-import type { AddressStore, StorageAddressData } from '$lib/stores/address.store';
+import type { AddressStore, AddressStoreData } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
@@ -168,7 +168,7 @@ export const validateAddress = async <T extends Address>({
 	$addressStore,
 	certifyAddress
 }: {
-	$addressStore: StorageAddressData<T>;
+	$addressStore: AddressStoreData<T>;
 	certifyAddress: (address: T) => Promise<ResultSuccess<string>>;
 }) => {
 	if (isNullish($addressStore)) {

--- a/src/frontend/src/lib/stores/address.store.ts
+++ b/src/frontend/src/lib/stores/address.store.ts
@@ -1,19 +1,19 @@
-import type { StorageStoreData } from '$lib/stores/storage.store';
 import type { Address, BtcAddress, EthAddress, SolAddress } from '$lib/types/address';
 import type { CertifiedData } from '$lib/types/store';
+import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
 type CertifiedAddressData<T extends Address> = CertifiedData<T>;
 
-export type StorageAddressData<T extends Address> = StorageStoreData<CertifiedAddressData<T>>;
+export type AddressStoreData<T extends Address> = Option<CertifiedAddressData<T>>;
 
-export interface AddressStore<T extends Address> extends Readable<StorageAddressData<T>> {
+export interface AddressStore<T extends Address> extends Readable<AddressStoreData<T>> {
 	set: (data: CertifiedAddressData<T>) => void;
 	reset: () => void;
 }
 
 const initAddressStore = <T extends Address>(): AddressStore<T> => {
-	const { subscribe, set } = writable<StorageAddressData<T>>(undefined);
+	const { subscribe, set } = writable<AddressStoreData<T>>(undefined);
 
 	return {
 		set: (data: CertifiedAddressData<T>) => set(data),

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -3,7 +3,7 @@ import { SUPPORTED_BITCOIN_NETWORK_IDS } from '$env/networks/networks.btc.env';
 import { SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
 import { SUPPORTED_SOLANA_NETWORK_IDS } from '$env/networks/networks.sol.env';
 import { TOKEN_ACCOUNT_ID_TYPES_CASE_SENSITIVE } from '$lib/constants/token-account-id.constants';
-import type { StorageAddressData } from '$lib/stores/address.store';
+import type { AddressStoreData } from '$lib/stores/address.store';
 import type { Address, OptionAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
@@ -13,7 +13,7 @@ import { parseBtcAddress, type BtcAddress } from '@dfinity/ckbtc';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const mapAddress = <T extends Address>(
-	$addressStore: StorageAddressData<T>
+	$addressStore: AddressStoreData<T>
 ): OptionAddress<T> => mapCertifiedData($addressStore);
 
 export const isBtcAddress = (address: BtcAddress | undefined): boolean => {

--- a/src/frontend/src/sol/components/receive/SolReceive.svelte
+++ b/src/frontend/src/sol/components/receive/SolReceive.svelte
@@ -9,7 +9,7 @@
 		solAddressDevnetStore,
 		solAddressLocalnetStore,
 		solAddressMainnetStore,
-		type StorageAddressData
+		type AddressStoreData
 	} from '$lib/stores/address.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -19,7 +19,7 @@
 
 	export let token: Token;
 
-	let addressData: StorageAddressData<SolAddress>;
+	let addressData: AddressStoreData<SolAddress>;
 	//TODO consolidate this logic together with btc into $networkAddress like it's done for ICP and ETH
 	$: addressData = isNetworkIdSOLDevnet($networkId)
 		? $solAddressDevnetStore

--- a/src/frontend/src/sol/services/sol-address.services.ts
+++ b/src/frontend/src/sol/services/sol-address.services.ts
@@ -25,7 +25,7 @@ import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
 	solAddressMainnetStore,
-	type StorageAddressData
+	type AddressStoreData
 } from '$lib/stores/address.store';
 import { i18n } from '$lib/stores/i18n.store';
 import type { SolAddress } from '$lib/types/address';
@@ -156,7 +156,7 @@ const certifySolAddressMainnet = (address: SolAddress): Promise<ResultSuccess<st
 		addressStore: solAddressMainnetStore
 	});
 
-export const validateSolAddressMainnet = async ($addressStore: StorageAddressData<SolAddress>) =>
+export const validateSolAddressMainnet = async ($addressStore: AddressStoreData<SolAddress>) =>
 	await validateAddress<SolAddress>({
 		$addressStore,
 		certifyAddress: certifySolAddressMainnet


### PR DESCRIPTION
# Motivation

In the address store initializer we do not really need to import `StorageStoreData` type, since we just need the `Option` modifier, and the `Storage` prefix does not really make sense in this context.
