### PR TITLE
test(fix): Mock sign out in `AuthHelpIdentityForm` tests

### DIFF
--- a/src/frontend/src/tests/lib/components/auth/AuthHelpIdentityForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/AuthHelpIdentityForm.spec.ts
@@ -13,6 +13,11 @@ import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
+vi.mock('$lib/services/auth.services', () => ({
+	signIn: vi.fn(),
+	nullishSignOut: vi.fn()
+}));
+
 describe('AuthHelpIdentityForm', () => {
 	const imageBannerSelector = `img[data-tid="${HELP_AUTH_IDENTITY_IMAGE_BANNER}"]`;
 	const signInButtonSelector = `button[data-tid="${HELP_AUTH_LEGACY_SIGN_IN_BUTTON}"]`;


### PR DESCRIPTION
# Motivation

To avoid raising errors for missing `window`, we mock the `nullishSignOut` function in tests for component `AuthHelpIdentityForm`.
