### PR TITLE
feat(devops): Do not floor coverage thresholds

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -91,11 +91,6 @@ jobs:
       - name: Remove old thresholds file
         run: rm vitest.config.before.ts
 
-      # To avoid a high frequency of PRs, we remove the decimals from the coverage thresholds
-      - name: Floor coverage thresholds (remove decimals)
-        run: |
-          sed -i -E 's/(lines|functions|branches|statements):[[:space:]]*([0-9]+)\.[0-9]+/\1: \2/g' vitest.config.ts
-
       - name: Check for Coverage Thresholds Changes
         id: check_changes
         run: |


### PR DESCRIPTION
# Motivation

We have reached a stable rhythm for coverage thresholds, so we won’t be increasing them aggressively with each PR. However, keeping a strict floor limit introduces the risk of falling close to that minimum and then needing to add a large batch of new tests all at once.

By removing the fixed floor for threshold values, we can maintain the right level of coverage while avoiding frequent or sudden updates to the limits.
