### PR TITLE
feat(frontend): implement askLlmToFilterContacts method

### DIFF
--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -1,9 +1,25 @@
 import type { chat_message_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
-import { AI_ASSISTANT_LLM_MODEL } from '$lib/constants/ai-assistant.constants';
-import type { ChatMessageContent } from '$lib/types/ai-assistant';
+import {
+	AI_ASSISTANT_FILTER_CONTACTS_PROMPT,
+	AI_ASSISTANT_LLM_MODEL,
+	AI_ASSISTANT_SYSTEM_PROMPT,
+	AI_ASSISTANT_TOOLS
+} from '$lib/constants/ai-assistant.constants';
+import { extendedAddressContacts as extendedAddressContactsStore } from '$lib/derived/contacts.derived';
+import type {
+	AiAssistantContactUi,
+	ChatMessageContent,
+	ToolCallArgument
+} from '$lib/types/ai-assistant';
+import type { ContactUi } from '$lib/types/contact';
+import {
+	parseFromAiAssistantContacts,
+	parseToAiAssistantContacts
+} from '$lib/utils/ai-assistant.utils';
 import type { Identity } from '@dfinity/agent';
-import { fromNullable, toNullable } from '@dfinity/utils';
+import { fromNullable, jsonReplacer, toNullable } from '@dfinity/utils';
+import { get } from 'svelte/store';
 
 /**
  * Gets a text or a tool response from LLM for the provided messages array.
@@ -40,4 +56,59 @@ export const askLlm = async ({
 			results: []
 		}
 	};
+};
+
+/**
+ * Makes a call to LLM to get a semantically filtered contacts.
+ *
+ * @async
+ * @param {Object} params - The parameters required to initiate a filter contacts LLM request.
+ * @param {Identity} params.identity - The user's identity for authentication.
+ * @param {Array} params.filterParams - Array of filter arguments based on which the search will be done by LLM.
+ * @returns {Promise<ChatMessageContent>} - Resolves with an array of filtered contacts.
+ */
+export const askLlmToFilterContacts = async ({
+	identity,
+	filterParams
+}: {
+	identity: Identity;
+	filterParams: ToolCallArgument[];
+}): Promise<ContactUi[]> => {
+	const extendedAddressContacts = get(extendedAddressContactsStore);
+	const aiAssistantContacts = parseToAiAssistantContacts(extendedAddressContacts);
+
+	const {
+		message: { content }
+	} = await llmChat({
+		request: {
+			model: AI_ASSISTANT_LLM_MODEL,
+			messages: [
+				{
+					system: {
+						content: AI_ASSISTANT_SYSTEM_PROMPT
+					}
+				},
+				{
+					user: {
+						content: `
+							${AI_ASSISTANT_FILTER_CONTACTS_PROMPT}
+								
+							Contacts: ${JSON.stringify(aiAssistantContacts, jsonReplacer)}
+							Arguments: "${JSON.stringify(filterParams)}"
+						`
+					}
+				}
+			],
+			tools: toNullable(AI_ASSISTANT_TOOLS)
+		},
+		identity
+	});
+
+	const filteredAiAssistantContacts: AiAssistantContactUi[] =
+		JSON.parse(fromNullable(content) ?? '', jsonReplacer)?.contacts ?? [];
+
+	return parseFromAiAssistantContacts({
+		aiAssistantContacts: filteredAiAssistantContacts,
+		extendedAddressContacts
+	});
 };

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -1,8 +1,14 @@
 import type { chat_response_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
-import { askLlm } from '$lib/services/ai-assistant.services';
+import { extendedAddressContacts } from '$lib/derived/contacts.derived';
+import { askLlm, askLlmToFilterContacts } from '$lib/services/ai-assistant.services';
+import { contactsStore } from '$lib/stores/contacts.store';
+import type { ContactUi } from '$lib/types/contact';
+import { parseToAiAssistantContacts } from '$lib/utils/ai-assistant.utils';
+import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { fromNullable, toNullable } from '@dfinity/utils';
+import { fromNullable, jsonReplacer, toNullable } from '@dfinity/utils';
+import { get } from 'svelte/store';
 
 vi.mock('$lib/api/llm.api');
 
@@ -35,6 +41,56 @@ describe('ai-assistant.services', () => {
 					results: []
 				}
 			});
+		});
+	});
+
+	describe('askLlmToFilterContacts', () => {
+		beforeEach(() => {
+			vi.resetAllMocks();
+
+			vi.stubGlobal('crypto', {
+				...crypto,
+				randomUUID: () => '12345678-1234-1234-1234-123456789abc'
+			});
+		});
+
+		it('returns filtered and parsed contacts', async () => {
+			const contacts = getMockContactsUi({
+				n: 1,
+				name: 'Test name',
+				addresses: [mockContactBtcAddressUi]
+			}) as unknown as ContactUi[];
+
+			contactsStore.set([...contacts]);
+
+			const storeData = get(extendedAddressContacts);
+
+			const aiAssistantContacts = parseToAiAssistantContacts(storeData);
+			const response = {
+				message: {
+					content: toNullable(
+						JSON.stringify(
+							{
+								contacts: Object.values(aiAssistantContacts).map((contact) => ({
+									...contact,
+									id: `${contact['id']}`
+								}))
+							},
+							jsonReplacer
+						)
+					),
+					tool_calls: toNullable()
+				}
+			} as chat_response_v1;
+
+			vi.mocked(llmChat).mockResolvedValue(response);
+
+			const result = await askLlmToFilterContacts({
+				identity: mockIdentity,
+				filterParams: [{ value: 'Btc', name: 'addressType' }]
+			});
+
+			expect(result).toStrictEqual([...Object.values(storeData)]);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We need to implement a method that is going to request a semantical contacts filter from LLM. It filters out all sensitive contacts info (addresses) before sending it to AI. After LLM replies, we parse the response to ContactUi[].
