### PR TITLE
refactor(frontend): Make util `parseSolToken2022Instruction` more type-safe

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions-token-2022.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token-2022.utils.ts
@@ -99,628 +99,451 @@ export const parseSolToken2022Instruction = (
 	assertIsInstructionWithAccounts(instruction);
 
 	const decodedInstruction = identifyToken2022Instruction(instruction);
-
-	if (decodedInstruction === Token2022Instruction.InitializeMint) {
-		return {
-			...parseInitializeMintInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeAccount) {
-		return {
-			...parseInitializeAccountInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeMultisig) {
-		return {
-			...parseInitializeMultisigInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeMultisig
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Transfer) {
-		return {
-			...parseTransferInstruction(instruction),
-			instructionType: Token2022Instruction.Transfer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Approve) {
-		return {
-			...parseApproveInstruction(instruction),
-			instructionType: Token2022Instruction.Approve
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Revoke) {
-		return {
-			...parseRevokeInstruction(instruction),
-			instructionType: Token2022Instruction.Revoke
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.SetAuthority) {
-		return {
-			...parseSetAuthorityInstruction(instruction),
-			instructionType: Token2022Instruction.SetAuthority
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.MintTo) {
-		return {
-			...parseMintToInstruction(instruction),
-			instructionType: Token2022Instruction.MintTo
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Burn) {
-		return {
-			...parseBurnInstruction(instruction),
-			instructionType: Token2022Instruction.Burn
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.CloseAccount) {
-		return {
-			...parseCloseAccountInstruction(instruction),
-			instructionType: Token2022Instruction.CloseAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.FreezeAccount) {
-		return {
-			...parseFreezeAccountInstruction(instruction),
-			instructionType: Token2022Instruction.FreezeAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ThawAccount) {
-		return {
-			...parseThawAccountInstruction(instruction),
-			instructionType: Token2022Instruction.ThawAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.TransferChecked) {
-		return {
-			...parseTransferCheckedInstruction(instruction),
-			instructionType: Token2022Instruction.TransferChecked
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ApproveChecked) {
-		return {
-			...parseApproveCheckedInstruction(instruction),
-			instructionType: Token2022Instruction.ApproveChecked
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.MintToChecked) {
-		return {
-			...parseMintToCheckedInstruction(instruction),
-			instructionType: Token2022Instruction.MintToChecked
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.BurnChecked) {
-		return {
-			...parseBurnCheckedInstruction(instruction),
-			instructionType: Token2022Instruction.BurnChecked
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeAccount2) {
-		return {
-			...parseInitializeAccount2Instruction(instruction),
-			instructionType: Token2022Instruction.InitializeAccount2
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.SyncNative) {
-		return {
-			...parseSyncNativeInstruction(instruction),
-			instructionType: Token2022Instruction.SyncNative
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeAccount3) {
-		return {
-			...parseInitializeAccount3Instruction(instruction),
-			instructionType: Token2022Instruction.InitializeAccount3
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeMultisig2) {
-		return {
-			...parseInitializeMultisig2Instruction(instruction),
-			instructionType: Token2022Instruction.InitializeMultisig2
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeMint2) {
-		return {
-			...parseInitializeMint2Instruction(instruction),
-			instructionType: Token2022Instruction.InitializeMint2
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.GetAccountDataSize) {
-		return {
-			...parseGetAccountDataSizeInstruction(instruction),
-			instructionType: Token2022Instruction.GetAccountDataSize
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeImmutableOwner) {
-		return {
-			...parseInitializeImmutableOwnerInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeImmutableOwner
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.AmountToUiAmount) {
-		return {
-			...parseAmountToUiAmountInstruction(instruction),
-			instructionType: Token2022Instruction.AmountToUiAmount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UiAmountToAmount) {
-		return {
-			...parseUiAmountToAmountInstruction(instruction),
-			instructionType: Token2022Instruction.UiAmountToAmount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeMintCloseAuthority) {
-		return {
-			...parseInitializeMintCloseAuthorityInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeMintCloseAuthority
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeTransferFeeConfig) {
-		return {
-			...parseInitializeTransferFeeConfigInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeTransferFeeConfig
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.TransferCheckedWithFee) {
-		return {
-			...parseTransferCheckedWithFeeInstruction(instruction),
-			instructionType: Token2022Instruction.TransferCheckedWithFee
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.WithdrawWithheldTokensFromMint) {
-		return {
-			...parseWithdrawWithheldTokensFromMintInstruction(instruction),
-			instructionType: Token2022Instruction.WithdrawWithheldTokensFromMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.WithdrawWithheldTokensFromAccounts) {
-		return {
-			...parseWithdrawWithheldTokensFromAccountsInstruction(instruction),
-			instructionType: Token2022Instruction.WithdrawWithheldTokensFromAccounts
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.HarvestWithheldTokensToMint) {
-		return {
-			...parseHarvestWithheldTokensToMintInstruction(instruction),
-			instructionType: Token2022Instruction.HarvestWithheldTokensToMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.SetTransferFee) {
-		return {
-			...parseSetTransferFeeInstruction(instruction),
-			instructionType: Token2022Instruction.SetTransferFee
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeConfidentialTransferMint) {
-		return {
-			...parseInitializeConfidentialTransferMintInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeConfidentialTransferMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateConfidentialTransferMint) {
-		return {
-			...parseUpdateConfidentialTransferMintInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateConfidentialTransferMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ConfigureConfidentialTransferAccount) {
-		return {
-			...parseConfigureConfidentialTransferAccountInstruction(instruction),
-			instructionType: Token2022Instruction.ConfigureConfidentialTransferAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ApproveConfidentialTransferAccount) {
-		return {
-			...parseApproveConfidentialTransferAccountInstruction(instruction),
-			instructionType: Token2022Instruction.ApproveConfidentialTransferAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EmptyConfidentialTransferAccount) {
-		return {
-			...parseEmptyConfidentialTransferAccountInstruction(instruction),
-			instructionType: Token2022Instruction.EmptyConfidentialTransferAccount
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ConfidentialDeposit) {
-		return {
-			...parseConfidentialDepositInstruction(instruction),
-			instructionType: Token2022Instruction.ConfidentialDeposit
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ConfidentialWithdraw) {
-		return {
-			...parseConfidentialWithdrawInstruction(instruction),
-			instructionType: Token2022Instruction.ConfidentialWithdraw
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ConfidentialTransfer) {
-		return {
-			...parseConfidentialTransferInstruction(instruction),
-			instructionType: Token2022Instruction.ConfidentialTransfer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ApplyConfidentialPendingBalance) {
-		return {
-			...parseApplyConfidentialPendingBalanceInstruction(instruction),
-			instructionType: Token2022Instruction.ApplyConfidentialPendingBalance
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EnableConfidentialCredits) {
-		return {
-			...parseEnableConfidentialCreditsInstruction(instruction),
-			instructionType: Token2022Instruction.EnableConfidentialCredits
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.DisableConfidentialCredits) {
-		return {
-			...parseDisableConfidentialCreditsInstruction(instruction),
-			instructionType: Token2022Instruction.DisableConfidentialCredits
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EnableNonConfidentialCredits) {
-		return {
-			...parseEnableNonConfidentialCreditsInstruction(instruction),
-			instructionType: Token2022Instruction.EnableNonConfidentialCredits
-		};
+	switch (decodedInstruction) {
+		case Token2022Instruction.InitializeMint:
+			return {
+				...parseInitializeMintInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeMint
+			};
+		case Token2022Instruction.InitializeAccount:
+			return {
+				...parseInitializeAccountInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeAccount
+			};
+		case Token2022Instruction.InitializeMultisig:
+			return {
+				...parseInitializeMultisigInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeMultisig
+			};
+		case Token2022Instruction.Transfer:
+			return {
+				...parseTransferInstruction(instruction),
+				instructionType: Token2022Instruction.Transfer
+			};
+		case Token2022Instruction.Approve:
+			return {
+				...parseApproveInstruction(instruction),
+				instructionType: Token2022Instruction.Approve
+			};
+		case Token2022Instruction.Revoke:
+			return {
+				...parseRevokeInstruction(instruction),
+				instructionType: Token2022Instruction.Revoke
+			};
+		case Token2022Instruction.SetAuthority:
+			return {
+				...parseSetAuthorityInstruction(instruction),
+				instructionType: Token2022Instruction.SetAuthority
+			};
+		case Token2022Instruction.MintTo:
+			return {
+				...parseMintToInstruction(instruction),
+				instructionType: Token2022Instruction.MintTo
+			};
+		case Token2022Instruction.Burn:
+			return {
+				...parseBurnInstruction(instruction),
+				instructionType: Token2022Instruction.Burn
+			};
+		case Token2022Instruction.CloseAccount:
+			return {
+				...parseCloseAccountInstruction(instruction),
+				instructionType: Token2022Instruction.CloseAccount
+			};
+		case Token2022Instruction.FreezeAccount:
+			return {
+				...parseFreezeAccountInstruction(instruction),
+				instructionType: Token2022Instruction.FreezeAccount
+			};
+		case Token2022Instruction.ThawAccount:
+			return {
+				...parseThawAccountInstruction(instruction),
+				instructionType: Token2022Instruction.ThawAccount
+			};
+		case Token2022Instruction.TransferChecked:
+			return {
+				...parseTransferCheckedInstruction(instruction),
+				instructionType: Token2022Instruction.TransferChecked
+			};
+		case Token2022Instruction.ApproveChecked:
+			return {
+				...parseApproveCheckedInstruction(instruction),
+				instructionType: Token2022Instruction.ApproveChecked
+			};
+		case Token2022Instruction.MintToChecked:
+			return {
+				...parseMintToCheckedInstruction(instruction),
+				instructionType: Token2022Instruction.MintToChecked
+			};
+		case Token2022Instruction.BurnChecked:
+			return {
+				...parseBurnCheckedInstruction(instruction),
+				instructionType: Token2022Instruction.BurnChecked
+			};
+		case Token2022Instruction.InitializeAccount2:
+			return {
+				...parseInitializeAccount2Instruction(instruction),
+				instructionType: Token2022Instruction.InitializeAccount2
+			};
+		case Token2022Instruction.SyncNative:
+			return {
+				...parseSyncNativeInstruction(instruction),
+				instructionType: Token2022Instruction.SyncNative
+			};
+		case Token2022Instruction.InitializeAccount3:
+			return {
+				...parseInitializeAccount3Instruction(instruction),
+				instructionType: Token2022Instruction.InitializeAccount3
+			};
+		case Token2022Instruction.InitializeMultisig2:
+			return {
+				...parseInitializeMultisig2Instruction(instruction),
+				instructionType: Token2022Instruction.InitializeMultisig2
+			};
+		case Token2022Instruction.InitializeMint2:
+			return {
+				...parseInitializeMint2Instruction(instruction),
+				instructionType: Token2022Instruction.InitializeMint2
+			};
+		case Token2022Instruction.GetAccountDataSize:
+			return {
+				...parseGetAccountDataSizeInstruction(instruction),
+				instructionType: Token2022Instruction.GetAccountDataSize
+			};
+		case Token2022Instruction.InitializeImmutableOwner:
+			return {
+				...parseInitializeImmutableOwnerInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeImmutableOwner
+			};
+		case Token2022Instruction.AmountToUiAmount:
+			return {
+				...parseAmountToUiAmountInstruction(instruction),
+				instructionType: Token2022Instruction.AmountToUiAmount
+			};
+		case Token2022Instruction.UiAmountToAmount:
+			return {
+				...parseUiAmountToAmountInstruction(instruction),
+				instructionType: Token2022Instruction.UiAmountToAmount
+			};
+		case Token2022Instruction.InitializeMintCloseAuthority:
+			return {
+				...parseInitializeMintCloseAuthorityInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeMintCloseAuthority
+			};
+		case Token2022Instruction.InitializeTransferFeeConfig:
+			return {
+				...parseInitializeTransferFeeConfigInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeTransferFeeConfig
+			};
+		case Token2022Instruction.TransferCheckedWithFee:
+			return {
+				...parseTransferCheckedWithFeeInstruction(instruction),
+				instructionType: Token2022Instruction.TransferCheckedWithFee
+			};
+		case Token2022Instruction.WithdrawWithheldTokensFromMint:
+			return {
+				...parseWithdrawWithheldTokensFromMintInstruction(instruction),
+				instructionType: Token2022Instruction.WithdrawWithheldTokensFromMint
+			};
+		case Token2022Instruction.WithdrawWithheldTokensFromAccounts:
+			return {
+				...parseWithdrawWithheldTokensFromAccountsInstruction(instruction),
+				instructionType: Token2022Instruction.WithdrawWithheldTokensFromAccounts
+			};
+		case Token2022Instruction.HarvestWithheldTokensToMint:
+			return {
+				...parseHarvestWithheldTokensToMintInstruction(instruction),
+				instructionType: Token2022Instruction.HarvestWithheldTokensToMint
+			};
+		case Token2022Instruction.SetTransferFee:
+			return {
+				...parseSetTransferFeeInstruction(instruction),
+				instructionType: Token2022Instruction.SetTransferFee
+			};
+		case Token2022Instruction.InitializeConfidentialTransferMint:
+			return {
+				...parseInitializeConfidentialTransferMintInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeConfidentialTransferMint
+			};
+		case Token2022Instruction.UpdateConfidentialTransferMint:
+			return {
+				...parseUpdateConfidentialTransferMintInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateConfidentialTransferMint
+			};
+		case Token2022Instruction.ConfigureConfidentialTransferAccount:
+			return {
+				...parseConfigureConfidentialTransferAccountInstruction(instruction),
+				instructionType: Token2022Instruction.ConfigureConfidentialTransferAccount
+			};
+		case Token2022Instruction.ApproveConfidentialTransferAccount:
+			return {
+				...parseApproveConfidentialTransferAccountInstruction(instruction),
+				instructionType: Token2022Instruction.ApproveConfidentialTransferAccount
+			};
+		case Token2022Instruction.EmptyConfidentialTransferAccount:
+			return {
+				...parseEmptyConfidentialTransferAccountInstruction(instruction),
+				instructionType: Token2022Instruction.EmptyConfidentialTransferAccount
+			};
+		case Token2022Instruction.ConfidentialDeposit:
+			return {
+				...parseConfidentialDepositInstruction(instruction),
+				instructionType: Token2022Instruction.ConfidentialDeposit
+			};
+		case Token2022Instruction.ConfidentialWithdraw:
+			return {
+				...parseConfidentialWithdrawInstruction(instruction),
+				instructionType: Token2022Instruction.ConfidentialWithdraw
+			};
+		case Token2022Instruction.ConfidentialTransfer:
+			return {
+				...parseConfidentialTransferInstruction(instruction),
+				instructionType: Token2022Instruction.ConfidentialTransfer
+			};
+		case Token2022Instruction.ApplyConfidentialPendingBalance:
+			return {
+				...parseApplyConfidentialPendingBalanceInstruction(instruction),
+				instructionType: Token2022Instruction.ApplyConfidentialPendingBalance
+			};
+		case Token2022Instruction.EnableConfidentialCredits:
+			return {
+				...parseEnableConfidentialCreditsInstruction(instruction),
+				instructionType: Token2022Instruction.EnableConfidentialCredits
+			};
+		case Token2022Instruction.DisableConfidentialCredits:
+			return {
+				...parseDisableConfidentialCreditsInstruction(instruction),
+				instructionType: Token2022Instruction.DisableConfidentialCredits
+			};
+		case Token2022Instruction.EnableNonConfidentialCredits:
+			return {
+				...parseEnableNonConfidentialCreditsInstruction(instruction),
+				instructionType: Token2022Instruction.EnableNonConfidentialCredits
+			};
+		case Token2022Instruction.DisableNonConfidentialCredits:
+			return {
+				...parseDisableNonConfidentialCreditsInstruction(instruction),
+				instructionType: Token2022Instruction.DisableNonConfidentialCredits
+			};
+		case Token2022Instruction.ConfidentialTransferWithFee:
+			return {
+				...parseConfidentialTransferWithFeeInstruction(instruction),
+				instructionType: Token2022Instruction.ConfidentialTransferWithFee
+			};
+		case Token2022Instruction.InitializeDefaultAccountState:
+			return {
+				...parseInitializeDefaultAccountStateInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeDefaultAccountState
+			};
+		case Token2022Instruction.UpdateDefaultAccountState:
+			return {
+				...parseUpdateDefaultAccountStateInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateDefaultAccountState
+			};
+		case Token2022Instruction.Reallocate:
+			return {
+				...parseReallocateInstruction(instruction),
+				instructionType: Token2022Instruction.Reallocate
+			};
+		case Token2022Instruction.EnableMemoTransfers:
+			return {
+				...parseEnableMemoTransfersInstruction(instruction),
+				instructionType: Token2022Instruction.EnableMemoTransfers
+			};
+		case Token2022Instruction.DisableMemoTransfers:
+			return {
+				...parseDisableMemoTransfersInstruction(instruction),
+				instructionType: Token2022Instruction.DisableMemoTransfers
+			};
+		case Token2022Instruction.CreateNativeMint:
+			return {
+				...parseCreateNativeMintInstruction(instruction),
+				instructionType: Token2022Instruction.CreateNativeMint
+			};
+		case Token2022Instruction.InitializeNonTransferableMint:
+			return {
+				...parseInitializeNonTransferableMintInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeNonTransferableMint
+			};
+		case Token2022Instruction.InitializeInterestBearingMint:
+			return {
+				...parseInitializeInterestBearingMintInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeInterestBearingMint
+			};
+		case Token2022Instruction.UpdateRateInterestBearingMint:
+			return {
+				...parseUpdateRateInterestBearingMintInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateRateInterestBearingMint
+			};
+		case Token2022Instruction.EnableCpiGuard:
+			return {
+				...parseEnableCpiGuardInstruction(instruction),
+				instructionType: Token2022Instruction.EnableCpiGuard
+			};
+		case Token2022Instruction.DisableCpiGuard:
+			return {
+				...parseDisableCpiGuardInstruction(instruction),
+				instructionType: Token2022Instruction.DisableCpiGuard
+			};
+		case Token2022Instruction.InitializePermanentDelegate:
+			return {
+				...parseInitializePermanentDelegateInstruction(instruction),
+				instructionType: Token2022Instruction.InitializePermanentDelegate
+			};
+		case Token2022Instruction.InitializeTransferHook:
+			return {
+				...parseInitializeTransferHookInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeTransferHook
+			};
+		case Token2022Instruction.UpdateTransferHook:
+			return {
+				...parseUpdateTransferHookInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateTransferHook
+			};
+		case Token2022Instruction.InitializeConfidentialTransferFee:
+			return {
+				...parseInitializeConfidentialTransferFeeInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeConfidentialTransferFee
+			};
+		case Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee:
+			return {
+				...parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction(instruction),
+				instructionType:
+					Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
+			};
+		case Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee:
+			return {
+				...parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction(
+					instruction
+				),
+				instructionType:
+					Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
+			};
+		case Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee:
+			return {
+				...parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction(instruction),
+				instructionType: Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
+			};
+		case Token2022Instruction.EnableHarvestToMint:
+			return {
+				...parseEnableHarvestToMintInstruction(instruction),
+				instructionType: Token2022Instruction.EnableHarvestToMint
+			};
+		case Token2022Instruction.DisableHarvestToMint:
+			return {
+				...parseDisableHarvestToMintInstruction(instruction),
+				instructionType: Token2022Instruction.DisableHarvestToMint
+			};
+		case Token2022Instruction.WithdrawExcessLamports:
+			return {
+				...parseWithdrawExcessLamportsInstruction(instruction),
+				instructionType: Token2022Instruction.WithdrawExcessLamports
+			};
+		case Token2022Instruction.InitializeMetadataPointer:
+			return {
+				...parseInitializeMetadataPointerInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeMetadataPointer
+			};
+		case Token2022Instruction.UpdateMetadataPointer:
+			return {
+				...parseUpdateMetadataPointerInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateMetadataPointer
+			};
+		case Token2022Instruction.InitializeGroupPointer:
+			return {
+				...parseInitializeGroupPointerInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeGroupPointer
+			};
+		case Token2022Instruction.UpdateGroupPointer:
+			return {
+				...parseUpdateGroupPointerInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateGroupPointer
+			};
+		case Token2022Instruction.InitializeGroupMemberPointer:
+			return {
+				...parseInitializeGroupMemberPointerInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeGroupMemberPointer
+			};
+		case Token2022Instruction.UpdateGroupMemberPointer:
+			return {
+				...parseUpdateGroupMemberPointerInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateGroupMemberPointer
+			};
+		case Token2022Instruction.InitializeScaledUiAmountMint:
+			return {
+				...parseInitializeScaledUiAmountMintInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeScaledUiAmountMint
+			};
+		case Token2022Instruction.UpdateMultiplierScaledUiMint:
+			return {
+				...parseUpdateMultiplierScaledUiMintInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateMultiplierScaledUiMint
+			};
+		case Token2022Instruction.InitializePausableConfig:
+			return {
+				...parseInitializePausableConfigInstruction(instruction),
+				instructionType: Token2022Instruction.InitializePausableConfig
+			};
+		case Token2022Instruction.Pause:
+			return {
+				...parsePauseInstruction(instruction),
+				instructionType: Token2022Instruction.Pause
+			};
+		case Token2022Instruction.Resume:
+			return {
+				...parseResumeInstruction(instruction),
+				instructionType: Token2022Instruction.Resume
+			};
+		case Token2022Instruction.InitializeTokenMetadata:
+			return {
+				...parseInitializeTokenMetadataInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeTokenMetadata
+			};
+		case Token2022Instruction.UpdateTokenMetadataField:
+			return {
+				...parseUpdateTokenMetadataFieldInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateTokenMetadataField
+			};
+		case Token2022Instruction.RemoveTokenMetadataKey:
+			return {
+				...parseRemoveTokenMetadataKeyInstruction(instruction),
+				instructionType: Token2022Instruction.RemoveTokenMetadataKey
+			};
+		case Token2022Instruction.UpdateTokenMetadataUpdateAuthority:
+			return {
+				...parseUpdateTokenMetadataUpdateAuthorityInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateTokenMetadataUpdateAuthority
+			};
+		case Token2022Instruction.EmitTokenMetadata:
+			return {
+				...parseEmitTokenMetadataInstruction(instruction),
+				instructionType: Token2022Instruction.EmitTokenMetadata
+			};
+		case Token2022Instruction.InitializeTokenGroup:
+			return {
+				...parseInitializeTokenGroupInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeTokenGroup
+			};
+		case Token2022Instruction.UpdateTokenGroupMaxSize:
+			return {
+				...parseUpdateTokenGroupMaxSizeInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateTokenGroupMaxSize
+			};
+		case Token2022Instruction.UpdateTokenGroupUpdateAuthority:
+			return {
+				...parseUpdateTokenGroupUpdateAuthorityInstruction(instruction),
+				instructionType: Token2022Instruction.UpdateTokenGroupUpdateAuthority
+			};
+		case Token2022Instruction.InitializeTokenGroupMember:
+			return {
+				...parseInitializeTokenGroupMemberInstruction(instruction),
+				instructionType: Token2022Instruction.InitializeTokenGroupMember
+			};
+		default: {
+			// Force compiler error on unhandled cases based on leftover types
+			const _: never = decodedInstruction;
+
+			return instruction;
+		}
 	}
-
-	if (decodedInstruction === Token2022Instruction.DisableNonConfidentialCredits) {
-		return {
-			...parseDisableNonConfidentialCreditsInstruction(instruction),
-			instructionType: Token2022Instruction.DisableNonConfidentialCredits
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.ConfidentialTransferWithFee) {
-		return {
-			...parseConfidentialTransferWithFeeInstruction(instruction),
-			instructionType: Token2022Instruction.ConfidentialTransferWithFee
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeDefaultAccountState) {
-		return {
-			...parseInitializeDefaultAccountStateInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeDefaultAccountState
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateDefaultAccountState) {
-		return {
-			...parseUpdateDefaultAccountStateInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateDefaultAccountState
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Reallocate) {
-		return {
-			...parseReallocateInstruction(instruction),
-			instructionType: Token2022Instruction.Reallocate
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EnableMemoTransfers) {
-		return {
-			...parseEnableMemoTransfersInstruction(instruction),
-			instructionType: Token2022Instruction.EnableMemoTransfers
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.DisableMemoTransfers) {
-		return {
-			...parseDisableMemoTransfersInstruction(instruction),
-			instructionType: Token2022Instruction.DisableMemoTransfers
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.CreateNativeMint) {
-		return {
-			...parseCreateNativeMintInstruction(instruction),
-			instructionType: Token2022Instruction.CreateNativeMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeNonTransferableMint) {
-		return {
-			...parseInitializeNonTransferableMintInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeNonTransferableMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeInterestBearingMint) {
-		return {
-			...parseInitializeInterestBearingMintInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeInterestBearingMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateRateInterestBearingMint) {
-		return {
-			...parseUpdateRateInterestBearingMintInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateRateInterestBearingMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EnableCpiGuard) {
-		return {
-			...parseEnableCpiGuardInstruction(instruction),
-			instructionType: Token2022Instruction.EnableCpiGuard
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.DisableCpiGuard) {
-		return {
-			...parseDisableCpiGuardInstruction(instruction),
-			instructionType: Token2022Instruction.DisableCpiGuard
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializePermanentDelegate) {
-		return {
-			...parseInitializePermanentDelegateInstruction(instruction),
-			instructionType: Token2022Instruction.InitializePermanentDelegate
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeTransferHook) {
-		return {
-			...parseInitializeTransferHookInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeTransferHook
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateTransferHook) {
-		return {
-			...parseUpdateTransferHookInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateTransferHook
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeConfidentialTransferFee) {
-		return {
-			...parseInitializeConfidentialTransferFeeInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeConfidentialTransferFee
-		};
-	}
-
-	if (
-		decodedInstruction ===
-		Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
-	) {
-		return {
-			...parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction(instruction),
-			instructionType: Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
-		};
-	}
-
-	if (
-		decodedInstruction ===
-		Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
-	) {
-		return {
-			...parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction(instruction),
-			instructionType:
-				Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
-		};
-	}
-
-	if (
-		decodedInstruction ===
-		Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
-	) {
-		return {
-			...parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction(instruction),
-			instructionType: Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EnableHarvestToMint) {
-		return {
-			...parseEnableHarvestToMintInstruction(instruction),
-			instructionType: Token2022Instruction.EnableHarvestToMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.DisableHarvestToMint) {
-		return {
-			...parseDisableHarvestToMintInstruction(instruction),
-			instructionType: Token2022Instruction.DisableHarvestToMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.WithdrawExcessLamports) {
-		return {
-			...parseWithdrawExcessLamportsInstruction(instruction),
-			instructionType: Token2022Instruction.WithdrawExcessLamports
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeMetadataPointer) {
-		return {
-			...parseInitializeMetadataPointerInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeMetadataPointer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateMetadataPointer) {
-		return {
-			...parseUpdateMetadataPointerInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateMetadataPointer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeGroupPointer) {
-		return {
-			...parseInitializeGroupPointerInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeGroupPointer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateGroupPointer) {
-		return {
-			...parseUpdateGroupPointerInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateGroupPointer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeGroupMemberPointer) {
-		return {
-			...parseInitializeGroupMemberPointerInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeGroupMemberPointer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateGroupMemberPointer) {
-		return {
-			...parseUpdateGroupMemberPointerInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateGroupMemberPointer
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeScaledUiAmountMint) {
-		return {
-			...parseInitializeScaledUiAmountMintInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeScaledUiAmountMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateMultiplierScaledUiMint) {
-		return {
-			...parseUpdateMultiplierScaledUiMintInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateMultiplierScaledUiMint
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializePausableConfig) {
-		return {
-			...parseInitializePausableConfigInstruction(instruction),
-			instructionType: Token2022Instruction.InitializePausableConfig
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Pause) {
-		return {
-			...parsePauseInstruction(instruction),
-			instructionType: Token2022Instruction.Pause
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.Resume) {
-		return {
-			...parseResumeInstruction(instruction),
-			instructionType: Token2022Instruction.Resume
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeTokenMetadata) {
-		return {
-			...parseInitializeTokenMetadataInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeTokenMetadata
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateTokenMetadataField) {
-		return {
-			...parseUpdateTokenMetadataFieldInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateTokenMetadataField
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.RemoveTokenMetadataKey) {
-		return {
-			...parseRemoveTokenMetadataKeyInstruction(instruction),
-			instructionType: Token2022Instruction.RemoveTokenMetadataKey
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateTokenMetadataUpdateAuthority) {
-		return {
-			...parseUpdateTokenMetadataUpdateAuthorityInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateTokenMetadataUpdateAuthority
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.EmitTokenMetadata) {
-		return {
-			...parseEmitTokenMetadataInstruction(instruction),
-			instructionType: Token2022Instruction.EmitTokenMetadata
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeTokenGroup) {
-		return {
-			...parseInitializeTokenGroupInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeTokenGroup
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateTokenGroupMaxSize) {
-		return {
-			...parseUpdateTokenGroupMaxSizeInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateTokenGroupMaxSize
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.UpdateTokenGroupUpdateAuthority) {
-		return {
-			...parseUpdateTokenGroupUpdateAuthorityInstruction(instruction),
-			instructionType: Token2022Instruction.UpdateTokenGroupUpdateAuthority
-		};
-	}
-
-	if (decodedInstruction === Token2022Instruction.InitializeTokenGroupMember) {
-		return {
-			...parseInitializeTokenGroupMemberInstruction(instruction),
-			instructionType: Token2022Instruction.InitializeTokenGroupMember
-		};
-	}
-
-	// Force compiler error on unhandled cases based on leftover types
-	const _: never = decodedInstruction;
-
-	return instruction;
 };

--- a/src/frontend/src/sol/utils/sol-instructions-token-2022.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token-2022.utils.ts
@@ -49,6 +49,7 @@ import {
 	parseInitializeMultisig2Instruction,
 	parseInitializeMultisigInstruction,
 	parseInitializeNonTransferableMintInstruction,
+	parseInitializePausableConfigInstruction,
 	parseInitializePermanentDelegateInstruction,
 	parseInitializeScaledUiAmountMintInstruction,
 	parseInitializeTokenGroupInstruction,
@@ -58,8 +59,10 @@ import {
 	parseInitializeTransferHookInstruction,
 	parseMintToCheckedInstruction,
 	parseMintToInstruction,
+	parsePauseInstruction,
 	parseReallocateInstruction,
 	parseRemoveTokenMetadataKeyInstruction,
+	parseResumeInstruction,
 	parseRevokeInstruction,
 	parseSetAuthorityInstruction,
 	parseSetTransferFeeInstruction,
@@ -96,432 +99,628 @@ export const parseSolToken2022Instruction = (
 	assertIsInstructionWithAccounts(instruction);
 
 	const decodedInstruction = identifyToken2022Instruction(instruction);
-	switch (decodedInstruction) {
-		case Token2022Instruction.InitializeMint:
-			return {
-				...parseInitializeMintInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeMint
-			};
-		case Token2022Instruction.InitializeAccount:
-			return {
-				...parseInitializeAccountInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeAccount
-			};
-		case Token2022Instruction.InitializeMultisig:
-			return {
-				...parseInitializeMultisigInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeMultisig
-			};
-		case Token2022Instruction.Transfer:
-			return {
-				...parseTransferInstruction(instruction),
-				instructionType: Token2022Instruction.Transfer
-			};
-		case Token2022Instruction.Approve:
-			return {
-				...parseApproveInstruction(instruction),
-				instructionType: Token2022Instruction.Approve
-			};
-		case Token2022Instruction.Revoke:
-			return {
-				...parseRevokeInstruction(instruction),
-				instructionType: Token2022Instruction.Revoke
-			};
-		case Token2022Instruction.SetAuthority:
-			return {
-				...parseSetAuthorityInstruction(instruction),
-				instructionType: Token2022Instruction.SetAuthority
-			};
-		case Token2022Instruction.MintTo:
-			return {
-				...parseMintToInstruction(instruction),
-				instructionType: Token2022Instruction.MintTo
-			};
-		case Token2022Instruction.Burn:
-			return {
-				...parseBurnInstruction(instruction),
-				instructionType: Token2022Instruction.Burn
-			};
-		case Token2022Instruction.CloseAccount:
-			return {
-				...parseCloseAccountInstruction(instruction),
-				instructionType: Token2022Instruction.CloseAccount
-			};
-		case Token2022Instruction.FreezeAccount:
-			return {
-				...parseFreezeAccountInstruction(instruction),
-				instructionType: Token2022Instruction.FreezeAccount
-			};
-		case Token2022Instruction.ThawAccount:
-			return {
-				...parseThawAccountInstruction(instruction),
-				instructionType: Token2022Instruction.ThawAccount
-			};
-		case Token2022Instruction.TransferChecked:
-			return {
-				...parseTransferCheckedInstruction(instruction),
-				instructionType: Token2022Instruction.TransferChecked
-			};
-		case Token2022Instruction.ApproveChecked:
-			return {
-				...parseApproveCheckedInstruction(instruction),
-				instructionType: Token2022Instruction.ApproveChecked
-			};
-		case Token2022Instruction.MintToChecked:
-			return {
-				...parseMintToCheckedInstruction(instruction),
-				instructionType: Token2022Instruction.MintToChecked
-			};
-		case Token2022Instruction.BurnChecked:
-			return {
-				...parseBurnCheckedInstruction(instruction),
-				instructionType: Token2022Instruction.BurnChecked
-			};
-		case Token2022Instruction.InitializeAccount2:
-			return {
-				...parseInitializeAccount2Instruction(instruction),
-				instructionType: Token2022Instruction.InitializeAccount2
-			};
-		case Token2022Instruction.SyncNative:
-			return {
-				...parseSyncNativeInstruction(instruction),
-				instructionType: Token2022Instruction.SyncNative
-			};
-		case Token2022Instruction.InitializeAccount3:
-			return {
-				...parseInitializeAccount3Instruction(instruction),
-				instructionType: Token2022Instruction.InitializeAccount3
-			};
-		case Token2022Instruction.InitializeMultisig2:
-			return {
-				...parseInitializeMultisig2Instruction(instruction),
-				instructionType: Token2022Instruction.InitializeMultisig2
-			};
-		case Token2022Instruction.InitializeMint2:
-			return {
-				...parseInitializeMint2Instruction(instruction),
-				instructionType: Token2022Instruction.InitializeMint2
-			};
-		case Token2022Instruction.GetAccountDataSize:
-			return {
-				...parseGetAccountDataSizeInstruction(instruction),
-				instructionType: Token2022Instruction.GetAccountDataSize
-			};
-		case Token2022Instruction.InitializeImmutableOwner:
-			return {
-				...parseInitializeImmutableOwnerInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeImmutableOwner
-			};
-		case Token2022Instruction.AmountToUiAmount:
-			return {
-				...parseAmountToUiAmountInstruction(instruction),
-				instructionType: Token2022Instruction.AmountToUiAmount
-			};
-		case Token2022Instruction.UiAmountToAmount:
-			return {
-				...parseUiAmountToAmountInstruction(instruction),
-				instructionType: Token2022Instruction.UiAmountToAmount
-			};
-		case Token2022Instruction.InitializeMintCloseAuthority:
-			return {
-				...parseInitializeMintCloseAuthorityInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeMintCloseAuthority
-			};
-		case Token2022Instruction.InitializeTransferFeeConfig:
-			return {
-				...parseInitializeTransferFeeConfigInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeTransferFeeConfig
-			};
-		case Token2022Instruction.TransferCheckedWithFee:
-			return {
-				...parseTransferCheckedWithFeeInstruction(instruction),
-				instructionType: Token2022Instruction.TransferCheckedWithFee
-			};
-		case Token2022Instruction.WithdrawWithheldTokensFromMint:
-			return {
-				...parseWithdrawWithheldTokensFromMintInstruction(instruction),
-				instructionType: Token2022Instruction.WithdrawWithheldTokensFromMint
-			};
-		case Token2022Instruction.WithdrawWithheldTokensFromAccounts:
-			return {
-				...parseWithdrawWithheldTokensFromAccountsInstruction(instruction),
-				instructionType: Token2022Instruction.WithdrawWithheldTokensFromAccounts
-			};
-		case Token2022Instruction.HarvestWithheldTokensToMint:
-			return {
-				...parseHarvestWithheldTokensToMintInstruction(instruction),
-				instructionType: Token2022Instruction.HarvestWithheldTokensToMint
-			};
-		case Token2022Instruction.SetTransferFee:
-			return {
-				...parseSetTransferFeeInstruction(instruction),
-				instructionType: Token2022Instruction.SetTransferFee
-			};
-		case Token2022Instruction.InitializeConfidentialTransferMint:
-			return {
-				...parseInitializeConfidentialTransferMintInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeConfidentialTransferMint
-			};
-		case Token2022Instruction.UpdateConfidentialTransferMint:
-			return {
-				...parseUpdateConfidentialTransferMintInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateConfidentialTransferMint
-			};
-		case Token2022Instruction.ConfigureConfidentialTransferAccount:
-			return {
-				...parseConfigureConfidentialTransferAccountInstruction(instruction),
-				instructionType: Token2022Instruction.ConfigureConfidentialTransferAccount
-			};
-		case Token2022Instruction.ApproveConfidentialTransferAccount:
-			return {
-				...parseApproveConfidentialTransferAccountInstruction(instruction),
-				instructionType: Token2022Instruction.ApproveConfidentialTransferAccount
-			};
-		case Token2022Instruction.EmptyConfidentialTransferAccount:
-			return {
-				...parseEmptyConfidentialTransferAccountInstruction(instruction),
-				instructionType: Token2022Instruction.EmptyConfidentialTransferAccount
-			};
-		case Token2022Instruction.ConfidentialDeposit:
-			return {
-				...parseConfidentialDepositInstruction(instruction),
-				instructionType: Token2022Instruction.ConfidentialDeposit
-			};
-		case Token2022Instruction.ConfidentialWithdraw:
-			return {
-				...parseConfidentialWithdrawInstruction(instruction),
-				instructionType: Token2022Instruction.ConfidentialWithdraw
-			};
-		case Token2022Instruction.ConfidentialTransfer:
-			return {
-				...parseConfidentialTransferInstruction(instruction),
-				instructionType: Token2022Instruction.ConfidentialTransfer
-			};
-		case Token2022Instruction.ApplyConfidentialPendingBalance:
-			return {
-				...parseApplyConfidentialPendingBalanceInstruction(instruction),
-				instructionType: Token2022Instruction.ApplyConfidentialPendingBalance
-			};
-		case Token2022Instruction.EnableConfidentialCredits:
-			return {
-				...parseEnableConfidentialCreditsInstruction(instruction),
-				instructionType: Token2022Instruction.EnableConfidentialCredits
-			};
-		case Token2022Instruction.DisableConfidentialCredits:
-			return {
-				...parseDisableConfidentialCreditsInstruction(instruction),
-				instructionType: Token2022Instruction.DisableConfidentialCredits
-			};
-		case Token2022Instruction.EnableNonConfidentialCredits:
-			return {
-				...parseEnableNonConfidentialCreditsInstruction(instruction),
-				instructionType: Token2022Instruction.EnableNonConfidentialCredits
-			};
-		case Token2022Instruction.DisableNonConfidentialCredits:
-			return {
-				...parseDisableNonConfidentialCreditsInstruction(instruction),
-				instructionType: Token2022Instruction.DisableNonConfidentialCredits
-			};
-		case Token2022Instruction.ConfidentialTransferWithFee:
-			return {
-				...parseConfidentialTransferWithFeeInstruction(instruction),
-				instructionType: Token2022Instruction.ConfidentialTransferWithFee
-			};
-		case Token2022Instruction.InitializeDefaultAccountState:
-			return {
-				...parseInitializeDefaultAccountStateInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeDefaultAccountState
-			};
-		case Token2022Instruction.UpdateDefaultAccountState:
-			return {
-				...parseUpdateDefaultAccountStateInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateDefaultAccountState
-			};
-		case Token2022Instruction.Reallocate:
-			return {
-				...parseReallocateInstruction(instruction),
-				instructionType: Token2022Instruction.Reallocate
-			};
-		case Token2022Instruction.EnableMemoTransfers:
-			return {
-				...parseEnableMemoTransfersInstruction(instruction),
-				instructionType: Token2022Instruction.EnableMemoTransfers
-			};
-		case Token2022Instruction.DisableMemoTransfers:
-			return {
-				...parseDisableMemoTransfersInstruction(instruction),
-				instructionType: Token2022Instruction.DisableMemoTransfers
-			};
-		case Token2022Instruction.CreateNativeMint:
-			return {
-				...parseCreateNativeMintInstruction(instruction),
-				instructionType: Token2022Instruction.CreateNativeMint
-			};
-		case Token2022Instruction.InitializeNonTransferableMint:
-			return {
-				...parseInitializeNonTransferableMintInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeNonTransferableMint
-			};
-		case Token2022Instruction.InitializeInterestBearingMint:
-			return {
-				...parseInitializeInterestBearingMintInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeInterestBearingMint
-			};
-		case Token2022Instruction.UpdateRateInterestBearingMint:
-			return {
-				...parseUpdateRateInterestBearingMintInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateRateInterestBearingMint
-			};
-		case Token2022Instruction.EnableCpiGuard:
-			return {
-				...parseEnableCpiGuardInstruction(instruction),
-				instructionType: Token2022Instruction.EnableCpiGuard
-			};
-		case Token2022Instruction.DisableCpiGuard:
-			return {
-				...parseDisableCpiGuardInstruction(instruction),
-				instructionType: Token2022Instruction.DisableCpiGuard
-			};
-		case Token2022Instruction.InitializePermanentDelegate:
-			return {
-				...parseInitializePermanentDelegateInstruction(instruction),
-				instructionType: Token2022Instruction.InitializePermanentDelegate
-			};
-		case Token2022Instruction.InitializeTransferHook:
-			return {
-				...parseInitializeTransferHookInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeTransferHook
-			};
-		case Token2022Instruction.UpdateTransferHook:
-			return {
-				...parseUpdateTransferHookInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateTransferHook
-			};
-		case Token2022Instruction.InitializeConfidentialTransferFee:
-			return {
-				...parseInitializeConfidentialTransferFeeInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeConfidentialTransferFee
-			};
-		case Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee:
-			return {
-				...parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction(instruction),
-				instructionType:
-					Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
-			};
-		case Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee:
-			return {
-				...parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction(
-					instruction
-				),
-				instructionType:
-					Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
-			};
-		case Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee:
-			return {
-				...parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction(instruction),
-				instructionType: Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
-			};
-		case Token2022Instruction.EnableHarvestToMint:
-			return {
-				...parseEnableHarvestToMintInstruction(instruction),
-				instructionType: Token2022Instruction.EnableHarvestToMint
-			};
-		case Token2022Instruction.DisableHarvestToMint:
-			return {
-				...parseDisableHarvestToMintInstruction(instruction),
-				instructionType: Token2022Instruction.DisableHarvestToMint
-			};
-		case Token2022Instruction.WithdrawExcessLamports:
-			return {
-				...parseWithdrawExcessLamportsInstruction(instruction),
-				instructionType: Token2022Instruction.WithdrawExcessLamports
-			};
-		case Token2022Instruction.InitializeMetadataPointer:
-			return {
-				...parseInitializeMetadataPointerInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeMetadataPointer
-			};
-		case Token2022Instruction.UpdateMetadataPointer:
-			return {
-				...parseUpdateMetadataPointerInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateMetadataPointer
-			};
-		case Token2022Instruction.InitializeGroupPointer:
-			return {
-				...parseInitializeGroupPointerInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeGroupPointer
-			};
-		case Token2022Instruction.UpdateGroupPointer:
-			return {
-				...parseUpdateGroupPointerInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateGroupPointer
-			};
-		case Token2022Instruction.InitializeGroupMemberPointer:
-			return {
-				...parseInitializeGroupMemberPointerInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeGroupMemberPointer
-			};
-		case Token2022Instruction.UpdateGroupMemberPointer:
-			return {
-				...parseUpdateGroupMemberPointerInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateGroupMemberPointer
-			};
-		case Token2022Instruction.InitializeScaledUiAmountMint:
-			return {
-				...parseInitializeScaledUiAmountMintInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeScaledUiAmountMint
-			};
-		case Token2022Instruction.UpdateMultiplierScaledUiMint:
-			return {
-				...parseUpdateMultiplierScaledUiMintInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateMultiplierScaledUiMint
-			};
-		case Token2022Instruction.InitializeTokenMetadata:
-			return {
-				...parseInitializeTokenMetadataInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeTokenMetadata
-			};
-		case Token2022Instruction.UpdateTokenMetadataField:
-			return {
-				...parseUpdateTokenMetadataFieldInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateTokenMetadataField
-			};
-		case Token2022Instruction.RemoveTokenMetadataKey:
-			return {
-				...parseRemoveTokenMetadataKeyInstruction(instruction),
-				instructionType: Token2022Instruction.RemoveTokenMetadataKey
-			};
-		case Token2022Instruction.UpdateTokenMetadataUpdateAuthority:
-			return {
-				...parseUpdateTokenMetadataUpdateAuthorityInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateTokenMetadataUpdateAuthority
-			};
-		case Token2022Instruction.EmitTokenMetadata:
-			return {
-				...parseEmitTokenMetadataInstruction(instruction),
-				instructionType: Token2022Instruction.EmitTokenMetadata
-			};
-		case Token2022Instruction.InitializeTokenGroup:
-			return {
-				...parseInitializeTokenGroupInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeTokenGroup
-			};
-		case Token2022Instruction.UpdateTokenGroupMaxSize:
-			return {
-				...parseUpdateTokenGroupMaxSizeInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateTokenGroupMaxSize
-			};
-		case Token2022Instruction.UpdateTokenGroupUpdateAuthority:
-			return {
-				...parseUpdateTokenGroupUpdateAuthorityInstruction(instruction),
-				instructionType: Token2022Instruction.UpdateTokenGroupUpdateAuthority
-			};
-		case Token2022Instruction.InitializeTokenGroupMember:
-			return {
-				...parseInitializeTokenGroupMemberInstruction(instruction),
-				instructionType: Token2022Instruction.InitializeTokenGroupMember
-			};
-		default:
-			return instruction;
+
+	if (decodedInstruction === Token2022Instruction.InitializeMint) {
+		return {
+			...parseInitializeMintInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeMint
+		};
 	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeAccount) {
+		return {
+			...parseInitializeAccountInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeMultisig) {
+		return {
+			...parseInitializeMultisigInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeMultisig
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Transfer) {
+		return {
+			...parseTransferInstruction(instruction),
+			instructionType: Token2022Instruction.Transfer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Approve) {
+		return {
+			...parseApproveInstruction(instruction),
+			instructionType: Token2022Instruction.Approve
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Revoke) {
+		return {
+			...parseRevokeInstruction(instruction),
+			instructionType: Token2022Instruction.Revoke
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.SetAuthority) {
+		return {
+			...parseSetAuthorityInstruction(instruction),
+			instructionType: Token2022Instruction.SetAuthority
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.MintTo) {
+		return {
+			...parseMintToInstruction(instruction),
+			instructionType: Token2022Instruction.MintTo
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Burn) {
+		return {
+			...parseBurnInstruction(instruction),
+			instructionType: Token2022Instruction.Burn
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.CloseAccount) {
+		return {
+			...parseCloseAccountInstruction(instruction),
+			instructionType: Token2022Instruction.CloseAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.FreezeAccount) {
+		return {
+			...parseFreezeAccountInstruction(instruction),
+			instructionType: Token2022Instruction.FreezeAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ThawAccount) {
+		return {
+			...parseThawAccountInstruction(instruction),
+			instructionType: Token2022Instruction.ThawAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.TransferChecked) {
+		return {
+			...parseTransferCheckedInstruction(instruction),
+			instructionType: Token2022Instruction.TransferChecked
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ApproveChecked) {
+		return {
+			...parseApproveCheckedInstruction(instruction),
+			instructionType: Token2022Instruction.ApproveChecked
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.MintToChecked) {
+		return {
+			...parseMintToCheckedInstruction(instruction),
+			instructionType: Token2022Instruction.MintToChecked
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.BurnChecked) {
+		return {
+			...parseBurnCheckedInstruction(instruction),
+			instructionType: Token2022Instruction.BurnChecked
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeAccount2) {
+		return {
+			...parseInitializeAccount2Instruction(instruction),
+			instructionType: Token2022Instruction.InitializeAccount2
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.SyncNative) {
+		return {
+			...parseSyncNativeInstruction(instruction),
+			instructionType: Token2022Instruction.SyncNative
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeAccount3) {
+		return {
+			...parseInitializeAccount3Instruction(instruction),
+			instructionType: Token2022Instruction.InitializeAccount3
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeMultisig2) {
+		return {
+			...parseInitializeMultisig2Instruction(instruction),
+			instructionType: Token2022Instruction.InitializeMultisig2
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeMint2) {
+		return {
+			...parseInitializeMint2Instruction(instruction),
+			instructionType: Token2022Instruction.InitializeMint2
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.GetAccountDataSize) {
+		return {
+			...parseGetAccountDataSizeInstruction(instruction),
+			instructionType: Token2022Instruction.GetAccountDataSize
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeImmutableOwner) {
+		return {
+			...parseInitializeImmutableOwnerInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeImmutableOwner
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.AmountToUiAmount) {
+		return {
+			...parseAmountToUiAmountInstruction(instruction),
+			instructionType: Token2022Instruction.AmountToUiAmount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UiAmountToAmount) {
+		return {
+			...parseUiAmountToAmountInstruction(instruction),
+			instructionType: Token2022Instruction.UiAmountToAmount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeMintCloseAuthority) {
+		return {
+			...parseInitializeMintCloseAuthorityInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeMintCloseAuthority
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeTransferFeeConfig) {
+		return {
+			...parseInitializeTransferFeeConfigInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeTransferFeeConfig
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.TransferCheckedWithFee) {
+		return {
+			...parseTransferCheckedWithFeeInstruction(instruction),
+			instructionType: Token2022Instruction.TransferCheckedWithFee
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.WithdrawWithheldTokensFromMint) {
+		return {
+			...parseWithdrawWithheldTokensFromMintInstruction(instruction),
+			instructionType: Token2022Instruction.WithdrawWithheldTokensFromMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.WithdrawWithheldTokensFromAccounts) {
+		return {
+			...parseWithdrawWithheldTokensFromAccountsInstruction(instruction),
+			instructionType: Token2022Instruction.WithdrawWithheldTokensFromAccounts
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.HarvestWithheldTokensToMint) {
+		return {
+			...parseHarvestWithheldTokensToMintInstruction(instruction),
+			instructionType: Token2022Instruction.HarvestWithheldTokensToMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.SetTransferFee) {
+		return {
+			...parseSetTransferFeeInstruction(instruction),
+			instructionType: Token2022Instruction.SetTransferFee
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeConfidentialTransferMint) {
+		return {
+			...parseInitializeConfidentialTransferMintInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeConfidentialTransferMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateConfidentialTransferMint) {
+		return {
+			...parseUpdateConfidentialTransferMintInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateConfidentialTransferMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ConfigureConfidentialTransferAccount) {
+		return {
+			...parseConfigureConfidentialTransferAccountInstruction(instruction),
+			instructionType: Token2022Instruction.ConfigureConfidentialTransferAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ApproveConfidentialTransferAccount) {
+		return {
+			...parseApproveConfidentialTransferAccountInstruction(instruction),
+			instructionType: Token2022Instruction.ApproveConfidentialTransferAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EmptyConfidentialTransferAccount) {
+		return {
+			...parseEmptyConfidentialTransferAccountInstruction(instruction),
+			instructionType: Token2022Instruction.EmptyConfidentialTransferAccount
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ConfidentialDeposit) {
+		return {
+			...parseConfidentialDepositInstruction(instruction),
+			instructionType: Token2022Instruction.ConfidentialDeposit
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ConfidentialWithdraw) {
+		return {
+			...parseConfidentialWithdrawInstruction(instruction),
+			instructionType: Token2022Instruction.ConfidentialWithdraw
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ConfidentialTransfer) {
+		return {
+			...parseConfidentialTransferInstruction(instruction),
+			instructionType: Token2022Instruction.ConfidentialTransfer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ApplyConfidentialPendingBalance) {
+		return {
+			...parseApplyConfidentialPendingBalanceInstruction(instruction),
+			instructionType: Token2022Instruction.ApplyConfidentialPendingBalance
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EnableConfidentialCredits) {
+		return {
+			...parseEnableConfidentialCreditsInstruction(instruction),
+			instructionType: Token2022Instruction.EnableConfidentialCredits
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.DisableConfidentialCredits) {
+		return {
+			...parseDisableConfidentialCreditsInstruction(instruction),
+			instructionType: Token2022Instruction.DisableConfidentialCredits
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EnableNonConfidentialCredits) {
+		return {
+			...parseEnableNonConfidentialCreditsInstruction(instruction),
+			instructionType: Token2022Instruction.EnableNonConfidentialCredits
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.DisableNonConfidentialCredits) {
+		return {
+			...parseDisableNonConfidentialCreditsInstruction(instruction),
+			instructionType: Token2022Instruction.DisableNonConfidentialCredits
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.ConfidentialTransferWithFee) {
+		return {
+			...parseConfidentialTransferWithFeeInstruction(instruction),
+			instructionType: Token2022Instruction.ConfidentialTransferWithFee
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeDefaultAccountState) {
+		return {
+			...parseInitializeDefaultAccountStateInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeDefaultAccountState
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateDefaultAccountState) {
+		return {
+			...parseUpdateDefaultAccountStateInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateDefaultAccountState
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Reallocate) {
+		return {
+			...parseReallocateInstruction(instruction),
+			instructionType: Token2022Instruction.Reallocate
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EnableMemoTransfers) {
+		return {
+			...parseEnableMemoTransfersInstruction(instruction),
+			instructionType: Token2022Instruction.EnableMemoTransfers
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.DisableMemoTransfers) {
+		return {
+			...parseDisableMemoTransfersInstruction(instruction),
+			instructionType: Token2022Instruction.DisableMemoTransfers
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.CreateNativeMint) {
+		return {
+			...parseCreateNativeMintInstruction(instruction),
+			instructionType: Token2022Instruction.CreateNativeMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeNonTransferableMint) {
+		return {
+			...parseInitializeNonTransferableMintInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeNonTransferableMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeInterestBearingMint) {
+		return {
+			...parseInitializeInterestBearingMintInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeInterestBearingMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateRateInterestBearingMint) {
+		return {
+			...parseUpdateRateInterestBearingMintInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateRateInterestBearingMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EnableCpiGuard) {
+		return {
+			...parseEnableCpiGuardInstruction(instruction),
+			instructionType: Token2022Instruction.EnableCpiGuard
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.DisableCpiGuard) {
+		return {
+			...parseDisableCpiGuardInstruction(instruction),
+			instructionType: Token2022Instruction.DisableCpiGuard
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializePermanentDelegate) {
+		return {
+			...parseInitializePermanentDelegateInstruction(instruction),
+			instructionType: Token2022Instruction.InitializePermanentDelegate
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeTransferHook) {
+		return {
+			...parseInitializeTransferHookInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeTransferHook
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateTransferHook) {
+		return {
+			...parseUpdateTransferHookInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateTransferHook
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeConfidentialTransferFee) {
+		return {
+			...parseInitializeConfidentialTransferFeeInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeConfidentialTransferFee
+		};
+	}
+
+	if (
+		decodedInstruction ===
+		Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
+	) {
+		return {
+			...parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction(instruction),
+			instructionType: Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
+		};
+	}
+
+	if (
+		decodedInstruction ===
+		Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
+	) {
+		return {
+			...parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction(instruction),
+			instructionType:
+				Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
+		};
+	}
+
+	if (
+		decodedInstruction ===
+		Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
+	) {
+		return {
+			...parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction(instruction),
+			instructionType: Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EnableHarvestToMint) {
+		return {
+			...parseEnableHarvestToMintInstruction(instruction),
+			instructionType: Token2022Instruction.EnableHarvestToMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.DisableHarvestToMint) {
+		return {
+			...parseDisableHarvestToMintInstruction(instruction),
+			instructionType: Token2022Instruction.DisableHarvestToMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.WithdrawExcessLamports) {
+		return {
+			...parseWithdrawExcessLamportsInstruction(instruction),
+			instructionType: Token2022Instruction.WithdrawExcessLamports
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeMetadataPointer) {
+		return {
+			...parseInitializeMetadataPointerInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeMetadataPointer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateMetadataPointer) {
+		return {
+			...parseUpdateMetadataPointerInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateMetadataPointer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeGroupPointer) {
+		return {
+			...parseInitializeGroupPointerInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeGroupPointer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateGroupPointer) {
+		return {
+			...parseUpdateGroupPointerInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateGroupPointer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeGroupMemberPointer) {
+		return {
+			...parseInitializeGroupMemberPointerInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeGroupMemberPointer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateGroupMemberPointer) {
+		return {
+			...parseUpdateGroupMemberPointerInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateGroupMemberPointer
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeScaledUiAmountMint) {
+		return {
+			...parseInitializeScaledUiAmountMintInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeScaledUiAmountMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateMultiplierScaledUiMint) {
+		return {
+			...parseUpdateMultiplierScaledUiMintInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateMultiplierScaledUiMint
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializePausableConfig) {
+		return {
+			...parseInitializePausableConfigInstruction(instruction),
+			instructionType: Token2022Instruction.InitializePausableConfig
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Pause) {
+		return {
+			...parsePauseInstruction(instruction),
+			instructionType: Token2022Instruction.Pause
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.Resume) {
+		return {
+			...parseResumeInstruction(instruction),
+			instructionType: Token2022Instruction.Resume
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeTokenMetadata) {
+		return {
+			...parseInitializeTokenMetadataInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeTokenMetadata
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateTokenMetadataField) {
+		return {
+			...parseUpdateTokenMetadataFieldInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateTokenMetadataField
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.RemoveTokenMetadataKey) {
+		return {
+			...parseRemoveTokenMetadataKeyInstruction(instruction),
+			instructionType: Token2022Instruction.RemoveTokenMetadataKey
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateTokenMetadataUpdateAuthority) {
+		return {
+			...parseUpdateTokenMetadataUpdateAuthorityInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateTokenMetadataUpdateAuthority
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.EmitTokenMetadata) {
+		return {
+			...parseEmitTokenMetadataInstruction(instruction),
+			instructionType: Token2022Instruction.EmitTokenMetadata
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeTokenGroup) {
+		return {
+			...parseInitializeTokenGroupInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeTokenGroup
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateTokenGroupMaxSize) {
+		return {
+			...parseUpdateTokenGroupMaxSizeInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateTokenGroupMaxSize
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.UpdateTokenGroupUpdateAuthority) {
+		return {
+			...parseUpdateTokenGroupUpdateAuthorityInstruction(instruction),
+			instructionType: Token2022Instruction.UpdateTokenGroupUpdateAuthority
+		};
+	}
+
+	if (decodedInstruction === Token2022Instruction.InitializeTokenGroupMember) {
+		return {
+			...parseInitializeTokenGroupMemberInstruction(instruction),
+			instructionType: Token2022Instruction.InitializeTokenGroupMember
+		};
+	}
+
+	// Force compiler error on unhandled cases based on leftover types
+	const _: never = decodedInstruction;
+
+	return instruction;
 };

--- a/src/frontend/src/tests/sol/utils/sol-instructions-token-2022.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-token-2022.utils.spec.ts
@@ -1,0 +1,1412 @@
+import type { SolInstruction } from '$sol/types/sol-instructions';
+import { parseSolToken2022Instruction } from '$sol/utils/sol-instructions-token-2022.utils';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+import {
+	Token2022Instruction,
+	identifyToken2022Instruction,
+	parseAmountToUiAmountInstruction,
+	parseApplyConfidentialPendingBalanceInstruction,
+	parseApproveCheckedInstruction,
+	parseApproveConfidentialTransferAccountInstruction,
+	parseApproveInstruction,
+	parseBurnCheckedInstruction,
+	parseBurnInstruction,
+	parseCloseAccountInstruction,
+	parseConfidentialDepositInstruction,
+	parseConfidentialTransferInstruction,
+	parseConfidentialTransferWithFeeInstruction,
+	parseConfidentialWithdrawInstruction,
+	parseConfigureConfidentialTransferAccountInstruction,
+	parseCreateNativeMintInstruction,
+	parseDisableConfidentialCreditsInstruction,
+	parseDisableCpiGuardInstruction,
+	parseDisableHarvestToMintInstruction,
+	parseDisableMemoTransfersInstruction,
+	parseDisableNonConfidentialCreditsInstruction,
+	parseEmitTokenMetadataInstruction,
+	parseEmptyConfidentialTransferAccountInstruction,
+	parseEnableConfidentialCreditsInstruction,
+	parseEnableCpiGuardInstruction,
+	parseEnableHarvestToMintInstruction,
+	parseEnableMemoTransfersInstruction,
+	parseEnableNonConfidentialCreditsInstruction,
+	parseFreezeAccountInstruction,
+	parseGetAccountDataSizeInstruction,
+	parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction,
+	parseHarvestWithheldTokensToMintInstruction,
+	parseInitializeAccount2Instruction,
+	parseInitializeAccount3Instruction,
+	parseInitializeAccountInstruction,
+	parseInitializeConfidentialTransferFeeInstruction,
+	parseInitializeConfidentialTransferMintInstruction,
+	parseInitializeDefaultAccountStateInstruction,
+	parseInitializeGroupMemberPointerInstruction,
+	parseInitializeGroupPointerInstruction,
+	parseInitializeImmutableOwnerInstruction,
+	parseInitializeInterestBearingMintInstruction,
+	parseInitializeMetadataPointerInstruction,
+	parseInitializeMint2Instruction,
+	parseInitializeMintCloseAuthorityInstruction,
+	parseInitializeMintInstruction,
+	parseInitializeMultisig2Instruction,
+	parseInitializeMultisigInstruction,
+	parseInitializeNonTransferableMintInstruction,
+	parseInitializePausableConfigInstruction,
+	parseInitializePermanentDelegateInstruction,
+	parseInitializeScaledUiAmountMintInstruction,
+	parseInitializeTokenGroupInstruction,
+	parseInitializeTokenGroupMemberInstruction,
+	parseInitializeTokenMetadataInstruction,
+	parseInitializeTransferFeeConfigInstruction,
+	parseInitializeTransferHookInstruction,
+	parseMintToCheckedInstruction,
+	parseMintToInstruction,
+	parsePauseInstruction,
+	parseReallocateInstruction,
+	parseRemoveTokenMetadataKeyInstruction,
+	parseResumeInstruction,
+	parseRevokeInstruction,
+	parseSetAuthorityInstruction,
+	parseSetTransferFeeInstruction,
+	parseSyncNativeInstruction,
+	parseThawAccountInstruction,
+	parseTransferCheckedInstruction,
+	parseTransferCheckedWithFeeInstruction,
+	parseTransferInstruction,
+	parseUiAmountToAmountInstruction,
+	parseUpdateConfidentialTransferMintInstruction,
+	parseUpdateDefaultAccountStateInstruction,
+	parseUpdateGroupMemberPointerInstruction,
+	parseUpdateGroupPointerInstruction,
+	parseUpdateMetadataPointerInstruction,
+	parseUpdateMultiplierScaledUiMintInstruction,
+	parseUpdateRateInterestBearingMintInstruction,
+	parseUpdateTokenGroupMaxSizeInstruction,
+	parseUpdateTokenGroupUpdateAuthorityInstruction,
+	parseUpdateTokenMetadataFieldInstruction,
+	parseUpdateTokenMetadataUpdateAuthorityInstruction,
+	parseUpdateTransferHookInstruction,
+	parseWithdrawExcessLamportsInstruction,
+	parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction,
+	parseWithdrawWithheldTokensFromAccountsInstruction,
+	parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction,
+	parseWithdrawWithheldTokensFromMintInstruction
+} from '@solana-program/token-2022';
+import { address } from '@solana/kit';
+
+vi.mock(import('@solana-program/token-2022'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		identifyToken2022Instruction: vi.fn(),
+		parseAmountToUiAmountInstruction: vi.fn(),
+		parseApplyConfidentialPendingBalanceInstruction: vi.fn(),
+		parseApproveCheckedInstruction: vi.fn(),
+		parseApproveConfidentialTransferAccountInstruction: vi.fn(),
+		parseApproveInstruction: vi.fn(),
+		parseBurnCheckedInstruction: vi.fn(),
+		parseBurnInstruction: vi.fn(),
+		parseCloseAccountInstruction: vi.fn(),
+		parseConfidentialDepositInstruction: vi.fn(),
+		parseConfidentialTransferInstruction: vi.fn(),
+		parseConfidentialTransferWithFeeInstruction: vi.fn(),
+		parseConfidentialWithdrawInstruction: vi.fn(),
+		parseConfigureConfidentialTransferAccountInstruction: vi.fn(),
+		parseCreateNativeMintInstruction: vi.fn(),
+		parseDisableConfidentialCreditsInstruction: vi.fn(),
+		parseDisableCpiGuardInstruction: vi.fn(),
+		parseDisableHarvestToMintInstruction: vi.fn(),
+		parseDisableMemoTransfersInstruction: vi.fn(),
+		parseDisableNonConfidentialCreditsInstruction: vi.fn(),
+		parseEmitTokenMetadataInstruction: vi.fn(),
+		parseEmptyConfidentialTransferAccountInstruction: vi.fn(),
+		parseEnableConfidentialCreditsInstruction: vi.fn(),
+		parseEnableCpiGuardInstruction: vi.fn(),
+		parseEnableHarvestToMintInstruction: vi.fn(),
+		parseEnableMemoTransfersInstruction: vi.fn(),
+		parseEnableNonConfidentialCreditsInstruction: vi.fn(),
+		parseFreezeAccountInstruction: vi.fn(),
+		parseGetAccountDataSizeInstruction: vi.fn(),
+		parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction: vi.fn(),
+		parseHarvestWithheldTokensToMintInstruction: vi.fn(),
+		parseInitializeAccount2Instruction: vi.fn(),
+		parseInitializeAccount3Instruction: vi.fn(),
+		parseInitializeAccountInstruction: vi.fn(),
+		parseInitializeConfidentialTransferFeeInstruction: vi.fn(),
+		parseInitializeConfidentialTransferMintInstruction: vi.fn(),
+		parseInitializeDefaultAccountStateInstruction: vi.fn(),
+		parseInitializeGroupMemberPointerInstruction: vi.fn(),
+		parseInitializeGroupPointerInstruction: vi.fn(),
+		parseInitializeImmutableOwnerInstruction: vi.fn(),
+		parseInitializeInterestBearingMintInstruction: vi.fn(),
+		parseInitializeMetadataPointerInstruction: vi.fn(),
+		parseInitializeMint2Instruction: vi.fn(),
+		parseInitializeMintCloseAuthorityInstruction: vi.fn(),
+		parseInitializeMintInstruction: vi.fn(),
+		parseInitializeMultisig2Instruction: vi.fn(),
+		parseInitializeMultisigInstruction: vi.fn(),
+		parseInitializeNonTransferableMintInstruction: vi.fn(),
+		parseInitializePausableConfigInstruction: vi.fn(),
+		parseInitializePermanentDelegateInstruction: vi.fn(),
+		parseInitializeScaledUiAmountMintInstruction: vi.fn(),
+		parseInitializeTokenGroupInstruction: vi.fn(),
+		parseInitializeTokenGroupMemberInstruction: vi.fn(),
+		parseInitializeTokenMetadataInstruction: vi.fn(),
+		parseInitializeTransferFeeConfigInstruction: vi.fn(),
+		parseInitializeTransferHookInstruction: vi.fn(),
+		parseMintToCheckedInstruction: vi.fn(),
+		parseMintToInstruction: vi.fn(),
+		parsePauseInstruction: vi.fn(),
+		parseReallocateInstruction: vi.fn(),
+		parseRemoveTokenMetadataKeyInstruction: vi.fn(),
+		parseResumeInstruction: vi.fn(),
+		parseRevokeInstruction: vi.fn(),
+		parseSetAuthorityInstruction: vi.fn(),
+		parseSetTransferFeeInstruction: vi.fn(),
+		parseSyncNativeInstruction: vi.fn(),
+		parseThawAccountInstruction: vi.fn(),
+		parseTransferCheckedInstruction: vi.fn(),
+		parseTransferCheckedWithFeeInstruction: vi.fn(),
+		parseTransferInstruction: vi.fn(),
+		parseUiAmountToAmountInstruction: vi.fn(),
+		parseUpdateConfidentialTransferMintInstruction: vi.fn(),
+		parseUpdateDefaultAccountStateInstruction: vi.fn(),
+		parseUpdateGroupMemberPointerInstruction: vi.fn(),
+		parseUpdateGroupPointerInstruction: vi.fn(),
+		parseUpdateMetadataPointerInstruction: vi.fn(),
+		parseUpdateMultiplierScaledUiMintInstruction: vi.fn(),
+		parseUpdateRateInterestBearingMintInstruction: vi.fn(),
+		parseUpdateTokenGroupMaxSizeInstruction: vi.fn(),
+		parseUpdateTokenGroupUpdateAuthorityInstruction: vi.fn(),
+		parseUpdateTokenMetadataFieldInstruction: vi.fn(),
+		parseUpdateTokenMetadataUpdateAuthorityInstruction: vi.fn(),
+		parseUpdateTransferHookInstruction: vi.fn(),
+		parseWithdrawExcessLamportsInstruction: vi.fn(),
+		parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction: vi.fn(),
+		parseWithdrawWithheldTokensFromAccountsInstruction: vi.fn(),
+		parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction: vi.fn(),
+		parseWithdrawWithheldTokensFromMintInstruction: vi.fn()
+	};
+});
+
+describe('sol-instructions-token-2022.utils', () => {
+	describe('parseSolToken2022Instruction', () => {
+		const mockInstruction: SolInstruction = {
+			accounts: [{ address: address(mockSolAddress), role: 3 }],
+			data: new Uint8Array([1, 2, 3]),
+			programAddress: address(mockSolAddress)
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should raise an error if the instruction is missing the data', () => {
+			const { data: _, ...withoutData } = mockInstruction;
+
+			expect(() => parseSolToken2022Instruction(withoutData)).toThrow(
+				'The instruction does not have any data'
+			);
+		});
+
+		it('should raise an error if the instruction is missing the accounts', () => {
+			const { accounts: _, ...withoutAccounts } = mockInstruction;
+
+			expect(() =>
+				parseSolToken2022Instruction(withoutAccounts as unknown as SolInstruction)
+			).toThrow('The instruction does not have any accounts');
+		});
+
+		it('should parse an InitializeMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.InitializeMint);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeMint
+			});
+
+			expect(parseInitializeMintInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeAccount
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeAccount
+			});
+
+			expect(parseInitializeAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMultisig instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeMultisig
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeMultisig
+			});
+
+			expect(parseInitializeMultisigInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Transfer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Transfer);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Transfer
+			});
+
+			expect(parseTransferInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an Approve instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Approve);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Approve
+			});
+
+			expect(parseApproveInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Revoke instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Revoke);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Revoke
+			});
+
+			expect(parseRevokeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a SetAuthority instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.SetAuthority);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.SetAuthority
+			});
+
+			expect(parseSetAuthorityInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a MintTo instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.MintTo);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.MintTo
+			});
+
+			expect(parseMintToInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Burn instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Burn);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Burn
+			});
+
+			expect(parseBurnInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a CloseAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.CloseAccount);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.CloseAccount
+			});
+
+			expect(parseCloseAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a FreezeAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.FreezeAccount);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.FreezeAccount
+			});
+
+			expect(parseFreezeAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a ThawAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.ThawAccount);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ThawAccount
+			});
+
+			expect(parseThawAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a TransferChecked instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.TransferChecked);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.TransferChecked
+			});
+
+			expect(parseTransferCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an ApproveChecked instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.ApproveChecked);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ApproveChecked
+			});
+
+			expect(parseApproveCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a MintToChecked instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.MintToChecked);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.MintToChecked
+			});
+
+			expect(parseMintToCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a BurnChecked instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.BurnChecked);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.BurnChecked
+			});
+
+			expect(parseBurnCheckedInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeAccount2 instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeAccount2
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeAccount2
+			});
+
+			expect(parseInitializeAccount2Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a SyncNative instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.SyncNative);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.SyncNative
+			});
+
+			expect(parseSyncNativeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeAccount3 instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeAccount3
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeAccount3
+			});
+
+			expect(parseInitializeAccount3Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMultisig2 instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeMultisig2
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeMultisig2
+			});
+
+			expect(parseInitializeMultisig2Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMint2 instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.InitializeMint2);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeMint2
+			});
+
+			expect(parseInitializeMint2Instruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a GetAccountDataSize instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.GetAccountDataSize
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.GetAccountDataSize
+			});
+
+			expect(parseGetAccountDataSizeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeImmutableOwner instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeImmutableOwner
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeImmutableOwner
+			});
+
+			expect(parseInitializeImmutableOwnerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an AmountToUiAmount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.AmountToUiAmount
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.AmountToUiAmount
+			});
+
+			expect(parseAmountToUiAmountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a UiAmountToAmount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UiAmountToAmount
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UiAmountToAmount
+			});
+
+			expect(parseUiAmountToAmountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeMintCloseAuthority instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeMintCloseAuthority
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeMintCloseAuthority
+			});
+
+			expect(parseInitializeMintCloseAuthorityInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeTransferFeeConfig instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeTransferFeeConfig
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeTransferFeeConfig
+			});
+
+			expect(parseInitializeTransferFeeConfigInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a TransferCheckedWithFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.TransferCheckedWithFee
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.TransferCheckedWithFee
+			});
+
+			expect(parseTransferCheckedWithFeeInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a WithdrawWithheldTokensFromMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.WithdrawWithheldTokensFromMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.WithdrawWithheldTokensFromMint
+			});
+
+			expect(parseWithdrawWithheldTokensFromMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a WithdrawWithheldTokensFromAccounts instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.WithdrawWithheldTokensFromAccounts
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.WithdrawWithheldTokensFromAccounts
+			});
+
+			expect(parseWithdrawWithheldTokensFromAccountsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a HarvestWithheldTokensToMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.HarvestWithheldTokensToMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.HarvestWithheldTokensToMint
+			});
+
+			expect(parseHarvestWithheldTokensToMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a SetTransferFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.SetTransferFee);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.SetTransferFee
+			});
+
+			expect(parseSetTransferFeeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeConfidentialTransferMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeConfidentialTransferMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeConfidentialTransferMint
+			});
+
+			expect(parseInitializeConfidentialTransferMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateConfidentialTransferMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateConfidentialTransferMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateConfidentialTransferMint
+			});
+
+			expect(parseUpdateConfidentialTransferMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a ConfigureConfidentialTransferAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ConfigureConfidentialTransferAccount
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ConfigureConfidentialTransferAccount
+			});
+
+			expect(parseConfigureConfidentialTransferAccountInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an ApproveConfidentialTransferAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ApproveConfidentialTransferAccount
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ApproveConfidentialTransferAccount
+			});
+
+			expect(parseApproveConfidentialTransferAccountInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an EmptyConfidentialTransferAccount instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.EmptyConfidentialTransferAccount
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EmptyConfidentialTransferAccount
+			});
+
+			expect(parseEmptyConfidentialTransferAccountInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a ConfidentialDeposit instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ConfidentialDeposit
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ConfidentialDeposit
+			});
+
+			expect(parseConfidentialDepositInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a ConfidentialWithdraw instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ConfidentialWithdraw
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ConfidentialWithdraw
+			});
+
+			expect(parseConfidentialWithdrawInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a ConfidentialTransfer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ConfidentialTransfer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ConfidentialTransfer
+			});
+
+			expect(parseConfidentialTransferInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an ApplyConfidentialPendingBalance instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ApplyConfidentialPendingBalance
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ApplyConfidentialPendingBalance
+			});
+
+			expect(parseApplyConfidentialPendingBalanceInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an EnableConfidentialCredits instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.EnableConfidentialCredits
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EnableConfidentialCredits
+			});
+
+			expect(parseEnableConfidentialCreditsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a DisableConfidentialCredits instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.DisableConfidentialCredits
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.DisableConfidentialCredits
+			});
+
+			expect(parseDisableConfidentialCreditsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an EnableNonConfidentialCredits instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.EnableNonConfidentialCredits
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EnableNonConfidentialCredits
+			});
+
+			expect(parseEnableNonConfidentialCreditsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a DisableNonConfidentialCredits instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.DisableNonConfidentialCredits
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.DisableNonConfidentialCredits
+			});
+
+			expect(parseDisableNonConfidentialCreditsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a ConfidentialTransferWithFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.ConfidentialTransferWithFee
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.ConfidentialTransferWithFee
+			});
+
+			expect(parseConfidentialTransferWithFeeInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeDefaultAccountState instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeDefaultAccountState
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeDefaultAccountState
+			});
+
+			expect(parseInitializeDefaultAccountStateInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateDefaultAccountState instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateDefaultAccountState
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateDefaultAccountState
+			});
+
+			expect(parseUpdateDefaultAccountStateInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a Reallocate instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Reallocate);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Reallocate
+			});
+
+			expect(parseReallocateInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an EnableMemoTransfers instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.EnableMemoTransfers
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EnableMemoTransfers
+			});
+
+			expect(parseEnableMemoTransfersInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a DisableMemoTransfers instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.DisableMemoTransfers
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.DisableMemoTransfers
+			});
+
+			expect(parseDisableMemoTransfersInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a CreateNativeMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.CreateNativeMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.CreateNativeMint
+			});
+
+			expect(parseCreateNativeMintInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeNonTransferableMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeNonTransferableMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeNonTransferableMint
+			});
+
+			expect(parseInitializeNonTransferableMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeInterestBearingMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeInterestBearingMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeInterestBearingMint
+			});
+
+			expect(parseInitializeInterestBearingMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateRateInterestBearingMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateRateInterestBearingMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateRateInterestBearingMint
+			});
+
+			expect(parseUpdateRateInterestBearingMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an EnableCpiGuard instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.EnableCpiGuard);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EnableCpiGuard
+			});
+
+			expect(parseEnableCpiGuardInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a DisableCpiGuard instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.DisableCpiGuard);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.DisableCpiGuard
+			});
+
+			expect(parseDisableCpiGuardInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializePermanentDelegate instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializePermanentDelegate
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializePermanentDelegate
+			});
+
+			expect(parseInitializePermanentDelegateInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeTransferHook instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeTransferHook
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeTransferHook
+			});
+
+			expect(parseInitializeTransferHookInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateTransferHook instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateTransferHook
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateTransferHook
+			});
+
+			expect(parseUpdateTransferHookInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeConfidentialTransferFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeConfidentialTransferFee
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeConfidentialTransferFee
+			});
+
+			expect(parseInitializeConfidentialTransferFeeInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a WithdrawWithheldTokensFromMintForConfidentialTransferFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType:
+					Token2022Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee
+			});
+
+			expect(
+				parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction
+			).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a WithdrawWithheldTokensFromAccountsForConfidentialTransferFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType:
+					Token2022Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee
+			});
+
+			expect(
+				parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction
+			).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a HarvestWithheldTokensToMintForConfidentialTransferFee instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee
+			});
+
+			expect(
+				parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction
+			).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an EnableHarvestToMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.EnableHarvestToMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EnableHarvestToMint
+			});
+
+			expect(parseEnableHarvestToMintInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a DisableHarvestToMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.DisableHarvestToMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.DisableHarvestToMint
+			});
+
+			expect(parseDisableHarvestToMintInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a WithdrawExcessLamports instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.WithdrawExcessLamports
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.WithdrawExcessLamports
+			});
+
+			expect(parseWithdrawExcessLamportsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeMetadataPointer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeMetadataPointer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeMetadataPointer
+			});
+
+			expect(parseInitializeMetadataPointerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateMetadataPointer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateMetadataPointer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateMetadataPointer
+			});
+
+			expect(parseUpdateMetadataPointerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeGroupPointer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeGroupPointer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeGroupPointer
+			});
+
+			expect(parseInitializeGroupPointerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateGroupPointer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateGroupPointer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateGroupPointer
+			});
+
+			expect(parseUpdateGroupPointerInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeGroupMemberPointer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeGroupMemberPointer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeGroupMemberPointer
+			});
+
+			expect(parseInitializeGroupMemberPointerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateGroupMemberPointer instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateGroupMemberPointer
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateGroupMemberPointer
+			});
+
+			expect(parseUpdateGroupMemberPointerInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeScaledUiAmountMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeScaledUiAmountMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeScaledUiAmountMint
+			});
+
+			expect(parseInitializeScaledUiAmountMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateMultiplierScaledUiMint instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateMultiplierScaledUiMint
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateMultiplierScaledUiMint
+			});
+
+			expect(parseUpdateMultiplierScaledUiMintInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializePausableConfig instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializePausableConfig
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializePausableConfig
+			});
+
+			expect(parseInitializePausableConfigInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a Pause instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Pause);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Pause
+			});
+
+			expect(parsePauseInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Resume instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(Token2022Instruction.Resume);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.Resume
+			});
+
+			expect(parseResumeInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeTokenMetadata instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeTokenMetadata
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeTokenMetadata
+			});
+
+			expect(parseInitializeTokenMetadataInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateTokenMetadataField instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateTokenMetadataField
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateTokenMetadataField
+			});
+
+			expect(parseUpdateTokenMetadataFieldInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a RemoveTokenMetadataKey instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.RemoveTokenMetadataKey
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.RemoveTokenMetadataKey
+			});
+
+			expect(parseRemoveTokenMetadataKeyInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateTokenMetadataUpdateAuthority instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateTokenMetadataUpdateAuthority
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateTokenMetadataUpdateAuthority
+			});
+
+			expect(parseUpdateTokenMetadataUpdateAuthorityInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an EmitTokenMetadata instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.EmitTokenMetadata
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.EmitTokenMetadata
+			});
+
+			expect(parseEmitTokenMetadataInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an InitializeTokenGroup instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeTokenGroup
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeTokenGroup
+			});
+
+			expect(parseInitializeTokenGroupInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse an UpdateTokenGroupMaxSize instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateTokenGroupMaxSize
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateTokenGroupMaxSize
+			});
+
+			expect(parseUpdateTokenGroupMaxSizeInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UpdateTokenGroupUpdateAuthority instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.UpdateTokenGroupUpdateAuthority
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.UpdateTokenGroupUpdateAuthority
+			});
+
+			expect(parseUpdateTokenGroupUpdateAuthorityInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an InitializeTokenGroupMember instruction', () => {
+			vi.mocked(identifyToken2022Instruction).mockReturnValue(
+				Token2022Instruction.InitializeTokenGroupMember
+			);
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual({
+				instructionType: Token2022Instruction.InitializeTokenGroupMember
+			});
+
+			expect(parseInitializeTokenGroupMemberInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should return the original instruction if it is not a recognised Token-2022 instruction', () => {
+			// @ts-expect-error intentional for testing unknown discriminant
+			vi.mocked(identifyToken2022Instruction).mockReturnValue('unknown-instruction');
+
+			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual(mockInstruction);
+
+			expect(parseInitializeMintInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeAccountInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeMultisigInstruction).not.toHaveBeenCalled();
+			expect(parseTransferInstruction).not.toHaveBeenCalled();
+			expect(parseApproveInstruction).not.toHaveBeenCalled();
+			expect(parseRevokeInstruction).not.toHaveBeenCalled();
+			expect(parseSetAuthorityInstruction).not.toHaveBeenCalled();
+			expect(parseMintToInstruction).not.toHaveBeenCalled();
+			expect(parseBurnInstruction).not.toHaveBeenCalled();
+			expect(parseCloseAccountInstruction).not.toHaveBeenCalled();
+			expect(parseFreezeAccountInstruction).not.toHaveBeenCalled();
+			expect(parseThawAccountInstruction).not.toHaveBeenCalled();
+			expect(parseTransferCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseApproveCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseMintToCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseBurnCheckedInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeAccount2Instruction).not.toHaveBeenCalled();
+			expect(parseSyncNativeInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeAccount3Instruction).not.toHaveBeenCalled();
+			expect(parseInitializeMultisig2Instruction).not.toHaveBeenCalled();
+			expect(parseInitializeMint2Instruction).not.toHaveBeenCalled();
+			expect(parseGetAccountDataSizeInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeImmutableOwnerInstruction).not.toHaveBeenCalled();
+			expect(parseAmountToUiAmountInstruction).not.toHaveBeenCalled();
+			expect(parseUiAmountToAmountInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeMintCloseAuthorityInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeTransferFeeConfigInstruction).not.toHaveBeenCalled();
+			expect(parseTransferCheckedWithFeeInstruction).not.toHaveBeenCalled();
+			expect(parseWithdrawWithheldTokensFromMintInstruction).not.toHaveBeenCalled();
+			expect(parseWithdrawWithheldTokensFromAccountsInstruction).not.toHaveBeenCalled();
+			expect(parseHarvestWithheldTokensToMintInstruction).not.toHaveBeenCalled();
+			expect(parseSetTransferFeeInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeConfidentialTransferMintInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateConfidentialTransferMintInstruction).not.toHaveBeenCalled();
+			expect(parseConfigureConfidentialTransferAccountInstruction).not.toHaveBeenCalled();
+			expect(parseApproveConfidentialTransferAccountInstruction).not.toHaveBeenCalled();
+			expect(parseEmptyConfidentialTransferAccountInstruction).not.toHaveBeenCalled();
+			expect(parseConfidentialDepositInstruction).not.toHaveBeenCalled();
+			expect(parseConfidentialWithdrawInstruction).not.toHaveBeenCalled();
+			expect(parseConfidentialTransferInstruction).not.toHaveBeenCalled();
+			expect(parseApplyConfidentialPendingBalanceInstruction).not.toHaveBeenCalled();
+			expect(parseEnableConfidentialCreditsInstruction).not.toHaveBeenCalled();
+			expect(parseDisableConfidentialCreditsInstruction).not.toHaveBeenCalled();
+			expect(parseEnableNonConfidentialCreditsInstruction).not.toHaveBeenCalled();
+			expect(parseDisableNonConfidentialCreditsInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeDefaultAccountStateInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateDefaultAccountStateInstruction).not.toHaveBeenCalled();
+			expect(parseReallocateInstruction).not.toHaveBeenCalled();
+			expect(parseEnableMemoTransfersInstruction).not.toHaveBeenCalled();
+			expect(parseDisableMemoTransfersInstruction).not.toHaveBeenCalled();
+			expect(parseCreateNativeMintInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeNonTransferableMintInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeInterestBearingMintInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateRateInterestBearingMintInstruction).not.toHaveBeenCalled();
+			expect(parseEnableCpiGuardInstruction).not.toHaveBeenCalled();
+			expect(parseDisableCpiGuardInstruction).not.toHaveBeenCalled();
+			expect(parseInitializePermanentDelegateInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeTransferHookInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateTransferHookInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeConfidentialTransferFeeInstruction).not.toHaveBeenCalled();
+			expect(
+				parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction
+			).not.toHaveBeenCalled();
+			expect(
+				parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction
+			).not.toHaveBeenCalled();
+			expect(
+				parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction
+			).not.toHaveBeenCalled();
+			expect(parseEnableHarvestToMintInstruction).not.toHaveBeenCalled();
+			expect(parseDisableHarvestToMintInstruction).not.toHaveBeenCalled();
+			expect(parseWithdrawExcessLamportsInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeMetadataPointerInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateMetadataPointerInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeGroupPointerInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateGroupPointerInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeGroupMemberPointerInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateGroupMemberPointerInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeScaledUiAmountMintInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateMultiplierScaledUiMintInstruction).not.toHaveBeenCalled();
+			expect(parseInitializePausableConfigInstruction).not.toHaveBeenCalled();
+			expect(parsePauseInstruction).not.toHaveBeenCalled();
+			expect(parseResumeInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeTokenMetadataInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateTokenMetadataFieldInstruction).not.toHaveBeenCalled();
+			expect(parseRemoveTokenMetadataKeyInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateTokenMetadataUpdateAuthorityInstruction).not.toHaveBeenCalled();
+			expect(parseEmitTokenMetadataInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeTokenGroupInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateTokenGroupMaxSizeInstruction).not.toHaveBeenCalled();
+			expect(parseUpdateTokenGroupUpdateAuthorityInstruction).not.toHaveBeenCalled();
+			expect(parseInitializeTokenGroupMemberInstruction).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

To make util `parseSolToken2022Instruction` more type-safe, we use a forced casting to never to discover if we forgot to track some specific variants.

Since we are here, we add tests.