### PR TITLE
feat(frontend): added icpSwap plausible events for links

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -18,6 +18,10 @@
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import { SwapErrorCodes } from '$lib/types/swap';
+	import {
+		TRACK_OPEN_DOCUMENTATION,
+		TRACK_OPEN_EXTERNAL_LINK
+	} from '$lib/constants/analytics.contants';
 
 	export let swapAmount: OptionAmount;
 	export let receiveAmount: number | undefined;
@@ -101,13 +105,25 @@
 						iconSize="15"
 						href={OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK}
 						ariaLabel={$i18n.swap.text.open_instructions_link}
-						>{$i18n.swap.error.swap_failed_instruction_link}</ExternalLink
-					>
+						trackEvent={{
+							name: TRACK_OPEN_DOCUMENTATION,
+							metadata: {
+								link: OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK
+							}
+						}}
+						>{$i18n.swap.error.swap_failed_instruction_link}
+					</ExternalLink>
 					{$i18n.swap.error.withdraw_failed_second_part}
 
 					<ExternalLink
 						iconSize="15"
 						href={$failedSwapError.url.url}
+						trackEvent={{
+							name: TRACK_OPEN_EXTERNAL_LINK,
+							metadata: {
+								link: $failedSwapError.url.url
+							}
+						}}
 						ariaLabel={$i18n.swap.text.open_icp_swap}>{$failedSwapError.url.text}</ExternalLink
 					>
 				{:else}

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -137,3 +137,7 @@ export const TRACK_PRIVACY_MODE_CHANGE = 'privacy_mode_change';
 // This event is used to track the number of calls to Infura's getLogs endpoint.
 // TODO: Remove these events once the issue is resolved.
 export const TRACK_INFURA_GET_LOGS_CALL = 'infura_get_logs_call';
+
+//Links
+export const TRACK_OPEN_DOCUMENTATION = 'open_documentation';
+export const TRACK_OPEN_EXTERNAL_LINK = 'open_external_link';

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -449,6 +449,7 @@ export const performManualWithdraw = async ({
 		trackEvent({
 			name: SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS,
 			metadata: {
+				dApp: SwapProvider.ICP_SWAP,
 				token: token.symbol,
 				tokenDirection: withdrawDestinationTokens ? 'receive' : 'pay'
 			}
@@ -464,6 +465,7 @@ export const performManualWithdraw = async ({
 		trackEvent({
 			name: SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED,
 			metadata: {
+				dApp: SwapProvider.ICP_SWAP,
 				token: token.symbol,
 				tokenDirection: withdrawDestinationTokens ? 'receive' : 'pay'
 			}


### PR DESCRIPTION
# Motivation

We want to track new events in icpSwap for external links and documentation link openings. In this PR, we have added new Plausible events to achieve this.

# Changes

- Added a new event to track opening the documentation link.
- Added a new event to track opening external links.
- Updated the event for manually withdrawing from icpSwap to include a new property: dApp.


