### PR TITLE
feat(frontend): load all icrc tokens for swap modal tokens

### DIFF
--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -74,7 +74,7 @@
 		// 1. If loadKongSwapTokens succeeds within 10s - show modal.
 		// 2. If loadKongSwapTokens does not succeed within 10s - show toast, do not show modal.
 		// 3. If loadKongSwapTokens throws - show toast, do not show modal.
-		await Promise.any([waitReady({ retries: 5, isDisabled }), loadKongSwapTokens()]);
+		await Promise.any([waitReady({ retries: 10, isDisabled }), loadKongSwapTokens()]);
 
 		busy.stop();
 

--- a/src/frontend/src/lib/components/swap/Swap.svelte
+++ b/src/frontend/src/lib/components/swap/Swap.svelte
@@ -36,47 +36,12 @@
 	setContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY, {
 		store: icTokenFeeStore
 	});
-
-	const isDisabled = (): boolean => isNullish($kongSwapTokensStore);
-
-	const loadKongSwapTokens = async (): Promise<'ready' | undefined> => {
-		if (isNullish($authIdentity)) {
-			await nullishSignOut();
-			return;
-		}
-
-		if (!isDisabled()) {
-			return 'ready';
-		}
-
-		try {
-			await loadKongSwapTokensService({
-				identity: $authIdentity,
-				allIcrcTokens: [ICP_TOKEN, ...$allIcrcTokens]
-			});
-
-			return 'ready';
-		} catch (_err: unknown) {
-			console.warn('Failed to load KongSwap tokens.');
-
-			return undefined;
-		}
-	};
-
+	
 	const onOpenSwap = async (tokenId: symbol) => {
 		if (isNullish($authIdentity)) {
 			await nullishSignOut();
 			return;
 		}
-
-		busy.start({ msg: $i18n.init.info.hold_loading });
-
-		// 1. If loadKongSwapTokens succeeds within 10s - show modal.
-		// 2. If loadKongSwapTokens does not succeed within 10s - show toast, do not show modal.
-		// 3. If loadKongSwapTokens throws - show toast, do not show modal.
-		await Promise.any([waitReady({ retries: 20, isDisabled }), loadKongSwapTokens()]);
-
-		busy.stop();
 
 		modalStore.openSwap(tokenId);
 

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -5,11 +5,7 @@
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
-	import {
-		allCrossChainSwapTokens,
-		allKongSwapCompatibleIcrcTokens,
-		allSwappableTokensDerived
-	} from '$lib/derived/all-tokens.derived';
+	import { allCrossChainSwapTokens, allIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -38,9 +34,7 @@
 		pinTokensWithBalanceAtTop({
 			$tokens: [
 				{ ...ICP_TOKEN, enabled: true },
-				...($allKongSwapCompatibleIcrcTokens.length === 0
-					? $allSwappableTokensDerived
-					: $allKongSwapCompatibleIcrcTokens),
+				...$allIcrcTokens,
 				...(VELORA_SWAP_ENABLED ? $allCrossChainSwapTokens : [])
 			].filter(
 				(token: Token) => token.id !== $sourceToken?.id && token.id !== $destinationToken?.id


### PR DESCRIPTION
# Motivation

We need to display allIcrcTokens instead of kongswapTokens in the swapModalTokenList.

# Changes

Updated the logic to use allIcrcTokens instead of kongswapTokens.

