### PR TITLE
fix(frontend): disabled testenvs for swap

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -10,6 +10,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LabelSize } from '$lib/types/components';
 	import type { NetworkId, Network as NetworkType, OptionNetworkId } from '$lib/types/network';
+	import { nonNullish } from '@dfinity/utils';
 
 	interface Props {
 		selectedNetworkId?: NetworkId;
@@ -63,7 +64,7 @@
 	{/each}
 </ul>
 
-{#if $testnetsEnabled && $networksTestnets.length}
+{#if $testnetsEnabled && $networksTestnets.length && nonNullish(supportedNetworks)}
 	<span class="mb-3 mt-6 flex px-3 font-bold" transition:slide={SLIDE_EASING}
 		>{$i18n.networks.test_networks}</span
 	>

--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import MainnetNetwork from '$lib/components/networks/MainnetNetwork.svelte';
 	import Network from '$lib/components/networks/Network.svelte';
@@ -10,7 +11,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LabelSize } from '$lib/types/components';
 	import type { NetworkId, Network as NetworkType, OptionNetworkId } from '$lib/types/network';
-	import { isNullish } from '@dfinity/utils';
 
 	interface Props {
 		selectedNetworkId?: NetworkId;

--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -10,7 +10,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LabelSize } from '$lib/types/components';
 	import type { NetworkId, Network as NetworkType, OptionNetworkId } from '$lib/types/network';
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish } from '@dfinity/utils';
 
 	interface Props {
 		selectedNetworkId?: NetworkId;
@@ -64,7 +64,7 @@
 	{/each}
 </ul>
 
-{#if $testnetsEnabled && $networksTestnets.length && nonNullish(supportedNetworks)}
+{#if $testnetsEnabled && $networksTestnets.length && isNullish(supportedNetworks)}
 	<span class="mb-3 mt-6 flex px-3 font-bold" transition:slide={SLIDE_EASING}
 		>{$i18n.networks.test_networks}</span
 	>


### PR DESCRIPTION
# Motivation

We need to disable testenvs for swap

# Changes

Added condition to show testenvs if supportedNetworks are not provided.

