### PR TITLE
feat(frontend): UTXO should be selected with at least 6 confirmations

### DIFF
--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -1,4 +1,4 @@
-import { UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
+import { CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
 import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { calculateUtxoSelection, filterAvailableUtxos } from '$btc/utils/btc-utxos.utils';
@@ -33,7 +33,7 @@ export const prepareBtcSend = async ({
 }: BtcReviewServiceParams): Promise<UtxosFee> => {
 	const bitcoinCanisterId = BITCOIN_CANISTER_IDS[IC_CKBTC_MINTER_CANISTER_ID];
 
-	const requiredMinConfirmations = UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
+	const requiredMinConfirmations = CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
 
 	// Get pending transactions to exclude locked UTXOs
 	const pendingTxIds = getPendingTransactionIds(source);

--- a/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
@@ -78,7 +78,7 @@ describe('btc-utxos.service', () => {
 				bitcoinCanisterId: 'ghsi2-tqaaa-aaaan-aaaca-cai',
 				address: mockBtcAddress,
 				network: mockNetwork,
-				minConfirmations: 1
+				minConfirmations: 6
 			});
 		});
 


### PR DESCRIPTION
# Motivation

The PR aims to ensure that the selection of  theUTXO when preparing the BTC send must have at least 6 confirmations. This change improves the reliability of BTC transaction handling.

# Changes

- Replaced the incorrect usage of `UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS` with `CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS` in the `btc-utxos.service.ts` file.
- Updated the test case in `btc-utxos.service.spec.ts` to align with the change, setting `minConfirmations` to 6 instead of 1.

# Tests

- Updated the test file `btc-utxos.service.spec.ts` to match the new constant by altering the expected value for `minConfirmations` to ensure proper validation of confirmed transactions.