### PR TITLE
chore(frontend): Remove unused dispatch in `TokensMenu`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensMenu.svelte
@@ -20,7 +20,6 @@
 	const manageTokensId = Symbol();
 
 	const toggleHideZeros = () => {
-		document.dispatchEvent(new CustomEvent('toggleHideZeros'));
 		emit({ message: 'oisyToggleZeroBalances' });
 	};
 


### PR DESCRIPTION
# Motivation

No need to dispatch an event in `TokensMenu` when triggering the `toggleHideZeros` click.
