### PR TITLE
feat(frontend): blocks importing nft tokens when the feature flag is not active

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -3,6 +3,7 @@
 	import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { get } from 'svelte/store';
+	import { NFTS_ENABLED } from '$env/nft.env';
 	import EthAddTokenReview from '$eth/components/tokens/EthAddTokenReview.svelte';
 	import { isInterfaceErc1155 } from '$eth/services/erc1155.services';
 	import type { SaveUserToken } from '$eth/services/erc20-user-tokens.services';
@@ -52,7 +53,6 @@
 	import { saveSplCustomTokens } from '$sol/services/manage-tokens.services';
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
-	import { NFTS_ENABLED } from '$env/nft.env';
 
 	let {
 		initialSearch,

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -52,6 +52,7 @@
 	import { saveSplCustomTokens } from '$sol/services/manage-tokens.services';
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
+	import { NFTS_ENABLED } from '$env/nft.env';
 
 	let {
 		initialSearch,
@@ -139,26 +140,28 @@
 			enabled: true
 		};
 
-		const isErc721 = await isInterfaceErc721({
-			address: ethContractAddress,
-			networkId: network.id
-		});
+		if (NFTS_ENABLED) {
+			const isErc721 = await isInterfaceErc721({
+				address: ethContractAddress,
+				networkId: network.id
+			});
 
-		if (isErc721) {
-			await saveErc721([newToken]);
+			if (isErc721) {
+				await saveErc721([newToken]);
 
-			return;
-		}
+				return;
+			}
 
-		const isErc1155 = await isInterfaceErc1155({
-			address: ethContractAddress,
-			networkId: network.id
-		});
+			const isErc1155 = await isInterfaceErc1155({
+				address: ethContractAddress,
+				networkId: network.id
+			});
 
-		if (isErc1155) {
-			await saveErc1155([newToken]);
+			if (isErc1155) {
+				await saveErc1155([newToken]);
 
-			return;
+				return;
+			}
 		}
 
 		if (ethMetadata.decimals > 0) {


### PR DESCRIPTION
# Motivation

As long as the `NFT` feature is not active it should not be possible to import `erc721` or `erc1155` contracts.
