### PR TITLE
feat(frontend): component to save the IDB store for balances

### DIFF
--- a/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
+++ b/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
@@ -1,19 +1,9 @@
 <script lang="ts">
 	import { type Snippet, untrack } from 'svelte';
-	import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
-	import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
-	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import { setIdbBalancesStore } from '$lib/api/idb-balances.api';
-	import {
-		setIdbBtcTransactions,
-		setIdbEthTransactions,
-		setIdbIcTransactions,
-		setIdbSolTransactions
-	} from '$lib/api/idb-transactions.api';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledTokens } from '$lib/derived/tokens.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
-	import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 
 	interface Props {
 		children?: Snippet;

--- a/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
+++ b/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
@@ -3,6 +3,7 @@
 	import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 	import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
+	import { setIdbBalancesStore } from '$lib/api/idb-balances.api';
 	import {
 		setIdbBtcTransactions,
 		setIdbEthTransactions,
@@ -11,16 +12,14 @@
 	} from '$lib/api/idb-transactions.api';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledTokens } from '$lib/derived/tokens.derived';
-	import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
-	import { setIdbBalancesStore } from '$lib/api/idb-balances.api';
 	import { balancesStore } from '$lib/stores/balances.store';
+	import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 
 	interface Props {
 		children?: Snippet;
 	}
 
 	let { children }: Props = $props();
-
 
 	// We don't need to track identity and tokens changes for every store, since we are interested in the final result of the balances store.
 	// And the balances store will be updated when the identity or tokens change too.
@@ -32,8 +31,6 @@
 			balancesStoreData: $balancesStore
 		});
 	});
-
-
 </script>
 
 {@render children?.()}

--- a/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
+++ b/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { type Snippet, untrack } from 'svelte';
+	import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
+	import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
+	import {
+		setIdbBtcTransactions,
+		setIdbEthTransactions,
+		setIdbIcTransactions,
+		setIdbSolTransactions
+	} from '$lib/api/idb-transactions.api';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { enabledTokens } from '$lib/derived/tokens.derived';
+	import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
+	import { setIdbBalancesStore } from '$lib/api/idb-balances.api';
+	import { balancesStore } from '$lib/stores/balances.store';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+
+	// We don't need to track identity and tokens changes for every store, since we are interested in the final result of the balances store.
+	// And the balances store will be updated when the identity or tokens change too.
+	// TODO: split it by single token to avoid unnecessary updates. This should happen directly
+	$effect(() => {
+		setIdbBalancesStore({
+			identity: untrack(() => $authIdentity),
+			tokens: untrack(() => $enabledTokens),
+			balancesStoreData: $balancesStore
+		});
+	});
+
+
+</script>
+
+{@render children?.()}

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -7,7 +7,6 @@
 	import RewardGuard from '$lib/components/guard/RewardGuard.svelte';
 	import ShortcutGuard from '$lib/components/guard/ShortcutGuard.svelte';
 	import UrlGuard from '$lib/components/guard/UrlGuard.svelte';
-	import Balance from '$lib/components/hero/Balance.svelte';
 	import Loader from '$lib/components/loaders/Loader.svelte';
 	import LoaderContacts from '$lib/components/loaders/LoaderContacts.svelte';
 	import LoaderMetamask from '$lib/components/loaders/LoaderMetamask.svelte';

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -13,6 +13,8 @@
 	import LoaderWallets from '$lib/components/loaders/LoaderWallets.svelte';
 	import UserSnapshotWorker from '$lib/components/rewards/UserSnapshotWorker.svelte';
 	import TransactionsIdbSetter from '$lib/components/transactions/TransactionsIdbSetter.svelte';
+	import Balance from '$lib/components/hero/Balance.svelte';
+	import BalancesIdbSetter from '$lib/components/balances/BalancesIdbSetter.svelte';
 </script>
 
 <LoaderUserProfile>
@@ -28,7 +30,9 @@
 										<UserSnapshotWorker>
 											<LoaderContacts>
 												<TransactionsIdbSetter>
+													<BalancesIdbSetter >
 													<slot />
+													</BalancesIdbSetter>
 												</TransactionsIdbSetter>
 											</LoaderContacts>
 										</UserSnapshotWorker>

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import LoaderEthBalances from '$eth/components/loaders/LoaderEthBalances.svelte';
 	import CkBTCUpdateBalanceListener from '$icp/components/core/CkBTCUpdateBalanceListener.svelte';
+	import BalancesIdbSetter from '$lib/components/balances/BalancesIdbSetter.svelte';
 	import ExchangeWorker from '$lib/components/exchange/ExchangeWorker.svelte';
 	import AddressGuard from '$lib/components/guard/AddressGuard.svelte';
 	import RewardGuard from '$lib/components/guard/RewardGuard.svelte';
 	import ShortcutGuard from '$lib/components/guard/ShortcutGuard.svelte';
 	import UrlGuard from '$lib/components/guard/UrlGuard.svelte';
+	import Balance from '$lib/components/hero/Balance.svelte';
 	import Loader from '$lib/components/loaders/Loader.svelte';
 	import LoaderContacts from '$lib/components/loaders/LoaderContacts.svelte';
 	import LoaderMetamask from '$lib/components/loaders/LoaderMetamask.svelte';
@@ -13,8 +15,6 @@
 	import LoaderWallets from '$lib/components/loaders/LoaderWallets.svelte';
 	import UserSnapshotWorker from '$lib/components/rewards/UserSnapshotWorker.svelte';
 	import TransactionsIdbSetter from '$lib/components/transactions/TransactionsIdbSetter.svelte';
-	import Balance from '$lib/components/hero/Balance.svelte';
-	import BalancesIdbSetter from '$lib/components/balances/BalancesIdbSetter.svelte';
 </script>
 
 <LoaderUserProfile>
@@ -30,8 +30,8 @@
 										<UserSnapshotWorker>
 											<LoaderContacts>
 												<TransactionsIdbSetter>
-													<BalancesIdbSetter >
-													<slot />
+													<BalancesIdbSetter>
+														<slot />
 													</BalancesIdbSetter>
 												</TransactionsIdbSetter>
 											</LoaderContacts>


### PR DESCRIPTION
# Motivation

Similar to what we did for the transactions stores, we will start using the IDB services that store the balances in the cache.

The idea is that each change in the balances store would trigger caching it. That is because the balances store is handled in various places in the code, and it becomes quite un-maintainsble to add the code in each use. 

# Changes

- Create component `BalancesIdbSetter` to cache the balances (very similar to the transacitons one): we separate the reactivity and we limit it only to the balances store. This will avoid useless updates.
- Add the `BalancesIdbSetter` to `Loaders`.

# Tests

Manual test worked too:

<img width="2560" height="769" alt="Screenshot 2025-07-18 at 01 29 01" src="https://github.com/user-attachments/assets/890deddc-b2b9-4cd5-b6e7-cfb06a721316" />



