### PR TITLE
fix(frontend): Wrong place for nullish assertion in `overwriteStoredIdentityKey`

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -85,11 +85,11 @@ const initAuthStore = (): AuthStore => {
 	 * TODO: Remove this when `authClient` will handle it by itself during login.
 	 */
 	const overwriteStoredIdentityKey = async () => {
-		// In the unlikely event of an error while setting a value in IndexedDB,
-		// we log out the user and refresh the page to prevent potential conflicts.
-		assertNonNullish(authClient);
-
 		try {
+			// In the unlikely event of an error while setting a value in IndexedDB,
+			// we log out the user and refresh the page to prevent potential conflicts.
+			assertNonNullish(authClient);
+
 			const key = authClient['_key'];
 
 			await authClientStorage.set(KEY_STORAGE_KEY, (key as ECDSAKeyIdentity).getKeyPair());

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -94,8 +94,6 @@ const initAuthStore = (): AuthStore => {
 
 			await authClientStorage.set(KEY_STORAGE_KEY, (key as ECDSAKeyIdentity).getKeyPair());
 		} catch (_: unknown) {
-			// In case of error in this flow, we prefer to log out the user and refresh the page to avoid possible further conflicts.
-
 			await authStore.signOut();
 
 			window.location.reload();


### PR DESCRIPTION
# Motivation

As noticed by @peterpeterparker , I made a mistake in PR https://github.com/dfinity/oisy-wallet/pull/9153: the nullish check for the `authClient` should have gone inside the try-catch statement.