### PR TITLE
chore(frontend): Remove unnecessary default values in `EditAvatar`

### DIFF
--- a/src/frontend/src/lib/components/contact/EditAvatar.svelte
+++ b/src/frontend/src/lib/components/contact/EditAvatar.svelte
@@ -22,8 +22,8 @@
 
 	const {
 		fileInput = $bindable<HTMLInputElement | undefined>(),
-		onReplaceImage = () => {},
-		onRemoveImage = () => {},
+		onReplaceImage,
+		onRemoveImage,
 		imageUrl
 	}: Props = $props();
 


### PR DESCRIPTION
# Motivation

Unnecessary initializers in EditAvatar for params `onReplaceImage` and `onRemoveImage`.