### PR TITLE
style(frontend): Remove fading from initial loader for frontend derivation

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -282,13 +282,11 @@
 		</div>
 	{/if}
 {:else}
-	<div in:fade>
 		<LoaderCollections>
 			<LoaderNfts>
 				{@render children()}
 			</LoaderNfts>
 		</LoaderCollections>
-	</div>
 {/if}
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -282,11 +282,11 @@
 		</div>
 	{/if}
 {:else}
-		<LoaderCollections>
-			<LoaderNfts>
-				{@render children()}
-			</LoaderNfts>
-		</LoaderCollections>
+	<LoaderCollections>
+		<LoaderNfts>
+			{@render children()}
+		</LoaderNfts>
+	</LoaderCollections>
 {/if}
 
 <style lang="scss">


### PR DESCRIPTION
# Motivation

Suggestion by @peterpeterparker: https://github.com/dfinity/oisy-wallet/pull/9290#pullrequestreview-3285157460

> That said, we can probably smoothness the loading even a bit more in other PRs.
> 
> For example, assuming you updated the resulting video provided in the PR after the first iteration, would removing the fade on line 285 even make the boot more smooth?


### Before

https://github.com/user-attachments/assets/79300c0f-c3dc-4437-93f6-0b30b14d6d61

### After


https://github.com/user-attachments/assets/31119d44-bc45-4a16-872b-c301f1221705


