### PR TITLE
fix(build): Missing `wss` sources in Content Security Policy

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -211,7 +211,7 @@ const updateCSP = (indexHtml) => {
 	const csp = `<meta
         http-equiv="Content-Security-Policy"
         content="default-src 'none';
-        connect-src 'self' ${NFTS_ENABLED ? 'https:' : allConnectSrc};
+        connect-src 'self' ${NFTS_ENABLED ? 'https: wss:' : allConnectSrc};
         img-src 'self' https: ipfs: data:;
         frame-src 'self' ${walletConnectFrameSrc} ${onramperConnectFrameSrc};
         manifest-src 'self';


### PR DESCRIPTION
# Motivation

We miss the WSS opening in the Content Security Policy sources