### PR TITLE
feat(frontend): added new params to approveToken before send

### DIFF
--- a/src/frontend/src/eth/types/send.ts
+++ b/src/frontend/src/eth/types/send.ts
@@ -1,6 +1,6 @@
 import type { EthereumNetwork } from '$eth/types/network';
 import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
-import type { ProgressStepsSend } from '$lib/enums/progress-steps';
+import type { ProgressStepsSend, ProgressStepsSwap } from '$lib/enums/progress-steps';
 import type { EthAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Network } from '$lib/types/network';
@@ -8,22 +8,35 @@ import type { TransferParams } from '$lib/types/send';
 import type { Token } from '$lib/types/token';
 import type { RequiredTransactionFeeData } from '$lib/types/transaction';
 
-export interface SendParams {
-	progress: (step: ProgressStepsSend) => void;
+export type ProgressStep = ProgressStepsSend | ProgressStepsSwap;
+
+type ProgressStepsEnum = typeof ProgressStepsSend | typeof ProgressStepsSwap;
+
+interface WithProgress {
+	progress: (step: ProgressStep) => void;
+	progressSteps?: ProgressStepsEnum;
+}
+
+export interface SendParams extends WithProgress {
 	lastProgressStep?: ProgressStepsSend;
 	token: Token;
 	sourceNetwork: EthereumNetwork;
 	targetNetwork?: Network | undefined;
 	identity: OptionIdentity;
-	minterInfo: OptionCertifiedMinterInfo;
+	minterInfo?: OptionCertifiedMinterInfo;
 }
 
 export type ApproveParams = Omit<TransferParams, 'maxPriorityFeePerGas' | 'maxFeePerGas'> &
-	Omit<SendParams, 'targetNetwork' | 'lastProgressStep'> &
-	RequiredTransactionFeeData;
-
-export type SignAndApproveParams = Omit<ApproveParams, 'from' | 'to' | 'progress' | 'minterInfo'> &
-	Partial<Pick<SendParams, 'progress'>> & {
-		nonce: number;
-		spender: EthAddress;
+	Omit<SendParams, 'targetNetwork' | 'lastProgressStep' | 'progress'> &
+	RequiredTransactionFeeData &
+	Omit<WithProgress, 'progressSteps'> & {
+		approveRequired?: boolean;
 	};
+
+export type SignAndApproveParams = Omit<
+	ApproveParams,
+	'from' | 'to' | 'minterInfo' | 'progress'
+> & {
+	nonce: number;
+	spender: EthAddress;
+} & Omit<WithProgress, 'progressSteps'>;


### PR DESCRIPTION
# Motivation

To support flexible approval flows, in this PR was introduced conditions to handle approvals using a custom spender when required.

# Changes

- Extended types to support approveRequired condition

- Introduced logic to optionally use to as the spender for approval
