### PR TITLE
feat(frontend): extend ReviewSendTokensToolResult with id and status

### DIFF
--- a/src/frontend/src/lib/types/ai-assistant.ts
+++ b/src/frontend/src/lib/types/ai-assistant.ts
@@ -39,6 +39,8 @@ export interface ShowContactsToolResult {
 export interface ReviewSendTokensToolResult {
 	amount: number;
 	token: Token;
+	sendCompleted: boolean;
+	id: string;
 	contact?: ExtendedAddressContactUi;
 	contactAddress?: ContactAddressUiWithId;
 	address?: Address;

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -136,7 +136,9 @@ export const parseReviewSendTokensToolArguments = ({
 		contactAddress,
 		address: addressFilter,
 		amount: parsedAmount,
-		token: tokenWithFallback
+		token: tokenWithFallback,
+		sendCompleted: false,
+		id: crypto.randomUUID().toString()
 	};
 };
 

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -49,6 +49,13 @@ describe('ai-assistant.utils', () => {
 
 	describe('parseReviewSendTokenToolArguments', () => {
 		const sendValue = 0.00001;
+		const mockRandomUUID = 'd7775002-80bf-4208-a2f0-84225281677a';
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => mockRandomUUID);
+		});
 
 		it('returns correct result when selectedContactAddressId is provided', () => {
 			expect(
@@ -75,7 +82,9 @@ describe('ai-assistant.utils', () => {
 				contactAddress: extendedAddressContactUi.addresses[0],
 				contact: extendedAddressContactUi,
 				amount: sendValue,
-				address: undefined
+				address: undefined,
+				id: mockRandomUUID,
+				sendCompleted: false
 			});
 		});
 
@@ -108,7 +117,9 @@ describe('ai-assistant.utils', () => {
 				contactAddress: undefined,
 				contact: undefined,
 				amount: sendValue,
-				address: mockEthAddress
+				address: mockEthAddress,
+				id: mockRandomUUID,
+				sendCompleted: false
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

We want to keep the send status of a ReviewSendTokensToolResult item in the store instead of component, so the data persists when console is getting closed and then reopened.

The store function to toggle the status, as well as the UI part of the feature will follow separately.
