### PR TITLE
feat(frontend): Migrate component `InfoBoxWrapper` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/core/Listener.svelte
+++ b/src/frontend/src/lib/components/core/Listener.svelte
@@ -10,22 +10,28 @@
 		isNetworkIdEvm,
 		isNetworkIdICP
 	} from '$lib/utils/network.utils';
+	import type { Snippet } from 'svelte';
 
-	export let token: OptionToken;
+	interface Props {
+		token: OptionToken;
+		children?: Snippet;
+	}
+
+	let { token, children }: Props = $props();
 </script>
 
 {#if isNullish(token) || $authNotSignedIn}
-	<slot />
+	{@render children?.()}
 {:else if isNetworkIdICP(token.network.id)}
-	<slot />
+	{@render children?.()}
 {:else if isNetworkIdBitcoin(token.network.id)}
 	<BitcoinListener>
-		<slot />
+		{@render children?.()}
 	</BitcoinListener>
 {:else if isNetworkIdEthereum(token.network.id) || isNetworkIdEvm(token.network.id)}
 	<EthListener {token}>
-		<slot />
+		{@render children?.()}
 	</EthListener>
 {:else}
-	<slot />
+	{@render children?.()}
 {/if}

--- a/src/frontend/src/lib/components/info/InfoBox.svelte
+++ b/src/frontend/src/lib/components/info/InfoBox.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
 	import { IconClose } from '@dfinity/gix-components';
+	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { SLIDE_EASING } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	export let hideInfo: boolean;
+	interface Props {
+		hideInfo: boolean;
+		children: Snippet;
+		onClick: () => void;
+	}
+
+	let { hideInfo, children, onClick }: Props = $props();
 </script>
 
 {#if !hideInfo}
@@ -12,9 +19,11 @@
 		class="relative mb-12 rounded-lg bg-primary px-6 py-4 text-primary"
 		transition:slide={SLIDE_EASING}
 	>
-		<button class="absolute right-2 top-2 text-tertiary" on:click aria-label={$i18n.core.text.close}
-			><IconClose /></button
+		<button
+			class="absolute right-2 top-2 text-tertiary"
+			onclick={onClick}
+			aria-label={$i18n.core.text.close}><IconClose /></button
 		>
-		<slot />
+		{@render children()}
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/info/InfoBoxWrapper.svelte
+++ b/src/frontend/src/lib/components/info/InfoBoxWrapper.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import InfoBox from '$lib/components/info/InfoBox.svelte';
 	import { type HideInfoKey, saveHideInfo, shouldHideInfo } from '$lib/utils/info.utils';
 
-	export let key: HideInfoKey | undefined;
+	interface Props {
+		key: HideInfoKey;
+		children: Snippet;
+	}
 
-	let hideInfo = true;
-	$: hideInfo = nonNullish(key) ? shouldHideInfo(key) : true;
+	let { key, children }: Props = $props();
+
+	let hideInfo = $derived(nonNullish(key) ? shouldHideInfo(key) : true);
 
 	const close = () => {
 		hideInfo = true;
@@ -19,6 +24,6 @@
 	};
 </script>
 
-<InfoBox {hideInfo} on:click={close}>
-	<slot />
+<InfoBox {hideInfo} onClick={close}>
+	{@render children()}
 </InfoBox>


### PR DESCRIPTION
# Motivation

Migrating InfoBoxWrapper component (and its direct children) to Svelte 5.