### PR TITLE
feat(frontend): split show all and show filtered contacts tools

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantToolResults.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantToolResults.svelte
@@ -16,7 +16,7 @@
 
 <div class="mb-5">
 	{#each results as { result, type }, index (index)}
-		{#if type === ToolResultType.SHOW_CONTACTS && nonNullish(result) && 'contacts' in result}
+		{#if (type === ToolResultType.SHOW_FILTERED_CONTACTS || type === ToolResultType.SHOW_ALL_CONTACTS) && nonNullish(result) && 'contacts' in result}
 			<AiAssistantShowContactsTool {...result} {onSendMessage} />
 		{:else if type === ToolResultType.REVIEW_SEND_TOKENS && nonNullish(result) && 'token' in result}
 			<SendTokenContext token={result.token}>

--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -33,11 +33,14 @@ export const getAiAssistantSystemPrompt = ({
 		- If tokenSymbol maps to multiple networkIds and networkId is not specified yet, ask: "On which network would you like to send {tokenSymbol}?".
 		- Never invent a networkId that isn’t in AVAILABLE TOKENS.
 	
-	- For 'show_contacts':
-		- Use when the user specifies a contact name or wants to choose from saved contacts.
-		- When calling show_contacts, filter by the addressType (values: 'Btc', 'Eth', 'Sol', 'Icrcv2') that corresponds to the token's networkId using the mapping below.
-		- If the user confirms a selection, immediately call 'review_send_tokens' with the selected "selectedContactAddressId" and previously provided "amountNumber" + "tokenSymbol".
-	
+	- For 'show_all_contacts':
+		- Call only when no filters are given (e.g. "Show me all contacts").
+		- Returns nothing; frontend displays all contacts.
+
+	- For 'show_filtered_contacts':
+		- Call only when filters are given (e.g. "Show me my ETH contacts" or when resolving a contact name together with a known token).
+		- Return only "addressIds" (addresses[].id) from the user’s contacts. Never include unrelated arguments like "amountNumber", "tokenSymbol", or "networkId". If no matches, return [].
+
 	MEMORY & CHAINING BEHAVIOR:
 	- Always remember values from earlier in the conversation (address, selectedContactAddressId, amountNumber, tokenSymbol, networkId) until the send action is complete.
 	- If "show_contacts" was called and the user confirms a specific contact/address, you MUST reuse the "selectedContactAddressId" from the tool result and proceed to "review_send_tokens" without asking again.
@@ -97,29 +100,30 @@ export const getAiAssistantToolsDescription = ({
 	[
 		{
 			function: {
-				name: 'show_contacts',
+				name: 'show_all_contacts',
 				description: toNullable(
-					"Retrieve contacts from the user's address book. Return ONLY a valid JSON object matching the exact provided schema. Do not include any extra commentary, markdown, or text outside the JSON."
+					"Show all contacts when no filters are provided (e.g. 'Show me all contacts'). Do not include commentary or extra text."
+				),
+				parameters: toNullable()
+			}
+		},
+		{
+			function: {
+				name: 'show_filtered_contacts',
+				description: toNullable(
+					'Filter the provided contacts list by semantic meaning and return only matching addressIds. Always return only { "addressIds": [...] }. If no matches, return an empty array. Never include any other fields.'
 				),
 				parameters: toNullable({
 					type: 'object',
 					properties: toNullable([
 						{
-							type: 'string',
-							name: 'searchQuery',
-							enum: toNullable(),
-							description: toNullable(
-								'Optional search term. Can be vague (e.g., "fruit", "crypto").'
-							)
-						},
-						{
 							type: 'array',
-							name: 'addressType',
-							enum: toNullable(['Btc', 'Eth', 'Sol', 'Icrcv2']),
-							description: toNullable("Optional filter for address types. Example: ['Btc', 'Eth'].")
+							name: 'addressIds',
+							description: toNullable('Array of matching address IDs.'),
+							enum: toNullable()
 						}
 					]),
-					required: toNullable()
+					required: toNullable(['addressIds'])
 				})
 			}
 		},
@@ -127,7 +131,7 @@ export const getAiAssistantToolsDescription = ({
 			function: {
 				name: 'review_send_tokens',
 				description: toNullable(
-					`Display an overview of the pending token transfer for user confirmation. Always return 4 arguments: "amountNumber" (string), "tokenSymbol" (string), "networkId" (string), and either "selectedContactAddressId" or "address". Do NOT send tokens yourself; sending will only happen via the UI button. If one of those arguments is not available, ask the user to provide it.`
+					`Display a pending token transfer for confirmation. Always return 4 arguments: "amountNumber" (string), "tokenSymbol" (string), "networkId" (string), and either "selectedContactAddressId" (string) or "address" (string). If one of those arguments is not available, ask the user to provide it.`
 				),
 				parameters: toNullable({
 					type: 'object',
@@ -137,7 +141,7 @@ export const getAiAssistantToolsDescription = ({
 							name: 'selectedContactAddressId',
 							enum: toNullable(),
 							description: toNullable(
-								'Unique ID of the address in the user’s contacts. Returned from show_contacts.'
+								'Unique ID of the specific blockchain address from a contact (addresses[].id).'
 							)
 						},
 						{

--- a/src/frontend/src/lib/types/ai-assistant.ts
+++ b/src/frontend/src/lib/types/ai-assistant.ts
@@ -44,7 +44,8 @@ export interface ReviewSendTokensToolResult {
 }
 
 export enum ToolResultType {
-	SHOW_CONTACTS = 'show_contacts',
+	SHOW_ALL_CONTACTS = 'show_all_contacts',
+	SHOW_FILTERED_CONTACTS = 'show_filtered_contacts',
 	REVIEW_SEND_TOKENS = 'review_send_tokens'
 }
 

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantToolResults.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantToolResults.spec.ts
@@ -20,14 +20,31 @@ describe('AiAssistantToolResults', () => {
 
 	const extendedContacts = get(extendedAddressContacts);
 
-	it('renders show_contacts tool correctly', () => {
+	it('renders show_all_contacts tool correctly', () => {
 		const { getByText } = render(AiAssistantToolResults, {
 			props: {
 				isLastItem: false,
 				onSendMessage: () => Promise.resolve(),
 				results: [
 					{
-						type: ToolResultType.SHOW_CONTACTS,
+						type: ToolResultType.SHOW_ALL_CONTACTS,
+						result: { contacts: Object.values(extendedContacts) }
+					}
+				]
+			}
+		});
+
+		expect(getByText(contacts[0].name)).toBeInTheDocument();
+	});
+
+	it('renders show_filtered_contacts tool correctly', () => {
+		const { getByText } = render(AiAssistantToolResults, {
+			props: {
+				isLastItem: false,
+				onSendMessage: () => Promise.resolve(),
+				results: [
+					{
+						type: ToolResultType.SHOW_FILTERED_CONTACTS,
 						result: { contacts: Object.values(extendedContacts) }
 					}
 				]

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -1,29 +1,30 @@
 import type { chat_response_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import { extendedAddressContacts } from '$lib/derived/contacts.derived';
-import { askLlm, askLlmToFilterContacts, executeTool } from '$lib/services/ai-assistant.services';
+import { askLlm, executeTool } from '$lib/services/ai-assistant.services';
 import { contactsStore } from '$lib/stores/contacts.store';
 import type { ContactUi } from '$lib/types/contact';
-import { parseToAiAssistantContacts } from '$lib/utils/ai-assistant.utils';
 import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { fromNullable, jsonReplacer, toNullable } from '@dfinity/utils';
+import { fromNullable, toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 vi.mock('$lib/api/llm.api');
 
 describe('ai-assistant.services', () => {
-	const toolCall = {
+	const mockRandomUUID = 'd7775002-80bf-4208-a2f0-84225281677a';
+
+	const showFilteredContactsToolCall = {
 		id: 'test',
 		function: {
-			name: 'show_contacts',
-			arguments: [{ value: 'Btc', name: 'addressType' }]
+			name: 'show_filtered_contacts',
+			arguments: [{ name: 'addressIds', value: `["${mockRandomUUID}"]` }]
 		}
 	};
-	const noAgumentsToolCall = {
-		...toolCall,
+	const showAllContactsToolCall = {
+		id: 'test',
 		function: {
-			...toolCall.function,
+			name: 'show_all_contacts',
 			arguments: []
 		}
 	};
@@ -62,7 +63,7 @@ describe('ai-assistant.services', () => {
 			const response = {
 				message: {
 					content: toNullable(),
-					tool_calls: toNullable(noAgumentsToolCall)
+					tool_calls: toNullable(showAllContactsToolCall)
 				}
 			} as chat_response_v1;
 
@@ -77,65 +78,15 @@ describe('ai-assistant.services', () => {
 			expect(result).toStrictEqual({
 				text: fromNullable(response.message.content),
 				tool: {
-					calls: [noAgumentsToolCall],
+					calls: [showAllContactsToolCall],
 					results: [
 						{
 							result: { contacts: [] },
-							type: 'show_contacts'
+							type: 'show_all_contacts'
 						}
 					]
 				}
 			});
-		});
-	});
-
-	describe('askLlmToFilterContacts', () => {
-		beforeEach(() => {
-			vi.resetAllMocks();
-
-			vi.stubGlobal('crypto', {
-				...crypto,
-				randomUUID: () => '12345678-1234-1234-1234-123456789abc'
-			});
-		});
-
-		it('returns filtered and parsed contacts', async () => {
-			const contacts = getMockContactsUi({
-				n: 1,
-				name: 'Test name',
-				addresses: [mockContactBtcAddressUi]
-			}) as unknown as ContactUi[];
-
-			contactsStore.set([...contacts]);
-
-			const storeData = get(extendedAddressContacts);
-
-			const aiAssistantContacts = parseToAiAssistantContacts(storeData);
-			const response = {
-				message: {
-					content: toNullable(
-						JSON.stringify(
-							{
-								contacts: Object.values(aiAssistantContacts).map((contact) => ({
-									...contact,
-									id: `${contact['id']}`
-								}))
-							},
-							jsonReplacer
-						)
-					),
-					tool_calls: toNullable()
-				}
-			} as chat_response_v1;
-
-			vi.mocked(llmChat).mockResolvedValue(response);
-
-			const result = await askLlmToFilterContacts({
-				identity: mockIdentity,
-				filterParams: [{ value: 'Btc', name: 'addressType' }]
-			});
-
-			expect(result).toStrictEqual({ contacts: Object.values(storeData) });
 		});
 	});
 
@@ -150,33 +101,32 @@ describe('ai-assistant.services', () => {
 			contactsStore.reset();
 			vi.clearAllMocks();
 
+			vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => mockRandomUUID);
 			contactsStore.set([...contacts]);
 		});
 
-		it('parses show_contacts tool and returns all contacts if no filter params provided', async () => {
-			const result = await executeTool({
-				identity: mockIdentity,
-				toolCall: noAgumentsToolCall,
+		it('parses show_all_contacts tool and returns all contacts', () => {
+			const result = executeTool({
+				toolCall: showAllContactsToolCall,
 				requestStartTimestamp: 1000
 			});
 
 			expect(result).toEqual({
-				type: 'show_contacts',
+				type: 'show_all_contacts',
 				result: {
 					contacts: Object.values(get(extendedAddressContacts))
 				}
 			});
 		});
 
-		it('parses show_contacts tool and returns contacts if filter params provided', async () => {
-			const result = await executeTool({
-				identity: mockIdentity,
-				toolCall,
+		it('parses show_filtered_contacts tool and returns contacts', () => {
+			const result = executeTool({
+				toolCall: showFilteredContactsToolCall,
 				requestStartTimestamp: 1000
 			});
 
 			expect(result).toEqual({
-				type: 'show_contacts',
+				type: 'show_filtered_contacts',
 				result: {
 					contacts: Object.values(get(extendedAddressContacts))
 				}


### PR DESCRIPTION
# Motivation

The next step is to split the current "show_contacts" tool into 2 separate tools: one for showing all contacts, and the other - filtered contacts.
