### PR TITLE
refactor(frontend): Change the loading condition in `LoaderEthBalances`

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderEthBalances.svelte
@@ -27,6 +27,7 @@
 		if (loading) {
 			return;
 		}
+
 		loading = true;
 
 		await Promise.allSettled([
@@ -46,7 +47,6 @@
 	$effect(() => {
 		// To trigger the load function when any of the dependencies change.
 		[$ethAddress, $enabledEthereumTokens, $enabledEvmTokens, $enabledErc20Tokens];
-		console.log('debounceLoad');
 		debounceLoad();
 	});
 


### PR DESCRIPTION
# Motivation

In component `LoaderEthBalances`, it is more correct to check if the component is already loading ONLY after we check if the address is set. That is because the logic should not even start if the Ethereum/EVMs networks are disabled.
