### PR TITLE
fix(devops): Avoid false positive when checking backend changes

### DIFF
--- a/.github/actions/check-backend-changes/action.yml
+++ b/.github/actions/check-backend-changes/action.yml
@@ -5,7 +5,7 @@ description: Check for changes in the backend-related code and return a boolean 
 outputs:
   backend:
     description: 'True if any relevant backend file changed'
-    value: ${{ steps.changes.outputs.backend }}
+    value: ${{ steps.compute.outputs.backend }}
 
 runs:
   using: 'composite'
@@ -20,7 +20,7 @@ runs:
         # The dockerfile used in this CI run, and the scripts it COPY's.
         # There may be some files in the frontend folder that contains 'backend' in their name.
         filters: |
-          backend:
+          backend_raw:
             - '**/*backend*'
             - 'src/backend/**'
             - 'src/shared/**'
@@ -28,4 +28,15 @@ runs:
             - '**/*rust*'
             - 'Dockerfile'
             - 'docker/**'
-            - '!src/frontend/**'
+          frontend:
+            - 'src/frontend/**'
+
+    - name: Compute final backend output
+      id: compute
+      shell: bash
+      run: |
+        if [[ "${{ steps.changes.outputs.backend_raw }}" == "true" && "${{ steps.changes.outputs.frontend }}" != "true" ]]; then
+          echo "backend=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "backend=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/check-backend-changes/action.yml
+++ b/.github/actions/check-backend-changes/action.yml
@@ -19,6 +19,7 @@ runs:
         # Rust files such as Cargo.lock, Cargo.toml and rust-toolchain.toml
         # The dockerfile used in this CI run, and the scripts it COPY's.
         # There may be some files in the frontend folder that contains 'backend' in their name.
+        # The filters are split because we could have false positive caused by the default of the action considering at least one filter to be true.
         filters: |
           backend_raw:
             - '**/*backend*'


### PR DESCRIPTION
# Motivation

The action that checks for backend changes is giving some false positive.

```
Detected 2 changed files
Results: Filter backend = true
Matching files: package-lock.json [modified] package.json [modified]
```

Action `dorny/paths-filter` uses **picomatch** globs. A filter is `true` if any rule matches (the default `predicate-quantifier` is some). A rule starting with `!` does not exclude unless we switch to `predicate-quantifier: 'every'`. With the default, “!patterns” won’t prevent other rules from matching.

However, that would create conflicts with the non-exclusive filters.

To fix it, we split the filters and compose them afterwards.



