### PR TITLE
feat(frontend): use send status from store in SendTokenTool

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendBtcToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendBtcToken.svelte
@@ -47,9 +47,10 @@
 		destination: Address;
 		sendCompleted: boolean;
 		sendEnabled: boolean;
+		onSendCompleted: () => void;
 	}
 
-	let { amount, destination, sendCompleted = $bindable(), sendEnabled }: Props = $props();
+	let { amount, destination, sendCompleted, onSendCompleted, sendEnabled }: Props = $props();
 
 	const { sendTokenNetworkId, sendTokenDecimals, sendToken, sendBalance, sendTokenSymbol } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
@@ -207,11 +208,10 @@
 				metadata: sendTrackingEventMetadata
 			});
 
+			onSendCompleted();
 			loading = false;
-			sendCompleted = true;
 		} catch (err: unknown) {
 			loading = false;
-			sendCompleted = false;
 
 			trackEvent({
 				name: TRACK_COUNT_BTC_SEND_ERROR,

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendEthToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendEthToken.svelte
@@ -57,6 +57,7 @@
 		sourceNetwork: EthereumNetwork;
 		sendCompleted: boolean;
 		sendEnabled: boolean;
+		onSendCompleted: () => void;
 	}
 
 	let {
@@ -64,8 +65,9 @@
 		destination,
 		nativeEthereumToken,
 		sourceNetwork,
-		sendCompleted = $bindable(),
-		sendEnabled
+		sendCompleted,
+		sendEnabled,
+		onSendCompleted
 	}: Props = $props();
 
 	const {
@@ -245,10 +247,9 @@
 				metadata: sendTrackingEventMetadata
 			});
 
-			sendCompleted = true;
+			onSendCompleted();
 			loading = false;
 		} catch (err: unknown) {
-			sendCompleted = false;
 			loading = false;
 
 			trackEvent({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendIcToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendIcToken.svelte
@@ -35,9 +35,10 @@
 		destination: Address;
 		sendCompleted: boolean;
 		sendEnabled: boolean;
+		onSendCompleted: () => void;
 	}
 
-	let { amount, destination, sendCompleted = $bindable(), sendEnabled }: Props = $props();
+	let { amount, destination, sendCompleted, onSendCompleted, sendEnabled }: Props = $props();
 
 	const { sendToken, sendBalance, sendTokenStandard, sendTokenSymbol, sendTokenDecimals } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
@@ -126,10 +127,9 @@
 				sendCompleted: trackAnalyticsOnSendComplete
 			});
 
-			sendCompleted = true;
+			onSendCompleted();
 			loading = false;
 		} catch (err: unknown) {
-			sendCompleted = false;
 			loading = false;
 
 			trackEvent({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
@@ -60,9 +60,10 @@
 		destination: Address;
 		sendCompleted: boolean;
 		sendEnabled: boolean;
+		onSendCompleted: () => void;
 	}
 
-	let { amount, destination, sendCompleted = $bindable(), sendEnabled }: Props = $props();
+	let { amount, destination, sendCompleted, onSendCompleted, sendEnabled }: Props = $props();
 
 	const {
 		sendToken,
@@ -217,10 +218,9 @@
 				metadata: sendTrackingEventMetadata
 			});
 
-			sendCompleted = true;
+			onSendCompleted();
 			loading = false;
 		} catch (err: unknown) {
-			sendCompleted = false;
 			loading = false;
 
 			trackEvent({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
@@ -16,6 +16,7 @@
 	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
 	import { DEFAULT_ETHEREUM_NETWORK } from '$lib/constants/networks.constants';
+	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { ReviewSendTokensToolResult } from '$lib/types/ai-assistant';
 	import {
@@ -30,7 +31,8 @@
 		sendEnabled: boolean;
 	}
 
-	let { amount, contact, address, contactAddress, sendEnabled }: Props = $props();
+	let { amount, contact, address, contactAddress, sendEnabled, sendCompleted, id }: Props =
+		$props();
 
 	const { sendToken, sendTokenExchangeRate, sendTokenNetworkId } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
@@ -43,7 +45,9 @@
 
 	let evmNativeEthereumToken = $derived($evmNativeToken ?? fallbackEvmToken);
 
-	let sendCompleted = $state(false);
+	const onSendCompleted = () => {
+		aiAssistantStore.setSendToolActionAsCompleted(id);
+	};
 </script>
 
 <SendTokenReview
@@ -66,25 +70,45 @@
 				{amount}
 				{destination}
 				nativeEthereumToken={$nativeEthereumTokenWithFallback}
+				{onSendCompleted}
+				{sendCompleted}
 				{sendEnabled}
 				sourceNetwork={$selectedEthereumNetwork ?? DEFAULT_ETHEREUM_NETWORK}
-				bind:sendCompleted
 			/>
 		{:else if isNetworkIdEvm($sendToken.network.id) && nonNullish(evmNativeEthereumToken)}
 			<AiAssistantReviewSendEthToken
 				{amount}
 				{destination}
 				nativeEthereumToken={evmNativeEthereumToken}
+				{onSendCompleted}
+				{sendCompleted}
 				{sendEnabled}
 				sourceNetwork={$selectedEvmNetwork ?? ($sendToken.network as EthereumNetwork)}
-				bind:sendCompleted
 			/>
 		{:else if isNetworkIdBitcoin($sendTokenNetworkId)}
-			<AiAssistantReviewSendBtcToken {amount} {destination} {sendEnabled} bind:sendCompleted />
+			<AiAssistantReviewSendBtcToken
+				{amount}
+				{destination}
+				{onSendCompleted}
+				{sendCompleted}
+				{sendEnabled}
+			/>
 		{:else if isNetworkIdSolana($sendToken.network.id)}
-			<AiAssistantReviewSendSolToken {amount} {destination} {sendEnabled} bind:sendCompleted />
+			<AiAssistantReviewSendSolToken
+				{amount}
+				{destination}
+				{onSendCompleted}
+				{sendCompleted}
+				{sendEnabled}
+			/>
 		{:else if isNetworkIdICP($sendTokenNetworkId)}
-			<AiAssistantReviewSendIcToken {amount} {destination} {sendEnabled} bind:sendCompleted />
+			<AiAssistantReviewSendIcToken
+				{amount}
+				{destination}
+				{onSendCompleted}
+				{sendCompleted}
+				{sendEnabled}
+			/>
 		{/if}
 	{/snippet}
 </SendTokenReview>


### PR DESCRIPTION
# Motivation

We need to apply the last changes in order to start using send statuses from store instead of component's state in SendTokenTool.
