### PR TITLE
feat(frontend): Replace token store with page-token store in transactions components

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
@@ -19,9 +19,9 @@
 		modalBtcTokenData,
 		modalBtcTransaction
 	} from '$lib/derived/modal.derived';
+	import { pageToken } from '$lib/derived/page-token.derived';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { token } from '$lib/stores/token.store';
-	import type { OptionToken } from '$lib/types/token';
+	import type { OptionToken, Token } from '$lib/types/token';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let selectedTransaction: BtcTransactionUi | undefined;
@@ -31,6 +31,9 @@
 			$modalOpen: $modalBtcTransaction,
 			$modalStore
 		}));
+
+	let token: Token;
+	$: token = $pageToken ?? DEFAULT_BITCOIN_TOKEN;
 </script>
 
 <BtcTransactionsHeader />
@@ -38,7 +41,7 @@
 <TransactionsSkeletons loading={$btcTransactionsNotInitialized}>
 	{#each $sortedBtcTransactions as transaction (transaction.data.id)}
 		<div transition:slide={SLIDE_DURATION}>
-			<BtcTransaction transaction={transaction.data} token={$token ?? DEFAULT_BITCOIN_TOKEN} />
+			<BtcTransaction transaction={transaction.data} {token} />
 		</div>
 	{/each}
 

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -28,10 +28,10 @@
 	import TransactionsPlaceholder from '$lib/components/transactions/TransactionsPlaceholder.svelte';
 	import Header from '$lib/components/ui/Header.svelte';
 	import { modalIcToken, modalIcTokenData, modalIcTransaction } from '$lib/derived/modal.derived';
+	import { pageToken } from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { token } from '$lib/stores/token.store';
-	import type { OptionToken } from '$lib/types/token';
+	import type { OptionToken, Token } from '$lib/types/token';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let ckEthereum: boolean;
@@ -56,7 +56,10 @@
 		}));
 
 	let noTransactions = false;
-	$: noTransactions = nonNullish($token) && $icTransactionsStore?.[$token.id] === null;
+	$: noTransactions = nonNullish($pageToken) && $icTransactionsStore?.[$pageToken.id] === null;
+
+	let token: Token;
+	$: token = $pageToken ?? ICP_TOKEN;
 </script>
 
 <Info />
@@ -76,14 +79,14 @@
 <IcTransactionsSkeletons>
 	<svelte:component
 		this={additionalListener}
-		token={$token ?? ICP_TOKEN}
+		{token}
 		ckEthereumNativeToken={$ckEthereumNativeToken}
 	>
 		{#if $icTransactions.length > 0}
-			<IcTransactionsScroll token={$token ?? ICP_TOKEN}>
+			<IcTransactionsScroll {token}>
 				{#each $icTransactions as transaction, index (`${transaction.data.id}-${index}`)}
 					<li in:slide={{ duration: transaction.data.status === 'pending' ? 250 : 0 }}>
-						<IcTransaction transaction={transaction.data} token={$token ?? ICP_TOKEN} />
+						<IcTransaction transaction={transaction.data} {token} />
 					</li>
 				{/each}
 			</IcTransactionsScroll>

--- a/src/frontend/src/icp/components/transactions/IcTransactionsSkeletons.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsSkeletons.svelte
@@ -2,10 +2,10 @@
 	import { isNullish } from '@dfinity/utils';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import TransactionsSkeletons from '$lib/components/transactions/TransactionsSkeletons.svelte';
-	import { token } from '$lib/stores/token.store';
+	import { pageToken } from '$lib/derived/page-token.derived';
 
 	let loading: boolean;
-	$: loading = isNullish($token) || $icTransactionsStore?.[$token.id] === undefined;
+	$: loading = isNullish($pageToken) || $icTransactionsStore?.[$pageToken.id] === undefined;
 </script>
 
 <TransactionsSkeletons {loading}>

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -10,10 +10,10 @@
 		modalSolTokenData,
 		modalSolTransaction
 	} from '$lib/derived/modal.derived';
+	import { pageToken } from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { token } from '$lib/stores/token.store';
-	import type { OptionToken } from '$lib/types/token';
+	import type { OptionToken, Token } from '$lib/types/token';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 	import SolTokenModal from '$sol/components/tokens/SolTokenModal.svelte';
 	import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
@@ -30,6 +30,9 @@
 			$modalOpen: $modalSolTransaction,
 			$modalStore
 		}));
+
+	let token: Token;
+	$: token = $pageToken ?? DEFAULT_SOLANA_TOKEN;
 </script>
 
 <Header>
@@ -38,10 +41,10 @@
 
 <SolTransactionsSkeletons>
 	{#if $solTransactions.length > 0}
-		<SolTransactionsScroll token={$token ?? DEFAULT_SOLANA_TOKEN}>
+		<SolTransactionsScroll {token}>
 			{#each $solTransactions as transaction, index (`${transaction.id}-${index}`)}
 				<li in:slide={SLIDE_DURATION}>
-					<SolTransaction {transaction} token={$token ?? DEFAULT_SOLANA_TOKEN} />
+					<SolTransaction {transaction} {token} />
 				</li>
 			{/each}
 		</SolTransactionsScroll>

--- a/src/frontend/src/sol/components/transactions/SolTransactionsSkeletons.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionsSkeletons.svelte
@@ -2,11 +2,11 @@
 	import { isNullish } from '@dfinity/utils';
 	import TransactionsSkeletons from '$lib/components/transactions/TransactionsSkeletons.svelte';
 	import { SOL_TRANSACTION_SKELETON_PREFIX } from '$lib/constants/test-ids.constants';
-	import { token } from '$lib/stores/token.store';
+	import { pageToken } from '$lib/derived/page-token.derived';
 	import { solTransactionsNotInitialized } from '$sol/derived/sol-transactions.derived';
 
 	let loading: boolean;
-	$: loading = isNullish($token) || $solTransactionsNotInitialized;
+	$: loading = isNullish($pageToken) || $solTransactionsNotInitialized;
 </script>
 
 <TransactionsSkeletons testIdPrefix={SOL_TRANSACTION_SKELETON_PREFIX} {loading}>


### PR DESCRIPTION
# Motivation

The transactions components are used always inside a page that has a token defined in the URL. So, in a continuous effort to deprecate the `token` store, we can replace it with `pageToken` in all these component.
