### PR TITLE
refactor(frontend): Correct type for the native required tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens.btc.env.ts
@@ -7,7 +7,7 @@ import {
 	BTC_TESTNET_NETWORK
 } from '$env/networks/networks.btc.env';
 import { BTC_TOKEN_GROUP } from '$env/tokens/groups/groups.btc.env';
-import type { Token, TokenId, TokenWithLinkedData } from '$lib/types/token';
+import type { RequiredToken, RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 
@@ -17,7 +17,7 @@ export const BTC_MAINNET_SYMBOL = 'BTC';
 
 export const BTC_MAINNET_TOKEN_ID: TokenId = parseTokenId(BTC_MAINNET_SYMBOL);
 
-export const BTC_MAINNET_TOKEN: TokenWithLinkedData = {
+export const BTC_MAINNET_TOKEN: RequiredTokenWithLinkedData = {
 	id: BTC_MAINNET_TOKEN_ID,
 	network: BTC_MAINNET_NETWORK,
 	standard: 'bitcoin',
@@ -36,7 +36,7 @@ export const BTC_TESTNET_SYMBOL = 'BTC (Testnet)';
 
 export const BTC_TESTNET_TOKEN_ID: TokenId = parseTokenId(BTC_TESTNET_SYMBOL);
 
-export const BTC_TESTNET_TOKEN: Token = {
+export const BTC_TESTNET_TOKEN: RequiredToken = {
 	id: BTC_TESTNET_TOKEN_ID,
 	network: BTC_TESTNET_NETWORK,
 	standard: 'bitcoin',
@@ -51,7 +51,7 @@ export const BTC_REGTEST_SYMBOL = 'BTC (Regtest)';
 
 export const BTC_REGTEST_TOKEN_ID: TokenId = parseTokenId(BTC_REGTEST_SYMBOL);
 
-export const BTC_REGTEST_TOKEN: Token = {
+export const BTC_REGTEST_TOKEN: RequiredToken = {
 	id: BTC_REGTEST_TOKEN_ID,
 	network: BTC_REGTEST_NETWORK,
 	standard: 'bitcoin',
@@ -63,8 +63,8 @@ export const BTC_REGTEST_TOKEN: Token = {
 };
 
 // The following tokens are used as fallback for any Bitcoin token defined in the token store.
-// That means that the order of the tokens in the array is important, to have a correct fallback chain.
-export const SUPPORTED_BITCOIN_TOKENS: Token[] = defineSupportedTokens({
+// That means that the order of the tokens in the array is important to have a correct fallback chain.
+export const SUPPORTED_BITCOIN_TOKENS: RequiredToken[] = defineSupportedTokens({
 	mainnetFlag: BTC_MAINNET_ENABLED,
 	mainnetTokens: [BTC_MAINNET_TOKEN],
 	testnetTokens: [BTC_TESTNET_TOKEN],

--- a/src/frontend/src/env/tokens/tokens.sol.env.ts
+++ b/src/frontend/src/env/tokens/tokens.sol.env.ts
@@ -4,7 +4,7 @@ import {
 	SOLANA_LOCAL_NETWORK,
 	SOLANA_MAINNET_NETWORK
 } from '$env/networks/networks.sol.env';
-import type { RequiredToken, Token, TokenId } from '$lib/types/token';
+import type { RequiredToken, TokenId } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 import sol from '$sol/assets/sol.svg';
@@ -59,7 +59,7 @@ export const SOLANA_LOCAL_TOKEN: RequiredToken = {
 	icon: sol
 };
 
-export const SUPPORTED_SOLANA_TOKENS: Token[] = defineSupportedTokens({
+export const SUPPORTED_SOLANA_TOKENS: RequiredToken[] = defineSupportedTokens({
 	mainnetFlag: SOL_MAINNET_ENABLED,
 	mainnetTokens: [SOLANA_TOKEN],
 	testnetTokens: [SOLANA_DEVNET_TOKEN],

--- a/src/frontend/src/eth/components/convert/ConvertToCkEth.svelte
+++ b/src/frontend/src/eth/components/convert/ConvertToCkEth.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumToken, nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertEth from '$icp-eth/components/convert/ConvertEth.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
@@ -25,13 +25,13 @@
 	})();
 </script>
 
-<ConvertEth ariaLabel={$i18n.convert.text.convert_to_cketh} nativeTokenId={$ethereumTokenId}>
+<ConvertEth ariaLabel={$i18n.convert.text.convert_to_cketh} nativeTokenId={$nativeEthereumTokenId}>
 	<IconCkConvert slot="icon" size="24" />
-	<span>{$ethereumToken.twinTokenSymbol ?? ''}</span>
+	<span>{$nativeEthereumToken.twinTokenSymbol ?? ''}</span>
 </ConvertEth>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckEthToken)}
-	<EthFeeStoreContext token={$ethereumToken}>
-		<ConvertModal destinationToken={ckEthToken} sourceToken={$ethereumToken} />
+	<EthFeeStoreContext token={$nativeEthereumToken}>
+		<ConvertModal destinationToken={ckEthToken} sourceToken={$nativeEthereumToken} />
 	</EthFeeStoreContext>
 {/if}

--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -8,7 +8,7 @@
 	import EthConvertReview from '$eth/components/convert/EthConvertReview.svelte';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { ethereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken } from '$eth/derived/token.derived';
 	import { send as executeSend } from '$eth/services/send.services';
 	import { ETH_FEE_CONTEXT_KEY } from '$eth/stores/eth-fee.store';
 	import type { EthereumNetwork } from '$eth/types/network';
@@ -89,7 +89,7 @@
 		}
 
 		const { valid } = assertCkEthMinterInfoLoaded({
-			minterInfo: $ckEthMinterInfoStore?.[$ethereumToken.id],
+			minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumToken.id],
 			network: ICP_NETWORK
 		});
 
@@ -135,7 +135,7 @@
 				sourceNetwork,
 				targetNetwork: ICP_NETWORK,
 				identity: $authIdentity,
-				minterInfo: $ckEthMinterInfoStore?.[$ethereumToken.id]
+				minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumToken.id]
 			});
 
 			trackEvent({
@@ -164,7 +164,7 @@
 <EthFeeContext
 	amount={sendAmount}
 	{destination}
-	nativeEthereumToken={$ethereumToken}
+	nativeEthereumToken={$nativeEthereumToken}
 	observe={currentStep?.name !== WizardStepsConvert.CONVERTING &&
 		currentStep?.name !== WizardStepsConvert.REVIEW}
 	sendToken={$sourceToken}
@@ -189,7 +189,7 @@
 	{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
 		<EthConvertProgress
 			{destination}
-			nativeEthereumToken={$ethereumToken}
+			nativeEthereumToken={$nativeEthereumToken}
 			sourceTokenId={$sourceToken.id}
 			bind:convertProgressStep
 		/>

--- a/src/frontend/src/eth/components/send/ConvertToCkErc20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkErc20.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumToken, nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import type { OptionErc20Token } from '$eth/types/erc20';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertEth from '$icp-eth/components/convert/ConvertEth.svelte';
@@ -34,14 +34,14 @@
 	ariaLabel={replacePlaceholders($i18n.convert.text.convert_to_ckerc20, {
 		$ckErc20: convertToSymbol
 	})}
-	nativeTokenId={$ethereumTokenId}
+	nativeTokenId={$nativeEthereumTokenId}
 >
 	<IconCkConvert slot="icon" size="24" />
 	<span>{convertToSymbol}</span>
 </ConvertEth>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckToken) && nonNullish($pageToken)}
-	<EthFeeStoreContext token={$ethereumToken}>
+	<EthFeeStoreContext token={$nativeEthereumToken}>
 		<ConvertModal destinationToken={ckToken} sourceToken={$pageToken} />
 	</EthFeeStoreContext>
 {/if}

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -6,7 +6,7 @@
 	import SwapEthForm from './SwapEthForm.svelte';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
-	import { ethereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken } from '$eth/derived/token.derived';
 	import {
 		ETH_FEE_CONTEXT_KEY,
 		initEthFeeContext,
@@ -95,7 +95,7 @@
 	let evmNativeEthereumToken = $derived($evmNativeToken ?? fallbackEvmToken);
 	const feeStore = initEthFeeStore();
 
-	let nativeEthereumToken = $derived(evmNativeEthereumToken ?? $ethereumToken);
+	let nativeEthereumToken = $derived(evmNativeEthereumToken ?? $nativeEthereumToken);
 
 	const feeSymbolStore = writable<string | undefined>(undefined);
 	const feeTokenIdStore = writable<TokenId | undefined>(undefined);

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -6,7 +6,7 @@
 	import SwapEthForm from './SwapEthForm.svelte';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
-	import { nativeEthereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken as nativeEthereumTokenStore } from '$eth/derived/token.derived';
 	import {
 		ETH_FEE_CONTEXT_KEY,
 		initEthFeeContext,
@@ -95,7 +95,7 @@
 	let evmNativeEthereumToken = $derived($evmNativeToken ?? fallbackEvmToken);
 	const feeStore = initEthFeeStore();
 
-	let nativeEthereumToken = $derived(evmNativeEthereumToken ?? $nativeEthereumToken);
+	let nativeEthereumToken = $derived(evmNativeEthereumToken ?? $nativeEthereumTokenStore);
 
 	const feeSymbolStore = writable<string | undefined>(undefined);
 	const feeTokenIdStore = writable<TokenId | undefined>(undefined);

--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -7,7 +7,7 @@
 	import EthTransactionModal from '$eth/components/transactions/EthTransactionModal.svelte';
 	import EthTransactionsSkeletons from '$eth/components/transactions/EthTransactionsSkeletons.svelte';
 	import { sortedEthTransactions } from '$eth/derived/eth-transactions.derived';
-	import { ethereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import type { EthTransactionUi } from '$eth/types/eth-transaction';
 	import { mapEthTransactionUi } from '$eth/utils/transactions.utils';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
@@ -28,7 +28,7 @@
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let ckMinterInfoAddresses = $derived(
-		toCkMinterInfoAddresses($ckEthMinterInfoStore?.[$ethereumTokenId])
+		toCkMinterInfoAddresses($ckEthMinterInfoStore?.[$nativeEthereumTokenId])
 	);
 
 	let sortedTransactionsUi = $derived(

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -7,7 +7,7 @@
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
-	import { ethereumToken, ethereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumToken, nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import { send as sendServices } from '$eth/services/wallet-connect.services';
 	import {
 		ETH_FEE_CONTEXT_KEY,
@@ -153,7 +153,7 @@
 			token: $sendToken,
 			progress: (step: ProgressStep) => (sendProgressStep = step),
 			identity: $authIdentity,
-			minterInfo: $ckEthMinterInfoStore?.[$ethereumTokenId],
+			minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumTokenId],
 			sourceNetwork,
 			targetNetwork
 		});
@@ -175,7 +175,7 @@
 		amount={amount.toString()}
 		{data}
 		{destination}
-		nativeEthereumToken={$ethereumToken}
+		nativeEthereumToken={$nativeEthereumToken}
 		observe={currentStep?.name !== WizardStepsSend.SENDING}
 		sendToken={$sendToken}
 		sendTokenId={$sendTokenId}

--- a/src/frontend/src/eth/derived/eth-transactions.derived.ts
+++ b/src/frontend/src/eth/derived/eth-transactions.derived.ts
@@ -1,4 +1,4 @@
-import { ethereumTokenId } from '$eth/derived/token.derived';
+import { nativeEthereumTokenId } from '$eth/derived/token.derived';
 import { ethTransactionsStore, type EthTransactionsData } from '$eth/stores/eth-transactions.store';
 import { mapEthTransactionUi } from '$eth/utils/transactions.utils';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
@@ -56,7 +56,7 @@ export const ethKnownDestinations: Readable<KnownDestinations> = derived(
 	[
 		ethTransactionsStore,
 		ckEthMinterInfoStore,
-		ethereumTokenId,
+		nativeEthereumTokenId,
 		ethAddress,
 		tokens,
 		tokenWithFallback

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -1,18 +1,21 @@
 import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
+import { evmNativeToken } from '$evm/derived/token.derived';
 import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
-import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
+import type { RequiredToken, TokenId } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
 /**
- * Native token - i.e. not ERC20 - for the selected Ethereum network.
+ * Native token - i.e. not ERC20 - for the selected Ethereum/EVM network.
  */
-export const nativeEthereumToken: Readable<RequiredTokenWithLinkedData> = derived(
-	[enabledEthereumTokens, selectedEthereumNetwork],
-	([$enabledEthereumTokens, $selectedEthereumNetwork]) =>
+export const nativeEthereumToken: Readable<RequiredToken> = derived(
+	[enabledEthereumTokens, selectedEthereumNetwork, evmNativeToken],
+	([$enabledEthereumTokens, $selectedEthereumNetwork, $evmNativeToken]) =>
 		$enabledEthereumTokens.find(
 			({ network: { id: networkId } }) => $selectedEthereumNetwork?.id === networkId
-		) ?? DEFAULT_ETHEREUM_TOKEN
+		) ??
+		$evmNativeToken ??
+		DEFAULT_ETHEREUM_TOKEN
 );
 
 export const nativeEthereumTokenId: Readable<TokenId> = derived(

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -5,9 +5,9 @@ import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
 /**
- * Ethereum (Ethereum or Sepolia) token - i.e. not ERC20.
+ * Ethereum/EVM native token - i.e. not ERC20.
  */
-export const ethereumToken: Readable<RequiredTokenWithLinkedData> = derived(
+export const nativeEthereumToken: Readable<RequiredTokenWithLinkedData> = derived(
 	[enabledEthereumTokens, selectedEthereumNetwork],
 	([$enabledEthereumTokens, $selectedEthereumNetwork]) =>
 		$enabledEthereumTokens.find(
@@ -15,4 +15,7 @@ export const ethereumToken: Readable<RequiredTokenWithLinkedData> = derived(
 		) ?? DEFAULT_ETHEREUM_TOKEN
 );
 
-export const ethereumTokenId: Readable<TokenId> = derived([ethereumToken], ([{ id }]) => id);
+export const nativeEthereumTokenId: Readable<TokenId> = derived(
+	[nativeEthereumToken],
+	([{ id }]) => id
+);

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -5,7 +5,7 @@ import type { RequiredTokenWithLinkedData, TokenId } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
 /**
- * Ethereum/EVM native token - i.e. not ERC20.
+ * Native token - i.e. not ERC20 - for the selected Ethereum network.
  */
 export const nativeEthereumToken: Readable<RequiredTokenWithLinkedData> = derived(
 	[enabledEthereumTokens, selectedEthereumNetwork],

--- a/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
+++ b/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { ethereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken } from '$eth/derived/token.derived';
 	import HowToConvertEthereumModal from '$icp/components/convert/HowToConvertEthereumModal.svelte';
 	import type { IcCkToken, IcToken } from '$icp/types/ic-token';
 	import eth from '$icp-eth/assets/eth.svg';
@@ -62,7 +62,7 @@
 </div>
 
 {#if $modalHowToConvertToTwinTokenEth && nonNullish(sourceToken) && nonNullish(destinationToken)}
-	<EthFeeStoreContext token={$ethereumToken}>
+	<EthFeeStoreContext token={$nativeEthereumToken}>
 		<HowToConvertEthereumModal {destinationToken} {sourceToken} />
 	</EthFeeStoreContext>
 {/if}

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -2,7 +2,7 @@ import { ERC20_TWIN_TOKENS_IDS } from '$env/tokens/tokens.erc20.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
-import { ethereumTokenId } from '$eth/derived/token.derived';
+import { nativeEthereumTokenId } from '$eth/derived/token.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { EthereumNetwork } from '$eth/types/network';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
@@ -75,7 +75,7 @@ export const ckEthereumNativeTokenEnabledNetwork: Readable<EthereumNetwork | und
  * The contract helper used to convert ETH -> ckETH.
  */
 export const ckEthHelperContractAddress: Readable<OptionEthAddress> = derived(
-	[ckEthMinterInfoStore, ethereumTokenId],
+	[ckEthMinterInfoStore, nativeEthereumTokenId],
 	([$ckEthMinterInfoStore, $ethereumTokenId]) =>
 		toCkEthHelperContractAddress($ckEthMinterInfoStore?.[$ethereumTokenId])
 );
@@ -84,7 +84,7 @@ export const ckEthHelperContractAddress: Readable<OptionEthAddress> = derived(
  * The contract helper used to convert Erc20 -> ckErc20.
  */
 export const ckErc20HelperContractAddress: Readable<OptionEthAddress> = derived(
-	[ckEthMinterInfoStore, ethereumTokenId],
+	[ckEthMinterInfoStore, nativeEthereumTokenId],
 	([$ckEthMinterInfoStore, $ethereumTokenId]) =>
 		toCkErc20HelperContractAddress($ckEthMinterInfoStore?.[$ethereumTokenId])
 );

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -3,7 +3,7 @@
 	import { getContext } from 'svelte';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
 	import { erc20UserTokens } from '$eth/derived/erc20.derived';
-	import { ethereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken } from '$eth/derived/token.derived';
 	import IcReceiveCkEthereumModal from '$icp/components/receive/IcReceiveCkEthereumModal.svelte';
 	import {
 		RECEIVE_TOKEN_CONTEXT_KEY,
@@ -45,7 +45,7 @@
 <ReceiveButtonWithModal isOpen={$modalCkETHReceive} open={openModal}>
 	{#snippet modal()}
 		{#if nonNullish(sourceToken) && nonNullish(destinationToken)}
-			<EthFeeStoreContext token={$ethereumToken}>
+			<EthFeeStoreContext token={$nativeEthereumToken}>
 				<IcReceiveCkEthereumModal {destinationToken} {sourceToken} on:nnsClose={close} />
 			</EthFeeStoreContext>
 		{/if}

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
@@ -2,7 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { ethereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken } from '$eth/derived/token.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { selectedEvmNetwork } from '$evm/derived/network.derived';
 	import { evmNativeToken } from '$evm/derived/token.derived';
@@ -65,7 +65,7 @@
 			<AiAssistantReviewSendEthToken
 				{amount}
 				{destination}
-				nativeEthereumToken={$ethereumToken}
+				nativeEthereumToken={$nativeEthereumToken}
 				{sendEnabled}
 				sourceNetwork={$selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK}
 				bind:sendCompleted

--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -8,7 +8,7 @@
 	import EthSendDestination from '$eth/components/send/EthSendDestination.svelte';
 	import { ethNetworkContacts } from '$eth/derived/eth-contacts.derived';
 	import { ethKnownDestinations } from '$eth/derived/eth-transactions.derived';
-	import { ethereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import IcSendDestination from '$icp/components/send/IcSendDestination.svelte';
 	import { icNetworkContacts } from '$icp/derived/ic-contacts.derived';
 	import { icKnownDestinations } from '$icp/derived/ic-transactions.derived';
@@ -88,7 +88,7 @@
 <ContentWithToolbar>
 	{#if isNetworkIdEthereum($sendTokenNetworkId) || isNetworkIdEvm($sendTokenNetworkId)}
 		<div data-tid={testId}>
-			<CkEthLoader isSendFlow={true} nativeTokenId={$ethereumTokenId}>
+			<CkEthLoader isSendFlow={true} nativeTokenId={$nativeEthereumTokenId}>
 				<LoaderMultipleEthTransactions>
 					<EthSendDestination
 						knownDestinations={$ethKnownDestinations}

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -5,7 +5,7 @@
 	import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { ethereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumToken } from '$eth/derived/token.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { selectedEvmNetwork } from '$evm/derived/network.derived';
 	import { evmNativeToken } from '$evm/derived/token.derived';
@@ -49,7 +49,7 @@
 		<EthSendTokenWizard
 			{currentStep}
 			{destination}
-			nativeEthereumToken={$ethereumToken}
+			nativeEthereumToken={$nativeEthereumToken}
 			{nft}
 			{selectedContact}
 			sourceNetwork={$selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK}

--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -17,10 +17,10 @@ import {
 	networkSolana
 } from '$lib/derived/network.derived';
 import { token } from '$lib/stores/token.store';
-import type { OptionTokenId, Token } from '$lib/types/token';
+import type { OptionTokenId, RequiredToken, Token } from '$lib/types/token';
 import { derived, type Readable } from 'svelte/store';
 
-export const defaultFallbackToken: Readable<Token> = derived(
+export const defaultFallbackToken: Readable<RequiredToken> = derived(
 	[
 		networkBitcoin,
 		networkEthereum,

--- a/src/frontend/src/lib/stores/convert.store.ts
+++ b/src/frontend/src/lib/stores/convert.store.ts
@@ -1,4 +1,4 @@
-import { ethereumToken } from '$eth/derived/token.derived';
+import { nativeEthereumToken } from '$eth/derived/token.derived';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
 import { ckEthMinterInfoStore, type CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
@@ -46,7 +46,7 @@ export const initConvertContext = (convertData: ConvertData): ConvertContext => 
 	);
 
 	const balanceForFee = derived(
-		[sourceToken, balancesStore, ethereumToken, ethereumFeeTokenCkEth, ckEthereumNativeToken],
+		[sourceToken, balancesStore, nativeEthereumToken, ethereumFeeTokenCkEth, ckEthereumNativeToken],
 		([
 			$sourceToken,
 			$balancesStore,

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -134,7 +134,7 @@ describe('EthConvertTokenWizard', () => {
 			.mockImplementation(() => readable(address));
 
 	const mockEthereumToken = (token = ETHEREUM_TOKEN) =>
-		vi.spyOn(tokensDerived, 'ethereumToken', 'get').mockImplementation(() => readable(token));
+		vi.spyOn(tokensDerived, 'nativeEthereumToken', 'get').mockImplementation(() => readable(token));
 
 	const clickConvertButton = async (container: HTMLElement) => {
 		const convertButtonSelector = '[data-tid="convert-review-button-next"]';


### PR DESCRIPTION
# Motivation

For consistency, we use the type `RequiredToken` for all the native tokens.
