### PR TITLE
feat(frontend): use beta feature flag in AI console button

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsoleButton.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsoleButton.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { fade } from 'svelte/transition';
 	import { AI_ASSISTANT_CONSOLE_ENABLED } from '$env/ai-assistant.env';
 	import AnimatedIconAiAssistant from '$lib/components/icons/animated/AnimatedIconAiAssistant.svelte';
 	import { AI_ASSISTANT_OPEN_CONSOLE } from '$lib/constants/analytics.contants';
 	import { AI_ASSISTANT_CONSOLE_BUTTON } from '$lib/constants/test-ids.constants';
 	import { authSignedIn } from '$lib/derived/auth.derived';
+	import { aiAssistantBetaEnabled } from '$lib/derived/user-experimental-features.derived';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -22,12 +24,13 @@
 	};
 </script>
 
-{#if $authSignedIn && AI_ASSISTANT_CONSOLE_ENABLED}
+{#if $authSignedIn && AI_ASSISTANT_CONSOLE_ENABLED && $aiAssistantBetaEnabled}
 	<button
 		class={`group flex items-center justify-center overflow-hidden duration-500 ${styleClass ?? ''}`}
 		aria-label={replaceOisyPlaceholders($i18n.footer.text.ai_assistant_console_button)}
 		data-tid={AI_ASSISTANT_CONSOLE_BUTTON}
 		onclick={onClick}
+		transition:fade
 	>
 		<AnimatedIconAiAssistant styleClass="transition group-hover:scale-[1.10]" />
 	</button>

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantConsoleButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantConsoleButton.spec.ts
@@ -1,16 +1,20 @@
 import * as aiAssistantEnv from '$env/ai-assistant.env';
 import AiAssistantConsoleButton from '$lib/components/ai-assistant/AiAssistantConsoleButton.svelte';
 import { AI_ASSISTANT_CONSOLE_BUTTON } from '$lib/constants/test-ids.constants';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import { mockAuthSignedIn } from '$tests/mocks/auth.mock';
+import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { render } from '@testing-library/svelte';
 
 describe('AiAssistantConsoleButton', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		userProfileStore.reset();
 	});
 
 	it('render the button if all conditions are met', () => {
 		mockAuthSignedIn(true);
+		userProfileStore.set({ certified: true, profile: mockUserProfile });
 		vi.spyOn(aiAssistantEnv, 'AI_ASSISTANT_CONSOLE_ENABLED', 'get').mockImplementation(() => true);
 
 		const { getByTestId } = render(AiAssistantConsoleButton);
@@ -20,6 +24,7 @@ describe('AiAssistantConsoleButton', () => {
 
 	it('does not render the button if feature flag is not on', () => {
 		mockAuthSignedIn(true);
+		userProfileStore.set({ certified: true, profile: mockUserProfile });
 
 		const { getByTestId } = render(AiAssistantConsoleButton);
 
@@ -27,6 +32,16 @@ describe('AiAssistantConsoleButton', () => {
 	});
 
 	it('does not render the button if user is not signed in', () => {
+		userProfileStore.set({ certified: true, profile: mockUserProfile });
+		vi.spyOn(aiAssistantEnv, 'AI_ASSISTANT_CONSOLE_ENABLED', 'get').mockImplementation(() => true);
+
+		const { getByTestId } = render(AiAssistantConsoleButton);
+
+		expect(() => getByTestId(AI_ASSISTANT_CONSOLE_BUTTON)).toThrow();
+	});
+
+	it('does not render the button if experimental feature setting is disabled', () => {
+		mockAuthSignedIn(true);
 		vi.spyOn(aiAssistantEnv, 'AI_ASSISTANT_CONSOLE_ENABLED', 'get').mockImplementation(() => true);
 
 		const { getByTestId } = render(AiAssistantConsoleButton);


### PR DESCRIPTION
# Motivation

In addition to the feature flag, we now also need to check the respective experimental feature setting before rendering the AI console button.
