### PR TITLE
feat(frontend): Translations for terms of use instruction

### DIFF
--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Podmínky použití",
 			"title": "",
-			"instruction": "",
+			"instruction": "Kliknutím na toto tlačítko souhlasíte s ",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Podmínky použití",
 			"title": "",
-			"instruction": "Kliknutím na toto tlačítko souhlasíte s ",
+			"instruction": "Kliknutím na toto tlačítko souhlasíte s $link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Nutzungsbedingungen",
 			"title": "",
-			"instruction": "Durch klicken auf Einloggen stimmst du den $link zu",
+			"instruction": "Durch Klicken auf diese Schaltfläche stimmst du den $link zu",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Conditions d'utilisation",
 			"title": "",
-			"instruction": "",
+			"instruction": "En cliquant sur ce bouton, vous acceptez les ",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Conditions d'utilisation",
 			"title": "",
-			"instruction": "En cliquant sur ce bouton, vous acceptez les ",
+			"instruction": "En cliquant sur ce bouton, vous acceptez les $link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Termini di utilizzo",
 			"title": "",
-			"instruction": "",
+			"instruction": "Cliccando su questo pulsante, accetti i ",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Termini di utilizzo",
 			"title": "",
-			"instruction": "Cliccando su questo pulsante, accetti i ",
+			"instruction": "Cliccando su questo pulsante, accetti i $link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "",
 			"title": "",
-			"instruction": "",
+			"instruction": "このボタンをクリックすると、以下に同意したことになります。",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "",
 			"title": "",
-			"instruction": "このボタンをクリックすると、以下に同意したことになります。",
+			"instruction": "このボタンをクリックすると、以下に同意したことになります。$link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Warunki użytkowania",
 			"title": "",
-			"instruction": "",
+			"instruction": "Klikając ten przycisk, zgadzasz się na ",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Warunki użytkowania",
 			"title": "",
-			"instruction": "Klikając ten przycisk, zgadzasz się na ",
+			"instruction": "Klikając ten przycisk, zgadzasz się na $link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Termos de Uso",
 			"title": "",
-			"instruction": "",
+			"instruction": "Ao clicar neste botão, você concorda com os ",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Termos de Uso",
 			"title": "",
-			"instruction": "Ao clicar neste botão, você concorda com os ",
+			"instruction": "Ao clicar neste botão, você concorda com os $link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Điều khoản sử dụng",
 			"title": "",
-			"instruction": "",
+			"instruction": "Bằng cách nhấp vào nút này, bạn đồng ý với ",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "Điều khoản sử dụng",
 			"title": "",
-			"instruction": "Bằng cách nhấp vào nút này, bạn đồng ý với ",
+			"instruction": "Bằng cách nhấp vào nút này, bạn đồng ý với $link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "使用条款",
 			"title": "",
-			"instruction": "点击此按钮即表示你同意",
+			"instruction": "点击此按钮即表示你同意$link",
 			"body": ""
 		},
 		"alt": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1621,7 +1621,7 @@
 		"text": {
 			"terms_of_use": "使用条款",
 			"title": "",
-			"instruction": "",
+			"instruction": "点击此按钮即表示你同意",
 			"body": ""
 		},
 		"alt": {


### PR DESCRIPTION
# Motivation

We added the "by clicking this button you agree...." text back.

# Changes

- Add translations for the other languages

# Tests
<img width="351" height="123" alt="image" src="https://github.com/user-attachments/assets/53bc9a12-b8c4-4945-82b2-40641970e625" />

<img width="351" height="123" alt="image" src="https://github.com/user-attachments/assets/b2b427d0-c7f3-41fa-8cd7-a94b5d63bda3" />

