### PR TITLE
feat(frontend): Always load all Ethereum transactions

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
-	import LoaderEthTransactions from '$eth/components/loaders/LoaderEthTransactions.svelte';
 	import EthTokenModal from '$eth/components/tokens/EthTokenModal.svelte';
 	import EthTransaction from '$eth/components/transactions/EthTransaction.svelte';
 	import EthTransactionModal from '$eth/components/transactions/EthTransactionModal.svelte';
@@ -54,19 +53,17 @@
 
 <Header>{$i18n.transactions.text.title}</Header>
 
-<LoaderEthTransactions>
-	<EthTransactionsSkeletons>
-		{#each sortedTransactionsUi as transaction (transaction.hash)}
-			<div transition:slide={SLIDE_DURATION}>
-				<EthTransaction token={$tokenWithFallback} {transaction} />
-			</div>
-		{/each}
+<EthTransactionsSkeletons>
+	{#each sortedTransactionsUi as transaction (transaction.hash)}
+		<div transition:slide={SLIDE_DURATION}>
+			<EthTransaction token={$tokenWithFallback} {transaction} />
+		</div>
+	{/each}
 
-		{#if $sortedEthTransactions.length === 0}
-			<TransactionsPlaceholder />
-		{/if}
-	</EthTransactionsSkeletons>
-</LoaderEthTransactions>
+	{#if $sortedEthTransactions.length === 0}
+		<TransactionsPlaceholder />
+	{/if}
+</EthTransactionsSkeletons>
 
 {#if $modalEthTransaction && nonNullish(selectedTransaction)}
 	<EthTransactionModal token={selectedToken} transaction={selectedTransaction} />

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -9,10 +9,7 @@
 	import IcTransaction from '$icp/components/transactions/IcTransaction.svelte';
 	import IcTransactionModal from '$icp/components/transactions/IcTransactionModal.svelte';
 	import IcTransactionsBitcoinStatus from '$icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte';
-	import IcTransactionsCkBtcListeners from '$icp/components/transactions/IcTransactionsCkBtcListeners.svelte';
-	import IcTransactionsCkEthereumListeners from '$icp/components/transactions/IcTransactionsCkEthereumListeners.svelte';
 	import IcTransactionsEthereumStatus from '$icp/components/transactions/IcTransactionsEthereumStatus.svelte';
-	import IcTransactionsNoListener from '$icp/components/transactions/IcTransactionsNoListener.svelte';
 	import IcTransactionsScroll from '$icp/components/transactions/IcTransactionsScroll.svelte';
 	import IcTransactionsSkeletons from '$icp/components/transactions/IcTransactionsSkeletons.svelte';
 	import {
@@ -25,7 +22,6 @@
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import type { IcTransactionUi } from '$icp/types/ic-transaction';
 	import { hasIndexCanister } from '$icp/validation/ic-token.validation';
-	import { ckEthereumNativeToken } from '$icp-eth/derived/cketh.derived';
 	import TransactionsPlaceholder from '$lib/components/transactions/TransactionsPlaceholder.svelte';
 	import Header from '$lib/components/ui/Header.svelte';
 	import { modalIcToken, modalIcTokenData, modalIcTransaction } from '$lib/derived/modal.derived';
@@ -36,14 +32,6 @@
 	import { mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let ckEthereum = $derived($tokenCkEthLedger || $tokenCkErc20Ledger);
-
-	let AdditionalListener = $derived(
-		$tokenCkBtcLedger
-			? IcTransactionsCkBtcListeners
-			: ckEthereum
-				? IcTransactionsCkEthereumListeners
-				: IcTransactionsNoListener
-	);
 
 	let selectedTransaction = $state<IcTransactionUi | undefined>();
 	let selectedToken = $state<OptionToken>();
@@ -79,25 +67,23 @@
 </Header>
 
 <IcTransactionsSkeletons>
-	<AdditionalListener ckEthereumNativeToken={$ckEthereumNativeToken} {token}>
-		{#if $icTransactions.length > 0}
-			<IcTransactionsScroll {token}>
-				{#each $icTransactions as transaction, index (`${transaction.data.id}-${index}`)}
-					<li in:slide={{ duration: transaction.data.status === 'pending' ? 250 : 0 }}>
-						<IcTransaction {token} transaction={transaction.data} />
-					</li>
-				{/each}
-			</IcTransactionsScroll>
-		{/if}
+	{#if $icTransactions.length > 0}
+		<IcTransactionsScroll {token}>
+			{#each $icTransactions as transaction, index (`${transaction.data.id}-${index}`)}
+				<li in:slide={{ duration: transaction.data.status === 'pending' ? 250 : 0 }}>
+					<IcTransaction {token} transaction={transaction.data} />
+				</li>
+			{/each}
+		</IcTransactionsScroll>
+	{/if}
 
-		{#if noTransactions}
-			<IcNoIndexPlaceholder
-				placeholderType={hasIndexCanister($tokenAsIcToken) ? 'not-working' : 'missing'}
-			/>
-		{:else if $icTransactions.length === 0}
-			<TransactionsPlaceholder />
-		{/if}
-	</AdditionalListener>
+	{#if noTransactions}
+		<IcNoIndexPlaceholder
+			placeholderType={hasIndexCanister($tokenAsIcToken) ? 'not-working' : 'missing'}
+		/>
+	{:else if $icTransactions.length === 0}
+		<TransactionsPlaceholder />
+	{/if}
 </IcTransactionsSkeletons>
 
 {#if $modalIcTransaction && nonNullish(selectedTransaction)}

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import LoaderEthBalances from '$eth/components/loaders/LoaderEthBalances.svelte';
+	import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
 	import CkBtcUpdateBalanceListener from '$icp/components/core/CkBtcUpdateBalanceListener.svelte';
 	import BalancesIdbSetter from '$lib/components/balances/BalancesIdbSetter.svelte';
+	import MultipleListeners from '$lib/components/core/MultipleListeners.svelte';
 	import ExchangeWorker from '$lib/components/exchange/ExchangeWorker.svelte';
 	import AddressGuard from '$lib/components/guard/AddressGuard.svelte';
 	import AgreementsGuard from '$lib/components/guard/AgreementsGuard.svelte';
@@ -16,6 +18,7 @@
 	import LoaderWallets from '$lib/components/loaders/LoaderWallets.svelte';
 	import UserSnapshotWorker from '$lib/components/rewards/UserSnapshotWorker.svelte';
 	import TransactionsIdbSetter from '$lib/components/transactions/TransactionsIdbSetter.svelte';
+	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 
 	interface Props {
 		children: Snippet;
@@ -32,21 +35,25 @@
 					<ShortcutGuard>
 						<RewardGuard>
 							<LoaderEthBalances>
-								<LoaderWallets>
-									<ExchangeWorker>
-										<LoaderMetamask>
-											<UserSnapshotWorker>
-												<LoaderContacts>
-													<TransactionsIdbSetter>
-														<BalancesIdbSetter>
-															{@render children()}
-														</BalancesIdbSetter>
-													</TransactionsIdbSetter>
-												</LoaderContacts>
-											</UserSnapshotWorker>
-										</LoaderMetamask>
-									</ExchangeWorker>
-								</LoaderWallets>
+								<MultipleListeners tokens={$enabledFungibleNetworkTokens}>
+									<LoaderMultipleEthTransactions>
+										<LoaderWallets>
+											<ExchangeWorker>
+												<LoaderMetamask>
+													<UserSnapshotWorker>
+														<LoaderContacts>
+															<TransactionsIdbSetter>
+																<BalancesIdbSetter>
+																	{@render children()}
+																</BalancesIdbSetter>
+															</TransactionsIdbSetter>
+														</LoaderContacts>
+													</UserSnapshotWorker>
+												</LoaderMetamask>
+											</ExchangeWorker>
+										</LoaderWallets>
+									</LoaderMultipleEthTransactions>
+								</MultipleListeners>
 							</LoaderEthBalances>
 						</RewardGuard>
 					</ShortcutGuard>

--- a/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
+++ b/src/frontend/src/lib/components/send/SendDestinationWizardStep.svelte
@@ -4,7 +4,6 @@
 	import BtcSendDestination from '$btc/components/send/BtcSendDestination.svelte';
 	import { btcNetworkContacts } from '$btc/derived/btc-contacts.derived';
 	import { btcKnownDestinations } from '$btc/derived/btc-transactions.derived';
-	import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
 	import EthSendDestination from '$eth/components/send/EthSendDestination.svelte';
 	import { ethNetworkContacts } from '$eth/derived/eth-contacts.derived';
 	import { ethKnownDestinations } from '$eth/derived/eth-transactions.derived';
@@ -89,24 +88,22 @@
 	{#if isNetworkIdEthereum($sendTokenNetworkId) || isNetworkIdEvm($sendTokenNetworkId)}
 		<div data-tid={testId}>
 			<CkEthLoader isSendFlow={true} nativeTokenId={$nativeEthereumTokenId}>
-				<LoaderMultipleEthTransactions>
-					<EthSendDestination
-						knownDestinations={$ethKnownDestinations}
-						networkContacts={$ethNetworkContacts}
-						token={$sendToken}
-						bind:destination
-						bind:invalidDestination
-						on:icQRCodeScan
-					/>
-					<SendDestinationTabs
-						knownDestinations={$ethKnownDestinations}
-						networkContacts={$ethNetworkContacts}
-						bind:destination
-						bind:activeSendDestinationTab
-						bind:selectedContact
-						on:icNext={next}
-					/>
-				</LoaderMultipleEthTransactions>
+				<EthSendDestination
+					knownDestinations={$ethKnownDestinations}
+					networkContacts={$ethNetworkContacts}
+					token={$sendToken}
+					bind:destination
+					bind:invalidDestination
+					on:icQRCodeScan
+				/>
+				<SendDestinationTabs
+					knownDestinations={$ethKnownDestinations}
+					networkContacts={$ethNetworkContacts}
+					bind:destination
+					bind:activeSendDestinationTab
+					bind:selectedContact
+					on:icNext={next}
+				/>
 			</CkEthLoader>
 		</div>
 	{:else if isNetworkIdICP($sendTokenNetworkId)}

--- a/src/frontend/src/routes/(app)/activity/+page.svelte
+++ b/src/frontend/src/routes/(app)/activity/+page.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-	import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
-	import MultipleListeners from '$lib/components/core/MultipleListeners.svelte';
 	import AllTransactions from '$lib/components/transactions/AllTransactions.svelte';
-	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 </script>
 
-<MultipleListeners tokens={$enabledFungibleNetworkTokens}>
-	<LoaderMultipleEthTransactions>
-		<AllTransactions />
-	</LoaderMultipleEthTransactions>
-</MultipleListeners>
+<AllTransactions />


### PR DESCRIPTION
# Motivation

Some of the sprinkles programs require to have the list of the user transactions too to work. For Ethereum and EVMs, the transactions loaders are created only in the Activity page and in the transactions list for each token.

Now, we need for all the pages (rewards, assets, etc). So, we move the main loader to the global `Loaders` component. And we remove the listeners from the transactions lists too.
