### PR TITLE
feat(frontend): Check for Ethereum/EVM tokens in `EthFeeStoreContext`

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeStoreContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeStoreContext.svelte
@@ -25,13 +25,13 @@
 
 	const feeDecimalsStore = writable<number | undefined>(undefined);
 
+	const feeExchangeRateStore = writable<number | undefined>(undefined);
+
 	$effect(() => {
 		feeSymbolStore.set(token.symbol);
 		feeTokenIdStore.set(token.id);
 		feeDecimalsStore.set(token.decimals);
 	});
-
-	const feeExchangeRateStore = writable<number | undefined>(undefined);
 
 	$effect(() => {
 		feeExchangeRateStore.set($exchanges?.[token.id]?.usd);

--- a/src/frontend/src/eth/components/fee/EthFeeStoreContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeStoreContext.svelte
@@ -9,6 +9,7 @@
 	} from '$eth/stores/eth-fee.store';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import type { Token, TokenId } from '$lib/types/token';
+	import { isNetworkIdEthereum, isNetworkIdEvm } from '$lib/utils/network.utils';
 
 	interface Props {
 		token: Token;
@@ -27,13 +28,36 @@
 
 	const feeExchangeRateStore = writable<number | undefined>(undefined);
 
+	let networkId = $derived(token.network.id);
+
+	let isEthNetwork = $derived(isNetworkIdEthereum(networkId) || isNetworkIdEvm(networkId));
+
+	const reset = () => {
+		feeSymbolStore.set(undefined);
+		feeTokenIdStore.set(undefined);
+		feeDecimalsStore.set(undefined);
+		feeExchangeRateStore.set(undefined);
+	};
+
 	$effect(() => {
+		if (!isEthNetwork) {
+			reset();
+
+			return;
+		}
+
 		feeSymbolStore.set(token.symbol);
 		feeTokenIdStore.set(token.id);
 		feeDecimalsStore.set(token.decimals);
 	});
 
 	$effect(() => {
+		if (!isEthNetwork) {
+			reset();
+
+			return;
+		}
+
 		feeExchangeRateStore.set($exchanges?.[token.id]?.usd);
 	});
 

--- a/src/frontend/src/eth/components/fee/EthFeeStoreContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeStoreContext.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
+	import { setContext, type Snippet } from 'svelte';
 	import { writable } from 'svelte/store';
 	import {
 		ETH_FEE_CONTEXT_KEY,
@@ -10,21 +10,32 @@
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import type { Token, TokenId } from '$lib/types/token';
 
-	export let token: Token;
+	interface Props {
+		token: Token;
+		children: Snippet;
+	}
+
+	let { token, children }: Props = $props();
 
 	const feeStore = initEthFeeStore();
 
 	const feeSymbolStore = writable<string | undefined>(undefined);
-	$: feeSymbolStore.set(token.symbol);
 
 	const feeTokenIdStore = writable<TokenId | undefined>(undefined);
-	$: feeTokenIdStore.set(token.id);
 
 	const feeDecimalsStore = writable<number | undefined>(undefined);
-	$: feeDecimalsStore.set(token.decimals);
+
+	$effect(() => {
+		feeSymbolStore.set(token.symbol);
+		feeTokenIdStore.set(token.id);
+		feeDecimalsStore.set(token.decimals);
+	});
 
 	const feeExchangeRateStore = writable<number | undefined>(undefined);
-	$: feeExchangeRateStore.set($exchanges?.[token.id]?.usd);
+
+	$effect(() => {
+		feeExchangeRateStore.set($exchanges?.[token.id]?.usd);
+	});
 
 	setContext<FeeContextType>(
 		ETH_FEE_CONTEXT_KEY,
@@ -38,4 +49,4 @@
 	);
 </script>
 
-<slot />
+{@render children()}


### PR DESCRIPTION
# Motivation

It makes more sense to run the effects in `EthFeeStoreContext` only when the token is an Ethereum/EVM token.