### PR TITLE
feat(frontend): Show amount in Solana WalletConnect sign flow

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -35,7 +35,6 @@
 		amount={amountDisplay}
 		{balance}
 		{destination}
-		showNullishAmountLabel
 		source={$solAddressMainnet ?? ''}
 		{token}
 	>


### PR DESCRIPTION
# Motivation

Since we are more confident about the information parsed from WalletConnect now during Solana transactions, we can show the total amount requested.

<img width="1356" height="1246" alt="Screenshot 2025-09-03 at 21 36 06" src="https://github.com/user-attachments/assets/cb37e19c-dcd1-424a-98b4-e3f9aef9565c" />

