### PR TITLE
feat(frontend): enabledNetworksSymbols derived store

### DIFF
--- a/src/frontend/src/env/networks/networks.icp.env.ts
+++ b/src/frontend/src/env/networks/networks.icp.env.ts
@@ -40,7 +40,7 @@ export const ICP_NETWORK: Network = {
  * It will be associated with what we call "testnet" tokens.
  * This allows us to simplify the filters of the token list and avoid polluting "real" ICP balance with the balances of the testnet tokens.
  */
-const ICP_PSEUDO_TESTNET_NETWORK_SYMBOL = 'ICP-PSEUDO-TESTNET';
+export const ICP_PSEUDO_TESTNET_NETWORK_SYMBOL = 'ICP-PSEUDO-TESTNET';
 
 export const ICP_PSEUDO_TESTNET_NETWORK_ID: NetworkId = parseNetworkId(
 	ICP_PSEUDO_TESTNET_NETWORK_SYMBOL

--- a/src/frontend/src/lib/derived/networks.derived.ts
+++ b/src/frontend/src/lib/derived/networks.derived.ts
@@ -38,6 +38,10 @@ export const networks: Readable<Network[]> = derived(
 	]
 );
 
+export const enabledNetworksSymbols: Readable<string[]> = derived([networks], ([$networks]) =>
+	$networks.map(({ id }) => `${id.description}`)
+);
+
 interface NetworksEnvs {
 	mainnets: Network[];
 	testnets: Network[];

--- a/src/frontend/src/tests/lib/derived/networks.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/networks.derived.spec.ts
@@ -1,0 +1,31 @@
+import { ARBITRUM_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK_SYMBOL } from '$env/networks/networks-evm/networks.evm.base.env';
+import { BSC_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks-evm/networks.evm.bsc.env';
+import { POLYGON_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks-evm/networks.evm.polygon.env';
+import { BTC_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.btc.env';
+import { ETHEREUM_NETWORK_SYMBOL } from '$env/networks/networks.eth.env';
+import {
+	ICP_NETWORK_SYMBOL,
+	ICP_PSEUDO_TESTNET_NETWORK_SYMBOL
+} from '$env/networks/networks.icp.env';
+import { SOLANA_MAINNET_NETWORK_SYMBOL } from '$env/networks/networks.sol.env';
+import { enabledNetworksSymbols } from '$lib/derived/networks.derived';
+import { get } from 'svelte/store';
+
+describe('networks.derived', () => {
+	describe('enabledNetworksSymbols', () => {
+		it('has correct data', () => {
+			expect(get(enabledNetworksSymbols)).toEqual([
+				BTC_MAINNET_NETWORK_SYMBOL,
+				ETHEREUM_NETWORK_SYMBOL,
+				ICP_NETWORK_SYMBOL,
+				ICP_PSEUDO_TESTNET_NETWORK_SYMBOL,
+				SOLANA_MAINNET_NETWORK_SYMBOL,
+				BASE_NETWORK_SYMBOL,
+				BSC_MAINNET_NETWORK_SYMBOL,
+				POLYGON_MAINNET_NETWORK_SYMBOL,
+				ARBITRUM_MAINNET_NETWORK_SYMBOL
+			]);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

For LLM to know which networks are currently enabled, we create a special derived store.
