### PR TITLE
feat(frontend): extended address contacts derived

### DIFF
--- a/src/frontend/src/lib/derived/contacts.derived.ts
+++ b/src/frontend/src/lib/derived/contacts.derived.ts
@@ -1,5 +1,5 @@
 import { contactsStore } from '$lib/stores/contacts.store';
-import type { ContactUi } from '$lib/types/contact';
+import type { ContactUi, ExtendedAddressContactUiMap } from '$lib/types/contact';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -18,4 +18,23 @@ export const contacts: Readable<ContactUi[]> = derived([contactsStore], ([$conta
 
 export const sortedContacts: Readable<ContactUi[]> = derived([contacts], ([$contacts]) =>
 	$contacts.sort((a, b) => a.name.localeCompare(b.name))
+);
+
+export const extendedAddressContacts: Readable<ExtendedAddressContactUiMap> = derived(
+	[contacts],
+	([$contacts]) =>
+		$contacts.reduce<ExtendedAddressContactUiMap>(
+			(acc, { addresses, id, ...rest }) => ({
+				...acc,
+				[`${id}`]: {
+					...rest,
+					id,
+					addresses: addresses.map((address) => ({
+						...address,
+						id: crypto.randomUUID().toString()
+					}))
+				}
+			}),
+			{}
+		)
 );

--- a/src/frontend/src/lib/types/contact.ts
+++ b/src/frontend/src/lib/types/contact.ts
@@ -12,3 +12,13 @@ export interface ContactUi extends Omit<Contact, 'addresses' | 'update_timestamp
 	updateTimestampNs: bigint;
 	image?: ContactImage | null;
 }
+
+export interface ContactAddressUiWithId extends ContactAddressUi {
+	id: string;
+}
+
+export interface ExtendedAddressContactUi extends Omit<ContactUi, 'addresses'> {
+	addresses: ContactAddressUiWithId[];
+}
+
+export type ExtendedAddressContactUiMap = Record<string, ExtendedAddressContactUi>;

--- a/src/frontend/src/tests/lib/derived/contacts.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/contacts.derived.spec.ts
@@ -1,7 +1,13 @@
-import { contacts, contactsNotInitialized, sortedContacts } from '$lib/derived/contacts.derived';
+import {
+	contacts,
+	contactsNotInitialized,
+	extendedAddressContacts,
+	sortedContacts
+} from '$lib/derived/contacts.derived';
 import { contactsStore } from '$lib/stores/contacts.store';
 import { mapToFrontendContact } from '$lib/utils/contact.utils';
 import { getMockContacts } from '$tests/mocks/contacts.mock';
+import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mock';
 import { get } from 'svelte/store';
 
 describe('contacts.derived', () => {
@@ -57,6 +63,31 @@ describe('contacts.derived', () => {
 			expect(sorted[0].name).toEqual('Alice');
 			expect(sorted[1].name).toEqual('Bob');
 			expect(sorted[2].name).toEqual('Charlie');
+		});
+	});
+
+	describe('extendedAddressContacts', () => {
+		it('should return empty object if no contact added or not initialized', () => {
+			expect(get(extendedAddressContacts)).toEqual({});
+		});
+
+		it('should return extended address contacts', () => {
+			const contactsData = getMockContacts({
+				n: 1,
+				names: ['Alice'],
+				addresses: [
+					[{ label: ['Test'], token_account_id: { Eth: { Public: mockEthAddress } } }],
+					[{ label: ['Test 2'], token_account_id: { Eth: { Public: mockEthAddress2 } } }]
+				]
+			}).map(mapToFrontendContact);
+
+			contactsData.forEach((contact) => contactsStore.addContact(contact));
+
+			const result = get(extendedAddressContacts);
+
+			result[`${contactsData[0].id}`].addresses.forEach((address) => {
+				expect(address).toHaveProperty('id');
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Since the original contact address schema does not include any unique identifiers, we need to create an extended store where we manually add `id` to each address. This is needed for the AI assistant feature - we will be hiding the address values before feeding the data to LLM, and then parsing the response back by using these generated ids.
