### PR TITLE
feat(frontend): Migrate main app layout component to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenu.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import NavigationMenuMainItems from '$lib/components/navigation/NavigationMenuMainItems.svelte';
 	import { SIDEBAR_NAVIGATION_MENU } from '$lib/constants/test-ids.constants';
+	import type {Snippet} from "svelte";
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
 </script>
 
 <div
@@ -12,6 +19,6 @@
 	</div>
 
 	<div class="my-4 flex h-full flex-col">
-		<slot />
+		{@render children()}
 	</div>
 </div>

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
 	import Responsive from '$lib/components/ui/Responsive.svelte';
+	import type {Snippet} from "svelte";
+
+	interface Props {
+		menu: Snippet;
+		children: Snippet;
+	}
+
+	let { menu, children }: Props = $props();
 </script>
 
 <main class="relative mx-auto max-w-screen-2.5xl pt-6 md:flex md:w-full md:flex-row lg:w-auto">
@@ -7,13 +15,13 @@
 		<div
 			class="invisible absolute -translate-x-full transition-all duration-200 ease-in-out md:visible md:fixed md:inset-y-0 md:mt-24 md:block md:min-w-36 md:translate-x-0 md:transition-none lg:min-w-44 xl:w-80 1.5xl:w-[22rem]"
 		>
-			<slot name="menu" />
+			{@render menu()}
 		</div>
 	</Responsive>
 
 	<div
 		class="mx-auto max-w-xl overflow-hidden px-3 transition-all duration-500 ease-linear md:ml-64 md:box-content md:w-sm md:max-w-none md:px-4 xl:ml-auto"
 	>
-		<slot />
+		{@render children()}
 	</div>
 </main>

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -2,7 +2,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import { onNavigate } from '$app/navigation';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import AiAssistantConsole from '$lib/components/ai-assistant/AiAssistantConsole.svelte';
 	import AiAssistantConsoleButton from '$lib/components/ai-assistant/AiAssistantConsoleButton.svelte';
 	import AuthGuard from '$lib/components/auth/AuthGuard.svelte';
@@ -22,17 +22,23 @@
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
 	import { isRouteTokens, isRouteTransactions } from '$lib/utils/nav.utils';
+	import type {Snippet} from "svelte";
 
-	let tokensRoute: boolean;
-	$: tokensRoute = isRouteTokens($page);
+	interface Props {
+		children: Snippet;
+	}
 
-	let transactionsRoute: boolean;
-	$: transactionsRoute = isRouteTransactions($page);
+	let { children }: Props = $props();
 
-	let showHero: boolean;
-	$: showHero = tokensRoute || transactionsRoute;
+	let tokensRoute = $derived(isRouteTokens(page));
 
-	$: token.set($pageToken);
+	let transactionsRoute = $derived(isRouteTransactions(page));
+
+	let showHero = $derived(tokensRoute || transactionsRoute);
+
+	$effect(() => {
+		token.set($pageToken);
+	});
 
 	// Source: https://svelte.dev/blog/view-transitions
 	onNavigate((navigation) => {
@@ -64,22 +70,24 @@
 
 		<AuthGuard>
 			<SplitPane>
-				<NavigationMenu slot="menu">
-					{#if tokensRoute}
-						<Responsive up="xl">
-							<div transition:fade class="hidden xl:block">
-								<DappsCarousel />
-							</div>
-						</Responsive>
-					{/if}
-				</NavigationMenu>
+				{#snippet menu()}
+					<NavigationMenu>
+						{#if tokensRoute}
+							<Responsive up="xl">
+								<div transition:fade class="hidden xl:block">
+									<DappsCarousel />
+								</div>
+							</Responsive>
+						{/if}
+					</NavigationMenu>
+				{/snippet}
 
 				{#if showHero}
 					<Hero />
 				{/if}
 
 				<Loaders>
-					<slot />
+					{@render children()}
 				</Loaders>
 			</SplitPane>
 


### PR DESCRIPTION
# Motivation

Migrating (app)/+layout component (and its direct children) to Svelte 5. 