### PR TITLE
refactor(frontend): Consistent re-sort of agreements

### DIFF
--- a/src/frontend/src/env/schema/env-agreements.schema.ts
+++ b/src/frontend/src/env/schema/env-agreements.schema.ts
@@ -6,7 +6,7 @@ const policyBlockSchema = z.object({
 });
 
 export const EnvAgreementsSchema = z.object({
-	licenseAgreement: policyBlockSchema,
 	termsOfUse: policyBlockSchema,
-	privacyPolicy: policyBlockSchema
+	privacyPolicy: policyBlockSchema,
+	licenseAgreement: policyBlockSchema
 });

--- a/src/frontend/src/lib/derived/user-agreements.derived.ts
+++ b/src/frontend/src/lib/derived/user-agreements.derived.ts
@@ -13,9 +13,9 @@ export const userAgreements: Readable<UserAgreements> = derived(
 
 		if (nonNullish(agreements)) {
 			return {
-				licenseAgreement: mapUserAgreement(agreements.license_agreement),
+				termsOfUse: mapUserAgreement(agreements.terms_of_use),
 				privacyPolicy: mapUserAgreement(agreements.privacy_policy),
-				termsOfUse: mapUserAgreement(agreements.terms_of_use)
+				licenseAgreement: mapUserAgreement(agreements.license_agreement)
 			};
 		}
 
@@ -26,9 +26,9 @@ export const userAgreements: Readable<UserAgreements> = derived(
 		};
 
 		return {
-			licenseAgreement: nullishAgreement,
+			termsOfUse: nullishAgreement,
 			privacyPolicy: nullishAgreement,
-			termsOfUse: nullishAgreement
+			licenseAgreement: nullishAgreement
 		};
 	}
 );

--- a/src/frontend/src/lib/types/user-agreements.ts
+++ b/src/frontend/src/lib/types/user-agreements.ts
@@ -7,9 +7,9 @@ export interface AgreementData {
 }
 
 export interface UserAgreements {
-	licenseAgreement: AgreementData;
-	privacyPolicy: AgreementData;
 	termsOfUse: AgreementData;
+	privacyPolicy: AgreementData;
+	licenseAgreement: AgreementData;
 }
 
 export type AgreementsToAccept = {


### PR DESCRIPTION
# Motivation

For consistency, we refactor the agreements in the warning banner to have the same sorting order of the home page:

<img width="374" height="147" alt="Screenshot 2025-10-03 at 15 54 47" src="https://github.com/user-attachments/assets/8fbedc86-84af-45ac-8c2d-070961e07cce" />

<img width="1094" height="138" alt="Screenshot 2025-10-03 at 16 18 49" src="https://github.com/user-attachments/assets/60ccf872-8c2d-4327-a5ed-3b19bac9fe0b" />
