### PR TITLE
feat(frontend): extend AI types and components with tools response

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -16,6 +16,7 @@
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { ChatMessage } from '$lib/types/ai-assistant';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 
@@ -24,10 +25,13 @@
 	let disabled = $derived(loading || isNullishOrEmpty(userInput));
 
 	let messagesToDisplay = $derived(
-		$aiAssistantChatMessages.filter(({ role }) => role !== 'system')
+		$aiAssistantChatMessages.reduce<ChatMessage[]>(
+			(acc, { data, role }) => [...acc, ...(role !== 'system' ? [{ role, data }] : [])],
+			[]
+		)
 	);
 
-	const sendMessage = async (message: string) => {
+	const sendMessage = async (messageText: string) => {
 		if (isNullish($authIdentity)) {
 			await nullishSignOut();
 			return;
@@ -35,27 +39,36 @@
 
 		aiAssistantStore.appendMessage({
 			role: 'user',
-			content: message
+			data: { text: messageText }
 		});
 
 		try {
 			loading = true;
 
-			const result = await askLlm({
+			const { text, tool } = await askLlm({
 				messages: $aiAssistantLlmMessages,
 				identity: $authIdentity
 			});
 
 			aiAssistantStore.appendMessage({
 				role: 'assistant',
-				content: isNullishOrEmpty(result) ? $i18n.ai_assistant.errors.no_response : result
+				data:
+					(tool?.calls ?? []).length > 0 && (tool?.results ?? []).length > 0
+						? {
+								tool
+							}
+						: {
+								text: isNullishOrEmpty(text) ? $i18n.ai_assistant.errors.no_response : text
+							}
 			});
 		} catch (err: unknown) {
 			console.error($i18n.ai_assistant.errors.unknown, err);
 
 			aiAssistantStore.appendMessage({
 				role: 'assistant',
-				content: $i18n.ai_assistant.errors.unknown
+				data: {
+					text: $i18n.ai_assistant.errors.unknown
+				}
 			});
 		}
 

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantMessages.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantMessages.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import AiAssistantBotMessage from '$lib/components/ai-assistant/AiAssistantBotMessage.svelte';
+	import AiAssistantToolResults from '$lib/components/ai-assistant/AiAssistantToolResults.svelte';
 	import AiAssistantUserMessage from '$lib/components/ai-assistant/AiAssistantUserMessage.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ChatMessage } from '$lib/types/ai-assistant';
@@ -15,10 +17,12 @@
 
 {#each messages as message, index (index)}
 	<div in:fade>
-		{#if message.role === 'user'}
-			<AiAssistantUserMessage content={message.content} />
-		{:else if message.role === 'assistant'}
-			<AiAssistantBotMessage content={message.content} />
+		{#if message.role === 'user' && nonNullish(message.data.text)}
+			<AiAssistantUserMessage content={message.data.text} />
+		{:else if message.role === 'assistant' && nonNullish(message.data.text)}
+			<AiAssistantBotMessage content={message.data.text} />
+		{:else if message.role === 'assistant' && nonNullish(message.data.tool?.results)}
+			<AiAssistantToolResults results={message.data.tool.results} />
 		{/if}
 	</div>
 {/each}

--- a/src/frontend/src/lib/derived/ai-assistant.derived.ts
+++ b/src/frontend/src/lib/derived/ai-assistant.derived.ts
@@ -2,7 +2,7 @@ import type { chat_message_v1 } from '$declarations/llm/llm.did';
 import { AI_ASSISTANT_SYSTEM_PROMPT } from '$lib/constants/ai-assistant.constants';
 import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 import type { ChatMessage } from '$lib/types/ai-assistant';
-import { toNullable } from '@dfinity/utils';
+import { notEmptyString, toNullable } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const aiAssistantConsoleOpen: Readable<boolean> = derived(
@@ -24,43 +24,46 @@ export const aiAssistantLlmMessages: Readable<chat_message_v1[]> = derived(
 		const recentHistory = ($aiAssistantStore?.chatHistory ?? []).slice(-10);
 
 		// Parse chat messages into LLM-compatible messages
-		const messages = recentHistory.reduce<chat_message_v1[]>((acc, { role, content }) => {
-			if (role === 'system') {
-				includesSystemMessage = true;
+		const messages = recentHistory.reduce<chat_message_v1[]>(
+			(acc, { role, data: { text, tool } }) => {
+				if (role === 'system' && notEmptyString(text)) {
+					includesSystemMessage = true;
 
-				return [
-					...acc,
-					{
-						system: {
-							content
+					return [
+						...acc,
+						{
+							system: {
+								content: text
+							}
 						}
-					}
-				];
-			}
-			if (role === 'assistant') {
-				return [
-					...acc,
-					{
-						assistant: {
-							content: toNullable(content),
-							tool_calls: toNullable()
+					];
+				}
+				if (role === 'assistant') {
+					return [
+						...acc,
+						{
+							assistant: {
+								content: toNullable(text),
+								tool_calls: tool?.calls ?? []
+							}
 						}
-					}
-				];
-			}
-			if (role === 'user') {
-				return [
-					...acc,
-					{
-						user: {
-							content
+					];
+				}
+				if (role === 'user' && notEmptyString(text)) {
+					return [
+						...acc,
+						{
+							user: {
+								content: text
+							}
 						}
-					}
-				];
-			}
+					];
+				}
 
-			return acc;
-		}, []);
+				return acc;
+			},
+			[]
+		);
 
 		// If no system message in recent history, add the default one
 		if (!includesSystemMessage) {

--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -1,6 +1,7 @@
 import type { chat_message_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import { AI_ASSISTANT_LLM_MODEL } from '$lib/constants/ai-assistant.constants';
+import type { ChatMessageContent } from '$lib/types/ai-assistant';
 import type { Identity } from '@dfinity/agent';
 import { fromNullable, toNullable } from '@dfinity/utils';
 
@@ -10,7 +11,7 @@ export const askLlm = async ({
 }: {
 	messages: chat_message_v1[];
 	identity: Identity;
-}): Promise<string | undefined> => {
+}): Promise<ChatMessageContent> => {
 	const {
 		message: { content }
 	} = await llmChat({
@@ -23,5 +24,11 @@ export const askLlm = async ({
 		identity
 	});
 
-	return fromNullable(content);
+	return {
+		text: fromNullable(content),
+		tool: {
+			calls: [],
+			results: []
+		}
+	};
 };

--- a/src/frontend/src/lib/stores/ai-assistant.store.ts
+++ b/src/frontend/src/lib/stores/ai-assistant.store.ts
@@ -19,7 +19,7 @@ const initialState = {
 	chatHistory: [
 		{
 			role: 'system',
-			content: AI_ASSISTANT_SYSTEM_PROMPT
+			data: { text: AI_ASSISTANT_SYSTEM_PROMPT }
 		}
 	]
 } as AiAssistant;

--- a/src/frontend/src/lib/types/ai-assistant.ts
+++ b/src/frontend/src/lib/types/ai-assistant.ts
@@ -4,9 +4,32 @@ import type {
 	ExtendedAddressContactUi
 } from '$lib/types/contact';
 
+export interface ChatMessageContent {
+	text?: string;
+	tool?: {
+		calls: ToolCall[];
+		results: ToolResult[];
+	};
+}
+
 export interface ChatMessage {
 	role: 'user' | 'assistant' | 'system';
-	content: string;
+	data: ChatMessageContent;
+}
+
+export interface ToolCallArgument {
+	name: string;
+	value: string;
+}
+
+interface ToolFunction {
+	name: string;
+	arguments: ToolCallArgument[];
+}
+
+export interface ToolCall {
+	id: string;
+	function: ToolFunction;
 }
 
 export interface ToolResult {

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantConsole.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantConsole.spec.ts
@@ -16,7 +16,7 @@ vi.mock('$lib/api/llm.api');
 describe('AiAssistantConsole', () => {
 	const message = {
 		role: 'user',
-		content: 'hey'
+		data: { text: 'hey' }
 	} as ChatMessage;
 	const newMessageContent = 'new message';
 	const responseContent = 'content';
@@ -47,7 +47,7 @@ describe('AiAssistantConsole', () => {
 
 		await waitFor(() => {
 			expect(() => getByText(en.ai_assistant.text.welcome_message)).toThrow();
-			expect(getByText(message.content)).toBeInTheDocument();
+			expect(getByText(message.data.text ?? '')).toBeInTheDocument();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantMessages.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantMessages.spec.ts
@@ -9,9 +9,9 @@ describe('AiAssistantUserMessages', () => {
 	const systemMessage = 'system message';
 
 	const messages = [
-		{ role: 'user', content: userMessage },
-		{ role: 'assistant', content: assistantMessage },
-		{ role: 'system', content: systemMessage }
+		{ role: 'user', data: { text: userMessage } },
+		{ role: 'assistant', data: { text: assistantMessage } },
+		{ role: 'system', data: { text: systemMessage } }
 	] as ChatMessage[];
 
 	it('renders correctly if loading is false', async () => {

--- a/src/frontend/src/tests/lib/derived/ai-assistant.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/ai-assistant.derived.spec.ts
@@ -11,7 +11,7 @@ import { get } from 'svelte/store';
 describe('ai-assistant.derived', () => {
 	const message = {
 		role: 'user',
-		content: 'hey'
+		data: { text: 'hey' }
 	} as ChatMessage;
 
 	beforeEach(() => {
@@ -32,7 +32,7 @@ describe('ai-assistant.derived', () => {
 		it('should return correct values', () => {
 			const defaultMessage = {
 				role: 'system',
-				content: AI_ASSISTANT_SYSTEM_PROMPT
+				data: { text: AI_ASSISTANT_SYSTEM_PROMPT }
 			} as ChatMessage;
 
 			expect(get(aiAssistantChatMessages)).toStrictEqual([defaultMessage]);
@@ -59,7 +59,7 @@ describe('ai-assistant.derived', () => {
 				defaultLlmMessage,
 				{
 					user: {
-						content: message.content
+						content: message.data.text
 					}
 				}
 			]);

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -28,7 +28,13 @@ describe('ai-assistant.services', () => {
 			});
 
 			expect(llmChat).toHaveBeenCalledOnce();
-			expect(result).toStrictEqual(fromNullable(response.message.content));
+			expect(result).toStrictEqual({
+				text: fromNullable(response.message.content),
+				tool: {
+					calls: [],
+					results: []
+				}
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/stores/ai-assistant.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/ai-assistant.store.spec.ts
@@ -11,7 +11,9 @@ describe('ai-assistant.store', () => {
 		chatHistory: [
 			{
 				role: 'system',
-				content: AI_ASSISTANT_SYSTEM_PROMPT
+				data: {
+					text: AI_ASSISTANT_SYSTEM_PROMPT
+				}
 			}
 		]
 	};
@@ -44,7 +46,7 @@ describe('ai-assistant.store', () => {
 	it('should append a message', () => {
 		const message = {
 			role: 'user',
-			content: 'hey'
+			data: { text: 'hey' }
 		} as ChatMessage;
 
 		aiAssistantStore.appendMessage(message);


### PR DESCRIPTION
# Motivation

As the next step of preparing our code for handling LLM tools, we need to extend the types and UI components with the `tool` field. The services that request and parse tool responses will be added in the next PRs.
