### PR TITLE
fix(frontend): Do not listen to ETH transaction status if already finalised

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
@@ -55,6 +55,11 @@
 	let status: 'included' | 'safe' | 'finalised' | undefined;
 
 	$: (() => {
+		if (status === 'finalised') {
+			disconnect();
+			return;
+		}
+
 		if (isNullish(currentBlockNumber)) {
 			status = undefined;
 			return;


### PR DESCRIPTION
# Motivation

Component `EthTransactionStatus` listens real-time to the block numbers, to verify the current status of the open transaction inside a Transaction modal. However, it is missing the logic that if the status is already finalised, it should not keep listening.
