### PR TITLE
refactor(frontend): New NFT trait badge type

### DIFF
--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -25,7 +25,8 @@
 		warning: 'bg-warning-subtle-20 text-warning-primary',
 		success: 'bg-success-subtle-20 text-success-primary',
 		outline: 'border border-tertiary bg-off-white',
-		disabled: 'bg-tertiary-inverted text-white'
+		disabled: 'bg-tertiary-inverted text-white',
+		'nft-trait': 'border border-secondary bg-primary'
 	};
 </script>
 

--- a/src/frontend/src/lib/types/style.ts
+++ b/src/frontend/src/lib/types/style.ts
@@ -16,7 +16,8 @@ export type BadgeVariant =
 	| 'warning'
 	| 'success'
 	| 'outline'
-	| 'disabled';
+	| 'disabled'
+	| 'nft-trait';
 
 export type TagVariant =
 	| 'default'


### PR DESCRIPTION
# Motivation

We need a new type of badge for the NFT traits.

# Changes

- Added variant to BadgeVariant
- Added styles for new variant

# Tests

<img width="197" height="90" alt="image" src="https://github.com/user-attachments/assets/527f744e-9d05-4912-a2c4-75ef3e898c74" />

