### PR TITLE
feat(frontend): displays nft balances

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Nft } from '$lib/types/nft';
@@ -29,7 +30,11 @@
 			<div class="bg-black/16 h-48 rounded-lg" data-tid={`${testId}-placeholder`}></div>
 		{/if}
 
-		<div class="absolute bottom-2 right-2">
+		<div class="absolute bottom-2 right-2 flex items-center gap-1">
+			{#if nonNullish(nft.balance)}
+				<Badge variant="outline" testId={`${testId}-balance`}>{nft.balance}x</Badge>
+			{/if}
+
 			<NetworkLogo
 				network={nft.contract.network}
 				size="xs"

--- a/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
@@ -1,5 +1,5 @@
 import NftCard from '$lib/components/nfts/NftCard.svelte';
-import { mockValidErc1155Nft, mockValidNft } from '$tests/mocks/nfts.mock';
+import { mockValidErc1155Nft, mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
 
 describe('NftCard', () => {

--- a/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
@@ -1,5 +1,5 @@
 import NftCard from '$lib/components/nfts/NftCard.svelte';
-import { mockValidNft } from '$tests/mocks/nfts.mock';
+import { mockValidErc1155Nft, mockValidNft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
 
 describe('NftCard', () => {
@@ -8,11 +8,12 @@ describe('NftCard', () => {
 	const imageSelector = `img[data-tid="${testId}-image"]`;
 	const imagePlaceholderSelector = `div[data-tid="${testId}-placeholder"]`;
 	const networkLogoSelector = `div[data-tid="${testId}-network-light-container"]`;
+	const balanceSelector = `span[data-tid="${testId}-balance"]`;
 
 	it('should render nft with metadata', () => {
 		const { container, getByText } = render(NftCard, {
 			props: {
-				nft: mockValidNft,
+				nft: mockValidErc1155Nft,
 				testId
 			}
 		});
@@ -25,8 +26,12 @@ describe('NftCard', () => {
 
 		expect(networkLogo).toBeInTheDocument();
 
-		expect(getByText(mockValidNft.contract.name)).toBeInTheDocument();
-		expect(getByText(`#${mockValidNft.id}`)).toBeInTheDocument();
+		const balance: HTMLSpanElement | null = container.querySelector(balanceSelector);
+
+		expect(balance).toBeInTheDocument();
+
+		expect(getByText(mockValidErc1155Nft.contract.name)).toBeInTheDocument();
+		expect(getByText(`#${mockValidErc1155Nft.id}`)).toBeInTheDocument();
 	});
 
 	it('should render image placeholder if no image is defined', () => {

--- a/src/frontend/src/tests/mocks/nfts.mock.ts
+++ b/src/frontend/src/tests/mocks/nfts.mock.ts
@@ -21,3 +21,22 @@ export const mockValidNft: Nft = {
 		name: 'MyContract'
 	}
 };
+
+export const mockValidErc1155Nft: Nft = {
+	name: 'Nyan',
+	id: parseNftId(725432),
+	imageUrl: 'https://ipfs.io/ipfs/QmUYeQEm8FquanaaiGKkubmvRwKLnMV8T3c4Ph9Eoup9Gy/27.png',
+	attributes: [
+		{ traitType: 'Background', value: 'Crimson Red' },
+		{ traitType: 'Type', value: 'Tone 4' }
+	],
+	balance: 2,
+	contract: {
+		id: parseTokenId('TokenId'),
+		address: mockEthAddress,
+		network: ETHEREUM_NETWORK,
+		standard: 'erc1155',
+		symbol: 'NYAN',
+		name: 'MyContract'
+	}
+};


### PR DESCRIPTION
# Motivation

Nfts of erc1155 contracts do have a balance which means we also want to display this balance for the nfts.

# Changes

- displays balances

# Tests

**before:**
<img width="455" height="428" alt="image" src="https://github.com/user-attachments/assets/0c7145fc-b6f9-4bb7-b22d-1916f348f72c" />

**after:**
<img width="470" height="431" alt="image" src="https://github.com/user-attachments/assets/2f8b52d8-ac78-4de7-ab87-2ee895221ea2" />
