### PR TITLE
feat(frontend): Extract component for contact with avatar

### DIFF
--- a/src/frontend/src/lib/components/contact/ContactWithAvatar.svelte
+++ b/src/frontend/src/lib/components/contact/ContactWithAvatar.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { notEmptyString } from '@dfinity/utils';
+	import { slide } from 'svelte/transition';
+	import Divider from '$lib/components/common/Divider.svelte';
+	import Avatar from '$lib/components/contact/Avatar.svelte';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
+	import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
+
+	interface Props {
+		contact: ContactUi;
+		contactAddress?: ContactAddressUi;
+	}
+
+	const { contact, contactAddress }: Props = $props();
+
+	const addressAlias = $derived(contactAddress?.label);
+</script>
+
+<span class="inline-flex min-w-0 items-center gap-1" in:slide={SLIDE_PARAMS}>
+	<span class="shrink-0">
+		<Avatar name={contact.name} image={contact.image} variant="xxs" />
+	</span>
+
+	<span class="flex min-w-0 flex-wrap items-center">
+		<span class="max-w-38 inline-block truncate">
+			{contact.name}
+		</span>
+		{#if notEmptyString(addressAlias)}
+			<span class="inline-flex items-center text-tertiary">
+				<Divider />
+				<span class="sm:max-w-29 lg:max-w-34 inline-block max-w-20 truncate">
+					{addressAlias}
+				</span>
+			</span>
+		{/if}
+	</span>
+</span>

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -4,6 +4,7 @@
 	import { isTokenErc721 } from '$eth/utils/erc721.utils';
 	import Divider from '$lib/components/common/Divider.svelte';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
+	import ContactWithAvatar from '$lib/components/contact/ContactWithAvatar.svelte';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import NftLogo from '$lib/components/nfts/NftLogo.svelte';
@@ -65,7 +66,7 @@
 
 	const iconWithOpacity: boolean = $derived(status === 'pending' || status === 'unconfirmed');
 
-	const contactAddress: string | undefined = $derived(
+	const address: string | undefined = $derived(
 		type === 'send'
 			? to
 			: type === 'receive'
@@ -75,15 +76,13 @@
 					: undefined
 	);
 
-	const contact: ContactUi | undefined = $derived(
-		nonNullish(contactAddress)
-			? getContactForAddress({ addressString: contactAddress, contactList: $contacts })
+	const contact = $derived(
+		nonNullish(address)
+			? getContactForAddress({ addressString: address, contactList: $contacts })
 			: undefined
 	);
 
-	const addressAlias: string | undefined = $derived(
-		filterAddressFromContact({ contact, address: contactAddress })?.label
-	);
+	const contactAddress = $derived(filterAddressFromContact({ contact, address }));
 
 	const network: Network | undefined = $derived(token.network);
 
@@ -175,28 +174,12 @@
 						{/if}
 
 						{#if nonNullish(contact)}
-							<span class="shrink-0">
-								<Avatar name={contact.name} image={contact.image} variant="xxs" />
+							<ContactWithAvatar {contact} {contactAddress} />
+						{:else if nonNullish(address)}
+							<span class="max-w-38 inline-block flex min-w-0 flex-wrap items-center truncate">
+								{shortenWithMiddleEllipsis({ text: address })}
 							</span>
 						{/if}
-
-						<span class="flex min-w-0 flex-wrap items-center">
-							<span class="max-w-38 inline-block truncate">
-								{#if nonNullish(contact)}
-									{contact.name}
-								{:else if nonNullish(contactAddress)}
-									{shortenWithMiddleEllipsis({ text: contactAddress })}
-								{/if}
-							</span>
-							{#if notEmptyString(addressAlias)}
-								<span class="inline-flex items-center text-tertiary">
-									<Divider />
-									<span class="sm:max-w-29 lg:max-w-34 inline-block max-w-20 truncate">
-										{addressAlias}
-									</span>
-								</span>
-							{/if}
-						</span>
 					</span>
 					<span class="truncate text-tertiary">
 						<TransactionStatusComponent {status} />

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import { nonNullish, notEmptyString } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import type { Component, Snippet } from 'svelte';
 	import { isTokenErc721 } from '$eth/utils/erc721.utils';
-	import Divider from '$lib/components/common/Divider.svelte';
-	import Avatar from '$lib/components/contact/Avatar.svelte';
 	import ContactWithAvatar from '$lib/components/contact/ContactWithAvatar.svelte';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
@@ -18,7 +16,6 @@
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { nftStore } from '$lib/stores/nft.store';
-	import type { ContactUi } from '$lib/types/contact';
 	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus, TransactionType } from '$lib/types/transaction';


### PR DESCRIPTION
# Motivation

We need a specific component that shows a string of the contact plus the avatar. Since the logic is already in the `Transaction` component, we can extract it.

No changes in the UI.

### Before

<img width="641" height="739" alt="Screenshot 2025-10-03 at 22 35 58" src="https://github.com/user-attachments/assets/db67bdef-deba-4175-b1a2-b511b105b01a" />

### After

<img width="646" height="747" alt="Screenshot 2025-10-03 at 22 35 44" src="https://github.com/user-attachments/assets/7e514964-f2c0-4732-9779-aa06ec4f32a1" />




