### PR TITLE
refactor(frontend): Token list settings uses bottom sheet

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensMenu.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 	import { Popover } from '@dfinity/gix-components';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
+	import List from '$lib/components/common/List.svelte';
+	import ListItem from '$lib/components/common/ListItem.svelte';
 	import IconHide from '$lib/components/icons/IconHide.svelte';
 	import IconManage from '$lib/components/icons/lucide/IconManage.svelte';
 	import TokensZeroBalanceToggle from '$lib/components/tokens/TokensZeroBalanceToggle.svelte';
+	import BottomSheet from '$lib/components/ui/BottomSheet.svelte';
+	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import NotificationBlob from '$lib/components/ui/NotificationBlob.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { hideZeroBalances } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -44,11 +49,11 @@
 	{/snippet}
 </ButtonIcon>
 
-<Popover bind:visible anchor={button} invisibleBackdrop direction="rtl">
+{#snippet content()}
 	<span class="mb-2 flex text-sm font-bold">{$i18n.tokens.manage.text.list_settings}</span>
-	<ul class="flex flex-col">
-		<li class="logo-button-list-item">
-			<LogoButton dividers onClick={toggleHideZeros}>
+	<List noPadding condensed>
+		<ListItem>
+			<LogoButton onClick={toggleHideZeros} fullWidth>
 				{#snippet logo()}
 					<IconHide />
 				{/snippet}
@@ -59,9 +64,9 @@
 					<TokensZeroBalanceToggle />
 				{/snippet}
 			</LogoButton>
-		</li>
-		<li class="logo-button-list-item">
-			<LogoButton dividers onClick={openManageTokens}>
+		</ListItem>
+		<ListItem>
+			<LogoButton onClick={openManageTokens} fullWidth>
 				{#snippet logo()}
 					<IconManage />
 				{/snippet}
@@ -69,6 +74,19 @@
 					<span class="text-sm font-normal">{$i18n.tokens.manage.text.title}</span>
 				{/snippet}
 			</LogoButton>
-		</li>
-	</ul>
-</Popover>
+		</ListItem>
+	</List>
+{/snippet}
+
+<Responsive up="sm">
+	<Popover bind:visible anchor={button} invisibleBackdrop direction="rtl">
+		{@render content()}
+	</Popover>
+</Responsive>
+<Responsive down="sm">
+	<BottomSheet {content} bind:visible>
+		{#snippet footer()}
+			<ButtonDone variant="secondary-light" onclick={() => (visible = false)} />
+		{/snippet}
+	</BottomSheet>
+</Responsive>


### PR DESCRIPTION
# Motivation

For the upcoming NFT pages we are going to use bottom sheets on mobile for the top right action menus. For consistency we also update the existing one on the token list page.

# Changes

- Added bottom sheet variant on small screens to render the conten instead of the popover
- Changed primitive list to our List component for styling consistency

# Tests

Desktop:
<img width="359" height="249" alt="image" src="https://github.com/user-attachments/assets/8af447dd-e5a7-49cc-95c2-b5264008b5c6" />

Small screens:
<img width="374" height="664" alt="image" src="https://github.com/user-attachments/assets/d7c013d8-6e41-49a3-b22e-0b55a34be3f8" />
