### PR TITLE
feat(frontend): record additional LLM tool usage metadata

### DIFF
--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -106,6 +106,7 @@ export const executeTool = ({
 	} = toolCall;
 
 	let result: ToolResult['result'] | undefined;
+	let additionalTrackingMetadata: Record<string, string> = {};
 
 	if (name === ToolResultType.SHOW_ALL_CONTACTS) {
 		result = { contacts: Object.values(get(extendedAddressContactsStore)) };
@@ -120,17 +121,30 @@ export const executeTool = ({
 			tokensUi: get(combinedDerivedSortedFungibleNetworkTokensUi),
 			networks: get(networks)
 		});
+
+		additionalTrackingMetadata = {
+			...(nonNullish(result.mainCard.token) && { requestedToken: result.mainCard.token.symbol }),
+			...(nonNullish(result.mainCard.network) && { requestedNetwork: result.mainCard.network.name })
+		};
 	} else if (name === ToolResultType.REVIEW_SEND_TOKENS) {
 		result = parseReviewSendTokensToolArguments({
 			filterParams,
 			extendedAddressContacts: get(extendedAddressContactsStore),
 			tokens: get(enabledTokens)
 		});
+
+		additionalTrackingMetadata = {
+			requestedToken: result.token.symbol
+		};
 	}
 
 	trackEvent({
 		name: AI_ASSISTANT_TOOL_EXECUTION_TRIGGERED,
-		metadata: generateAiAssistantResponseEventMetadata({ toolName: name, requestStartTimestamp })
+		metadata: generateAiAssistantResponseEventMetadata({
+			toolName: name,
+			requestStartTimestamp,
+			additionalMetadata: additionalTrackingMetadata
+		})
 	});
 
 	return { type: name as ToolResult['type'], result };

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -275,15 +275,18 @@ export const parseShowBalanceToolArguments = ({
 
 export const generateAiAssistantResponseEventMetadata = ({
 	requestStartTimestamp,
-	toolName
+	toolName,
+	additionalMetadata
 }: {
 	requestStartTimestamp: number;
 	toolName?: string;
+	additionalMetadata?: Record<string, string>;
 }) => {
 	const responseTimeMs = Date.now() - requestStartTimestamp;
 
 	return {
 		...(notEmptyString(toolName) && { toolName }),
+		...(nonNullish(additionalMetadata) && additionalMetadata),
 		responseTime: `${responseTimeMs / 1000}s`,
 		responseTimeCategory:
 			responseTimeMs <= 100

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -213,18 +213,21 @@ describe('ai-assistant.utils', () => {
 		});
 
 		it('returns correct result with a tool name', () => {
+			const additionalMetadata = { testParam: 'test' };
 			const requestStartTimestamp = 1000000;
 			vi.spyOn(Date, 'now').mockReturnValue(requestStartTimestamp + 4000000);
 
 			expect(
 				generateAiAssistantResponseEventMetadata({
 					toolName: 'test',
-					requestStartTimestamp
+					requestStartTimestamp,
+					additionalMetadata
 				})
 			).toEqual({
 				toolName: 'test',
 				responseTime: '4000s',
-				responseTimeCategory: '100000+'
+				responseTimeCategory: '100000+',
+				...additionalMetadata
 			});
 		});
 


### PR DESCRIPTION
# Motivation

We want to collect additional metadata when an LLM tool got triggered.
