### PR TITLE
feat(frontend): nft images should be displayed correctly

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -22,7 +22,7 @@
 				alt={replacePlaceholders($i18n.nfts.alt.card.image, {
 					$tokenId: nft.id.toString()
 				})}
-				styleClass="h-48 object-cover"
+				styleClass="h-48 object-contain bg-black"
 				testId={`${testId}-image`}
 			/>
 		{:else}

--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -22,6 +22,7 @@
 				alt={replacePlaceholders($i18n.nfts.alt.card.image, {
 					$tokenId: nft.id.toString()
 				})}
+				styleClass="h-48 object-cover"
 				testId={`${testId}-image`}
 			/>
 		{:else}


### PR DESCRIPTION
# Motivation

The images of the nfts were displayed in different sizes, but we want to display all of the the same size.

# Changes

- displays all images the same size

# Tests

**before:**
<img width="469" height="421" alt="image" src="https://github.com/user-attachments/assets/50dab0f7-49a5-469a-968e-4ffe62ad6818" />


**after:**
<img width="458" height="443" alt="image" src="https://github.com/user-attachments/assets/24ce6f8e-57b6-4026-81e3-13154911a7c5" />

