### PR TITLE
refactor(frontend): Simplify method pickAuthClient of authStore

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -59,7 +59,12 @@ const initAuthStore = (): AuthStore => {
 			return refreshed;
 		}
 
-		return authClient ?? refreshed;
+		// When the user signs out, we trigger a call to `sync()`.
+		// The `sync()` method creates a new `AuthClient` (since the previous one was nullified on sign-out), causing the creation of new identity keys in IndexedDB.
+		// To avoid using such keys (or tampered ones) for the next login, we use the method `safeCreateAuthClient()` which clears any stored keys before creating a new `AuthClient`.
+		// We do it only if the user is not authenticated, because if it is, then it is theoretically already safe (or at least, it is out of our control to make it safer).
+		// If it is already authenticated, it is theoretically already safe (or at least, it is out of our control to make it safer)
+		return await safeCreateAuthClient();
 	};
 
 	/**
@@ -108,22 +113,7 @@ const initAuthStore = (): AuthStore => {
 
 		const isAuthenticated: boolean = await authClient.isAuthenticated();
 
-		if (!isAuthenticated) {
-			// When the user signs out, we trigger a call to `sync()`.
-			// The `sync()` method creates a new `AuthClient` (since the previous one was nullified on sign-out), causing the creation of new identity keys in IndexedDB.
-			// To avoid using such keys (or tampered ones) for the next login, we use the method `safeCreateAuthClient()` which clears any stored keys before creating a new `AuthClient`.
-			// We do it only if the user is not authenticated, because if it is, then it is theoretically already safe (or at least, it is out of our control to make it safer).
-			authClient = await safeCreateAuthClient();
-
-			set({ identity: null });
-
-			return;
-		}
-
-		// If it is already authenticated, it is theoretically already safe (or at least, it is out of our control to make it safer)
-		set({
-			identity: authClient.getIdentity()
-		});
+		set({ identity: isAuthenticated ? authClient.getIdentity() : null });
 	};
 
 	return {


### PR DESCRIPTION
# Motivation

There is a sort of redundant logic in the method that chooses the `authClient` to use in `authStore.sync`.

Basically, we want that when there is no authentication done by the existing `autClient` or a new one, we recreate the `authClient` safely (removing the identity key).

We already do that, but no real reason to have it in a different method than the one that chooses which `authClient` to use.

It seems more coherent.
