### PR TITLE
fix(frontend): Do not show expired toast for locked state

### DIFF
--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -116,7 +116,8 @@
 			"preview": "معاينة $oisy_name بمجرد تسجيل الدخول، على سطح المكتب والجوال"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "أنت غير مسجل الدخول. يرجى تسجيل الدخول للمتابعة.",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -116,7 +116,8 @@
 			"preview": "Náhled $oisy_name po přihlášení, na počítači i mobilu"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Nejste přihlášeni. Pro pokračování se prosím přihlaste.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -116,7 +116,8 @@
 			"preview": "Vorschau von $oisy_name nach Anmeldung, sowohl auf Desktop als auch mobil"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Du bist nicht angemeldet. Bitte melde Dich an, um fortzufahren.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -116,7 +116,8 @@
 			"preview": "Preview of $oisy_name once signed in, both on desktop and mobile"
 		},
 		"message": {
-			"refreshed_authentication": "This page was refreshed to reflect the login done in another tab."
+			"refreshed_authentication": "This page was refreshed to reflect the login done in another tab.",
+			"session_locked": "Your session was locked in another tab."
 		},
 		"warning": {
 			"not_signed_in": "You are not signed in. Please sign in to continue.",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -116,7 +116,8 @@
 			"preview": "Aperçu de $oisy_name une fois connecté, sur ordinateur et mobile"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Vous n'êtes pas connecté. Veuillez vous connecter pour continuer.",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -116,7 +116,8 @@
 			"preview": "साइन इन करने के बाद $oisy_name का पूर्वावलोकन, डेस्कटॉप और मोबाइल दोनों पर"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "आपने साइन इन नहीं किया है। कृपया जारी रखने के लिए साइन इन करें।",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -116,7 +116,8 @@
 			"preview": "Anteprima di $oisy_name una volta effettuato l'accesso, sia su desktop che su mobile"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Non sei connesso. Effettua il login per continuare.",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -116,7 +116,8 @@
 			"preview": "ログイン後の $oisy_name（PC・モバイル）プレビュー"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "サインインしていません。続行するにはサインインしてください。",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -116,7 +116,8 @@
 			"preview": "Podgląd $oisy_name po zalogowaniu, zarówno na komputerze stacjonarnym, jak i telefonie"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Nie jesteś zalogowany. Zaloguj się, aby kontynuować.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -116,7 +116,8 @@
 			"preview": "Pré-visualização de $oisy_name após o login, tanto no desktop quanto no celular"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Você não está logado. Por favor, faça login para continuar.",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -116,7 +116,8 @@
 			"preview": "Предварительный просмотр $oisy_name после входа в систему, как на настольном компьютере, так и на мобильном устройстве"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Вы не вошли в систему. Пожалуйста, войдите, чтобы продолжить.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -116,7 +116,8 @@
 			"preview": "Xem trước $oisy_name sau khi đăng nhập, cả trên máy tính và thiết bị di động"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "Bạn chưa đăng nhập. Vui lòng đăng nhập để tiếp tục.",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -116,7 +116,8 @@
 			"preview": "$oisy_name 登录后的桌面和移动端预览图"
 		},
 		"message": {
-			"refreshed_authentication": ""
+			"refreshed_authentication": "",
+			"session_locked": ""
 		},
 		"warning": {
 			"not_signed_in": "您尚未登录。请登录以继续。",

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -37,12 +37,14 @@ import { trackEvent } from '$lib/services/analytics.services';
 import { authStore, type AuthSignInParams } from '$lib/stores/auth.store';
 import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
+import { AUTH_LOCK_KEY } from '$lib/stores/locked.store';
 import { toastsClean, toastsError, toastsShow } from '$lib/stores/toasts.store';
 import { AuthClientNotInitializedError } from '$lib/types/errors';
 import type { ToastMsg } from '$lib/types/toast';
 import { emit } from '$lib/utils/events.utils';
 import { gotoReplaceRoot } from '$lib/utils/nav.utils';
 import { replaceHistory } from '$lib/utils/route.utils';
+import { get as getStorage } from '$lib/utils/storage.utils';
 import { randomWait } from '$lib/utils/time.utils';
 import type { ToastLevel } from '@dfinity/gix-components';
 import type { Principal } from '@dfinity/principal';
@@ -148,15 +150,25 @@ export const nullishSignOut = (): Promise<void> =>
 	warnSignOut(get(i18n).auth.warning.not_signed_in);
 
 export const idleSignOut = (): Promise<void> => {
-	const text = get(i18n).auth.warning.session_expired;
+	const locked = getStorage({ key: AUTH_LOCK_KEY });
+
+	const level: ToastLevel = locked ? 'info' : 'warn';
+
+	const text = locked
+		? get(i18n).auth.message.session_locked
+		: get(i18n).auth.warning.session_expired;
+
+	const reason = locked ? 'session_locked' : 'session_expired';
+
 	trackEvent({
 		name: TRACK_SIGN_OUT_WITH_WARNING,
-		metadata: { level: 'warn', text, reason: 'session_expired', clearStorages: 'false' }
+		metadata: { level, text, reason, clearStorages: 'false' }
 	});
+
 	return logout({
 		msg: {
-			text: get(i18n).auth.warning.session_expired,
-			level: 'warn'
+			text,
+			level
 		},
 		clearCurrentPrincipalStorages: false
 	});

--- a/src/frontend/src/lib/stores/locked.store.ts
+++ b/src/frontend/src/lib/stores/locked.store.ts
@@ -16,8 +16,10 @@ export interface AuthLockStore extends ReturnType<typeof initStorageStore<boolea
 	unlock: (options?: ToggleLockOptions) => void;
 }
 
+export const AUTH_LOCK_KEY = 'authLocked';
+
 const createAuthLockStore = (): AuthLockStore => {
-	const store = initStorageStore<boolean>({ key: 'authLocked', defaultValue: false });
+	const store = initStorageStore<boolean>({ key: AUTH_LOCK_KEY, defaultValue: false });
 
 	const updateLock = ({
 		newValue,

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -110,7 +110,7 @@ interface I18nAuth {
 		advanced_cryptography: string;
 	};
 	alt: { preview: string };
-	message: { refreshed_authentication: string };
+	message: { refreshed_authentication: string; session_locked: string };
 	warning: { not_signed_in: string; session_expired: string; reload_and_retry: string };
 	error: {
 		no_internet_identity: string;

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -1,13 +1,21 @@
 import { walletConnectPaired } from '$eth/stores/wallet-connect.store';
-import { signOut } from '$lib/services/auth.services';
+import {
+	TRACK_SIGN_OUT_SUCCESS,
+	TRACK_SIGN_OUT_WITH_WARNING
+} from '$lib/constants/analytics.contants';
+import { trackEvent } from '$lib/services/analytics.services';
+import { idleSignOut, signOut } from '$lib/services/auth.services';
 import { authStore } from '$lib/stores/auth.store';
+import { AUTH_LOCK_KEY } from '$lib/stores/locked.store';
 import * as eventsUtils from '$lib/utils/events.utils';
 import { emit } from '$lib/utils/events.utils';
 import { delMultiKeysByPrincipal } from '$lib/utils/idb.utils';
 import * as timeUtils from '$lib/utils/time.utils';
 import { randomWait } from '$lib/utils/time.utils';
+import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import * as idbKeyval from 'idb-keyval';
+import type { MockInstance } from 'vitest';
 
 vi.mock('$lib/utils/idb.utils', () => ({
 	delMultiKeysByPrincipal: vi.fn()
@@ -15,6 +23,10 @@ vi.mock('$lib/utils/idb.utils', () => ({
 
 vi.mock('$lib/utils/time.utils', () => ({
 	randomWait: vi.fn()
+}));
+
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: vi.fn()
 }));
 
 const rootLocation = 'https://oisy.com/';
@@ -31,29 +43,41 @@ const mockLocation = (url: string) => {
 };
 
 describe('auth.services', () => {
+	let signOutSpy: MockInstance;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		signOutSpy = vi.spyOn(authStore, 'signOut');
+
+		vi.spyOn(eventsUtils, 'emit');
+
+		vi.spyOn(timeUtils, 'randomWait').mockImplementation(vi.fn());
+
+		vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+		mockLocation(rootLocation);
+
+		localStorage.clear();
+	});
+
+	describe('signIn', () => {});
+
 	describe('signOut', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();
-
-			vi.spyOn(eventsUtils, 'emit');
-
-			vi.spyOn(timeUtils, 'randomWait').mockImplementation(vi.fn());
 		});
 
 		it('should call the signOut function of the authStore without resetting the url', async () => {
-			const signOutSpy = vi.spyOn(authStore, 'signOut');
-
 			mockLocation(activityLocation);
 
 			await signOut({});
 
-			expect(signOutSpy).toHaveBeenCalled();
+			expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
 			expect(window.location.href).toEqual(activityLocation);
 		});
 
 		it('should call the signOut function of the authStore and resetting the url', async () => {
-			const signOutSpy = vi.spyOn(authStore, 'signOut');
-
 			vi.mock('$lib/utils/nav.utils', () => ({
 				gotoReplaceRoot: () => mockLocation(rootLocation)
 			}));
@@ -64,20 +88,18 @@ describe('auth.services', () => {
 
 			await signOut({ resetUrl: true });
 
-			expect(signOutSpy).toHaveBeenCalled();
+			expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
 			expect(window.location.href).toEqual(rootLocation);
 		});
 
 		it('should call the signOut function of the authStore and clear the session storage', async () => {
-			const signOutSpy = vi.spyOn(authStore, 'signOut');
-
 			sessionStorage.setItem('key', 'value');
 
 			expect(sessionStorage.getItem('key')).toEqual('value');
 
 			await signOut({});
 
-			expect(signOutSpy).toHaveBeenCalled();
+			expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
 			expect(sessionStorage.getItem('key')).toBeNull();
 		});
 
@@ -104,13 +126,11 @@ describe('auth.services', () => {
 		});
 
 		it("should disconnect WalletConnect's session", async () => {
-			const signOutSpy = vi.spyOn(authStore, 'signOut');
-
 			await signOut({});
 
 			expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
 
-			expect(signOutSpy).toHaveBeenCalled();
+			expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
 		});
 
 		it("should wait for WalletConnect's session to be disconnected", async () => {
@@ -151,6 +171,286 @@ describe('auth.services', () => {
 
 			Array.from({ length: maxSeconds }).forEach((_, i) => {
 				expect(randomWait).toHaveBeenNthCalledWith(i + 1, { min: 1000, max: 1000 });
+			});
+		});
+
+		it('should track the sign out event', async () => {
+			await signOut({});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_SIGN_OUT_SUCCESS,
+				metadata: {
+					reason: 'user',
+					level: '',
+					text: '',
+					source: '',
+					resetUrl: 'false',
+					clearStorages: 'true'
+				}
+			});
+		});
+
+		it('should not append a message to the reload URL', async () => {
+			await signOut({});
+
+			expect(window.history.replaceState).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('idleSignOut', () => {
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		describe('when the session is not locked', () => {
+			const expectedText = en.auth.warning.session_expired;
+
+			beforeEach(() => {
+				localStorage.setItem(AUTH_LOCK_KEY, 'false');
+			});
+
+			it('should call the signOut function of the authStore without resetting the url', async () => {
+				mockLocation(activityLocation);
+
+				expect(window.location.href).toEqual(activityLocation);
+
+				await idleSignOut();
+
+				expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
+				expect(window.location.href).toEqual(activityLocation);
+			});
+
+			it('should call the signOut function of the authStore and clear the session storage', async () => {
+				const signOutSpy = vi.spyOn(authStore, 'signOut');
+
+				sessionStorage.setItem('key', 'value');
+
+				expect(sessionStorage.getItem('key')).toEqual('value');
+
+				await idleSignOut();
+
+				expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
+				expect(sessionStorage.getItem('key')).toBeNull();
+			});
+
+			it('should not clean the IDB storage for the current principal', async () => {
+				vi.spyOn(authStore, 'subscribe').mockImplementation((fn) => {
+					fn({ identity: mockIdentity });
+					return () => {};
+				});
+
+				await idleSignOut();
+
+				expect(idbKeyval.del).not.toHaveBeenCalled();
+
+				expect(delMultiKeysByPrincipal).not.toHaveBeenCalled();
+			});
+
+			it('should not clean the IDB storage for all principals', async () => {
+				await idleSignOut();
+
+				expect(idbKeyval.clear).not.toHaveBeenCalled();
+			});
+
+			it("should disconnect WalletConnect's session", async () => {
+				const signOutSpy = vi.spyOn(authStore, 'signOut');
+
+				await idleSignOut();
+
+				expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
+
+				expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
+			});
+
+			it("should wait for WalletConnect's session to be disconnected", async () => {
+				const maxSeconds = 10;
+
+				walletConnectPaired.set(true);
+
+				let i = 0;
+				vi.spyOn(timeUtils, 'randomWait').mockImplementation(async () => {
+					i++;
+					if (i >= maxSeconds / 2) {
+						walletConnectPaired.set(false);
+					}
+					await Promise.resolve();
+				});
+
+				await idleSignOut();
+
+				expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
+
+				expect(randomWait).toHaveBeenCalledTimes(maxSeconds / 2);
+
+				Array.from({ length: maxSeconds / 2 }).forEach((_, i) => {
+					expect(randomWait).toHaveBeenNthCalledWith(i + 1, { min: 1000, max: 1000 });
+				});
+			});
+
+			it("should wait for WalletConnect's session to be disconnected for a maximum 10 seconds", async () => {
+				const maxSeconds = 10;
+
+				walletConnectPaired.set(true);
+
+				await idleSignOut();
+
+				expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
+
+				expect(randomWait).toHaveBeenCalledTimes(maxSeconds);
+
+				Array.from({ length: maxSeconds }).forEach((_, i) => {
+					expect(randomWait).toHaveBeenNthCalledWith(i + 1, { min: 1000, max: 1000 });
+				});
+			});
+
+			it('should track the sign out event', async () => {
+				await idleSignOut();
+
+				expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+					name: TRACK_SIGN_OUT_WITH_WARNING,
+					metadata: {
+						reason: 'session_expired',
+						level: 'warn',
+						text: expectedText,
+						clearStorages: 'false'
+					}
+				});
+			});
+
+			it('should append a message to the reload URL', async () => {
+				await idleSignOut();
+
+				expect(window.history.replaceState).toHaveBeenCalledExactlyOnceWith(
+					{},
+					'',
+					new URL(`${rootLocation}?msg=${encodeURI(encodeURI(expectedText))}&level=warn`)
+				);
+			});
+		});
+
+		describe('when the session is locked', () => {
+			const expectedText = en.auth.message.session_locked;
+
+			beforeEach(() => {
+				localStorage.setItem(AUTH_LOCK_KEY, 'true');
+			});
+
+			it('should call the signOut function of the authStore without resetting the url', async () => {
+				mockLocation(activityLocation);
+
+				expect(window.location.href).toEqual(activityLocation);
+
+				await idleSignOut();
+
+				expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
+				expect(window.location.href).toEqual(activityLocation);
+			});
+
+			it('should call the signOut function of the authStore and clear the session storage', async () => {
+				const signOutSpy = vi.spyOn(authStore, 'signOut');
+
+				sessionStorage.setItem('key', 'value');
+
+				expect(sessionStorage.getItem('key')).toEqual('value');
+
+				await idleSignOut();
+
+				expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
+				expect(sessionStorage.getItem('key')).toBeNull();
+			});
+
+			it('should clean the IDB storage for the current principal', async () => {
+				vi.spyOn(authStore, 'subscribe').mockImplementation((fn) => {
+					fn({ identity: mockIdentity });
+					return () => {};
+				});
+
+				await idleSignOut();
+
+				expect(idbKeyval.del).not.toHaveBeenCalled();
+
+				expect(delMultiKeysByPrincipal).not.toHaveBeenCalled();
+			});
+
+			it('should not clean the IDB storage for all principals', async () => {
+				await idleSignOut();
+
+				expect(idbKeyval.clear).not.toHaveBeenCalled();
+			});
+
+			it("should disconnect WalletConnect's session", async () => {
+				const signOutSpy = vi.spyOn(authStore, 'signOut');
+
+				await idleSignOut();
+
+				expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
+
+				expect(signOutSpy).toHaveBeenCalledExactlyOnceWith();
+			});
+
+			it("should wait for WalletConnect's session to be disconnected", async () => {
+				const maxSeconds = 10;
+
+				walletConnectPaired.set(true);
+
+				let i = 0;
+				vi.spyOn(timeUtils, 'randomWait').mockImplementation(async () => {
+					i++;
+					if (i >= maxSeconds / 2) {
+						walletConnectPaired.set(false);
+					}
+					await Promise.resolve();
+				});
+
+				await idleSignOut();
+
+				expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
+
+				expect(randomWait).toHaveBeenCalledTimes(maxSeconds / 2);
+
+				Array.from({ length: maxSeconds / 2 }).forEach((_, i) => {
+					expect(randomWait).toHaveBeenNthCalledWith(i + 1, { min: 1000, max: 1000 });
+				});
+			});
+
+			it("should wait for WalletConnect's session to be disconnected for a maximum 10 seconds", async () => {
+				const maxSeconds = 10;
+
+				walletConnectPaired.set(true);
+
+				await idleSignOut();
+
+				expect(emit).toHaveBeenCalledExactlyOnceWith({ message: 'oisyDisconnectWalletConnect' });
+
+				expect(randomWait).toHaveBeenCalledTimes(maxSeconds);
+
+				Array.from({ length: maxSeconds }).forEach((_, i) => {
+					expect(randomWait).toHaveBeenNthCalledWith(i + 1, { min: 1000, max: 1000 });
+				});
+			});
+
+			it('should track the sign out event', async () => {
+				await idleSignOut();
+
+				expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+					name: TRACK_SIGN_OUT_WITH_WARNING,
+					metadata: {
+						reason: 'session_locked',
+						level: 'info',
+						text: expectedText,
+						clearStorages: 'false'
+					}
+				});
+			});
+
+			it('should append a message to the reload URL', async () => {
+				await idleSignOut();
+
+				expect(window.history.replaceState).toHaveBeenCalledExactlyOnceWith(
+					{},
+					'',
+					new URL(`${rootLocation}?msg=${encodeURI(encodeURI(expectedText))}&level=info`)
+				);
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

If the user has more than one tab open with OISY, when it locks one, the other will reload the page BUT show a toast message for the expired session. And that is not correct.

The reason being that the worker for idle sign out does not differentiate between locked state and expired session.

# Changes

- Expose locked key for local storage.
- When calling the idle sign out, check first if locked or not, and appropriately return the correct message.

# Tests

Added some tests and a practical one:

### Before

https://github.com/user-attachments/assets/d095adfc-f74b-4196-a6ea-9e5d0f97fc9d

### After


https://github.com/user-attachments/assets/f6e28666-834f-4d18-a53a-bd89c1dd7f2b


