### PR TITLE
feat(frontend): AI console automatic scrolling

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -48,6 +48,8 @@ Element.prototype.animate = (
 	return animation;
 };
 
+Element.prototype.scrollTo = vi.fn();
+
 vi.mock('$app/stores', () => ({
 	page: mockPage
 }));


### PR DESCRIPTION
# Motivation

We want the following behaviour to be implemented: 
* when the log is at the bottom, and new content comes in (user entry or LLM), then scroll down automatically
* f the user manually scrolls up a bit, avoid automating scrolling to the bottom
* user types and sends - always scroll to the bottom
