### PR TITLE
fix(frontend): Avoid concurrency from cache in Ethereum transactions loaders

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { debounce, isNullish } from '@dfinity/utils';
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { onMount, type Snippet } from 'svelte';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import { loadErc20Balances, loadEthBalances } from '$eth/services/eth-balance.services';
@@ -18,6 +18,14 @@
 	let { children }: Props = $props();
 
 	let loading = $state(false);
+	let timer = $state<NodeJS.Timeout | undefined>();
+
+	const resetTimer = () => {
+		if (nonNullish(timer)) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+	};
 
 	const onLoad = async () => {
 		if (isNullish($ethAddress)) {
@@ -25,6 +33,14 @@
 		}
 
 		if (loading) {
+			resetTimer();
+
+			timer = setTimeout(() => {
+				resetTimer();
+
+				onLoad();
+			}, 500);
+
 			return;
 		}
 
@@ -47,6 +63,7 @@
 	$effect(() => {
 		// To trigger the load function when any of the dependencies change.
 		[$ethAddress, $enabledEthereumTokens, $enabledEvmTokens, $enabledErc20Tokens];
+
 		debounceLoad();
 	});
 
@@ -54,10 +71,6 @@
 		const principal = $authIdentity?.getPrincipal();
 
 		if (isNullish(principal)) {
-			return;
-		}
-
-		if (loading) {
 			return;
 		}
 
@@ -76,8 +89,6 @@
 		);
 
 		loading = false;
-
-		await onLoad();
 	});
 </script>
 

--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -22,6 +22,14 @@
 	let { children }: Props = $props();
 
 	let loading = $state(false);
+	let timer = $state<NodeJS.Timeout | undefined>();
+
+	const resetTimer = () => {
+		if (nonNullish(timer)) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+	};
 
 	let tokens = $derived([
 		...$enabledEthereumTokens,
@@ -32,6 +40,14 @@
 
 	const onLoad = async () => {
 		if (loading) {
+			resetTimer();
+
+			timer = setTimeout(() => {
+				resetTimer();
+
+				onLoad();
+			}, 500);
+
 			return;
 		}
 
@@ -71,10 +87,6 @@
 			return;
 		}
 
-		if (loading) {
-			return;
-		}
-
 		loading = true;
 
 		await Promise.allSettled(
@@ -94,8 +106,6 @@
 		);
 
 		loading = false;
-
-		await onLoad();
 	};
 
 	const debounceLoadFromCache = debounce(loadFromCache);


### PR DESCRIPTION
# Motivation

In all loaders for Ethereum/EVM transactions, we should avoid syncing the transaction store from cache at the same time that we query from real data.