### PR TITLE
refactor(frontend): Split CAIP-10 chains keys into mainnet and devnet

### DIFF
--- a/src/frontend/src/env/caip10-chains.env.ts
+++ b/src/frontend/src/env/caip10-chains.env.ts
@@ -38,4 +38,12 @@ export const CAIP10_CHAINS: Record<
 	})
 };
 
-export const CAIP10_CHAINS_KEYS = Object.keys(CAIP10_CHAINS);
+const CAIP10_CHAINS_KEYS = Object.keys(CAIP10_CHAINS);
+
+export const CAIP10_MAINNET_CHAINS_KEYS = CAIP10_CHAINS_KEYS.filter(
+	(key) => CAIP10_CHAINS[key].network === SolanaNetworks.mainnet
+);
+
+export const CAIP10_DEVNET_CHAINS_KEYS = CAIP10_CHAINS_KEYS.filter(
+	(key) => CAIP10_CHAINS[key].network === SolanaNetworks.devnet
+);

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -1,5 +1,6 @@
 import {
-	CAIP10_CHAINS_KEYS,
+	CAIP10_DEVNET_CHAINS_KEYS,
+	CAIP10_MAINNET_CHAINS_KEYS,
 	LEGACY_SOLANA_DEVNET_NAMESPACE,
 	LEGACY_SOLANA_MAINNET_NAMESPACE
 } from '$env/caip10-chains.env';
@@ -150,7 +151,10 @@ export const initWalletConnect = async ({
 				...(nonNullish(solAddressMainnet) || nonNullish(solAddressDevnet)
 					? {
 							solana: {
-								chains: CAIP10_CHAINS_KEYS,
+								chains: [
+									...(nonNullish(solAddressMainnet) ? CAIP10_MAINNET_CHAINS_KEYS : []),
+									...(nonNullish(solAddressDevnet) ? CAIP10_DEVNET_CHAINS_KEYS : [])
+								],
 								methods: [
 									SESSION_REQUEST_SOL_SIGN_TRANSACTION,
 									SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION,


### PR DESCRIPTION
# Motivation

To avoid passing unnecessary CAIP keys, we split them into mainnet and devnet.
