### PR TITLE
chore(frontend): Fix AI Assistant Gitbook link

### DIFF
--- a/src/frontend/src/env/oisy.metadata.json
+++ b/src/frontend/src/env/oisy.metadata.json
@@ -6,7 +6,7 @@
 	"OISY_REPO_URL": "https://github.com/dfinity/oisy-wallet",
 	"OISY_TWITTER_URL": "https://x.com/oisy",
 	"OISY_DOCS_URL": "https://docs.oisy.com",
-	"OISY_AI_ASSISTANT_DOCS_URL": "https://docs.oisy.com/using-oisy-wallet/ai_assistant",
+	"OISY_AI_ASSISTANT_DOCS_URL": "https://docs.oisy.com/using-oisy-wallet/ai-assistant",
 	"OISY_SUPPORT_URL": "https://docs.oisy.com/using-oisy-wallet/support",
 	"OISY_REWARDS_URL": "https://docs.oisy.com/rewards",
 	"OISY_REFERRAL_URL": "https://docs.oisy.com/rewards",


### PR DESCRIPTION
# Motivation

Our PM used an underscore in the link, although it's obvious that gitbook uses dashes.

# Changes

- change the link

# Tests
<img width="879" height="485" alt="image" src="https://github.com/user-attachments/assets/a1f09f82-ab3f-491c-a4e2-af52e245842b" />

