### PR TITLE
chore(frontend): Remove unnecessary `undefined` type in optional params

### DIFF
--- a/src/frontend/src/eth/utils/qr-code.utils.ts
+++ b/src/frontend/src/eth/utils/qr-code.utils.ts
@@ -14,7 +14,7 @@ export const decodeQrCode = ({
 	erc20Tokens
 }: {
 	status: QrStatus;
-	code?: string | undefined;
+	code?: string;
 	expectedToken: OptionToken;
 	ethereumTokens: Token[];
 	erc20Tokens: Erc20Token[];

--- a/src/frontend/src/icp/stores/ethereum-fee.store.ts
+++ b/src/frontend/src/icp/stores/ethereum-fee.store.ts
@@ -2,7 +2,7 @@ import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
 export type EthereumFeeStoreData = Option<{
-	maxTransactionFee?: bigint | undefined;
+	maxTransactionFee?: bigint;
 }>;
 
 export interface EthereumFeeStore extends Readable<EthereumFeeStoreData> {

--- a/src/frontend/src/lib/utils/qr-code.utils.ts
+++ b/src/frontend/src/lib/utils/qr-code.utils.ts
@@ -92,7 +92,7 @@ export const decodeQrCode = ({
 	expectedToken
 }: {
 	status: QrStatus;
-	code?: string | undefined;
+	code?: string;
 	expectedToken?: OptionToken;
 }): QrResponse => {
 	if (status !== 'success') {


### PR DESCRIPTION
# Motivation

Small refactoring to remove unnecessary `undefined` type from optional params.
