### PR TITLE
feat(frontend): Add custom currency to util `formatCurrency`

### DIFF
--- a/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountExchange.svelte
@@ -7,6 +7,7 @@
 		CONVERT_AMOUNT_EXCHANGE_SKELETON,
 		CONVERT_AMOUNT_EXCHANGE_VALUE
 	} from '$lib/constants/test-ids.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import type { OptionAmount } from '$lib/types/send';
 	import { formatCurrency } from '$lib/utils/format.utils';
 
@@ -23,7 +24,8 @@
 				value:
 					usdValue === 0 || usdValue > EXCHANGE_USD_AMOUNT_THRESHOLD
 						? usdValue
-						: EXCHANGE_USD_AMOUNT_THRESHOLD
+						: EXCHANGE_USD_AMOUNT_THRESHOLD,
+				currency: $currentCurrency
 			})
 		: undefined;
 </script>

--- a/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeAmountDisplay.svelte
@@ -3,6 +3,7 @@
 	import { fade } from 'svelte/transition';
 	import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
 	import { EXCHANGE_USD_AMOUNT_THRESHOLD } from '$lib/constants/exchange.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { usdValue } from '$lib/utils/exchange.utils';
 	import { formatToken, formatCurrency } from '$lib/utils/format.utils';
 
@@ -35,10 +36,11 @@
 		<div class="text-tertiary">
 			{#if usdAmount < EXCHANGE_USD_AMOUNT_THRESHOLD}
 				{`( < ${formatCurrency({
-					value: EXCHANGE_USD_AMOUNT_THRESHOLD
+					value: EXCHANGE_USD_AMOUNT_THRESHOLD,
+					currency: $currentCurrency
 				})} )`}
 			{:else}
-				{`( ${formatCurrency({ value: usdAmount })} )`}
+				{`( ${formatCurrency({ value: usdAmount, currency: $currentCurrency })} )`}
 			{/if}
 		</div>
 	{/if}

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -4,6 +4,7 @@
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import DelayedTooltip from '$lib/components/ui/DelayedTooltip.svelte';
 	import { allBalancesZero } from '$lib/derived/balances.derived';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
@@ -29,14 +30,14 @@
 			{#if hideBalance}
 				<IconDots variant="lg" times={6} styleClass="my-4.25" />
 			{:else}
-				{formatCurrency({ value: totalUsd })}
+				{formatCurrency({ value: totalUsd, currency: $currentCurrency })}
 			{/if}
 		{:else}
 			<span class="animate-pulse">
 				{#if hideBalance}
 					<IconDots variant="lg" times={6} styleClass="my-4.25" />
 				{:else}
-					{formatCurrency({ value: 0 })}
+					{formatCurrency({ value: 0, currency: $currentCurrency })}
 				{/if}
 			</span>
 		{/if}

--- a/src/frontend/src/lib/components/networks/NetworkButton.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkButton.svelte
@@ -6,6 +6,7 @@
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LabelSize } from '$lib/types/components';
@@ -73,7 +74,7 @@ TODO: Find a way to have the "All networks" not be a fallback for undefined netw
 					{#if $isPrivacyMode}
 						<IconDots variant="xs" />
 					{:else}
-						{formatCurrency({ value: usdBalance })}
+						{formatCurrency({ value: usdBalance, currency: $currentCurrency })}
 					{/if}
 				{/if}
 			</span>

--- a/src/frontend/src/lib/components/rewards/RewardEarnings.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardEarnings.svelte
@@ -18,6 +18,7 @@
 	} from '$lib/constants/test-ids.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { networkId } from '$lib/derived/network.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
@@ -128,7 +129,7 @@
 			class:animate-pulse={loading}
 			>{replacePlaceholders($i18n.rewards.text.sprinkles_earned, {
 				$noOfSprinkles: amountOfRewards.toString(),
-				$amount: formatCurrency({ value: totalRewardUsd })
+				$amount: formatCurrency({ value: totalRewardUsd, currency: $currentCurrency })
 			})}
 		</div>
 

--- a/src/frontend/src/lib/components/rewards/RewardEarningsCard.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardEarningsCard.svelte
@@ -5,6 +5,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { formatToken, formatCurrency } from '$lib/utils/format.utils';
 
 	interface Props {
@@ -25,7 +26,9 @@
 		})
 	);
 
-	const displayUsdAmount = $derived(formatCurrency({ value: usdAmount }));
+	const displayUsdAmount = $derived(
+		formatCurrency({ value: usdAmount, currency: $currentCurrency })
+	);
 </script>
 
 {#if nonNullish(token)}

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -8,6 +8,7 @@
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { EXCHANGE_USD_AMOUNT_THRESHOLD } from '$lib/constants/exchange.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import { formatToken, formatCurrency } from '$lib/utils/format.utils';
@@ -59,11 +60,13 @@
 					{sourceTokenTransferFee + sourceTokenApproveFee} {getTokenDisplaySymbol($sourceToken)}
 				{:else if sourceTokenTotalFeeUSD < EXCHANGE_USD_AMOUNT_THRESHOLD}
 					{`< ${formatCurrency({
-						value: EXCHANGE_USD_AMOUNT_THRESHOLD
+						value: EXCHANGE_USD_AMOUNT_THRESHOLD,
+						currency: $currentCurrency
 					})}`}
 				{:else}
 					{formatCurrency({
-						value: sourceTokenTotalFeeUSD
+						value: sourceTokenTotalFeeUSD,
+						currency: $currentCurrency
 					})}
 				{/if}
 			{/snippet}

--- a/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
@@ -14,6 +14,7 @@
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { SwapMappedResult } from '$lib/types/swap';
 	import { formatTokenBigintToNumber, formatCurrency } from '$lib/utils/format.utils';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 
 	const dispatch = createEventDispatcher<{
 		icSelectProvider: SwapMappedResult;
@@ -44,7 +45,7 @@
 				displayDecimals: token.decimals
 			}) * exchangeRate;
 
-		return formatCurrency({ value: usdValue });
+		return formatCurrency({ value: usdValue, currency: $currentCurrency });
 	};
 </script>
 

--- a/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProviderListModal.svelte
@@ -6,6 +6,7 @@
 	import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		SWAP_AMOUNTS_CONTEXT_KEY,
@@ -14,7 +15,6 @@
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { SwapMappedResult } from '$lib/types/swap';
 	import { formatTokenBigintToNumber, formatCurrency } from '$lib/utils/format.utils';
-	import { currentCurrency } from '$lib/derived/currency.derived';
 
 	const dispatch = createEventDispatcher<{
 		icSelectProvider: SwapMappedResult;

--- a/src/frontend/src/lib/components/tokens/TokenExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeBalance.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenFinancialData } from '$lib/types/token';
 	import { formatCurrency } from '$lib/utils/format.utils';
@@ -11,7 +12,7 @@
 
 <output class="break-all">
 	{#if nonNullish(balance) && nonNullish(usdBalance)}
-		{formatCurrency({ value: usdBalance })}
+		{formatCurrency({ value: usdBalance, currency: $currentCurrency })}
 	{:else if isNullish(balance) || isNullish(usdBalance)}
 		<span class="animate-pulse">{nullishBalanceMessage ?? '-'}</span>
 	{:else}

--- a/src/frontend/src/lib/components/tokens/TokenInputAmountExchange.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputAmountExchange.svelte
@@ -12,6 +12,7 @@
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import { formatCurrency } from '$lib/utils/format.utils';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 
 	export let amount: OptionAmount;
 	export let exchangeRate: number | undefined;
@@ -25,7 +26,8 @@
 
 	let formattedUSDAmount: string | undefined;
 	$: formattedUSDAmount = formatCurrency({
-		value: nonNullish(amount) && nonNullish(exchangeRate) ? Number(amount) * exchangeRate : 0
+		value: nonNullish(amount) && nonNullish(exchangeRate) ? Number(amount) * exchangeRate : 0,
+		currency : $currentCurrency
 	});
 
 	let formattedTokenAmount: string | undefined;

--- a/src/frontend/src/lib/components/tokens/TokenInputAmountExchange.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputAmountExchange.svelte
@@ -7,12 +7,12 @@
 		TOKEN_INPUT_AMOUNT_EXCHANGE_UNAVAILABLE,
 		TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE
 	} from '$lib/constants/test-ids.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import { formatCurrency } from '$lib/utils/format.utils';
-	import { currentCurrency } from '$lib/derived/currency.derived';
 
 	export let amount: OptionAmount;
 	export let exchangeRate: number | undefined;
@@ -27,7 +27,7 @@
 	let formattedUSDAmount: string | undefined;
 	$: formattedUSDAmount = formatCurrency({
 		value: nonNullish(amount) && nonNullish(exchangeRate) ? Number(amount) * exchangeRate : 0,
-		currency : $currentCurrency
+		currency: $currentCurrency
 	});
 
 	let formattedTokenAmount: string | undefined;

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -1,6 +1,6 @@
 import { ETHEREUM_DEFAULT_DECIMALS } from '$env/tokens/tokens.eth.env';
 import { MILLISECONDS_IN_DAY, NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
-import type { Currencies } from '$lib/enums/currencies';
+import type { Currency } from '$lib/enums/currency';
 import { Languages } from '$lib/enums/languages';
 import type { AmountString } from '$lib/types/amount';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -173,7 +173,7 @@ export const formatCurrency = ({
 	options
 }: {
 	value: number;
-	currency: Currencies;
+	currency: Currency;
 	options?: {
 		minFraction?: number;
 		maxFraction?: number;

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -1,5 +1,6 @@
 import { ETHEREUM_DEFAULT_DECIMALS } from '$env/tokens/tokens.eth.env';
 import { MILLISECONDS_IN_DAY, NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
+import type { Currencies } from '$lib/enums/currencies';
 import { Languages } from '$lib/enums/languages';
 import type { AmountString } from '$lib/types/amount';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -168,9 +169,11 @@ export const formatSecondsToNormalizedDate = ({
 
 export const formatCurrency = ({
 	value,
+	currency,
 	options
 }: {
 	value: number;
+	currency: Currencies;
 	options?: {
 		minFraction?: number;
 		maxFraction?: number;
@@ -178,15 +181,10 @@ export const formatCurrency = ({
 		symbol?: boolean;
 	};
 }): string => {
-	const {
-		minFraction = 2,
-		maxFraction = 2,
-		maximumSignificantDigits,
-		symbol = true
-	} = options ?? {};
+	const { minFraction, maxFraction, maximumSignificantDigits, symbol = true } = options ?? {};
 
 	return new Intl.NumberFormat('en-US', {
-		...(symbol && { style: 'currency', currency: 'USD' }),
+		...(symbol && { style: 'currency', currency: currency.toUpperCase() }),
 		minimumFractionDigits: minFraction,
 		maximumFractionDigits: maxFraction,
 		...(nonNullish(maximumSignificantDigits) && { maximumSignificantDigits })

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeAmountDisplay.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeAmountDisplay.spec.ts
@@ -1,6 +1,6 @@
 import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
 import { EXCHANGE_USD_AMOUNT_THRESHOLD } from '$lib/constants/exchange.constants';
-import { Currencies } from '$lib/enums/currencies';
+import { Currency } from '$lib/enums/currency';
 import { formatCurrency } from '$lib/utils/format.utils';
 import { render } from '@testing-library/svelte';
 
@@ -38,7 +38,7 @@ describe('ExchangeAmountDisplay', () => {
 		it('should correctly render the USD amount if it is greater or equal than the threshold', () => {
 			const mockExchangeRateBigAmount = (EXCHANGE_USD_AMOUNT_THRESHOLD * 2) / mockAmountNumber;
 
-			const expectedUsdAmount = `( ${formatCurrency({ value: mockAmountNumber * mockExchangeRateBigAmount, currency: Currencies.USD })} )`;
+			const expectedUsdAmount = `( ${formatCurrency({ value: mockAmountNumber * mockExchangeRateBigAmount, currency: Currency.USD })} )`;
 
 			const { getByText } = render(ExchangeAmountDisplay, {
 				props: { ...mockProps, exchangeRate: mockExchangeRateBigAmount }
@@ -50,7 +50,7 @@ describe('ExchangeAmountDisplay', () => {
 		it('should render the threshold if the USD amount is less the threshold', () => {
 			const mockExchangeRateSmallAmount = EXCHANGE_USD_AMOUNT_THRESHOLD / 2 / mockAmountNumber;
 
-			const expectedUsdAmount = `( < ${formatCurrency({ value: EXCHANGE_USD_AMOUNT_THRESHOLD, currency: Currencies.USD })} )`;
+			const expectedUsdAmount = `( < ${formatCurrency({ value: EXCHANGE_USD_AMOUNT_THRESHOLD, currency: Currency.USD })} )`;
 
 			const { getByText } = render(ExchangeAmountDisplay, {
 				props: { ...mockProps, exchangeRate: mockExchangeRateSmallAmount }

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeAmountDisplay.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeAmountDisplay.spec.ts
@@ -1,5 +1,6 @@
 import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
 import { EXCHANGE_USD_AMOUNT_THRESHOLD } from '$lib/constants/exchange.constants';
+import { Currencies } from '$lib/enums/currencies';
 import { formatCurrency } from '$lib/utils/format.utils';
 import { render } from '@testing-library/svelte';
 
@@ -37,7 +38,7 @@ describe('ExchangeAmountDisplay', () => {
 		it('should correctly render the USD amount if it is greater or equal than the threshold', () => {
 			const mockExchangeRateBigAmount = (EXCHANGE_USD_AMOUNT_THRESHOLD * 2) / mockAmountNumber;
 
-			const expectedUsdAmount = `( ${formatCurrency({ value: mockAmountNumber * mockExchangeRateBigAmount })} )`;
+			const expectedUsdAmount = `( ${formatCurrency({ value: mockAmountNumber * mockExchangeRateBigAmount, currency: Currencies.USD })} )`;
 
 			const { getByText } = render(ExchangeAmountDisplay, {
 				props: { ...mockProps, exchangeRate: mockExchangeRateBigAmount }
@@ -49,7 +50,7 @@ describe('ExchangeAmountDisplay', () => {
 		it('should render the threshold if the USD amount is less the threshold', () => {
 			const mockExchangeRateSmallAmount = EXCHANGE_USD_AMOUNT_THRESHOLD / 2 / mockAmountNumber;
 
-			const expectedUsdAmount = `( < ${formatCurrency({ value: EXCHANGE_USD_AMOUNT_THRESHOLD })} )`;
+			const expectedUsdAmount = `( < ${formatCurrency({ value: EXCHANGE_USD_AMOUNT_THRESHOLD, currency: Currencies.USD })} )`;
 
 			const { getByText } = render(ExchangeAmountDisplay, {
 				props: { ...mockProps, exchangeRate: mockExchangeRateSmallAmount }

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,6 +1,6 @@
 import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 import { DEFAULT_BITCOIN_TOKEN } from '$lib/constants/tokens.constants';
-import { Currencies } from '$lib/enums/currencies';
+import { Currency } from '$lib/enums/currency';
 import { Languages } from '$lib/enums/languages';
 import {
 	formatCurrency,
@@ -586,21 +586,21 @@ describe('format.utils', () => {
 	});
 
 	describe('formatCurrency', () => {
-		const testCases: { value: number; currency: Currencies; expected: string }[] = [
-			{ value: 1234.56, currency: Currencies.USD, expected: '$1’234.56' },
-			{ value: 987654321.12, currency: Currencies.EUR, expected: '€987’654’321.12' },
-			{ value: 0.99, currency: Currencies.GBP, expected: '£0.99' },
-			{ value: 1000000, currency: Currencies.JPY, expected: '¥1’000’000' },
+		const testCases: { value: number; currency: Currency; expected: string }[] = [
+			{ value: 1234.56, currency: Currency.USD, expected: '$1’234.56' },
+			{ value: 987654321.12, currency: Currency.EUR, expected: '€987’654’321.12' },
+			{ value: 0.99, currency: Currency.GBP, expected: '£0.99' },
+			{ value: 1000000, currency: Currency.JPY, expected: '¥1’000’000' },
 
-			{ value: 123456789.99, currency: Currencies.CHF, expected: 'CHF 123’456’789.99' },
-			{ value: 0, currency: Currencies.USD, expected: '$0.00' },
-			{ value: -1234.56, currency: Currencies.USD, expected: '-$1’234.56' },
-			{ value: -987654321.12, currency: Currencies.EUR, expected: '-€987’654’321.12' },
-			{ value: 12345, currency: Currencies.GBP, expected: '£12’345.00' },
+			{ value: 123456789.99, currency: Currency.CHF, expected: 'CHF 123’456’789.99' },
+			{ value: 0, currency: Currency.USD, expected: '$0.00' },
+			{ value: -1234.56, currency: Currency.USD, expected: '-$1’234.56' },
+			{ value: -987654321.12, currency: Currency.EUR, expected: '-€987’654’321.12' },
+			{ value: 12345, currency: Currency.GBP, expected: '£12’345.00' },
 
-			{ value: 1000000.99, currency: Currencies.JPY, expected: '¥1’000’001' },
-			{ value: 1000000.4, currency: Currencies.JPY, expected: '¥1’000’000' },
-			{ value: 123456789.12345, currency: Currencies.CHF, expected: 'CHF 123’456’789.12' }
+			{ value: 1000000.99, currency: Currency.JPY, expected: '¥1’000’001' },
+			{ value: 1000000.4, currency: Currency.JPY, expected: '¥1’000’000' },
+			{ value: 123456789.12345, currency: Currency.CHF, expected: 'CHF 123’456’789.12' }
 		];
 
 		it.each(testCases)(

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -599,7 +599,8 @@ describe('format.utils', () => {
 			{ value: 12345, currency: Currencies.GBP, expected: '£12’345.00' },
 
 			{ value: 1000000.99, currency: Currencies.JPY, expected: '¥1’000’001' },
-			{ value: 1000000.4, currency: Currencies.JPY, expected: '¥1’000’000' }
+			{ value: 1000000.4, currency: Currencies.JPY, expected: '¥1’000’000' },
+			{ value: 123456789.12345, currency: Currencies.CHF, expected: 'CHF 123’456’789.12' }
 		];
 
 		it.each(testCases)(

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1,7 +1,9 @@
 import { EIGHT_DECIMALS, ZERO } from '$lib/constants/app.constants';
 import { DEFAULT_BITCOIN_TOKEN } from '$lib/constants/tokens.constants';
+import { Currencies } from '$lib/enums/currencies';
 import { Languages } from '$lib/enums/languages';
 import {
+	formatCurrency,
 	formatNanosecondsToDate,
 	formatSecondsToDate,
 	formatSecondsToNormalizedDate,
@@ -9,6 +11,7 @@ import {
 	formatToken,
 	formatTokenBigintToNumber
 } from '$lib/utils/format.utils';
+import { describe } from 'vitest';
 
 describe('format.utils', () => {
 	describe('formatToken', () => {
@@ -580,5 +583,30 @@ describe('format.utils', () => {
 				})
 			).toBe(0);
 		});
+	});
+
+	describe('formatCurrency', () => {
+		const testCases: { value: number; currency: Currencies; expected: string }[] = [
+			{ value: 1234.56, currency: Currencies.USD, expected: '$1’234.56' },
+			{ value: 987654321.12, currency: Currencies.EUR, expected: '€987’654’321.12' },
+			{ value: 0.99, currency: Currencies.GBP, expected: '£0.99' },
+			{ value: 1000000, currency: Currencies.JPY, expected: '¥1’000’000' },
+
+			{ value: 123456789.99, currency: Currencies.CHF, expected: 'CHF 123’456’789.99' },
+			{ value: 0, currency: Currencies.USD, expected: '$0.00' },
+			{ value: -1234.56, currency: Currencies.USD, expected: '-$1’234.56' },
+			{ value: -987654321.12, currency: Currencies.EUR, expected: '-€987’654’321.12' },
+			{ value: 12345, currency: Currencies.GBP, expected: '£12’345.00' },
+
+			{ value: 1000000.99, currency: Currencies.JPY, expected: '¥1’000’001' },
+			{ value: 1000000.4, currency: Currencies.JPY, expected: '¥1’000’000' }
+		];
+
+		it.each(testCases)(
+			`should format value $value for currency $currency as expected`,
+			({ value, currency, expected }) => {
+				expect(formatCurrency({ value, currency })).toBe(expected);
+			}
+		);
 	});
 });


### PR DESCRIPTION
# Motivation

We will let the users choose their own currency. So, we need to start formatting it correctly (some of them have 3 decimals, other no decimals at all).

The `Intl` library knows these rules when `currency` is selected in method `NumberFormat`, so we can rely on it (see [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#currency_formatting)).

# Changes

- Add currency param in util `formatCurrency`.
- Use it to define the currency in `Intl.NumberFormat()`.
- Adapt the consumers to use the store `currentCurrency`.
- Remove constraints of minimum and maximum digits: the library knows exactly how many digits each currency should have.

# Tests

Added test cases.
