### PR TITLE
feat(frontend): added new swap icrc tokens store

### DIFF
--- a/src/frontend/src/lib/stores/swap-icrc-tokens.store.ts
+++ b/src/frontend/src/lib/stores/swap-icrc-tokens.store.ts
@@ -1,0 +1,26 @@
+import type { IcToken } from '$icp/types/ic-token';
+import { writable, type Readable } from 'svelte/store';
+
+export type SwappableToken = IcToken & {
+	isIcrc2: boolean;
+};
+
+export type SwappableTokensStoreData = SwappableToken[];
+
+export interface SwappableTokensStore extends Readable<SwappableTokensStoreData> {
+	setSwappableTokens: (data: SwappableTokensStoreData) => void;
+}
+
+const initSwappableIcrcTokensStore = (): SwappableTokensStore => {
+	const { subscribe, set } = writable<SwappableTokensStoreData>(undefined);
+
+	return {
+		subscribe,
+
+		setSwappableTokens: (data: SwappableTokensStoreData) => {
+			set(data);
+		}
+	};
+};
+
+export const swappableIcrcTokensStore = initSwappableIcrcTokensStore();

--- a/src/frontend/src/tests/lib/stores/swap-icrc-tokens.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap-icrc-tokens.store.spec.ts
@@ -1,0 +1,51 @@
+import { ICP_TOKEN, TESTICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import {
+	swappableIcrcTokensStore,
+	type SwappableToken,
+	type SwappableTokensStore
+} from '$lib/stores/swap-icrc-tokens.store';
+import { get } from 'svelte/store';
+
+describe('swappable-icrc-tokens.store', () => {
+	describe('initSwappableIcrcTokensStore', () => {
+		let mockStore: SwappableTokensStore;
+
+		beforeEach(() => {
+			mockStore = swappableIcrcTokensStore;
+		});
+
+		describe('setSwappableTokens', () => {
+			it('should set tokens when store is empty', () => {
+				const tokens: SwappableToken[] = [
+					{ ...ICP_TOKEN, isIcrc2: true },
+					{ ...TESTICP_TOKEN, isIcrc2: false }
+				];
+
+				mockStore.setSwappableTokens(tokens);
+
+				expect(get(mockStore)).toEqual(tokens);
+			});
+
+			it('should replace existing tokens with new ones', () => {
+				const initialTokens: SwappableToken[] = [{ ...ICP_TOKEN, isIcrc2: true }];
+
+				mockStore.setSwappableTokens(initialTokens);
+
+				const newTokens: SwappableToken[] = [{ ...TESTICP_TOKEN, isIcrc2: false }];
+
+				mockStore.setSwappableTokens(newTokens);
+
+				expect(get(mockStore)).toEqual(newTokens);
+			});
+
+			it('should set an empty array', () => {
+				const tokens: SwappableToken[] = [{ ...TESTICP_TOKEN, isIcrc2: false }];
+
+				mockStore.setSwappableTokens(tokens);
+				mockStore.setSwappableTokens([]);
+
+				expect(get(mockStore)).toEqual([]);
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We need to remove the dependency on KongSwap tokens and use allIcrcTokens as a fallback, but with an additional property isIcrc2, derived from icrc1_supportedStandard.
The scope of this PR includes creating a new store that will contain all of these tokens with the added property.

# Changes

Created a new swap-icrc-tokens.store.

# Tests

Added test coverage for the new store.
