### PR TITLE
feat(frontend): removes section mapping to collection

### DIFF
--- a/src/frontend/src/lib/schema/nft.schema.ts
+++ b/src/frontend/src/lib/schema/nft.schema.ts
@@ -1,4 +1,3 @@
-import type { CustomTokenSection } from '$lib/enums/custom-token-section';
 import type { Network } from '$lib/types/network';
 import type { TokenId, TokenStandard } from '$lib/types/token';
 import * as z from 'zod';
@@ -24,8 +23,7 @@ export const NftCollectionSchema = z.object({
 	symbol: z.string().optional(),
 	id: z.custom<TokenId>(),
 	network: z.custom<Network>(),
-	standard: z.custom<TokenStandard>(),
-	section: z.custom<CustomTokenSection>().optional()
+	standard: z.custom<TokenStandard>()
 });
 
 export const NftSchema = z.object({

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -157,8 +157,7 @@ export const mapTokenToCollection = (token: NonFungibleToken): NftCollection =>
 		network: token.network,
 		standard: token.standard,
 		...(notEmptyString(token.symbol) && { symbol: token.symbol }),
-		...(notEmptyString(token.name) && { name: token.name }),
-		...(nonNullish(token.section) && { state: token.section })
+		...(notEmptyString(token.name) && { name: token.name })
 	});
 
 export const getEnabledNfts = ({


### PR DESCRIPTION
# Motivation

We don't want to map the `section` field from the `custom token` to the `collection`.
