### PR TITLE
chore(frontend): Enable French language support

### DIFF
--- a/src/frontend/src/env/i18n.ts
+++ b/src/frontend/src/env/i18n.ts
@@ -6,6 +6,7 @@ export const SUPPORTED_LANGUAGES = Object.entries(Languages);
 export const LANGUAGES = {
 	[Languages.ENGLISH]: 'English',
 	[Languages.CZECH]: 'Čeština',
+	[Languages.FRENCH]: 'Français',
 	[Languages.GERMAN]: 'Deutsch',
 	[Languages.ITALIAN]: 'Italiano',
 	[Languages.PORTUGUESE]: 'Português',

--- a/src/frontend/src/lib/enums/languages.ts
+++ b/src/frontend/src/lib/enums/languages.ts
@@ -2,6 +2,7 @@ export enum Languages {
 	ENGLISH = 'en',
 	CZECH = 'cs',
 	GERMAN = 'de',
+	FRENCH = 'fr',
 	ITALIAN = 'it',
 	PORTUGUESE = 'pt',
 	VIETNAMESE = 'vi',

--- a/src/frontend/src/lib/stores/i18n.store.ts
+++ b/src/frontend/src/lib/stores/i18n.store.ts
@@ -4,6 +4,7 @@ import { Languages } from '$lib/enums/languages';
 import cs from '$lib/i18n/cs.json';
 import de from '$lib/i18n/de.json';
 import en from '$lib/i18n/en.json';
+import fr from '$lib/i18n/fr.json';
 import it from '$lib/i18n/it.json';
 import pt from '$lib/i18n/pt.json';
 import vi from '$lib/i18n/vi.json';
@@ -26,6 +27,11 @@ const csI18n = (): I18n => ({
 const deI18n = (): I18n => ({
 	...mergeWithFallback({ refLang: enI18n(), targetLang: de as I18n }),
 	lang: Languages.GERMAN
+});
+
+const frI18n = (): I18n => ({
+	...mergeWithFallback({ refLang: enI18n(), targetLang: fr as I18n }),
+	lang: Languages.FRENCH
 });
 
 const itI18n = (): I18n => ({
@@ -54,6 +60,8 @@ const loadLang = (lang: Languages): I18n => {
 			return zhcnI18n();
 		case Languages.CZECH:
 			return csI18n();
+		case Languages.FRENCH:
+			return frI18n();
 		case Languages.GERMAN:
 			return deI18n();
 		case Languages.ITALIAN:

--- a/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
@@ -201,7 +201,7 @@ describe('i18n-utils', () => {
 		};
 
 		it('returns ENGLISH when language is unsupported', () => {
-			mockNavigatorLanguage('fr-FR');
+			mockNavigatorLanguage('la-VA');
 
 			expect(getDefaultLang()).toBe(Languages.ENGLISH);
 		});


### PR DESCRIPTION
# Motivation

Supporting more languages

# Changes
- enable French

# Tests
- adjusted the i18n test to not use `fr-FR` locale as example for a "not supported" language anymore, and use `la-VA` instead (eheh)