### PR TITLE
feat(frontend): Filter by Nfts utils method

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -419,3 +419,17 @@ export const saveAllCustomTokens = async ({
 			: [])
 	]);
 };
+
+export const filterTokensByNft = ({
+	tokens,
+	filterNfts
+}: {
+	tokens: Token[];
+	filterNfts?: boolean;
+}): Token[] =>
+	isNullish(filterNfts)
+		? tokens
+		: tokens.filter((t) => {
+				const isNft = isTokenErc1155(t) || isTokenErc721(t);
+				return filterNfts ? isNft : !isNft;
+			});

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -28,6 +28,7 @@ import {
 	defineEnabledTokens,
 	filterEnabledTokens,
 	filterTokens,
+	filterTokensByNft,
 	findToken,
 	groupTogglableTokens,
 	pinEnabledTokensAtTop,
@@ -853,6 +854,39 @@ describe('tokens.utils', () => {
 			expect(saveIcrcCustomTokens).toHaveBeenCalledWith(
 				expect.objectContaining({ progress, onSuccess, modalNext })
 			);
+		});
+	});
+
+	describe('filterTokensByNft', () => {
+		const nft1 = { ...mockValidErc721Token, name: 'Cool Nft' };
+		const nft2 = { ...mockValidErc1155Token, name: 'Even cooler Nft' };
+		const tokens = [ETHEREUM_TOKEN, SOLANA_TOKEN, BONK_TOKEN, nft1, nft2];
+
+		it('should return all tokens when no filter is provided', () => {
+			const result = filterTokensByNft({ tokens });
+
+			expect(result).toHaveLength(5);
+			expect(result).toEqual(tokens);
+		});
+
+		it('should return all non Nfts when filterNfts is false', () => {
+			const result = filterTokensByNft({ tokens, filterNfts: false });
+
+			expect(result).toHaveLength(3);
+			expect(result).toEqual([ETHEREUM_TOKEN, SOLANA_TOKEN, BONK_TOKEN]);
+		});
+
+		it('should return all Nfts when filterNfts is true', () => {
+			const result = filterTokensByNft({ tokens, filterNfts: true });
+
+			expect(result).toHaveLength(2);
+			expect(result).toEqual([nft1, nft2]);
+		});
+
+		it('should return an empty list if tokens is empty', () => {
+			const result = filterTokensByNft({ tokens: [], filterNfts: false });
+
+			expect(result).toHaveLength(0);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

For the upcoming PR #9285 we need a function to filter a list of tokens to only get Nfts, non Nfts or all.

# Changes

Added utils function

# Tests

Added tests