### PR TITLE
refactor(frontend): remove unnecessary default slot in `EthSendTokenWizard`

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -343,7 +343,5 @@
 		>
 			<ButtonBack slot="cancel" onclick={back} />
 		</EthSendForm>
-	{:else}
-		<slot />
 	{/if}
 </EthFeeContext>


### PR DESCRIPTION
# Motivation

There is no usage of default slot in `EthSendTokenWizard`, so we can remove it.
