### PR TITLE
chore(rewards): Bump rewards canister release

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -539,8 +539,8 @@
 		},
 		"rewards": {
 			"type": "custom",
-			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.5.9/rewards.did",
-			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.5.9/rewards.wasm.gz",
+			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.5.10/rewards.did",
+			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.5.10/rewards.wasm.gz",
 			"remote": {
 				"id": {
 					"ic": "nynz6-haaaa-aaaan-qzqda-cai",

--- a/src/declarations/rewards/rewards.did
+++ b/src/declarations/rewards/rewards.did
@@ -68,9 +68,9 @@ type CampaignEligibility = record {
 	///
 	criteria : vec CriterionEligibility;
 	///
-	probability_multiplier : nat32;
+	probability_multiplier : opt nat32;
 	///
-	probability_multiplier_enabled : bool
+	probability_multiplier_enabled : opt bool
 
 };
 /// A span of time.
@@ -447,7 +447,7 @@ type UsageAwardConfig = record {
 	campaign_name : opt text;
 	/// Rules for probability multipliers based on satisfied criteria.
 	/// Maps multiplier values to lists of criterion names that must be satisfied.
-	probability_multiplier_rules : vec record { nat32; vec CriterionName }
+	probability_multiplier_rules : opt vec record { nat32; vec CriterionName }
 };
 type UsageAwardEvent = record {
 	name : text;

--- a/src/declarations/rewards/rewards.did.d.ts
+++ b/src/declarations/rewards/rewards.did.d.ts
@@ -55,8 +55,8 @@ export interface AwardFilter {
 	campaign_id: [] | [string];
 }
 export interface CampaignEligibility {
-	probability_multiplier_enabled: boolean;
-	probability_multiplier: number;
+	probability_multiplier_enabled: [] | [boolean];
+	probability_multiplier: [] | [number];
 	available: boolean;
 	eligible: boolean;
 	criteria: Array<CriterionEligibility>;
@@ -289,7 +289,7 @@ export interface UsageAndHolding {
 }
 export interface UsageAwardConfig {
 	cycle_duration: CandidDuration;
-	probability_multiplier_rules: Array<[number, Array<CriterionName>]>;
+	probability_multiplier_rules: [] | [Array<[number, Array<CriterionName>]>];
 	awards: Array<UsageAwardEvent>;
 	eligibility_criteria: UsageCriteria;
 	campaign_name: [] | [string];

--- a/src/declarations/rewards/rewards.factory.certified.did.js
+++ b/src/declarations/rewards/rewards.factory.certified.did.js
@@ -66,7 +66,7 @@ export const idlFactory = ({ IDL }) => {
 	const UsageCriteria = IDL.Record({ criteria: IDL.Vec(Criterion) });
 	const UsageAwardConfig = IDL.Record({
 		cycle_duration: CandidDuration,
-		probability_multiplier_rules: IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName))),
+		probability_multiplier_rules: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName)))),
 		awards: IDL.Vec(UsageAwardEvent),
 		eligibility_criteria: UsageCriteria,
 		campaign_name: IDL.Opt(IDL.Text)
@@ -113,8 +113,8 @@ export const idlFactory = ({ IDL }) => {
 		criterion: Criterion
 	});
 	const CampaignEligibility = IDL.Record({
-		probability_multiplier_enabled: IDL.Bool,
-		probability_multiplier: IDL.Nat32,
+		probability_multiplier_enabled: IDL.Opt(IDL.Bool),
+		probability_multiplier: IDL.Opt(IDL.Nat32),
 		available: IDL.Bool,
 		eligible: IDL.Bool,
 		criteria: IDL.Vec(CriterionEligibility)
@@ -438,7 +438,7 @@ export const init = ({ IDL }) => {
 	const UsageCriteria = IDL.Record({ criteria: IDL.Vec(Criterion) });
 	const UsageAwardConfig = IDL.Record({
 		cycle_duration: CandidDuration,
-		probability_multiplier_rules: IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName))),
+		probability_multiplier_rules: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName)))),
 		awards: IDL.Vec(UsageAwardEvent),
 		eligibility_criteria: UsageCriteria,
 		campaign_name: IDL.Opt(IDL.Text)

--- a/src/declarations/rewards/rewards.factory.did.js
+++ b/src/declarations/rewards/rewards.factory.did.js
@@ -66,7 +66,7 @@ export const idlFactory = ({ IDL }) => {
 	const UsageCriteria = IDL.Record({ criteria: IDL.Vec(Criterion) });
 	const UsageAwardConfig = IDL.Record({
 		cycle_duration: CandidDuration,
-		probability_multiplier_rules: IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName))),
+		probability_multiplier_rules: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName)))),
 		awards: IDL.Vec(UsageAwardEvent),
 		eligibility_criteria: UsageCriteria,
 		campaign_name: IDL.Opt(IDL.Text)
@@ -113,8 +113,8 @@ export const idlFactory = ({ IDL }) => {
 		criterion: Criterion
 	});
 	const CampaignEligibility = IDL.Record({
-		probability_multiplier_enabled: IDL.Bool,
-		probability_multiplier: IDL.Nat32,
+		probability_multiplier_enabled: IDL.Opt(IDL.Bool),
+		probability_multiplier: IDL.Opt(IDL.Nat32),
 		available: IDL.Bool,
 		eligible: IDL.Bool,
 		criteria: IDL.Vec(CriterionEligibility)
@@ -444,7 +444,7 @@ export const init = ({ IDL }) => {
 	const UsageCriteria = IDL.Record({ criteria: IDL.Vec(Criterion) });
 	const UsageAwardConfig = IDL.Record({
 		cycle_duration: CandidDuration,
-		probability_multiplier_rules: IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName))),
+		probability_multiplier_rules: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Nat32, IDL.Vec(CriterionName)))),
 		awards: IDL.Vec(UsageAwardEvent),
 		eligibility_criteria: UsageCriteria,
 		campaign_name: IDL.Opt(IDL.Text)

--- a/src/frontend/src/lib/types/reward.ts
+++ b/src/frontend/src/lib/types/reward.ts
@@ -56,8 +56,8 @@ export interface CampaignEligibility {
 	available: boolean;
 	eligible: boolean;
 	criteria: CampaignCriterion[];
-	probabilityMultiplierEnabled: boolean;
-	probabilityMultiplier: number;
+	probabilityMultiplierEnabled?: boolean;
+	probabilityMultiplier?: number;
 }
 
 export interface CampaignCriterion {

--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -16,7 +16,7 @@ import type {
 	RewardResult
 } from '$lib/types/reward';
 import type { Identity } from '@dfinity/agent';
-import { isNullish } from '@dfinity/utils';
+import { fromNullable, isNullish } from '@dfinity/utils';
 
 export const INITIAL_REWARD_RESULT = 'initialRewardResult';
 
@@ -112,8 +112,8 @@ export const mapEligibilityReport = (eligibilityReport: EligibilityReport): Camp
 			available: eligibility.available,
 			eligible: eligibility.eligible,
 			criteria,
-			probabilityMultiplierEnabled: eligibility.probability_multiplier_enabled,
-			probabilityMultiplier: eligibility.probability_multiplier
+			probabilityMultiplierEnabled: fromNullable(eligibility.probability_multiplier_enabled),
+			probabilityMultiplier: fromNullable(eligibility.probability_multiplier)
 		};
 	});
 

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -42,8 +42,8 @@ describe('reward-code', () => {
 			eligible: true,
 			available: true,
 			criteria: [],
-			probability_multiplier_enabled: false,
-			probability_multiplier: 1
+			probability_multiplier_enabled: [false],
+			probability_multiplier: [1]
 		};
 		const mockEligibilityReport: EligibilityReport = {
 			campaigns: [[campaignId, campaign]]

--- a/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
@@ -509,8 +509,8 @@ describe('rewards.utils', () => {
 										}
 									}
 								],
-								probability_multiplier_enabled: false,
-								probability_multiplier: 1
+								probability_multiplier_enabled: [false],
+								probability_multiplier: [1]
 							}
 						]
 					]
@@ -558,8 +558,8 @@ describe('rewards.utils', () => {
 										}
 									}
 								],
-								probability_multiplier_enabled: false,
-								probability_multiplier: 1
+								probability_multiplier_enabled: [false],
+								probability_multiplier: [1]
 							}
 						]
 					]
@@ -607,8 +607,8 @@ describe('rewards.utils', () => {
 										}
 									}
 								],
-								probability_multiplier_enabled: false,
-								probability_multiplier: 1
+								probability_multiplier_enabled: [false],
+								probability_multiplier: [1]
 							}
 						]
 					]
@@ -655,8 +655,8 @@ describe('rewards.utils', () => {
 										}
 									}
 								],
-								probability_multiplier_enabled: false,
-								probability_multiplier: 1
+								probability_multiplier_enabled: [false],
+								probability_multiplier: [1]
 							}
 						]
 					]
@@ -702,8 +702,8 @@ describe('rewards.utils', () => {
 										}
 									}
 								],
-								probability_multiplier_enabled: false,
-								probability_multiplier: 1
+								probability_multiplier_enabled: [false],
+								probability_multiplier: [1]
 							}
 						]
 					]
@@ -746,8 +746,8 @@ describe('rewards.utils', () => {
 									}
 								}
 							],
-							probability_multiplier_enabled: false,
-							probability_multiplier: 1
+							probability_multiplier_enabled: [false],
+							probability_multiplier: [1]
 						}
 					]
 				]
@@ -800,8 +800,8 @@ describe('rewards.utils', () => {
 									}
 								}
 							],
-							probability_multiplier_enabled: false,
-							probability_multiplier: 1
+							probability_multiplier_enabled: toNullable(),
+							probability_multiplier: toNullable()
 						}
 					]
 				]
@@ -826,9 +826,7 @@ describe('rewards.utils', () => {
 							type: RewardCriterionType.MIN_TOTAL_ASSETS_USD,
 							usd: 1000
 						}
-					],
-					probabilityMultiplierEnabled: false,
-					probabilityMultiplier: 1
+					]
 				}
 			]);
 		});


### PR DESCRIPTION
# Motivation
The candid API has new fields that were not marked as optional.  They need to be optional, so that the new front end code works with the old rewards canister.

# Changes
- Bump rewards canister

# Tests
