### PR TITLE
feat(frontend): Markdown Sidebar

### DIFF
--- a/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
+++ b/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
@@ -12,10 +12,12 @@
 	const { headings }: Props = $props();
 
 	let activeId: string | undefined = $state();
+	let observer: IntersectionObserver | undefined;
+	const observed = new Set<Element>();
 
 	onMount(() => {
 		// Scroll spy to highlight active item
-		const observer = new IntersectionObserver(
+		observer = new IntersectionObserver(
 			(entries) => {
 				entries.forEach((entry) => {
 					if (entry.isIntersecting) {
@@ -29,11 +31,19 @@
 		headings.forEach(({ id }) => {
 			if (nonNullish(id)) {
 				const el = document.getElementById(id);
-				if (nonNullish(el)) {
+				if (nonNullish(el) && nonNullish(observer)) {
 					observer.observe(el);
+					observed.add(el);
 				}
 			}
 		});
+
+		// cleanup observers
+		return () => {
+			observed.forEach((el) => observer?.unobserve(el));
+			observer?.disconnect();
+			observed.clear();
+		};
 	});
 </script>
 

--- a/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
+++ b/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import List from '$lib/components/common/List.svelte';
+	import ListItem from '$lib/components/common/ListItem.svelte';
+
+	interface Props {
+		text: string;
+	}
+
+	const { text }: Props = $props();
+
+	type HeadingType = {
+		title: string;
+		id: string;
+	};
+
+	let headings: HeadingType[] = $state([]);
+	let activeId: string | undefined = $state();
+
+	// Extract ### headings and assign IDs
+	onMount(() => {
+		const lines = text.split('\n');
+		headings = lines.reduce<HeadingType[]>((acc, line) => {
+			if (!line.startsWith('###')) return acc;
+
+			const title = line
+				.replace(/^###\s*/, '')
+				.replace(/\\/g, '')
+				.trim();
+			const id = title
+				.toLowerCase()
+				.replace(/[^a-z0-9]+/g, '-') // slug
+				.replace(/^-+|-+$/g, ''); // trim hyphens
+
+			acc = [...acc, { id, title }];
+			return acc;
+		}, []);
+
+		// Scroll spy to highlight active item
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						activeId = entry.target.id;
+					}
+				});
+			},
+			{ rootMargin: '0px 0px -80% 0px', threshold: 0 }
+		);
+
+		headings.forEach(({ id }) => {
+			const el = document.getElementById(id);
+			if (el) {
+				observer.observe(el);
+			}
+		});
+	});
+</script>
+
+<div class="fixed right-12 top-10 hidden rounded-2xl bg-primary py-2 xl:block 1.5lg:top-28">
+	<List condensed styleClass="pr-3">
+		{#each headings as { id, title }, index (id)}
+			<ListItem>
+				<a href={`#${id}`} class="w-full no-underline">
+					<span
+						class:text-primary={nonNullish(activeId) ? activeId === id : index === 0}
+						class="text-xs">{title}</span
+					>
+				</a>
+			</ListItem>
+		{/each}
+	</List>
+</div>

--- a/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
+++ b/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
@@ -50,10 +50,10 @@
 <List condensed styleClass="pr-3">
 	{#each headings as { id, text }, index (id)}
 		<ListItem>
-			<a href={`#${id}`} class="w-full no-underline">
+			<a class="w-full no-underline" href={`#${id}`}>
 				<span
-					class:text-primary={nonNullish(activeId) ? activeId === id : index === 0}
-					class="text-xs">{text}</span
+					class="text-xs"
+					class:text-primary={nonNullish(activeId) ? activeId === id : index === 0}>{text}</span
 				>
 			</a>
 		</ListItem>

--- a/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
+++ b/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
@@ -13,7 +13,7 @@
 
 	let activeId: string | undefined = $state();
 	let observer: IntersectionObserver | undefined;
-	const observed = new Set<Element>();
+	let observed: Element[] = [];
 
 	onMount(() => {
 		// Scroll spy to highlight active item
@@ -33,7 +33,7 @@
 				const el = document.getElementById(id);
 				if (nonNullish(el) && nonNullish(observer)) {
 					observer.observe(el);
-					observed.add(el);
+					observed = [...observed, el];
 				}
 			}
 		});
@@ -42,7 +42,7 @@
 		return () => {
 			observed.forEach((el) => observer?.unobserve(el));
 			observer?.disconnect();
-			observed.clear();
+			observed = [];
 		};
 	});
 </script>

--- a/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
+++ b/src/frontend/src/lib/components/ui/MarkdownSidebar.svelte
@@ -3,40 +3,17 @@
 	import { onMount } from 'svelte';
 	import List from '$lib/components/common/List.svelte';
 	import ListItem from '$lib/components/common/ListItem.svelte';
+	import type { MarkdownBlockType } from '$lib/types/markdown';
 
 	interface Props {
-		text: string;
+		headings: MarkdownBlockType[];
 	}
 
-	const { text }: Props = $props();
+	const { headings }: Props = $props();
 
-	type HeadingType = {
-		title: string;
-		id: string;
-	};
-
-	let headings: HeadingType[] = $state([]);
 	let activeId: string | undefined = $state();
 
-	// Extract ### headings and assign IDs
 	onMount(() => {
-		const lines = text.split('\n');
-		headings = lines.reduce<HeadingType[]>((acc, line) => {
-			if (!line.startsWith('###')) return acc;
-
-			const title = line
-				.replace(/^###\s*/, '')
-				.replace(/\\/g, '')
-				.trim();
-			const id = title
-				.toLowerCase()
-				.replace(/[^a-z0-9]+/g, '-') // slug
-				.replace(/^-+|-+$/g, ''); // trim hyphens
-
-			acc = [...acc, { id, title }];
-			return acc;
-		}, []);
-
 		// Scroll spy to highlight active item
 		const observer = new IntersectionObserver(
 			(entries) => {
@@ -50,25 +27,25 @@
 		);
 
 		headings.forEach(({ id }) => {
-			const el = document.getElementById(id);
-			if (el) {
-				observer.observe(el);
+			if (nonNullish(id)) {
+				const el = document.getElementById(id);
+				if (nonNullish(el)) {
+					observer.observe(el);
+				}
 			}
 		});
 	});
 </script>
 
-<div class="fixed right-12 top-10 hidden rounded-2xl bg-primary py-2 xl:block 1.5lg:top-28">
-	<List condensed styleClass="pr-3">
-		{#each headings as { id, title }, index (id)}
-			<ListItem>
-				<a href={`#${id}`} class="w-full no-underline">
-					<span
-						class:text-primary={nonNullish(activeId) ? activeId === id : index === 0}
-						class="text-xs">{title}</span
-					>
-				</a>
-			</ListItem>
-		{/each}
-	</List>
-</div>
+<List condensed styleClass="pr-3">
+	{#each headings as { id, text }, index (id)}
+		<ListItem>
+			<a href={`#${id}`} class="w-full no-underline">
+				<span
+					class:text-primary={nonNullish(activeId) ? activeId === id : index === 0}
+					class="text-xs">{text}</span
+				>
+			</a>
+		</ListItem>
+	{/each}
+</List>

--- a/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
@@ -1,6 +1,6 @@
 import MarkdownSidebar from '$lib/components/ui/MarkdownSidebar.svelte';
 import type { MarkdownBlockType } from '$lib/types/markdown';
-import { nonNullish } from '@dfinity/utils';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { cleanup, render, waitFor } from '@testing-library/svelte';
 
 // ---- Mock IntersectionObserver ----
@@ -40,18 +40,18 @@ const insertHeadingsIntoDOM = (blocks: MarkdownBlockType[]) => {
 	});
 };
 
-beforeEach(() => {
-	observedElements = [];
-	ioCallbacks = [];
-});
-
-afterEach(() => {
-	cleanup();
-	// Clean any headings we appended
-	document.body.querySelectorAll('h3').forEach((h) => h.remove());
-});
-
 describe('MarkdownSidebar', () => {
+	beforeEach(() => {
+		observedElements = [];
+		ioCallbacks = [];
+	});
+
+	afterEach(() => {
+		cleanup();
+		// Clean any headings we appended
+		document.body.querySelectorAll('h3').forEach((h) => h.remove());
+	});
+
 	it('renders links for headings with correct hrefs and highlights the first by default', async () => {
 		const headings: MarkdownBlockType[] = [
 			{ type: 'header', text: 'Acceptance of Terms', id: 'heading-1' },
@@ -91,9 +91,13 @@ describe('MarkdownSidebar', () => {
 		expect(span3).not.toHaveClass('text-primary');
 
 		// Component should start observing the actual <h3> nodes
-		const h1 = document.getElementById('heading-1')!;
-		const h2 = document.getElementById('heading-2')!;
-		const h3 = document.getElementById('heading-3')!;
+		const h1 = document.getElementById('heading-1');
+		assertNonNullish(h1);
+		const h2 = document.getElementById('heading-2');
+		assertNonNullish(h2);
+		const h3 = document.getElementById('heading-3');
+		assertNonNullish(h3);
+
 		expect(observedElements).toEqual(expect.arrayContaining([h1, h2, h3]));
 
 		// Simulate that heading-2 becomes the visible one

--- a/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
@@ -18,7 +18,7 @@ class MockIntersectionObserver {
 	unobserve() {}
 	disconnect() {}
 }
-vi.stubGlobal('IntersectionObserver', MockIntersectionObserver as any);
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
 
 // Helper to trigger all IO callbacks
 const triggerIntersect = (targets: Element[]) => {

--- a/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
@@ -1,0 +1,113 @@
+import MarkdownSidebar from '$lib/components/ui/MarkdownSidebar.svelte';
+import { cleanup, render, waitFor } from '@testing-library/svelte';
+
+// ---- Mock IntersectionObserver ----
+type IOEntry = { target: Element; isIntersecting: boolean; intersectionRatio?: number };
+let observedElements: Element[] = [];
+let ioCallbacks: ((entries: IOEntry[]) => void)[] = [];
+
+class MockIntersectionObserver {
+	private cb: (entries: IOEntry[]) => void;
+	constructor(cb: (entries: IOEntry[]) => void) {
+		this.cb = cb;
+		ioCallbacks.push(cb);
+	}
+	observe(el: Element) {
+		observedElements.push(el);
+	}
+	unobserve() {}
+	disconnect() {}
+}
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver as any);
+
+// Helper to trigger all IO callbacks
+const triggerIntersect = (targets: Element[]) => {
+	const entries = targets.map((t) => ({ target: t, isIntersecting: true, intersectionRatio: 1 }));
+	ioCallbacks.forEach((cb) => cb(entries));
+};
+
+// ---- Helpers to attach real <h3 id="..."> into the document ----
+const insertHeadingsIntoDOM = (idsAndText: Array<{ id: string; text: string }>) => {
+	idsAndText.forEach(({ id, text }) => {
+		const h = document.createElement('h3');
+		h.id = id;
+		h.textContent = text;
+		document.body.appendChild(h);
+	});
+};
+
+beforeEach(() => {
+	observedElements = [];
+	ioCallbacks = [];
+});
+
+afterEach(() => {
+	cleanup();
+	// Clean any headings we appended
+	document.body.querySelectorAll('h3').forEach((h) => h.remove());
+});
+
+describe('MarkdownSidebar', () => {
+	it('renders links for headings with correct hrefs and highlights the first by default', async () => {
+		const headings = [
+			{ type: 'header', text: 'Acceptance of Terms', id: 'heading-1' },
+			{ type: 'header', text: 'Description of our Services', id: 'heading-2' },
+			{ type: 'header', text: 'Account Access and Security', id: 'heading-3' }
+		] as const;
+
+		// Put real <h3> elements in the DOM so the component can observe them
+		insertHeadingsIntoDOM(headings.map(({ id, text }) => ({ id, text })));
+
+		const { getByRole } = render(MarkdownSidebar, {
+			props: { headings: headings as any }
+		});
+
+		// Links rendered with correct text and hrefs
+		const link1 = getByRole('link', { name: 'Acceptance of Terms' }) as HTMLAnchorElement;
+		const link2 = getByRole('link', {
+			name: 'Description of our Services'
+		}) as HTMLAnchorElement;
+		const link3 = getByRole('link', {
+			name: 'Account Access and Security'
+		}) as HTMLAnchorElement;
+
+		// Use getAttribute to avoid jsdom absolute URL normalization
+		expect(link1.getAttribute('href')).toBe('#heading-1');
+		expect(link2.getAttribute('href')).toBe('#heading-2');
+		expect(link3.getAttribute('href')).toBe('#heading-3');
+
+		// First item should be highlighted initially (activeId is undefined => index === 0)
+		const span1 = link1.querySelector('span');
+		expect(span1).toHaveClass('text-primary');
+
+		const span2 = link2.querySelector('span');
+		expect(span2).not.toHaveClass('text-primary');
+
+		const span3 = link3.querySelector('span');
+		expect(span3).not.toHaveClass('text-primary');
+
+		// Component should start observing the actual <h3> nodes
+		const h1 = document.getElementById('heading-1')!;
+		const h2 = document.getElementById('heading-2')!;
+		const h3 = document.getElementById('heading-3')!;
+		expect(observedElements).toEqual(expect.arrayContaining([h1, h2, h3]));
+
+		// Simulate that heading-2 becomes the visible one
+		triggerIntersect([h2]);
+
+		await waitFor(() => {
+			expect(span2).toHaveClass('text-primary');
+			expect(span1).not.toHaveClass('text-primary');
+			expect(span3).not.toHaveClass('text-primary');
+		});
+
+		// Now simulate heading-3 intersecting
+		triggerIntersect([h3]);
+
+		await waitFor(() => {
+			expect(span3).toHaveClass('text-primary');
+			expect(span1).not.toHaveClass('text-primary');
+			expect(span2).not.toHaveClass('text-primary');
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
@@ -4,7 +4,11 @@ import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { cleanup, render, waitFor } from '@testing-library/svelte';
 
 // ---- Mock IntersectionObserver ----
-type IOEntry = { target: Element; isIntersecting: boolean; intersectionRatio?: number };
+interface IOEntry {
+	target: Element;
+	isIntersecting: boolean;
+	intersectionRatio?: number;
+}
 let observedElements: Element[] = [];
 let ioCallbacks: ((entries: IOEntry[]) => void)[] = [];
 
@@ -63,7 +67,7 @@ describe('MarkdownSidebar', () => {
 		insertHeadingsIntoDOM(headings);
 
 		const { getByRole } = render(MarkdownSidebar, {
-			props: { headings: headings }
+			props: { headings }
 		});
 
 		// Links rendered with correct text and hrefs
@@ -82,12 +86,15 @@ describe('MarkdownSidebar', () => {
 
 		// First item should be highlighted initially (activeId is undefined => index === 0)
 		const span1 = link1.querySelector('span');
+
 		expect(span1).toHaveClass('text-primary');
 
 		const span2 = link2.querySelector('span');
+
 		expect(span2).not.toHaveClass('text-primary');
 
 		const span3 = link3.querySelector('span');
+
 		expect(span3).not.toHaveClass('text-primary');
 
 		// Component should start observing the actual <h3> nodes

--- a/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MarkdownSidebar.spec.ts
@@ -1,4 +1,6 @@
 import MarkdownSidebar from '$lib/components/ui/MarkdownSidebar.svelte';
+import type { MarkdownBlockType } from '$lib/types/markdown';
+import { nonNullish } from '@dfinity/utils';
 import { cleanup, render, waitFor } from '@testing-library/svelte';
 
 // ---- Mock IntersectionObserver ----
@@ -27,12 +29,14 @@ const triggerIntersect = (targets: Element[]) => {
 };
 
 // ---- Helpers to attach real <h3 id="..."> into the document ----
-const insertHeadingsIntoDOM = (idsAndText: Array<{ id: string; text: string }>) => {
-	idsAndText.forEach(({ id, text }) => {
-		const h = document.createElement('h3');
-		h.id = id;
-		h.textContent = text;
-		document.body.appendChild(h);
+const insertHeadingsIntoDOM = (blocks: MarkdownBlockType[]) => {
+	blocks.forEach(({ id, text }) => {
+		if (nonNullish(id)) {
+			const h = document.createElement('h3');
+			h.id = id;
+			h.textContent = text;
+			document.body.appendChild(h);
+		}
 	});
 };
 
@@ -49,17 +53,17 @@ afterEach(() => {
 
 describe('MarkdownSidebar', () => {
 	it('renders links for headings with correct hrefs and highlights the first by default', async () => {
-		const headings = [
+		const headings: MarkdownBlockType[] = [
 			{ type: 'header', text: 'Acceptance of Terms', id: 'heading-1' },
 			{ type: 'header', text: 'Description of our Services', id: 'heading-2' },
 			{ type: 'header', text: 'Account Access and Security', id: 'heading-3' }
-		] as const;
+		];
 
 		// Put real <h3> elements in the DOM so the component can observe them
-		insertHeadingsIntoDOM(headings.map(({ id, text }) => ({ id, text })));
+		insertHeadingsIntoDOM(headings);
 
 		const { getByRole } = render(MarkdownSidebar, {
-			props: { headings: headings as any }
+			props: { headings: headings }
 		});
 
 		// Links rendered with correct text and hrefs


### PR DESCRIPTION
# Motivation

For the new Terms of Use, License agreement pages, we add a sidebar component that renders a table of contents for a list of MarkdownBlocks.

# Changes

Added component

# Tests

Added tests