### PR TITLE
feat(frontend): clear idb-addresses methods

### DIFF
--- a/src/frontend/src/lib/api/idb-addresses.api.ts
+++ b/src/frontend/src/lib/api/idb-addresses.api.ts
@@ -15,7 +15,7 @@ import type {
 } from '$lib/types/idb-addresses';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, del, get, set, update, type UseStore } from 'idb-keyval';
+import { clear, createStore, del, get, set, update, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const idbAddressesStore = (key: string): UseStore =>
@@ -114,3 +114,9 @@ export const deleteIdbEthAddress = (principal: Principal): Promise<void> =>
 
 export const deleteIdbSolAddressMainnet = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbSolAddressesStoreMainnet);
+
+export const clearIdbBtcAddressMainnet = (): Promise<void> => clear(idbBtcAddressesStoreMainnet);
+
+export const clearIdbEthAddress = (): Promise<void> => clear(idbEthAddressesStore);
+
+export const clearIdbSolAddressMainnet = (): Promise<void> => clear(idbSolAddressesStoreMainnet);

--- a/src/frontend/src/tests/lib/api/idb-addresses.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-addresses.api.spec.ts
@@ -1,4 +1,7 @@
 import {
+	clearIdbBtcAddressMainnet,
+	clearIdbEthAddress,
+	clearIdbSolAddressMainnet,
 	deleteIdbBtcAddressMainnet,
 	deleteIdbEthAddress,
 	deleteIdbSolAddressMainnet,
@@ -162,6 +165,30 @@ describe('idb-addresses.api', () => {
 			await updateIdbSolAddressMainnetLastUsage(mockPrincipal);
 
 			expect(idbKeyval.update).toHaveBeenCalled();
+		});
+	});
+
+	describe('clearIdbBtcAddressMainnet', () => {
+		it('should clear BTC addresses', async () => {
+			await clearIdbBtcAddressMainnet();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbEthAddress', () => {
+		it('should clear ETH addresses', async () => {
+			await clearIdbEthAddress();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbSolAddressMainnet', () => {
+		it('should clear SOL addresses', async () => {
+			await clearIdbSolAddressMainnet();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Similar as with the deletion per principal, we now need all the methods for a complete "clear" of IDB addresses.