### PR TITLE
feat(frontend): add transparent background to QR code scanner

### DIFF
--- a/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
+++ b/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
@@ -51,7 +51,6 @@
 
 <style lang="scss">
 	.qr-code-wrapper {
-		--primary-rgb: 50, 20, 105;
-		color: rgba(var(--primary-rgb), 0.6);
+		color: transparent;
 	}
 </style>


### PR DESCRIPTION
# Motivation
QR scanner used old colors 

# Changes
- Remove blue-purple overlay from QR scanner camera view
- Use elegant single-line CSS solution: color: transparent
- Improve user experience with clear, unobstructed camera view for QR scanning

# Tests
Before: 
<img width="652" height="712" alt="image" src="https://github.com/user-attachments/assets/da508dcc-c77a-48ad-a0f3-1ae6c8d71740" />

After: 
<img width="628" height="708" alt="image" src="https://github.com/user-attachments/assets/209da7c5-1cb2-45cc-9a21-f6dc1708087c" />

