### PR TITLE
feat(frontend): consider "loading" flag in ShowContactsTool

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantMessages.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantMessages.svelte
@@ -31,6 +31,7 @@
 		{:else if message.role === 'assistant' && nonNullish(message.data.tool?.results)}
 			<AiAssistantToolResults
 				isLastItem={messages.length - 1 === index}
+				{loading}
 				{onSendMessage}
 				results={message.data.tool.results}
 			/>

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantShowContactsTool.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantShowContactsTool.svelte
@@ -10,9 +10,10 @@
 
 	interface Props extends ShowContactsToolResult {
 		onSendMessage: (params: { messageText?: string; context?: string }) => Promise<void>;
+		loading: boolean;
 	}
 
-	let { contacts, onSendMessage }: Props = $props();
+	let { contacts, loading, onSendMessage }: Props = $props();
 
 	let allAddresses = $derived(
 		contacts.reduce<{ contact: ExtendedAddressContactUi; address: ContactAddressUiWithId }[]>(
@@ -40,13 +41,14 @@
 			{address}
 			{contact}
 			onClick={async () =>
-				await onSendMessage({
+				!loading &&
+				(await onSendMessage({
 					messageText: replacePlaceholders($i18n.ai_assistant.text.send_to_message, {
 						$contact_name: contact.name,
 						$address_info: `${isEmptyString(address.label) ? '' : `${address.label}: `}${shortenWithMiddleEllipsis({ text: address.address })}`
 					}),
 					context: `Send destination information: "selectedContactAddressId" - ${address.id}; "addressType": ${address.addressType}.`
-				})}
+				}))}
 		/>
 	{/each}
 {:else}

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantToolResults.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantToolResults.svelte
@@ -9,15 +9,16 @@
 		results: ToolResult[];
 		onSendMessage: (params: { messageText?: string; context?: string }) => Promise<void>;
 		isLastItem: boolean;
+		loading: boolean;
 	}
 
-	let { results, onSendMessage, isLastItem }: Props = $props();
+	let { results, onSendMessage, isLastItem, loading }: Props = $props();
 </script>
 
 <div class="mb-5">
 	{#each results as { result, type }, index (index)}
 		{#if (type === ToolResultType.SHOW_FILTERED_CONTACTS || type === ToolResultType.SHOW_ALL_CONTACTS) && nonNullish(result) && 'contacts' in result}
-			<AiAssistantShowContactsTool {...result} {onSendMessage} />
+			<AiAssistantShowContactsTool {...result} {loading} {onSendMessage} />
 		{:else if type === ToolResultType.REVIEW_SEND_TOKENS && nonNullish(result) && 'token' in result}
 			<SendTokenContext token={result.token}>
 				<AiAssistantReviewSendTokenTool

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantShowContactsTool.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantShowContactsTool.spec.ts
@@ -21,7 +21,8 @@ describe('AiAssistantShowContactsTool', () => {
 	const extendedContacts = get(extendedAddressContacts);
 	const props = {
 		onSendMessage: () => Promise.resolve(),
-		contacts: Object.values(extendedContacts)
+		contacts: Object.values(extendedContacts),
+		loading: false
 	};
 
 	it('renders no contacts found message', () => {

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantToolResults.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantToolResults.spec.ts
@@ -24,6 +24,7 @@ describe('AiAssistantToolResults', () => {
 		const { getByText } = render(AiAssistantToolResults, {
 			props: {
 				isLastItem: false,
+				false: false,
 				onSendMessage: () => Promise.resolve(),
 				results: [
 					{
@@ -41,6 +42,7 @@ describe('AiAssistantToolResults', () => {
 		const { getByText } = render(AiAssistantToolResults, {
 			props: {
 				isLastItem: false,
+				false: false,
 				onSendMessage: () => Promise.resolve(),
 				results: [
 					{
@@ -58,6 +60,7 @@ describe('AiAssistantToolResults', () => {
 		const { getByText } = render(AiAssistantToolResults, {
 			props: {
 				isLastItem: false,
+				loading: false,
 				onSendMessage: () => Promise.resolve(),
 				results: [
 					{
@@ -76,6 +79,7 @@ describe('AiAssistantToolResults', () => {
 		const { getByText } = render(AiAssistantToolResults, {
 			props: {
 				isLastItem: false,
+				loading: false,
 				onSendMessage: () => Promise.resolve(),
 				// @ts-expect-error Testing unknown tool type
 				results: [{ type: 'unknown_tool', result: contacts } as ToolResult]


### PR DESCRIPTION
# Motivation

If AI console is already in the loading state, we need to prevent additional clicks on ShowContactTool items.
