### PR TITLE
feat(frontend): fixes network list types

### DIFF
--- a/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
+++ b/src/frontend/src/env/networks/networks-evm/networks.evm.env.ts
@@ -2,7 +2,7 @@ import { SUPPORTED_BASE_NETWORKS } from '$env/networks/networks-evm/networks.evm
 import { SUPPORTED_BSC_NETWORKS } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import { SUPPORTED_POLYGON_NETWORKS } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import type { EthereumChainId, EthereumNetwork } from '$eth/types/network';
-import type { Network, NetworkId } from '$lib/types/network';
+import type { NetworkId } from '$lib/types/network';
 import { SUPPORTED_ARBITRUM_NETWORKS } from './networks.evm.arbitrum.env';
 
 export const SUPPORTED_EVM_NETWORKS: EthereumNetwork[] = [
@@ -18,11 +18,11 @@ export const SUPPORTED_EVM_NETWORKS_CHAIN_IDS: EthereumChainId[] = SUPPORTED_EVM
 	({ chainId }) => chainId
 );
 
-export const SUPPORTED_EVM_MAINNET_NETWORKS: Network[] = SUPPORTED_EVM_NETWORKS.filter(
+export const SUPPORTED_EVM_MAINNET_NETWORKS: EthereumNetwork[] = SUPPORTED_EVM_NETWORKS.filter(
 	({ env }) => env === 'mainnet'
 );
 
-export const SUPPORTED_EVM_TESTNET_NETWORKS: Network[] = SUPPORTED_EVM_NETWORKS.filter(
+export const SUPPORTED_EVM_TESTNET_NETWORKS: EthereumNetwork[] = SUPPORTED_EVM_NETWORKS.filter(
 	({ env }) => env === 'testnet'
 );
 


### PR DESCRIPTION
# Motivation

Since all the evm networks are `ethereum` networks, we change the networks list types from `Network` to `EthereumNetwork`
