### PR TITLE
fix(frontend): disabled icrc1 tokens for icpSwap

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -19,9 +19,17 @@
 		destinationToken: IcToken | undefined;
 		slippageValue: OptionAmount;
 		children?: Snippet;
+		isSourceTokenIcrc2: boolean;
 	}
 
-	let { amount, sourceToken, destinationToken, slippageValue, children }: Props = $props();
+	let {
+		amount,
+		sourceToken,
+		destinationToken,
+		slippageValue,
+		children,
+		isSourceTokenIcrc2
+	}: Props = $props();
 
 	const { store } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
@@ -51,7 +59,8 @@
 				destinationToken,
 				amount,
 				tokens: $tokens,
-				slippage: slippageValue ?? SWAP_DEFAULT_SLIPPAGE_VALUE
+				slippage: slippageValue ?? SWAP_DEFAULT_SLIPPAGE_VALUE,
+				isSourceTokenIcrc2
 			});
 
 			if (swapAmounts.length === 0) {

--- a/src/frontend/src/lib/components/swap/SwapWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapWizard.svelte
@@ -204,6 +204,7 @@
 		sourceToken={$sourceToken}
 		destinationToken={$destinationToken}
 		{slippageValue}
+		isSourceTokenIcrc2={$isSourceTokenIcrc2}
 	>
 		{#if currentStep?.name === WizardStepsSwap.SWAP}
 			<SwapForm

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -160,11 +160,9 @@ export const fetchSwapAmounts = async ({
 			if (provider.key === SwapProvider.KONG_SWAP) {
 				const swap = result.value as SwapAmountsReply;
 				mapped = provider.mapQuoteResult({ swap, tokens });
-			} else if (provider.key === SwapProvider.ICP_SWAP) {
-				if (isSourceTokenIcrc2) {
-					const swap = result.value as ICPSwapResult;
-					mapped = provider.mapQuoteResult({ swap, slippage });
-				}
+			} else if (provider.key === SwapProvider.ICP_SWAP && isSourceTokenIcrc2) {
+				const swap = result.value as ICPSwapResult;
+				mapped = provider.mapQuoteResult({ swap, slippage });
 			}
 
 			if (mapped && Number(mapped.receiveAmount) > 0) {

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -133,7 +133,8 @@ export const fetchSwapAmounts = async ({
 	destinationToken,
 	amount,
 	tokens,
-	slippage
+	slippage,
+	isSourceTokenIcrc2
 }: FetchSwapAmountsParams): Promise<SwapMappedResult[]> => {
 	const sourceAmount = parseToken({
 		value: `${amount}`,
@@ -160,8 +161,10 @@ export const fetchSwapAmounts = async ({
 				const swap = result.value as SwapAmountsReply;
 				mapped = provider.mapQuoteResult({ swap, tokens });
 			} else if (provider.key === SwapProvider.ICP_SWAP) {
-				const swap = result.value as ICPSwapResult;
-				mapped = provider.mapQuoteResult({ swap, slippage });
+				if (isSourceTokenIcrc2) {
+					const swap = result.value as ICPSwapResult;
+					mapped = provider.mapQuoteResult({ swap, slippage });
+				}
 			}
 
 			if (mapped && Number(mapped.receiveAmount) > 0) {

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -49,6 +49,7 @@ export interface FetchSwapAmountsParams {
 	amount: string | number;
 	tokens: Token[];
 	slippage: string | number;
+	isSourceTokenIcrc2: boolean;
 }
 
 export type Slippage = string | number;

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -74,7 +74,8 @@ describe('fetchSwapAmounts', () => {
 			destinationToken,
 			amount,
 			tokens: mockTokens,
-			slippage
+			slippage,
+			isSourceTokenIcrc2: true
 		});
 
 		expect(result).toHaveLength(2);
@@ -102,7 +103,8 @@ describe('fetchSwapAmounts', () => {
 			destinationToken,
 			amount,
 			tokens: mockTokens,
-			slippage
+			slippage,
+			isSourceTokenIcrc2: true
 		});
 
 		expect(result).toHaveLength(1);
@@ -125,7 +127,8 @@ describe('fetchSwapAmounts', () => {
 			destinationToken,
 			amount,
 			tokens: mockTokens,
-			slippage
+			slippage,
+			isSourceTokenIcrc2: true
 		});
 
 		expect(result).toHaveLength(1);
@@ -145,12 +148,34 @@ describe('fetchSwapAmounts', () => {
 			destinationToken,
 			amount,
 			tokens: mockTokens,
-			slippage
+			slippage,
+			isSourceTokenIcrc2: true
 		});
 
 		expect(result).toHaveLength(2);
 		expect(result[0].provider).toBe(SwapProvider.ICP_SWAP);
 		expect(result[1].provider).toBe(SwapProvider.KONG_SWAP);
+	});
+
+	it('should skip icp swap if token is icrc1', async () => {
+		const kongSwapResponse = { receive_amount: 800n, slippage: 0.5 } as SwapAmountsReply;
+		const icpSwapResponse = { receiveAmount: 950n, slippage: 0.5 } as unknown as ICPSwapAmountReply;
+
+		vi.mocked(kongBackendApi.kongSwapAmounts).mockResolvedValue(kongSwapResponse);
+		vi.mocked(icpSwapBackend.icpSwapAmounts).mockResolvedValue(icpSwapResponse);
+
+		const result = await fetchSwapAmounts({
+			identity: mockIdentity,
+			sourceToken,
+			destinationToken,
+			amount,
+			tokens: mockTokens,
+			slippage,
+			isSourceTokenIcrc2: false
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe(SwapProvider.KONG_SWAP);
 	});
 });
 


### PR DESCRIPTION
# Motivation

As we encountered issues with ICRC-1 tokens when swapping via ICPSwap, this PR disables swap logic for ICRC-1 tokens in ICPSwap.


