### PR TITLE
refactor(frontend): Use existing component in `SendSource`

### DIFF
--- a/src/frontend/src/lib/components/send/SendSource.svelte
+++ b/src/frontend/src/lib/components/send/SendSource.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import ExchangeAmountDisplay from '$lib/components/exchange/ExchangeAmountDisplay.svelte';
-	import Value from '$lib/components/ui/Value.svelte';
+	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionBalance } from '$lib/types/balance';
@@ -13,31 +13,19 @@
 	export let exchangeRate: number | undefined = undefined;
 </script>
 
-<Value element="div" ref="source">
-	{#snippet label()}
-		{$i18n.send.text.source}
-	{/snippet}
+<WalletConnectModalValue label={$i18n.send.text.source} ref="source">
+	{source}
+</WalletConnectModalValue>
 
-	{#snippet content()}
-		{source}
-	{/snippet}
-</Value>
-
-<Value element="div" ref="balance">
-	{#snippet label()}
-		{$i18n.send.text.balance}
-	{/snippet}
-
-	{#snippet content()}
-		{#if nonNullish(token)}
-			<ExchangeAmountDisplay
-				amount={balance ?? ZERO}
-				decimals={token.decimals}
-				{exchangeRate}
-				symbol={token.symbol}
-			/>
-		{:else}
-			&ZeroWidthSpace;
-		{/if}
-	{/snippet}
-</Value>
+<WalletConnectModalValue label={$i18n.send.text.balance} ref="balance">
+	{#if nonNullish(token)}
+		<ExchangeAmountDisplay
+			amount={balance ?? ZERO}
+			decimals={token.decimals}
+			{exchangeRate}
+			symbol={token.symbol}
+		/>
+	{:else}
+		&ZeroWidthSpace;
+	{/if}
+</WalletConnectModalValue>


### PR DESCRIPTION
# Motivation

To be consistent, we can use existing component `WalletConnectModalValue` in `SendSource`.
