### PR TITLE
feat(frontend): optional "progress" param on sending ETH

### DIFF
--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -275,7 +275,7 @@ export const send = async ({
 }: Omit<TransferParams, 'maxPriorityFeePerGas' | 'maxFeePerGas'> &
 	SendParams &
 	RequiredTransactionFeeData): Promise<{ hash: string }> => {
-	progress(ProgressStepsSend.INITIALIZATION);
+	progress?.(ProgressStepsSend.INITIALIZATION);
 
 	const { transactionNeededApproval, nonce } = await approve({
 		progress,
@@ -297,7 +297,7 @@ export const send = async ({
 	// Explicitly do not await to proceed in the background and allow the UI to continue
 	processTransactionSent({ token, transaction: transactionSent });
 
-	progress(lastProgressStep);
+	progress?.(lastProgressStep);
 
 	return { hash: transactionSent.hash };
 };
@@ -409,7 +409,7 @@ const sendTransaction = async ({
 							: infuraErc20Providers(networkId).populateTransaction
 				}));
 
-	progress(ProgressStepsSend.SIGN_TRANSFER);
+	progress?.(ProgressStepsSend.SIGN_TRANSFER);
 
 	const rawTransaction = await signTransaction({
 		identity,
@@ -417,7 +417,7 @@ const sendTransaction = async ({
 		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 	});
 
-	progress(ProgressStepsSend.TRANSFER);
+	progress?.(ProgressStepsSend.TRANSFER);
 
 	return await sendTransaction(rawTransaction);
 };
@@ -570,7 +570,7 @@ export const approve = async ({
 	});
 
 	if (approvalCheckResult === 'existingApprovalIsEnough') {
-		progress(progressSteps.APPROVE);
+		progress?.(progressSteps.APPROVE);
 		return { transactionNeededApproval: false, nonce };
 	}
 

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -163,7 +163,7 @@ export const send = ({
 
 				await listener.approveRequest({ id, topic, message: hash });
 
-				progress(lastProgressStep);
+				progress?.(lastProgressStep);
 
 				trackEvent({
 					name: TRACK_COUNT_WC_ETH_SEND_SUCCESS,

--- a/src/frontend/src/eth/types/send.ts
+++ b/src/frontend/src/eth/types/send.ts
@@ -13,7 +13,7 @@ export type ProgressStep = ProgressStepsSend | ProgressStepsSwap;
 type ProgressStepsEnum = typeof ProgressStepsSend | typeof ProgressStepsSwap;
 
 interface WithProgress {
-	progress: (step: ProgressStep) => void;
+	progress?: (step: ProgressStep) => void;
 	progressSteps?: ProgressStepsEnum;
 }
 


### PR DESCRIPTION
# Motivation

Since send ETH services are going to be used outside of regular send/convert flows (AI console), we need to make progress param as optional.
