### PR TITLE
feat(frontend): add icrc custom tokens initialization status stores

### DIFF
--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -169,3 +169,13 @@ export const allKnownIcrcTokensLedgerCanisterIds: Readable<LedgerCanisterIdText[
 		];
 	}
 );
+
+export const icrcCustomTokensInitialized: Readable<boolean> = derived(
+	[icrcCustomTokensStore],
+	([$icrcCustomTokensStore]) => $icrcCustomTokensStore !== undefined
+);
+
+export const icrcCustomTokensNotInitialized: Readable<boolean> = derived(
+	[icrcCustomTokensInitialized],
+	([$icrcCustomTokensInitialized]) => !$icrcCustomTokensInitialized
+);


### PR DESCRIPTION
# Motivation

Similar to other networks, we need to add new icrc custom tokens derived stores - `icrcCustomTokensInitialized` and `icrcCustomTokensNotInitialized`. They will be used on the GLDT staking page.
