### PR TITLE
feat(frontend): Remove ERC20 dependency from the manage tokens modal

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher, getContext, onMount, setContext, type Snippet } from 'svelte';
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
 	import EnableTokenToggle from '$lib/components/tokens/EnableTokenToggle.svelte';
 	import ModalNetworksFilter from '$lib/components/tokens/ModalNetworksFilter.svelte';
@@ -71,8 +70,6 @@
 		setTokens(allTokensSorted);
 	});
 
-	let loading = $derived($erc20UserTokensNotInitialized);
-
 	let showNetworks = $state(false);
 
 	const onSelectNetwork = () => {
@@ -120,7 +117,7 @@
 	<ModalNetworksFilter on:icNetworkFilter={() => (showNetworks = false)} />
 {:else}
 	<ModalTokensList
-		{loading}
+		loading={false}
 		networkSelectorViewOnly={nonNullish($selectedNetwork)}
 		on:icSelectNetworkFilter={onSelectNetwork}
 	>


### PR DESCRIPTION
# Motivation

The manage tokens modal sets the loading state based on the ERC20 tokens store being initialized, however it is not coherent, since it is used for all networks and it has no direct dependency on ERC20 tokens.

Furthermore, it means that if the Ethereum/EVM networks are disabled, we would be waiting for the store to load infinitely.