### PR TITLE
refactor(frontend): Use existing util for current time in `AcceptAgreementsModal`

### DIFF
--- a/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
+++ b/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
@@ -3,6 +3,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { agreementsData } from '$env/agreements.env';
 	import type { EnvAgreements } from '$env/types/env-agreements';
+	import { nowInBigIntNanoSeconds } from '$icp/utils/date.utils';
 	import { updateUserAgreements } from '$lib/api/backend.api';
 	import agreementsBanner from '$lib/assets/banner-agreements.svg';
 	import AcceptAgreementsCheckbox from '$lib/components/agreements/AcceptAgreementsCheckbox.svelte';
@@ -28,7 +29,6 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { UserAgreements } from '$lib/types/user-agreements';
 	import { emit } from '$lib/utils/events.utils';
-    import {nowInBigIntNanoSeconds} from "$icp/utils/date.utils";
 
 	type AgreementsToAcceptType = {
 		[K in keyof EnvAgreements]?: boolean;
@@ -85,7 +85,7 @@
 						...acc,
 						[agreement]: {
 							accepted,
-                            lastAcceptedTimestamp: nowInBigIntNanoSeconds(),
+							lastAcceptedTimestamp: nowInBigIntNanoSeconds(),
 							lastUpdatedTimestamp:
 								agreementsData[agreement as keyof EnvAgreements].lastUpdatedTimestamp
 						}

--- a/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
+++ b/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
@@ -28,6 +28,7 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { UserAgreements } from '$lib/types/user-agreements';
 	import { emit } from '$lib/utils/events.utils';
+    import {nowInBigIntNanoSeconds} from "$icp/utils/date.utils";
 
 	type AgreementsToAcceptType = {
 		[K in keyof EnvAgreements]?: boolean;
@@ -84,7 +85,7 @@
 						...acc,
 						[agreement]: {
 							accepted,
-							lastAcceptedTimestamp: Date.now(),
+                            lastAcceptedTimestamp: nowInBigIntNanoSeconds(),
 							lastUpdatedTimestamp:
 								agreementsData[agreement as keyof EnvAgreements].lastUpdatedTimestamp
 						}

--- a/src/frontend/src/tests/lib/components/agreements/AcceptAgreementsModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/agreements/AcceptAgreementsModal.spec.ts
@@ -194,12 +194,12 @@ describe('AcceptAgreementsModal', () => {
 			agreements: {
 				termsOfUse: {
 					accepted: true,
-					lastAcceptedTimestamp: expect.any(Number),
+					lastAcceptedTimestamp: expect.any(BigInt),
 					lastUpdatedTimestamp: agreementsData.termsOfUse.lastUpdatedTimestamp
 				},
 				privacyPolicy: {
 					accepted: true,
-					lastAcceptedTimestamp: expect.any(Number),
+					lastAcceptedTimestamp: expect.any(BigInt),
 					lastUpdatedTimestamp: agreementsData.privacyPolicy.lastUpdatedTimestamp
 				}
 			}


### PR DESCRIPTION
# Motivation

For the current time in `bigint` we already have the util `nowInBigIntNanoSeconds`.
