### PR TITLE
build(frontend): bump verifiable-credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@dfinity/oisy-wallet-signer": "^0.2.3",
 				"@dfinity/principal": "^2.4.1",
 				"@dfinity/utils": "^2.13.2",
-				"@dfinity/verifiable-credentials": "^0.0.4",
+				"@dfinity/verifiable-credentials": "^1.1.0",
 				"@dfinity/zod-schemas": "^1.0.0",
 				"@metamask/detect-provider": "^2.0.0",
 				"@noble/ed25519": "^2.3.0",
@@ -585,18 +585,18 @@
 			}
 		},
 		"node_modules/@dfinity/verifiable-credentials": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@dfinity/verifiable-credentials/-/verifiable-credentials-0.0.4.tgz",
-			"integrity": "sha512-vnGbsyvkNh4bxvZe5MqCIVrO6w1TGpNk1ho+S4lOtLbzlFtBYx3E4z+RgFF0iEQPhlYDaAkVBGmo/oO+F14G7Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/verifiable-credentials/-/verifiable-credentials-1.1.0.tgz",
+			"integrity": "sha512-PpjM+h16za1npCa21RcIY7PW3v4e3aGk/yyzz9yJSTapcv4dtsVTuzG0v6ckXfOGnjB+Modc/mldohYo7bu2mA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"nanoid": "^5.0.7"
 			},
 			"engines": {
-				"node": ">=v20.11.1"
+				"node": ">=v22"
 			},
 			"peerDependencies": {
-				"@dfinity/principal": "^2.0.0"
+				"@dfinity/principal": "*"
 			}
 		},
 		"node_modules/@dfinity/verifiable-credentials/node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"@dfinity/oisy-wallet-signer": "^0.2.3",
 		"@dfinity/principal": "^2.4.1",
 		"@dfinity/utils": "^2.13.2",
-		"@dfinity/verifiable-credentials": "^0.0.4",
+		"@dfinity/verifiable-credentials": "^1.1.0",
 		"@dfinity/zod-schemas": "^1.0.0",
 		"@metamask/detect-provider": "^2.0.0",
 		"@noble/ed25519": "^2.3.0",


### PR DESCRIPTION
# Motivation

The latest version of `verifiable-credentials` accepts any principal library which is useful for maintenance reason.

# Changes

- Bump latest `@dfinity/verifiable-credentials`