### PR TITLE
refactor(frontend): Make util `parseSolTokenInstruction` more type-safe

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
@@ -37,133 +37,184 @@ export const parseSolTokenInstruction = (
 	assertIsInstructionWithAccounts(instruction);
 
 	const decodedInstruction = identifyTokenInstruction(instruction);
-	switch (decodedInstruction) {
-		case TokenInstruction.InitializeMint:
-			return {
-				...parseInitializeMintInstruction(instruction),
-				instructionType: TokenInstruction.InitializeMint
-			};
-		case TokenInstruction.InitializeAccount:
-			return {
-				...parseInitializeAccountInstruction(instruction),
-				instructionType: TokenInstruction.InitializeAccount
-			};
-		case TokenInstruction.InitializeMultisig:
-			return {
-				...parseInitializeMultisigInstruction(instruction),
-				instructionType: TokenInstruction.InitializeMultisig
-			};
-		case TokenInstruction.Transfer:
-			return {
-				...parseTransferInstruction(instruction),
-				instructionType: TokenInstruction.Transfer
-			};
-		case TokenInstruction.Approve:
-			return {
-				...parseApproveInstruction(instruction),
-				instructionType: TokenInstruction.Approve
-			};
-		case TokenInstruction.Revoke:
-			return {
-				...parseRevokeInstruction(instruction),
-				instructionType: TokenInstruction.Revoke
-			};
-		case TokenInstruction.SetAuthority:
-			return {
-				...parseSetAuthorityInstruction(instruction),
-				instructionType: TokenInstruction.SetAuthority
-			};
-		case TokenInstruction.MintTo:
-			return {
-				...parseMintToInstruction(instruction),
-				instructionType: TokenInstruction.MintTo
-			};
-		case TokenInstruction.Burn:
-			return {
-				...parseBurnInstruction(instruction),
-				instructionType: TokenInstruction.Burn
-			};
-		case TokenInstruction.CloseAccount:
-			return {
-				...parseCloseAccountInstruction(instruction),
-				instructionType: TokenInstruction.CloseAccount
-			};
-		case TokenInstruction.FreezeAccount:
-			return {
-				...parseFreezeAccountInstruction(instruction),
-				instructionType: TokenInstruction.FreezeAccount
-			};
-		case TokenInstruction.ThawAccount:
-			return {
-				...parseThawAccountInstruction(instruction),
-				instructionType: TokenInstruction.ThawAccount
-			};
-		case TokenInstruction.TransferChecked:
-			return {
-				...parseTransferCheckedInstruction(instruction),
-				instructionType: TokenInstruction.TransferChecked
-			};
-		case TokenInstruction.ApproveChecked:
-			return {
-				...parseApproveCheckedInstruction(instruction),
-				instructionType: TokenInstruction.ApproveChecked
-			};
-		case TokenInstruction.MintToChecked:
-			return {
-				...parseMintToCheckedInstruction(instruction),
-				instructionType: TokenInstruction.MintToChecked
-			};
-		case TokenInstruction.BurnChecked:
-			return {
-				...parseBurnCheckedInstruction(instruction),
-				instructionType: TokenInstruction.BurnChecked
-			};
-		case TokenInstruction.InitializeAccount2:
-			return {
-				...parseInitializeAccount2Instruction(instruction),
-				instructionType: TokenInstruction.InitializeAccount2
-			};
-		case TokenInstruction.SyncNative:
-			return {
-				...parseSyncNativeInstruction(instruction),
-				instructionType: TokenInstruction.SyncNative
-			};
-		case TokenInstruction.InitializeAccount3:
-			return {
-				...parseInitializeAccount3Instruction(instruction),
-				instructionType: TokenInstruction.InitializeAccount3
-			};
-		case TokenInstruction.InitializeMultisig2:
-			return {
-				...parseInitializeMultisig2Instruction(instruction),
-				instructionType: TokenInstruction.InitializeMultisig2
-			};
-		case TokenInstruction.InitializeMint2:
-			return {
-				...parseInitializeMint2Instruction(instruction),
-				instructionType: TokenInstruction.InitializeMint2
-			};
-		case TokenInstruction.GetAccountDataSize:
-			return {
-				...parseGetAccountDataSizeInstruction(instruction),
-				instructionType: TokenInstruction.GetAccountDataSize
-			};
-		case TokenInstruction.InitializeImmutableOwner:
-			return {
-				...parseInitializeImmutableOwnerInstruction(instruction),
-				instructionType: TokenInstruction.InitializeImmutableOwner
-			};
-		case TokenInstruction.AmountToUiAmount:
-			return {
-				...parseAmountToUiAmountInstruction(instruction),
-				instructionType: TokenInstruction.AmountToUiAmount
-			};
-		case TokenInstruction.UiAmountToAmount:
-			return {
-				...parseUiAmountToAmountInstruction(instruction),
-				instructionType: TokenInstruction.UiAmountToAmount
-			};
-		default:
-			return instruction;
+
+	if (decodedInstruction === TokenInstruction.InitializeMint) {
+		return {
+			...parseInitializeMintInstruction(instruction),
+			instructionType: TokenInstruction.InitializeMint
+		};
 	}
+
+	if (decodedInstruction === TokenInstruction.InitializeAccount) {
+		return {
+			...parseInitializeAccountInstruction(instruction),
+			instructionType: TokenInstruction.InitializeAccount
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.InitializeMultisig) {
+		return {
+			...parseInitializeMultisigInstruction(instruction),
+			instructionType: TokenInstruction.InitializeMultisig
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.Transfer) {
+		return {
+			...parseTransferInstruction(instruction),
+			instructionType: TokenInstruction.Transfer
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.Approve) {
+		return {
+			...parseApproveInstruction(instruction),
+			instructionType: TokenInstruction.Approve
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.Revoke) {
+		return {
+			...parseRevokeInstruction(instruction),
+			instructionType: TokenInstruction.Revoke
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.SetAuthority) {
+		return {
+			...parseSetAuthorityInstruction(instruction),
+			instructionType: TokenInstruction.SetAuthority
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.MintTo) {
+		return {
+			...parseMintToInstruction(instruction),
+			instructionType: TokenInstruction.MintTo
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.Burn) {
+		return {
+			...parseBurnInstruction(instruction),
+			instructionType: TokenInstruction.Burn
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.CloseAccount) {
+		return {
+			...parseCloseAccountInstruction(instruction),
+			instructionType: TokenInstruction.CloseAccount
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.FreezeAccount) {
+		return {
+			...parseFreezeAccountInstruction(instruction),
+			instructionType: TokenInstruction.FreezeAccount
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.ThawAccount) {
+		return {
+			...parseThawAccountInstruction(instruction),
+			instructionType: TokenInstruction.ThawAccount
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.TransferChecked) {
+		return {
+			...parseTransferCheckedInstruction(instruction),
+			instructionType: TokenInstruction.TransferChecked
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.ApproveChecked) {
+		return {
+			...parseApproveCheckedInstruction(instruction),
+			instructionType: TokenInstruction.ApproveChecked
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.MintToChecked) {
+		return {
+			...parseMintToCheckedInstruction(instruction),
+			instructionType: TokenInstruction.MintToChecked
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.BurnChecked) {
+		return {
+			...parseBurnCheckedInstruction(instruction),
+			instructionType: TokenInstruction.BurnChecked
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.InitializeAccount2) {
+		return {
+			...parseInitializeAccount2Instruction(instruction),
+			instructionType: TokenInstruction.InitializeAccount2
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.SyncNative) {
+		return {
+			...parseSyncNativeInstruction(instruction),
+			instructionType: TokenInstruction.SyncNative
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.InitializeAccount3) {
+		return {
+			...parseInitializeAccount3Instruction(instruction),
+			instructionType: TokenInstruction.InitializeAccount3
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.InitializeMultisig2) {
+		return {
+			...parseInitializeMultisig2Instruction(instruction),
+			instructionType: TokenInstruction.InitializeMultisig2
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.InitializeMint2) {
+		return {
+			...parseInitializeMint2Instruction(instruction),
+			instructionType: TokenInstruction.InitializeMint2
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.GetAccountDataSize) {
+		return {
+			...parseGetAccountDataSizeInstruction(instruction),
+			instructionType: TokenInstruction.GetAccountDataSize
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.InitializeImmutableOwner) {
+		return {
+			...parseInitializeImmutableOwnerInstruction(instruction),
+			instructionType: TokenInstruction.InitializeImmutableOwner
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.AmountToUiAmount) {
+		return {
+			...parseAmountToUiAmountInstruction(instruction),
+			instructionType: TokenInstruction.AmountToUiAmount
+		};
+	}
+
+	if (decodedInstruction === TokenInstruction.UiAmountToAmount) {
+		return {
+			...parseUiAmountToAmountInstruction(instruction),
+			instructionType: TokenInstruction.UiAmountToAmount
+		};
+	}
+
+	// Force compiler error on unhandled cases based on leftover types
+	const _: never = decodedInstruction;
+
+	return instruction;
 };

--- a/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
@@ -37,184 +37,137 @@ export const parseSolTokenInstruction = (
 	assertIsInstructionWithAccounts(instruction);
 
 	const decodedInstruction = identifyTokenInstruction(instruction);
+	switch (decodedInstruction) {
+		case TokenInstruction.InitializeMint:
+			return {
+				...parseInitializeMintInstruction(instruction),
+				instructionType: TokenInstruction.InitializeMint
+			};
+		case TokenInstruction.InitializeAccount:
+			return {
+				...parseInitializeAccountInstruction(instruction),
+				instructionType: TokenInstruction.InitializeAccount
+			};
+		case TokenInstruction.InitializeMultisig:
+			return {
+				...parseInitializeMultisigInstruction(instruction),
+				instructionType: TokenInstruction.InitializeMultisig
+			};
+		case TokenInstruction.Transfer:
+			return {
+				...parseTransferInstruction(instruction),
+				instructionType: TokenInstruction.Transfer
+			};
+		case TokenInstruction.Approve:
+			return {
+				...parseApproveInstruction(instruction),
+				instructionType: TokenInstruction.Approve
+			};
+		case TokenInstruction.Revoke:
+			return {
+				...parseRevokeInstruction(instruction),
+				instructionType: TokenInstruction.Revoke
+			};
+		case TokenInstruction.SetAuthority:
+			return {
+				...parseSetAuthorityInstruction(instruction),
+				instructionType: TokenInstruction.SetAuthority
+			};
+		case TokenInstruction.MintTo:
+			return {
+				...parseMintToInstruction(instruction),
+				instructionType: TokenInstruction.MintTo
+			};
+		case TokenInstruction.Burn:
+			return {
+				...parseBurnInstruction(instruction),
+				instructionType: TokenInstruction.Burn
+			};
+		case TokenInstruction.CloseAccount:
+			return {
+				...parseCloseAccountInstruction(instruction),
+				instructionType: TokenInstruction.CloseAccount
+			};
+		case TokenInstruction.FreezeAccount:
+			return {
+				...parseFreezeAccountInstruction(instruction),
+				instructionType: TokenInstruction.FreezeAccount
+			};
+		case TokenInstruction.ThawAccount:
+			return {
+				...parseThawAccountInstruction(instruction),
+				instructionType: TokenInstruction.ThawAccount
+			};
+		case TokenInstruction.TransferChecked:
+			return {
+				...parseTransferCheckedInstruction(instruction),
+				instructionType: TokenInstruction.TransferChecked
+			};
+		case TokenInstruction.ApproveChecked:
+			return {
+				...parseApproveCheckedInstruction(instruction),
+				instructionType: TokenInstruction.ApproveChecked
+			};
+		case TokenInstruction.MintToChecked:
+			return {
+				...parseMintToCheckedInstruction(instruction),
+				instructionType: TokenInstruction.MintToChecked
+			};
+		case TokenInstruction.BurnChecked:
+			return {
+				...parseBurnCheckedInstruction(instruction),
+				instructionType: TokenInstruction.BurnChecked
+			};
+		case TokenInstruction.InitializeAccount2:
+			return {
+				...parseInitializeAccount2Instruction(instruction),
+				instructionType: TokenInstruction.InitializeAccount2
+			};
+		case TokenInstruction.SyncNative:
+			return {
+				...parseSyncNativeInstruction(instruction),
+				instructionType: TokenInstruction.SyncNative
+			};
+		case TokenInstruction.InitializeAccount3:
+			return {
+				...parseInitializeAccount3Instruction(instruction),
+				instructionType: TokenInstruction.InitializeAccount3
+			};
+		case TokenInstruction.InitializeMultisig2:
+			return {
+				...parseInitializeMultisig2Instruction(instruction),
+				instructionType: TokenInstruction.InitializeMultisig2
+			};
+		case TokenInstruction.InitializeMint2:
+			return {
+				...parseInitializeMint2Instruction(instruction),
+				instructionType: TokenInstruction.InitializeMint2
+			};
+		case TokenInstruction.GetAccountDataSize:
+			return {
+				...parseGetAccountDataSizeInstruction(instruction),
+				instructionType: TokenInstruction.GetAccountDataSize
+			};
+		case TokenInstruction.InitializeImmutableOwner:
+			return {
+				...parseInitializeImmutableOwnerInstruction(instruction),
+				instructionType: TokenInstruction.InitializeImmutableOwner
+			};
+		case TokenInstruction.AmountToUiAmount:
+			return {
+				...parseAmountToUiAmountInstruction(instruction),
+				instructionType: TokenInstruction.AmountToUiAmount
+			};
+		case TokenInstruction.UiAmountToAmount:
+			return {
+				...parseUiAmountToAmountInstruction(instruction),
+				instructionType: TokenInstruction.UiAmountToAmount
+			};
+		default: {
+			// Force compiler error on unhandled cases based on leftover types
+			const _: never = decodedInstruction;
 
-	if (decodedInstruction === TokenInstruction.InitializeMint) {
-		return {
-			...parseInitializeMintInstruction(instruction),
-			instructionType: TokenInstruction.InitializeMint
-		};
+			return instruction;
+		}
 	}
-
-	if (decodedInstruction === TokenInstruction.InitializeAccount) {
-		return {
-			...parseInitializeAccountInstruction(instruction),
-			instructionType: TokenInstruction.InitializeAccount
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.InitializeMultisig) {
-		return {
-			...parseInitializeMultisigInstruction(instruction),
-			instructionType: TokenInstruction.InitializeMultisig
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.Transfer) {
-		return {
-			...parseTransferInstruction(instruction),
-			instructionType: TokenInstruction.Transfer
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.Approve) {
-		return {
-			...parseApproveInstruction(instruction),
-			instructionType: TokenInstruction.Approve
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.Revoke) {
-		return {
-			...parseRevokeInstruction(instruction),
-			instructionType: TokenInstruction.Revoke
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.SetAuthority) {
-		return {
-			...parseSetAuthorityInstruction(instruction),
-			instructionType: TokenInstruction.SetAuthority
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.MintTo) {
-		return {
-			...parseMintToInstruction(instruction),
-			instructionType: TokenInstruction.MintTo
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.Burn) {
-		return {
-			...parseBurnInstruction(instruction),
-			instructionType: TokenInstruction.Burn
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.CloseAccount) {
-		return {
-			...parseCloseAccountInstruction(instruction),
-			instructionType: TokenInstruction.CloseAccount
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.FreezeAccount) {
-		return {
-			...parseFreezeAccountInstruction(instruction),
-			instructionType: TokenInstruction.FreezeAccount
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.ThawAccount) {
-		return {
-			...parseThawAccountInstruction(instruction),
-			instructionType: TokenInstruction.ThawAccount
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.TransferChecked) {
-		return {
-			...parseTransferCheckedInstruction(instruction),
-			instructionType: TokenInstruction.TransferChecked
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.ApproveChecked) {
-		return {
-			...parseApproveCheckedInstruction(instruction),
-			instructionType: TokenInstruction.ApproveChecked
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.MintToChecked) {
-		return {
-			...parseMintToCheckedInstruction(instruction),
-			instructionType: TokenInstruction.MintToChecked
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.BurnChecked) {
-		return {
-			...parseBurnCheckedInstruction(instruction),
-			instructionType: TokenInstruction.BurnChecked
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.InitializeAccount2) {
-		return {
-			...parseInitializeAccount2Instruction(instruction),
-			instructionType: TokenInstruction.InitializeAccount2
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.SyncNative) {
-		return {
-			...parseSyncNativeInstruction(instruction),
-			instructionType: TokenInstruction.SyncNative
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.InitializeAccount3) {
-		return {
-			...parseInitializeAccount3Instruction(instruction),
-			instructionType: TokenInstruction.InitializeAccount3
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.InitializeMultisig2) {
-		return {
-			...parseInitializeMultisig2Instruction(instruction),
-			instructionType: TokenInstruction.InitializeMultisig2
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.InitializeMint2) {
-		return {
-			...parseInitializeMint2Instruction(instruction),
-			instructionType: TokenInstruction.InitializeMint2
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.GetAccountDataSize) {
-		return {
-			...parseGetAccountDataSizeInstruction(instruction),
-			instructionType: TokenInstruction.GetAccountDataSize
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.InitializeImmutableOwner) {
-		return {
-			...parseInitializeImmutableOwnerInstruction(instruction),
-			instructionType: TokenInstruction.InitializeImmutableOwner
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.AmountToUiAmount) {
-		return {
-			...parseAmountToUiAmountInstruction(instruction),
-			instructionType: TokenInstruction.AmountToUiAmount
-		};
-	}
-
-	if (decodedInstruction === TokenInstruction.UiAmountToAmount) {
-		return {
-			...parseUiAmountToAmountInstruction(instruction),
-			instructionType: TokenInstruction.UiAmountToAmount
-		};
-	}
-
-	// Force compiler error on unhandled cases based on leftover types
-	const _: never = decodedInstruction;
-
-	return instruction;
 };

--- a/src/frontend/src/tests/sol/utils/sol-instructions-token.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-token.utils.spec.ts
@@ -1,0 +1,384 @@
+import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
+import type { SolInstruction } from '$sol/types/sol-instructions';
+import { parseSolTokenInstruction } from '$sol/utils/sol-instructions-token.utils';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+import {
+	TokenInstruction,
+	identifyTokenInstruction,
+	parseAmountToUiAmountInstruction,
+	parseApproveCheckedInstruction,
+	parseApproveInstruction,
+	parseBurnCheckedInstruction,
+	parseBurnInstruction,
+	parseCloseAccountInstruction,
+	parseFreezeAccountInstruction,
+	parseGetAccountDataSizeInstruction,
+	parseInitializeAccount2Instruction,
+	parseInitializeAccount3Instruction,
+	parseInitializeAccountInstruction,
+	parseInitializeImmutableOwnerInstruction,
+	parseInitializeMint2Instruction,
+	parseInitializeMintInstruction,
+	parseInitializeMultisig2Instruction,
+	parseInitializeMultisigInstruction,
+	parseMintToCheckedInstruction,
+	parseMintToInstruction,
+	parseRevokeInstruction,
+	parseSetAuthorityInstruction,
+	parseSyncNativeInstruction,
+	parseThawAccountInstruction,
+	parseTransferCheckedInstruction,
+	parseTransferInstruction,
+	parseUiAmountToAmountInstruction
+} from '@solana-program/token';
+import { address } from '@solana/kit';
+
+vi.mock(import('@solana-program/token'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		identifyTokenInstruction: vi.fn(),
+		parseAmountToUiAmountInstruction: vi.fn(),
+		parseApproveCheckedInstruction: vi.fn(),
+		parseApproveInstruction: vi.fn(),
+		parseBurnCheckedInstruction: vi.fn(),
+		parseBurnInstruction: vi.fn(),
+		parseCloseAccountInstruction: vi.fn(),
+		parseFreezeAccountInstruction: vi.fn(),
+		parseGetAccountDataSizeInstruction: vi.fn(),
+		parseInitializeAccount2Instruction: vi.fn(),
+		parseInitializeAccount3Instruction: vi.fn(),
+		parseInitializeAccountInstruction: vi.fn(),
+		parseInitializeImmutableOwnerInstruction: vi.fn(),
+		parseInitializeMint2Instruction: vi.fn(),
+		parseInitializeMintInstruction: vi.fn(),
+		parseInitializeMultisig2Instruction: vi.fn(),
+		parseInitializeMultisigInstruction: vi.fn(),
+		parseMintToCheckedInstruction: vi.fn(),
+		parseMintToInstruction: vi.fn(),
+		parseRevokeInstruction: vi.fn(),
+		parseSetAuthorityInstruction: vi.fn(),
+		parseSyncNativeInstruction: vi.fn(),
+		parseThawAccountInstruction: vi.fn(),
+		parseTransferCheckedInstruction: vi.fn(),
+		parseTransferInstruction: vi.fn(),
+		parseUiAmountToAmountInstruction: vi.fn()
+	};
+});
+
+describe('sol-instructions-token.utils', () => {
+	describe('parseSolTokenInstruction', () => {
+		const mockInstruction: SolInstruction = {
+			accounts: [{ address: address(mockSolAddress), role: 3 }],
+			data: new Uint8Array([1, 2, 3]),
+			programAddress: address(TOKEN_PROGRAM_ADDRESS)
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should raise an error if the instruction is missing the data', () => {
+			const { data: _, ...withoutData } = mockInstruction;
+
+			expect(() => parseSolTokenInstruction(withoutData)).toThrow(
+				'The instruction does not have any data'
+			);
+		});
+
+		it('should raise an error if the instruction is missing the accounts', () => {
+			const { accounts: _, ...withoutAccounts } = mockInstruction;
+
+			expect(() => parseSolTokenInstruction(withoutAccounts as unknown as SolInstruction)).toThrow(
+				'The instruction does not have any accounts'
+			);
+		});
+
+		it('should parse an InitializeMint instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeMint);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeMint
+			});
+
+			expect(parseInitializeMintInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeAccount instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeAccount);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeAccount
+			});
+
+			expect(parseInitializeAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMultisig instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeMultisig);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeMultisig
+			});
+
+			expect(parseInitializeMultisigInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Transfer instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.Transfer);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.Transfer
+			});
+
+			expect(parseTransferInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an Approve instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.Approve);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.Approve
+			});
+
+			expect(parseApproveInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Revoke instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.Revoke);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.Revoke
+			});
+
+			expect(parseRevokeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a SetAuthority instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.SetAuthority);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.SetAuthority
+			});
+
+			expect(parseSetAuthorityInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a MintTo instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.MintTo);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.MintTo
+			});
+
+			expect(parseMintToInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Burn instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.Burn);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.Burn
+			});
+
+			expect(parseBurnInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a CloseAccount instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.CloseAccount);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.CloseAccount
+			});
+
+			expect(parseCloseAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a FreezeAccount instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.FreezeAccount);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.FreezeAccount
+			});
+
+			expect(parseFreezeAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a ThawAccount instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.ThawAccount);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.ThawAccount
+			});
+
+			expect(parseThawAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a TransferChecked instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.TransferChecked);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.TransferChecked
+			});
+
+			expect(parseTransferCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an ApproveChecked instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.ApproveChecked);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.ApproveChecked
+			});
+
+			expect(parseApproveCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a MintToChecked instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.MintToChecked);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.MintToChecked
+			});
+
+			expect(parseMintToCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a BurnChecked instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.BurnChecked);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.BurnChecked
+			});
+
+			expect(parseBurnCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeAccount2 instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeAccount2);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeAccount2
+			});
+
+			expect(parseInitializeAccount2Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a SyncNative instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.SyncNative);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.SyncNative
+			});
+
+			expect(parseSyncNativeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeAccount3 instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeAccount3);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeAccount3
+			});
+
+			expect(parseInitializeAccount3Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMultisig2 instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeMultisig2);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeMultisig2
+			});
+
+			expect(parseInitializeMultisig2Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMint2 instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.InitializeMint2);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeMint2
+			});
+
+			expect(parseInitializeMint2Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a GetAccountDataSize instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.GetAccountDataSize);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.GetAccountDataSize
+			});
+
+			expect(parseGetAccountDataSizeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeImmutableOwner instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(
+				TokenInstruction.InitializeImmutableOwner
+			);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.InitializeImmutableOwner
+			});
+
+			expect(parseInitializeImmutableOwnerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an AmountToUiAmount instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.AmountToUiAmount);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.AmountToUiAmount
+			});
+
+			expect(parseAmountToUiAmountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a UiAmountToAmount instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.UiAmountToAmount);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.UiAmountToAmount
+			});
+
+			expect(parseUiAmountToAmountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should return the original instruction if it is not a recognised Token instruction', () => {
+			// @ts-expect-error intentional for testing unknown discriminant
+			vi.mocked(identifyTokenInstruction).mockReturnValue('unknown-instruction');
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual(mockInstruction);
+
+			expect(parseInitializeMintInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeAccountInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeMultisigInstruction).not.toHaveBeenCalled();
+			expect(parseTransferInstruction).not.toHaveBeenCalled();
+			expect(parseApproveInstruction).not.toHaveBeenCalled();
+			expect(parseRevokeInstruction).not.toHaveBeenCalled();
+			expect(parseSetAuthorityInstruction).not.toHaveBeenCalled();
+			expect(parseMintToInstruction).not.toHaveBeenCalled();
+			expect(parseBurnInstruction).not.toHaveBeenCalled();
+			expect(parseCloseAccountInstruction).not.toHaveBeenCalled();
+			expect(parseFreezeAccountInstruction).not.toHaveBeenCalled();
+			expect(parseThawAccountInstruction).not.toHaveBeenCalled();
+			expect(parseTransferCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseApproveCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseMintToCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseBurnCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeAccount2Instruction).not.toHaveBeenCalled();
+			expect(parseSyncNativeInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeAccount3Instruction).not.toHaveBeenCalled();
+			expect(parseInitializeMultisig2Instruction).not.toHaveBeenCalled();
+			expect(parseInitializeMint2Instruction).not.toHaveBeenCalled();
+			expect(parseGetAccountDataSizeInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeImmutableOwnerInstruction).not.toHaveBeenCalled();
+			expect(parseAmountToUiAmountInstruction).not.toHaveBeenCalled();
+			expect(parseUiAmountToAmountInstruction).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

To make util `parseSolTokenInstruction` more type-safe, we use a forced casting to never to discover if we forgot to track some specific variants.

Since we are here, we add tests.