### PR TITLE
chore(frontend): Remove index canister from CLOUD

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -11,7 +11,6 @@
 	},
 	"CLOUD": {
 		"ledgerCanisterId": "pcj6u-uaaaa-aaaak-aewnq-cai",
-		"indexCanisterId": "72uqs-pqaaa-aaaak-aes7a-cai",
 		"decimals": 8,
 		"name": "Crypto Cloud",
 		"symbol": "CLOUD",


### PR DESCRIPTION
# Motivation

CLOUD index canister is dead for a while

# Changes

- Remove the index from its config

# Tests

