### PR TITLE
fix(frontend): adjusted custom error for customValidate

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthForm.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthForm.svelte
@@ -103,6 +103,20 @@
 			return 'insufficient-funds-for-fee';
 		}
 	};
+
+	$effect(() => {
+		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
+			const parsedAmount = parseToken({
+				value: `${swapAmount}`,
+				unitName: $sourceToken.decimals
+			});
+
+			const newErrorType = customValidate(parsedAmount);
+			if (newErrorType !== errorType) {
+				errorType = newErrorType;
+			}
+		}
+	});
 </script>
 
 <NewSwapForm


### PR DESCRIPTION
# Motivation

CustomValidate wasn’t being triggered after sourceToken changed. This PR adds a reactive Svelte effect to recalculate and run the validation whenever sourceToken updates.

# Changes

Added a Svelte effect to validate sourceToken on change.

