### PR TITLE
style(frontend): Capitalize first letter of currency name

### DIFF
--- a/src/frontend/src/lib/components/currency/CurrencyDropdown.svelte
+++ b/src/frontend/src/lib/components/currency/CurrencyDropdown.svelte
@@ -18,6 +18,7 @@
 	import { currencyStore } from '$lib/stores/currency.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { getCurrencyName, getCurrencySymbol } from '$lib/utils/currency.utils';
+	import { capitalizeFirstLetter } from '../../../tests/utils/string-utils';
 
 	let dropdown = $state<Dropdown>();
 
@@ -90,7 +91,7 @@
 								{/if}
 							</span>
 							<div class="flex w-full flex-row justify-between gap-5">
-								{name}
+						{capitalizeFirstLetter(name)}
 								<span class="text-right text-tertiary">{symbol}</span>
 							</div>
 						</Button>


### PR DESCRIPTION
# Motivation

Some languages have the name of the currencies lowercase by default. So, to make it more proper, we make the first letter uppercase in the dropdown list of currencies.

### Before

<img width="758" height="1336" alt="Screenshot 2025-08-26 at 11 20 20" src="https://github.com/user-attachments/assets/57021543-2081-4378-8d3b-32578d85a37b" />

### After

<img width="774" height="1294" alt="Screenshot 2025-08-26 at 11 19 44" src="https://github.com/user-attachments/assets/d5f5654e-cd6c-43e6-ac9f-8b3df534025b" />

