### PR TITLE
test(frontend): Use `toNullable` util in rewards canister tests

### DIFF
--- a/src/frontend/src/tests/icp/utils/btc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/btc.utils.spec.ts
@@ -1,4 +1,6 @@
 // Hoisted holder for values used/assigned inside the vi.mock factory
+import { toNullable } from '@dfinity/utils';
+
 interface TxEntry {
 	txid: unknown;
 	utxos?: Array<{
@@ -101,7 +103,7 @@ describe('btc.utils', () => {
 
 		it('returns empty array when address not in populated store', () => {
 			const storeValue: StoreValue = {
-				'other-addr': { certified: true as const, data: [{ txid: [1] }] }
+				'other-addr': { certified: true as const, data: [{ txid: toNullable(1) }] }
 			};
 			mockStoreApi.setStoreValue(storeValue);
 

--- a/src/frontend/src/tests/icp/utils/btc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/btc.utils.spec.ts
@@ -1,6 +1,6 @@
-// Hoisted holder for values used/assigned inside the vi.mock factory
 import { toNullable } from '@dfinity/utils';
 
+// Hoisted holder for values used/assigned inside the vi.mock factory
 interface TxEntry {
 	txid: unknown;
 	utxos?: Array<{

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -43,7 +43,7 @@ describe('reward-code', () => {
 			available: true,
 			criteria: [],
 			probability_multiplier_enabled: [false],
-			probability_multiplier: [1]
+			probability_multiplier: toNullable(1)
 		};
 		const mockEligibilityReport: EligibilityReport = {
 			campaigns: [[campaignId, campaign]]

--- a/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
@@ -510,7 +510,7 @@ describe('rewards.utils', () => {
 									}
 								],
 								probability_multiplier_enabled: [false],
-								probability_multiplier: [1]
+								probability_multiplier: toNullable(1)
 							}
 						]
 					]
@@ -559,7 +559,7 @@ describe('rewards.utils', () => {
 									}
 								],
 								probability_multiplier_enabled: [false],
-								probability_multiplier: [1]
+								probability_multiplier: toNullable(1)
 							}
 						]
 					]
@@ -608,7 +608,7 @@ describe('rewards.utils', () => {
 									}
 								],
 								probability_multiplier_enabled: [false],
-								probability_multiplier: [1]
+								probability_multiplier: toNullable(1)
 							}
 						]
 					]
@@ -656,7 +656,7 @@ describe('rewards.utils', () => {
 									}
 								],
 								probability_multiplier_enabled: [false],
-								probability_multiplier: [1]
+								probability_multiplier: toNullable(1)
 							}
 						]
 					]
@@ -703,7 +703,7 @@ describe('rewards.utils', () => {
 									}
 								],
 								probability_multiplier_enabled: [false],
-								probability_multiplier: [1]
+								probability_multiplier: toNullable(1)
 							}
 						]
 					]
@@ -747,7 +747,7 @@ describe('rewards.utils', () => {
 								}
 							],
 							probability_multiplier_enabled: [false],
-							probability_multiplier: [1]
+							probability_multiplier: toNullable(1)
 						}
 					]
 				]


### PR DESCRIPTION
# Motivation

Whenever possible, we use the `toNullable` util for the tests of the rewards canister.
