### PR TITLE
feat(frontend): added new gradient border to token input component

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputNetworkWrapper.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputNetworkWrapper.svelte
@@ -2,7 +2,6 @@
 	import type { Snippet } from 'svelte';
 	import { isNetworkIdETH } from '$icp/utils/ic-send.utils';
 	import type { NetworkId } from '$lib/types/network';
-	
 	import {
 		isNetworkIdArbitrum,
 		isNetworkIdBase,
@@ -10,13 +9,13 @@
 		isNetworkIdICP,
 		isNetworkIdPolygon
 	} from '$lib/utils/network.utils';
-	
+
 	interface Props {
 		tokenNetworkId?: NetworkId;
 		tokenInput: Snippet;
 		showGradient: boolean;
 	}
-	
+
 	let { tokenNetworkId, tokenInput, showGradient }: Props = $props();
 </script>
 


### PR DESCRIPTION
# Motivation

For cross chain swaps, we need to display a gradient border that corresponds to the token’s network.

# Changes

Introduced a new component that applies a network-specific gradient border wrapper around the token, based on the selected network.

# Tests

<img width="488" height="345" alt="image" src="https://github.com/user-attachments/assets/3214bbfc-9748-48bf-86cf-0b4611ce23aa" />
