### PR TITLE
refactor(frontend): Sticky headers overlapping mobile nav

### DIFF
--- a/src/frontend/src/lib/components/navigation/MobileNavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/MobileNavigationMenu.svelte
@@ -5,7 +5,7 @@
 
 <Responsive down="md">
 	<div
-		class="mobile-nav z-2 border-t-1 visible fixed bottom-0 left-0 right-0 flex flex-row border-tertiary bg-primary-inverted-alt md:hidden"
+		class="mobile-nav z-3 border-t-1 visible fixed bottom-0 left-0 right-0 flex flex-row border-tertiary bg-primary-inverted-alt md:hidden"
 		data-tid={MOBILE_NAVIGATION_MENU}
 	>
 		<slot />

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -94,7 +94,7 @@
 				</SplitPane>
 
 				<Responsive down="md">
-					<div class="z-2 fixed bottom-16 right-2 block md:hidden">
+					<div class="z-3 fixed bottom-16 right-2 block md:hidden">
 						<AiAssistantConsoleButton styleClass="mb-2" />
 					</div>
 				</Responsive>


### PR DESCRIPTION
# Motivation

Since the sticky headers for transaction dates can also appear at the bottom of a page it can overlap the mobile nav.

# Changes

Changed z-index for mobile nav and AI assistant to 3.

# Tests

Before:
<img width="434" height="711" alt="image" src="https://github.com/user-attachments/assets/aea9cf86-2085-407d-af83-b166ae07ebc0" />

After:
<img width="434" height="711" alt="image" src="https://github.com/user-attachments/assets/80dd7704-bf09-4da0-b45e-9d8bc4abbd03" />

The AI assistant still covers the mobile nav:
<img width="434" height="711" alt="image" src="https://github.com/user-attachments/assets/d4be2af4-f3aa-4018-9b30-8e43f7c3d39d" />

The header modals and popups still cover the mobile nav:
<img width="434" height="711" alt="image" src="https://github.com/user-attachments/assets/a1ba2ada-46ac-43a8-a736-03f9277dde8c" />

<img width="434" height="711" alt="image" src="https://github.com/user-attachments/assets/6d4ee121-8685-4e6f-a34b-f41bcec212a8" />

