### PR TITLE
refactor(frontend): Extract type for certified IC transactions data

### DIFF
--- a/src/frontend/src/icp/stores/ic-transactions.store.ts
+++ b/src/frontend/src/icp/stores/ic-transactions.store.ts
@@ -1,4 +1,5 @@
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import {
 	initTransactionsStore,
 	type CertifiedTransaction,
@@ -8,5 +9,7 @@ import {
 export type IcCertifiedTransaction = CertifiedTransaction<IcTransactionUi>;
 
 export type IcTransactionsData = TransactionsData<IcTransactionUi>;
+
+export type IcCertifiedTransactionsData = CertifiedStoreData<IcTransactionsData>;
 
 export const icTransactionsStore = initTransactionsStore<IcTransactionUi>();

--- a/src/frontend/src/icp/utils/ic-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ic-transactions.utils.ts
@@ -3,7 +3,10 @@ import type { BtcStatusesData } from '$icp/stores/btc.store';
 import type { CkBtcPendingUtxosData } from '$icp/stores/ckbtc-utxos.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
 import type { IcPendingTransactionsData } from '$icp/stores/ic-pending-transactions.store';
-import type { IcCertifiedTransaction } from '$icp/stores/ic-transactions.store';
+import type {
+	IcCertifiedTransaction,
+	IcCertifiedTransactionsData
+} from '$icp/stores/ic-transactions.store';
 import type { IcCkToken, IcToken } from '$icp/types/ic-token';
 import type {
 	IcTransaction,
@@ -28,7 +31,7 @@ import {
 import { mapIcpTransaction } from '$icp/utils/icp-transactions.utils';
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import type { CertifiedTransaction, TransactionsData } from '$lib/stores/transactions.store';
+import type { CertifiedTransaction } from '$lib/stores/transactions.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Token } from '$lib/types/token';
 
@@ -96,7 +99,7 @@ export const getIcExtendedTransactions = ({
 	btcStatusesStore
 }: {
 	token: Token;
-	icTransactionsStore: CertifiedStoreData<TransactionsData<IcTransactionUi>>;
+	icTransactionsStore: IcCertifiedTransactionsData;
 	btcStatusesStore: CertifiedStoreData<BtcStatusesData>;
 }) =>
 	(icTransactionsStore?.[token.id] ?? []).map((transaction) =>
@@ -119,7 +122,7 @@ export const getAllIcTransactions = ({
 	ckBtcPendingUtxoTransactions: CertifiedTransaction<IcTransactionUi>[];
 	ckEthPendingTransactions: CertifiedTransaction<IcTransactionUi>[];
 	icExtendedTransactions: CertifiedTransaction<IcTransactionUi>[];
-	icTransactionsStore: CertifiedStoreData<TransactionsData<IcTransactionUi>>;
+	icTransactionsStore: IcCertifiedTransactionsData;
 	btcStatusesStore: CertifiedStoreData<BtcStatusesData>;
 	ckBtcMinterInfoStore: CertifiedStoreData<CkBtcMinterInfoData>;
 	ckBtcPendingUtxosStore: CertifiedStoreData<CkBtcPendingUtxosData>;

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -5,6 +5,7 @@ import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.sol.env';
 import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
+import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { nullishSignOut } from '$lib/services/auth.services';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -78,7 +79,7 @@ export const setIdbEthTransactions = (
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbEthTransactionsStore });
 
 export const setIdbIcTransactions = (
-	params: SetIdbTransactionsParams<CertifiedStoreData<TransactionsData<IcTransactionUi>>>
+	params: SetIdbTransactionsParams<IcCertifiedTransactionsData>
 ): Promise<void> =>
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbIcTransactionsStore });
 

--- a/src/frontend/src/lib/types/idb-transactions.ts
+++ b/src/frontend/src/lib/types/idb-transactions.ts
@@ -1,6 +1,6 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
-import type { IcTransactionUi } from '$icp/types/ic-transaction';
+import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -12,7 +12,7 @@ import type { Principal } from '@dfinity/principal';
 export type IdbTransactionsStoreData =
 	| CertifiedStoreData<TransactionsData<BtcTransactionUi>>
 	| EthTransactionsData
-	| CertifiedStoreData<TransactionsData<IcTransactionUi>>
+	| IcCertifiedTransactionsData
 	| CertifiedStoreData<TransactionsData<SolTransactionUi>>;
 
 export interface SetIdbTransactionsParams<T extends IdbTransactionsStoreData> {

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -8,7 +8,6 @@ import type { BtcStatusesData } from '$icp/stores/btc.store';
 import type { CkBtcPendingUtxosData } from '$icp/stores/ckbtc-utxos.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
 import type { IcPendingTransactionsData } from '$icp/stores/ic-pending-transactions.store';
-import type { IcTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { getCkBtcPendingUtxoTransactions } from '$icp/utils/ckbtc-transactions.utils';
 import { getCkEthPendingTransactions } from '$icp/utils/cketh-transactions.utils';
@@ -76,7 +75,7 @@ export const mapAllTransactionsUi = ({
 	$ethAddress: OptionEthAddress;
 	$solTransactions: CertifiedStoreData<TransactionsData<SolTransactionUi>>;
 	$btcStatuses: CertifiedStoreData<BtcStatusesData>;
-	$icTransactionsStore: CertifiedStoreData<IcTransactionsData>;
+	$icTransactionsStore: IcCertifiedTransactionsData;
 	$ckBtcPendingUtxosStore: CertifiedStoreData<CkBtcPendingUtxosData>;
 	$icPendingTransactionsStore: CertifiedStoreData<IcPendingTransactionsData>;
 }): AllTransactionUiWithCmp[] => {

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -8,6 +8,7 @@ import type { BtcStatusesData } from '$icp/stores/btc.store';
 import type { CkBtcPendingUtxosData } from '$icp/stores/ckbtc-utxos.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
 import type { IcPendingTransactionsData } from '$icp/stores/ic-pending-transactions.store';
+import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { getCkBtcPendingUtxoTransactions } from '$icp/utils/ckbtc-transactions.utils';
 import { getCkEthPendingTransactions } from '$icp/utils/cketh-transactions.utils';

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -32,6 +32,7 @@ import type {
 	EthTransactionsData
 } from '$eth/stores/eth-transactions.store';
 import type { EthTransactionType } from '$eth/types/eth-transaction';
+import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic-transaction';
 import { ZERO } from '$lib/constants/app.constants';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -101,7 +102,7 @@ describe('transactions.utils', () => {
 		};
 
 		const mockIcTransactionsUi: IcTransactionUi[] = createMockIcTransactionsUi(7);
-		const mockIcTransactions: CertifiedStoreData<TransactionsData<IcTransactionUi>> = {
+		const mockIcTransactions: IcCertifiedTransactionsData = {
 			[ICP_TOKEN_ID]: mockIcTransactionsUi.map((data) => ({ data, certified }))
 		};
 
@@ -468,7 +469,7 @@ describe('transactions.utils', () => {
 		};
 
 		const mockIcTransactionsUi: IcTransactionUi[] = createMockIcTransactionsUi(7);
-		const mockIcTransactions: CertifiedStoreData<TransactionsData<IcTransactionUi>> = {
+		const mockIcTransactions: IcCertifiedTransactionsData = {
 			[ICP_TOKEN_ID]: mockIcTransactionsUi.map((data) => ({
 				data: { ...data, type: 'receive' },
 				certified: false
@@ -520,7 +521,7 @@ describe('transactions.utils', () => {
 			});
 
 			it('should filter only received micro transactions', () => {
-				const mockIcSendTransactions: CertifiedStoreData<TransactionsData<IcTransactionUi>> = {
+				const mockIcSendTransactions: IcCertifiedTransactionsData = {
 					[ICP_TOKEN_ID]: mockIcTransactionsUi.map((data) => ({ data, certified: false }))
 				};
 
@@ -786,7 +787,7 @@ describe('transactions.utils', () => {
 			tokens: [ETHEREUM_TOKEN, SEPOLIA_TOKEN, PEPE_TOKEN]
 		};
 		const mockIcTransactionStoreData: {
-			transactionsStoreData: CertifiedStoreData<TransactionsData<IcTransactionUi>>;
+			transactionsStoreData: IcCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {
@@ -1124,7 +1125,7 @@ describe('transactions.utils', () => {
 			tokens: [ETHEREUM_TOKEN, SEPOLIA_TOKEN, PEPE_TOKEN]
 		};
 		const mockIcTransactionStoreData: {
-			transactionsStoreData: CertifiedStoreData<TransactionsData<IcTransactionUi>>;
+			transactionsStoreData: IcCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {


### PR DESCRIPTION
# Motivation

Creating a single type `IcCertifiedTransactionsData` to avoid duplication of code.
