### PR TITLE
feat(frontend): prevent scheduler re-execution when disabled

### DIFF
--- a/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
@@ -33,6 +33,7 @@
 	const dispatch = createEventDispatcher();
 
 	let schedulerTimer: NodeJS.Timeout | undefined;
+	let isActive = true;
 
 	const updatePrepareBtcSend = async () => {
 		try {
@@ -63,12 +64,16 @@
 	const startScheduler = () => {
 		// Stop existing scheduler if it exists
 		stopScheduler();
+		isActive = true;
 
 		// Start the recurring scheduler
 		const scheduleNext = () => {
 			schedulerTimer = setTimeout(async () => {
-				await updatePrepareBtcSend();
-				scheduleNext();
+				// only execute next update if still active
+				if (isActive) {
+					await updatePrepareBtcSend();
+					scheduleNext();
+				}
 			}, BTC_UTXOS_FEE_UPDATE_INTERVAL);
 		};
 
@@ -76,6 +81,8 @@
 	};
 
 	const stopScheduler = () => {
+		isActive = false;
+
 		if (schedulerTimer) {
 			// Clear existing timer
 			clearTimeout(schedulerTimer);


### PR DESCRIPTION
# Motivation

Currently the execution chain of the scheduled `updatePrepareBtcSend(..)` is not interupted when `stopScheduler() `is called by `onMount` in BtcUtxosFee.svelte 

# Changes

- Added a new reactive variable isActive to manage the scheduler's state.
- Integrated isActive into the startScheduler logic to ensure updates are only performed while active.
- Updated stopScheduler to set isActive to false, effectively halting further unwanted updates.

# Tests

Tested on fe2.oisy.com that the scheduled calls of `updatePrepareBtcSend` immediatly stops when navigating away from BtcSendReview.