### PR TITLE
feat(frontend): expose icrc1SupportedStandards of ledger-icrc

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -11,6 +11,7 @@ import {
 	type IcrcAllowance,
 	type IcrcBlockIndex,
 	type IcrcGetBlocksResult,
+	type IcrcStandardRecord,
 	type IcrcSubaccount,
 	type IcrcTokenMetadataResponse,
 	type IcrcTokens
@@ -226,6 +227,30 @@ export const getBlocks = async ({
 	const { getBlocks } = await ledgerCanister({ identity, ledgerCanisterId });
 
 	return getBlocks({ certified, ...rest });
+};
+
+/**
+ * Retrieves the ledger ICRC1 supported standards.
+ *
+ * @param {Object} params - The parameters for fetching supported standards.
+ * @param {boolean} [params.certified=true] - Whether the data should be certified.
+ * @param {OptionIdentity} params.identity - The identity to use for the request.
+ * @param {CanisterIdText} params.ledgerCanisterId - The ledger canister ID.
+ * @returns {Promise<IcrcStandardRecord[]>} The array of all supported standards.
+ */
+export const icrc1SupportedStandards = async ({
+	certified = true,
+	identity,
+	ledgerCanisterId
+}: {
+	identity: OptionIdentity;
+	ledgerCanisterId: CanisterIdText;
+} & QueryParams): Promise<IcrcStandardRecord[]> => {
+	assertNonNullish(identity);
+
+	const { icrc1SupportedStandards } = await ledgerCanister({ identity, ledgerCanisterId });
+
+	return icrc1SupportedStandards({ certified });
 };
 
 const ledgerCanister = async ({

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -4,6 +4,7 @@ import {
 	approve,
 	balance,
 	getBlocks,
+	icrc1SupportedStandards,
 	metadata,
 	transactionFee,
 	transfer
@@ -517,6 +518,47 @@ describe('icrc-ledger.api', () => {
 
 		it('throws an error if identity is undefined', async () => {
 			await expect(getBlocks({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('icrc1SupportedStandards', () => {
+		const params = {
+			certified: true,
+			ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+			identity: mockIdentity
+		};
+
+		const supportedStandards = [
+			{ name: 'ICRC-1', url: 'https://github.com/dfinity/ICRC-1' },
+			{ name: 'ICRC-2', url: 'https://github.com/dfinity/ICRC-2' }
+		];
+
+		beforeEach(() => {
+			ledgerCanisterMock.icrc1SupportedStandards.mockResolvedValue(supportedStandards);
+		});
+
+		it('successfully calls icrc1SupportedStandards endpoint', async () => {
+			const result = await icrc1SupportedStandards(params);
+
+			expect(result).toEqual(supportedStandards);
+
+			expect(ledgerCanisterMock.icrc1SupportedStandards).toHaveBeenCalledExactlyOnceWith({
+				certified: true
+			});
+		});
+
+		it('successfully calls icrc1SupportedStandards endpoint as query', async () => {
+			const result = await icrc1SupportedStandards({ ...params, certified: false });
+
+			expect(result).toEqual(supportedStandards);
+
+			expect(ledgerCanisterMock.icrc1SupportedStandards).toHaveBeenCalledExactlyOnceWith({
+				certified: false
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(icrc1SupportedStandards({ ...params, identity: undefined })).rejects.toThrow();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Since we now use the latest ledger-icrc package version, we can expose the newly added API method needed for identifying whether a ledger supports e.g. ICRC-2 standard.
