### PR TITLE
test(frontend): Extract mock Snippet as variable

### DIFF
--- a/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderEthBalances.spec.ts
@@ -11,7 +11,7 @@ import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { createMockErc20Tokens } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { render } from '@testing-library/svelte';
@@ -181,17 +181,15 @@ describe('LoaderEthBalances', () => {
 	it('should not handle errors', async () => {
 		vi.mocked(loadEthBalances).mockRejectedValue(new Error('Error loading balances'));
 
-		const testId = 'test-id';
-
 		const { getByTestId } = render(LoaderEthBalances, {
 			props: {
-				children: createMockSnippet(testId)
+				children: mockSnippet
 			}
 		});
 
 		await tick();
 
-		expect(getByTestId(testId)).toBeInTheDocument();
+		expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 
 		expect(loadEthBalances).toHaveBeenCalledOnce();
 		expect(loadEthBalances).toHaveBeenNthCalledWith(1, mainnetTokens);

--- a/src/frontend/src/tests/icp/components/transactions/IcIndexCanisterStatus.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcIndexCanisterStatus.spec.ts
@@ -1,14 +1,11 @@
 import IcIndexCanisterStatus from '$icp/components/transactions/IcIndexCanisterStatus.svelte';
 import { emit } from '$lib/utils/events.utils';
 import en from '$tests/mocks/i18n.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 import { cleanup, render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 
 describe('IcIndexCanisterStatus', () => {
-	const mockTestId = 'mock-test-id';
-	const mockSnippet = createMockSnippet(mockTestId);
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -25,7 +22,7 @@ describe('IcIndexCanisterStatus', () => {
 		});
 
 		await waitFor(() => {
-			expect(getByTestId(mockTestId)).toBeInTheDocument();
+			expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 
 			expect(
 				queryByText(en.receive.icp.text.checking_index_canister_status)
@@ -41,7 +38,7 @@ describe('IcIndexCanisterStatus', () => {
 		});
 
 		await waitFor(() => {
-			expect(getByTestId(mockTestId)).toBeInTheDocument();
+			expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 
 			expect(
 				queryByText(en.receive.icp.text.checking_index_canister_status)
@@ -54,7 +51,7 @@ describe('IcIndexCanisterStatus', () => {
 
 		expect(queryByText(en.receive.icp.text.checking_index_canister_status)).toBeInTheDocument();
 
-		expect(queryByTestId(mockTestId)).not.toBeInTheDocument();
+		expect(queryByTestId(mockSnippetTestId)).not.toBeInTheDocument();
 	});
 
 	it('should unmount the loading status if it receives a negative event oisyIndexCanisterBalanceOutOfSync', async () => {
@@ -70,12 +67,12 @@ describe('IcIndexCanisterStatus', () => {
 
 		expect(queryByText(en.receive.icp.text.checking_index_canister_status)).toBeInTheDocument();
 
-		expect(queryByTestId(mockTestId)).not.toBeInTheDocument();
+		expect(queryByTestId(mockSnippetTestId)).not.toBeInTheDocument();
 
 		emit({ message: 'oisyIndexCanisterBalanceOutOfSync', detail: false });
 
 		await waitFor(() => {
-			expect(getByTestId(mockTestId)).toBeInTheDocument();
+			expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 
 			expect(
 				queryByText(en.receive.icp.text.checking_index_canister_status)

--- a/src/frontend/src/tests/icp/components/transactions/IcTransactionsScroll.spec.ts
+++ b/src/frontend/src/tests/icp/components/transactions/IcTransactionsScroll.spec.ts
@@ -14,7 +14,7 @@ import {
 	IntersectionObserverActiveInterval,
 	IntersectionObserverPassive
 } from '$tests/mocks/infinite-scroll.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { createIcTransactionUiMockList } from '$tests/utils/transactions-stores.test-utils';
 import { render } from '@testing-library/svelte';
 
@@ -32,8 +32,6 @@ describe('IcTransactionsScroll', () => {
 	const mockTransactions: IcTransactionUi[] = createIcTransactionUiMockList(2);
 
 	const mockLastId = mockTransactions[mockTransactions.length - 1].id;
-
-	const mockSnippet = createMockSnippet('Mock Snippet');
 
 	beforeAll(() => {
 		Object.defineProperty(window, 'IntersectionObserver', {

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeWorker.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeWorker.spec.ts
@@ -7,12 +7,10 @@ import {
 } from '$lib/services/worker.exchange.services';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { currencyStore } from '$lib/stores/currency.store';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
 
 describe('ExchangeWorker', () => {
-	const mockSnippet = createMockSnippet('Mock Snippet');
-
 	const stopExchangeTimer = vi.fn();
 	const startExchangeTimer = vi.fn();
 	const destroy = vi.fn();

--- a/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/AddressGuard.spec.ts
@@ -17,7 +17,7 @@ import * as solAddressServices from '$sol/services/sol-address.services';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import {
 	mockNetworksSettings,
@@ -31,8 +31,6 @@ import type { MockInstance } from 'vitest';
 
 describe('AddressGuard', () => {
 	let apiMock: MockInstance;
-
-	const mockSnippet = createMockSnippet('Mock Snippet');
 
 	beforeEach(() => {
 		vi.restoreAllMocks();

--- a/src/frontend/src/tests/lib/components/guard/AgreementsGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/AgreementsGuard.spec.ts
@@ -3,15 +3,13 @@ import { agreementsData } from '$env/agreements.env';
 import AgreementsGuard from '$lib/components/guard/AgreementsGuard.svelte';
 import { AGREEMENTS_MODAL } from '$lib/constants/test-ids.constants';
 import { userProfileStore } from '$lib/stores/user-profile.store';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { mockUserAgreements, mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { toNullable } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
 
 describe('AgreementsGuard', () => {
 	const certified = false;
-
-	const mockSnippet = createMockSnippet('mock-snippet');
 
 	const mockParams = { children: mockSnippet };
 

--- a/src/frontend/src/tests/lib/components/guard/ShortcutGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/ShortcutGuard.spec.ts
@@ -1,14 +1,12 @@
 import ShortcutGuard from '$lib/components/guard/ShortcutGuard.svelte';
 import { isPrivacyMode } from '$lib/derived/settings.derived';
 import { setPrivacyMode } from '$lib/utils/privacy.utils';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
 describe('ShortcutGuard', () => {
 	describe('Privacy mode', () => {
-		const mockSnippet = createMockSnippet('Mock Snippet');
-
 		const keyDownEvent = new KeyboardEvent('keydown', { key: 'p' });
 
 		beforeEach(() => {

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -39,7 +39,7 @@ import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import {
 	mockNetworksSettings,
@@ -127,8 +127,6 @@ vi.mock('$sol/services/spl.services', () => ({
 }));
 
 describe('Loader', () => {
-	const mockSnippet = createMockSnippet('Mock Snippet');
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
@@ -3,14 +3,12 @@ import * as loadUserServices from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { emit } from '$lib/utils/events.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { mockUserProfile } from '$tests/mocks/user-profile.mock';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
 describe('LoaderUserProfile', () => {
-	const mockSnippet = createMockSnippet('Mock Snippet');
-
 	beforeEach(() => {
 		vi.restoreAllMocks();
 

--- a/src/frontend/src/tests/lib/components/nfts/NftImageConsent.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftImageConsent.spec.ts
@@ -6,7 +6,7 @@ import * as nftsUtils from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { AZUKI_ELEMENTAL_BEANS_TOKEN } from '$tests/mocks/erc721-tokens.mock';
 import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
@@ -29,7 +29,7 @@ describe('NftImageConsent', () => {
 
 		const { getByRole, getByText } = render(NftImageConsent, {
 			nft: nftAzuki,
-			children: createMockSnippet('children'),
+			children: mockSnippet,
 			showMessage: true,
 			type: 'card'
 		});
@@ -51,7 +51,7 @@ describe('NftImageConsent', () => {
 
 		const { getByRole, getByText } = render(NftImageConsent, {
 			nft: nftAzuki,
-			children: createMockSnippet('children'),
+			children: mockSnippet,
 			showMessage: true,
 			type: 'card'
 		});
@@ -73,7 +73,7 @@ describe('NftImageConsent', () => {
 
 		const { getByRole } = render(NftImageConsent, {
 			nft: nftAzuki,
-			children: createMockSnippet('children'),
+			children: mockSnippet,
 			showMessage: true,
 			type: 'card'
 		});
@@ -93,7 +93,7 @@ describe('NftImageConsent', () => {
 
 		const { queryAllByRole, queryByText, getByTestId } = render(NftImageConsent, {
 			nft: nftAzuki,
-			children: createMockSnippet('children'),
+			children: mockSnippet,
 			showMessage: true,
 			type: 'card'
 		});
@@ -103,7 +103,7 @@ describe('NftImageConsent', () => {
 
 		expect(queryAllByRole('button')).toHaveLength(0);
 
-		const children = getByTestId('children');
+		const children = getByTestId(mockSnippetTestId);
 
 		expect(children).toBeInTheDocument();
 	});
@@ -113,7 +113,7 @@ describe('NftImageConsent', () => {
 
 		const { queryAllByRole, queryByText } = render(NftImageConsent, {
 			nft: nftAzuki,
-			children: createMockSnippet('children'),
+			children: mockSnippet,
 			showMessage: false,
 			type: 'card'
 		});

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsSkeletons.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsSkeletons.spec.ts
@@ -11,14 +11,12 @@ import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import AllTransactionsSkeletons from '$lib/components/transactions/AllTransactionsSkeletons.svelte';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 
 describe('AllTransactionsSkeletons', () => {
 	const testIdPrefix = 'skeleton-card';
-
-	const mockSnippet = createMockSnippet('Mock Snippet');
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/frontend/src/tests/lib/components/transactions/TransactionsSkeletons.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/TransactionsSkeletons.spec.ts
@@ -1,10 +1,8 @@
 import TransactionsSkeletons from '$lib/components/transactions/TransactionsSkeletons.svelte';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
 
 describe('TransactionsSkeletons', () => {
-	const mockSnippet = createMockSnippet('Mock Snippet');
-
 	it('should render SkeletonCards when loading is true', () => {
 		const { getByTestId } = render(TransactionsSkeletons, {
 			props: { loading: true, testIdPrefix: 'skeleton-card', children: mockSnippet }

--- a/src/frontend/src/tests/lib/components/ui/BgImg.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/BgImg.spec.ts
@@ -1,6 +1,6 @@
 import BgImg from '$lib/components/ui/BgImg.svelte';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 
 const IMG = 'https://example.com/pic.png';
 
@@ -117,10 +117,10 @@ describe('BgImg', () => {
 		const { getByTestId } = render(BgImg, {
 			ariaLabel: 'with-children',
 			imageUrl: IMG,
-			children: createMockSnippet('children')
+			children: mockSnippet
 		});
 
-		expect(getByTestId('children')).toBeInTheDocument();
+		expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 	});
 
 	it('omits box-shadow when shadow="none"', () => {

--- a/src/frontend/src/tests/lib/components/ui/DelayedTooltip.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/DelayedTooltip.spec.ts
@@ -1,11 +1,11 @@
 import DelayedTooltip from '$lib/components/ui/DelayedTooltip.svelte';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 
 describe('DelayedTooltip', () => {
-	const testId = 'test-content';
-	const children = createMockSnippet(testId);
+	const testId = mockSnippetTestId;
+	const children = mockSnippet;
 
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/src/frontend/src/tests/lib/components/ui/Tabs.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Tabs.spec.ts
@@ -1,7 +1,7 @@
 import { goto } from '$app/navigation';
 import Tabs from '$lib/components/ui/Tabs.svelte';
 import type { NonEmptyArray } from '$lib/types/utils';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 
 vi.mock('$app/navigation', () => ({
@@ -19,7 +19,7 @@ describe('Tabs', () => {
 			id: string;
 			path?: string | undefined;
 		}>,
-		children: createMockSnippet('snippet')
+		children: mockSnippet
 	};
 
 	it('renders component correctly', () => {
@@ -27,7 +27,7 @@ describe('Tabs', () => {
 
 		expect(getByText(props.tabs[0].label)).toBeInTheDocument();
 		expect(getByText(props.tabs[1].label)).toBeInTheDocument();
-		expect(getByTestId('snippet')).toBeInTheDocument();
+		expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 	});
 
 	it('correctly navigates to provided paths', async () => {
@@ -47,7 +47,7 @@ describe('Tabs', () => {
 
 		expect(tab0).toBeInTheDocument();
 		expect(tab1).toBeInTheDocument();
-		expect(getByTestId('snippet')).toBeInTheDocument();
+		expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
 
 		await fireEvent.click(tab0);
 

--- a/src/frontend/src/tests/mocks/snippet.mock.ts
+++ b/src/frontend/src/tests/mocks/snippet.mock.ts
@@ -4,3 +4,7 @@ export const createMockSnippet = (testId: string) =>
 	createRawSnippet(() => ({
 		render: () => `<span data-tid=${testId}>Mock Snippet</span>`
 	}));
+
+export const mockSnippetTestId = 'mock-snippet';
+
+export const mockSnippet = createMockSnippet(mockSnippetTestId);

--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -2,7 +2,7 @@ import * as analytics from '$lib/services/analytics.services';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import App from '$routes/+layout.svelte';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
 
 vi.mock(import('$lib/services/worker.auth.services'), async (importOriginal) => {
@@ -16,8 +16,6 @@ vi.mock(import('$lib/services/worker.auth.services'), async (importOriginal) => 
 });
 
 describe('App Layout', () => {
-	const mockSnippet = createMockSnippet('Mock Snippet');
-
 	beforeAll(() => {
 		Object.defineProperty(window, 'matchMedia', {
 			writable: true,

--- a/src/frontend/src/tests/sol/components/core/SolLoaderWallets.spec.ts
+++ b/src/frontend/src/tests/sol/components/core/SolLoaderWallets.spec.ts
@@ -8,7 +8,7 @@ import {
 import SolLoaderWallets from '$sol/components/core/SolLoaderWallets.svelte';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
 import { initSolWalletWorker } from '$sol/services/worker.sol-wallet.services';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { render } from '@testing-library/svelte';
@@ -19,8 +19,6 @@ vi.mock('$sol/services/worker.sol-wallet.services', () => ({
 }));
 
 describe('SolLoaderWallets', () => {
-	const mockSnippet = createMockSnippet('Mock Snippet');
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionsScroll.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionsScroll.spec.ts
@@ -8,7 +8,7 @@ import {
 	IntersectionObserverActive,
 	IntersectionObserverPassive
 } from '$tests/mocks/infinite-scroll.mock';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { render } from '@testing-library/svelte';
@@ -26,8 +26,6 @@ describe('SolTransactionsScroll', () => {
 	}));
 
 	const mockLastSignature = mockTransactions[mockTransactions.length - 1].signature;
-
-	const mockSnippet = createMockSnippet('Mock Snippet');
 
 	beforeAll(() => {
 		Object.defineProperty(window, 'IntersectionObserver', {


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we extract the mock Snippet to a specific segregated variable.
