### PR TITLE
feat(frontend): Debounce wallet workers trigger

### DIFF
--- a/src/frontend/src/lib/components/core/WalletWorkers.svelte
+++ b/src/frontend/src/lib/components/core/WalletWorkers.svelte
@@ -31,8 +31,10 @@
 	});
 
 	const triggerTimer = () => workers.forEach((worker) => worker.trigger());
+
+	const debounceTriggerTimer = debounce(triggerTimer, 1000);
 </script>
 
-<svelte:window on:oisyTriggerWallet={triggerTimer} />
+<svelte:window on:oisyTriggerWallet={debounceTriggerTimer} />
 
 <slot />

--- a/src/frontend/src/tests/lib/components/core/WalletWorkers.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/WalletWorkers.spec.ts
@@ -94,6 +94,8 @@ describe('WalletWorkers', () => {
 
 		emit({ message: 'oisyTriggerWallet' });
 
+		await waitTimer();
+
 		expect(trigger).toHaveBeenCalledTimes(tokens.length);
 	});
 


### PR DESCRIPTION
# Motivation

To avoid too many calls on loading, we debounce the trigger of the wallet workers.

