### PR TITLE
feat(frontend): Specific component for values in WalletConnect modals

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectData.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectData.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import Copy from '$lib/components/ui/Copy.svelte';
-	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
@@ -10,21 +10,15 @@
 		label: string;
 	}
 
-	let { data, label: labelStr }: Props = $props();
+	let { data, label }: Props = $props();
 </script>
 
 {#if nonNullish(data)}
-	<ModalValue>
-		{#snippet label()}{labelStr}{/snippet}
-
-		{#snippet mainValue()}
-			<div id="data" class="flex items-center gap-1 font-normal">
-				{shortenWithMiddleEllipsis({ text: data })}<Copy
-					inline
-					text={$i18n.wallet_connect.text.raw_copied}
-					value={data}
-				/>
-			</div>
-		{/snippet}
-	</ModalValue>
+	<WalletConnectModalValue {label} ref="data">
+		{shortenWithMiddleEllipsis({ text: data })}<Copy
+			inline
+			text={$i18n.wallet_connect.text.raw_copied}
+			value={data}
+		/>
+	</WalletConnectModalValue>
 {/if}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectModalValue.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectModalValue.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		label: string;
+		ref: string;
+		children: Snippet;
+	}
+
+	let { label, ref, children }: Props = $props();
+</script>
+
+<label class="font-bold" for={ref}>{label}</label>
+
+<div id={ref} class="mb-4 flex items-center gap-1 font-normal">
+	{@render children()}
+</div>


### PR DESCRIPTION
# Motivation

As per decision, the WalletCOnnect modal should not give the impression that the transaction is native of OISY, meaning, as hint, that it should have a different style from the normal modals. We are opting for a simple one.

So, as first step we extract a common component for the component `WalletConnectModalValue`. 

Example:

<img width="424" height="79" alt="Screenshot 2025-10-03 at 17 12 24" src="https://github.com/user-attachments/assets/7e0b4901-8ebc-45e7-8b91-f7183a396adc" />

