### PR TITLE
chore(frontend): assert signer usage of new cbor library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@dfinity/gix-components": "^7.0.0-next-2025-07-22",
 				"@dfinity/ledger-icp": "^4.0.0",
 				"@dfinity/ledger-icrc": "^2.9.1",
-				"@dfinity/oisy-wallet-signer": "^0.2.3",
+				"@dfinity/oisy-wallet-signer": "^0.2.4-next-2025-07-25",
 				"@dfinity/principal": "^2.4.1",
 				"@dfinity/utils": "^2.13.2",
 				"@dfinity/verifiable-credentials": "^0.0.4",
@@ -380,6 +380,13 @@
 				"@dfinity/principal": "^2.4.1"
 			}
 		},
+		"node_modules/@dfinity/cbor": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.2.tgz",
+			"integrity": "sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
 		"node_modules/@dfinity/ckbtc": {
 			"version": "3.1.14",
 			"resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-3.1.14.tgz",
@@ -544,23 +551,22 @@
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-0.2.3.tgz",
-			"integrity": "sha512-dQ3RJbMDrzsVYqNxc1JqHVfqpIGAKIjyFGaoLPpfDBwXFp8eX9YFsriDDqs32g9lfERCLCaAlgF+2KKLIkcM3w==",
+			"version": "0.2.4-next-2025-07-25",
+			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-0.2.4-next-2025-07-25.tgz",
+			"integrity": "sha512-lW9dgYnmZGqfZCam1XAv2zOENMFa9va1+Cgq2xKcy2s/jsmNgqzHGN9HCweQ8bwkaYRt+0VyTI9pvZAhicVZmg==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=22"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.4.0",
-				"@dfinity/candid": "^2.4.0",
-				"@dfinity/ledger-icp": ">=4",
-				"@dfinity/ledger-icrc": "^2",
-				"@dfinity/principal": "^2.4.0",
-				"@dfinity/utils": "^2.13.0",
-				"@dfinity/zod-schemas": "^1.0.0",
-				"borc": "^2.1.1",
-				"simple-cbor": "^0.4.1",
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/cbor": "*",
+				"@dfinity/ledger-icp": "*",
+				"@dfinity/ledger-icrc": "*",
+				"@dfinity/principal": "*",
+				"@dfinity/utils": "*",
+				"@dfinity/zod-schemas": "*",
 				"zod": "^3.25"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"@dfinity/gix-components": "^7.0.0-next-2025-07-22",
 		"@dfinity/ledger-icp": "^4.0.0",
 		"@dfinity/ledger-icrc": "^2.9.1",
-		"@dfinity/oisy-wallet-signer": "^0.2.3",
+		"@dfinity/oisy-wallet-signer": "^0.2.4-next-2025-07-25",
 		"@dfinity/principal": "^2.4.1",
 		"@dfinity/utils": "^2.13.2",
 		"@dfinity/verifiable-credentials": "^0.0.4",


### PR DESCRIPTION
# Motivation

We must no necessarely introduce this change in OISY but, I would like to deploy it on staging to proceed with some manually testing of the signer. Therefore opening this PR to trigger a deploy.

# Changes

- Update OISY Wallet Signer next which uses the new `@dfinity/cbor` library.
