### PR TITLE
feat(frontend): Add fee label in WalletConnect modal

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSendReview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
@@ -55,7 +56,11 @@
 	>
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />
 
-		<EthFeeDisplay slot="fee" />
+		<EthFeeDisplay slot="fee">
+			{#snippet label()}
+				<Html text={$i18n.fee.text.max_fee_eth} />
+			{/snippet}
+		</EthFeeDisplay>
 
 		<SendReviewNetwork slot="network" {sourceNetwork} {targetNetwork} token={$sendToken} />
 	</SendData>


### PR DESCRIPTION
# Motivation

Component `EthFeeDisplay` requires a label to be shown correctly.

### Before

<img width="659" height="740" alt="Screenshot 2025-09-29 at 09 37 12" src="https://github.com/user-attachments/assets/81a05869-c9a8-4375-b3fe-a955ff0e0e0e" />

### After

<img width="675" height="772" alt="Screenshot 2025-09-29 at 09 38 06" src="https://github.com/user-attachments/assets/79f4ddea-ab83-40aa-8597-5adc1571e417" />

