### PR TITLE
refactor(frontend): Extract component for ETH WalletConnect message

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import type { WalletKitTypes } from '@reown/walletkit';
+	import {
+		getSignParamsMessageUtf8,
+		getSignParamsMessageTypedDataV4
+	} from '$eth/utils/wallet-connect.utils';
+	import Json from '$lib/components/ui/Json.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		request: WalletKitTypes.SessionRequest;
+	}
+
+	let { request }: Props = $props();
+
+	let json = $derived.by(() => {
+		try {
+			return getSignParamsMessageTypedDataV4(request.params.request.params);
+		} catch (_: unknown) {
+			return undefined;
+		}
+	});
+</script>
+
+<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.message}:</p>
+{#if nonNullish(json)}
+	<div class="rounded-xs mt-4 bg-disabled p-4">
+		<Json _collapsed={true} {json} />
+	</div>
+{:else}
+	<p class="mb-4 font-normal">
+		<output class="break-all">{getSignParamsMessageUtf8(request.params.request.params)}</output>
+	</p>
+{/if}

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import type { WalletKitTypes } from '@reown/walletkit';
-	import {
-		getSignParamsMessageUtf8,
-		getSignParamsMessageHex
-	} from '$eth/utils/wallet-connect.utils';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Json from '$lib/components/ui/Json.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import EthWalletConnectMessage from '$eth/components/wallet-connect/EthWalletConnectMessage.svelte';
 
 	interface Props {
 		request: WalletKitTypes.SessionRequest;
@@ -17,17 +12,6 @@
 	}
 
 	let { request, onApprove, onReject }: Props = $props();
-
-	let message = $derived(getSignParamsMessageHex(request.params.request.params));
-
-	let json = $state<unknown | undefined>();
-	$effect(() => {
-		try {
-			json = JSON.parse(message);
-		} catch (_err: unknown) {
-			json = undefined;
-		}
-	});
 </script>
 
 <ContentWithToolbar>
@@ -36,16 +20,7 @@
 		{request.params.request.method}
 	</p>
 
-	<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.message}:</p>
-	{#if nonNullish(json)}
-		<div class="rounded-xs mt-4 bg-disabled p-4">
-			<Json _collapsed={true} {json} />
-		</div>
-	{:else}
-		<p class="mb-4 font-normal">
-			<output class="break-all">{getSignParamsMessageUtf8(request.params.request.params)}</output>
-		</p>
-	{/if}
+	<EthWalletConnectMessage {request} />
 
 	{#snippet toolbar()}
 		<WalletConnectActions {onApprove} {onReject} />

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { WalletKitTypes } from '@reown/walletkit';
+	import EthWalletConnectMessage from '$eth/components/wallet-connect/EthWalletConnectMessage.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import EthWalletConnectMessage from '$eth/components/wallet-connect/EthWalletConnectMessage.svelte';
 
 	interface Props {
 		request: WalletKitTypes.SessionRequest;


### PR DESCRIPTION
# Motivation

We want to make the WalletConnect modal more verbose and try to parse the messages for Ethereum sign transactions.

To this scope, we first extract a specific component for the message.