### PR TITLE
fix(frontend): Remove ERC20 dependency from menu buttons

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftSettingsMenu.svelte
+++ b/src/frontend/src/lib/components/nfts/NftSettingsMenu.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import List from '$lib/components/common/List.svelte';
 	import ListItem from '$lib/components/common/ListItem.svelte';
 	import ListItemButton from '$lib/components/common/ListItemButton.svelte';
@@ -36,7 +35,6 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
-	disabled={$erc20UserTokensNotInitialized}
 	link={false}
 	onclick={() => (visible = true)}
 	styleClass={visible ? 'active' : ''}

--- a/src/frontend/src/lib/components/nfts/NftSortMenu.svelte
+++ b/src/frontend/src/lib/components/nfts/NftSortMenu.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import List from '$lib/components/common/List.svelte';
 	import ListItem from '$lib/components/common/ListItem.svelte';
 	import ListItemButton from '$lib/components/common/ListItemButton.svelte';
@@ -22,7 +21,6 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
-	disabled={$erc20UserTokensNotInitialized}
 	link={false}
 	onclick={() => (visible = true)}
 	styleClass={visible ? 'active' : ''}

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -4,7 +4,6 @@
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 	import { afterNavigate } from '$app/navigation';
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import IconMoreVertical from '$lib/components/icons/lucide/IconMoreVertical.svelte';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
 	import {
@@ -82,7 +81,6 @@
 	class="pointer-events-auto ml-auto flex gap-0.5 font-bold"
 	aria-label={$i18n.tokens.alt.context_menu}
 	data-tid={`${testId}-button`}
-	disabled={$erc20UserTokensNotInitialized}
 	onclick={() => (visible = true)}
 >
 	<IconMoreVertical />

--- a/src/frontend/src/lib/components/tokens/TokensFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensFilter.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { afterNavigate } from '$app/navigation';
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import IconSearch from '$lib/components/icons/IconSearch.svelte';
 	import SlidingInput from '$lib/components/ui/SlidingInput.svelte';
 	import { TOKEN_LIST_FILTER } from '$lib/constants/test-ids.constants';
@@ -29,7 +28,6 @@
 
 <SlidingInput
 	ariaLabel={$i18n.tokens.alt.filter_button}
-	disabled={$erc20UserTokensNotInitialized}
 	inputPlaceholder={$i18n.tokens.text.filter_placeholder}
 	{overflowableContent}
 	testIdPrefix={TOKEN_LIST_FILTER}

--- a/src/frontend/src/lib/components/tokens/TokensMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensMenu.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import List from '$lib/components/common/List.svelte';
 	import ListItem from '$lib/components/common/ListItem.svelte';
 	import IconHide from '$lib/components/icons/IconHide.svelte';
@@ -32,7 +31,6 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
-	disabled={$erc20UserTokensNotInitialized}
 	link={false}
 	onclick={() => (visible = true)}
 	styleClass={visible ? 'active' : ''}


### PR DESCRIPTION
# Motivation

The menu buttons were all enable-dependent on the ERC20 tokens store being initialized, however it is not coherent, since they are used for all networks and none of them really has any direct dependency on ERC20 tokens.

Furthermore, it means that if the Ethereum/EVM networks are disabled, all these components would be disabled too, and it does not really work for the user.
