### PR TITLE
refactor(frontend): Simplify util `parseMetadataResourceUrl`

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc721.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc721.providers.ts
@@ -56,13 +56,11 @@ export class InfuraErc721Provider {
 		};
 
 		const tokenUri = await erc721Contract.tokenURI(tokenId);
-		const errorTokenUri = new InvalidTokenUri(tokenId, contractAddress);
 
-		const metadataUrl = parseMetadataResourceUrl({ url: tokenUri, error: errorTokenUri });
-
-		if (isNullish(metadataUrl)) {
-			throw errorTokenUri;
-		}
+		const metadataUrl = parseMetadataResourceUrl({
+			url: tokenUri,
+			error: new InvalidTokenUri(tokenId, contractAddress)
+		});
 
 		const response = await fetch(metadataUrl);
 		const metadata = await response.json();

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -59,18 +59,18 @@ const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
 	return new URL(parsedNewUrl.data);
 };
 
-export const parseMetadataResourceUrl = ({
-	url,
-	error
-}: {
-	url: string;
-	error: NftError;
-}): URL | undefined => {
+export const parseMetadataResourceUrl = ({ url, error }: { url: string; error: NftError }): URL => {
 	const parsedUrl = UrlSchema.safeParse(url);
 
 	if (!parsedUrl.success) {
 		throw error;
 	}
 
-	return adaptMetadataResourceUrl(new URL(parsedUrl.data));
+	const adaptedUrl = adaptMetadataResourceUrl(new URL(parsedUrl.data));
+
+	if (isNullish(adaptedUrl)) {
+		throw error;
+	}
+
+	return adaptedUrl;
 };


### PR DESCRIPTION
# Motivation

It does not really make sense that util `parseMetadataResourceUrl` returns an undefined value. In fact, it is expected to always return an URL since the input is an URL. If it is not parsable, it will already raise an error as first step.

So, just to be type-safe, we include the nullish check inside it.
