### PR TITLE
feat(frontend): adds tokenId to transaction

### DIFF
--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -39,6 +39,7 @@ export type Transaction = Omit<EthersTransaction, 'data' | 'from'> &
 		timestamp?: number;
 		pendingTimestamp?: number;
 		displayTimestamp?: number;
+		tokenId?: number;
 	};
 
 export type TransactionFeeData = Pick<FeeData, 'maxFeePerGas' | 'maxPriorityFeePerGas'> & {


### PR DESCRIPTION
# Motivation

The `Transaction` object should also support nft transactions which means it needs an optional `tokenId` field.

# Changes

- adds `tokenId` to `Transaction`
