### PR TITLE
feat(frontend): add Avatar variant

### DIFF
--- a/src/frontend/src/lib/components/contact/Avatar.svelte
+++ b/src/frontend/src/lib/components/contact/Avatar.svelte
@@ -27,7 +27,8 @@
 			lg: 'text-[25.6px]', // size: 64px
 			md: 'text-[19.2px]', // size: 48px
 			sm: 'text-[16px]', // size: 40px
-			xs: 'text-[12.8px]' // size: 32px
+			xs: 'text-[12.8px]', // size: 32px
+			xxs: 'text-[10px]' // size: 24px
 		}[variant]
 	);
 

--- a/src/frontend/src/lib/components/contact/AvatarWithBadge.svelte
+++ b/src/frontend/src/lib/components/contact/AvatarWithBadge.svelte
@@ -33,7 +33,8 @@
 			lg: '64px',
 			md: '48px',
 			sm: '40px',
-			xs: '32px'
+			xs: '32px',
+			xxs: '24px'
 		}[variant]
 	);
 

--- a/src/frontend/src/lib/types/style.ts
+++ b/src/frontend/src/lib/types/style.ts
@@ -29,7 +29,7 @@ export type TagVariant =
 	| 'success'
 	| 'outline';
 
-export type AvatarVariants = 'xl' | 'lg' | 'md' | 'sm' | 'xs';
+export type AvatarVariants = 'xl' | 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
 
 export type ModalHeroVariant = 'default' | 'success';
 


### PR DESCRIPTION
# Motivation

Design needs a smaller avatar size for transaction lists
This Pr is part of https://github.com/dfinity/oisy-wallet/pull/8695

# Changes

Added size="xxc" variant to Avatar styles.

# Tests

Manual test