### PR TITLE
refactor(frontend): Extract sub-service of `getAccountInfo` for Solana RPC

### DIFF
--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -197,6 +197,18 @@ export const estimatePriorityFee = async ({
 	);
 };
 
+export const getAccountInfo = async ({
+	address,
+	network
+}: {
+	address: SolAddress;
+	network: SolanaNetworkType;
+}) => {
+	const { getAccountInfo } = solanaHttpRpc(network);
+
+	return await getAccountInfo(solAddress(address), { encoding: 'jsonParsed' }).send();
+};
+
 export const getTokenInfo = async ({
 	address,
 	network
@@ -209,10 +221,7 @@ export const getTokenInfo = async ({
 	mintAuthority?: SplTokenAddress;
 	freezeAuthority?: SplTokenAddress;
 }> => {
-	const { getAccountInfo } = solanaHttpRpc(network);
-	const token = solAddress(address);
-
-	const { value } = await getAccountInfo(token, { encoding: 'jsonParsed' }).send();
+	const { value } = await getAccountInfo({ address, network });
 
 	const { owner, data } = value ?? {};
 
@@ -242,10 +251,7 @@ export const getAccountOwner = async ({
 	address: SolAddress;
 	network: SolanaNetworkType;
 }): Promise<SolAddress | undefined> => {
-	const { getAccountInfo } = solanaHttpRpc(network);
-	const account = solAddress(address);
-
-	const { value } = await getAccountInfo(account, { encoding: 'jsonParsed' }).send();
+	const { value } = await getAccountInfo({ address, network });
 
 	if (isNullish(value?.data) || !('parsed' in value.data)) {
 		return undefined;
@@ -268,10 +274,7 @@ export const checkIfAccountExists = async ({
 	address: SolAddress;
 	network: SolanaNetworkType;
 }): Promise<boolean> => {
-	const { getAccountInfo } = solanaHttpRpc(network);
-	const account = solAddress(address);
-
-	const { value } = await getAccountInfo(account, { encoding: 'jsonParsed' }).send();
+	const { value } = await getAccountInfo({ address, network });
 
 	return nonNullish(value);
 };

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -1,6 +1,7 @@
 import { ZERO } from '$lib/constants/app.constants';
 import type { SolAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
+import { getAccountInfo } from '$sol/api/solana.api';
 import {
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
 	COMPUTE_BUDGET_PROGRAM_ADDRESS,
@@ -8,7 +9,6 @@ import {
 	TOKEN_2022_PROGRAM_ADDRESS,
 	TOKEN_PROGRAM_ADDRESS
 } from '$sol/constants/sol.constants';
-import { solanaHttpRpc } from '$sol/providers/sol-rpc.providers';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type {
 	SolInstruction,
@@ -76,7 +76,7 @@ import {
 	parseTransferInstruction,
 	parseUiAmountToAmountInstruction
 } from '@solana-program/token';
-import { address, assertIsInstructionWithAccounts, assertIsInstructionWithData } from '@solana/kit';
+import { assertIsInstructionWithAccounts, assertIsInstructionWithData } from '@solana/kit';
 
 const mapSystemParsedInstruction = ({
 	type,
@@ -148,11 +148,7 @@ const mapTokenParsedInstruction = async ({
 			return { value: BigInt(value), from, to, tokenAddress };
 		}
 
-		const { getAccountInfo } = solanaHttpRpc(network);
-
-		const { value: sourceResult } = await getAccountInfo(address(from), {
-			encoding: 'jsonParsed'
-		}).send();
+		const { value: sourceResult } = await getAccountInfo({ address: from, network });
 
 		if (nonNullish(sourceResult) && 'parsed' in sourceResult.data) {
 			const {
@@ -166,9 +162,7 @@ const mapTokenParsedInstruction = async ({
 			return { value: BigInt(value), from, to, tokenAddress };
 		}
 
-		const { value: destinationResult } = await getAccountInfo(address(to), {
-			encoding: 'jsonParsed'
-		}).send();
+		const { value: destinationResult } = await getAccountInfo({ address: to, network });
 
 		if (nonNullish(destinationResult) && 'parsed' in destinationResult.data) {
 			const {


### PR DESCRIPTION
# Motivation

For better manageability, we extract a sub-service for the Solana RPC: `getAccountInfo`.
