### PR TITLE
feat(frontend): Expand icon

### DIFF
--- a/src/frontend/src/lib/components/icons/IconExpand.svelte
+++ b/src/frontend/src/lib/components/icons/IconExpand.svelte
@@ -4,11 +4,17 @@
 	interface Props {
 		size?: string;
 		expanded?: boolean;
+		axis?: 'x' | 'y';
 	}
 
-	let { size = '20', expanded = false }: Props = $props();
+	let { size = '20', expanded = false, axis = 'x' }: Props = $props();
 </script>
 
-<span class="flex transition-transform duration-500" class:rotate-x-180={expanded}>
+<span
+	class="flex transition-transform duration-500"
+	class:rotate-x-180={expanded}
+	class:rotate-x-0={!expanded}
+	class:rotate-90={axis === 'y'}
+>
 	<IconExpandMore {size} />
 </span>


### PR DESCRIPTION
# Motivation

The current expand icon can be adjusted to be able to also display horizontal arrows.

# Changes

Adjusted classes and introduced axis prop.

Also added a new wrapper span to keep the transform origin local to that element.

Current usages are not affected by these changes.

# Tests

`axis="x" expanded={false}`
<img width="47" height="56" alt="image" src="https://github.com/user-attachments/assets/0f9370e2-1a79-4dba-a49e-6a0aa61fb398" />

`axis="x" expanded={true}`
<img width="47" height="56" alt="image" src="https://github.com/user-attachments/assets/112b9a85-28c0-49de-8c77-75436f0a2c67" />

`axis="y" expanded={false}`
<img width="47" height="56" alt="image" src="https://github.com/user-attachments/assets/3fd0bd32-00a4-44eb-aa9d-f387bf3e5f6a" />

`axis="y" expanded={true}`
<img width="47" height="56" alt="image" src="https://github.com/user-attachments/assets/2e3422c8-0ac1-4c78-9b70-ea9e027a89df" />
