### PR TITLE
refactor(frontend): Start deprecating `alchemy-sdk` in `AlchemyProvider`

### DIFF
--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -118,17 +118,18 @@ export const initPendingTransactionsListener = ({
 };
 
 export class AlchemyProvider {
-	private readonly provider: Alchemy;
+	// TODO: Remove this class in favor of the new provider when we remove completely alchemy-sdk
+	private readonly deprecatedProvider: Alchemy;
 
 	constructor(private readonly network: Network) {
-		this.provider = new Alchemy({
+		this.deprecatedProvider = new Alchemy({
 			apiKey: ALCHEMY_API_KEY,
 			network: this.network
 		});
 	}
 
 	getTransaction = async (hash: string): Promise<TransactionResponseWithBigInt | null> => {
-		const transaction = await this.provider.core.getTransaction(hash);
+		const transaction = await this.deprecatedProvider.core.getTransaction(hash);
 
 		if (isNullish(transaction)) {
 			return transaction;
@@ -153,11 +154,14 @@ export class AlchemyProvider {
 		address: EthAddress;
 		tokens: NonFungibleToken[];
 	}): Promise<Nft[]> => {
-		const result: AlchemyProviderOwnedNfts = await this.provider.nft.getNftsForOwner(address, {
-			contractAddresses: tokens.map((token) => token.address),
-			omitMetadata: false,
-			orderBy: NftOrdering.TRANSFERTIME
-		});
+		const result: AlchemyProviderOwnedNfts = await this.deprecatedProvider.nft.getNftsForOwner(
+			address,
+			{
+				contractAddresses: tokens.map((token) => token.address),
+				omitMetadata: false,
+				orderBy: NftOrdering.TRANSFERTIME
+			}
+		);
 
 		return result.ownedNfts.reduce<Nft[]>((acc, ownedNft) => {
 			const {
@@ -211,7 +215,8 @@ export class AlchemyProvider {
 
 	// https://www.alchemy.com/docs/reference/nft-api-endpoints/nft-api-endpoints/nft-ownership-endpoints/get-contracts-for-owner-v-3
 	getTokensForOwner = async (address: EthAddress): Promise<OwnedContract[]> => {
-		const result: AlchemyProviderContracts = await this.provider.nft.getContractsForOwner(address);
+		const result: AlchemyProviderContracts =
+			await this.deprecatedProvider.nft.getContractsForOwner(address);
 
 		return result.contracts.reduce<OwnedContract[]>((acc, ownedContract) => {
 			const tokenStandard =

--- a/src/frontend/src/tests/eth/providers/alchemy.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/alchemy.providers.spec.ts
@@ -254,7 +254,8 @@ describe('alchemy.providers', () => {
 
 				expect(provider).toBeInstanceOf(AlchemyProvider);
 
-				expect(provider).toHaveProperty('provider');
+				expect(provider).toHaveProperty('deprecatedProvider');
+				expect(provider).not.toHaveProperty('provider');
 			});
 		});
 


### PR DESCRIPTION
# Motivation

It was announced that [alchemy-sdk](https://github.com/alchemyplatform/alchemy-sdk-js) will be deprecated soon:

> Warning
> 
> The Alchemy SDK JS has been deprecated and will be archived January 2026. The software will only receive minimal support until then. New and existing users are encourage to use the following tools instead:

So, we need to start taking care of the migration.

In this first PR we just rename the current provider of class `AlchemyProvider`, so that we can include a new one after and slowly migrate.