### PR TITLE
feat(frontend): added new functionality to btain quote result for EVMsupported networks

### DIFF
--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -18,3 +18,6 @@ export const SWAP_ETH_TOKEN_PLACEHOLDER = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeee
 
 export const OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK =
 	'https://docs.oisy.com/using-oisy-wallet/how-tos/swapping-tokens#manually-withdraw-funds-from-icpswap';
+
+export const SWAP_MODE = 'all';
+export const SWAP_SIDE = 'SELL';

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -10,7 +10,7 @@ import { getPoolCanister } from '$lib/api/icp-swap-factory.api';
 import { deposit, depositFrom, swap as swapIcp, withdraw } from '$lib/api/icp-swap-pool.api';
 import { kongSwap, kongTokens } from '$lib/api/kong_backend.api';
 import { KONG_BACKEND_CANISTER_ID, NANO_SECONDS_IN_MINUTE } from '$lib/constants/app.constants';
-import { ICP_SWAP_POOL_FEE } from '$lib/constants/swap.constants';
+import { ICP_SWAP_POOL_FEE, SWAP_MODE, SWAP_SIDE } from '$lib/constants/swap.constants';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { swapProviders } from '$lib/providers/swap.providers';
 import { i18n } from '$lib/stores/i18n.store';
@@ -22,20 +22,28 @@ import {
 	SwapErrorCodes,
 	SwapProvider,
 	type FetchSwapAmountsParams,
+	type GetQuoteParams,
 	type ICPSwapResult,
 	type IcpSwapManualWithdrawParams,
 	type IcpSwapWithdrawParams,
 	type IcpSwapWithdrawResponse,
 	type SwapMappedResult,
-	type SwapParams
+	type SwapParams,
+	type VeloraQuoteParams
 } from '$lib/types/swap';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
 import { parseToken } from '$lib/utils/parse.utils';
-import { calculateSlippage } from '$lib/utils/swap.utils';
+import {
+	calculateSlippage,
+	geSwapEthTokenAddress,
+	mapVeloraMarketSwapResult,
+	mapVeloraSwapResult
+} from '$lib/utils/swap.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { constructSimpleSDK } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 import { trackEvent } from './analytics.services';
 import { throwSwapError } from './swap-errors.services';
@@ -479,4 +487,72 @@ export const performManualWithdraw = async ({
 			swapSucceded: withdrawDestinationTokens
 		};
 	}
+};
+
+// This wrapper keeps the return type uniform (array of SwapMappedResult),
+// so we can plug in more DEX quote providers later without changing callers.
+// Each provider can push its mapped result into the array, easy extendability.
+export const fetchSwapAmountsEVM = async ({
+	sourceToken,
+	destinationToken,
+	amount,
+	userAddress
+}: VeloraQuoteParams): Promise<SwapMappedResult[]> => {
+	const swapAmountsResults = await fetchVeloraSwapAmount({
+		sourceToken,
+		destinationToken,
+		amount,
+		userAddress
+	});
+
+	if (isNullish(swapAmountsResults)) {
+		return [];
+	}
+
+	return [swapAmountsResults];
+};
+
+const fetchVeloraSwapAmount = async ({
+	sourceToken,
+	destinationToken,
+	amount,
+	userAddress
+}: VeloraQuoteParams): Promise<SwapMappedResult | null> => {
+	const {
+		network: { chainId: destChainId }
+	} = destinationToken;
+
+	const {
+		network: { chainId: srcChainId }
+	} = sourceToken;
+
+	const sdk = constructSimpleSDK({
+		chainId: Number(srcChainId),
+		fetch: window.fetch
+	});
+
+	const baseParams: GetQuoteParams = {
+		amount,
+		srcToken: geSwapEthTokenAddress(sourceToken),
+		destToken: geSwapEthTokenAddress(destinationToken),
+		srcDecimals: sourceToken.decimals,
+		destDecimals: destinationToken.decimals,
+		mode: SWAP_MODE,
+		side: SWAP_SIDE,
+		userAddress
+	};
+
+	const data = await sdk.quote.getQuote(
+		srcChainId !== destChainId ? { ...baseParams, destChainId: Number(destChainId) } : baseParams
+	);
+
+	if ('delta' in data) {
+		return mapVeloraSwapResult(data.delta);
+	}
+
+	if ('market' in data) {
+		return mapVeloraMarketSwapResult(data.market);
+	}
+
+	return null;
 };

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -1,10 +1,12 @@
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { IcToken } from '$icp/types/ic-token';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import type { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import type { Token } from '$lib/types/token';
 import type { Identity } from '@dfinity/agent';
-import type { BridgePrice, DeltaPrice, OptimalRate } from '@velora-dex/sdk';
+import type { BridgePrice, DeltaPrice, OptimalRate, QuoteParams } from '@velora-dex/sdk';
+import type { EthAddress } from './address';
 import type { OptionIdentity } from './identity';
 import type { Amount, OptionAmount } from './send';
 
@@ -164,6 +166,17 @@ export interface FormatSlippageParams {
 }
 
 export type VeloraSwapDetails = DeltaPrice & BridgePrice & OptimalRate;
+
+export interface GetQuoteParams extends QuoteParams<'all'> {
+	destChainId?: number;
+}
+
+export interface VeloraQuoteParams {
+	sourceToken: Erc20Token;
+	destinationToken: Erc20Token;
+	amount: string;
+	userAddress: EthAddress;
+}
 
 export interface GetWithdrawableTokenParams {
 	tokenAddress: string;

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1,4 +1,5 @@
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { IcToken } from '$icp/types/ic-token';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import * as icpSwapPool from '$lib/api/icp-swap-pool.api';
@@ -8,6 +9,7 @@ import { trackEvent } from '$lib/services/analytics.services';
 import * as icpSwapBackend from '$lib/services/icp-swap.services';
 import {
 	fetchSwapAmounts,
+	fetchSwapAmountsEVM,
 	loadKongSwapTokens,
 	performManualWithdraw,
 	withdrawICPSwapAfterFailedSwap
@@ -15,9 +17,20 @@ import {
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import type { ICPSwapAmountReply } from '$lib/types/api';
 import type { OptionIdentity } from '$lib/types/identity';
-import { SwapErrorCodes, SwapProvider } from '$lib/types/swap';
+import {
+	SwapErrorCodes,
+	SwapProvider,
+	type SwapMappedResult,
+	type VeloraSwapDetails
+} from '$lib/types/swap';
+import {
+	geSwapEthTokenAddress,
+	mapVeloraMarketSwapResult,
+	mapVeloraSwapResult
+} from '$lib/utils/swap.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { kongIcToken, mockKongBackendTokens } from '$tests/mocks/kong_backend.mock';
+import { constructSimpleSDK } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 
 vi.mock(import('$env/icp-swap.env'), async (importOriginal) => {
@@ -44,6 +57,39 @@ vi.mock('$lib/api/icp-swap-pool.api', () => ({
 vi.mock('$lib/services/analytics.services', () => ({
 	trackEvent: vi.fn()
 }));
+
+vi.mock('@velora-dex/sdk', () => ({
+	constructSimpleSDK: vi.fn()
+}));
+
+vi.mock('$lib/utils/swap.utils', async (importOriginal) => {
+	const actual = await importOriginal();
+
+	return {
+		...(actual as Record<string, unknown>),
+		geSwapEthTokenAddress: vi.fn(),
+
+		mapVeloraSwapResult: vi.fn(
+			(): SwapMappedResult => ({
+				provider: SwapProvider.VELORA,
+				receiveAmount: 1n,
+				receiveOutMinimum: 2n,
+				swapDetails: {} as VeloraSwapDetails,
+				type: 'delta'
+			})
+		),
+
+		mapVeloraMarketSwapResult: vi.fn(
+			(): SwapMappedResult => ({
+				provider: SwapProvider.VELORA,
+				receiveAmount: 1n,
+				receiveOutMinimum: 2n,
+				swapDetails: {} as VeloraSwapDetails,
+				type: 'market'
+			})
+		)
+	};
+});
 
 describe('fetchSwapAmounts', () => {
 	const mockTokens = [
@@ -176,6 +222,87 @@ describe('fetchSwapAmounts', () => {
 
 		expect(result).toHaveLength(1);
 		expect(result[0].provider).toBe(SwapProvider.KONG_SWAP);
+	});
+});
+
+describe('fetchSwapAmountsEVM', () => {
+	const sourceToken = {
+		symbol: 'SRC',
+		decimals: 18,
+		network: { chainId: '1' },
+		address: '0xSrcAddress'
+	} as unknown as Erc20Token;
+
+	const destinationToken = {
+		symbol: 'DST',
+		decimals: 6,
+		network: { chainId: '137' },
+		address: '0xDestAddress'
+	} as unknown as Erc20Token;
+
+	const amount = '1000000000000000000';
+	const userAddress = '0xUser';
+
+	const mockGetQuote = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.mocked(constructSimpleSDK).mockReturnValue({
+			quote: { getQuote: mockGetQuote }
+		} as unknown as ReturnType<typeof constructSimpleSDK>);
+	});
+
+	afterEach(() => {
+		mockGetQuote.mockReset();
+	});
+
+	it('returns [] when quote has neither delta nor market', async () => {
+		mockGetQuote.mockResolvedValue({});
+
+		const result = await fetchSwapAmountsEVM({
+			sourceToken,
+			destinationToken,
+			amount,
+			userAddress
+		});
+
+		expect(mapVeloraSwapResult).not.toHaveBeenCalled();
+		expect(mapVeloraMarketSwapResult).not.toHaveBeenCalled();
+		expect(result).toEqual([]);
+	});
+
+	it('calls delta mapper when quote contains delta and returns single-item array', async () => {
+		mockGetQuote.mockResolvedValue({ delta: { receiveAmount: '123' } });
+
+		const result = await fetchSwapAmountsEVM({
+			sourceToken,
+			destinationToken,
+			amount,
+			userAddress
+		});
+
+		expect(geSwapEthTokenAddress).toHaveBeenCalledTimes(2);
+		expect(mapVeloraSwapResult).toHaveBeenCalledOnce();
+		expect(mapVeloraMarketSwapResult).not.toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe(SwapProvider.VELORA);
+	});
+
+	it('calls market mapper when quote contains market and returns single-item array', async () => {
+		mockGetQuote.mockResolvedValue({ market: { receiveAmount: '456' } });
+
+		const result = await fetchSwapAmountsEVM({
+			sourceToken,
+			destinationToken,
+			amount,
+			userAddress
+		});
+
+		expect(mapVeloraMarketSwapResult).toHaveBeenCalledOnce();
+		expect(mapVeloraSwapResult).not.toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe(SwapProvider.VELORA);
 	});
 });
 


### PR DESCRIPTION
# Motivation

Provide an extensible, uniform way to fetch EVM swap quotes so it’s easy to add more DEX providers later (starting with Velora) without touching call sites.

# Changes

- Added fetchSwapAmountsEVM aggregator that returns a uniform SwapMappedResult[] and currently sources quotes from Velora.
- Normalized Velora responses (delta / market) via mappers; return [] when no route is found.

# Tests

Added test for new functionality
