### PR TITLE
feat(backend)!: Add ERC-1155 standard to custom tokens

### DIFF
--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -8,7 +8,7 @@ use shared::types::{
     },
     TokenVersion,
 };
-
+use shared::types::custom_token::Erc1155Token;
 use crate::utils::{
     assertion::{assert_custom_tokens_eq, assert_tokens_data_eq},
     mock::CALLER,
@@ -75,6 +75,17 @@ static ERC721_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
     enabled: true,
     version: None,
 });
+static ERC1155_TOKEN_ID: LazyLock<ErcTokenId> =
+    LazyLock::new(|| ErcTokenId("dgdsfgdsfgfgd".to_string()));
+static ERC1155_CHAIN_ID: LazyLock<ChainId> = LazyLock::new(|| 42161);
+static ERC1155_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
+    token: Token::Erc1155(Erc1155Token {
+        token_address: ERC1155_TOKEN_ID.clone(),
+        chain_id: ERC1155_CHAIN_ID.clone(),
+    }),
+    enabled: true,
+    version: None,
+});
 static LOTS_OF_CUSTOM_TOKENS: LazyLock<Vec<CustomToken>> = LazyLock::new(|| {
     vec![
         USER_TOKEN.clone(),
@@ -82,6 +93,7 @@ static LOTS_OF_CUSTOM_TOKENS: LazyLock<Vec<CustomToken>> = LazyLock::new(|| {
         SPL_TOKEN.clone(),
         ERC20_TOKEN.clone(),
         ERC721_TOKEN.clone(),
+        ERC1155_TOKEN.clone(),
     ]
 });
 
@@ -124,6 +136,11 @@ fn test_remove_custom_erc20_token() {
 #[test]
 fn test_remove_custom_erc721_token() {
     test_remove_custom_token(&ERC721_TOKEN)
+}
+
+#[test]
+fn test_remove_custom_erc1155_token() {
+    test_remove_custom_token(&ERC1155_TOKEN)
 }
 
 #[test]

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -29,6 +29,7 @@ use crate::{
     },
     validate::{validate_on_deserialize, Validate},
 };
+use crate::types::custom_token::Erc1155Token;
 
 // Constants for validation limits
 const CONTACT_MAX_NAME_LENGTH: usize = 100;
@@ -93,7 +94,11 @@ impl From<&Token> for CustomTokenId {
                 token_address,
                 chain_id,
                 ..
-            }) => CustomTokenId::Ethereum(token_address.clone(), *chain_id),
+            }) | Token::Erc1155(Erc1155Token {
+                                                               token_address,
+                                                               chain_id,
+                                                               ..
+                                                           }) => CustomTokenId::Ethereum(token_address.clone(), *chain_id),
         }
     }
 }
@@ -466,6 +471,7 @@ impl Validate for Token {
             Token::SplMainnet(token) | Token::SplDevnet(token) => token.validate(),
             Token::Erc20(token) => token.validate(),
             Token::Erc721(token) => token.validate(),
+            Token::Erc1155(token) => token.validate(),
         }
     }
 }
@@ -503,6 +509,12 @@ impl Validate for Erc20Token {
 }
 
 impl Validate for Erc721Token {
+    fn validate(&self) -> Result<(), candid::Error> {
+        self.token_address.validate()
+    }
+}
+
+impl Validate for Erc1155Token {
     fn validate(&self) -> Result<(), candid::Error> {
         self.token_address.validate()
     }
@@ -645,4 +657,5 @@ validate_on_deserialize!(SplTokenId);
 validate_on_deserialize!(Erc20Token);
 validate_on_deserialize!(ErcTokenId);
 validate_on_deserialize!(Erc721Token);
+validate_on_deserialize!(Erc1155Token);
 validate_on_deserialize!(UserToken);

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -56,6 +56,14 @@ pub struct Erc721Token {
     pub chain_id: ChainId,
 }
 
+/// An ERC1155 compliant token on the Ethereum or EVM-compatible networks.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+#[serde(remote = "Self")]
+pub struct Erc1155Token {
+    pub token_address: ErcTokenId,
+    pub chain_id: ChainId,
+}
+
 /// A variant describing any token
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 #[repr(u8)]
@@ -65,6 +73,7 @@ pub enum Token {
     SplDevnet(SplToken) = 2,
     Erc20(Erc20Token) = 3,
     Erc721(Erc721Token) = 4,
+    Erc1155(Erc1155Token) = 5,
 }
 
 /// User preferences for any token

--- a/src/shared/src/types/token_standard.rs
+++ b/src/shared/src/types/token_standard.rs
@@ -27,6 +27,13 @@ pub enum TokenStandard {
     ///
     /// - [ERC721 Spec](https://eips.ethereum.org/EIPS/eip-721)
     ERC721,
+    /// Standard for the Ethereum blockchain
+    ///
+    /// # Used for:
+    /// - Both fungible tokens and NFTs on ETH and other EVM networks.
+    ///
+    /// - [ERC1155 Spec](https://eips.ethereum.org/EIPS/eip-1155)
+    ERC1155,
     /// Standard for the Bitcoin blockchain
     ///
     /// # Used for:


### PR DESCRIPTION
# Motivation

We are going to support ERC-1155 standard for the Ethereum/EVM tokens. So, we add it as type in the backend.

BREAKING CHANGE: the Backend interface will show an additional variant for `CustomToken`.
