### PR TITLE
refactor(frontend): removes unused semicolon from abi definition

### DIFF
--- a/src/frontend/src/eth/constants/erc165.constants.ts
+++ b/src/frontend/src/eth/constants/erc165.constants.ts
@@ -1,2 +1,2 @@
 // https://eips.ethereum.org/EIPS/eip-165
-export const ERC165_ABI = ['function supportsInterface(bytes4 interfaceID) view returns (bool);'];
+export const ERC165_ABI = ['function supportsInterface(bytes4 interfaceID) view returns (bool)'];


### PR DESCRIPTION
# Motivation

When importing an erc1155 contract there is an warning displayed in the browsers console because there is an unexpected `;` in the abi defintion. To prevent this, we remove it from the definition.

# Changes

- removes unused `;` from abi