### PR TITLE
refactor(frontend): truncate too long names

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -45,7 +45,7 @@
 	</div>
 
 	<div class="px-2 pt-2">
-		<h3 class="text-xs font-semibold text-tertiary">{nft.contract.name}</h3>
+		<h3 class="truncate text-xs font-semibold text-tertiary">{nft.contract.name}</h3>
 		<span class="text-xs text-tertiary">{`#${nft.id}`}</span>
 	</div>
 </div>


### PR DESCRIPTION
# Motivation

The names that are too long should be truncated.

# Tests

**before:**
<img width="472" height="432" alt="image" src="https://github.com/user-attachments/assets/783a3f32-dddf-4cfa-a4c8-a8863bacd509" />


**after:**
<img width="481" height="433" alt="image" src="https://github.com/user-attachments/assets/54faa77e-8e40-411c-8469-06c120a2d5dc" />
