### PR TITLE
feat(frontend): show GLDT stake modal content card

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStake.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStake.svelte
@@ -2,12 +2,13 @@
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate, goto } from '$app/navigation';
 	import { EARNING_ENABLED } from '$env/earning';
+	import GldtStakeContentCard from '$icp/components/stake/gldt/GldtStakeContentCard.svelte';
 	import IconBackArrow from '$lib/components/icons/lucide/IconBackArrow.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { networkId } from '$lib/derived/network.derived';
-	import { i18n } from '$lib/stores/i18n.store.js';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { networkUrl } from '$lib/utils/nav.utils';
 
 	let fromRoute = $state<NavigationTarget | null>(null);
@@ -43,4 +44,4 @@
 	<PageTitle>{$i18n.earning.cards.gold_description}</PageTitle>
 </div>
 
-<h3>Coming soon</h3>
+<GldtStakeContentCard />

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeContentCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeContentCard.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import {
+		enabledIcrcTokens,
+		icrcTokens,
+		icrcCustomTokensNotInitialized,
+		icrcCustomTokensInitialized
+	} from '$icp/derived/icrc.derived';
+	import { loadCustomTokens } from '$icp/services/icrc.services';
+	import { setCustomToken } from '$icp-eth/services/custom-token.services';
+	import { isGLDTToken } from '$icp-eth/utils/token.utils';
+	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
+	import StakeModal from '$lib/components/stake/StakeModal.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonWithModal from '$lib/components/ui/ButtonWithModal.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { modalGldtStake } from '$lib/derived/modal.derived';
+	import { nullishSignOut } from '$lib/services/auth.services';
+	import { autoLoadSingleToken } from '$lib/services/token.services';
+	import { balancesStore } from '$lib/stores/balances.store';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import { formatCurrency, formatToken } from '$lib/utils/format.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { calculateTokenUsdAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	let gldtToken = $derived($enabledIcrcTokens.find((token) => isGLDTToken(token)));
+
+	let gldtTokenBalance = $derived(
+		nonNullish(gldtToken) ? ($balancesStore?.[gldtToken?.id]?.data ?? ZERO) : ZERO
+	);
+
+	let gldtTokenSymbol = $derived(nonNullish(gldtToken) ? getTokenDisplaySymbol(gldtToken) : 'GLDT');
+
+	let gldtTokenUsdBalance = $derived(
+		nonNullish(gldtToken)
+			? (calculateTokenUsdAmount({
+					amount: gldtTokenBalance,
+					token: gldtToken,
+					$exchanges
+				}) ?? 0)
+			: 0
+	);
+
+	const enableStakingToken = async () => {
+		if (isNullish($authIdentity)) {
+			await nullishSignOut();
+			return;
+		}
+
+		const token = $icrcTokens.find((token) => isGLDTToken(token));
+
+		await autoLoadSingleToken({
+			token,
+			identity: $authIdentity,
+			setToken: setCustomToken,
+			loadTokens: loadCustomTokens,
+			errorMessage: $i18n.init.error.icrc_custom_token
+		});
+	};
+</script>
+
+<StakeContentCard>
+	{#snippet content()}
+		{#if nonNullish(gldtToken)}
+			<span class="font-bold">
+				{formatCurrency({
+					value: gldtTokenUsdBalance,
+					currency: $currentCurrency,
+					exchangeRate: $currencyExchangeStore,
+					language: $currentLanguage
+				})}
+			</span>
+
+			<span class="text-tertiary">
+				{formatToken({
+					value: gldtTokenBalance,
+					unitName: gldtToken.decimals
+				})}
+				{gldtTokenSymbol}
+			</span>
+		{:else if $icrcCustomTokensInitialized}
+			<span class="text-tertiary">
+				{replacePlaceholders($i18n.stake.text.enable_token_text, {
+					$token_symbol: gldtTokenSymbol
+				})}
+			</span>
+		{/if}
+	{/snippet}
+
+	{#snippet buttons()}
+		{#if nonNullish(gldtToken)}
+			<ButtonWithModal isOpen={$modalGldtStake} onOpen={modalStore.openGldtStake}>
+				{#snippet button(onclick)}
+					<Button disabled={gldtTokenBalance === ZERO} fullWidth {onclick}>
+						{replacePlaceholders($i18n.stake.text.stake, {
+							$token_symbol: gldtTokenSymbol
+						})}
+					</Button>
+				{/snippet}
+
+				{#snippet modal()}
+					<StakeModal token={gldtToken} />
+				{/snippet}
+			</ButtonWithModal>
+		{:else}
+			<Button fullWidth loading={$icrcCustomTokensNotInitialized} onclick={enableStakingToken}>
+				{replacePlaceholders($i18n.stake.text.enable_token_button, {
+					$token_symbol: gldtTokenSymbol
+				})}
+			</Button>
+		{/if}
+	{/snippet}
+</StakeContentCard>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "Stake $token_symbol",
+			"enable_token_text": "You need to enable $token_symbol",
+			"enable_token_button": "Enable $token_symbol",
 			"review": "Review transaction",
 			"executing_transaction": "Executing transaction...",
 			"unsupported_token_staking": "Staking for the selected token is not supported.",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1705,6 +1705,8 @@
 	"stake": {
 		"text": {
 			"stake": "",
+			"enable_token_text": "",
+			"enable_token_button": "",
 			"review": "",
 			"executing_transaction": "",
 			"unsupported_token_staking": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1382,6 +1382,8 @@ interface I18nEarning {
 interface I18nStake {
 	text: {
 		stake: string;
+		enable_token_text: string;
+		enable_token_button: string;
 		review: string;
 		executing_transaction: string;
 		unsupported_token_staking: string;

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeContentCard.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeContentCard.spec.ts
@@ -1,0 +1,48 @@
+import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import GldtStakeContentCard from '$icp/components/stake/gldt/GldtStakeContentCard.svelte';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import en from '$tests/mocks/i18n.mock';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
+import { render } from '@testing-library/svelte';
+
+describe('GldtStakeContentCard', () => {
+	beforeEach(() => {
+		icrcCustomTokensStore.resetAll();
+	});
+
+	it('should display correct values if GLDT token is not available', () => {
+		icrcCustomTokensStore.set({
+			data: mockIcrcCustomToken,
+			certified: false
+		});
+
+		const { container } = render(GldtStakeContentCard);
+
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.enable_token_button, { $token_symbol: 'GLDT' })
+		);
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.enable_token_text, { $token_symbol: 'GLDT' })
+		);
+	});
+
+	it('should display correct values if GLDT token is available', () => {
+		icrcCustomTokensStore.set({
+			data: {
+				...mockIcrcCustomToken,
+				standard: 'icrc',
+				enabled: true,
+				ledgerCanisterId: GLDT_LEDGER_CANISTER_ID,
+				symbol: 'GLDT'
+			},
+			certified: false
+		});
+
+		const { container } = render(GldtStakeContentCard);
+
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.stake, { $token_symbol: 'GLDT' })
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

We can now add the GLDT stake modal content card (incl. the button that shows it) to the respective page. The card itself is not styled yet.