### PR TITLE
feat(frontend): added swapWithWithdrawing prop to SwapWizard

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -29,7 +29,7 @@
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { OptionAmount } from '$lib/types/send';
-	import { SwapErrorCodes } from '$lib/types/swap';
+	import { SwapErrorCodes, SwapProvider } from '$lib/types/swap';
 	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isSwapError } from '$lib/utils/swap.utils';
@@ -203,7 +203,11 @@
 		{:else if currentStep?.name === WizardStepsSwap.REVIEW}
 			<SwapReview on:icSwap={swap} on:icBack {slippageValue} {swapAmount} {receiveAmount} />
 		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
-			<SwapProgress bind:swapProgressStep />
+			<SwapProgress
+				bind:swapProgressStep
+				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
+					SwapProvider.ICP_SWAP}
+			/>
 		{/if}
 	</SwapAmountsContext>
 </IcTokenFeeContext>

--- a/src/frontend/src/tests/lib/components/swap/SwapWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapWizard.spec.ts
@@ -22,7 +22,8 @@ const BASE_PROPS = {
 	swapAmount: '1',
 	receiveAmount: 2,
 	slippageValue: '0.5',
-	swapProgressStep: ProgressStepsSwap.INITIALIZATION
+	swapProgressStep: ProgressStepsSwap.INITIALIZATION,
+	swapFailedProgressSteps: []
 };
 
 describe('SwapWizard', () => {


### PR DESCRIPTION
# Motivation

Added support for showing the Withdrawing step in the SwapWizard only for the ICP Swap provider.

# Changes

- Introduced swapWithWithdrawing prop in SwapWizardUpdated test props
- Updated related test props accordingly
