### PR TITLE
feat(frontend): Migrate component `PageTitle` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/ui/PageTitle.svelte
+++ b/src/frontend/src/lib/components/ui/PageTitle.svelte
@@ -1,1 +1,11 @@
-<h1 class="mb-5 mt-6"><slot /></h1>
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+<h1 class="mb-5 mt-6">{@render children()}</h1>


### PR DESCRIPTION
# Motivation

Migrating `PageTitle` component to Svelte 5.
