### PR TITLE
feat(frontend): Harden metadata to avoid external images

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -9,6 +9,7 @@ import { i18n } from '$lib/stores/i18n.store';
 import type { EthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { hardenMetadata } from '$lib/utils/metadata.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { Contract, type ContractTransaction } from 'ethers/contract';
 import { InfuraProvider, type Networkish } from 'ethers/providers';
@@ -30,11 +31,13 @@ export class InfuraErc20Provider implements Erc20Provider {
 			erc20Contract.decimals()
 		]);
 
-		return {
+		const metadata: Erc20Metadata = {
 			name,
 			symbol,
 			decimals: Number(decimals)
 		};
+
+		return hardenMetadata(metadata);
 	};
 
 	balance = ({

--- a/src/frontend/src/lib/utils/metadata.utils.ts
+++ b/src/frontend/src/lib/utils/metadata.utils.ts
@@ -1,0 +1,7 @@
+import type { TokenMetadata } from '$lib/types/token';
+
+// The Content Security Policy (CSP) allows any/most image URL.
+// For now we will harden the token metadata by removing the icon since it may be provided by a unsafe URL.
+// TODO: Make the user choose whether to keep the icon or not.
+export const hardenMetadata = <T extends Partial<TokenMetadata>>({ icon: _, ...rest }: T): T =>
+	rest as T;

--- a/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
+++ b/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
@@ -20,6 +20,7 @@
 	import { getSplMetadata } from '$sol/services/spl.services';
 	import type { SplTokenAddress } from '$sol/types/spl';
 	import { safeMapNetworkIdToNetwork } from '$sol/utils/safe-network.utils';
+	import { hardenMetadata } from '$lib/utils/metadata.utils';
 
 	export let tokenAddress: SplTokenAddress | undefined;
 	export let metadata: TokenMetadata | undefined;
@@ -73,7 +74,7 @@
 				return;
 			}
 
-			metadata = { ...splMetadata, decimals };
+			metadata = { ...hardenMetadata(splMetadata), decimals };
 
 			if (
 				$splTokens?.find(


### PR DESCRIPTION
# Motivation

To implement NFT and all their features, we need to open our Content Security Policy (CSP) to allow external URL (see PR https://github.com/dfinity/oisy-wallet/pull/7160): the images of NFTs are stored in an URL in their metadata.

However that allows all types of sources to be able to provide image URLs to OISY.

The only use-case we are aware of right now are the token icons: when an user add a custom token, the icon may come as an URL. We were blocking it until now, so we keep the same behaviour until we provide a more complex way of letting the user approve them. 

# Changes

- Create util hardenMetadata: it simply removes the icon if it is an URL.
- Apply the util in all possible usage: ERC20 and SPL.

# Tests

No changes.