### PR TITLE
feat(frontend): added new SwapIcpForm component

### DIFF
--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { createEventDispatcher, getContext } from 'svelte';
+	import SwapFees from '$lib/components/swap/SwapFees.svelte';
+	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
+	import Hr from '$lib/components/ui/Hr.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { SWAP_SLIPPAGE_INVALID_VALUE } from '$lib/constants/swap.constants';
+	import {
+		SWAP_AMOUNTS_CONTEXT_KEY,
+		type SwapAmountsContext
+	} from '$lib/stores/swap-amounts.store';
+	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
+	import { validateUserAmount } from '$lib/utils/user-amount.utils';
+	import NewSwapForm from '$lib/components/swap/NewSwapForm.svelte';
+
+	interface Props {
+		swapAmount: OptionAmount;
+		receiveAmount?: number;
+		slippageValue: OptionAmount;
+		sourceTokenFee?: bigint;
+		isSwapAmountsLoading: boolean;
+		onShowTokensList: (tokenSource: 'source' | 'destination') => void;
+		onClose: () => void;
+		onNext: () => void;
+	}
+
+	let {
+		swapAmount = $bindable(),
+		receiveAmount = $bindable(),
+		slippageValue = $bindable(),
+		sourceTokenFee,
+		isSwapAmountsLoading,
+		onShowTokensList,
+		onClose,
+		onNext
+	}: Props = $props();
+
+	const { sourceToken, destinationToken, sourceTokenBalance, isSourceTokenIcrc2 } =
+		getContext<SwapContext>(SWAP_CONTEXT_KEY);
+
+	let errorType: TokenActionErrorType = $state<TokenActionErrorType | undefined>(undefined);
+
+	let totalFee: bigint | undefined = $derived(
+		(sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n)
+	);
+
+	const customValidate = (userAmount: bigint): TokenActionErrorType =>
+		nonNullish($sourceToken)
+			? validateUserAmount({
+					userAmount,
+					token: $sourceToken,
+					balance: $sourceTokenBalance,
+					fee: totalFee,
+					isSwapFlow: true
+				})
+			: undefined;
+</script>
+
+<NewSwapForm
+	bind:swapAmount
+	bind:receiveAmount
+	bind:slippageValue
+	{errorType}
+	fee={totalFee}
+	{isSwapAmountsLoading}
+	{onClose}
+	onCustomValidate={customValidate}
+	{onNext}
+	{onShowTokensList}
+>
+	{#snippet swapDetails()}
+		{#if nonNullish($destinationToken) && nonNullish($sourceToken)}
+			<Hr spacing="md" />
+
+			<div class="flex flex-col gap-3">
+				<SwapProvider on:icShowProviderList showSelectButton {slippageValue} />
+				<SwapFees />
+			</div>
+		{/if}
+	{/snippet}
+</NewSwapForm>

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -38,7 +38,7 @@
 
 	let errorType: TokenActionErrorType = $state<TokenActionErrorType | undefined>(undefined);
 
-	let totalFee: bigint | undefined = $derived(
+	let totalFee = $derived(
 		(sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n)
 	);
 

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -36,7 +36,7 @@
 	const { sourceToken, destinationToken, sourceTokenBalance, isSourceTokenIcrc2 } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	let errorType: TokenActionErrorType = $state<TokenActionErrorType | undefined>(undefined);
+	let errorType = $state<TokenActionErrorType | undefined>();
 
 	let totalFee = $derived(
 		(sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n)

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
 	import SwapFees from '$lib/components/swap/SwapFees.svelte';
 	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
-	import { SWAP_SLIPPAGE_INVALID_VALUE } from '$lib/constants/swap.constants';
-	import {
-		SWAP_AMOUNTS_CONTEXT_KEY,
-		type SwapAmountsContext
-	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { TokenActionErrorType } from '$lib/types/token-action';

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import NewSwapForm from '$lib/components/swap/NewSwapForm.svelte';
 	import SwapFees from '$lib/components/swap/SwapFees.svelte';
 	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
@@ -9,7 +10,6 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
-	import NewSwapForm from '$lib/components/swap/NewSwapForm.svelte';
 
 	interface Props {
 		swapAmount: OptionAmount;
@@ -38,9 +38,7 @@
 
 	let errorType = $state<TokenActionErrorType | undefined>();
 
-	let totalFee = $derived(
-		(sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n)
-	);
+	let totalFee = $derived((sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n));
 
 	const customValidate = (userAmount: bigint): TokenActionErrorType =>
 		nonNullish($sourceToken)

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpForm.spec.ts
@@ -1,0 +1,157 @@
+import SwapIcpForm from '$icp/components/swap/SwapIcpForm.svelte';
+import { IC_TOKEN_FEE_CONTEXT_KEY, icTokenFeeStore } from '$icp/stores/ic-token-fee.store';
+import {
+	SWAP_SWITCH_TOKENS_BUTTON,
+	TOKEN_INPUT_CURRENCY_TOKEN
+} from '$lib/constants/test-ids.constants';
+import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
+import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
+import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('SwapIcpForm', () => {
+	const mockContext = new Map();
+
+	beforeEach(() => {
+		const originalSwapContext = initSwapContext({
+			sourceToken: mockValidIcToken,
+			destinationToken: mockValidIcCkToken
+		});
+
+		const mockSwapContext = {
+			...originalSwapContext,
+			sourceTokenExchangeRate: readable(10),
+			destinationTokenExchangeRate: readable(2),
+			isSourceTokenIcrc2: readable(false)
+		};
+
+		mockContext.set(SWAP_CONTEXT_KEY, mockSwapContext);
+
+		icTokenFeeStore.setIcTokenFee({
+			tokenSymbol: mockValidIcToken.symbol,
+			fee: 1000n
+		});
+		mockContext.set(IC_TOKEN_FEE_CONTEXT_KEY, { store: icTokenFeeStore });
+
+		mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: initSwapAmountsStore() });
+	});
+
+	const props = {
+		swapAmount: '1',
+		receiveAmount: 2,
+		slippageValue: '0.5',
+		sourceTokenFee: 1000n,
+		isSwapAmountsLoading: false,
+		onShowTokensList: () => {},
+		onClose: () => {},
+		onNext: () => {}
+	};
+
+	const amountSelector = `input[data-tid="${TOKEN_INPUT_CURRENCY_TOKEN}"]`;
+	const switchButtonSelector = `button[data-tid="${SWAP_SWITCH_TOKENS_BUTTON}"]`;
+
+	it('should render all fields', () => {
+		const { container, getByTestId } = render(SwapIcpForm, {
+			props,
+			context: mockContext
+		});
+
+		const amount: HTMLInputElement | null = container.querySelector(amountSelector);
+
+		expect(amount).not.toBeNull();
+
+		expect(getByTestId(SWAP_SWITCH_TOKENS_BUTTON)).toBeInTheDocument();
+
+		const switchButton: HTMLButtonElement | null = container.querySelector(switchButtonSelector);
+
+		expect(switchButton).not.toBeNull();
+	});
+
+	it('should render the component', () => {
+		const { container } = render(SwapIcpForm, {
+			props,
+			context: mockContext
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should render swap details when tokens are selected', () => {
+		const { container } = render(SwapIcpForm, {
+			props,
+			context: mockContext
+		});
+
+		expect(
+			container.textContent?.includes('fee') ?? container.querySelector('[class*="fee"]')
+		).toBeTruthy();
+	});
+
+	it('should not render swap details when no destination token', () => {
+		const contextWithoutDestination = new Map();
+		const swapContextWithoutDestination = initSwapContext({
+			sourceToken: mockValidIcToken,
+			destinationToken: undefined
+		});
+
+		contextWithoutDestination.set(SWAP_CONTEXT_KEY, swapContextWithoutDestination);
+		contextWithoutDestination.set(IC_TOKEN_FEE_CONTEXT_KEY, { store: icTokenFeeStore });
+		contextWithoutDestination.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: initSwapAmountsStore() });
+
+		const { container } = render(SwapIcpForm, {
+			props,
+			context: contextWithoutDestination
+		});
+
+		expect(container.querySelector('hr')).not.toBeInTheDocument();
+	});
+
+	it('should handle loading state', () => {
+		const { container } = render(SwapIcpForm, {
+			props: {
+				...props,
+				isSwapAmountsLoading: true
+			},
+			context: mockContext
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should calculate total fee for ICRC2 tokens', () => {
+		const icrc2Context = new Map();
+		const icrc2SwapContext = {
+			...initSwapContext({
+				sourceToken: mockValidIcToken,
+				destinationToken: mockValidIcCkToken
+			}),
+			isSourceTokenIcrc2: readable(true)
+		};
+
+		icrc2Context.set(SWAP_CONTEXT_KEY, icrc2SwapContext);
+		icrc2Context.set(IC_TOKEN_FEE_CONTEXT_KEY, { store: icTokenFeeStore });
+		icrc2Context.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: initSwapAmountsStore() });
+
+		const { container } = render(SwapIcpForm, {
+			props: {
+				...props,
+				sourceTokenFee: 1000n
+			},
+			context: icrc2Context
+		});
+
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should render exchange value displays', () => {
+		const { container } = render(SwapIcpForm, {
+			props,
+			context: mockContext
+		});
+
+		const exchangeValues = container.querySelectorAll('[data-tid="swap-amount-exchange-value"]');
+
+		expect(exchangeValues).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
# Motivation

This PR introduces a new SwapIcpForm component, that is main Wrapper for SwapForm but works only with ICP networks.

# Changes

- Added new NewSwapForm component

# Tests

Covered new logic with tests.