### PR TITLE
feat(frontend): Use component `Value` in `WalletConnectModalValue`

### DIFF
--- a/src/frontend/src/lib/components/ui/Value.svelte
+++ b/src/frontend/src/lib/components/ui/Value.svelte
@@ -13,6 +13,6 @@
 
 <label class="font-bold" for={ref}>{@render label()}</label>
 
-<svelte:element this={element} id={ref} class="mb-4 items-center gap-1 break-all font-normal">
+<svelte:element this={element} id={ref} class="mb-4 gap-1 break-all font-normal">
 	{@render content?.()}
 </svelte:element>

--- a/src/frontend/src/lib/components/ui/Value.svelte
+++ b/src/frontend/src/lib/components/ui/Value.svelte
@@ -13,6 +13,6 @@
 
 <label class="font-bold" for={ref}>{@render label()}</label>
 
-<svelte:element this={element} id={ref} class="mb-4 gap-1 break-all font-normal">
+<svelte:element this={element} id={ref} class="mb-4 break-all font-normal">
 	{@render content?.()}
 </svelte:element>

--- a/src/frontend/src/lib/components/ui/Value.svelte
+++ b/src/frontend/src/lib/components/ui/Value.svelte
@@ -12,6 +12,7 @@
 </script>
 
 <label class="font-bold" for={ref}>{@render label()}</label>
-<svelte:element this={element} id={ref} class="mb-4 break-all font-normal"
-	>{@render content?.()}</svelte:element
->
+
+<svelte:element this={element} id={ref} class="mb-4 items-center gap-1 break-all font-normal">
+	{@render content?.()}
+</svelte:element>

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectModalValue.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectModalValue.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Value from '$lib/components/ui/Value.svelte';
 
 	interface Props {
 		label: string;
@@ -7,11 +8,15 @@
 		children: Snippet;
 	}
 
-	let { label, ref, children }: Props = $props();
+	let { label: labelStr, ref, children }: Props = $props();
 </script>
 
-<label class="font-bold" for={ref}>{label}</label>
+<Value element="div" {ref}>
+	{#snippet label()}
+		{labelStr}
+	{/snippet}
 
-<div id={ref} class="mb-4 flex items-center gap-1 font-normal">
-	{@render children()}
-</div>
+	{#snippet content()}
+		{@render children()}
+	{/snippet}
+</Value>


### PR DESCRIPTION
# Motivation

To avoid repetition of code and for manageability, we can re-use component `Value` in component `WalletConnectModalValue`.
