### PR TITLE
fix(frontend): Settings translation fixes

### DIFF
--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -59,7 +59,7 @@
 </script>
 
 <SettingsCard>
-	<svelte:fragment slot="title">General</svelte:fragment>
+	<svelte:fragment slot="title">{$i18n.settings.text.general}</svelte:fragment>
 
 	<SettingsCardItem>
 		<svelte:fragment slot="key">

--- a/src/frontend/src/lib/components/settings/SettingsExperimentalFeatures.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsExperimentalFeatures.svelte
@@ -48,13 +48,13 @@
 		});
 	};
 
-	const labelsByFeatureId: Record<ExperimentalFeatureId, Record<string, string>> = {
+	const labelsByFeatureId: Record<ExperimentalFeatureId, Record<string, string>> = $derived({
 		AiAssistantBeta: {
 			title: replaceOisyPlaceholders($i18n.ai_assistant.text.title),
 			description: $i18n.ai_assistant.text.feature_description,
 			learnMore: OISY_AI_ASSISTANT_DOCS_URL
 		}
-	};
+	});
 </script>
 
 <SettingsCard>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "الإعدادات",
+			"general": "",
 			"principal": "العنوان الاساسي الخاص بك",
 			"principal_copied": "تم نسخ العنوان الأساسي",
 			"principal_description": "معرفك لـ $oisy_name. تم إنشاؤه بواسطة هويتك على الإنترنت.",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Nastavení",
+			"general": "",
 			"principal": "Váše Hlavní ICP ID",
 			"principal_copied": "Hlavní ICP ID zkopírováno do schránky",
 			"principal_description": "Vaše ID pro $oisy_name. Vytvořeno vaší Internetovou Identitou.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -580,7 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Einrichten",
-            "general": "Allgemein",
+			"general": "Allgemein",
 			"principal": "Dein Principal",
 			"principal_copied": "Principal in Zwischenablage kopiert",
 			"principal_description": "Deine ID für $oisy_name. Erstellt durch deine Internet Identity.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Einrichten",
+            "general": "Allgemein",
 			"principal": "Dein Principal",
 			"principal_copied": "Principal in Zwischenablage kopiert",
 			"principal_description": "Deine ID für $oisy_name. Erstellt durch deine Internet Identity.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Settings",
+            "general": "General",
 			"principal": "Your Principal",
 			"principal_copied": "Principal copied to clipboard",
 			"principal_description": "Your ID for the $oisy_name. Created by your Internet Identity.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -580,7 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Settings",
-            "general": "General",
+			"general": "General",
 			"principal": "Your Principal",
 			"principal_copied": "Principal copied to clipboard",
 			"principal_description": "Your ID for the $oisy_name. Created by your Internet Identity.",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Paramètres",
+			"general": "",
 			"principal": "Votre Principal",
 			"principal_copied": "Principal copié dans le presse-papiers",
 			"principal_description": "Votre ID pour $oisy_name. Créé par votre Internet Identity.",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "सेटिंग्स",
+			"general": "",
 			"principal": "आपका प्रिंसिपल",
 			"principal_copied": "प्रिंसिपल क्लिपबोर्ड पर कॉपी किया गया",
 			"principal_description": "$oisy_name के लिए आपकी आईडी। आपकी इंटरनेट आइडेंटिटी द्वारा बनाया गया।",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Impostazioni",
+			"general": "",
 			"principal": "Il tuo Principal",
 			"principal_copied": "Principal copiato negli appunti",
 			"principal_description": "Il tuo ID per $oisy_name. Creato dalla tua Internet Identity.",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "設定",
+			"general": "",
 			"principal": "あなたのPrincipal",
 			"principal_copied": "Principalがコピーされました",
 			"principal_description": "$oisy_nameのあなたのIDです。Internet Identityによって作成されます",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Ustawienia",
+			"general": "",
 			"principal": "Twój Principal",
 			"principal_copied": "Principal skopiowany do schowka",
 			"principal_description": "Twój identyfikator dla $oisy_name. Utworzony przez Twoją tożsamość internetową.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Configurações",
+			"general": "",
 			"principal": "Seu Principal",
 			"principal_copied": "Principal copiado para a área de transferência",
 			"principal_description": "Seu ID para $oisy_name. Criado pela sua Internet Identity.",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Настройки",
+			"general": "",
 			"principal": "Ваш Принципал",
 			"principal_copied": "Принципал скопирован в буфер обмена",
 			"principal_description": "Ваш ID для $oisy_name. Создан вашей Internet Identity.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "Cài đặt",
+			"general": "",
 			"principal": "Principal của bạn",
 			"principal_copied": "Principal đã được sao chép vào khay nhớ tạm",
 			"principal_description": "ID của bạn cho $oisy_name. Được tạo bởi Internet Identity của bạn.",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -580,6 +580,7 @@
 	"settings": {
 		"text": {
 			"title": "设置",
+			"general": "",
 			"principal": "你的 Principal",
 			"principal_copied": "Principal 已复制到剪贴板",
 			"principal_description": "你在 $oisy_name 中的身份标识，由 Internet Identity 创建。",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -434,6 +434,7 @@ interface I18nHero {
 interface I18nSettings {
 	text: {
 		title: string;
+		general: string;
 		principal: string;
 		principal_copied: string;
 		principal_description: string;


### PR DESCRIPTION
# Motivation

Fixing some small translation issues.

# Changes

- Adjusted AI setting translation (havent been reactive so didnt change on language change)
- Added translation for hardcoded "General" text

# Tests

DE:
<img width="636" height="684" alt="image" src="https://github.com/user-attachments/assets/276b6a21-cbcb-4bc3-9a39-e7ae85736789" />

EN:
<img width="636" height="684" alt="image" src="https://github.com/user-attachments/assets/007cc5a2-2116-4f00-a907-50a3a79b8ca1" />

FR:
<img width="636" height="684" alt="image" src="https://github.com/user-attachments/assets/6d6ae2ef-3fdd-470f-84b2-5804c8aa67f5" />
