### PR TITLE
feat(frontend): adjust "show_contacts" tool

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantShowContactsTool.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantShowContactsTool.svelte
@@ -2,11 +2,11 @@
 	import AiAssistantShowContactsToolItem from '$lib/components/ai-assistant/AiAssistantShowContactsToolItem.svelte';
 	import { MAX_DISPLAYED_ADDRESSES_NUMBER } from '$lib/constants/ai-assistant.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
+	import type { ContactAddressUi, ContactUi, ExtendedAddressContactUi } from '$lib/types/contact';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
-		contacts: ContactUi[];
+		contacts: ExtendedAddressContactUi[];
 	}
 
 	let { contacts }: Props = $props();

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantToolResults.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantToolResults.svelte
@@ -13,7 +13,7 @@
 <div class="mb-5">
 	{#each results as { result, type }, index (index)}
 		{#if type === 'show_contacts' && nonNullish(result)}
-			<AiAssistantShowContactsTool contacts={result} />
+			<AiAssistantShowContactsTool contacts={result.contacts} />
 		{/if}
 	{/each}
 </div>

--- a/src/frontend/src/lib/types/ai-assistant.ts
+++ b/src/frontend/src/lib/types/ai-assistant.ts
@@ -1,11 +1,8 @@
-import type {
-	ContactAddressUiWithId,
-	ContactUi,
-	ExtendedAddressContactUi
-} from '$lib/types/contact';
+import type { ContactAddressUiWithId, ExtendedAddressContactUi } from '$lib/types/contact';
 
 export interface ChatMessageContent {
 	text?: string;
+	context?: string;
 	tool?: {
 		calls: ToolCall[];
 		results: ToolResult[];
@@ -32,9 +29,14 @@ export interface ToolCall {
 	function: ToolFunction;
 }
 
+export interface ShowContactsToolResult {
+	contacts: ExtendedAddressContactUi[];
+	message?: string;
+}
+
 export interface ToolResult {
-	type: 'show_contacts';
-	result?: ContactUi[];
+	type: 'show_contacts' | 'review_send_tokens';
+	result?: ShowContactsToolResult;
 }
 
 export interface AiAssistantContactUi

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -1,5 +1,5 @@
 import type { AiAssistantContactUi, AiAssistantContactUiMap } from '$lib/types/ai-assistant';
-import type { ContactUi, ExtendedAddressContactUiMap } from '$lib/types/contact';
+import type { ExtendedAddressContactUi, ExtendedAddressContactUiMap } from '$lib/types/contact';
 
 export const parseToAiAssistantContacts = (
 	extendedAddressContacts: ExtendedAddressContactUiMap
@@ -23,17 +23,15 @@ export const parseFromAiAssistantContacts = ({
 }: {
 	aiAssistantContacts: AiAssistantContactUi[];
 	extendedAddressContacts: ExtendedAddressContactUiMap;
-}): ContactUi[] =>
-	aiAssistantContacts.reduce<ContactUi[]>(
+}): ExtendedAddressContactUi[] =>
+	aiAssistantContacts.reduce<ExtendedAddressContactUi[]>(
 		(acc, { id, addresses }) => [
 			...acc,
 			{
 				...extendedAddressContacts[`${id}`],
-				addresses: extendedAddressContacts[`${id}`].addresses
-					.filter(({ id: addressId }) =>
-						addresses.some((filteredAddress) => filteredAddress.id === addressId)
-					)
-					.map(({ id: _, ...rest }) => ({ ...rest }))
+				addresses: extendedAddressContacts[`${id}`].addresses.filter(({ id: addressId }) =>
+					addresses.some((filteredAddress) => filteredAddress.id === addressId)
+				)
 			}
 		],
 		[]

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantShowContactsTool.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantShowContactsTool.spec.ts
@@ -1,11 +1,14 @@
 import AiAssistantShowContactsTool from '$lib/components/ai-assistant/AiAssistantShowContactsTool.svelte';
 import { MAX_DISPLAYED_ADDRESSES_NUMBER } from '$lib/constants/ai-assistant.constants';
+import { extendedAddressContacts } from '$lib/derived/contacts.derived';
+import { contactsStore } from '$lib/stores/contacts.store';
 import type { ContactUi } from '$lib/types/contact';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 
 describe('AiAssistantShowContactsTool', () => {
 	const contacts = getMockContactsUi({
@@ -13,8 +16,11 @@ describe('AiAssistantShowContactsTool', () => {
 		name: 'Multiple Addresses Contact',
 		addresses: [mockContactBtcAddressUi]
 	}) as unknown as ContactUi[];
+	contacts.forEach((contact) => contactsStore.addContact(contact));
+
+	const extendedContacts = get(extendedAddressContacts);
 	const props = {
-		contacts
+		contacts: Object.values(extendedContacts)
 	};
 
 	it('renders no contacts found message', () => {

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantToolResults.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantToolResults.spec.ts
@@ -1,8 +1,11 @@
 import AiAssistantToolResults from '$lib/components/ai-assistant/AiAssistantToolResults.svelte';
+import { extendedAddressContacts } from '$lib/derived/contacts.derived';
+import { contactsStore } from '$lib/stores/contacts.store';
 import type { ToolResult } from '$lib/types/ai-assistant';
 import type { ContactUi } from '$lib/types/contact';
 import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
 import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 
 describe('AiAssistantToolResults', () => {
 	const contacts = getMockContactsUi({
@@ -10,6 +13,9 @@ describe('AiAssistantToolResults', () => {
 		name: 'Multiple Addresses Contact',
 		addresses: [mockContactBtcAddressUi]
 	}) as unknown as ContactUi[];
+	contacts.forEach((contact) => contactsStore.addContact(contact));
+
+	const extendedContacts = get(extendedAddressContacts);
 
 	it('renders known tool correctly', () => {
 		const { getByText } = render(AiAssistantToolResults, {
@@ -17,7 +23,7 @@ describe('AiAssistantToolResults', () => {
 				results: [
 					{
 						type: 'show_contacts',
-						result: contacts
+						result: { contacts: Object.values(extendedContacts) }
 					}
 				]
 			}

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -80,7 +80,7 @@ describe('ai-assistant.services', () => {
 					calls: [noAgumentsToolCall],
 					results: [
 						{
-							result: [],
+							result: { contacts: [] },
 							type: 'show_contacts'
 						}
 					]
@@ -135,7 +135,7 @@ describe('ai-assistant.services', () => {
 				filterParams: [{ value: 'Btc', name: 'addressType' }]
 			});
 
-			expect(result).toStrictEqual([...contacts]);
+			expect(result).toStrictEqual({ contacts: Object.values(storeData) });
 		});
 	});
 
@@ -161,7 +161,9 @@ describe('ai-assistant.services', () => {
 
 			expect(result).toEqual({
 				type: 'show_contacts',
-				result: contacts
+				result: {
+					contacts: Object.values(get(extendedAddressContacts))
+				}
 			});
 		});
 
@@ -173,7 +175,9 @@ describe('ai-assistant.services', () => {
 
 			expect(result).toEqual({
 				type: 'show_contacts',
-				result: contacts
+				result: {
+					contacts: Object.values(get(extendedAddressContacts))
+				}
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -50,7 +50,7 @@ describe('ai-assistant.utils', () => {
 					aiAssistantContacts: [aiAssistantContact],
 					extendedAddressContacts: storeData
 				})
-			).toEqual([...contactsData]);
+			).toEqual(Object.values(storeData));
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We need to adjust the "show_contacts" tool - it should now return extended contact information (incl. address ids). Also, in the next PRs, there will be an additional response flag introduced (`message`).
