### PR TITLE
fix(frontend): prevent AI input being zoomed on mobile Safari

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantForm.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantForm.svelte
@@ -20,7 +20,7 @@
 	};
 </script>
 
-<div class="border-t border-secondary px-4 py-3 pb-4 text-xs">
+<div class="border-t border-secondary px-4 py-3 pb-4 text-base sm:text-xs">
 	<form method="POST" onsubmit={onSubmit}>
 		<InputText
 			name="message"


### PR DESCRIPTION
# Motivation

We need to increase the font size for mobile screens to prevent the default zooming to form elements if the size is less than 16px. From the design point of view, it also makes sense to apply this change.
