### PR TITLE
feat(frontend): improves loading of nft metadata image

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc721.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc721.providers.ts
@@ -89,7 +89,7 @@ export class InfuraErc721Provider {
 		const response = await fetch(metadataUrl);
 		const metadata = await response.json();
 
-		const imageUrl = extractImageUrl(metadata.image);
+		const imageUrl = extractImageUrl(metadata.image ?? metadata.image_url);
 
 		const mappedAttributes = (metadata?.attributes ?? []).map(
 			(attr: { trait_type: string; value: string | number }) => ({


### PR DESCRIPTION
# Motivation

The metadata of an `nft` can contain the url to the image as `image` or `image_url`. We want to be able to support both options.

# Changes

- improves loading of metadata image