### PR TITLE
chore(frontend): Do not reset proposal on WalletConnect listener reset

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -107,7 +107,6 @@
 
 	const resetListener = () => {
 		listener = undefined;
-		proposal = null;
 	};
 
 	const initListener = async () => {
@@ -171,12 +170,12 @@
 			return;
 		}
 
-		// Address is not defined. We need it at least one between the Ethereum address and the Solana address.
+		// Address is not defined. We need at least one between the Ethereum address and the Solana address.
 		if (isNullish($ethAddress) && isNullish($solAddressMainnet)) {
 			return;
 		}
 
-		// For simplicity reason we just display an error for now if the user has already opened the WalletConnect modal.
+		// For simplicity reason, we just display an error for now if the user has already opened the WalletConnect modal.
 		// Technically, we could potentially check which steps are in progress and eventually jump or not, but let's keep it simple for now.
 		if ($modalWalletConnectAuth) {
 			toastsError({


### PR DESCRIPTION
# Motivation

When we reset the listener in WalletConnect, we don't need to reset the proposal: it already pertains to the other flows (onMount, onDestroy, etc).
