### PR TITLE
feat(frontend): increasing BTC fee rate precision

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -172,7 +172,7 @@ export const validateBtcSend = async ({
 	}
 
 	// 4. Validate fee calculation matches expected transaction structure ( recipient + change)
-	const feeRateSatoshisPerVByte = await getFeeRateFromPercentiles({
+	const feeRateMiliSatoshisPerVByte = await getFeeRateFromPercentiles({
 		network,
 		identity
 	});
@@ -180,7 +180,7 @@ export const validateBtcSend = async ({
 		numInputs: utxos.length,
 		numOutputs: 2
 	});
-	const expectedMinFee = BigInt(estimatedTxSize) * feeRateSatoshisPerVByte;
+	const expectedMinFee = (BigInt(estimatedTxSize) * feeRateMiliSatoshisPerVByte) / 1000n;
 
 	// Allow some tolerance for fee calculation differences (±10%)
 	const feeToleranceRange = expectedMinFee / BTC_SEND_FEE_TOLERANCE_PERCENTAGE;

--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -1,4 +1,4 @@
-import { CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
+import { UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
 import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { calculateUtxoSelection, filterAvailableUtxos } from '$btc/utils/btc-utxos.utils';
@@ -33,7 +33,7 @@ export const prepareBtcSend = async ({
 }: BtcReviewServiceParams): Promise<UtxosFee> => {
 	const bitcoinCanisterId = BITCOIN_CANISTER_IDS[IC_CKBTC_MINTER_CANISTER_ID];
 
-	const requiredMinConfirmations = CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
+	const requiredMinConfirmations = UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
 
 	// Get pending transactions to exclude locked UTXOs
 	const pendingTxIds = getPendingTransactionIds(source);
@@ -127,20 +127,20 @@ export const getFeeRateFromPercentiles = async ({
 	// Use median fee percentile
 	const medianIndex = Math.floor(fee_percentiles.length / 2);
 
-	// Convert from millisats to sats (divide by 1000)
-	const feeRateSatsPerVByte = fee_percentiles[medianIndex];
+	// Use median fee percentile
+	const medianFeeMillisatsPerVByte = fee_percentiles[medianIndex];
 
 	// Apply minimum and maximum limits
 	const MIN_FEE_RATE = 1_000n; // 1 sat/vbyte minimum
 	const MAX_FEE_RATE = 100_000n; // 100 sat/vbyte maximum
 
-	if (feeRateSatsPerVByte < MIN_FEE_RATE) {
+	if (medianFeeMillisatsPerVByte < MIN_FEE_RATE) {
 		return MIN_FEE_RATE;
 	}
 
-	if (feeRateSatsPerVByte > MAX_FEE_RATE) {
+	if (medianFeeMillisatsPerVByte > MAX_FEE_RATE) {
 		return MAX_FEE_RATE;
 	}
 
-	return feeRateSatsPerVByte;
+	return medianFeeMillisatsPerVByte;
 };

--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -37,9 +37,6 @@ export const prepareBtcSend = async ({
 
 	// Get pending transactions to exclude locked UTXOs
 	const pendingTxIds = getPendingTransactionIds(source);
-	if (isNullish(pendingTxIds)) {
-		throw new Error('Pending transactions have not been iitialied');
-	}
 
 	// Convert amount to satoshis
 	const amountSatoshis = convertNumberToSatoshis({ amount });

--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -1,4 +1,4 @@
-import { UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
+import { CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
 import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { calculateUtxoSelection, filterAvailableUtxos } from '$btc/utils/btc-utxos.utils';
@@ -33,16 +33,19 @@ export const prepareBtcSend = async ({
 }: BtcReviewServiceParams): Promise<UtxosFee> => {
 	const bitcoinCanisterId = BITCOIN_CANISTER_IDS[IC_CKBTC_MINTER_CANISTER_ID];
 
-	const requiredMinConfirmations = UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
+	const requiredMinConfirmations = CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
 
 	// Get pending transactions to exclude locked UTXOs
 	const pendingTxIds = getPendingTransactionIds(source);
+	if (isNullish(pendingTxIds)) {
+		throw new Error('Pending transactions have not been iitialied');
+	}
 
 	// Convert amount to satoshis
 	const amountSatoshis = convertNumberToSatoshis({ amount });
 
 	// Step 1: Get current fee percentiles from backend
-	const feeRateSatoshisPerVByte = await getFeeRateFromPercentiles({
+	const feeRateMiliSatoshisPerVByte = await getFeeRateFromPercentiles({
 		identity,
 		network
 	});
@@ -87,7 +90,7 @@ export const prepareBtcSend = async ({
 	const selection = calculateUtxoSelection({
 		availableUtxos: filteredUtxos,
 		amountSatoshis,
-		feeRateSatoshisPerVByte
+		feeRateMiliSatoshisPerVByte
 	});
 
 	// Check if there were insufficient funds during UTXO selection
@@ -126,14 +129,13 @@ export const getFeeRateFromPercentiles = async ({
 
 	// Use median fee percentile
 	const medianIndex = Math.floor(fee_percentiles.length / 2);
-	const medianFeeMillisatsPerVByte = fee_percentiles[medianIndex];
 
 	// Convert from millisats to sats (divide by 1000)
-	const feeRateSatsPerVByte = medianFeeMillisatsPerVByte / 1000n;
+	const feeRateSatsPerVByte = fee_percentiles[medianIndex];
 
 	// Apply minimum and maximum limits
-	const MIN_FEE_RATE = 1n; // 1 sat/vbyte minimum
-	const MAX_FEE_RATE = 100n; // 100 sat/vbyte maximum
+	const MIN_FEE_RATE = 1_000n; // 1 sat/vbyte minimum
+	const MAX_FEE_RATE = 100_000n; // 100 sat/vbyte maximum
 
 	if (feeRateSatsPerVByte < MIN_FEE_RATE) {
 		return MIN_FEE_RATE;

--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -54,11 +54,11 @@ export const estimateTransactionSize = ({
 export const calculateUtxoSelection = ({
 	availableUtxos,
 	amountSatoshis,
-	feeRateSatoshisPerVByte
+	feeRateMiliSatoshisPerVByte
 }: {
 	availableUtxos: Utxo[];
 	amountSatoshis: bigint;
-	feeRateSatoshisPerVByte: bigint;
+	feeRateMiliSatoshisPerVByte: bigint;
 }): UtxoSelectionResult => {
 	if (availableUtxos.length === 0) {
 		return {
@@ -92,7 +92,7 @@ export const calculateUtxoSelection = ({
 			numInputs: selectedUtxos.length,
 			numOutputs: 2
 		});
-		estimatedFee = BigInt(txSize) * feeRateSatoshisPerVByte;
+		estimatedFee = (BigInt(txSize) * feeRateMiliSatoshisPerVByte) / 1000n;
 		const totalRequired = amountSatoshis + estimatedFee;
 
 		// Check if we have enough to cover amount and fee

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -127,7 +127,7 @@ describe('btc-send.services', () => {
 			vi.spyOn(btcUtils, 'getPendingTransactionIds').mockReturnValue([]);
 			vi.spyOn(btcUtxosUtils, 'extractUtxoTxIds').mockReturnValue(['txid1', 'txid2']);
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4n);
+			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 		});
 
 		it('should pass validation for valid UTXOs and parameters', async () => {
@@ -278,7 +278,7 @@ describe('btc-send.services', () => {
 			it('should throw InvalidFeeCalculation error when fee is too low', async () => {
 				// Mock estimated transaction size and fee rate to make expected fee higher than provided fee
 				vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(1000);
-				vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(10n);
+				vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(10000n);
 
 				const params = {
 					...defaultValidateParams,
@@ -321,7 +321,7 @@ describe('btc-send.services', () => {
 		it('should throw InsufficientBalanceForFee error when UTXOs have insufficient funds', async () => {
 			// Use smaller fee and transaction size for consistent calculation
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1n);
+			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
 
 			const params = {
 				...defaultValidateParams,
@@ -343,7 +343,7 @@ describe('btc-send.services', () => {
 		it('should accept fee within tolerance range', async () => {
 			// Mock transaction size for predictable fee calculation
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4n);
+			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 
 			const expectedFee = BigInt(250) * 4n; // 1000 satoshis
 			const toleranceRange = expectedFee / 10n; // 100 satoshis
@@ -377,7 +377,7 @@ describe('btc-send.services', () => {
 
 			// Mock the transaction size estimation for 2 inputs
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(370);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(3n);
+			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(3000n);
 
 			const params = {
 				...defaultValidateParams,
@@ -404,7 +404,7 @@ describe('btc-send.services', () => {
 
 		it('should validate exact fee tolerance boundaries', async () => {
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4n);
+			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 
 			const expectedFee = 250n * 4n; // 1000 satoshis
 			const toleranceRange = expectedFee / 10n; // 100 satoshis

--- a/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
@@ -237,14 +237,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// Should apply minimum fee rate of 1 sat/vbyte (median 200n millisats = 0n sats, so minimum applies)
-			expect(result).toBe(1n);
+			// Should apply minimum fee rate of 1000n millisats/vbyte (median 200n millisats < 1000n, so minimum applies)
+			expect(result).toBe(1_000n);
 		});
 
 		it('should return capped fee rate when calculated fee is too high', async () => {
 			// Very high fees in millisats that should trigger maximum fee rate cap
 			const highFeePercentiles = {
-				fee_percentiles: [200000n, 300000n, 500000n]
+				fee_percentiles: [200_000n, 300_000n, 500_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(highFeePercentiles);
@@ -254,14 +254,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// Should cap at maximum fee rate of 100 sat/vbyte (median 300000n millisats = 300n sats, so cap applies)
-			expect(result).toBe(100n);
+			// Should cap at maximum fee rate of 100_000n millisats/vbyte (median 300_000n > 100_000n, so cap applies)
+			expect(result).toBe(100_000n);
 		});
 
 		it('should correctly convert from millisats to sats using median', async () => {
-			// Fee percentiles in millisats per vbyte - median should be 6000n millisats = 6n sats
+			// Fee percentiles in millisats per vbyte - median should be 6000n millisats
 			const feePercentiles = {
-				fee_percentiles: [2000n, 4000n, 6000n, 8000n, 10000n]
+				fee_percentiles: [2_000n, 4_000n, 6_000n, 8_000n, 10_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(feePercentiles);
@@ -271,14 +271,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// Median of [2000n, 4000n, 6000n, 8000n, 10000n] is 6000n millisats = 6n sats
-			expect(result).toBe(6n);
+			// Median of [2_000n, 4_000n, 6_000n, 8_000n, 10_000n] is 6_000n millisats
+			expect(result).toBe(6_000n);
 		});
 
 		it('should handle odd number of fee percentiles correctly', async () => {
 			// Odd number of percentiles - median should be middle element
 			const oddFeePercentiles = {
-				fee_percentiles: [3000n, 5000n, 7000n]
+				fee_percentiles: [3_000n, 5_000n, 7_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(oddFeePercentiles);
@@ -288,14 +288,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// Median of [3000n, 5000n, 7000n] is 5000n millisats = 5n sats
-			expect(result).toBe(5n);
+			// Median of [3_000n, 5_000n, 7_000n] is 5_000n millisats
+			expect(result).toBe(5_000n);
 		});
 
 		it('should handle even number of fee percentiles correctly', async () => {
 			// Even number of percentiles - should take middle element (index 1 for length 4)
 			const evenFeePercentiles = {
-				fee_percentiles: [2000n, 4000n, 6000n, 8000n]
+				fee_percentiles: [2_000n, 4_000n, 6_000n, 8_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(evenFeePercentiles);
@@ -305,14 +305,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// Math.floor(4 / 2) = 2, so percentiles[2] = 6000n millisats = 6n sats
-			expect(result).toBe(6n);
+			// Math.floor(4 / 2) = 2, so percentiles[2] = 6_000n millisats
+			expect(result).toBe(6_000n);
 		});
 
 		it('should handle single fee percentile correctly', async () => {
 			// Single percentile - should use that value as median
 			const singleFeePercentile = {
-				fee_percentiles: [5000n]
+				fee_percentiles: [5_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(singleFeePercentile);
@@ -322,8 +322,8 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// Single value 5000n millisats = 5n sats
-			expect(result).toBe(5n);
+			// Single value 5_000n millisats
+			expect(result).toBe(5_000n);
 		});
 
 		it('should handle zero fee percentile with minimum fallback', async () => {
@@ -339,14 +339,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// 0n millisats = 0n sats, should apply minimum of 1n sat/vbyte
-			expect(result).toBe(1n);
+			// 0n millisats, should apply minimum of 1_000n millisats/vbyte
+			expect(result).toBe(1_000n);
 		});
 
 		it('should handle boundary case at minimum fee rate threshold', async () => {
-			// Exactly 1000n millisats = 1n sat/vbyte (should not trigger minimum)
+			// Exactly 1_000n millisats/vbyte (should not trigger minimum)
 			const boundaryFeePercentiles = {
-				fee_percentiles: [1000n]
+				fee_percentiles: [1_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(boundaryFeePercentiles);
@@ -356,14 +356,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// 1000n millisats = 1n sat/vbyte, should not trigger minimum fallback
-			expect(result).toBe(1n);
+			// 1_000n millisats/vbyte, should not trigger minimum fallback
+			expect(result).toBe(1_000n);
 		});
 
 		it('should handle boundary case at maximum fee rate threshold', async () => {
-			// Exactly 100000n millisats = 100n sat/vbyte (should not trigger cap)
+			// Exactly 100_000n millisats/vbyte (should not trigger cap)
 			const boundaryFeePercentiles = {
-				fee_percentiles: [100000n]
+				fee_percentiles: [100_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(boundaryFeePercentiles);
@@ -373,8 +373,8 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// 100000n millisats = 100n sat/vbyte, should not trigger cap
-			expect(result).toBe(100n);
+			// 100_000n millisats/vbyte, should not trigger cap
+			expect(result).toBe(100_000n);
 		});
 
 		it('should handle testnet network correctly', async () => {
@@ -419,7 +419,7 @@ describe('btc-utxos.service', () => {
 		});
 
 		it('should handle very small non-zero fee that rounds to zero', async () => {
-			// Fee smaller than 1000n millisats will round to 0n sats, triggering minimum
+			// Fee smaller than 1_000n millisats will trigger minimum
 			const smallFeePercentiles = {
 				fee_percentiles: [999n]
 			};
@@ -431,14 +431,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// 999n millisats = 0n sats (rounded down), should apply minimum of 1n sat/vbyte
-			expect(result).toBe(1n);
+			// 999n millisats < 1_000n, should apply minimum of 1_000n millisats/vbyte
+			expect(result).toBe(1_000n);
 		});
 
 		it('should handle fee rate just above maximum threshold', async () => {
-			// Fee just above 100000n millisats should be capped
+			// Fee just above 100_000n millisats should be capped
 			const aboveMaxFeePercentiles = {
-				fee_percentiles: [100001n]
+				fee_percentiles: [100_001n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(aboveMaxFeePercentiles);
@@ -448,14 +448,14 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// 100001n millisats = 100n sats (rounded down), should not be capped
-			expect(result).toBe(100n);
+			// 100_001n millisats > 100_000n, should be capped to 100_000n millisats/vbyte
+			expect(result).toBe(100_000n);
 		});
 
 		it('should handle fee rate significantly above maximum threshold', async () => {
 			// Fee significantly above maximum should be capped
 			const wayAboveMaxFeePercentiles = {
-				fee_percentiles: [500000n]
+				fee_percentiles: [500_000n]
 			};
 
 			vi.spyOn(backendApi, 'getCurrentBtcFeePercentiles').mockResolvedValue(
@@ -467,8 +467,8 @@ describe('btc-utxos.service', () => {
 				network: mockNetwork
 			});
 
-			// 500000n millisats = 500n sats, should be capped to 100n sat/vbyte
-			expect(result).toBe(100n);
+			// 500_000n millisats > 100_000n, should be capped to 100_000n millisats/vbyte
+			expect(result).toBe(100_000n);
 		});
 	});
 });

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -125,7 +125,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: utxos,
 				amountSatoshis: 250_000n,
-				feeRateMiliSatoshisPerVByte: 10n
+				feeRateMiliSatoshisPerVByte: 10000n
 			});
 
 			expect(result.selectedUtxos.length).toBeGreaterThan(0);
@@ -139,7 +139,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: utxos,
 				amountSatoshis: 100_000n,
-				feeRateMiliSatoshisPerVByte: 1n
+				feeRateMiliSatoshisPerVByte: 1000n
 			});
 
 			// Should select the largest UTXO first (300_000)
@@ -152,7 +152,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: [createMockUtxo({ value: 500_000 })],
 				amountSatoshis: 100_000n,
-				feeRateMiliSatoshisPerVByte: 1n
+				feeRateMiliSatoshisPerVByte: 1000n
 			});
 
 			// With 1 sat/vbyte and estimated tx size of 140 bytes, fee = 140 sats
@@ -166,7 +166,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: [],
 				amountSatoshis: 100_000n,
-				feeRateMiliSatoshisPerVByte: 10n
+				feeRateMiliSatoshisPerVByte: 10000n
 			});
 
 			expect(result.selectedUtxos).toHaveLength(0);
@@ -182,7 +182,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: smallUtxos,
 				amountSatoshis: 900n,
-				feeRateMiliSatoshisPerVByte: 100n // High fee rate will make it insufficient
+				feeRateMiliSatoshisPerVByte: 100000n // High fee rate will make it insufficient
 			});
 
 			expect(result.sufficientFunds).toBeFalsy();

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -125,7 +125,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: utxos,
 				amountSatoshis: 250_000n,
-				feeRateSatoshisPerVByte: 10n
+				feeRateMiliSatoshisPerVByte: 10n
 			});
 
 			expect(result.selectedUtxos.length).toBeGreaterThan(0);
@@ -139,7 +139,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: utxos,
 				amountSatoshis: 100_000n,
-				feeRateSatoshisPerVByte: 1n
+				feeRateMiliSatoshisPerVByte: 1n
 			});
 
 			// Should select the largest UTXO first (300_000)
@@ -152,7 +152,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: [createMockUtxo({ value: 500_000 })],
 				amountSatoshis: 100_000n,
-				feeRateSatoshisPerVByte: 1n
+				feeRateMiliSatoshisPerVByte: 1n
 			});
 
 			// With 1 sat/vbyte and estimated tx size of 140 bytes, fee = 140 sats
@@ -166,7 +166,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: [],
 				amountSatoshis: 100_000n,
-				feeRateSatoshisPerVByte: 10n
+				feeRateMiliSatoshisPerVByte: 10n
 			});
 
 			expect(result.selectedUtxos).toHaveLength(0);
@@ -182,7 +182,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: smallUtxos,
 				amountSatoshis: 900n,
-				feeRateSatoshisPerVByte: 100n // High fee rate will make it insufficient
+				feeRateMiliSatoshisPerVByte: 100n // High fee rate will make it insufficient
 			});
 
 			expect(result.sufficientFunds).toBeFalsy();
@@ -196,7 +196,7 @@ describe('btc-utxos.utils', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: [createMockUtxo({ value: 100_000 })],
 				amountSatoshis: 50_000n,
-				feeRateSatoshisPerVByte: ZERO
+				feeRateMiliSatoshisPerVByte: ZERO
 			});
 
 			expect(result.changeAmount).toBe(50_000n); // No fees


### PR DESCRIPTION
# Motivation

The PR is aiming to improve precision in fee calculation for Bitcoin transactions by switching the unit from satoshis per vbyte to millisatoshis per vbyte. Currently only working with satochi the calculated fee can deviate up to 50 % (e.g. 1456 is rounded to 1). This PR ensures more accurate fee estimates.

# Changes

- Changed the fee unit returned by `getFeeRateFromPercentiles(..)` from `feeRateSatoshisPerVByte` ` to `feeRateMiliSatoshisPerVByte`
- Updated fee rate multiplications and divisions accordingly, introducing more precise calculations by working in millisatoshis.
- Adjusted minimum and maximum fee thresholds to align with the new unit.
- Updated tests to reflect the changes in fee calculation, including adjustments to expected results and test case values.

# Tests

- Modified test expectations in `btc-utxos.service.spec.ts` and `btc-utxos.utils.spec.ts` to validate millisatoshis per vbyte logic.
- Ensured cases with different fee rate values (e.g., boundary values, edge cases, and typical values) behave as expected.
- Covered scenarios such as minimum/maximum thresholds, rounding boundary cases, and high/low fee rates.