### PR TITLE
fix(frontend): Displays empty nfts list when collections are all empty

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftsList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftsList.svelte
@@ -96,13 +96,13 @@
 	);
 
 	const isEmptyList = $derived.by(() => {
-		const hasNoCollections = nftCollections.length === 0;
+		const hasOnlyEmptyCollections = nftCollections.filter((c) => c.nfts.length > 0).length === 0;
 		const hasCommonCollections = commonCollections.length > 0;
 		const hasVisibleSpamCollections = $showSpam && spamCollections.length > 0;
 		const hasVisibleHiddenCollections = $showHidden && hiddenCollections.length > 0;
 
 		return (
-			hasNoCollections ||
+			hasOnlyEmptyCollections ||
 			!(hasCommonCollections || hasVisibleSpamCollections || hasVisibleHiddenCollections)
 		);
 	});


### PR DESCRIPTION
# Motivation

Since we don't know if we are still loading nfts or not, we do not display the skeletons anymore when all imported collections are empty.

# Tests

**Old:**
<img width="475" height="370" alt="image" src="https://github.com/user-attachments/assets/8ba159cb-8d95-4184-b9f1-6c96a4781ecf" />


**New:**
<img width="452" height="347" alt="image" src="https://github.com/user-attachments/assets/2746ecdd-3247-495f-9771-8e7b0c4784e1" />

