### PR TITLE
feat(frontend): Sort currencies by name in dropdown

### DIFF
--- a/src/frontend/src/lib/components/currency/CurrencyDropdown.svelte
+++ b/src/frontend/src/lib/components/currency/CurrencyDropdown.svelte
@@ -48,12 +48,10 @@
 			return nonNullish(name)
 				? [...acc, { key, currency, name, symbol: parseSymbolString({ currency, language }) }]
 				: acc;
-
-
-		}, [])
+		}, []);
 	});
 
-	let sortedCurrencies = $derived(currencies.sort((a, b) => a.name.localeCompare(b.name)))
+	let sortedCurrencies = $derived(currencies.sort((a, b) => a.name.localeCompare(b.name)));
 </script>
 
 <span class="currency-selector min-w-32">
@@ -73,7 +71,7 @@
 
 		{#snippet items()}
 			<List noPadding condensed testId={CURRENCY_SWITCHER_DROPDOWN}>
-				{#each sortedCurrencies as { key,currency, name, symbol}, index (index + key)}
+				{#each sortedCurrencies as { key, currency, name, symbol }, index (index + key)}
 					<ListItem>
 						<Button
 							onclick={() => handleCurrencyChange(currency)}

--- a/src/frontend/src/lib/components/currency/CurrencyDropdown.svelte
+++ b/src/frontend/src/lib/components/currency/CurrencyDropdown.svelte
@@ -36,6 +36,24 @@
 		currencyStore.switchCurrency(currency);
 		dropdown?.close();
 	};
+
+	let currencies = $derived.by(() => {
+		const language = $currentLanguage;
+
+		return SUPPORTED_CURRENCIES.reduce<
+			{ key: string; currency: Currency; name: string; symbol: string }[]
+		>((acc, [key, currency]) => {
+			const name = getCurrencyName({ currency, language });
+
+			return nonNullish(name)
+				? [...acc, { key, currency, name, symbol: parseSymbolString({ currency, language }) }]
+				: acc;
+
+
+		}, [])
+	});
+
+	let sortedCurrencies = $derived(currencies.sort((a, b) => a.name.localeCompare(b.name)))
 </script>
 
 <span class="currency-selector min-w-32">
@@ -55,16 +73,10 @@
 
 		{#snippet items()}
 			<List noPadding condensed testId={CURRENCY_SWITCHER_DROPDOWN}>
-				{#each SUPPORTED_CURRENCIES as [currencyKey, currencyVal], index (index + currencyKey)}
-					{@const name = getCurrencyName({ currency: currencyVal, language: $currentLanguage })}
-					{@const symbolString = parseSymbolString({
-						currency: currencyVal,
-						language: $currentLanguage
-					})}
-
+				{#each sortedCurrencies as { key,currency, name, symbol}, index (index + key)}
 					<ListItem>
 						<Button
-							onclick={() => handleCurrencyChange(currencyVal)}
+							onclick={() => handleCurrencyChange(currency)}
 							fullWidth
 							contentFullWidth
 							alignLeft
@@ -72,16 +84,16 @@
 							styleClass="py-1 rounded-md font-normal text-primary underline-none pl-0.5 min-w-28"
 							colorStyle="tertiary-alt"
 							transparent
-							testId={`${CURRENCY_SWITCHER_DROPDOWN_BUTTON}-${currencyVal}`}
+							testId={`${CURRENCY_SWITCHER_DROPDOWN_BUTTON}-${currency}`}
 						>
 							<span class="pt-0.75 w-[20px] text-brand-primary">
-								{#if $currentCurrency === currencyVal}
+								{#if $currentCurrency === currency}
 									<IconCheck size="20" />
 								{/if}
 							</span>
 							<div class="flex w-full flex-row justify-between gap-5">
 								{name}
-								<span class="text-right text-tertiary">{symbolString}</span>
+								<span class="text-right text-tertiary">{symbol}</span>
 							</div>
 						</Button>
 					</ListItem>


### PR DESCRIPTION
# Motivation

The list of currencies in the dropdown should be sorted by their name in the current language.

# Changes

- Create mapped and sorted currencies list in CurrencyDropdown component.
- Adapt the rest of the component.

# Tests

Current tests shall work. And a practical one:

<img width="680" height="812" alt="Screenshot 2025-07-21 at 09 59 04" src="https://github.com/user-attachments/assets/25412782-4ac1-47c2-bb10-d4782e83e3f5" />
<img width="714" height="740" alt="Screenshot 2025-07-21 at 09 59 15" src="https://github.com/user-attachments/assets/b63ffd04-2270-49a0-82db-497d3344c365" />
<img width="716" height="786" alt="Screenshot 2025-07-21 at 09 59 25" src="https://github.com/user-attachments/assets/2cfd5a34-8160-4cb4-9c1d-d4ca5a9421c4" />

