### PR TITLE
feat(frontend): BreadcrumbNavigation

### DIFF
--- a/src/frontend/src/lib/components/ui/BreadcrumbNavigation.svelte
+++ b/src/frontend/src/lib/components/ui/BreadcrumbNavigation.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	interface Props {
+		items: { label: string; url: string }[];
+	}
+
+	const { items }: Props = $props();
+</script>
+
+<div class="flex gap-2 text-xs font-bold">
+	{#each items as item}
+		<a href={item.url} class="text-brand-primary no-underline">{item.label}</a><span>/</span>
+	{/each}
+</div>

--- a/src/frontend/src/tests/lib/components/ui/BreadcrumbNavigation.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/BreadcrumbNavigation.spec.ts
@@ -1,0 +1,68 @@
+import BreadcrumbNavigation from '$lib/components/ui/BreadcrumbNavigation.svelte';
+import { render, screen } from '@testing-library/svelte';
+
+const items = [
+	{ label: 'Home', url: '/' },
+	{ label: 'Collections', url: '/collections' },
+	{ label: 'Azuki', url: '/collections/azuki' }
+];
+
+describe('BreadcrumbNavigation', () => {
+	it('renders all items as links with correct labels and hrefs', () => {
+		render(BreadcrumbNavigation, { items });
+
+		const links = screen.getAllByRole('link');
+		expect(links).toHaveLength(items.length);
+
+		links.forEach((link, i) => {
+			expect(link).toHaveTextContent(items[i].label);
+			expect(link).toHaveAttribute('href', items[i].url);
+		});
+	});
+
+	it('preserves item order', () => {
+		render(BreadcrumbNavigation, { items });
+
+		const labelsInDom = screen.getAllByRole('link').map((a) => a.textContent);
+		expect(labelsInDom).toEqual(items.map((i) => i.label));
+	});
+
+	it('applies link styles', () => {
+		render(BreadcrumbNavigation, { items });
+		const links = screen.getAllByRole('link');
+
+		links.forEach((link) => {
+			expect(link).toHaveClass('text-brand-primary');
+			expect(link).toHaveClass('no-underline');
+		});
+	});
+
+	it('renders a separator after each item', () => {
+		const { container } = render(BreadcrumbNavigation, { items });
+
+		// Matches the <span>/</span> nodes
+		const separators = Array.from(container.querySelectorAll('span')).filter(
+			(el) => el.textContent === '/'
+		);
+		expect(separators).toHaveLength(items.length);
+	});
+
+	it('renders nothing when items is empty', () => {
+		const { container } = render(BreadcrumbNavigation, { items: [] });
+
+		expect(screen.queryAllByRole('link')).toHaveLength(0);
+
+		// no separators either
+		const seps = Array.from(container.querySelectorAll('span')).filter(
+			(el) => el.textContent === '/'
+		);
+		expect(seps).toHaveLength(0);
+	});
+
+	it('has expected wrapper styles', () => {
+		const { container } = render(BreadcrumbNavigation, { items });
+		const wrapper = container.firstElementChild as HTMLElement;
+
+		expect(wrapper).toHaveClass('flex', 'gap-2', 'text-xs', 'font-bold');
+	});
+});


### PR DESCRIPTION
# Motivation

We need a simple breadcrumb component for the upcoming NFT pages.

# Changes

Added component

# Tests

Added tests

<img width="222" height="62" alt="image" src="https://github.com/user-attachments/assets/e4d6a3cc-f382-46b3-9657-51c1b67405e4" />
