### PR TITLE
refactor(frontend): remove unnecessary default slot in `SolSendTokenWizard`

### DIFF
--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -224,7 +224,5 @@
 		>
 			<ButtonBack slot="cancel" onclick={back} />
 		</SolSendForm>
-	{:else}
-		<slot />
 	{/if}
 </SolFeeContext>


### PR DESCRIPTION
# Motivation

There is no usage of default slot in `SolSendTokenWizard`, so we can remove it.
