### PR TITLE
fix(frontend): fixed send input padding value

### DIFF
--- a/src/frontend/src/lib/components/send/SendInputDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendInputDestination.svelte
@@ -168,4 +168,8 @@
 		--focus-background-contrast: var(--color-border-error-solid);
 		--input-background-contrast: var(--color-border-error-solid);
 	}
+
+	:global(.send-input-destination div.input-field input) {
+		--input-padding-inner-end: calc(var(--spacing) * 20);
+	}
 </style>


### PR DESCRIPTION
# Motivation

Address Field does not show the right end of the address

# Changes

Override the gix/components default padding value and set the input’s right padding to 80px so the full value remains visible.
