### PR TITLE
refactor(frontend): Done button variant

### DIFF
--- a/src/frontend/src/lib/components/ui/ButtonDone.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonDone.svelte
@@ -5,11 +5,12 @@
 	interface Props {
 		onclick: () => void;
 		testId?: string;
+		variant?: 'primary' | 'secondary-light';
 	}
 
-	let { onclick, testId }: Props = $props();
+	let { onclick, testId, variant = 'primary' }: Props = $props();
 </script>
 
-<Button colorStyle="primary" paddingSmall {testId} fullWidth type="button" {onclick}>
+<Button colorStyle={variant} paddingSmall {testId} fullWidth type="button" {onclick}>
 	{$i18n.core.text.done}
 </Button>


### PR DESCRIPTION
# Motivation

We need an additional variant for the ButtonDone component.

# Changes

Added optional variant prop.

# Tests

Variant primary or prop not passed:
<img width="373" height="67" alt="image" src="https://github.com/user-attachments/assets/a3c79d41-6596-4523-b0a5-3f0e03a76b11" />


Variant secondary-light
<img width="511" height="128" alt="image" src="https://github.com/user-attachments/assets/34f296cb-90cc-44ca-b62c-9cd785b9e0b2" />