### PR TITLE
feat(frontend): Generalize transfer methods for ICP-standard tokens

### DIFF
--- a/src/frontend/src/icp/api/icp-ledger.api.ts
+++ b/src/frontend/src/icp/api/icp-ledger.api.ts
@@ -1,6 +1,6 @@
-import { ICP_LEDGER_CANISTER_ID } from '$env/networks/networks.icp.env';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 import { getAgent } from '$lib/actors/agents.ic';
+import type { CanisterIdText } from '$lib/types/canister';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
 import { AccountIdentifier, LedgerCanister, type BlockHeight } from '@dfinity/ledger-icp';
@@ -11,15 +11,17 @@ import { assertNonNullish, toNullable } from '@dfinity/utils';
 export const transfer = async ({
 	identity,
 	to,
-	amount
+	amount,
+	ledgerCanisterId
 }: {
 	identity: OptionIdentity;
 	to: string;
 	amount: bigint;
+	ledgerCanisterId: CanisterIdText;
 }): Promise<BlockHeight> => {
 	assertNonNullish(identity);
 
-	const { transfer } = await ledgerCanister(identity);
+	const { transfer } = await ledgerCanister({ identity, ledgerCanisterId });
 
 	return transfer({
 		to: AccountIdentifier.fromHex(to),
@@ -31,16 +33,18 @@ export const icrc1Transfer = async ({
 	identity,
 	to,
 	amount,
-	createdAt
+	createdAt,
+	ledgerCanisterId
 }: {
 	identity: OptionIdentity;
 	to: IcrcAccount;
 	amount: bigint;
 	createdAt?: bigint;
+	ledgerCanisterId: CanisterIdText;
 }): Promise<BlockHeight> => {
 	assertNonNullish(identity);
 
-	const { icrc1Transfer } = await ledgerCanister(identity);
+	const { icrc1Transfer } = await ledgerCanister({ identity, ledgerCanisterId });
 
 	return icrc1Transfer({
 		to: {
@@ -52,11 +56,17 @@ export const icrc1Transfer = async ({
 	});
 };
 
-const ledgerCanister = async (identity: Identity): Promise<LedgerCanister> => {
+const ledgerCanister = async ({
+	identity,
+	ledgerCanisterId
+}: {
+	identity: Identity;
+	ledgerCanisterId: CanisterIdText;
+}): Promise<LedgerCanister> => {
 	const agent = await getAgent({ identity });
 
 	return LedgerCanister.create({
 		agent,
-		canisterId: Principal.fromText(ICP_LEDGER_CANISTER_ID)
+		canisterId: Principal.fromText(ledgerCanisterId)
 	});
 };

--- a/src/frontend/src/icp/services/ic-send.services.ts
+++ b/src/frontend/src/icp/services/ic-send.services.ts
@@ -13,14 +13,13 @@ import {
 	convertCkETHToEth,
 	convertCkErc20ToErc20
 } from '$icp/services/ck.services';
-import type { IcTransferParams } from '$icp/types/ic-send';
+import type { IcSendParams, IcTransferParams } from '$icp/types/ic-send';
 import type { IcToken } from '$icp/types/ic-token';
 import { invalidIcrcAddress } from '$icp/utils/icrc-account.utils';
 import { isTokenDip20, isTokenIcrc } from '$icp/utils/icrc.utils';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NetworkId } from '$lib/types/network';
-import type { PartialSpecific } from '$lib/types/utils';
 import { invalidIcpAddress } from '$lib/utils/account.utils';
 import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
@@ -101,7 +100,8 @@ const send = async ({
 	}
 
 	await sendIcp({
-		...rest
+		...rest,
+		ledgerCanisterId
 	});
 };
 
@@ -111,8 +111,7 @@ export const sendIcrc = ({
 	identity,
 	ledgerCanisterId,
 	progress
-}: PartialSpecific<IcTransferParams, 'progress'> &
-	Pick<IcToken, 'ledgerCanisterId'>): Promise<IcrcBlockIndex> => {
+}: IcSendParams): Promise<IcrcBlockIndex> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 
 	// UI validates addresses and disable form if not compliant. Therefore, this issue should unlikely happen.
@@ -134,8 +133,9 @@ export const sendIcp = ({
 	to,
 	amount,
 	identity,
+	ledgerCanisterId,
 	progress
-}: PartialSpecific<IcTransferParams, 'progress'>): Promise<BlockHeight> => {
+}: IcSendParams): Promise<BlockHeight> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 	const validIcpAddress = !invalidIcpAddress(to);
 
@@ -149,11 +149,13 @@ export const sendIcp = ({
 	return validIcrcAddress
 		? icrc1TransferIcp({
 				identity,
+				ledgerCanisterId,
 				to: decodeIcrcAccount(to),
 				amount
 			})
 		: transferIcp({
 				identity,
+				ledgerCanisterId,
 				to,
 				amount
 			});
@@ -165,8 +167,7 @@ export const sendDip20 = ({
 	identity,
 	ledgerCanisterId,
 	progress
-}: PartialSpecific<IcTransferParams, 'progress'> &
-	Pick<IcToken, 'ledgerCanisterId'>): Promise<bigint> => {
+}: IcSendParams): Promise<bigint> => {
 	const validIcrcAddress = !invalidIcrcAddress(to);
 
 	// UI validates addresses and disable form if not compliant. Therefore, this issue should unlikely happen.

--- a/src/frontend/src/tests/icp/api/icp-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icp-ledger.api.spec.ts
@@ -1,5 +1,6 @@
 import { icrc1Transfer, transfer } from '$icp/api/icp-ledger.api';
 import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
+import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import {
 	mockAccountIdentifierText,
 	mockIdentity,
@@ -30,7 +31,8 @@ describe('icp-ledger.api', () => {
 		const params = {
 			to: mockAccountIdentifierText,
 			amount,
-			identity: mockIdentity
+			identity: mockIdentity,
+			ledgerCanisterId: mockLedgerCanisterId
 		};
 
 		const mockBlock: BlockHeight = 123n;
@@ -78,7 +80,8 @@ describe('icp-ledger.api', () => {
 			to,
 			amount,
 			identity: mockIdentity,
-			createdAt
+			createdAt,
+			ledgerCanisterId: mockLedgerCanisterId
 		};
 
 		const mockIndex: IcrcBlockIndex = 123n;

--- a/src/frontend/src/tests/icp/services/ic-send.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-send.services.spec.ts
@@ -23,6 +23,7 @@ import * as accountUtils from '$lib/utils/account.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import en from '$tests/mocks/i18n.mock';
 import {
+	mockLedgerCanisterId,
 	mockValidDip20Token,
 	mockValidIcCkToken,
 	mockValidIcToken,
@@ -177,7 +178,8 @@ describe('ic-send.services', () => {
 					expect(icrc1TransferIcp).toHaveBeenNthCalledWith(1, {
 						identity: mockIdentity,
 						to: decodeIcrcAccount(mockPrincipalText2),
-						amount: mockAmount
+						amount: mockAmount,
+						ledgerCanisterId: mockLedgerCanisterId
 					});
 
 					expect(transferIcp).not.toHaveBeenCalled();
@@ -193,7 +195,8 @@ describe('ic-send.services', () => {
 					expect(transferIcp).toHaveBeenNthCalledWith(1, {
 						identity: mockIdentity,
 						to: mockPrincipalText2,
-						amount: mockAmount
+						amount: mockAmount,
+						ledgerCanisterId: mockLedgerCanisterId
 					});
 
 					expect(icrc1TransferIcp).not.toHaveBeenCalled();
@@ -602,6 +605,7 @@ describe('ic-send.services', () => {
 			to: mockPrincipalText2,
 			amount: mockAmount,
 			identity: mockIdentity,
+			ledgerCanisterId: mockLedgerCanisterId,
 			progress: mockProgress
 		};
 
@@ -619,7 +623,8 @@ describe('ic-send.services', () => {
 			expect(icrc1TransferIcp).toHaveBeenNthCalledWith(1, {
 				identity: mockIdentity,
 				to: decodeIcrcAccount(mockPrincipalText2),
-				amount: mockAmount
+				amount: mockAmount,
+				ledgerCanisterId: mockLedgerCanisterId
 			});
 
 			expect(transferIcp).not.toHaveBeenCalled();
@@ -635,7 +640,8 @@ describe('ic-send.services', () => {
 			expect(transferIcp).toHaveBeenNthCalledWith(1, {
 				identity: mockIdentity,
 				to: mockPrincipalText2,
-				amount: mockAmount
+				amount: mockAmount,
+				ledgerCanisterId: mockLedgerCanisterId
 			});
 
 			expect(icrc1TransferIcp).not.toHaveBeenCalled();


### PR DESCRIPTION
# Motivation

We are going to onboard more tokens with standard `icp` (as defined in the the codebase). That means that we need to generalize all the services and workers for this type of standard, since right now they are "hard-coded" to be used only by ICP token.

In this PR, we generalize the transfer methods of the ICP-standard tokens (similar to the other IC methods).

# Changes

- Modify methods `transfer` and `icrc1Transfer` of ICP ledger to accept the ledger canister ID as param.
- Adapt initializer of the ICP ledger canister.
- Adapt send service for ICP tokens.

# Tests

Adapted current tests.
