### PR TITLE
feat(frontend): Replace standard of token store with page-token store

### DIFF
--- a/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceiveMetamask.svelte
@@ -7,9 +7,9 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { networkEthereum } from '$lib/derived/network.derived';
-	import { tokenStandard } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
+	import {pageTokenStandard} from "$lib/derived/page-token.derived";
 
 	const receiveModal = async () => {
 		if (!$metamaskAvailable) {
@@ -31,7 +31,7 @@
 	// TODO: The Metamask button currently does not support sending ERC20 tokens - it always populates an ETH transaction.
 	// We aim to fix this, but for now, the functionality is commented out.
 	let tokenStandardEth = true;
-	$: tokenStandardEth = $tokenStandard === 'ethereum';
+	$: tokenStandardEth = $pageTokenStandard === 'ethereum';
 </script>
 
 {#if $metamaskAvailable && $networkEthereum && tokenStandardEth}

--- a/src/frontend/src/eth/components/tokens/EthTokenMenu.svelte
+++ b/src/frontend/src/eth/components/tokens/EthTokenMenu.svelte
@@ -8,13 +8,12 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { TOKEN_MENU_ETH } from '$lib/constants/test-ids.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
-	import { pageToken } from '$lib/derived/page-token.derived';
-	import { tokenStandard } from '$lib/derived/token.derived';
+	import {pageToken, pageTokenStandard} from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	let explorerUrl: string | undefined;
 	$: explorerUrl = nonNullish($pageToken)
-		? $tokenStandard === 'erc20'
+		? $pageTokenStandard === 'erc20'
 			? `${getExplorerUrl({ token: $pageToken })}/token/${($pageToken as Erc20Token).address}`
 			: notEmptyString($ethAddress)
 				? `${getExplorerUrl({ token: $pageToken })}/address/${$ethAddress}`

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -14,7 +14,7 @@ import { tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 import type { IcCkToken } from '$icp/types/ic-token';
 import { isTokenCkErc20Ledger, isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
-import { tokenStandard, tokenWithFallback } from '$lib/derived/token.derived';
+import { tokenWithFallback } from '$lib/derived/token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { OptionBalance } from '$lib/types/balance';
@@ -95,19 +95,9 @@ export const ckErc20HelperContractAddress: Readable<OptionEthAddress> = derived(
  * - on network ICP if the token is ckETH
  */
 export const ethToCkETHEnabled: Readable<boolean> = derived(
-	[
-		tokenStandard,
-		tokenWithFallbackAsIcToken,
-		selectedEthereumNetwork,
-		ckEthereumNativeTokenEnabledNetwork
-	],
-	([
-		$tokenStandard,
-		$tokenWithFallbackAsIcToken,
-		$selectedEthereumNetwork,
-		$ckEthereumNativeTokenEnabledNetwork
-	]) =>
-		($tokenStandard === 'ethereum' && nonNullish($selectedEthereumNetwork)) ||
+	[tokenWithFallbackAsIcToken, selectedEthereumNetwork, ckEthereumNativeTokenEnabledNetwork],
+	([$tokenWithFallbackAsIcToken, $selectedEthereumNetwork, $ckEthereumNativeTokenEnabledNetwork]) =>
+		($tokenWithFallbackAsIcToken.standard === 'ethereum' && nonNullish($selectedEthereumNetwork)) ||
 		(isTokenCkEthLedger($tokenWithFallbackAsIcToken) &&
 			nonNullish($ckEthereumNativeTokenEnabledNetwork))
 );

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -5,7 +5,7 @@ import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import { routeNetwork, routeToken } from '$lib/derived/nav.derived';
-import type { OptionToken } from '$lib/types/token';
+import type { OptionToken, OptionTokenStandard } from '$lib/types/token';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
 import { isNullish } from '@dfinity/utils';
@@ -58,4 +58,9 @@ export const pageToken: Readable<OptionToken> = derived(
 				name === $routeToken && networkId.description === $routeNetwork
 		);
 	}
+);
+
+export const pageTokenStandard: Readable<OptionTokenStandard> = derived(
+	[pageToken],
+	([$pageToken]) => $pageToken?.standard
 );

--- a/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
@@ -1,5 +1,3 @@
-import * as btcEnv from '$env/networks/networks.btc.env';
-import * as ethEnv from '$env/networks/networks.eth.env';
 import { JUP_TOKEN } from '$env/tokens/tokens-spl/tokens.jup.env';
 import {
 	BTC_MAINNET_TOKEN,
@@ -12,7 +10,7 @@ import { SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN, SOLANA_TOKEN } from '$env/toke
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import * as appConstants from '$lib/constants/app.constants';
-import { pageToken } from '$lib/derived/page-token.derived';
+import { pageToken, pageTokenStandard } from '$lib/derived/page-token.derived';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
@@ -21,97 +19,188 @@ import { mockPage } from '$tests/mocks/page.store.mock';
 import { get } from 'svelte/store';
 
 describe('page-token.derived', () => {
-	beforeEach(() => {
-		vi.resetAllMocks();
-		mockPage.reset();
-		vi.spyOn(btcEnv, 'BTC_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-		vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => true);
+	describe('pageToken', () => {
+		beforeEach(() => {
+			vi.resetAllMocks();
 
-		vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
-			fn([{ ...JUP_TOKEN, enabled: true }]);
-			return () => {};
+			mockPage.reset();
+
+			vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
+				fn([{ ...JUP_TOKEN, enabled: true }]);
+				return () => {};
+			});
 		});
-	});
 
-	it('should return undefined when no token in route', () => {
-		expect(get(pageToken)).toBeUndefined();
-	});
+		it('should return undefined when no token in route', () => {
+			expect(get(pageToken)).toBeUndefined();
+		});
 
-	it.each([ICP_TOKEN, BTC_MAINNET_TOKEN, SOLANA_TOKEN, ETHEREUM_TOKEN])(
-		'should find $name token',
-		(token) => {
-			mockPage.mock({ token: token.name, network: token.network.id.description });
+		it.each([ICP_TOKEN, BTC_MAINNET_TOKEN, SOLANA_TOKEN, ETHEREUM_TOKEN])(
+			'should find $name token',
+			(token) => {
+				mockPage.mock({ token: token.name, network: token.network.id.description });
 
-			expect(get(pageToken)).toBe(token);
-		}
-	);
+				expect(get(pageToken)).toBe(token);
+			}
+		);
 
-	it.each([BTC_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, SEPOLIA_TOKEN])(
-		'should find $name token',
-		(token) => {
+		it.each([BTC_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, SEPOLIA_TOKEN])(
+			'should find $name token',
+			(token) => {
+				vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
+					fn(true);
+					return () => {};
+				});
+
+				mockPage.mock({ token: token.name, network: token.network.id.description });
+
+				expect(get(pageToken)).toBe(token);
+			}
+		);
+
+		it.each([BTC_REGTEST_TOKEN, SOLANA_LOCAL_TOKEN])('should find $name token', (token) => {
 			vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
 				fn(true);
 				return () => {};
 			});
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 			mockPage.mock({ token: token.name, network: token.network.id.description });
 
 			expect(get(pageToken)).toBe(token);
-		}
-	);
-
-	it.each([BTC_REGTEST_TOKEN, SOLANA_LOCAL_TOKEN])('should find $name token', (token) => {
-		vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
-			fn(true);
-			return () => {};
 		});
-		vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
-		mockPage.mock({ token: token.name, network: token.network.id.description });
+		it('should find ERC20 token', () => {
+			const mockToken = { ...mockValidErc20Token, enabled: true };
+			erc20UserTokensStore.setAll([{ data: mockToken, certified: true }]);
+			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
 
-		expect(get(pageToken)).toBe(token);
+			expect(get(pageToken)?.symbol).toBe(mockToken.symbol);
+		});
+
+		it('should find ICRC token', () => {
+			const mockToken = { ...mockIcrcCustomToken, enabled: true };
+			icrcCustomTokensStore.setAll([{ data: mockToken, certified: true }]);
+			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+
+			expect(get(pageToken)?.symbol).toBe(mockToken.symbol);
+		});
+
+		it('should find SPL token', () => {
+			const mockToken = JUP_TOKEN;
+			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+
+			expect(get(pageToken)?.symbol).toBe(mockToken.symbol);
+		});
+
+		it('should return undefined when token is not found in any list', () => {
+			mockPage.mock({ token: 'non-existent-token' });
+
+			expect(get(pageToken)).toBeUndefined();
+		});
+
+		it('should return undefined when token name matches but network does not', () => {
+			const mockToken = { ...mockValidErc20Token, enabled: true };
+			mockPage.mock({ token: mockToken.name, network: 'non-existent-network' });
+
+			expect(get(pageToken)).toBeUndefined();
+		});
+
+		it('should return undefined when token network matches but name does not', () => {
+			const mockToken = { ...mockValidErc20Token, enabled: true };
+			mockPage.mock({ token: 'non-existent-token', network: mockToken.network.name });
+
+			expect(get(pageToken)).toBeUndefined();
+		});
 	});
 
-	it('should find ERC20 token', () => {
-		const mockToken = { ...mockValidErc20Token, enabled: true };
-		erc20UserTokensStore.setAll([{ data: mockToken, certified: true }]);
-		mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+	describe('pageTokenStandard', () => {
+		beforeEach(() => {
+			vi.resetAllMocks();
 
-		expect(get(pageToken)?.symbol).toBe(mockToken.symbol);
-	});
+			mockPage.reset();
 
-	it('should find ICRC token', () => {
-		const mockToken = { ...mockIcrcCustomToken, enabled: true };
-		icrcCustomTokensStore.setAll([{ data: mockToken, certified: true }]);
-		mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+			vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
+				fn([{ ...JUP_TOKEN, enabled: true }]);
+				return () => {};
+			});
+		});
 
-		expect(get(pageToken)?.symbol).toBe(mockToken.symbol);
-	});
+		it('should return undefined when page token is undefined', () => {
+			expect(get(pageTokenStandard)).toBeUndefined();
 
-	it('should find SPL token', () => {
-		const mockToken = JUP_TOKEN;
-		mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+			mockPage.mock({ token: 'non-existent-token' });
 
-		expect(get(pageToken)?.symbol).toBe(mockToken.symbol);
-	});
+			expect(get(pageToken)).toBeUndefined();
 
-	it('should return undefined when token is not found in any list', () => {
-		mockPage.mock({ token: 'non-existent-token' });
+			mockPage.mock({ token: mockValidErc20Token.name, network: 'non-existent-network' });
 
-		expect(get(pageToken)).toBeUndefined();
-	});
+			expect(get(pageToken)).toBeUndefined();
 
-	it('should return undefined when token name matches but network does not', () => {
-		const mockToken = { ...mockValidErc20Token, enabled: true };
-		mockPage.mock({ token: mockToken.name, network: 'non-existent-network' });
+			mockPage.mock({ token: 'non-existent-token', network: mockValidErc20Token.network.name });
 
-		expect(get(pageToken)).toBeUndefined();
-	});
+			expect(get(pageToken)).toBeUndefined();
+		});
 
-	it('should return undefined when token network matches but name does not', () => {
-		const mockToken = { ...mockValidErc20Token, enabled: true };
-		mockPage.mock({ token: 'non-existent-token', network: mockToken.network.name });
+		it.each([ICP_TOKEN, BTC_MAINNET_TOKEN, SOLANA_TOKEN, ETHEREUM_TOKEN])(
+			'should return the standard for $name token',
+			(token) => {
+				mockPage.mock({ token: token.name, network: token.network.id.description });
 
-		expect(get(pageToken)).toBeUndefined();
+				expect(get(pageTokenStandard)).toBe(token.standard);
+			}
+		);
+
+		it.each([BTC_TESTNET_TOKEN, SOLANA_DEVNET_TOKEN, SEPOLIA_TOKEN])(
+			'should return the standard for $name token',
+			(token) => {
+				vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
+					fn(true);
+					return () => {};
+				});
+
+				mockPage.mock({ token: token.name, network: token.network.id.description });
+
+				expect(get(pageTokenStandard)).toBe(token.standard);
+			}
+		);
+
+		it.each([BTC_REGTEST_TOKEN, SOLANA_LOCAL_TOKEN])(
+			'should return the standard for $name token',
+			(token) => {
+				vi.spyOn(testnetsEnabled, 'subscribe').mockImplementation((fn) => {
+					fn(true);
+					return () => {};
+				});
+				vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
+
+				mockPage.mock({ token: token.name, network: token.network.id.description });
+
+				expect(get(pageTokenStandard)).toBe(token.standard);
+			}
+		);
+
+		it('should return the standard for ERC20 token', () => {
+			const mockToken = { ...mockValidErc20Token, enabled: true };
+			erc20UserTokensStore.setAll([{ data: mockToken, certified: true }]);
+			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+
+			expect(get(pageTokenStandard)).toBe(mockToken.standard);
+		});
+
+		it('should return the standard for ICRC token', () => {
+			const mockToken = { ...mockIcrcCustomToken, enabled: true };
+			icrcCustomTokensStore.setAll([{ data: mockToken, certified: true }]);
+			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+
+			expect(get(pageTokenStandard)).toBe(mockToken.standard);
+		});
+
+		it('should return the standard for SPL token', () => {
+			const mockToken = JUP_TOKEN;
+			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
+
+			expect(get(pageTokenStandard)).toBe(mockToken.standard);
+		});
 	});
 });

--- a/src/frontend/src/tests/utils/derived.test-utils.ts
+++ b/src/frontend/src/tests/utils/derived.test-utils.ts
@@ -35,12 +35,7 @@ import { networks, networksMainnets, networksTestnets } from '$lib/derived/netwo
 import { pageToken } from '$lib/derived/page-token.derived';
 import { hideZeroBalances, showZeroBalances } from '$lib/derived/settings.derived';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
-import {
-	tokenId,
-	tokenStandard,
-	tokenToggleable,
-	tokenWithFallback
-} from '$lib/derived/token.derived';
+import { tokenId, tokenToggleable, tokenWithFallback } from '$lib/derived/token.derived';
 import {
 	enabledErc20Tokens,
 	enabledIcTokens,
@@ -93,7 +88,6 @@ const derivedList: Record<string, Readable<unknown>> = {
 	showZeroBalances,
 	testnetsEnabled,
 	tokenId,
-	tokenStandard,
 	tokenToggleable,
 	tokenWithFallback,
 	tokenWithFallbackAsIcToken,


### PR DESCRIPTION
# Motivation

In a continuous effort to deprecated the `token` store, we replace the derived `tokenStandard` with the equivalent `pageTokenStandard`.
