### PR TITLE
refactor(frontend): Rename custom token param in util `mapDefaultTokenToToggleable`

### DIFF
--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -45,7 +45,7 @@ const erc20DefaultTokensToggleable: Readable<Erc20TokenToggleable[]> = derived(
 	[erc20DefaultTokens, erc20UserTokens],
 	([$erc20DefaultTokens, $erc20UserTokens]) =>
 		$erc20DefaultTokens.map(({ address, network, ...rest }) => {
-			const userToken = $erc20UserTokens.find(
+			const customToken = $erc20UserTokens.find(
 				({ address: contractAddress, network: contractNetwork }) =>
 					contractAddress === address && network.chainId === contractNetwork.chainId
 			);
@@ -56,7 +56,7 @@ const erc20DefaultTokensToggleable: Readable<Erc20TokenToggleable[]> = derived(
 					network,
 					...rest
 				},
-				userToken
+				customToken
 			});
 		})
 );

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -63,15 +63,15 @@ const icrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
 
 const icrcDefaultTokensToggleable: Readable<IcTokenToggleable[]> = derived(
 	[icrcDefaultTokens, icrcCustomTokens],
-	([$icrcDefaultTokens, $icrcUserTokens]) =>
+	([$icrcDefaultTokens, $icrcCustomTokens]) =>
 		$icrcDefaultTokens.map(({ ledgerCanisterId, ...rest }) => {
-			const userToken = $icrcUserTokens.find(
-				({ ledgerCanisterId: userLedgerCanisterId }) => userLedgerCanisterId === ledgerCanisterId
+			const customToken = $icrcCustomTokens.find(
+				({ ledgerCanisterId: customLedgerCanisterId }) => customLedgerCanisterId === ledgerCanisterId
 			);
 
 			return mapDefaultTokenToToggleable<IcToken>({
 				defaultToken: { ledgerCanisterId, ...rest },
-				userToken
+	customToken
 			});
 		})
 );

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -67,10 +67,10 @@ export const getMaxTransactionAmount = ({
  */
 export const mapDefaultTokenToToggleable = <T extends Token>({
 	defaultToken,
-	userToken
+	customToken
 }: {
 	defaultToken: T;
-	userToken: TokenToggleable<T> | undefined;
+	customToken: TokenToggleable<T> | undefined;
 }): TokenToggleable<T> => {
 	const ledgerCanisterId =
 		'ledgerCanisterId' in defaultToken &&
@@ -89,9 +89,9 @@ export const mapDefaultTokenToToggleable = <T extends Token>({
 		...defaultToken,
 		enabled:
 			isEnabledByDefault ||
-			(isNullish(userToken?.enabled) && isSuggestedToken) ||
-			userToken?.enabled === true,
-		version: userToken?.version
+			(isNullish(customToken?.enabled) && isSuggestedToken) ||
+			customToken?.enabled === true,
+		version: customToken?.version
 	};
 };
 

--- a/src/frontend/src/sol/derived/spl.derived.ts
+++ b/src/frontend/src/sol/derived/spl.derived.ts
@@ -45,7 +45,7 @@ const splDefaultTokensToggleable: Readable<SplTokenToggleable[]> = derived(
 	[splDefaultTokens, splCustomTokens],
 	([$splDefaultTokens, $splCustomTokens]) =>
 		$splDefaultTokens.map(({ address, network, ...rest }) => {
-			const userToken = $splCustomTokens.find(
+			const customToken = $splCustomTokens.find(
 				({ address: contractAddress, network: contractNetwork }) =>
 					contractAddress === address &&
 					(network as SolanaNetwork).chainId === (contractNetwork as SolanaNetwork).chainId
@@ -57,7 +57,7 @@ const splDefaultTokensToggleable: Readable<SplTokenToggleable[]> = derived(
 					network,
 					...rest
 				},
-				userToken
+				customToken
 			});
 		})
 );

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -389,7 +389,7 @@ describe('token.utils', () => {
 				it('should enable the token if user enables it', () => {
 					const result = mapDefaultTokenToToggleable({
 						defaultToken: token,
-						userToken: { ...token, enabled: true }
+						customToken: { ...token, enabled: true }
 					});
 
 					expect(result.enabled).toBeTruthy();
@@ -398,16 +398,16 @@ describe('token.utils', () => {
 				it('should not enable the token if user has not enabled it', () => {
 					const result = mapDefaultTokenToToggleable({
 						defaultToken: token,
-						userToken: { ...token, enabled: false }
+						customToken: { ...token, enabled: false }
 					});
 
 					expect(result.enabled).toBeFalsy();
 				});
 
-				it('should not enable the token if userToken is undefined', () => {
+				it('should not enable the token if customToken is undefined', () => {
 					const result = mapDefaultTokenToToggleable({
 						defaultToken: token,
-						userToken: undefined
+						customToken: undefined
 					});
 
 					expect(result.enabled).toBeFalsy();
@@ -434,25 +434,25 @@ describe('token.utils', () => {
 		])('$description - Default/Suggested Tokens', ({ token, setupMock }) => {
 			beforeEach(() => setupMock(token.ledgerCanisterId));
 
-			it('should enable the token if no userToken', () => {
-				const result = mapDefaultTokenToToggleable({ defaultToken: token, userToken: undefined });
+			it('should enable the token if no customToken', () => {
+				const result = mapDefaultTokenToToggleable({ defaultToken: token, customToken: undefined });
 
 				expect(result.enabled).toBeTruthy();
 			});
 
-			it('should enable the token if userToken has enabled false', () => {
+			it('should enable the token if customToken has enabled false', () => {
 				const result = mapDefaultTokenToToggleable({
 					defaultToken: token,
-					userToken: { ...token, enabled: false }
+					customToken: { ...token, enabled: false }
 				});
 
 				expect(result.enabled).toBeTruthy();
 			});
 
-			it('should enable the token if userToken has enabled true', () => {
+			it('should enable the token if customToken has enabled true', () => {
 				const result = mapDefaultTokenToToggleable({
 					defaultToken: token,
-					userToken: { ...token, enabled: true }
+					customToken: { ...token, enabled: true }
 				});
 
 				expect(result.enabled).toBeTruthy();
@@ -477,25 +477,25 @@ describe('token.utils', () => {
 				beforeEach(() => setupMock(token.ledgerCanisterId));
 			}
 
-			it('should enable the token if no userToken', () => {
-				const result = mapDefaultTokenToToggleable({ defaultToken: token, userToken: undefined });
+			it('should enable the token if no customToken', () => {
+				const result = mapDefaultTokenToToggleable({ defaultToken: token, customToken: undefined });
 
 				expect(result.enabled).toBeTruthy();
 			});
 
-			it('should not enable the token if userToken has enabled false', () => {
+			it('should not enable the token if customToken has enabled false', () => {
 				const result = mapDefaultTokenToToggleable({
 					defaultToken: token,
-					userToken: { ...token, enabled: false }
+					customToken: { ...token, enabled: false }
 				});
 
 				expect(result.enabled).toBeFalsy();
 			});
 
-			it('should enable the token if userToken has enabled true', () => {
+			it('should enable the token if customToken has enabled true', () => {
 				const result = mapDefaultTokenToToggleable({
 					defaultToken: token,
-					userToken: { ...token, enabled: true }
+					customToken: { ...token, enabled: true }
 				});
 
 				expect(result.enabled).toBeTruthy();


### PR DESCRIPTION
# Motivation

The correct name for the param in util `mapDefaultTokenToToggleable` is `customToken`.
