### PR TITLE
fix(frontend): Do not bind undefined props with empty string

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthAddTokenForm.svelte
+++ b/src/frontend/src/eth/components/tokens/EthAddTokenForm.svelte
@@ -6,7 +6,7 @@
 		contractAddress?: string;
 	}
 
-	let { contractAddress = $bindable('') }: Props = $props();
+	let { contractAddress = $bindable() }: Props = $props();
 </script>
 
 <label class="font-bold" for="destination">{$i18n.tokens.text.contract_address}:</label>

--- a/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddTokenForm.svelte
@@ -11,8 +11,8 @@
 	}
 
 	let {
-		ledgerCanisterId = $bindable(''),
-		indexCanisterId = $bindable(''),
+		ledgerCanisterId = $bindable(),
+		indexCanisterId = $bindable(),
 		editMode = false
 	}: Props = $props();
 </script>


### PR DESCRIPTION
# Motivation

At runtime, we receive an error that an optional string should not be binded with an empty string, but with `undefined`.