### PR TITLE
feat(frontend): Add service to save agreements in `AcceptAgreementsModal`

### DIFF
--- a/src/frontend/src/lib/components/agreements/AcceptAgreementsCheckbox.svelte
+++ b/src/frontend/src/lib/components/agreements/AcceptAgreementsCheckbox.svelte
@@ -8,14 +8,15 @@
 		agreementLink: Snippet;
 		onChange: () => void;
 		inputId: string;
+		testId: string;
 		isOutdated: boolean;
 	}
 
-	const { checked, agreementLink, onChange, inputId, isOutdated }: Props = $props();
+	const { checked, agreementLink, onChange, inputId, testId, isOutdated }: Props = $props();
 </script>
 
 <span class="flex items-center gap-1">
-	<Checkbox checked={checked ?? false} {inputId} preventDefault={true} on:nnsChange={onChange}>
+	<Checkbox checked={checked ?? false} {inputId} {testId} on:nnsChange={onChange}>
 		{#if isOutdated}
 			{$i18n.agreements.text.i_have_accepted_updated}
 		{:else}

--- a/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
+++ b/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
+	import { isNullish } from '@dfinity/utils';
+	import { agreementsData } from '$env/agreements.env';
 	import type { EnvAgreements } from '$env/types/env-agreements';
+	import { updateUserAgreements } from '$lib/api/backend.api';
 	import agreementsBanner from '$lib/assets/banner-agreements.svg';
 	import AcceptAgreementsCheckbox from '$lib/components/agreements/AcceptAgreementsCheckbox.svelte';
 	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
@@ -11,10 +14,20 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
-	import { AGREEMENTS_MODAL } from '$lib/constants/test-ids.constants';
+	import {
+		AGREEMENTS_MODAL,
+		AGREEMENTS_MODAL_ACCEPT_BUTTON,
+		AGREEMENTS_MODAL_CHECKBOX_LICENSE_AGREEMENT,
+		AGREEMENTS_MODAL_CHECKBOX_PRIVACY_POLICY,
+		AGREEMENTS_MODAL_CHECKBOX_TERMS_OF_USE
+	} from '$lib/constants/test-ids.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { hasOutdatedAgreements, outdatedAgreements } from '$lib/derived/user-agreements.derived';
-	import { warnSignOut } from '$lib/services/auth.services';
+	import { nullishSignOut, warnSignOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { UserAgreements } from '$lib/types/user-agreements';
+	import { emit } from '$lib/utils/events.utils';
 
 	type AgreementsToAcceptType = {
 		[K in keyof EnvAgreements]?: boolean;
@@ -48,6 +61,8 @@
 		agreementsToAccept[type] = !agreementsToAccept[type];
 	};
 
+	let savingAgreements = $state(false);
+
 	const onReject = () => {
 		// TODO: Add (non-awaited?) services to save the user agreements rejection status
 
@@ -55,7 +70,46 @@
 	};
 
 	const onAccept = async () => {
-		// TODO: Add services to save the user agreements acceptance status
+		if (isNullish($authIdentity)) {
+			await nullishSignOut();
+			return;
+		}
+
+		savingAgreements = true;
+
+		const agreements: UserAgreements = Object.entries(agreementsToAccept).reduce<UserAgreements>(
+			(acc, [agreement, accepted]) => {
+				if (accepted) {
+					return {
+						...acc,
+						[agreement]: {
+							accepted,
+							lastAcceptedTimestamp: Date.now(),
+							lastUpdatedTimestamp:
+								agreementsData[agreement as keyof EnvAgreements].lastUpdatedTimestamp
+						}
+					};
+				}
+				return acc;
+			},
+			{} as UserAgreements
+		);
+
+		try {
+			await updateUserAgreements({
+				identity: $authIdentity,
+				agreements
+			});
+
+			emit({ message: 'oisyRefreshUserProfile' });
+		} catch (err: unknown) {
+			toastsError({
+				msg: { text: $i18n.agreements.error.cannot_update_user_agreements },
+				err
+			});
+		} finally {
+			savingAgreements = false;
+		}
 	};
 </script>
 
@@ -81,6 +135,7 @@
 					inputId="termsOfUseCheckbox"
 					isOutdated={$hasOutdatedAgreements}
 					onChange={() => toggleAccept('termsOfUse')}
+					testId={AGREEMENTS_MODAL_CHECKBOX_TERMS_OF_USE}
 				>
 					{#snippet agreementLink()}
 						<TermsOfUseLink noUnderline>
@@ -97,6 +152,7 @@
 					inputId="privacyPolicyCheckbox"
 					isOutdated={$hasOutdatedAgreements}
 					onChange={() => toggleAccept('privacyPolicy')}
+					testId={AGREEMENTS_MODAL_CHECKBOX_PRIVACY_POLICY}
 				>
 					{#snippet agreementLink()}
 						<PrivacyPolicyLink noUnderline>
@@ -113,6 +169,7 @@
 					inputId="licenseAgreementCheckbox"
 					isOutdated={$hasOutdatedAgreements}
 					onChange={() => toggleAccept('licenseAgreement')}
+					testId={AGREEMENTS_MODAL_CHECKBOX_LICENSE_AGREEMENT}
 				>
 					{#snippet agreementLink()}
 						<LicenseLink noUnderline>
@@ -130,7 +187,13 @@
 				<Button colorStyle="secondary-light" onclick={onReject}>
 					{$i18n.core.text.reject}
 				</Button>
-				<Button colorStyle="primary" {disabled} onclick={onAccept}>
+				<Button
+					colorStyle="primary"
+					{disabled}
+					loading={savingAgreements}
+					onclick={onAccept}
+					testId={AGREEMENTS_MODAL_ACCEPT_BUTTON}
+				>
 					{$i18n.agreements.text.accept_and_continue}
 				</Button>
 			</ButtonGroup>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -275,3 +275,8 @@ export const AI_ASSISTANT_SEND_TOKENS_SUCCESS_MESSAGE = 'ai-assistant-send-token
 
 // Agreements
 export const AGREEMENTS_MODAL = 'agreements-modal';
+export const AGREEMENTS_MODAL_CHECKBOX_TERMS_OF_USE = 'agreements-modal-checkbox-terms-of-use';
+export const AGREEMENTS_MODAL_CHECKBOX_PRIVACY_POLICY = 'agreements-modal-checkbox-privacy-policy';
+export const AGREEMENTS_MODAL_CHECKBOX_LICENSE_AGREEMENT =
+	'agreements-modal-checkbox-license-agreement';
+export const AGREEMENTS_MODAL_ACCEPT_BUTTON = 'agreements-modal-accept-button';

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "Ich habe die Dokumente gelesen und stimme ihnen zu.",
 			"i_have_accepted_updated": "Ich habe die angepassten Dokumente gelesen und stimme ihnen zu.",
 			"accept_and_continue": "Zustimmen und weiterfahren"
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "I have read and agree to the",
 			"i_have_accepted_updated": "I have read and agree to the updated",
 			"accept_and_continue": "Accept and continue"
+		},
+		"error": {
+			"cannot_update_user_agreements": "Something went wrong when updating your agreements."
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1489,6 +1489,9 @@
 			"i_have_accepted": "",
 			"i_have_accepted_updated": "",
 			"accept_and_continue": ""
+		},
+		"error": {
+			"cannot_update_user_agreements": ""
 		}
 	},
 	"license_agreement": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1223,6 +1223,7 @@ interface I18nAgreements {
 		i_have_accepted_updated: string;
 		accept_and_continue: string;
 	};
+	error: { cannot_update_user_agreements: string };
 }
 
 interface I18nLicense_agreement {

--- a/src/frontend/src/tests/lib/components/agreements/AcceptAgreementsModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/agreements/AcceptAgreementsModal.spec.ts
@@ -12,6 +12,8 @@ import { i18n } from '$lib/stores/i18n.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { AgreementData, UserAgreements } from '$lib/types/user-agreements';
+import * as eventsUtils from '$lib/utils/events.utils';
+import { emit } from '$lib/utils/events.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -52,6 +54,8 @@ describe('AcceptAgreementsModal', () => {
 		vi.spyOn(backendApi, 'updateUserAgreements').mockImplementation(vi.fn());
 
 		vi.spyOn(toastsStore, 'toastsError');
+
+		vi.spyOn(eventsUtils, 'emit');
 	});
 
 	it('shows updated title when hasOutdatedAgreements = true', () => {
@@ -161,6 +165,8 @@ describe('AcceptAgreementsModal', () => {
 		expect(authServices.nullishSignOut).toHaveBeenCalledOnce();
 
 		expect(backendApi.updateUserAgreements).not.toHaveBeenCalled();
+
+		expect(emit).not.toHaveBeenCalled();
 	});
 
 	it('clicking Accept calls updateUserAgreements with no selected agreement', async () => {
@@ -172,6 +178,8 @@ describe('AcceptAgreementsModal', () => {
 			identity: mockIdentity,
 			agreements: {}
 		});
+
+		expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyRefreshUserProfile' });
 	});
 
 	it('clicking Accept calls updateUserAgreements with some agreements selected', async () => {
@@ -196,6 +204,8 @@ describe('AcceptAgreementsModal', () => {
 				}
 			}
 		});
+
+		expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyRefreshUserProfile' });
 	});
 
 	it('clicking Accept shows an error toast when updateUserAgreements fails', async () => {
@@ -210,6 +220,8 @@ describe('AcceptAgreementsModal', () => {
 			msg: { text: en.agreements.error.cannot_update_user_agreements },
 			err: mockError
 		});
+
+		expect(emit).not.toHaveBeenCalled();
 	});
 
 	it('accept button is disabled initially with all three rendered', () => {
@@ -223,7 +235,9 @@ describe('AcceptAgreementsModal', () => {
 	it('accept button enables after all three are toggled when all three are rendered', async () => {
 		const { getByRole, getAllByRole } = render(AcceptAgreementsModal);
 
-		const acceptBtn = getByRole('button', { name: get(i18n).agreements.text.accept_and_continue });
+		const acceptBtn = getByRole('button', {
+			name: get(i18n).agreements.text.accept_and_continue
+		});
 		const checkboxes = getAllByRole('checkbox');
 
 		for (const cb of checkboxes) {

--- a/src/frontend/src/tests/lib/components/agreements/AcceptAgreementsModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/agreements/AcceptAgreementsModal.spec.ts
@@ -1,8 +1,20 @@
+import { agreementsData } from '$env/agreements.env';
+import * as backendApi from '$lib/api/backend.api';
 import AcceptAgreementsModal from '$lib/components/agreements/AcceptAgreementsModal.svelte';
+import {
+	AGREEMENTS_MODAL_ACCEPT_BUTTON,
+	AGREEMENTS_MODAL_CHECKBOX_PRIVACY_POLICY,
+	AGREEMENTS_MODAL_CHECKBOX_TERMS_OF_USE
+} from '$lib/constants/test-ids.constants';
 import * as agreementsDerived from '$lib/derived/user-agreements.derived';
 import * as authServices from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
+import * as toastsStore from '$lib/stores/toasts.store';
+import { toastsError } from '$lib/stores/toasts.store';
 import type { AgreementData, UserAgreements } from '$lib/types/user-agreements';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import en from '$tests/mocks/i18n.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
 import { cleanup, fireEvent, render } from '@testing-library/svelte';
 import { get, writable, type Writable } from 'svelte/store';
 
@@ -13,6 +25,8 @@ describe('AcceptAgreementsModal', () => {
 
 	beforeEach(() => {
 		cleanup();
+
+		mockAuthStore();
 
 		hasOutdatedStore = writable(false);
 		vi.spyOn(agreementsDerived, 'hasOutdatedAgreements', 'get').mockReturnValue(hasOutdatedStore);
@@ -32,8 +46,12 @@ describe('AcceptAgreementsModal', () => {
 
 		vi.spyOn(agreementsDerived, 'outdatedAgreements', 'get').mockReturnValue(outdatedStore);
 
-		// Warn sign out stub
-		vi.spyOn(authServices, 'warnSignOut').mockImplementation(() => new Promise<void>(() => {}));
+		vi.spyOn(authServices, 'warnSignOut').mockImplementation(vi.fn());
+		vi.spyOn(authServices, 'nullishSignOut').mockImplementation(vi.fn());
+
+		vi.spyOn(backendApi, 'updateUserAgreements').mockImplementation(vi.fn());
+
+		vi.spyOn(toastsStore, 'toastsError');
 	});
 
 	it('shows updated title when hasOutdatedAgreements = true', () => {
@@ -131,6 +149,67 @@ describe('AcceptAgreementsModal', () => {
 		await fireEvent.click(getByRole('button', { name: get(i18n).core.text.reject }));
 
 		expect(authServices.warnSignOut).toHaveBeenCalledWith(get(i18n).agreements.text.reject_warning);
+	});
+
+	it('clicking Accept calls nullishSignOut if the identity is nullish', async () => {
+		mockAuthStore(null);
+
+		const { getByTestId } = render(AcceptAgreementsModal);
+
+		await fireEvent.click(getByTestId(AGREEMENTS_MODAL_ACCEPT_BUTTON));
+
+		expect(authServices.nullishSignOut).toHaveBeenCalledOnce();
+
+		expect(backendApi.updateUserAgreements).not.toHaveBeenCalled();
+	});
+
+	it('clicking Accept calls updateUserAgreements with no selected agreement', async () => {
+		const { getByTestId } = render(AcceptAgreementsModal);
+
+		await fireEvent.click(getByTestId(AGREEMENTS_MODAL_ACCEPT_BUTTON));
+
+		expect(backendApi.updateUserAgreements).toHaveBeenCalledExactlyOnceWith({
+			identity: mockIdentity,
+			agreements: {}
+		});
+	});
+
+	it('clicking Accept calls updateUserAgreements with some agreements selected', async () => {
+		const { getByTestId } = render(AcceptAgreementsModal);
+
+		await fireEvent.click(getByTestId(AGREEMENTS_MODAL_CHECKBOX_TERMS_OF_USE));
+		await fireEvent.click(getByTestId(AGREEMENTS_MODAL_CHECKBOX_PRIVACY_POLICY));
+		await fireEvent.click(getByTestId(AGREEMENTS_MODAL_ACCEPT_BUTTON));
+
+		expect(backendApi.updateUserAgreements).toHaveBeenCalledExactlyOnceWith({
+			identity: mockIdentity,
+			agreements: {
+				termsOfUse: {
+					accepted: true,
+					lastAcceptedTimestamp: expect.any(Number),
+					lastUpdatedTimestamp: agreementsData.termsOfUse.lastUpdatedTimestamp
+				},
+				privacyPolicy: {
+					accepted: true,
+					lastAcceptedTimestamp: expect.any(Number),
+					lastUpdatedTimestamp: agreementsData.privacyPolicy.lastUpdatedTimestamp
+				}
+			}
+		});
+	});
+
+	it('clicking Accept shows an error toast when updateUserAgreements fails', async () => {
+		const mockError = new Error('Failed to update');
+		vi.spyOn(backendApi, 'updateUserAgreements').mockRejectedValue(mockError);
+
+		const { getByTestId } = render(AcceptAgreementsModal);
+
+		await fireEvent.click(getByTestId(AGREEMENTS_MODAL_ACCEPT_BUTTON));
+
+		expect(toastsError).toHaveBeenCalledWith({
+			msg: { text: en.agreements.error.cannot_update_user_agreements },
+			err: mockError
+		});
 	});
 
 	it('accept button is disabled initially with all three rendered', () => {


### PR DESCRIPTION
# Motivation

We add the services to save the user agreements in the `AcceptAgreementsModal`.

# Changes

- Use backend method `updateUserAgreements` when accepting the terms and agreements.
- Emit call to refresh the user profile.
- Remove `preventDefault` settings in the checkbox.

# Tests

Included unittests (and test IDs). But here a practical on:


https://github.com/user-attachments/assets/aed235e4-0907-4c9f-a0b0-5f915f324326


