### PR TITLE
feat(frontend): extract AddressBook modal configuration

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { WizardModal, type WizardStep } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onDestroy, onMount } from 'svelte';
 	import type { ContactImage } from '$declarations/backend/backend.did';
@@ -18,6 +18,7 @@
 	import ShowContactStep from '$lib/components/address-book/ShowContactStep.svelte';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
+	import { AddressBookWizardSteps } from '$lib/config/addressbook-modalsteps.config';
 	import {
 		TRACK_CONTACT_CREATE_ERROR,
 		TRACK_CONTACT_CREATE_SUCCESS,
@@ -103,53 +104,7 @@
 		)
 	);
 
-	const steps: WizardSteps<AddressBookSteps> = [
-		{
-			name: AddressBookSteps.ADDRESS_BOOK,
-			title: $i18n.address_book.text.title
-		},
-		{
-			name: AddressBookSteps.SAVE_ADDRESS,
-			title: $i18n.address.save.title
-		},
-		{
-			name: AddressBookSteps.CREATE_CONTACT,
-			title: $i18n.address_book.create_contact.title
-		},
-		{
-			name: AddressBookSteps.SHOW_CONTACT,
-			title: $i18n.address_book.show_contact.title
-		},
-		{
-			name: AddressBookSteps.EDIT_CONTACT,
-			title: $i18n.address_book.edit_contact.title
-		},
-		{
-			name: AddressBookSteps.EDIT_CONTACT_NAME,
-			title: $i18n.contact.form.add_new_contact
-		},
-		{
-			name: AddressBookSteps.DELETE_CONTACT,
-			title: $i18n.contact.delete.title
-		},
-		{
-			name: AddressBookSteps.SHOW_ADDRESS,
-			// The title will be replaced with the name. No title is needed here.
-			title: ''
-		},
-		{
-			name: AddressBookSteps.EDIT_ADDRESS,
-			title: $i18n.address_book.edit_contact.title
-		},
-		{
-			name: AddressBookSteps.QR_CODE_SCAN,
-			title: $i18n.address.qr.title
-		},
-		{
-			name: AddressBookSteps.DELETE_ADDRESS,
-			title: $i18n.address.delete.title
-		}
-	];
+	const steps = $derived(AddressBookWizardSteps({ i18n: $i18n }));
 
 	let currentStep: WizardStep<AddressBookSteps> | undefined = $state();
 

--- a/src/frontend/src/lib/config/addressbook-modalsteps.config.ts
+++ b/src/frontend/src/lib/config/addressbook-modalsteps.config.ts
@@ -1,0 +1,53 @@
+import { AddressBookSteps } from '$lib/enums/progress-steps';
+import type { WizardStepsParams } from '$lib/types/steps';
+import type { WizardSteps } from '@dfinity/gix-components';
+
+export const AddressBookWizardSteps = ({
+	i18n
+}: WizardStepsParams): WizardSteps<AddressBookSteps> => [
+	{
+		name: AddressBookSteps.ADDRESS_BOOK,
+		title: i18n.address_book.text.title
+	},
+	{
+		name: AddressBookSteps.SAVE_ADDRESS,
+		title: i18n.address.save.title
+	},
+	{
+		name: AddressBookSteps.CREATE_CONTACT,
+		title: i18n.address_book.create_contact.title
+	},
+	{
+		name: AddressBookSteps.SHOW_CONTACT,
+		title: i18n.address_book.show_contact.title
+	},
+	{
+		name: AddressBookSteps.EDIT_CONTACT,
+		title: i18n.address_book.edit_contact.title
+	},
+	{
+		name: AddressBookSteps.EDIT_CONTACT_NAME,
+		title: i18n.contact.form.add_new_contact
+	},
+	{
+		name: AddressBookSteps.DELETE_CONTACT,
+		title: i18n.contact.delete.title
+	},
+	{
+		name: AddressBookSteps.SHOW_ADDRESS,
+		// The title will be replaced with the name. No title is needed here.
+		title: ''
+	},
+	{
+		name: AddressBookSteps.EDIT_ADDRESS,
+		title: i18n.address_book.edit_contact.title
+	},
+	{
+		name: AddressBookSteps.QR_CODE_SCAN,
+		title: i18n.address.qr.title
+	},
+	{
+		name: AddressBookSteps.DELETE_ADDRESS,
+		title: i18n.address.delete.title
+	}
+];


### PR DESCRIPTION
# Motivation
To improve maintainability and readability of the AddressBook modal by moving its configuration into a separate module, reducing complexity inside the modal component.

# Changes
Extracted AddressBook modal configuration into its own file.
Updated steps initialization to use the new configuration.
Removed redundant inline configuration code from the modal component.

# Tests
Verified that the modal still opens and functions as expected.
Checked navigation through modal steps.