### PR TITLE
fix(frontend): Exclude test files from coverage calculation

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,10 +81,10 @@ export default defineConfig(
 				// TODO: increase the thresholds slowly up to an acceptable 90% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 11.42,
-					branches: 12.27,
-					functions: 11.28,
-					lines: 11.42
+					statements: 79,
+					branches: 87,
+					functions: 80,
+					lines: 79
 				}
 			}
 		}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -71,17 +71,20 @@ export default defineConfig(
 			watch: false,
 			silent: false,
 			setupFiles: ['./vitest.setup.ts'],
-			include: ['./src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+			include: ['src/frontend/src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
 			coverage: {
-				include: ['src/frontend'],
-				exclude: ['src/frontend/src/routes/**/+page.ts'],
+				include: ['src/frontend/src'],
+				exclude: [
+					'src/frontend/src/routes/**/+page.ts',
+					'src/frontend/src/**/*.{test,spec}.?(c|m)[jt]s?(x)'
+				],
 				// TODO: increase the thresholds slowly up to an acceptable 90% at least
 				thresholds: {
 					autoUpdate: true,
-					statements: 91.42,
-					branches: 92.27,
-					functions: 81.28,
-					lines: 91.42
+					statements: 11.42,
+					branches: 12.27,
+					functions: 11.28,
+					lines: 11.42
 				}
 			}
 		}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -82,7 +82,7 @@ export default defineConfig(
 				thresholds: {
 					autoUpdate: true,
 					statements: 79,
-					branches: 87,
+					branches: 86,
 					functions: 80,
 					lines: 79
 				}


### PR DESCRIPTION
# Motivation

I never noticed that the test files were included in the coverage calculation of `vitest`. This is conceptually wrong and obviously it raises the average a lot, since we MUST run them to have the coverage.
