### PR TITLE
refactor(frontend): renames mockValidNft to mockValidErc721Nft

### DIFF
--- a/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
@@ -1,5 +1,5 @@
 import NftCard from '$lib/components/nfts/NftCard.svelte';
-import { mockValidNft } from '$tests/mocks/nfts.mock';
+import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
 
 describe('NftCard', () => {
@@ -12,7 +12,7 @@ describe('NftCard', () => {
 	it('should render nft with metadata', () => {
 		const { container, getByText } = render(NftCard, {
 			props: {
-				nft: mockValidNft,
+				nft: mockValidErc721Nft,
 				testId
 			}
 		});
@@ -25,14 +25,14 @@ describe('NftCard', () => {
 
 		expect(networkLogo).toBeInTheDocument();
 
-		expect(getByText(mockValidNft.contract.name)).toBeInTheDocument();
-		expect(getByText(`#${mockValidNft.id}`)).toBeInTheDocument();
+		expect(getByText(mockValidErc721Nft.contract.name)).toBeInTheDocument();
+		expect(getByText(`#${mockValidErc721Nft.id}`)).toBeInTheDocument();
 	});
 
 	it('should render image placeholder if no image is defined', () => {
 		const { container, getByText } = render(NftCard, {
 			props: {
-				nft: { ...mockValidNft, imageUrl: null },
+				nft: { ...mockValidErc721Nft, imageUrl: null },
 				testId
 			}
 		});
@@ -46,7 +46,7 @@ describe('NftCard', () => {
 
 		expect(networkLogo).toBeInTheDocument();
 
-		expect(getByText(mockValidNft.contract.name)).toBeInTheDocument();
-		expect(getByText(`#${mockValidNft.id}`)).toBeInTheDocument();
+		expect(getByText(mockValidErc721Nft.contract.name)).toBeInTheDocument();
+		expect(getByText(`#${mockValidErc721Nft.id}`)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/stores/nft.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/nft.store.spec.ts
@@ -2,7 +2,7 @@ import { nftStore } from '$lib/stores/nft.store';
 import type { Nft } from '$lib/types/nft';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { mockEthAddress2 } from '$tests/mocks/eth.mock';
-import { mockValidNft } from '$tests/mocks/nfts.mock';
+import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { get } from 'svelte/store';
 
 describe('nftStore', () => {
@@ -16,8 +16,8 @@ describe('nftStore', () => {
 
 	describe('addAll', () => {
 		it('should add NFTs to store', () => {
-			const mockNft1 = mockValidNft;
-			const mockNft2 = { ...mockValidNft, id: parseNftId(837364) };
+			const mockNft1 = mockValidErc721Nft;
+			const mockNft2 = { ...mockValidErc721Nft, id: parseNftId(837364) };
 
 			nftStore.addAll([mockNft1, mockNft2]);
 
@@ -25,26 +25,26 @@ describe('nftStore', () => {
 		});
 
 		it('should not add already existing NFTs to store', () => {
-			const duplicateNft = { ...mockValidNft };
+			const duplicateNft = { ...mockValidErc721Nft };
 
-			nftStore.addAll([mockValidNft]);
+			nftStore.addAll([mockValidErc721Nft]);
 
-			expect(get(nftStore)).toEqual([mockValidNft]);
+			expect(get(nftStore)).toEqual([mockValidErc721Nft]);
 
 			nftStore.addAll([duplicateNft]);
 
-			expect(get(nftStore)).toEqual([mockValidNft]);
+			expect(get(nftStore)).toEqual([mockValidErc721Nft]);
 		});
 
 		it('should add NFT with same token id but different contract address', () => {
 			const similarNft: Nft = {
-				...mockValidNft,
-				contract: { ...mockValidNft.contract, address: mockEthAddress2 }
+				...mockValidErc721Nft,
+				contract: { ...mockValidErc721Nft.contract, address: mockEthAddress2 }
 			};
 
-			nftStore.addAll([mockValidNft, similarNft]);
+			nftStore.addAll([mockValidErc721Nft, similarNft]);
 
-			expect(get(nftStore)).toEqual([mockValidNft, similarNft]);
+			expect(get(nftStore)).toEqual([mockValidErc721Nft, similarNft]);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -8,7 +8,7 @@ import { getNftsByNetworks, parseMetadataResourceUrl } from '$lib/utils/nfts.uti
 import { parseNftId } from '$lib/validation/nft.validation';
 import { AZUKI_ELEMENTAL_BEANS_TOKEN, DE_GODS_TOKEN } from '$tests/mocks/erc721-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
-import { mockValidNft } from '$tests/mocks/nfts.mock';
+import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 
 describe('nfts.utils', () => {
 	const erc721Tokens: Erc721CustomToken[] = [
@@ -17,29 +17,29 @@ describe('nfts.utils', () => {
 	];
 
 	const mockNft1: Nft = {
-		...mockValidNft,
+		...mockValidErc721Nft,
 		contract: {
-			...mockValidNft.contract,
+			...mockValidErc721Nft.contract,
 			address: AZUKI_ELEMENTAL_BEANS_TOKEN.address,
 			network: POLYGON_AMOY_NETWORK
 		}
 	};
 
 	const mockNft2: Nft = {
-		...mockValidNft,
+		...mockValidErc721Nft,
 		id: parseNftId(12632),
 		contract: {
-			...mockValidNft.contract,
+			...mockValidErc721Nft.contract,
 			address: AZUKI_ELEMENTAL_BEANS_TOKEN.address,
 			network: POLYGON_AMOY_NETWORK
 		}
 	};
 
 	const mockNft3: Nft = {
-		...mockValidNft,
+		...mockValidErc721Nft,
 		id: parseNftId(843764),
 		contract: {
-			...mockValidNft.contract,
+			...mockValidErc721Nft.contract,
 			address: DE_GODS_TOKEN.address,
 			network: POLYGON_AMOY_NETWORK
 		}

--- a/src/frontend/src/tests/mocks/nfts.mock.ts
+++ b/src/frontend/src/tests/mocks/nfts.mock.ts
@@ -4,7 +4,7 @@ import { parseNftId } from '$lib/validation/nft.validation';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 
-export const mockValidNft: Nft = {
+export const mockValidErc721Nft: Nft = {
 	name: 'Beanz 123',
 	id: parseNftId(173563),
 	imageUrl: 'https://ipfs.io/ipfs/QmUYeQEm8FquanaaiGKkubmvRwKLnMV8T3c4Ph9Eoup9Gy/27.png',


### PR DESCRIPTION
# Motivation

Since we also have nfts of erc1155 contract, we want to have a more specific naming for the nft mocks.

# Changes

- updates naming
