### PR TITLE
feat(frontend): hide buyButton on hero

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -53,6 +53,7 @@
 	let sendAction = $derived(!$allBalancesZero || isTransactionsPage);
 
 	let buyAction = $derived(!$networkICP || nonNullish($pageToken?.buy));
+	let tooManyButtons = $derived(convertErc20 || convertEth);
 </script>
 
 <div class="flex w-full justify-center pt-8" role="toolbar">
@@ -103,7 +104,7 @@
 			{/if}
 		{/if}
 
-		{#if buyAction}
+		{#if buyAction && !tooManyButtons}
 			<Buy />
 		{/if}
 	</HeroButtonGroup>


### PR DESCRIPTION
# Motivation

We need to hide buy button where there are too many buttons

# Changes

Added condition tooManyButtons to hide BuyButton

# Tests


Before: 
<img width="491" height="250" alt="image" src="https://github.com/user-attachments/assets/c51ec8e8-1144-4981-9ccc-3af3bc20dcde" />
<img width="479" height="245" alt="image" src="https://github.com/user-attachments/assets/6df4c2fb-2571-4e76-8633-6d230a6c5552" />

After: 
