### PR TITLE
test(frontend): Mock page from Svelte state

### DIFF
--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -1,3 +1,4 @@
+import { page } from '$app/state';
 import type { Token } from '$lib/types/token';
 import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
 import type { Page } from '@sveltejs/kit';
@@ -12,20 +13,24 @@ const initialStoreValue = {
 
 const initPageStoreMock = () => {
 	const { subscribe, set } = writable<Partial<Page>>(initialStoreValue);
+	page.data = initialStoreValue.data;
+	page.route = initialStoreValue.route;
 
 	return {
 		subscribe,
-		mock: (data: Partial<RouteParams>) =>
-			set({
-				data
-			}),
-		mockUrl: (url: URL) => {
-			set({
-				url
-			});
+		mock: (data: Partial<RouteParams>) => {
+			set({ data });
+			page.data = data;
 		},
-		mockToken: ({ name, network: { id: networkId } }: Token) =>
-			set({ data: { token: name, network: networkId.description } }),
+		mockUrl: (url: URL) => {
+			set({ url });
+			page.url = url;
+		},
+		mockToken: ({ name, network: { id: networkId } }: Token) => {
+			const data = { token: name, network: networkId.description };
+			set({ data });
+			page.data = data;
+		},
 
 		reset: () => set(initialStoreValue)
 	};

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -51,6 +51,10 @@ vi.mock('$app/stores', () => ({
 	page: mockPage
 }));
 
+vi.mock('$app/state', () => ({
+	page: {}
+}));
+
 vi.mock(import('$lib/actors/agents.ic'), async (importOriginal) => {
 	const actual = await importOriginal();
 	return {


### PR DESCRIPTION
# Motivation

Since the `page` store is deprecated in favour of `page` state, we first create a way to mock both, to help with the migration.
