### PR TITLE
feat(frontend): Enables to skip the first interval of IntervalLoader

### DIFF
--- a/src/frontend/src/lib/components/core/IntervalLoader.svelte
+++ b/src/frontend/src/lib/components/core/IntervalLoader.svelte
@@ -5,10 +5,11 @@
 	interface Props {
 		onLoad: () => Promise<void>;
 		interval: number;
+		skipInitialLoad?: boolean;
 		children?: Snippet;
 	}
 
-	let { onLoad, interval, children }: Props = $props();
+	let { onLoad, interval, skipInitialLoad = false, children }: Props = $props();
 
 	let timer: NodeJS.Timeout | undefined = undefined;
 
@@ -17,7 +18,9 @@
 			return;
 		}
 
-		await onLoad();
+		if (!skipInitialLoad) {
+			await onLoad();
+		}
 
 		timer = setInterval(onLoad, interval);
 	};

--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -13,10 +13,11 @@
 	import { findRemovedNfts, getUpdatedNfts } from '$lib/utils/nfts.utils';
 
 	interface Props {
+		skipInitialLoad?: boolean;
 		children?: Snippet;
 	}
 
-	let { children }: Props = $props();
+	let { skipInitialLoad = true, children }: Props = $props();
 
 	const handleRemovedNfts = ({
 		token,
@@ -73,6 +74,6 @@
 	};
 </script>
 
-<IntervalLoader interval={NFT_TIMER_INTERVAL_MILLIS} {onLoad}>
+<IntervalLoader interval={NFT_TIMER_INTERVAL_MILLIS} {onLoad} {skipInitialLoad}>
 	{@render children?.()}
 </IntervalLoader>

--- a/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderNfts.spec.ts
@@ -84,7 +84,11 @@ describe('LoaderNfts', () => {
 			mockGetNftsForOwner.mockResolvedValueOnce([mockNft1, mockNft2]);
 			mockGetNftsForOwner.mockResolvedValueOnce([mockNft3]);
 
-			render(LoaderNfts);
+			render(LoaderNfts, {
+				props: {
+					skipInitialLoad: false
+				}
+			});
 
 			await waitFor(() => {
 				expect(mockGetNftsForOwner).toHaveBeenCalledTimes(2);
@@ -110,7 +114,11 @@ describe('LoaderNfts', () => {
 			mockGetNftsForOwner.mockResolvedValueOnce([mockNft1, mockNft2]);
 			mockGetNftsForOwner.mockResolvedValueOnce([mockNft3]);
 
-			render(LoaderNfts);
+			render(LoaderNfts, {
+				props: {
+					skipInitialLoad: false
+				}
+			});
 
 			await waitFor(() => {
 				expect(mockGetNftsForOwner).toHaveBeenCalledTimes(2);
@@ -144,7 +152,11 @@ describe('LoaderNfts', () => {
 			mockGetNftsForOwner.mockResolvedValueOnce([mockNft1]);
 			mockGetNftsForOwner.mockResolvedValueOnce([]);
 
-			render(LoaderNfts);
+			render(LoaderNfts, {
+				props: {
+					skipInitialLoad: false
+				}
+			});
 
 			await waitFor(() => {
 				expect(mockGetNftsForOwner).toHaveBeenCalledTimes(2);
@@ -191,7 +203,11 @@ describe('LoaderNfts', () => {
 			mockGetNftsForOwner.mockResolvedValueOnce([customMockNft1]);
 			mockGetNftsForOwner.mockResolvedValueOnce([]);
 
-			render(LoaderNfts);
+			render(LoaderNfts, {
+				props: {
+					skipInitialLoad: false
+				}
+			});
 
 			await waitFor(() => {
 				expect(mockGetNftsForOwner).toHaveBeenCalledTimes(2);
@@ -247,7 +263,11 @@ describe('LoaderNfts', () => {
 			]);
 			mockGetNftsForOwner.mockResolvedValueOnce([{ ...customMockNft3, balance: 3 }]);
 
-			render(LoaderNfts);
+			render(LoaderNfts, {
+				props: {
+					skipInitialLoad: false
+				}
+			});
 
 			await waitFor(() => {
 				expect(mockGetNftsForOwner).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
# Motivation

When using an `IntervalLoader` we want to be able to skip the first loading process.
