### PR TITLE
feat(frontend): Map ERC1155 in custom tokens util

### DIFF
--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -27,8 +27,7 @@ export type SaveCustomToken = UserTokenState &
 export type SaveCustomTokenWithKey = UserTokenState &
 	(
 		| TokenVariant<'Icrc', IcrcSaveCustomToken>
-		| TokenVariant<'Erc20', ErcSaveCustomToken>
-		| TokenVariant<'Erc721', ErcSaveCustomToken>
+		| TokenVariant<'Erc20' | 'Erc721' | 'Erc1155', ErcSaveCustomToken>
 		| TokenVariant<'SplDevnet' | 'SplMainnet', SplSaveCustomToken>
 	);
 

--- a/src/frontend/src/lib/utils/custom-token.utils.ts
+++ b/src/frontend/src/lib/utils/custom-token.utils.ts
@@ -62,6 +62,10 @@ export const toCustomToken = ({
 			return { Erc721: toErcCustomToken(rest) };
 		}
 
+		if (networkKey === 'Erc1155') {
+			return { Erc1155: toErcCustomToken(rest) };
+		}
+
 		if (networkKey === 'SplMainnet') {
 			return { SplMainnet: toSplCustomToken(rest) };
 		}

--- a/src/frontend/src/tests/lib/utils/custom-token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/custom-token.utils.spec.ts
@@ -35,7 +35,7 @@ describe('custom-token.utils', () => {
 			});
 		});
 
-		it('should return correct type for Icrc network', () => {
+		it('should return correct type for Icrc network key', () => {
 			const networkKey = 'Icrc';
 
 			expect(
@@ -72,7 +72,7 @@ describe('custom-token.utils', () => {
 			});
 		});
 
-		it('should return correct type for Ethereum/EVM erc20 network', () => {
+		it('should return correct type for Ethereum/EVM Erc20 network key', () => {
 			expect(
 				toCustomToken({
 					...mockParams,
@@ -91,7 +91,7 @@ describe('custom-token.utils', () => {
 			});
 		});
 
-		it('should return correct type for Ethereum/EVM erc721 network', () => {
+		it('should return correct type for Ethereum/EVM Erc721 network key', () => {
 			expect(
 				toCustomToken({
 					...mockParams,
@@ -110,7 +110,26 @@ describe('custom-token.utils', () => {
 			});
 		});
 
-		it('should return correct type for SplMainnet network', () => {
+		it('should return correct type for Ethereum/EVM Erc1155 network key', () => {
+			expect(
+				toCustomToken({
+					...mockParams,
+					networkKey: 'Erc1155',
+					address: 'mock-token-address',
+					chainId: 123n
+				})
+			).toEqual({
+				...partialExpected,
+				token: {
+					Erc1155: {
+						token_address: 'mock-token-address',
+						chain_id: 123n
+					}
+				}
+			});
+		});
+
+		it('should return correct type for SplMainnet network key', () => {
 			expect(
 				toCustomToken({
 					...mockParams,
@@ -131,7 +150,7 @@ describe('custom-token.utils', () => {
 			});
 		});
 
-		it('should return correct type for SplDevnet network', () => {
+		it('should return correct type for SplDevnet network key', () => {
 			expect(
 				toCustomToken({
 					...mockParams,


### PR DESCRIPTION
# Motivation

Similar to ERC20 and ERC721, we integrate ERC1155 in the util that maps Frontend custom tokens to Backend ones.
