### PR TITLE
refactor(frontend): Extract type for certified BTC transactions data

### DIFF
--- a/src/frontend/src/btc/stores/btc-transactions.store.ts
+++ b/src/frontend/src/btc/stores/btc-transactions.store.ts
@@ -1,6 +1,9 @@
 import type { BtcTransactionUi } from '$btc/types/btc';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import { initTransactionsStore, type TransactionsData } from '$lib/stores/transactions.store';
 
 export type BtcTransactionsData = TransactionsData<BtcTransactionUi>;
+
+export type BtcCertifiedTransactionsData = CertifiedStoreData<BtcTransactionsData>;
 
 export const btcTransactionsStore = initTransactionsStore<BtcTransactionUi>();

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import type { BtcCertifiedTransactionsData } from '$btc/stores/btc-transactions.store';
 import type { BtcTransactionUi } from '$btc/types/btc';
 import { BTC_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
@@ -68,7 +69,7 @@ export const setIdbTransactionsStore = async <T extends IdbTransactionsStoreData
 };
 
 export const setIdbBtcTransactions = (
-	params: SetIdbTransactionsParams<CertifiedStoreData<TransactionsData<BtcTransactionUi>>>
+	params: SetIdbTransactionsParams<BtcCertifiedTransactionsData>
 ): Promise<void> =>
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbBtcTransactionsStore });
 

--- a/src/frontend/src/lib/types/idb-transactions.ts
+++ b/src/frontend/src/lib/types/idb-transactions.ts
@@ -1,4 +1,4 @@
-import type { BtcTransactionUi } from '$btc/types/btc';
+import type { BtcCertifiedTransactionsData } from '$btc/stores/btc-transactions.store';
 import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -10,7 +10,7 @@ import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { Principal } from '@dfinity/principal';
 
 export type IdbTransactionsStoreData =
-	| CertifiedStoreData<TransactionsData<BtcTransactionUi>>
+	| BtcCertifiedTransactionsData
 	| EthTransactionsData
 	| CertifiedStoreData<TransactionsData<IcTransactionUi>>
 	| CertifiedStoreData<TransactionsData<SolTransactionUi>>;

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -1,4 +1,4 @@
-import type { BtcTransactionUi } from '$btc/types/btc';
+import type { BtcCertifiedTransactionsData } from '$btc/stores/btc-transactions.store';
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
 import { mapEthTransactionUi } from '$eth/utils/transactions.utils';
@@ -69,7 +69,7 @@ export const mapAllTransactionsUi = ({
 	$icPendingTransactionsStore
 }: {
 	tokens: Token[];
-	$btcTransactions: CertifiedStoreData<TransactionsData<BtcTransactionUi>>;
+	$btcTransactions: BtcCertifiedTransactionsData;
 	$ethTransactions: EthTransactionsData;
 	$ckEthMinterInfo: CertifiedStoreData<CkEthMinterInfoData>;
 	$ckBtcMinterInfoStore: CertifiedStoreData<CkBtcMinterInfoData>;

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1,3 +1,4 @@
+import type { BtcCertifiedTransactionsData } from '$btc/stores/btc-transactions.store';
 import type { BtcTransactionUi } from '$btc/types/btc';
 import type { BtcTransactionType } from '$btc/types/btc-transaction';
 import * as ethEnv from '$env/networks/networks.eth.env';
@@ -73,7 +74,7 @@ describe('transactions.utils', () => {
 
 		const mockBtcTestnetTransactions: BtcTransactionUi[] = createMockBtcTransactionsUi(3);
 
-		const mockBtcTransactions: CertifiedStoreData<TransactionsData<BtcTransactionUi>> = {
+		const mockBtcTransactions: BtcCertifiedTransactionsData = {
 			[BTC_MAINNET_TOKEN_ID]: mockBtcMainnetTransactions.map((data) => ({ data, certified })),
 			[BTC_TESTNET_TOKEN_ID]: mockBtcTestnetTransactions.map((data) => ({ data, certified }))
 		};
@@ -254,7 +255,7 @@ describe('transactions.utils', () => {
 			});
 
 			it('should return an empty array if there are no transactions for BTC mainnet', () => {
-				const mockBtcTransactions: CertifiedStoreData<TransactionsData<BtcTransactionUi>> = {
+				const mockBtcTransactions: BtcCertifiedTransactionsData = {
 					[BTC_TESTNET_TOKEN_ID]: mockBtcTestnetTransactions.map((data) => ({ data, certified }))
 				};
 
@@ -457,7 +458,7 @@ describe('transactions.utils', () => {
 		const tokens = [...btcTokens, ...ethTokens, ...icTokens, ...solTokens];
 
 		const mockBtcMainnetTransactions: BtcTransactionUi[] = createMockBtcTransactionsUi(3);
-		const mockBtcTransactions: CertifiedStoreData<TransactionsData<BtcTransactionUi>> = {
+		const mockBtcTransactions: BtcCertifiedTransactionsData = {
 			[BTC_MAINNET_TOKEN_ID]: mockBtcMainnetTransactions.map((data) => ({ data, certified: false }))
 		};
 
@@ -759,7 +760,7 @@ describe('transactions.utils', () => {
 		});
 
 		const mockBtcTransactionStoreData: {
-			transactionsStoreData: CertifiedStoreData<TransactionsData<BtcTransactionUi>>;
+			transactionsStoreData: BtcCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {
@@ -1097,7 +1098,7 @@ describe('transactions.utils', () => {
 		});
 
 		const mockBtcTransactionStoreData: {
-			transactionsStoreData: CertifiedStoreData<TransactionsData<BtcTransactionUi>>;
+			transactionsStoreData: BtcCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {


### PR DESCRIPTION
# Motivation

Creating a single type `BtcCertifiedTransactionsData` to avoid duplication of code.