### PR TITLE
feat(devops): Always run devops checks

### DIFF
--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: change
         with:
@@ -80,6 +81,7 @@ jobs:
               - scripts/download-canister-api.test
               - scripts/download-canister-api
               - .github/workflows/devops-checks.yml
+
       - name: Run test
         if: steps.change.outputs.any == 'true'
         run: scripts/download-canister-api.test

--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -2,9 +2,6 @@ name: Check devops code
 
 on:
   pull_request:
-    paths:
-      - # Note: shell scripts not ending in .sh can be found with: scripts/format.sh.sh --list | grep -vE '[.]sh$'
-        '**/*.sh'
   merge_group:
   workflow_dispatch:
 
@@ -21,10 +18,20 @@ jobs:
         with:
           persist-credentials: false
 
+      # Note: shell scripts not ending in .sh can be found with: scripts/format.sh.sh --list | grep -vE '[.]sh$'
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: change
+        with:
+          filters: |
+            shell:
+              - '**/*.sh'
+
       - name: Install shellcheck
+        if: steps.change.outputs.any == 'true'
         run: ./scripts/setup shellcheck
 
       - name: Lint shell scripts
+        if: steps.change.outputs.any == 'true'
         run: scripts/lint.sh.sh
 
   lint-github-actions:
@@ -37,10 +44,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: change
+        with:
+          filters: |
+            gha:
+              - '.github/**/*'
+              - '**/*.yml'
+              - '**/*.yaml'
+
       - name: Install zizmor
+        if: steps.change.outputs.any == 'true'
         run: ./scripts/setup cargo-binstall zizmor
 
       - name: Lint GitHub workflows
+        if: steps.change.outputs.any == 'true'
         run: scripts/lint.github.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Motivation

We want to use the status check `devops-checks-pass` to allow (or not) the merging of a PR. However, we have the issue that if the PR does not modify the files specified in the event trigger (in this case .sh files), the workflow does not run, and the status check is not elaborated. 

To bypass this issue, we specify the files to watch for each job of the workflow, so that the workflow always runs, but not necessarily "work" if the files are not changed.

# Changes

- Use action `dorny/paths-filter` to filter changes of specific files to which each job refers to.

# Tests

The CI workflow ran in this same PR correctly.
