### PR TITLE
feat(frontend): render AI console inside the footer

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -95,7 +95,7 @@
 </script>
 
 <div
-	class="fixed bottom-0 right-0 z-10 flex h-full min-h-full w-full flex-col justify-between rounded-2xl bg-primary md:bottom-6 md:right-8 md:h-[calc(100vh-7.25rem)] md:min-h-[25rem] md:w-[22.5rem]"
+	class="pointer-events-auto fixed bottom-0 right-0 flex h-full min-h-full w-full flex-col justify-between rounded-2xl bg-primary md:bottom-6 md:right-8 md:h-[calc(100vh-7.25rem)] md:min-h-[25rem] md:w-[22.5rem]"
 	transition:fade
 >
 	<div class="border-b-1 flex items-center justify-between border-brand-subtle-10 px-4 py-2">

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -2,6 +2,7 @@
 	import { IconGitHub } from '@dfinity/gix-components';
 	import { page } from '$app/state';
 	import { NEW_AGREEMENTS_ENABLED } from '$env/agreements.env';
+	import AiAssistantConsole from '$lib/components/ai-assistant/AiAssistantConsole.svelte';
 	import AiAssistantConsoleButton from '$lib/components/ai-assistant/AiAssistantConsoleButton.svelte';
 	import IconDfinity from '$lib/components/icons/IconDfinity.svelte';
 	import IconHeart from '$lib/components/icons/IconHeart.svelte';
@@ -12,6 +13,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import ExternalLinkIcon from '$lib/components/ui/ExternalLinkIcon.svelte';
 	import { OISY_REPO_URL, OISY_TWITTER_URL } from '$lib/constants/oisy.constants';
+	import { aiAssistantConsoleOpen } from '$lib/derived/ai-assistant.derived';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -21,7 +23,7 @@
 </script>
 
 <footer
-	class="z-1 pointer-events-none mx-auto flex w-full max-w-screen-2.5xl flex-1 flex-col items-center justify-end px-4 pt-5 sm:flex-1 sm:grow sm:flex-row sm:items-end sm:justify-between sm:px-8 md:pb-5 md:pt-12 lg:fixed lg:inset-x-0 lg:bottom-0"
+	class="pointer-events-none mx-auto flex w-full max-w-screen-2.5xl flex-1 flex-col items-center justify-end px-4 pt-5 sm:flex-1 sm:grow sm:flex-row sm:items-end sm:justify-between sm:px-8 md:pb-5 md:pt-12 lg:fixed lg:inset-x-0 lg:bottom-0"
 	class:md:bottom-0={$authSignedIn}
 	class:md:fixed={$authSignedIn}
 	class:md:h-md:grid={$authNotSignedIn}
@@ -30,6 +32,8 @@
 	class:md:inset-x-0={$authSignedIn}
 	class:pb-24={$authSignedIn}
 	class:sm:sticky={$authNotSignedIn}
+	class:z-1={!$aiAssistantConsoleOpen}
+	class:z-3={$aiAssistantConsoleOpen}
 >
 	<div
 		class="pointer-events-none flex w-full flex-col items-center justify-between md:flex-row md:gap-4"
@@ -84,46 +88,50 @@
 			</div>
 		{/if}
 
-		<div
-			class="item pointer-events-auto flex flex-col items-end px-6 text-xs md:px-0 lg:max-w-48 2xl:text-sm"
-			class:1.5md:translate-x-0={$authSignedIn}
-			class:1.5md:visible={$authSignedIn}
-			class:1.5xl:max-w-none={$authSignedIn}
-			class:lg:max-w-none={$authNotSignedIn}
-			class:md:duration-200={$authSignedIn}
-			class:md:ease-in-out={$authSignedIn}
-			class:md:h-md:pr-4={$authNotSignedIn}
-			class:md:invisible={$authSignedIn}
-			class:md:transition-all={$authSignedIn}
-			class:md:translate-x-full={$authSignedIn}
-			class:sm:max-w-none={$authNotSignedIn}
-			class:xl:max-w-80={$authSignedIn}
-			class:xl:max-w-none={$authNotSignedIn}
-		>
-			<AiAssistantConsoleButton styleClass="mb-4 hidden md:block" />
-			<div class="flex flex-col items-center pt-2 sm:flex-row sm:items-start sm:gap-2">
-				<span class="-mt-[0.35rem]"><IconDfinity size="30" /></span>
-				<span
-					class="text-center md:text-left"
-					class:1.5md:h-md:block={$authNotSignedIn}
-					class:md:h-md:hidden={$authNotSignedIn}
-					class:md:hidden={$authSignedIn}
-					class:xl:block={$authSignedIn}
-				>
-					{$i18n.footer.text.incubated_with}
-					<IconHeart styleClass="inline-flex mb-1" />
-					{$i18n.footer.text.by}
-					<ExternalLink
-						ariaLabel={$i18n.footer.alt.dfinity}
-						color="blue"
-						href="https://dfinity.org"
-						iconVisible={false}
+		{#if $aiAssistantConsoleOpen}
+			<AiAssistantConsole />
+		{:else}
+			<div
+				class="item pointer-events-auto flex flex-col items-end px-6 text-xs md:px-0 lg:max-w-48 2xl:text-sm"
+				class:1.5md:translate-x-0={$authSignedIn}
+				class:1.5md:visible={$authSignedIn}
+				class:1.5xl:max-w-none={$authSignedIn}
+				class:lg:max-w-none={$authNotSignedIn}
+				class:md:duration-200={$authSignedIn}
+				class:md:ease-in-out={$authSignedIn}
+				class:md:h-md:pr-4={$authNotSignedIn}
+				class:md:invisible={$authSignedIn}
+				class:md:transition-all={$authSignedIn}
+				class:md:translate-x-full={$authSignedIn}
+				class:sm:max-w-none={$authNotSignedIn}
+				class:xl:max-w-80={$authSignedIn}
+				class:xl:max-w-none={$authNotSignedIn}
+			>
+				<AiAssistantConsoleButton styleClass="mb-4 hidden md:block" />
+				<div class="flex flex-col items-center pt-2 sm:flex-row sm:items-start sm:gap-2">
+					<span class="-mt-[0.35rem]"><IconDfinity size="30" /></span>
+					<span
+						class="text-center md:text-left"
+						class:1.5md:h-md:block={$authNotSignedIn}
+						class:md:h-md:hidden={$authNotSignedIn}
+						class:md:hidden={$authSignedIn}
+						class:xl:block={$authSignedIn}
 					>
-						{$i18n.footer.text.dfinity_foundation}
-					</ExternalLink>
-					<span class="whitespace-nowrap">{$i18n.footer.text.copyright}</span>
-				</span>
+						{$i18n.footer.text.incubated_with}
+						<IconHeart styleClass="inline-flex mb-1" />
+						{$i18n.footer.text.by}
+						<ExternalLink
+							ariaLabel={$i18n.footer.alt.dfinity}
+							color="blue"
+							href="https://dfinity.org"
+							iconVisible={false}
+						>
+							{$i18n.footer.text.dfinity_foundation}
+						</ExternalLink>
+						<span class="whitespace-nowrap">{$i18n.footer.text.copyright}</span>
+					</span>
+				</div>
 			</div>
-		</div>
+		{/if}
 	</div>
 </footer>

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -4,7 +4,6 @@
 	import { fade } from 'svelte/transition';
 	import { onNavigate } from '$app/navigation';
 	import { page } from '$app/state';
-	import AiAssistantConsole from '$lib/components/ai-assistant/AiAssistantConsole.svelte';
 	import AiAssistantConsoleButton from '$lib/components/ai-assistant/AiAssistantConsoleButton.svelte';
 	import AuthGuard from '$lib/components/auth/AuthGuard.svelte';
 	import LockPage from '$lib/components/auth/LockPage.svelte';
@@ -19,7 +18,6 @@
 	import NavigationMenuMainItems from '$lib/components/navigation/NavigationMenuMainItems.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import SplitPane from '$lib/components/ui/SplitPane.svelte';
-	import { aiAssistantConsoleOpen } from '$lib/derived/ai-assistant.derived';
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { isAuthLocked } from '$lib/derived/locked.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
@@ -112,11 +110,7 @@
 				<Modals />
 			</AuthGuard>
 
-			{#if $aiAssistantConsoleOpen}
-				<AiAssistantConsole />
-			{:else}
-				<Footer />
-			{/if}
+			<Footer />
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
# Motivation

We need to move the AI console inside the footer so the soical icons can be properly rendered when the console is open. It also solves the positioning issues.

<img width="1228" height="742" alt="Screenshot 2025-08-30 at 12 01 24" src="https://github.com/user-attachments/assets/07d4f666-193b-4e3e-a9b8-d761a48a3436" />

<img width="1231" height="745" alt="Screenshot 2025-08-30 at 12 01 17" src="https://github.com/user-attachments/assets/98f4c7d9-a405-4bcb-aae1-13fe29f65266" />
