### PR TITLE
feat(frontend): Load SPL custom tokens with query and update

### DIFF
--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -60,8 +60,7 @@ export const loadCustomTokens = ({
 				err
 			});
 		},
-		identity,
-		strategy: 'query'
+		identity
 	});
 
 const loadSplCustomTokens = async (params: LoadCustomTokenParams): Promise<CustomToken[]> =>


### PR DESCRIPTION
# Motivation

It does not make sense the only SPL tokens are being loaded with query. We should use the default strategy that is both query and update, like the other custom tokens.