### PR TITLE
fix(frontend): Dont remove url params with redirects

### DIFF
--- a/src/frontend/src/routes/(app)/+page.ts
+++ b/src/frontend/src/routes/(app)/+page.ts
@@ -2,5 +2,5 @@ import { AppPath } from '$lib/constants/routes.constants';
 import { redirect } from '@sveltejs/kit';
 
 export const load = () => {
-	throw redirect(308, AppPath.Tokens); // 308 permanent redirect status code
+	throw redirect(308, AppPath.Tokens + window.location.search); // 308 permanent redirect status code
 };

--- a/src/frontend/src/routes/(app)/assets/+page.ts
+++ b/src/frontend/src/routes/(app)/assets/+page.ts
@@ -2,5 +2,5 @@ import { AppPath } from '$lib/constants/routes.constants';
 import { redirect } from '@sveltejs/kit';
 
 export const load = () => {
-	throw redirect(308, AppPath.Tokens); // 308 permanent redirect status code
+	throw redirect(308, AppPath.Tokens + window.location.search); // 308 permanent redirect status code
 };


### PR DESCRIPTION
# Motivation

The code url param gets removed when redirecting from root (/) to the new token page url (/assets/tokens)

# Changes

Redirect to the correct URLs using the `window.location.search` as well

# Tests


https://github.com/user-attachments/assets/8465c60f-e56c-4b7c-809f-8496978bdf4f


