### PR TITLE
feat(frontend): Sync balances from IDB cache during initial wallet sync

### DIFF
--- a/src/frontend/src/lib/api/idb-balances.api.ts
+++ b/src/frontend/src/lib/api/idb-balances.api.ts
@@ -44,7 +44,7 @@ export const setIdbBalancesStore = async ({
 	);
 };
 
-export const getIdbBalances = (params: GetIdbBalancesParams): Promise<Balance[] | undefined> =>
+export const getIdbBalances = (params: GetIdbBalancesParams): Promise<Balance | undefined> =>
 	get(toKey(params), idbBalancesStore);
 
 export const deleteIdbBalances = (principal: Principal): Promise<void> =>

--- a/src/frontend/src/lib/services/listener.services.ts
+++ b/src/frontend/src/lib/services/listener.services.ts
@@ -1,11 +1,61 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
+import { getIdbBalances } from '$lib/api/idb-balances.api';
 import { authIdentity } from '$lib/derived/auth.derived';
+import { balancesStore } from '$lib/stores/balances.store';
 import type { TransactionsStore } from '$lib/stores/transactions.store';
 import type { GetIdbTransactionsParams } from '$lib/types/idb-transactions';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
+
+const syncTransactionsFromCache = async <
+	T extends BtcTransactionUi | IcTransactionUi | SolTransactionUi
+>({
+	tokenId,
+	getIdbTransactions,
+	transactionsStore,
+	...params
+}: GetIdbTransactionsParams & {
+	getIdbTransactions: (params: GetIdbTransactionsParams) => Promise<T[] | undefined>;
+	transactionsStore: TransactionsStore<T>;
+}) => {
+	const transactions = await getIdbTransactions({
+		...params,
+		tokenId
+	});
+
+	if (isNullish(transactions)) {
+		return;
+	}
+
+	transactionsStore.append({
+		tokenId,
+		transactions: transactions.map((transaction) => ({
+			data: transaction,
+			certified: false
+		}))
+	});
+};
+
+const syncBalancesFromCache = async ({ tokenId, ...params }: GetIdbTransactionsParams) => {
+	const balance = await getIdbBalances({
+		...params,
+		tokenId
+	});
+
+	if (isNullish(balance)) {
+		return;
+	}
+
+	balancesStore.set({
+		id: tokenId,
+		data: {
+			data: balance,
+			certified: false
+		}
+	});
+};
 
 export const syncWalletFromIdbCache = async <
 	T extends BtcTransactionUi | IcTransactionUi | SolTransactionUi
@@ -26,21 +76,19 @@ export const syncWalletFromIdbCache = async <
 		return;
 	}
 
-	const transactions = await getIdbTransactions({
-		...params,
+	const principal = identity.getPrincipal();
+
+	await syncTransactionsFromCache<T>({
 		tokenId,
-		principal: identity.getPrincipal()
+		getIdbTransactions,
+		transactionsStore,
+		principal,
+		...params
 	});
 
-	if (isNullish(transactions)) {
-		return;
-	}
-
-	transactionsStore.append({
+	await syncBalancesFromCache({
 		tokenId,
-		transactions: transactions.map((transaction) => ({
-			data: transaction,
-			certified: false
-		}))
+		principal,
+		...params
 	});
 };

--- a/src/frontend/src/lib/services/listener.services.ts
+++ b/src/frontend/src/lib/services/listener.services.ts
@@ -57,7 +57,6 @@ const syncBalancesFromCache = async ({ tokenId, ...params }: GetIdbTransactionsP
 	});
 };
 
-
 export const syncWalletFromIdbCache = async <
 	T extends BtcTransactionUi | IcTransactionUi | SolTransactionUi
 >({


### PR DESCRIPTION
# Motivation

Similar to what we did for transactions, we sync the IDB cache with our balances store when there is the first initialization sync.

# Changes

- Created service to get a balance from IDB cache by token.
- Use the new service in `syncWalletFromIdbCache`.

# Tests

New tests.
