### PR TITLE
fix(frontend): Pass correct address to Solana WalletConnect sign modal

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -133,6 +133,7 @@
 </script>
 
 <WizardModal bind:this={modal} onClose={reject} {steps} bind:currentStep>
+	{request}
 	{#snippet title()}
 		<WalletConnectModalTitle>
 			{$i18n.wallet_connect.text.sign_message}
@@ -151,6 +152,7 @@
 			destination={destination ?? ''}
 			onApprove={sign}
 			onReject={reject}
+			source={address ?? ''}
 			{token}
 		/>
 	{/if}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -133,7 +133,6 @@
 </script>
 
 <WizardModal bind:this={modal} onClose={reject} {steps} bind:currentStep>
-	{request}
 	{#snippet title()}
 		<WalletConnectModalTitle>
 			{$i18n.wallet_connect.text.sign_message}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -5,7 +5,6 @@
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import WalletConnectData from '$lib/components/wallet-connect/WalletConnectData.svelte';
-	import { solAddressMainnet } from '$lib/derived/address.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
@@ -14,13 +13,14 @@
 	interface Props {
 		amount?: bigint;
 		destination: string;
+		source: string;
 		data?: string;
 		token: Token;
 		onApprove: () => void;
 		onReject: () => void;
 	}
 
-	let { amount, destination, data, token, onApprove, onReject }: Props = $props();
+	let { amount, destination,source, data, token, onApprove, onReject }: Props = $props();
 
 	let balance = $derived($balancesStore?.[token.id]?.data);
 
@@ -30,13 +30,12 @@
 </script>
 
 <ContentWithToolbar>
-	<!-- TODO: add address for devnet and testnet -->
 	<SendData
 		amount={amountDisplay}
 		{balance}
 		{destination}
 		showNullishAmountLabel
-		source={$solAddressMainnet ?? ''}
+		{source}
 		{token}
 	>
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />


### PR DESCRIPTION
# Motivation

To solve a pending TODO, we pass the source address directly to the Solana WalletConnect modal.
