### PR TITLE
feat(frontend): correctly validate UTXO tx ids's

### DIFF
--- a/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFee.svelte
@@ -33,6 +33,7 @@
 	const dispatch = createEventDispatcher();
 
 	let schedulerTimer: NodeJS.Timeout | undefined;
+	let isActive = true;
 
 	const updatePrepareBtcSend = async () => {
 		try {
@@ -63,12 +64,16 @@
 	const startScheduler = () => {
 		// Stop existing scheduler if it exists
 		stopScheduler();
+		isActive = true;
 
 		// Start the recurring scheduler
 		const scheduleNext = () => {
 			schedulerTimer = setTimeout(async () => {
-				await updatePrepareBtcSend();
-				scheduleNext();
+				// only execute next update if still active
+				if (isActive) {
+					await updatePrepareBtcSend();
+					scheduleNext();
+				}
 			}, BTC_UTXOS_FEE_UPDATE_INTERVAL);
 		};
 
@@ -76,6 +81,8 @@
 	};
 
 	const stopScheduler = () => {
+		isActive = false;
+
 		if (schedulerTimer) {
 			// Clear existing timer
 			clearTimeout(schedulerTimer);

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -1,10 +1,11 @@
 import { BTC_SEND_FEE_TOLERANCE_PERCENTAGE } from '$btc/constants/btc.constants';
+import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 import { getFeeRateFromPercentiles } from '$btc/services/btc-utxos.service';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { estimateTransactionSize, extractUtxoTxIds } from '$btc/utils/btc-utxos.utils';
 import type { SendBtcResponse } from '$declarations/signer/signer.did';
-import { getPendingTransactionIds } from '$icp/utils/btc.utils';
+import { getPendingTransactionUtxoTxIds, txidStringToUint8Array } from '$icp/utils/btc.utils';
 import { addPendingBtcTransaction } from '$lib/api/backend.api';
 import { sendBtc as sendBtcApi } from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';
@@ -14,11 +15,11 @@ import { toastsError } from '$lib/stores/toasts.store';
 import type { BtcAddress } from '$lib/types/address';
 import type { Amount } from '$lib/types/send';
 import { invalidAmount } from '$lib/utils/input.utils';
-import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
+import { mapBitcoinNetworkToNetworkId, mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import type { Identity } from '@dfinity/agent';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
-import { hexStringToUint8Array, nonNullish, toNullable } from '@dfinity/utils';
+import { isNullish, nonNullish, toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 interface BtcSendServiceParams {
@@ -155,11 +156,24 @@ export const validateBtcSend = async ({
 	}
 
 	// 2. Check if UTXOs are still unspent (not locked by pending transactions)
-	const pendingTxIds = getPendingTransactionIds(source);
-	if (pendingTxIds.length > 0) {
+	// It is very important that the pending transactions are updated before validating the UTXOs
+	await loadBtcPendingSentTransactions({
+		identity,
+		networkId: mapBitcoinNetworkToNetworkId(network), // we want to avoid having to pass redundant data to the function
+		address: source
+	});
+
+	const utxoTxIds = getPendingTransactionUtxoTxIds(source);
+
+	if (isNullish(utxoTxIds)) {
+		// when no pending transactions have been initiated, we cannot validate UTXO's and therefore, validation must fail
+		throw new BtcValidationError(BtcSendValidationError.UtxoLocked);
+	}
+
+	if (utxoTxIds.length > 0) {
 		const providedUtxoTxIds = extractUtxoTxIds(utxos);
 		for (const utxoTxId of providedUtxoTxIds) {
-			if (pendingTxIds.includes(utxoTxId)) {
+			if (utxoTxIds.includes(utxoTxId)) {
 				throw new BtcValidationError(BtcSendValidationError.UtxoLocked);
 			}
 		}
@@ -225,7 +239,7 @@ export const sendBtc = async ({
 		identity,
 		network: mapToSignerBitcoinNetwork({ network }),
 		address: source,
-		txId: hexStringToUint8Array(txid),
+		txId: txidStringToUint8Array(txid),
 		utxos: utxosFee.utxos
 	});
 

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -4,7 +4,6 @@ import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { estimateTransactionSize, extractUtxoTxIds } from '$btc/utils/btc-utxos.utils';
 import type { SendBtcResponse } from '$declarations/signer/signer.did';
-import { getPendingTransactionIds } from '$icp/utils/btc.utils';
 import { addPendingBtcTransaction } from '$lib/api/backend.api';
 import { sendBtc as sendBtcApi } from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';

--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -1,15 +1,16 @@
 import { CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
+import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { calculateUtxoSelection, filterAvailableUtxos } from '$btc/utils/btc-utxos.utils';
 import { BITCOIN_CANISTER_IDS, IC_CKBTC_MINTER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import { getUtxosQuery } from '$icp/api/bitcoin.api';
-import { getPendingTransactionIds } from '$icp/utils/btc.utils';
+import { getPendingTransactionUtxoTxIds } from '$icp/utils/btc.utils';
 import { getCurrentBtcFeePercentiles } from '$lib/api/backend.api';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BtcAddress } from '$lib/types/address';
 import type { Amount } from '$lib/types/send';
-import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
+import { mapBitcoinNetworkToNetworkId, mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import type { Identity } from '@dfinity/agent';
 import type { BitcoinNetwork } from '@dfinity/ckbtc';
 import { isNullish } from '@dfinity/utils';
@@ -35,8 +36,17 @@ export const prepareBtcSend = async ({
 
 	const requiredMinConfirmations = CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
 
-	// Get pending transactions to exclude locked UTXOs
-	const pendingTxIds = getPendingTransactionIds(source);
+	// Get pending UTXO transaction IDs to exclude locked UTXOs
+	// It is very important that the pending transactions are updated before validating the UTXOs
+	await loadBtcPendingSentTransactions({
+		identity,
+		networkId: mapBitcoinNetworkToNetworkId(network), // we want to avoid having to pass redundant data to the function
+		address: source
+	});
+	const pendingUtxoTxIds = getPendingTransactionUtxoTxIds(source);
+	if (isNullish(pendingUtxoTxIds)) {
+		throw new Error('Pending transactions have not been initialized');
+	}
 
 	// Convert amount to satoshis
 	const amountSatoshis = convertNumberToSatoshis({ amount });
@@ -71,7 +81,7 @@ export const prepareBtcSend = async ({
 		utxos: allUtxos,
 		options: {
 			minConfirmations: requiredMinConfirmations,
-			pendingTxIds
+			pendingUtxoTxIds
 		}
 	});
 

--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -1,6 +1,6 @@
+import { utxoTxIdToString } from '$icp/utils/btc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Utxo } from '@dfinity/ckbtc';
-import { uint8ArrayToHexString } from '@dfinity/utils';
 
 export interface UtxoSelectionResult {
 	selectedUtxos: Utxo[];
@@ -9,12 +9,6 @@ export interface UtxoSelectionResult {
 	sufficientFunds: boolean;
 	feeSatoshis: bigint;
 }
-
-/**
- * Converts a UTXO transaction ID (Uint8Array) to a hex string
- */
-export const utxoTxIdToString = (txid: Uint8Array | number[]): string =>
-	uint8ArrayToHexString(txid);
 
 /**
  * Extracts transaction IDs from an array of UTXOs
@@ -124,14 +118,14 @@ export const calculateUtxoSelection = ({
  */
 export const filterLockedUtxos = ({
 	utxos,
-	pendingTxIds
+	pendingUtxoTxIds
 }: {
 	utxos: Utxo[];
-	pendingTxIds: string[];
+	pendingUtxoTxIds: string[];
 }): Utxo[] =>
 	utxos.filter((utxo) => {
 		const txIdHex = utxoTxIdToString(utxo.outpoint.txid);
-		return !pendingTxIds.includes(txIdHex);
+		return !pendingUtxoTxIds.includes(txIdHex);
 	});
 
 /**
@@ -144,10 +138,10 @@ export const filterAvailableUtxos = ({
 	utxos: Utxo[];
 	options: {
 		minConfirmations: number;
-		pendingTxIds: string[];
+		pendingUtxoTxIds: string[];
 	};
 }): Utxo[] => {
-	const { minConfirmations, pendingTxIds } = options;
+	const { minConfirmations, pendingUtxoTxIds } = options;
 
 	// First filter by confirmations to ensure transaction security
 	// Note: UTXOs are pre-filtered by the Bitcoin canister endpoint
@@ -164,6 +158,6 @@ export const filterAvailableUtxos = ({
 	// Then filter out locked UTXOs
 	return filterLockedUtxos({
 		utxos: confirmedUtxos,
-		pendingTxIds
+		pendingUtxoTxIds
 	});
 };

--- a/src/frontend/src/icp/utils/btc.utils.ts
+++ b/src/frontend/src/icp/utils/btc.utils.ts
@@ -15,7 +15,13 @@ import { ZERO } from '$lib/constants/app.constants';
 import type { NetworkId } from '$lib/types/network';
 import type { CertifiedData } from '$lib/types/store';
 import type { TokenId } from '$lib/types/token';
-import { isNullish, nonNullish, notEmptyString, uint8ArrayToHexString } from '@dfinity/utils';
+import {
+	hexStringToUint8Array,
+	isNullish,
+	nonNullish,
+	notEmptyString,
+	uint8ArrayToHexString
+} from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 /**
@@ -42,56 +48,108 @@ export const utxoTxIdToString = (txid: Uint8Array | number[]): string =>
 	uint8ArrayToHexString(Uint8Array.from(txid).toReversed());
 
 /**
- * Converts a PendingTransaction txid to a hex string format
- * @param tx - The pending transaction containing the txid
- * @returns The txid as a hex string, or null if conversion fails
+ * Convert a Bitcoin transaction ID hex string to Uint8Array with proper byte reversal.
+ * Bitcoin transaction IDs are displayed in reverse byte order compared to their binary representation.
+ *
+ * @param txidHex - Bitcoin transaction ID as hex string (human-readable format)
+ * @returns Uint8Array - Transaction ID in binary format (bytes reversed)
  */
-export const convertPendingTransactionTxid = (tx: PendingTransaction): string | null => {
-	let txidString: string;
+export const txidStringToUint8Array = (txidHex: string): Uint8Array =>
+	Uint8Array.from(hexStringToUint8Array(txidHex)).reverse();
 
-	// Handle Uint8Array case (txid: Uint8Array )
-	if (tx.txid instanceof Uint8Array) {
-		txidString = Array.from(tx.txid)
-			.map((b: number) => b.toString(16).padStart(2, '0'))
-			.join('');
-	}
-	// Handle number array case (txid: number[])
-	else if (Array.isArray(tx.txid)) {
-		txidString = tx.txid.map((b: number) => b.toString(16).padStart(2, '0')).join('');
-	}
-	// Fallback, convert to string representation
-	else {
-		txidString = String(tx.txid);
-	}
+/**
+ * Convert a pending transaction's txid to human-readable hex string format.
+ * Uses the same byte reversal logic as utxoTxIdToString for consistency.
+ *
+ * @param tx - PendingTransaction containing the txid
+ * @returns string | null - Human-readable transaction ID or null if empty
+ */
+export const pendingTransactionTxidToString = (tx: PendingTransaction): string | null => {
+	const txidString = utxoTxIdToString(tx.txid);
 
 	// Return the txid string only if it's not empty
 	return notEmptyString(txidString) ? txidString : null;
 };
 
-export const getPendingTransactions = (
-	address: string
-): Omit<CertifiedData<Array<PendingTransaction> | null>, 'certified'> & {
-	certified: true;
-} => {
+/**
+ * Safely retrieves pending transactions for a given Bitcoin address from the store.
+ *
+ * @param address - The Bitcoin address to get pending transactions for
+ * @returns Array of pending transactions, or null when:
+ *   - Store hasn't been initialized yet
+ *   - Address doesn't exist in store (hasn't been loaded)
+ *   - Backend retrieval failed (setPendingTransactionsError was called)
+ */
+export const getPendingTransactions = (address: string): Array<PendingTransaction> | null => {
 	const storeData = get(btcPendingSentTransactionsStore);
-	return storeData[address];
+
+	// Case 1: Store not initialized, return null
+	if (isNullish(storeData) || Object.keys(storeData).length === 0) {
+		return null;
+	}
+
+	// Case 2: Address exists in store, return actual data (may be null if backend failed)
+	if (address in storeData) {
+		return storeData[address].data;
+	}
+
+	// Case 3: Address not in store yet, return empty array for transactions
+	return [];
 };
 
 /**
  * Get pending transaction IDs from the store to exclude locked UTXOs
+ * @param address - Bitcoin address to get pending transaction IDs for
+ * @returns Array of pending transaction ID strings, or null if no pending data available
+ * @throws Error when the store has not been initialized
  */
-export const getPendingTransactionIds = (address: string): string[] => {
+export const getPendingTransactionIds = (address: string): string[] | null => {
 	const pendingTransactions = getPendingTransactions(address);
 
-	if (isNullish(pendingTransactions?.data)) {
-		return [];
+	if (isNullish(pendingTransactions)) {
+		return null;
 	}
 
-	// Use the utility function to convert txids and filter out nulls
-	return pendingTransactions.data
-		.map(convertPendingTransactionTxid)
+	// Use the utility function to convert transaction IDs and filter out nulls
+	return pendingTransactions
+		.map(pendingTransactionTxidToString)
 		.filter((txid): txid is string => nonNullish(txid));
 };
+
+/**
+ * Get all UTXO transaction IDs from all pending transactions for a given address.
+ * These are the transaction IDs that UTXOs reference (inputs being spent), not the pending transaction IDs themselves.
+ *
+ * @param address - Bitcoin address to get pending UTXO transaction IDs for
+ * @returns Array of UTXO transaction ID strings, or null if no pending data available
+ */
+export const getPendingTransactionUtxoTxIds = (address: string): string[] | null => {
+	const pendingTransactions = getPendingTransactions(address);
+
+	if (isNullish(pendingTransactions)) {
+		return null;
+	}
+
+	// Extract all UTXO transaction IDs from all pending transactions
+	const utxoTxIds: string[] = [];
+
+	for (const tx of pendingTransactions) {
+		if (nonNullish(tx.utxos)) {
+			for (const utxo of tx.utxos) {
+				if (nonNullish(utxo?.outpoint?.txid)) {
+					const utxoTxId = utxoTxIdToString(utxo.outpoint.txid);
+					if (notEmptyString(utxoTxId)) {
+						utxoTxIds.push(utxoTxId);
+					}
+				}
+			}
+		}
+	}
+
+	// Remove duplicates and return
+	return Array.from(new Set(utxoTxIds));
+};
+
 /**
  * Calculates Bitcoin wallet balance breakdown following standard Bitcoin accounting principles.
  *
@@ -120,13 +178,7 @@ export const getBtcWalletBalance = ({
 	providerTransactions: CertifiedData<BtcTransactionUi>[] | null;
 }): BtcWalletBalance => {
 	// Retrieve pending outgoing transactions from local store with safe fallback
-	const pendingData = getPendingTransactions(address);
-	let pendingTransactions: Array<PendingTransaction> = [];
-
-	// Handle the various states the store data can be in
-	if (nonNullish(pendingData?.data)) {
-		pendingTransactions = pendingData.data;
-	}
+	const pendingTransactions = getPendingTransactions(address) ?? [];
 
 	// Calculate locked balance: UTXOs being used as inputs in pending outgoing transactions
 	// If pendingTransactions is empty (due to error or no data), locked balance will be 0

--- a/src/frontend/src/icp/utils/btc.utils.ts
+++ b/src/frontend/src/icp/utils/btc.utils.ts
@@ -169,10 +169,10 @@ export const getPendingTransactionUtxoTxIds = (address: string): string[] | null
  * @returns Structured balance object with confirmed, unconfirmed, locked, and total amounts
  */
 export const getBtcWalletBalance = ({
-																			address,
-																			confirmedBalance,
-																			providerTransactions
-																		}: {
+	address,
+	confirmedBalance,
+	providerTransactions
+}: {
 	address: string;
 	confirmedBalance: bigint;
 	providerTransactions: CertifiedData<BtcTransactionUi>[] | null;
@@ -186,10 +186,10 @@ export const getBtcWalletBalance = ({
 		// Safely calculate UTXO sum with additional error handling
 		const txUtxoValue = nonNullish(tx.utxos)
 			? tx.utxos.reduce((utxoSum, utxo) => {
-				// Ensure utxo.value is valid before adding
-				const utxoValue = nonNullish(utxo?.value) ? BigInt(utxo.value) : ZERO;
-				return utxoSum + utxoValue;
-			}, ZERO)
+					// Ensure utxo.value is valid before adding
+					const utxoValue = nonNullish(utxo?.value) ? BigInt(utxo.value) : ZERO;
+					return utxoSum + utxoValue;
+				}, ZERO)
 			: ZERO;
 
 		return sum + txUtxoValue;
@@ -200,15 +200,15 @@ export const getBtcWalletBalance = ({
 	// When providerTransactions is null (certified=true), unconfirmedBalance will be 0
 	const unconfirmedBalance = nonNullish(providerTransactions)
 		? providerTransactions.reduce((sum, tx) => {
-			if (
-				tx.data.status === 'unconfirmed' &&
-				tx.data.type === 'receive' &&
-				nonNullish(tx.data.value)
-			) {
-				return sum + tx.data.value;
-			}
-			return sum;
-		}, ZERO)
+				if (
+					tx.data.status === 'unconfirmed' &&
+					tx.data.type === 'receive' &&
+					nonNullish(tx.data.value)
+				) {
+					return sum + tx.data.value;
+				}
+				return sum;
+			}, ZERO)
 		: ZERO;
 
 	// Total balance represents the user's complete Bitcoin holdings

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -91,6 +91,15 @@ const mapper: Record<symbol, BitcoinNetwork> = {
 export const mapNetworkIdToBitcoinNetwork = (networkId: NetworkId): BitcoinNetwork | undefined =>
 	mapper[networkId];
 
+export const mapBitcoinNetworkToNetworkId = (network: BitcoinNetwork): NetworkId | undefined => {
+	const reverseMapper: Record<BitcoinNetwork, NetworkId> = {
+		mainnet: BTC_MAINNET_NETWORK_ID,
+		testnet: BTC_TESTNET_NETWORK_ID,
+		regtest: BTC_REGTEST_NETWORK_ID
+	};
+	return reverseMapper[network];
+};
+
 export const showTokenFilteredBySelectedNetwork = ({
 	token,
 	$selectedNetwork,

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -1,3 +1,4 @@
+import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
 import { sendBtc, validateBtcSend, type SendBtcParams } from '$btc/services/btc-send.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
@@ -10,7 +11,7 @@ import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { mockUtxosFee } from '$tests/mocks/btc.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import type { Utxo } from '@dfinity/ckbtc';
-import { hexStringToUint8Array, toNullable } from '@dfinity/utils';
+import { toNullable } from '@dfinity/utils';
 
 // Mock environment variables (same as btc-utxos.service.spec.ts)
 vi.mock('$env/networks/networks.icrc.env', () => ({
@@ -41,6 +42,9 @@ describe('btc-send.services', () => {
 				.spyOn(backendAPI, 'addPendingBtcTransaction')
 				.mockResolvedValue(true);
 			const sendBtcApiSpy = vi.spyOn(signerAPI, 'sendBtc').mockResolvedValue({ txid });
+			const txidStringToUint8ArraySpy = vi
+				.spyOn(btcUtils, 'txidStringToUint8Array')
+				.mockReturnValue(new Uint8Array());
 			const onProgressSpy = vi.spyOn(defaultParams, 'onProgress');
 
 			await sendBtc(defaultParams);
@@ -63,12 +67,14 @@ describe('btc-send.services', () => {
 
 			expect(onProgressSpy).toHaveBeenCalled();
 
+			expect(txidStringToUint8ArraySpy).toHaveBeenCalledWith(txid);
+
 			expect(addPendingBtcTransactionSpy).toHaveBeenCalledOnce();
 			expect(addPendingBtcTransactionSpy).toHaveBeenCalledWith({
 				identity: defaultParams.identity,
 				network: mapToSignerBitcoinNetwork({ network: defaultParams.network }),
 				address: defaultParams.source,
-				txId: hexStringToUint8Array(txid),
+				txId: new Uint8Array(),
 				utxos: defaultParams.utxosFee.utxos
 			});
 		});
@@ -124,7 +130,11 @@ describe('btc-send.services', () => {
 			vi.clearAllMocks();
 
 			// Then set up default mocks
-			vi.spyOn(btcUtils, 'getPendingTransactionIds').mockReturnValue([]);
+			vi.spyOn(
+				btcPendingSentTransactionsServices,
+				'loadBtcPendingSentTransactions'
+			).mockResolvedValue({ success: true });
+			vi.spyOn(btcUtils, 'getPendingTransactionUtxoTxIds').mockReturnValue([]);
 			vi.spyOn(btcUtxosUtils, 'extractUtxoTxIds').mockReturnValue(['txid1', 'txid2']);
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
@@ -262,7 +272,7 @@ describe('btc-send.services', () => {
 		});
 
 		it('should throw UtxoLocked error when UTXO is in pending transactions', async () => {
-			vi.spyOn(btcUtils, 'getPendingTransactionIds').mockReturnValue(['txid1']);
+			vi.spyOn(btcUtils, 'getPendingTransactionUtxoTxIds').mockReturnValue(['txid1']);
 			vi.spyOn(btcUtxosUtils, 'extractUtxoTxIds').mockReturnValue(['txid1']);
 
 			await expect(validateBtcSend(defaultValidateParams)).rejects.toThrow(BtcValidationError);

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -4,9 +4,9 @@ import {
 	extractUtxoTxIds,
 	filterAvailableUtxos,
 	filterLockedUtxos,
-	utxoTxIdToString,
 	type UtxoSelectionResult
 } from '$btc/utils/btc-utxos.utils';
+import { utxoTxIdToString } from '$icp/utils/btc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Utxo } from '@dfinity/ckbtc';
 
@@ -31,18 +31,18 @@ describe('btc-utxos.utils', () => {
 	});
 
 	describe('utxoTxIdToString', () => {
-		it('should convert Uint8Array to hex string', () => {
+		it('should convert Uint8Array to hex string with byte reversal', () => {
 			const txid = new Uint8Array([1, 2, 3, 4]);
 			const result = utxoTxIdToString(txid);
 
-			expect(result).toBe('01020304');
+			expect(result).toBe('04030201');
 		});
 
-		it('should convert number array to hex string', () => {
+		it('should convert number array to hex string with byte reversal', () => {
 			const txid = [1, 2, 3, 4];
 			const result = utxoTxIdToString(txid);
 
-			expect(result).toBe('01020304');
+			expect(result).toBe('04030201');
 		});
 
 		it('should handle empty array', () => {
@@ -62,7 +62,7 @@ describe('btc-utxos.utils', () => {
 
 			const result = extractUtxoTxIds(utxos);
 
-			expect(result).toEqual(['01020304', '05060708']);
+			expect(result).toEqual(['04030201', '08070605']);
 		});
 
 		it('should return empty array for empty input', () => {
@@ -222,11 +222,11 @@ describe('btc-utxos.utils', () => {
 		];
 
 		it('should filter out locked UTXOs', () => {
-			const pendingTxIds = ['01020304', '090a0b0c']; // Hex of [1,2,3,4] and [9,10,11,12]
+			const pendingUtxoTxIds = ['04030201', '0c0b0a09']; // Hex of [1,2,3,4] and [9,10,11,12] reversed
 
 			const result = filterLockedUtxos({
 				utxos,
-				pendingTxIds
+				pendingUtxoTxIds
 			});
 
 			expect(result).toHaveLength(1);
@@ -236,7 +236,7 @@ describe('btc-utxos.utils', () => {
 		it('should return all UTXOs when no pending transactions', () => {
 			const result = filterLockedUtxos({
 				utxos,
-				pendingTxIds: []
+				pendingUtxoTxIds: []
 			});
 
 			expect(result).toHaveLength(3);
@@ -245,7 +245,7 @@ describe('btc-utxos.utils', () => {
 		it('should handle empty UTXO array', () => {
 			const result = filterLockedUtxos({
 				utxos: [],
-				pendingTxIds: ['01020304']
+				pendingUtxoTxIds: ['04030201']
 			});
 
 			expect(result).toEqual([]);
@@ -274,7 +274,7 @@ describe('btc-utxos.utils', () => {
 				utxos,
 				options: {
 					minConfirmations: 6,
-					pendingTxIds: []
+					pendingUtxoTxIds: []
 				}
 			});
 
@@ -287,7 +287,7 @@ describe('btc-utxos.utils', () => {
 				utxos,
 				options: {
 					minConfirmations: 1,
-					pendingTxIds: []
+					pendingUtxoTxIds: []
 				}
 			});
 
@@ -297,13 +297,13 @@ describe('btc-utxos.utils', () => {
 		});
 
 		it('should filter out locked UTXOs', () => {
-			const pendingTxIds = ['05060708']; // Hex of [5, 6, 7, 8]
+			const pendingUtxoTxIds = ['08070605']; // Hex of [5, 6, 7, 8] reversed
 
 			const result = filterAvailableUtxos({
 				utxos,
 				options: {
 					minConfirmations: 6,
-					pendingTxIds
+					pendingUtxoTxIds
 				}
 			});
 
@@ -312,13 +312,13 @@ describe('btc-utxos.utils', () => {
 		});
 
 		it('should apply both confirmation and lock filters', () => {
-			const pendingTxIds = ['090a0b0c']; // Hex of [9, 10, 11, 12]
+			const pendingUtxoTxIds = ['0c0b0a09']; // Hex of [9, 10, 11, 12] reversed
 
 			const result = filterAvailableUtxos({
 				utxos,
 				options: {
 					minConfirmations: 10,
-					pendingTxIds
+					pendingUtxoTxIds
 				}
 			});
 
@@ -332,7 +332,7 @@ describe('btc-utxos.utils', () => {
 				utxos: [],
 				options: {
 					minConfirmations: 1,
-					pendingTxIds: []
+					pendingUtxoTxIds: []
 				}
 			});
 


### PR DESCRIPTION
# Motivation

This Pull Request aims to enhance the Bitcoin transaction handling functionality by addressing issues related to pending transactions and fixing the incorrect processing of UTXOs (unspent transaction outputs).

# Changes

- Load pending transactions into the store before checking for locked UTXOs in the `prepareBtcSend` and `validateBtcSend` functions, ensuring data is always up to date.

- Introduced the function `getPendingTransactionUtxoTxIds()`, which correctly returns the txids of the relevant UTXOs (instead of incorectly using `getPendingTransactionIds())`.

- Reorganized utility functions related to txid conversion, ensuring that txids are stored correctly when saving pending transactions (during BTC sends).

- Using as variable name 'pendingUtxoTxIds' consistently  for UTXO txid's for pending (locked) transactions 

# Tests

- Updated unit tests to cover the new `getPendingTransactionUtxoTxIds` function.
- Refactored and extended tests for `btc-send.services` and `btc-utxos.service`.
- Mocked new data structures like UTXOs tied to transactions in store-related tests.
- Added comprehensive tests for scenarios like empty UTXO arrays, byte-reversed transaction IDs, and null pending transaction data.
