### PR TITLE
feat(frontend): added new modal network list store

### DIFF
--- a/src/frontend/src/lib/stores/modal-networks-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-networks-list.store.ts
@@ -1,20 +1,23 @@
 import type { Network, NetworkId } from '$lib/types/network';
-import { nonNullish } from '@dfinity/utils';
 import { derived, writable, type Readable } from 'svelte/store';
 
 export interface ModalNetworksListData {
 	networks: Network[];
-	allowedNetworkIds?: NetworkId[];
+	allowedNetworkIds: NetworkId[];
 }
 
 export const initModalNetworksListContext = (
 	initialData: ModalNetworksListData
 ): ModalNetworksListContext => {
-	const data = writable<ModalNetworksListData>(initialData);
+	const data = writable<ModalNetworksListData>({
+		networks: initialData.networks,
+		allowedNetworkIds: initialData.allowedNetworkIds ?? []
+	});
+
 	const { update } = data;
 
 	const filteredNetworks = derived(data, ({ networks, allowedNetworkIds }) =>
-		nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 0
+		allowedNetworkIds.length > 0
 			? networks.filter((network) => allowedNetworkIds.includes(network.id))
 			: networks
 	);
@@ -22,15 +25,17 @@ export const initModalNetworksListContext = (
 	return {
 		filteredNetworks,
 		setNetworks: (networks: Network[]) => update((state) => ({ ...state, networks })),
-		setAllowedNetworkIds: (ids?: NetworkId[]) =>
-			update((state) => ({ ...state, allowedNetworkIds: ids }))
+		setAllowedNetworkIds: (ids: NetworkId[]) =>
+			update((state) => ({ ...state, allowedNetworkIds: ids })),
+		resetAllowedNetworkIds: () => update((state) => ({ ...state, allowedNetworkIds: [] }))
 	};
 };
 
 export interface ModalNetworksListContext {
 	filteredNetworks: Readable<Network[]>;
 	setNetworks: (networks: Network[]) => void;
-	setAllowedNetworkIds: (ids?: NetworkId[]) => void;
+	setAllowedNetworkIds: (ids: NetworkId[]) => void;
+	resetAllowedNetworkIds: () => void;
 }
 
 export const MODAL_NETWORKS_LIST_CONTEXT_KEY = Symbol('modal-networks-list');

--- a/src/frontend/src/lib/stores/modal-networks-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-networks-list.store.ts
@@ -1,0 +1,36 @@
+import type { Network, NetworkId } from '$lib/types/network';
+import { nonNullish } from '@dfinity/utils';
+import { derived, writable, type Readable } from 'svelte/store';
+
+export interface ModalNetworksListData {
+	networks: Network[];
+	allowedNetworkIds?: NetworkId[];
+}
+
+export const initModalNetworksListContext = (
+	initialData: ModalNetworksListData
+): ModalNetworksListContext => {
+	const data = writable<ModalNetworksListData>(initialData);
+	const { update } = data;
+
+	const filteredNetworks = derived(data, ({ networks, allowedNetworkIds }) =>
+		nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 0
+			? networks.filter((network) => allowedNetworkIds.includes(network.id))
+			: networks
+	);
+
+	return {
+		filteredNetworks,
+		setNetworks: (networks: Network[]) => update((state) => ({ ...state, networks })),
+		setAllowedNetworkIds: (ids?: NetworkId[]) =>
+			update((state) => ({ ...state, allowedNetworkIds: ids }))
+	};
+};
+
+export interface ModalNetworksListContext {
+	filteredNetworks: Readable<Network[]>;
+	setNetworks: (networks: Network[]) => void;
+	setAllowedNetworkIds: (ids?: NetworkId[]) => void;
+}
+
+export const MODAL_NETWORKS_LIST_CONTEXT_KEY = Symbol('modal-networks-list');

--- a/src/frontend/src/tests/lib/stores/modal-networks-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-networks-list.store.spec.ts
@@ -23,14 +23,6 @@ describe('modalNetworksListStore', () => {
 		expect(get(filteredNetworks)).toEqual([ICP_NETWORK, ETHEREUM_NETWORK]);
 	});
 
-	it('should return all networks when no allowedNetworkIds provided', () => {
-		const { filteredNetworks } = initModalNetworksListContext({
-			networks: mockNetworks
-		});
-
-		expect(get(filteredNetworks)).toEqual(mockNetworks);
-	});
-
 	it('should return all networks when allowedNetworkIds is empty array', () => {
 		const { filteredNetworks } = initModalNetworksListContext({
 			networks: mockNetworks,
@@ -84,15 +76,15 @@ describe('modalNetworksListStore', () => {
 		expect(get(filteredNetworks)).toEqual([ETHEREUM_NETWORK, BASE_NETWORK]);
 	});
 
-	it('should clear filter when setAllowedNetworkIds is called with undefined', () => {
-		const { filteredNetworks, setAllowedNetworkIds } = initModalNetworksListContext({
+	it('should reset filter when calledresetAllowedNetworksIds', () => {
+		const { filteredNetworks, resetAllowedNetworkIds } = initModalNetworksListContext({
 			networks: mockNetworks,
 			allowedNetworkIds: [ICP_NETWORK.id]
 		});
 
 		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
 
-		setAllowedNetworkIds(undefined);
+		resetAllowedNetworkIds();
 
 		expect(get(filteredNetworks)).toEqual(mockNetworks);
 	});

--- a/src/frontend/src/tests/lib/stores/modal-networks-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-networks-list.store.spec.ts
@@ -1,0 +1,142 @@
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
+import { BSC_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { initModalNetworksListContext } from '$lib/stores/modal-networks-list.store';
+import { get } from 'svelte/store';
+
+describe('modalNetworksListStore', () => {
+	const mockNetworks = [
+		ICP_NETWORK,
+		ETHEREUM_NETWORK,
+		SEPOLIA_NETWORK,
+		BASE_NETWORK,
+		BSC_MAINNET_NETWORK
+	];
+
+	it('should have all expected values with initial data', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: [ICP_NETWORK.id, ETHEREUM_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK, ETHEREUM_NETWORK]);
+	});
+
+	it('should return all networks when no allowedNetworkIds provided', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: mockNetworks
+		});
+
+		expect(get(filteredNetworks)).toEqual(mockNetworks);
+	});
+
+	it('should return all networks when allowedNetworkIds is empty array', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: []
+		});
+
+		expect(get(filteredNetworks)).toEqual(mockNetworks);
+	});
+
+	it('should filter networks by allowedNetworkIds', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: [SEPOLIA_NETWORK.id, BASE_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([SEPOLIA_NETWORK, BASE_NETWORK]);
+	});
+
+	it('should filter networks with single allowedNetworkId', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: [ICP_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+	});
+
+	it('should update networks using setNetworks', () => {
+		const { filteredNetworks, setNetworks } = initModalNetworksListContext({
+			networks: [ICP_NETWORK],
+			allowedNetworkIds: [ICP_NETWORK.id, ETHEREUM_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+
+		setNetworks([ICP_NETWORK, ETHEREUM_NETWORK]);
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK, ETHEREUM_NETWORK]);
+	});
+
+	it('should update allowedNetworkIds using setAllowedNetworkIds', () => {
+		const { filteredNetworks, setAllowedNetworkIds } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: [ICP_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+
+		setAllowedNetworkIds([ETHEREUM_NETWORK.id, BASE_NETWORK.id]);
+
+		expect(get(filteredNetworks)).toEqual([ETHEREUM_NETWORK, BASE_NETWORK]);
+	});
+
+	it('should clear filter when setAllowedNetworkIds is called with undefined', () => {
+		const { filteredNetworks, setAllowedNetworkIds } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: [ICP_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+
+		setAllowedNetworkIds(undefined);
+
+		expect(get(filteredNetworks)).toEqual(mockNetworks);
+	});
+
+	it('should clear filter when setAllowedNetworkIds is called with empty array', () => {
+		const { filteredNetworks, setAllowedNetworkIds } = initModalNetworksListContext({
+			networks: mockNetworks,
+			allowedNetworkIds: [ICP_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+
+		setAllowedNetworkIds([]);
+
+		expect(get(filteredNetworks)).toEqual(mockNetworks);
+	});
+
+	it('should handle empty networks array', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: [],
+			allowedNetworkIds: [ICP_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([]);
+	});
+
+	it('should update when both networks and allowedNetworkIds are changed', () => {
+		const { filteredNetworks, setNetworks, setAllowedNetworkIds } = initModalNetworksListContext({
+			networks: [ICP_NETWORK],
+			allowedNetworkIds: [ICP_NETWORK.id]
+		});
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+
+		setNetworks([ICP_NETWORK, ETHEREUM_NETWORK, BASE_NETWORK]);
+
+		expect(get(filteredNetworks)).toEqual([ICP_NETWORK]);
+
+		setAllowedNetworkIds([ETHEREUM_NETWORK.id, BASE_NETWORK.id]);
+
+		expect(get(filteredNetworks)).toEqual([ETHEREUM_NETWORK, BASE_NETWORK]);
+
+		setNetworks([ICP_NETWORK, ETHEREUM_NETWORK, BASE_NETWORK, BSC_MAINNET_NETWORK]);
+
+		expect(get(filteredNetworks)).toEqual([ETHEREUM_NETWORK, BASE_NETWORK]);
+	});
+});


### PR DESCRIPTION
# Motivation

To enable selecting different networks for cross-chain swaps, we need a store to manage the list of networks shown in the modal and update filters accordingly.

# Changes

Added new modalNetworksListStore to manage network selection for the modal.

# Tests

Covered the new store with unit tests.