### PR TITLE
feat(backend): Increase maximum token length to one thousand

### DIFF
--- a/src/backend/src/token.rs
+++ b/src/backend/src/token.rs
@@ -4,7 +4,7 @@ use shared::types::TokenVersion;
 
 use crate::types::{Candid, StoredPrincipal, VMem};
 
-const MAX_TOKEN_LIST_LENGTH: usize = 100;
+const MAX_TOKEN_LIST_LENGTH: usize = 1000;
 
 pub fn add_to_user_token<T>(
     stored_principal: StoredPrincipal,


### PR DESCRIPTION
# Motivation

Increasing the maximum limit of tokens for each user to 1_000. 
