### PR TITLE
refactor(frontend): Split all props interfaces from the deconstruction

### DIFF
--- a/src/frontend/src/lib/components/address-book/AddressBookQrCode.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookQrCode.svelte
@@ -5,7 +5,11 @@
 	import IconAddressType from '$lib/components/address/IconAddressType.svelte';
 	import type { ContactAddressUi } from '$lib/types/contact';
 
-	const { address }: { address: ContactAddressUi } = $props();
+	interface Props {
+		address: ContactAddressUi;
+	}
+
+	const { address }: Props = $props();
 
 	let render = $state(true);
 

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantShowBalanceToolCard.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantShowBalanceToolCard.svelte
@@ -18,15 +18,7 @@
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
-	let {
-		token,
-		tokenCount,
-		totalUsdBalance,
-		styleClass,
-		network,
-		cardDescription,
-		onClick
-	}: {
+	interface Props {
 		totalUsdBalance: number;
 		tokenCount?: number;
 		token?: TokenUi;
@@ -34,7 +26,10 @@
 		network?: Network;
 		cardDescription?: Snippet;
 		onClick: () => void;
-	} = $props();
+	}
+
+	let { token, tokenCount, totalUsdBalance, styleClass, network, cardDescription, onClick }: Props =
+		$props();
 
 	let formattedTotalUsdBalance = $derived(
 		formatCurrency({

--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -23,11 +23,13 @@
 	import type { Token } from '$lib/types/token';
 	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 
-	let {
-		initialSearch,
-		infoElement,
-		isNftsPage
-	}: { initialSearch?: string; infoElement?: Snippet; isNftsPage?: boolean } = $props();
+	interface Props {
+		initialSearch?: string;
+		infoElement?: Snippet;
+		isNftsPage?: boolean;
+	}
+
+	let { initialSearch, infoElement, isNftsPage }: Props = $props();
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -56,11 +56,13 @@
 	import type { SolanaNetwork } from '$sol/types/network';
 	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 
-	let {
-		initialSearch,
-		onClose = () => {},
-		infoElement
-	}: { initialSearch?: string; onClose?: () => void; infoElement?: Snippet } = $props();
+	interface Props {
+		initialSearch?: string;
+		onClose?: () => void;
+		infoElement?: Snippet;
+	}
+
+	let { initialSearch, onClose = () => {}, infoElement }: Props = $props();
 
 	const isNftsPage = $derived(isRouteNfts(page));
 

--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -16,19 +16,21 @@
 	import type { Token } from '$lib/types/token';
 	import { isDesktop } from '$lib/utils/device.utils';
 
+	interface Props {
+		networkSelectorViewOnly: boolean;
+		loading: boolean;
+		tokenListItem: Snippet<[Token, () => void]>;
+		toolbar: Snippet;
+		noResults?: Snippet;
+	}
+
 	let {
 		networkSelectorViewOnly = false,
 		loading,
 		tokenListItem,
 		toolbar,
 		noResults
-	}: {
-		networkSelectorViewOnly: boolean;
-		loading: boolean;
-		tokenListItem: Snippet<[Token, () => void]>;
-		toolbar: Snippet;
-		noResults?: Snippet;
-	} = $props();
+	}: Props = $props();
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -18,19 +18,21 @@
 	import { isCardDataTogglableToken } from '$lib/utils/token-card.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
+	interface Props {
+		data: CardData;
+		testIdPrefix?: typeof TOKEN_CARD | typeof TOKEN_GROUP;
+		asNetwork?: boolean;
+		hover?: boolean;
+		onToggle?: (t: CustomEvent<Token>) => void;
+	}
+
 	let {
 		data,
 		testIdPrefix = TOKEN_CARD,
 		asNetwork = false,
 		hover = false,
 		onToggle
-	}: {
-		data: CardData;
-		testIdPrefix?: typeof TOKEN_CARD | typeof TOKEN_GROUP;
-		asNetwork?: boolean;
-		hover?: boolean;
-		onToggle?: (t: CustomEvent<Token>) => void;
-	} = $props();
+	}: Props = $props();
 
 	const dispatch = createEventDispatcher();
 

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -18,7 +18,11 @@
 	import { mapHeaderData } from '$lib/utils/token-card.utils';
 	import { getFilteredTokenGroup } from '$lib/utils/token-list.utils.js';
 
-	let { tokenGroup }: { tokenGroup: TokenUiGroup } = $props();
+	interface Props {
+		tokenGroup: TokenUiGroup;
+	}
+
+	let { tokenGroup }: Props = $props();
 
 	const isExpanded: boolean = $derived(
 		($tokenGroupStore ?? {})[tokenGroup.id]?.isExpanded ?? false

--- a/src/frontend/src/lib/components/tokens/TokensFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensFilter.svelte
@@ -8,7 +8,11 @@
 	import { tokenListStore } from '$lib/stores/token-list.store';
 	import { isTokensPath, isTransactionsPath } from '$lib/utils/nav.utils';
 
-	let { overflowableContent }: { overflowableContent?: Snippet } = $props();
+	interface Props {
+		overflowableContent?: Snippet;
+	}
+
+	let { overflowableContent }: Props = $props();
 
 	let inputValue = $derived($tokenListStore.filter);
 

--- a/src/frontend/src/lib/components/ui/ButtonPaste.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonPaste.svelte
@@ -4,7 +4,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { readClipboard } from '$lib/utils/share.utils';
 
-	let { onpaste }: { onpaste: (text: string) => void } = $props();
+	interface Props {
+		onpaste: (text: string) => void;
+	}
+
+	let { onpaste }: Props = $props();
 
 	const handlePaste = async () => {
 		const text = await readClipboard();

--- a/src/frontend/src/lib/components/ui/ButtonReset.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonReset.svelte
@@ -3,7 +3,12 @@
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	let { ariaLabel, onclick }: { ariaLabel?: string; onclick: () => void } = $props();
+	interface Props {
+		ariaLabel?: string;
+		onclick: () => void;
+	}
+
+	let { ariaLabel, onclick }: Props = $props();
 </script>
 
 <ButtonIcon

--- a/src/frontend/src/lib/components/ui/CollapsibleBottomSheet.svelte
+++ b/src/frontend/src/lib/components/ui/CollapsibleBottomSheet.svelte
@@ -8,17 +8,14 @@
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
-	let {
-		content,
-		contentHeader,
-		contentFooter,
-		showContentHeader = false
-	}: {
+	interface Props {
 		content: Snippet;
 		contentHeader: Snippet<[{ isInBottomSheet: boolean }]>;
 		contentFooter?: Snippet<[closeFn: () => void]>;
 		showContentHeader?: boolean;
-	} = $props();
+	}
+
+	let { content, contentHeader, contentFooter, showContentHeader = false }: Props = $props();
 
 	let expanded = $state(false);
 </script>

--- a/src/frontend/src/lib/components/ui/SlidingInput.svelte
+++ b/src/frontend/src/lib/components/ui/SlidingInput.svelte
@@ -10,6 +10,16 @@
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants.js';
 	import { i18n } from '$lib/stores/i18n.store';
 
+	interface Props {
+		inputValue: string;
+		inputPlaceholder: string;
+		ariaLabel: string;
+		testIdPrefix?: string;
+		disabled?: boolean;
+		icon: Snippet;
+		overflowableContent?: Snippet;
+	}
+
 	let {
 		inputValue = $bindable(''),
 		inputPlaceholder,
@@ -18,15 +28,7 @@
 		disabled = false,
 		icon: slidingIcon,
 		overflowableContent
-	}: {
-		inputValue: string;
-		inputPlaceholder: string;
-		ariaLabel: string;
-		testIdPrefix?: string;
-		disabled?: boolean;
-		icon: Snippet;
-		overflowableContent?: Snippet;
-	} = $props();
+	}: Props = $props();
 
 	let visible = $state(false);
 

--- a/src/frontend/src/tests/lib/components/address-book/InputContactNameTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/address-book/InputContactNameTestHost.svelte
@@ -2,15 +2,13 @@
 	import InputContactName from '$lib/components/address-book/InputContactName.svelte';
 	import type { ContactUi } from '$lib/types/contact';
 
-	let {
-		contact = $bindable(),
-		disabled,
-		isValid = $bindable()
-	}: {
+	interface Props {
 		contact: Partial<ContactUi>;
 		disabled?: boolean;
 		isValid: boolean;
-	} = $props();
+	}
+
+	let { contact = $bindable(), disabled, isValid = $bindable() }: Props = $props();
 
 	// Expose the isValid value for testing
 	export const getIsValid = () => isValid;

--- a/src/frontend/src/tests/lib/components/address/InputAddressAliasTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/address/InputAddressAliasTestHost.svelte
@@ -2,15 +2,13 @@
 	import InputAddressAlias from '$lib/components/address/InputAddressAlias.svelte';
 	import type { ContactAddressUi } from '$lib/types/contact';
 
-	let {
-		address = $bindable(),
-		disableAddressField,
-		isValid = $bindable()
-	}: {
+	interface Props {
 		address: Partial<ContactAddressUi>;
 		disableAddressField?: boolean;
 		isValid: boolean;
-	} = $props();
+	}
+
+	let { address = $bindable(), disableAddressField, isValid = $bindable() }: Props = $props();
 
 	// Expose the isValid value for testing
 	export const getIsValid = () => isValid;

--- a/src/frontend/src/tests/lib/components/send/SendDestinationWizardStepTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/send/SendDestinationWizardStepTestHost.svelte
@@ -8,6 +8,16 @@
 	import type { ContactUi } from '$lib/types/contact';
 	import type { SendDestinationTab } from '$lib/types/send';
 
+	interface Props {
+		destination: string;
+		activeSendDestinationTab: SendDestinationTab;
+		selectedContact: Writable<ContactUi>;
+		onBack: () => void;
+		onNext: () => void;
+		onClose: () => void;
+		onQRCodeScan: () => void;
+	}
+
 	let {
 		destination,
 		activeSendDestinationTab,
@@ -16,15 +26,7 @@
 		onNext,
 		onClose,
 		onQRCodeScan
-	}: {
-		destination: string;
-		activeSendDestinationTab: SendDestinationTab;
-		selectedContact: Writable<ContactUi>;
-		onBack: () => void;
-		onNext: () => void;
-		onClose: () => void;
-		onQRCodeScan: () => void;
-	} = $props();
+	}: Props = $props();
 
 	const steps = allSendWizardSteps({ i18n: $i18n });
 


### PR DESCRIPTION
# Motivation

To be more consistent, we separate the Props interface from the declaration construction of the variables.

### Note

This makes it easier if at some point we want to use such interface, for example:

```ts
	import AddressItemActions, {
		type Props as AddressItemActionsProps
	} from '$lib/components/contact/AddressItemActions.svelte';
```
