### PR TITLE
feat(frontend): ignore kong token metrics if price is 0

### DIFF
--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -32,7 +32,7 @@ export const formatKongSwapToCoingeckoPrices = (
 	tokens: KongSwapToken[]
 ): CoingeckoSimpleTokenPriceResponse =>
 	tokens.reduce<CoingeckoSimpleTokenPriceResponse>((acc, { token, metrics }) => {
-		if (isNullish(token) || isNullish(metrics?.price)) {
+		if (isNullish(token) || isNullish(metrics?.price) || metrics.price === 0) {
 			return acc;
 		}
 

--- a/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
@@ -39,6 +39,15 @@ describe('formatKongSwapToCoingeckoPrices', () => {
 		expect(result).toEqual({});
 	});
 
+	it('skips tokenData where metrics.price is 0', () => {
+		const mock = createMockKongSwapToken({
+			metrics: { price: 0 }
+		});
+		const result = formatKongSwapToCoingeckoPrices([mock]);
+
+		expect(result).toEqual({});
+	});
+
 	it('parses even if some optional metrics fields are missing', () => {
 		const mock = createMockKongSwapToken({
 			token: { canister_id: MOCK_CANISTER_ID_1 },


### PR DESCRIPTION
# Motivation

In case kong token metrics does not have a price yet (e.g. there is no a pool yet created for the token), we want to ignore it completely instead of showing the token balance as 0.
