### PR TITLE
chore(frontend): Remove duplicate error message for importing tokens

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
@@ -100,7 +100,7 @@
 			validateMetadata();
 		} catch (err: unknown) {
 			toastsError({
-				msg: { text: $i18n.tokens.error.loading_metadata },
+				msg: { text: $i18n.tokens.import.error.loading_metadata },
 				err
 			});
 

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -977,7 +977,6 @@
 			"unexpected": "Při ukládání tokenu se něco pokazilo.",
 			"unexpected_hiding": "Při skrývání tokenu se něco pokazilo.",
 			"already_available": "Token je již k dispozici.",
-			"loading_metadata": "Chyba při načítání metadat tokenu.",
 			"not_toggleable": "Token nelze přepnout, nelze jej skrýt.",
 			"incomplete_metadata": "V metadatech není uveden žádný název ani symbol.",
 			"duplicate_metadata": "Token s podobným názvem nebo symbolem již existuje.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -977,7 +977,6 @@
 			"unexpected": "Beim Speichern des Tokens ist etwas schiefgelaufen.",
 			"unexpected_hiding": "Beim Verbergen des Tokens ist etwas schiefgelaufen.",
 			"already_available": "Token ist bereits verfügbar.",
-			"loading_metadata": "Fehler beim Laden der Metadaten des Tokens.",
 			"not_toggleable": "Token kann nicht ausgeblendet werden.",
 			"incomplete_metadata": "Kein Name oder Symbol in den Metadaten vorhanden.",
 			"duplicate_metadata": "Ein Token mit einem ähnlichen Namen oder Symbol existiert bereits.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -977,7 +977,6 @@
 			"unexpected": "Something went wrong while saving the token.",
 			"unexpected_hiding": "Something went wrong while hiding the token.",
 			"already_available": "Token is already available.",
-			"loading_metadata": "Error while loading the metadata of the token.",
 			"not_toggleable": "Token is not toggleable, it can not be hidden.",
 			"incomplete_metadata": "No name or symbol is provided in the metadata.",
 			"duplicate_metadata": "A token with a similar name or symbol already exists.",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -977,7 +977,6 @@
 			"unexpected": "Qualcosa è andato storto durante il salvataggio del token.",
 			"unexpected_hiding": "Qualcosa è andato storto nel nascondere il token.",
 			"already_available": "Token già disponibile.",
-			"loading_metadata": "Errore durante il caricamento dei metadati del token.",
 			"not_toggleable": "Il token non è attivabile/disattivabile, non può essere nascosto.",
 			"incomplete_metadata": "Nessun nome o simbolo è fornito nei metadati.",
 			"duplicate_metadata": "Un token con un nome o simbolo simile esiste già.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -977,7 +977,6 @@
 			"unexpected": "Algo deu errado ao salvar o token.",
 			"unexpected_hiding": "Algo deu errado ao ocultar o token.",
 			"already_available": "Token já disponível.",
-			"loading_metadata": "Erro ao carregar os metadados do token.",
 			"not_toggleable": "O token não é alternável, não pode ser ocultado.",
 			"incomplete_metadata": "Nenhum nome ou símbolo é fornecido nos metadados.",
 			"duplicate_metadata": "Um token com nome ou símbolo semelhante já existe.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -977,7 +977,6 @@
 			"unexpected": "Đã xảy ra lỗi trong khi lưu token.",
 			"unexpected_hiding": "Đã xảy ra lỗi trong khi ẩn token.",
 			"already_available": "Token đã có sẵn.",
-			"loading_metadata": "Lỗi khi tải metadata của token.",
 			"not_toggleable": "Token không thể chuyển đổi, không thể ẩn.",
 			"incomplete_metadata": "Không có tên hoặc ký hiệu được cung cấp trong metadata.",
 			"duplicate_metadata": "Đã tồn tại một token có tên hoặc ký hiệu tương tự.",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -977,7 +977,6 @@
 			"unexpected": "保存代币时发生错误。",
 			"unexpected_hiding": "隐藏代币时发生错误。",
 			"already_available": "代币已存在。",
-			"loading_metadata": "加载代币元数据时出错。",
 			"not_toggleable": "代币不可切换，无法隐藏。",
 			"incomplete_metadata": "元数据中未提供名称或符号。",
 			"duplicate_metadata": "已存在名称或符号相似的代币。",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -819,7 +819,6 @@ interface I18nTokens {
 		unexpected: string;
 		unexpected_hiding: string;
 		already_available: string;
-		loading_metadata: string;
 		not_toggleable: string;
 		incomplete_metadata: string;
 		duplicate_metadata: string;

--- a/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
+++ b/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
@@ -92,7 +92,7 @@
 			}
 		} catch (err: unknown) {
 			toastsError({
-				msg: { text: $i18n.tokens.error.loading_metadata },
+				msg: { text: $i18n.tokens.import.error.loading_metadata },
 				err
 			});
 


### PR DESCRIPTION
# Motivation

There is a duplicate message for errors in importing tokens.