### PR TITLE
refactor(frontend): Rename prop for QR code events

### DIFF
--- a/src/frontend/src/icp/components/convert/IcConvertTokenWizard.svelte
+++ b/src/frontend/src/icp/components/convert/IcConvertTokenWizard.svelte
@@ -64,8 +64,8 @@
 		onNext: () => void;
 		onDestination: () => void;
 		onDestinationBack: () => void;
-		onIcQrCodeBack: () => void;
-		onIcQrCodeScan: () => void;
+		onQrCodeBack: () => void;
+		onQrCodeScan: () => void;
 	}
 
 	let {
@@ -80,8 +80,8 @@
 		onNext,
 		onDestination,
 		onDestinationBack,
-		onIcQrCodeBack,
-		onIcQrCodeScan
+		onQrCodeBack,
+		onQrCodeScan
 	}: Props = $props();
 
 	const { sourceToken, destinationToken } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
@@ -241,7 +241,7 @@
 				tokenStandard={$destinationToken.standard}
 				on:icBack={back}
 				bind:customDestination
-				on:icQRCodeScan={onIcQrCodeScan}
+				on:icQRCodeScan={onQrCodeScan}
 				on:icDestinationBack={onDestinationBack}
 			>
 				<svelte:fragment slot="title">{$i18n.convert.text.send_to}</svelte:fragment>
@@ -250,7 +250,7 @@
 			<SendQrCodeScan
 				expectedToken={$destinationToken}
 				onDecodeQrCode={decodeQrCode}
-				{onIcQrCodeBack}
+				{onQrCodeBack}
 				bind:destination={customDestination}
 				bind:amount={sendAmount}
 			/>

--- a/src/frontend/src/lib/components/convert/ConvertModal.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertModal.svelte
@@ -69,9 +69,9 @@
 			onClose={close}
 			onDestination={() => goToStep(WizardStepsConvert.DESTINATION)}
 			onDestinationBack={() => goToStep(WizardStepsConvert.CONVERT)}
-			onIcQrCodeBack={() => goToStep(WizardStepsConvert.DESTINATION)}
-			onIcQrCodeScan={() => goToStep(WizardStepsConvert.QR_CODE_SCAN)}
 			onNext={modal.next}
+			onQrCodeBack={() => goToStep(WizardStepsConvert.DESTINATION)}
+			onQrCodeScan={() => goToStep(WizardStepsConvert.QR_CODE_SCAN)}
 			bind:sendAmount
 			bind:receiveAmount
 			bind:convertProgressStep

--- a/src/frontend/src/lib/components/convert/ConvertWizard.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertWizard.svelte
@@ -26,8 +26,8 @@
 		onNext: () => void;
 		onDestination: () => void;
 		onDestinationBack: () => void;
-		onIcQrCodeBack: () => void;
-		onIcQrCodeScan: () => void;
+		onQrCodeBack: () => void;
+		onQrCodeScan: () => void;
 	}
 
 	let {
@@ -42,8 +42,8 @@
 		onNext,
 		onDestination,
 		onDestinationBack,
-		onIcQrCodeBack,
-		onIcQrCodeScan
+		onQrCodeBack,
+		onQrCodeScan
 	}: Props = $props();
 
 	const { sourceToken } = getContext<ConvertContext>(CONVERT_CONTEXT_KEY);
@@ -79,9 +79,9 @@
 		{onClose}
 		{onDestination}
 		{onDestinationBack}
-		{onIcQrCodeBack}
-		{onIcQrCodeScan}
 		{onNext}
+		{onQrCodeBack}
+		{onQrCodeScan}
 		bind:sendAmount
 		bind:receiveAmount
 		bind:convertProgressStep

--- a/src/frontend/src/lib/components/send/SendQrCodeScan.svelte
+++ b/src/frontend/src/lib/components/send/SendQrCodeScan.svelte
@@ -23,7 +23,7 @@
 			code?: string;
 			expectedToken: OptionToken;
 		}) => QrResponse;
-		onIcQrCodeBack: () => void;
+		onQrCodeBack: () => void;
 	}
 
 	let {
@@ -31,7 +31,7 @@
 		destination = $bindable(),
 		amount = $bindable(),
 		onDecodeQrCode,
-		onIcQrCodeBack
+		onQrCodeBack
 	}: Props = $props();
 
 	const onScan = ({ status, code }: { status: QrStatus; code?: string }) => {
@@ -39,7 +39,7 @@
 
 		if (qrResponse.status === 'token_incompatible') {
 			toastsError({ msg: { text: $i18n.send.error.incompatible_token } });
-			onIcQrCodeBack();
+			onQrCodeBack();
 			return;
 		}
 
@@ -51,16 +51,16 @@
 			({ amount } = qrResponse);
 		}
 
-		onIcQrCodeBack();
+		onQrCodeBack();
 	};
 </script>
 
 <ContentWithToolbar styleClass="flex flex-col items-center gap-3 md:gap-4 w-full">
-	<QrCodeScanner onBack={onIcQrCodeBack} {onScan} />
+	<QrCodeScanner onBack={onQrCodeBack} {onScan} />
 
 	{#snippet toolbar()}
 		<ButtonGroup>
-			<ButtonBack onclick={onIcQrCodeBack} />
+			<ButtonBack onclick={onQrCodeBack} />
 		</ButtonGroup>
 	{/snippet}
 </ContentWithToolbar>


### PR DESCRIPTION
# Motivation

To be coherent:

- `onIcQrCodeBack` --> `onQrCodeBack`
- `onIcQrCodeScan` --> `onQrCodeScan`
