### PR TITLE
test(frontend): Improve mocks for auth identity store

### DIFF
--- a/src/frontend/src/tests/mocks/auth.mock.ts
+++ b/src/frontend/src/tests/mocks/auth.mock.ts
@@ -1,10 +1,16 @@
 import * as authStore from '$lib/derived/auth.derived';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import type { Identity } from '@dfinity/agent';
+import { nonNullish } from '@dfinity/utils';
 import { readable } from 'svelte/store';
 
-export const mockAuthStore = (value: Identity | null = mockIdentity) =>
+export const mockAuthStore = (value: Identity | null = mockIdentity) => {
 	vi.spyOn(authStore, 'authIdentity', 'get').mockImplementation(() => readable(value));
 
-export const mockAuthSignedIn = (value = true) =>
+	mockAuthSignedIn(nonNullish(value));
+};
+
+export const mockAuthSignedIn = (value = true) => {
 	vi.spyOn(authStore, 'authSignedIn', 'get').mockImplementation(() => readable(value));
+	vi.spyOn(authStore, 'authNotSignedIn', 'get').mockImplementation(() => readable(!value));
+};

--- a/src/frontend/src/tests/mocks/auth.mock.ts
+++ b/src/frontend/src/tests/mocks/auth.mock.ts
@@ -1,14 +1,10 @@
 import * as authStore from '$lib/derived/auth.derived';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import type { Identity } from '@dfinity/agent';
-import { nonNullish } from '@dfinity/utils';
 import { readable } from 'svelte/store';
 
-export const mockAuthStore = (value: Identity | null = mockIdentity) => {
+export const mockAuthStore = (value: Identity | null = mockIdentity) =>
 	vi.spyOn(authStore, 'authIdentity', 'get').mockImplementation(() => readable(value));
-
-	mockAuthSignedIn(nonNullish(value));
-};
 
 export const mockAuthSignedIn = (value = true) => {
 	vi.spyOn(authStore, 'authSignedIn', 'get').mockImplementation(() => readable(value));


### PR DESCRIPTION
# Motivation

To be really thorough with the mocking of the auth store, we need to expand `mockAuthSignedIn` to cover the derived `authNotSignedIn`. 
