### PR TITLE
feat(frontend): extend ModalHero component

### DIFF
--- a/src/frontend/src/lib/components/common/ModalHero.svelte
+++ b/src/frontend/src/lib/components/common/ModalHero.svelte
@@ -8,10 +8,11 @@
 		title?: Snippet;
 		subtitle?: Snippet;
 		description?: Snippet;
+		content?: Snippet;
 		variant?: ModalHeroVariant;
 	}
 
-	const { logo, title, subtitle, description, variant = 'default' }: Props = $props();
+	const { logo, title, subtitle, description, content, variant = 'default' }: Props = $props();
 </script>
 
 <div
@@ -42,6 +43,12 @@
 	{#if nonNullish(description)}
 		<div class="text-sm text-tertiary">
 			{@render description()}
+		</div>
+	{/if}
+
+	{#if nonNullish(content)}
+		<div class="mt-4 w-full">
+			{@render content()}
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
# Motivation

We need to extend `ModalHero` to accept additional slot "content".

<img width="334" height="496" alt="Screenshot 2025-08-24 at 18 09 52" src="https://github.com/user-attachments/assets/8bd3803f-252a-44d6-97ba-cebd7499f78a" />
