### PR TITLE
refactor(frontend): Use util `isTokenIcp` whenever possible

### DIFF
--- a/src/frontend/src/icp/derived/ic-contacts.derived.ts
+++ b/src/frontend/src/icp/derived/ic-contacts.derived.ts
@@ -1,7 +1,6 @@
-import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
 import { tryToParseIcrcAccountStringToAccountIdentifierText } from '$icp/utils/icp-account.utils';
 import { isIcrcAddress } from '$icp/utils/icrc-account.utils';
-import { isTokenIcrc } from '$icp/utils/icrc.utils';
+import { isTokenIcp, isTokenIcrc } from '$icp/utils/icrc.utils';
 import { contacts } from '$lib/derived/contacts.derived';
 import { tokenWithFallback } from '$lib/derived/token.derived';
 import type { NetworkContacts } from '$lib/types/contacts';
@@ -12,8 +11,8 @@ import { derived, type Readable } from 'svelte/store';
 export const icNetworkContacts: Readable<NetworkContacts> = derived(
 	[contacts, tokenWithFallback],
 	([$contacts, $tokenWithFallback]) => {
-		const isIcpToken = $tokenWithFallback.id === ICP_TOKEN_ID;
-		const isIcrcToken = isTokenIcrc({ standard: $tokenWithFallback.standard });
+		const isIcpToken = isTokenIcp($tokenWithFallback);
+		const isIcrcToken = isTokenIcrc($tokenWithFallback);
 
 		const allIcNetworkContacts = getNetworkContacts({ addressType: 'Icrcv2', contacts: $contacts });
 

--- a/src/frontend/src/icp/derived/ic-transactions.derived.ts
+++ b/src/frontend/src/icp/derived/ic-transactions.derived.ts
@@ -7,6 +7,7 @@ import { ckBtcMinterInfoStore } from '$icp/stores/ckbtc.store';
 import { icPendingTransactionsStore } from '$icp/stores/ic-pending-transactions.store';
 import { icTransactionsStore, type IcTransactionsData } from '$icp/stores/ic-transactions.store';
 import { getAllIcTransactions, getIcExtendedTransactions } from '$icp/utils/ic-transactions.utils';
+import { isTokenIcp } from '$icp/utils/icrc.utils';
 import { tokenWithFallback } from '$lib/derived/token.derived';
 import { tokens } from '$lib/derived/tokens.derived';
 import type { TokenId } from '$lib/types/token';
@@ -65,7 +66,7 @@ export const icTransactions: Readable<NonNullable<IcTransactionsData>> = derived
 export const icKnownDestinations: Readable<KnownDestinations> = derived(
 	[icTransactionsStore, tokens, tokenWithFallback],
 	([$icTransactionsStore, $tokens, $tokenWithFallback]) => {
-		const isIcpToken = $tokenWithFallback.id === ICP_TOKEN_ID;
+		const isIcpToken = isTokenIcp($tokenWithFallback);
 		const { [ICP_TOKEN_ID]: icpTransactions, ...icCkTransactionsStore } =
 			$icTransactionsStore ?? {};
 		const icpTransactionsStore = { [ICP_TOKEN_ID]: icpTransactions ?? [] };

--- a/src/frontend/src/icp/utils/ic-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ic-transactions.utils.ts
@@ -1,4 +1,3 @@
-import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
 import type { BtcStatusesData } from '$icp/stores/btc.store';
 import type { CkBtcPendingUtxosData } from '$icp/stores/ckbtc-utxos.store';
 import type { CkBtcMinterInfoData } from '$icp/stores/ckbtc.store';
@@ -30,6 +29,7 @@ import {
 } from '$icp/utils/ic-send.utils';
 import { mapIcpTransaction } from '$icp/utils/icp-transactions.utils';
 import { mapIcrcTransaction } from '$icp/utils/icrc-transactions.utils';
+import { isTokenIcp } from '$icp/utils/icrc.utils';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { CertifiedTransaction } from '$lib/stores/transactions.store';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -45,11 +45,10 @@ export const mapIcTransaction = ({
 	identity: OptionIdentity;
 }): IcTransactionUi => {
 	const {
-		id: tokenId,
 		network: { env }
 	} = token;
 
-	if (tokenId === ICP_TOKEN_ID) {
+	if (isTokenIcp(token)) {
 		return mapIcpTransaction({ transaction: transaction as IcpTransaction, ...rest });
 	}
 


### PR DESCRIPTION
# Motivation

We can use util `isTokenIcp` to define if a token is an `icp` standard, instead of comparing it directly with the ICP token.