### PR TITLE
refactor(frontend): Migrate `TransactionsDateGroup` to Svelte 5

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -1,30 +1,24 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import type { BtcTransactionStatus, BtcTransactionUi } from '$btc/types/btc';
-	import type { BtcTransactionType } from '$btc/types/btc-transaction';
+	import type { BtcTransactionUi } from '$btc/types/btc';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
 
-	export let transaction: BtcTransactionUi;
-	export let token: Token;
-	export let iconType: 'token' | 'transaction' = 'transaction';
+	interface Props {
+		transaction: BtcTransactionUi;
+		token: Token;
+		iconType?: 'token' | 'transaction';
+	}
 
-	let value: bigint | undefined;
-	let timestamp: bigint | undefined;
-	let status: BtcTransactionStatus;
-	let type: BtcTransactionType;
-	let to: string[] | undefined;
-	let from: string | undefined;
+	let { transaction, token, iconType = 'transaction' }: Props = $props();
 
-	$: ({ type, status, value, timestamp, to, from } = transaction);
+	let { type, status, value, timestamp, to, from } = $derived(transaction);
 
-	let label: string;
-	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
+	let label = $derived(type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive);
 
-	let amount: bigint | undefined;
-	$: amount = nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined;
+	let amount = $derived(nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined);
 
 	const modalId = Symbol();
 </script>

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -1,26 +1,22 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import IcTransactionLabel from '$icp/components/transactions/IcTransactionLabel.svelte';
-	import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic-transaction';
+	import type { IcTransactionUi } from '$icp/types/ic-transaction';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { NANO_SECONDS_IN_SECOND } from '$lib/constants/app.constants';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus } from '$lib/types/transaction';
 
-	export let transaction: IcTransactionUi;
-	export let token: Token;
-	export let iconType: 'token' | 'transaction' = 'transaction';
+	interface Props {
+		transaction: IcTransactionUi;
+		token: Token;
+		iconType?: 'token' | 'transaction';
+	}
 
-	let type: IcTransactionType;
-	let transactionTypeLabel: string | undefined;
-	let value: bigint | undefined;
-	let timestampNanoseconds: bigint | undefined;
-	let incoming: boolean | undefined;
-	let to: string | undefined;
-	let from: string | undefined;
+	let { transaction, token, iconType = 'transaction' }: Props = $props();
 
-	$: ({
+	let {
 		type,
 		typeLabel: transactionTypeLabel,
 		value,
@@ -28,21 +24,19 @@
 		incoming,
 		to,
 		from
-	} = transaction);
+	} = $derived(transaction);
 
-	let pending = false;
-	$: pending = transaction?.status === 'pending';
+	let pending = $derived(transaction?.status === 'pending');
 
-	let status: TransactionStatus;
-	$: status = pending ? 'pending' : 'confirmed';
+	let status: TransactionStatus = $derived(pending ? 'pending' : 'confirmed');
 
-	let amount: bigint | undefined;
-	$: amount = nonNullish(value) ? (incoming ? value : value * -1n) : value;
+	let amount = $derived(nonNullish(value) ? (incoming ? value : value * -1n) : value);
 
-	let timestamp: number | undefined;
-	$: timestamp = nonNullish(timestampNanoseconds)
-		? Number(timestampNanoseconds / NANO_SECONDS_IN_SECOND)
-		: undefined;
+	let timestamp = $derived(
+		nonNullish(timestampNanoseconds)
+			? Number(timestampNanoseconds / NANO_SECONDS_IN_SECOND)
+			: undefined
+	);
 
 	const modalId = Symbol();
 </script>

--- a/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
@@ -7,9 +7,13 @@
 	import type { AllTransactionUiWithCmpNonEmptyList } from '$lib/types/transaction';
 	import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
 
-	export let formattedDate: string;
-	export let transactions: AllTransactionUiWithCmpNonEmptyList;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		formattedDate: string;
+		transactions: AllTransactionUiWithCmpNonEmptyList;
+		testId?: string;
+	}
+
+	let { formattedDate, transactions, testId }: Props = $props();
 </script>
 
 {#if transactions.length > 0}

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -1,39 +1,29 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import type { Commitment } from '@solana/kit';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus } from '$lib/types/transaction';
-	import type { SolTransactionType, SolTransactionUi } from '$sol/types/sol-transaction';
+	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 
-	export let transaction: SolTransactionUi;
-	export let token: Token;
-	export let iconType: 'token' | 'transaction' = 'transaction';
+	interface Props {
+		transaction: SolTransactionUi;
+		token: Token;
+		iconType?: 'token' | 'transaction';
+	}
 
-	let type: SolTransactionType;
-	let value: bigint | undefined;
-	let timestamp: bigint | undefined;
-	let status: Commitment | null;
-	let to: string | undefined;
-	let from: string | undefined;
-	let toOwner: string | undefined;
-	let fromOwner: string | undefined;
+	let { transaction, token, iconType = 'transaction' }: Props = $props();
 
-	$: ({ type, value, timestamp, status, to, from, toOwner, fromOwner } = transaction);
+	let { type, value, timestamp, status, to, from, toOwner, fromOwner } = $derived(transaction);
 
-	let label: string;
-	$: label = type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive;
+	let label = $derived(type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive);
 
-	let pending: boolean;
-	$: pending = status === 'processed' || isNullish(status);
+	let pending = $derived(status === 'processed' || isNullish(status));
 
-	let transactionStatus: TransactionStatus;
-	$: transactionStatus = pending ? 'pending' : 'confirmed';
+	let transactionStatus: TransactionStatus = $derived(pending ? 'pending' : 'confirmed');
 
-	let amount: bigint | undefined;
-	$: amount = nonNullish(value) ? (type === 'send' ? value * -1n : value) : value;
+	let amount = $derived(nonNullish(value) ? (type === 'send' ? value * -1n : value) : value);
 
 	const modalId = Symbol();
 </script>


### PR DESCRIPTION
# Motivation

Migrate component `TransactionsDateGroup` (and its direct children) to Svelte 5.
