### PR TITLE
fix(frontend): Split currency store from exchange rate

### DIFF
--- a/src/frontend/src/lib/derived/currency.derived.ts
+++ b/src/frontend/src/lib/derived/currency.derived.ts
@@ -1,4 +1,5 @@
 import type { Currencies } from '$lib/enums/currencies';
+import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { currencyStore } from '$lib/stores/currency.store';
 import { derived, type Readable } from 'svelte/store';
 
@@ -8,6 +9,6 @@ export const currentCurrency: Readable<Currencies> = derived(
 );
 
 export const currentCurrencyExchangeRate: Readable<number | null> = derived(
-	[currencyStore],
+	[currencyExchangeStore],
 	([{ exchangeRateToUsd }]) => exchangeRateToUsd
 );

--- a/src/frontend/src/lib/stores/currency-exchange.store.ts
+++ b/src/frontend/src/lib/stores/currency-exchange.store.ts
@@ -11,6 +11,8 @@ export interface CurrencyExchangeStore extends Readable<CurrencyExchangeData> {
 	setExchangeRate: (exchangeRate: CurrencyExchangeData['exchangeRateToUsd']) => void;
 }
 
+// Since the currencyStore is a type of storage store, we cannot use it in the workers (no browser API support), especially in the one that updates the exchange rate of the current currency.
+// So we split the currency store into two separate stores: one for the currency and another for the exchange rate.
 export const initCurrencyExchangeStore = (): CurrencyExchangeStore => {
 	const DEFAULT: CurrencyExchangeData = {
 		currency: Currencies.USD,

--- a/src/frontend/src/lib/stores/currency-exchange.store.ts
+++ b/src/frontend/src/lib/stores/currency-exchange.store.ts
@@ -1,0 +1,33 @@
+import { Currencies } from '$lib/enums/currencies';
+import type { CurrencyData } from '$lib/stores/currency.store';
+import { writable, type Readable } from 'svelte/store';
+
+export interface CurrencyExchangeData extends CurrencyData {
+	exchangeRateToUsd: number | null;
+}
+
+export interface CurrencyExchangeStore extends Readable<CurrencyExchangeData> {
+	setExchangeRateCurrency: (currency: CurrencyExchangeData['currency']) => void;
+	setExchangeRate: (exchangeRate: CurrencyExchangeData['exchangeRateToUsd']) => void;
+}
+
+export const initCurrencyExchangeStore = (): CurrencyExchangeStore => {
+	const DEFAULT: CurrencyExchangeData = {
+		currency: Currencies.USD,
+		exchangeRateToUsd: 1
+	};
+
+	const { subscribe, set, update } = writable<CurrencyExchangeData>(DEFAULT);
+
+	return {
+		setExchangeRateCurrency: (currency: CurrencyExchangeData['currency']) => {
+			// When the currency changes, we reset the exchange rate to null to avoid showing wrong data in the UI
+			set({ currency, exchangeRateToUsd: currency === Currencies.USD ? 1 : null });
+		},
+		setExchangeRate: (exchangeRate: CurrencyExchangeData['exchangeRateToUsd']) =>
+			update((state) => ({ ...state, exchangeRateToUsd: exchangeRate })),
+		subscribe
+	};
+};
+
+export const currencyExchangeStore = initCurrencyExchangeStore();

--- a/src/frontend/src/lib/stores/currency.store.ts
+++ b/src/frontend/src/lib/stores/currency.store.ts
@@ -1,39 +1,31 @@
 import { Currencies } from '$lib/enums/currencies';
+import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { initStorageStore } from '$lib/stores/storage.store';
 import type { Readable } from 'svelte/store';
 
 export interface CurrencyData {
 	currency: Currencies;
-	exchangeRateToUsd: number | null;
 }
 
 export interface CurrencyStore extends Readable<CurrencyData> {
 	switchCurrency: (currency: CurrencyData['currency']) => void;
-	setExchangeRate: (exchangeRate: CurrencyData['exchangeRateToUsd']) => void;
 }
 
 const CURRENCY_STORAGE_KEY = 'currency';
 
 export const initCurrencyStore = (): CurrencyStore => {
-	const DEFAULT: CurrencyData = {
-		currency: Currencies.USD,
-		exchangeRateToUsd: 1
-	};
+	const DEFAULT: CurrencyData = { currency: Currencies.USD };
 
-	const { set, subscribe, update } = initStorageStore<CurrencyData>({
+	const { set, subscribe } = initStorageStore<CurrencyData>({
 		key: CURRENCY_STORAGE_KEY,
 		defaultValue: DEFAULT
 	});
 
 	return {
-		switchCurrency: (currency: CurrencyData['currency']) =>
-			// When the currency changes, we reset the exchange rate to null to avoid showing wrong data in the UI
-			set({
-				key: CURRENCY_STORAGE_KEY,
-				value: { currency, exchangeRateToUsd: currency === Currencies.USD ? 1 : null }
-			}),
-		setExchangeRate: (exchangeRate: CurrencyData['exchangeRateToUsd']) =>
-			update((state) => ({ ...state, exchangeRateToUsd: exchangeRate })),
+		switchCurrency: (currency: CurrencyData['currency']) => {
+			set({ key: CURRENCY_STORAGE_KEY, value: { currency } });
+			currencyExchangeStore.setExchangeRateCurrency(currency);
+		},
 		subscribe
 	};
 };

--- a/src/frontend/src/tests/lib/derived/currency.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/currency.derived.spec.ts
@@ -1,5 +1,6 @@
 import { currentCurrency, currentCurrencyExchangeRate } from '$lib/derived/currency.derived';
 import { Currencies } from '$lib/enums/currencies';
+import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { currencyStore } from '$lib/stores/currency.store';
 import { get } from 'svelte/store';
 
@@ -34,7 +35,7 @@ describe('currency.derived', () => {
 
 	describe('currentCurrencyExchangeRate', () => {
 		beforeEach(() => {
-			currencyStore.switchCurrency(Currencies.USD);
+			currencyExchangeStore.setExchangeRateCurrency(Currencies.USD);
 		});
 
 		it('should initialize with the default value', () => {
@@ -44,27 +45,37 @@ describe('currency.derived', () => {
 		it('should return the current value from the currency store', () => {
 			expect(get(currentCurrencyExchangeRate)).toEqual(1);
 
-			currencyStore.setExchangeRate(101);
+			currencyExchangeStore.setExchangeRate(101);
 
 			expect(get(currentCurrencyExchangeRate)).toEqual(101);
 
-			currencyStore.setExchangeRate(1.5);
+			currencyExchangeStore.setExchangeRate(1.5);
 
 			expect(get(currentCurrencyExchangeRate)).toEqual(1.5);
 		});
 
 		it('should return null if exchange rate is not set', () => {
-			currencyStore.setExchangeRate(1.2);
+			currencyExchangeStore.setExchangeRate(1.2);
 
 			expect(get(currentCurrencyExchangeRate)).toEqual(1.2);
 
-			currencyStore.setExchangeRate(null);
+			currencyExchangeStore.setExchangeRate(null);
 
 			expect(get(currentCurrencyExchangeRate)).toBeNull();
 		});
 
 		it('should return null when the language is switched', () => {
-			currencyStore.setExchangeRate(1.2);
+			currencyExchangeStore.setExchangeRate(1.2);
+
+			expect(get(currentCurrencyExchangeRate)).toEqual(1.2);
+
+			currencyExchangeStore.setExchangeRateCurrency(Currencies.CHF);
+
+			expect(get(currentCurrencyExchangeRate)).toBeNull();
+		});
+
+		it('should return null when the language is switched in the currencyStore', () => {
+			currencyExchangeStore.setExchangeRate(1.2);
 
 			expect(get(currentCurrencyExchangeRate)).toEqual(1.2);
 

--- a/src/frontend/src/tests/lib/stores/currency-exchange.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/currency-exchange.store.spec.ts
@@ -1,0 +1,103 @@
+import { Currencies } from '$lib/enums/currencies';
+import {
+	initCurrencyExchangeStore,
+	type CurrencyExchangeStore
+} from '$lib/stores/currency-exchange.store';
+import { get } from 'svelte/store';
+
+describe('currency-exchange.store', () => {
+	describe('initCurrencyExchangeStore', () => {
+		let mockStore: CurrencyExchangeStore;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			mockStore = initCurrencyExchangeStore();
+		});
+
+		it('should initialize with default value', () => {
+			const store = initCurrencyExchangeStore();
+
+			expect(get(store)).toEqual({
+				currency: Currencies.USD,
+				exchangeRateToUsd: 1
+			});
+		});
+
+		describe('setExchangeRateCurrency', () => {
+			it('should switch the currency', () => {
+				expect(get(mockStore).currency).toEqual(Currencies.USD);
+
+				mockStore.setExchangeRateCurrency(Currencies.CHF);
+
+				expect(get(mockStore).currency).toEqual(Currencies.CHF);
+			});
+
+			it('should switch the currency back and forth', () => {
+				expect(get(mockStore).currency).toEqual(Currencies.USD);
+
+				mockStore.setExchangeRateCurrency(Currencies.CHF);
+
+				expect(get(mockStore).currency).toEqual(Currencies.CHF);
+
+				mockStore.setExchangeRateCurrency(Currencies.JPY);
+
+				expect(get(mockStore).currency).toEqual(Currencies.JPY);
+
+				mockStore.setExchangeRateCurrency(Currencies.USD);
+
+				expect(get(mockStore).currency).toEqual(Currencies.USD);
+			});
+
+			it('should set the exchange rate to null for non-USD currencies', () => {
+				expect(get(mockStore).exchangeRateToUsd).toBe(1);
+
+				mockStore.setExchangeRateCurrency(Currencies.CHF);
+
+				expect(get(mockStore).exchangeRateToUsd).toBeNull();
+
+				mockStore.setExchangeRateCurrency(Currencies.JPY);
+
+				expect(get(mockStore).exchangeRateToUsd).toBeNull();
+			});
+
+			it('should set the exchange rate to 1 for USD', () => {
+				expect(get(mockStore).exchangeRateToUsd).toBe(1);
+
+				mockStore.setExchangeRateCurrency(Currencies.CHF);
+
+				expect(get(mockStore).exchangeRateToUsd).toBeNull();
+
+				mockStore.setExchangeRateCurrency(Currencies.USD);
+
+				expect(get(mockStore).exchangeRateToUsd).toBe(1);
+			});
+		});
+
+		describe('setExchangeRate', () => {
+			it('should set the exchange rate', () => {
+				expect(get(mockStore).exchangeRateToUsd).toBe(1);
+
+				mockStore.setExchangeRate(1.5);
+
+				expect(get(mockStore).exchangeRateToUsd).toBe(1.5);
+
+				mockStore.setExchangeRate(101);
+
+				expect(get(mockStore).exchangeRateToUsd).toBe(101);
+			});
+
+			it('should not change the currency', () => {
+				expect(get(mockStore).currency).toEqual(Currencies.USD);
+
+				mockStore.setExchangeRate(1.5);
+
+				expect(get(mockStore).currency).toEqual(Currencies.USD);
+
+				mockStore.setExchangeRate(101);
+
+				expect(get(mockStore).currency).toEqual(Currencies.USD);
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/stores/currency.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/currency.store.spec.ts
@@ -1,4 +1,5 @@
 import { Currencies } from '$lib/enums/currencies';
+import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import {
 	initCurrencyStore,
 	type CurrencyData,
@@ -15,7 +16,7 @@ vi.mock('$lib/utils/storage.utils', () => ({
 
 describe('currency.store', () => {
 	describe('initCurrencyStore', () => {
-		const mockData: CurrencyData = { currency: Currencies.CHF, exchangeRateToUsd: 1.5 };
+		const mockData: CurrencyData = { currency: Currencies.CHF };
 
 		let mockStore: CurrencyStore;
 
@@ -25,6 +26,8 @@ describe('currency.store', () => {
 			vi.mocked(getStorage).mockImplementation(() => {});
 
 			mockStore = initCurrencyStore();
+
+			vi.spyOn(currencyExchangeStore, 'setExchangeRateCurrency');
 		});
 
 		it('should initialize with the value from storage', () => {
@@ -40,10 +43,7 @@ describe('currency.store', () => {
 
 			const store = initCurrencyStore();
 
-			expect(get(store)).toEqual({
-				currency: Currencies.USD,
-				exchangeRateToUsd: 1
-			});
+			expect(get(store)).toEqual({ currency: Currencies.USD });
 		});
 
 		describe('switchCurrency', () => {
@@ -72,53 +72,41 @@ describe('currency.store', () => {
 			});
 
 			it('should set the exchange rate to null for non-USD currencies', () => {
-				expect(get(mockStore).exchangeRateToUsd).toBe(1);
+				expect(get(currencyExchangeStore).exchangeRateToUsd).toBe(1);
 
 				mockStore.switchCurrency(Currencies.CHF);
 
-				expect(get(mockStore).exchangeRateToUsd).toBeNull();
+				expect(get(currencyExchangeStore).exchangeRateToUsd).toBeNull();
+				expect(currencyExchangeStore.setExchangeRateCurrency).toHaveBeenCalledExactlyOnceWith(
+					Currencies.CHF
+				);
 
 				mockStore.switchCurrency(Currencies.JPY);
 
-				expect(get(mockStore).exchangeRateToUsd).toBeNull();
+				expect(get(currencyExchangeStore).exchangeRateToUsd).toBeNull();
+				expect(currencyExchangeStore.setExchangeRateCurrency).toHaveBeenCalledTimes(2);
+				expect(currencyExchangeStore.setExchangeRateCurrency).toHaveBeenNthCalledWith(
+					2,
+					Currencies.JPY
+				);
 			});
 
 			it('should set the exchange rate to 1 for USD', () => {
-				expect(get(mockStore).exchangeRateToUsd).toBe(1);
-
 				mockStore.switchCurrency(Currencies.CHF);
 
-				expect(get(mockStore).exchangeRateToUsd).toBeNull();
+				expect(get(currencyExchangeStore).exchangeRateToUsd).toBeNull();
+				expect(currencyExchangeStore.setExchangeRateCurrency).toHaveBeenCalledExactlyOnceWith(
+					Currencies.CHF
+				);
 
 				mockStore.switchCurrency(Currencies.USD);
 
-				expect(get(mockStore).exchangeRateToUsd).toBe(1);
-			});
-		});
-
-		describe('setExchangeRate', () => {
-			it('should set the exchange rate', () => {
-				expect(get(mockStore).exchangeRateToUsd).toBe(1);
-
-				mockStore.setExchangeRate(1.5);
-
-				expect(get(mockStore).exchangeRateToUsd).toBe(1.5);
-
-				mockStore.setExchangeRate(101);
-
-				expect(get(mockStore).exchangeRateToUsd).toBe(101);
-			});
-
-			it('should not change the currency', () => {
-				expect(get(mockStore).currency).toEqual(Currencies.USD);
-
-				mockStore.setExchangeRate(1.5);
-
-				expect(get(mockStore).currency).toEqual(Currencies.USD);
-
-				mockStore.setExchangeRate(101);
-
-				expect(get(mockStore).currency).toEqual(Currencies.USD);
+				expect(get(currencyExchangeStore).exchangeRateToUsd).toBe(1);
+				expect(currencyExchangeStore.setExchangeRateCurrency).toHaveBeenCalledTimes(2);
+				expect(currencyExchangeStore.setExchangeRateCurrency).toHaveBeenNthCalledWith(
+					2,
+					Currencies.USD
+				);
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/7835, we are going to use the exchange worker to update the exchange rate of the current currency, setting it in the currency store. However we have an issue: since the currency store is a type of storage store too (it caches the data, so it requires browser API support), we cannot use it in a worker.

To solve this issue, we split the store into two parts: one will have the simple currency, and it is the one used all over the UI. And the other has the exchange rate and the reference currency.

# Changes

- Create a new currency-exchange store that is a simple `writable`: it will have the exchange rate and its reference currency.
- Adapt the existing currency store to have only the `switchCurrency` method: this will however always reset the exchange rate in the other store, to avoid wrong data in the UI.
- NOTE: the functions where copied from one place to the other

# Tests

Adapted tests.
