### PR TITLE
feat(frontend): Use interface to distinguish ERC721 in ManageTokensModal

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc721.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc721.providers.ts
@@ -1,7 +1,8 @@
 import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
-import { INFURA_API_KEY } from '$env/rest/infura.env';
+import { Erc165Identifier } from '$eth/constants/erc.constants';
 import { ERC721_ABI } from '$eth/constants/erc721.constants';
+import { InfuraErc165Provider } from '$eth/providers/infura-erc165.providers';
 import type { Erc721ContractAddress, Erc721Metadata } from '$eth/types/erc721';
 import { i18n } from '$lib/stores/i18n.store';
 import { InvalidMetadataImageUrl, InvalidTokenUri } from '$lib/types/errors';
@@ -11,15 +12,11 @@ import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { Contract } from 'ethers/contract';
-import { InfuraProvider, type Networkish } from 'ethers/providers';
 import { get } from 'svelte/store';
 
-export class InfuraErc721Provider {
-	private readonly provider: InfuraProvider;
-
-	constructor(private readonly network: Networkish) {
-		this.provider = new InfuraProvider(this.network, INFURA_API_KEY);
-	}
+export class InfuraErc721Provider extends InfuraErc165Provider {
+	isInterfaceErc721 = (contract: Erc721ContractAddress): Promise<boolean> =>
+		this.isSupportedInterface({ contract, interfaceId: Erc165Identifier.ERC721 });
 
 	metadata = async ({
 		address

--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -3,6 +3,7 @@ import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
 import { erc721CustomTokensStore } from '$eth/stores/erc721-custom-tokens.store';
+import type { Erc721ContractAddress } from '$eth/types/erc721';
 import type { Erc721CustomToken } from '$eth/types/erc721-custom-token';
 import { getIdbEthTokens, setIdbEthTokens } from '$lib/api/idb-tokens.api';
 import { loadNetworkCustomTokens } from '$lib/services/custom-tokens.services';
@@ -10,9 +11,22 @@ import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { LoadCustomTokenParams } from '$lib/types/custom-token';
 import type { OptionIdentity } from '$lib/types/identity';
+import type { NetworkId } from '$lib/types/network';
 import { parseCustomTokenId } from '$lib/utils/custom-token.utils';
 import { assertNonNullish, fromNullable, queryAndUpdate } from '@dfinity/utils';
 import { get } from 'svelte/store';
+
+export const isInterfaceErc721 = async ({
+	networkId,
+	address
+}: {
+	networkId: NetworkId;
+	address: Erc721ContractAddress['address'];
+}): Promise<boolean> => {
+	const { isInterfaceErc721 } = infuraErc721Providers(networkId);
+
+	return await isInterfaceErc721({ address });
+};
 
 export const loadErc721Tokens = async ({
 	identity

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -46,6 +46,8 @@
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 	import { isInterfaceErc721 } from '$eth/services/erc721.services';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import { TRACK_COUNT_BTC_SEND_ERROR, TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.contants';
 
 	let {
 		initialSearch,
@@ -151,6 +153,14 @@
 
 			return
 		}
+
+		trackEvent({
+			name: TRACK_UNRECOGNISED_ERC_INTERFACE,
+			metadata: {
+				address:newToken.address,
+				network: `${newToken.network.id.description}`
+			}
+		});
 
 		// TODO: Warn the user that if no interface is encountered, it falls back to standard ERC721
 		await saveErc721([newToken]);

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -5,6 +5,7 @@
 	import { get } from 'svelte/store';
 	import EthAddTokenReview from '$eth/components/tokens/EthAddTokenReview.svelte';
 	import type { SaveUserToken } from '$eth/services/erc20-user-tokens.services';
+	import { isInterfaceErc721 } from '$eth/services/erc721.services';
 	import {
 		saveErc20UserTokens,
 		saveErc721CustomTokens
@@ -21,12 +22,14 @@
 	import AddTokenByNetwork from '$lib/components/manage/AddTokenByNetwork.svelte';
 	import ManageTokens from '$lib/components/manage/ManageTokens.svelte';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
+	import { TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.contants';
 	import { addTokenSteps } from '$lib/constants/steps.constants';
 	import { MANAGE_TOKENS_MODAL } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { WizardStepsManageTokens } from '$lib/enums/wizard-steps';
+	import { trackEvent } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
@@ -45,9 +48,6 @@
 	import { saveSplCustomTokens } from '$sol/services/manage-tokens.services';
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
-	import { isInterfaceErc721 } from '$eth/services/erc721.services';
-	import { trackEvent } from '$lib/services/analytics.services';
-	import { TRACK_COUNT_BTC_SEND_ERROR, TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.contants';
 
 	let {
 		initialSearch,
@@ -145,19 +145,18 @@
 			return;
 		}
 
-
 		if (ethMetadata.decimals > 0) {
 			await saveErc20Deprecated([newToken]);
 
 			await saveErc20([newToken]);
 
-			return
+			return;
 		}
 
 		trackEvent({
 			name: TRACK_UNRECOGNISED_ERC_INTERFACE,
 			metadata: {
-				address:newToken.address,
+				address: newToken.address,
 				network: `${newToken.network.id.description}`
 			}
 		});

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -45,6 +45,7 @@
 	import { saveSplCustomTokens } from '$sol/services/manage-tokens.services';
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
+	import { isInterfaceErc721 } from '$eth/services/erc721.services';
 
 	let {
 		initialSearch,
@@ -131,10 +132,24 @@
 			enabled: true
 		};
 
+		const isErc721 = await isInterfaceErc721({
+			address: ethContractAddress,
+			networkId: network.id
+		});
+
+		if (isErc721) {
+			await saveErc721([newToken]);
+
+			return;
+		}
+
+
 		if (ethMetadata.decimals > 0) {
 			await saveErc20Deprecated([newToken]);
 
 			await saveErc20([newToken]);
+
+			return
 		}
 
 		// TODO: Warn the user that if no interface is encountered, it falls back to standard ERC721

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -73,6 +73,7 @@ export const TRACK_COUNT_SWAP_ERROR = 'swap_error';
 export const TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS = 'manage_tokens_enable_success';
 export const TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS = 'manage_tokens_disable_success';
 export const TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR = 'manage_tokens_save_error';
+export const TRACK_UNRECOGNISED_ERC_INTERFACE = 'unrecognised_erc_interface';
 
 // Contacts
 export const TRACK_CONTACT_CREATE_SUCCESS = 'contact_create_success';


### PR DESCRIPTION
# Motivation

To have a better control of the ERC tokens imported by the user, we replicate the interface check done with ERC115, but we do it for ERC721 this time.

Furthermore, we implement a tracking event for unrecognized interfaces.

# Changes

- Make class `InfuraErc721Provider` extend `InfuraErc165Provider` (similar to `InfuraErc1155Provider`).
- Create method `isInterfaceErc721` for class `InfuraErc721Provider`.
- Create service to check if an ERC is indeed a 721 interface and use it when saving new custom tokens.
- Track event for unrecognized interfaces.

# Tests

No changes in local replica.
