### PR TITLE
fix(build): Correct filter for Ethereum in manifest

### DIFF
--- a/src/frontend/static/manifest.webmanifest
+++ b/src/frontend/static/manifest.webmanifest
@@ -36,7 +36,7 @@
 	"shortcuts": [
 		{
 			"name": "Ethereum",
-			"url": "/",
+			"url": "/?network=ETH",
 			"icons": [{ "src": "/icons/eth.png", "type": "image/png", "sizes": "192x192" }]
 		},
 		{


### PR DESCRIPTION
# Motivation

A small correction in the manifest when we create short-links for Ethereum.
