### PR TITLE
fix(devops): Remove `merge_group` trigger from PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,6 @@ on:
       - reopened
       - synchronize
       - labeled
-  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
# Motivation

The PR that merges all the PRs in the merge queue does not require the PR checks.
