### PR TITLE
feat(frontend): optional "progress" param on sending SOL

### DIFF
--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -293,14 +293,14 @@ export const sendSol = async ({
 	source
 }: {
 	identity: OptionIdentity;
-	progress: (step: ProgressStepsSendSol) => void;
 	token: Token;
 	amount: bigint;
 	prioritizationFee: bigint;
 	destination: SolAddress;
 	source: SolAddress;
+	progress?: (step: ProgressStepsSendSol) => void;
 }): Promise<Signature> => {
-	progress(ProgressStepsSendSol.INITIALIZATION);
+	progress?.(ProgressStepsSendSol.INITIALIZATION);
 
 	const {
 		network: { id: networkId }
@@ -347,20 +347,20 @@ export const sendSol = async ({
 		transactionMessage
 	);
 
-	progress(ProgressStepsSendSol.SIGN);
+	progress?.(ProgressStepsSendSol.SIGN);
 
 	const { signedTransaction, signature } = await signTransaction(
 		prioritizationFee > ZERO ? transactionMessageWithComputeUnitPrice : transactionMessage
 	);
 
-	progress(ProgressStepsSendSol.SEND);
+	progress?.(ProgressStepsSendSol.SEND);
 
 	await sendSignedTransaction({
 		rpc,
 		signedTransaction
 	});
 
-	progress(ProgressStepsSendSol.CONFIRM);
+	progress?.(ProgressStepsSendSol.CONFIRM);
 
 	await confirmSignedTransaction({
 		rpc,
@@ -368,7 +368,7 @@ export const sendSol = async ({
 		signedTransaction
 	});
 
-	progress(ProgressStepsSendSol.DONE);
+	progress?.(ProgressStepsSendSol.DONE);
 
 	return signature;
 };


### PR DESCRIPTION
# Motivation

Since `sendSol` is going to be used outside of regular send/convert flows (AI console), we need to make progress param as optional.
