### PR TITLE
refactor(frontend): Make util `parseSolSystemInstruction` more type-safe

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
@@ -25,73 +25,100 @@ export const parseSolSystemInstruction = (
 	assertIsInstructionWithAccounts(instruction);
 
 	const decodedInstruction = identifySystemInstruction(instruction);
-	switch (decodedInstruction) {
-		case SystemInstruction.CreateAccount:
-			return {
-				...parseCreateAccountInstruction(instruction),
-				instructionType: SystemInstruction.CreateAccount
-			};
-		case SystemInstruction.Assign:
-			return {
-				...parseAssignInstruction(instruction),
-				instructionType: SystemInstruction.Assign
-			};
-		case SystemInstruction.TransferSol:
-			return {
-				...parseTransferSolInstruction(instruction),
-				instructionType: SystemInstruction.TransferSol
-			};
-		case SystemInstruction.CreateAccountWithSeed:
-			return {
-				...parseCreateAccountWithSeedInstruction(instruction),
-				instructionType: SystemInstruction.CreateAccountWithSeed
-			};
-		case SystemInstruction.AdvanceNonceAccount:
-			return {
-				...parseAdvanceNonceAccountInstruction(instruction),
-				instructionType: SystemInstruction.AdvanceNonceAccount
-			};
-		case SystemInstruction.WithdrawNonceAccount:
-			return {
-				...parseWithdrawNonceAccountInstruction(instruction),
-				instructionType: SystemInstruction.WithdrawNonceAccount
-			};
-		case SystemInstruction.InitializeNonceAccount:
-			return {
-				...parseInitializeNonceAccountInstruction(instruction),
-				instructionType: SystemInstruction.InitializeNonceAccount
-			};
-		case SystemInstruction.AuthorizeNonceAccount:
-			return {
-				...parseAuthorizeNonceAccountInstruction(instruction),
-				instructionType: SystemInstruction.AuthorizeNonceAccount
-			};
-		case SystemInstruction.Allocate:
-			return {
-				...parseAllocateInstruction(instruction),
-				instructionType: SystemInstruction.Allocate
-			};
-		case SystemInstruction.AllocateWithSeed:
-			return {
-				...parseAllocateWithSeedInstruction(instruction),
-				instructionType: SystemInstruction.AllocateWithSeed
-			};
-		case SystemInstruction.AssignWithSeed:
-			return {
-				...parseAssignWithSeedInstruction(instruction),
-				instructionType: SystemInstruction.AssignWithSeed
-			};
-		case SystemInstruction.TransferSolWithSeed:
-			return {
-				...parseTransferSolWithSeedInstruction(instruction),
-				instructionType: SystemInstruction.TransferSolWithSeed
-			};
-		case SystemInstruction.UpgradeNonceAccount:
-			return {
-				...parseUpgradeNonceAccountInstruction(instruction),
-				instructionType: SystemInstruction.UpgradeNonceAccount
-			};
-		default:
-			return instruction;
+
+	if (decodedInstruction === SystemInstruction.CreateAccount) {
+		return {
+			...parseCreateAccountInstruction(instruction),
+			instructionType: SystemInstruction.CreateAccount
+		};
 	}
+
+	if (decodedInstruction === SystemInstruction.Assign) {
+		return {
+			...parseAssignInstruction(instruction),
+			instructionType: SystemInstruction.Assign
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.TransferSol) {
+		return {
+			...parseTransferSolInstruction(instruction),
+			instructionType: SystemInstruction.TransferSol
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.CreateAccountWithSeed) {
+		return {
+			...parseCreateAccountWithSeedInstruction(instruction),
+			instructionType: SystemInstruction.CreateAccountWithSeed
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.AdvanceNonceAccount) {
+		return {
+			...parseAdvanceNonceAccountInstruction(instruction),
+			instructionType: SystemInstruction.AdvanceNonceAccount
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.WithdrawNonceAccount) {
+		return {
+			...parseWithdrawNonceAccountInstruction(instruction),
+			instructionType: SystemInstruction.WithdrawNonceAccount
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.InitializeNonceAccount) {
+		return {
+			...parseInitializeNonceAccountInstruction(instruction),
+			instructionType: SystemInstruction.InitializeNonceAccount
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.AuthorizeNonceAccount) {
+		return {
+			...parseAuthorizeNonceAccountInstruction(instruction),
+			instructionType: SystemInstruction.AuthorizeNonceAccount
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.Allocate) {
+		return {
+			...parseAllocateInstruction(instruction),
+			instructionType: SystemInstruction.Allocate
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.AllocateWithSeed) {
+		return {
+			...parseAllocateWithSeedInstruction(instruction),
+			instructionType: SystemInstruction.AllocateWithSeed
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.AssignWithSeed) {
+		return {
+			...parseAssignWithSeedInstruction(instruction),
+			instructionType: SystemInstruction.AssignWithSeed
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.TransferSolWithSeed) {
+		return {
+			...parseTransferSolWithSeedInstruction(instruction),
+			instructionType: SystemInstruction.TransferSolWithSeed
+		};
+	}
+
+	if (decodedInstruction === SystemInstruction.UpgradeNonceAccount) {
+		return {
+			...parseUpgradeNonceAccountInstruction(instruction),
+			instructionType: SystemInstruction.UpgradeNonceAccount
+		};
+	}
+
+	// Force compiler error on unhandled cases based on leftover types
+	const _: never = decodedInstruction;
+
+	return instruction;
 };

--- a/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
@@ -25,100 +25,77 @@ export const parseSolSystemInstruction = (
 	assertIsInstructionWithAccounts(instruction);
 
 	const decodedInstruction = identifySystemInstruction(instruction);
+	switch (decodedInstruction) {
+		case SystemInstruction.CreateAccount:
+			return {
+				...parseCreateAccountInstruction(instruction),
+				instructionType: SystemInstruction.CreateAccount
+			};
+		case SystemInstruction.Assign:
+			return {
+				...parseAssignInstruction(instruction),
+				instructionType: SystemInstruction.Assign
+			};
+		case SystemInstruction.TransferSol:
+			return {
+				...parseTransferSolInstruction(instruction),
+				instructionType: SystemInstruction.TransferSol
+			};
+		case SystemInstruction.CreateAccountWithSeed:
+			return {
+				...parseCreateAccountWithSeedInstruction(instruction),
+				instructionType: SystemInstruction.CreateAccountWithSeed
+			};
+		case SystemInstruction.AdvanceNonceAccount:
+			return {
+				...parseAdvanceNonceAccountInstruction(instruction),
+				instructionType: SystemInstruction.AdvanceNonceAccount
+			};
+		case SystemInstruction.WithdrawNonceAccount:
+			return {
+				...parseWithdrawNonceAccountInstruction(instruction),
+				instructionType: SystemInstruction.WithdrawNonceAccount
+			};
+		case SystemInstruction.InitializeNonceAccount:
+			return {
+				...parseInitializeNonceAccountInstruction(instruction),
+				instructionType: SystemInstruction.InitializeNonceAccount
+			};
+		case SystemInstruction.AuthorizeNonceAccount:
+			return {
+				...parseAuthorizeNonceAccountInstruction(instruction),
+				instructionType: SystemInstruction.AuthorizeNonceAccount
+			};
+		case SystemInstruction.Allocate:
+			return {
+				...parseAllocateInstruction(instruction),
+				instructionType: SystemInstruction.Allocate
+			};
+		case SystemInstruction.AllocateWithSeed:
+			return {
+				...parseAllocateWithSeedInstruction(instruction),
+				instructionType: SystemInstruction.AllocateWithSeed
+			};
+		case SystemInstruction.AssignWithSeed:
+			return {
+				...parseAssignWithSeedInstruction(instruction),
+				instructionType: SystemInstruction.AssignWithSeed
+			};
+		case SystemInstruction.TransferSolWithSeed:
+			return {
+				...parseTransferSolWithSeedInstruction(instruction),
+				instructionType: SystemInstruction.TransferSolWithSeed
+			};
+		case SystemInstruction.UpgradeNonceAccount:
+			return {
+				...parseUpgradeNonceAccountInstruction(instruction),
+				instructionType: SystemInstruction.UpgradeNonceAccount
+			};
+		default: {
+			// Force compiler error on unhandled cases based on leftover types
+			const _: never = decodedInstruction;
 
-	if (decodedInstruction === SystemInstruction.CreateAccount) {
-		return {
-			...parseCreateAccountInstruction(instruction),
-			instructionType: SystemInstruction.CreateAccount
-		};
+			return instruction;
+		}
 	}
-
-	if (decodedInstruction === SystemInstruction.Assign) {
-		return {
-			...parseAssignInstruction(instruction),
-			instructionType: SystemInstruction.Assign
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.TransferSol) {
-		return {
-			...parseTransferSolInstruction(instruction),
-			instructionType: SystemInstruction.TransferSol
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.CreateAccountWithSeed) {
-		return {
-			...parseCreateAccountWithSeedInstruction(instruction),
-			instructionType: SystemInstruction.CreateAccountWithSeed
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.AdvanceNonceAccount) {
-		return {
-			...parseAdvanceNonceAccountInstruction(instruction),
-			instructionType: SystemInstruction.AdvanceNonceAccount
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.WithdrawNonceAccount) {
-		return {
-			...parseWithdrawNonceAccountInstruction(instruction),
-			instructionType: SystemInstruction.WithdrawNonceAccount
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.InitializeNonceAccount) {
-		return {
-			...parseInitializeNonceAccountInstruction(instruction),
-			instructionType: SystemInstruction.InitializeNonceAccount
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.AuthorizeNonceAccount) {
-		return {
-			...parseAuthorizeNonceAccountInstruction(instruction),
-			instructionType: SystemInstruction.AuthorizeNonceAccount
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.Allocate) {
-		return {
-			...parseAllocateInstruction(instruction),
-			instructionType: SystemInstruction.Allocate
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.AllocateWithSeed) {
-		return {
-			...parseAllocateWithSeedInstruction(instruction),
-			instructionType: SystemInstruction.AllocateWithSeed
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.AssignWithSeed) {
-		return {
-			...parseAssignWithSeedInstruction(instruction),
-			instructionType: SystemInstruction.AssignWithSeed
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.TransferSolWithSeed) {
-		return {
-			...parseTransferSolWithSeedInstruction(instruction),
-			instructionType: SystemInstruction.TransferSolWithSeed
-		};
-	}
-
-	if (decodedInstruction === SystemInstruction.UpgradeNonceAccount) {
-		return {
-			...parseUpgradeNonceAccountInstruction(instruction),
-			instructionType: SystemInstruction.UpgradeNonceAccount
-		};
-	}
-
-	// Force compiler error on unhandled cases based on leftover types
-	const _: never = decodedInstruction;
-
-	return instruction;
 };

--- a/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
@@ -1,0 +1,240 @@
+import { SYSTEM_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
+import type { SolInstruction } from '$sol/types/sol-instructions';
+import { parseSolSystemInstruction } from '$sol/utils/sol-instructions-system.utils';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+import {
+	SystemInstruction,
+	identifySystemInstruction,
+	parseAdvanceNonceAccountInstruction,
+	parseAllocateInstruction,
+	parseAllocateWithSeedInstruction,
+	parseAssignInstruction,
+	parseAssignWithSeedInstruction,
+	parseAuthorizeNonceAccountInstruction,
+	parseCreateAccountInstruction,
+	parseCreateAccountWithSeedInstruction,
+	parseInitializeNonceAccountInstruction,
+	parseTransferSolInstruction,
+	parseTransferSolWithSeedInstruction,
+	parseUpgradeNonceAccountInstruction,
+	parseWithdrawNonceAccountInstruction
+} from '@solana-program/system';
+import { address } from '@solana/kit';
+
+vi.mock(import('@solana-program/system'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		identifySystemInstruction: vi.fn(),
+		parseAdvanceNonceAccountInstruction: vi.fn(),
+		parseAllocateInstruction: vi.fn(),
+		parseAllocateWithSeedInstruction: vi.fn(),
+		parseAssignInstruction: vi.fn(),
+		parseAssignWithSeedInstruction: vi.fn(),
+		parseAuthorizeNonceAccountInstruction: vi.fn(),
+		parseCreateAccountInstruction: vi.fn(),
+		parseCreateAccountWithSeedInstruction: vi.fn(),
+		parseInitializeNonceAccountInstruction: vi.fn(),
+		parseTransferSolInstruction: vi.fn(),
+		parseTransferSolWithSeedInstruction: vi.fn(),
+		parseUpgradeNonceAccountInstruction: vi.fn(),
+		parseWithdrawNonceAccountInstruction: vi.fn()
+	};
+});
+
+describe('sol-instructions-system.utils', () => {
+	describe('parseSolSystemInstruction', () => {
+		const mockInstruction: SolInstruction = {
+			accounts: [{ address: address(mockSolAddress), role: 3 }],
+			data: new Uint8Array([1, 2, 3]),
+			programAddress: address(SYSTEM_PROGRAM_ADDRESS)
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should raise an error if the instruction is missing the data', () => {
+			const { data: _, ...withoutData } = mockInstruction;
+
+			expect(() => parseSolSystemInstruction(withoutData)).toThrow(
+				'The instruction does not have any data'
+			);
+		});
+
+		it('should raise an error if the instruction is missing the accounts', () => {
+			const { accounts: _, ...withoutAccounts } = mockInstruction;
+
+			expect(() => parseSolSystemInstruction(withoutAccounts as unknown as SolInstruction)).toThrow(
+				'The instruction does not have any accounts'
+			);
+		});
+
+		it('should parse a CreateAccount instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.CreateAccount);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.CreateAccount
+			});
+
+			expect(parseCreateAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an Assign instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.Assign);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.Assign
+			});
+
+			expect(parseAssignInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a TransferSol instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.TransferSol);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.TransferSol
+			});
+
+			expect(parseTransferSolInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a CreateAccountWithSeed instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.CreateAccountWithSeed
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.CreateAccountWithSeed
+			});
+
+			expect(parseCreateAccountWithSeedInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an AdvanceNonceAccount instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.AdvanceNonceAccount
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.AdvanceNonceAccount
+			});
+
+			expect(parseAdvanceNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a WithdrawNonceAccount instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.WithdrawNonceAccount
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.WithdrawNonceAccount
+			});
+
+			expect(parseWithdrawNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeNonceAccount instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.InitializeNonceAccount
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.InitializeNonceAccount
+			});
+
+			expect(parseInitializeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an AuthorizeNonceAccount instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.AuthorizeNonceAccount
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.AuthorizeNonceAccount
+			});
+
+			expect(parseAuthorizeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an Allocate instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.Allocate);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.Allocate
+			});
+
+			expect(parseAllocateInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an AllocateWithSeed instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.AllocateWithSeed);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.AllocateWithSeed
+			});
+
+			expect(parseAllocateWithSeedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an AssignWithSeed instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.AssignWithSeed);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.AssignWithSeed
+			});
+
+			expect(parseAssignWithSeedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a TransferSolWithSeed instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.TransferSolWithSeed
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.TransferSolWithSeed
+			});
+
+			expect(parseTransferSolWithSeedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an UpgradeNonceAccount instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.UpgradeNonceAccount
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.UpgradeNonceAccount
+			});
+
+			expect(parseUpgradeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should return the original instruction if it is not a recognised System instruction', () => {
+			// @ts-expect-error intentional for testing unknown discriminant
+			vi.mocked(identifySystemInstruction).mockReturnValue('unknown-instruction');
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual(mockInstruction);
+
+			expect(parseCreateAccountInstruction).not.toHaveBeenCalled();
+			expect(parseAssignInstruction).not.toHaveBeenCalled();
+			expect(parseTransferSolInstruction).not.toHaveBeenCalled();
+			expect(parseCreateAccountWithSeedInstruction).not.toHaveBeenCalled();
+			expect(parseAdvanceNonceAccountInstruction).not.toHaveBeenCalled();
+			expect(parseWithdrawNonceAccountInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeNonceAccountInstruction).not.toHaveBeenCalled();
+			expect(parseAuthorizeNonceAccountInstruction).not.toHaveBeenCalled();
+			expect(parseAllocateInstruction).not.toHaveBeenCalled();
+			expect(parseAllocateWithSeedInstruction).not.toHaveBeenCalled();
+			expect(parseAssignWithSeedInstruction).not.toHaveBeenCalled();
+			expect(parseTransferSolWithSeedInstruction).not.toHaveBeenCalled();
+			expect(parseUpgradeNonceAccountInstruction).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
@@ -101,9 +101,7 @@ describe('sol-instructions-system.utils', () => {
 		});
 
 		it('should parse a CreateAccountWithSeed instruction', () => {
-			vi.mocked(identifySystemInstruction).mockReturnValue(
-				SystemInstruction.CreateAccountWithSeed
-			);
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.CreateAccountWithSeed);
 
 			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
 				instructionType: SystemInstruction.CreateAccountWithSeed
@@ -115,9 +113,7 @@ describe('sol-instructions-system.utils', () => {
 		});
 
 		it('should parse an AdvanceNonceAccount instruction', () => {
-			vi.mocked(identifySystemInstruction).mockReturnValue(
-				SystemInstruction.AdvanceNonceAccount
-			);
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.AdvanceNonceAccount);
 
 			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
 				instructionType: SystemInstruction.AdvanceNonceAccount
@@ -127,9 +123,7 @@ describe('sol-instructions-system.utils', () => {
 		});
 
 		it('should parse a WithdrawNonceAccount instruction', () => {
-			vi.mocked(identifySystemInstruction).mockReturnValue(
-				SystemInstruction.WithdrawNonceAccount
-			);
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.WithdrawNonceAccount);
 
 			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
 				instructionType: SystemInstruction.WithdrawNonceAccount
@@ -147,19 +141,21 @@ describe('sol-instructions-system.utils', () => {
 				instructionType: SystemInstruction.InitializeNonceAccount
 			});
 
-			expect(parseInitializeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+			expect(parseInitializeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
 		});
 
 		it('should parse an AuthorizeNonceAccount instruction', () => {
-			vi.mocked(identifySystemInstruction).mockReturnValue(
-				SystemInstruction.AuthorizeNonceAccount
-			);
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.AuthorizeNonceAccount);
 
 			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
 				instructionType: SystemInstruction.AuthorizeNonceAccount
 			});
 
-			expect(parseAuthorizeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+			expect(parseAuthorizeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
 		});
 
 		it('should parse an Allocate instruction', () => {
@@ -193,9 +189,7 @@ describe('sol-instructions-system.utils', () => {
 		});
 
 		it('should parse a TransferSolWithSeed instruction', () => {
-			vi.mocked(identifySystemInstruction).mockReturnValue(
-				SystemInstruction.TransferSolWithSeed
-			);
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.TransferSolWithSeed);
 
 			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
 				instructionType: SystemInstruction.TransferSolWithSeed
@@ -205,9 +199,7 @@ describe('sol-instructions-system.utils', () => {
 		});
 
 		it('should parse an UpgradeNonceAccount instruction', () => {
-			vi.mocked(identifySystemInstruction).mockReturnValue(
-				SystemInstruction.UpgradeNonceAccount
-			);
+			vi.mocked(identifySystemInstruction).mockReturnValue(SystemInstruction.UpgradeNonceAccount);
 
 			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
 				instructionType: SystemInstruction.UpgradeNonceAccount


### PR DESCRIPTION
# Motivation

To make util `parseSolSystemInstruction` more type-safe, we use a forced casting to never to discover if we forgot to track some specific variants.

Since we are here, we add tests.