### PR TITLE
feat(frontend): Util to parse NFT metadata URLs

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc721.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc721.providers.ts
@@ -8,8 +8,8 @@ import { InvalidMetadataImageUrl, InvalidTokenUri } from '$lib/types/errors';
 import type { NetworkId } from '$lib/types/network';
 import type { NftMetadata } from '$lib/types/nft';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
-import { UrlSchema } from '$lib/validation/url.validation';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { Contract } from 'ethers/contract';
 import { InfuraProvider, type Networkish } from 'ethers/providers';
@@ -45,34 +45,25 @@ export class InfuraErc721Provider {
 	}): Promise<NftMetadata> => {
 		const erc721Contract = new Contract(contractAddress, ERC721_ABI, this.provider);
 
-		const resolveResourceUrl = (url: URL): URL => {
-			const IPFS_PREFIX = 'ipfs://';
-			if (url.href.startsWith(IPFS_PREFIX)) {
-				return new URL(url.href.replace(IPFS_PREFIX, 'https://ipfs.io/ipfs/'));
-			}
-
-			return url;
-		};
-
 		const extractImageUrl = (imageUrl: string | undefined): URL | undefined => {
 			if (isNullish(imageUrl)) {
 				return undefined;
 			}
 
-			const parsedMetadataUrl = UrlSchema.safeParse(imageUrl);
-			if (!parsedMetadataUrl.success) {
-				throw new InvalidMetadataImageUrl(tokenId, contractAddress);
-			}
-
-			return resolveResourceUrl(new URL(parsedMetadataUrl.data));
+			return parseMetadataResourceUrl({
+				url: imageUrl,
+				error: new InvalidMetadataImageUrl(tokenId, contractAddress)
+			});
 		};
 
-		const parsedTokenUri = UrlSchema.safeParse(await erc721Contract.tokenURI(tokenId));
-		if (!parsedTokenUri.success) {
-			throw new InvalidTokenUri(tokenId, contractAddress);
-		}
+		const tokenUri = await erc721Contract.tokenURI(tokenId);
+		const errorTokenUri = new InvalidTokenUri(tokenId, contractAddress);
 
-		const metadataUrl = resolveResourceUrl(new URL(parsedTokenUri.data));
+		const metadataUrl = parseMetadataResourceUrl({ url: tokenUri, error: errorTokenUri });
+
+		if (isNullish(metadataUrl)) {
+			throw errorTokenUri;
+		}
 
 		const response = await fetch(metadataUrl);
 		const metadata = await response.json();

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -1,5 +1,5 @@
 import type { Erc721Token } from '$eth/types/erc721';
-import { NftError } from '$lib/types/errors';
+import type { NftError } from '$lib/types/errors';
 import type { Nft, NftsByNetwork } from '$lib/types/nft';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { isNullish, nonNullish } from '@dfinity/utils';

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -1,5 +1,7 @@
 import type { Erc721Token } from '$eth/types/erc721';
+import { NftError } from '$lib/types/errors';
 import type { Nft, NftsByNetwork } from '$lib/types/nft';
+import { UrlSchema } from '$lib/validation/url.validation';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const getNftsByNetworks = ({
@@ -36,4 +38,39 @@ export const getNftsByNetworks = ({
 	});
 
 	return nftsByToken;
+};
+
+const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
+	const IPFS_PROTOCOL = 'ipfs:';
+	const IPFS_GATEWAY = 'https://ipfs.io/ipfs/';
+
+	if (url.protocol !== IPFS_PROTOCOL) {
+		return url;
+	}
+
+	const newUrl = url.href.replace(`${IPFS_PROTOCOL}//`, IPFS_GATEWAY);
+
+	const parsedNewUrl = UrlSchema.safeParse(newUrl);
+
+	if (!parsedNewUrl.success) {
+		return;
+	}
+
+	return new URL(parsedNewUrl.data);
+};
+
+export const parseMetadataResourceUrl = ({
+	url,
+	error
+}: {
+	url: string;
+	error: NftError;
+}): URL | undefined => {
+	const parsedUrl = UrlSchema.safeParse(url);
+
+	if (!parsedUrl.success) {
+		throw error;
+	}
+
+	return adaptMetadataResourceUrl(new URL(parsedUrl.data));
 };

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -1,8 +1,10 @@
 import { POLYGON_AMOY_NETWORK } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import type { Erc721CustomToken } from '$eth/types/erc721-custom-token';
+import { NftError } from '$lib/types/errors';
 import type { Nft, NftsByNetwork } from '$lib/types/nft';
-import { getNftsByNetworks } from '$lib/utils/nfts.utils';
+import { getNftsByNetworks, parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { AZUKI_ELEMENTAL_BEANS_TOKEN, DE_GODS_TOKEN } from '$tests/mocks/erc721-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
@@ -157,6 +159,66 @@ describe('nfts.utils', () => {
 			const expectedResult = {};
 
 			expect(result).toEqual(expectedResult);
+		});
+	});
+
+	describe('parseMetadataResourceUrl', () => {
+		const mockError = new NftError(123456, PEPE_TOKEN.address);
+
+		it('should raise an error if URL is not a parseable URL', () => {
+			const url = 'invalid-url';
+
+			expect(() => parseMetadataResourceUrl({ url, error: mockError })).toThrow(mockError);
+		});
+
+		it('should return the same URL if not IPFS protocol', () => {
+			const url = 'https://example.com/metadata.json';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result).toBeInstanceOf(URL);
+			expect(result?.href).toBe(url);
+		});
+
+		it('should transform a valid ipfs:// URL to ipfs.io', () => {
+			const url = 'ipfs://Qm12345abcde/metadata.json';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result).toBeInstanceOf(URL);
+			expect(result?.href).toBe('https://ipfs.io/ipfs/Qm12345abcde/metadata.json');
+		});
+
+		it('should handle malformed IPFS path', () => {
+			const url = 'ipfs://';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('https://ipfs.io/ipfs/');
+		});
+
+		it('should handle transformed IPFS URL with emojis', () => {
+			const url = 'ipfs://??//💣';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('https://ipfs.io/ipfs/??//%F0%9F%92%A3');
+		});
+
+		it('should handle IPFS URL that is not valid per UrlSchema', () => {
+			const url = 'ipfs:??//💣';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('ipfs:??//%F0%9F%92%A3');
+		});
+
+		it('should handle empty IPFS string', () => {
+			const url = 'ipfs:// ';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('ipfs:/');
+		});
+
+		it('should not allow URL with localhost', () => {
+			const url = 'http://localhost:3000/some-data';
+
+			expect(() => parseMetadataResourceUrl({ url, error: mockError })).toThrow(mockError);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

For standard ERC-1155, we will require the same parser of URLs as the ones used for ERC-721. Basically, we need to adapt `ipfs:` protocols and parse the string to an URL.

To do so, we extract the existing code in a separate util.

# Changes

- Create util parseMetadataResourceUrl that is a copy of the existing code in the Infura ERC721 providers.
- Adapt the rest of the code.

# Tests

Created tests.
