### PR TITLE
chore(frontend): Add missing texts for currency feature

### DIFF
--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -33,7 +33,7 @@
 			"more_items": "+$items 更多",
 			"select": "选择",
 			"language": "语言",
-			"currency": ""
+			"currency": "货币"
 		},
 		"info": {
 			"test_banner": "仅供测试使用！"
@@ -45,7 +45,7 @@
 			"open_details": "打开详情",
 			"close_details": "关闭详情",
 			"switch_language": "切换语言",
-			"switch_currency": ""
+			"switch_currency": "切换货币"
 		},
 		"warning": {
 			"do_not_close": "交易完成前请勿关闭此标签页"


### PR DESCRIPTION
# Motivation

Currency feature needs localized texts, but labels for chinese are missing.

<img width="274" height="139" alt="image" src="https://github.com/user-attachments/assets/75cb3a60-b5e1-401e-8434-fec1faec65c4" />


# Changes

- Add Chinese

# Tests
<img width="246" height="586" alt="image" src="https://github.com/user-attachments/assets/51a845e9-8773-49a9-a8e4-f638e5368a66" />

