### PR TITLE
feat(frontend): Create general util to check a pseudo-testnet IC token

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -7,6 +7,7 @@ import {
 } from '$env/networks/networks.icp.env';
 import icpLight from '$icp/assets/icp-light.svg';
 import { ICP_TRANSACTION_FEE_E8S } from '$icp/constants/icp.constants';
+import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcToken } from '$icp/types/ic-token';
 import type { RequiredToken, TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -61,4 +62,6 @@ export const TESTICP_TOKEN: IcToken = {
 	explorerUrl: ICP_EXPLORER_URL
 };
 
-export const ICP_LEDGER_CANISTER_TESTNET_IDS = [TESTICP_TOKEN.ledgerCanisterId];
+export const ICP_LEDGER_CANISTER_TESTNET_IDS: LedgerCanisterIdText[] = [
+	TESTICP_TOKEN.ledgerCanisterId
+];

--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -60,3 +60,5 @@ export const TESTICP_TOKEN: IcToken = {
 	indexCanisterId: 'qcuy6-bqaaa-aaaai-aqmqq-cai',
 	explorerUrl: ICP_EXPLORER_URL
 };
+
+export const ICP_LEDGER_CANISTER_TESTNET_IDS = [TESTICP_TOKEN.ledgerCanisterId];

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -9,7 +9,7 @@ import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcToken } from '$icp/types/ic-token';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+import { isTokenIcTestnet } from '$icp/utils/ic-ledger.utils';
 import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { CanisterIdText } from '$lib/types/canister';
@@ -18,13 +18,13 @@ import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
- * The list of Icrc default tokens - i.e. the statically configured Icrc tokens of Oisy + their metadata, unique ids etc. fetched at runtime.
+ * The list of Icrc default tokens - i.e. the statically configured Icrc tokens of Oisy + their metadata, unique IDs, etc. fetched at runtime.
  */
 const icrcDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcDefaultTokensStore, testnetsEnabled],
 	([$icrcTokensStore, $testnetsEnabled]) =>
 		($icrcTokensStore?.map(({ data: token }) => token) ?? []).filter(
-			(token) => $testnetsEnabled || !isTokenIcrcTestnet(token)
+			(token) => $testnetsEnabled || !isTokenIcTestnet(token)
 		)
 );
 
@@ -51,13 +51,13 @@ const icrcDefaultTokensCanisterIds: Readable<CanisterIdText[]> = derived(
 
 /**
  * The list of Icrc tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
- * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "custom token" in the backend.
+ * i.e. default tokens are configured on the client side. If the user disables or enables a default token, this token is added as a "custom token" in the backend.
  */
 const icrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
 	[icrcCustomTokensStore, testnetsEnabled],
 	([$icrcCustomTokensStore, $testnetsEnabled]) =>
 		($icrcCustomTokensStore?.map(({ data: token }) => token) ?? []).filter(
-			(token) => $testnetsEnabled || !isTokenIcrcTestnet(token)
+			(token) => $testnetsEnabled || !isTokenIcTestnet(token)
 		)
 );
 

--- a/src/frontend/src/icp/utils/ic-ledger.utils.ts
+++ b/src/frontend/src/icp/utils/ic-ledger.utils.ts
@@ -1,0 +1,6 @@
+import type { IcToken } from '$icp/types/ic-token';
+import { isTokenIcpTestnet } from '$icp/utils/icp-ledger.utils';
+import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+
+export const isTokenIcTestnet = (token: Partial<IcToken>): boolean =>
+	isTokenIcpTestnet(token) || isTokenIcrcTestnet(token);

--- a/src/frontend/src/icp/utils/icp-ledger.utils.ts
+++ b/src/frontend/src/icp/utils/icp-ledger.utils.ts
@@ -1,0 +1,6 @@
+import { ICP_LEDGER_CANISTER_TESTNET_IDS } from '$env/tokens/tokens.icp.env';
+import type { IcToken } from '$icp/types/ic-token';
+import { nonNullish } from '@dfinity/utils';
+
+export const isTokenIcpTestnet = ({ ledgerCanisterId }: Partial<IcToken>): boolean =>
+	nonNullish(ledgerCanisterId) && ICP_LEDGER_CANISTER_TESTNET_IDS.includes(ledgerCanisterId);

--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -13,7 +13,7 @@ import type {
 	IcTokenWithoutIdExtended,
 	IcrcCustomToken
 } from '$icp/types/icrc-custom-token';
-import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+import { isTokenIcTestnet } from '$icp/utils/ic-ledger.utils';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { TokenCategory, TokenMetadata } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -64,7 +64,7 @@ const CUSTOM_SYMBOLS_BY_LEDGER_CANISTER_ID: Record<LedgerCanisterIdText, string>
  *          - `ICP_PSEUDO_TESTNET_NETWORK` for known "testnet" tokens
  */
 const mapIcNetwork = (ledgerCanisterId: LedgerCanisterIdText) =>
-	isTokenIcrcTestnet({ ledgerCanisterId }) ? ICP_PSEUDO_TESTNET_NETWORK : ICP_NETWORK;
+	isTokenIcTestnet({ ledgerCanisterId }) ? ICP_PSEUDO_TESTNET_NETWORK : ICP_NETWORK;
 
 export const mapIcrcToken = ({
 	metadata,

--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -15,7 +15,7 @@ import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import { toCkMinterInfoAddresses } from '$icp-eth/utils/cketh.utils';
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
-import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+import { isTokenIcTestnet } from '$icp/utils/ic-ledger.utils';
 import { registerAirdropRecipient } from '$lib/api/reward.api';
 import {
 	NANO_SECONDS_IN_MILLISECOND,
@@ -190,7 +190,7 @@ const toAnySnapshot = ({
 		return;
 	}
 
-	const isTestnet = networkEnv === 'testnet' || isTokenIcrcTestnet(token);
+	const isTestnet = networkEnv === 'testnet' || isTokenIcTestnet(token);
 
 	// This does not happen, but we need it to make it type-safe
 	assertNonNullish(networkId.description);

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -18,7 +18,7 @@ import {
 	SOLANA_MAINNET_NETWORK_ID,
 	SUPPORTED_SOLANA_NETWORK_IDS
 } from '$env/networks/networks.sol.env';
-import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
+import { isTokenIcTestnet } from '$icp/utils/ic-ledger.utils';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { SolanaNetwork } from '$sol/types/network';
@@ -100,7 +100,7 @@ export const showTokenFilteredBySelectedNetwork = ({
 	$selectedNetwork: Network | undefined;
 	$pseudoNetworkChainFusion: boolean;
 }): boolean =>
-	($pseudoNetworkChainFusion && !isTokenIcrcTestnet(token) && token.network.env !== 'testnet') ||
+	($pseudoNetworkChainFusion && !isTokenIcTestnet(token) && token.network.env !== 'testnet') ||
 	$selectedNetwork?.id === token.network.id;
 
 export const showTokenFilteredBySelectedNetworks = ({
@@ -112,7 +112,7 @@ export const showTokenFilteredBySelectedNetworks = ({
 	$selectedNetworks: NetworkId[] | undefined;
 	$pseudoNetworkChainFusion: boolean;
 }): boolean =>
-	($pseudoNetworkChainFusion && !isTokenIcrcTestnet(token) && token.network.env !== 'testnet') ||
+	($pseudoNetworkChainFusion && !isTokenIcTestnet(token) && token.network.env !== 'testnet') ||
 	(nonNullish($selectedNetworks) && $selectedNetworks?.includes(token.network.id));
 
 /**


### PR DESCRIPTION
# Motivation

Currently, we have an util that checks if an ICRC token is a pseudo-testnet one. However, we need to generalize it for other standard, for example ICP standard.

# Changes

- Create list of ICP-standard ledger canister "testnet" IDs.
- Create util to check if na ICP-standard token is a "testnet" one.
- Create util to generalize any IC token: it merges ICP and ICRC standards checks.
- Apply it in the code. 

# Tests

Current tests should suffice.