### PR TITLE
chore(frontend): fix main.js loader paths

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -3,7 +3,7 @@
 import { config } from 'dotenv';
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { ENV, findHtmlFiles } from './build.utils.mjs';
 
 config({ path: `.env.${ENV}` });
@@ -12,7 +12,10 @@ const buildCsp = (htmlFile) => {
 	// 1. We extract the start script parsed by SvelteKit into the html file
 	const indexHTMLWithoutStartScript = extractStartScript(htmlFile);
 	// 2. We add our custom script loader - we inject it at build time because it would throw an error when developing locally if missing
-	const indexHTMLWithScriptLoader = injectScriptLoader(indexHTMLWithoutStartScript);
+	const indexHTMLWithScriptLoader = injectScriptLoader({
+		content: indexHTMLWithoutStartScript,
+		filePath: htmlFile
+	});
 	// 3. Replace preloaders
 	const indexHTMLWithPreloaders = injectLinkPreloader(indexHTMLWithScriptLoader);
 	// 4. remove the content-security-policy tag injected by SvelteKit
@@ -29,16 +32,26 @@ const removeDefaultCspTag = (indexHtml) =>
 /**
  * We need a script loader to implement a proper Content Security Policy. See `updateCSP` doc for more information.
  */
-const injectScriptLoader = (indexHtml) =>
-	indexHtml.replace(
+const injectScriptLoader = ({ content, filePath }) => {
+	// We need to provide the relative path to the script; otherwise, it will be resolved from the root at runtime.
+	// This isn't an issue if all loaders are consistent and use the same name,
+	// but it could become a problem if Svelte changes its approach or we start hashing the script names.
+	const buildDir = join(process.cwd(), 'build');
+	const scriptName = 'main.js';
+
+	const parentFolders = relative(buildDir, dirname(filePath));
+	const loaderSrc = `${parentFolders !== '' ? `/${parentFolders}/` : ''}${scriptName}`;
+
+	return content.replace(
 		'<!-- SCRIPT_LOADER -->',
 		`<script sveltekit-loader>
       const loader = document.createElement("script");
       loader.type = "module";
-      loader.src = "main.js";
+      loader.src = "${loaderSrc}";
       document.head.appendChild(loader);
     </script>`
 	);
+};
 
 /**
  * Calculating the sh256 value for the preloaded link and whitelisting these seem not to be supported by the Content-Security-Policy.


### PR DESCRIPTION
# Motivation

> TL;DR: we got lucky

I implemented a 404 page in the Juno Console. One thing led to another, and I ended up having to hash the filenames of `main.js` loaders (because 404.html and index.html both live in the same folder, at the root). That’s when I noticed an issue on mainnet: the loaders were no longer being loaded, and the frontend was crashing!

The root cause was that the loader was always being fetched from the root directory. This wouldn’t normally be an issue—*if* all loaders had the same content and were named `main.js` but, since I started hashing the filenames… yolo.

Long story short, I fixed the issue by using a relative path for the loaders (in this [PR](https://github.com/junobuild/juno/pull/1826)). While doing that, I realized the same issue exists in OISY. Fortunately, because all the loaders are currently identical, it hasn’t caused any problems yet. Still, for future-proofing, it’s probably best to address it now.

# Notes

I double-checked NNS dapp. It’s fine there, thanks to a PR from @bitdivine back in February 2023.

# Changes

- In `build.csk.mjs`, when `injectScriptLoader`, calculate a parent relative path and use it to load the `main.js` script loader from the related HTML page.
