### PR TITLE
refactor(frontend): Migrate component `TokenInput` to Svelte 5

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendAmount.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendAmount.svelte
@@ -56,17 +56,17 @@
 <div class="mb-4">
 	<TokenInput
 		autofocus={nonNullish($sendToken)}
-		customErrorValidate={customValidate}
 		displayUnit={inputUnit}
 		exchangeRate={$sendTokenExchangeRate}
+		onClick={onTokensList}
+		onCustomErrorValidate={customValidate}
 		token={$sendToken}
 		bind:amount
 		bind:error={amountError}
-		on:click={onTokensList}
 	>
-		<span slot="title">{$i18n.core.text.amount}</span>
+		{#snippet title()}{$i18n.core.text.amount}{/snippet}
 
-		<svelte:fragment slot="amount-info">
+		{#snippet amountInfo()}
 			{#if nonNullish($sendToken)}
 				<div class="text-tertiary">
 					<TokenInputAmountExchange
@@ -77,9 +77,9 @@
 					/>
 				</div>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 
-		<svelte:fragment slot="balance">
+		{#snippet balance()}
 			{#if nonNullish($sendToken)}
 				<MaxBalanceButton
 					balance={$sendBalance}
@@ -88,6 +88,6 @@
 					bind:amount
 				/>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 	</TokenInput>
 </div>

--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -109,7 +109,7 @@
 		bind:amountSetToMax
 		bind:error={insufficientFundsError}
 	>
-		{#snippet title()}$i18n.core.text.amount}{/snippet}
+		{#snippet title()}{$i18n.core.text.amount}{/snippet}
 
 		{#snippet amountInfo()}
 			{#if nonNullish($sendToken)}

--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -100,18 +100,18 @@
 <div class="mb-4">
 	<TokenInput
 		autofocus={nonNullish($sendToken)}
-		customErrorValidate={customValidate}
 		displayUnit={inputUnit}
 		exchangeRate={$sendTokenExchangeRate}
+		onClick={onTokensList}
+		onCustomErrorValidate={customValidate}
 		token={$sendToken}
 		bind:amount
 		bind:amountSetToMax
 		bind:error={insufficientFundsError}
-		on:click={onTokensList}
 	>
-		<span slot="title">{$i18n.core.text.amount}</span>
+		{#snippet title()}$i18n.core.text.amount}{/snippet}
 
-		<svelte:fragment slot="amount-info">
+		{#snippet amountInfo()}
 			{#if nonNullish($sendToken)}
 				<div class="text-tertiary">
 					<TokenInputAmountExchange
@@ -122,9 +122,9 @@
 					/>
 				</div>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 
-		<svelte:fragment slot="balance">
+		{#snippet balance()}
 			{#if nonNullish($sendToken)}
 				<MaxBalanceButton
 					balance={$sendBalance}
@@ -135,6 +135,6 @@
 					bind:amountSetToMax
 				/>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 	</TokenInput>
 </div>

--- a/src/frontend/src/icp/components/send/IcSendAmount.svelte
+++ b/src/frontend/src/icp/components/send/IcSendAmount.svelte
@@ -51,17 +51,17 @@
 <div class="mb-4">
 	<TokenInput
 		autofocus={nonNullish($sendToken)}
-		customErrorValidate={customValidate}
 		displayUnit={inputUnit}
 		exchangeRate={$sendTokenExchangeRate}
+		onClick={onTokensList}
+		onCustomErrorValidate={customValidate}
 		token={$sendToken}
 		bind:amount
 		bind:error={amountError}
-		on:click={onTokensList}
 	>
-		<span slot="title">{$i18n.core.text.amount}</span>
+		{#snippet title()}{$i18n.core.text.amount}{/snippet}
 
-		<svelte:fragment slot="amount-info">
+		{#snippet amountInfo()}
 			{#if nonNullish($sendToken)}
 				<div class="text-tertiary">
 					<TokenInputAmountExchange
@@ -72,9 +72,9 @@
 					/>
 				</div>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 
-		<svelte:fragment slot="balance">
+		{#snippet balance()}
 			{#if nonNullish($sendToken)}
 				<MaxBalanceButton
 					balance={$sendBalance}
@@ -84,6 +84,6 @@
 					bind:amount
 				/>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 	</TokenInput>
 </div>

--- a/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountDestination.svelte
@@ -41,19 +41,22 @@
 	isSelectable={false}
 	token={$destinationToken}
 >
-	<div slot="amount-info" class="text-tertiary">
-		<TokenInputAmountExchange
-			amount={receiveAmount}
-			exchangeRate={$destinationTokenExchangeRate}
-			token={$destinationToken}
-			bind:displayUnit={exchangeValueUnit}
-		/>
-	</div>
+	{#snippet amountInfo()}
+		<div class="text-tertiary">
+			<TokenInputAmountExchange
+				amount={receiveAmount}
+				exchangeRate={$destinationTokenExchangeRate}
+				token={$destinationToken}
+				bind:displayUnit={exchangeValueUnit}
+			/>
+		</div>
+	{/snippet}
 
-	<TokenInputBalance
-		slot="balance"
-		balance={$destinationTokenBalance}
-		testId="convert-amount-destination-balance"
-		token={$destinationToken}
-	/>
+	{#snippet balance()}
+		<TokenInputBalance
+			balance={$destinationTokenBalance}
+			testId="convert-amount-destination-balance"
+			token={$destinationToken}
+		/>
+	{/snippet}
 </TokenInput>

--- a/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
+++ b/src/frontend/src/lib/components/convert/ConvertAmountSource.svelte
@@ -35,7 +35,7 @@
 
 	$: (errorType, setErrorType(errorType));
 
-	const customValidate = (userAmount: bigint): TokenActionErrorType =>
+	const onCustomValidate = (userAmount: bigint): TokenActionErrorType =>
 		validateUserAmount({
 			userAmount,
 			token: $sourceToken,
@@ -84,37 +84,40 @@
 </script>
 
 <TokenInput
-	{customValidate}
 	displayUnit={inputUnit}
 	exchangeRate={$sourceTokenExchangeRate}
 	isSelectable={false}
+	{onCustomValidate}
 	token={$sourceToken}
 	bind:amount={sendAmount}
 	bind:errorType
 	bind:amountSetToMax
 >
-	<div slot="amount-info" class="text-tertiary">
-		<TokenInputAmountExchange
-			amount={sendAmount}
-			exchangeRate={$sourceTokenExchangeRate}
-			token={$sourceToken}
-			bind:displayUnit={exchangeValueUnit}
-		/>
-	</div>
+	{#snippet amountInfo()}
+		<div class="text-tertiary">
+			<TokenInputAmountExchange
+				amount={sendAmount}
+				exchangeRate={$sourceTokenExchangeRate}
+				token={$sourceToken}
+				bind:displayUnit={exchangeValueUnit}
+			/>
+		</div>
+	{/snippet}
 
-	<button
-		slot="balance"
-		class="font-semibold transition-all"
-		class:animate-pulse={isNullish(maxAmount)}
-		class:text-brand-primary={!isZeroBalance && isNullish(errorType) && nonNullish(maxAmount)}
-		class:text-error-primary={isZeroBalance || nonNullish(errorType)}
-		class:text-tertiary={isNullish(maxAmount)}
-		data-tid="convert-amount-source-balance"
-		on:click|preventDefault={setMax}
-	>
-		{$i18n.convert.text.max_balance}:
-		{nonNullish(maxAmount)
-			? `${maxAmount} ${$sourceToken.symbol}`
-			: $i18n.convert.text.calculating_max_amount}
-	</button>
+	{#snippet balance()}
+		<button
+			class="font-semibold transition-all"
+			class:animate-pulse={isNullish(maxAmount)}
+			class:text-brand-primary={!isZeroBalance && isNullish(errorType) && nonNullish(maxAmount)}
+			class:text-error-primary={isZeroBalance || nonNullish(errorType)}
+			class:text-tertiary={isNullish(maxAmount)}
+			data-tid="convert-amount-source-balance"
+			on:click|preventDefault={setMax}
+		>
+			{$i18n.convert.text.max_balance}:
+			{nonNullish(maxAmount)
+				? `${maxAmount} ${$sourceToken.symbol}`
+				: $i18n.convert.text.calculating_max_amount}
+		</button>
+	{/snippet}
 </TokenInput>

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -151,19 +151,19 @@
 				>
 					{#snippet tokenInput()}
 						<TokenInput
-							customValidate={onCustomValidate}
 							displayUnit={inputUnit}
 							exchangeRate={$sourceTokenExchangeRate}
+							onClick={() => onShowTokensList('source')}
+							{onCustomValidate}
 							showTokenNetwork
 							token={$sourceToken}
 							bind:amount={swapAmount}
 							bind:errorType
 							bind:amountSetToMax
-							on:click={() => onShowTokensList('source')}
 						>
-							<span slot="title">{$i18n.tokens.text.source_token_title}</span>
+							{#snippet title()}{$i18n.tokens.text.source_token_title}{/snippet}
 
-							<svelte:fragment slot="amount-info">
+							{#snippet amountInfo()}
 								{#if nonNullish($sourceToken)}
 									<div class="text-tertiary">
 										<TokenInputAmountExchange
@@ -174,9 +174,9 @@
 										/>
 									</div>
 								{/if}
-							</svelte:fragment>
+							{/snippet}
 
-							<svelte:fragment slot="balance">
+							{#snippet balance()}
 								{#if nonNullish($sourceToken)}
 									{#if nonNullish(fee)}
 										<MaxBalanceButton
@@ -193,7 +193,7 @@
 										</div>
 									{/if}
 								{/if}
-							</svelte:fragment>
+							{/snippet}
 						</TokenInput>
 					{/snippet}
 				</TokenInputNetworkWrapper>
@@ -215,13 +215,13 @@
 						displayUnit={inputUnit}
 						exchangeRate={$destinationTokenExchangeRate}
 						loading={swapAmountsLoading}
+						onClick={() => onShowTokensList('destination')}
 						showTokenNetwork
 						token={$destinationToken}
-						on:click={() => onShowTokensList('destination')}
 					>
-						<span slot="title">{$i18n.tokens.text.destination_token_title}</span>
+						{#snippet title()}{$i18n.tokens.text.destination_token_title}{/snippet}
 
-						<svelte:fragment slot="amount-info">
+						{#snippet amountInfo()}
 							{#if nonNullish($destinationToken)}
 								{#if showSwapNotOfferedError}
 									<div class="text-error-primary" transition:slide={SLIDE_DURATION}
@@ -246,13 +246,13 @@
 									</div>
 								{/if}
 							{/if}
-						</svelte:fragment>
+						{/snippet}
 
-						<svelte:fragment slot="balance">
+						{#snippet balance()}
 							{#if nonNullish($destinationToken)}
 								<TokenInputBalance balance={$destinationTokenBalance} token={$destinationToken} />
 							{/if}
-						</svelte:fragment>
+						{/snippet}
 					</TokenInput>
 				{/snippet}
 			</TokenInputNetworkWrapper>

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { IconExpandMore } from '@dfinity/gix-components';
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
+	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
@@ -20,33 +20,59 @@
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
-	export let token: Token | undefined = undefined;
-	export let amount: OptionAmount;
-	export let name = 'token-input';
-	export let displayUnit: DisplayUnit = 'token';
-	export let exchangeRate: number | undefined = undefined;
-	export let disabled = false;
-	export let placeholder = '0';
-	export let errorType: TokenActionErrorType = undefined;
-	// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
-	export let error: Error | undefined = undefined;
-	export let amountSetToMax = false;
-	export let loading = false;
-	export let isSelectable = true;
-	export let autofocus = false;
-	export let customValidate: (userAmount: bigint) => TokenActionErrorType = () => undefined;
-	export let customErrorValidate: (userAmount: bigint) => Error | undefined = () => undefined;
-	export let showTokenNetwork = false;
+	interface Props {
+		token?: Token;
+		amount: OptionAmount;
+		name?: string;
+		displayUnit?: DisplayUnit;
+		exchangeRate?: number;
+		disabled?: boolean;
+		placeholder?: string;
+		errorType?: TokenActionErrorType;
+		// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
+		error?: Error;
+		amountSetToMax?: boolean;
+		loading?: boolean;
+		isSelectable?: boolean;
+		autofocus?: boolean;
+		onCustomValidate?: (userAmount: bigint) => TokenActionErrorType;
+		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
+		showTokenNetwork?: boolean;
+		onClick?: () => void;
+		title?: Snippet;
+		amountInfo: Snippet;
+		balance: Snippet;
+	}
 
-	const dispatch = createEventDispatcher();
+	let {
+		token,
+		amount = $bindable(),
+		name = 'token-input',
+		displayUnit = 'token',
+		exchangeRate,
+		disabled = false,
+		placeholder = '0',
+		errorType = $bindable(),
+		error = $bindable(),
+		amountSetToMax = $bindable(false),
+		loading = false,
+		isSelectable = true,
+		autofocus = false,
+		onCustomValidate = () => undefined,
+		onCustomErrorValidate = () => undefined,
+		showTokenNetwork = false,
+		onClick,
+		title,
+		amountInfo,
+		balance
+	}: Props = $props();
 
-	let focused: boolean;
+	let focused = $state(false);
 	const onFocus = () => (focused = true);
 	const onBlur = () => (focused = false);
 
 	const onInput = () => {
 		amountSetToMax = false;
-		dispatch('nnsInput');
 	};
 
 	const validate = () => {
@@ -60,12 +86,17 @@
 			unitName: token.decimals
 		});
 
-		errorType = customValidate(parsedValue);
-		error = customErrorValidate(parsedValue);
+		errorType = onCustomValidate(parsedValue);
+		error = onCustomErrorValidate(parsedValue);
 	};
 
 	const debounceValidate = debounce(validate, 300);
-	$: (amount, token, debounceValidate());
+
+	$effect(() => {
+		[amount, token];
+
+		debounceValidate();
+	});
 </script>
 
 <div
@@ -76,7 +107,7 @@
 	class:border-secondary={!focused}
 >
 	<div class="space-between mb-2 flex justify-between text-sm font-bold">
-		<slot name="title" />
+		{@render title?.()}
 		{#if showTokenNetwork && nonNullish(token)}
 			<div class="flex text-xs font-normal text-tertiary">
 				<span class="mr-1 text-sm">On {token.network.name}</span>
@@ -123,7 +154,7 @@
 					/>
 				{/if}
 			{:else}
-				<button class="h-full w-full pl-3 text-base" on:click
+				<button class="h-full w-full pl-3 text-base" onclick={onClick}
 					>{$i18n.tokens.text.select_token}</button
 				>
 			{/if}
@@ -131,7 +162,7 @@
 
 		<div class="h-3/4 w-[1px] bg-disabled"></div>
 
-		<button class="flex h-full gap-1 px-3" disabled={!isSelectable} on:click>
+		<button class="flex h-full gap-1 px-3" disabled={!isSelectable} onclick={onClick}>
 			{#if token}
 				<TokenLogo data={token} logoSize="xs" />
 				<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
@@ -151,9 +182,9 @@
 	</TokenInputContainer>
 
 	<div class="mt-2 flex min-h-6 items-center justify-between text-sm">
-		<slot name="amount-info" />
+		{@render amountInfo()}
 
-		<slot name="balance" />
+		{@render balance()}
 	</div>
 </div>
 

--- a/src/frontend/src/sol/components/send/SolSendAmount.svelte
+++ b/src/frontend/src/sol/components/send/SolSendAmount.svelte
@@ -76,17 +76,17 @@
 <div class="mb-4">
 	<TokenInput
 		autofocus={nonNullish($sendToken)}
-		customErrorValidate={customValidate}
 		displayUnit={inputUnit}
 		exchangeRate={$sendTokenExchangeRate}
+		onClick={onTokensList}
+		onCustomErrorValidate={customValidate}
 		token={$sendToken}
 		bind:amount
 		bind:error={amountError}
-		on:click={onTokensList}
 	>
-		<span slot="title">{$i18n.core.text.amount}</span>
+		{#snippet title()}{$i18n.core.text.amount}{/snippet}
 
-		<svelte:fragment slot="amount-info">
+		{#snippet amountInfo()}
 			{#if nonNullish($sendToken)}
 				<div class="text-tertiary">
 					<TokenInputAmountExchange
@@ -97,9 +97,9 @@
 					/>
 				</div>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 
-		<svelte:fragment slot="balance">
+		{#snippet balance()}
 			{#if nonNullish($sendToken)}
 				<MaxBalanceButton
 					balance={$sendBalance}
@@ -109,6 +109,6 @@
 					bind:amount
 				/>
 			{/if}
-		</svelte:fragment>
+		{/snippet}
 	</TokenInput>
 </div>


### PR DESCRIPTION
# Motivation

Migrating component `TokenInput` to Svelte 5.

Notice that the event `nnsInput` was never used in any of the consumers.
