### PR TITLE
feat(frontend): adjusted swapError to have optional message and variant

### DIFF
--- a/src/frontend/src/lib/services/swap-errors.services.ts
+++ b/src/frontend/src/lib/services/swap-errors.services.ts
@@ -1,21 +1,27 @@
-import type { SwapErrorKey } from '$lib/types/swap';
+import type { SwapErrorCodes } from '$lib/types/swap';
 
 export const throwSwapError = ({
 	code,
-	message
+	message = undefined,
+	variant = undefined
 }: {
-	code: SwapErrorKey;
-	message: string;
+	code: SwapErrorCodes;
+	message?: string;
+	variant?: 'error' | 'warning' | 'info';
 }): never => {
-	throw new SwapError(code, message);
+	throw new SwapError(code, message, variant);
 };
 
 export class SwapError extends Error {
+	public readonly variant?: 'error' | 'warning' | 'info';
+
 	constructor(
-		public readonly code: SwapErrorKey,
-		message: string
+		public readonly code: SwapErrorCodes,
+		message?: string,
+		variant?: 'error' | 'warning' | 'info'
 	) {
 		super(message);
 		this.name = 'SwapError';
+		this.variant = variant;
 	}
 }

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -25,8 +25,13 @@ export enum VeloraSwapTypes {
 
 export enum SwapErrorCodes {
 	WITHDRAW_FAILED = 'withdraw_failed',
+	SWAP_SUCCESS_WITHDRAW_FAILED = 'swap_success_withdraw_failed',
 	DEPOSIT_FAILED = 'deposit_error',
-	SWAP_FAILED_WITHDRAW_SUCESS = 'swap_failed_withdraw_success'
+	SWAP_FAILED_WITHDRAW_SUCESS = 'swap_failed_withdraw_success',
+	SWAP_FAILED_2ND_WITHDRAW_SUCCESS = 'swap_failed_2nd_withdraw_success',
+	SWAP_FAILED_WITHDRAW_FAILED = 'swap_failed_withdraw_failed',
+	ICP_SWAP_WITHDRAW_SUCCESS = 'ICPSwap_withdraw_success',
+	ICP_SWAP_WITHDRAW_FAILED = 'ICPSwap_withdraw_failed'
 }
 export interface ProviderFee {
 	fee: bigint;

--- a/src/frontend/src/tests/lib/services/swap-errors.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap-errors.services.spec.ts
@@ -1,104 +1,96 @@
 import { SwapError, throwSwapError } from '$lib/services/swap-errors.services';
+import { SwapErrorCodes } from '$lib/types/swap';
 import en from '$tests/mocks/i18n.mock';
 
 describe('SwapError Service', () => {
 	describe('throwSwapError', () => {
-		it('should throw SwapError for deposit_error', () => {
-			expect(() =>
-				throwSwapError({ code: 'deposit_error', message: en.swap.error.deposit_error })
-			).toThrow(SwapError);
-		});
-
-		it('should throw SwapError for withdraw_failed', () => {
-			expect(() =>
-				throwSwapError({ code: 'withdraw_failed', message: en.swap.error.withdraw_failed })
-			).toThrow(SwapError);
-		});
-
-		it('should throw SwapError for swap_failed_withdraw_success', () => {
+		it('throws SwapError with message', () => {
 			expect(() =>
 				throwSwapError({
-					code: 'swap_failed_withdraw_success',
-					message: en.swap.error.swap_failed_withdraw_success
+					code: SwapErrorCodes.SWAP_FAILED_WITHDRAW_FAILED,
+					message: en.swap.error.withdraw_failed,
+					variant: 'error'
 				})
 			).toThrow(SwapError);
 		});
 
-		it('should throw correct error messages', () => {
-			expect(() =>
-				throwSwapError({ code: 'deposit_error', message: en.swap.error.deposit_error })
-			).toThrow(en.swap.error.deposit_error);
-
-			expect(() =>
-				throwSwapError({ code: 'withdraw_failed', message: en.swap.error.withdraw_failed })
-			).toThrow(en.swap.error.withdraw_failed);
-
+		it('throws SwapError without message', () => {
 			expect(() =>
 				throwSwapError({
-					code: 'swap_failed_withdraw_success',
+					code: SwapErrorCodes.SWAP_FAILED_WITHDRAW_FAILED
+				})
+			).toThrow(SwapError);
+		});
+
+		it('throws correct message when provided', () => {
+			expect(() =>
+				throwSwapError({
+					code: SwapErrorCodes.SWAP_FAILED_WITHDRAW_SUCESS,
 					message: en.swap.error.swap_failed_withdraw_success
 				})
 			).toThrow(en.swap.error.swap_failed_withdraw_success);
 		});
+
+		it('includes variant if provided', () => {
+			try {
+				throwSwapError({
+					code: SwapErrorCodes.DEPOSIT_FAILED,
+					message: en.swap.error.deposit_error,
+					variant: 'warning'
+				});
+			} catch (e) {
+				expect(e).toBeInstanceOf(SwapError);
+				expect((e as SwapError).variant).toBe('warning');
+			}
+		});
 	});
 
 	describe('SwapError class', () => {
-		it('should be instantiated with deposit_error and correct message', () => {
-			const error = new SwapError('deposit_error', en.swap.error.deposit_error);
-
-			expect(error.code).toBe('deposit_error');
-			expect(error.message).toBe(en.swap.error.deposit_error);
-			expect(error.name).toBe('SwapError');
-		});
-
-		it('should be instantiated with withdraw_failed and correct message', () => {
-			const error = new SwapError('withdraw_failed', en.swap.error.withdraw_failed);
-
-			expect(error.code).toBe('withdraw_failed');
-			expect(error.message).toBe(en.swap.error.withdraw_failed);
-			expect(error.name).toBe('SwapError');
-		});
-
-		it('should be instantiated with swap_failed_withdraw_success and correct message', () => {
+		it('can be created with all fields', () => {
 			const error = new SwapError(
-				'swap_failed_withdraw_success',
-				en.swap.error.swap_failed_withdraw_success
+				SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS,
+				'Withdrawal succeeded manually',
+				'info'
 			);
 
-			expect(error.code).toBe('swap_failed_withdraw_success');
-			expect(error.message).toBe(en.swap.error.swap_failed_withdraw_success);
-			expect(error.name).toBe('SwapError');
+			expect(error).toBeInstanceOf(SwapError);
+			expect(error.code).toBe(SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS);
+			expect(error.message).toBe('Withdrawal succeeded manually');
+			expect(error.variant).toBe('info');
+		});
+
+		it('can be created with only code', () => {
+			const error = new SwapError(SwapErrorCodes.SWAP_FAILED_WITHDRAW_FAILED);
+
+			expect(error).toBeInstanceOf(SwapError);
+			expect(error.code).toBe(SwapErrorCodes.SWAP_FAILED_WITHDRAW_FAILED);
+			expect(error.message).toBe('');
+			expect(error.variant).toBeUndefined();
 		});
 	});
 
-	describe('Real use-case scenarios', () => {
-		it('should handle deposit_error correctly', () => {
-			try {
-				throwSwapError({ code: 'deposit_error', message: en.swap.error.deposit_error });
-			} catch (error) {
-				expect((error as SwapError).code).toBe('deposit_error');
-				expect((error as SwapError).message).toBe(en.swap.error.deposit_error);
-			}
-		});
-
-		it('should handle swap_failed_withdraw_success correctly', () => {
+	describe('Real use-case throw handling', () => {
+		it('handles withdraw_failed correctly', () => {
 			try {
 				throwSwapError({
-					code: 'swap_failed_withdraw_success',
-					message: en.swap.error.swap_failed_withdraw_success
+					code: SwapErrorCodes.WITHDRAW_FAILED,
+					message: en.swap.error.withdraw_failed
 				});
 			} catch (error) {
-				expect((error as SwapError).code).toBe('swap_failed_withdraw_success');
-				expect((error as SwapError).message).toBe(en.swap.error.swap_failed_withdraw_success);
+				expect(error).toBeInstanceOf(SwapError);
+				expect((error as SwapError).code).toBe(SwapErrorCodes.WITHDRAW_FAILED);
 			}
 		});
 
-		it('should handle withdraw_failed correctly', () => {
+		it('handles deposit_failed without variant', () => {
 			try {
-				throwSwapError({ code: 'withdraw_failed', message: en.swap.error.withdraw_failed });
+				throwSwapError({
+					code: SwapErrorCodes.DEPOSIT_FAILED,
+					message: en.swap.error.deposit_error
+				});
 			} catch (error) {
-				expect((error as SwapError).code).toBe('withdraw_failed');
-				expect((error as SwapError).message).toBe(en.swap.error.withdraw_failed);
+				expect((error as SwapError).code).toBe(SwapErrorCodes.DEPOSIT_FAILED);
+				expect((error as SwapError).variant).toBeUndefined();
 			}
 		});
 	});


### PR DESCRIPTION
# Motivation

The ICP Swap flow needs to raise SwapError without a message in some cases and with a severity level in others. To support this, SwapError should accept an optional message and a new variant field.

# Changes

- Made message optional.
- Added variant?: 'error' | 'warning' | 'info'.

# Tests

Covered new logix with the tests