### PR TITLE
fix(frontend): Correctly delete the multi-keys from IDB cache

### DIFF
--- a/src/frontend/src/lib/api/idb-balances.api.ts
+++ b/src/frontend/src/lib/api/idb-balances.api.ts
@@ -2,9 +2,10 @@ import { browser } from '$app/environment';
 import { nullishSignOut } from '$lib/services/auth.services';
 import type { Balance } from '$lib/types/balance';
 import type { GetIdbBalancesParams, SetIdbBalancesParams } from '$lib/types/idb-balances';
+import { delMultiKeysByPrincipal } from '$lib/utils/storage.utils';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, del, get, set as idbSet, type UseStore } from 'idb-keyval';
+import { createStore, get, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const createIdbBalancesStore = (): UseStore =>
@@ -48,4 +49,4 @@ export const getIdbBalances = (params: GetIdbBalancesParams): Promise<Balance | 
 	get(toKey(params), idbBalancesStore);
 
 export const deleteIdbBalances = (principal: Principal): Promise<void> =>
-	del(principal.toText(), idbBalancesStore);
+	delMultiKeysByPrincipal({ principal, store: idbBalancesStore });

--- a/src/frontend/src/lib/api/idb-balances.api.ts
+++ b/src/frontend/src/lib/api/idb-balances.api.ts
@@ -2,7 +2,7 @@ import { browser } from '$app/environment';
 import { nullishSignOut } from '$lib/services/auth.services';
 import type { Balance } from '$lib/types/balance';
 import type { GetIdbBalancesParams, SetIdbBalancesParams } from '$lib/types/idb-balances';
-import { delMultiKeysByPrincipal } from '$lib/utils/storage.utils';
+import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
 import { createStore, get, set as idbSet, type UseStore } from 'idb-keyval';

--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -14,10 +14,11 @@ import type {
 	IdbTransactionsStoreData,
 	SetIdbTransactionsParams
 } from '$lib/types/idb-transactions';
+import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, del, get, set as idbSet, type UseStore } from 'idb-keyval';
+import { createStore, get, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const idbTransactionsStore = (key: string): UseStore =>
@@ -104,13 +105,13 @@ export const getIdbSolTransactions = (
 ): Promise<SolTransactionUi[] | undefined> => get(toKey(params), idbSolTransactionsStore);
 
 export const deleteIdbBtcTransactions = (principal: Principal): Promise<void> =>
-	del(principal.toText(), idbBtcTransactionsStore);
+	delMultiKeysByPrincipal({ principal, store: idbBtcTransactionsStore });
 
 export const deleteIdbEthTransactions = (principal: Principal): Promise<void> =>
-	del(principal.toText(), idbEthTransactionsStore);
+	delMultiKeysByPrincipal({ principal, store: idbEthTransactionsStore });
 
 export const deleteIdbIcTransactions = (principal: Principal): Promise<void> =>
-	del(principal.toText(), idbIcTransactionsStore);
+	delMultiKeysByPrincipal({ principal, store: idbIcTransactionsStore });
 
 export const deleteIdbSolTransactions = (principal: Principal): Promise<void> =>
-	del(principal.toText(), idbSolTransactionsStore);
+	delMultiKeysByPrincipal({ principal, store: idbSolTransactionsStore });

--- a/src/frontend/src/lib/utils/idb.utils.ts
+++ b/src/frontend/src/lib/utils/idb.utils.ts
@@ -1,0 +1,25 @@
+import { browser } from '$app/environment';
+import type { Principal } from '@dfinity/principal';
+import { delMany, keys, type UseStore } from 'idb-keyval';
+
+export const delMultiKeysByPrincipal = async ({
+	principal,
+	store
+}: {
+	principal: Principal;
+	store: UseStore;
+}) => {
+	if (!browser) {
+		return;
+	}
+
+	const allKeys = await keys(store);
+	const principalText = principal.toText();
+	const filteredKeys = allKeys.filter((key) => Array.isArray(key) && key[0] === principalText);
+
+	if (filteredKeys.length === 0) {
+		return;
+	}
+
+	await delMany(filteredKeys, store);
+};

--- a/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
@@ -22,7 +22,7 @@ vi.mock('idb-keyval', () => ({
 	update: vi.fn()
 }));
 
-vi.mock('$lib/utils/storage.utils', () => ({
+vi.mock('$lib/utils/idb.utils', () => ({
 	delMultiKeysByPrincipal: vi.fn()
 }));
 

--- a/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
@@ -4,6 +4,7 @@ import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { deleteIdbBalances, getIdbBalances, setIdbBalancesStore } from '$lib/api/idb-balances.api';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Balance } from '$lib/types/balance';
+import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
 import { createStore } from 'idb-keyval';
@@ -16,7 +17,13 @@ vi.mock('idb-keyval', () => ({
 	set: vi.fn(),
 	get: vi.fn(),
 	del: vi.fn(),
+	delMany: vi.fn(),
+	keys: vi.fn(),
 	update: vi.fn()
+}));
+
+vi.mock('$lib/utils/storage.utils', () => ({
+	delMultiKeysByPrincipal: vi.fn()
 }));
 
 vi.mock('$app/environment', () => ({
@@ -222,10 +229,10 @@ describe('idb-balances.api', () => {
 		it('should delete balances', async () => {
 			await deleteIdbBalances(mockPrincipal);
 
-			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
-				mockPrincipal.toText(),
-				expect.any(Object)
-			);
+			expect(delMultiKeysByPrincipal).toHaveBeenCalledExactlyOnceWith({
+				principal: mockPrincipal,
+				store: expect.any(Object)
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -14,6 +14,7 @@ import {
 	getIdbSolTransactions,
 	setIdbTransactionsStore
 } from '$lib/api/idb-transactions.api';
+import { delMultiKeysByPrincipal } from '$lib/utils/storage.utils';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc-transactions.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
@@ -28,6 +29,8 @@ vi.mock('idb-keyval', () => ({
 	set: vi.fn(),
 	get: vi.fn(),
 	del: vi.fn(),
+	delMany: vi.fn(),
+	keys: vi.fn(),
 	update: vi.fn()
 }));
 
@@ -284,10 +287,10 @@ describe('idb-transactions.api', () => {
 		it('should delete BTC tokens', async () => {
 			await deleteIdbBtcTransactions(mockPrincipal);
 
-			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
-				mockPrincipal.toText(),
-				expect.any(Object)
-			);
+			expect(delMultiKeysByPrincipal).toHaveBeenCalledExactlyOnceWith({
+				principal: mockPrincipal,
+				store: expect.any(Object)
+			});
 		});
 	});
 
@@ -295,10 +298,10 @@ describe('idb-transactions.api', () => {
 		it('should delete ETH transactions', async () => {
 			await deleteIdbEthTransactions(mockPrincipal);
 
-			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
-				mockPrincipal.toText(),
-				expect.any(Object)
-			);
+			expect(delMultiKeysByPrincipal).toHaveBeenCalledExactlyOnceWith({
+				principal: mockPrincipal,
+				store: expect.any(Object)
+			});
 		});
 	});
 
@@ -306,10 +309,10 @@ describe('idb-transactions.api', () => {
 		it('should delete IC transactions', async () => {
 			await deleteIdbIcTransactions(mockPrincipal);
 
-			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
-				mockPrincipal.toText(),
-				expect.any(Object)
-			);
+			expect(delMultiKeysByPrincipal).toHaveBeenCalledExactlyOnceWith({
+				principal: mockPrincipal,
+				store: expect.any(Object)
+			});
 		});
 	});
 
@@ -317,10 +320,10 @@ describe('idb-transactions.api', () => {
 		it('should delete SOL transactions', async () => {
 			await deleteIdbSolTransactions(mockPrincipal);
 
-			expect(idbKeyval.del).toHaveBeenCalledExactlyOnceWith(
-				mockPrincipal.toText(),
-				expect.any(Object)
-			);
+			expect(delMultiKeysByPrincipal).toHaveBeenCalledExactlyOnceWith({
+				principal: mockPrincipal,
+				store: expect.any(Object)
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -14,7 +14,7 @@ import {
 	getIdbSolTransactions,
 	setIdbTransactionsStore
 } from '$lib/api/idb-transactions.api';
-import { delMultiKeysByPrincipal } from '$lib/utils/storage.utils';
+import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import { createMockBtcTransactionsUi } from '$tests/mocks/btc-transactions.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -42,6 +42,10 @@ vi.mock('$lib/services/auth.services', () => ({
 	nullishSignOut: vi.fn()
 }));
 
+vi.mock('$lib/utils/idb.utils', () => ({
+	delMultiKeysByPrincipal: vi.fn()
+}));
+
 describe('idb-transactions.api', () => {
 	const mockIdbTransactionsStore = createStore('mock-store', 'mock-store');
 

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -1,5 +1,6 @@
 import { signOut } from '$lib/services/auth.services';
 import { authStore } from '$lib/stores/auth.store';
+import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
 
@@ -10,7 +11,13 @@ vi.mock('idb-keyval', () => ({
 	set: vi.fn(),
 	get: vi.fn(),
 	del: vi.fn(),
+	delMany: vi.fn(),
+	keys: vi.fn(),
 	update: vi.fn()
+}));
+
+vi.mock('$lib/utils/idb.utils', () => ({
+	delMultiKeysByPrincipal: vi.fn()
 }));
 
 const rootLocation = 'https://oisy.com/';
@@ -81,8 +88,11 @@ describe('auth.services', () => {
 
 			await signOut({});
 
-			// 3 addresses + 3(+1) tokens + 4 transactions + 1 balances
-			expect(idbKeyval.del).toHaveBeenCalledTimes(12);
+			// 3 addresses + 3(+1) tokens
+			expect(idbKeyval.del).toHaveBeenCalledTimes(7);
+
+			// 4 transactions + 1 balances
+			expect(delMultiKeysByPrincipal).toHaveBeenCalledTimes(5);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/idb.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/idb.utils.spec.ts
@@ -1,0 +1,87 @@
+import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+import { delMany, keys, type UseStore } from 'idb-keyval';
+
+vi.mock('idb-keyval', () => ({
+	createStore: vi.fn(() => ({
+		/* mock store implementation */
+	})),
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn(),
+	delMany: vi.fn(),
+	keys: vi.fn(),
+	update: vi.fn()
+}));
+
+describe('idb.utils', () => {
+	describe('delMultiKeysByPrincipal', () => {
+		const expectedKeys = [
+			[mockPrincipal.toText(), 'token1', 'network1'],
+			[mockPrincipal.toText(), 'token2', 'network2']
+		];
+
+		const nonMatchingKeys = [
+			['mockPrincipal2', 'token1', 'network1'],
+			['mockPrincipal2', 'token3', 'network3'],
+			['mockPrincipal3', 'token1', 'network1']
+		];
+
+		const mockKeys = [...expectedKeys, ...nonMatchingKeys];
+
+		const mockStore = {} as unknown as UseStore;
+
+		const mockParams = { principal: mockPrincipal, store: mockStore };
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.mocked(keys).mockResolvedValue(mockKeys);
+		});
+
+		it('should delete the data with the correct keys', async () => {
+			await delMultiKeysByPrincipal(mockParams);
+
+			expect(keys).toHaveBeenCalledExactlyOnceWith(mockStore);
+			expect(delMany).toHaveBeenCalledExactlyOnceWith(expectedKeys, mockStore);
+		});
+
+		it('should not delete anything if no keys match the principal', async () => {
+			vi.mocked(keys).mockResolvedValueOnce(nonMatchingKeys);
+
+			await delMultiKeysByPrincipal(mockParams);
+
+			expect(delMany).not.toHaveBeenCalled();
+		});
+
+		it('should handle empty keys array', async () => {
+			vi.mocked(keys).mockResolvedValueOnce([]);
+
+			await delMultiKeysByPrincipal(mockParams);
+
+			expect(delMany).not.toHaveBeenCalled();
+		});
+
+		it('should handle errors gracefully', async () => {
+			vi.mocked(delMany).mockRejectedValueOnce(new Error('Mocked error'));
+
+			await expect(delMultiKeysByPrincipal(mockParams)).rejects.toThrow();
+
+			expect(delMany).toHaveBeenCalledExactlyOnceWith(expectedKeys, mockStore);
+		});
+
+		it('should handle keys that are not arrays', async () => {
+			const mixedKeys = [
+				[mockPrincipal.toText(), 'token1', 'network1'],
+				['someOtherKey'],
+				[mockPrincipal.toText(), 'token2', 'network2']
+			];
+
+			vi.mocked(keys).mockResolvedValueOnce(mixedKeys);
+
+			await delMultiKeysByPrincipal(mockParams);
+
+			expect(delMany).toHaveBeenCalledExactlyOnceWith([mixedKeys[0], mixedKeys[2]], mockStore);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

The IDB cache for transactions and balances uses multi-keys for the database. That means that we need to delete all the keys that starts with user's principal.

# Changes

- Create IDB util to delete data from cache if multi-keys and the first one is a principal.
- Adapt existing methods.

# Tests

Added tests and manual test worked.
