### PR TITLE
feat(frontend): improve WalletConnect QR scanner styling

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectForm.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectForm.svelte
@@ -103,8 +103,8 @@
 		position: relative;
 
 		outline-offset: var(--padding-0_25x);
-		outline: var(--color-base-black) dashed var(--padding-0_5x);
-		--primary-rgb: 59, 0, 185;
+		outline: var(--color-foreground-tertiary) dashed var(--padding-0_25x);
+		color: transparent;
 		overflow: hidden;
 
 		margin: 0 auto;


### PR DESCRIPTION

# Motivation
The QR code scanner used old colors. 

# Changes
- Remove purple background overlay for transparent camera view
- Update outline to use tertiary color with thinner dashed border
- Create cleaner, more polished QR scanning interface

# Tests
<img width="732" height="877" alt="image" src="https://github.com/user-attachments/assets/721f088c-6568-4a24-a4c9-83ee9a857b7e" />
<img width="655" height="787" alt="image" src="https://github.com/user-attachments/assets/044c8586-b1b0-4745-b3b0-75c535094ac4" />

