### PR TITLE
refactor(frontend): rename addressId to selectedContactAddressId

### DIFF
--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -29,18 +29,18 @@ export const getAiAssistantSystemPrompt = ({
 			1. First, always extract a numeric string into "amountNumber". It must contain only a number (e.g., "10", "0.5").
 			2. Then, always check if the token string matches one of the AVAILABLE TOKENS exactly before assigning it to "tokenSymbol".
 			3. If the token is not in AVAILABLE TOKENS, do not proceed further.
-		- Only call when all 4 arguments "amountNumber" (string), "tokenSymbol" (string), "networkId" (string), and either "addressId" or "address" (string) are provided.
+		- Only call when all 4 arguments "amountNumber" (string), "tokenSymbol" (string), "networkId" (string), and either "selectedContactAddressId" or "address" (string) are provided.
 		- If tokenSymbol maps to multiple networkIds and networkId is not specified yet, ask: "On which network would you like to send {tokenSymbol}?".
 		- Never invent a networkId that isn’t in AVAILABLE TOKENS.
 	
 	- For 'show_contacts':
 		- Use when the user specifies a contact name or wants to choose from saved contacts.
 		- When calling show_contacts, filter by the addressType (values: 'Btc', 'Eth', 'Sol', 'Icrcv2') that corresponds to the token's networkId using the mapping below.
-		- If the user confirms a selection, immediately call 'review_send_tokens' with the selected "addressId" and previously provided "amountNumber" + "tokenSymbol".
+		- If the user confirms a selection, immediately call 'review_send_tokens' with the selected "selectedContactAddressId" and previously provided "amountNumber" + "tokenSymbol".
 	
 	MEMORY & CHAINING BEHAVIOR:
-	- Always remember values from earlier in the conversation (address, addressId, amountNumber, tokenSymbol, networkId) until the send action is complete.
-	- If "show_contacts" was called and the user confirms a specific contact/address, you MUST reuse the "addressId" from the tool result and proceed to "review_send_tokens" without asking again.
+	- Always remember values from earlier in the conversation (address, selectedContactAddressId, amountNumber, tokenSymbol, networkId) until the send action is complete.
+	- If "show_contacts" was called and the user confirms a specific contact/address, you MUST reuse the "selectedContactAddressId" from the tool result and proceed to "review_send_tokens" without asking again.
 	
 	NETWORKID → addressType mapping:
 	- BTC → Btc
@@ -127,14 +127,14 @@ export const getAiAssistantToolsDescription = ({
 			function: {
 				name: 'review_send_tokens',
 				description: toNullable(
-					`Display an overview of the pending token transfer for user confirmation. Always return 4 arguments: "amountNumber" (string), "tokenSymbol" (string), "networkId" (string), and either "addressId" or "address". Do NOT send tokens yourself; sending will only happen via the UI button. If one of those arguments is not available, ask the user to provide it.`
+					`Display an overview of the pending token transfer for user confirmation. Always return 4 arguments: "amountNumber" (string), "tokenSymbol" (string), "networkId" (string), and either "selectedContactAddressId" or "address". Do NOT send tokens yourself; sending will only happen via the UI button. If one of those arguments is not available, ask the user to provide it.`
 				),
 				parameters: toNullable({
 					type: 'object',
 					properties: toNullable([
 						{
 							type: 'string',
-							name: 'addressId',
+							name: 'selectedContactAddressId',
 							enum: toNullable(),
 							description: toNullable(
 								'Unique ID of the address in the user’s contacts. Returned from show_contacts.'

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -95,36 +95,42 @@ export const parseReviewSendTokensToolArguments = ({
 	tokens: Token[];
 	extendedAddressContacts: ExtendedAddressContactUiMap;
 }): ReviewSendTokensToolResult => {
-	const { addressIdFilter, amountNumberFilter, tokenSymbolFilter, addressFilter, networkIdFilter } =
-		filterParams.reduce<{
-			addressIdFilter?: string;
-			amountNumberFilter?: string;
-			tokenSymbolFilter?: string;
-			addressFilter?: string;
-			networkIdFilter?: string;
-		}>(
-			(acc, { value, name }) => ({
-				addressIdFilter: name === 'addressId' ? value : acc.addressIdFilter,
-				addressFilter: name === 'address' ? value : acc.addressFilter,
-				amountNumberFilter: name === 'amountNumber' ? value : acc.amountNumberFilter,
-				tokenSymbolFilter: name === 'tokenSymbol' ? value : acc.tokenSymbolFilter,
-				networkIdFilter: name === 'networkId' ? value : acc.networkIdFilter
-			}),
-			{
-				addressIdFilter: undefined,
-				amountNumberFilter: undefined,
-				tokenSymbolFilter: undefined,
-				addressFilter: undefined,
-				networkIdFilter: undefined
-			}
-		);
+	const {
+		selectedContactAddressIdFilter,
+		amountNumberFilter,
+		tokenSymbolFilter,
+		addressFilter,
+		networkIdFilter
+	} = filterParams.reduce<{
+		selectedContactAddressIdFilter?: string;
+		amountNumberFilter?: string;
+		tokenSymbolFilter?: string;
+		addressFilter?: string;
+		networkIdFilter?: string;
+	}>(
+		(acc, { value, name }) => ({
+			selectedContactAddressIdFilter:
+				name === 'selectedContactAddressId' ? value : acc.selectedContactAddressIdFilter,
+			addressFilter: name === 'address' ? value : acc.addressFilter,
+			amountNumberFilter: name === 'amountNumber' ? value : acc.amountNumberFilter,
+			tokenSymbolFilter: name === 'tokenSymbol' ? value : acc.tokenSymbolFilter,
+			networkIdFilter: name === 'networkId' ? value : acc.networkIdFilter
+		}),
+		{
+			selectedContactAddressIdFilter: undefined,
+			amountNumberFilter: undefined,
+			tokenSymbolFilter: undefined,
+			addressFilter: undefined,
+			networkIdFilter: undefined
+		}
+	);
 
 	const { contact, contactAddress } = Object.values(extendedAddressContacts).reduce<
 		Pick<ReviewSendTokensToolResult, 'contact' | 'contactAddress'>
 	>(
 		(acc, extendedAddressContactUi) => {
 			const address = extendedAddressContactUi.addresses.find(
-				({ id: addressId }) => addressId === addressIdFilter
+				({ id: addressId }) => addressId === selectedContactAddressIdFilter
 			);
 
 			if (nonNullish(address)) {

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -63,13 +63,13 @@ describe('ai-assistant.utils', () => {
 	describe('parseReviewSendTokenToolArguments', () => {
 		const sendValue = 0.00001;
 
-		it('returns correct result when addressId is provided', () => {
+		it('returns correct result when selectedContactAddressId is provided', () => {
 			expect(
 				parseReviewSendTokensToolArguments({
 					filterParams: [
 						{
 							value: extendedAddressContactUi.addresses[0].id,
-							name: 'addressId'
+							name: 'selectedContactAddressId'
 						},
 						{
 							value: `${sendValue}`,


### PR DESCRIPTION
# Motivation

To prepare the LLM system prompt for the new functionality, we need to rename `addressId` arg to `selectedContactAddressId`.
