### PR TITLE
fix(frontend): Correct type in service `getIdbBalances`

### DIFF
--- a/src/frontend/src/lib/api/idb-balances.api.ts
+++ b/src/frontend/src/lib/api/idb-balances.api.ts
@@ -44,7 +44,7 @@ export const setIdbBalancesStore = async ({
 	);
 };
 
-export const getIdbBalances = (params: GetIdbBalancesParams): Promise<Balance[] | undefined> =>
+export const getIdbBalances = (params: GetIdbBalancesParams): Promise<Balance | undefined> =>
 	get(toKey(params), idbBalancesStore);
 
 export const deleteIdbBalances = (principal: Principal): Promise<void> =>


### PR DESCRIPTION
# Motivation

The return type of `getIdbBalances` is not a possible array of `Balance` but a single possible `Balance`.
