### PR TITLE
fix(frontend): fixed modal networks list onClick

### DIFF
--- a/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
@@ -13,20 +13,17 @@
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
-	import type { OptionNetworkId } from '$lib/types/network';
+	import type { Network, OptionNetworkId } from '$lib/types/network';
 
 	interface Props {
 		allNetworksEnabled?: boolean;
+		filteredNetworks?: Network[];
 	}
 
-	let { allNetworksEnabled }: Props = $props();
+	let { allNetworksEnabled, filteredNetworks }: Props = $props();
 
 	const { setFilterNetwork, filterNetwork } = getContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY
-	);
-
-	const { filteredNetworks } = getContext<ModalNetworksListContext>(
-		MODAL_NETWORKS_LIST_CONTEXT_KEY
 	);
 
 	const dispatch = createEventDispatcher();
@@ -49,7 +46,7 @@
 		labelsSize="lg"
 		onSelected={onNetworkSelect}
 		selectedNetworkId={$filterNetwork?.id}
-		supportedNetworks={$filteredNetworks}
+		supportedNetworks={filteredNetworks}
 	/>
 
 	{#snippet toolbar()}


### PR DESCRIPTION
# Motivation

Fix for ModalNetworksFilter component to set filteredNetworks via props as it broke component in another places

# Changes

Removed Context and pass filteredNetworks via props

