### PR TITLE
chore(frontend): Adjust link to ICPSwap help page

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -12,7 +12,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
-	import { OISY_DOCS_SWAP_LINK } from '$lib/constants/swap.constants';
+	import { OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK } from '$lib/constants/swap.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
@@ -81,7 +81,7 @@
 					{$i18n.swap.error.withdraw_failed_first_part}
 					<ExternalLink
 						iconSize="15"
-						href={OISY_DOCS_SWAP_LINK}
+						href={OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK}
 						ariaLabel={$i18n.swap.text.open_instructions_link}
 						>{$i18n.swap.error.swap_failed_instruction_link}</ExternalLink
 					>

--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -16,5 +16,5 @@ export const ICP_SWAP_POOL_FEE = 3000n;
 
 export const SWAP_ETH_TOKEN_PLACEHOLDER = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
-export const OISY_DOCS_SWAP_LINK =
-	'https://docs.oisy.com/using-oisy-wallet/how-tos/swapping-tokens';
+export const OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK =
+	'https://docs.oisy.com/using-oisy-wallet/how-tos/swapping-tokens#manually-withdraw-funds-from-icpswap';


### PR DESCRIPTION
# Motivation

<img width="586" height="505" alt="image" src="https://github.com/user-attachments/assets/c3446ade-6e44-424c-9687-f0452f3579b4" />

This Link should go to a specific anchor, about withdraw from ICPSwap.

# Changes

- adjust the link and the constant name

# Tests

