### PR TITLE
feat(frontend): Markdown utils

### DIFF
--- a/src/frontend/src/lib/types/markdown.ts
+++ b/src/frontend/src/lib/types/markdown.ts
@@ -1,0 +1,5 @@
+export interface MarkdownBlockType {
+	type: 'header' | 'default';
+	text: string;
+	id?: string;
+}

--- a/src/frontend/src/lib/utils/markdown.utils.ts
+++ b/src/frontend/src/lib/utils/markdown.utils.ts
@@ -1,0 +1,17 @@
+import type { MarkdownBlockType } from '$lib/types/markdown';
+
+export const getMarkdownBlocks = ({
+	md,
+	headingDesignator
+}: {
+	md: string;
+	headingDesignator: string;
+}): MarkdownBlockType[] =>
+	md.split('\n').map((line: string) => {
+		if (line.startsWith(headingDesignator)) {
+			const title = line.slice(headingDesignator.length).trim();
+			const id = title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+			return { type: 'header', text: title, id };
+		}
+		return { type: 'default', text: line };
+	});

--- a/src/frontend/src/tests/lib/utils/markdown.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/markdown.utils.spec.ts
@@ -1,0 +1,60 @@
+import { getMarkdownBlocks } from '$lib/utils/markdown.utils';
+
+describe('getMarkdownBlocks', () => {
+	it('splits markdown into blocks with headers and defaults', () => {
+		const md = `### First Heading
+Some paragraph text
+### Second Heading`;
+
+		const result = getMarkdownBlocks({ md, headingDesignator: '###' });
+
+		expect(result).toEqual([
+			{ type: 'header', text: 'First Heading', id: 'first-heading' },
+			{ type: 'default', text: 'Some paragraph text' },
+			{ type: 'header', text: 'Second Heading', id: 'second-heading' }
+		]);
+	});
+
+	it('trims spaces after heading designator', () => {
+		const md = '###    Spaced Heading';
+		const result = getMarkdownBlocks({ md, headingDesignator: '###' });
+		expect(result[0]).toEqual({
+			type: 'header',
+			text: 'Spaced Heading',
+			id: 'spaced-heading'
+		});
+	});
+
+	it('handles non-heading lines correctly', () => {
+		const md = 'Just some text';
+		const result = getMarkdownBlocks({ md, headingDesignator: '###' });
+		expect(result).toEqual([{ type: 'default', text: 'Just some text' }]);
+	});
+
+	it('generates slugified IDs with dashes', () => {
+		const md = '### Heading With !@#$ Symbols';
+		const result = getMarkdownBlocks({ md, headingDesignator: '###' });
+		expect(result[0].id).toBe('heading-with-symbols');
+	});
+
+	it('supports custom heading designators', () => {
+		const md = `## Custom H2
+Some text`;
+		const result = getMarkdownBlocks({ md, headingDesignator: '##' });
+
+		expect(result[0]).toEqual({
+			type: 'header',
+			text: 'Custom H2',
+			id: 'custom-h2'
+		});
+		expect(result[1]).toEqual({
+			type: 'default',
+			text: 'Some text'
+		});
+	});
+
+	it('returns empty array for empty string', () => {
+		const result = getMarkdownBlocks({ md: '', headingDesignator: '###' });
+		expect(result).toEqual([{ type: 'default', text: '' }]);
+	});
+});


### PR DESCRIPTION
# Motivation

For the new Terms of Use, License Agreement etc were going to use a Markdown syntax to store/render the documents.

In order to be able to display a sidebar with links to the main headings, we need to split it the markdown and mark headings to display the table of contents.

# Changes

Added utils for getting blocks for a markdown string

# Tests

Added tests
