### PR TITLE
feat(frontend): Services to clear IDB balances stores

### DIFF
--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -3,6 +3,7 @@ import {
 	deleteIdbEthAddress,
 	deleteIdbSolAddressMainnet
 } from '$lib/api/idb-addresses.api';
+import { deleteIdbBalances } from '$lib/api/idb-balances.api';
 import {
 	deleteIdbEthTokens,
 	deleteIdbEthTokensDeprecated,
@@ -145,6 +146,8 @@ const emptyIdbIcTransactions = (): Promise<void> => emptyIdbStore(deleteIdbIcTra
 
 const emptyIdbSolTransactions = (): Promise<void> => emptyIdbStore(deleteIdbSolTransactions);
 
+const emptyIdbBalances = (): Promise<void> => emptyIdbStore(deleteIdbBalances);
+
 // eslint-disable-next-line require-await
 const clearSessionStorage = async () => {
 	sessionStorage.clear();
@@ -174,7 +177,8 @@ const logout = async ({
 			emptyIdbBtcTransactions(),
 			emptyIdbEthTransactions(),
 			emptyIdbIcTransactions(),
-			emptyIdbSolTransactions()
+			emptyIdbSolTransactions(),
+			emptyIdbBalances()
 		]);
 	}
 

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -81,8 +81,8 @@ describe('auth.services', () => {
 
 			await signOut({});
 
-			// 3 addresses + 3(+1) tokens + 4 transactions
-			expect(idbKeyval.del).toHaveBeenCalledTimes(11);
+			// 3 addresses + 3(+1) tokens + 4 transactions + 1 balances
+			expect(idbKeyval.del).toHaveBeenCalledTimes(12);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

When the user logs out, we need to clean the IDB stores that cached the balances.
