### PR TITLE
chore(frontend): Remove unused event in `ManageTokensModal`

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -352,7 +352,6 @@
 			{infoElement}
 			{initialSearch}
 			{isNftsPage}
-			on:icClose={close}
 			on:icAddToken={modal.next}
 			on:icSave={saveTokens}
 		/>


### PR DESCRIPTION
# Motivation

Component `ManageTokens` does not emit the event `icClose`. So we can remove it in `ManageTokensModal`.
