### PR TITLE
refactor(frontend): Avoid effect in Transactions list components

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactions.svelte
@@ -20,18 +20,14 @@
 	} from '$lib/derived/modal.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken } from '$lib/types/token';
 	import { groupTransactionsByDate, mapTransactionModalData } from '$lib/utils/transaction.utils';
 
-	let selectedTransaction = $state<BtcTransactionUi | undefined>();
-	let selectedToken = $state<OptionToken>();
-	$effect(() => {
-		({ transaction: selectedTransaction, token: selectedToken } =
-			mapTransactionModalData<BtcTransactionUi>({
-				$modalOpen: $modalBtcTransaction,
-				$modalStore
-			}));
-	});
+	let { transaction: selectedTransaction, token: selectedToken } = $derived(
+		mapTransactionModalData<BtcTransactionUi>({
+			$modalOpen: $modalBtcTransaction,
+			$modalStore
+		})
+	);
 
 	let token = $derived($pageToken ?? DEFAULT_BITCOIN_TOKEN);
 

--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -22,7 +22,6 @@
 	import { tokenWithFallback } from '$lib/derived/token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken } from '$lib/types/token';
 	import { groupTransactionsByDate, mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let ckMinterInfoAddresses = $derived(
@@ -39,15 +38,12 @@
 		)
 	);
 
-	let selectedTransaction = $state<EthTransactionUi | undefined>();
-	let selectedToken = $state<OptionToken>();
-	$effect(() => {
-		({ transaction: selectedTransaction, token: selectedToken } =
-			mapTransactionModalData<EthTransactionUi>({
-				$modalOpen: $modalEthTransaction,
-				$modalStore
-			}));
-	});
+	let { transaction: selectedTransaction, token: selectedToken } = $derived(
+		mapTransactionModalData<EthTransactionUi>({
+			$modalOpen: $modalEthTransaction,
+			$modalStore
+		})
+	);
 
 	let token = $derived($tokenWithFallback);
 

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -28,20 +28,16 @@
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken } from '$lib/types/token';
 	import { groupTransactionsByDate, mapTransactionModalData } from '$lib/utils/transaction.utils';
 
 	let ckEthereum = $derived($tokenCkEthLedger || $tokenCkErc20Ledger);
 
-	let selectedTransaction = $state<IcTransactionUi | undefined>();
-	let selectedToken = $state<OptionToken>();
-	$effect(() => {
-		({ transaction: selectedTransaction, token: selectedToken } =
-			mapTransactionModalData<IcTransactionUi>({
-				$modalOpen: $modalIcTransaction,
-				$modalStore
-			}));
-	});
+	let { transaction: selectedTransaction, token: selectedToken } = $derived(
+		mapTransactionModalData<IcTransactionUi>({
+			$modalOpen: $modalIcTransaction,
+			$modalStore
+		})
+	);
 
 	let noTransactions = $derived(
 		nonNullish($pageToken) && $icTransactionsStore?.[$pageToken.id] === null

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -13,7 +13,6 @@
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OptionToken } from '$lib/types/token';
 	import { groupTransactionsByDate, mapTransactionModalData } from '$lib/utils/transaction.utils';
 	import SolTokenModal from '$sol/components/tokens/SolTokenModal.svelte';
 	import SolTransactionModal from '$sol/components/transactions/SolTransactionModal.svelte';
@@ -22,15 +21,12 @@
 	import { solTransactions } from '$sol/derived/sol-transactions.derived';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 
-	let selectedTransaction = $state<SolTransactionUi | undefined>();
-	let selectedToken = $state<OptionToken>();
-	$effect(() => {
-		({ transaction: selectedTransaction, token: selectedToken } =
-			mapTransactionModalData<SolTransactionUi>({
-				$modalOpen: $modalSolTransaction,
-				$modalStore
-			}));
-	});
+	let { transaction: selectedTransaction, token: selectedToken } = $derived(
+		mapTransactionModalData<SolTransactionUi>({
+			$modalOpen: $modalSolTransaction,
+			$modalStore
+		})
+	);
 
 	let token = $derived($pageToken ?? DEFAULT_SOLANA_TOKEN);
 


### PR DESCRIPTION
# Motivation

To be more consistent, and because it is simpler as code, we can remove the $effect rune to define the selected token and transaction in all the Transactions list components.