### PR TITLE
refactor(frontend): Move `transformAgreementsJsonBigint` to specific module

### DIFF
--- a/src/frontend/src/lib/utils/agreements.utils.ts
+++ b/src/frontend/src/lib/utils/agreements.utils.ts
@@ -3,27 +3,6 @@ import type { EnvAgreements } from '$env/types/env-agreements';
 import { MILLISECONDS_IN_SECOND } from '$lib/constants/app.constants';
 import { formatSecondsToDate } from '$lib/utils/format.utils';
 
-export const transformAgreementsJsonBigint = (
-	json: Record<string, { lastUpdatedTimestamp: { __bigint__: string }; lastUpdatedDate: string }>
-): EnvAgreements => {
-	const res: Record<string, { lastUpdatedTimestamp: bigint; lastUpdatedDate: string }> = {};
-	Object.entries(json).forEach(
-		([
-			key,
-			{
-				lastUpdatedTimestamp: { __bigint__ },
-				...rest
-			}
-		]) => {
-			res[key] = {
-				...rest,
-				lastUpdatedTimestamp: BigInt(__bigint__)
-			};
-		}
-	);
-	return res as EnvAgreements;
-};
-
 export const getAgreementLastUpdated = ({
 	type,
 	$i18n

--- a/src/frontend/src/lib/utils/env.agreements.utils.ts
+++ b/src/frontend/src/lib/utils/env.agreements.utils.ts
@@ -1,0 +1,22 @@
+import type { EnvAgreements } from '$env/types/env-agreements';
+
+export const transformAgreementsJsonBigint = (
+	json: Record<string, { lastUpdatedTimestamp: { __bigint__: string }; lastUpdatedDate: string }>
+): EnvAgreements => {
+	const res: Record<string, { lastUpdatedTimestamp: bigint; lastUpdatedDate: string }> = {};
+	Object.entries(json).forEach(
+		([
+			key,
+			{
+				lastUpdatedTimestamp: { __bigint__ },
+				...rest
+			}
+		]) => {
+			res[key] = {
+				...rest,
+				lastUpdatedTimestamp: BigInt(__bigint__)
+			};
+		}
+	);
+	return res as EnvAgreements;
+};

--- a/src/frontend/src/tests/lib/utils/agreements.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/agreements.utils.spec.ts
@@ -1,35 +1,33 @@
 import * as agreementsEnv from '$env/agreements.env';
 import type { EnvAgreements } from '$env/types/env-agreements';
 import { MILLISECONDS_IN_SECOND } from '$lib/constants/app.constants';
-import {
-	getAgreementLastUpdated,
-	transformAgreementsJsonBigint
-} from '$lib/utils/agreements.utils';
+import { getAgreementLastUpdated } from '$lib/utils/agreements.utils';
+import { transformAgreementsJsonBigint } from '$lib/utils/env.agreements.utils';
 import { formatSecondsToDate } from '$lib/utils/format.utils';
-
-const mock = {
-	licenceAgreement: {
-		lastUpdatedDate: '2025-08-27T06:15Z',
-		lastUpdatedTimestamp: { __bigint__: '1756245600000' }
-	},
-	termsOfUse: {
-		lastUpdatedDate: '2025-08-27T06:15Z',
-		lastUpdatedTimestamp: { __bigint__: '1756245600000' }
-	},
-	privacyPolicy: {
-		lastUpdatedDate: '2025-08-27T06:15Z',
-		lastUpdatedTimestamp: { __bigint__: '1756245600000' }
-	}
-};
-
-vi.spyOn(agreementsEnv, 'agreementsData', 'get').mockImplementation(
-	() => transformAgreementsJsonBigint(mock) as unknown as EnvAgreements
-);
 
 describe('agreements.utils', () => {
 	describe('getAgreementLastUpdated', () => {
+		const mock = {
+			licenceAgreement: {
+				lastUpdatedDate: '2025-08-27T06:15Z',
+				lastUpdatedTimestamp: { __bigint__: '1756245600000' }
+			},
+			termsOfUse: {
+				lastUpdatedDate: '2025-08-27T06:15Z',
+				lastUpdatedTimestamp: { __bigint__: '1756245600000' }
+			},
+			privacyPolicy: {
+				lastUpdatedDate: '2025-08-27T06:15Z',
+				lastUpdatedTimestamp: { __bigint__: '1756245600000' }
+			}
+		};
+
 		beforeEach(() => {
 			vi.restoreAllMocks();
+
+			vi.spyOn(agreementsEnv, 'agreementsData', 'get').mockImplementation(
+				() => transformAgreementsJsonBigint(mock) as unknown as EnvAgreements
+			);
 		});
 
 		it('parses env JSON with z.parse(schema, data) and formats the expected section', () => {
@@ -52,27 +50,6 @@ describe('agreements.utils', () => {
 					}
 				})
 			);
-		});
-	});
-
-	describe('transformAgreementsJsonBigint', () => {
-		it('converts all __bigint__ markers to bigint and preserves other fields', () => {
-			const out = transformAgreementsJsonBigint({ ...mock });
-
-			// Values are bigints
-			expect(typeof out.licenceAgreement.lastUpdatedTimestamp).toBe('bigint');
-			expect(typeof out.termsOfUse.lastUpdatedTimestamp).toBe('bigint');
-			expect(typeof out.privacyPolicy.lastUpdatedTimestamp).toBe('bigint');
-
-			// Exact bigint value
-			expect(out.licenceAgreement.lastUpdatedTimestamp).toBe(1756245600000n);
-			expect(out.termsOfUse.lastUpdatedTimestamp).toBe(1756245600000n);
-			expect(out.privacyPolicy.lastUpdatedTimestamp).toBe(1756245600000n);
-
-			// Other fields preserved
-			expect(out.licenceAgreement.lastUpdatedDate).toBe('2025-08-27T06:15Z');
-			expect(out.termsOfUse.lastUpdatedDate).toBe('2025-08-27T06:15Z');
-			expect(out.privacyPolicy.lastUpdatedDate).toBe('2025-08-27T06:15Z');
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/env.agreements.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/env.agreements.utils.spec.ts
@@ -1,0 +1,39 @@
+import { transformAgreementsJsonBigint } from '$lib/utils/env.agreements.utils';
+
+describe('env.agreements.utils', () => {
+	describe('transformAgreementsJsonBigint', () => {
+		const mock = {
+			licenceAgreement: {
+				lastUpdatedDate: '2025-08-27T06:15Z',
+				lastUpdatedTimestamp: { __bigint__: '1756245600000' }
+			},
+			termsOfUse: {
+				lastUpdatedDate: '2025-08-27T06:15Z',
+				lastUpdatedTimestamp: { __bigint__: '1756245600000' }
+			},
+			privacyPolicy: {
+				lastUpdatedDate: '2025-08-27T06:15Z',
+				lastUpdatedTimestamp: { __bigint__: '1756245600000' }
+			}
+		};
+
+		it('converts all __bigint__ markers to bigint and preserves other fields', () => {
+			const out = transformAgreementsJsonBigint({ ...mock });
+
+			// Values are bigints
+			expect(typeof out.licenceAgreement.lastUpdatedTimestamp).toBe('bigint');
+			expect(typeof out.termsOfUse.lastUpdatedTimestamp).toBe('bigint');
+			expect(typeof out.privacyPolicy.lastUpdatedTimestamp).toBe('bigint');
+
+			// Exact bigint value
+			expect(out.licenceAgreement.lastUpdatedTimestamp).toBe(1756245600000n);
+			expect(out.termsOfUse.lastUpdatedTimestamp).toBe(1756245600000n);
+			expect(out.privacyPolicy.lastUpdatedTimestamp).toBe(1756245600000n);
+
+			// Other fields preserved
+			expect(out.licenceAgreement.lastUpdatedDate).toBe('2025-08-27T06:15Z');
+			expect(out.termsOfUse.lastUpdatedDate).toBe('2025-08-27T06:15Z');
+			expect(out.privacyPolicy.lastUpdatedDate).toBe('2025-08-27T06:15Z');
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Util `transformAgreementsJsonBigint` is used to set agreementsData, that by itself it will be used inside the `agreements.utils` module, risking a looped called.

To avoid it, we move it to a different module, specific for it. 
