### PR TITLE
feat(frontend): Sync ETH balances from cache

### DIFF
--- a/src/frontend/src/lib/services/listener.services.ts
+++ b/src/frontend/src/lib/services/listener.services.ts
@@ -1,17 +1,13 @@
-import type { BtcTransactionUi } from '$btc/types/btc';
-import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { getIdbBalances } from '$lib/api/idb-balances.api';
 import { authIdentity } from '$lib/derived/auth.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { TransactionsStore } from '$lib/stores/transactions.store';
 import type { GetIdbTransactionsParams } from '$lib/types/idb-transactions';
-import type { SolTransactionUi } from '$sol/types/sol-transaction';
+import type { AnyTransaction } from '$lib/types/transaction';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-const syncTransactionsFromCache = async <
-	T extends BtcTransactionUi | IcTransactionUi | SolTransactionUi
->({
+const syncTransactionsFromCache = async <T extends AnyTransaction>({
 	tokenId,
 	getIdbTransactions,
 	transactionsStore,
@@ -38,7 +34,7 @@ const syncTransactionsFromCache = async <
 	});
 };
 
-const syncBalancesFromCache = async ({ tokenId, ...params }: GetIdbTransactionsParams) => {
+export const syncBalancesFromCache = async ({ tokenId, ...params }: GetIdbTransactionsParams) => {
 	const balance = await getIdbBalances({
 		...params,
 		tokenId
@@ -57,9 +53,7 @@ const syncBalancesFromCache = async ({ tokenId, ...params }: GetIdbTransactionsP
 	});
 };
 
-export const syncWalletFromIdbCache = async <
-	T extends BtcTransactionUi | IcTransactionUi | SolTransactionUi
->({
+export const syncWalletFromIdbCache = async <T extends AnyTransaction>({
 	tokenId,
 	getIdbTransactions,
 	transactionsStore,

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
@@ -4,10 +4,13 @@ import LoaderEthBalances from '$eth/components/loaders/LoaderEthBalances.svelte'
 import { loadErc20Balances, loadEthBalances } from '$eth/services/eth-balance.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
+import { syncBalancesFromCache } from '$lib/services/listener.services';
 import { ethAddressStore } from '$lib/stores/address.store';
 import type { Token } from '$lib/types/token';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { createMockErc20Tokens } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { createMockSnippet } from '$tests/mocks/snippet.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
@@ -17,6 +20,10 @@ import { tick } from 'svelte';
 vi.mock('$eth/services/eth-balance.services', () => ({
 	loadEthBalances: vi.fn(),
 	loadErc20Balances: vi.fn()
+}));
+
+vi.mock('$lib/services/listener.services', () => ({
+	syncBalancesFromCache: vi.fn()
 }));
 
 describe('LoaderEthBalances', () => {
@@ -34,6 +41,8 @@ describe('LoaderEthBalances', () => {
 
 		vi.useFakeTimers();
 
+		mockAuthStore();
+
 		setupTestnetsStore('disabled');
 		setupUserNetworksStore('allEnabled');
 
@@ -47,6 +56,36 @@ describe('LoaderEthBalances', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	it('should sync balances from the cache on mount', async () => {
+		render(LoaderEthBalances);
+
+		await tick();
+
+		expect(syncBalancesFromCache).toHaveBeenCalledTimes(
+			mainnetTokens.length + mockErc20DefaultTokens.length
+		);
+
+		[...mainnetTokens, ...mockErc20DefaultTokens].forEach(
+			({ id: tokenId, network: { id: networkId } }, index) => {
+				expect(syncBalancesFromCache).toHaveBeenNthCalledWith(index + 1, {
+					principal: mockIdentity.getPrincipal(),
+					tokenId,
+					networkId
+				});
+			}
+		);
+	});
+
+	it('should not sync balances from the cache on mount if not logged in', async () => {
+		mockAuthStore(null);
+
+		render(LoaderEthBalances);
+
+		await tick();
+
+		expect(syncBalancesFromCache).not.toHaveBeenCalled();
 	});
 
 	it('should call `loadEthBalances` on mount', async () => {


### PR DESCRIPTION
# Motivation

We should sync the ETH balances from the IDB cache, like the other networks.

# Changes

Adapt component `LoaderEthBalances` to sync IDB cache on mounting.

# Tests

Added tests.
