### PR TITLE
fix(devops): Run E2E tests for merge group when necessary

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         shardTotal: [10]
     if: ${{(github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
-      (github.event_name == 'pull_request' && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
+      ((github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.shardIndex }}
       cancel-in-progress: true


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/9332, I forgot to add the condition of E2E tests for merge group in another step of the workflow.
