### PR TITLE
feat(frontend): added render of NewSwapModal component

### DIFF
--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -28,6 +28,8 @@
 	} from '$lib/stores/swap-amounts.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
 	import { waitReady } from '$lib/utils/timeout.utils';
+	import { VELORA_SWAP_ENABLED } from '$env/velora-swap.env';
+	import NewSwapModal from './NewSwapModal.svelte';
 
 	setContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY, {
 		store: initSwapAmountsStore()
@@ -103,5 +105,9 @@
 </script>
 
 <SwapButtonWithModal isOpen={$modalSwap} onOpen={onOpenSwap}>
-	<SwapModal on:nnsClose />
+	{#if VELORA_SWAP_ENABLED}
+		<NewSwapModal on:nnsClose />
+	{:else}
+		<SwapModal on:nnsClose />
+	{/if}
 </SwapButtonWithModal>

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { setContext } from 'svelte';
+	import NewSwapModal from './NewSwapModal.svelte';
+	import { VELORA_SWAP_ENABLED } from '$env/velora-swap.env';
 	import {
 		loadDisabledIcrcTokensBalances,
 		loadDisabledIcrcTokensExchanges
@@ -28,8 +30,6 @@
 	} from '$lib/stores/swap-amounts.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
 	import { waitReady } from '$lib/utils/timeout.utils';
-	import { VELORA_SWAP_ENABLED } from '$env/velora-swap.env';
-	import NewSwapModal from './NewSwapModal.svelte';
 
 	setContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY, {
 		store: initSwapAmountsStore()


### PR DESCRIPTION
# Motivation

We need a safe way to transition to the new NewSwapModal without breaking existing functionality. By introducing a feature flag (VELORA_SWAP_ENABLED), we can toggle between the old SwapModal and the new implementation, making rollback easy if needed.

# Changes

Added conditional rendering: NewSwapModal when VELORA_SWAP_ENABLED is true, otherwise SwapModal

