### PR TITLE
fix(devops): Do not run unnecessary E2E tests for merge queue

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,8 @@ jobs:
 
   oisy-backend-wasm:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'pull_request' || github.event_name != 'merge_group' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{(github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+      (github.event_name == 'pull_request' && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
     needs: check-e2e-changes
     permissions:
       contents: write
@@ -91,7 +92,8 @@ jobs:
         os: ${{ fromJson(needs.define-matrix.outputs.os-matrix) }}
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         shardTotal: [10]
-    if: ${{ github.event_name != 'pull_request' || github.event_name != 'merge_group' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{(github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+      (github.event_name == 'pull_request' && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.shardIndex }}
       cancel-in-progress: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   oisy-backend-wasm:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.event_name != 'pull_request' || github.event_name != 'merge_group' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     needs: check-e2e-changes
     permissions:
       contents: write
@@ -91,7 +91,7 @@ jobs:
         os: ${{ fromJson(needs.define-matrix.outputs.os-matrix) }}
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         shardTotal: [10]
-    if: ${{ github.event_name != 'pull_request' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
+    if: ${{ github.event_name != 'pull_request' || github.event_name != 'merge_group' || needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots') }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.shardIndex }}
       cancel-in-progress: true


### PR DESCRIPTION
# Motivation

For the merge queue, we are running ALWAYS the E2E tests. However, it is not necessary if there are not changed files related to it (for now).
