### PR TITLE
fix(frontend): Ignore unsupported Solana methods in WalletConnect

### DIFF
--- a/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
@@ -440,7 +440,10 @@ describe('wallet-connect.services', () => {
 				message: { signature: mockSignature }
 			});
 
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
+				'WalletConnect Solana transaction send error',
+				mockError
+			);
 		});
 
 		describe('with other WalletConnect methods', () => {
@@ -458,63 +461,27 @@ describe('wallet-connect.services', () => {
 				}
 			};
 
-			it('should return success when signing is successful', async () => {
+			it('should not sign the transactions', async () => {
 				const result = await sign(mockParamsOther);
 
-				expect(result).toStrictEqual({ success: true });
+				expect(result).toEqual({ success: false });
 
-				expect(signTransaction).toHaveBeenCalledExactlyOnceWith(mockTransactionMessage);
+				expect(signTransaction).not.toHaveBeenCalled();
 
-				expect(sendSignedTransaction).toHaveBeenCalledExactlyOnceWith({
-					signedTransaction: mockSolSignedTransaction,
-					rpc: expect.any(Object)
-				});
+				expect(sendSignedTransaction).not.toHaveBeenCalled();
 
-				expect(mockParams.progress).toHaveBeenCalledTimes(3);
-				expect(mockParams.progress).toHaveBeenNthCalledWith(1, ProgressStepsSendSol.SIGN);
-				expect(mockParams.progress).toHaveBeenNthCalledWith(
-					2,
-					ProgressStepsSign.APPROVE_WALLET_CONNECT
-				);
-				expect(mockParams.progress).toHaveBeenNthCalledWith(3, ProgressStepsSendSol.DONE);
-			});
+				expect(mockParams.progress).toHaveBeenCalledExactlyOnceWith(ProgressStepsSendSol.SIGN);
 
-			it('should not wait for errors when sending', async () => {
-				const mockError = new Error('mock-send-error');
+				expect(mockListener.approveRequest).not.toHaveBeenCalled();
 
-				vi.spyOn(solSendServices, 'sendSignedTransaction').mockImplementationOnce(() => {
-					throw mockError;
-				});
+				expect(mockListener.rejectRequest).not.toHaveBeenCalled();
 
-				const result = await sign(mockParamsOther);
+				expect(spyToastsShow).not.toHaveBeenCalled();
+				expect(spyToastsError).not.toHaveBeenCalled();
 
-				expect(result).toStrictEqual({ success: true });
+				expect(trackEvent).not.toHaveBeenCalled();
 
-				expect(signTransaction).toHaveBeenCalledExactlyOnceWith(mockTransactionMessage);
-
-				expect(sendSignedTransaction).toHaveBeenCalledExactlyOnceWith({
-					signedTransaction: mockSolSignedTransaction,
-					rpc: expect.any(Object)
-				});
-
-				expect(mockParams.progress).toHaveBeenCalledTimes(3);
-				expect(mockParams.progress).toHaveBeenNthCalledWith(1, ProgressStepsSendSol.SIGN);
-				expect(mockParams.progress).toHaveBeenNthCalledWith(
-					2,
-					ProgressStepsSign.APPROVE_WALLET_CONNECT
-				);
-				expect(mockParams.progress).toHaveBeenNthCalledWith(3, ProgressStepsSendSol.DONE);
-
-				expect(mockListener.approveRequest).toHaveBeenCalledExactlyOnceWith({
-					topic: mockRequest.topic,
-					id: mockRequest.id,
-					message: { signature: mockSignature }
-				});
-
-				expect(console.warn).toHaveBeenCalledExactlyOnceWith(
-					'WalletConnect Solana transaction send error',
-					mockError
-				);
+				expect(console.warn).not.toHaveBeenCalled();
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

When signing a Solana transaction with WalletConnect, we are doing it for all the methods, because we have an "implicit" filter when passing the allowed methods to the counterparty.

However, to be technically correct and being able to reuse the `sign` service, we should avoid processing the signature for methods that we are not supporting.

# Changes

- Extract subservice to sign and send a WalletConnect transaction from `sign` service.
- Check if the method is allowed, otherwise return an empty signature and raise failed processing.

# Tests

Adapted tests.
