### PR TITLE
fix(frontend): Set nullish listener for pending transactions when unmounting

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeContext.svelte
@@ -183,6 +183,7 @@
 	});
 	onDestroy(() => {
 		listener?.disconnect();
+		listener = undefined;
 		clearTimeout(listenerCallbackTimer);
 	});
 

--- a/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
+++ b/src/frontend/src/icp-eth/components/core/CkEthereumPendingTransactionsListener.svelte
@@ -136,7 +136,10 @@
 	// - The scheduled minter info updates are important because we use the information it provides to query the Ethereum network starting from a specific block index.
 	$: ($balance, toContractAddress, debounceLoadPendingTransactions());
 
-	onDestroy(async () => await listener?.disconnect());
+	onDestroy(async () => {
+		await listener?.disconnect();
+		listener = undefined;
+	});
 </script>
 
 <slot />


### PR DESCRIPTION
# Motivation

We must set the listeners to nullish to be double-sure to destroy the object.