### PR TITLE
feat(frontend): clear idb-balances methods

### DIFF
--- a/src/frontend/src/lib/api/idb-balances.api.ts
+++ b/src/frontend/src/lib/api/idb-balances.api.ts
@@ -5,7 +5,7 @@ import type { GetIdbBalancesParams, SetIdbBalancesParams } from '$lib/types/idb-
 import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, get, set as idbSet, type UseStore } from 'idb-keyval';
+import { clear, createStore, get, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const createIdbBalancesStore = (): UseStore =>
@@ -50,3 +50,5 @@ export const getIdbBalances = (params: GetIdbBalancesParams): Promise<Balance | 
 
 export const deleteIdbBalances = (principal: Principal): Promise<void> =>
 	delMultiKeysByPrincipal({ principal, store: idbBalancesStore });
+
+export const clearIdbBalances = (): Promise<void> => clear(idbBalancesStore);

--- a/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-balances.api.spec.ts
@@ -1,7 +1,12 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
-import { deleteIdbBalances, getIdbBalances, setIdbBalancesStore } from '$lib/api/idb-balances.api';
+import {
+	clearIdbBalances,
+	deleteIdbBalances,
+	getIdbBalances,
+	setIdbBalancesStore
+} from '$lib/api/idb-balances.api';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Balance } from '$lib/types/balance';
 import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
@@ -221,6 +226,14 @@ describe('idb-balances.api', () => {
 				principal: mockPrincipal,
 				store: expect.any(Object)
 			});
+		});
+	});
+
+	describe('clearIdbBalances', () => {
+		it('should clear balances', async () => {
+			await clearIdbBalances();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Similar as with the deletion per principal, we now need all the methods for a complete "clear" of IDB balances.
