### PR TITLE
chore(frontend): Remove windoge tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -88,25 +88,6 @@
 			"__bigint__": "10"
 		}
 	},
-	"XP": {
-		"ledgerCanisterId": "wqihv-qyaaa-aaaak-afjoa-cai",
-		"indexCanisterId": "7hwgv-uaaaa-aaaao-qjv7q-cai",
-		"decimals": 8,
-		"name": "WindogeXP",
-		"symbol": "XP",
-		"fee": {
-			"__bigint__": "100000000"
-		}
-	},
-	"EXE": {
-		"ledgerCanisterId": "rh2pm-ryaaa-aaaan-qeniq-cai",
-		"fee": {
-			"__bigint__": "100000"
-		},
-		"name": "Windoge98",
-		"symbol": "EXE",
-		"decimals": 8
-	},
 	"BOB": {
 		"ledgerCanisterId": "7pail-xaaaa-aaaas-aabmq-cai",
 		"decimals": 8,


### PR DESCRIPTION
# Motivation

- Windoge98 has no index
- WindogeXP ledger just was not responding due to a low cycles balance, causing an error for all users. (I topped it up a little).

# Changes

- remove them

# Tests
<img width="611" height="659" alt="image" src="https://github.com/user-attachments/assets/bb1941f5-937b-468b-98b0-3284dfda4ae5" />
