### PR TITLE
feat(frontend): add StakeForm component

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeForm.svelte
+++ b/src/frontend/src/lib/components/stake/StakeForm.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext, type Snippet } from 'svelte';
+	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
+	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
+	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import { STAKE_FORM_REVIEW_BUTTON } from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { DisplayUnit } from '$lib/types/swap';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
+	import { invalidAmount } from '$lib/utils/input.utils';
+
+	interface Props {
+		amount: OptionAmount;
+		totalFee?: bigint;
+		onCustomValidate?: (userAmount: bigint) => TokenActionErrorType;
+		onClose: () => void;
+		onNext: () => void;
+		fee?: Snippet;
+		provider?: Snippet;
+	}
+
+	let {
+		amount = $bindable(),
+		totalFee,
+		onCustomValidate,
+		onClose,
+		onNext,
+		fee,
+		provider
+	}: Props = $props();
+
+	const { sendToken, sendTokenExchangeRate, sendBalance } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let errorType = $state<TokenActionErrorType | undefined>();
+	let amountSetToMax = $state(false);
+	let exchangeValueUnit = $state<DisplayUnit>('usd');
+	let inputUnit = $derived<DisplayUnit>(exchangeValueUnit === 'token' ? 'usd' : 'token');
+
+	let invalid = $derived(invalidAmount(amount) || nonNullish(errorType));
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-8">
+		<TokenInput
+			displayUnit={inputUnit}
+			exchangeRate={$sendTokenExchangeRate}
+			isSelectable={false}
+			{onCustomValidate}
+			showTokenNetwork
+			token={$sendToken}
+			bind:amount
+			bind:errorType
+			bind:amountSetToMax
+		>
+			{#snippet title()}{$i18n.core.text.amount}{/snippet}
+
+			{#snippet amountInfo()}
+				<div class="text-tertiary">
+					<TokenInputAmountExchange
+						{amount}
+						exchangeRate={$sendTokenExchangeRate}
+						token={$sendToken}
+						bind:displayUnit={exchangeValueUnit}
+					/>
+				</div>
+			{/snippet}
+
+			{#snippet balance()}
+				<MaxBalanceButton
+					balance={$sendBalance}
+					error={nonNullish(errorType)}
+					fee={totalFee}
+					token={$sendToken}
+					bind:amountSetToMax
+					bind:amount
+				/>
+			{/snippet}
+		</TokenInput>
+	</div>
+
+	{@render provider?.()}
+
+	{@render fee?.()}
+
+	{#snippet toolbar()}
+		<ButtonGroup testId="toolbar">
+			<ButtonCancel onclick={onClose} />
+
+			<Button disabled={invalid} onclick={onNext} testId={STAKE_FORM_REVIEW_BUTTON}>
+				{$i18n.send.text.review}
+			</Button>
+		</ButtonGroup>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -304,3 +304,6 @@ export const DATE_BADGE_ICON = 'date-badge-icon';
 
 // Confirmation modal
 export const CONFIRMATION_MODAL = 'confirmation-modal';
+
+// Stake
+export const STAKE_FORM_REVIEW_BUTTON = 'stake-form-next-button';

--- a/src/frontend/src/tests/lib/components/stake/StakeForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeForm.spec.ts
@@ -1,0 +1,37 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import StakeForm from '$lib/components/stake/StakeForm.svelte';
+import { STAKE_FORM_REVIEW_BUTTON } from '$lib/constants/test-ids.constants';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { render } from '@testing-library/svelte';
+
+describe('StakeForm', () => {
+	const mockContext = () =>
+		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+
+	const props = {
+		amount: 0.01,
+		onClose: () => {},
+		onNext: () => {}
+	};
+
+	it('should keep the next button clickable if all requirements are met', () => {
+		const { getByTestId } = render(StakeForm, {
+			props,
+			context: mockContext()
+		});
+
+		expect(getByTestId(STAKE_FORM_REVIEW_BUTTON)).not.toHaveAttribute('disabled');
+	});
+
+	it('should disable the next button clickable if amount is incorrect', () => {
+		const { getByTestId } = render(StakeForm, {
+			props: {
+				...props,
+				amount: undefined
+			},
+			context: mockContext()
+		});
+
+		expect(getByTestId(STAKE_FORM_REVIEW_BUTTON)).toHaveAttribute('disabled');
+	});
+});


### PR DESCRIPTION
# Motivation

We start adding components for the staking flow with the new StakeForm component. It will be extended later with additional data.

<img width="601" height="575" alt="Screenshot 2025-10-09 at 12 37 34" src="https://github.com/user-attachments/assets/5add1cdd-1974-4641-9af8-05a3e504eb44" />
