### PR TITLE
refactor(frontend): Rename derived store for native Ethereum token

### DIFF
--- a/src/frontend/src/eth/components/convert/ConvertToCkEth.svelte
+++ b/src/frontend/src/eth/components/convert/ConvertToCkEth.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { nativeEthereumToken, nativeEthereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback, nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertEth from '$icp-eth/components/convert/ConvertEth.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
@@ -28,11 +28,11 @@
 
 <ConvertEth ariaLabel={$i18n.convert.text.convert_to_cketh} nativeTokenId={$nativeEthereumTokenId}>
 	<IconCkConvert slot="icon" size="24" />
-	<span>{($nativeEthereumToken as RequiredTokenWithLinkedData).twinTokenSymbol ?? ''}</span>
+	<span>{($nativeEthereumTokenWithFallback as RequiredTokenWithLinkedData).twinTokenSymbol ?? ''}</span>
 </ConvertEth>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckEthToken)}
-	<EthFeeStoreContext token={$nativeEthereumToken}>
-		<ConvertModal destinationToken={ckEthToken} sourceToken={$nativeEthereumToken} />
+	<EthFeeStoreContext token={$nativeEthereumTokenWithFallback}>
+		<ConvertModal destinationToken={ckEthToken} sourceToken={$nativeEthereumTokenWithFallback} />
 	</EthFeeStoreContext>
 {/if}

--- a/src/frontend/src/eth/components/convert/ConvertToCkEth.svelte
+++ b/src/frontend/src/eth/components/convert/ConvertToCkEth.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { nativeEthereumTokenWithFallback, nativeEthereumTokenId } from '$eth/derived/token.derived';
+	import {
+		nativeEthereumTokenWithFallback,
+		nativeEthereumTokenId
+	} from '$eth/derived/token.derived';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertEth from '$icp-eth/components/convert/ConvertEth.svelte';
 	import ConvertModal from '$lib/components/convert/ConvertModal.svelte';
@@ -28,7 +31,9 @@
 
 <ConvertEth ariaLabel={$i18n.convert.text.convert_to_cketh} nativeTokenId={$nativeEthereumTokenId}>
 	<IconCkConvert slot="icon" size="24" />
-	<span>{($nativeEthereumTokenWithFallback as RequiredTokenWithLinkedData).twinTokenSymbol ?? ''}</span>
+	<span
+		>{($nativeEthereumTokenWithFallback as RequiredTokenWithLinkedData).twinTokenSymbol ?? ''}</span
+	>
 </ConvertEth>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckEthToken)}

--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -8,7 +8,7 @@
 	import EthConvertReview from '$eth/components/convert/EthConvertReview.svelte';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { nativeEthereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 	import { send as executeSend } from '$eth/services/send.services';
 	import { ETH_FEE_CONTEXT_KEY } from '$eth/stores/eth-fee.store';
 	import type { EthereumNetwork } from '$eth/types/network';
@@ -89,7 +89,7 @@
 		}
 
 		const { valid } = assertCkEthMinterInfoLoaded({
-			minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumToken.id],
+			minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumTokenWithFallback.id],
 			network: ICP_NETWORK
 		});
 
@@ -135,7 +135,7 @@
 				sourceNetwork,
 				targetNetwork: ICP_NETWORK,
 				identity: $authIdentity,
-				minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumToken.id]
+				minterInfo: $ckEthMinterInfoStore?.[$nativeEthereumTokenWithFallback.id]
 			});
 
 			trackEvent({
@@ -164,7 +164,7 @@
 <EthFeeContext
 	amount={sendAmount}
 	{destination}
-	nativeEthereumToken={$nativeEthereumToken}
+	nativeEthereumToken={$nativeEthereumTokenWithFallback}
 	observe={currentStep?.name !== WizardStepsConvert.CONVERTING &&
 		currentStep?.name !== WizardStepsConvert.REVIEW}
 	sendToken={$sourceToken}
@@ -189,7 +189,7 @@
 	{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
 		<EthConvertProgress
 			{destination}
-			nativeEthereumToken={$nativeEthereumToken}
+			nativeEthereumToken={$nativeEthereumTokenWithFallback}
 			sourceTokenId={$sourceToken.id}
 			bind:convertProgressStep
 		/>

--- a/src/frontend/src/eth/components/send/ConvertToCkErc20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkErc20.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { nativeEthereumToken, nativeEthereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback, nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import type { OptionErc20Token } from '$eth/types/erc20';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertEth from '$icp-eth/components/convert/ConvertEth.svelte';
@@ -41,7 +41,7 @@
 </ConvertEth>
 
 {#if $modalConvertToTwinTokenCkEth && nonNullish(ckToken) && nonNullish($pageToken)}
-	<EthFeeStoreContext token={$nativeEthereumToken}>
+	<EthFeeStoreContext token={$nativeEthereumTokenWithFallback}>
 		<ConvertModal destinationToken={ckToken} sourceToken={$pageToken} />
 	</EthFeeStoreContext>
 {/if}

--- a/src/frontend/src/eth/components/send/ConvertToCkErc20.svelte
+++ b/src/frontend/src/eth/components/send/ConvertToCkErc20.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { nativeEthereumTokenWithFallback, nativeEthereumTokenId } from '$eth/derived/token.derived';
+	import {
+		nativeEthereumTokenWithFallback,
+		nativeEthereumTokenId
+	} from '$eth/derived/token.derived';
 	import type { OptionErc20Token } from '$eth/types/erc20';
 	import type { IcCkToken } from '$icp/types/ic-token';
 	import ConvertEth from '$icp-eth/components/convert/ConvertEth.svelte';

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -6,7 +6,7 @@
 	import SwapEthForm from './SwapEthForm.svelte';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
-	import { nativeEthereumToken as nativeEthereumTokenStore } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 	import {
 		ETH_FEE_CONTEXT_KEY,
 		initEthFeeContext,
@@ -84,7 +84,7 @@
 	 */
 	const feeStore = initEthFeeStore();
 
-	let nativeEthereumToken = $derived($nativeEthereumTokenStore);
+	let nativeEthereumToken = $derived($nativeEthereumTokenWithFallback);
 
 	const feeSymbolStore = writable<string | undefined>(undefined);
 	const feeTokenIdStore = writable<TokenId | undefined>(undefined);

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -7,7 +7,10 @@
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
-	import { nativeEthereumTokenWithFallback, nativeEthereumTokenId } from '$eth/derived/token.derived';
+	import {
+		nativeEthereumTokenWithFallback,
+		nativeEthereumTokenId
+	} from '$eth/derived/token.derived';
 	import { send as sendServices } from '$eth/services/wallet-connect.services';
 	import {
 		ETH_FEE_CONTEXT_KEY,

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendTokenModal.svelte
@@ -7,7 +7,7 @@
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
 	import WalletConnectSendReview from '$eth/components/wallet-connect/WalletConnectSendReview.svelte';
 	import { walletConnectSendSteps } from '$eth/constants/steps.constants';
-	import { nativeEthereumToken, nativeEthereumTokenId } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback, nativeEthereumTokenId } from '$eth/derived/token.derived';
 	import { send as sendServices } from '$eth/services/wallet-connect.services';
 	import {
 		ETH_FEE_CONTEXT_KEY,
@@ -175,7 +175,7 @@
 		amount={amount.toString()}
 		{data}
 		{destination}
-		nativeEthereumToken={$nativeEthereumToken}
+		nativeEthereumToken={$nativeEthereumTokenWithFallback}
 		observe={currentStep?.name !== WizardStepsSend.SENDING}
 		sendToken={$sendToken}
 		sendTokenId={$sendTokenId}

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -13,16 +13,12 @@ export const nativeEthereumToken: Readable<RequiredToken | undefined> = derived(
 	([$enabledEthereumTokens, $selectedEthereumNetwork, $evmNativeToken]) =>
 		$enabledEthereumTokens.find(
 			({ network: { id: networkId } }) => $selectedEthereumNetwork?.id === networkId
-		) ??
-		$evmNativeToken
+		) ?? $evmNativeToken
 );
-
 
 export const nativeEthereumTokenWithFallback: Readable<RequiredToken> = derived(
 	[nativeEthereumToken, defaultFallbackToken],
-	([$nativeEthereumToken, $defaultFallbackToken]) =>
-		$nativeEthereumToken ??
-		$defaultFallbackToken
+	([$nativeEthereumToken, $defaultFallbackToken]) => $nativeEthereumToken ?? $defaultFallbackToken
 );
 
 export const nativeEthereumTokenId: Readable<TokenId> = derived(

--- a/src/frontend/src/eth/derived/token.derived.ts
+++ b/src/frontend/src/eth/derived/token.derived.ts
@@ -8,17 +8,24 @@ import { derived, type Readable } from 'svelte/store';
 /**
  * Native token - i.e. not ERC20 - for the selected Ethereum/EVM network.
  */
-export const nativeEthereumToken: Readable<RequiredToken> = derived(
-	[enabledEthereumTokens, selectedEthereumNetwork, evmNativeToken, defaultFallbackToken],
-	([$enabledEthereumTokens, $selectedEthereumNetwork, $evmNativeToken, $defaultFallbackToken]) =>
+export const nativeEthereumToken: Readable<RequiredToken | undefined> = derived(
+	[enabledEthereumTokens, selectedEthereumNetwork, evmNativeToken],
+	([$enabledEthereumTokens, $selectedEthereumNetwork, $evmNativeToken]) =>
 		$enabledEthereumTokens.find(
 			({ network: { id: networkId } }) => $selectedEthereumNetwork?.id === networkId
 		) ??
-		$evmNativeToken ??
+		$evmNativeToken
+);
+
+
+export const nativeEthereumTokenWithFallback: Readable<RequiredToken> = derived(
+	[nativeEthereumToken, defaultFallbackToken],
+	([$nativeEthereumToken, $defaultFallbackToken]) =>
+		$nativeEthereumToken ??
 		$defaultFallbackToken
 );
 
 export const nativeEthereumTokenId: Readable<TokenId> = derived(
-	[nativeEthereumToken],
+	[nativeEthereumTokenWithFallback],
 	([{ id }]) => id
 );

--- a/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
+++ b/src/frontend/src/icp-eth/components/info/InfoEthereum.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
-	import { nativeEthereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 	import HowToConvertEthereumModal from '$icp/components/convert/HowToConvertEthereumModal.svelte';
 	import type { IcCkToken, IcToken } from '$icp/types/ic-token';
 	import eth from '$icp-eth/assets/eth.svg';
@@ -62,7 +62,7 @@
 </div>
 
 {#if $modalHowToConvertToTwinTokenEth && nonNullish(sourceToken) && nonNullish(destinationToken)}
-	<EthFeeStoreContext token={$nativeEthereumToken}>
+	<EthFeeStoreContext token={$nativeEthereumTokenWithFallback}>
 		<HowToConvertEthereumModal {destinationToken} {sourceToken} />
 	</EthFeeStoreContext>
 {/if}

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereum.svelte
@@ -3,7 +3,7 @@
 	import { getContext } from 'svelte';
 	import EthFeeStoreContext from '$eth/components/fee/EthFeeStoreContext.svelte';
 	import { erc20UserTokens } from '$eth/derived/erc20.derived';
-	import { nativeEthereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 	import IcReceiveCkEthereumModal from '$icp/components/receive/IcReceiveCkEthereumModal.svelte';
 	import {
 		RECEIVE_TOKEN_CONTEXT_KEY,
@@ -45,7 +45,7 @@
 <ReceiveButtonWithModal isOpen={$modalCkETHReceive} open={openModal}>
 	{#snippet modal()}
 		{#if nonNullish(sourceToken) && nonNullish(destinationToken)}
-			<EthFeeStoreContext token={$nativeEthereumToken}>
+			<EthFeeStoreContext token={$nativeEthereumTokenWithFallback}>
 				<IcReceiveCkEthereumModal {destinationToken} {sourceToken} on:nnsClose={close} />
 			</EthFeeStoreContext>
 		{/if}

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
@@ -2,7 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { nativeEthereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { selectedEvmNetwork } from '$evm/derived/network.derived';
 	import { evmNativeToken } from '$evm/derived/token.derived';
@@ -65,7 +65,7 @@
 			<AiAssistantReviewSendEthToken
 				{amount}
 				{destination}
-				nativeEthereumToken={$nativeEthereumToken}
+				nativeEthereumToken={$nativeEthereumTokenWithFallback}
 				{sendEnabled}
 				sourceNetwork={$selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK}
 				bind:sendCompleted

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -5,7 +5,7 @@
 	import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 	import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
-	import { nativeEthereumToken } from '$eth/derived/token.derived';
+	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { selectedEvmNetwork } from '$evm/derived/network.derived';
 	import { evmNativeToken } from '$evm/derived/token.derived';
@@ -49,7 +49,7 @@
 		<EthSendTokenWizard
 			{currentStep}
 			{destination}
-			nativeEthereumToken={$nativeEthereumToken}
+			nativeEthereumToken={$nativeEthereumTokenWithFallback}
 			{nft}
 			{selectedContact}
 			sourceNetwork={$selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK}

--- a/src/frontend/src/lib/stores/convert.store.ts
+++ b/src/frontend/src/lib/stores/convert.store.ts
@@ -1,4 +1,4 @@
-import { nativeEthereumToken } from '$eth/derived/token.derived';
+import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
 import { ckEthMinterInfoStore, type CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
@@ -46,7 +46,7 @@ export const initConvertContext = (convertData: ConvertData): ConvertContext => 
 	);
 
 	const balanceForFee = derived(
-		[sourceToken, balancesStore, nativeEthereumToken, ethereumFeeTokenCkEth, ckEthereumNativeToken],
+		[sourceToken, balancesStore, nativeEthereumTokenWithFallback, ethereumFeeTokenCkEth, ckEthereumNativeToken],
 		([
 			$sourceToken,
 			$balancesStore,

--- a/src/frontend/src/lib/stores/convert.store.ts
+++ b/src/frontend/src/lib/stores/convert.store.ts
@@ -46,7 +46,13 @@ export const initConvertContext = (convertData: ConvertData): ConvertContext => 
 	);
 
 	const balanceForFee = derived(
-		[sourceToken, balancesStore, nativeEthereumTokenWithFallback, ethereumFeeTokenCkEth, ckEthereumNativeToken],
+		[
+			sourceToken,
+			balancesStore,
+			nativeEthereumTokenWithFallback,
+			ethereumFeeTokenCkEth,
+			ckEthereumNativeToken
+		],
 		([
 			$sourceToken,
 			$balancesStore,

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -134,7 +134,7 @@ describe('EthConvertTokenWizard', () => {
 			.mockImplementation(() => readable(address));
 
 	const mockEthereumToken = (token = ETHEREUM_TOKEN) =>
-		vi.spyOn(tokensDerived, 'nativeEthereumToken', 'get').mockImplementation(() => readable(token));
+		vi.spyOn(tokensDerived, 'nativeEthereumTokenWithFallback', 'get').mockImplementation(() => readable(token));
 
 	const clickConvertButton = async (container: HTMLElement) => {
 		const convertButtonSelector = '[data-tid="convert-review-button-next"]';

--- a/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/convert/EthConvertTokenWizard.spec.ts
@@ -134,7 +134,9 @@ describe('EthConvertTokenWizard', () => {
 			.mockImplementation(() => readable(address));
 
 	const mockEthereumToken = (token = ETHEREUM_TOKEN) =>
-		vi.spyOn(tokensDerived, 'nativeEthereumTokenWithFallback', 'get').mockImplementation(() => readable(token));
+		vi
+			.spyOn(tokensDerived, 'nativeEthereumTokenWithFallback', 'get')
+			.mockImplementation(() => readable(token));
 
 	const clickConvertButton = async (container: HTMLElement) => {
 		const convertButtonSelector = '[data-tid="convert-review-button-next"]';


### PR DESCRIPTION
# Motivation

To be more consistent, we rename the derived store `nativeEthereumToken` to `nativeEthereumTokenWithFallback`, extracting the one without fallback.
