### PR TITLE
feat(frontend): Migrate component `NetworkWithLogo` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworkWithLogo.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkWithLogo.svelte
@@ -12,5 +12,7 @@
 </script>
 
 <TextWithLogo name={network.name} {logo}>
-	<NetworkLogo slot="icon" {network} />
+	{#snippet icon()}
+		<NetworkLogo {network} />
+	{/snippet}
 </TextWithLogo>

--- a/src/frontend/src/lib/components/ui/TextWithLogo.svelte
+++ b/src/frontend/src/lib/components/ui/TextWithLogo.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type {Snippet} from 'svelte';
 
-	export let name: string;
-	export let logo: 'start' | 'end' = 'end';
-	export let description: string | undefined = undefined;
+	interface Props {
+		name: string;
+		logo?: 'start' | 'end';
+		description?: string;
+		icon:Snippet;
+	}
+
+	let { name, logo = 'end', description, icon }: Props = $props();
 </script>
 
 <span
@@ -19,5 +25,5 @@
 			<span class="text-left text-xs leading-none text-tertiary">{description}</span>
 		{/if}
 	</span>
-	<slot name="icon" />
+	{@render icon()}
 </span>

--- a/src/frontend/src/lib/components/ui/TextWithLogo.svelte
+++ b/src/frontend/src/lib/components/ui/TextWithLogo.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import type {Snippet} from 'svelte';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		name: string;
 		logo?: 'start' | 'end';
 		description?: string;
-		icon:Snippet;
+		icon: Snippet;
 	}
 
 	let { name, logo = 'end', description, icon }: Props = $props();


### PR DESCRIPTION
# Motivation

Migrating `NetworkWithLogo` component (and its direct children) to Svelte 5.
