### PR TITLE
feat(frontend): clear idb-transactions methods

### DIFF
--- a/src/frontend/src/lib/api/idb-transactions.api.ts
+++ b/src/frontend/src/lib/api/idb-transactions.api.ts
@@ -20,7 +20,7 @@ import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import { createStore, get, set as idbSet, type UseStore } from 'idb-keyval';
+import { clear, createStore, get, set as idbSet, type UseStore } from 'idb-keyval';
 
 // There is no IndexedDB in SSG. Since this initialization occurs at the module's root, SvelteKit would encounter an error during the dapp bundling process, specifically a "ReferenceError [Error]: indexedDB is not defined". Therefore, the object for bundling on NodeJS side.
 const idbTransactionsStore = (key: string): UseStore =>
@@ -117,3 +117,11 @@ export const deleteIdbIcTransactions = (principal: Principal): Promise<void> =>
 
 export const deleteIdbSolTransactions = (principal: Principal): Promise<void> =>
 	delMultiKeysByPrincipal({ principal, store: idbSolTransactionsStore });
+
+export const clearIdbBtcTransactions = (): Promise<void> => clear(idbBtcTransactionsStore);
+
+export const clearIdbEthTransactions = (): Promise<void> => clear(idbEthTransactionsStore);
+
+export const clearIdbIcTransactions = (): Promise<void> => clear(idbIcTransactionsStore);
+
+export const clearIdbSolTransactions = (): Promise<void> => clear(idbSolTransactionsStore);

--- a/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-transactions.api.spec.ts
@@ -4,6 +4,10 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import {
+	clearIdbBtcTransactions,
+	clearIdbEthTransactions,
+	clearIdbIcTransactions,
+	clearIdbSolTransactions,
 	deleteIdbBtcTransactions,
 	deleteIdbEthTransactions,
 	deleteIdbIcTransactions,
@@ -317,6 +321,38 @@ describe('idb-transactions.api', () => {
 				principal: mockPrincipal,
 				store: expect.any(Object)
 			});
+		});
+	});
+
+	describe('clearIdbBtcTransactions', () => {
+		it('should clear BTC transactions', async () => {
+			await clearIdbBtcTransactions();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbEthTransactions', () => {
+		it('should clear ETH transactions', async () => {
+			await clearIdbEthTransactions();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbIcTransactions', () => {
+		it('should clear IC transactions', async () => {
+			await clearIdbIcTransactions();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbSolTransactions', () => {
+		it('should clear SOL transactions', async () => {
+			await clearIdbSolTransactions();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
 		});
 	});
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -86,6 +86,7 @@ vi.mock('idb-keyval', () => ({
 	set: vi.fn(),
 	get: vi.fn(),
 	del: vi.fn(),
+	clear: vi.fn(),
 	delMany: vi.fn(),
 	keys: vi.fn(() => []),
 	update: vi.fn()


### PR DESCRIPTION
# Motivation

Similar as with the deletion per principal, we now need all the methods for a complete "clear" of IDB transactions.
