### PR TITLE
style(frontend): Minimum width for PWA warning banner

### DIFF
--- a/src/frontend/src/lib/components/core/Banner.svelte
+++ b/src/frontend/src/lib/components/core/Banner.svelte
@@ -39,7 +39,7 @@
 <!-- TODO remove this WarningBanner again as soon a solution is found for enabling display type standalone  -->
 {#if isPWAStandalone() && pwaBannerVisible}
 	<div
-		class="fixed left-[50%] top-6 z-10 flex -translate-x-[50%] justify-between gap-4 rounded-lg bg-primary"
+		class="fixed left-[50%] top-6 z-10 flex min-w-80 -translate-x-[50%] justify-between gap-4 rounded-lg bg-primary"
 	>
 		<WarningBanner>
 			<span class="w-full px-2">{replaceOisyPlaceholders($i18n.core.warning.standalone_mode)}</span>


### PR DESCRIPTION
# Motivation

Increasing the minimum width of the warning banner for PWA (same as the Beta warning banner).

### Before

<img width="434" height="935" alt="Screenshot 2025-10-08 at 08 44 19" src="https://github.com/user-attachments/assets/86c52926-b6e7-4631-9fc6-763859660f8d" />

### After

<img width="434" height="935" alt="Screenshot 2025-10-08 at 08 44 42" src="https://github.com/user-attachments/assets/01413470-bb02-4fce-bf2c-e5fd73e2ebf0" />



