### PR TITLE
feat(devops): Ignore test folder when checking unused Svelte components

### DIFF
--- a/scripts/check.unused.svelte.mjs
+++ b/scripts/check.unused.svelte.mjs
@@ -13,7 +13,8 @@ const DATA_DIR_PATH = resolve(process.cwd(), DATA_DIR);
 
 const REMOVE_FILES = process.argv.includes('--remove-files');
 
-const findSvelteFiles = (dir) => findFiles({ dir, extensions: ['.svelte'] });
+// TODO: Check if the svelte files in the tests are actually used, and used ONLY in the tests
+const findSvelteFiles = (dir) => findFiles({ dir, extensions: ['.svelte'], ignoreDirs: ['tests'] });
 
 const findSearchFiles = (dir) => findFiles({ dir, extensions: ['.svelte', '.ts'] });
 


### PR DESCRIPTION
# Motivation

The CI that checks for unused Svelte components, ignores the tests: we want to see if the components are effectively used.

However, it is giving false positive for Svelte components that are auxiliary and used ONLY in the tests.

For now, we ignore such component in the analysis, and we will follow-up with a way to check if they are effectively used, and used ONLY in the tests.
