### PR TITLE
feat(devops): Reduce coverage threshold margins to 0.10%

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -42,14 +42,14 @@ jobs:
         run: npm run test:coverage
 
       # The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
-      - name: Reduce coverage thresholds by 0.50%
+      - name: Reduce coverage thresholds by 0.10%
         run: |
           node -e "
           const fs = require('fs');
           const file = 'vitest.config.ts';
           const text = fs.readFileSync(file, 'utf8');
           const updated = text.replace(/(lines|functions|branches|statements):\s*([0-9]+(?:\.[0-9]+)?)/g, (_, key, value) => {
-            const reduced = (parseFloat(value) - 0.5).toFixed(2);
+            const reduced = (parseFloat(value) - 0.1).toFixed(2);
             return \`\${key}: \${reduced}\`;
           });
           fs.writeFileSync(file, updated);


### PR DESCRIPTION
# Motivation

We don't need 50 bps of margins in the coverage thresholds. The flakiness is at maximum 0.05%, so we can reduce it and still be conservative.