### PR TITLE
feat(frontend): added new step failed to progress Steps

### DIFF
--- a/src/frontend/src/lib/components/ui/InProgress.svelte
+++ b/src/frontend/src/lib/components/ui/InProgress.svelte
@@ -36,7 +36,7 @@
 		}) as ProgressSteps;
 	};
 
-	$: progressStep, updateSteps();
+	$: (progressStep, updateSteps());
 </script>
 
 <div class="px-2 pb-3">

--- a/src/frontend/src/lib/components/ui/InProgress.svelte
+++ b/src/frontend/src/lib/components/ui/InProgress.svelte
@@ -8,6 +8,7 @@
 	export let progressStep: string;
 	export let steps: NonEmptyArray<ProgressStep | StaticStep>;
 	export let type: 'progress' | 'static' = 'progress';
+	export let failedSteps: string[] = [];
 
 	let cmp: typeof StaticSteps | typeof ProgressStepsCmp;
 	$: cmp = type === 'static' ? StaticSteps : ProgressStepsCmp;
@@ -20,20 +21,22 @@
 	const updateSteps = () => {
 		const progressIndex = dynamicSteps.findIndex(({ step }) => step === progressStep);
 
-		dynamicSteps = dynamicSteps.map((step, index) =>
-			step.step === progressStep
-				? {
-						...step,
-						state: 'in_progress'
-					}
-				: {
-						...step,
-						state: index < progressIndex || progressStep === 'done' ? 'completed' : 'next'
-					}
-		) as ProgressSteps;
+		dynamicSteps = dynamicSteps.map((step, index) => {
+			if (failedSteps.includes(step.step)) {
+				return { ...step, state: 'failed' };
+			}
+
+			if (step.step === progressStep) {
+				return { ...step, state: 'in_progress' };
+			}
+			return {
+				...step,
+				state: index < progressIndex || progressStep === 'done' ? 'completed' : 'next'
+			};
+		}) as ProgressSteps;
 	};
 
-	$: (progressStep, updateSteps());
+	$: progressStep, updateSteps();
 </script>
 
 <div class="px-2 pb-3">

--- a/src/frontend/src/lib/components/ui/InProgressWizard.svelte
+++ b/src/frontend/src/lib/components/ui/InProgressWizard.svelte
@@ -16,12 +16,14 @@
 		progressStep?: string;
 		steps: ProgressSteps;
 		warningType?: 'transaction' | 'manage';
+		failedSteps?: string[];
 	}
 
 	let {
 		progressStep = ProgressStepsSend.INITIALIZATION,
 		steps,
-		warningType = 'transaction'
+		warningType = 'transaction',
+		failedSteps = []
 	}: Props = $props();
 
 	const startConfirmToClose = () => {
@@ -60,5 +62,5 @@
 		</span>
 	</MessageBox>
 
-	<InProgress {progressStep} {steps} />
+	<InProgress {progressStep} {steps} {failedSteps} />
 </div>

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -335,6 +335,13 @@ div.step {
 		}
 	}
 
+	&.failed {
+		.state {
+			color: var(--negative-emphasis) !important;
+			background: var(--color-background-error-light) !important;
+		}
+	}
+
 	&.next {
 		.text {
 			color: var(--color-foreground-primary);


### PR DESCRIPTION
# Motivation

To support displaying a failed step in the ProgressSteps component (e.g., when a step fails in the swap flow), we need to adjust the logic to check whether a specific step is marked as failed.

# Changes

- Added a new failedSteps prop that can be updated from the parent component
- Added a condition to identify and highlight failed steps
- Adjusted styles for failed step

