### PR TITLE
refactor(frontend): Use ERC utils in `LoaderNfts`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -6,6 +6,8 @@
 	import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
 	import type { InfuraErc165Provider } from '$eth/providers/infura-erc165.providers';
 	import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
+	import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
+	import { isTokenErc721 } from '$eth/utils/erc721.utils';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import { NFT_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
@@ -126,10 +128,10 @@
 
 	const onLoad = async () => {
 		for (const token of $enabledNonFungibleTokens) {
-			if (token.standard === 'erc721') {
+			if (isTokenErc721(token)) {
 				await handleErc721(token);
 			}
-			if (token.standard === 'erc1155') {
+			if (isTokenErc1155(token)) {
 				await handleErc1155(token);
 			}
 		}


### PR DESCRIPTION
# Motivation

To avoid duplication of code, we use the existing ERC utils in component `LoaderNfts` to identify the standard of the tokens.