### PR TITLE
feat(frontend): Use util `assertNever` from`@dfinity/utils`

### DIFF
--- a/src/frontend/src/btc/utils/btc-address.utils.ts
+++ b/src/frontend/src/btc/utils/btc-address.utils.ts
@@ -5,13 +5,13 @@ import {
 	btcAddressTestnet
 } from '$lib/derived/address.derived';
 import type { NetworkId } from '$lib/types/network';
-import { assertNever } from '$lib/types/utils';
 import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
 import {
 	BtcAddressType,
 	parseBtcAddress as parseBtcAddressCkbtc,
 	type BtcAddressInfo
 } from '@dfinity/ckbtc';
+import { assertNever } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 const createBtcAddressFromAddressInfo = ({ info }: { info: BtcAddressInfo }): BtcAddress => {
@@ -58,7 +58,7 @@ export const getBtcAddressString = (address: BtcAddress): string => {
 		return address.P2TR;
 	}
 
-	return assertNever({ variable: address, typeName: 'BtcAddress' });
+	assertNever(address, `Unexpected BtcAddress: ${address}`);
 };
 
 /**

--- a/src/frontend/src/icp/utils/icp-account.utils.ts
+++ b/src/frontend/src/icp/utils/icp-account.utils.ts
@@ -1,9 +1,8 @@
 import type { Icrcv2AccountId } from '$declarations/backend/backend.did';
-import { assertNever } from '$lib/types/utils';
 import { AccountIdentifier, isIcpAccountIdentifier, SubAccount } from '@dfinity/ledger-icp';
 import { decodeIcrcAccount, encodeIcrcAccount } from '@dfinity/ledger-icrc';
 import type { Principal } from '@dfinity/principal';
-import { fromNullable, nonNullish, toNullable } from '@dfinity/utils';
+import { assertNever, fromNullable, nonNullish, toNullable } from '@dfinity/utils';
 
 export const getAccountIdentifier = (principal: Principal): AccountIdentifier =>
 	AccountIdentifier.fromPrincipal({ principal, subAccount: undefined });
@@ -52,7 +51,7 @@ export const getIcrcv2AccountIdString = (accountId: Icrcv2AccountId): string => 
 		});
 	}
 
-	return assertNever({ variable: accountId, typeName: 'Icrcv2AccountId' });
+	assertNever(accountId, `Unexpected Icrcv2AccountId: ${accountId}`);
 };
 
 /**

--- a/src/frontend/src/lib/derived/user-experimental-features.derived.ts
+++ b/src/frontend/src/lib/derived/user-experimental-features.derived.ts
@@ -4,7 +4,7 @@ import type {
 	ExperimentalFeatureId,
 	UserExperimentalFeatures
 } from '$lib/types/user-experimental-features';
-import { isNullish } from '@dfinity/utils';
+import { assertNever, isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const userExperimentalFeatures: Readable<UserExperimentalFeatures | null> = derived(
@@ -22,10 +22,7 @@ export const userExperimentalFeatures: Readable<UserExperimentalFeatures | null>
 				return 'AiAssistantBeta';
 			}
 
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = key;
-
-			throw new Error(`Unknown feature key: ${key}`);
+			assertNever(key, `Unknown feature key: ${key}`);
 		};
 
 		return {

--- a/src/frontend/src/lib/derived/user-networks.derived.ts
+++ b/src/frontend/src/lib/derived/user-networks.derived.ts
@@ -35,7 +35,7 @@ import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import { userSettingsNetworks } from '$lib/derived/user-profile.derived';
 import type { NetworkId } from '$lib/types/network';
 import type { UserNetworks } from '$lib/types/user-networks';
-import { isNullish } from '@dfinity/utils';
+import { assertNever, isNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const userNetworks: Readable<UserNetworks> = derived(
@@ -113,10 +113,7 @@ export const userNetworks: Readable<UserNetworks> = derived(
 				return ARBITRUM_SEPOLIA_NETWORK_ID;
 			}
 
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = key;
-
-			throw new Error(`Unknown network key: ${key}`);
+			assertNever(key, `Unknown network key: ${key}`);
 		};
 
 		return {

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -19,26 +19,6 @@ export type PartialSpecific<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T,
 export type NonEmptyArray<T> = [T, ...T[]];
 
 /**
- * Utility function for exhaustive type checking in TypeScript.
- *
- * This function is used to ensure all possible cases in a discriminated union or enum
- * are handled. When TypeScript narrows a variable to type `never`, it means all possible
- * types have been handled.
- *
- * @param params.variable - The value that should be of type `never` if all cases are handled
- * @param params.typeName - A string describing the type being checked (for error message)
- */
-export const assertNever = ({
-	variable,
-	typeName
-}: {
-	variable: never;
-	typeName: string;
-}): never => {
-	throw new Error(`Unexpected ${typeName}: ${variable}`);
-};
-
-/**
  * Returns all keys of a union type. For example:
  *   KeyOfUnion<{ a: number } | { b: string } | { d: { ... } }>
  * will result in: 'a' | 'b' | 'd'

--- a/src/frontend/src/lib/utils/agreements-formatter.utils.ts
+++ b/src/frontend/src/lib/utils/agreements-formatter.utils.ts
@@ -12,6 +12,7 @@ import PrivacyPolicyLink from '$lib/components/privacy-policy/PrivacyPolicyLink.
 import TermsOfUseLink from '$lib/components/terms-of-use/TermsOfUseLink.svelte';
 import type { AgreementsToAccept } from '$lib/types/user-agreements';
 import { componentToHtml } from '$lib/utils/component.utils';
+import { assertNever } from '@dfinity/utils';
 import type { Component, ComponentProps } from 'svelte';
 
 const renderAgreementItemHtml = <T extends Component>({
@@ -50,10 +51,7 @@ const mapAgreementToComponent = (
 		return PrivacyPolicyLink;
 	}
 
-	// Force compiler error on unhandled cases based on leftover types
-	const _: never = agreementType;
-
-	throw new Error(`Unmapped agreement type: ${agreementType}`);
+	assertNever(agreementType, `Unmapped agreement type: ${agreementType}`);
 };
 
 export const formatUpdatedAgreementsHtml = ({

--- a/src/frontend/src/lib/utils/custom-token.utils.ts
+++ b/src/frontend/src/lib/utils/custom-token.utils.ts
@@ -19,7 +19,7 @@ import { parseTokenId } from '$lib/validation/token.validation';
 import type { SolanaChainId } from '$sol/types/network';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { Principal } from '@dfinity/principal';
-import { nonNullish, toNullable } from '@dfinity/utils';
+import { assertNever, nonNullish, toNullable } from '@dfinity/utils';
 
 const toIcrcCustomToken = ({
 	ledgerCanisterId,
@@ -83,10 +83,7 @@ export const toCustomToken = ({
 			return { SplDevnet: toSplCustomToken(rest) };
 		}
 
-		// Force compiler error on unhandled cases based on leftover types
-		const _: never = networkKey;
-
-		throw new Error(`Unsupported network key: ${networkKey}`);
+		assertNever(networkKey, `Unsupported network key: ${networkKey}`);
 	};
 
 	return {

--- a/src/frontend/src/lib/utils/token-account-id.utils.ts
+++ b/src/frontend/src/lib/utils/token-account-id.utils.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/constants/token-account-id.constants';
 import type { Network } from '$lib/types/network';
 import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
-import { assertNever } from '$lib/types/utils';
+import { assertNever } from '@dfinity/utils';
 
 export const getTokenAccountIdAddressString = (tokenAccountId: TokenAccountId): string => {
 	if ('Btc' in tokenAccountId) {
@@ -23,7 +23,7 @@ export const getTokenAccountIdAddressString = (tokenAccountId: TokenAccountId): 
 		return tokenAccountId.Sol;
 	}
 
-	return assertNever({ variable: tokenAccountId, typeName: 'TokenAccountId' });
+	assertNever(tokenAccountId, `Unexpected TokenAccountId: ${tokenAccountId}`);
 };
 
 export const getDiscriminatorForTokenAccountId = (
@@ -42,7 +42,7 @@ export const getDiscriminatorForTokenAccountId = (
 		return 'Sol';
 	}
 
-	return assertNever({ variable: tokenAccountId, typeName: 'TokenAccountId' });
+	assertNever(tokenAccountId, `Unexpected TokenAccountId: ${tokenAccountId}`);
 };
 
 export const getNetworksForTokenAccountIdType = (addressType: TokenAccountIdTypes): Network[] =>

--- a/src/frontend/src/sol/canisters/sol-rpc.canister.ts
+++ b/src/frontend/src/sol/canisters/sol-rpc.canister.ts
@@ -16,7 +16,7 @@ import type { CreateCanisterOptions } from '$lib/types/canister';
 import { JSON_PARSED, SOL_RPC_CONFIG } from '$sol/canisters/sol-rpc.constants';
 import { SolRpcCanisterError, assertConsistentResponse } from '$sol/canisters/sol-rpc.errors';
 import type { SolanaNetworkType } from '$sol/types/network';
-import { Canister, createServices, fromNullable, toNullable } from '@dfinity/utils';
+import { Canister, assertNever, createServices, fromNullable, toNullable } from '@dfinity/utils';
 
 export const networkToCluster = (network: SolanaNetworkType): SolanaCluster => {
 	if (network === 'devnet') {
@@ -29,10 +29,7 @@ export const networkToCluster = (network: SolanaNetworkType): SolanaCluster => {
 		return { Mainnet: null };
 	}
 
-	// Force compiler error on unhandled cases based on leftover types
-	const _: never = network;
-
-	throw new Error(`Unknown network: ${network}`);
+	assertNever(network, `Unknown network: ${network}`);
 };
 
 const rpcSources = (network: SolanaNetworkType): RpcSources => ({

--- a/src/frontend/src/sol/canisters/sol-rpc.errors.ts
+++ b/src/frontend/src/sol/canisters/sol-rpc.errors.ts
@@ -1,6 +1,6 @@
 import type { RpcError, RpcSource } from '$declarations/sol_rpc/sol_rpc.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
-import { fromNullable, jsonReplacer } from '@dfinity/utils';
+import { assertNever, fromNullable, jsonReplacer } from '@dfinity/utils';
 
 export const assertConsistentResponse: <T>(
 	response: { Consistent: T } | { Inconsistent: Array<[RpcSource, T]> }
@@ -54,9 +54,6 @@ export class SolRpcCanisterError extends CanisterInternalError {
 			return;
 		}
 
-		// Force compiler error on unhandled cases based on leftover types
-		const _: never = err;
-
-		super('Unknown SOL RPC Error');
+		assertNever(err, 'Unknown SOL RPC Error');
 	}
 }

--- a/src/frontend/src/sol/utils/sol-instructions-ata.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-ata.utils.ts
@@ -1,4 +1,5 @@
 import type { SolInstruction, SolParsedAtaInstruction } from '$sol/types/sol-instructions';
+import { assertNever } from '@dfinity/utils';
 import {
 	AssociatedTokenInstruction,
 	identifyAssociatedTokenInstruction,
@@ -32,10 +33,7 @@ export const parseSolAtaInstruction = (
 				instructionType: AssociatedTokenInstruction.RecoverNestedAssociatedToken
 			};
 		default: {
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = decodedInstruction;
-
-			return instruction;
+			assertNever(decodedInstruction, `Unknown Solana ATA instruction: ${decodedInstruction}`);
 		}
 	}
 };

--- a/src/frontend/src/sol/utils/sol-instructions-compute-budget.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-compute-budget.utils.ts
@@ -2,6 +2,7 @@ import type {
 	SolInstruction,
 	SolParsedComputeBudgetInstruction
 } from '$sol/types/sol-instructions';
+import { assertNever } from '@dfinity/utils';
 import {
 	ComputeBudgetInstruction,
 	identifyComputeBudgetInstruction,
@@ -46,10 +47,10 @@ export const parseSolComputeBudgetInstruction = (
 				instructionType: ComputeBudgetInstruction.SetLoadedAccountsDataSizeLimit
 			};
 		default: {
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = decodedInstruction;
-
-			return instruction;
+			assertNever(
+				decodedInstruction,
+				`Unknown Solana Compute Budget instruction: ${decodedInstruction}`
+			);
 		}
 	}
 };

--- a/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
@@ -1,4 +1,5 @@
 import type { SolInstruction, SolParsedSystemInstruction } from '$sol/types/sol-instructions';
+import { assertNever } from '@dfinity/utils';
 import {
 	SystemInstruction,
 	identifySystemInstruction,
@@ -92,10 +93,7 @@ export const parseSolSystemInstruction = (
 				instructionType: SystemInstruction.UpgradeNonceAccount
 			};
 		default: {
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = decodedInstruction;
-
-			return instruction;
+			assertNever(decodedInstruction, `Unknown Solana System instruction: ${decodedInstruction}`);
 		}
 	}
 };

--- a/src/frontend/src/sol/utils/sol-instructions-token-2022.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token-2022.utils.ts
@@ -1,4 +1,5 @@
 import type { SolInstruction, SolParsedToken2022Instruction } from '$sol/types/sol-instructions';
+import { assertNever } from '@dfinity/utils';
 import {
 	Token2022Instruction,
 	identifyToken2022Instruction,
@@ -540,10 +541,10 @@ export const parseSolToken2022Instruction = (
 				instructionType: Token2022Instruction.InitializeTokenGroupMember
 			};
 		default: {
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = decodedInstruction;
-
-			return instruction;
+			assertNever(
+				decodedInstruction,
+				`Unknown Solana Token 2022 instruction: ${decodedInstruction}`
+			);
 		}
 	}
 };

--- a/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
@@ -1,4 +1,5 @@
 import type { SolInstruction, SolParsedTokenInstruction } from '$sol/types/sol-instructions';
+import { assertNever } from '@dfinity/utils';
 import {
 	TokenInstruction,
 	identifyTokenInstruction,
@@ -32,7 +33,7 @@ import { assertIsInstructionWithAccounts, assertIsInstructionWithData } from '@s
 
 export const parseSolTokenInstruction = (
 	instruction: SolInstruction
-): SolInstruction | SolParsedTokenInstruction => {
+): SolParsedTokenInstruction => {
 	assertIsInstructionWithData<Uint8Array>(instruction);
 	assertIsInstructionWithAccounts(instruction);
 
@@ -164,10 +165,7 @@ export const parseSolTokenInstruction = (
 				instructionType: TokenInstruction.UiAmountToAmount
 			};
 		default: {
-			// Force compiler error on unhandled cases based on leftover types
-			const _: never = decodedInstruction;
-
-			return instruction;
+			assertNever(decodedInstruction, `Unknown Solana Token instruction: ${decodedInstruction}`);
 		}
 	}
 };

--- a/src/frontend/src/tests/sol/utils/sol-instructions-ata.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-ata.utils.spec.ts
@@ -96,11 +96,9 @@ describe('sol-instructions-ata.utils', () => {
 			// @ts-expect-error intentional for testing unknown discriminant
 			vi.mocked(identifyAssociatedTokenInstruction).mockReturnValue('unknown-instruction');
 
-			expect(parseSolAtaInstruction(mockInstruction)).toStrictEqual(mockInstruction);
-
-			expect(parseCreateAssociatedTokenInstruction).not.toHaveBeenCalled();
-			expect(parseCreateAssociatedTokenIdempotentInstruction).not.toHaveBeenCalled();
-			expect(parseRecoverNestedAssociatedTokenInstruction).not.toHaveBeenCalled();
+			expect(() => parseSolAtaInstruction(mockInstruction)).toThrow(
+				'Unknown Solana ATA instruction: unknown-instruction'
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/sol/utils/sol-instructions-compute-budget.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-compute-budget.utils.spec.ts
@@ -108,17 +108,13 @@ describe('sol-instructions-compute-budget.utils', () => {
 			);
 		});
 
-		it('should return the original instruction if it is not a recognized Compute Budget instruction', () => {
+		it('should raise an error if it is not a recognized Compute Budget instruction', () => {
 			// @ts-expect-error intentional for testing unknown discriminant
 			vi.mocked(identifyComputeBudgetInstruction).mockReturnValue('unknown-instruction');
 
-			expect(parseSolComputeBudgetInstruction(mockInstruction)).toStrictEqual(mockInstruction);
-
-			expect(parseRequestUnitsInstruction).not.toHaveBeenCalled();
-			expect(parseRequestHeapFrameInstruction).not.toHaveBeenCalled();
-			expect(parseSetComputeUnitLimitInstruction).not.toHaveBeenCalled();
-			expect(parseSetComputeUnitPriceInstruction).not.toHaveBeenCalled();
-			expect(parseSetLoadedAccountsDataSizeLimitInstruction).not.toHaveBeenCalled();
+			expect(() => parseSolComputeBudgetInstruction(mockInstruction)).toThrow(
+				'Unknown Solana Compute Budget instruction: unknown-instruction'
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
@@ -208,25 +208,13 @@ describe('sol-instructions-system.utils', () => {
 			expect(parseUpgradeNonceAccountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
 		});
 
-		it('should return the original instruction if it is not a recognised System instruction', () => {
+		it('should raise an error if it is not a recognised System instruction', () => {
 			// @ts-expect-error intentional for testing unknown discriminant
 			vi.mocked(identifySystemInstruction).mockReturnValue('unknown-instruction');
 
-			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual(mockInstruction);
-
-			expect(parseCreateAccountInstruction).not.toHaveBeenCalled();
-			expect(parseAssignInstruction).not.toHaveBeenCalled();
-			expect(parseTransferSolInstruction).not.toHaveBeenCalled();
-			expect(parseCreateAccountWithSeedInstruction).not.toHaveBeenCalled();
-			expect(parseAdvanceNonceAccountInstruction).not.toHaveBeenCalled();
-			expect(parseWithdrawNonceAccountInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeNonceAccountInstruction).not.toHaveBeenCalled();
-			expect(parseAuthorizeNonceAccountInstruction).not.toHaveBeenCalled();
-			expect(parseAllocateInstruction).not.toHaveBeenCalled();
-			expect(parseAllocateWithSeedInstruction).not.toHaveBeenCalled();
-			expect(parseAssignWithSeedInstruction).not.toHaveBeenCalled();
-			expect(parseTransferSolWithSeedInstruction).not.toHaveBeenCalled();
-			expect(parseUpgradeNonceAccountInstruction).not.toHaveBeenCalled();
+			expect(() => parseSolSystemInstruction(mockInstruction)).toThrow(
+				'Unknown Solana System instruction: unknown-instruction'
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/sol/utils/sol-instructions-token-2022.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-token-2022.utils.spec.ts
@@ -1309,104 +1309,13 @@ describe('sol-instructions-token-2022.utils', () => {
 			);
 		});
 
-		it('should return the original instruction if it is not a recognised Token-2022 instruction', () => {
+		it('should raise an error if it is not a recognised Token-2022 instruction', () => {
 			// @ts-expect-error intentional for testing unknown discriminant
 			vi.mocked(identifyToken2022Instruction).mockReturnValue('unknown-instruction');
 
-			expect(parseSolToken2022Instruction(mockInstruction)).toStrictEqual(mockInstruction);
-
-			expect(parseInitializeMintInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeAccountInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeMultisigInstruction).not.toHaveBeenCalled();
-			expect(parseTransferInstruction).not.toHaveBeenCalled();
-			expect(parseApproveInstruction).not.toHaveBeenCalled();
-			expect(parseRevokeInstruction).not.toHaveBeenCalled();
-			expect(parseSetAuthorityInstruction).not.toHaveBeenCalled();
-			expect(parseMintToInstruction).not.toHaveBeenCalled();
-			expect(parseBurnInstruction).not.toHaveBeenCalled();
-			expect(parseCloseAccountInstruction).not.toHaveBeenCalled();
-			expect(parseFreezeAccountInstruction).not.toHaveBeenCalled();
-			expect(parseThawAccountInstruction).not.toHaveBeenCalled();
-			expect(parseTransferCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseApproveCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseMintToCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseBurnCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeAccount2Instruction).not.toHaveBeenCalled();
-			expect(parseSyncNativeInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeAccount3Instruction).not.toHaveBeenCalled();
-			expect(parseInitializeMultisig2Instruction).not.toHaveBeenCalled();
-			expect(parseInitializeMint2Instruction).not.toHaveBeenCalled();
-			expect(parseGetAccountDataSizeInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeImmutableOwnerInstruction).not.toHaveBeenCalled();
-			expect(parseAmountToUiAmountInstruction).not.toHaveBeenCalled();
-			expect(parseUiAmountToAmountInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeMintCloseAuthorityInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeTransferFeeConfigInstruction).not.toHaveBeenCalled();
-			expect(parseTransferCheckedWithFeeInstruction).not.toHaveBeenCalled();
-			expect(parseWithdrawWithheldTokensFromMintInstruction).not.toHaveBeenCalled();
-			expect(parseWithdrawWithheldTokensFromAccountsInstruction).not.toHaveBeenCalled();
-			expect(parseHarvestWithheldTokensToMintInstruction).not.toHaveBeenCalled();
-			expect(parseSetTransferFeeInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeConfidentialTransferMintInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateConfidentialTransferMintInstruction).not.toHaveBeenCalled();
-			expect(parseConfigureConfidentialTransferAccountInstruction).not.toHaveBeenCalled();
-			expect(parseApproveConfidentialTransferAccountInstruction).not.toHaveBeenCalled();
-			expect(parseEmptyConfidentialTransferAccountInstruction).not.toHaveBeenCalled();
-			expect(parseConfidentialDepositInstruction).not.toHaveBeenCalled();
-			expect(parseConfidentialWithdrawInstruction).not.toHaveBeenCalled();
-			expect(parseConfidentialTransferInstruction).not.toHaveBeenCalled();
-			expect(parseApplyConfidentialPendingBalanceInstruction).not.toHaveBeenCalled();
-			expect(parseEnableConfidentialCreditsInstruction).not.toHaveBeenCalled();
-			expect(parseDisableConfidentialCreditsInstruction).not.toHaveBeenCalled();
-			expect(parseEnableNonConfidentialCreditsInstruction).not.toHaveBeenCalled();
-			expect(parseDisableNonConfidentialCreditsInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeDefaultAccountStateInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateDefaultAccountStateInstruction).not.toHaveBeenCalled();
-			expect(parseReallocateInstruction).not.toHaveBeenCalled();
-			expect(parseEnableMemoTransfersInstruction).not.toHaveBeenCalled();
-			expect(parseDisableMemoTransfersInstruction).not.toHaveBeenCalled();
-			expect(parseCreateNativeMintInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeNonTransferableMintInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeInterestBearingMintInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateRateInterestBearingMintInstruction).not.toHaveBeenCalled();
-			expect(parseEnableCpiGuardInstruction).not.toHaveBeenCalled();
-			expect(parseDisableCpiGuardInstruction).not.toHaveBeenCalled();
-			expect(parseInitializePermanentDelegateInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeTransferHookInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateTransferHookInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeConfidentialTransferFeeInstruction).not.toHaveBeenCalled();
-			expect(
-				parseWithdrawWithheldTokensFromMintForConfidentialTransferFeeInstruction
-			).not.toHaveBeenCalled();
-			expect(
-				parseWithdrawWithheldTokensFromAccountsForConfidentialTransferFeeInstruction
-			).not.toHaveBeenCalled();
-			expect(
-				parseHarvestWithheldTokensToMintForConfidentialTransferFeeInstruction
-			).not.toHaveBeenCalled();
-			expect(parseEnableHarvestToMintInstruction).not.toHaveBeenCalled();
-			expect(parseDisableHarvestToMintInstruction).not.toHaveBeenCalled();
-			expect(parseWithdrawExcessLamportsInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeMetadataPointerInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateMetadataPointerInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeGroupPointerInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateGroupPointerInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeGroupMemberPointerInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateGroupMemberPointerInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeScaledUiAmountMintInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateMultiplierScaledUiMintInstruction).not.toHaveBeenCalled();
-			expect(parseInitializePausableConfigInstruction).not.toHaveBeenCalled();
-			expect(parsePauseInstruction).not.toHaveBeenCalled();
-			expect(parseResumeInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeTokenMetadataInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateTokenMetadataFieldInstruction).not.toHaveBeenCalled();
-			expect(parseRemoveTokenMetadataKeyInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateTokenMetadataUpdateAuthorityInstruction).not.toHaveBeenCalled();
-			expect(parseEmitTokenMetadataInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeTokenGroupInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateTokenGroupMaxSizeInstruction).not.toHaveBeenCalled();
-			expect(parseUpdateTokenGroupUpdateAuthorityInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeTokenGroupMemberInstruction).not.toHaveBeenCalled();
+			expect(() => parseSolToken2022Instruction(mockInstruction)).toThrow(
+				'Unknown Solana Token 2022 instruction: unknown-instruction'
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/sol/utils/sol-instructions-token.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-token.utils.spec.ts
@@ -348,37 +348,13 @@ describe('sol-instructions-token.utils', () => {
 			expect(parseUiAmountToAmountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
 		});
 
-		it('should return the original instruction if it is not a recognised Token instruction', () => {
+		it('should raise an error if it is not a recognised Token instruction', () => {
 			// @ts-expect-error intentional for testing unknown discriminant
 			vi.mocked(identifyTokenInstruction).mockReturnValue('unknown-instruction');
 
-			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual(mockInstruction);
-
-			expect(parseInitializeMintInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeAccountInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeMultisigInstruction).not.toHaveBeenCalled();
-			expect(parseTransferInstruction).not.toHaveBeenCalled();
-			expect(parseApproveInstruction).not.toHaveBeenCalled();
-			expect(parseRevokeInstruction).not.toHaveBeenCalled();
-			expect(parseSetAuthorityInstruction).not.toHaveBeenCalled();
-			expect(parseMintToInstruction).not.toHaveBeenCalled();
-			expect(parseBurnInstruction).not.toHaveBeenCalled();
-			expect(parseCloseAccountInstruction).not.toHaveBeenCalled();
-			expect(parseFreezeAccountInstruction).not.toHaveBeenCalled();
-			expect(parseThawAccountInstruction).not.toHaveBeenCalled();
-			expect(parseTransferCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseApproveCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseMintToCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseBurnCheckedInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeAccount2Instruction).not.toHaveBeenCalled();
-			expect(parseSyncNativeInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeAccount3Instruction).not.toHaveBeenCalled();
-			expect(parseInitializeMultisig2Instruction).not.toHaveBeenCalled();
-			expect(parseInitializeMint2Instruction).not.toHaveBeenCalled();
-			expect(parseGetAccountDataSizeInstruction).not.toHaveBeenCalled();
-			expect(parseInitializeImmutableOwnerInstruction).not.toHaveBeenCalled();
-			expect(parseAmountToUiAmountInstruction).not.toHaveBeenCalled();
-			expect(parseUiAmountToAmountInstruction).not.toHaveBeenCalled();
+			expect(() => parseSolTokenInstruction(mockInstruction)).toThrow(
+				'Unknown Solana Token instruction: unknown-instruction'
+			);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

With @peterpeterparker 's PR https://github.com/dfinity/ic-js/pull/1081, a new util `assertNever` was released:

> /**
>  * Utility to enforce exhaustiveness checks in TypeScript.
>  *
>  * This function should only be called in branches of a `switch` or conditional
>  * that should be unreachable if the union type has been fully handled.
>  *
>  * By typing the parameter as `never`, the compiler will emit an error if
>  * a new variant is added to the union but not covered in the logic.
>  *
>  * @param _ - A value that should be of type `never`. If this is not the case,
>  *            the TypeScript compiler will flag a type error.
>  * @param message - Optional custom error message to include in the thrown error.
>  * @throws {Error} Always throws when invoked at runtime.
>  *
>  */

We can use it in a few places in the codebase, since we are applying a similar logic.

# Changes

- Add the usage of `assertNever` from `@dfinity/utils` in all places with `const ...: never = ...`.
- Replace existing `assertNever` with the one from the library.

# Tests

Current tests work as expected.
