### PR TITLE
refactor(frontend): Create zod schemas for types of currency stores

### DIFF
--- a/src/frontend/src/lib/schema/currency.schema.ts
+++ b/src/frontend/src/lib/schema/currency.schema.ts
@@ -1,7 +1,7 @@
-import { Currencies } from '$lib/enums/currencies';
+import { Currency } from '$lib/enums/currency';
 import * as z from 'zod/v4';
 
-export const CurrencySchema = z.enum(Currencies);
+export const CurrencySchema = z.enum(Currency);
 
 export const CurrencyDataSchema = z.object({
 	currency: CurrencySchema

--- a/src/frontend/src/lib/schema/currency.schema.ts
+++ b/src/frontend/src/lib/schema/currency.schema.ts
@@ -1,0 +1,13 @@
+import { Currencies } from '$lib/enums/currencies';
+import * as z from 'zod/v4';
+
+export const CurrencySchema = z.enum(Currencies);
+
+export const CurrencyDataSchema = z.object({
+	currency: CurrencySchema
+});
+
+export const CurrencyExchangeDataSchema = z.object({
+	...CurrencyDataSchema.shape,
+	exchangeRateToUsd: z.number().nullable()
+});

--- a/src/frontend/src/lib/stores/currency-exchange.store.ts
+++ b/src/frontend/src/lib/stores/currency-exchange.store.ts
@@ -1,10 +1,6 @@
 import { Currencies } from '$lib/enums/currencies';
-import type { CurrencyData } from '$lib/stores/currency.store';
+import type { CurrencyExchangeData } from '$lib/types/currency';
 import { writable, type Readable } from 'svelte/store';
-
-export interface CurrencyExchangeData extends CurrencyData {
-	exchangeRateToUsd: number | null;
-}
 
 export interface CurrencyExchangeStore extends Readable<CurrencyExchangeData> {
 	setExchangeRateCurrency: (currency: CurrencyExchangeData['currency']) => void;

--- a/src/frontend/src/lib/stores/currency-exchange.store.ts
+++ b/src/frontend/src/lib/stores/currency-exchange.store.ts
@@ -1,7 +1,5 @@
-import { Currencies } from '$lib/enums/currencies';
-import type { CurrencyExchangeData } from '$lib/types/currency';
 import { Currency } from '$lib/enums/currency';
-import type { CurrencyData } from '$lib/stores/currency.store';
+import type { CurrencyExchangeData } from '$lib/types/currency';
 import { writable, type Readable } from 'svelte/store';
 
 export interface CurrencyExchangeStore extends Readable<CurrencyExchangeData> {

--- a/src/frontend/src/lib/stores/currency.store.ts
+++ b/src/frontend/src/lib/stores/currency.store.ts
@@ -1,11 +1,8 @@
 import { Currencies } from '$lib/enums/currencies';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { initStorageStore } from '$lib/stores/storage.store';
+import type { CurrencyData } from '$lib/types/currency';
 import type { Readable } from 'svelte/store';
-
-export interface CurrencyData {
-	currency: Currencies;
-}
 
 export interface CurrencyStore extends Readable<CurrencyData> {
 	switchCurrency: (currency: CurrencyData['currency']) => void;

--- a/src/frontend/src/lib/types/currency.ts
+++ b/src/frontend/src/lib/types/currency.ts
@@ -1,4 +1,4 @@
-import { CurrencyExchangeDataSchema, type CurrencyDataSchema } from '$lib/schema/currency.schema';
+import type { CurrencyExchangeDataSchema, CurrencyDataSchema } from '$lib/schema/currency.schema';
 import type * as z from 'zod/v4';
 
 export type CurrencyData = z.infer<typeof CurrencyDataSchema>;

--- a/src/frontend/src/lib/types/currency.ts
+++ b/src/frontend/src/lib/types/currency.ts
@@ -1,4 +1,4 @@
-import type { CurrencyExchangeDataSchema, CurrencyDataSchema } from '$lib/schema/currency.schema';
+import type { CurrencyDataSchema, CurrencyExchangeDataSchema } from '$lib/schema/currency.schema';
 import type * as z from 'zod/v4';
 
 export type CurrencyData = z.infer<typeof CurrencyDataSchema>;

--- a/src/frontend/src/lib/types/currency.ts
+++ b/src/frontend/src/lib/types/currency.ts
@@ -1,0 +1,6 @@
+import { CurrencyExchangeDataSchema, type CurrencyDataSchema } from '$lib/schema/currency.schema';
+import type * as z from 'zod/v4';
+
+export type CurrencyData = z.infer<typeof CurrencyDataSchema>;
+
+export type CurrencyExchangeData = z.infer<typeof CurrencyExchangeDataSchema>;

--- a/src/frontend/src/tests/lib/stores/currency.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/currency.store.spec.ts
@@ -1,10 +1,7 @@
 import { Currencies } from '$lib/enums/currencies';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
-import {
-	initCurrencyStore,
-	type CurrencyData,
-	type CurrencyStore
-} from '$lib/stores/currency.store';
+import { initCurrencyStore, type CurrencyStore } from '$lib/stores/currency.store';
+import type { CurrencyData } from '$lib/types/currency';
 import { get as getStorage } from '$lib/utils/storage.utils';
 import { get } from 'svelte/store';
 


### PR DESCRIPTION
# Motivation

We will need the interfaces and types of the currency stores to be used by the workers types too. Since the latter are set in zod, it seems a good time to migrate the others to zod too.
