### PR TITLE
feat(backend)!: Single interface for ERC tokens in CustomToken

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -185,13 +185,7 @@ type DefiniteCanisterSettingsArgs = record {
 	compute_allocation : nat
 };
 type DeleteContactResult = variant { Ok : nat64; Err : ContactError };
-type Erc20Token = record {
-	decimals : opt nat8;
-	token_address : text;
-	chain_id : nat64;
-	symbol : opt text
-};
-type Erc721Token = record { token_address : text; chain_id : nat64 };
+type ErcToken = record { token_address : text; chain_id : nat64 };
 type EthAddress = variant { Public : text };
 type GetAllowedCyclesError = variant {
 	Other : text;
@@ -313,9 +307,9 @@ type SupportedCredential = record {
 };
 type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {
-	Erc20 : Erc20Token;
+	Erc20 : ErcToken;
 	Icrc : IcrcToken;
-	Erc721 : Erc721Token;
+	Erc721 : ErcToken;
 	SplDevnet : SplToken;
 	SplMainnet : SplToken
 };

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -185,6 +185,7 @@ type DefiniteCanisterSettingsArgs = record {
 	compute_allocation : nat
 };
 type DeleteContactResult = variant { Ok : nat64; Err : ContactError };
+type ErcToken = record { token_address : text; chain_id : nat64 };
 type EthAddress = variant { Public : text };
 type GetAllowedCyclesError = variant {
 	Other : text;
@@ -308,6 +309,7 @@ type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {
 	Erc20 : ErcToken;
 	Icrc : IcrcToken;
+	Erc721 : ErcToken;
 	SplDevnet : SplToken;
 	SplMainnet : SplToken
 };

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -3,12 +3,11 @@ use std::sync::LazyLock;
 use candid::Principal;
 use shared::types::{
     custom_token::{
-        ChainId, CustomToken,  ErcTokenId, IcrcToken, SplToken, SplTokenId,
-        Token,
+        ChainId, CustomToken, ErcToken, ErcTokenId, IcrcToken, SplToken, SplTokenId, Token,
     },
     TokenVersion,
 };
-use shared::types::custom_token::ErcToken;
+
 use crate::utils::{
     assertion::{assert_custom_tokens_eq, assert_tokens_data_eq},
     mock::CALLER,

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use candid::Principal;
 use shared::types::{
     custom_token::{
-        ChainId, CustomToken, Erc20Token, Erc721Token, ErcTokenId, IcrcToken, SplToken, SplTokenId,
+        ChainId, CustomToken,  ErcTokenId, IcrcToken, SplToken, SplTokenId,
         Token,
     },
     TokenVersion,

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -8,7 +8,7 @@ use shared::types::{
     },
     TokenVersion,
 };
-
+use shared::types::custom_token::ErcToken;
 use crate::utils::{
     assertion::{assert_custom_tokens_eq, assert_tokens_data_eq},
     mock::CALLER,
@@ -55,11 +55,9 @@ static ERC20_TOKEN_ID: LazyLock<ErcTokenId> =
     LazyLock::new(|| ErcTokenId("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string()));
 static ERC20_CHAIN_ID: LazyLock<ChainId> = LazyLock::new(|| 8453);
 static ERC20_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
-    token: Token::Erc20(Erc20Token {
+    token: Token::Erc20(ErcToken {
         token_address: ERC20_TOKEN_ID.clone(),
         chain_id: ERC20_CHAIN_ID.clone(),
-        symbol: Some("USDC".to_string()),
-        decimals: Some(u8::MAX),
     }),
     enabled: true,
     version: None,
@@ -68,7 +66,7 @@ static ERC721_TOKEN_ID: LazyLock<ErcTokenId> =
     LazyLock::new(|| ErcTokenId("0x8821bee2ba0df28761afff119d66390d594cd280".to_string()));
 static ERC721_CHAIN_ID: LazyLock<ChainId> = LazyLock::new(|| 137);
 static ERC721_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
-    token: Token::Erc721(Erc721Token {
+    token: Token::Erc721(ErcToken {
         token_address: ERC721_TOKEN_ID.clone(),
         chain_id: ERC721_CHAIN_ID.clone(),
     }),

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -185,13 +185,7 @@ type DefiniteCanisterSettingsArgs = record {
 	compute_allocation : nat
 };
 type DeleteContactResult = variant { Ok : nat64; Err : ContactError };
-type Erc20Token = record {
-	decimals : opt nat8;
-	token_address : text;
-	chain_id : nat64;
-	symbol : opt text
-};
-type Erc721Token = record { token_address : text; chain_id : nat64 };
+type ErcToken = record { token_address : text; chain_id : nat64 };
 type EthAddress = variant { Public : text };
 type GetAllowedCyclesError = variant {
 	Other : text;
@@ -313,9 +307,9 @@ type SupportedCredential = record {
 };
 type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {
-	Erc20 : Erc20Token;
+	Erc20 : ErcToken;
 	Icrc : IcrcToken;
-	Erc721 : Erc721Token;
+	Erc721 : ErcToken;
 	SplDevnet : SplToken;
 	SplMainnet : SplToken
 };

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -185,6 +185,7 @@ type DefiniteCanisterSettingsArgs = record {
 	compute_allocation : nat
 };
 type DeleteContactResult = variant { Ok : nat64; Err : ContactError };
+type ErcToken = record { token_address : text; chain_id : nat64 };
 type EthAddress = variant { Public : text };
 type GetAllowedCyclesError = variant {
 	Other : text;
@@ -308,6 +309,7 @@ type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {
 	Erc20 : ErcToken;
 	Icrc : IcrcToken;
+	Erc721 : ErcToken;
 	SplDevnet : SplToken;
 	SplMainnet : SplToken
 };

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -193,13 +193,7 @@ export interface DefiniteCanisterSettingsArgs {
 	compute_allocation: bigint;
 }
 export type DeleteContactResult = { Ok: bigint } | { Err: ContactError };
-export interface Erc20Token {
-	decimals: [] | [number];
-	token_address: string;
-	chain_id: bigint;
-	symbol: [] | [string];
-}
-export interface Erc721Token {
+export interface ErcToken {
 	token_address: string;
 	chain_id: bigint;
 }
@@ -336,9 +330,9 @@ export interface TestnetsSettings {
 	show_testnets: boolean;
 }
 export type Token =
-	| { Erc20: Erc20Token }
+	| { Erc20: ErcToken }
 	| { Icrc: IcrcToken }
-	| { Erc721: Erc721Token }
+	| { Erc721: ErcToken }
 	| { SplDevnet: SplToken }
 	| { SplMainnet: SplToken };
 export type TokenAccountId =

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -193,6 +193,7 @@ export interface DefiniteCanisterSettingsArgs {
 	compute_allocation: bigint;
 }
 export type DeleteContactResult = { Ok: bigint } | { Err: ContactError };
+export interface ErcToken {
 	token_address: string;
 	chain_id: bigint;
 }
@@ -331,6 +332,7 @@ export interface TestnetsSettings {
 export type Token =
 	| { Erc20: ErcToken }
 	| { Icrc: IcrcToken }
+	| { Erc721: ErcToken }
 	| { SplDevnet: SplToken }
 	| { SplMainnet: SplToken };
 export type TokenAccountId =

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -360,19 +360,13 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
-	const Erc20Token = IDL.Record({
-		decimals: IDL.Opt(IDL.Nat8),
+	const ErcToken = IDL.Record({
 		token_address: IDL.Text,
-		chain_id: IDL.Nat64,
-		symbol: IDL.Opt(IDL.Text)
+		chain_id: IDL.Nat64
 	});
 	const IcrcToken = IDL.Record({
 		ledger_id: IDL.Principal,
 		index_id: IDL.Opt(IDL.Principal)
-	});
-	const Erc721Token = IDL.Record({
-		token_address: IDL.Text,
-		chain_id: IDL.Nat64
 	});
 	const SplToken = IDL.Record({
 		decimals: IDL.Opt(IDL.Nat8),
@@ -380,9 +374,9 @@ export const idlFactory = ({ IDL }) => {
 		symbol: IDL.Opt(IDL.Text)
 	});
 	const Token = IDL.Variant({
-		Erc20: Erc20Token,
+		Erc20: ErcToken,
 		Icrc: IcrcToken,
-		Erc721: Erc721Token,
+		Erc721: ErcToken,
 		SplDevnet: SplToken,
 		SplMainnet: SplToken
 	});

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -360,6 +360,7 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
+	const ErcToken = IDL.Record({
 		token_address: IDL.Text,
 		chain_id: IDL.Nat64
 	});
@@ -375,6 +376,7 @@ export const idlFactory = ({ IDL }) => {
 	const Token = IDL.Variant({
 		Erc20: ErcToken,
 		Icrc: IcrcToken,
+		Erc721: ErcToken,
 		SplDevnet: SplToken,
 		SplMainnet: SplToken
 	});

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -360,19 +360,13 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
-	const Erc20Token = IDL.Record({
-		decimals: IDL.Opt(IDL.Nat8),
+	const ErcToken = IDL.Record({
 		token_address: IDL.Text,
-		chain_id: IDL.Nat64,
-		symbol: IDL.Opt(IDL.Text)
+		chain_id: IDL.Nat64
 	});
 	const IcrcToken = IDL.Record({
 		ledger_id: IDL.Principal,
 		index_id: IDL.Opt(IDL.Principal)
-	});
-	const Erc721Token = IDL.Record({
-		token_address: IDL.Text,
-		chain_id: IDL.Nat64
 	});
 	const SplToken = IDL.Record({
 		decimals: IDL.Opt(IDL.Nat8),
@@ -380,9 +374,9 @@ export const idlFactory = ({ IDL }) => {
 		symbol: IDL.Opt(IDL.Text)
 	});
 	const Token = IDL.Variant({
-		Erc20: Erc20Token,
+		Erc20: ErcToken,
 		Icrc: IcrcToken,
-		Erc721: Erc721Token,
+		Erc721: ErcToken,
 		SplDevnet: SplToken,
 		SplMainnet: SplToken
 	});

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -360,6 +360,7 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		status_code: IDL.Nat16
 	});
+	const ErcToken = IDL.Record({
 		token_address: IDL.Text,
 		chain_id: IDL.Nat64
 	});
@@ -375,6 +376,7 @@ export const idlFactory = ({ IDL }) => {
 	const Token = IDL.Variant({
 		Erc20: ErcToken,
 		Icrc: IcrcToken,
+		Erc721: ErcToken,
 		SplDevnet: SplToken,
 		SplMainnet: SplToken
 	});

--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -1,4 +1,4 @@
-import type { CustomToken, Erc20Token as Erc721Token } from '$declarations/backend/backend.did';
+import type { CustomToken, ErcToken } from '$declarations/backend/backend.did';
 import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
@@ -56,7 +56,7 @@ const loadCustomTokensWithMetadata = async (
 
 		const customTokenPromises = erc721CustomTokens
 			.filter(
-				(customToken): customToken is CustomToken & { token: { Erc721: Erc721Token } } =>
+				(customToken): customToken is CustomToken & { token: { Erc721: ErcToken } } =>
 					'Erc721' in customToken.token
 			)
 			.map(async ({ token, enabled, version: versionNullable }) => {

--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -1,6 +1,5 @@
 import type { Token as BackendToken } from '$declarations/backend/backend.did';
 import type { Erc20Token } from '$eth/types/erc20';
-import type { Erc721Token } from '$eth/types/erc721';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
@@ -17,22 +16,19 @@ type TokenVariant<K extends CustomTokenNetworkKeys, T> = T & { networkKey: K };
 
 export type IcrcSaveCustomToken = Pick<IcrcCustomToken, 'ledgerCanisterId' | 'indexCanisterId'>;
 
-export type Erc20SaveCustomToken = Pick<Erc20Token, 'address' | 'decimals' | 'symbol'> &
+export type ErcSaveCustomToken = Pick<Erc20Token, 'address'> &
 	Pick<Erc20Token['network'], 'chainId'>;
-
-export type Erc721SaveCustomToken = Pick<Erc721Token, 'address'> &
-	Pick<Erc721Token['network'], 'chainId'>;
 
 export type SplSaveCustomToken = Pick<SplToken, 'address' | 'decimals' | 'symbol'>;
 
 export type SaveCustomToken = UserTokenState &
-	(IcrcSaveCustomToken | Erc20SaveCustomToken | Erc721SaveCustomToken | SplSaveCustomToken);
+	(IcrcSaveCustomToken | ErcSaveCustomToken | SplSaveCustomToken);
 
 export type SaveCustomTokenWithKey = UserTokenState &
 	(
 		| TokenVariant<'Icrc', IcrcSaveCustomToken>
-		| TokenVariant<'Erc20', Erc20SaveCustomToken>
-		| TokenVariant<'Erc721', Erc721SaveCustomToken>
+		| TokenVariant<'Erc20', ErcSaveCustomToken>
+		| TokenVariant<'Erc721', ErcSaveCustomToken>
 		| TokenVariant<'SplDevnet' | 'SplMainnet', SplSaveCustomToken>
 	);
 

--- a/src/frontend/src/lib/utils/custom-token.utils.ts
+++ b/src/frontend/src/lib/utils/custom-token.utils.ts
@@ -1,14 +1,12 @@
 import type {
 	CustomToken,
-	Erc20Token,
-	Erc20Token as Erc721Token,
+	ErcToken,
 	IcrcToken,
 	SplToken,
 	Token
 } from '$declarations/backend/backend.did';
 import type {
-	Erc20SaveCustomToken,
-	Erc721SaveCustomToken,
+	ErcSaveCustomToken,
 	IcrcSaveCustomToken,
 	SaveCustomTokenWithKey,
 	SplSaveCustomToken
@@ -26,18 +24,10 @@ const toIcrcCustomToken = ({
 	)
 });
 
-const toErc20CustomToken = ({
+const toErcCustomToken = ({
 	address: token_address,
 	chainId: chain_id
-}: Erc20SaveCustomToken): Erc20Token => ({
-	token_address,
-	chain_id
-});
-
-const toErc721CustomToken = ({
-	address: token_address,
-	chainId: chain_id
-}: Erc721SaveCustomToken): Erc721Token => ({
+}: ErcSaveCustomToken): ErcToken => ({
 	token_address,
 	chain_id
 });
@@ -64,12 +54,8 @@ export const toCustomToken = ({
 			return { Icrc: toIcrcCustomToken(rest) };
 		}
 
-		if (networkKey === 'Erc20') {
-			return { Erc20: toErc20CustomToken(rest) };
-		}
-
-		if (networkKey === 'Erc721') {
-			return { Erc721: toErc721CustomToken(rest) };
+		if (networkKey === 'Erc20' || networkKey === 'Erc721') {
+			return { Erc20: toErcCustomToken(rest) };
 		}
 
 		if (networkKey === 'SplMainnet') {

--- a/src/frontend/src/lib/utils/custom-token.utils.ts
+++ b/src/frontend/src/lib/utils/custom-token.utils.ts
@@ -54,8 +54,12 @@ export const toCustomToken = ({
 			return { Icrc: toIcrcCustomToken(rest) };
 		}
 
-		if (networkKey === 'Erc20' || networkKey === 'Erc721') {
+		if (networkKey === 'Erc20') {
 			return { Erc20: toErcCustomToken(rest) };
+		}
+
+		if (networkKey === 'Erc721') {
+			return { Erc721: toErcCustomToken(rest) };
 		}
 
 		if (networkKey === 'SplMainnet') {

--- a/src/frontend/src/tests/lib/utils/custom-token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/custom-token.utils.spec.ts
@@ -78,9 +78,7 @@ describe('custom-token.utils', () => {
 					...mockParams,
 					networkKey: 'Erc20',
 					address: 'mock-token-address',
-					chainId: 123n,
-					decimals: 8,
-					symbol: 'mock-symbol'
+					chainId: 123n
 				})
 			).toEqual({
 				...partialExpected,

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -11,7 +11,7 @@ use crate::{
             Contact, ContactAddressData, ContactImage, CreateContactRequest, UpdateContactRequest,
         },
         custom_token::{
-            CustomToken, CustomTokenId, Erc20Token, Erc721Token, ErcTokenId, IcrcToken, SplToken,
+            CustomToken, CustomTokenId, ErcTokenId, IcrcToken, SplToken,
             SplTokenId, Token,
         },
         dapp::{AddDappSettingsError, DappCarouselSettings, DappSettings, MAX_DAPP_ID_LIST_LENGTH},
@@ -29,6 +29,7 @@ use crate::{
     },
     validate::{validate_on_deserialize, Validate},
 };
+use crate::types::custom_token::ErcToken;
 
 // Constants for validation limits
 const CONTACT_MAX_NAME_LENGTH: usize = 100;
@@ -84,12 +85,12 @@ impl From<&Token> for CustomTokenId {
             Token::SplDevnet(SplToken { token_address, .. }) => {
                 CustomTokenId::SolDevnet(token_address.clone())
             }
-            Token::Erc20(Erc20Token {
+            Token::Erc20(ErcToken {
                 token_address,
                 chain_id,
                 ..
             })
-            | Token::Erc721(Erc721Token {
+            | Token::Erc721(ErcToken {
                 token_address,
                 chain_id,
                 ..
@@ -486,23 +487,7 @@ impl Validate for SplToken {
     }
 }
 
-impl Validate for Erc20Token {
-    fn validate(&self) -> Result<(), candid::Error> {
-        use crate::types::MAX_SYMBOL_LENGTH;
-        if let Some(symbol) = &self.symbol {
-            if symbol.chars().count() > MAX_SYMBOL_LENGTH {
-                return Err(candid::Error::msg(format!(
-                    "Symbol too long: {} > {}",
-                    symbol.len(),
-                    MAX_SYMBOL_LENGTH
-                )));
-            }
-        }
-        self.token_address.validate()
-    }
-}
-
-impl Validate for Erc721Token {
+impl Validate for ErcToken {
     fn validate(&self) -> Result<(), candid::Error> {
         self.token_address.validate()
     }
@@ -642,7 +627,6 @@ validate_on_deserialize!(CustomTokenId);
 validate_on_deserialize!(IcrcToken);
 validate_on_deserialize!(SplToken);
 validate_on_deserialize!(SplTokenId);
-validate_on_deserialize!(Erc20Token);
+validate_on_deserialize!(ErcToken);
 validate_on_deserialize!(ErcTokenId);
-validate_on_deserialize!(Erc721Token);
 validate_on_deserialize!(UserToken);

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -464,8 +464,7 @@ impl Validate for Token {
         match self {
             Token::Icrc(token) => token.validate(),
             Token::SplMainnet(token) | Token::SplDevnet(token) => token.validate(),
-            Token::Erc20(token) => token.validate(),
-            Token::Erc721(token) => token.validate(),
+            Token::Erc20(token) | Token::Erc721(token) => token.validate(),
         }
     }
 }

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -11,8 +11,8 @@ use crate::{
             Contact, ContactAddressData, ContactImage, CreateContactRequest, UpdateContactRequest,
         },
         custom_token::{
-            CustomToken, CustomTokenId, ErcTokenId, IcrcToken, SplToken,
-            SplTokenId, Token,
+            CustomToken, CustomTokenId, ErcToken, ErcTokenId, IcrcToken, SplToken, SplTokenId,
+            Token,
         },
         dapp::{AddDappSettingsError, DappCarouselSettings, DappSettings, MAX_DAPP_ID_LIST_LENGTH},
         network::{
@@ -29,7 +29,6 @@ use crate::{
     },
     validate::{validate_on_deserialize, Validate},
 };
-use crate::types::custom_token::ErcToken;
 
 // Constants for validation limits
 const CONTACT_MAX_NAME_LENGTH: usize = 100;

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -38,7 +38,8 @@ pub struct ErcTokenId(pub String);
 /// IDs may be found on: <https://chainlist.org/>
 pub type ChainId = u64;
 
-/// An ERC compliant token on the Ethereum or EVM-compatible networks (for example, ERC20, ERC721, ERC1155).
+/// An ERC compliant token on the Ethereum or EVM-compatible networks (for example, ERC20, ERC721,
+/// ERC1155).
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 #[serde(remote = "Self")]
 pub struct ErcToken {

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -38,20 +38,10 @@ pub struct ErcTokenId(pub String);
 /// IDs may be found on: <https://chainlist.org/>
 pub type ChainId = u64;
 
-/// An ERC20 compliant token on the Ethereum or EVM-compatible networks.
+/// An ERC compliant token on the Ethereum or EVM-compatible networks (for example, ERC20, ERC721, ERC1155).
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 #[serde(remote = "Self")]
-pub struct Erc20Token {
-    pub token_address: ErcTokenId,
-    pub chain_id: ChainId,
-    pub symbol: Option<String>,
-    pub decimals: Option<u8>,
-}
-
-/// An ERC721 compliant token on the Ethereum or EVM-compatible networks.
-#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-#[serde(remote = "Self")]
-pub struct Erc721Token {
+pub struct ErcToken {
     pub token_address: ErcTokenId,
     pub chain_id: ChainId,
 }
@@ -63,8 +53,8 @@ pub enum Token {
     Icrc(IcrcToken) = 0,
     SplMainnet(SplToken) = 1,
     SplDevnet(SplToken) = 2,
-    Erc20(Erc20Token) = 3,
-    Erc721(Erc721Token) = 4,
+    Erc20(ErcToken) = 3,
+    Erc721(ErcToken) = 4,
 }
 
 /// User preferences for any token

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -250,115 +250,56 @@ mod custom_token {
         //! Tests for the erc20 module.
         use super::*;
         use crate::{
-            types::MAX_SYMBOL_LENGTH,
             validate::{test_validate_on_deserialize, TestVector, Validate},
         };
 
         test_validate_on_deserialize!(
-            Erc20Token,
+            ErcToken,
             vec![
                 TestVector {
-                    input: Erc20Token {
+                    input: ErcToken {
                         token_address: ErcTokenId(
                             "0x1234567890123456789012345678901234567890".to_string()
                         ),
-                        chain_id: 1,
-                        symbol: Some("☃☃☃ ☃ ☃☃☃".to_string()),
-                        decimals: Some(6),
+                        chain_id: 1
                     },
                     valid: true,
                     description: "Valid Erc20Token",
                 },
                 TestVector {
-                    input: Erc20Token {
-                        token_address: ErcTokenId(
-                            "0x1234567890123456789012345678901234567890".to_string()
-                        ),
-                        chain_id: 1,
-                        symbol: None,
-                        decimals: None,
-                    },
-                    valid: true,
-                    description: "Erc20Token without a symbol or decimals",
-                },
-                TestVector {
-                    input: Erc20Token {
+                    input: ErcToken {
                         token_address: ErcTokenId(
                             "0x12345678901234567890123456789012345678".to_string()
                         ),
                         chain_id: 1,
-                        symbol: Some("Bouncy Castle".to_string()),
-                        decimals: Some(6),
                     },
                     valid: false,
                     description: "Erc20Token with a token address that is too short",
                 },
                 TestVector {
-                    input: Erc20Token {
+                    input: ErcToken {
                         token_address: ErcTokenId("1".repeat(99)),
                         chain_id: 1,
-                        symbol: Some("Bouncy Castle".to_string()),
-                        decimals: Some(6),
                     },
                     valid: false,
                     description: "Erc20Token with a token address that is too long",
                 },
                 TestVector {
-                    input: Erc20Token {
-                        token_address: ErcTokenId(
-                            "0x1234567890123456789012345678901234567890".to_string()
-                        ),
-                        chain_id: 1,
-                        symbol: Some("B".repeat(MAX_SYMBOL_LENGTH + 1)),
-                        decimals: Some(6),
-                    },
-                    valid: false,
-                    description: "Too long symbol",
-                },
-                TestVector {
-                    input: Erc20Token {
-                        token_address: ErcTokenId(
-                            "0x1234567890123456789012345678901234567890".to_string()
-                        ),
-                        chain_id: 1,
-                        symbol: Some("Bouncy Castle".to_string()),
-                        decimals: Some(255),
-                    },
-                    valid: true,
-                    description: "Maximum decimals",
-                },
-                TestVector {
-                    input: Erc20Token {
-                        token_address: ErcTokenId(
-                            "0x1234567890123456789012345678901234567890".to_string()
-                        ),
-                        chain_id: 1,
-                        symbol: Some("Bouncy Castle".to_string()),
-                        decimals: Some(0),
-                    },
-                    valid: true,
-                    description: "Minimum decimals",
-                },
-                TestVector {
-                    input: Erc20Token {
+                    input: ErcToken {
                         token_address: ErcTokenId(
                             "0x1234567890123456789012345678901234567890".to_string()
                         ),
                         chain_id: 2 ^ 64 - 1,
-                        symbol: Some("Bouncy Castle".to_string()),
-                        decimals: Some(6),
                     },
                     valid: true,
                     description: "Maximum chain ID",
                 },
                 TestVector {
-                    input: Erc20Token {
+                    input: ErcToken {
                         token_address: ErcTokenId(
                             "0x1234567890123456789012345678901234567890".to_string()
                         ),
                         chain_id: 0,
-                        symbol: Some("Bouncy Castle".to_string()),
-                        decimals: Some(6),
                     },
                     valid: true,
                     description: "Minimum chain ID",

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -249,9 +249,7 @@ mod custom_token {
     mod erc20 {
         //! Tests for the erc20 module.
         use super::*;
-        use crate::{
-            validate::{test_validate_on_deserialize, TestVector, Validate},
-        };
+        use crate::validate::{test_validate_on_deserialize, TestVector, Validate};
 
         test_validate_on_deserialize!(
             ErcToken,


### PR DESCRIPTION
# Motivation

We want to have a single interface for ERC tokens in the backend: the existing ERC20 and ERC721 interfaces are the exact same after PR https://github.com/dfinity/oisy-wallet/pull/7970.

BREAKING CHANGE: the interface's name of the `CustomToken` variant ERC20 and ERC721 changed.

# Changes

- Merge ERC20 and ERC721 interfaces into a single one without symbol and decimals.
- Adapt the frontend.

# Tests

Current tests where adapted.
