### PR TITLE
refactor(frontend): Simplify logic in `RewardGuard`

### DIFF
--- a/src/frontend/src/lib/components/guard/RewardGuard.svelte
+++ b/src/frontend/src/lib/components/guard/RewardGuard.svelte
@@ -57,27 +57,31 @@
 	});
 
 	const handleWelcomeModal = (timestamp: bigint) => {
+		if (timestamp !== ZERO || nonNullish($modalStore?.type) || hasDisplayedWelcome || $hasUrlCode) {
+			return;
+		}
+
 		const season1Episode4Campaign = rewardCampaigns.find(
 			({ id }) => id === SPRINKLES_SEASON_1_EPISODE_4_ID
 		);
 
+		if (isNullish(season1Episode4Campaign)) {
+			return;
+		}
+
 		if (
-			nonNullish(timestamp) &&
-			timestamp === ZERO &&
-			nonNullish(season1Episode4Campaign) &&
 			isOngoingCampaign({
 				startDate: season1Episode4Campaign.startDate,
 				endDate: season1Episode4Campaign.endDate
-			}) &&
-			isNullish($modalStore?.type) &&
-			!hasDisplayedWelcome &&
-			!$hasUrlCode
+			})
 		) {
 			hasDisplayedWelcome = true;
+
 			trackEvent({
 				name: TRACK_WELCOME_OPEN,
 				metadata: { campaignId: `${season1Episode4Campaign.id}` }
 			});
+
 			modalStore.openWelcome({
 				id: welcomeModalId,
 				data: { reward: season1Episode4Campaign }

--- a/src/frontend/src/tests/lib/components/guard/RewardGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/RewardGuard.spec.ts
@@ -58,243 +58,246 @@ describe('RewardGuard', () => {
 		trackEvent: vi.fn()
 	}));
 
-	it('should open reward state modal for leaderboard', async () => {
-		const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.LEADERBOARD] };
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward, customMockedReward]],
-			last_snapshot_timestamp: [lastTimestamp],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+	describe('reward state modal', () => {
+		it('should open for leaderboard', async () => {
+			const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.LEADERBOARD] };
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward, customMockedReward]],
+				last_snapshot_timestamp: [lastTimestamp],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
 
-		render(RewardGuard);
+			render(RewardGuard);
 
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: { reward: mockRewardCampaign, rewardType: RewardType.LEADERBOARD },
-				type: 'reward-state'
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: { reward: mockRewardCampaign, rewardType: RewardType.LEADERBOARD },
+					type: 'reward-state'
+				});
+
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_REWARD_CAMPAIGN_WIN,
+					metadata: {
+						campaignId: mockRewardCampaign.id,
+						type: RewardType.LEADERBOARD
+					}
+				});
 			});
+		});
 
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_REWARD_CAMPAIGN_WIN,
-				metadata: {
-					campaignId: mockRewardCampaign.id,
-					type: RewardType.LEADERBOARD
-				}
+		it('should open for jackpot', async () => {
+			const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.JACKPOT] };
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward, customMockedReward]],
+				last_snapshot_timestamp: [lastTimestamp],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+
+			render(RewardGuard);
+
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: { reward: mockRewardCampaign, rewardType: RewardType.JACKPOT },
+					type: 'reward-state'
+				});
+
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_REWARD_CAMPAIGN_WIN,
+					metadata: {
+						campaignId: mockRewardCampaign.id,
+						type: RewardType.JACKPOT
+					}
+				});
+			});
+		});
+
+		it('should open for referrer', async () => {
+			const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.REFERRER] };
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward, customMockedReward]],
+				last_snapshot_timestamp: [lastTimestamp],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+
+			render(RewardGuard);
+
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: { reward: mockRewardCampaign, rewardType: RewardType.REFERRER },
+					type: 'reward-state'
+				});
+
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_REWARD_CAMPAIGN_WIN,
+					metadata: {
+						campaignId: mockRewardCampaign.id,
+						type: RewardType.REFERRER
+					}
+				});
+			});
+		});
+
+		it('should open for referee', async () => {
+			const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.REFEREE] };
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward, customMockedReward]],
+				last_snapshot_timestamp: [lastTimestamp],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+
+			render(RewardGuard);
+
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: { reward: mockRewardCampaign, rewardType: RewardType.REFEREE },
+					type: 'reward-state'
+				});
+
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_REWARD_CAMPAIGN_WIN,
+					metadata: {
+						campaignId: mockRewardCampaign.id,
+						type: RewardType.REFEREE
+					}
+				});
+			});
+		});
+
+		it('should open for referral', async () => {
+			const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.REFERRAL] };
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward, customMockedReward]],
+				last_snapshot_timestamp: [lastTimestamp],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+
+			render(RewardGuard);
+
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: { reward: mockRewardCampaign, rewardType: RewardType.REFERRAL },
+					type: 'reward-state'
+				});
+
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_REWARD_CAMPAIGN_WIN,
+					metadata: {
+						campaignId: mockRewardCampaign.id,
+						type: RewardType.REFERRAL
+					}
+				});
+			});
+		});
+
+		it('should open for normal airdrop', async () => {
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward]],
+				last_snapshot_timestamp: [lastTimestamp],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+
+			render(RewardGuard);
+
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: { reward: mockRewardCampaign, rewardType: RewardType.AIRDROP },
+					type: 'reward-state'
+				});
+
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_REWARD_CAMPAIGN_WIN,
+					metadata: {
+						campaignId: mockRewardCampaign.id,
+						type: RewardType.AIRDROP
+					}
+				});
 			});
 		});
 	});
 
-	it('should open reward state modal for jackpot', async () => {
-		const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.JACKPOT] };
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward, customMockedReward]],
-			last_snapshot_timestamp: [lastTimestamp],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+	describe('welcome modal', () => {
+		it('should open with the most recent ongoing campaign', async () => {
+			const expectedRewardCampaign: RewardCampaignDescription | undefined =
+				mockRewardCampaigns.find(({ id }) => id === SPRINKLES_SEASON_1_EPISODE_4_ID);
 
-		render(RewardGuard);
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [],
+				last_snapshot_timestamp: [0n],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
 
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: { reward: mockRewardCampaign, rewardType: RewardType.JACKPOT },
-				type: 'reward-state'
-			});
+			render(RewardGuard);
 
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_REWARD_CAMPAIGN_WIN,
-				metadata: {
-					campaignId: mockRewardCampaign.id,
-					type: RewardType.JACKPOT
-				}
-			});
-		});
-	});
+			await waitFor(() => {
+				expect(get(modalStore)).toEqual({
+					id: get(modalStore)?.id,
+					data: {
+						reward: { ...expectedRewardCampaign, startDate: new Date('2025-02-05T14:28:02.288Z') }
+					},
+					type: 'welcome'
+				});
 
-	it('should open reward state modal for referrer', async () => {
-		const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.REFERRER] };
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward, customMockedReward]],
-			last_snapshot_timestamp: [lastTimestamp],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
-
-		render(RewardGuard);
-
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: { reward: mockRewardCampaign, rewardType: RewardType.REFERRER },
-				type: 'reward-state'
-			});
-
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_REWARD_CAMPAIGN_WIN,
-				metadata: {
-					campaignId: mockRewardCampaign.id,
-					type: RewardType.REFERRER
-				}
+				expect(trackEvent).toHaveBeenNthCalledWith(1, {
+					name: TRACK_WELCOME_OPEN,
+					metadata: {
+						campaignId: SPRINKLES_SEASON_1_EPISODE_4_ID
+					}
+				});
 			});
 		});
-	});
 
-	it('should open reward state modal for referee', async () => {
-		const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.REFEREE] };
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward, customMockedReward]],
-			last_snapshot_timestamp: [lastTimestamp],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
+		it('should not open if another modal is already opened', async () => {
+			const mockedUserData: UserData = {
+				is_vip: [false],
+				superpowers: [],
+				airdrops: [],
+				usage_awards: [[mockedReward]],
+				last_snapshot_timestamp: [0n],
+				sprinkles: []
+			};
+			vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
 
-		render(RewardGuard);
+			render(RewardGuard);
 
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: { reward: mockRewardCampaign, rewardType: RewardType.REFEREE },
-				type: 'reward-state'
-			});
-
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_REWARD_CAMPAIGN_WIN,
-				metadata: {
-					campaignId: mockRewardCampaign.id,
-					type: RewardType.REFEREE
-				}
-			});
-		});
-	});
-
-	it('should open reward state modal for referral', async () => {
-		const customMockedReward: RewardInfo = { ...mockedReward, name: [RewardType.REFERRAL] };
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward, customMockedReward]],
-			last_snapshot_timestamp: [lastTimestamp],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
-
-		render(RewardGuard);
-
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: { reward: mockRewardCampaign, rewardType: RewardType.REFERRAL },
-				type: 'reward-state'
-			});
-
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_REWARD_CAMPAIGN_WIN,
-				metadata: {
-					campaignId: mockRewardCampaign.id,
-					type: RewardType.REFERRAL
-				}
-			});
-		});
-	});
-
-	it('should open reward state modal for normal airdrop', async () => {
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward]],
-			last_snapshot_timestamp: [lastTimestamp],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
-
-		render(RewardGuard);
-
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: { reward: mockRewardCampaign, rewardType: RewardType.AIRDROP },
-				type: 'reward-state'
-			});
-
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_REWARD_CAMPAIGN_WIN,
-				metadata: {
-					campaignId: mockRewardCampaign.id,
-					type: RewardType.AIRDROP
-				}
-			});
-		});
-	});
-
-	it('should open welcome modal', async () => {
-		const expectedRewardCampaign: RewardCampaignDescription | undefined = mockRewardCampaigns.find(
-			({ id }) => id === SPRINKLES_SEASON_1_EPISODE_4_ID
-		);
-
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [],
-			last_snapshot_timestamp: [0n],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
-
-		render(RewardGuard);
-
-		await waitFor(() => {
-			expect(get(modalStore)).toEqual({
-				id: get(modalStore)?.id,
-				data: {
-					reward: { ...expectedRewardCampaign, startDate: new Date('2025-02-05T14:28:02.288Z') }
-				},
-				type: 'welcome'
-			});
-
-			expect(trackEvent).toHaveBeenNthCalledWith(1, {
-				name: TRACK_WELCOME_OPEN,
-				metadata: {
-					campaignId: SPRINKLES_SEASON_1_EPISODE_4_ID
-				}
-			});
-		});
-	});
-
-	it('should not open welcome modal if another modal is already opened', async () => {
-		const mockedUserData: UserData = {
-			is_vip: [false],
-			superpowers: [],
-			airdrops: [],
-			usage_awards: [[mockedReward]],
-			last_snapshot_timestamp: [0n],
-			sprinkles: []
-		};
-		vi.spyOn(rewardApi, 'getUserInfo').mockResolvedValue(mockedUserData);
-
-		render(RewardGuard);
-
-		await waitFor(() => {
-			expect(get(modalStore)).not.toEqual({
-				id: get(modalStore)?.id,
-				type: 'welcome'
+			await waitFor(() => {
+				expect(get(modalStore)).not.toEqual({
+					id: get(modalStore)?.id,
+					type: 'welcome'
+				});
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

We simplify a bit the logic of `RewardGuard` to be faster. And we re-organize the tests to split them.
