### PR TITLE
feat(frontend): adjusted logic of icpSwap to set swapSucced prop

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,20 +2,6 @@ name: Backend Tests
 
 on:
   pull_request:
-    paths:
-      - # Scripts, GitHub actions that contain 'backend' in their path.
-        '**/*backend*'
-      - # The backend source code
-        'src/backend/**'
-      - 'src/shared/**'
-      - # Rust files such as Cargo.lock, Cargo.toml and rust-toolchain.toml
-        '**/Cargo*'
-      - '**/*rust*'
-      - # The dockerfile used in this CI run, and the scripts it COPY's.
-        'Dockerfile'
-      - 'docker/**'
-      - # There may be some files in frontend folder that contains 'backend' in their name.
-        '!src/frontend/**'
   merge_group:
   workflow_dispatch:
 
@@ -32,7 +18,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check if backend files changed
+        id: changes
+        uses: ./.github/actions/check-backend-changes
+
       - name: Build Base Docker Image
+        if: steps.changes.outputs.any == 'true'
         uses: ./.github/actions/docker-build-base
 
   docker-build:
@@ -52,7 +43,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check if backend files changed
+        id: changes
+        uses: ./.github/actions/check-backend-changes
+
       - name: Build canister WASM
+        if: steps.changes.outputs.any == 'true'
         uses: ./.github/actions/docker-build-backend
         with:
           name: ${{ matrix.name }}
@@ -69,7 +65,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check if backend files changed
+        id: changes
+        uses: ./.github/actions/check-backend-changes
+
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: steps.changes.outputs.any == 'true'
         with:
           path: |
             ~/.cargo/registry
@@ -78,15 +79,18 @@ jobs:
           key: ${{ runner.os }}-cargo-backend-tests-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
 
       - name: Download backend.wasm.gz
+        if: steps.changes.outputs.any == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: backend.wasm.gz
           path: .
 
       - name: Install dfx
+        if: steps.changes.outputs.any == 'true'
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: 'Run backend tests'
+        if: steps.changes.outputs.any == 'true'
         working-directory: .
         run: ./scripts/test.backend.sh
 
@@ -104,19 +108,24 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - name: Check if backend files changed
+        id: changes
+        uses: ./.github/actions/check-backend-changes
       - name: 'Run when backend candid interface changes'
+        if: steps.changes.outputs.any == 'true'
         # Goal: Run only when the backend candid interface changes, otherwise
         # every PR after a breaking change will also have to be marked as a breaking change
         # until deployment to production.  As it is, any PRs that change the backend candid
         # will still need to be announced as a breaking change, but that is probably acceptable,
         # and it makes it clear if the API is revised to no longer be breaking.
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
+        id: api-changes
         with:
           filters: |
             api:
               - 'src/backend/backend.did'
       - name: 'Check whether the PR description & title mention "breaking interface"'
+        if: steps.changes.outputs.any == 'true'
         id: conventional-commit
         run: |
           # See the conventional commit conventions for how to mark a breaking change: https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-both--and-breaking-change-footer
@@ -132,12 +141,12 @@ jobs:
           fi
       - name: Need to check for breaking changes
         id: check-for-breaking-changes
-        # Run if the interface has changed but the PR is NOT marked as a breaking change.
-        if: (steps.changes.outputs.api == 'true') && !((steps.conventional-commit.outputs.BREAKING_DESCRIPTION == 'true') && (steps.conventional-commit.outputs.BREAKING_TITLE == 'true'))
+        # Run if the interface has changed, but the PR is NOT marked as a breaking change.
+        if: (steps.changes.outputs.any == 'true') && (steps.api-changes.outputs.api == 'true') && !((steps.conventional-commit.outputs.BREAKING_DESCRIPTION == 'true') && (steps.conventional-commit.outputs.BREAKING_TITLE == 'true'))
         run: echo "EXPECT_NO_BREAKING_CHANGES=true" | tee -a "$GITHUB_OUTPUT" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        if: steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true'
+        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         with:
           path: |
             ~/.cargo/registry
@@ -146,18 +155,18 @@ jobs:
           key: ${{ runner.os }}-cargo-backend-tests-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
 
       - name: Install dfx
-        if: steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true'
+        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: Download backend.wasm.gz
-        if: steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true'
+        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: backend.wasm.gz
           path: .
 
       - name: 'Run backend tests'
-        if: steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true'
+        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         working-directory: .
         run: |
           set -euxo pipefail # Ensure that the `exit 1` causes this step to fail.

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -122,7 +122,8 @@
 						$failedSwapError?.errorType === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED),
 				withdrawDestinationTokens:
 					nonNullish($failedSwapError?.errorType) &&
-					$failedSwapError?.errorType === SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED
+					($failedSwapError?.errorType === SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED ||
+						$failedSwapError?.swapSucceded)
 			});
 
 			progress(ProgressStepsSwap.DONE);
@@ -157,6 +158,7 @@
 					message: err.message,
 					variant: err.variant ?? 'info',
 					errorType: err.code,
+					swapSucceded: err.swapSucceded,
 					url: {
 						url: `https://app.icpswap.com/swap?input=${$sourceToken.ledgerCanisterId}&output=${$destinationToken.ledgerCanisterId}`,
 						text: 'icpswap.com'

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -48,7 +48,6 @@
 		slippageValue = $bindable<OptionAmount>(),
 		swapProgressStep = $bindable<string>(),
 		swapFailedProgressSteps = $bindable<string[]>(),
-
 		currentStep
 	}: Props = $props();
 
@@ -226,6 +225,7 @@
 		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
 			<SwapProgress
 				bind:swapProgressStep
+				bind:failedSteps={swapFailedProgressSteps}
 				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
 					SwapProvider.ICP_SWAP}
 			/>

--- a/src/frontend/src/lib/services/swap-errors.services.ts
+++ b/src/frontend/src/lib/services/swap-errors.services.ts
@@ -1,5 +1,6 @@
 import type { SwapErrorCodes } from '$lib/types/swap';
 
+//TODO: revisit throwSwapError
 export const throwSwapError = ({
 	code,
 	message,

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -240,7 +240,7 @@ export const fetchIcpSwap = async ({
 
 		progress(ProgressStepsSwap.WITHDRAW);
 
-		const { code, message, variant } = await performManualWithdraw({
+		const { code, message, variant, swapSucceded } = await performManualWithdraw({
 			withdrawDestinationTokens,
 			setFailedProgressStep,
 			identity,
@@ -254,7 +254,8 @@ export const fetchIcpSwap = async ({
 		throwSwapError({
 			code,
 			message,
-			variant
+			variant,
+			swapSucceded
 		});
 	}
 
@@ -356,7 +357,8 @@ export const fetchIcpSwap = async ({
 
 			throwSwapError({
 				code: SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED,
-				variant: 'error'
+				variant: 'error',
+				swapSucceded: true
 			});
 		}
 	}
@@ -462,7 +464,7 @@ export const performManualWithdraw = async ({
 			name: SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED,
 			metadata: {
 				token: token.symbol,
-				tokenOrigin: withdrawDestinationTokens ? 'receive' : 'pay'
+				tokenDirection: withdrawDestinationTokens ? 'receive' : 'pay'
 			}
 		});
 
@@ -470,7 +472,8 @@ export const performManualWithdraw = async ({
 
 		return {
 			code: SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED,
-			variant: 'error'
+			variant: 'error',
+			swapSucceded: withdrawDestinationTokens ? true : false
 		};
 	}
 };

--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -11,6 +11,7 @@ export interface SwapError {
 	message: string;
 	url?: { url: string; text: string };
 	errorType?: string;
+	swapSucceded?: boolean;
 }
 
 export interface SwapData {

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -153,6 +153,7 @@ export interface IcpSwapWithdrawResponse {
 	code: SwapErrorCodes;
 	message?: string;
 	variant?: 'error' | 'warning' | 'info';
+	swapSucceded?: boolean;
 }
 
 export interface FormatSlippageParams {

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -289,7 +289,7 @@ describe('performManualWithdraw', () => {
 			name: SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED,
 			metadata: {
 				token: 'ICP',
-				tokenOrigin: 'receive'
+				tokenDirection: 'receive'
 			}
 		});
 		expect(setFailedProgressStep).toHaveBeenCalledWith(ProgressStepsSwap.WITHDRAW);


### PR DESCRIPTION
# Motivation

For icpSwap, we need to track whether the swap was successful in order to determine whether to retrieve the source token or the destination token. This status is now stored.

# Changes

Added logic to store swapSucceded status
