### PR TITLE
refactor(frontend): Migrate `Transactions` component to Svelte 5

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
@@ -21,19 +21,20 @@
 	} from '$lib/derived/modal.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken, Token } from '$lib/types/token';
+	import type { OptionToken } from '$lib/types/token';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
-	let selectedTransaction: BtcTransactionUi | undefined;
-	let selectedToken: OptionToken;
-	$: ({ transaction: selectedTransaction, token: selectedToken } =
-		mapTransactionModalData<BtcTransactionUi>({
-			$modalOpen: $modalBtcTransaction,
-			$modalStore
-		}));
+	let selectedTransaction = $state<BtcTransactionUi | undefined>();
+	let selectedToken = $state<OptionToken>();
+	$effect(() => {
+		({ transaction: selectedTransaction, token: selectedToken } =
+			mapTransactionModalData<BtcTransactionUi>({
+				$modalOpen: $modalBtcTransaction,
+				$modalStore
+			}));
+	});
 
-	let token: Token;
-	$: token = $pageToken ?? DEFAULT_BITCOIN_TOKEN;
+	let token = $derived($pageToken ?? DEFAULT_BITCOIN_TOKEN);
 </script>
 
 <BtcTransactionsHeader />

--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -24,29 +24,32 @@
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { EthAddress } from '$lib/types/address';
 	import type { OptionToken } from '$lib/types/token';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
-	let ckMinterInfoAddresses: EthAddress[] = [];
-	$: ckMinterInfoAddresses = toCkMinterInfoAddresses($ckEthMinterInfoStore?.[$ethereumTokenId]);
-
-	let sortedTransactionsUi: EthTransactionUi[];
-	$: sortedTransactionsUi = $sortedEthTransactions.map(({ data: transaction }) =>
-		mapEthTransactionUi({
-			transaction,
-			ckMinterInfoAddresses,
-			ethAddress: $ethAddress
-		})
+	let ckMinterInfoAddresses = $derived(
+		toCkMinterInfoAddresses($ckEthMinterInfoStore?.[$ethereumTokenId])
 	);
 
-	let selectedTransaction: EthTransactionUi | undefined;
-	let selectedToken: OptionToken;
-	$: ({ transaction: selectedTransaction, token: selectedToken } =
-		mapTransactionModalData<EthTransactionUi>({
-			$modalOpen: $modalEthTransaction,
-			$modalStore
-		}));
+	let sortedTransactionsUi = $derived(
+		$sortedEthTransactions.map(({ data: transaction }) =>
+			mapEthTransactionUi({
+				transaction,
+				ckMinterInfoAddresses,
+				ethAddress: $ethAddress
+			})
+		)
+	);
+
+	let selectedTransaction = $state<EthTransactionUi | undefined>();
+	let selectedToken = $state<OptionToken>();
+	$effect(() => {
+		({ transaction: selectedTransaction, token: selectedToken } =
+			mapTransactionModalData<EthTransactionUi>({
+				$modalOpen: $modalEthTransaction,
+				$modalStore
+			}));
+	});
 </script>
 
 <Header>{$i18n.transactions.text.title}</Header>

--- a/src/frontend/src/lib/components/transactions/Transactions.svelte
+++ b/src/frontend/src/lib/components/transactions/Transactions.svelte
@@ -22,17 +22,19 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
-	import type { OptionToken } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import SolTransactions from '$sol/components/transactions/SolTransactions.svelte';
 
-	let token: OptionToken;
-	$: token = $allTokens.find(
-		(token) =>
-			token.name === $routeToken && $routeNetwork && token.network.id.description === $routeNetwork
+	let token = $derived(
+		$allTokens.find(
+			(token) =>
+				token.name === $routeToken &&
+				$routeNetwork &&
+				token.network.id.description === $routeNetwork
+		)
 	);
 
-	let timer: NodeJS.Timeout | undefined;
+	let timer = $state<NodeJS.Timeout | undefined>();
 
 	const manageTokensId = Symbol();
 

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -13,7 +13,7 @@
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken, Token } from '$lib/types/token';
+	import type { OptionToken } from '$lib/types/token';
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 	import SolTokenModal from '$sol/components/tokens/SolTokenModal.svelte';
 	import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
@@ -23,16 +23,17 @@
 	import { solTransactions } from '$sol/derived/sol-transactions.derived';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 
-	let selectedTransaction: SolTransactionUi | undefined;
-	let selectedToken: OptionToken;
-	$: ({ transaction: selectedTransaction, token: selectedToken } =
-		mapTransactionModalData<SolTransactionUi>({
-			$modalOpen: $modalSolTransaction,
-			$modalStore
-		}));
+	let selectedTransaction = $state<SolTransactionUi | undefined>();
+	let selectedToken = $state<OptionToken>();
+	$effect(() => {
+		({ transaction: selectedTransaction, token: selectedToken } =
+			mapTransactionModalData<SolTransactionUi>({
+				$modalOpen: $modalSolTransaction,
+				$modalStore
+			}));
+	});
 
-	let token: Token;
-	$: token = $pageToken ?? DEFAULT_SOLANA_TOKEN;
+	let token = $derived($pageToken ?? DEFAULT_SOLANA_TOKEN);
 </script>
 
 <Header>


### PR DESCRIPTION
# Motivation

Migrating `Transactions` component (and its direct children) to Svelte 5.
