### PR TITLE
feat(backend)!: Add image source flag to `ErcToken` structure

### DIFF
--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -57,6 +57,7 @@ static ERC20_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
     token: Token::Erc20(ErcToken {
         token_address: ERC20_TOKEN_ID.clone(),
         chain_id: ERC20_CHAIN_ID.clone(),
+        allow_img_source: None,
     }),
     enabled: true,
     version: None,
@@ -68,6 +69,7 @@ static ERC721_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
     token: Token::Erc721(ErcToken {
         token_address: ERC721_TOKEN_ID.clone(),
         chain_id: ERC721_CHAIN_ID.clone(),
+        allow_img_source: Some(true),
     }),
     enabled: true,
     version: None,
@@ -79,6 +81,7 @@ static ERC1155_TOKEN: LazyLock<CustomToken> = LazyLock::new(|| CustomToken {
     token: Token::Erc1155(ErcToken {
         token_address: ERC1155_TOKEN_ID.clone(),
         chain_id: ERC1155_CHAIN_ID.clone(),
+        allow_img_source: Some(false),
     }),
     enabled: true,
     version: None,

--- a/src/shared/src/types/custom_token.rs
+++ b/src/shared/src/types/custom_token.rs
@@ -45,6 +45,7 @@ pub type ChainId = u64;
 pub struct ErcToken {
     pub token_address: ErcTokenId,
     pub chain_id: ChainId,
+    pub allow_img_source: Option<bool>,
 }
 
 /// A variant describing any token

--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -259,7 +259,8 @@ mod custom_token {
                         token_address: ErcTokenId(
                             "0x1234567890123456789012345678901234567890".to_string()
                         ),
-                        chain_id: 1
+                        chain_id: 1,
+                        allow_img_source: None,
                     },
                     valid: true,
                     description: "Valid Erc20Token",
@@ -270,6 +271,7 @@ mod custom_token {
                             "0x12345678901234567890123456789012345678".to_string()
                         ),
                         chain_id: 1,
+                        allow_img_source: None
                     },
                     valid: false,
                     description: "Erc20Token with a token address that is too short",
@@ -278,6 +280,7 @@ mod custom_token {
                     input: ErcToken {
                         token_address: ErcTokenId("1".repeat(99)),
                         chain_id: 1,
+                                               allow_img_source: None
                     },
                     valid: false,
                     description: "Erc20Token with a token address that is too long",
@@ -288,6 +291,7 @@ mod custom_token {
                             "0x1234567890123456789012345678901234567890".to_string()
                         ),
                         chain_id: 2 ^ 64 - 1,
+                                               allow_img_source: None
                     },
                     valid: true,
                     description: "Maximum chain ID",
@@ -298,9 +302,32 @@ mod custom_token {
                             "0x1234567890123456789012345678901234567890".to_string()
                         ),
                         chain_id: 0,
+                                               allow_img_source: None
                     },
                     valid: true,
                     description: "Minimum chain ID",
+                },
+                                TestVector {
+                    input: ErcToken {
+                        token_address: ErcTokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
+                        chain_id: 0,
+                                               allow_img_source: Some(true)
+                    },
+                    valid: true,
+                    description: "Erc20Token with allow_img_source set to true",
+                },
+                                TestVector {
+                    input: ErcToken {
+                        token_address: ErcTokenId(
+                            "0x1234567890123456789012345678901234567890".to_string()
+                        ),
+                        chain_id: 0,
+                                               allow_img_source: Some(false)
+                    },
+                    valid: true,
+                    description: "Erc20Token with allow_img_source set to false",
                 },
             ]
         );


### PR DESCRIPTION
# Motivation

We want to allow the user to choose to trust the source of images of a specific token, being it either for NFT images or icon/logo. So we add an optional flag to the `ErcToken` structure representing 3 states: not yet decided (`null`), allowed (`true`), not allowed (`false`).

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
