### PR TITLE
feat(frontend): Button authenticate with help

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import SigningInHelpLink from '$lib/components/auth/SigningInHelpLink.svelte';
+	import ButtonAuthenticate from '$lib/components/ui/ButtonAuthenticate.svelte';
+	import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
+	import { signIn } from '$lib/services/auth.services';
+	import { modalStore } from '$lib/stores/modal.store';
+
+	interface Props {
+		fullWidth?: boolean;
+		helpAlignment?: 'inherit' | 'center';
+		needHelpLink?: boolean;
+	}
+
+	let { fullWidth = false, helpAlignment = 'inherit', needHelpLink = true }: Props = $props();
+
+	const modalId = Symbol();
+
+	const onclick = async () => {
+		const { success } = await signIn({});
+
+		if (success === 'cancelled' || success === 'error') {
+			modalStore.openAuthHelp({ id: modalId, data: false });
+		}
+	};
+</script>
+
+<div
+	class="flex w-full flex-col items-center md:items-start"
+	class:md:items-center={helpAlignment === 'center'}
+>
+	<ButtonAuthenticate {fullWidth} {onclick} />
+
+	<span
+		class="mt-4 flex flex-col text-sm text-tertiary"
+		class:text-center={helpAlignment === 'center'}
+		class:w-full={fullWidth}
+	>
+		{#if needHelpLink}
+			<SigningInHelpLink styleClass="mt-4" testId={AUTH_SIGNING_IN_HELP_LINK} />
+		{/if}
+	</span>
+</div>

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithLicense.svelte
@@ -7,6 +7,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
+	// TODO: remove this component once NEW_AGREEMENTS feature is implemented and live
+
 	interface Props {
 		fullWidth?: boolean;
 		licenseAlignment?: 'inherit' | 'center';

--- a/src/frontend/src/tests/lib/components/auth/ButtonAuthenticateWithHelp.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/ButtonAuthenticateWithHelp.spec.ts
@@ -1,0 +1,62 @@
+import ButtonAuthenticateWithHelp from '$lib/components/auth/ButtonAuthenticateWithHelp.svelte';
+import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
+import * as auth from '$lib/services/auth.services';
+import { modalStore } from '$lib/stores/modal.store';
+import { render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+describe('ButtonAuthenticateWithHelp', () => {
+	const signInButtonSelector = `button[data-tid="login-button"]`;
+	const SigningInHelpLinkSpanSelector = `span[data-tid="${AUTH_SIGNING_IN_HELP_LINK}"]`;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		modalStore.close();
+	});
+
+	it('should render sign in button', () => {
+		const { container } = render(ButtonAuthenticateWithHelp);
+
+		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
+		expect(signInButton).toBeInTheDocument();
+
+		const SigningInHelpLinkSpan: HTMLSpanElement | null = container.querySelector(
+			SigningInHelpLinkSpanSelector
+		);
+
+		expect(SigningInHelpLinkSpan).toBeInTheDocument();
+	});
+
+	it('should open auth help modal on failed sign in', async () => {
+		const authSpy = vi.spyOn(auth, 'signIn').mockResolvedValue({ success: 'cancelled' });
+
+		const { container } = render(ButtonAuthenticateWithHelp);
+
+		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
+		expect(signInButton).toBeInTheDocument();
+
+		await waitFor(() => signInButton?.click());
+
+		expect(authSpy).toHaveBeenCalledOnce();
+
+		expect(get(modalStore)?.type).toBe('auth-help');
+	});
+
+	it('should do nothing on successful sign in', async () => {
+		const authSpy = vi.spyOn(auth, 'signIn').mockResolvedValue({ success: 'ok' });
+
+		const { container } = render(ButtonAuthenticateWithHelp);
+
+		const signInButton: HTMLButtonElement | null = container.querySelector(signInButtonSelector);
+
+		expect(signInButton).toBeInTheDocument();
+
+		await waitFor(() => signInButton?.click());
+
+		expect(authSpy).toHaveBeenCalledOnce();
+
+		expect(get(modalStore)?.type).toBeUndefined();
+	});
+});


### PR DESCRIPTION
# Motivation

For the refactoring of the new agreements, we will no longer need the ButtonAuthenticateWithLicense. We add a modified and stripped down version and will remove it once the full feature is done.

# Changes

Added new modified component and added TODO for removing the old component later

# Tests

Added test
