### PR TITLE
feat(frontend): Derived store with current currency symbol

### DIFF
--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -8,10 +8,12 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import DelayedTooltip from '$lib/components/ui/DelayedTooltip.svelte';
 	import { AMOUNT_DATA } from '$lib/constants/test-ids.constants';
+	import { currentCurrencySymbol } from '$lib/derived/currency.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionTokenUi } from '$lib/types/token';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { setPrivacyMode } from '$lib/utils/privacy.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
@@ -67,7 +69,9 @@
 					<TokenExchangeBalance
 						balance={token?.balance}
 						usdBalance={token?.usdBalance}
-						nullishBalanceMessage={$i18n.hero.text.unavailable_balance}
+						nullishBalanceMessage={replacePlaceholders($i18n.hero.text.unavailable_balance, {
+							$currencySymbol: $currentCurrencySymbol
+						})}
 					/>
 				</DelayedTooltip>
 			{:else}

--- a/src/frontend/src/lib/derived/currency.derived.ts
+++ b/src/frontend/src/lib/derived/currency.derived.ts
@@ -1,6 +1,8 @@
+import { currentLanguage } from '$lib/derived/i18n.derived';
 import type { Currency } from '$lib/enums/currency';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { currencyStore } from '$lib/stores/currency.store';
+import { getCurrencySymbol } from '$lib/utils/currency.utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const currentCurrency: Readable<Currency> = derived(
@@ -11,4 +13,9 @@ export const currentCurrency: Readable<Currency> = derived(
 export const currentCurrencyExchangeRate: Readable<number | null> = derived(
 	[currencyExchangeStore],
 	([{ exchangeRateToUsd }]) => exchangeRateToUsd
+);
+
+export const currentCurrencySymbol: Readable<string> = derived(
+	[currentCurrency, currentLanguage],
+	([currency, language]) => getCurrencySymbol({ currency, language }) ?? '$'
 );

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "Váš zůstatek",
-			"unavailable_balance": "$ hodnota není k dispozici",
+			"unavailable_balance": "$currencySymbol hodnota není k dispozici",
 			"hidden_balance": "Váš zůstatek je skrytý",
 			"top_up": "Doplňte si peněženku a začněte ji používat!",
 			"learn_more_about_erc20_icp": "Více se dozvíte o ERC20 ICP na Ethereu.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "Dein Guthaben",
-			"unavailable_balance": "$ Wert ist nicht verfügbar",
+			"unavailable_balance": "$currencySymbol Wert ist nicht verfügbar",
 			"hidden_balance": "Dein Guthaben ist ausgeblendet",
 			"top_up": "Lade dein Wallet auf, um es zu nutzen!",
 			"learn_more_about_erc20_icp": "Erfahre mehr über ERC20 ICP auf Ethereum.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "Your balance",
-			"unavailable_balance": "$ value is not available",
+			"unavailable_balance": "$currencySymbol value is not available",
 			"hidden_balance": "Your balance is hidden",
 			"top_up": "Top up your wallet to start using it!",
 			"learn_more_about_erc20_icp": "Learn more about ERC20 ICP on Ethereum.",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "Il tuo saldo",
-			"unavailable_balance": "Valore in $ non disponibile",
+			"unavailable_balance": "Valore in $currencySymbol non disponibile",
 			"hidden_balance": "Il tuo saldo è nascosto",
 			"top_up": "Ricarica il tuo wallet per iniziare a usarlo!",
 			"learn_more_about_erc20_icp": "Scopri di più su ERC20 ICP su Ethereum.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "Seu saldo",
-			"unavailable_balance": "$ valor não disponível",
+			"unavailable_balance": "$currencySymbol valor não disponível",
 			"hidden_balance": "O seu saldo está escondido",
 			"top_up": "Carregue sua carteira para começar a usá-la!",
 			"learn_more_about_erc20_icp": "Saiba mais sobre ERC20 ICP no Ethereum.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "Số dư của bạn",
-			"unavailable_balance": "Giá trị $ không khả dụng",
+			"unavailable_balance": "Giá trị $currencySymbol không khả dụng",
 			"hidden_balance": "Số dư của bạn bị ẩn",
 			"top_up": "Nạp tiền vào ví của bạn để bắt đầu sử dụng!",
 			"learn_more_about_erc20_icp": "Tìm hiểu thêm về ERC20 ICP trên Ethereum.",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -506,7 +506,7 @@
 	"hero": {
 		"text": {
 			"available_balance": "你的余额",
-			"unavailable_balance": "$ 值不可用",
+			"unavailable_balance": "$currencySymbol 值不可用",
 			"hidden_balance": "你的余额已隐藏",
 			"top_up": "充值你的钱包以开始使用！",
 			"learn_more_about_erc20_icp": "了解更多关于以太坊上的 ERC20 ICP。",

--- a/src/frontend/src/tests/lib/derived/currency.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/currency.derived.spec.ts
@@ -1,7 +1,13 @@
-import { currentCurrency, currentCurrencyExchangeRate } from '$lib/derived/currency.derived';
+import {
+	currentCurrency,
+	currentCurrencyExchangeRate,
+	currentCurrencySymbol
+} from '$lib/derived/currency.derived';
 import { Currency } from '$lib/enums/currency';
+import { Languages } from '$lib/enums/languages';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { currencyStore } from '$lib/stores/currency.store';
+import { i18n } from '$lib/stores/i18n.store';
 import { get } from 'svelte/store';
 
 vi.mock('idb-keyval', () => ({
@@ -83,5 +89,40 @@ describe('currency.derived', () => {
 
 			expect(get(currentCurrencyExchangeRate)).toBeNull();
 		});
+	});
+
+	describe('currentCurrencySymbol', () => {
+		const testCases = [
+			{ currency: Currency.USD, language: Languages.ENGLISH, expected: '$' },
+			{ currency: Currency.EUR, language: Languages.ENGLISH, expected: '€' },
+			{ currency: Currency.CHF, language: Languages.ENGLISH, expected: 'CHF' },
+			{ currency: Currency.JPY, language: Languages.ENGLISH, expected: '¥' },
+			{ currency: Currency.CNY, language: Languages.ENGLISH, expected: 'CN¥' },
+			{ currency: Currency.USD, language: Languages.GERMAN, expected: '$' },
+			{ currency: Currency.EUR, language: Languages.GERMAN, expected: '€' },
+			{ currency: Currency.CHF, language: Languages.GERMAN, expected: 'CHF' },
+			{ currency: Currency.JPY, language: Languages.GERMAN, expected: '¥' },
+			{ currency: Currency.CNY, language: Languages.GERMAN, expected: 'CN¥' },
+			{ currency: Currency.USD, language: Languages.CHINESE_SIMPLIFIED, expected: 'US$' },
+			{ currency: Currency.EUR, language: Languages.CHINESE_SIMPLIFIED, expected: '€' },
+			{ currency: Currency.CHF, language: Languages.CHINESE_SIMPLIFIED, expected: 'CHF' },
+			{ currency: Currency.JPY, language: Languages.CHINESE_SIMPLIFIED, expected: 'JP¥' },
+			{ currency: Currency.CNY, language: Languages.CHINESE_SIMPLIFIED, expected: '¥' }
+		];
+
+		beforeEach(() => {
+			currencyStore.switchCurrency(Currency.USD);
+			i18n.switchLang(Languages.ENGLISH);
+		});
+
+		it.each(testCases)(
+			`should return $expected for $currency in $language`,
+			({ currency, language, expected }) => {
+				currencyStore.switchCurrency(currency);
+				i18n.switchLang(language);
+
+				expect(get(currentCurrencySymbol)).toEqual(expected);
+			}
+		);
 	});
 });


### PR DESCRIPTION
# Motivation

It is useful to have a direct derived store for the current currency symbol:

<img width="1428" height="868" alt="Screenshot 2025-07-21 at 11 36 35" src="https://github.com/user-attachments/assets/b5950161-a611-4f2b-9a16-7332e17a4ab1" />
