### PR TITLE
feat(frontend): Extract service to fetch URI JSON for ERC721

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc721.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc721.providers.ts
@@ -2,13 +2,12 @@ import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
 import { ERC721_ABI } from '$eth/constants/erc721.constants';
+import { fetchMetadataFromUri } from '$eth/services/erc.services';
 import type { Erc721ContractAddress, Erc721Metadata } from '$eth/types/erc721';
 import { i18n } from '$lib/stores/i18n.store';
-import { InvalidMetadataImageUrl, InvalidTokenUri } from '$lib/types/errors';
 import type { NetworkId } from '$lib/types/network';
 import type { NftId, NftMetadata } from '$lib/types/nft';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
-import { parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { Contract } from 'ethers/contract';
 import { InfuraProvider, type Networkish } from 'ethers/providers';
@@ -39,40 +38,32 @@ export class InfuraErc721Provider {
 		contractAddress,
 		tokenId
 	}: {
-		contractAddress: string;
+		contractAddress: Erc721ContractAddress['address'];
 		tokenId: NftId;
 	}): Promise<NftMetadata> => {
 		const erc721Contract = new Contract(contractAddress, ERC721_ABI, this.provider);
 
-		const extractImageUrl = (imageUrl: string | undefined): URL | undefined => {
-			if (isNullish(imageUrl)) {
-				return undefined;
-			}
-
-			return parseMetadataResourceUrl({
-				url: imageUrl,
-				error: new InvalidMetadataImageUrl(tokenId, contractAddress)
-			});
-		};
-
 		const tokenUri = await erc721Contract.tokenURI(tokenId);
 
-		const metadataUrl = parseMetadataResourceUrl({
-			url: tokenUri,
-			error: new InvalidTokenUri(tokenId, contractAddress)
+		const { metadata, imageUrl } = await fetchMetadataFromUri({
+			metadataUrl: tokenUri,
+			contractAddress,
+			tokenId
 		});
 
-		const response = await fetch(metadataUrl);
-		const metadata = await response.json();
+		if (isNullish(metadata)) {
+			return { id: tokenId, ...(nonNullish(imageUrl) && { imageUrl: imageUrl.href }) };
+		}
 
-		const imageUrl = extractImageUrl(metadata.image ?? metadata.image_url);
-
-		const mappedAttributes = (metadata?.attributes ?? []).map(
-			(attr: { trait_type: string; value: string | number }) => ({
-				traitType: attr.trait_type,
-				value: attr.value.toString()
-			})
-		);
+		const mappedAttributes =
+			'attributes' in metadata
+				? (metadata.attributes ?? []).map(
+						(attr: { trait_type: string; value: string | number }) => ({
+							traitType: attr.trait_type,
+							value: attr.value.toString()
+						})
+					)
+				: [];
 
 		return {
 			id: tokenId,

--- a/src/frontend/src/eth/services/erc.services.ts
+++ b/src/frontend/src/eth/services/erc.services.ts
@@ -1,0 +1,62 @@
+import type { Erc1155ContractAddress, Erc1155UriJson } from '$eth/types/erc1155';
+import type { Erc721ContractAddress, Erc721UriJson } from '$eth/types/erc721';
+import { InvalidMetadataImageUrl, InvalidTokenUri } from '$lib/types/errors';
+import type { NftId } from '$lib/types/nft';
+import { parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
+import { isNullish } from '@dfinity/utils';
+
+const extractImageUrl = ({
+	imageUrl,
+	contractAddress,
+	tokenId
+}: {
+	imageUrl: string | undefined;
+	contractAddress: Erc721ContractAddress['address'] | Erc1155ContractAddress['address'];
+	tokenId: NftId;
+}): URL | undefined => {
+	if (isNullish(imageUrl)) {
+		return undefined;
+	}
+
+	return parseMetadataResourceUrl({
+		url: imageUrl,
+		error: new InvalidMetadataImageUrl(tokenId, contractAddress)
+	});
+};
+
+export const fetchMetadataFromUri = async ({
+	metadataUrl: url,
+	contractAddress,
+	tokenId
+}: {
+	metadataUrl: string | undefined;
+	contractAddress: Erc721ContractAddress['address'] | Erc1155ContractAddress['address'];
+	tokenId: NftId;
+}): Promise<{
+	metadata: Erc721UriJson | Erc1155UriJson | undefined;
+	imageUrl: URL | undefined;
+}> => {
+	if (isNullish(url)) {
+		return { metadata: undefined, imageUrl: undefined };
+	}
+
+	const metadataUrl = parseMetadataResourceUrl({
+		url,
+		error: new InvalidTokenUri(tokenId, contractAddress)
+	});
+
+	const response = await fetch(metadataUrl);
+	const metadata = await response.json();
+
+	if (isNullish(metadata)) {
+		return { metadata: undefined, imageUrl: undefined };
+	}
+
+	const imageUrl = extractImageUrl({
+		imageUrl: metadata.image ?? metadata.image_url,
+		contractAddress,
+		tokenId
+	});
+
+	return { metadata, imageUrl };
+};

--- a/src/frontend/src/eth/types/erc1155.ts
+++ b/src/frontend/src/eth/types/erc1155.ts
@@ -13,3 +13,23 @@ export type Erc1155ContractAddress = ContractAddress;
 export type Erc1155Contract = Erc1155ContractAddress;
 
 export type Erc1155Metadata = TokenMetadata;
+
+// https://eips.ethereum.org/EIPS/eip-1155#erc-1155-metadata-uri-json-schema
+export interface Erc1155UriJson {
+	name?: string;
+	decimals?: number;
+	description?: string;
+	image?: string;
+	properties?: Record<string, NestedUriJsonPropertyMap>;
+}
+
+type NestedUriJsonValue =
+	| string
+	| number
+	| boolean
+	| NestedUriJsonValue[]
+	| NestedUriJsonPropertyMap;
+
+interface NestedUriJsonPropertyMap {
+	[key: string]: NestedUriJsonValue;
+}

--- a/src/frontend/src/eth/types/erc721.ts
+++ b/src/frontend/src/eth/types/erc721.ts
@@ -13,3 +13,13 @@ export type Erc721ContractAddress = ContractAddress;
 export type Erc721Contract = Erc721ContractAddress;
 
 export type Erc721Metadata = TokenMetadata;
+
+export interface Erc721UriJson {
+	name?: string;
+	image?: string;
+	image_url?: string;
+	attributes?: {
+		trait_type: string;
+		value: string;
+	}[];
+}

--- a/src/frontend/src/tests/eth/services/erc.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc.services.spec.ts
@@ -1,0 +1,150 @@
+import { EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
+import { fetchMetadataFromUri } from '$eth/services/erc.services';
+import { InvalidMetadataImageUrl, InvalidTokenUri } from '$lib/types/errors';
+import * as nftsUtils from '$lib/utils/nfts.utils';
+import { parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
+import { parseNftId } from '$lib/validation/nft.validation';
+
+global.fetch = vi.fn();
+
+describe('erc.services', () => {
+	describe('fetchMetadataFromUri', () => {
+		const contractAddress = EURC_TOKEN.address;
+		const tokenId = parseNftId(12345);
+		const metadataUrl = 'ipfs://metadata-hash';
+		const expectedMetadataUrl = new URL('https://ipfs.io/ipfs/metadata-hash');
+
+		const mockParams = {
+			metadataUrl,
+			contractAddress,
+			tokenId
+		};
+
+		const mockMetadataResponse = {
+			name: 'Asset Name',
+			description: 'Lorem ipsum...',
+			image: `https://s3.amazonaws.com/your-bucket/images/${tokenId}.png`,
+			properties: {
+				simple_property: 'example value',
+				rich_property: {
+					name: 'Name',
+					value: '123',
+					display_value: '123 Example Value',
+					class: 'emphasis',
+					css: {
+						color: '#ffffff',
+						'font-weight': 'bold',
+						'text-decoration': 'underline'
+					}
+				},
+				array_property: {
+					name: 'Name',
+					value: [1, 2, 3, 4],
+					class: 'emphasis'
+				}
+			}
+		};
+
+		const mockFetch = vi.mocked(fetch);
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			mockFetch.mockResolvedValue({
+				ok: true,
+				json: () => mockMetadataResponse
+			} as unknown as Response);
+
+			vi.spyOn(nftsUtils, 'parseMetadataResourceUrl');
+		});
+
+		it('should return undefined if metadata URL is nullish', async () => {
+			const result = await fetchMetadataFromUri({
+				...mockParams,
+				metadataUrl: undefined
+			});
+
+			expect(result).toEqual({ metadata: undefined, imageUrl: undefined });
+		});
+
+		it('should fetch metadata', async () => {
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(mockFetch).toHaveBeenCalledExactlyOnceWith(expectedMetadataUrl);
+
+			expect(result).toEqual({
+				metadata: mockMetadataResponse,
+				imageUrl: new URL(mockMetadataResponse.image)
+			});
+		});
+
+		it('should return undefined if metadata JSON is nullish', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => undefined
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(result).toEqual({ metadata: undefined, imageUrl: undefined });
+		});
+
+		it('should handle nullish image URL', async () => {
+			mockFetch.mockResolvedValue({
+				ok: true,
+				json: () => ({
+					...mockMetadataResponse,
+					image: undefined
+				})
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(result).toEqual({
+				metadata: {
+					...mockMetadataResponse,
+					image: undefined
+				},
+				imageUrl: undefined
+			});
+		});
+
+		it('should handle different keys for image URL', async () => {
+			const mockImageUrl = 'https://example.com/image.png';
+
+			mockFetch.mockResolvedValue({
+				ok: true,
+				json: () => ({
+					...mockMetadataResponse,
+					image: undefined,
+					image_url: mockImageUrl
+				})
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(result).toEqual({
+				metadata: {
+					...mockMetadataResponse,
+					image: undefined,
+					image_url: mockImageUrl
+				},
+				imageUrl: new URL(mockImageUrl)
+			});
+		});
+
+		it('should parse the URLs correctly', async () => {
+			await fetchMetadataFromUri(mockParams);
+
+			expect(parseMetadataResourceUrl).toHaveBeenCalledTimes(2);
+			expect(parseMetadataResourceUrl).toHaveBeenNthCalledWith(1, {
+				url: metadataUrl,
+				error: new InvalidTokenUri(tokenId, contractAddress)
+			});
+			expect(parseMetadataResourceUrl).toHaveBeenNthCalledWith(2, {
+				url: mockMetadataResponse.image,
+				error: new InvalidMetadataImageUrl(tokenId, contractAddress)
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

In this PR we extract a service from `InfuraErc721Provider` class: the one responsible to fetch the JSON file linked to a token URI. It will be useful since we will re-use it for ERC1155.

# Changes

- Create types for ERC721 and ERC1155 JSON interfaces.
- Extract service `fetchMetadataFromUri` that is responsible to fetch the metadata JSON from a token URI and parsing the image URL correctly too.

# Tests

Added tests.
