### PR TITLE
chore(frontend): Remove POPEYE icrc token

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -9,16 +9,6 @@
 			"__bigint__": "10000"
 		}
 	},
-	"POPEYE": {
-		"ledgerCanisterId": "6fvyi-faaaa-aaaam-qbiga-cai",
-		"indexCanisterId": "gg3c3-6iaaa-aaaah-aq6dq-cai",
-		"decimals": 8,
-		"name": "Popeye The Sailor",
-		"symbol": "POPEYE",
-		"fee": {
-			"__bigint__": "1000000"
-		}
-	},
 	"CLOUD": {
 		"ledgerCanisterId": "pcj6u-uaaaa-aaaak-aewnq-cai",
 		"indexCanisterId": "72uqs-pqaaa-aaaak-aes7a-cai",


### PR DESCRIPTION
# Motivation

Their index canister is dead for a while now

# Changes

- Remove POPEYE from our curated tokenlist

# Tests

