### PR TITLE
feat(frontend): Add domain name in WalletConnect modal for Ethereum

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
@@ -4,6 +4,7 @@
 	import WalletConnectSignReview from '$eth/components/wallet-connect/WalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$eth/constants/steps.constants';
 	import { signMessage } from '$eth/services/wallet-connect.services';
+	import { getSignParamsMessageTypedDataV4 } from '$eth/utils/wallet-connect.utils';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import WalletConnectModalTitle from '$lib/components/wallet-connect/WalletConnectModalTitle.svelte';
 	import { ProgressStepsSign } from '$lib/enums/progress-steps';
@@ -11,10 +12,16 @@
 	import { reject as rejectServices } from '$lib/services/wallet-connect.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import type { OptionString } from '$lib/types/string';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
 
 	export let listener: OptionWalletConnectListener;
 	export let request: WalletKitTypes.SessionRequest;
+
+	let domainName: OptionString;
+	$: ({
+		domain: { name: domainName }
+	} = getSignParamsMessageTypedDataV4(request.params.request.params));
 
 	/**
 	 * Modal
@@ -66,7 +73,9 @@
 
 <WizardModal bind:this={modal} onClose={reject} {steps} bind:currentStep>
 	{#snippet title()}
-		<WalletConnectModalTitle>{$i18n.wallet_connect.text.sign_message}</WalletConnectModalTitle>
+		<WalletConnectModalTitle
+			>{domainName ?? $i18n.wallet_connect.text.sign_message}</WalletConnectModalTitle
+		>
 	{/snippet}
 
 	{#if currentStep?.name === WizardStepsSign.SIGNING}


### PR DESCRIPTION
# Motivation

We want to include the Ethereum domain name in the WalletConnect sign modal.

<img width="616" height="741" alt="Screenshot 2025-10-07 at 09 47 58" src="https://github.com/user-attachments/assets/96687861-d16b-421d-a39b-874acf06061c" />

