### PR TITLE
refactor(frontend): licenceAgreement --> licenseAgreement

### DIFF
--- a/src/frontend/src/env/agreements.json
+++ b/src/frontend/src/env/agreements.json
@@ -1,5 +1,5 @@
 {
-	"licenceAgreement": {
+	"licenseAgreement": {
 		"lastUpdatedDate": "2025-08-27T06:15Z",
 		"lastUpdatedTimestamp": {
 			"__bigint__": "1756245600000"

--- a/src/frontend/src/env/schema/env-agreements.schema.ts
+++ b/src/frontend/src/env/schema/env-agreements.schema.ts
@@ -6,7 +6,7 @@ const policyBlockSchema = z.object({
 });
 
 export const EnvAgreementsSchema = z.object({
-	licenceAgreement: policyBlockSchema,
+	licenseAgreement: policyBlockSchema,
 	termsOfUse: policyBlockSchema,
 	privacyPolicy: policyBlockSchema
 });

--- a/src/frontend/src/tests/lib/utils/agreements.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/agreements.utils.spec.ts
@@ -8,7 +8,7 @@ import {
 import { formatSecondsToDate } from '$lib/utils/format.utils';
 
 const mock = {
-	licenceAgreement: {
+	licenseAgreement: {
 		lastUpdatedDate: '2025-08-27T06:15Z',
 		lastUpdatedTimestamp: { __bigint__: '1756245600000' }
 	},
@@ -60,17 +60,17 @@ describe('agreements.utils', () => {
 			const out = transformAgreementsJsonBigint({ ...mock });
 
 			// Values are bigints
-			expect(typeof out.licenceAgreement.lastUpdatedTimestamp).toBe('bigint');
+			expect(typeof out.licenseAgreement.lastUpdatedTimestamp).toBe('bigint');
 			expect(typeof out.termsOfUse.lastUpdatedTimestamp).toBe('bigint');
 			expect(typeof out.privacyPolicy.lastUpdatedTimestamp).toBe('bigint');
 
 			// Exact bigint value
-			expect(out.licenceAgreement.lastUpdatedTimestamp).toBe(1756245600000n);
+			expect(out.licenseAgreement.lastUpdatedTimestamp).toBe(1756245600000n);
 			expect(out.termsOfUse.lastUpdatedTimestamp).toBe(1756245600000n);
 			expect(out.privacyPolicy.lastUpdatedTimestamp).toBe(1756245600000n);
 
 			// Other fields preserved
-			expect(out.licenceAgreement.lastUpdatedDate).toBe('2025-08-27T06:15Z');
+			expect(out.licenseAgreement.lastUpdatedDate).toBe('2025-08-27T06:15Z');
 			expect(out.termsOfUse.lastUpdatedDate).toBe('2025-08-27T06:15Z');
 			expect(out.privacyPolicy.lastUpdatedDate).toBe('2025-08-27T06:15Z');
 		});


### PR DESCRIPTION
# Motivation

Small renaming for consistency `licenceAgreement` --> `licenseAgreement`
