### PR TITLE
feat(frontend): Show IC token metadata error only for Custom tokens

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -98,13 +98,6 @@ const loadDefaultIcrc = ({
 				name: TRACK_COUNT_IC_LOADING_ICRC_CANISTER_ERROR,
 				metadata: { ...mapIcErrorMetadata(err), ledgerCanisterId }
 			});
-
-			toastsShow({
-				text: replacePlaceholders(get(i18n).init.error.icrc_canister_loading, {
-					$ledgerCanisterId: ledgerCanisterId
-				}),
-				level: 'warn'
-			});
 		},
 		strategy,
 		identity: new AnonymousIdentity()
@@ -228,14 +221,26 @@ const loadCustomIcrcTokensData = async ({
 			// For development purposes, we want to see the error in the console.
 			console.error(result.reason);
 
-			const { token } = tokens[index];
+			const { enabled, token } = tokens[index];
 
 			if ('Icrc' in token) {
 				const {
 					Icrc: { ledger_id }
 				} = token;
 
-				icrcCustomTokensStore.reset(ledger_id.toString());
+				const ledgerCanisterId = ledger_id.toText();
+
+				icrcCustomTokensStore.reset(ledgerCanisterId);
+
+				// To avoid pollute the screen, we show the toast error only after the update call.
+				if (enabled && certified) {
+					toastsShow({
+						text: replacePlaceholders(get(i18n).init.error.icrc_canister_loading, {
+							$ledgerCanisterId: ledgerCanisterId
+						}),
+						level: 'warn'
+					});
+				}
 			}
 
 			return acc;


### PR DESCRIPTION
# Motivation

When we initially load the default tokens, we show an error if the ledger canister fails to give us the metadata.

However, it does not really make sense to do it for the default tokens, but only for the custom tokens: the user is interested in the error ONLY if the token was among the enabled ones.

# Changes

- Remove the toast message from the loading of default tokens.
- Add the same message to the loading of custom tokens.
- Show the error message after the update call.

# Tests

Added tests.
