### PR TITLE
fix(frontend): Dont persist search modal tokenlist

### DIFF
--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -32,10 +32,11 @@
 
 	const dispatch = createEventDispatcher();
 
-	const { filteredTokens, filterNetwork, filterQuery, setFilterQuery } =
-		getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+	const { filteredTokens, filterNetwork, setFilterQuery } = getContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY
+	);
 
-	let filter = $state($filterQuery ?? '');
+	let filter = $state('');
 
 	$effect(() => {
 		setFilterQuery(filter);


### PR DESCRIPTION
# Motivation

If we leave the tokenlist in modals we should not persist the last search.

# Changes

Achieved by not using the context flterQuery value as the initial state value

# Tests


https://github.com/user-attachments/assets/415b2021-b4e6-4dea-aefd-617b614a775b


