### PR TITLE
feat(frontend): added new filter by networks id to modal-tokens-list store

### DIFF
--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -1,11 +1,14 @@
 import { ZERO } from '$lib/constants/app.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
-import type { Network } from '$lib/types/network';
+import type { Network, NetworkId } from '$lib/types/network';
 import type { Token, TokenUi } from '$lib/types/token';
-import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
+import {
+	filterTokensForSelectedNetwork,
+	filterTokensForSelectedNetworks
+} from '$lib/utils/network.utils';
 import { filterTokens, pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, writable, type Readable } from 'svelte/store';
 
 export interface ModalTokensListData {
@@ -14,6 +17,7 @@ export interface ModalTokensListData {
 	filterNetwork?: Network;
 	filterZeroBalance?: boolean;
 	sortByBalance?: boolean;
+	filterNetworksIds?: NetworkId[];
 }
 
 export const initModalTokensListContext = (
@@ -27,6 +31,7 @@ export const initModalTokensListContext = (
 	const filterNetwork = derived([data], ([{ filterNetwork }]) => filterNetwork);
 	const filterZeroBalance = derived([data], ([{ filterZeroBalance }]) => filterZeroBalance);
 	const sortByBalance = derived([data], ([{ sortByBalance }]) => sortByBalance ?? true);
+	const filterNetworksIds = derived([data], ([{ filterNetworksIds }]) => filterNetworksIds);
 
 	const filteredTokens = derived(
 		[
@@ -36,7 +41,8 @@ export const initModalTokensListContext = (
 			filterZeroBalance,
 			sortByBalance,
 			exchanges,
-			balancesStore
+			balancesStore,
+			filterNetworksIds
 		],
 		([
 			$tokens,
@@ -45,12 +51,21 @@ export const initModalTokensListContext = (
 			$filterZeroBalance,
 			$sortByBalance,
 			$exchanges,
-			$balances
+			$balances,
+			$filterNetworksIds
 		]) => {
 			const filteredByQuery = filterTokens({ tokens: $tokens, filter: $filterQuery ?? '' });
 
+			const filteredByNetworkIds = nonNullish($filterNetworksIds)
+				? filterTokensForSelectedNetworks([
+						filteredByQuery,
+						$filterNetworksIds,
+						isNullish($filterNetworksIds)
+					])
+				: filteredByQuery;
+
 			const filteredByNetwork = filterTokensForSelectedNetwork([
-				filteredByQuery,
+				filteredByNetworkIds,
 				$filterNetwork,
 				isNullish($filterNetwork)
 			]);
@@ -89,6 +104,11 @@ export const initModalTokensListContext = (
 			update((state) => ({
 				...state,
 				filterNetwork: network
+			})),
+		setFilterNetworksIds: (networksIds: NetworkId[] | undefined) =>
+			update((state) => ({
+				...state,
+				filterNetworksIds: networksIds
 			}))
 	};
 };
@@ -100,6 +120,7 @@ export interface ModalTokensListContext {
 	setTokens: (tokens: Token[]) => void;
 	setFilterQuery: (query: string) => void;
 	setFilterNetwork: (network: Network | undefined) => void;
+	setFilterNetworksIds: (networksIds: NetworkId[] | undefined) => void;
 }
 
 export const MODAL_TOKENS_LIST_CONTEXT_KEY = Symbol('modal-tokens-list');

--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -56,13 +56,14 @@ export const initModalTokensListContext = (
 		]) => {
 			const filteredByQuery = filterTokens({ tokens: $tokens, filter: $filterQuery ?? '' });
 
-			const filteredByNetworkIds = nonNullish($filterNetworksIds)
-				? filterTokensForSelectedNetworks([
-						filteredByQuery,
-						$filterNetworksIds,
-						isNullish($filterNetworksIds)
-					])
-				: filteredByQuery;
+			const filteredByNetworkIds =
+				nonNullish($filterNetworksIds) && $filterNetworksIds.length > 0
+					? filterTokensForSelectedNetworks([
+							filteredByQuery,
+							$filterNetworksIds,
+							isNullish($filterNetworksIds)
+						])
+					: filteredByQuery;
 
 			const filteredByNetwork = filterTokensForSelectedNetwork([
 				filteredByNetworkIds,

--- a/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
@@ -266,5 +266,30 @@ describe('modalTokensListStore', () => {
 
 			expect(result).toHaveLength(2);
 		});
+
+		it('should clear filterNetworksIds when setFilterNetworksIds is called with empty array', () => {
+			const { filteredTokens } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [],
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi4, mockTokenUi3]);
+		});
+
+		it('should clear filterNetworksIds when changed setFilterNetworksIds to empty array', () => {
+			const { filteredTokens, setFilterNetworksIds } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi4, mockTokenUi3]);
+
+			setFilterNetworksIds([]);
+
+			const result = get(filteredTokens);
+
+			expect(result).toEqual([mockTokenUi4, mockTokenUi3]);
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
@@ -1,6 +1,9 @@
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { ARB_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.arb.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcToken } from '$icp/types/ic-token';
 import { ZERO } from '$lib/constants/app.constants';
@@ -128,5 +131,140 @@ describe('modalTokensListStore', () => {
 		expect(get(filterNetwork)).toBe(ICP_NETWORK);
 		expect(get(filterQuery)).toBe(undefined);
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi1]);
+	});
+
+	describe('modalTokensListStore - filterNetworksIds', () => {
+		const ethExchangeValue = 3;
+		const ethBalance = bn1Bi;
+
+		const mockToken3 = { ...ETHEREUM_TOKEN, enabled: true };
+		const mockToken4 = { ...ARB_TOKEN, enabled: true };
+
+		const mockTokenUi3 = {
+			...mockToken3,
+			balance: ethBalance,
+			usdBalance: usdValue({
+				balance: ethBalance,
+				decimals: ETHEREUM_TOKEN.decimals,
+				exchangeRate: ethExchangeValue
+			})
+		};
+		const mockTokenUi4 = {
+			...mockToken4,
+			balance: ethBalance,
+			usdBalance: usdValue({
+				balance: ethBalance,
+				decimals: ARB_TOKEN.decimals,
+				exchangeRate: ethExchangeValue
+			})
+		};
+
+		beforeEach(() => {
+			mockPage.reset();
+
+			balancesStore.set({
+				id: mockToken3.id,
+				data: { data: ethBalance, certified: true }
+			});
+			balancesStore.set({
+				id: mockToken4.id,
+				data: { data: ethBalance, certified: true }
+			});
+
+			vi.spyOn(exchanges, 'exchanges', 'get').mockImplementation(() =>
+				readable({
+					[mockToken3.id]: { usd: ethExchangeValue },
+					[mockToken4.id]: { usd: ethExchangeValue }
+				})
+			);
+		});
+
+		it('should filter tokens by filterNetworksIds when provided', () => {
+			const { filteredTokens } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [ETHEREUM_NETWORK.id],
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
+		});
+
+		it('should not filter when filterNetworksIds is undefined', () => {
+			const { filteredTokens } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterZeroBalance: false
+			});
+
+			const result = get(filteredTokens);
+
+			expect(result).toHaveLength(2);
+
+			expect(result).toEqual([mockTokenUi4, mockTokenUi3]);
+		});
+
+		it('should filter tokens by multiple network IDs', () => {
+			const { filteredTokens } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
+				filterZeroBalance: false
+			});
+
+			const result = get(filteredTokens);
+
+			expect(result).toHaveLength(2);
+			expect(result).toEqual([mockTokenUi4, mockTokenUi3]);
+		});
+
+		it('should combine filterNetworksIds with filterNetwork', () => {
+			const { filteredTokens } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
+				filterNetwork: ETHEREUM_NETWORK,
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
+		});
+
+		it('should combine filterNetworksIds with filterQuery', () => {
+			const { filteredTokens } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
+				filterQuery: 'Ethereum',
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
+		});
+
+		it('should update filterNetworksIds using setFilterNetworksIds', () => {
+			const { filteredTokens, setFilterNetworksIds } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [ETHEREUM_NETWORK.id],
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
+
+			setFilterNetworksIds([ARBITRUM_MAINNET_NETWORK.id]);
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi4]);
+		});
+
+		it('should clear filterNetworksIds when setFilterNetworksIds is called with undefined', () => {
+			const { filteredTokens, setFilterNetworksIds } = initModalTokensListContext({
+				tokens: [mockToken3, mockToken4],
+				filterNetworksIds: [ETHEREUM_NETWORK.id],
+				filterZeroBalance: false
+			});
+
+			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
+
+			setFilterNetworksIds(undefined);
+
+			const result = get(filteredTokens);
+
+			expect(result).toHaveLength(2);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

To enable selecting different networks for cross-chain swaps, we need to update modal-tokens list store to manage the list of tokens filtered by networks ids

# Changes

Added new filterNetworksIds to manage tokens selection for the modal.

# Tests

Covered the new logic with tests.