### PR TITLE
feat(frontend): user experimental features derived stores

### DIFF
--- a/src/frontend/src/lib/derived/user-experimental-features.derived.ts
+++ b/src/frontend/src/lib/derived/user-experimental-features.derived.ts
@@ -1,0 +1,43 @@
+import type { ExperimentalFeatureSettingsFor } from '$declarations/backend/backend.did';
+import { userExperimentalFeaturesSettings } from '$lib/derived/user-profile.derived';
+import type {
+	ExperimentalFeatureId,
+	UserExperimentalFeatures
+} from '$lib/types/user-experimental-features';
+import { isNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const userExperimentalFeatures: Readable<UserExperimentalFeatures | null> = derived(
+	[userExperimentalFeaturesSettings],
+	([$userExperimentalFeaturesSettings]) => {
+		const userExperimentalFeatures = $userExperimentalFeaturesSettings?.experimental_features;
+
+		if (isNullish(userExperimentalFeatures) || userExperimentalFeatures.length === 0) {
+			// No enabled experimental features
+			return null;
+		}
+
+		const keyToFeatureId = (key: ExperimentalFeatureSettingsFor): ExperimentalFeatureId => {
+			if ('AiAssistantBeta' in key) {
+				return 'AiAssistantBeta';
+			}
+
+			// Force compiler error on unhandled cases based on leftover types
+			const _: never = key;
+
+			throw new Error(`Unknown feature key: ${key}`);
+		};
+
+		return {
+			...userExperimentalFeatures.reduce<UserExperimentalFeatures>((acc, [key, { enabled }]) => {
+				const featureId: ExperimentalFeatureId = keyToFeatureId(key);
+				return { ...acc, [featureId]: { enabled } };
+			}, {} as UserExperimentalFeatures)
+		};
+	}
+);
+
+export const aiAssistantBetaEnabled: Readable<boolean> = derived(
+	[userExperimentalFeatures],
+	([$userExperimentalFeatures]) => $userExperimentalFeatures?.AiAssistantBeta?.enabled ?? false
+);

--- a/src/frontend/src/tests/lib/derived/user-experimental-features.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-experimental-features.derived.spec.ts
@@ -1,0 +1,65 @@
+import {
+	aiAssistantBetaEnabled,
+	userExperimentalFeatures
+} from '$lib/derived/user-experimental-features.derived';
+import { userProfileStore } from '$lib/stores/user-profile.store';
+import { mockUserExperimentalFeatures } from '$tests/mocks/user-experimental-features.mock';
+import {
+	mockExperimentalFeaturesSettings,
+	mockUserProfile,
+	mockUserSettings
+} from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+describe('user-experimental-features.derived', () => {
+	const certified = true;
+
+	describe('userExperimentalFeatures', () => {
+		it('should be null when user profile is not set', () => {
+			userProfileStore.reset();
+
+			expect(get(userExperimentalFeatures)).toEqual(null);
+		});
+
+		it('should return be null when user experimental features are nullish', () => {
+			userProfileStore.set({
+				certified,
+				profile: {
+					...mockUserProfile,
+					settings: toNullable({
+						...mockUserSettings,
+						experimental_features: {
+							...mockExperimentalFeaturesSettings,
+							experimental_features: []
+						}
+					})
+				}
+			});
+
+			expect(get(userExperimentalFeatures)).toEqual(null);
+		});
+
+		it('should return the user experimental features if they are set', () => {
+			userProfileStore.set({ certified, profile: mockUserProfile });
+
+			expect(get(userExperimentalFeatures)).toEqual({
+				...mockUserExperimentalFeatures
+			});
+		});
+	});
+
+	describe('aiAssistantBetaEnabled', () => {
+		it('should be false when user profile is not set', () => {
+			userProfileStore.reset();
+
+			expect(get(aiAssistantBetaEnabled)).toBeFalsy();
+		});
+
+		it('should be true when AI assistant feature is set', () => {
+			userProfileStore.set({ certified, profile: mockUserProfile });
+
+			expect(get(aiAssistantBetaEnabled)).toBeTruthy();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Now, we need to create some additional derived stores for the  user experimental features functionality.
