### PR TITLE
chore(backend): Fix lint warning in documentation

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -491,7 +491,7 @@ service : (Arg) -> {
 	// # Returns
 	// * `Ok(GetContactResult)` - The requested contact if found
 	// # Errors
-	// * `ContactNotFound` - If no contact for the proivided contact_id could be found
+	// * `ContactNotFound` - If no contact for the provided `contact_id` could be found
 	get_contact : (nat64) -> (GetContactResult) query;
 	// Returns all contacts for the caller
 	//

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -959,7 +959,7 @@ pub fn delete_contact(contact_id: u64) -> DeleteContactResult {
 /// # Returns
 /// * `Ok(GetContactResult)` - The requested contact if found
 /// # Errors
-/// * `ContactNotFound` - If no contact for the proivided contact_id could be found
+/// * `ContactNotFound` - If no contact for the provided `contact_id` could be found
 #[query(guard = "caller_is_not_anonymous")]
 #[must_use]
 pub fn get_contact(contact_id: u64) -> GetContactResult {

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -491,7 +491,7 @@ service : (Arg) -> {
 	// # Returns
 	// * `Ok(GetContactResult)` - The requested contact if found
 	// # Errors
-	// * `ContactNotFound` - If no contact for the proivided contact_id could be found
+	// * `ContactNotFound` - If no contact for the provided `contact_id` could be found
 	get_contact : (nat64) -> (GetContactResult) query;
 	// Returns all contacts for the caller
 	//


### PR DESCRIPTION
# Motivation

With the new version of rust (PR https://github.com/dfinity/oisy-wallet/pull/8180), we have a lint warning in the documentation:

```
error: item in documentation is missing backticks
   --> src/backend/src/lib.rs:962:59
    |
962 | /// * `ContactNotFound` - If no contact for the proivided contact_id could be found
    |                                                           ^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
    = note: `-D clippy::doc-markdown` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::doc_markdown)]`
help: try
    |
962 - /// * `ContactNotFound` - If no contact for the proivided contact_id could be found
962 + /// * `ContactNotFound` - If no contact for the proivided `contact_id` could be found
    |
```


We fix it here, since the bot is not allowed to change such files.