### PR TITLE
fix(frontend): Correct balance in WalletConnect ETH send modal

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
@@ -12,7 +12,7 @@
 	import WalletConnectData from '$lib/components/wallet-connect/WalletConnectData.svelte';
 	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { ethAddress } from '$lib/derived/address.derived';
-	import { balance } from '$lib/derived/balances.derived';
+	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Network } from '$lib/types/network';
@@ -44,13 +44,15 @@
 		erc20Approve && nonNullish(data) ? decodeErc20AbiDataValue({ data }) : amount
 	);
 
-	const { sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendToken, sendTokenId } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let balance = $derived($balancesStore?.[$sendTokenId]?.data);
 </script>
 
 <ContentWithToolbar>
 	<SendData
 		amount={formatToken({ value: amountDisplay })}
-		balance={$balance}
+		{balance}
 		{destination}
 		source={$ethAddress ?? ''}
 		token={$sendToken}


### PR DESCRIPTION
# Motivation

We want to show the correct balance in the WalletConnect ETH send modal: right now was taking a derived store that uses the page token. However, typically, it is not defined for WalletConnect interactions.


### Before


### After

<img width="604" height="752" alt="Screenshot 2025-10-07 at 10 06 58" src="https://github.com/user-attachments/assets/efbe82c1-a6c7-43cf-b5d3-8cd1a7e0f4a9" />
