### PR TITLE
fix(devops): Run E2E tests for merge group when necessary

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,7 +39,7 @@ jobs:
   oisy-backend-wasm:
     runs-on: ubuntu-24.04
     if: ${{(github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
-      (github.event_name == 'pull_request' && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
+      ((github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
     needs: check-e2e-changes
     permissions:
       contents: write


### PR DESCRIPTION
# Motivation

When one of the PRs in the merge group has changed E2E-related files, the E2E tests should run, since we have a compulsory status check in those cases.