### PR TITLE
feat(frontend): Use existing component for `SendDataDestination`

### DIFF
--- a/src/frontend/src/lib/components/send/SendDataDestination.svelte
+++ b/src/frontend/src/lib/components/send/SendDataDestination.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
@@ -10,12 +10,6 @@
 	let { destination }: Props = $props();
 </script>
 
-<ModalValue>
-	{#snippet label()}
-		{$i18n.send.text.destination}
-	{/snippet}
-
-	{#snippet mainValue()}
-		{shortenWithMiddleEllipsis({ text: destination })}
-	{/snippet}
-</ModalValue>
+<WalletConnectModalValue label={$i18n.send.text.destination} ref="destination">
+	{shortenWithMiddleEllipsis({ text: destination })}
+</WalletConnectModalValue>

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectData.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectData.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import Copy from '$lib/components/ui/Copy.svelte';
-	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
@@ -10,21 +10,15 @@
 		label: string;
 	}
 
-	let { data, label: labelStr }: Props = $props();
+	let { data, label }: Props = $props();
 </script>
 
 {#if nonNullish(data)}
-	<ModalValue>
-		{#snippet label()}{labelStr}{/snippet}
-
-		{#snippet mainValue()}
-			<div id="data" class="flex items-center gap-1 font-normal">
-				{shortenWithMiddleEllipsis({ text: data })}<Copy
-					inline
-					text={$i18n.wallet_connect.text.raw_copied}
-					value={data}
-				/>
-			</div>
-		{/snippet}
-	</ModalValue>
+	<WalletConnectModalValue {label} ref="data">
+		{shortenWithMiddleEllipsis({ text: data })}<Copy
+			inline
+			text={$i18n.wallet_connect.text.raw_copied}
+			value={data}
+		/>
+	</WalletConnectModalValue>
 {/if}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectModalValue.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectModalValue.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		label: string;
+		ref: string;
+		children: Snippet;
+	}
+
+	let { label, ref, children }: Props = $props();
+</script>
+
+<label class="font-bold" for={ref}>{label}</label>
+
+<div id={ref} class="mb-4 flex items-center gap-1 font-normal">
+	{@render children()}
+</div>


### PR DESCRIPTION
# Motivation

We can use existing component `WalletConnectModalValue` in `SendDataDestination`.
