### PR TITLE
style(frontend): add text highlighting to the AI console messages

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantUserMessage.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantUserMessage.svelte
@@ -8,8 +8,15 @@
 
 <div class="mb-5 flex w-full justify-end text-sm">
 	<div
-		class="flex w-[85%] flex-col justify-center rounded-xl rounded-tr-none bg-brand-primary px-3 py-4 text-primary-inverted"
+		class="message flex w-[85%] flex-col justify-center rounded-xl rounded-tr-none bg-brand-primary px-3 py-4 text-primary-inverted"
 	>
 		{content}
 	</div>
 </div>
+
+<style lang="scss">
+	.message::selection {
+		background: var(--color-foreground-tertiary-inverted);
+		color: var(--color-foreground-primary-inverted);
+	}
+</style>


### PR DESCRIPTION
# Motivation

Currently, the selected/highlighted text that is placed inside an element with "primary" background color is not really visible (happens in most of the browsers). It is accepted in most of the cases, but in the AI console it would be really great to allow users to do so. The solution is to add a custom styling for the highlighted text.

Before:
<img width="378" height="183" alt="Screenshot 2025-10-01 at 12 48 01" src="https://github.com/user-attachments/assets/cfe1d98a-6da1-4462-8df8-717b9d3a4221" />


After:
<img width="371" height="207" alt="Screenshot 2025-10-01 at 12 44 39" src="https://github.com/user-attachments/assets/5ba12631-0ca5-430f-8b4d-fac8207432d2" />
