### PR TITLE
feat(frontend): remove id from addresses while parsing LLM result

### DIFF
--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -29,9 +29,11 @@ export const parseFromAiAssistantContacts = ({
 			...acc,
 			{
 				...extendedAddressContacts[`${id}`],
-				addresses: extendedAddressContacts[`${id}`].addresses.filter(({ id: addressId }) =>
-					addresses.some((filteredAddress) => filteredAddress.id === addressId)
-				)
+				addresses: extendedAddressContacts[`${id}`].addresses
+					.filter(({ id: addressId }) =>
+						addresses.some((filteredAddress) => filteredAddress.id === addressId)
+					)
+					.map(({ id: _, ...rest }) => ({ ...rest }))
 			}
 		],
 		[]

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -90,7 +90,7 @@ describe('ai-assistant.services', () => {
 				filterParams: [{ value: 'Btc', name: 'addressType' }]
 			});
 
-			expect(result).toStrictEqual([...Object.values(storeData)]);
+			expect(result).toStrictEqual([...contacts]);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -50,7 +50,7 @@ describe('ai-assistant.utils', () => {
 					aiAssistantContacts: [aiAssistantContact],
 					extendedAddressContacts: storeData
 				})
-			).toEqual([extendedAddressContactUi]);
+			).toEqual([...contactsData]);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

To be aligned with the ContactUi interface, we need to remove `id` from addresses when parsing LLM response.