### PR TITLE
feat(frontend): added manual loading if isIcrc2 token is Swap

### DIFF
--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -15,6 +15,8 @@
 		swapAmount: OptionAmount;
 		receiveAmount?: number;
 		slippageValue: OptionAmount;
+		isSourceTokenIcrc2?: boolean;
+
 		sourceTokenFee?: bigint;
 		isSwapAmountsLoading: boolean;
 		onShowTokensList: (tokenSource: 'source' | 'destination') => void;
@@ -26,6 +28,7 @@
 		swapAmount = $bindable(),
 		receiveAmount = $bindable(),
 		slippageValue = $bindable(),
+		isSourceTokenIcrc2,
 		sourceTokenFee,
 		isSwapAmountsLoading,
 		onShowTokensList,
@@ -33,12 +36,16 @@
 		onNext
 	}: Props = $props();
 
-	const { sourceToken, destinationToken, sourceTokenBalance, isSourceTokenIcrc2 } =
+	const { sourceToken, destinationToken, sourceTokenBalance } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	let errorType = $state<TokenActionErrorType | undefined>();
 
-	let totalFee = $derived((sourceTokenFee ?? ZERO) * ($isSourceTokenIcrc2 ? 2n : 1n));
+	let totalFee = $derived(
+		nonNullish(isSourceTokenIcrc2)
+			? (sourceTokenFee ?? ZERO) * (isSourceTokenIcrc2 ? 2n : 1n)
+			: undefined
+	);
 
 	const customValidate = (userAmount: bigint): TokenActionErrorType =>
 		nonNullish($sourceToken)
@@ -70,7 +77,7 @@
 
 			<div class="flex flex-col gap-3">
 				<SwapProvider showSelectButton {slippageValue} on:icShowProviderList />
-				<SwapFees />
+				<SwapFees {isSourceTokenIcrc2} />
 			</div>
 		{/if}
 	{/snippet}

--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -23,7 +23,7 @@
 		destinationToken?: Token;
 		slippageValue: OptionAmount;
 		children?: Snippet;
-		isSourceTokenIcrc2: boolean;
+		isSourceTokenIcrc2?: boolean;
 		isSwapAmountsLoading: boolean;
 		enableAmountUpdates?: boolean;
 		pauseAmountUpdates?: boolean;

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -14,7 +14,12 @@
 	import { formatToken, formatCurrency } from '$lib/utils/format.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
-	const { destinationToken, sourceToken, sourceTokenExchangeRate, isSourceTokenIcrc2 } =
+	interface Props {
+		isSourceTokenIcrc2?: boolean;
+	}
+	let { isSourceTokenIcrc2 }: Props = $props();
+
+	const { destinationToken, sourceToken, sourceTokenExchangeRate } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { store: icTokenFeeStore } = getContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY);
@@ -32,7 +37,7 @@
 	let sourceTokenTransferFee = $derived(Number(sourceTokenTransferFeeDisplay));
 
 	let sourceTokenApproveFeeDisplay = $derived(
-		$isSourceTokenIcrc2 ? sourceTokenTransferFeeDisplay : '0'
+		isSourceTokenIcrc2 ? sourceTokenTransferFeeDisplay : '0'
 	);
 
 	let sourceTokenApproveFee = $derived(Number(sourceTokenApproveFeeDisplay));
@@ -53,7 +58,7 @@
 				{/snippet}
 
 				{#snippet mainValue()}
-					{#if isNullish($icTokenFeeStore?.[$sourceToken.symbol])}
+					{#if isNullish($icTokenFeeStore?.[$sourceToken.symbol]) || isNullish(isSourceTokenIcrc2)}
 						<div class="w-14 sm:w-16">
 							<SkeletonText />
 						</div>
@@ -73,7 +78,7 @@
 		{/snippet}
 
 		{#snippet listItems()}
-			{#if $isSourceTokenIcrc2 && sourceTokenApproveFee !== 0}
+			{#if isSourceTokenIcrc2 && sourceTokenApproveFee !== 0}
 				<SwapFee
 					fee={sourceTokenApproveFeeDisplay}
 					feeLabel={$i18n.swap.text.approval_fee}

--- a/src/frontend/src/lib/components/swap/SwapTokenWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokenWizard.svelte
@@ -36,11 +36,11 @@
 		onBack
 	}: Props = $props();
 
-	const { sourceToken, destinationToken, isSourceTokenIcrc2 } =
-		getContext<SwapContext>(SWAP_CONTEXT_KEY);
+	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	let isSwapAmountsLoading = $state(false);
 	let manualPause = $state(false);
+	let isSourceTokenIcrc2 = $state(undefined);
 
 	let enableAmountUpdates = $derived(!isNetworkIdICP($sourceToken?.network?.id));
 
@@ -59,7 +59,7 @@
 	amount={swapAmount}
 	destinationToken={$destinationToken}
 	{enableAmountUpdates}
-	isSourceTokenIcrc2={$isSourceTokenIcrc2}
+	{isSourceTokenIcrc2}
 	pauseAmountUpdates={shouldPause}
 	{slippageValue}
 	sourceToken={$sourceToken}
@@ -77,6 +77,7 @@
 			bind:receiveAmount
 			bind:slippageValue
 			bind:swapProgressStep
+			bind:isSourceTokenIcrc2
 			on:icClose
 			on:icShowTokensList
 			on:icShowProviderList


### PR DESCRIPTION
# Motivation

We no longer need to obtain the icrc2 value from Kongswap. Instead, we should call the ledger directly to retrieve the supported standards for ICRC tokens.

# Changes

- Removed the dependency on the general store.
- Updated the component to call the ledger directly to determine isIcrc2.

