### PR TITLE
fix(frontend): load kongswap tokens

### DIFF
--- a/src/frontend/src/lib/api/kong_backend.api.ts
+++ b/src/frontend/src/lib/api/kong_backend.api.ts
@@ -37,7 +37,8 @@ export const kongSwap = async ({
 export const kongTokens = async ({
 	identity,
 	canisterId,
-	nullishIdentityErrorMessage
+	nullishIdentityErrorMessage,
+	tokenLedgerCanisterId
 }: CanisterApiFunctionParams): Promise<TokenReply[]> => {
 	const { tokens } = await kongBackendCanister({
 		identity,
@@ -45,7 +46,7 @@ export const kongTokens = async ({
 		nullishIdentityErrorMessage
 	});
 
-	return tokens();
+	return tokens(tokenLedgerCanisterId);
 };
 
 const kongBackendCanister = async ({

--- a/src/frontend/src/lib/canisters/kong_backend.canister.ts
+++ b/src/frontend/src/lib/canisters/kong_backend.canister.ts
@@ -85,12 +85,12 @@ export class KongBackendCanister extends Canister<KongBackendService> {
 		throw mapKongBackendCanisterError(response.Err);
 	};
 
-	tokens = async (): Promise<TokenReply[]> => {
+	tokens = async (tokenLedgerCanisterId?: string): Promise<TokenReply[]> => {
 		const { tokens } = this.caller({
 			certified: false
 		});
 
-		const response = await tokens(toNullable());
+		const response = await tokens(toNullable(tokenLedgerCanisterId));
 
 		if ('Ok' in response) {
 			return response.Ok;

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -58,7 +58,7 @@
 		try {
 			await loadKongSwapTokensService({
 				identity: $authIdentity,
-				allIcrcTokens: [{ ...ICP_TOKEN }, ...$allIcrcTokens]
+				allIcrcTokens: [ICP_TOKEN, ...$allIcrcTokens]
 			});
 
 			return 'ready';

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -43,7 +43,7 @@
 		store: icTokenFeeStore
 	});
 
-	const isDisabled = (): boolean => isNullish($kongSwapTokensStore) || isNullish($allIcrcTokens);
+	const isDisabled = (): boolean => isNullish($kongSwapTokensStore);
 
 	const loadKongSwapTokens = async (): Promise<'ready' | undefined> => {
 		if (isNullish($authIdentity)) {

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -33,6 +33,7 @@
 	} from '$lib/stores/swap-amounts.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
 	import { waitReady } from '$lib/utils/timeout.utils';
+	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 
 	setContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY, {
 		store: initSwapAmountsStore()
@@ -57,7 +58,7 @@
 		try {
 			await loadKongSwapTokensService({
 				identity: $authIdentity,
-				allIcrcTokens: $allIcrcTokens
+				allIcrcTokens: [{ ...ICP_TOKEN }, ...$allIcrcTokens]
 			});
 
 			return 'ready';

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -14,7 +14,10 @@
 	} from '$icp/stores/ic-token-fee.store';
 	import SwapButtonWithModal from '$lib/components/swap/SwapButtonWithModal.svelte';
 	import SwapModal from '$lib/components/swap/SwapModal.svelte';
-	import { allDisabledKongSwapCompatibleIcrcTokens } from '$lib/derived/all-tokens.derived';
+	import {
+		allDisabledKongSwapCompatibleIcrcTokens,
+		allIcrcTokens
+	} from '$lib/derived/all-tokens.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalSwap } from '$lib/derived/modal.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
@@ -39,7 +42,7 @@
 		store: icTokenFeeStore
 	});
 
-	const isDisabled = (): boolean => isNullish($kongSwapTokensStore);
+	const isDisabled = (): boolean => isNullish($kongSwapTokensStore) || isNullish($allIcrcTokens);
 
 	const loadKongSwapTokens = async (): Promise<'ready' | undefined> => {
 		if (isNullish($authIdentity)) {
@@ -53,7 +56,8 @@
 
 		try {
 			await loadKongSwapTokensService({
-				identity: $authIdentity
+				identity: $authIdentity,
+				allIcrcTokens: $allIcrcTokens
 			});
 
 			return 'ready';

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -165,8 +165,6 @@ export const loadKongSwapTokens = async ({
 	identity: Identity;
 	allIcrcTokens: IcToken[];
 }): Promise<void> => {
-	console.log('allIcrcTokens', allIcrcTokens);
-
 	const kongSwapTokens = await Promise.allSettled(
 		allIcrcTokens.map((token: IcToken) =>
 			kongTokens({
@@ -176,24 +174,20 @@ export const loadKongSwapTokens = async ({
 		)
 	);
 
-	console.log('kongSwapTokens', kongSwapTokens);
-
-	const processedTokens = kongSwapTokens.reduce<KongSwapTokensStoreData>((acc, result) => {
+	const supportedTokens = kongSwapTokens.reduce<KongSwapTokensStoreData>((acc, result) => {
 		if (result.status === 'fulfilled') {
 			return result.value.reduce<KongSwapTokensStoreData>(
-				(acc, kongToken) =>
+				(innerAcc, kongToken) =>
 					'IC' in kongToken && !kongToken.IC.is_removed && kongToken.IC.chain === 'IC'
-						? { ...acc, [kongToken.IC.symbol]: kongToken.IC }
-						: acc,
-				{}
+						? { ...innerAcc, [kongToken.IC.symbol]: kongToken.IC }
+						: innerAcc,
+				acc
 			);
 		}
 		return acc;
 	}, {});
 
-	console.log({ processedTokens });
-
-	kongSwapTokensStore.setKongSwapTokens(processedTokens);
+	kongSwapTokensStore.setKongSwapTokens(supportedTokens);
 };
 
 export const fetchSwapAmounts = async ({

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -165,6 +165,8 @@ export const loadKongSwapTokens = async ({
 	identity: Identity;
 	allIcrcTokens: IcToken[];
 }): Promise<void> => {
+	console.log('allIcrcTokens', allIcrcTokens);
+
 	const kongSwapTokens = await Promise.allSettled(
 		allIcrcTokens.map((token: IcToken) =>
 			kongTokens({
@@ -173,6 +175,8 @@ export const loadKongSwapTokens = async ({
 			})
 		)
 	);
+
+	console.log('kongSwapTokens', kongSwapTokens);
 
 	const processedTokens = kongSwapTokens.reduce<KongSwapTokensStoreData>((acc, result) => {
 		if (result.status === 'fulfilled') {
@@ -186,6 +190,8 @@ export const loadKongSwapTokens = async ({
 		}
 		return acc;
 	}, {});
+
+	console.log({ processedTokens });
 
 	kongSwapTokensStore.setKongSwapTokens(processedTokens);
 };

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -187,8 +187,6 @@ export const loadKongSwapTokens = async ({
 		return acc;
 	}, {});
 
-	console.log(supportedTokens);
-
 	kongSwapTokensStore.setKongSwapTokens(supportedTokens);
 };
 
@@ -248,13 +246,6 @@ const fetchSwapAmountsICP = async ({
 			})
 		)
 	);
-
-
-	console.log({isSourceTokenIcrc2});
-	
-
-	console.log({settledResults});
-	
 
 	const mappedProvidersResults = enabledProviders.reduce<SwapMappedResult[]>(
 		(acc, provider, index) => {

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -187,6 +187,8 @@ export const loadKongSwapTokens = async ({
 		return acc;
 	}, {});
 
+	console.log(supportedTokens);
+
 	kongSwapTokensStore.setKongSwapTokens(supportedTokens);
 };
 

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -249,6 +249,9 @@ const fetchSwapAmountsICP = async ({
 		)
 	);
 
+	console.log({settledResults});
+	
+
 	const mappedProvidersResults = enabledProviders.reduce<SwapMappedResult[]>(
 		(acc, provider, index) => {
 			const result = settledResults[index];

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -249,6 +249,10 @@ const fetchSwapAmountsICP = async ({
 		)
 	);
 
+
+	console.log({isSourceTokenIcrc2});
+	
+
 	console.log({settledResults});
 	
 

--- a/src/frontend/src/lib/types/canister.ts
+++ b/src/frontend/src/lib/types/canister.ts
@@ -16,6 +16,7 @@ export type CanisterApiFunctionParams<T = unknown> = T & {
 	nullishIdentityErrorMessage?: string;
 	identity: OptionIdentity;
 	canisterId?: CanisterIdText;
+	tokenLedgerCanisterId?: string;
 };
 
 export interface CreateCanisterOptions<T> extends Omit<CanisterOptions<T>, 'canisterId' | 'agent'> {

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -36,6 +36,7 @@ import {
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockValidIcToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { kongIcToken, mockKongBackendTokens } from '$tests/mocks/kong_backend.mock';
 import { constructSimpleSDK } from '@velora-dex/sdk';
@@ -750,7 +751,7 @@ describe('loadKongSwapTokens', () => {
 	it('properly updates kongSwapToken store with the fetched tokens', async () => {
 		vi.spyOn(kongBackendApi, 'kongTokens').mockResolvedValue(mockKongBackendTokens);
 
-		await loadKongSwapTokens({ identity: mockIdentity });
+		await loadKongSwapTokens({ identity: mockIdentity, allIcrcTokens: [mockIcrcCustomToken] });
 
 		expect(get(kongSwapTokensStore)).toStrictEqual({
 			[kongIcToken.symbol]: kongIcToken
@@ -760,7 +761,7 @@ describe('loadKongSwapTokens', () => {
 	it('properly does not update store if no IC kongTokens available', async () => {
 		vi.spyOn(kongBackendApi, 'kongTokens').mockResolvedValue([{ ...mockKongBackendTokens[1] }]);
 
-		await loadKongSwapTokens({ identity: mockIdentity });
+		await loadKongSwapTokens({ identity: mockIdentity, allIcrcTokens: [mockIcrcCustomToken] });
 
 		expect(get(kongSwapTokensStore)).toStrictEqual({});
 	});


### PR DESCRIPTION
# Motivation

We encountered an issue retrieving tokens from the KongSwap canister due to a response-size limit. As a hotfix, we switched to fetching tokens individually.

# Changes

- Implemented Promise.allSettled in allIcrcTokens to request tokens one by one.
- For each supported token, retrieve metadata from kong_swap.

# Tests

Fixed tests.
