### PR TITLE
fix(frontend): Avoid re-using existing identity keys for `AuthClient` instance

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -7,7 +7,11 @@ import {
 } from '$lib/constants/app.constants';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Option } from '$lib/types/utils';
-import { createAuthClient, getOptionalDerivationOrigin } from '$lib/utils/auth.utils';
+import {
+	createAuthClient,
+	getOptionalDerivationOrigin,
+	safeCreateAuthClient
+} from '$lib/utils/auth.utils';
 import { popupCenter } from '$lib/utils/window.utils';
 import type { Identity } from '@dfinity/agent';
 import type { AuthClient } from '@dfinity/auth-client';
@@ -40,7 +44,7 @@ const initAuthStore = (): AuthStore => {
 		subscribe,
 
 		sync: async () => {
-			authClient = authClient ?? (await createAuthClient());
+			authClient = authClient ?? (await safeCreateAuthClient());
 			const isAuthenticated: boolean = await authClient.isAuthenticated();
 
 			set({
@@ -51,7 +55,7 @@ const initAuthStore = (): AuthStore => {
 		signIn: ({ domain }: AuthSignInParams) =>
 			// eslint-disable-next-line no-async-promise-executor
 			new Promise<void>(async (resolve, reject) => {
-				authClient = authClient ?? (await createAuthClient());
+				authClient = authClient ?? (await safeCreateAuthClient());
 
 				const identityProvider = nonNullish(INTERNET_IDENTITY_CANISTER_ID)
 					? /apple/i.test(navigator?.vendor)

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -1,6 +1,6 @@
 import { AUTH_TIMER_INTERVAL, NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
 import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
-import { createAuthClient } from '$lib/utils/auth.utils';
+import { safeCreateAuthClient } from '$lib/utils/auth.utils';
 import { IdbStorage, KEY_STORAGE_DELEGATION, type AuthClient } from '@dfinity/auth-client';
 import { DelegationChain, isDelegationValid } from '@dfinity/identity';
 
@@ -50,12 +50,12 @@ const onIdleSignOut = async () => {
 };
 
 /**
- * If user is not authenticated - i.e. no identity or anonymous and there is no valid delegation chain, then identity is not valid
+ * If the user is not authenticated - i.e. no identity or anonymous and there is no valid delegation chain, then identity is not valid
  *
  * @returns true if authenticated
  */
 const checkAuthentication = async (): Promise<boolean> => {
-	const authClient: AuthClient = await createAuthClient();
+	const authClient: AuthClient = await safeCreateAuthClient();
 	return authClient.isAuthenticated();
 };
 


### PR DESCRIPTION
# Motivation

This PR addresses a security finding from Trail of Bits concerning how `@dfinity/auth-client` persists identity keys in IndexedDB and how those keys are reused on sign-in.

### The issue

When the user signs out (or is signed out), the current `AuthClient` instance removes the delegated identity from IndexedDB. That triggers the `onstorage` event, which calls syncAuthStore(). That function immediately creates a new `AuthClient` by calling `createAuthClient`, which in turn generates a fresh ECDSA identity key and saves it to IndexedDB.

This behavior is expected, and not an outright vulnerability on its own. However, it has the side effect that when the user next signs in, the new `AuthClient` will reuse whatever identity key is already in IndexedDB. This means that if an attacker with access to the browser can plant a key in IndexedDB before the next login, the `AuthClient` will use that key with Internet Identity to obtain a valid signed delegation.

### Why not fix in `agent-js` directly?

The reason keys are stored in IndexedDB at all is to persist the authentication state across browser sessions. If we generated a new in-memory key every time, the user would have to log in with Internet Identity on every page load — a significant degradation of user experience.

Thus, this cannot be solved in auth-client alone without forcing re-logins on every session.

### Solution (suggestion by @ilbertt )

Instead, we fix this on OISY's side by taking control of storage management.

# Changes

- Service `createAuthClient` will now accept a custom IDB storage to pass when creating a new `AuthClient` instance.
- Created new service `safeCreateAuthClient` that deleted any IDB-stored keys before creating a new `AuthClient` instance.
- Use the new service in the code where necessary (we don't use it during sign out, since the real issue may exists eithr on sign in or on sync.

# Test

Tested manually in a test canister and no changes perceived for the user's experience.