### PR TITLE
feat(frontend): add noBorder prop to the List context

### DIFF
--- a/src/frontend/src/lib/components/common/List.svelte
+++ b/src/frontend/src/lib/components/common/List.svelte
@@ -8,6 +8,7 @@
 		styleClass?: string;
 		condensed?: boolean;
 		noPadding?: boolean;
+		noBorder?: boolean;
 		children?: Snippet;
 		testId?: string;
 	}
@@ -18,6 +19,7 @@
 		styleClass = '',
 		condensed = true,
 		noPadding = false,
+		noBorder = false,
 		children,
 		testId
 	}: Props = $props();
@@ -26,9 +28,10 @@
 		variant: ListVariant;
 		condensed?: boolean;
 		noPadding?: boolean;
+		noBorder?: boolean;
 	}
 
-	setContext<ListContext>('list-context', { variant, condensed, noPadding });
+	setContext<ListContext>('list-context', { variant, condensed, noPadding, noBorder });
 </script>
 
 {#if element === 'ul'}

--- a/src/frontend/src/lib/components/common/ListItem.svelte
+++ b/src/frontend/src/lib/components/common/ListItem.svelte
@@ -11,11 +11,11 @@
 
 	const { children, styleClass }: Props = $props();
 
-	const { variant, condensed, noPadding } = getContext<ListContext>('list-context');
+	const { variant, condensed, noPadding, noBorder } = getContext<ListContext>('list-context');
 
 	const classes: { [key in ListVariant]: string } = {
 		none: `ml-3 ${condensed || noPadding ? 'py-0' : 'py-1'} ${styleClass ?? ''}`,
-		styled: `border-b-1 last-of-type:border-b-0 flex flex-row justify-between border-brand-subtle-10 ${!noPadding ? (condensed ? 'py-1.5 px-1' : 'py-2.5 px-1') : ''} ${styleClass ?? ''}`
+		styled: `flex flex-row justify-between ${!noPadding ? (condensed ? 'py-1.5 px-1' : 'py-2.5 px-1') : ''} ${!noBorder ? 'border-b-1 last-of-type:border-b-0 border-brand-subtle-10' : ''} ${styleClass ?? ''}`
 	};
 </script>
 


### PR DESCRIPTION
# Motivation

To reuse the List component/context in the AI console, we need to extend it with an additional prop - `noBorder`.
