### PR TITLE
refactor(frontend): Reorganize the tests for App Layout

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -42,14 +42,14 @@ jobs:
         run: npm run test:coverage
 
       # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
-      - name: Reduce coverage thresholds by 0.50%
+      - name: Reduce coverage thresholds by 0.10%
         run: |
           node -e "
           const fs = require('fs');
           const file = 'vitest.config.ts';
           const text = fs.readFileSync(file, 'utf8');
           const updated = text.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
-            const reduced = (parseFloat(value) - 0.5).toFixed(2);
+            const reduced = (parseFloat(value) - 0.1).toFixed(2);
             return \`\${key}: \${reduced}\`;
           });
           fs.writeFileSync(file, updated);

--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -42,14 +42,14 @@ jobs:
         run: npm run test:coverage
 
       # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
-      - name: Reduce coverage thresholds by 0.10%
+      - name: Reduce coverage thresholds by 0.50%
         run: |
           node -e "
           const fs = require('fs');
           const file = 'vitest.config.ts';
           const text = fs.readFileSync(file, 'utf8');
           const updated = text.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
-            const reduced = (parseFloat(value) - 0.1).toFixed(2);
+            const reduced = (parseFloat(value) - 0.5).toFixed(2);
             return \`\${key}: \${reduced}\`;
           });
           fs.writeFileSync(file, updated);

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -110,11 +110,19 @@
 		spinner?.remove();
 	});
 
+	const handleBroadcastLoginSuccess = async () => {
+		await authStore.forceSync();
+
+		// TODO: add a toast success for when it is refreshed and logged in, while before it was logged out
+
+		// TODO: add a warning banner for the hedge case in which the tab was already logged in and now is refreshed with another identity
+	};
+
 	const openBc = () => {
 		try {
 			const bc = new AuthBroadcastChannel();
 
-			bc.onLoginSuccess(authStore.forceSync);
+			bc.onLoginSuccess(handleBroadcastLoginSuccess);
 
 			return () => {
 				bc?.close();

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -34,9 +34,9 @@
 
 	const init = async () => {
 		/**
-		 * We use `Promise.allSettled` to ensure that all initialization functions run,
+		 * We use `Promise.allSettled` to ensure that all initialisation functions run,
 		 * regardless of whether some of them fail. This avoids blocking the entire app
-		 * if non-critical services like analytics or i18n fail to initialize.
+		 * if non-critical services like analytics or i18n fail to initialise.
 		 *
 		 * Each service handles its own error handling,
 		 * and we avoid surfacing errors to the user here to keep the UX clean.
@@ -95,7 +95,7 @@
 	 */
 
 	// To improve the UX while the app is loading on mainnet we display a spinner which is attached statically in the index.html files.
-	// Once the authentication has been initialized we know most JavaScript resources has been loaded and therefore we can hide the spinner, the loading information.
+	// Once the authentication has been initialised, we know most JavaScript resources have been loaded, and therefore we can hide the spinner, the loading information.
 	$effect(() => {
 		if (!browser) {
 			return;

--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -149,6 +149,10 @@ describe('App Layout', () => {
 		});
 
 		describe('on login success message', () => {
+			beforeEach(() => {
+				vi.clearAllMocks();
+			});
+
 			it('should trigger the forced re-synchronization', () => {
 				const spy = vi.spyOn(authStore, 'forceSync');
 

--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -4,6 +4,7 @@ import * as authBroadcastServices from '$lib/services/auth-broadcast.services';
 import { AuthBroadcastChannel } from '$lib/services/auth-broadcast.services';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
+import * as toastsStore from '$lib/stores/toasts.store';
 import App from '$routes/+layout.svelte';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
@@ -19,10 +20,6 @@ vi.mock(import('$lib/services/worker.auth.services'), async (importOriginal) => 
 });
 
 describe('App Layout', () => {
-	const mockChannels = new Map<string, BroadcastChannel>();
-
-	const broadcastChannelCloseSpy = vi.fn();
-
 	beforeAll(() => {
 		Object.defineProperty(window, 'matchMedia', {
 			writable: true,
@@ -35,43 +32,6 @@ describe('App Layout', () => {
 				dispatchEvent: vi.fn()
 			}))
 		});
-	});
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-
-		vi.stubGlobal(
-			'BroadcastChannel',
-			vi.fn((name: string) => {
-				const postMessage = vi.fn();
-
-				const channel =
-					mockChannels.get(name) ??
-					({
-						name,
-						onmessage: null,
-						postMessage,
-						close: broadcastChannelCloseSpy
-					} as unknown as BroadcastChannel);
-
-				postMessage.mockImplementation((message: unknown) => {
-					const event = new MessageEvent('message', {
-						data: message,
-						origin: OISY_URL
-					});
-
-					channel.onmessage?.(event);
-				});
-
-				mockChannels.set(name, channel);
-
-				return channel;
-			})
-		);
-	});
-
-	afterEach(() => {
-		vi.unstubAllGlobals();
 	});
 
 	it('should render the app layout', () => {
@@ -102,64 +62,113 @@ describe('App Layout', () => {
 		expect(spy).toHaveBeenCalledOnce();
 	});
 
-	it('should listen to BroadcastChannel events for auth synchronization', () => {
+	describe('when handling AuthBroadcastChannel', () => {
 		const channelName = AuthBroadcastChannel.CHANNEL_NAME;
+
 		const loginSuccessMessage = AuthBroadcastChannel.MESSAGE_LOGIN_SUCCESS;
 
-		const spy = vi.spyOn(authStore, 'forceSync');
+		const mockChannels = new Map<string, BroadcastChannel>();
 
-		render(App, { children: mockSnippet });
+		const broadcastChannelCloseSpy = vi.fn();
 
-		spy.mockClear();
+		beforeEach(() => {
+			vi.clearAllMocks();
 
-		const newBc = new BroadcastChannel(channelName);
+			vi.stubGlobal(
+				'BroadcastChannel',
+				vi.fn((name: string) => {
+					const postMessage = vi.fn();
 
-		newBc.postMessage(loginSuccessMessage);
+					const channel =
+						mockChannels.get(name) ??
+						({
+							name,
+							onmessage: null,
+							postMessage,
+							close: broadcastChannelCloseSpy
+						} as unknown as BroadcastChannel);
 
-		expect(spy).toHaveBeenCalledExactlyOnceWith();
-	});
+					postMessage.mockImplementation((message: unknown) => {
+						const event = new MessageEvent('message', {
+							data: message,
+							origin: OISY_URL
+						});
 
-	it('should destroy the BroadcastChannel on unmount', () => {
-		const channelName = AuthBroadcastChannel.CHANNEL_NAME;
-		const loginSuccessMessage = AuthBroadcastChannel.MESSAGE_LOGIN_SUCCESS;
+						channel.onmessage?.(event);
+					});
 
-		const spy = vi.spyOn(authStore, 'forceSync');
+					mockChannels.set(name, channel);
 
-		const { unmount } = render(App, { children: mockSnippet });
+					return channel;
+				})
+			);
+		});
 
-		spy.mockClear();
+		afterEach(() => {
+			vi.unstubAllGlobals();
+		});
 
-		const newBc = new BroadcastChannel(channelName);
+		it('should destroy the channel on unmount', () => {
+			const spy = vi.spyOn(authStore, 'forceSync');
 
-		newBc.postMessage(loginSuccessMessage);
+			const { unmount } = render(App, { children: mockSnippet });
 
-		expect(spy).toHaveBeenCalledExactlyOnceWith();
+			spy.mockClear();
 
-		expect(broadcastChannelCloseSpy).not.toHaveBeenCalled();
+			const newBc = new BroadcastChannel(channelName);
 
-		spy.mockClear();
+			newBc.postMessage(loginSuccessMessage);
 
-		unmount();
+			expect(spy).toHaveBeenCalledExactlyOnceWith();
 
-		expect(broadcastChannelCloseSpy).toHaveBeenCalledExactlyOnceWith();
+			expect(broadcastChannelCloseSpy).not.toHaveBeenCalled();
 
-		newBc.postMessage(loginSuccessMessage);
+			spy.mockClear();
 
-		expect(spy).toHaveBeenCalledExactlyOnceWith();
-	});
+			unmount();
 
-	it('should initialize a BroadcastChannel for auth synchronization', () => {
-		const spy = vi.fn();
+			expect(broadcastChannelCloseSpy).toHaveBeenCalledExactlyOnceWith();
 
-		vi.spyOn(authBroadcastServices, 'AuthBroadcastChannel').mockReturnValueOnce({
-			onLoginSuccess: spy,
-			close: vi.fn()
-		} as unknown as AuthBroadcastChannel);
+			newBc.postMessage(loginSuccessMessage);
 
-		expect(spy).not.toHaveBeenCalled();
+			expect(spy).toHaveBeenCalledExactlyOnceWith();
+		});
 
-		render(App, { children: mockSnippet });
+		it('should initialize a channel for auth synchronization', () => {
+			const spy = vi.fn();
 
-		expect(spy).toHaveBeenCalledExactlyOnceWith(authStore.forceSync);
+			vi.spyOn(authBroadcastServices, 'AuthBroadcastChannel').mockReturnValueOnce({
+				onLoginSuccess: spy,
+				close: vi.fn()
+			} as unknown as AuthBroadcastChannel);
+
+			expect(spy).not.toHaveBeenCalled();
+
+			render(App, { children: mockSnippet });
+
+			expect(spy).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
+		});
+
+		describe('on login success message', () => {
+			beforeEach(() => {
+				vi.clearAllMocks();
+
+				vi.spyOn(toastsStore, 'toastsShow');
+			});
+
+			it('should trigger the forced re-synchronization', () => {
+				const spy = vi.spyOn(authStore, 'forceSync');
+
+				render(App, { children: mockSnippet });
+
+				spy.mockClear();
+
+				const newBc = new BroadcastChannel(channelName);
+
+				newBc.postMessage(loginSuccessMessage);
+
+				expect(spy).toHaveBeenCalledExactlyOnceWith();
+			});
+		});
 	});
 });

--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -4,7 +4,6 @@ import * as authBroadcastServices from '$lib/services/auth-broadcast.services';
 import { AuthBroadcastChannel } from '$lib/services/auth-broadcast.services';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
-import * as toastsStore from '$lib/stores/toasts.store';
 import App from '$routes/+layout.svelte';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
@@ -150,12 +149,6 @@ describe('App Layout', () => {
 		});
 
 		describe('on login success message', () => {
-			beforeEach(() => {
-				vi.clearAllMocks();
-
-				vi.spyOn(toastsStore, 'toastsShow');
-			});
-
 			it('should trigger the forced re-synchronization', () => {
 				const spy = vi.spyOn(authStore, 'forceSync');
 


### PR DESCRIPTION
# Motivation

Just a small refactoring to reorganize correctly the tests of the main app `layout` dividing the flow of the `BroadcastChannel` in a different `describe` statement.
