### PR TITLE
feat(frontend): Do not wait for Signer allowance if derivation is in frontend

### DIFF
--- a/src/frontend/src/lib/services/loader.services.ts
+++ b/src/frontend/src/lib/services/loader.services.ts
@@ -1,3 +1,4 @@
+import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
 import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
@@ -118,11 +119,16 @@ export const initLoader = async ({
 	// We are loading the addresses from the backend. Consequently, we aim to animate this operation and offer the user an explanation of what is happening. To achieve this, we will present this information within a modal.
 	setProgressModal(true);
 
-	const { success: initSignerAllowanceSuccess } = await initSignerAllowance();
+	if (FRONTEND_DERIVATION_ENABLED) {
+		// We do not need to await this call, as it is required for signing transactions only and not for the generic initialization.
+		initSignerAllowance();
+	} else {
+		const { success: initSignerAllowanceSuccess } = await initSignerAllowance();
 
-	if (!initSignerAllowanceSuccess) {
-		// Sign-out is handled within the service.
-		return;
+		if (!initSignerAllowanceSuccess) {
+			// Sign-out is handled within the service.
+			return;
+		}
 	}
 
 	const errorNetworkIds: NetworkId[] = err?.map(({ networkId }) => networkId) ?? [];


### PR DESCRIPTION
# Motivation

When we initialize the UI, we are requesting an allowance to the Chain Fusion signer. This is useful for most of the calls that we do to the Chain Fusion signer, for example deriving the addresses, or sign a transaction.

However, if we are deriving the addresses in the frontend, we do not need tov await for the call to finish. We can accept the fact that the user will take some time until the next transaction signing, enough for the call to complete.

In any case, even if the call is not completed, the error received will just tell the user to re-try. And if there is an error, the call service will sign-out.


# Results

Initialization in beta canister is much faster:


https://github.com/user-attachments/assets/8d0a500d-e47d-4813-91d3-91c8711f59f4

