### PR TITLE
feat(frontend): Use `transferChecked` for all Token-2022 SPL

### DIFF
--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -4,6 +4,7 @@ import type { OptionSolAddress, SolAddress } from '$lib/types/address';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Token } from '$lib/types/token';
 import { loadTokenAccount } from '$sol/api/solana.api';
+import { TOKEN_2022_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import { solanaHttpRpc, solanaWebSocketRpc } from '$sol/providers/sol-rpc.providers';
 import { signTransaction } from '$sol/services/sol-sign.services';
 import {
@@ -208,7 +209,15 @@ const createSplTokenTransactionMessage = async ({
 
 	const config = { programAddress: solAddress(tokenOwnerAddress) };
 
-	const transferInstruction = nonNullish(tokenMintAuthority)
+	// Theoretically, transferChecked is available for Token program address too, not only Token 2022 program address.
+	// It is indeed safer, and we should use it whenever possible.
+	// However, some wallets do not support it yet and the transaction will be rejected.
+	// So we use it only when we are sure the token is a Token 2022 one,
+	// or if it has a mint authority (which is not the case of locked tokens).
+	const useCheckedTransfer =
+		nonNullish(tokenMintAuthority) || tokenOwnerAddress === TOKEN_2022_PROGRAM_ADDRESS;
+
+	const transferInstruction = useCheckedTransfer
 		? getTransferCheckedInstruction(
 				{
 					...transferParams,
@@ -217,7 +226,7 @@ const createSplTokenTransactionMessage = async ({
 				},
 				config
 			)
-		: getTransferInstruction(transferParams, { programAddress: solAddress(tokenOwnerAddress) });
+		: getTransferInstruction(transferParams, config);
 
 	return pipe(await createDefaultTransaction({ rpc, feePayer: signer }), (tx) =>
 		appendTransactionMessageInstructions(

--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -215,7 +215,7 @@ const createSplTokenTransactionMessage = async ({
 	// So we use it only when we are sure the token is a Token 2022 one,
 	// or if it has a mint authority (which is not the case of locked tokens).
 	const useCheckedTransfer =
-		nonNullish(tokenMintAuthority) || tokenOwnerAddress === TOKEN_2022_PROGRAM_ADDRESS;
+		tokenOwnerAddress === TOKEN_2022_PROGRAM_ADDRESS || nonNullish(tokenMintAuthority);
 
 	const transferInstruction = useCheckedTransfer
 		? getTransferCheckedInstruction(

--- a/src/frontend/src/sol/services/sol-send.services.ts
+++ b/src/frontend/src/sol/services/sol-send.services.ts
@@ -209,7 +209,7 @@ const createSplTokenTransactionMessage = async ({
 
 	const config = { programAddress: solAddress(tokenOwnerAddress) };
 
-	// Theoretically, transferChecked is available for Token program address too, not only Token 2022 program address.
+	// Theoretically, `transferChecked` is available for Token program address too, not only Token 2022 program address.
 	// It is indeed safer, and we should use it whenever possible.
 	// However, some wallets do not support it yet and the transaction will be rejected.
 	// So we use it only when we are sure the token is a Token 2022 one,

--- a/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-send.services.spec.ts
@@ -4,6 +4,7 @@ import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { signWithSchnorr } from '$lib/api/signer.api';
 import type { SolAddress } from '$lib/types/address';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { TOKEN_2022_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import { solanaHttpRpc, solanaWebSocketRpc } from '$sol/providers/sol-rpc.providers';
 import { sendSol } from '$sol/services/sol-send.services';
 import * as accountServices from '$sol/services/spl-accounts.services';
@@ -258,6 +259,34 @@ describe('sol-send.services', () => {
 					amount: mockAmount
 				},
 				{ programAddress: DEVNET_USDC_TOKEN.owner }
+			);
+		});
+
+		it('should send Token-2022 SPL tokens successfully', async () => {
+			await expect(
+				sendSol({
+					...mockParams,
+					token: { ...DEVNET_USDC_TOKEN, owner: TOKEN_2022_PROGRAM_ADDRESS } as SplToken
+				})
+			).resolves.not.toThrow();
+
+			expect(spyMapNetworkIdToNetwork).toHaveBeenCalledWith(DEVNET_USDC_TOKEN.network.id);
+
+			expect(pipe).toHaveBeenCalledTimes(4);
+			expect(appendTransactionMessageInstructions).toHaveBeenCalledExactlyOnceWith(
+				['mock-transfer-checked-instruction'],
+				mockTx
+			);
+			expect(getTransferCheckedInstruction).toHaveBeenCalledWith(
+				{
+					source: mockAtaAddress,
+					destination: mockAtaAddress2,
+					mint: DEVNET_USDC_TOKEN.address,
+					decimals: DEVNET_USDC_TOKEN.decimals,
+					authority: mockSigner,
+					amount: mockAmount
+				},
+				{ programAddress: TOKEN_2022_PROGRAM_ADDRESS }
 			);
 		});
 


### PR DESCRIPTION
# Motivation

It is actually safer to use `transferChecked` for all Token-2022 programs in Solana.
