### PR TITLE
refactor(frontend): Remove fee calculation in `Transaction`

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransaction.svelte
@@ -18,13 +18,15 @@
 
 	let label = $derived(type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive);
 
-	let amount = $derived(nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined);
+	let displayAmount = $derived(
+		nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined
+	);
 
 	const modalId = Symbol();
 </script>
 
 <Transaction
-	{amount}
+	{displayAmount}
 	{from}
 	{iconType}
 	onClick={() => modalStore.openBtcTransaction({ id: modalId, data: { transaction, token } })}

--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -57,7 +57,7 @@
 					: $i18n.receive.text.receive
 	);
 
-	let amount = $derived(value * (type === 'send' || type === 'deposit' ? -1n : 1n));
+	let displayAmount = $derived(value * (type === 'send' || type === 'deposit' ? -1n : 1n));
 
 	let transactionDate = $derived(timestamp ?? displayTimestamp);
 
@@ -65,7 +65,7 @@
 </script>
 
 <Transaction
-	{amount}
+	{displayAmount}
 	{from}
 	{iconType}
 	onClick={() => modalStore.openEthTransaction({ id: modalId, data: { transaction, token } })}

--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -32,7 +32,7 @@
 
 	let status: TransactionStatus = $derived(pending ? 'pending' : 'confirmed');
 
-	let amount = $derived(
+	let displayAmount = $derived(
 		type === 'approve'
 			? (fee ?? ZERO) * -1n
 			: nonNullish(value)
@@ -52,8 +52,8 @@
 </script>
 
 <Transaction
-	{amount}
 	{approveSpender}
+	{displayAmount}
 	{from}
 	{iconType}
 	onClick={() => modalStore.openIcTransaction({ id: modalId, data: { transaction, token } })}

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -30,7 +30,7 @@
 	import { parseNftId } from '$lib/validation/nft.validation';
 
 	interface Props {
-		amount?: bigint;
+		displayAmount?: bigint;
 		type: TransactionType;
 		status: TransactionStatus;
 		timestamp?: number;
@@ -42,12 +42,11 @@
 		tokenId?: number;
 		children?: Snippet;
 		onClick?: () => void;
-		fee?: bigint;
 		approveSpender?: string;
 	}
 
 	const {
-		amount: cardAmount,
+		displayAmount,
 		type,
 		status,
 		timestamp,
@@ -59,15 +58,8 @@
 		tokenId,
 		children,
 		onClick,
-		fee,
 		approveSpender
 	}: Props = $props();
-
-	const incoming = $derived(type === 'receive' || type === 'withdraw' || type === 'mint');
-
-	const amountWithFee = $derived(
-		nonNullish(cardAmount) && nonNullish(fee) && !incoming ? cardAmount + fee : cardAmount
-	);
 
 	const cardIcon: Component = $derived(mapTransactionIcon({ type, status }));
 
@@ -143,12 +135,12 @@
 			{/snippet}
 
 			{#snippet amount()}
-				{#if nonNullish(amountWithFee) && !isTokenErc721(token)}
+				{#if nonNullish(displayAmount) && !isTokenErc721(token)}
 					{#if $isPrivacyMode}
 						<IconDots />
 					{:else}
 						<Amount
-							amount={amountWithFee}
+							amount={displayAmount}
 							decimals={token.decimals}
 							formatPositiveAmount
 							symbol={getTokenDisplaySymbol(token)}

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -23,13 +23,13 @@
 
 	let transactionStatus: TransactionStatus = $derived(pending ? 'pending' : 'confirmed');
 
-	let amount = $derived(nonNullish(value) ? (type === 'send' ? value * -1n : value) : value);
+	let displayAmount = $derived(nonNullish(value) ? (type === 'send' ? value * -1n : value) : value);
 
 	const modalId = Symbol();
 </script>
 
 <Transaction
-	{amount}
+	{displayAmount}
 	from={fromOwner ?? from}
 	{iconType}
 	onClick={() => modalStore.openSolTransaction({ id: modalId, data: { transaction, token } })}

--- a/src/frontend/src/tests/lib/components/transactions/Transaction.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/Transaction.spec.ts
@@ -68,7 +68,7 @@ describe('Transaction (single)', () => {
 		testContact = undefined;
 
 		const { container } = render(Transaction, {
-			amount: 42n,
+			displayAmount: 42n,
 			type: 'receive',
 			status: 'confirmed',
 			timestamp: 1_690_000_000,
@@ -101,7 +101,7 @@ describe('Transaction (single)', () => {
 		setPrivacyMode({ enabled: true });
 
 		const { container } = render(Transaction, {
-			amount: 10n,
+			displayAmount: 10n,
 			type: 'send',
 			status: 'pending',
 			token: ICP_TOKEN,
@@ -117,7 +117,7 @@ describe('Transaction (single)', () => {
 		mockIsErc721 = true;
 
 		render(Transaction, {
-			amount: 999n,
+			displayAmount: 999n,
 			type: 'send',
 			status: 'confirmed',
 			token: NFT_TEST_TOKEN as unknown as AppToken,
@@ -155,7 +155,7 @@ describe('Transaction (single)', () => {
 			token: ICP_TOKEN,
 			iconType: 'token',
 			from: '0xaddr',
-			amount: 1n
+			displayAmount: 1n
 		});
 
 		await expect(screen.findByText(/ICP/)).resolves.toBeInTheDocument();


### PR DESCRIPTION
# Motivation

The `fee` prop of `Transaction` component is never used. So, the logic of adding the `fee` for incoming transactions is not used. We can remove it and decide that the amount that is passed to `Transaction` is the one to be displayed.