### PR TITLE
refactor(build): Add metadata type in additional ICRC tokens script

### DIFF
--- a/scripts/build.tokens.icrc.ts
+++ b/scripts/build.tokens.icrc.ts
@@ -31,7 +31,7 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 		throw new Error(`Error parsing tokens.icrc.json: ${icrcTokensParsed.error.message}`);
 	}
 
-	const icrcTokens = icrcTokensParsed.data;
+	const { data: icrcTokens } = icrcTokensParsed;
 
 	return await Object.entries(icrcTokens).reduce<Promise<TokensAndIcons>>(
 		async (acc, [key, token]) => {

--- a/scripts/build.tokens.icrc.ts
+++ b/scripts/build.tokens.icrc.ts
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
 import { EnvAdditionalIcrcTokensSchema } from '$env/schema/env-additional-icrc-token.schema';
-import icrcTokensJson from '$env/tokens/tokens.icrc.json';
 import type { EnvAdditionalIcrcTokensWithMetadata } from '$env/types/env-icrc-additional-token';
 import type { EnvTokenSymbol } from '$env/types/env-token-common';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
-import { isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
-import { existsSync, writeFileSync } from 'node:fs';
+import { isNullish, jsonReplacer, jsonReviver, nonNullish } from '@dfinity/utils';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadMetadata, saveLogo } from './build.tokens.utils';
 import { ADDITIONAL_ICRC_JSON_FILE } from './constants.mjs';
@@ -21,9 +20,18 @@ interface TokensAndIcons {
 }
 
 const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
+	const icrcTokensJson = JSON.parse(
+		readFileSync(ADDITIONAL_ICRC_JSON_FILE).toString(),
+		jsonReviver
+	);
+
 	const icrcTokensParsed = EnvAdditionalIcrcTokensSchema.safeParse(icrcTokensJson);
 
-	const icrcTokens = icrcTokensParsed.success ? icrcTokensParsed.data : {};
+	if (!icrcTokensParsed.success) {
+		throw new Error(`Error parsing tokens.icrc.json: ${icrcTokensParsed.error.message}`);
+	}
+
+	const icrcTokens = icrcTokensParsed.data;
 
 	return await Object.entries(icrcTokens).reduce<Promise<TokensAndIcons>>(
 		async (acc, [key, token]) => {
@@ -31,16 +39,13 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 				throw new Error(`Data is missing for token symbol ${key}.`);
 			}
 
-			const { ledgerCanisterId: savedLedgerCanisterId, indexCanisterId: savedIndexCanisterId } =
-				token;
+			const { ledgerCanisterId, indexCanisterId, ...rest } = token;
 
-			if (isNullish(savedLedgerCanisterId)) {
+			if (isNullish(ledgerCanisterId)) {
 				throw new Error(`Ledger canister ID is missing for token symbol ${key}.`);
 			}
 
 			const { tokens: accTokens, icons: accIcons } = await acc;
-
-			const { ledgerCanisterId, ...rest } = token;
 
 			const metadataWithIcon = await loadMetadata(ledgerCanisterId);
 
@@ -61,10 +66,9 @@ const buildIcrcTokens = async (): Promise<TokensAndIcons> => {
 					...accTokens,
 					[key]: {
 						ledgerCanisterId,
+						indexCanisterId,
 						...rest,
-						...metadata,
-						// We override the metadata index canister ID with the one from the saved JSON, in case we want to use a particular one that is not the official one
-						indexCanisterId: savedIndexCanisterId
+						...metadata
 					}
 				},
 				icons: [

--- a/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-additional-icrc-token.schema.ts
@@ -1,14 +1,16 @@
-import { EnvIcTokenSchema } from '$env/schema/env-icrc-token.schema';
+import {
+	EnvIcTokenWithMetadataSchema,
+	OptionalEnvIcTokenWithMetadataSchema
+} from '$env/schema/env-icrc-token.schema';
 import { EnvTokenSymbolSchema } from '$env/schema/env-token-common.schema';
 import * as z from 'zod/v4';
 
-// TODO, extract the union into it's own schema
 export const EnvAdditionalIcrcTokensSchema = z.record(
 	EnvTokenSymbolSchema,
-	z.union([z.undefined(), EnvIcTokenSchema])
+	OptionalEnvIcTokenWithMetadataSchema
 );
 
 export const EnvAdditionalIcrcTokensWithMetadataSchema = z.record(
 	EnvTokenSymbolSchema,
-	EnvIcTokenSchema
+	EnvIcTokenWithMetadataSchema
 );

--- a/src/frontend/src/env/schema/env-icrc-token.schema.ts
+++ b/src/frontend/src/env/schema/env-icrc-token.schema.ts
@@ -6,7 +6,7 @@ export const EnvIcrcTokenMetadataSchema = z.object({
 	symbol: z.string(),
 	fee: z.bigint(),
 	alternativeName: z.optional(z.string()),
-	url: z.optional(z.string().url())
+	url: z.optional(z.url())
 });
 
 export const EnvIcrcTokenIconSchema = z.object({
@@ -22,3 +22,18 @@ export const EnvIcTokenSchema = z.object({
 	ledgerCanisterId: z.string(),
 	indexCanisterId: z.string().optional()
 });
+
+const OptionalEnvIcrcTokenMetadataSchema = z.union([
+	EnvIcrcTokenMetadataSchema,
+	EnvIcrcTokenMetadataSchema.partial()
+]);
+
+export const EnvIcTokenWithMetadataSchema = z.intersection(
+	EnvIcTokenSchema,
+	OptionalEnvIcrcTokenMetadataSchema
+);
+
+export const OptionalEnvIcTokenWithMetadataSchema = z.union([
+	z.undefined(),
+	EnvIcTokenWithMetadataSchema
+]);


### PR DESCRIPTION
# Motivation

The additional ICRC tokens may or may not have metadata. Since we already map them, it is useful to have a type to track it.

# Changes

- Create a new type that include the IC env tokens but with optional metadata.
- Use the new type in the additional ICRC script flow.
- Adapt the parser to the new schema: we require `jsonReviver` for the `BigInt` values.
- Remove useless deconstruction when reassigning the token: the metadata object does not contain the index canister. 

# Tests

The CI should run as expected.
