### PR TITLE
feat(dependabot): Let it bump lint packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,5 @@ updates:
     ignore:
       - dependency-name: '@dfinity/*'
       - dependency-name: '@types/*'
-      - dependency-name: '@typescript-eslint/*'
-      - dependency-name: 'eslint'
-      - dependency-name: 'eslint-*'
       - dependency-name: 'typescript'
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Motivation

We will allow dependabot to bump the lint packages, to keep up with current updates.
