### PR TITLE
feat(frontend): allow to do not provide allowedNetworksIds to initModalNetworksListContext

### DIFF
--- a/src/frontend/src/lib/stores/modal-networks-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-networks-list.store.ts
@@ -1,9 +1,10 @@
 import type { Network, NetworkId } from '$lib/types/network';
+import { nonNullish } from '@dfinity/utils';
 import { derived, writable, type Readable } from 'svelte/store';
 
 export interface ModalNetworksListData {
 	networks: Network[];
-	allowedNetworkIds: NetworkId[];
+	allowedNetworkIds?: NetworkId[];
 }
 
 export const initModalNetworksListContext = (
@@ -11,13 +12,13 @@ export const initModalNetworksListContext = (
 ): ModalNetworksListContext => {
 	const data = writable<ModalNetworksListData>({
 		networks: initialData.networks,
-		allowedNetworkIds: initialData.allowedNetworkIds ?? []
+		allowedNetworkIds: initialData?.allowedNetworkIds ?? []
 	});
 
 	const { update } = data;
 
 	const filteredNetworks = derived(data, ({ networks, allowedNetworkIds }) =>
-		allowedNetworkIds.length > 0
+		nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 0
 			? networks.filter((network) => allowedNetworkIds.includes(network.id))
 			: networks
 	);

--- a/src/frontend/src/tests/lib/stores/modal-networks-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-networks-list.store.spec.ts
@@ -23,6 +23,14 @@ describe('modalNetworksListStore', () => {
 		expect(get(filteredNetworks)).toEqual([ICP_NETWORK, ETHEREUM_NETWORK]);
 	});
 
+	it('should have all expected values with initial data where allowedNetworkIds are not provided', () => {
+		const { filteredNetworks } = initModalNetworksListContext({
+			networks: mockNetworks
+		});
+
+		expect(get(filteredNetworks)).toEqual(mockNetworks);
+	});
+
 	it('should return all networks when allowedNetworkIds is empty array', () => {
 		const { filteredNetworks } = initModalNetworksListContext({
 			networks: mockNetworks,


### PR DESCRIPTION
# Motivation

Make the store more reusable. Some consumers don’t need network restrictions, so requiring allowedNetworkIds adds unnecessary friction. This PR makes that property optional.

# Changes

- Made allowedNetworkIds optional in the context API

# Tests

Added new test to cover this change.