### PR TITLE
fix(frontend): Include ICP tokens in filter for ICRC custom tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -71,6 +71,10 @@ export const SUPPORTED_ICP_TOKENS: RequiredToken<Omit<IcToken, 'deprecated'>>[] 
 		testnetTokens: [TESTICP_TOKEN]
 	});
 
+export const SUPPORTED_ICP_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = SUPPORTED_ICP_TOKENS.map(
+	({ ledgerCanisterId }) => ledgerCanisterId
+);
+
 export const ICP_LEDGER_CANISTER_TESTNET_IDS: LedgerCanisterIdText[] = [
 	TESTICP_TOKEN.ledgerCanisterId
 ];

--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -16,9 +16,10 @@ import type { CanisterIdText } from '$lib/types/canister';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
+import { SUPPORTED_ICP_TOKENS } from '$env/tokens/tokens.icp.env';
 
 /**
- * The list of ICRC default tokens - i.e. the statically configured ICRC tokens of Oisy + their metadata, unique IDs, etc. fetched at runtime.
+ * The list of ICRC default tokens - i.e. the statically configured ICRC tokens of OISY + their metadata, unique IDs, etc. fetched at runtime.
  */
 const icrcDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcDefaultTokensStore, testnetsEnabled],
@@ -29,7 +30,7 @@ const icrcDefaultTokens: Readable<IcToken[]> = derived(
 );
 
 /**
- * The list of Icrc tokens that are default for Chain Fusion, in the order provided by the static list.
+ * The list of ICRC tokens that are default for Chain Fusion, in the order provided by the static list.
  */
 export const icrcChainFusionDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcDefaultTokens],
@@ -42,7 +43,7 @@ export const icrcChainFusionDefaultTokens: Readable<IcToken[]> = derived(
 );
 
 /**
- * A flatten list of the default ICRC Ledger canister Id.
+ * A flatten list of the default ICRC Ledger canister ID.
  */
 const icrcDefaultTokensCanisterIds: Readable<CanisterIdText[]> = derived(
 	[icrcDefaultTokens],
@@ -50,7 +51,7 @@ const icrcDefaultTokensCanisterIds: Readable<CanisterIdText[]> = derived(
 );
 
 /**
- * The list of Icrc tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
+ * The list of ICRC tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
  * i.e. default tokens are configured on the client side. If the user disables or enables a default token, this token is added as a "custom token" in the backend.
  */
 const icrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
@@ -77,7 +78,7 @@ const icrcDefaultTokensToggleable: Readable<IcTokenToggleable[]> = derived(
 );
 
 /**
- * The list of default tokens that are enabled - i.e. the list of default Icrc tokens minus those disabled by the user.
+ * The list of default tokens that are enabled - i.e. the list of default ICRC tokens minus those disabled by the user.
  */
 const enabledIcrcDefaultTokens: Readable<IcToken[]> = derived(
 	[icrcDefaultTokensToggleable],
@@ -85,14 +86,14 @@ const enabledIcrcDefaultTokens: Readable<IcToken[]> = derived(
 );
 
 /**
- * The list of Icrc tokens enabled by the user - i.e. saved in the backend canister as enabled - minus those that duplicate default tokens.
- * We do so because the default statically configured are those to be used for various feature. This is notably useful for ERC20 <> ckERC20 conversion given that tokens on both sides (ETH an IC) should know about each others ("Twin Token" links).
+ * The list of ICRC tokens enabled by the user - i.e. saved in the backend canister as enabled - minus those that duplicate default tokens.
+ * We do so because the default statically configured are those to be used for various features. This is notably useful for ERC20 <> ckERC20 conversion given that tokens on both sides (ETH an IC) should know about each other ("Twin Token" links).
  */
 const icrcCustomTokensToggleable: Readable<IcrcCustomToken[]> = derived(
 	[icrcCustomTokens, icrcDefaultTokensCanisterIds],
 	([$icrcCustomTokens, $icrcDefaultTokensCanisterIds]) =>
 		$icrcCustomTokens.filter(
-			({ ledgerCanisterId }) => !$icrcDefaultTokensCanisterIds.includes(ledgerCanisterId)
+			({ ledgerCanisterId }) => ![...SUPPORTED_ICP_TOKENS, ...$icrcDefaultTokensCanisterIds].includes(ledgerCanisterId)
 		)
 );
 
@@ -102,7 +103,7 @@ const enabledIcrcCustomTokens: Readable<IcrcCustomToken[]> = derived(
 );
 
 /**
- * The list of all Icrc tokens.
+ * The list of all ICRC tokens.
  */
 export const icrcTokens: Readable<IcrcCustomToken[]> = derived(
 	[icrcDefaultTokensToggleable, icrcCustomTokensToggleable],
@@ -118,7 +119,7 @@ export const sortedIcrcTokens: Readable<IcrcCustomToken[]> = derived(
 );
 
 /**
- * The list of Icrc tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
+ * The list of ICRC tokens that are either enabled by default (static config) or enabled by the users regardless if they are custom or default.
  */
 export const enabledIcrcTokens: Readable<IcToken[]> = derived(
 	[enabledIcrcDefaultTokens, enabledIcrcCustomTokens],


### PR DESCRIPTION
# Motivation

There are built-in ICP tokens that should superseed any custom token with the same ledger canister ID. So we include the list in the filter of the derived store, to avoid duplicates (for example TESTICP).
