### PR TITLE
fix(frontend): Use mapper for IC errors during saving of custom tokens

### DIFF
--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -17,6 +17,7 @@ import type { OptionIdentity } from '$lib/types/identity';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { NonEmptyArray } from '$lib/types/utils';
+import { mapIcErrorMetadata } from '$lib/utils/error.utils';
 import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 import type { Identity } from '@dfinity/agent';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -119,9 +120,7 @@ export const saveTokens = async <
 
 		trackEvent({
 			name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
-			metadata: {
-				error: `${err}`
-			}
+			metadata: mapIcErrorMetadata(err)
 		});
 	}
 };

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -134,5 +134,34 @@ describe('manage-tokens.services', () => {
 				metadata: { error: 'Save failed' }
 			});
 		});
+
+		it('should map IC errors for the event tracking', async () => {
+			mockSave.mockRejectedValueOnce(
+				new Error(
+					'AgentError: Call failed:\n' +
+						'  Canister: doked-biaaa-aaaar-qag2a-cai\n' +
+						'  Method: set_many_custom_tokens (update)\n' +
+						'  "Request ID": "25cb1e3181d25a6e05ad2feefc2fb0c10a2e3dae56477edc23ea31eb2f367838"\n' +
+						'  "Error code": "IC0503"\n' +
+						'  "Reject code": "5"\n' +
+						'  "Reject message": "Error from Canister doked-biaaa-aaaar-qag2a-cai: Canister called `ic0.trap` with message: \'Version mismatch, token update not allowed\'.\n' +
+						'Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly"\n'
+				)
+			);
+
+			await saveTokens(params);
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
+				metadata: {
+					Canister: 'doked-biaaa-aaaar-qag2a-cai',
+					'Error code': 'IC0503',
+					Method: 'set_many_custom_tokens (update)',
+					'Reject code': '5',
+					'Reject message':
+						"Error from Canister doked-biaaa-aaaar-qag2a-cai: Canister called `ic0.trap` with message: 'Version mismatch, token update not allowed'."
+				}
+			});
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -129,10 +129,9 @@ describe('manage-tokens.services', () => {
 			});
 			expect(mockOnError).toHaveBeenCalledOnce();
 
-			expect(trackEvent).toHaveBeenCalledOnce();
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
-				metadata: { error: 'Error: Save failed' }
+				metadata: { error: 'Save failed' }
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

To have an easier analysis of the errors, we use the mapper for the IC errors when saving custom tokens.
