### PR TITLE
refactor(frontend): Use existing util in `batch` service

### DIFF
--- a/src/frontend/src/lib/services/batch.services.ts
+++ b/src/frontend/src/lib/services/batch.services.ts
@@ -1,3 +1,5 @@
+import { randomWait } from '$lib/utils/time.utils';
+
 export const batch = async function* <T>({
 	promises,
 	batchSize
@@ -9,7 +11,7 @@ export const batch = async function* <T>({
 		const batch = promises.slice(i, i + batchSize);
 		const results = await Promise.allSettled(batch.map((fn) => fn()));
 		yield results;
-		await new Promise((resolve) => setTimeout(resolve, 1000));
+		await randomWait({})
 	}
 };
 


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we can use util `randomWait` in service `batch`.
