### PR TITLE
chore(frontend): Temporarily Disable Japanese support

### DIFF
--- a/src/frontend/src/env/i18n.ts
+++ b/src/frontend/src/env/i18n.ts
@@ -10,7 +10,6 @@ export const LANGUAGES = {
 	[Languages.GERMAN]: 'Deutsch',
 	[Languages.HINDI]: 'हिन्दी',
 	[Languages.ITALIAN]: 'Italiano',
-	[Languages.JAPANESE]: '日本語',
 	[Languages.PORTUGUESE]: 'Português',
 	[Languages.VIETNAMESE]: 'Tiếng việt',
 	[Languages.CHINESE_SIMPLIFIED]: '中文 (简体)'

--- a/src/frontend/src/lib/enums/languages.ts
+++ b/src/frontend/src/lib/enums/languages.ts
@@ -5,6 +5,7 @@ export enum Languages {
 	FRENCH = 'fr',
 	HINDI = 'hi',
 	ITALIAN = 'it',
+	JAPANESE = 'ja',
 	PORTUGUESE = 'pt',
 	VIETNAMESE = 'vi',
 	CHINESE_SIMPLIFIED = 'zh-CN'

--- a/src/frontend/src/lib/enums/languages.ts
+++ b/src/frontend/src/lib/enums/languages.ts
@@ -5,7 +5,6 @@ export enum Languages {
 	FRENCH = 'fr',
 	HINDI = 'hi',
 	ITALIAN = 'it',
-	JAPANESE = 'ja',
 	PORTUGUESE = 'pt',
 	VIETNAMESE = 'vi',
 	CHINESE_SIMPLIFIED = 'zh-CN'


### PR DESCRIPTION
# Motivation

Akeel wants to enable Polish first, and then Japanese in the next release.

# Changes

- Remove Japanese from the Languages enumeration

# Tests

