### PR TITLE
feat(frontend): Use `TransferChecked` in Solana send flow

### DIFF
--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -329,9 +329,7 @@ export const sendSol = async ({
 				destination,
 				amount,
 				network: solNetwork,
-				tokenAddress: token.address,
-				tokenOwnerAddress: token.owner,
-				tokenMintAuthority: token.mintAuthority
+				token
 			})
 		: await createSolTransactionMessage({
 				signer,


### PR DESCRIPTION
# WIP - Needs to clean the debbuging

# Motivation

According to [Solana documentation](https://solana.com/docs/tokens/basics/transfer-tokens), a more safe way of transferring tokens between accounts is `TransferChecked` instead of the simple `Transfer` method.

The difference is that the checked method verify the mint authority and the decimals too, guaranteeing that it is indeed the token that the user wants to transfer.

However, that entails that not all tokens can use it: not all of them have a defined `mintAuthority`.

So, for now, we use it ONLY when the mintAuthority is defined.

# Changes

- Refactor service `createSplTokenTransactionMessage` to use method `getTransferCheckedInstruction` when the `mintAuthority` of the token is non-nullish.
- Adapt the rest of the code.

# Tests

Tests adapted and a practical one:
