### PR TITLE
refactor(frontend): Rename network slot in `SendData`

### DIFF
--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -20,7 +20,7 @@
 	<SendDataDestination {destination} />
 {/if}
 
-<slot name="network" />
+<slot name="sourceNtwork" />
 
 <SendDataAmount {amount} {exchangeRate} showNullishLabel={showNullishAmountLabel} {token} />
 

--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -20,7 +20,7 @@
 	<SendDataDestination {destination} />
 {/if}
 
-<slot name="sourceNtwork" />
+<slot name="sourceNetwork" />
 
 <SendDataAmount {amount} {exchangeRate} showNullishLabel={showNullishAmountLabel} {token} />
 

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -35,7 +35,7 @@
 
 		<!-- TODO: add checks for insufficient funds if and when we are able to correctly parse the amount -->
 
-		<ReviewNetwork slot="network" sourceNetwork={token.network} />
+		<ReviewNetwork slot="sourceNtwork" sourceNetwork={token.network} />
 	</SendData>
 
 	{#snippet toolbar()}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -35,7 +35,7 @@
 
 		<!-- TODO: add checks for insufficient funds if and when we are able to correctly parse the amount -->
 
-		<ReviewNetwork slot="sourceNtwork" sourceNetwork={token.network} />
+		<ReviewNetwork slot="sourceNetwork" sourceNetwork={token.network} />
 	</SendData>
 
 	{#snippet toolbar()}


### PR DESCRIPTION
# Motivation

Since we are going to add a `destinationNetwork` in `SendData`, we rename the existing network slot to `sourceNetwork`.
