### PR TITLE
feat(frontend): extends Logo implementation

### DIFF
--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -15,7 +15,15 @@
 		testId?: string;
 	}
 
-	let { src, alt = '', size = 'xxs', color = 'off-white', ring = false, rounded = true, testId }: Props = $props();
+	let {
+		src,
+		alt = '',
+		size = 'xxs',
+		color = 'off-white',
+		ring = false,
+		rounded = true,
+		testId
+	}: Props = $props();
 
 	let sizePx = $state(logoSizes[size]);
 

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -11,7 +11,7 @@
 		size?: LogoSize;
 		color?: 'off-white' | 'white';
 		ring?: boolean;
-		rounded?: boolean;
+		circle?: boolean;
 		testId?: string;
 	}
 
@@ -21,7 +21,7 @@
 		size = 'xxs',
 		color = 'off-white',
 		ring = false,
-		rounded = true,
+		circle = true,
 		testId
 	}: Props = $props();
 
@@ -37,8 +37,8 @@
 	class:bg-white={color === 'white' && !isReady}
 	class:opacity-10={!isReady}
 	class:ring-2={ring}
-	class:rounded-full={rounded}
-	class:rounded-lg={!rounded}
+	class:rounded-full={circle}
+	class:rounded-lg={!circle}
 	style={`width: ${sizePx}; height: ${sizePx}; transition: opacity 0.15s ease-in;`}
 	data-tid={testId}
 >

--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -11,10 +11,11 @@
 		size?: LogoSize;
 		color?: 'off-white' | 'white';
 		ring?: boolean;
+		rounded?: boolean;
 		testId?: string;
 	}
 
-	let { src, alt = '', size = 'xxs', color = 'off-white', ring = false, testId }: Props = $props();
+	let { src, alt = '', size = 'xxs', color = 'off-white', ring = false, rounded = true, testId }: Props = $props();
 
 	let sizePx = $state(logoSizes[size]);
 
@@ -23,11 +24,13 @@
 </script>
 
 <div
-	class="flex items-center justify-center overflow-hidden rounded-full ring-primary"
+	class="flex items-center justify-center overflow-hidden ring-primary"
 	class:bg-off-white={color === 'off-white' && !isReady}
 	class:bg-white={color === 'white' && !isReady}
 	class:opacity-10={!isReady}
 	class:ring-2={ring}
+	class:rounded-full={rounded}
+	class:rounded-lg={!rounded}
 	style={`width: ${sizePx}; height: ${sizePx}; transition: opacity 0.15s ease-in;`}
 	data-tid={testId}
 >
@@ -39,7 +42,6 @@
 			height={sizePx}
 			onLoad={() => (loadingError = false)}
 			onError={() => (loadingError = true)}
-			rounded
 		/>
 	{:else}
 		<IconRandom size={sizePx} text={alt} />


### PR DESCRIPTION
# Motivation

The `Logo` should not always be displayed rounded. It should be configurable whether the `Logo` is rounded or not. 

# Changes

- updates `Logo`
