### PR TITLE
feat(frontend): Remove RSIC.OT from ICRC additional tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -133,15 +133,6 @@
 			"__bigint__": "10"
 		}
 	},
-	"RSIC.OT": {
-		"ledgerCanisterId": "i44ka-paaaa-aaaar-qbonq-cai",
-		"decimals": 0,
-		"name": "RSIC•GENESIS•RUNE",
-		"symbol": "RSIC.OT",
-		"fee": {
-			"__bigint__": "10"
-		}
-	},
 	"BDC.OT": {
 		"ledgerCanisterId": "2ulkl-dqaaa-aaaar-qaijq-cai",
 		"decimals": 0,


### PR DESCRIPTION
# Motivation

Token RSIC.OT has the ledger without cycles, and it seems it is not being maintained. We remove it from our list or ICRC additional tokens.
