### PR TITLE
feat(frontend): Remove toast error when ETH token disabled for loading transactions

### DIFF
--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -167,16 +167,6 @@ const loadErcTransactions = async ({
 	);
 
 	if (isNullish(token)) {
-		const {
-			transactions: {
-				error: { no_token_loading_transaction }
-			}
-		} = get(i18n);
-
-		toastsError({
-			msg: { text: no_token_loading_transaction }
-		});
-
 		return { success: false };
 	}
 

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "خطأ أثناء تحميل المعاملات.",
 			"loading_transactions_symbol": "خطأ أثناء تحميل معاملات $symbol.",
-			"no_token_loading_transaction": "لم يتم العثور على التوكن. لا يمكن تحميل المعاملات.",
 			"uncertified_transactions_removed": "تم تحديد العديد من المعاملات غير المصدقة وإزالتها لاحقًا من القوائم المعروضة.",
 			"loading_pending_ck_ethereum_transactions": "حدث خطأ ما أثناء جلب معاملات $network المعلقة.",
 			"get_transaction_for_hash": "فشل في الحصول على المعاملة من الرمز (hash: $hash) المقدم.",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Chyba při načítání transakcí.",
 			"loading_transactions_symbol": "Chyba při načítání transakcí $symbol.",
-			"no_token_loading_transaction": "Token nebyl nalezen. Transakce nelze načíst.",
 			"uncertified_transactions_removed": "Bylo identifikováno několik necertifikovaných transakcí, které byly následně odstraněny ze zobrazených seznamů.",
 			"loading_pending_ck_ethereum_transactions": "Při načítání nevyřízených transakcí $network se něco pokazilo.",
 			"get_transaction_for_hash": "Nepodařilo se získat transakci z poskytnutého hashe ($hash).",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Fehler beim Laden der Transaktionen.",
 			"loading_transactions_symbol": "Fehler beim Laden der $symbol-Transaktionen.",
-			"no_token_loading_transaction": "Token nicht gefunden. Transaktionen können nicht geladen werden.",
 			"uncertified_transactions_removed": "Mehrere nicht zertifizierte Transaktionen wurden erkannt und anschließend aus den angezeigten Listen entfernt.",
 			"loading_pending_ck_ethereum_transactions": "Beim Abrufen der ausstehenden $network-Transaktionen ist etwas schiefgelaufen.",
 			"get_transaction_for_hash": "Konnte die Transaktion mit dem angegebenen Hash ($hash) nicht abrufen.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Error while loading the transactions.",
 			"loading_transactions_symbol": "Error while loading the $symbol transactions.",
-			"no_token_loading_transaction": "Token not found. Transactions cannot be loaded.",
 			"uncertified_transactions_removed": "Several uncertified transactions were identified and subsequently removed from the displayed lists.",
 			"loading_pending_ck_ethereum_transactions": "Something went wrong while fetching the pending $network transactions.",
 			"get_transaction_for_hash": "Failed to get the transaction from the provided (hash: $hash).",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Erreur lors du chargement des transactions.",
 			"loading_transactions_symbol": "Erreur lors du chargement des transactions de $symbol.",
-			"no_token_loading_transaction": "Token introuvable. Les transactions ne peuvent pas être chargées.",
 			"uncertified_transactions_removed": "Plusieurs transactions non certifiées ont été identifiées et par la suite supprimées des listes affichées.",
 			"loading_pending_ck_ethereum_transactions": "Quelque chose s'est mal passé lors de la récupération des transactions en attente de $network.",
 			"get_transaction_for_hash": "Échec de l'obtention de la transaction à partir du hachage fourni ($hash).",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "लेनदेन लोड करते समय त्रुटि।",
 			"loading_transactions_symbol": "$symbol लेनदेन लोड करते समय त्रुटि।",
-			"no_token_loading_transaction": "टोकन नहीं मिला। लेनदेन लोड नहीं किए जा सकते।",
 			"uncertified_transactions_removed": "कई अप्रमाणित लेनदेन की पहचान की गई और बाद में प्रदर्शित सूचियों से हटा दिया गया।",
 			"loading_pending_ck_ethereum_transactions": "लंबित $network लेनदेन लाते समय कुछ गलत हो गया।",
 			"get_transaction_for_hash": "प्रदान किए गए (हैश: $hash) से लेनदेन प्राप्त करने में विफल रहा।",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Errore durante il caricamento delle transazioni.",
 			"loading_transactions_symbol": "Errore durante il caricamento delle transazioni di $symbol.",
-			"no_token_loading_transaction": "Token non trovato. Impossibile caricare le transazioni.",
 			"uncertified_transactions_removed": "Diverse transazioni non certificate sono state identificate e successivamente rimosse dagli elenchi visualizzati.",
 			"loading_pending_ck_ethereum_transactions": "Qualcosa è andato storto durante il recupero delle transazioni in sospeso di $network.",
 			"get_transaction_for_hash": "Impossibile ottenere la transazione dall'hash fornito ($hash).",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "取引の読み込み中にエラーが発生しました。",
 			"loading_transactions_symbol": "$symbol取引の読み込み中にエラーが発生しました。",
-			"no_token_loading_transaction": "トークンが見つかりません。取引を読み込むことができません。",
 			"uncertified_transactions_removed": "いくつかの未認証の取引が特定され、表示されたリストから削除されました。",
 			"loading_pending_ck_ethereum_transactions": "保留中の$networkトランザクションの取得中に問題が発生しました。",
 			"get_transaction_for_hash": "提供された（ハッシュ：$hash）から取引を取得できませんでした。",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Błąd podczas ładowania transakcji.",
 			"loading_transactions_symbol": "Błąd podczas ładowania transakcji $symbol.",
-			"no_token_loading_transaction": "Nie znaleziono tokena. Nie można załadować transakcji.",
 			"uncertified_transactions_removed": "Zidentyfikowano kilka niecertyfikowanych transakcji, które następnie usunięto z wyświetlanych list.",
 			"loading_pending_ck_ethereum_transactions": "Coś poszło nie tak podczas pobierania oczekujących transakcji $network.",
 			"get_transaction_for_hash": "Nie udało się pobrać transakcji z podanego hasha ($hash).",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Erro ao carregar as transações.",
 			"loading_transactions_symbol": "Erro ao carregar as transações $symbol.",
-			"no_token_loading_transaction": "Token não encontrado. Transações não podem ser carregadas.",
 			"uncertified_transactions_removed": "Várias transações não certificadas foram identificadas e subsequentemente removidas das listas exibidas.",
 			"loading_pending_ck_ethereum_transactions": "Algo deu errado ao buscar as transações pendentes de $network.",
 			"get_transaction_for_hash": "Falha ao obter a transação a partir do hash fornecido ($hash).",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Ошибка при загрузке транзакций.",
 			"loading_transactions_symbol": "Ошибка при загрузке транзакций $symbol.",
-			"no_token_loading_transaction": "Токен не найден. Транзакции не могут быть загружены.",
 			"uncertified_transactions_removed": "Были идентифицированы несколько несертифицированных транзакций, которые впоследствии были удалены из отображаемых списков.",
 			"loading_pending_ck_ethereum_transactions": "Что-то пошло не так при получении ожидающих транзакций $network.",
 			"get_transaction_for_hash": "Не удалось получить транзакцию по предоставленному хешу ($hash).",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "Lỗi khi tải các giao dịch.",
 			"loading_transactions_symbol": "Lỗi khi tải các giao dịch $symbol.",
-			"no_token_loading_transaction": "Không tìm thấy token. Không thể tải các giao dịch.",
 			"uncertified_transactions_removed": "Một số giao dịch chưa được chứng nhận đã được xác định và sau đó bị xóa khỏi danh sách hiển thị.",
 			"loading_pending_ck_ethereum_transactions": "Đã xảy ra lỗi trong khi tìm nạp các giao dịch $network đang chờ xử lý.",
 			"get_transaction_for_hash": "Không thể lấy giao dịch từ (hash: $hash) được cung cấp.",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1315,7 +1315,6 @@
 		"error": {
 			"loading_transactions": "加载交易记录时出错。",
 			"loading_transactions_symbol": "加载 $symbol 的交易记录时出错。",
-			"no_token_loading_transaction": "未找到代币，无法加载交易记录。",
 			"uncertified_transactions_removed": "检测到一些未经认证的交易，已从显示列表中移除。",
 			"loading_pending_ck_ethereum_transactions": "获取 $network 待处理交易时发生错误。",
 			"get_transaction_for_hash": "根据提供的哈希值（hash: $hash）获取交易失败。",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1122,7 +1122,6 @@ interface I18nTransactions {
 	error: {
 		loading_transactions: string;
 		loading_transactions_symbol: string;
-		no_token_loading_transaction: string;
 		uncertified_transactions_removed: string;
 		loading_pending_ck_ethereum_transactions: string;
 		get_transaction_for_hash: string;

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -101,16 +101,13 @@ describe('eth-transactions.services', () => {
 				expect(result).toEqual({ success: false });
 			});
 
-			it('should raise an error if token is not enabled', async () => {
+			it('should return false if token is not enabled', async () => {
 				const result = await loadEthereumTransactions({
 					networkId: ETHEREUM_NETWORK_ID,
 					tokenId: USDT_TOKEN_ID,
 					standard: USDT_TOKEN.standard
 				});
 
-				expect(spyToastsError).toHaveBeenCalledWith({
-					msg: { text: en.transactions.error.no_token_loading_transaction }
-				});
 				expect(result).toEqual({ success: false });
 			});
 


### PR DESCRIPTION
# Motivation

There is really no need for a toast error when a token that was being used to fetch transaction is suddenly disabled.
