### PR TITLE
feat(frontend): Modal get symbol util

### DIFF
--- a/src/frontend/src/lib/utils/modal.utils.ts
+++ b/src/frontend/src/lib/utils/modal.utils.ts
@@ -6,3 +6,8 @@ export const closeModal = (reset: () => void) => {
 	// The modal closes in 200ms. We defer the reset until after to avoid showing any changes while the modal is closing, which can be glitchy.
 	setTimeout(() => reset(), 250);
 };
+
+const symbols: Record<string, symbol> = {};
+
+export const getSymbol = (identifier: string) =>
+	symbols[identifier] ?? (symbols[identifier] = Symbol(identifier));

--- a/src/frontend/src/tests/lib/utils/modal.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/modal.utils.spec.ts
@@ -1,0 +1,16 @@
+import { getSymbol } from '$lib/utils/modal.utils';
+
+describe('modal.utils', () => {
+	it('should cache and return the modal id if it isnt cached yet', () => {
+		const symbol = getSymbol('doesnt exist');
+
+		expect(typeof symbol).toBe('symbol');
+	});
+
+	it('should return the same symbol if the modal id is cached', () => {
+		const symbol1 = getSymbol('doesnt exist');
+		const symbol2 = getSymbol('doesnt exist');
+
+		expect(symbol1).toBe(symbol2);
+	});
+});


### PR DESCRIPTION
# Motivation

Adding a modal util method to set/get unique symbols, which can be used to uniquely address modals when opening.

# Changes
Added method


# Tests

Added tests
