### PR TITLE
feat(frontend): Generalize ICP wallet workers for any token

### DIFF
--- a/src/frontend/src/icp/utils/wallet.utils.ts
+++ b/src/frontend/src/icp/utils/wallet.utils.ts
@@ -1,12 +1,13 @@
 import { initDip20WalletWorker } from '$icp/services/worker.dip20-wallet.services';
 import { initIcpWalletWorker } from '$icp/services/worker.icp-wallet.services';
 import { initIcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
+import type { IcToken } from '$icp/types/ic-token';
 import { isTokenDip20, isTokenIcrc } from '$icp/utils/icrc.utils';
 import type { InitWalletWorkerFn } from '$lib/types/listener';
 
-export const initWalletWorker: InitWalletWorkerFn = ({ token }) =>
+export const initWalletWorker: InitWalletWorkerFn<IcToken> = ({ token }) =>
 	isTokenIcrc(token)
 		? initIcrcWalletWorker(token)
 		: isTokenDip20(token)
 			? initDip20WalletWorker(token)
-			: initIcpWalletWorker();
+			: initIcpWalletWorker(token);

--- a/src/frontend/src/tests/icp/utils/wallet.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/wallet.utils.spec.ts
@@ -31,8 +31,7 @@ describe('wallet.utils', () => {
 
 			initWalletWorker({ token });
 
-			expect(initIcrcWalletWorker).toHaveBeenCalledOnce();
-			expect(initIcrcWalletWorker).toHaveBeenNthCalledWith(1, token);
+			expect(initIcrcWalletWorker).toHaveBeenCalledExactlyOnceWith(token);
 		});
 
 		it('should initialize the worker for DIP-20 tokens', () => {
@@ -43,8 +42,7 @@ describe('wallet.utils', () => {
 
 			initWalletWorker({ token });
 
-			expect(initDip20WalletWorker).toHaveBeenCalledOnce();
-			expect(initDip20WalletWorker).toHaveBeenNthCalledWith(1, token);
+			expect(initDip20WalletWorker).toHaveBeenCalledExactlyOnceWith(token);
 		});
 
 		it('should initialize the worker for ICP token', () => {
@@ -55,11 +53,12 @@ describe('wallet.utils', () => {
 
 			initWalletWorker({ token });
 
-			expect(initIcpWalletWorker).toHaveBeenCalledOnce();
+			expect(initIcpWalletWorker).toHaveBeenCalledExactlyOnceWith(token);
 
 			initWalletWorker({ token: ICP_TOKEN });
 
 			expect(initIcpWalletWorker).toHaveBeenCalledTimes(2);
+			expect(initIcpWalletWorker).toHaveBeenNthCalledWith(2, ICP_TOKEN);
 		});
 
 		it('should call initIcpWalletWorker for all other cases', () => {


### PR DESCRIPTION
# Motivation

We are going to onboard more tokens with standard `icp` (as defined in the the codebase). That means that we need to generalize all the services and workers for this type of standard, since right now they are "hard-coded" to be used only by ICP token.

In this PR, we generalize the input data for the ICP wallet worker.

# Changes

- Worker initializer now accepts a token as input (similar to the other IC workers).
- Remove hard-coded ICP token data.
- Adapt generic IC wallet worker initializer to accept `token` as input.

# Tests

Adapted tests.
