### PR TITLE
feat(frontend): Remove ERC20 dependency from the manage tokens button

### DIFF
--- a/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
+++ b/src/frontend/src/lib/components/tokens/ManageTokensButton.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import IconManage from '$lib/components/icons/lucide/IconManage.svelte';
 	import { MANAGE_TOKENS_MODAL_BUTTON } from '$lib/constants/test-ids.constants';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
-	let disabled = $derived($erc20UserTokensNotInitialized || $authNotSignedIn);
+	let disabled = $derived($authNotSignedIn);
 
 	const manageTokensId = $state(Symbol());
 </script>


### PR DESCRIPTION
# Motivation

The manage tokens button was enable-dependent on the ERC20 tokens store being initialized, however it is not coherent, since it is used for all networks and it has no direct dependency on ERC20 tokens.

Furthermore, it means that if the Ethereum/EVM networks are disabled, it would be disabled too, and it does not really work for the user.
