### PR TITLE
feat(frontend): added new icp-swap getPoolMetadata call

### DIFF
--- a/src/frontend/src/lib/api/icp-swap-pool.api.ts
+++ b/src/frontend/src/lib/api/icp-swap-pool.api.ts
@@ -1,3 +1,4 @@
+import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did';
 import { ICPSwapPoolCanister } from '$lib/canisters/icp-swap-pool.canister';
 import type {
 	ICPSwapDepositWithdrawParams,
@@ -5,6 +6,7 @@ import type {
 	ICPSwapQuoteSwapParams
 } from '$lib/types/api';
 import type { CanisterApiFunctionParamsWithCanisterId } from '$lib/types/canister';
+import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { assertNonNullish } from '@dfinity/utils';
 
@@ -76,4 +78,12 @@ export const getUserUnusedBalance = async ({
 }> => {
 	const { getUserUnusedBalance } = await getPoolCanister({ identity, canisterId });
 	return getUserUnusedBalance(principal);
+};
+
+export const getPoolMetadata = async ({
+	identity,
+	canisterId
+}: CanisterApiFunctionParamsWithCanisterId<{ identity: Identity }>): Promise<PoolMetadata> => {
+	const { getPoolMetadata } = await getPoolCanister({ identity, canisterId });
+	return getPoolMetadata();
 };

--- a/src/frontend/src/lib/canisters/icp-swap-pool.canister.ts
+++ b/src/frontend/src/lib/canisters/icp-swap-pool.canister.ts
@@ -1,5 +1,6 @@
 import type {
 	DepositArgs,
+	PoolMetadata,
 	Result,
 	SwapArgs,
 	_SERVICE as SwapPoolService,
@@ -128,6 +129,23 @@ export class ICPSwapPoolCanister extends Canister<SwapPoolService> {
 	): Promise<{ balance0: bigint; balance1: bigint }> => {
 		const { getUserUnusedBalance } = this.caller({ certified: false });
 		const response = await getUserUnusedBalance(principal);
+
+		if ('ok' in response) {
+			return response.ok;
+		}
+
+		throw mapIcpSwapFactoryError(response.err);
+	};
+
+	/**
+	 * Retrieves metadata for the pool.
+	 *
+	 * @returns Object containing PoolMetadata object.
+	 * @throws CanisterInternalError if fetching metadata fails.
+	 */
+	getPoolMetadata = async (): Promise<PoolMetadata> => {
+		const { metadata } = this.caller({ certified: false });
+		const response = await metadata();
 
 		if ('ok' in response) {
 			return response.ok;

--- a/src/frontend/src/tests/lib/canisters/icp-swap-pool.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/icp-swap-pool.spec.ts
@@ -235,4 +235,53 @@ describe('icp_swap_pool.canister', () => {
 			await expect(result).rejects.toThrow(mockResponseError);
 		});
 	});
+
+	describe('getPoolMetadata', () => {
+		it('returns pool metadata successfully', async () => {
+			const mockPoolMetadata = {
+				fee: BigInt(3000),
+				key: 'pool-icp-wtn',
+				sqrtPriceX96: BigInt('3950336'),
+				tick: BigInt(12345),
+				liquidity: BigInt(500000000000n),
+				token0: {
+					address: 'ryjl3-tyaaa-aaaaa-aaaba-cai',
+					standard: 'icrc1'
+				},
+				token1: {
+					address: 'qaa6y-5yaaa-aaaaa-aaafa-cai',
+					standard: 'icrc2'
+				},
+				maxLiquidityPerTick: BigInt('913129639935'),
+				nextPositionId: BigInt(42)
+			};
+			service.metadata.mockResolvedValue({ ok: mockPoolMetadata });
+			const { getPoolMetadata } = await createPool({ serviceOverride: service });
+			const result = await getPoolMetadata();
+
+			expect(result).toEqual(mockPoolMetadata);
+		});
+
+		it('throws CanisterInternalError on error variant', async () => {
+			service.metadata.mockResolvedValue({
+				err: { InternalError: 'Failed to get pool metadata' }
+			});
+			const { getPoolMetadata } = await createPool({ serviceOverride: service });
+			const result = getPoolMetadata();
+
+			await expect(result).rejects.toThrow(
+				new CanisterInternalError('Internal error: Failed to get pool metadata')
+			);
+		});
+
+		it('throws raw error if getPoolMetadata throws', async () => {
+			service.metadata.mockImplementation(() => {
+				throw mockResponseError;
+			});
+			const { getPoolMetadata } = await createPool({ serviceOverride: service });
+			const result = getPoolMetadata();
+
+			await expect(result).rejects.toThrow(mockResponseError);
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

We need to fetch ICP Swap pool metadata to compare token0 and token1 addresses with balance0 and balance1, ensuring we withdraw the correct token amounts after a failed swap.

# Changes

- Added a new getPoolMetadata API that calls the ICP Swap canister’s metadata method.

# Tests

Covered new logic with tests.
