### PR TITLE
feat(frontend): Nft filter changes

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
@@ -7,6 +7,9 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NftCollectionUi } from '$lib/types/nft';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
+	import { filterSortByCollection } from '$lib/utils/nfts.utils';
+	import { tokenListStore } from '$lib/stores/token-list.store';
+	import { nftSortStore } from '$lib/stores/settings.store';
 
 	interface Props {
 		collection: NftCollectionUi;
@@ -38,7 +41,7 @@
 				</span>
 				<span class="absolute z-0 h-full w-full bg-secondary-alt"></span>
 
-				{#each collection.nfts as nft, index (`${nft.id}-${index}`)}
+				{#each filterSortByCollection( { items: collection.nfts, filter: $tokenListStore.filter, sort: $nftSortStore } ) as nft, index (`${nft.id}-${index}`)}
 					{#if index < 4 && nonNullish(nft.imageUrl)}
 						<div class="relative aspect-square overflow-hidden rounded-lg bg-secondary-alt">
 							<BgImg

--- a/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
@@ -18,6 +18,14 @@
 	}
 
 	const { collection, disabled, testId }: Props = $props();
+
+	const collectionNfts = $derived(
+		filterSortByCollection({
+			items: collection.nfts,
+			filter: $tokenListStore.filter,
+			sort: $nftSortStore
+		})
+	);
 </script>
 
 <a
@@ -41,7 +49,7 @@
 				</span>
 				<span class="absolute z-0 h-full w-full bg-secondary-alt"></span>
 
-				{#each filterSortByCollection( { items: collection.nfts, filter: $tokenListStore.filter, sort: $nftSortStore } ) as nft, index (`${nft.id}-${index}`)}
+				{#each collectionNfts as nft, index (`${nft.id}-${index}`)}
 					{#if index < 4 && nonNullish(nft.imageUrl)}
 						<div class="relative aspect-square overflow-hidden rounded-lg bg-secondary-alt">
 							<BgImg

--- a/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
@@ -5,11 +5,11 @@
 	import BgImg from '$lib/components/ui/BgImg.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { nftSortStore } from '$lib/stores/settings.store';
+	import { tokenListStore } from '$lib/stores/token-list.store';
 	import type { NftCollectionUi } from '$lib/types/nft';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { filterSortByCollection } from '$lib/utils/nfts.utils';
-	import { tokenListStore } from '$lib/stores/token-list.store';
-	import { nftSortStore } from '$lib/stores/settings.store';
 
 	interface Props {
 		collection: NftCollectionUi;

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -242,7 +242,7 @@ const matchesFilter = (item: Nft | NftCollectionUi, filter: string): boolean => 
 		// search by collections nfts name or id
 		return (item.nfts ?? []).some(
 			(nft) =>
-				nft.name?.toLowerCase().includes(lower) || String(nft.id)?.toLowerCase().includes(lower)
+				nft.name?.toLowerCase().includes(lower) ?? String(nft.id)?.toLowerCase().includes(lower)
 		);
 	}
 

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -230,6 +230,7 @@ const isCollectionUi = (item: Nft | NftCollectionUi): item is NftCollectionUi =>
 const isNft = (item: Nft | NftCollectionUi): item is Nft =>
 	'collection' in item && !('nfts' in item);
 
+//@ts-ignore @typescript-eslint/prefer-nullish-coalescing
 const matchesFilter = ({
 	item,
 	filter

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -230,7 +230,6 @@ const isCollectionUi = (item: Nft | NftCollectionUi): item is NftCollectionUi =>
 const isNft = (item: Nft | NftCollectionUi): item is Nft =>
 	'collection' in item && !('nfts' in item);
 
-//@ts-ignore @typescript-eslint/prefer-nullish-coalescing
 const matchesFilter = ({
 	item,
 	filter
@@ -247,10 +246,11 @@ const matchesFilter = ({
 			return true;
 		}
 		// search by collections nfts name or id
-		return (item.nfts ?? []).some(
-			(nft) =>
+		return (item.nfts ?? []).some((nft) => {
+			return (
 				nft.name?.toLowerCase().includes(lower) || String(nft.id)?.toLowerCase().includes(lower)
-		);
+			);
+		});
 	}
 
 	// search nfts by id, name or collection name

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -230,7 +230,13 @@ const isCollectionUi = (item: Nft | NftCollectionUi): item is NftCollectionUi =>
 const isNft = (item: Nft | NftCollectionUi): item is Nft =>
 	'collection' in item && !('nfts' in item);
 
-const matchesFilter = (item: Nft | NftCollectionUi, filter: string): boolean => {
+const matchesFilter = ({
+	item,
+	filter
+}: {
+	item: Nft | NftCollectionUi;
+	filter: string;
+}): boolean => {
 	const lower = filter.toLowerCase();
 
 	if (isCollectionUi(item)) {
@@ -267,7 +273,7 @@ export const filterSortByCollection: FilterSortByCollection = <T extends Nft | N
 	let result = items;
 
 	if (nonNullish(filter)) {
-		result = result.filter((it) => matchesFilter(it, filter));
+		result = result.filter((item) => matchesFilter({ item, filter }));
 	}
 
 	if (nonNullish(sort)) {

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -246,11 +246,11 @@ const matchesFilter = ({
 			return true;
 		}
 		// search by collections nfts name or id
-		return (item.nfts ?? []).some((nft) => {
-			return (
-				nft.name?.toLowerCase().includes(lower) || String(nft.id)?.toLowerCase().includes(lower)
-			);
-		});
+		return (item.nfts ?? []).some(
+			(nft) =>
+				(nft.name?.toLowerCase().includes(lower) ?? false) ||
+				(String(nft.id)?.toLowerCase().includes(lower) ?? false)
+		);
 	}
 
 	// search nfts by id, name or collection name

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -248,7 +248,7 @@ const matchesFilter = ({
 		// search by collections nfts name or id
 		return (item.nfts ?? []).some(
 			(nft) =>
-				nft.name?.toLowerCase().includes(lower) ?? String(nft.id)?.toLowerCase().includes(lower)
+				nft.name?.toLowerCase().includes(lower) || String(nft.id)?.toLowerCase().includes(lower)
 		);
 	}
 

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -600,22 +600,70 @@ describe('nfts.utils', () => {
 			return [ui[1], ui[0]];
 		})();
 
-		it('filters by collection name (case-insensitive substring)', () => {
+		it('filters NFTs by collection.name (case-insensitive substring)', () => {
 			const res = filterSortByCollection({
 				items: base,
-				filter: 'azu' // lowercase
+				filter: 'azu' // lowercase substring
 			});
-
 			expect(res).toEqual([nftAzuki2, nftAzuki1]);
 		});
 
-		it('sorts by collection name ascending', () => {
+		it('filters NFTs by nft.name', () => {
+			const custom = { ...nftAzuki1, name: 'Super Special NFT' };
+			const res = filterSortByCollection({
+				items: [custom, nftDeGods],
+				filter: 'special'
+			});
+			expect(res).toEqual([custom]);
+		});
+
+		it('filters NFTs by nft.id', () => {
+			const custom = { ...nftAzuki1, id: parseNftId(987654321) };
+			const res = filterSortByCollection({
+				items: [custom, nftDeGods],
+				filter: '987654321'
+			});
+			expect(res).toEqual([custom]);
+		});
+
+		it('filters collection UIs by collection.name', () => {
+			const res = filterSortByCollection({
+				items: collections,
+				filter: 'god'
+			});
+			expect(res).toHaveLength(1);
+			expect(res[0].collection.address).toBe(DE_GODS_TOKEN.address);
+		});
+
+		it('filters collection UIs by inner nft.name', () => {
+			const tokens = [AZUKI_ELEMENTAL_BEANS_TOKEN];
+			const custom = { ...nftAzuki1, name: 'Ultra Rare Azuki' };
+			const ui = getNftCollectionUi({
+				$nonFungibleTokens: tokens,
+				$nftStore: [custom]
+			});
+			const res = filterSortByCollection({ items: ui, filter: 'ultra rare' });
+			expect(res).toHaveLength(1);
+			expect(res[0].nfts).toEqual([custom]);
+		});
+
+		it('filters collection UIs by inner nft.id', () => {
+			const tokens = [AZUKI_ELEMENTAL_BEANS_TOKEN];
+			const custom = { ...nftAzuki1, id: parseNftId(123456789) };
+			const ui = getNftCollectionUi({
+				$nonFungibleTokens: tokens,
+				$nftStore: [custom]
+			});
+			const res = filterSortByCollection({ items: ui, filter: '123456789' });
+			expect(res).toHaveLength(1);
+			expect(res[0].nfts).toEqual([custom]);
+		});
+
+		it('sorts NFTs by collection name ascending', () => {
 			const res = filterSortByCollection({
 				items: base,
 				sort: { type: 'collection-name', order: 'asc' }
 			});
-
-			// "Azuki..." then "DeGods"
 			expect(res.map((n) => n.collection.name)).toEqual([
 				'Azuki Elemental Beans',
 				'Azuki Elemental Beans',
@@ -623,13 +671,11 @@ describe('nfts.utils', () => {
 			]);
 		});
 
-		it('sorts by collection name descending', () => {
+		it('sorts NFTs by collection name descending', () => {
 			const res = filterSortByCollection({
 				items: base,
 				sort: { type: 'collection-name', order: 'desc' }
 			});
-
-			// "DeGods" then "Azuki..."
 			expect(res.map((n) => n.collection.name)).toEqual([
 				'DeGods',
 				'Azuki Elemental Beans',
@@ -637,95 +683,72 @@ describe('nfts.utils', () => {
 			]);
 		});
 
-		it('applies filter then sort', () => {
+		it('sorts collection UIs by name ascending', () => {
+			const res = filterSortByCollection({
+				items: collections,
+				sort: { type: 'collection-name', order: 'asc' }
+			});
+			const expected = [azukiName, deGodsName].sort((a, b) => collator.compare(a ?? '', b ?? ''));
+			expect(res.map((c) => c.collection.name ?? '')).toEqual(expected);
+		});
+
+		it('sorts collection UIs by name descending', () => {
+			const res = filterSortByCollection({
+				items: collections,
+				sort: { type: 'collection-name', order: 'desc' }
+			});
+			const expected = [azukiName, deGodsName]
+				.sort((a, b) => collator.compare(a ?? '', b ?? ''))
+				.reverse();
+			expect(res.map((c) => c.collection.name ?? '')).toEqual(expected);
+		});
+
+		it('applies filter then sort for NFTs', () => {
 			const res = filterSortByCollection({
 				items: base,
 				filter: 'god',
 				sort: { type: 'collection-name', order: 'asc' }
 			});
-
-			// Only DeGods remains; sorted trivially
 			expect(res).toEqual([nftDeGods]);
 		});
 
-		it('returns the same reference when neither filter nor sort is provided', () => {
-			const input = [...base];
-			const res = filterSortByCollection({ items: input });
-
-			expect(res).toBe(input);
-		});
-
-		it('returns a new array when sort is provided (immutability)', () => {
-			const input = [...base];
-			const res = filterSortByCollection({
-				items: input,
-				sort: { type: 'collection-name', order: 'asc' }
-			});
-
-			expect(res).not.toBe(input);
-		});
-
-		it('filters collections by collection.name (case-insensitive substring)', () => {
-			const res = filterSortByCollection({
-				items: collections,
-				filter: filterSub
-			});
-
-			expect(res).toHaveLength(1);
-			expect(res[0].collection.address).toBe(AZUKI_ELEMENTAL_BEANS_TOKEN.address);
-		});
-
-		it('sorts collections by name ascending', () => {
-			const res = filterSortByCollection({
-				items: collections,
-				sort: { type: 'collection-name', order: 'asc' }
-			});
-
-			const expectedOrder = [azukiName, deGodsName].sort((a, b) =>
-				collator.compare(a ?? '', b ?? '')
-			);
-
-			expect(res.map((c) => c.collection.name ?? '')).toEqual(expectedOrder);
-		});
-
-		it('sorts collections by name descending', () => {
-			const res = filterSortByCollection({
-				items: collections,
-				sort: { type: 'collection-name', order: 'desc' }
-			});
-
-			const expectedOrder = [azukiName, deGodsName]
-				.sort((a, b) => collator.compare(a ?? '', b ?? ''))
-				.reverse();
-
-			expect(res.map((c) => c.collection.name ?? '')).toEqual(expectedOrder);
-		});
-
-		it('applies filter for collection then sort', () => {
+		it('applies filter then sort for collections', () => {
 			const res = filterSortByCollection({
 				items: collections,
 				filter: 'god',
 				sort: { type: 'collection-name', order: 'asc' }
 			});
-
 			expect(res).toHaveLength(1);
 			expect(res[0].collection.address).toBe(DE_GODS_TOKEN.address);
 		});
 
-		it('returns the same reference when neither filter nor sort is provided for collections', () => {
-			const input = [...collections];
+		it('returns the same reference when neither filter nor sort is provided (NFTs)', () => {
+			const input = [...base];
 			const res = filterSortByCollection({ items: input });
-
 			expect(res).toBe(input);
 		});
 
-		it('returns a new array when sort is provided for collections (immutability)', () => {
+		it('returns the same reference when neither filter nor sort is provided (collections)', () => {
+			const input = [...collections];
+			const res = filterSortByCollection({ items: input });
+			expect(res).toBe(input);
+		});
+
+		it('returns a new array when sort is provided (NFTs)', () => {
+			const input = [...base];
+			const res = filterSortByCollection({
+				items: input,
+				sort: { type: 'collection-name', order: 'asc' }
+			});
+			expect(res).not.toBe(input);
+		});
+
+		it('returns a new array when sort is provided (collections)', () => {
 			const input = [...collections];
 			const res = filterSortByCollection({
 				items: input,
 				sort: { type: 'collection-name', order: 'asc' }
 			});
-
 			expect(res).not.toBe(input);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -605,6 +605,7 @@ describe('nfts.utils', () => {
 				items: base,
 				filter: 'azu' // lowercase substring
 			});
+
 			expect(res).toEqual([nftAzuki2, nftAzuki1]);
 		});
 
@@ -614,6 +615,7 @@ describe('nfts.utils', () => {
 				items: [custom, nftDeGods],
 				filter: 'special'
 			});
+
 			expect(res).toEqual([custom]);
 		});
 
@@ -623,6 +625,7 @@ describe('nfts.utils', () => {
 				items: [custom, nftDeGods],
 				filter: '987654321'
 			});
+
 			expect(res).toEqual([custom]);
 		});
 
@@ -631,6 +634,7 @@ describe('nfts.utils', () => {
 				items: collections,
 				filter: 'god'
 			});
+
 			expect(res).toHaveLength(1);
 			expect(res[0].collection.address).toBe(DE_GODS_TOKEN.address);
 		});
@@ -643,6 +647,7 @@ describe('nfts.utils', () => {
 				$nftStore: [custom]
 			});
 			const res = filterSortByCollection({ items: ui, filter: 'ultra rare' });
+
 			expect(res).toHaveLength(1);
 			expect(res[0].nfts).toEqual([custom]);
 		});
@@ -655,6 +660,7 @@ describe('nfts.utils', () => {
 				$nftStore: [custom]
 			});
 			const res = filterSortByCollection({ items: ui, filter: '123456789' });
+
 			expect(res).toHaveLength(1);
 			expect(res[0].nfts).toEqual([custom]);
 		});
@@ -664,6 +670,7 @@ describe('nfts.utils', () => {
 				items: base,
 				sort: { type: 'collection-name', order: 'asc' }
 			});
+
 			expect(res.map((n) => n.collection.name)).toEqual([
 				'Azuki Elemental Beans',
 				'Azuki Elemental Beans',
@@ -676,6 +683,7 @@ describe('nfts.utils', () => {
 				items: base,
 				sort: { type: 'collection-name', order: 'desc' }
 			});
+
 			expect(res.map((n) => n.collection.name)).toEqual([
 				'DeGods',
 				'Azuki Elemental Beans',
@@ -689,6 +697,7 @@ describe('nfts.utils', () => {
 				sort: { type: 'collection-name', order: 'asc' }
 			});
 			const expected = [azukiName, deGodsName].sort((a, b) => collator.compare(a ?? '', b ?? ''));
+
 			expect(res.map((c) => c.collection.name ?? '')).toEqual(expected);
 		});
 
@@ -700,6 +709,7 @@ describe('nfts.utils', () => {
 			const expected = [azukiName, deGodsName]
 				.sort((a, b) => collator.compare(a ?? '', b ?? ''))
 				.reverse();
+
 			expect(res.map((c) => c.collection.name ?? '')).toEqual(expected);
 		});
 
@@ -709,6 +719,7 @@ describe('nfts.utils', () => {
 				filter: 'god',
 				sort: { type: 'collection-name', order: 'asc' }
 			});
+
 			expect(res).toEqual([nftDeGods]);
 		});
 
@@ -718,6 +729,7 @@ describe('nfts.utils', () => {
 				filter: 'god',
 				sort: { type: 'collection-name', order: 'asc' }
 			});
+
 			expect(res).toHaveLength(1);
 			expect(res[0].collection.address).toBe(DE_GODS_TOKEN.address);
 		});
@@ -725,12 +737,14 @@ describe('nfts.utils', () => {
 		it('returns the same reference when neither filter nor sort is provided (NFTs)', () => {
 			const input = [...base];
 			const res = filterSortByCollection({ items: input });
+
 			expect(res).toBe(input);
 		});
 
 		it('returns the same reference when neither filter nor sort is provided (collections)', () => {
 			const input = [...collections];
 			const res = filterSortByCollection({ items: input });
+
 			expect(res).toBe(input);
 		});
 
@@ -740,6 +754,7 @@ describe('nfts.utils', () => {
 				items: input,
 				sort: { type: 'collection-name', order: 'asc' }
 			});
+
 			expect(res).not.toBe(input);
 		});
 
@@ -749,6 +764,7 @@ describe('nfts.utils', () => {
 				items: input,
 				sort: { type: 'collection-name', order: 'asc' }
 			});
+
 			expect(res).not.toBe(input);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -115,11 +115,6 @@ describe('nfts.utils', () => {
 	const azukiName = mapTokenToCollection(AZUKI_ELEMENTAL_BEANS_TOKEN).name ?? '';
 	const deGodsName = mapTokenToCollection(DE_GODS_TOKEN).name ?? '';
 
-	const filterSub =
-		azukiName && azukiName.length >= 3
-			? azukiName.slice(1, 4).toLowerCase()
-			: azukiName.toLowerCase();
-
 	describe('findNft', () => {
 		it('should return existing nft', () => {
 			const nfts = [mockNft1, mockNft2, mockNft3];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,7 +79,7 @@ export default defineConfig(
 				thresholds: {
 					autoUpdate: true,
 					statements: 91.39,
-					branches: 92.25,
+					branches: 92.27,
 					functions: 81.25,
 					lines: 91.39
 				}


### PR DESCRIPTION
# Motivation

We need to make some adjustments to the Nft search filtering.

- The search should match all collections by collection name or if any Nft in that collection matches the query in Nft name or Nft token ID.

- The search should match all Nfts by collection name, Nft name or Nft token ID.

- Nft collection cards should display only the matched Nfts.

# Changes

- Adjusted the filter method in Nfts util with some utility functions to clean the filter method up
- Also use the filter method in NftCollectionCard

# Tests

Adjusted/extended filter utils tests to cover all different new cases