### PR TITLE
test(frontend): Be more generic excluding test files from coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,7 +76,7 @@ export default defineConfig(
 				include: ['src/frontend/src'],
 				exclude: [
 					'src/frontend/src/routes/**/+page.ts',
-					'src/frontend/src/**/*.{test,spec}.?(c|m)[jt]s?(x)'
+					'src/frontend/src/tests'
 				],
 				// TODO: increase the thresholds slowly up to an acceptable 90% at least
 				thresholds: {


### PR DESCRIPTION
# Motivation

To be more correct, we can really exclude the entire `tests` folder from the coverage analysis.
