### PR TITLE
feat(frontend): handles updated nfts

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -111,9 +111,9 @@
 	};
 
 	const handleUpdatedNfts = ({
-															 token,
-															 inventory
-														 }: {
+		token,
+		inventory
+	}: {
 		token: NonFungibleToken;
 		inventory: OwnedNft[];
 	}) => {

--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -13,7 +13,7 @@
 	import { loadNftIdsOfToken } from '$lib/services/nft.services';
 	import { nftStore } from '$lib/stores/nft.store';
 	import type { NftId, NonFungibleToken, OwnedNft } from '$lib/types/nft';
-	import { findNewNftIds, findRemovedNfts } from '$lib/utils/nfts.utils';
+	import { findNewNftIds, findRemovedNfts, getUpdatedNfts } from '$lib/utils/nfts.utils';
 
 	interface Props {
 		children?: Snippet;
@@ -63,6 +63,7 @@
 		}
 
 		handleRemovedNfts({ token, inventory: inventory.map((ownedNft) => ownedNft.id) });
+		handleUpdatedNfts({ token, inventory });
 		handleNewNfts({
 			token,
 			inventory: inventory.map((ownedNft) => ownedNft.id),
@@ -106,6 +107,20 @@
 
 		if (removedNfts.length > 0) {
 			nftStore.removeSelectedNfts(removedNfts);
+		}
+	};
+
+	const handleUpdatedNfts = ({
+															 token,
+															 inventory
+														 }: {
+		token: NonFungibleToken;
+		inventory: OwnedNft[];
+	}) => {
+		const updatedNfts = getUpdatedNfts({ nfts: $nftStore ?? [], token, inventory });
+
+		if (updatedNfts.length > 0) {
+			nftStore.updateSelectedNfts(updatedNfts);
 		}
 	};
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
@@ -240,4 +240,64 @@ describe('LoaderNfts', () => {
 			});
 		});
 	});
+
+	describe('handleUpdatedNfts', () => {
+		const mockNft1 = {
+			...mockValidErc1155Nft,
+			id: mockNftId1,
+			collection: {
+				...mockValidErc1155Nft.collection,
+				address: NYAN_CAT_TOKEN.address,
+				network: NYAN_CAT_TOKEN.network
+			}
+		};
+		const mockNft2 = {
+			...mockValidErc1155Nft,
+			id: mockNftId2,
+			collection: {
+				...mockValidErc1155Nft.collection,
+				address: NYAN_CAT_TOKEN.address,
+				network: NYAN_CAT_TOKEN.network
+			}
+		};
+		const mockNft3 = {
+			...mockValidErc1155Nft,
+			id: mockNftId3,
+			collection: {
+				...mockValidErc1155Nft.collection,
+				address: BUILD_AN_APE_TOKEN.address,
+				network: BUILD_AN_APE_TOKEN.network
+			}
+		};
+
+		beforeEach(() => {
+			nftStore.resetAll();
+			nftStore.addAll([mockNft1, mockNft2, mockNft3]);
+
+			erc1155CustomTokensStore.setAll([
+				{ data: mockedEnabledNyanToken, certified: false },
+				{ data: mockedEnabledApeToken, certified: false }
+			]);
+		});
+
+		it('should update erc1155 nfts from the nft store', async () => {
+			mockGetNftIdsForOwner.mockResolvedValueOnce([
+				{ id: mockNftId1, balance: 2 },
+				{ id: mockNftId2, balance: 1 }
+			]);
+			mockGetNftIdsForOwner.mockResolvedValueOnce([{ id: mockNftId3, balance: 3 }]);
+
+			render(LoaderNfts);
+
+			await waitFor(() => {
+				expect(mockGetNftIdsForOwner).toHaveBeenCalledTimes(2);
+
+				expect(get(nftStore)).toEqual([
+					mockNft1,
+					{ ...mockNft2, balance: 1 },
+					{ ...mockNft3, balance: 3 }
+				]);
+			});
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

When the application is running we want to check in an interval of 2 minutes if the user has some updated nfts. If nfts were updated, we want to also update them in the application.
