### PR TITLE
refactor(frontend): Refer to new path for `xtc_ledger` bindings

### DIFF
--- a/src/frontend/src/icp/canisters/xtc-ledger.canister.ts
+++ b/src/frontend/src/icp/canisters/xtc-ledger.canister.ts
@@ -1,4 +1,4 @@
-import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import { idlFactory as idlCertifiedFactoryXtcLedger } from '$declarations/xtc_ledger/xtc_ledger.factory.certified.did';
 import { idlFactory as idlFactoryXtcLedger } from '$declarations/xtc_ledger/xtc_ledger.factory.did';
 import { mapXtcLedgerCanisterError } from '$icp/canisters/xtc-ledger.errors';

--- a/src/frontend/src/icp/canisters/xtc-ledger.errors.ts
+++ b/src/frontend/src/icp/canisters/xtc-ledger.errors.ts
@@ -1,4 +1,4 @@
-import type { TxError } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { TxError } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
 export const mapXtcLedgerCanisterError = (err: TxError): CanisterInternalError => {

--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import { IcWalletScheduler, type IcWalletMsg } from '$icp/schedulers/ic-wallet.scheduler';
 import type { Dip20TransactionWithId } from '$icp/types/api';
 import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic-transaction';

--- a/src/frontend/src/icp/types/api.ts
+++ b/src/frontend/src/icp/types/api.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 
 export interface Dip20TransactionWithId {
 	id: bigint;

--- a/src/frontend/src/icp/types/ic-transaction.ts
+++ b/src/frontend/src/icp/types/ic-transaction.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import type { Dip20TransactionWithId } from '$icp/types/api';
 import type { icpTransactionTypes } from '$lib/schema/transaction.schema';
 import type { TransactionId, TransactionType } from '$lib/types/transaction';

--- a/src/frontend/src/icp/utils/dip20-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/dip20-transactions.utils.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import type { Dip20TransactionWithId } from '$icp/types/api';
 import type {
 	Dip20Transaction,

--- a/src/frontend/src/icp/workers/dip20-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/dip20-wallet.worker.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import { balance, transactions } from '$icp/api/xtc-ledger.api';
 import { IcWalletBalanceAndTransactionsScheduler } from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';

--- a/src/frontend/src/tests/icp/canisters/xtc-ledger.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/xtc-ledger.canister.spec.ts
@@ -1,4 +1,4 @@
-import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/xtc_ledger.did';
+import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
 import { XtcLedgerCanister } from '$icp/canisters/xtc-ledger.canister';
 import type { XtcLedgerTransferParams } from '$icp/types/xtc-ledger';
 import { CanisterInternalError } from '$lib/canisters/errors';


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/9521, we are going to introduce the use of library [`@icp-sdk/bindgen`](https://js.icp.build/bindgen/latest/) that helps us creating the bindings, substituting effectively `dfx generate`.

However, since the new library saves the generated files in a sub-directory /declarations, we need to adapt our code. And the change is quite through a lot of files.

To easy this transition, in this PR we just change the imports that refers to `xtc_ledger` bindings to the new path.
