### PR TITLE
build(frontend): bump zod-schemas for any principal lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@dfinity/principal": "^2.4.1",
 				"@dfinity/utils": "^2.13.2",
 				"@dfinity/verifiable-credentials": "^0.0.4",
-				"@dfinity/zod-schemas": "^1.0.0",
+				"@dfinity/zod-schemas": "^1.1.0",
 				"@metamask/detect-provider": "^2.0.0",
 				"@noble/ed25519": "^2.3.0",
 				"@noble/hashes": "^1.8.0",
@@ -618,13 +618,13 @@
 			}
 		},
 		"node_modules/@dfinity/zod-schemas": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.0.0.tgz",
-			"integrity": "sha512-5ApkpRO8hqTb7B9GH4H8FljY/r6hh3zpA/HFeeozIHieyebAzB748+4T9/oL6T7udkvlfWPMulbmjSHerm3B9A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.1.0.tgz",
+			"integrity": "sha512-lhZTMN5bwbk+BgWA+tFto4ltrJVa+14KLssOwBtuFD980hqgP+dpAIEZQnIEZDU8x/51u2yGEpMDFubHjW2C5g==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/principal": "^2.0.0",
-				"zod": "^3.25"
+				"@dfinity/principal": "*",
+				"zod": "3.25"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -13140,21 +13140,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/svelte-confetti": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/svelte-confetti/-/svelte-confetti-2.3.2.tgz",
@@ -14654,21 +14639,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13140,6 +13140,21 @@
 				}
 			}
 		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/svelte-confetti": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/svelte-confetti/-/svelte-confetti-2.3.2.tgz",
@@ -14639,6 +14654,21 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"@dfinity/principal": "^2.4.1",
 		"@dfinity/utils": "^2.13.2",
 		"@dfinity/verifiable-credentials": "^0.0.4",
-		"@dfinity/zod-schemas": "^1.0.0",
+		"@dfinity/zod-schemas": "^1.1.0",
 		"@metamask/detect-provider": "^2.0.0",
 		"@noble/ed25519": "^2.3.0",
 		"@noble/hashes": "^1.8.0",


### PR DESCRIPTION
# Motivation

`zod-schemas` has been patched to accept any `@dfinity/principal` version which is technically correct and makes the maintenance easier.

# Changes

- Bump v1.1.0