### PR TITLE
refactor(frontend): Use ERC tokens utils to check the standard

### DIFF
--- a/src/frontend/src/eth/utils/erc1155.utils.ts
+++ b/src/frontend/src/eth/utils/erc1155.utils.ts
@@ -2,7 +2,7 @@ import type { Erc1155Token } from '$eth/types/erc1155';
 import type { Erc1155CustomToken } from '$eth/types/erc1155-custom-token';
 import type { Token } from '$lib/types/token';
 
-export const isTokenErc1155CustomToken = (token: Token): token is Erc1155CustomToken =>
-	token.standard === 'erc1155' && 'enabled' in token;
-
 export const isTokenErc1155 = (token: Token): token is Erc1155Token => token.standard === 'erc1155';
+
+export const isTokenErc1155CustomToken = (token: Token): token is Erc1155CustomToken =>
+	isTokenErc1155(token) && 'enabled' in token;

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -46,10 +46,10 @@ export const mapErc20Icon = (symbol: string): string | undefined => {
 	}
 };
 
+export const isTokenErc20 = (token: Token): token is Erc20Token => token.standard === 'erc20';
+
 export const isTokenEthereumUserToken = (token: Token): token is EthereumUserToken =>
-	(token.standard === 'ethereum' || token.standard === 'erc20') && 'enabled' in token;
+	(token.standard === 'ethereum' || isTokenErc20(token)) && 'enabled' in token;
 
 export const isTokenErc20UserToken = (token: Token): token is Erc20UserToken =>
-	token.standard === 'erc20' && 'enabled' in token && 'address' in token && 'exchange' in token;
-
-export const isTokenErc20 = (token: Token): token is Erc20Token => token.standard === 'erc20';
+	isTokenErc20(token) && 'enabled' in token && 'address' in token && 'exchange' in token;

--- a/src/frontend/src/eth/utils/erc721.utils.ts
+++ b/src/frontend/src/eth/utils/erc721.utils.ts
@@ -2,7 +2,7 @@ import type { Erc721Token } from '$eth/types/erc721';
 import type { Erc721CustomToken } from '$eth/types/erc721-custom-token';
 import type { Token } from '$lib/types/token';
 
-export const isTokenErc721CustomToken = (token: Token): token is Erc721CustomToken =>
-	token.standard === 'erc721' && 'enabled' in token;
-
 export const isTokenErc721 = (token: Token): token is Erc721Token => token.standard === 'erc721';
+
+export const isTokenErc721CustomToken = (token: Token): token is Erc721CustomToken =>
+	isTokenErc721(token) && 'enabled' in token;

--- a/src/frontend/src/eth/utils/token.utils.ts
+++ b/src/frontend/src/eth/utils/token.utils.ts
@@ -1,10 +1,11 @@
 import { ERC20_TWIN_TOKENS_IDS } from '$env/tokens/tokens.erc20.env';
 import { ERC20_ICP_SYMBOL } from '$eth/constants/erc20-icp.constants';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import type { OptionToken, TokenId } from '$lib/types/token';
 import { zeroPadValue } from 'ethers/utils';
 
 export const isErc20Icp = (token: OptionToken): boolean =>
-	token?.symbol === ERC20_ICP_SYMBOL && token?.standard === 'erc20';
+	token?.symbol === ERC20_ICP_SYMBOL && isTokenErc20(token);
 
 export const isSupportedErc20TwinTokenId = (tokenId: TokenId): boolean =>
 	ERC20_TWIN_TOKENS_IDS.includes(tokenId);

--- a/src/frontend/src/lib/components/nfts/NftCollectionActionButtons.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionActionButtons.svelte
@@ -16,6 +16,8 @@
 	import { CustomTokenSection } from '$lib/enums/custom-token-section';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NonFungibleToken } from '$lib/types/nft';
+    import {isTokenErc1155} from "$eth/utils/erc1155.utils";
+    import {isTokenErc721} from "$eth/utils/erc721.utils";
 
 	interface Props {
 		token: NonFungibleToken;
@@ -29,7 +31,7 @@
 		}
 
 		if (nonNullish(token)) {
-			if (token.standard === 'erc721') {
+			if ( isTokenErc721(  token)) {
 				await saveCustomErc721Token({
 					identity: $authIdentity,
 					tokens: [
@@ -41,8 +43,11 @@
 						}
 					]
 				});
+
+                return
 			}
-			if (token.standard === 'erc1155') {
+
+			if (isTokenErc1155( token)) {
 				await saveCustomErc1155Token({
 					identity: $authIdentity,
 					tokens: [
@@ -54,6 +59,8 @@
 						}
 					]
 				});
+
+                return
 			}
 		}
 	};

--- a/src/frontend/src/lib/components/nfts/NftCollectionActionButtons.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionActionButtons.svelte
@@ -2,6 +2,8 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { saveCustomTokens as saveCustomErc1155Token } from '$eth/services/erc1155-custom-tokens.services';
 	import { saveCustomTokens as saveCustomErc721Token } from '$eth/services/erc721-custom-tokens.services';
+	import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
+	import { isTokenErc721 } from '$eth/utils/erc721.utils';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
 	import IconEye from '$lib/components/icons/lucide/IconEye.svelte';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
@@ -16,8 +18,6 @@
 	import { CustomTokenSection } from '$lib/enums/custom-token-section';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NonFungibleToken } from '$lib/types/nft';
-    import {isTokenErc1155} from "$eth/utils/erc1155.utils";
-    import {isTokenErc721} from "$eth/utils/erc721.utils";
 
 	interface Props {
 		token: NonFungibleToken;
@@ -31,7 +31,7 @@
 		}
 
 		if (nonNullish(token)) {
-			if ( isTokenErc721(  token)) {
+			if (isTokenErc721(token)) {
 				await saveCustomErc721Token({
 					identity: $authIdentity,
 					tokens: [
@@ -44,10 +44,10 @@
 					]
 				});
 
-                return
+				return;
 			}
 
-			if (isTokenErc1155( token)) {
+			if (isTokenErc1155(token)) {
 				await saveCustomErc1155Token({
 					identity: $authIdentity,
 					tokens: [
@@ -60,7 +60,7 @@
 					]
 				});
 
-                return
+				return;
 			}
 		}
 	};

--- a/src/frontend/src/lib/components/nfts/NftImageConsentModal.svelte
+++ b/src/frontend/src/lib/components/nfts/NftImageConsentModal.svelte
@@ -3,6 +3,8 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { saveCustomTokens as saveErc1155CustomTokens } from '$eth/services/erc1155-custom-tokens.services';
 	import { saveCustomTokens as saveErc721CustomTokens } from '$eth/services/erc721-custom-tokens.services';
+	import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
+	import { isTokenErc721 } from '$eth/utils/erc721.utils';
 	import IconImageDownload from '$lib/components/icons/IconImageDownload.svelte';
 	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
 	import AddressActions from '$lib/components/ui/AddressActions.svelte';
@@ -24,8 +26,6 @@
 		getAllowMediaForNft,
 		getNftCollectionUi
 	} from '$lib/utils/nfts.utils';
-    import {isTokenErc1155} from "$eth/utils/erc1155.utils";
-    import {isTokenErc721} from "$eth/utils/erc721.utils";
 
 	interface Props {
 		collection: NftCollection;
@@ -64,7 +64,7 @@
 	const save = async () => {
 		saveLoading = true;
 		if (nonNullish(token) && nonNullish($authIdentity)) {
-			if ( isTokenErc721(  token)) {
+			if (isTokenErc721(token)) {
 				await saveErc721CustomTokens({
 					tokens: [
 						{
@@ -75,7 +75,7 @@
 					],
 					identity: $authIdentity
 				});
-			} else if (isTokenErc1155( token)) {
+			} else if (isTokenErc1155(token)) {
 				await saveErc1155CustomTokens({
 					tokens: [
 						{

--- a/src/frontend/src/lib/components/nfts/NftImageConsentModal.svelte
+++ b/src/frontend/src/lib/components/nfts/NftImageConsentModal.svelte
@@ -24,6 +24,8 @@
 		getAllowMediaForNft,
 		getNftCollectionUi
 	} from '$lib/utils/nfts.utils';
+    import {isTokenErc1155} from "$eth/utils/erc1155.utils";
+    import {isTokenErc721} from "$eth/utils/erc721.utils";
 
 	interface Props {
 		collection: NftCollection;
@@ -62,7 +64,7 @@
 	const save = async () => {
 		saveLoading = true;
 		if (nonNullish(token) && nonNullish($authIdentity)) {
-			if (token.standard === 'erc721') {
+			if ( isTokenErc721(  token)) {
 				await saveErc721CustomTokens({
 					tokens: [
 						{
@@ -73,7 +75,7 @@
 					],
 					identity: $authIdentity
 				});
-			} else if (token.standard === 'erc1155') {
+			} else if (isTokenErc1155( token)) {
 				await saveErc1155CustomTokens({
 					tokens: [
 						{

--- a/src/frontend/src/tests/eth/utils/erc1155.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc1155.utils.spec.ts
@@ -11,6 +11,26 @@ import { MOCK_ERC1155_TOKENS } from '$tests/mocks/erc1155-tokens.mock';
 import { MOCK_ERC721_TOKENS } from '$tests/mocks/erc721-tokens.mock';
 
 describe('erc1155.utils', () => {
+	describe('isTokenErc1155', () => {
+		it.each(MOCK_ERC1155_TOKENS)('should return true for token $name', (token) => {
+			expect(isTokenErc1155(token)).toBeTruthy();
+		});
+
+		it.each([
+			ICP_TOKEN,
+			...SUPPORTED_BITCOIN_TOKENS,
+			...SUPPORTED_ETHEREUM_TOKENS,
+			...SUPPORTED_EVM_TOKENS,
+			...SUPPORTED_SOLANA_TOKENS,
+			...SPL_TOKENS,
+			...ERC20_TWIN_TOKENS,
+			...EVM_ERC20_TOKENS,
+			...MOCK_ERC721_TOKENS
+		])('should return false for token $name', (token) => {
+			expect(isTokenErc1155(token)).toBeFalsy();
+		});
+	});
+
 	describe('isTokenErc721UserToken', () => {
 		it.each(
 			MOCK_ERC1155_TOKENS.map((token) => ({
@@ -40,26 +60,6 @@ describe('erc1155.utils', () => {
 			...MOCK_ERC721_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isTokenErc1155CustomToken(token)).toBeFalsy();
-		});
-	});
-
-	describe('isTokenErc1155', () => {
-		it.each(MOCK_ERC1155_TOKENS)('should return true for token $name', (token) => {
-			expect(isTokenErc1155(token)).toBeTruthy();
-		});
-
-		it.each([
-			ICP_TOKEN,
-			...SUPPORTED_BITCOIN_TOKENS,
-			...SUPPORTED_ETHEREUM_TOKENS,
-			...SUPPORTED_EVM_TOKENS,
-			...SUPPORTED_SOLANA_TOKENS,
-			...SPL_TOKENS,
-			...ERC20_TWIN_TOKENS,
-			...EVM_ERC20_TOKENS,
-			...MOCK_ERC721_TOKENS
-		])('should return false for token $name', (token) => {
-			expect(isTokenErc1155(token)).toBeFalsy();
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -134,6 +134,26 @@ describe('erc20.utils', () => {
 		);
 	});
 
+	describe('isTokenErc20', () => {
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS])(
+			'should return true for token $name',
+			(token) => {
+				expect(isTokenErc20(token)).toBeTruthy();
+			}
+		);
+
+		it.each([
+			ICP_TOKEN,
+			...SUPPORTED_BITCOIN_TOKENS,
+			...SUPPORTED_ETHEREUM_TOKENS,
+			...SUPPORTED_EVM_TOKENS,
+			...SUPPORTED_SOLANA_TOKENS,
+			...SPL_TOKENS
+		])('should return false for token $name', (token) => {
+			expect(isTokenErc20(token)).toBeFalsy();
+		});
+	});
+
 	describe('isTokenEthereumUserToken', () => {
 		const tokens = [
 			...SUPPORTED_ETHEREUM_TOKENS,
@@ -212,26 +232,6 @@ describe('erc20.utils', () => {
 			...SPL_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isTokenErc20UserToken(token)).toBeFalsy();
-		});
-	});
-
-	describe('isTokenErc20', () => {
-		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS])(
-			'should return true for token $name',
-			(token) => {
-				expect(isTokenErc20(token)).toBeTruthy();
-			}
-		);
-
-		it.each([
-			ICP_TOKEN,
-			...SUPPORTED_BITCOIN_TOKENS,
-			...SUPPORTED_ETHEREUM_TOKENS,
-			...SUPPORTED_EVM_TOKENS,
-			...SUPPORTED_SOLANA_TOKENS,
-			...SPL_TOKENS
-		])('should return false for token $name', (token) => {
-			expect(isTokenErc20(token)).toBeFalsy();
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/utils/erc721.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc721.utils.spec.ts
@@ -15,7 +15,27 @@ import {
 } from '$tests/mocks/erc721-tokens.mock';
 
 describe('erc721.utils', () => {
-	describe('isTokenErc721UserToken', () => {
+	describe('isTokenErc721', () => {
+		it.each(MOCK_ERC721_TOKENS)('should return true for token $name', (token) => {
+			expect(isTokenErc721(token)).toBeTruthy();
+		});
+
+		it.each([
+			ICP_TOKEN,
+			...SUPPORTED_BITCOIN_TOKENS,
+			...SUPPORTED_ETHEREUM_TOKENS,
+			...SUPPORTED_EVM_TOKENS,
+			...SUPPORTED_SOLANA_TOKENS,
+			...SPL_TOKENS,
+			...ERC20_TWIN_TOKENS,
+			...EVM_ERC20_TOKENS,
+			...MOCK_ERC1155_TOKENS
+		])('should return false for token $name', (token) => {
+			expect(isTokenErc721(token)).toBeFalsy();
+		});
+	});
+
+	describe('isTokenErc721CustomToken', () => {
 		const tokens = [AZUKI_ELEMENTAL_BEANS_TOKEN, DE_GODS_TOKEN];
 
 		it.each(
@@ -46,26 +66,6 @@ describe('erc721.utils', () => {
 			...MOCK_ERC1155_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isTokenErc721CustomToken(token)).toBeFalsy();
-		});
-	});
-
-	describe('isTokenErc721', () => {
-		it.each(MOCK_ERC721_TOKENS)('should return true for token $name', (token) => {
-			expect(isTokenErc721(token)).toBeTruthy();
-		});
-
-		it.each([
-			ICP_TOKEN,
-			...SUPPORTED_BITCOIN_TOKENS,
-			...SUPPORTED_ETHEREUM_TOKENS,
-			...SUPPORTED_EVM_TOKENS,
-			...SUPPORTED_SOLANA_TOKENS,
-			...SPL_TOKENS,
-			...ERC20_TWIN_TOKENS,
-			...EVM_ERC20_TOKENS,
-			...MOCK_ERC1155_TOKENS
-		])('should return false for token $name', (token) => {
-			expect(isTokenErc721(token)).toBeFalsy();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

When possible we would prefer to use the utils `isTokenErc1155`, `isTokenErc721` and `isTokenErc20`.
