### PR TITLE
feat(devops): Schedule update of vitest coverage threshold

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -1,9 +1,8 @@
 name: Update Frontend Test Coverage Thresholds
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '30 3 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# Motivation

Since we are increasing the coverage slowly, we can think of just schedule the CI that updated the thresholds once per day, instead of each push to `main`. In any case, if needed, we can trigger it manually.
