### PR TITLE
refactor(frontend): Extract type for certified SOL transactions data

### DIFF
--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -14,6 +14,7 @@ import type {
 	IdbTransactionsStoreData,
 	SetIdbTransactionsParams
 } from '$lib/types/idb-transactions';
+import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.store';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
@@ -83,7 +84,7 @@ export const setIdbIcTransactions = (
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbIcTransactionsStore });
 
 export const setIdbSolTransactions = (
-	params: SetIdbTransactionsParams<CertifiedStoreData<TransactionsData<SolTransactionUi>>>
+	params: SetIdbTransactionsParams<SolCertifiedTransactionsData>
 ): Promise<void> =>
 	setIdbTransactionsStore({ ...params, idbTransactionsStore: idbSolTransactionsStore });
 

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -9,8 +9,6 @@ import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { nullishSignOut } from '$lib/services/auth.services';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import type { TransactionsData } from '$lib/stores/transactions.store';
 import type {
 	GetIdbTransactionsParams,
 	IdbTransactionsStoreData,

--- a/src/frontend/src/lib/types/idb-transactions.ts
+++ b/src/frontend/src/lib/types/idb-transactions.ts
@@ -6,14 +6,14 @@ import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId } from '$lib/types/token';
-import type { SolTransactionUi } from '$sol/types/sol-transaction';
+import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.store';
 import type { Principal } from '@dfinity/principal';
 
 export type IdbTransactionsStoreData =
 	| CertifiedStoreData<TransactionsData<BtcTransactionUi>>
 	| EthTransactionsData
 	| CertifiedStoreData<TransactionsData<IcTransactionUi>>
-	| CertifiedStoreData<TransactionsData<SolTransactionUi>>;
+	| SolCertifiedTransactionsData;
 
 export interface SetIdbTransactionsParams<T extends IdbTransactionsStoreData> {
 	identity: OptionIdentity;

--- a/src/frontend/src/lib/types/idb-transactions.ts
+++ b/src/frontend/src/lib/types/idb-transactions.ts
@@ -1,8 +1,6 @@
 import type { BtcCertifiedTransactionsData } from '$btc/stores/btc-transactions.store';
 import type { EthTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId } from '$lib/types/token';

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -20,7 +20,6 @@ import {
 } from '$icp/utils/ic-transactions.utils';
 import { MICRO_TRANSACTION_USD_THRESHOLD, ZERO } from '$lib/constants/app.constants';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Token } from '$lib/types/token';

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -39,6 +39,7 @@ import {
 	isNetworkIdSepolia,
 	isNetworkIdSolana
 } from '$lib/utils/network.utils';
+import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.store';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
@@ -74,7 +75,7 @@ export const mapAllTransactionsUi = ({
 	$ckEthMinterInfo: CertifiedStoreData<CkEthMinterInfoData>;
 	$ckBtcMinterInfoStore: CertifiedStoreData<CkBtcMinterInfoData>;
 	$ethAddress: OptionEthAddress;
-	$solTransactions: CertifiedStoreData<TransactionsData<SolTransactionUi>>;
+	$solTransactions: SolCertifiedTransactionsData;
 	$btcStatuses: CertifiedStoreData<BtcStatusesData>;
 	$icTransactionsStore: CertifiedStoreData<IcTransactionsData>;
 	$ckBtcPendingUtxosStore: CertifiedStoreData<CkBtcPendingUtxosData>;

--- a/src/frontend/src/sol/stores/sol-transactions.store.ts
+++ b/src/frontend/src/sol/stores/sol-transactions.store.ts
@@ -1,6 +1,15 @@
-import { initTransactionsStore, type CertifiedTransaction } from '$lib/stores/transactions.store';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
+import {
+	initTransactionsStore,
+	type CertifiedTransaction,
+	type TransactionsData
+} from '$lib/stores/transactions.store';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 
 export type SolCertifiedTransaction = CertifiedTransaction<SolTransactionUi>;
+
+export type SolTransactionsData = TransactionsData<SolTransactionUi>;
+
+export type SolCertifiedTransactionsData = CertifiedStoreData<SolTransactionsData>;
 
 export const solTransactionsStore = initTransactionsStore<SolTransactionUi>();

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -36,8 +36,6 @@ import type { EthTransactionType } from '$eth/types/eth-transaction';
 import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic-transaction';
 import { ZERO } from '$lib/constants/app.constants';
-import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import type { TransactionsData } from '$lib/stores/transactions.store';
 import type { Token } from '$lib/types/token';
 import type { AllTransactionUiWithCmp, AnyTransactionUi } from '$lib/types/transaction';
 import {

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -51,6 +51,7 @@ import {
 	mapAllTransactionsUi,
 	sortTransactions
 } from '$lib/utils/transactions.utils';
+import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.store';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc-transactions.mock';
 import { createMockEthCertifiedTransactions } from '$tests/mocks/eth-transactions.mock';
@@ -106,7 +107,7 @@ describe('transactions.utils', () => {
 		};
 
 		const mockSolTransactionsUi: SolTransactionUi[] = createMockSolTransactionsUi(4);
-		const mockSolTransactions: CertifiedStoreData<TransactionsData<SolTransactionUi>> = {
+		const mockSolTransactions: SolCertifiedTransactionsData = {
 			[SOLANA_TOKEN_ID]: mockSolTransactionsUi.map((data) => ({ data, certified }))
 		};
 
@@ -798,7 +799,7 @@ describe('transactions.utils', () => {
 			tokens: [ICP_TOKEN]
 		};
 		const mockSolTransactionStoreData: {
-			transactionsStoreData: CertifiedStoreData<TransactionsData<SolTransactionUi>>;
+			transactionsStoreData: SolCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {
@@ -1136,7 +1137,7 @@ describe('transactions.utils', () => {
 			tokens: [ICP_TOKEN]
 		};
 		const mockSolTransactionStoreData: {
-			transactionsStoreData: CertifiedStoreData<TransactionsData<SolTransactionUi>>;
+			transactionsStoreData: SolCertifiedTransactionsData;
 			tokens: Token[];
 		} = {
 			transactionsStoreData: {


### PR DESCRIPTION
# Motivation

Creating a single type `SolCertifiedTransactionsData` to avoid duplication of code.