### PR TITLE
feat(frontend): Set IDB lock cache to false on login

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -3,8 +3,8 @@
 	import ButtonAuthenticate from '$lib/components/ui/ButtonAuthenticate.svelte';
 	import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
 	import { signIn } from '$lib/services/auth.services';
-	import { modalStore } from '$lib/stores/modal.store';
 	import { authLocked } from '$lib/stores/locked.store';
+	import { modalStore } from '$lib/stores/modal.store';
 
 	interface Props {
 		fullWidth?: boolean;

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -4,6 +4,7 @@
 	import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
 	import { signIn } from '$lib/services/auth.services';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { authLocked } from '$lib/stores/locked.store';
 
 	interface Props {
 		fullWidth?: boolean;
@@ -18,7 +19,9 @@
 	const onclick = async () => {
 		const { success } = await signIn({});
 
-		if (success === 'cancelled' || success === 'error') {
+		if (success === 'ok') {
+			authLocked.unlock({ source: 'login from landing page' });
+		} else if (success === 'cancelled' || success === 'error') {
 			modalStore.openAuthHelp({ id: modalId, data: false });
 		}
 	};

--- a/src/frontend/src/tests/lib/components/auth/ButtonAuthenticateWithHelp.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/ButtonAuthenticateWithHelp.spec.ts
@@ -1,6 +1,7 @@
 import ButtonAuthenticateWithHelp from '$lib/components/auth/ButtonAuthenticateWithHelp.svelte';
 import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
 import * as auth from '$lib/services/auth.services';
+import { authLocked } from '$lib/stores/locked.store';
 import { modalStore } from '$lib/stores/modal.store';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
@@ -44,8 +45,10 @@ describe('ButtonAuthenticateWithHelp', () => {
 		expect(get(modalStore)?.type).toBe('auth-help');
 	});
 
-	it('should do nothing on successful sign in', async () => {
+	it('should set the lock store to false on successful sign in', async () => {
 		const authSpy = vi.spyOn(auth, 'signIn').mockResolvedValue({ success: 'ok' });
+
+		vi.spyOn(authLocked, 'unlock').mockImplementationOnce(vi.fn());
 
 		const { container } = render(ButtonAuthenticateWithHelp);
 
@@ -58,5 +61,9 @@ describe('ButtonAuthenticateWithHelp', () => {
 		expect(authSpy).toHaveBeenCalledOnce();
 
 		expect(get(modalStore)?.type).toBeUndefined();
+
+		expect(authLocked.unlock).toHaveBeenCalledExactlyOnceWith({
+			source: 'login from landing page'
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

Just to be sure, we set the auth lock store to false on login.
