### PR TITLE
refactor(frontend): Remove unnecessary generic from `TokenUi` in `SwapTokensList`

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -29,7 +29,7 @@
 		icCloseTokensList: void;
 	}>();
 
-	let tokens: TokenUi<Token>[] = $derived(
+	let tokens: TokenUi[] = $derived(
 		pinTokensWithBalanceAtTop({
 			$tokens: [
 				{ ...ICP_TOKEN, enabled: true },
@@ -47,7 +47,7 @@
 		setTokens(tokens);
 	});
 
-	const onIcTokenButtonClick = ({ detail: token }: CustomEvent<TokenUi<Token>>) => {
+	const onIcTokenButtonClick = ({ detail: token }: CustomEvent<TokenUi>) => {
 		dispatch('icSelectToken', token);
 	};
 </script>


### PR DESCRIPTION
# Motivation

Type `TokenUi` has already `Token` as generic default.
