### PR TITLE
feat(frontend): ListItemButton

### DIFF
--- a/src/frontend/src/lib/components/common/ListItemButton.svelte
+++ b/src/frontend/src/lib/components/common/ListItemButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+	import IconCheck from '$lib/components/icons/IconCheck.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import type { Snippet } from 'svelte';
-	import IconCheck from '$lib/components/icons/IconCheck.svelte';
 
 	interface Props {
 		onclick: () => void;

--- a/src/frontend/src/lib/components/common/ListItemButton.svelte
+++ b/src/frontend/src/lib/components/common/ListItemButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import IconCheck from '$lib/components/icons/IconCheck.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import type { Snippet } from 'svelte';
 
 	interface Props {
 		onclick: () => void;

--- a/src/frontend/src/lib/components/common/ListItemButton.svelte
+++ b/src/frontend/src/lib/components/common/ListItemButton.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/Button.svelte';
+	import type { Snippet } from 'svelte';
+	import IconCheck from '$lib/components/icons/IconCheck.svelte';
+
+	interface Props {
+		onclick: () => void;
+		selectable?: boolean;
+		selected?: boolean;
+		children: Snippet;
+		testId?: string;
+	}
+
+	const { onclick, selectable, selected, children, testId }: Props = $props();
+</script>
+
+<Button
+	{onclick}
+	fullWidth
+	alignLeft
+	styleClass="py-3 rounded-md text-primary underline-none pl-0.5 min-w-28"
+	colorStyle="tertiary-alt"
+	transparent
+	{testId}
+>
+	{#if selectable}
+		<span class="pt-0.75 w-[20px] text-brand-primary">
+			{#if selected}
+				<IconCheck size="20" />
+			{/if}
+		</span>
+	{/if}
+	<span class="font-normal">{@render children()}</span>
+</Button>

--- a/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
@@ -46,7 +46,7 @@ describe('ListItemButton', () => {
 		});
 
 		const host = container.querySelector(`[data-tid="${testId}"]`);
-		expect(host.querySelector('svg')).not.toBeInTheDocument();
+		expect(host?.querySelector('svg')).not.toBeInTheDocument();
 	});
 
 	it('renders selectable wrapper but no icon when selected=false', () => {
@@ -60,9 +60,9 @@ describe('ListItemButton', () => {
 		});
 
 		const host = container.querySelector(`[data-tid="${testId}"]`);
-		const selectableSpan = host.querySelector('span.w-\\[20px\\]');
+		const selectableSpan = host?.querySelector('span.w-\\[20px\\]');
 		expect(selectableSpan).toBeInTheDocument();
-		expect(host.querySelector('svg')).not.toBeInTheDocument();
+		expect(host?.querySelector('svg')).not.toBeInTheDocument();
 	});
 
 	it('renders the check icon when selectable=true and selected=true', () => {
@@ -76,6 +76,6 @@ describe('ListItemButton', () => {
 		});
 
 		const host = container.querySelector(`[data-tid="${testId}"]`);
-		expect(host.querySelector('svg')).toBeInTheDocument();
+		expect(host?.querySelector('svg')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
@@ -1,0 +1,81 @@
+import ListItemButtonTest from '$tests/lib/components/common/ListItemButtonTest.svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+
+const LABEL = 'Choose me';
+
+describe('ListItemButton', () => {
+	it('renders the label via children snippet', () => {
+		const { getByRole } = render(ListItemButtonTest, {
+			onclick: vi.fn(),
+			children: LABEL
+		});
+
+		expect(getByRole('button', { name: LABEL })).toBeInTheDocument();
+	});
+
+	it('calls onclick when clicked', async () => {
+		const onClick = vi.fn();
+		const { getByRole } = render(ListItemButtonTest, {
+			onclick: onClick,
+			children: LABEL
+		});
+
+		await fireEvent.click(getByRole('button', { name: LABEL }));
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+
+	it('forwards testId to the underlying Button element', () => {
+		const testId = 'row-1';
+		const { container } = render(ListItemButtonTest, {
+			onclick: vi.fn(),
+			children: LABEL,
+			testId
+		});
+
+		// The base Button uses data-tid
+		const el = container.querySelector(`[data-tid="${testId}"]`);
+		expect(el).toBeInTheDocument();
+	});
+
+	it('does not render the check icon when selectable is not set', () => {
+		const testId = 'row-no-selectable';
+		const { container } = render(ListItemButtonTest, {
+			onclick: vi.fn(),
+			children: LABEL,
+			testId
+		});
+
+		const host = container.querySelector(`[data-tid="${testId}"]`)!;
+		expect(host.querySelector('svg')).not.toBeInTheDocument();
+	});
+
+	it('renders selectable wrapper but no icon when selected=false', () => {
+		const testId = 'row-unselected';
+		const { container } = render(ListItemButtonTest, {
+			onclick: vi.fn(),
+			children: LABEL,
+			selectable: true,
+			selected: false,
+			testId
+		});
+
+		const host = container.querySelector(`[data-tid="${testId}"]`)!;
+		const selectableSpan = host.querySelector('span.w-\\[20px\\]');
+		expect(selectableSpan).toBeInTheDocument();
+		expect(host.querySelector('svg')).not.toBeInTheDocument();
+	});
+
+	it('renders the check icon when selectable=true and selected=true', () => {
+		const testId = 'row-selected';
+		const { container } = render(ListItemButtonTest, {
+			onclick: vi.fn(),
+			children: LABEL,
+			selectable: true,
+			selected: true,
+			testId
+		});
+
+		const host = container.querySelector(`[data-tid="${testId}"]`)!;
+		expect(host.querySelector('svg')).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
@@ -45,7 +45,7 @@ describe('ListItemButton', () => {
 			testId
 		});
 
-		const host = container.querySelector(`[data-tid="${testId}"]`)!;
+		const host = container.querySelector(`[data-tid="${testId}"]`);
 		expect(host.querySelector('svg')).not.toBeInTheDocument();
 	});
 
@@ -59,7 +59,7 @@ describe('ListItemButton', () => {
 			testId
 		});
 
-		const host = container.querySelector(`[data-tid="${testId}"]`)!;
+		const host = container.querySelector(`[data-tid="${testId}"]`);
 		const selectableSpan = host.querySelector('span.w-\\[20px\\]');
 		expect(selectableSpan).toBeInTheDocument();
 		expect(host.querySelector('svg')).not.toBeInTheDocument();
@@ -75,7 +75,7 @@ describe('ListItemButton', () => {
 			testId
 		});
 
-		const host = container.querySelector(`[data-tid="${testId}"]`)!;
+		const host = container.querySelector(`[data-tid="${testId}"]`);
 		expect(host.querySelector('svg')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/ListItemButton.spec.ts
@@ -21,7 +21,8 @@ describe('ListItemButton', () => {
 		});
 
 		await fireEvent.click(getByRole('button', { name: LABEL }));
-		expect(onClick).toHaveBeenCalledTimes(1);
+
+		expect(onClick).toHaveBeenCalledOnce();
 	});
 
 	it('forwards testId to the underlying Button element', () => {
@@ -34,6 +35,7 @@ describe('ListItemButton', () => {
 
 		// The base Button uses data-tid
 		const el = container.querySelector(`[data-tid="${testId}"]`);
+
 		expect(el).toBeInTheDocument();
 	});
 
@@ -46,6 +48,7 @@ describe('ListItemButton', () => {
 		});
 
 		const host = container.querySelector(`[data-tid="${testId}"]`);
+
 		expect(host?.querySelector('svg')).not.toBeInTheDocument();
 	});
 
@@ -61,7 +64,9 @@ describe('ListItemButton', () => {
 
 		const host = container.querySelector(`[data-tid="${testId}"]`);
 		const selectableSpan = host?.querySelector('span.w-\\[20px\\]');
+
 		expect(selectableSpan).toBeInTheDocument();
+
 		expect(host?.querySelector('svg')).not.toBeInTheDocument();
 	});
 
@@ -76,6 +81,7 @@ describe('ListItemButton', () => {
 		});
 
 		const host = container.querySelector(`[data-tid="${testId}"]`);
+
 		expect(host?.querySelector('svg')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/common/ListItemButtonTest.svelte
+++ b/src/frontend/src/tests/lib/components/common/ListItemButtonTest.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import ListItemButton from '$lib/components/common/ListItemButton.svelte';
+
+	interface Props {
+		children: string;
+		onclick: () => void;
+		selected?: boolean;
+		selectable?: boolean;
+		testId?: string;
+	}
+
+	const { children: label, ...props }: Props = $props();
+</script>
+
+<ListItemButton {...props}>
+	{#snippet children()}
+		{label}
+	{/snippet}
+</ListItemButton>

--- a/src/frontend/src/tests/lib/components/common/ListItemButtonTest.svelte
+++ b/src/frontend/src/tests/lib/components/common/ListItemButtonTest.svelte
@@ -13,9 +13,5 @@
 </script>
 
 <ListItemButton {...props}>
-	{#snippet children()}
-		<span>
-			{label}
-		</span>
-	{/snippet}
+	{label}
 </ListItemButton>

--- a/src/frontend/src/tests/lib/components/common/ListItemButtonTest.svelte
+++ b/src/frontend/src/tests/lib/components/common/ListItemButtonTest.svelte
@@ -14,6 +14,8 @@
 
 <ListItemButton {...props}>
 	{#snippet children()}
-		{label}
+		<span>
+			{label}
+		</span>
 	{/snippet}
 </ListItemButton>


### PR DESCRIPTION
# Motivation

We make a shared component for ListItems that render a button, as it will be used in multiple Popover menus on the assets page.

# Changes

- Added component

# Tests

Added tests
