### PR TITLE
feat(frontend): add loading to avatar

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditContactStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditContactStep.svelte
@@ -52,6 +52,7 @@
 	}: Props = $props();
 
 	let fileInput = $state<HiddenFileInput | undefined>();
+	let loading = $state(false);
 
 	let imageUrl = $derived(nonNullish(contact.image) ? imageToDataUrl(contact.image) : undefined);
 
@@ -60,6 +61,7 @@
 		if (isNullish(selected)) {
 			return;
 		}
+		loading = true;
 
 		// Compress image to 100KB max and resize to max 200px.
 		// This limitation is defined by the backend: check the constraints of the related methods.
@@ -75,14 +77,17 @@
 			return;
 		}
 		await onAvatarEdit(img);
+		loading = false;
 	};
 
 	const replaceImage = (): void => {
 		fileInput?.triggerClick();
 	};
 	const removeImage = (): void => {
+		loading = true;
 		imageUrl = undefined;
 		onAvatarEdit(null);
+		loading = false;
 	};
 </script>
 
@@ -95,6 +100,7 @@
 					image={contact.image}
 					variant="xs"
 					styleClass="md:text-[19.2px]"
+					{loading}
 				/>
 				{#if AVATAR_ENABLED}
 					<span

--- a/src/frontend/src/lib/components/contact/Avatar.svelte
+++ b/src/frontend/src/lib/components/contact/Avatar.svelte
@@ -5,7 +5,7 @@
 	import Img from '$lib/components/ui/Img.svelte';
 	import LoaderWithOverlay from '$lib/components/ui/LoaderWithOverlay.svelte';
 	import { CONTACT_BACKGROUND_COLORS } from '$lib/constants/contact.constants';
-	import { AVATAR_IMAGE } from '$lib/constants/test-ids.constants';
+	import { AVATAR_IMAGE, AVATAR_LOADER } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { AvatarVariants } from '$lib/types/style';
 	import { imageToDataUrl } from '$lib/utils/contact-image.utils';
@@ -60,7 +60,10 @@
 	aria-label={ariaLabel}
 >
 	{#if loading}
-		<LoaderWithOverlay />
+		<LoaderWithOverlay
+			testId={AVATAR_LOADER}
+			ariaLabel={$i18n.address_book.avatar.avatar_loading}
+		/>
 	{:else if nonNullish(blobUrl)}
 		<Img src={blobUrl} alt={ariaLabel} styleClass="h-full w-full object-cover" rounded />
 	{:else if nonNullish(initials)}

--- a/src/frontend/src/lib/components/contact/Avatar.svelte
+++ b/src/frontend/src/lib/components/contact/Avatar.svelte
@@ -3,6 +3,7 @@
 	import type { ContactImage } from '$declarations/backend/backend.did';
 	import emptyOisyLogo from '$lib/assets/oisy-logo-empty.svg';
 	import Img from '$lib/components/ui/Img.svelte';
+	import LoaderWithOverlay from '$lib/components/ui/LoaderWithOverlay.svelte';
 	import { CONTACT_BACKGROUND_COLORS } from '$lib/constants/contact.constants';
 	import { AVATAR_IMAGE } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -15,9 +16,10 @@
 		variant?: AvatarVariants;
 		image?: ContactImage | null;
 		styleClass?: string;
+		loading?: boolean;
 	}
 
-	const { name, image, variant = 'md', styleClass }: AvatarProps = $props();
+	const { name, image, variant = 'md', styleClass, loading }: AvatarProps = $props();
 
 	const font = $derived(
 		{
@@ -53,11 +55,13 @@
 </script>
 
 <div
-	class={`${commonClasses} flex items-center justify-center ${isNullish(blobUrl) ? bgColor : ''}`}
+	class={`${commonClasses} relative flex items-center justify-center ${isNullish(blobUrl) ? bgColor : ''}`}
 	data-tid={AVATAR_IMAGE}
 	aria-label={ariaLabel}
 >
-	{#if nonNullish(blobUrl)}
+	{#if loading}
+		<LoaderWithOverlay />
+	{:else if nonNullish(blobUrl)}
 		<Img src={blobUrl} alt={ariaLabel} styleClass="h-full w-full object-cover" rounded />
 	{:else if nonNullish(initials)}
 		<span class="font-bold text-white">{initials}</span>

--- a/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
+++ b/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
@@ -1,0 +1,24 @@
+<div class="avatar-spinner-overlay" role="status" aria-label="Uploading image">
+	<svg
+		id="app-spinner"
+		preserveAspectRatio="xMidYMid meet"
+		focusable="false"
+		aria-hidden="true"
+		data-tid="spinner"
+		viewBox="0 0 100 100"
+	>
+		<circle cx="50%" cy="50%" r="45" />
+	</svg>
+</div>
+
+<style>
+	.avatar-spinner-overlay {
+		position: absolute;
+		inset: 0;
+		border-radius: 50%;
+		background: rgba(255, 255, 255, 0.4);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
+++ b/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
@@ -1,22 +1,26 @@
 <script lang="ts">
-import { AVATAR_LOADER } from '$lib/constants/test-ids.constants';
-import { i18n } from '$lib/stores/i18n.store';
+	interface Props {
+		testId?: string;
+		ariaLabel?: string;
+		styleClass?: string;
+	}
 
+	const { testId, ariaLabel, styleClass }: Props = $props();
 </script>
 
-<!-- SCRIPT_LOADER -->
-<div 
-    class="avatar-spinner-overlay" 
-    role="status" 
-    data-tid={AVATAR_LOADER}
-	aria-label={$i18n.address_book.avatar.avatar_loading} >
+<div
+	class={`avatar-spinner-overlay ${styleClass ?? ''}`}
+	role="status"
+	data-tid={testId}
+	aria-label={ariaLabel}
+>
 	<svg
-        id="app-spinner"
-        preserveAspectRatio="xMidYMid meet"
-        focusable="false"
-        aria-hidden="true"
-        data-tid="spinner"
-        viewBox="0 0 100 100"
+		id="app-spinner"
+		preserveAspectRatio="xMidYMid meet"
+		focusable="false"
+		aria-hidden="true"
+		data-tid="spinner"
+		viewBox="0 0 100 100"
 	>
 		<circle cx="50%" cy="50%" r="45" />
 	</svg>

--- a/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
+++ b/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
@@ -1,24 +1,23 @@
-<div class="avatar-spinner-overlay" role="status" aria-label="Uploading image">
+<script lang="ts">
+import { AVATAR_LOADER } from '$lib/constants/test-ids.constants';
+import { i18n } from '$lib/stores/i18n.store';
+
+</script>
+
+<!-- SCRIPT_LOADER -->
+<div 
+    class="avatar-spinner-overlay" 
+    role="status" 
+    data-tid={AVATAR_LOADER}
+	aria-label={$i18n.address_book.avatar.avatar_loading} >
 	<svg
-		id="app-spinner"
-		preserveAspectRatio="xMidYMid meet"
-		focusable="false"
-		aria-hidden="true"
-		data-tid="spinner"
-		viewBox="0 0 100 100"
+        id="app-spinner"
+        preserveAspectRatio="xMidYMid meet"
+        focusable="false"
+        aria-hidden="true"
+        data-tid="spinner"
+        viewBox="0 0 100 100"
 	>
 		<circle cx="50%" cy="50%" r="45" />
 	</svg>
 </div>
-
-<style>
-	.avatar-spinner-overlay {
-		position: absolute;
-		inset: 0;
-		border-radius: 50%;
-		background: rgba(255, 255, 255, 0.4);
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
-</style>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -243,6 +243,7 @@ export const AVATAR_IMAGE = 'avatar-image';
 export const AVATAR_WITH_BADGE_FALLBACK_IMAGE = 'avatar-with-badge-fallback-image';
 export const AVATAR_BADGE = 'avatar-badge';
 export const AVATAR_UPLOAD_IMAGE = 'avatar-upload-image';
+export const AVATAR_LOADER = 'avatar-loader';
 
 // Contact Card test IDs
 export const CONTACT_CARD = 'contact-card';

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1288,7 +1288,8 @@
 		},
 		"avatar": {
 			"default": "Default avatar",
-			"avatar_for": "Avatar for"
+			"avatar_for": "Avatar for",
+			"avatar_loading": "Avatar is loading..."
 		},
 		"edit_avatar": {
 			"menu_title": "Contact Image",

--- a/src/frontend/src/lib/styles/global/layout.scss
+++ b/src/frontend/src/lib/styles/global/layout.scss
@@ -6,7 +6,6 @@ header {
 .avatar-spinner-overlay {
 	position: absolute;
 	inset: 0;
-	border-radius: 50%;
 	background-color: color-mix(in srgb, var(--color-base-white) 40%, transparent);
 	display: flex;
 	justify-content: center;

--- a/src/frontend/src/lib/styles/global/layout.scss
+++ b/src/frontend/src/lib/styles/global/layout.scss
@@ -3,3 +3,12 @@
 header {
 	margin: 0 auto;
 }
+.avatar-spinner-overlay {
+	position: absolute;
+	inset: 0;
+	border-radius: 50%;
+	background-color: color-mix(in srgb, var(--color-base-white) 40%, transparent);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1087,7 +1087,7 @@ interface I18nAddress_book {
 	};
 	alt: { show_addresses_of_contact: string; hide_addresses: string };
 	edit_contact: { title: string; add_address: string; delete_contact: string };
-	avatar: { default: string; avatar_for: string };
+	avatar: { default: string; avatar_for: string; avatar_loading: string };
 	edit_avatar: {
 		menu_title: string;
 		upload_image: string;

--- a/src/frontend/src/tests/lib/components/ui/LoaderWithOverlay.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/LoaderWithOverlay.spec.ts
@@ -1,0 +1,32 @@
+import LoaderWithOverlay from '$lib/components/ui/LoaderWithOverlay.svelte';
+import { render } from '@testing-library/svelte';
+
+describe('LoaderWithOverlay', () => {
+	it('renders with default structure', () => {
+		const { getByRole, getByTestId } = render(LoaderWithOverlay, {
+			props: {
+				testId: 'avatar-loader',
+				ariaLabel: 'Loading avatar...'
+			}
+		});
+
+		const overlay = getByRole('status');
+
+		expect(overlay).toBeInTheDocument();
+		expect(overlay).toHaveAttribute('aria-label', 'Loading avatar...');
+		expect(getByTestId('avatar-loader')).toBe(overlay);
+		expect(getByTestId('spinner')).toBeInTheDocument();
+	});
+
+	it('applies custom styleClass if provided', () => {
+		const { container } = render(LoaderWithOverlay, {
+			props: {
+				styleClass: 'custom-class'
+			}
+		});
+
+		const div = container.querySelector('.avatar-spinner-overlay');
+
+		expect(div?.classList.contains('custom-class')).toBeTruthy();
+	});
+});


### PR DESCRIPTION
# Motivation

A lightweight and flexible avatar loading spinner component was needed to indicate loading states in a consistent and accessible way. 

# Changes

Adding new component which could be reused as a LoaderWithOverlay
Implemented a simple SVG-based circular spinner with semantic role and accessibility tags.

# Tests

Manually tested component rendering in various usage contexts.
Confirmed spinner displays and animates as expected.
Adding Unit tests for rendering and style applies.
<img width="1084" height="814" alt="Screenshot 2025-07-25 at 10 33 59" src="https://github.com/user-attachments/assets/c071e734-9372-488b-91b8-8e2f20d6a9ac" />

