### PR TITLE
feat(frontend): add StakeContentCard component

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeContentCard.svelte
+++ b/src/frontend/src/lib/components/stake/StakeContentCard.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		content: Snippet;
+		buttons: Snippet;
+	}
+
+	let { content, buttons }: Props = $props();
+</script>
+
+<!-- TODO: add styling according to the designs -->
+<div class="flex w-1/2 flex-col items-center rounded-xl bg-secondary p-4">
+	<div class="mb-8 flex justify-center gap-2">
+		{@render content()}
+	</div>
+
+	{@render buttons()}
+</div>

--- a/src/frontend/src/tests/lib/components/stake/StakeContentCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeContentCard.spec.ts
@@ -1,0 +1,19 @@
+import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
+import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { render } from '@testing-library/svelte';
+
+describe('StakeContentCard', () => {
+	const props = {
+		content: createMockSnippet('content'),
+		buttons: createMockSnippet('buttons')
+	};
+
+	it('renders provided snippets correctly', () => {
+		const { getByTestId } = render(StakeContentCard, {
+			props
+		});
+
+		expect(getByTestId('content')).toBeInTheDocument();
+		expect(getByTestId('buttons')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to add a new component that is going to render basic staking data (balance, APY info, buttons, etc). 

Note: the styling will be added later.