### PR TITLE
feat(frontend): Remove deprecated zod method `.merge`

### DIFF
--- a/src/frontend/src/env/schema/env-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-icrc-token.schema.ts
@@ -13,8 +13,10 @@ export const EnvIcrcTokenIconSchema = z.object({
 	icon: z.string().optional()
 });
 
-export const EnvIcrcTokenMetadataWithIconSchema =
-	EnvIcrcTokenMetadataSchema.merge(EnvIcrcTokenIconSchema);
+export const EnvIcrcTokenMetadataWithIconSchema = z.object({
+	...EnvIcrcTokenMetadataSchema.shape,
+	...EnvIcrcTokenIconSchema.shape
+});
 
 export const EnvIcTokenSchema = z.object({
 	ledgerCanisterId: z.string(),

--- a/src/frontend/src/env/schema/env-sns-token.schema.ts
+++ b/src/frontend/src/env/schema/env-sns-token.schema.ts
@@ -2,9 +2,11 @@ import { EnvIcrcTokenMetadataSchema, EnvIcTokenSchema } from '$env/schema/env-ic
 import { IcTokenDeprecatedSchema } from '$icp/schema/ic-token-deprecated.schema';
 import * as z from 'zod/v4';
 
-export const EnvSnsTokenSchema = EnvIcTokenSchema.extend({
+export const EnvSnsTokenSchema = z.object({
+	...EnvIcTokenSchema.shape,
 	rootCanisterId: z.string(),
-	metadata: EnvIcrcTokenMetadataSchema
-}).merge(IcTokenDeprecatedSchema);
+	metadata: EnvIcrcTokenMetadataSchema,
+	...IcTokenDeprecatedSchema.shape
+});
 
 export const EnvSnsTokensSchema = z.array(EnvSnsTokenSchema);

--- a/src/frontend/src/env/schema/env-token-ckerc20.schema.ts
+++ b/src/frontend/src/env/schema/env-token-ckerc20.schema.ts
@@ -16,9 +16,10 @@ export const EnvCkErc20TokenDataSchema = EnvIcTokenSchema.extend({
 	erc20ContractAddress: EnvErc20ContractAddressSchema
 });
 
-export const EnvCkErc20WithMetadataSchema = EnvCkErc20TokenDataSchema.merge(
-	EnvIcrcTokenMetadataSchema
-);
+export const EnvCkErc20WithMetadataSchema = z.object({
+	...EnvCkErc20TokenDataSchema.shape,
+	...EnvIcrcTokenMetadataSchema.shape
+});
 
 export const EnvCkErc20TokensRawSchema = z.record(
 	EnvTokenSymbolSchema,

--- a/src/frontend/src/icp/schema/ic-token.schema.ts
+++ b/src/frontend/src/icp/schema/ic-token.schema.ts
@@ -34,15 +34,27 @@ export const IcCkMetadataSchema = IcCkLinkedAssetsSchema.partial().extend({
 	minterCanisterId: CanisterIdTextSchema
 });
 
-export const IcInterfaceSchema = IcCanistersSchema.merge(IcAppMetadataSchema);
+export const IcInterfaceSchema = z.object({
+	...IcCanistersSchema.shape,
+	...IcAppMetadataSchema.shape
+});
 
-export const IcTokenSchema = TokenSchema.merge(IcFeeSchema)
-	.merge(IcInterfaceSchema)
-	.merge(IcTokenDeprecatedSchema);
+export const IcTokenSchema = z.object({
+	...TokenSchema.shape,
+	...IcFeeSchema.shape,
+	...IcInterfaceSchema.shape,
+	...IcTokenDeprecatedSchema.shape
+});
 
 export const IcTokenWithoutIdSchema = IcTokenSchema.omit({ id: true }).strict();
 
-export const IcCkTokenSchema = IcTokenSchema.merge(IcCkMetadataSchema.partial());
+export const IcCkTokenSchema = z.object({
+	...IcTokenSchema.shape,
+	...IcCkMetadataSchema.partial().shape
+});
 
-export const IcCkInterfaceSchema =
-	IcInterfaceSchema.merge(IcCkMetadataSchema).merge(TokenGroupPropSchema);
+export const IcCkInterfaceSchema = z.object({
+	...IcInterfaceSchema.shape,
+	...IcCkMetadataSchema.shape,
+	...TokenGroupPropSchema.shape
+});

--- a/src/frontend/src/lib/schema/nft.schema.ts
+++ b/src/frontend/src/lib/schema/nft.schema.ts
@@ -14,12 +14,11 @@ export const NftMetadataSchema = z.object({
 	attributes: z.array(NftAttributeSchema).optional()
 });
 
-export const NftSchema = z
-	.object({
-		contract: z.object({
-			address: z.string(),
-			enabled: z.boolean(),
-			name: z.string()
-		})
-	})
-	.merge(NftMetadataSchema);
+export const NftSchema = z.object({
+	contract: z.object({
+		address: z.string(),
+		enabled: z.boolean(),
+		name: z.string()
+	}),
+	...NftMetadataSchema.shape
+});

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -71,13 +71,15 @@ export const PostMessageDataRequestExchangeTimerSchema = z.object({
 	splAddresses: z.array(z.custom<SplTokenAddress>())
 });
 
-export const PostMessageDataRequestIcrcSchema = IcCanistersSchema.merge(
-	NetworkSchema.pick({ env: true })
-);
+export const PostMessageDataRequestIcrcSchema = z.object({
+	...IcCanistersSchema.shape,
+	...NetworkSchema.pick({ env: true }).shape
+});
 
-export const PostMessageDataRequestIcrcStrictSchema = IcCanistersStrictSchema.merge(
-	NetworkSchema.pick({ env: true })
-);
+export const PostMessageDataRequestIcrcStrictSchema = z.object({
+	...IcCanistersStrictSchema.shape,
+	...NetworkSchema.pick({ env: true }).shape
+});
 
 export const PostMessageDataRequestDip20Schema = z.object({
 	canisterId: CanisterIdTextSchema

--- a/src/frontend/src/lib/schema/token.schema.ts
+++ b/src/frontend/src/lib/schema/token.schema.ts
@@ -52,14 +52,13 @@ export const TokenBuyableSchema = z.object({
 	buy: z.custom<AtLeastOne<TokenBuy>>().optional()
 });
 
-export const TokenSchema = z
-	.object({
-		id: TokenIdSchema,
-		network: NetworkSchema,
-		standard: TokenStandardSchema,
-		category: TokenCategorySchema
-	})
-	.merge(TokenMetadataSchema)
-	.merge(TokenAppearanceSchema)
-	.merge(TokenBuyableSchema)
-	.merge(TokenGroupPropSchema);
+export const TokenSchema = z.object({
+	id: TokenIdSchema,
+	network: NetworkSchema,
+	standard: TokenStandardSchema,
+	category: TokenCategorySchema,
+	...TokenMetadataSchema.shape,
+	...TokenAppearanceSchema.shape,
+	...TokenBuyableSchema.shape,
+	...TokenGroupPropSchema.shape
+});


### PR DESCRIPTION
# Motivation

As per [zod documentation](https://zod.dev/v4/changelog?id=deprecates-merge), the `.merge` method is deprecated.

The suggestion is to replace it:

```
// .merge (deprecated)
const ExtendedSchema = BaseSchema.merge(AdditionalSchema);
 
// .extend (recommended)
const ExtendedSchema = BaseSchema.extend(AdditionalSchema.shape);
 
// or use destructuring (best tsc performance)
const ExtendedSchema = z.object({
  ...BaseSchema.shape,
  ...AdditionalSchema.shape,
});
```

We choose the deconstruction.

# Changes

- Change all instances of `.merge` to a deconstruction method.

# Tests

All current tests should work as usual.
