### PR TITLE
feat(frontend): Use `zod` for Onramper ID

### DIFF
--- a/src/frontend/src/lib/schema/network.schema.ts
+++ b/src/frontend/src/lib/schema/network.schema.ts
@@ -1,7 +1,5 @@
+import { OnramperNetworkIdSchema } from '$lib/schema/onramper.schema';
 import type { CoingeckoPlatformId } from '$lib/types/coingecko';
-import type { NetworkBuy } from '$lib/types/network';
-import type { OnramperNetworkId } from '$lib/types/onramper';
-import type { AtLeastOne } from '$lib/types/utils';
 import { UrlSchema } from '$lib/validation/url.validation';
 import * as z from 'zod';
 
@@ -15,8 +13,8 @@ export const NetworkExchangeSchema = z.object({
 });
 
 // TODO: use Zod to validate the OnramperNetworkId
-export const NetworkBuySchema = z.object({
-	onramperId: z.custom<OnramperNetworkId>().optional()
+const NetworkBuySchema = z.object({
+	onramperId: OnramperNetworkIdSchema
 });
 
 export const NetworkAppMetadataSchema = z.object({
@@ -32,8 +30,8 @@ const IconSchema = z
 /**
  * Zod schema defining the shape of a network-like object.
  *
- * This schema represents both actual networks (e.g., the Internet Computer, Ethereum, Bitcoin mainnet)
- * and "pseudo-networks" used for development or simulation purposes. For example, the
+ * This schema represents both actual networks (e.g. the Internet Computer, Ethereum, Bitcoin mainnet)
+ * and "pseudo-networks" used for development or simulation. For example, the
  * `ICP_PSEUDO_TESTNET_NETWORK` mimics the structure of the IC network but is used to
  * isolate testnet tokens such as `ckSepoliaETH` from production data.
  *
@@ -46,5 +44,5 @@ export const NetworkSchema = z.object({
 	name: z.string(),
 	icon: IconSchema.optional(),
 	exchange: NetworkExchangeSchema.optional(),
-	buy: z.custom<AtLeastOne<NetworkBuy>>().optional()
+	buy: NetworkBuySchema.optional()
 });

--- a/src/frontend/src/lib/schema/token.schema.ts
+++ b/src/frontend/src/lib/schema/token.schema.ts
@@ -1,8 +1,6 @@
 import { NetworkSchema } from '$lib/schema/network.schema';
+import { OnramperIdSchema } from '$lib/schema/onramper.schema';
 import { TokenGroupPropSchema } from '$lib/schema/token-group.schema';
-import type { OnramperId } from '$lib/types/onramper';
-import type { TokenBuy } from '$lib/types/token';
-import type { AtLeastOne } from '$lib/types/utils';
 import * as z from 'zod';
 
 export const TokenIdSchema = z.symbol().brand<'TokenId'>();
@@ -45,13 +43,12 @@ export const TokenAppearanceSchema = z.object({
 	alwaysShowInTokenGroup: z.boolean().optional()
 });
 
-// TODO: use Zod to validate the OnramperId
-export const TokenBuySchema = z.object({
-	onramperId: z.custom<OnramperId>().optional()
+const TokenBuySchema = z.object({
+	onramperId: OnramperIdSchema
 });
 
 export const TokenBuyableSchema = z.object({
-	buy: z.custom<AtLeastOne<TokenBuy>>().optional()
+	buy: TokenBuySchema.optional()
 });
 
 export const TokenSchema = z.object({

--- a/src/frontend/src/lib/types/network.ts
+++ b/src/frontend/src/lib/types/network.ts
@@ -1,6 +1,5 @@
 import type {
 	NetworkAppMetadataSchema,
-	NetworkBuySchema,
 	NetworkEnvironmentSchema,
 	NetworkExchangeSchema,
 	NetworkIdSchema,
@@ -16,8 +15,6 @@ export type NetworkEnvironment = z.infer<typeof NetworkEnvironmentSchema>;
 export type Network = z.infer<typeof NetworkSchema>;
 
 export type NetworkExchange = z.infer<typeof NetworkExchangeSchema>;
-
-export type NetworkBuy = z.infer<typeof NetworkBuySchema>;
 
 export type NetworkAppMetadata = z.infer<typeof NetworkAppMetadataSchema>;
 

--- a/src/frontend/src/lib/types/onramper.ts
+++ b/src/frontend/src/lib/types/onramper.ts
@@ -1,21 +1,11 @@
 import type { Currency } from '$lib/enums/currency';
+import type { OnramperIdSchema, OnramperNetworkIdSchema } from '$lib/schema/onramper.schema';
 import type { BtcAddress, EthAddress } from '$lib/types/address';
+import type * as z from 'zod';
 
-// The list of networks that are supported by Onramper can be found here:
-// https://docs.onramper.com/docs/network-support
-export type OnramperNetworkId =
-	| 'icp'
-	| 'bitcoin'
-	| 'ethereum'
-	| 'solana'
-	| 'base'
-	| 'bsc'
-	| 'polygon'
-	| 'arbitrum';
+export type OnramperNetworkId = z.infer<typeof OnramperNetworkIdSchema>;
 
-// The list of cryptocurrencies that are supported by Onramper can be found here:
-// https://docs.onramper.com/docs/crypto-asset-support
-export type OnramperId = string;
+export type OnramperId = z.infer<typeof OnramperIdSchema>;
 
 // The list of fiat currencies that are supported by Onramper can be found here:
 // https://docs.onramper.com/docs/fiat-currency-support

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -1,6 +1,5 @@
 import type {
 	TokenAppearanceSchema,
-	TokenBuySchema,
 	TokenBuyableSchema,
 	TokenCategorySchema,
 	TokenIdSchema,
@@ -26,8 +25,6 @@ export type TokenMetadata = z.infer<typeof TokenMetadataSchema>;
 export type TokenAppearance = z.infer<typeof TokenAppearanceSchema>;
 
 export type TokenBuyable = z.infer<typeof TokenBuyableSchema>;
-
-export type TokenBuy = z.infer<typeof TokenBuySchema>;
 
 export interface TokenLinkedData {
 	twinTokenSymbol?: string;

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -14,9 +14,6 @@ export type ResultSuccessReduced<T = unknown> = ResultSuccess<T[]>;
 // eslint-disable-next-line local-rules/use-option-type-wrapper
 export type Option<T> = T | null | undefined;
 
-export type AtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
-	{ [K in Keys]-?: Required<Pick<T, K>> & Partial<Omit<T, K>> }[Keys];
-
 export type PartialSpecific<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export type NonEmptyArray<T> = [T, ...T[]];

--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -1,6 +1,5 @@
 import {
 	NetworkAppMetadataSchema,
-	NetworkBuySchema,
 	NetworkEnvironmentSchema,
 	NetworkIdSchema,
 	NetworkSchema
@@ -39,28 +38,6 @@ describe('network.schema', () => {
 			const invalidEnv = 'unsupported-env';
 
 			expect(() => NetworkEnvironmentSchema.parse(invalidEnv)).toThrow();
-		});
-	});
-
-	describe('NetworkBuySchema', () => {
-		it('should validate with an optional onramperId', () => {
-			const validBuy = { onramperId: 'icp' };
-
-			expect(NetworkBuySchema.parse(validBuy)).toEqual(validBuy);
-		});
-
-		it('should validate with an empty object (onramperId optional)', () => {
-			const validBuy = {};
-
-			expect(NetworkBuySchema.parse(validBuy)).toEqual(validBuy);
-		});
-
-		// TODO: unskip the below when we have a way to validate OnramperNetworkId
-		// For now this test is failing because the OnramperNetworkId is not correctly validated
-		it.skip('should fail validation with an invalid onramperId', () => {
-			const invalidBuy = { onramperId: 'invalid-id' };
-
-			expect(() => NetworkBuySchema.parse(invalidBuy)).toThrow();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/schema/token.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/token.schema.spec.ts
@@ -2,7 +2,6 @@ import { SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import {
 	TokenAppearanceSchema,
 	TokenBuyableSchema,
-	TokenBuySchema,
 	TokenCategorySchema,
 	TokenIdSchema,
 	TokenMetadataSchema,
@@ -179,20 +178,6 @@ describe('token.schema', () => {
 			};
 
 			expect(() => TokenAppearanceSchema.parse(invalidAppearance)).toThrow();
-		});
-	});
-
-	describe('TokenBuySchema', () => {
-		it('should validate with an optional onramperId', () => {
-			const validBuy = { onramperId: 'valid-id' };
-
-			expect(TokenBuySchema.parse(validBuy)).toEqual(validBuy);
-		});
-
-		it('should validate with an empty object (onramperId optional)', () => {
-			const validBuy = {};
-
-			expect(TokenBuySchema.parse(validBuy)).toEqual(validBuy);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

We should use `zod` to define most of our types: in this PR we switch the Onramper ID to zod schemas.

# Changes

- Create schemas for Onramper IDs.
- Adapt existing types.
- Remove unused types `TokenBuy` and `NetworkBuy`.
- Remove global export of `TokenBuySchema` and `NetworkBuySchema`: it is not necessary anymore.
- Remove deprecated util function `AtLeastOne`.

# Tests

Current tests should work as expected: We remove the ones that were redundant for the types that are not exported globally anymore.
