### PR TITLE
refactor(frontend): Move WalletConnect method inside `EthWalletConnectMessage`

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -20,6 +20,8 @@
 
 	let { request }: Props = $props();
 
+	let method = $derived(request.params.request.method);
+
 	let json = $derived.by(() => {
 		try {
 			return getSignParamsMessageTypedDataV4(request.params.request.params);
@@ -97,6 +99,9 @@
 		}
 	});
 </script>
+
+<p class="mb-0 font-bold">{$i18n.wallet_connect.text.method}:</p>
+<p class="mb-4 font-normal">{method}</p>
 
 {#if nonNullish(token)}
 	<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.token}:</p>

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -100,7 +100,7 @@
 	});
 </script>
 
-<p class="mb-0 font-bold">{$i18n.wallet_connect.text.method}:</p>
+<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.method}:</p>
 <p class="mb-4 font-normal">{method}</p>
 
 {#if nonNullish(token)}

--- a/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/WalletConnectSignReview.svelte
@@ -3,7 +3,6 @@
 	import EthWalletConnectMessage from '$eth/components/wallet-connect/EthWalletConnectMessage.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
-	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
 		request: WalletKitTypes.SessionRequest;
@@ -15,11 +14,6 @@
 </script>
 
 <ContentWithToolbar>
-	<p class="mb-0 font-bold">{$i18n.wallet_connect.text.method}:</p>
-	<p class="mb-4 font-normal">
-		{request.params.request.method}
-	</p>
-
 	<EthWalletConnectMessage {request} />
 
 	{#snippet toolbar()}

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -77,6 +77,18 @@ describe('EthWalletConnectMessage', () => {
 		expect(getByText('{ ... }')).toBeInTheDocument();
 	});
 
+	it('should render the method', () => {
+		const { getByText } = render(EthWalletConnectMessage, {
+			props: {
+				request
+			}
+		});
+
+		expect(getByText(`${en.wallet_connect.text.method}:`)).toBeInTheDocument();
+
+		expect(getByText(SESSION_REQUEST_ETH_SIGN_V4)).toBeInTheDocument();
+	});
+
 	it('should render the token if it is enabled', () => {
 		const { getByText } = render(EthWalletConnectMessage, {
 			props: {
@@ -163,6 +175,7 @@ describe('EthWalletConnectMessage', () => {
 
 	it('should handle an empty token in the message', () => {
 		const newRequest: WalletKitTypes.SessionRequest = {
+			...request,
 			params: {
 				request: {
 					method: SESSION_REQUEST_ETH_SIGN_V4,
@@ -232,6 +245,7 @@ describe('EthWalletConnectMessage', () => {
 
 	it('should handle missing details in the message', () => {
 		const newRequest: WalletKitTypes.SessionRequest = {
+			...request,
 			params: {
 				request: {
 					method: SESSION_REQUEST_ETH_SIGN_V4,
@@ -278,6 +292,7 @@ describe('EthWalletConnectMessage', () => {
 
 	it('should handle empty details in the message', () => {
 		const newRequest: WalletKitTypes.SessionRequest = {
+			...request,
 			params: {
 				request: {
 					method: SESSION_REQUEST_ETH_SIGN_V4,


### PR DESCRIPTION
# Motivation

To keep everything in one place, we move the method of WalletConnect inside the component `EthWalletConnectMessage`.