### PR TITLE
fix(frontend): Pass decimals of Ethereum token when calculating fee

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeContext.svelte
@@ -62,7 +62,6 @@
 
 			const params: GetFeeData = {
 				to: mapAddressStartsWith0x(destination !== '' ? destination : $ethAddress),
-
 				from: mapAddressStartsWith0x($ethAddress)
 			};
 
@@ -108,7 +107,7 @@
 
 			const erc20GasFeeParams = {
 				contract: sendToken as Erc20Token,
-				amount: parseToken({ value: `${amount ?? '1'}` }),
+				amount: parseToken({ value: `${amount ?? '1'}`, unitName: sendToken.decimals }),
 				sourceNetwork,
 				...params
 			};


### PR DESCRIPTION
# Motivation

When we estimate the fee for an Ethereum transaction for ERC20, we take the maximum estimate between an `approve` transaction and a `transfer` transaction, provided the inputs.

However, since we are not passing the correct decimals of the ERC20 token, the `transfer` transaction would return an error of insufficient balance, and provide no estimate gas.

For example, if the user inputs `123` for the amount of a certain token with 9 decimals, instead of calculating the fee for `123_000_000_000`, we would be calculating it for `123_000_000_000_000_000_000` (18 decimals, that is the default of the util `parseToken`). And it most probably fails due to insufficient token balance.

To fix it, we pass the decimals of the token we are trying to send.
