### PR TITLE
refactor(frontend): Rename type of Ethereum transactions data

### DIFF
--- a/src/frontend/src/eth/stores/eth-transactions.store.ts
+++ b/src/frontend/src/eth/stores/eth-transactions.store.ts
@@ -29,12 +29,14 @@ interface EthTransactionsStore<T extends TransactionTypes>
 
 export type EthCertifiedTransaction = CertifiedTransaction<Transaction>;
 
-export type EthTransactionsData = CertifiedStoreData<TransactionsData<Transaction>>;
+type EthTransactionsData = TransactionsData<Transaction>;
+
+export type EthCertifiedTransactionsData = CertifiedStoreData<EthTransactionsData>;
 
 const initEthTransactionsStore = (): EthTransactionsStore<Transaction> => {
-	const INITIAL: EthTransactionsData = {} as EthTransactionsData;
+	const INITIAL: EthCertifiedTransactionsData = {} as EthCertifiedTransactionsData;
 
-	const { subscribe, update, set } = writable<EthTransactionsData>(INITIAL);
+	const { subscribe, update, set } = writable<EthCertifiedTransactionsData>(INITIAL);
 
 	return {
 		set: ({ tokenId, transactions }: TransactionsStoreParams<Transaction>) =>

--- a/src/frontend/src/eth/stores/eth-transactions.store.ts
+++ b/src/frontend/src/eth/stores/eth-transactions.store.ts
@@ -29,7 +29,7 @@ interface EthTransactionsStore<T extends TransactionTypes>
 
 export type EthCertifiedTransaction = CertifiedTransaction<Transaction>;
 
-type EthTransactionsData = TransactionsData<Transaction>;
+export type EthTransactionsData = TransactionsData<Transaction>;
 
 export type EthCertifiedTransactionsData = CertifiedStoreData<EthTransactionsData>;
 

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -4,7 +4,7 @@ import { BTC_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.sol.env';
-import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
+import type { EthCertifiedTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { nullishSignOut } from '$lib/services/auth.services';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -73,7 +73,7 @@ export const setIdbBtcTransactions = (
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbBtcTransactionsStore });
 
 export const setIdbEthTransactions = (
-	params: SetIdbTransactionsParams<EthTransactionsData>
+	params: SetIdbTransactionsParams<EthCertifiedTransactionsData>
 ): Promise<void> =>
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbEthTransactionsStore });
 
@@ -93,7 +93,8 @@ export const getIdbBtcTransactions = (
 
 export const getIdbEthTransactions = (
 	params: GetIdbTransactionsParams
-): Promise<EthTransactionsData[] | undefined> => get(toKey(params), idbEthTransactionsStore);
+): Promise<EthCertifiedTransactionsData[] | undefined> =>
+	get(toKey(params), idbEthTransactionsStore);
 
 export const getIdbIcTransactions = (
 	params: GetIdbTransactionsParams

--- a/src/frontend/src/lib/types/idb-transactions.ts
+++ b/src/frontend/src/lib/types/idb-transactions.ts
@@ -1,5 +1,5 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
-import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
+import type { EthCertifiedTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
@@ -11,7 +11,7 @@ import type { Principal } from '@dfinity/principal';
 
 export type IdbTransactionsStoreData =
 	| CertifiedStoreData<TransactionsData<BtcTransactionUi>>
-	| EthTransactionsData
+	| EthCertifiedTransactionsData
 	| CertifiedStoreData<TransactionsData<IcTransactionUi>>
 	| CertifiedStoreData<TransactionsData<SolTransactionUi>>;
 

--- a/src/frontend/src/lib/types/transactions.ts
+++ b/src/frontend/src/lib/types/transactions.ts
@@ -1,5 +1,5 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
-import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
+import type { EthCertifiedTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
@@ -11,7 +11,7 @@ export interface TransactionsStoreCheckParams {
 	// TODO: set unified type when we harmonize the transaction stores
 	transactionsStoreData:
 		| CertifiedStoreData<TransactionsData<IcTransactionUi | BtcTransactionUi | SolTransactionUi>>
-		| EthTransactionsData;
+		| EthCertifiedTransactionsData;
 	tokens: Token[];
 }
 

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -1,6 +1,6 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
-import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
+import type { EthCertifiedTransactionsData } from '$eth/stores/eth-transactions.store';
 import { mapEthTransactionUi } from '$eth/utils/transactions.utils';
 import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
 import { toCkMinterInfoAddresses } from '$icp-eth/utils/cketh.utils';
@@ -70,7 +70,7 @@ export const mapAllTransactionsUi = ({
 }: {
 	tokens: Token[];
 	$btcTransactions: CertifiedStoreData<TransactionsData<BtcTransactionUi>>;
-	$ethTransactions: EthTransactionsData;
+	$ethTransactions: EthCertifiedTransactionsData;
 	$ckEthMinterInfo: CertifiedStoreData<CkEthMinterInfoData>;
 	$ckBtcMinterInfoStore: CertifiedStoreData<CkBtcMinterInfoData>;
 	$ethAddress: OptionEthAddress;

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -29,7 +29,7 @@ import { ICP_TOKEN, ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN, SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
 import type {
 	EthCertifiedTransaction,
-	EthTransactionsData
+	EthCertifiedTransactionsData
 } from '$eth/stores/eth-transactions.store';
 import type { EthTransactionType } from '$eth/types/eth-transaction';
 import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic-transaction';
@@ -92,7 +92,7 @@ describe('transactions.utils', () => {
 		const mockBnbMainnetTransactions: EthCertifiedTransaction[] =
 			createMockEthCertifiedTransactions(2);
 
-		const mockEthTransactions: EthTransactionsData = {
+		const mockEthTransactions: EthCertifiedTransactionsData = {
 			[ETHEREUM_TOKEN_ID]: mockEthMainnetTransactions,
 			[SEPOLIA_TOKEN_ID]: mockSepoliaTransactions,
 			[PEPE_TOKEN_ID]: mockErc20Transactions,
@@ -314,7 +314,7 @@ describe('transactions.utils', () => {
 			it('should return an empty array if there are no transactions any of the tokens', () => {
 				const tokens = [ETHEREUM_TOKEN, SEPOLIA_TOKEN];
 
-				const mockEthTransactions: EthTransactionsData = {
+				const mockEthTransactions: EthCertifiedTransactionsData = {
 					[PEPE_TOKEN_ID]: mockErc20Transactions
 				};
 
@@ -328,7 +328,7 @@ describe('transactions.utils', () => {
 			});
 
 			it('should map correctly if there are no transactions for some of the tokens', () => {
-				const mockEthTransactions: EthTransactionsData = {
+				const mockEthTransactions: EthCertifiedTransactionsData = {
 					[PEPE_TOKEN_ID]: mockErc20Transactions
 				};
 
@@ -463,7 +463,7 @@ describe('transactions.utils', () => {
 
 		const mockEthMainnetTransactions: EthCertifiedTransaction[] =
 			createMockEthCertifiedTransactions(5);
-		const mockEthTransactions: EthTransactionsData = {
+		const mockEthTransactions: EthCertifiedTransactionsData = {
 			[ETHEREUM_TOKEN_ID]: mockEthMainnetTransactions
 		};
 
@@ -775,7 +775,7 @@ describe('transactions.utils', () => {
 			tokens: [BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN]
 		};
 		const mockEthTransactionStoreData: {
-			transactionsStoreData: EthTransactionsData;
+			transactionsStoreData: EthCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {
@@ -1113,7 +1113,7 @@ describe('transactions.utils', () => {
 			tokens: [BTC_MAINNET_TOKEN, BTC_TESTNET_TOKEN]
 		};
 		const mockEthTransactionStoreData: {
-			transactionsStoreData: EthTransactionsData;
+			transactionsStoreData: EthCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {


### PR DESCRIPTION
# Motivation

To normalize with the other transactions store, we rename the variable  `EthTransactionsData` to `EthCertifiedTransactionsData`.
