### PR TITLE
feat(frontend): Track network in ETH send flow

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -184,7 +184,8 @@
 			trackEvent({
 				name: TRACK_COUNT_ETH_SEND_SUCCESS,
 				metadata: {
-					token: $sendToken.symbol
+					token: $sendToken.symbol,
+					network: sourceNetwork.id.description ?? `${$sendToken.network.id.description}`,
 				}
 			});
 
@@ -193,7 +194,8 @@
 			trackEvent({
 				name: TRACK_COUNT_ETH_SEND_ERROR,
 				metadata: {
-					token: $sendToken.symbol
+					token: $sendToken.symbol,
+					network: sourceNetwork.id.description ?? `${$sendToken.network.id.description}`,
 				}
 			});
 

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -185,7 +185,7 @@
 				name: TRACK_COUNT_ETH_SEND_SUCCESS,
 				metadata: {
 					token: $sendToken.symbol,
-					network: sourceNetwork.id.description ?? `${$sendToken.network.id.description}`,
+					network: sourceNetwork.id.description ?? `${$sendToken.network.id.description}`
 				}
 			});
 
@@ -195,7 +195,7 @@
 				name: TRACK_COUNT_ETH_SEND_ERROR,
 				metadata: {
 					token: $sendToken.symbol,
-					network: sourceNetwork.id.description ?? `${$sendToken.network.id.description}`,
+					network: sourceNetwork.id.description ?? `${$sendToken.network.id.description}`
 				}
 			});
 


### PR DESCRIPTION
# Motivation

It is useful to track which network is being used in the ETH send flow.
