### PR TITLE
chore(frontend): Remove unnecessary assertion in `sign` service of WalletConnect

### DIFF
--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -128,8 +128,6 @@ export const sign = ({
 			try {
 				progress(ProgressStepsSign.SIGN);
 
-				assertNonNullish(address);
-
 				const rpc = solanaHttpRpc(solNetwork);
 
 				const signer = createSigner({


### PR DESCRIPTION
# Motivation

There is no need for a nullish assertion on address in `sign` service of WalletConnect: we already raise an error before, if it is nullish.