### PR TITLE
refactor(frontend): Remove unnecessary deconstruction in `setLifetimeAndFeePayerToTransaction`

### DIFF
--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -76,15 +76,10 @@ export const setLifetimeAndFeePayerToTransaction = async ({
 	const { getLatestBlockhash } = rpc;
 	const { value: latestBlockhash } = await getLatestBlockhash({ commitment: 'confirmed' }).send();
 
-	const correctedLatestBlockhash = {
-		...latestBlockhash,
-		lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
-	};
-
 	return pipe(
 		transactionMessage,
 		(tx) => setFeePayerToTransaction({ transactionMessage: tx, feePayer }),
-		(tx) => setTransactionMessageLifetimeUsingBlockhash(correctedLatestBlockhash, tx)
+		(tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx)
 	);
 };
 


### PR DESCRIPTION
# Motivation

Just noticed that in service `setLifetimeAndFeePayerToTransaction` there is an unnecessary deconstruction of the `latestBlockhash` object.