### PR TITLE
refactor(frontend): Migrate `SkeletonCard` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/ui/SkeletonCard.svelte
+++ b/src/frontend/src/lib/components/ui/SkeletonCard.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import Card from '$lib/components/ui/Card.svelte';
 	import SkeletonLogo from '$lib/components/ui/SkeletonLogo.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 
-	export let testId: string | undefined = undefined;
+	interface Props {
+		testId?: string;
+		children?: Snippet;
+	}
+
+	let { testId, children }: Props = $props();
 </script>
 
 <Card {testId}>
-	<span class="inline-block w-[120px] max-w-full sm:w-[200px]"><slot><SkeletonText /></slot></span>
+	<span class="inline-block w-[120px] max-w-full sm:w-[200px]">
+		{#if nonNullish(children)}
+			{@render children()}
+		{:else}
+			<SkeletonText />
+		{/if}
+	</span>
 
 	{#snippet amount()}
 		<span class="inline-block w-full max-w-[100px]"><SkeletonText /></span>

--- a/src/frontend/src/lib/components/ui/SkeletonLogo.svelte
+++ b/src/frontend/src/lib/components/ui/SkeletonLogo.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let size: 'small' | 'big' = 'small';
+	interface Props {
+		size?: 'small' | 'big';
+	}
+
+	let { size = 'small' }: Props = $props();
 </script>
 
 <div aria-hidden="true">


### PR DESCRIPTION
# Motivation

Migrate component `SkeletonCard` (and its direct children) to Svelte 5.
