### PR TITLE
test(backend): Mute Pocket IC server

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -56,7 +56,7 @@ fi
 scripts/download-immutable.sh "https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_SERVER_VERSION}/pocket-ic-x86_64-${PLATFORM}.gz" "${POCKET_IC_SERVER_PATH}.gz"
 
 export POCKET_IC_BIN="../../${POCKET_IC_SERVER_PATH}"
-export POCKET_IC_MUTE_SERVER=""
+export POCKET_IC_MUTE_SERVER=1
 
 ./scripts/download-canister-api --network ic --canister backend
 

--- a/src/shared/src/types/agreement.rs
+++ b/src/shared/src/types/agreement.rs
@@ -76,7 +76,6 @@ pub struct UpdateUserAgreementsRequest {
     pub agreements: UserAgreements,
 }
 
-
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct NewTypeForCI {
     pub a: u32,

--- a/src/shared/src/types/agreement.rs
+++ b/src/shared/src/types/agreement.rs
@@ -75,3 +75,9 @@ pub struct UpdateUserAgreementsRequest {
     pub current_user_version: Option<Version>,
     pub agreements: UserAgreements,
 }
+
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct NewTypeForCI {
+    pub a: u32,
+}

--- a/src/shared/src/types/agreement.rs
+++ b/src/shared/src/types/agreement.rs
@@ -75,8 +75,3 @@ pub struct UpdateUserAgreementsRequest {
     pub current_user_version: Option<Version>,
     pub agreements: UserAgreements,
 }
-
-#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
-pub struct NewTypeForCI {
-    pub a: u32,
-}


### PR DESCRIPTION
# Motivation

There are too many logs entry during the backend tests:

<img width="1492" height="785" alt="Screenshot 2025-10-03 at 21 20 26" src="https://github.com/user-attachments/assets/087429e5-3b6e-4525-b729-a006c0dd8e78" />

As per [forum suggestion](https://forum.dfinity.org/t/pocketic-multi-subnet-canister-testing/24901/11), we mute the server specifically.

The [custom test run](https://github.com/dfinity/oisy-wallet/actions/runs/18231427006/job/51915714079) in this same PR shows that it works:

<img width="1224" height="792" alt="Screenshot 2025-10-03 at 21 19 23" src="https://github.com/user-attachments/assets/7db7e142-c623-4791-b541-dae7ec360252" />

