### PR TITLE
ci(bot): Allow bot to modify tokens images logos

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -10,7 +10,10 @@ e2e/**/*.png
 declarations/**/*
 src/frontend/src/env/tokens/tokens.*.json
 src/frontend/src/env/tokens/tokens-erc20/
-src/frontend/static/icons/sns/*
+src/frontend/static/icons/dip20/*.png
+src/frontend/static/icons/icrc/*.png
+src/frontend/static/icons/sns/*.png
+src/frontend/src/icp/assets/*.svg
 src/frontend/src/**/*.svelte
 src/frontend/src/tests/**/*.spec.ts
 src/frontend/src/tests/**/*.mock.ts


### PR DESCRIPTION
# Motivation

Since some CI updates icons and logos of IC tokens, we need to allow the Bot to update them.
