### PR TITLE
feat(frontend): Sync ETH transactions from cache in component `LoaderMultipleEthTransactions`

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -30,7 +30,6 @@
 
 		loading = true;
 
-
 		if ($tokenNotInitialized) {
 			tokenIdLoaded = undefined;
 			loading = false;

--- a/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthTransactions.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import { ethTransactionsInitialized } from '$eth/derived/eth-transactions.derived';
 	import { tokenNotInitialized } from '$eth/derived/nav.derived';
 	import {
 		loadEthereumTransactions,
 		reloadEthereumTransactions
 	} from '$eth/services/eth-transactions.services';
+	import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+	import { getIdbEthTransactions } from '$lib/api/idb-transactions.api';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import { FAILURE_THRESHOLD, WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { tokenWithFallback } from '$lib/derived/token.derived';
+	import { syncTransactionsFromCache } from '$lib/services/listener.services';
 	import type { TokenId } from '$lib/types/token';
 	import { isNetworkIdEthereum, isNetworkIdEvm } from '$lib/utils/network.utils';
 
@@ -22,6 +29,7 @@
 		}
 
 		loading = true;
+
 
 		if ($tokenNotInitialized) {
 			tokenIdLoaded = undefined;
@@ -76,6 +84,31 @@
 	const reload = async () => {
 		await load({ reload: true });
 	};
+
+	onMount(async () => {
+		if ($ethTransactionsInitialized) {
+			return;
+		}
+
+		const principal = $authIdentity?.getPrincipal();
+
+		if (isNullish(principal)) {
+			return;
+		}
+
+		const {
+			network: { id: networkId },
+			id: tokenId
+		} = $tokenWithFallback;
+
+		await syncTransactionsFromCache({
+			principal,
+			tokenId,
+			networkId,
+			getIdbTransactions: getIdbEthTransactions,
+			transactionsStore: ethTransactionsStore
+		});
+	});
 </script>
 
 <IntervalLoader onLoad={reload} interval={WALLET_TIMER_INTERVAL_MILLIS}>

--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
-	import { debounce, isNullish } from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import {
 		batchLoadTransactions,
 		batchResultsToTokenId
 	} from '$eth/services/eth-transactions-batch.services';
+	import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 	import { enabledEvmTokens } from '$evm/derived/tokens.derived';
+	import { getIdbEthTransactions } from '$lib/api/idb-transactions.api';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledErc20Tokens } from '$lib/derived/tokens.derived';
+	import { syncTransactionsFromCache } from '$lib/services/listener.services';
 	import type { TokenId } from '$lib/types/token';
 
 	// TODO: make it more functional
@@ -46,6 +51,32 @@
 	const debounceLoad = debounce(onLoad, 1000);
 
 	$: ($enabledEthereumTokens, $enabledErc20Tokens, $enabledEvmTokens, debounceLoad());
+
+	onMount(async () => {
+		const principal = $authIdentity?.getPrincipal();
+
+		if (isNullish(principal)) {
+			return;
+		}
+
+		await Promise.allSettled(
+			[...$enabledEthereumTokens, ...$enabledErc20Tokens, ...$enabledEvmTokens].map(
+				async ({ id: tokenId, network: { id: networkId } }) => {
+					if (nonNullish($ethTransactionsStore?.[tokenId])) {
+						return;
+					}
+
+					await syncTransactionsFromCache({
+						principal,
+						tokenId,
+						networkId,
+						getIdbTransactions: getIdbEthTransactions,
+						transactionsStore: ethTransactionsStore
+					});
+				}
+			)
+		);
+	});
 </script>
 
 <IntervalLoader {onLoad} interval={WALLET_TIMER_INTERVAL_MILLIS}>

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -14,6 +14,7 @@ import type {
 	IdbTransactionsStoreData,
 	SetIdbTransactionsParams
 } from '$lib/types/idb-transactions';
+import type { Transaction } from '$lib/types/transaction';
 import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.store';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { Principal } from '@dfinity/principal';
@@ -94,8 +95,7 @@ export const getIdbBtcTransactions = (
 
 export const getIdbEthTransactions = (
 	params: GetIdbTransactionsParams
-): Promise<EthCertifiedTransactionsData[] | undefined> =>
-	get(toKey(params), idbEthTransactionsStore);
+): Promise<Transaction[] | undefined> => get(toKey(params), idbEthTransactionsStore);
 
 export const getIdbIcTransactions = (
 	params: GetIdbTransactionsParams

--- a/src/frontend/src/lib/services/listener.services.ts
+++ b/src/frontend/src/lib/services/listener.services.ts
@@ -7,7 +7,7 @@ import type { AnyTransaction } from '$lib/types/transaction';
 import { isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-const syncTransactionsFromCache = async <T extends AnyTransaction>({
+export const syncTransactionsFromCache = async <T extends AnyTransaction>({
 	tokenId,
 	getIdbTransactions,
 	transactionsStore,

--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthTransactions.spec.ts
@@ -1,12 +1,21 @@
-import { BASE_SEPOLIA_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
+import {
+	BASE_NETWORK_ID,
+	BASE_SEPOLIA_NETWORK_ID
+} from '$env/networks/networks-evm/networks.evm.base.env';
 import { SEPOLIA_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import {
 	BASE_ETH_TOKEN,
+	BASE_ETH_TOKEN_ID,
 	BASE_SEPOLIA_ETH_TOKEN,
 	BASE_SEPOLIA_ETH_TOKEN_ID
 } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
-import { ETHEREUM_TOKEN, SEPOLIA_TOKEN, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
+import {
+	ETHEREUM_TOKEN,
+	ETHEREUM_TOKEN_ID,
+	SEPOLIA_TOKEN,
+	SEPOLIA_TOKEN_ID
+} from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import LoaderEthTransactions from '$eth/components/loaders/LoaderEthTransactions.svelte';
 import {
@@ -14,16 +23,26 @@ import {
 	reloadEthereumTransactions
 } from '$eth/services/eth-transactions.services';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
+import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+import { getIdbEthTransactions } from '$lib/api/idb-transactions.api';
 import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+import { syncTransactionsFromCache } from '$lib/services/listener.services';
 import { token } from '$lib/stores/token.store';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { render, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 
 vi.mock('$eth/services/eth-transactions.services', () => ({
 	loadEthereumTransactions: vi.fn(),
 	reloadEthereumTransactions: vi.fn()
+}));
+
+vi.mock('$lib/services/listener.services', () => ({
+	syncTransactionsFromCache: vi.fn()
 }));
 
 describe('LoaderEthTransactions', () => {
@@ -32,6 +51,8 @@ describe('LoaderEthTransactions', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+
+		mockAuthStore();
 
 		setupTestnetsStore('enabled');
 		setupUserNetworksStore('allEnabled');
@@ -45,6 +66,71 @@ describe('LoaderEthTransactions', () => {
 		erc20UserTokensStore.setAll([
 			{ data: { ...SEPOLIA_PEPE_TOKEN, enabled: true }, certified: false }
 		]);
+	});
+
+	describe('on mount', () => {
+		it('should sync balances from the IDB cache', async () => {
+			mockPage.mock({ token: ETHEREUM_TOKEN.name });
+			token.set(BASE_ETH_TOKEN);
+
+			render(LoaderEthTransactions);
+
+			await tick();
+
+			expect(syncTransactionsFromCache).toHaveBeenCalledExactlyOnceWith({
+				principal: mockIdentity.getPrincipal(),
+				tokenId: BASE_ETH_TOKEN_ID,
+				networkId: BASE_NETWORK_ID,
+				getIdbTransactions: getIdbEthTransactions,
+				transactionsStore: ethTransactionsStore
+			});
+		});
+
+		it('should not sync balances from the IDB cache if not signed in', async () => {
+			mockPage.mock({ token: ETHEREUM_TOKEN.name });
+			token.set(BASE_ETH_TOKEN);
+
+			mockAuthStore(null);
+
+			render(LoaderEthTransactions);
+
+			await tick();
+
+			expect(syncTransactionsFromCache).not.toHaveBeenCalled();
+		});
+
+		it('should not sync balances from the IDB cache if transactions store is already initialized', async () => {
+			mockPage.mock({ token: ETHEREUM_TOKEN.name });
+			token.set(BASE_ETH_TOKEN);
+
+			ethTransactionsStore.set({ tokenId: BASE_ETH_TOKEN_ID, transactions: [] });
+
+			render(LoaderEthTransactions);
+
+			await tick();
+
+			expect(syncTransactionsFromCache).not.toHaveBeenCalled();
+		});
+
+		it('should sync balances from the IDB cache if transactions store is not initialized for the specific token', async () => {
+			mockPage.mock({ token: ETHEREUM_TOKEN.name });
+			token.set(BASE_ETH_TOKEN);
+
+			ethTransactionsStore.reset(BASE_ETH_TOKEN_ID);
+			ethTransactionsStore.set({ tokenId: ETHEREUM_TOKEN_ID, transactions: [] });
+
+			render(LoaderEthTransactions);
+
+			await tick();
+
+			expect(syncTransactionsFromCache).toHaveBeenCalledExactlyOnceWith({
+				principal: mockIdentity.getPrincipal(),
+				tokenId: BASE_ETH_TOKEN.id,
+				networkId: BASE_ETH_TOKEN.network.id,
+				getIdbTransactions: getIdbEthTransactions,
+				transactionsStore: ethTransactionsStore
+			});
+		});
 	});
 
 	it('should not load transactions if token is not initialized', async () => {


### PR DESCRIPTION
# Motivation

Similar to what we did for component `LoaderEthTransactions` in PR https://github.com/dfinity/oisy-wallet/pull/7995, we load transactions for Ethereum/EVM networks from the IDB cache at the first try in component `LoaderMultipleEthTransactions`.
