### PR TITLE
style(frontend): Make the agreements hyperlinks blue in the warning banner

### DIFF
--- a/src/frontend/src/lib/components/license-agreement/LicenseAgreementLink.svelte
+++ b/src/frontend/src/lib/components/license-agreement/LicenseAgreementLink.svelte
@@ -10,9 +10,10 @@
 		noUnderline?: boolean;
 		testId?: string;
 		icon?: Snippet;
+		color?: 'blue' | 'inherit';
 	}
 
-	let { noUnderline = false, testId, icon }: Props = $props();
+	let { noUnderline = false, testId, icon, color = 'inherit' }: Props = $props();
 
 	const handleClick = () => {
 		trackEvent({
@@ -24,7 +25,12 @@
 
 <a
 	class="inline-flex items-center gap-1"
+	class:active:text-brand-primary-alt={color === 'inherit'}
+	class:active:text-brand-secondary={color === 'blue'}
+	class:hover:text-brand-primary-alt={color === 'inherit'}
+	class:hover:text-brand-secondary={color === 'blue'}
 	class:no-underline={noUnderline}
+	class:text-brand-primary-alt={color === 'blue'}
 	aria-label={replaceOisyPlaceholders($i18n.license_agreement.alt.license_agreement)}
 	data-tid={testId}
 	href="/license-agreement"

--- a/src/frontend/src/lib/components/privacy-policy/PrivacyPolicyLink.svelte
+++ b/src/frontend/src/lib/components/privacy-policy/PrivacyPolicyLink.svelte
@@ -10,9 +10,10 @@
 		noUnderline?: boolean;
 		testId?: string;
 		icon?: Snippet;
+		color?: 'blue' | 'inherit';
 	}
 
-	let { noUnderline = false, testId, icon }: Props = $props();
+	let { noUnderline = false, testId, icon, color = 'inherit' }: Props = $props();
 
 	const handleClick = () => {
 		trackEvent({
@@ -24,7 +25,12 @@
 
 <a
 	class="inline-flex items-center gap-1"
+	class:active:text-brand-primary-alt={color === 'inherit'}
+	class:active:text-brand-secondary={color === 'blue'}
+	class:hover:text-brand-primary-alt={color === 'inherit'}
+	class:hover:text-brand-secondary={color === 'blue'}
 	class:no-underline={noUnderline}
+	class:text-brand-primary-alt={color === 'blue'}
 	aria-label={replaceOisyPlaceholders($i18n.privacy_policy.alt.privacy_policy)}
 	data-tid={testId}
 	href="/privacy-policy"

--- a/src/frontend/src/lib/components/terms-of-use/TermsOfUseLink.svelte
+++ b/src/frontend/src/lib/components/terms-of-use/TermsOfUseLink.svelte
@@ -10,9 +10,10 @@
 		noUnderline?: boolean;
 		testId?: string;
 		icon?: Snippet;
+		color?: 'blue' | 'inherit';
 	}
 
-	let { noUnderline = false, testId, icon }: Props = $props();
+	let { noUnderline = false, testId, icon, color = 'inherit' }: Props = $props();
 
 	const handleClick = () => {
 		trackEvent({
@@ -24,7 +25,12 @@
 
 <a
 	class="inline-flex items-center gap-1"
+	class:active:text-brand-primary-alt={color === 'inherit'}
+	class:active:text-brand-secondary={color === 'blue'}
+	class:hover:text-brand-primary-alt={color === 'inherit'}
+	class:hover:text-brand-secondary={color === 'blue'}
 	class:no-underline={noUnderline}
+	class:text-brand-primary-alt={color === 'blue'}
 	aria-label={replaceOisyPlaceholders($i18n.terms_of_use.alt.terms_of_use)}
 	data-tid={testId}
 	href="/terms-of-use"

--- a/src/frontend/src/lib/utils/agreements-formatter.utils.ts
+++ b/src/frontend/src/lib/utils/agreements-formatter.utils.ts
@@ -69,7 +69,8 @@ export const formatUpdatedAgreementsHtml = ({
 		renderAgreementItemHtml({
 			agreementType: camelToSnake(agreementType as keyof EnvAgreements),
 			i18n,
-			Component: mapAgreementToComponent(agreementType as keyof EnvAgreements)
+			Component: mapAgreementToComponent(agreementType as keyof EnvAgreements),
+			props: { color: 'blue' }
 		})
 	);
 

--- a/src/frontend/src/tests/lib/utils/agreements-formatter.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/agreements-formatter.utils.spec.ts
@@ -23,17 +23,17 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a>, ' +
-						'our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Terms of Use Link">Terms of Use <!----></a>, ' +
-						'and our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
+						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a>, ' +
+						'our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Terms of Use Link">Terms of Use <!----></a>, ' +
+						'and our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
 					[Languages.ITALIAN]:
-						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a>, ' +
-						'i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a> ' +
-						'e la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
+						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a>, ' +
+						'i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a> ' +
+						'e la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a>, ' +
-						'unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a> ' +
-						'und unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
+						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a>, ' +
+						'unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a> ' +
+						'und unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
 				}
 			},
 			{
@@ -43,14 +43,14 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a> ' +
-						'and our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Terms of Use Link">Terms of Use <!----></a>',
+						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a> ' +
+						'and our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Terms of Use Link">Terms of Use <!----></a>',
 					[Languages.ITALIAN]:
-						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a> ' +
-						'e i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a>',
+						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a> ' +
+						'e i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a> ' +
-						'und unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a>'
+						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a> ' +
+						'und unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a>'
 				}
 			},
 			{
@@ -60,14 +60,14 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a> ' +
-						'and our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
+						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a> ' +
+						'and our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
 					[Languages.ITALIAN]:
-						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a> ' +
-						'e la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
+						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a> ' +
+						'e la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a> ' +
-						'und unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
+						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a> ' +
+						'und unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
 				}
 			},
 			{
@@ -77,14 +77,14 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Terms of Use Link">Terms of Use <!----></a> ' +
-						'and our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
+						'our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Terms of Use Link">Terms of Use <!----></a> ' +
+						'and our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
 					[Languages.ITALIAN]:
-						'i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a> ' +
-						'e la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
+						'i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a> ' +
+						'e la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a> ' +
-						'und unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
+						'unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a> ' +
+						'und unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
 				}
 			},
 			{
@@ -93,11 +93,11 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a>',
+						'our <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="The OISY Wallet License Agreement">License Agreement <!----></a>',
 					[Languages.ITALIAN]:
-						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a>',
+						'il nostro <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="L\'Accordo di Licenza di OISY Wallet">Accordo di Licenza <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a>'
+						'unsere <a href="/license-agreement" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Die Lizenzvereinbarung von OISY Wallet">Lizenzvereinbarung <!----></a>'
 				}
 			},
 			{
@@ -106,11 +106,11 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Terms of Use Link">Terms of Use <!----></a>',
+						'our <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Terms of Use Link">Terms of Use <!----></a>',
 					[Languages.ITALIAN]:
-						'i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a>',
+						'i nostri <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link ai termini di utilizzo">Termini di utilizzo <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a>'
+						'unsere <a href="/terms-of-use" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zu den Nutzungsbedingungen">Nutzungsbedingungen <!----></a>'
 				}
 			},
 			{
@@ -119,11 +119,11 @@ describe('agreements-formatter.utils', () => {
 				},
 				expected: {
 					[Languages.ENGLISH]:
-						'our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
+						'our <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Privacy Policy Link">Privacy Policy <!----></a>',
 					[Languages.ITALIAN]:
-						'la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
+						'la nostra <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link all\'informativa sulla privacy">Politica sulla riservatezza <!----></a>',
 					[Languages.GERMAN]:
-						'unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
+						'unsere <a href="/privacy-policy" target="_blank" class="inline-flex items-center gap-1 active:text-brand-secondary hover:text-brand-secondary text-brand-primary-alt" aria-label="Link zur Datenschutzrichtlinie">Datenschutzrichtlinie <!----></a>'
 				}
 			}
 		];


### PR DESCRIPTION
# Motivation

To be consistent we make the hyperlinks of the warning banner for agreements in the same color of the other hyperlinks.

<img width="1259" height="966" alt="Screenshot 2025-10-08 at 14 47 39" src="https://github.com/user-attachments/assets/660e61d3-e2fb-42c3-8262-498abb97ee3e" />


