### PR TITLE
feat(devops): Remove `merge_group` trigger where not needed

### DIFF
--- a/.github/workflows/auto-update-i18n.yml
+++ b/.github/workflows/auto-update-i18n.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'src/frontend/src/lib/i18n/*'
       - 'src/frontend/src/lib/types/i18n.d.ts'
-  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/frontend-reproducibility.yaml
+++ b/.github/workflows/frontend-reproducibility.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - package-lock.json
-  merge_group:
   release:
     types: [ released ]
   workflow_dispatch:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -5,7 +5,6 @@ on:
     types: [closed]
     branches:
       - main
-  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
# Motivation

After an empirical test, even comparing with other repos, we found out that for using the merge queue, we need the `merge_group` trigger only where we have status checks. 
