### PR TITLE
refactor(frontend): remove obsolete AI assistant methods

### DIFF
--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -63,33 +63,6 @@ export const getAiAssistantSystemPrompt = ({
 	AVAILABLE CONTACTS:
 	${availableContacts}`;
 
-export const getAiAssistantFilterContactsPrompt = (
-	filterParams: string
-) => `You are a strict semantic filter engine.
-Given a list of contacts and a user query, return ONLY contacts that semantically match.
-- Use concept reasoning: e.g., "fruit" → pineapple.
-- Filter addresses by "addressType" if provided
-- If no matching contacts are found (after applying the above rules), return an empty contacts array and include a "message" field using this exact format: "It looks like you don’t have any saved contacts with a {networkName} address. You can either provide a {networkName} address directly or choose a different token." Replace {networkName} with the friendly blockchain name derived from the token (e.g., SOL → Sol, ICP → ICP).
-
-Return ONLY this JSON schema:
-{
-  "contacts": [
-    {
-    	"id": string,
-      "name": string,
-      "addresses": [
-        { "id": string, "label"?: string, "addressType": "Btc" | "Eth" | "Sol" | "Icrcv2" }
-      ]
-    }
-  ],
-  "message"?: string
-}
-
-Arguments: "${filterParams}".
-
-Do NOT include json or any Markdown.
-Do NOT include extra text.`;
-
 export const getAiAssistantToolsDescription = ({
 	enabledNetworksSymbols,
 	enabledTokensSymbols

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -1,12 +1,11 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type {
-	AiAssistantContactUi,
 	AiAssistantContactUiMap,
 	ReviewSendTokensToolResult,
 	ShowContactsToolResult,
 	ToolCallArgument
 } from '$lib/types/ai-assistant';
-import type { ExtendedAddressContactUi, ExtendedAddressContactUiMap } from '$lib/types/contact';
+import type { ExtendedAddressContactUiMap } from '$lib/types/contact';
 import type { Token } from '$lib/types/token';
 import { jsonReplacer, nonNullish, notEmptyString } from '@dfinity/utils';
 
@@ -25,26 +24,6 @@ export const parseToAiAssistantContacts = (
 			}
 		};
 	}, {});
-
-export const parseFromAiAssistantContacts = ({
-	aiAssistantContacts,
-	extendedAddressContacts
-}: {
-	aiAssistantContacts: AiAssistantContactUi[];
-	extendedAddressContacts: ExtendedAddressContactUiMap;
-}): ExtendedAddressContactUi[] =>
-	aiAssistantContacts.reduce<ExtendedAddressContactUi[]>(
-		(acc, { id, addresses }) => [
-			...acc,
-			{
-				...extendedAddressContacts[`${id}`],
-				addresses: extendedAddressContacts[`${id}`].addresses.filter(({ id: addressId }) =>
-					addresses.some((filteredAddress) => filteredAddress.id === addressId)
-				)
-			}
-		],
-		[]
-	);
 
 export const parseShowFilteredContactsToolArguments = ({
 	filterParams,

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -5,7 +5,6 @@ import { extendedAddressContacts } from '$lib/derived/contacts.derived';
 import { contactsStore } from '$lib/stores/contacts.store';
 import {
 	generateAiAssistantResponseEventMetadata,
-	parseFromAiAssistantContacts,
 	parseReviewSendTokensToolArguments,
 	parseShowFilteredContactsToolArguments,
 	parseToAiAssistantContacts
@@ -46,17 +45,6 @@ describe('ai-assistant.utils', () => {
 			expect(parseToAiAssistantContacts(storeData)).toEqual({
 				[`${aiAssistantContact.id}`]: aiAssistantContact
 			});
-		});
-	});
-
-	describe('parseFromAiAssistantContacts', () => {
-		it('returns correct result', () => {
-			expect(
-				parseFromAiAssistantContacts({
-					aiAssistantContacts: [aiAssistantContact],
-					extendedAddressContacts: storeData
-				})
-			).toEqual(Object.values(storeData));
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Since we now use a tool to filter contacts, we can remove the obsolete utils/services.
