### PR TITLE
chore(frontend): Add deprecated tag to Alchemy provider from `alchemy-sdk`

### DIFF
--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -118,7 +118,10 @@ export const initPendingTransactionsListener = ({
 };
 
 export class AlchemyProvider {
-	// TODO: Remove this class in favor of the new provider when we remove completely alchemy-sdk
+	/**
+	 * TODO: Remove this class in favor of the new provider when we remove completely alchemy-sdk
+	 * @deprecated This approach works for now but does not align with the new architectural requirements.
+	 */
 	private readonly deprecatedProvider: Alchemy;
 
 	constructor(private readonly network: Network) {


### PR DESCRIPTION
# Motivation

Since `alchemy-sdk` library will be deprecated soon (see [documentation warning](https://github.com/alchemyplatform/alchemy-sdk-js)), we are starting to migrate it.

However, there should be a `deprecated` tag, to make devs aware of it.
