### PR TITLE
feat(frontend): Differentiate the modal of WalletConnect

### DIFF
--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -18,6 +18,8 @@
 
 <slot name="sourceNetwork" />
 
+<slot name="destinationNetwork" />
+
 <SendDataAmount {amount} {exchangeRate} showNullishLabel={showNullishAmountLabel} {token} />
 
 <SendSource {balance} {exchangeRate} {source} {token} />


### PR DESCRIPTION
# Motivation

As per decision, the WalletConnect modal should not give the impression that the transaction is native of OISY, meaning, as hint, that it should have a different style from the normal modals. We are opting for a simple one: label + data.

# Changes

- Add slot for destination network in `SendData`.
- Rollback `WalletConnectSendReview` to use a `SendData`.
- Mount the networks slots: source and destination.
- Adapt the other slots.

# Note

We will tackle additional data and adjustments of single data components in other PRs. For example, we will need to change the fee component to be simpler.

# Tests

Example:

<img width="621" height="748" alt="Screenshot 2025-10-03 at 21 51 26" src="https://github.com/user-attachments/assets/f61a92e5-9b64-47af-a912-a933fbe44561" />

