### PR TITLE
refactor(frontend): Extract types of Token UI to separate modules

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantShowBalanceToolCard.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantShowBalanceToolCard.svelte
@@ -14,9 +14,9 @@
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
-	import type { TokenUi } from '$lib/types/token';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import type { TokenUi } from '$lib/types/token-ui';
 
 	interface Props {
 		totalUsdBalance: number;

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantShowBalanceToolCard.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantShowBalanceToolCard.svelte
@@ -14,9 +14,9 @@
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
+	import type { TokenUi } from '$lib/types/token-ui';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
-	import type { TokenUi } from '$lib/types/token-ui';
 
 	interface Props {
 		totalUsdBalance: number;

--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import TokenExchangeValueSkeleton from '$lib/components/tokens/TokenExchangeValueSkeleton.svelte';
-	import type { TokenUi } from '$lib/types/token';
 	import type { CardData } from '$lib/types/token-card';
+	import type { TokenUi } from '$lib/types/token-ui';
 
 	export let data: CardData;
 

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -12,10 +12,10 @@
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionTokenUi } from '$lib/types/token-ui';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { setPrivacyMode } from '$lib/utils/privacy.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
-	import type { OptionTokenUi } from '$lib/types/token-ui';
 
 	interface Props {
 		token: OptionTokenUi;

--- a/src/frontend/src/lib/components/hero/Balance.svelte
+++ b/src/frontend/src/lib/components/hero/Balance.svelte
@@ -12,10 +12,10 @@
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { OptionTokenUi } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { setPrivacyMode } from '$lib/utils/privacy.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import type { OptionTokenUi } from '$lib/types/token-ui';
 
 	interface Props {
 		token: OptionTokenUi;

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -18,8 +18,8 @@
 	} from '$lib/stores/modal-tokens-list.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { Token } from '$lib/types/token';
-	import { pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
 	import type { TokenUi } from '$lib/types/token-ui';
+	import { pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
 
 	interface Props {
 		onSelectToken: (token: Token) => void;

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -17,8 +17,9 @@
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
-	import type { Token, TokenUi } from '$lib/types/token';
+	import type { Token } from '$lib/types/token';
 	import { pinTokensWithBalanceAtTop } from '$lib/utils/tokens.utils';
+	import type { TokenUi } from '$lib/types/token-ui';
 
 	interface Props {
 		onSelectToken: (token: Token) => void;

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -11,12 +11,12 @@
 	import { tokenGroupStore } from '$lib/stores/token-group.store';
 	import { tokenListStore } from '$lib/stores/token-list.store';
 	import type { CardData } from '$lib/types/token-card';
+	import type { TokenUi } from '$lib/types/token-ui';
+	import type { TokenUiGroup } from '$lib/types/token-ui-group';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
 	import { mapHeaderData } from '$lib/utils/token-card.utils';
 	import { getFilteredTokenGroup } from '$lib/utils/token-list.utils.js';
-	import type { TokenUi } from '$lib/types/token-ui';
-	import type { TokenUiGroup } from '$lib/types/token-ui-group';
 
 	interface Props {
 		tokenGroup: TokenUiGroup;

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -10,13 +10,13 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { tokenGroupStore } from '$lib/stores/token-group.store';
 	import { tokenListStore } from '$lib/stores/token-list.store';
-	import type { TokenUi } from '$lib/types/token';
 	import type { CardData } from '$lib/types/token-card';
-	import type { TokenUiGroup } from '$lib/types/token-group';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
 	import { mapHeaderData } from '$lib/utils/token-card.utils';
 	import { getFilteredTokenGroup } from '$lib/utils/token-list.utils.js';
+	import type { TokenUi } from '$lib/types/token-ui';
+	import type { TokenUiGroup } from '$lib/types/token-ui-group';
 
 	interface Props {
 		tokenGroup: TokenUiGroup;

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -3,8 +3,8 @@
 	import { onDestroy, type Snippet } from 'svelte';
 	import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { showZeroBalances } from '$lib/derived/settings.derived';
-	import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';
 	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
+	import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';
 
 	interface Props {
 		tokens: TokenUiOrGroupUi[] | undefined;

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -3,8 +3,8 @@
 	import { onDestroy, type Snippet } from 'svelte';
 	import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { showZeroBalances } from '$lib/derived/settings.derived';
-	import type { TokenUiOrGroupUi } from '$lib/types/token-group';
 	import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';
+	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 	interface Props {
 		tokens: TokenUiOrGroupUi[] | undefined;

--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -19,11 +19,11 @@
 	import { tokenListStore } from '$lib/stores/token-list.store';
 	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
-	import type { TokenUiOrGroupUi } from '$lib/types/token-group';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
 	import { isTokenUiGroup, sortTokenOrGroupUi } from '$lib/utils/token-group.utils';
 	import { getDisabledOrModifiedTokens, getFilteredTokenList } from '$lib/utils/token-list.utils';
 	import { saveAllCustomTokens } from '$lib/utils/tokens.utils';
+	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 	let tokens: TokenUiOrGroupUi[] | undefined = $state();
 

--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -19,11 +19,11 @@
 	import { tokenListStore } from '$lib/stores/token-list.store';
 	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
+	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
 	import { isTokenUiGroup, sortTokenOrGroupUi } from '$lib/utils/token-group.utils';
 	import { getDisabledOrModifiedTokens, getFilteredTokenList } from '$lib/utils/token-list.utils';
 	import { saveAllCustomTokens } from '$lib/utils/tokens.utils';
-	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 	let tokens: TokenUiOrGroupUi[] | undefined = $state();
 

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -10,9 +10,9 @@
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { TokenUi } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import type { TokenUi } from '$lib/types/token-ui';
 
 	let enabledTokensWithoutTransaction = $derived(
 		$enabledFungibleNetworkTokens

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -10,9 +10,9 @@
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { TokenUi } from '$lib/types/token-ui';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
-	import type { TokenUi } from '$lib/types/token-ui';
 
 	let enabledTokensWithoutTransaction = $derived(
 		$enabledFungibleNetworkTokens

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -8,10 +8,10 @@ import {
 import { balancesStore } from '$lib/stores/balances.store';
 import type { NonFungibleToken } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
+import type { TokenUi } from '$lib/types/token-ui';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
-import type { TokenUi } from '$lib/types/token-ui';
 
 /**
  * All user-enabled fungible tokens matching the selected network or chain fusion.

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -7,10 +7,11 @@ import {
 } from '$lib/derived/tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { NonFungibleToken } from '$lib/types/nft';
-import type { Token, TokenUi } from '$lib/types/token';
+import type { Token } from '$lib/types/token';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
 import { pinTokensWithBalanceAtTop, sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
+import type { TokenUi } from '$lib/types/token-ui';
 
 /**
  * All user-enabled fungible tokens matching the selected network or chain fusion.

--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -2,7 +2,7 @@ import { ZERO } from '$lib/constants/app.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Network, NetworkId } from '$lib/types/network';
-import type { Token, TokenUi } from '$lib/types/token';
+import type { Token } from '$lib/types/token';
 import {
 	filterTokensForSelectedNetwork,
 	filterTokensForSelectedNetworks
@@ -14,6 +14,7 @@ import {
 } from '$lib/utils/tokens.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, writable, type Readable } from 'svelte/store';
+import type { TokenUi } from '$lib/types/token-ui';
 
 export interface ModalTokensListData {
 	tokens: Token[];

--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -3,6 +3,7 @@ import { exchanges } from '$lib/derived/exchange.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import type { Network, NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
+import type { TokenUi } from '$lib/types/token-ui';
 import {
 	filterTokensForSelectedNetwork,
 	filterTokensForSelectedNetworks
@@ -14,7 +15,6 @@ import {
 } from '$lib/utils/tokens.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, writable, type Readable } from 'svelte/store';
-import type { TokenUi } from '$lib/types/token-ui';
 
 export interface ModalTokensListData {
 	tokens: Token[];

--- a/src/frontend/src/lib/types/ai-assistant.ts
+++ b/src/frontend/src/lib/types/ai-assistant.ts
@@ -1,7 +1,8 @@
 import type { Address } from '$lib/types/address';
 import type { ContactAddressUiWithId, ExtendedAddressContactUi } from '$lib/types/contact';
 import type { Network } from '$lib/types/network';
-import type { Token, TokenStandard, TokenUi } from '$lib/types/token';
+import type { Token, TokenStandard } from '$lib/types/token';
+import type { TokenUi } from '$lib/types/token-ui';
 
 export interface ChatMessageContent {
 	text?: string;

--- a/src/frontend/src/lib/types/token-card.ts
+++ b/src/frontend/src/lib/types/token-card.ts
@@ -1,5 +1,4 @@
 import type { Network } from '$lib/types/network';
-
 import type { TokenUi } from '$lib/types/token-ui';
 
 export type CardData = Pick<

--- a/src/frontend/src/lib/types/token-card.ts
+++ b/src/frontend/src/lib/types/token-card.ts
@@ -1,5 +1,6 @@
 import type { Network } from '$lib/types/network';
-import type { TokenUi } from '$lib/types/token';
+
+import type { TokenUi } from '$lib/types/token-ui';
 
 export type CardData = Pick<
 	TokenUi,

--- a/src/frontend/src/lib/types/token-group.ts
+++ b/src/frontend/src/lib/types/token-group.ts
@@ -3,8 +3,6 @@ import type {
 	TokenGroupPropSchema,
 	TokenGroupSchema
 } from '$lib/schema/token-group.schema';
-import type { TokenFinancialData, TokenUi } from '$lib/types/token';
-import type { NonEmptyArray } from '$lib/types/utils';
 import type * as z from 'zod';
 
 export type TokenGroupId = z.infer<typeof TokenGroupIdSchema>;
@@ -12,12 +10,3 @@ export type TokenGroupId = z.infer<typeof TokenGroupIdSchema>;
 export type TokenGroupData = z.infer<typeof TokenGroupSchema>;
 
 export type TokenGroup = z.infer<typeof TokenGroupPropSchema>;
-
-export type TokenUiGroup = {
-	id: TokenGroupId;
-	decimals: number;
-	groupData: TokenGroupData;
-	tokens: NonEmptyArray<TokenUi>;
-} & TokenFinancialData;
-
-export type TokenUiOrGroupUi = { token: TokenUi } | { group: TokenUiGroup };

--- a/src/frontend/src/lib/types/token-ui-group.ts
+++ b/src/frontend/src/lib/types/token-ui-group.ts
@@ -1,0 +1,13 @@
+import type { TokenUi } from '$lib/types/token-ui';
+import type { NonEmptyArray } from '$lib/types/utils';
+import type { TokenFinancialData } from '$lib/types/token';
+import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
+
+export type TokenUiGroup = {
+	id: TokenGroupId;
+	decimals: number;
+	groupData: TokenGroupData;
+	tokens: NonEmptyArray<TokenUi>;
+} & TokenFinancialData;
+
+export type TokenUiOrGroupUi = { token: TokenUi } | { group: TokenUiGroup };

--- a/src/frontend/src/lib/types/token-ui-group.ts
+++ b/src/frontend/src/lib/types/token-ui-group.ts
@@ -1,7 +1,7 @@
-import type { TokenUi } from '$lib/types/token-ui';
-import type { NonEmptyArray } from '$lib/types/utils';
 import type { TokenFinancialData } from '$lib/types/token';
 import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { NonEmptyArray } from '$lib/types/utils';
 
 export type TokenUiGroup = {
 	id: TokenGroupId;

--- a/src/frontend/src/lib/types/token-ui.ts
+++ b/src/frontend/src/lib/types/token-ui.ts
@@ -1,0 +1,9 @@
+import type { Token, TokenFinancialData } from '$lib/types/token';
+import type { Option } from '$lib/types/utils';
+
+export type TokenUi<T extends Token = Token> = T & TokenFinancialData;
+
+export type TokenUiGroupable<T extends Token = Token> = Omit<TokenUi<T>, 'groupData'> &
+	Required<Pick<TokenUi<T>, 'groupData'>>;
+
+export type OptionTokenUi = Option<TokenUi>;

--- a/src/frontend/src/lib/types/token.ts
+++ b/src/frontend/src/lib/types/token.ts
@@ -55,10 +55,3 @@ export interface TokenFinancialData {
 	balance?: Exclude<OptionBalance, undefined>;
 	usdBalance?: number;
 }
-
-export type TokenUi<T extends Token = Token> = T & TokenFinancialData;
-
-export type TokenUiGroupable<T extends Token = Token> = Omit<TokenUi<T>, 'groupData'> &
-	Required<Pick<TokenUi<T>, 'groupData'>>;
-
-export type OptionTokenUi = Option<TokenUi>;

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -11,10 +11,10 @@ import type {
 import type { ExtendedAddressContactUiMap } from '$lib/types/contact';
 import type { Network } from '$lib/types/network';
 import type { RequiredTokenWithLinkedData, Token } from '$lib/types/token';
+import type { TokenUi } from '$lib/types/token-ui';
 import { isTokenNonFungible } from '$lib/utils/nft.utils';
 import { sumTokensUiUsdBalance } from '$lib/utils/tokens.utils';
 import { jsonReplacer, nonNullish, notEmptyString } from '@dfinity/utils';
-import type { TokenUi } from '$lib/types/token-ui';
 
 export const parseToAiAssistantContacts = (
 	extendedAddressContacts: ExtendedAddressContactUiMap

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -10,10 +10,11 @@ import type {
 } from '$lib/types/ai-assistant';
 import type { ExtendedAddressContactUiMap } from '$lib/types/contact';
 import type { Network } from '$lib/types/network';
-import type { RequiredTokenWithLinkedData, Token, TokenUi } from '$lib/types/token';
+import type { RequiredTokenWithLinkedData, Token } from '$lib/types/token';
 import { isTokenNonFungible } from '$lib/utils/nft.utils';
 import { sumTokensUiUsdBalance } from '$lib/utils/tokens.utils';
 import { jsonReplacer, nonNullish, notEmptyString } from '@dfinity/utils';
+import type { TokenUi } from '$lib/types/token-ui';
 
 export const parseToAiAssistantContacts = (
 	extendedAddressContacts: ExtendedAddressContactUiMap

--- a/src/frontend/src/lib/utils/token-card.utils.ts
+++ b/src/frontend/src/lib/utils/token-card.utils.ts
@@ -1,8 +1,8 @@
 import { TokenSchema } from '$lib/schema/token.schema';
 import type { Token } from '$lib/types/token';
 import type { CardData } from '$lib/types/token-card';
-import type { TokenUiGroup } from '$lib/types/token-group';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { TokenUiGroup } from '$lib/types/token-ui-group';
 
 /** Maps the token group to the card data of the card that will be used as "summary" for the group.
  *

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -1,11 +1,11 @@
 import { ZERO } from '$lib/constants/app.constants';
 import type { TokenId } from '$lib/types/token';
 import type { TokenGroupId } from '$lib/types/token-group';
+import type { TokenUi, TokenUiGroupable } from '$lib/types/token-ui';
+import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { normalizeTokenToDecimals } from '$lib/utils/parse.utils';
 import { sumBalances, sumUsdBalances } from '$lib/utils/token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { TokenUi, TokenUiGroupable } from '$lib/types/token-ui';
-import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 /**
  * Type guard to check if an object is of type TokenUiGroup.

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -1,9 +1,11 @@
 import { ZERO } from '$lib/constants/app.constants';
-import type { TokenId, TokenUi, TokenUiGroupable } from '$lib/types/token';
-import type { TokenGroupId, TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-group';
+import type { TokenId } from '$lib/types/token';
+import type { TokenGroupId } from '$lib/types/token-group';
 import { normalizeTokenToDecimals } from '$lib/utils/parse.utils';
 import { sumBalances, sumUsdBalances } from '$lib/utils/token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { TokenUi, TokenUiGroupable } from '$lib/types/token-ui';
+import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 /**
  * Type guard to check if an object is of type TokenUiGroup.

--- a/src/frontend/src/lib/utils/token-list.utils.ts
+++ b/src/frontend/src/lib/utils/token-list.utils.ts
@@ -1,10 +1,11 @@
 import type { Network } from '$lib/types/network';
-import type { Token, TokenUi } from '$lib/types/token';
-import type { TokenUiOrGroupUi } from '$lib/types/token-group';
+import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { showTokenFilteredBySelectedNetwork } from '$lib/utils/network.utils';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 const getFilterCondition = ({ filter, token }: { filter: string; token: TokenUi }): boolean =>
 	token.name.toLowerCase().indexOf(filter.toLowerCase()) >= 0 ||

--- a/src/frontend/src/lib/utils/token-list.utils.ts
+++ b/src/frontend/src/lib/utils/token-list.utils.ts
@@ -1,11 +1,11 @@
 import type { Network } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { showTokenFilteredBySelectedNetwork } from '$lib/utils/network.utils';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { TokenUi } from '$lib/types/token-ui';
-import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 const getFilterCondition = ({ filter, token }: { filter: string; token: TokenUi }): boolean =>
 	token.name.toLowerCase().indexOf(filter.toLowerCase()) >= 0 ||

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -12,13 +12,14 @@ import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import type { OptionBalance } from '$lib/types/balance';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { ExchangesData } from '$lib/types/exchange';
-import type { RequiredTokenWithLinkedData, Token, TokenStandard, TokenUi } from '$lib/types/token';
+import type { RequiredTokenWithLinkedData, Token, TokenStandard } from '$lib/types/token';
 import type { CardData } from '$lib/types/token-card';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { TokenUi } from '$lib/types/token-ui';
 
 /**
  * Calculates the maximum amount for a transaction.

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -15,11 +15,11 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { RequiredTokenWithLinkedData, Token, TokenStandard } from '$lib/types/token';
 import type { CardData } from '$lib/types/token-card';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { TokenUi } from '$lib/types/token-ui';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import type { TokenUi } from '$lib/types/token-ui';
 
 /**
  * Calculates the maximum amount for a transaction.

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -28,6 +28,7 @@ import type { OptionIdentity } from '$lib/types/identity';
 import type { Token, TokenToPin } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { TokenUi } from '$lib/types/token-ui';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
 import { calculateTokenUsdBalance, mapTokenUi } from '$lib/utils/token.utils';
@@ -37,7 +38,6 @@ import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
 import { isTokenSplToggleable } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import type { TokenUi } from '$lib/types/token-ui';
 
 /**
  * Sorts tokens by market cap, name and network name, pinning the specified ones at the top of the list in the order they are provided.

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -25,7 +25,7 @@ import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import { toastsShow } from '$lib/stores/toasts.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { OptionIdentity } from '$lib/types/identity';
-import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
+import type { Token, TokenToPin } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { UserNetworks } from '$lib/types/user-networks';
@@ -37,6 +37,7 @@ import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
 import { isTokenSplToggleable } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
+import type { TokenUi } from '$lib/types/token-ui';
 
 /**
  * Sorts tokens by market cap, name and network name, pinning the specified ones at the top of the list in the order they are provided.

--- a/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandler.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandler.spec.ts
@@ -1,7 +1,6 @@
 import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 import { showZeroBalances } from '$lib/derived/settings.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
-import type { TokenUiOrGroupUi } from '$lib/types/token-group';
 import { randomWait } from '$lib/utils/time.utils';
 import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';
 import TokensDisplayHandlerTest from '$tests/lib/components/tokens/TokensDisplayHandlerTest.svelte';
@@ -15,6 +14,7 @@ import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
+import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 vi.mock(import('$lib/utils/token-group.utils'), async (importOriginal) => {
 	const actual = await importOriginal();

--- a/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandler.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandler.spec.ts
@@ -1,6 +1,7 @@
 import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 import { showZeroBalances } from '$lib/derived/settings.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { randomWait } from '$lib/utils/time.utils';
 import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';
 import TokensDisplayHandlerTest from '$tests/lib/components/tokens/TokensDisplayHandlerTest.svelte';
@@ -14,7 +15,6 @@ import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
-import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 vi.mock(import('$lib/utils/token-group.utils'), async (importOriginal) => {
 	const actual = await importOriginal();

--- a/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandlerTest.svelte
+++ b/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandlerTest.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import TokensDisplayHandler from '$lib/components/tokens/TokensDisplayHandler.svelte';
-	import type { TokenUiOrGroupUi } from '$lib/types/token-group';
+
+	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 	interface Props {
 		animating: boolean;

--- a/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandlerTest.svelte
+++ b/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandlerTest.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import TokensDisplayHandler from '$lib/components/tokens/TokensDisplayHandler.svelte';
-
 	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 	interface Props {

--- a/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
@@ -4,9 +4,9 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { Token } from '$lib/types/token';
 import type { CardData } from '$lib/types/token-card';
-import type { TokenUiGroup } from '$lib/types/token-group';
 import { isCardDataTogglableToken, mapHeaderData } from '$lib/utils/token-card.utils';
 import { bn1Bi } from '$tests/mocks/balances.mock';
+import type { TokenUiGroup } from '$lib/types/token-ui-group';
 
 describe('mapHeaderData', () => {
 	const mockGroup = ETH_TOKEN_GROUP;

--- a/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-card.utils.spec.ts
@@ -4,9 +4,9 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import type { Token } from '$lib/types/token';
 import type { CardData } from '$lib/types/token-card';
+import type { TokenUiGroup } from '$lib/types/token-ui-group';
 import { isCardDataTogglableToken, mapHeaderData } from '$lib/utils/token-card.utils';
 import { bn1Bi } from '$tests/mocks/balances.mock';
-import type { TokenUiGroup } from '$lib/types/token-ui-group';
 
 describe('mapHeaderData', () => {
 	const mockGroup = ETH_TOKEN_GROUP;

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -11,8 +11,7 @@ import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
-import type { Token, TokenUi } from '$lib/types/token';
-import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-group';
+import type { Token } from '$lib/types/token';
 import { last } from '$lib/utils/array.utils';
 import { normalizeTokenToDecimals } from '$lib/utils/parse.utils';
 import {
@@ -26,6 +25,8 @@ import {
 import { bn1Bi, bn2Bi, bn3Bi } from '$tests/mocks/balances.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { assertNonNullish } from '@dfinity/utils';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 const tokens: TokenUi[] = [
 	{

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -12,6 +12,8 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Token } from '$lib/types/token';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { last } from '$lib/utils/array.utils';
 import { normalizeTokenToDecimals } from '$lib/utils/parse.utils';
 import {
@@ -25,8 +27,6 @@ import {
 import { bn1Bi, bn2Bi, bn3Bi } from '$tests/mocks/balances.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { assertNonNullish } from '@dfinity/utils';
-import type { TokenUi } from '$lib/types/token-ui';
-import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 const tokens: TokenUi[] = [
 	{

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -4,8 +4,7 @@ import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import type { Network } from '$lib/types/network';
-import type { Token, TokenUi } from '$lib/types/token';
-import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-group';
+import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { showTokenFilteredBySelectedNetwork } from '$lib/utils/network.utils';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
@@ -14,6 +13,8 @@ import {
 	getFilteredTokenGroup,
 	getFilteredTokenList
 } from '$lib/utils/token-list.utils';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 // Mock data for tokens
 const token1: TokenUi = BTC_MAINNET_TOKEN;

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -6,6 +6,8 @@ import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import type { Network } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { TokenUi } from '$lib/types/token-ui';
+import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { showTokenFilteredBySelectedNetwork } from '$lib/utils/network.utils';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
 import {
@@ -13,8 +15,6 @@ import {
 	getFilteredTokenGroup,
 	getFilteredTokenList
 } from '$lib/utils/token-list.utils';
-import type { TokenUi } from '$lib/types/token-ui';
-import type { TokenUiGroup, TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 
 // Mock data for tokens
 const token1: TokenUi = BTC_MAINNET_TOKEN;

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -22,6 +22,7 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type { Network } from '$lib/types/network';
 import type { Token, TokenToPin } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
+import type { TokenUi } from '$lib/types/token-ui';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { usdValue } from '$lib/utils/exchange.utils';
 import {
@@ -48,7 +49,6 @@ import i18nMock from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockTokens, mockValidToken } from '$tests/mocks/tokens.mock';
-import type { TokenUi } from '$lib/types/token-ui';
 
 vi.mock('$lib/utils/exchange.utils', () => ({
 	usdValue: vi.fn()

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -20,7 +20,7 @@ import type { CertifiedStoreData } from '$lib/stores/certified.store';
 import { toastsShow } from '$lib/stores/toasts.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Network } from '$lib/types/network';
-import type { Token, TokenToPin, TokenUi } from '$lib/types/token';
+import type { Token, TokenToPin } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { usdValue } from '$lib/utils/exchange.utils';
@@ -48,6 +48,7 @@ import i18nMock from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockTokens, mockValidToken } from '$tests/mocks/tokens.mock';
+import type { TokenUi } from '$lib/types/token-ui';
 
 vi.mock('$lib/utils/exchange.utils', () => ({
 	usdValue: vi.fn()


### PR DESCRIPTION
# Motivation

To avoid circular reference, we extract the types for Token UI and Token Group UI to separate modules.
