### PR TITLE
refactor(frontend): Split params in service `createSplTokenTransactionMessage`

### DIFF
--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -190,21 +190,22 @@ const createSplTokenTransactionMessage = async ({
 		tokenOwnerAddress
 	});
 
-	const transferInstruction = getTransferInstruction(
-		{
-			source: solAddress(sourceTokenAccountAddress),
-			destination: solAddress(
-				destinationIsAtaAddress
-					? destination
-					: mustCreateDestinationTokenAccount
-						? calculatedDestinationTokenAccountAddress
-						: destinationTokenAccountAddress
-			),
-			authority: signer,
-			amount
-		},
-		{ programAddress: solAddress(tokenOwnerAddress) }
-	);
+	const transferParams = {
+		source: solAddress(sourceTokenAccountAddress),
+		destination: solAddress(
+			destinationIsAtaAddress
+				? destination
+				: mustCreateDestinationTokenAccount
+					? calculatedDestinationTokenAccountAddress
+					: destinationTokenAccountAddress
+		),
+		authority: signer,
+		amount
+	};
+
+	const config = { programAddress: solAddress(tokenOwnerAddress) };
+
+	const transferInstruction = getTransferInstruction(transferParams, config);
 
 	return pipe(await createDefaultTransaction({ rpc, feePayer: signer }), (tx) =>
 		appendTransactionMessageInstructions(


### PR DESCRIPTION
# Motivation

In preparation of using `TransferChecked` (PR https://github.com/dfinity/oisy-wallet/pull/7919), we refactor service `createSplTokenTransactionMessage` a bit: we split the transfer parameters from the function. They will be used again by both type of transfer.