### PR TITLE
fix(frontend): Disable WalletConnect button when trying to reconnect

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectButton.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectButton.svelte
@@ -6,19 +6,22 @@
 	import { ethAddressNotLoaded, solAddressMainnetNotLoaded } from '$lib/derived/address.derived';
 
 	interface Props {
+		loading?: boolean;
 		ariaLabel?: string;
 		onclick: () => void;
 		children?: Snippet;
 	}
 
-	let { ariaLabel, onclick, children }: Props = $props();
+	let { loading = false, ariaLabel, onclick, children }: Props = $props();
+
+	let disabled = $derived(loading || ($ethAddressNotLoaded && $solAddressMainnetNotLoaded));
 </script>
 
 <button
 	class="tertiary-alt h-10"
 	class:icon={isNullish(children)}
 	aria-label={ariaLabel}
-	disabled={$ethAddressNotLoaded && $solAddressMainnetNotLoaded}
+	{disabled}
 	{onclick}
 	in:fade
 >

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectButton.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectButton.svelte
@@ -1,19 +1,27 @@
 <script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
 	import { ethAddressNotLoaded, solAddressMainnetNotLoaded } from '$lib/derived/address.derived';
 
-	export let ariaLabel: string | undefined = undefined;
+	interface Props {
+		ariaLabel?: string;
+		onclick: () => void;
+		children?: Snippet;
+	}
+
+	let { ariaLabel, onclick, children }: Props = $props();
 </script>
 
 <button
 	class="tertiary-alt h-10"
-	class:icon={!$$slots.default}
+	class:icon={isNullish(children)}
 	aria-label={ariaLabel}
 	disabled={$ethAddressNotLoaded && $solAddressMainnetNotLoaded}
-	on:click
+	{onclick}
 	in:fade
 >
 	<IconWalletConnect size="24" />
-	<slot />
+	{@render children?.()}
 </button>

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -147,7 +147,7 @@
 		}
 	};
 
-	// One try to sign in using the Oisy Wallet listed in the WalletConnect app and the sign-in occurs through URL
+	// One try to sign in using the Oisy Wallet listed in the WalletConnect app, and the sign-in occurs through URL
 	const uriConnect = async () => {
 		if (isNullish($walletConnectUri)) {
 			return;
@@ -377,13 +377,21 @@
 
 	$: walletConnectPaired.set(nonNullish(listener));
 
+	let reconnecting = true;
+
 	const reconnect = async () => {
-		// If the listener is already initialized, we don't need to do anything.
+		reconnecting = true
+
+		// If the listener is already initialised, we don't need to do anything.
 		if (nonNullish(listener)) {
+			reconnecting = false;
+
 			return;
 		}
 
 		if ($loading || (isNullish($ethAddress) && isNullish($solAddressMainnet))) {
+			reconnecting = false;
+
 			return;
 		}
 
@@ -395,6 +403,21 @@
 				solAddress: $solAddressMainnet,
 				cleanSlate: false
 			});
+
+			// Reattach handlers so incoming requests work after refresh
+			attachHandlers(listener);
+
+			// Check for persisted sessions
+			const sessions = listener.getActiveSessions();
+
+			if (Object.keys(sessions).length === 0) {
+				walletConnectPaired.set(false);
+
+				await disconnectListener();
+			} else {
+				// We have at least one active session – consider ourselves connected
+				walletConnectPaired.set(true);
+			}
 		} catch (err: unknown) {
 			toastsError({
 				msg: { text: $i18n.wallet_connect.error.connect },
@@ -402,26 +425,9 @@
 			});
 
 			resetListener();
-
-			return;
+		} finally {
+			reconnecting = false;
 		}
-
-		// Reattach handlers so incoming requests work after refresh
-		attachHandlers(listener);
-
-		// Check for persisted sessions
-		const sessions = listener.getActiveSessions();
-
-		if (Object.keys(sessions).length === 0) {
-			walletConnectPaired.set(false);
-
-			await disconnectListener();
-
-			return;
-		}
-
-		// We have at least one active session – consider ourselves connected
-		walletConnectPaired.set(true);
 	};
 
 	$: ($ethAddress, $solAddressMainnet, $loading, (async () => await reconnect())());
@@ -442,7 +448,11 @@
 		{$i18n.wallet_connect.text.disconnect}
 	</WalletConnectButton>
 {:else}
-	<WalletConnectButton ariaLabel={$i18n.wallet_connect.text.name} onclick={openWalletConnectAuth} />
+	<WalletConnectButton
+		ariaLabel={$i18n.wallet_connect.text.name}
+		loading={reconnecting}
+		onclick={openWalletConnectAuth}
+	/>
 {/if}
 
 {#if $modalWalletConnectAuth}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -438,14 +438,11 @@
 </script>
 
 {#if nonNullish(listener)}
-	<WalletConnectButton on:click={disconnect}>
+	<WalletConnectButton onclick={disconnect}>
 		{$i18n.wallet_connect.text.disconnect}
 	</WalletConnectButton>
 {:else}
-	<WalletConnectButton
-		ariaLabel={$i18n.wallet_connect.text.name}
-		on:click={openWalletConnectAuth}
-	/>
+	<WalletConnectButton ariaLabel={$i18n.wallet_connect.text.name} onclick={openWalletConnectAuth} />
 {/if}
 
 {#if $modalWalletConnectAuth}


### PR DESCRIPTION
# Motivation

When trying to reconnect to WalletConnect, we should disable the button just to avoid that the user clicks by mistake.

# Changes

- Add property `loading` to `WalletConnectButton`.
- Disable the button with either `loading` or with current logic (address-related).
- Adapt consumer to pass the `loading` prop during reconnecting.

# Tests

### Before

https://github.com/user-attachments/assets/9a748f15-0ec4-406b-b584-3df16c945639

### After

https://github.com/user-attachments/assets/e4da42fa-4c99-4b6f-9d10-6fe30a9d51c1


