### PR TITLE
remove breaking the value for the token into the modal

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalance.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <TokenBalanceSkeleton {data}>
-	<output class="break-all" data-tid={testId}>
+	<output data-tid={testId}>
 		{#if nonNullish(data.balance)}
 			{#if hideBalance}
 				{@render privacyBalance?.()}


### PR DESCRIPTION
# Motivation

The token selector UI currently breaks the token amount display when large token values are entered, causing visual misalignment.

# Changes

Remove break-all class that will make the text goes on the 2 lines

# Tests

Verified layout with various token name lengths and large numeric values
Checked responsive behavior on different screen sizes