### PR TITLE
feat(frontend): shortens the short date string

### DIFF
--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -123,7 +123,7 @@ export const formatNanosecondsToTimestamp = (nanoseconds: bigint): number => {
 };
 
 export const formatToShortDateString = ({ date, i18n }: { date: Date; i18n: I18n }): string =>
-	date.toLocaleDateString(i18n?.lang ?? Languages.ENGLISH, { month: 'long' });
+	date.toLocaleDateString(i18n?.lang ?? Languages.ENGLISH, { month: 'short' });
 
 const getRelativeTimeFormatter = (language?: Languages) =>
 	new Intl.RelativeTimeFormat(language ?? Languages.ENGLISH, { numeric: 'auto' });

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -530,7 +530,7 @@ describe('format.utils', () => {
 				i18n: {} as unknown as I18n
 			});
 
-			expect(result).toBe('January');
+			expect(result).toBe('Jan');
 		});
 
 		it('formats date to month name in German locale', () => {
@@ -539,7 +539,7 @@ describe('format.utils', () => {
 				i18n: { lang: 'de' } as unknown as I18n
 			});
 
-			expect(result).toBe('Januar');
+			expect(result).toBe('Jan');
 		});
 
 		it('formats date to month name in French locale', () => {
@@ -548,7 +548,7 @@ describe('format.utils', () => {
 				i18n: { lang: 'fr' } as unknown as I18n
 			});
 
-			expect(result).toBe('janvier');
+			expect(result).toBe('janv.');
 		});
 
 		it('handles invalid date input by returning "Invalid Date"', () => {


### PR DESCRIPTION
# Motivation

The date for the `DateBadges` is displayed with the month written as long word (example: September). But the month should only be written with 3 digits (example: Sep).


# Tests

**New:**
<img width="109" height="25" alt="image" src="https://github.com/user-attachments/assets/765bf9c3-2a55-4c74-b1f6-b3ea409d3395" />

