### PR TITLE
refactor(frontend): Rename the `loading` store for the initial loader

### DIFF
--- a/src/frontend/src/lib/components/guard/UrlGuard.svelte
+++ b/src/frontend/src/lib/components/guard/UrlGuard.svelte
@@ -7,7 +7,7 @@
 	import { modalVipRewardState, modalVipRewardStateData } from '$lib/derived/modal.derived';
 	import { QrCodeType } from '$lib/enums/qr-code-types';
 	import { claimVipReward, setReferrer } from '$lib/services/reward.services';
-	import { loading } from '$lib/stores/loader.store';
+	import { initialLoading } from '$lib/stores/loader.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { hasUrlCode } from '$lib/stores/url-code.store';
 	import { removeSearchParam } from '$lib/utils/nav.utils';
@@ -22,7 +22,7 @@
 
 	$effect(() => {
 		const handleSearchParams = async () => {
-			if (!$loading && page.url.searchParams.has('code') && nonNullish($authIdentity)) {
+			if (!$initialLoading && page.url.searchParams.has('code') && nonNullish($authIdentity)) {
 				const rewardCode = page.url.searchParams.get('code');
 				if (nonNullish(rewardCode)) {
 					hasUrlCode.set(true);
@@ -40,7 +40,7 @@
 				}
 			}
 
-			if (!$loading && page.url.searchParams.has('referrer') && nonNullish($authIdentity)) {
+			if (!$initialLoading && page.url.searchParams.has('referrer') && nonNullish($authIdentity)) {
 				const referrerCode = page.url.searchParams.get('referrer');
 				if (nonNullish(referrerCode)) {
 					const numericalReferrerCode = Number(referrerCode);

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -69,7 +69,6 @@
 		loadSolAddressMainnet
 	} from '$sol/services/sol-address.services';
 	import { loadSplTokens } from '$sol/services/spl.services';
-	import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
 
 	interface Props {
 		children: Snippet;

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -57,7 +57,7 @@
 	import { initLoader } from '$lib/services/loader.services';
 	import { loadNfts } from '$lib/services/nft.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { loading } from '$lib/stores/loader.store';
+	import { initialLoading } from '$lib/stores/loader.store';
 	import { nftStore } from '$lib/stores/nft.store';
 	import type { ProgressSteps } from '$lib/types/progress-steps';
 	import { emit } from '$lib/utils/events.utils';
@@ -69,6 +69,7 @@
 		loadSolAddressMainnet
 	} from '$sol/services/sol-address.services';
 	import { loadSplTokens } from '$sol/services/spl.services';
+	import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
 
 	interface Props {
 		children: Snippet;
@@ -102,7 +103,7 @@
 		}
 
 		// A small delay for display animation purpose.
-		setTimeout(() => loading.set(false), 1000);
+		setTimeout(() => initialLoading.set(false), 1000);
 	});
 
 	let progressDone = $derived(progressStep === ProgressStepsLoader.DONE);
@@ -256,7 +257,7 @@
 	});
 </script>
 
-{#if $loading}
+{#if $initialLoading}
 	{#if progressModal}
 		<div class="login-modal" in:fade={{ delay: 0, duration: 250 }}>
 			<Modal testId={LOADER_MODAL}>

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -26,7 +26,7 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { loading } from '$lib/stores/loader.store';
+	import { initialLoading } from '$lib/stores/loader.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import type { Option } from '$lib/types/utils';
@@ -167,7 +167,7 @@
 		}
 
 		// We are still loading ETH address and other data. Boot screen load.
-		if ($loading) {
+		if ($initialLoading) {
 			return;
 		}
 
@@ -197,7 +197,7 @@
 	};
 
 	$effect(() => {
-		[$ethAddress, $solAddressMainnet, $walletConnectUri, $loading];
+		[$ethAddress, $solAddressMainnet, $walletConnectUri, $initialLoading];
 
 		untrack(() => uriConnect());
 	});
@@ -413,7 +413,7 @@
 			return;
 		}
 
-		if ($loading || (isNullish($ethAddress) && isNullish($solAddressMainnet))) {
+		if ($initialLoading || (isNullish($ethAddress) && isNullish($solAddressMainnet))) {
 			reconnecting = false;
 
 			return;
@@ -451,7 +451,7 @@
 	};
 
 	$effect(() => {
-		[$ethAddress, $solAddressMainnet, $loading];
+		[$ethAddress, $solAddressMainnet, $initialLoading];
 
 		untrack(() => reconnect());
 	});

--- a/src/frontend/src/lib/services/loader.services.ts
+++ b/src/frontend/src/lib/services/loader.services.ts
@@ -15,7 +15,7 @@ import { errorSignOut, nullishSignOut, signOut } from '$lib/services/auth.servic
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
-import { loading } from '$lib/stores/loader.store';
+import { initialLoading } from '$lib/stores/loader.store';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
 import type { ResultSuccess } from '$lib/types/utils';
@@ -131,7 +131,7 @@ export const initLoader = async ({
 	const { success: addressIdbSuccess, err } = await loadIdbAddresses(enabledNetworkIds);
 
 	if (addressIdbSuccess) {
-		loading.set(false);
+		initialLoading.set(false);
 
 		await progressAndLoad();
 

--- a/src/frontend/src/lib/stores/loader.store.ts
+++ b/src/frontend/src/lib/stores/loader.store.ts
@@ -1,3 +1,3 @@
 import { writable } from 'svelte/store';
 
-export const loading = writable<boolean>(true);
+export const initialLoading = writable<boolean>(true);

--- a/src/frontend/src/tests/lib/components/guard/UrlGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/UrlGuard.spec.ts
@@ -1,7 +1,7 @@
 import UrlGuard from '$lib/components/guard/UrlGuard.svelte';
 import { QrCodeType } from '$lib/enums/qr-code-types';
 import * as rewardService from '$lib/services/reward.services';
-import { loading } from '$lib/stores/loader.store';
+import { initialLoading } from '$lib/stores/loader.store';
 import { modalStore } from '$lib/stores/modal.store';
 import * as navUtils from '$lib/utils/nav.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
@@ -16,7 +16,7 @@ describe('UrlGuard', () => {
 		mockPage.reset();
 		modalStore.close();
 
-		loading.set(false);
+		initialLoading.set(false);
 		mockAuthStore();
 	});
 

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -24,7 +24,7 @@ import {
 	solAddressLocalnetStore,
 	solAddressMainnetStore
 } from '$lib/stores/address.store';
-import { loading } from '$lib/stores/loader.store';
+import { initialLoading } from '$lib/stores/loader.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 import * as splDerived from '$sol/derived/spl.derived';
@@ -142,7 +142,7 @@ describe('Loader', () => {
 		await waitFor(() => {
 			expect(queryByTestId(LOADER_MODAL)).toBeNull();
 
-			expect(get(loading)).toBeFalsy();
+			expect(get(initialLoading)).toBeFalsy();
 		});
 	});
 
@@ -156,7 +156,7 @@ describe('Loader', () => {
 
 	describe('while loading', () => {
 		beforeEach(() => {
-			loading.set(true);
+			initialLoading.set(true);
 			vi.mocked(initLoader).mockImplementationOnce(
 				async ({ setProgressModal }: { setProgressModal: (value: boolean) => void }) => {
 					setProgressModal(true);

--- a/src/frontend/src/tests/lib/services/loader.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/loader.services.spec.ts
@@ -9,7 +9,7 @@ import { nullishSignOut, signOut } from '$lib/services/auth.services';
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { initLoader, initSignerAllowance } from '$lib/services/loader.services';
 import { authStore } from '$lib/stores/auth.store';
-import { loading } from '$lib/stores/loader.store';
+import { initialLoading } from '$lib/stores/loader.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { LoadIdbAddressError } from '$lib/types/errors';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
@@ -158,7 +158,7 @@ describe('loader.services', () => {
 			expect(mockProgressAndLoad).toHaveBeenCalledOnce();
 			expect(mockValidateAddresses).toHaveBeenCalledOnce();
 
-			expect(get(loading)).toBeFalsy();
+			expect(get(initialLoading)).toBeFalsy();
 		});
 
 		it('should not load addresses from the backend if the IDB addresses are loaded', async () => {


### PR DESCRIPTION
# Motivation

To avoid confusion, we rename the store `loading` to `initialLoading`, since it is set ONLY during the first loading process.