### PR TITLE
fix(frontend): Avoid sign int if auth client is not defined

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -5,14 +5,16 @@ import {
 	INTERNET_IDENTITY_CANISTER_ID,
 	TEST
 } from '$lib/constants/app.constants';
+import { i18n } from '$lib/stores/i18n.store';
+import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Option } from '$lib/types/utils';
 import { createAuthClient, getOptionalDerivationOrigin } from '$lib/utils/auth.utils';
 import { popupCenter } from '$lib/utils/window.utils';
 import type { Identity } from '@dfinity/agent';
 import type { AuthClient } from '@dfinity/auth-client';
-import { nonNullish } from '@dfinity/utils';
-import { writable, type Readable } from 'svelte/store';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import { get, writable, type Readable } from 'svelte/store';
 
 export interface AuthStoreData {
 	identity: OptionIdentity;
@@ -51,7 +53,14 @@ const initAuthStore = (): AuthStore => {
 		signIn: ({ domain }: AuthSignInParams) =>
 			// eslint-disable-next-line no-async-promise-executor
 			new Promise<void>(async (resolve, reject) => {
-				authClient = authClient ?? (await createAuthClient());
+				// When signing in, we require the authClient to be safely defined through the sync method (called when the window loads).
+				// We are not able to recreate authClient safely here since there are some browsers (like Safari) that block popups if there is an addition async call in this call stack.
+				if (isNullish(authClient)) {
+					toastsError({
+						msg: { text: get(i18n).auth.warning.reload_and_retry }
+					});
+					return;
+				}
 
 				const identityProvider = nonNullish(INTERNET_IDENTITY_CANISTER_ID)
 					? /apple/i.test(navigator?.vendor)


### PR DESCRIPTION
# Motivation

Related to PR https://github.com/dfinity/oisy-wallet/pull/8398.

To complete the fix in the previous PR, we modify method `signIn`.

When signing in, we require the `authClient` object to be safely defined through the `sync` method (called when the window loads).

We are not able to recreate `authClient` safely directly inside `signIn`, since there are some browsers (like Safari) that block popups if there is an addition async call in this call stack.




