### PR TITLE
feat(frontend): Derived store for SPL custom token initialization

### DIFF
--- a/src/frontend/src/sol/derived/spl.derived.ts
+++ b/src/frontend/src/sol/derived/spl.derived.ts
@@ -22,8 +22,10 @@ const splDefaultTokensAddresses: Readable<SplTokenAddress[]> = derived(
 );
 
 /**
- * The list of SPL tokens the user has added, enabled or disabled. Can contains default tokens for example if user has disabled a default tokens.
- * i.e. default tokens are configured on the client side. If user disable or enable a default tokens, this token is added as a "user token" in the backend.
+ * The list of SPL tokens the user has added, enabled or disabled.
+ * Can contain default tokens, for example, if the user has disabled a default token.
+ * i.e. default tokens are configured on the client side.
+ * If a user disables or enables a default token, this token is added as a "user token" in the backend.
  */
 const splCustomTokens: Readable<SplCustomToken[]> = derived(
 	[splCustomTokensStore, enabledSolanaNetworksIds],
@@ -112,4 +114,14 @@ export const enabledSplTokenAddresses: Readable<SplTokenAddress[]> = derived(
 			$enabledSplTokens.map(({ address, owner }) => [`${address}|${owner}`, address])
 		).values()
 	]
+);
+
+export const splCustomTokensInitialized: Readable<boolean> = derived(
+	[splCustomTokensStore],
+	([$splCustomTokensStore]) => $splCustomTokensStore !== undefined
+);
+
+export const splCustomTokensNotInitialized: Readable<boolean> = derived(
+	[splCustomTokensInitialized],
+	([$splCustomTokensInitialized]) => !$splCustomTokensInitialized
 );


### PR DESCRIPTION
# Motivation

We require some derived store to check if the SPL custom tokens are initialized: it must be not `undefined` (`null` is considered initialized but reset).

Note that I was unable to create a test for them, since the other tests in the same module already initialize the store...
