### PR TITLE
style(frontend): Use correct colors for toast warning

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -396,8 +396,8 @@ div.select {
 	--toast-error-background: var(--color-background-error-light);
 	--toast-error-color: var(--color-foreground-error-secondary);
 
-	--toast-warn-background: var(--color-background-error-light);
-	--toast-warn-color: var(--color-foreground-error-secondary);
+	--toast-warn-background: var(--color-background-warning-light);
+	--toast-warn-color: var(--color-foreground-warning-secondary);
 }
 
 // Tooltip


### PR DESCRIPTION
# Motivation

The toast warning should have the correct color of the warning and not of the error.

### Before

<img width="1270" height="190" alt="Screenshot 2025-07-29 at 13 56 25" src="https://github.com/user-attachments/assets/2e088779-a89b-4eda-8c34-bd10c73052bb" />

### After

<img width="1248" height="160" alt="Screenshot 2025-07-29 at 14 01 14" src="https://github.com/user-attachments/assets/39fcda03-7715-4306-827c-29e3a5f38b06" />

