### PR TITLE
fix(devops): Correct output name for steps in backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -133,24 +133,20 @@ jobs:
           # chore(frontend)!: drop support for Node 6
           if [[ "$TITLE" =~ ^([a-z]+)(\([-a-zA-Z0-9,]+\))\!\: ]]; then
             echo "BREAKING_TITLE=true" | tee -a "$GITHUB_OUTPUT" | tee -a "$GITHUB_STEP_SUMMARY"
-          else
-            echo "BREAKING_TITLE=true" | tee -a "$GITHUB_OUTPUT" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
           # The PR body needs a line declaring the breaking change, e.g.:
           # BREAKING CHANGE: use JavaScript features not available in Node 6.
           if grep -qE '^BREAKING CHANGE: ' <<<"$DESCRIPTION"; then
             echo "BREAKING_DESCRIPTION=true" | tee -a "$GITHUB_OUTPUT" | tee -a "$GITHUB_STEP_SUMMARY"
-          else
-            echo "BREAKING_DESCRIPTION=false" | tee -a "$GITHUB_OUTPUT" | tee -a "$GITHUB_STEP_SUMMARY"
           fi
       - name: Need to check for breaking changes
         id: check-for-breaking-changes
         # Run if the interface has changed, but the PR is NOT marked as a breaking change.
-        if: steps.changes.outputs.any == 'true' && steps.api-changes.outputs.api == 'true' && !(steps.conventional-commit.outputs.BREAKING_DESCRIPTION == 'true' && steps.conventional-commit.outputs.BREAKING_TITLE == 'true')
+        if: (steps.changes.outputs.backend == 'true') && (steps.api-changes.outputs.api == 'true') && !((steps.conventional-commit.outputs.BREAKING_DESCRIPTION == 'true') && (steps.conventional-commit.outputs.BREAKING_TITLE == 'true'))
         run: echo "EXPECT_NO_BREAKING_CHANGES=true" | tee -a "$GITHUB_OUTPUT" | tee -a "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
+        if: (steps.changes.outputs.backend == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         with:
           path: |
             ~/.cargo/registry
@@ -159,18 +155,18 @@ jobs:
           key: ${{ runner.os }}-cargo-backend-tests-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
 
       - name: Install dfx
-        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
+        if: (steps.changes.outputs.backend == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: Download backend.wasm.gz
-        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
+        if: (steps.changes.outputs.backend == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: backend.wasm.gz
           path: .
 
       - name: 'Run backend tests'
-        if: (steps.changes.outputs.any == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
+        if: (steps.changes.outputs.backend == 'true') && (steps.check-for-breaking-changes.outputs.EXPECT_NO_BREAKING_CHANGES == 'true')
         working-directory: .
         run: |
           set -euxo pipefail # Ensure that the `exit 1` causes this step to fail.


### PR DESCRIPTION
# Motivation

In the backend tests CIs we were using the wrong output for the job `breaking-interface`