### PR TITLE
refactor(frontend): Migrate WalletConnect sign modals to Svelte 5

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish } from '@dfinity/utils';
 	import type { WalletKitTypes } from '@reown/walletkit';
-	import { onMount } from 'svelte';
+	import { untrack } from 'svelte';
 	import {
 		SOLANA_DEVNET_TOKEN,
 		SOLANA_LOCAL_TOKEN,
@@ -21,8 +22,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionSolAddress } from '$lib/types/address';
-	import type { NetworkId } from '$lib/types/network';
-	import type { Token } from '$lib/types/token';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
 	import { isNetworkIdSOLDevnet, isNetworkIdSOLLocal } from '$lib/utils/network.utils';
 	import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
@@ -34,52 +33,56 @@
 	} from '$sol/services/wallet-connect.services';
 	import type { SolanaNetwork } from '$sol/types/network';
 
-	export let listener: OptionWalletConnectListener;
-	export let request: WalletKitTypes.SessionRequest;
-	export let network: SolanaNetwork;
+	interface Props {
+		listener: OptionWalletConnectListener;
+		request: WalletKitTypes.SessionRequest;
+		network: SolanaNetwork;
+	}
+
+	let { listener = $bindable(), request, network }: Props = $props();
 
 	/**
 	 * Transaction
 	 */
 
-	let networkId: NetworkId;
-	$: ({ id: networkId } = network);
+	let { id: networkId } = $derived(network);
 
-	let address: OptionSolAddress;
-	let token: Token;
-	$: [address, token] = isNetworkIdSOLDevnet(networkId)
-		? [$solAddressDevnet, SOLANA_DEVNET_TOKEN]
-		: isNetworkIdSOLLocal(networkId)
-			? [$solAddressLocal, SOLANA_LOCAL_TOKEN]
-			: [$solAddressMainnet, SOLANA_TOKEN];
+	let [address, token] = $derived(
+		isNetworkIdSOLDevnet(networkId)
+			? [$solAddressDevnet, SOLANA_DEVNET_TOKEN]
+			: isNetworkIdSOLLocal(networkId)
+				? [$solAddressLocal, SOLANA_LOCAL_TOKEN]
+				: [$solAddressMainnet, SOLANA_TOKEN]
+	);
 
-	let signWithSending = false;
-	let data: string;
-	let amount: bigint | undefined;
-	let destination: OptionSolAddress;
-	let application: string;
-
-	onMount(async () => {
-		const {
-			params: {
-				request: {
-					method,
-					params: { transaction }
-				}
-			},
-			verifyContext: {
-				verified: { origin }
+	let {
+		params: {
+			request: {
+				method,
+				params: { transaction: data }
 			}
-		} = request;
+		},
+		verifyContext: {
+			verified: { origin: application }
+		}
+	} = $derived(request);
 
-		signWithSending = method === SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION;
-		data = transaction;
-		application = origin;
+	let signWithSending = $derived(method === SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION);
 
+	let amount = $state<bigint | undefined>();
+	let destination = $state<OptionSolAddress>();
+
+	const updateData = async () => {
 		({ amount, destination } = await decodeService({
 			base64EncodedTransactionMessage: data,
 			networkId
 		}));
+	};
+
+	$effect(() => {
+		[data, networkId];
+
+		untrack(() => updateData());
 	});
 
 	/**
@@ -97,8 +100,8 @@
 		}
 	];
 
-	let currentStep: WizardStep<WizardStepsSign> | undefined;
-	let modal: WizardModal<WizardStepsSign>;
+	let currentStep = $state<WizardStep<WizardStepsSign> | undefined>();
+	let modal = $state<WizardModal<WizardStepsSign>>();
 
 	const close = () => modalStore.close();
 
@@ -106,7 +109,9 @@
 	 * WalletConnect
 	 */
 
-	let signProgressStep: string = ProgressStepsSign.INITIALIZATION;
+	let signProgressStep = $state<ProgressStepsSign | ProgressStepsSendSol.SEND>(
+		ProgressStepsSign.INITIALIZATION
+	);
 
 	/**
 	 * Reject a transaction
@@ -123,6 +128,10 @@
 	 */
 
 	const sign = async () => {
+		if (isNullish(modal)) {
+			return;
+		}
+
 		const { success } = await signService({
 			request,
 			listener,


### PR DESCRIPTION
# Motivation

Migrating `EthWalletConnectSignModal` and `SolWalletConnectSignModal`.
