### PR TITLE
feat(frontend): added new swapSucceded property to ICP Swap Error

### DIFF
--- a/src/frontend/src/lib/services/swap-errors.services.ts
+++ b/src/frontend/src/lib/services/swap-errors.services.ts
@@ -3,25 +3,30 @@ import type { SwapErrorCodes } from '$lib/types/swap';
 export const throwSwapError = ({
 	code,
 	message,
-	variant
+	variant,
+	swapSucceded
 }: {
 	code: SwapErrorCodes;
 	message?: string;
 	variant?: 'error' | 'warning' | 'info';
+	swapSucceded?: boolean;
 }): never => {
-	throw new SwapError(code, message, variant);
+	throw new SwapError(code, message, variant, swapSucceded);
 };
 
 export class SwapError extends Error {
 	public readonly variant?: 'error' | 'warning' | 'info';
+	public readonly swapSucceded?: boolean;
 
 	constructor(
 		public readonly code: SwapErrorCodes,
 		message?: string,
-		variant?: 'error' | 'warning' | 'info'
+		variant?: 'error' | 'warning' | 'info',
+		swapSucceded?: boolean
 	) {
 		super(message);
 		this.name = 'SwapError';
 		this.variant = variant;
+		this.swapSucceded = swapSucceded;
 	}
 }

--- a/src/frontend/src/tests/lib/services/swap-errors.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap-errors.services.spec.ts
@@ -22,6 +22,23 @@ describe('SwapError Service', () => {
 			).toThrow(SwapError);
 		});
 
+		it('throws SwapError without swapSucceded', () => {
+			expect(() =>
+				throwSwapError({
+					code: SwapErrorCodes.WITHDRAW_FAILED
+				})
+			).toThrow(SwapError);
+		});
+
+		it('throws SwapError with swapSucceded', () => {
+			expect(() =>
+				throwSwapError({
+					code: SwapErrorCodes.WITHDRAW_FAILED,
+					swapSucceded: true
+				})
+			).toThrow(SwapError);
+		});
+
 		it('throws correct message when provided', () => {
 			expect(() =>
 				throwSwapError({


### PR DESCRIPTION
# Motivation

We need to track the status of swapSucceeded to determine whether to withdraw the destination or source token after a failed swap.

# Changes

Added swapSucceeded property to SwapError for improved error context

# Tests

Added unit tests