### PR TITLE
feat(frontend): Post index canister data to ICP wallet worker

### DIFF
--- a/src/frontend/src/icp/api/icp-index.api.ts
+++ b/src/frontend/src/icp/api/icp-index.api.ts
@@ -1,4 +1,4 @@
-import { ICP_INDEX_CANISTER_ID } from '$env/networks/networks.icp.env';
+import type { IndexCanisterIdText } from '$icp/types/canister';
 import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
 import { getAgent } from '$lib/actors/agents.ic';
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
@@ -12,12 +12,14 @@ export const getTransactions = async ({
 	identity,
 	start,
 	maxResults = WALLET_PAGINATION,
+	indexCanisterId,
 	certified = true
 }: {
 	owner: Principal;
 	identity: OptionIdentity;
 	start?: bigint;
 	maxResults?: bigint;
+	indexCanisterId: IndexCanisterIdText;
 } & QueryParams): Promise<GetAccountIdentifierTransactionsResponse> => {
 	assertNonNullish(identity);
 
@@ -25,7 +27,7 @@ export const getTransactions = async ({
 
 	const { getTransactions } = IndexCanister.create({
 		agent,
-		canisterId: Principal.fromText(ICP_INDEX_CANISTER_ID)
+		canisterId: Principal.fromText(indexCanisterId)
 	});
 
 	return getTransactions({

--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -42,6 +42,7 @@ const getTransactions = async ({
 	}
 
 	const { transactions } = await getTransactionsIcp({
+		indexCanisterId,
 		...rest
 	});
 	return transactions.flatMap(mapTransactionIcpToSelf);

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -1,4 +1,4 @@
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_INDEX_CANISTER_ID, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
 import { syncWallet, syncWalletFromCache } from '$icp/services/ic-listener.services';
 import {
@@ -8,6 +8,7 @@ import {
 import type { WalletWorker } from '$lib/types/listener';
 import type {
 	PostMessage,
+	PostMessageDataRequestIcp,
 	PostMessageDataResponseError,
 	PostMessageDataResponseWallet,
 	PostMessageDataResponseWalletCleanUp
@@ -63,14 +64,16 @@ export const initIcpWalletWorker = async (): Promise<WalletWorker> => {
 	return {
 		start: () => {
 			worker?.postMessage({
-				msg: 'startIcpWalletTimer'
-			});
+				msg: 'startIcpWalletTimer',
+				data: { indexCanisterId: ICP_INDEX_CANISTER_ID }
+			} as PostMessage<PostMessageDataRequestIcp>);
 		},
 		stop,
 		trigger: () => {
 			worker?.postMessage({
-				msg: 'triggerIcpWalletTimer'
-			});
+				msg: 'triggerIcpWalletTimer',
+				data: { indexCanisterId: ICP_INDEX_CANISTER_ID }
+			} as PostMessage<PostMessageDataRequestIcp>);
 		},
 		destroy: () => {
 			if (isDestroying) {

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -10,19 +10,24 @@ import type {
 	Transaction,
 	TransactionWithId
 } from '@dfinity/ledger-icp';
-import { isNullish } from '@dfinity/utils';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
 
 const getBalanceAndTransactions = ({
 	identity,
-	certified
-}: SchedulerJobParams<PostMessageDataRequestIcp>): Promise<GetAccountIdentifierTransactionsResponse> =>
-	getTransactions({
+	certified,
+	data
+}: SchedulerJobParams<PostMessageDataRequestIcp>): Promise<GetAccountIdentifierTransactionsResponse> => {
+	assertNonNullish(data, 'No data - indexCanisterId - provided to fetch transactions.');
+
+	return getTransactions({
 		identity,
 		certified,
 		owner: identity.getPrincipal(),
 		// We query tip to discover the new transactions
-		start: undefined
+		start: undefined,
+		...data
 	});
+};
 
 const mapTransaction = ({
 	transaction,

--- a/src/frontend/src/tests/icp/services/ic-transactions.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-transactions.services.spec.ts
@@ -68,8 +68,7 @@ describe('ic-transactions.services', () => {
 			const mockError = new Error('Test error, Request ID: 423, status: rejected');
 			onLoadTransactionsError({ tokenId, error: mockError });
 
-			expect(spyAnalytics).toHaveBeenCalledOnce();
-			expect(spyAnalytics).toHaveBeenNthCalledWith(1, {
+			expect(spyAnalytics).toHaveBeenCalledExactlyOnceWith({
 				name: TRACK_COUNT_IC_LOADING_TRANSACTIONS_ERROR,
 				metadata: {
 					tokenId: tokenId.description,
@@ -81,9 +80,7 @@ describe('ic-transactions.services', () => {
 		it('should log error to console', () => {
 			onLoadTransactionsError({ tokenId, error: mockError });
 
-			expect(console.warn).toHaveBeenCalledOnce();
-			expect(console.warn).toHaveBeenNthCalledWith(
-				1,
+			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
 				`${get(i18n).transactions.error.loading_transactions}:`,
 				mockError
 			);
@@ -251,6 +248,7 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -258,6 +256,7 @@ describe('ic-transactions.services', () => {
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -293,12 +292,14 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
 				maxResults: WALLET_PAGINATION,
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
 				maxResults: WALLET_PAGINATION,
@@ -311,6 +312,7 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -318,6 +320,7 @@ describe('ic-transactions.services', () => {
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -440,6 +443,7 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -447,6 +451,7 @@ describe('ic-transactions.services', () => {
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -468,6 +473,7 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(lastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -475,6 +481,7 @@ describe('ic-transactions.services', () => {
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(lastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -490,6 +497,7 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -497,6 +505,7 @@ describe('ic-transactions.services', () => {
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -512,6 +521,7 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).toHaveBeenCalledTimes(2);
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(1, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,
@@ -519,6 +529,7 @@ describe('ic-transactions.services', () => {
 				certified: false
 			});
 			expect(getTransactionsIcp).toHaveBeenNthCalledWith(2, {
+				indexCanisterId: mockToken.indexCanisterId,
 				start: BigInt(mockLastId),
 				owner: mockIdentity.getPrincipal(),
 				identity: mockIdentity,


### PR DESCRIPTION
# Motivation

We are going to onboard more tokens with standard `icp` (as defined in the the codebase). That means that we need to generalize all the services and workers for this type of standard, since right now they are "hard-coded" to be used only by ICP token.

Following up PR https://github.com/dfinity/oisy-wallet/pull/8316, we are starting to pass the index canister data through postMessage to the ICP wallet worker.

# Changes

- Pass index canister ID in the message when posting to the ICP wallet worker.
- Adapt function getTransactions to accept the index canister ID.
- Since for now, we still do not generalize for any icp-standard token, we hard-code it for ICP token index canister.

# Tests

Current tests are sufficient, once adapted.