### PR TITLE
test(frontend): Move `idb-keyval` mocks to vitest setup file

### DIFF
--- a/src/frontend/src/tests/eth/services/erc1155.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc1155.services.spec.ts
@@ -16,14 +16,6 @@ import { toNullable } from '@dfinity/utils';
 import * as idbKeyval from 'idb-keyval';
 import { get } from 'svelte/store';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$lib/api/backend.api', () => ({
 	listCustomTokens: vi.fn()
 }));

--- a/src/frontend/src/tests/eth/services/erc20.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20.services.spec.ts
@@ -29,14 +29,6 @@ import * as idbKeyval from 'idb-keyval';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$lib/api/backend.api', () => ({
 	listUserTokens: vi.fn(),
 	listCustomTokens: vi.fn()

--- a/src/frontend/src/tests/eth/services/erc721.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc721.services.spec.ts
@@ -20,14 +20,6 @@ import * as idbKeyval from 'idb-keyval';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$lib/api/backend.api', () => ({
 	listCustomTokens: vi.fn()
 }));

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -17,14 +17,6 @@ import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$app/environment', () => ({
 	browser: true
 }));

--- a/src/frontend/src/tests/icp/services/icrc.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc.services.spec.ts
@@ -28,14 +28,6 @@ import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$app/environment', () => ({
 	browser: true
 }));

--- a/src/frontend/src/tests/lib/api/idb-addresses.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-addresses.api.spec.ts
@@ -15,14 +15,6 @@ import {
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$app/environment', () => ({
 	browser: true
 }));

--- a/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
@@ -10,16 +10,6 @@ import * as idbKeyval from 'idb-keyval';
 import { createStore } from 'idb-keyval';
 import { get } from 'svelte/store';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	delMany: vi.fn(),
-	keys: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$lib/utils/idb.utils', () => ({
 	delMultiKeysByPrincipal: vi.fn()
 }));

--- a/src/frontend/src/tests/lib/api/idb-tokens.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-tokens.api.spec.ts
@@ -30,14 +30,6 @@ import { toNullable } from '@dfinity/utils';
 import * as idbKeyval from 'idb-keyval';
 import { createStore } from 'idb-keyval';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$app/environment', () => ({
 	browser: true
 }));

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -22,16 +22,6 @@ import * as idbKeyval from 'idb-keyval';
 import { createStore } from 'idb-keyval';
 import { get } from 'svelte/store';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	delMany: vi.fn(),
-	keys: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$app/environment', () => ({
 	browser: true
 }));

--- a/src/frontend/src/tests/lib/derived/currency.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/currency.derived.spec.ts
@@ -11,14 +11,6 @@ import { currencyStore } from '$lib/stores/currency.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { get } from 'svelte/store';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 describe('currency.derived', () => {
 	describe('currentCurrency', () => {
 		it('should initialize with the default currency', () => {

--- a/src/frontend/src/tests/lib/derived/i18n.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/i18n.derived.spec.ts
@@ -3,14 +3,6 @@ import { Languages } from '$lib/enums/languages';
 import { i18n } from '$lib/stores/i18n.store';
 import { get } from 'svelte/store';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	update: vi.fn()
-}));
-
 describe('i18n.derived', () => {
 	describe('currentLanguage', () => {
 		beforeEach(() => {

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -4,16 +4,6 @@ import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	delMany: vi.fn(),
-	keys: vi.fn(),
-	update: vi.fn()
-}));
-
 vi.mock('$lib/utils/idb.utils', () => ({
 	delMultiKeysByPrincipal: vi.fn()
 }));

--- a/src/frontend/src/tests/lib/utils/idb.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/idb.utils.spec.ts
@@ -2,16 +2,6 @@ import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import { delMany, keys, type UseStore } from 'idb-keyval';
 
-vi.mock('idb-keyval', () => ({
-	createStore: vi.fn(() => ({})),
-	set: vi.fn(),
-	get: vi.fn(),
-	del: vi.fn(),
-	delMany: vi.fn(),
-	keys: vi.fn(),
-	update: vi.fn()
-}));
-
 describe('idb.utils', () => {
 	describe('delMultiKeysByPrincipal', () => {
 		const expectedKeys = [

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -81,6 +81,16 @@ vi.mock('ethers/providers', () => {
 	};
 });
 
+vi.mock('idb-keyval', () => ({
+	createStore: vi.fn(() => ({})),
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn(),
+	delMany: vi.fn(),
+	keys: vi.fn(),
+	update: vi.fn()
+}));
+
 failTestsThatLogToConsole();
 
 if (process.env.ALLOW_LOGGING_FOR_DEBUGGING) {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -87,7 +87,7 @@ vi.mock('idb-keyval', () => ({
 	get: vi.fn(),
 	del: vi.fn(),
 	delMany: vi.fn(),
-	keys: vi.fn(),
+	keys: vi.fn(() => []),
 	update: vi.fn()
 }));
 


### PR DESCRIPTION
# Motivation

The package `idb-keyval` is mocked a lot of times, and in general there is no practical use-case yet where we need it working completely in the unittests, because it uses the browser. So, to avoid repetition of code, we move it to the file that has the Vitest setup.
