### PR TITLE
feat(frontend): Show Nft description

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -14,6 +14,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store.js';
 	import type { Nft, NonFungibleToken } from '$lib/types/nft';
+	import ExpandText from '$lib/components/ui/ExpandText.svelte';
 
 	interface Props {
 		token?: NonFungibleToken;
@@ -95,6 +96,12 @@
 			<span class="block max-w-80">
 				<SkeletonText />
 			</span>
+		{/if}
+
+		{#if nonNullish(nft?.description)}
+			<div class="mb-5 text-sm">
+				<ExpandText text={nft.description} maxWords={20} />
+			</div>
 		{/if}
 
 		<NftMetadataList {nft} />

--- a/src/frontend/src/tests/lib/components/nfts/NftHero.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftHero.spec.ts
@@ -27,7 +27,7 @@ describe('NftHero', () => {
 	it('should render the nft data', () => {
 		const { getByText } = render(NftHero, {
 			props: {
-				nft: mockValidErc1155Nft
+				nft: { ...mockValidErc1155Nft, description: 'Test description about the NFT' }
 			}
 		});
 
@@ -38,6 +38,12 @@ describe('NftHero', () => {
 		);
 
 		expect(name).toBeInTheDocument();
+
+		const description: HTMLElement | null = getByText('Test description about the NFT');
+
+		assertNonNullish(description);
+
+		expect(description).toBeInTheDocument();
 
 		const standard: HTMLElement | null = getByText(mockNftollectionUi.collection.standard);
 


### PR DESCRIPTION
# Motivation
We want to display the nft description on the Nft page.

# Changes

Added description

# Tests

Extended test

<img width="619" height="273" alt="image" src="https://github.com/user-attachments/assets/b2f9e76c-09e4-4687-8ae4-446a80be7d1b" />
