### PR TITLE
refactor(frontend): Extract type for Agreements to accept

### DIFF
--- a/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
+++ b/src/frontend/src/lib/components/agreements/AcceptAgreementsModal.svelte
@@ -28,21 +28,17 @@
 	import { nullishSignOut, warnSignOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
-	import type { UserAgreements } from '$lib/types/user-agreements';
+	import type { AgreementsToAccept, UserAgreements } from '$lib/types/user-agreements';
 	import { emit } from '$lib/utils/events.utils';
 
-	type AgreementsToAcceptType = {
-		[K in keyof EnvAgreements]?: boolean;
-	};
-
-	let agreementsToAccept = $state<AgreementsToAcceptType>({});
+	let agreementsToAccept = $state<AgreementsToAccept>({});
 
 	let updatingAgreements = $state(true);
 
 	$effect(() => {
 		updatingAgreements = true;
 
-		agreementsToAccept = Object.keys($outdatedAgreements).reduce<AgreementsToAcceptType>(
+		agreementsToAccept = Object.keys($outdatedAgreements).reduce<AgreementsToAccept>(
 			(acc, agreementType) => ({
 				...acc,
 				[agreementType as keyof EnvAgreements]: false
@@ -59,7 +55,7 @@
 
 	let disabled = $derived(!acceptedAllAgreements || updatingAgreements);
 
-	const toggleAccept = (type: keyof AgreementsToAcceptType) => {
+	const toggleAccept = (type: keyof AgreementsToAccept) => {
 		agreementsToAccept[type] = !agreementsToAccept[type];
 	};
 

--- a/src/frontend/src/lib/types/user-agreements.ts
+++ b/src/frontend/src/lib/types/user-agreements.ts
@@ -1,3 +1,5 @@
+import type { EnvAgreements } from '$env/types/env-agreements';
+
 export interface AgreementData {
 	accepted: boolean | undefined;
 	lastAcceptedTimestamp: bigint | undefined;
@@ -9,3 +11,7 @@ export interface UserAgreements {
 	privacyPolicy: AgreementData;
 	termsOfUse: AgreementData;
 }
+
+export type AgreementsToAccept = {
+	[K in keyof EnvAgreements]?: boolean;
+};


### PR DESCRIPTION
# Motivation

Since we are going to reuse it, we extract the type that defines the agreements to accept.
