### PR TITLE
feat(frontend): track review_send_token tool confirmation

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendBtcToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendBtcToken.svelte
@@ -17,6 +17,7 @@
 	import { invalidSendAmount } from '$btc/utils/input.utils';
 	import Button from '$lib/components/ui/Button.svelte';
 	import {
+		AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
 		AI_ASSISTANT_SEND_TOKEN_SOURCE,
 		TRACK_COUNT_BTC_SEND_ERROR,
 		TRACK_COUNT_BTC_SEND_SUCCESS,
@@ -102,9 +103,18 @@
 			? mapNetworkIdToBitcoinNetwork($sendTokenNetworkId)
 			: undefined;
 
-		const trackingEventMetadata = {
+		const sharedTrackingEventMetadata = {
 			token: $sendTokenSymbol,
-			network: `${$sendTokenNetworkId.description}`,
+			network: `${$sendTokenNetworkId.description}`
+		};
+
+		trackEvent({
+			name: AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
+			metadata: sharedTrackingEventMetadata
+		});
+
+		const sendTrackingEventMetadata = {
+			...sharedTrackingEventMetadata,
 			source: AI_ASSISTANT_SEND_TOKEN_SOURCE
 		};
 
@@ -170,7 +180,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_BTC_VALIDATION_ERROR,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			toastsError({
@@ -192,7 +202,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_BTC_SEND_SUCCESS,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			loading = false;
@@ -203,7 +213,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_BTC_SEND_ERROR,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			toastsError({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendEthToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendEthToken.svelte
@@ -23,6 +23,7 @@
 	import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 	import Button from '$lib/components/ui/Button.svelte';
 	import {
+		AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
 		AI_ASSISTANT_SEND_TOKEN_SOURCE,
 		TRACK_COUNT_ETH_SEND_ERROR,
 		TRACK_COUNT_ETH_SEND_SUCCESS
@@ -152,9 +153,18 @@
 	);
 
 	const send = async () => {
-		const trackingEventMetadata = {
+		const sharedTrackingEventMetadata = {
 			token: $sendTokenSymbol,
-			network: `${$sendTokenNetworkId.description}`,
+			network: `${$sendTokenNetworkId.description}`
+		};
+
+		trackEvent({
+			name: AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
+			metadata: sharedTrackingEventMetadata
+		});
+
+		const sendTrackingEventMetadata = {
+			...sharedTrackingEventMetadata,
 			source: AI_ASSISTANT_SEND_TOKEN_SOURCE
 		};
 
@@ -229,7 +239,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_ETH_SEND_SUCCESS,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			sendCompleted = true;
@@ -240,7 +250,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_ETH_SEND_ERROR,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			toastsError({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendIcToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendIcToken.svelte
@@ -9,6 +9,7 @@
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import Button from '$lib/components/ui/Button.svelte';
 	import {
+		AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
 		AI_ASSISTANT_SEND_TOKEN_SOURCE,
 		TRACK_COUNT_IC_SEND_ERROR,
 		TRACK_COUNT_IC_SEND_SUCCESS
@@ -62,8 +63,17 @@
 	let loading = $state(false);
 
 	const send = async () => {
-		const trackingEventMetadata = {
-			token: $sendTokenSymbol,
+		const sharedTrackingEventMetadata = {
+			token: $sendTokenSymbol
+		};
+
+		trackEvent({
+			name: AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
+			metadata: sharedTrackingEventMetadata
+		});
+
+		const sendTrackingEventMetadata = {
+			...sharedTrackingEventMetadata,
 			source: AI_ASSISTANT_SEND_TOKEN_SOURCE
 		};
 
@@ -105,7 +115,7 @@
 			const trackAnalyticsOnSendComplete = () => {
 				trackEvent({
 					name: TRACK_COUNT_IC_SEND_SUCCESS,
-					metadata: trackingEventMetadata
+					metadata: sendTrackingEventMetadata
 				});
 			};
 
@@ -123,7 +133,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_IC_SEND_ERROR,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			toastsError({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
@@ -12,6 +12,7 @@
 	import SendFeeInfo from '$lib/components/send/SendFeeInfo.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import {
+		AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
 		AI_ASSISTANT_SEND_TOKEN_SOURCE,
 		TRACK_COUNT_SOL_SEND_ERROR,
 		TRACK_COUNT_SOL_SEND_SUCCESS
@@ -148,8 +149,17 @@
 	);
 
 	const send = async () => {
-		const trackingEventMetadata = {
-			token: $sendTokenSymbol,
+		const sharedTrackingEventMetadata = {
+			token: $sendTokenSymbol
+		};
+
+		trackEvent({
+			name: AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
+			metadata: sharedTrackingEventMetadata
+		});
+
+		const sendTrackingEventMetadata = {
+			...sharedTrackingEventMetadata,
 			source: AI_ASSISTANT_SEND_TOKEN_SOURCE
 		};
 
@@ -203,7 +213,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_SOL_SEND_SUCCESS,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			sendCompleted = true;
@@ -214,7 +224,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_SOL_SEND_ERROR,
-				metadata: trackingEventMetadata
+				metadata: sendTrackingEventMetadata
 			});
 
 			const errorMsg = isSolanaError(err, SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED)

--- a/src/frontend/src/lib/constants/analytics.contants.ts
+++ b/src/frontend/src/lib/constants/analytics.contants.ts
@@ -156,3 +156,5 @@ export const TRACK_OPEN_AGREEMENT = 'open_agreement';
 
 // AI Assistant
 export const AI_ASSISTANT_SEND_TOKEN_SOURCE = 'ai-assistant';
+export const AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION =
+	'ai_assistant_review_send_tool_confirmation';


### PR DESCRIPTION
# Motivation

On top of "success"/"failed" send events, we'd like to track how many times the review_send_token tool was confirmed.
