### PR TITLE
feat(frontend): Remove toast error for loading transactions or balance without address

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -12,7 +12,6 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledErc20Tokens, enabledNonFungibleTokens } from '$lib/derived/tokens.derived';
 	import { syncTransactionsFromCache } from '$lib/services/listener.services';
-	import { ethAddress } from '$lib/derived/address.derived';
 
 	interface Props {
 		children: Snippet;
@@ -30,11 +29,6 @@
 	]);
 
 	const onLoad = async () => {
-		if (isNullish($ethAddress)) {
-			return
-		}
-
-
 		if (loading) {
 			return;
 		}

--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -12,6 +12,7 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledErc20Tokens, enabledNonFungibleTokens } from '$lib/derived/tokens.derived';
 	import { syncTransactionsFromCache } from '$lib/services/listener.services';
+	import { ethAddress } from '$lib/derived/address.derived';
 
 	interface Props {
 		children: Snippet;
@@ -29,6 +30,11 @@
 	]);
 
 	const onLoad = async () => {
+		if (isNullish($ethAddress)) {
+			return
+		}
+
+
 		if (loading) {
 			return;
 		}

--- a/src/frontend/src/eth/services/eth-balance.services.ts
+++ b/src/frontend/src/eth/services/eth-balance.services.ts
@@ -8,7 +8,6 @@ import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { trackEvent } from '$lib/services/analytics.services';
 import { balancesStore } from '$lib/stores/balances.store';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsError } from '$lib/stores/toasts.store';
 import type { OptionEthAddress } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { Token, TokenId } from '$lib/types/token';
@@ -41,7 +40,6 @@ const loadEthBalance = async ({
 	} = get(i18n);
 
 	if (isNullish(address)) {
-
 		return { success: false };
 	}
 
@@ -88,8 +86,6 @@ const loadErc20Balance = async ({
 	} = get(i18n);
 
 	if (isNullish(address)) {
-
-
 		return { success: false };
 	}
 

--- a/src/frontend/src/eth/services/eth-balance.services.ts
+++ b/src/frontend/src/eth/services/eth-balance.services.ts
@@ -36,14 +36,11 @@ const loadEthBalance = async ({
 
 	const {
 		init: {
-			error: { eth_address_unknown, loading_balance }
+			error: { loading_balance }
 		}
 	} = get(i18n);
 
 	if (isNullish(address)) {
-		toastsError({
-			msg: { text: eth_address_unknown }
-		});
 
 		return { success: false };
 	}
@@ -86,14 +83,12 @@ const loadErc20Balance = async ({
 
 	const {
 		init: {
-			error: { eth_address_unknown, loading_balance }
+			error: { loading_balance }
 		}
 	} = get(i18n);
 
 	if (isNullish(address)) {
-		toastsError({
-			msg: { text: eth_address_unknown }
-		});
+
 
 		return { success: false };
 	}

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -70,15 +70,6 @@ const loadEthTransactions = async ({
 	const address = get(addressStore);
 
 	if (isNullish(address)) {
-		const {
-			init: {
-				error: { eth_address_unknown }
-			}
-		} = get(i18n);
-
-		toastsError({
-			msg: { text: eth_address_unknown }
-		});
 
 		return { success: false };
 	}
@@ -143,15 +134,7 @@ const loadErcTransactions = async ({
 	const address = get(addressStore);
 
 	if (isNullish(address)) {
-		const {
-			init: {
-				error: { eth_address_unknown }
-			}
-		} = get(i18n);
 
-		toastsError({
-			msg: { text: eth_address_unknown }
-		});
 
 		return { success: false };
 	}

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -17,7 +17,6 @@ import { ethAddress as addressStore } from '$lib/derived/address.derived';
 import { trackEvent } from '$lib/services/analytics.services';
 import { retryWithDelay } from '$lib/services/rest.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { toastsError } from '$lib/stores/toasts.store';
 import type { Address } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
 import type { TokenId, TokenStandard } from '$lib/types/token';
@@ -70,7 +69,6 @@ const loadEthTransactions = async ({
 	const address = get(addressStore);
 
 	if (isNullish(address)) {
-
 		return { success: false };
 	}
 
@@ -134,8 +132,6 @@ const loadErcTransactions = async ({
 	const address = get(addressStore);
 
 	if (isNullish(address)) {
-
-
 		return { success: false };
 	}
 

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "لا يوجد مزود Infura ERC1155 لشبكة $network",
 			"no_infura_erc20_icp_provider": "لا يوجد مزود Infura ERC20 ICP لشبكة $network",
 			"no_solana_network": "لا يوجد شبكة Solana لشبكة $network",
-			"eth_address_unknown": "عنوان ETH غير معروف.",
 			"loading_address": "خطأ أثناء تحميل عنوان $symbol.",
 			"loading_balance": "خطأ أثناء تحميل رصيد $symbol لشبكة $network.",
 			"erc20_contracts": "خطأ أثناء تحميل عقود ERC20.",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Žádný poskytovatel Infura ERC1155 pro síť $network",
 			"no_infura_erc20_icp_provider": "Žádný poskytovatel Infura ERC20 ICP pro síť $network",
 			"no_solana_network": "Žádná síť Solana pro síť $network",
-			"eth_address_unknown": "Adresa ETH je neznámá.",
 			"loading_address": "Chyba při načítání adresy $symbol.",
 			"loading_balance": "Chyba při načítání zůstatku $symbol pro síť $network.",
 			"erc20_contracts": "Chyba při načítání smluv ERC20.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Kein Infura-ERC1155-Anbieter für Netzwerk $network",
 			"no_infura_erc20_icp_provider": "Kein Infura-ERC20-ICP-Anbieter für Netzwerk $network",
 			"no_solana_network": "Kein Solana-Netzwerk für Netzwerk $network",
-			"eth_address_unknown": "ETH-Adresse ist unbekannt.",
 			"loading_address": "Fehler beim Laden der Adresse für $symbol.",
 			"loading_balance": "Fehler beim Laden des $symbol-Saldos für Netzwerk $network.",
 			"erc20_contracts": "Fehler beim Laden der ERC20-Verträge.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "No Infura ERC1155 provider for network $network",
 			"no_infura_erc20_icp_provider": "No Infura ERC20 ICP provider for network $network",
 			"no_solana_network": "No Solana network for network $network",
-			"eth_address_unknown": "ETH address is unknown.",
 			"loading_address": "Error while loading the $symbol address.",
 			"loading_balance": "Error while loading $symbol balance for network $network.",
 			"erc20_contracts": "Error while loading the ERC20 contracts.",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Pas de fournisseur Infura ERC1155 pour le réseau $network",
 			"no_infura_erc20_icp_provider": "Pas de fournisseur Infura ERC20 ICP pour le réseau $network",
 			"no_solana_network": "Pas de réseau Solana pour le réseau $network",
-			"eth_address_unknown": "L'adresse ETH est inconnue.",
 			"loading_address": "Erreur lors du chargement de l'adresse $symbol.",
 			"loading_balance": "Erreur lors du chargement du solde $symbol pour le réseau $network.",
 			"erc20_contracts": "Erreur lors du chargement des contrats ERC20.",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "नेटवर्क $network के लिए कोई इंफुरा ERC1155 प्रदाता नहीं है",
 			"no_infura_erc20_icp_provider": "नेटवर्क $network के लिए कोई इंफुरा ERC20 ICP प्रदाता नहीं है",
 			"no_solana_network": "नेटवर्क $network के लिए कोई सोलाना नेटवर्क नहीं है",
-			"eth_address_unknown": "ETH पता अज्ञात है।",
 			"loading_address": "$symbol पता लोड करते समय त्रुटि।",
 			"loading_balance": "नेटवर्क $network के लिए $symbol बैलेंस लोड करते समय त्रुटि।",
 			"erc20_contracts": "ERC20 कॉन्ट्रैक्ट लोड करते समय त्रुटि।",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Nessun provider Infura ERC1155 per la rete $network",
 			"no_infura_erc20_icp_provider": "Nessun provider Infura ERC20 ICP per la rete $network",
 			"no_solana_network": "Nessuna rete Solana per la rete $network",
-			"eth_address_unknown": "L'indirizzo ETH è sconosciuto.",
 			"loading_address": "Errore durante il caricamento dell'indirizzo $symbol.",
 			"loading_balance": "Errore durante il caricamento del saldo $symbol per la rete $network.",
 			"erc20_contracts": "Errore durante il caricamento dei contratti ERC20.",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "ネットワーク$networkのInfura ERC1155プロバイダーが存在しません",
 			"no_infura_erc20_icp_provider": "ネットワーク$networkのInfura ERC20 ICPプロバイダーが存在しません",
 			"no_solana_network": "ネットワーク$networkのSolanaネットワークが存在しません",
-			"eth_address_unknown": "ETHアドレスが不明です",
 			"loading_address": "$symbolアドレスの読み込み中にエラーが発生しました",
 			"loading_balance": "ネットワーク$networkの$symbol残高の読み込み中にエラーが発生しました",
 			"erc20_contracts": "ERC20コントラクトの読み込み中にエラーが発生しました",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Brak dostawcy Infura ERC1155 dla sieci $network",
 			"no_infura_erc20_icp_provider": "Brak dostawcy Infura ERC20 ICP dla sieci $network",
 			"no_solana_network": "Brak sieci Solana dla sieci $network",
-			"eth_address_unknown": "Nieznany adres ETH.",
 			"loading_address": "Błąd podczas ładowania adresu $symbol.",
 			"loading_balance": "Błąd podczas ładowania salda $symbol dla sieci $network.",
 			"erc20_contracts": "Błąd podczas ładowania kontraktów ERC20.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Nenhum provedor Infura ERC1155 para a rede $network",
 			"no_infura_erc20_icp_provider": "Nenhum provedor Infura ERC20 ICP para a rede $network",
 			"no_solana_network": "Nenhuma rede Solana para a rede $network",
-			"eth_address_unknown": "Endereço ETH desconhecido.",
 			"loading_address": "Erro ao carregar o endereço $symbol.",
 			"loading_balance": "Erro ao carregar o saldo $symbol para a rede $network.",
 			"erc20_contracts": "Erro ao carregar os contratos ERC20.",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Нет поставщика Infura ERC1155 для сети $network",
 			"no_infura_erc20_icp_provider": "Нет поставщика Infura ERC20 ICP для сети $network",
 			"no_solana_network": "Нет сети Solana для сети $network",
-			"eth_address_unknown": "Адрес ETH неизвестен.",
 			"loading_address": "Ошибка при загрузке адреса $symbol.",
 			"loading_balance": "Ошибка при загрузке баланса $symbol для сети $network.",
 			"erc20_contracts": "Ошибка при загрузке контрактов ERC20.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "Không có nhà cung cấp Infura ERC1155 cho mạng $network",
 			"no_infura_erc20_icp_provider": "Không có nhà cung cấp Infura ERC20 Icp cho mạng $network",
 			"no_solana_network": "Không có mạng Solana cho mạng $network",
-			"eth_address_unknown": "Địa chỉ ETH không xác định.",
 			"loading_address": "Lỗi khi tải địa chỉ $symbol.",
 			"loading_balance": "Lỗi khi tải số dư $symbol cho mạng $network.",
 			"erc20_contracts": "Lỗi khi tải các hợp đồng ERC20.",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -535,7 +535,6 @@
 			"no_infura_erc1155_provider": "没有 $network 网络的 Infura ERC1155 提供商",
 			"no_infura_erc20_icp_provider": "没有 $network 网络的 Infura ERC20 ICP 提供商",
 			"no_solana_network": "没有 $network 网络的 Solana 网络配置",
-			"eth_address_unknown": "ETH 地址未知。",
 			"loading_address": "加载 $symbol 地址时出错。",
 			"loading_balance": "加载 $network 网络上的 $symbol 余额时出错。",
 			"erc20_contracts": "加载 ERC20 合约时出错。",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -387,7 +387,6 @@ interface I18nInit {
 		no_infura_erc1155_provider: string;
 		no_infura_erc20_icp_provider: string;
 		no_solana_network: string;
-		eth_address_unknown: string;
 		loading_address: string;
 		loading_balance: string;
 		erc20_contracts: string;

--- a/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
@@ -202,8 +202,6 @@ describe('eth-balance.services', () => {
 			expect(result).toEqual({ success: false });
 
 			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
-
-
 		});
 
 		it('should use the ETH address store if the input address is nullish', async () => {

--- a/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
@@ -19,8 +19,6 @@ import { TRACK_COUNT_ETH_LOADING_BALANCE_ERROR } from '$lib/constants/analytics.
 import { trackEvent } from '$lib/services/analytics.services';
 import { ethAddressStore } from '$lib/stores/address.store';
 import { balancesStore } from '$lib/stores/balances.store';
-import * as toastsStore from '$lib/stores/toasts.store';
-import { toastsError } from '$lib/stores/toasts.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { createMockErc20Tokens, mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
@@ -60,7 +58,6 @@ describe('eth-balance.services', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();
 
-			vi.spyOn(toastsStore, 'toastsError');
 			vi.spyOn(infuraProvidersLib, 'infuraProviders');
 
 			mockProvider.prototype.getBalance = mockGetBalance;
@@ -76,7 +73,6 @@ describe('eth-balance.services', () => {
 
 			expect(result).toEqual({ success: false });
 
-			expect(toastsError).toHaveBeenCalledTimes(mockTokens.length);
 		});
 
 		it('should call the balance provider', async () => {
@@ -186,7 +182,6 @@ describe('eth-balance.services', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();
 
-			vi.spyOn(toastsStore, 'toastsError');
 			vi.spyOn(infuraErc20ProvidersLib, 'infuraErc20Providers');
 
 			mockContract.prototype.balanceOf =
@@ -201,7 +196,6 @@ describe('eth-balance.services', () => {
 
 			expect(result).toEqual({ success: false });
 
-			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
 		});
 
 		it('should use the ETH address store if the input address is nullish', async () => {
@@ -211,7 +205,6 @@ describe('eth-balance.services', () => {
 
 			expect(result).toEqual({ success: true });
 
-			expect(toastsError).not.toHaveBeenCalled();
 		});
 
 		it('should call the balance provider', async () => {
@@ -311,7 +304,6 @@ describe('eth-balance.services', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();
 
-			vi.spyOn(toastsStore, 'toastsError');
 			vi.spyOn(infuraProvidersLib, 'infuraProviders');
 			vi.spyOn(infuraErc20ProvidersLib, 'infuraErc20Providers');
 

--- a/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
@@ -77,12 +77,6 @@ describe('eth-balance.services', () => {
 			expect(result).toEqual({ success: false });
 
 			expect(toastsError).toHaveBeenCalledTimes(mockTokens.length);
-
-			mockTokens.forEach((_, index) => {
-				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
-					msg: { text: en.init.error.eth_address_unknown }
-				});
-			});
 		});
 
 		it('should call the balance provider', async () => {
@@ -209,11 +203,7 @@ describe('eth-balance.services', () => {
 
 			expect(toastsError).toHaveBeenCalledTimes(mockErc20DefaultTokens.length);
 
-			mockErc20DefaultTokens.forEach((_, index) => {
-				expect(toastsError).toHaveBeenNthCalledWith(index + 1, {
-					msg: { text: en.init.error.eth_address_unknown }
-				});
-			});
+
 		});
 
 		it('should use the ETH address store if the input address is nullish', async () => {

--- a/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-balance.services.spec.ts
@@ -72,7 +72,6 @@ describe('eth-balance.services', () => {
 			const result = await loadEthBalances(mockTokens);
 
 			expect(result).toEqual({ success: false });
-
 		});
 
 		it('should call the balance provider', async () => {
@@ -195,7 +194,6 @@ describe('eth-balance.services', () => {
 			const result = await loadErc20Balances({ ...mockParams, address: null });
 
 			expect(result).toEqual({ success: false });
-
 		});
 
 		it('should use the ETH address store if the input address is nullish', async () => {
@@ -204,7 +202,6 @@ describe('eth-balance.services', () => {
 			const result = await loadErc20Balances({ ...mockParams, address: null });
 
 			expect(result).toEqual({ success: true });
-
 		});
 
 		it('should call the balance provider', async () => {

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -35,7 +35,6 @@ vi.mock('$lib/services/analytics.services', () => ({
 }));
 
 describe('eth-transactions.services', () => {
-
 	const mockErc20UserTokens = [USDC_TOKEN, LINK_TOKEN, PEPE_TOKEN].map((token) => ({
 		data: { ...token, enabled: true },
 		certified: false

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -95,9 +95,6 @@ describe('eth-transactions.services', () => {
 					standard: mockStandard
 				});
 
-				expect(spyToastsError).toHaveBeenCalledWith({
-					msg: { text: en.init.error.eth_address_unknown }
-				});
 				expect(result).toEqual({ success: false });
 			});
 

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -16,7 +16,6 @@ import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR } from '$lib/constants/analytics.contants';
 import { trackEvent } from '$lib/services/analytics.services';
 import { ethAddressStore } from '$lib/stores/address.store';
-import * as toastsStore from '$lib/stores/toasts.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockValidErc1155Token } from '$tests/mocks/erc1155-tokens.mock';
 import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
@@ -36,7 +35,6 @@ vi.mock('$lib/services/analytics.services', () => ({
 }));
 
 describe('eth-transactions.services', () => {
-	let spyToastsError: MockInstance;
 
 	const mockErc20UserTokens = [USDC_TOKEN, LINK_TOKEN, PEPE_TOKEN].map((token) => ({
 		data: { ...token, enabled: true },
@@ -45,8 +43,6 @@ describe('eth-transactions.services', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-
-		spyToastsError = vi.spyOn(toastsStore, 'toastsError');
 
 		ethAddressStore.set({ data: mockEthAddress, certified: false });
 		erc20UserTokensStore.setAll(mockErc20UserTokens);


### PR DESCRIPTION
# Motivation

There is no need to provide an error feedback to the user if during loading of transactions/balances, the ETH address is not available (still loading, disabled, etc).