### PR TITLE
fix(frontend): Make balance for fee reactive

### DIFF
--- a/src/frontend/src/lib/components/send/SendFeeInfo.svelte
+++ b/src/frontend/src/lib/components/send/SendFeeInfo.svelte
@@ -18,13 +18,14 @@
 		feeTokenId?: OptionTokenId;
 		feeSymbol?: OptionString;
 	}
+
 	let { decimals, feeSymbol, feeTokenId }: Props = $props();
 
 	const { sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const balanceForFee = nonNullish(feeTokenId)
+	let balanceForFee = $derived(nonNullish(feeTokenId)
 		? ($balancesStore?.[feeTokenId]?.data ?? ZERO)
-		: ZERO;
+		: ZERO);
 </script>
 
 {#if nonNullish(feeSymbol) && $sendTokenSymbol !== feeSymbol}

--- a/src/frontend/src/lib/components/send/SendFeeInfo.svelte
+++ b/src/frontend/src/lib/components/send/SendFeeInfo.svelte
@@ -23,9 +23,9 @@
 
 	const { sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	let balanceForFee = $derived(nonNullish(feeTokenId)
-		? ($balancesStore?.[feeTokenId]?.data ?? ZERO)
-		: ZERO);
+	let balanceForFee = $derived(
+		nonNullish(feeTokenId) ? ($balancesStore?.[feeTokenId]?.data ?? ZERO) : ZERO
+	);
 </script>
 
 {#if nonNullish(feeSymbol) && $sendTokenSymbol !== feeSymbol}


### PR DESCRIPTION
# Motivation

The balance exposed during the fee payment was not reactive.

### Before

<img width="636" height="740" alt="Screenshot 2025-10-06 at 15 26 38" src="https://github.com/user-attachments/assets/c48c28ec-bf37-425c-a9ad-6e23d764a399" />

### After

<img width="621" height="742" alt="Screenshot 2025-10-06 at 15 33 09" src="https://github.com/user-attachments/assets/f6901b51-6cde-4ec4-8282-968b3f60511f" />

