### PR TITLE
feat(frontend): Replace Toggleable prop of token store with page-token store

### DIFF
--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -12,7 +12,7 @@
 	import HideTokenReview from '$lib/components/tokens/HideTokenReview.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { tokenToggleable } from '$lib/derived/token.derived';
+	import { pageTokenToggleable } from '$lib/derived/page-token.derived';
 	import { ProgressStepsHideToken } from '$lib/enums/progress-steps';
 	import { WizardStepsHideToken } from '$lib/enums/wizard-steps';
 	import { nullishSignOut } from '$lib/services/auth.services';
@@ -34,7 +34,7 @@
 			return;
 		}
 
-		if (!$tokenToggleable) {
+		if (!$pageTokenToggleable) {
 			toastsError({
 				msg: { text: $i18n.tokens.error.not_toggleable }
 			});

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -14,7 +14,7 @@
 		networkICP,
 		networkSolana
 	} from '$lib/derived/network.derived';
-	import { tokenToggleable } from '$lib/derived/token.derived';
+	import { pageTokenToggleable } from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { token } from '$lib/stores/token.store';
@@ -91,7 +91,7 @@
 
 <Popover bind:visible anchor={button} invisibleBackdrop direction="rtl">
 	<div class="flex flex-col gap-1">
-		{#if $tokenToggleable}
+		{#if $pageTokenToggleable}
 			<ButtonMenu ariaLabel={hideTokenLabel} onclick={hideToken}>
 				{hideTokenLabel}
 			</ButtonMenu>

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -2,13 +2,18 @@ import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
+import { isTokenEthereumUserToken } from '$eth/utils/erc20.utils';
+import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
+import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 import { routeNetwork, routeToken } from '$lib/derived/nav.derived';
 import type { OptionToken, OptionTokenStandard } from '$lib/types/token';
+import { isIcrcTokenToggleEnabled } from '$lib/utils/token-toggle.utils';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
-import { isNullish } from '@dfinity/utils';
+import { isTokenSpl, isTokenSplToggleable } from '$sol/utils/spl.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -64,3 +69,17 @@ export const pageTokenStandard: Readable<OptionTokenStandard> = derived(
 	[pageToken],
 	([$pageToken]) => $pageToken?.standard
 );
+
+export const pageTokenToggleable: Readable<boolean> = derived([pageToken], ([$pageToken]) => {
+	if (nonNullish($pageToken)) {
+		return icTokenIcrcCustomToken($pageToken)
+			? isIcrcTokenToggleEnabled($pageToken)
+			: isTokenEthereumUserToken($pageToken)
+				? isNotDefaultEthereumToken($pageToken)
+				: isTokenSpl($pageToken)
+					? isTokenSplToggleable($pageToken)
+					: false;
+	}
+
+	return false;
+});

--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -1,6 +1,3 @@
-import { isTokenEthereumUserToken } from '$eth/utils/erc20.utils';
-import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
-import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 import {
 	DEFAULT_ARBITRUM_TOKEN,
 	DEFAULT_BASE_TOKEN,
@@ -20,10 +17,7 @@ import {
 	networkSolana
 } from '$lib/derived/network.derived';
 import { token } from '$lib/stores/token.store';
-import type { OptionTokenId, OptionTokenStandard, Token } from '$lib/types/token';
-import { isIcrcTokenToggleEnabled } from '$lib/utils/token-toggle.utils';
-import { isTokenSpl, isTokenSplToggleable } from '$sol/utils/spl.utils';
-import { nonNullish } from '@dfinity/utils';
+import type { OptionTokenId, Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
 export const defaultFallbackToken: Readable<Token> = derived(
@@ -80,22 +74,3 @@ export const tokenWithFallback: Readable<Token> = derived(
 );
 
 export const tokenId: Readable<OptionTokenId> = derived([token], ([$token]) => $token?.id);
-
-export const tokenStandard: Readable<OptionTokenStandard> = derived(
-	[token],
-	([$token]) => $token?.standard
-);
-
-export const tokenToggleable: Readable<boolean> = derived([token], ([$token]) => {
-	if (nonNullish($token)) {
-		return icTokenIcrcCustomToken($token)
-			? isIcrcTokenToggleEnabled($token)
-			: isTokenEthereumUserToken($token)
-				? isNotDefaultEthereumToken($token)
-				: isTokenSpl($token)
-					? isTokenSplToggleable($token)
-					: false;
-	}
-
-	return false;
-});

--- a/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/page-token.derived.spec.ts
@@ -1,4 +1,6 @@
+import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { JUP_TOKEN } from '$env/tokens/tokens-spl/tokens.jup.env';
+import { TRUMP_TOKEN } from '$env/tokens/tokens-spl/tokens.trump.env';
 import {
 	BTC_MAINNET_TOKEN,
 	BTC_REGTEST_TOKEN,
@@ -7,13 +9,22 @@ import {
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
+import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
+import type { Erc20UserToken } from '$eth/types/erc20-user-token';
+import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import * as appConstants from '$lib/constants/app.constants';
-import { pageToken, pageTokenStandard } from '$lib/derived/page-token.derived';
+import { pageToken, pageTokenStandard, pageTokenToggleable } from '$lib/derived/page-token.derived';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
+import type { RequiredTokenWithLinkedData } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
+import type { SplCustomToken } from '$sol/types/spl-custom-token';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { get } from 'svelte/store';
@@ -201,6 +212,172 @@ describe('page-token.derived', () => {
 			mockPage.mock({ token: mockToken.name, network: mockToken.network.id.description });
 
 			expect(get(pageTokenStandard)).toBe(mockToken.standard);
+		});
+	});
+
+	describe('pageTokenToggleable', () => {
+		const mockErc20UserToken: Erc20UserToken = {
+			...mockValidErc20Token,
+			id: parseTokenId('ERC20UserTokenId'),
+			symbol: 'EUTK',
+			address: `${mockValidErc20Token.address}2`,
+			version: undefined,
+			enabled: true
+		};
+
+		const mockIcrcCustomToken: IcrcCustomToken = {
+			...mockValidIcToken,
+			ledgerCanisterId: `${mockValidIcToken.ledgerCanisterId}2`,
+			version: 1n,
+			enabled: true
+		};
+
+		beforeEach(() => {
+			vi.resetAllMocks();
+
+			mockPage.reset();
+		});
+
+		it('should return false for nullish token', () => {
+			expect(get(pageTokenToggleable)).toBeFalsy();
+		});
+
+		it('should return true if default ERC20 user token is toggleable', () => {
+			vi.spyOn(enabledErc20Tokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockErc20UserToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockErc20UserToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return true if custom ERC20 user token is toggleable', () => {
+			const mockToken = { ...mockErc20UserToken, category: 'custom' as const };
+
+			vi.spyOn(enabledErc20Tokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return false if default Ethereum user token is toggleable', () => {
+			const mockToken = {
+				...mockErc20UserToken,
+				standard: 'ethereum' as const
+			} as RequiredTokenWithLinkedData;
+
+			vi.spyOn(enabledEthereumTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeFalsy();
+		});
+
+		it('should return true if custom Ethereum user token is toggleable', () => {
+			const mockToken = {
+				...mockErc20UserToken,
+				category: 'custom' as const,
+				standard: 'ethereum' as const
+			} as RequiredTokenWithLinkedData;
+
+			vi.spyOn(enabledEthereumTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return false if ICRC default token is toggleable', () => {
+			vi.spyOn(enabledIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockIcrcCustomToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockIcrcCustomToken);
+
+			expect(get(pageTokenToggleable)).toBeFalsy();
+		});
+
+		it('should return true if ICRC custom token is toggleable', () => {
+			const mockToken = { ...mockIcrcCustomToken, category: 'custom' as const };
+
+			vi.spyOn(enabledIcrcTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return false if BTC token is toggleable', () => {
+			mockPage.mockToken(BTC_MAINNET_TOKEN);
+
+			expect(get(pageTokenToggleable)).toBeFalsy();
+		});
+
+		it('should return false if Sepolia token is toggleable', () => {
+			mockPage.mockToken(SEPOLIA_TOKEN);
+
+			expect(get(pageTokenToggleable)).toBeFalsy();
+		});
+
+		it('should return true if BONK token is toggleable', () => {
+			const mockToken = { ...BONK_TOKEN, enabled: true };
+
+			vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return true if TRUMP token is toggleable', () => {
+			const mockToken = { ...TRUMP_TOKEN, enabled: true };
+
+			vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return true if TRUMP token is toggleable but not enabled', () => {
+			const mockToken = { ...TRUMP_TOKEN, enabled: false };
+
+			vi.spyOn(enabledSplTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockToken]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockToken);
+
+			expect(get(pageTokenToggleable)).toBeTruthy();
+		});
+
+		it('should return false if Solana token is toggleable', () => {
+			mockPage.mockToken({ ...SOLANA_TOKEN, enabled: true } as SplCustomToken);
+
+			expect(get(pageTokenToggleable)).toBeFalsy();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/derived/token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/token.derived.spec.ts
@@ -9,41 +9,17 @@ import { SUPPORTED_SOLANA_NETWORK_IDS } from '$env/networks/networks.sol.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { BNB_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import { POL_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
-import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
-import { TRUMP_TOKEN } from '$env/tokens/tokens-spl/tokens.trump.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
-import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
-import type { Erc20UserToken } from '$eth/types/erc20-user-token';
-import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import { defaultFallbackToken, tokenToggleable } from '$lib/derived/token.derived';
+import { defaultFallbackToken } from '$lib/derived/token.derived';
 import { token } from '$lib/stores/token.store';
-import { parseTokenId } from '$lib/validation/token.validation';
-import type { SplCustomToken } from '$sol/types/spl-custom-token';
-import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
-import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { get } from 'svelte/store';
 
 describe('token.derived', () => {
-	const mockEr20UserToken: Erc20UserToken = {
-		...mockValidErc20Token,
-		id: parseTokenId('Erc20UserTokenId'),
-		symbol: 'EUTK',
-		address: `${mockValidErc20Token.address}2`,
-		version: undefined,
-		enabled: true
-	};
-
-	const mockIcrcCustomToken: IcrcCustomToken = {
-		...mockValidIcToken,
-		ledgerCanisterId: `${mockValidIcToken.ledgerCanisterId}2`,
-		version: 1n,
-		enabled: true
-	};
-
 	beforeEach(() => {
 		token.reset();
 	});
@@ -152,84 +128,6 @@ describe('token.derived', () => {
 
 				expect(get(defaultFallbackToken)).toEqual(ETHEREUM_TOKEN);
 			});
-		});
-	});
-
-	describe('tokenToggleable', () => {
-		it('should return false for nullish token', () => {
-			expect(get(tokenToggleable)).toBeFalsy();
-		});
-
-		it('should return true if default erc20 user token is toggleable', () => {
-			token.set(mockEr20UserToken);
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return true if custom erc20 user token is toggleable', () => {
-			token.set({ ...mockEr20UserToken, category: 'custom' });
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return false if default ethereum user token is toggleable', () => {
-			token.set({ ...mockEr20UserToken, standard: 'ethereum' });
-
-			expect(get(tokenToggleable)).toBeFalsy();
-		});
-
-		it('should return true if custom ethereum user token is toggleable', () => {
-			token.set({ ...mockEr20UserToken, category: 'custom', standard: 'ethereum' });
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return false if icrc default token is toggleable', () => {
-			token.set(mockIcrcCustomToken);
-
-			expect(get(tokenToggleable)).toBeFalsy();
-		});
-
-		it('should return true if icrc custom token is toggleable', () => {
-			token.set({ ...mockIcrcCustomToken, category: 'custom' });
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return false if btc token is toggleable', () => {
-			token.set(BTC_MAINNET_TOKEN);
-
-			expect(get(tokenToggleable)).toBeFalsy();
-		});
-
-		it('should return false if sepolia token is toggleable', () => {
-			token.set(SEPOLIA_TOKEN);
-
-			expect(get(tokenToggleable)).toBeFalsy();
-		});
-
-		it('should return true if BONK token is toggleable', () => {
-			token.set({ ...BONK_TOKEN, enabled: true } as SplCustomToken);
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return true if Trump token is toggleable', () => {
-			token.set({ ...TRUMP_TOKEN, enabled: true } as SplCustomToken);
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return true if Trump token is toggleable but not enabled', () => {
-			token.set({ ...TRUMP_TOKEN, enabled: false } as SplCustomToken);
-
-			expect(get(tokenToggleable)).toBeTruthy();
-		});
-
-		it('should return false if Solana token is toggleable', () => {
-			token.set({ ...SOLANA_TOKEN, enabled: true } as SplCustomToken);
-
-			expect(get(tokenToggleable)).toBeFalsy();
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -1,3 +1,4 @@
+import type { Token } from '$lib/types/token';
 import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
 import type { Page } from '@sveltejs/kit';
 import { writable } from 'svelte/store';

--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -23,6 +23,8 @@ const initPageStoreMock = () => {
 				url
 			});
 		},
+		mockToken: ({ name, network: { id: networkId } }: Token) =>
+			set({ data: { token: name, network: networkId.description } }),
 
 		reset: () => set(initialStoreValue)
 	};

--- a/src/frontend/src/tests/utils/derived.test-utils.ts
+++ b/src/frontend/src/tests/utils/derived.test-utils.ts
@@ -35,7 +35,7 @@ import { networks, networksMainnets, networksTestnets } from '$lib/derived/netwo
 import { pageToken } from '$lib/derived/page-token.derived';
 import { hideZeroBalances, showZeroBalances } from '$lib/derived/settings.derived';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
-import { tokenId, tokenToggleable, tokenWithFallback } from '$lib/derived/token.derived';
+import { tokenId, tokenWithFallback } from '$lib/derived/token.derived';
 import {
 	enabledErc20Tokens,
 	enabledIcTokens,
@@ -88,7 +88,6 @@ const derivedList: Record<string, Readable<unknown>> = {
 	showZeroBalances,
 	testnetsEnabled,
 	tokenId,
-	tokenToggleable,
 	tokenWithFallback,
 	tokenWithFallbackAsIcToken,
 	tokens,


### PR DESCRIPTION
# Motivation

In an effort to deprecate the token store, we replace the `tokenToggleable` derived store with the equivalent that is derived from the `pageToken`.

It is ok, since the consumers all refers to places where the page token is defined.

# Changes

- Create copy of `tokenToggleable` store as `pageTokenToggleable`.
- Adapt usages.
- Unrelated: we remove deprecated `tokenStandard` derived store.

# Tests

Added tests.
