### PR TITLE
feat(frontend): Migrate `LicenseLink` component to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/license-agreement/LicenseLink.svelte
+++ b/src/frontend/src/lib/components/license-agreement/LicenseLink.svelte
@@ -2,8 +2,12 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	export let noUnderline = false;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		noUnderline?: boolean;
+		testId?: string;
+	}
+
+	let { noUnderline = false, testId }: Props = $props();
 </script>
 
 <a


### PR DESCRIPTION
# Motivation

Migrating `LicenseLink` to Svelte 5.
