### PR TITLE
fix(frontend): fixes the findNftsByToken utils function

### DIFF
--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -4,9 +4,9 @@ import type { EthAddress } from '$lib/types/address';
 import type { NftError } from '$lib/types/errors';
 import type { NetworkId } from '$lib/types/network';
 import type { Nft, NftCollection, NftCollectionUi, NftId, NonFungibleToken } from '$lib/types/nft';
+import { areAddressesEqual } from '$lib/utils/address.utils';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
-import { areAddressesEqual } from '$lib/utils/address.utils';
 
 export const findNft = ({
 	nfts,
@@ -29,8 +29,12 @@ export const findNftsByToken = ({
 	nfts: Nft[];
 	token: NonFungibleToken;
 }): Nft[] =>
-	nfts.filter(
-		(nft) => areAddressesEqual({address1: nft.collection.address, address2: tokenAddress, networkId: tokenNetwork.id})
+	nfts.filter((nft) =>
+		areAddressesEqual({
+			address1: nft.collection.address,
+			address2: tokenAddress,
+			networkId: tokenNetwork.id
+		})
 	);
 
 export const findNftsByNetwork = ({


### PR DESCRIPTION
# Motivation

The `findNftsByToken` function did not correctly compare the token addresses. 
