### PR TITLE
feat(frontend): do not send contact id to LLM

### DIFF
--- a/src/frontend/src/lib/derived/ai-assistant.derived.ts
+++ b/src/frontend/src/lib/derived/ai-assistant.derived.ts
@@ -24,7 +24,7 @@ export const aiAssistantChatMessages: Readable<ChatMessage[]> = derived(
 export const aiAssistantSystemMessage: Readable<chat_message_v1> = derived(
 	[extendedAddressContacts, enabledTokens],
 	([$extendedAddressContacts, $enabledTokens]) => {
-		const aiAssistantContacts = parseToAiAssistantContacts($extendedAddressContacts);
+		const aiAssistantContacts = Object.values(parseToAiAssistantContacts($extendedAddressContacts));
 		const aiEnabledTokens = $enabledTokens.map(({ name, symbol, network: { id: networkId } }) => ({
 			name,
 			symbol,

--- a/src/frontend/src/lib/types/ai-assistant.ts
+++ b/src/frontend/src/lib/types/ai-assistant.ts
@@ -55,7 +55,7 @@ export interface ToolResult {
 }
 
 export interface AiAssistantContactUi
-	extends Omit<ExtendedAddressContactUi, 'addresses' | 'image' | 'updateTimestampNs'> {
+	extends Omit<ExtendedAddressContactUi, 'addresses' | 'image' | 'updateTimestampNs' | 'id'> {
 	addresses: Omit<ContactAddressUiWithId, 'address'>[];
 }
 

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -13,13 +13,12 @@ export const parseToAiAssistantContacts = (
 	extendedAddressContacts: ExtendedAddressContactUiMap
 ): AiAssistantContactUiMap =>
 	Object.keys(extendedAddressContacts).reduce<AiAssistantContactUiMap>((acc, contactId) => {
-		const { name, id, addresses } = extendedAddressContacts[contactId];
+		const { name, addresses } = extendedAddressContacts[contactId];
 
 		return {
 			...acc,
 			[contactId]: {
 				name,
-				id,
 				addresses: addresses.map(({ address: _, ...restAddress }) => restAddress)
 			}
 		};

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -29,7 +29,6 @@ describe('ai-assistant.utils', () => {
 	const storeData = get(extendedAddressContacts);
 	const extendedAddressContactUi = storeData[`${contactsData[0].id}`];
 	const aiAssistantContact = {
-		id: extendedAddressContactUi.id,
 		name: extendedAddressContactUi.name,
 		addresses: [
 			{
@@ -43,7 +42,7 @@ describe('ai-assistant.utils', () => {
 	describe('parseToAiAssistantContacts', () => {
 		it('returns correct result', () => {
 			expect(parseToAiAssistantContacts(storeData)).toEqual({
-				[`${aiAssistantContact.id}`]: aiAssistantContact
+				[`${extendedAddressContactUi.id}`]: aiAssistantContact
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

To not confuse LLM with both contact and address ID, we need to clean up the former from the related stores/params.
