### PR TITLE
feat(frontend): improve responsive text sizing for balance components

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <span class="flex flex-col items-center gap-1">
-	<output class="mt-7 inline-block break-all text-5xl font-bold">
+	<output class="mt-7 inline-block break-all text-4xl font-bold md:text-5xl">
 		{#if $loaded && nonNullish(balance)}
 			{#if hideBalance}
 				<IconDots styleClass="my-4.25" times={6} variant="lg" />

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -28,7 +28,7 @@
 
 <span class="flex flex-col gap-1">
 	<output
-		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold lg:text-5xl"
+		class="inline-flex w-full flex-row justify-center gap-3 break-words text-4xl font-bold md:text-5xl"
 		data-tid={AMOUNT_DATA}
 	>
 		{#if nonNullish(token?.balance) && nonNullish(token?.symbol)}


### PR DESCRIPTION
# Motivation

We have an issue for wallet balances with non dollar currencies - they don't fit into the balance block

# Changes

- Update Balance.svelte to use responsive text sizing (text-4xl on small, text-5xl starting medium)
- Update ExchangeBalance.svelte to use responsive text sizing (text-4xl on small, text-5xl starting medium)
- Ensures larger balance amounts fit properly on small mobile devices
- Maintains visual hierarchy across all screen sizes

# Tests
**Issue:** 
<img width="393" height="491" alt="image" src="https://github.com/user-attachments/assets/4a478f02-ea3a-4551-b23d-d7a602c991f8" />


**Now:** 
<img width="377" height="318" alt="image" src="https://github.com/user-attachments/assets/f1e337ad-f948-4965-86c1-e1091b0c79aa" />
<img width="379" height="321" alt="image" src="https://github.com/user-attachments/assets/e23be722-0e56-4631-a975-6fae8b71b316" />
