### PR TITLE
feat(frontend): use clearAllPrincipalsStorages on logout in LockPage

### DIFF
--- a/src/frontend/src/lib/components/auth/LockPage.svelte
+++ b/src/frontend/src/lib/components/auth/LockPage.svelte
@@ -29,7 +29,7 @@
 
 	const handleLogout = async () => {
 		authLocked.unlock({ source: 'logout from lock page' });
-		await signOut({ resetUrl: true });
+		await signOut({ resetUrl: true, clearAllPrincipalsStorages: true });
 	};
 </script>
 


### PR DESCRIPTION
# Motivation

The only thing left is to start using the clearAllPrincipalsStorages option on logout in LockPage.
