### PR TITLE
build(deps): Bump `alchemy-sdk` and remove override of `axios` and `elliptic`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@solana/kit": "^3.0.3",
 				"@velora-dex/sdk": "^9.0.0",
 				"@walletconnect/auth-client": "^2.1.2",
-				"alchemy-sdk": "3.6.3",
+				"alchemy-sdk": "^3.6.4",
 				"bitcoinjs-lib": "^6.1.7",
 				"browser-image-compression": "^2.0.2",
 				"buffer": "^6.0.3",
@@ -1158,14 +1158,6 @@
 				}
 			}
 		},
-		"node_modules/@eslint/config-array/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@eslint/config-helpers": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
@@ -1248,14 +1240,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.32.0",
@@ -1612,7 +1596,8 @@
 		"node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+			"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+			"license": "MIT"
 		},
 		"node_modules/@ethersproject/keccak256": {
 			"version": "5.8.0",
@@ -4059,24 +4044,15 @@
 			}
 		},
 		"node_modules/@solana/errors/node_modules/chalk": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-			"integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
 			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@solana/errors/node_modules/commander": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-			"integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/@solana/fast-stable-stringify": {
@@ -5636,9 +5612,9 @@
 			}
 		},
 		"node_modules/@solana/web3.js": {
-			"version": "1.98.2",
-			"resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.2.tgz",
-			"integrity": "sha512-BqVwEG+TaG2yCkBMbD3C4hdpustR4FpuUFRPUmqRZYYlPI9Hg4XMWxHWOWRzHE9Lkc9NDjzXFX7lDXSgzC7R1A==",
+			"version": "1.98.4",
+			"resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+			"integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.25.0",
@@ -5847,13 +5823,6 @@
 				}
 			}
 		},
-		"node_modules/@sveltejs/vite-plugin-svelte-inspector/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/debug": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -5871,13 +5840,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.17",
@@ -6511,14 +6473,6 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@typescript-eslint/project-service": {
 			"version": "8.38.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.38.0.tgz",
@@ -6560,14 +6514,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@typescript-eslint/project-service/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "8.38.0",
@@ -6650,14 +6596,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "8.38.0",
@@ -6750,14 +6688,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "8.38.0",
@@ -6901,13 +6831,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@vitest/coverage-v8/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@vitest/eslint-plugin": {
 			"version": "1.3.12",
@@ -7598,9 +7521,9 @@
 			}
 		},
 		"node_modules/alchemy-sdk": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-3.6.3.tgz",
-			"integrity": "sha512-AHSJGxJf3r8blvp97RatmiyBFTGtWH9pWDmdsv8mngdANuLvxRLhTU5Abf1lX2u6JzE7ulgG8/x0BsMLAEmAjA==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-3.6.4.tgz",
+			"integrity": "sha512-c1CZIywrqlGIcTfUB/LGNWZCtt4vcMgS4JRgz2QQq1f6oJ+jHf1EGPxM9G35zkXun5W6yBO+pnnrf/HO+whRdg==",
 			"license": "MIT",
 			"dependencies": {
 				"@ethersproject/abi": "^5.7.0",
@@ -7615,7 +7538,7 @@
 				"@ethersproject/wallet": "^5.7.0",
 				"@ethersproject/web": "^5.7.0",
 				"@solana/web3.js": "^1.87.6",
-				"axios": "^1.7.4",
+				"axios": "^1.12.0",
 				"sturdy-websocket": "^0.2.1",
 				"websocket": "^1.0.34"
 			}
@@ -7970,7 +7893,8 @@
 		"node_modules/bech32": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+			"license": "MIT"
 		},
 		"node_modules/bip174": {
 			"version": "2.1.1",
@@ -8329,10 +8253,13 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"license": "MIT"
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+			"integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -8540,6 +8467,12 @@
 			"dependencies": {
 				"ms": "2.0.0"
 			}
+		},
+		"node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
 		},
 		"node_modules/decimal.js": {
 			"version": "10.6.0",
@@ -9254,14 +9187,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"node_modules/eslint-import-resolver-node/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/eslint-module-utils": {
 			"version": "2.12.1",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
@@ -9291,14 +9216,6 @@
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
-		},
-		"node_modules/eslint-module-utils/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/eslint-plugin-es-x": {
 			"version": "7.8.0",
@@ -9400,14 +9317,6 @@
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/eslint-plugin-import/node_modules/semver": {
 			"version": "6.3.1",
@@ -9632,14 +9541,6 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
-		},
-		"node_modules/eslint/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
@@ -10696,13 +10597,6 @@
 				}
 			}
 		},
-		"node_modules/https-proxy-agent/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/humanize-ms": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -11418,13 +11312,6 @@
 				}
 			}
 		},
-		"node_modules/istanbul-lib-source-maps/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/istanbul-reports": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -11485,6 +11372,12 @@
 			"version": "12.20.55",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
 			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+			"license": "MIT"
+		},
+		"node_modules/jayson/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"license": "MIT"
 		},
 		"node_modules/jayson/node_modules/ws": {
@@ -12299,9 +12192,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
 		"node_modules/multiformats": {
@@ -13682,9 +13575,9 @@
 			}
 		},
 		"node_modules/rpc-websockets": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.3.tgz",
-			"integrity": "sha512-I+kNjW0udB4Fetr3vvtRuYZJS0PcSPyyvBcH5sDdoV8DFs5E4W2pTr7aiMlKfPxANTClP9RlqCPolj9dd5MsEA==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.2.0.tgz",
+			"integrity": "sha512-DS/XHdPxplQTtNRKiBCRWGBJfjOk56W7fyFUpiYi9fSTWTzoEMbUkn3J4gB0IMniIEVeAGR1/rzFQogzD5MxvQ==",
 			"license": "LGPL-3.0-only",
 			"dependencies": {
 				"@swc/helpers": "^0.5.11",
@@ -13893,7 +13786,8 @@
 		"node_modules/scrypt-js": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "7.6.3",
@@ -15532,13 +15426,6 @@
 				}
 			}
 		},
-		"node_modules/vite-node/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/vite/node_modules/fdir": {
 			"version": "6.4.6",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -15685,13 +15572,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/vitest/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/vitest/node_modules/picomatch": {
 			"version": "4.0.2",
@@ -16070,6 +15950,7 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
 			"integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.32"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"@solana/kit": "^3.0.3",
 		"@velora-dex/sdk": "^9.0.0",
 		"@walletconnect/auth-client": "^2.1.2",
-		"alchemy-sdk": "3.6.3",
+		"alchemy-sdk": "^3.6.4",
 		"bitcoinjs-lib": "^6.1.7",
 		"browser-image-compression": "^2.0.2",
 		"buffer": "^6.0.3",
@@ -144,9 +144,7 @@
 		"@ethersproject/providers": {
 			"ws": "^7.5.10"
 		},
-		"elliptic": "^6.6.1",
-		"cookie": "^0.7.0",
-		"axios": "^1.12.0"
+		"cookie": "^0.7.0"
 	},
 	"engines": {
 		"npm": ">=10.9.0 <11.0.0",


### PR DESCRIPTION
# Motivation

The [latest version v3.6.4](https://github.com/alchemyplatform/alchemy-sdk-js/releases/tag/v3.6.4) of `alchemy-sdk` removes the `axios` vulnerability that we were solving by overriding the installed version (see PR https://github.com/dfinity/oisy-wallet/pull/8820).

### Related Issue:

- https://github.com/alchemyplatform/alchemy-sdk-js/issues/486