### PR TITLE
feat(frontend): provide amount to the estimation of Ethereum gas

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeContext.svelte
@@ -99,25 +99,30 @@
 				)
 			});
 
-			// We estimate gas only when it is not a ck-conversion (i.e. target network is not ICP).
-			// Otherwise, we would need to emulate the data that are provided to the minter contract address.
-			const estimatedGas = isNetworkICP(targetNetwork)
-				? undefined
-				: await safeEstimateGas({ ...params, data });
-
 			if (isSupportedEthTokenId(sendTokenId) || isSupportedEvmNativeTokenId(sendTokenId)) {
+				// We estimate gas only when it is not a ck-conversion (i.e. target network is not ICP).
+				// Otherwise, we would need to emulate the data that are provided to the minter contract address.
+				const estimatedGas = isNetworkICP(targetNetwork)
+					? undefined
+					: await safeEstimateGas({
+							...params,
+							...(nonNullish(amount) ? { value: BigInt(amount.toString()) } : {}),
+							data
+						});
+
 				feeStore.setFee({
 					...feeData,
 					gas: maxBigInt(feeDataGas, estimatedGas)
 				});
+
 				return;
 			}
 
 			const erc20GasFeeParams = {
+				...params,
 				contract: sendToken as Erc20Token,
 				amount: parseToken({ value: `${amount ?? '1'}`, unitName: sendToken.decimals }),
-				sourceNetwork,
-				...params
+				sourceNetwork
 			};
 
 			if (isSupportedErc20TwinTokenId(sendTokenId)) {

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -14,6 +14,7 @@ import { isNetworkIdICP } from '$lib/utils/network.utils';
 export interface GetFeeData {
 	from: EthAddress;
 	to: EthAddress;
+	value?: bigint;
 	data?: string;
 }
 


### PR DESCRIPTION
# Motivation

The correct way to estimate the Ethereum transaction is to pass the amount.

# Changes

- Move gas estimation inside the correct `if` condition.
- Provide additional `amount` if is not nullish.

# Tests

Current tests should work.
