### PR TITLE
fix(frontend): mocks loadNftIdsOfToken to prevent loading nfts

### DIFF
--- a/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
@@ -26,6 +26,8 @@ describe('LoaderNfts', () => {
 	let etherscanProvidersSpy: MockInstance;
 	let alchemyProvidersSpy: MockInstance;
 
+	let loadNftIdsOfTokenSpy: MockInstance;
+
 	const mockErc721TokenInventory = vi.fn();
 	const mockGetNftIdsForOwner = vi.fn();
 
@@ -60,12 +62,13 @@ describe('LoaderNfts', () => {
 		setupUserNetworksStore('allEnabled');
 
 		ethAddressStore.set({ data: mockEthAddress, certified: false });
+
+		loadNftIdsOfTokenSpy = vi.spyOn(nftServicesModule, 'loadNftIdsOfToken');
 	});
 
 	describe('handleNewNfts', () => {
 		let infuraErc721ProvidersSpy: MockInstance;
 		let infuraErc1155ProvidersSpy: MockInstance;
-		let loadNftIdsOfTokenSpy: MockInstance;
 
 		beforeEach(() => {
 			infuraErc721ProvidersSpy = vi.spyOn(infuraErc721ProvidersModule, 'infuraErc721Providers');
@@ -73,8 +76,6 @@ describe('LoaderNfts', () => {
 
 			infuraErc1155ProvidersSpy = vi.spyOn(infuraErc1155ProvidersModule, 'infuraErc1155Providers');
 			infuraErc1155ProvidersSpy.mockReturnValue({});
-
-			loadNftIdsOfTokenSpy = vi.spyOn(nftServicesModule, 'loadNftIdsOfToken');
 		});
 
 		it('should add new ERC721 nfts of loaded nft ids', async () => {
@@ -244,8 +245,6 @@ describe('LoaderNfts', () => {
 	});
 
 	describe('handleUpdatedNfts', () => {
-		let loadNftIdsOfTokenSpy: MockInstance;
-
 		const mockNft1 = {
 			...mockValidErc1155Nft,
 			id: mockNftId1,
@@ -284,8 +283,6 @@ describe('LoaderNfts', () => {
 				{ data: mockedEnabledNyanToken, certified: false },
 				{ data: mockedEnabledApeToken, certified: false }
 			]);
-
-			loadNftIdsOfTokenSpy = vi.spyOn(nftServicesModule, 'loadNftIdsOfToken');
 		});
 
 		it('should update ERC1155 nfts from the nft store', async () => {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
@@ -244,6 +244,8 @@ describe('LoaderNfts', () => {
 	});
 
 	describe('handleUpdatedNfts', () => {
+		let loadNftIdsOfTokenSpy: MockInstance;
+
 		const mockNft1 = {
 			...mockValidErc1155Nft,
 			id: mockNftId1,
@@ -282,6 +284,8 @@ describe('LoaderNfts', () => {
 				{ data: mockedEnabledNyanToken, certified: false },
 				{ data: mockedEnabledApeToken, certified: false }
 			]);
+
+			loadNftIdsOfTokenSpy = vi.spyOn(nftServicesModule, 'loadNftIdsOfToken');
 		});
 
 		it('should update ERC1155 nfts from the nft store', async () => {


### PR DESCRIPTION
# Motivation

The `handleUpdatedNfts` test case failes sometimes and we want to fix it. To solve this we mock `loadNftIdsOfToken` to prevent that some additional nfts are loaded.
