### PR TITLE
chore(frontend): Add authorities to new Solana x-stock tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-spl/tokens.aznx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.aznx.env.ts
@@ -21,5 +21,7 @@ export const AZNX_TOKEN: RequiredSplToken = {
 	decimals: AZNX_DECIMALS,
 	icon: aznx,
 	address: 'Xs3ZFkPYT2BN7qBMqf1j1bfTeTm1rFzEFSsQ1z3wAKU',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.cmcsax.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.cmcsax.env.ts
@@ -21,5 +21,7 @@ export const CMCSAX_TOKEN: RequiredSplToken = {
 	decimals: CMCSAX_DECIMALS,
 	icon: cmcsax,
 	address: 'XsvKCaNsxg2GN8jjUmq71qukMJr7Q1c5R2Mk9P8kcS8',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.cscox.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.cscox.env.ts
@@ -21,5 +21,7 @@ export const CSCOX_TOKEN: RequiredSplToken = {
 	decimals: CSCOX_DECIMALS,
 	icon: cscox,
 	address: 'Xsr3pdLQyXvDJBFgpR5nexCEZwXvigb8wbPYp4YoNFf',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.dfdvx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.dfdvx.env.ts
@@ -21,5 +21,7 @@ export const DFDVX_TOKEN: RequiredSplToken = {
 	decimals: DFDVX_DECIMALS,
 	icon: dfdvx,
 	address: 'Xs2yquAgsHByNzx68WJC55WHjHBvG9JsMB7CWjTLyPy',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.hdx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.hdx.env.ts
@@ -21,5 +21,6 @@ export const HDX_TOKEN: RequiredSplToken = {
 	decimals: HDX_DECIMALS,
 	icon: hdx,
 	address: 'XszjVtyhowGjSC5odCqBpW1CtXXwXjYokymrk7fGKD3',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
-};
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.hdx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.hdx.env.ts
@@ -24,3 +24,4 @@ export const HDX_TOKEN: RequiredSplToken = {
 	owner: TOKEN_2022_PROGRAM_ADDRESS,
 	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
 	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
+};

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.honx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.honx.env.ts
@@ -21,5 +21,7 @@ export const HONX_TOKEN: RequiredSplToken = {
 	decimals: HONX_DECIMALS,
 	icon: honx,
 	address: 'XsRbLZthfABAPAfumWNEJhPyiKDW6TvDVeAeW7oKqA2',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.llyx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.llyx.env.ts
@@ -21,5 +21,7 @@ export const LLYX_TOKEN: RequiredSplToken = {
 	decimals: LLYX_DECIMALS,
 	icon: llyx,
 	address: 'Xsnuv4omNoHozR6EEW5mXkw8Nrny5rB3jVfLqi6gKMH',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.pepx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.pepx.env.ts
@@ -21,5 +21,7 @@ export const PEPX_TOKEN: RequiredSplToken = {
 	decimals: PEPX_DECIMALS,
 	icon: pepx,
 	address: 'Xsv99frTRUeornyvCfvhnDesQDWuvns1M852Pez91vF',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.pgx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.pgx.env.ts
@@ -21,5 +21,7 @@ export const PGX_TOKEN: RequiredSplToken = {
 	decimals: PGX_DECIMALS,
 	icon: pgx,
 	address: 'XsYdjDjNUygZ7yGKfQaB6TxLh2gC6RRjzLtLAGJrhzV',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.unhx.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.unhx.env.ts
@@ -21,5 +21,7 @@ export const UNHX_TOKEN: RequiredSplToken = {
 	decimals: UNHX_DECIMALS,
 	icon: unhx,
 	address: 'XszvaiXGPwvk2nwb3o9C1CX4K6zH8sez11E6uyup6fe',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };

--- a/src/frontend/src/env/tokens/tokens-spl/tokens.vtix.env.ts
+++ b/src/frontend/src/env/tokens/tokens-spl/tokens.vtix.env.ts
@@ -21,5 +21,7 @@ export const VTIX_TOKEN: RequiredSplToken = {
 	decimals: VTIX_DECIMALS,
 	icon: vtix,
 	address: 'XsssYEQjzxBCFgvYFFNuhJFBeHNdLWYeUSP8F45cDr9',
-	owner: TOKEN_2022_PROGRAM_ADDRESS
+	owner: TOKEN_2022_PROGRAM_ADDRESS,
+	mintAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs',
+	freezeAuthority: 'JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs'
 };


### PR DESCRIPTION
# Motivation

We add the relevant authorities for all the new x-stocks Solana 2022 tokens.
