### PR TITLE
refactor(frontend): Refer to new path for `icp_swap_factory` bindings

### DIFF
--- a/src/frontend/src/lib/api/icp-swap-factory.api.ts
+++ b/src/frontend/src/lib/api/icp-swap-factory.api.ts
@@ -1,4 +1,4 @@
-import type { PoolData } from '$declarations/icp_swap_factory/icp_swap_factory.did';
+import type { PoolData } from '$declarations/icp_swap_factory/declarations/icp_swap_factory.did';
 import { ICPSwapFactoryCanister } from '$lib/canisters/icp-swap-factory.canister';
 import { ICP_SWAP_FACTORY_CANISTER_ID } from '$lib/constants/app.constants';
 import type { ICPSwapGetPoolParams } from '$lib/types/api';

--- a/src/frontend/src/lib/canisters/icp-swap-factory.canister.ts
+++ b/src/frontend/src/lib/canisters/icp-swap-factory.canister.ts
@@ -2,7 +2,7 @@ import type {
 	GetPoolArgs,
 	PoolData,
 	_SERVICE as SwapFactoryService
-} from '$declarations/icp_swap_factory/icp_swap_factory.did';
+} from '$declarations/icp_swap_factory/declarations/icp_swap_factory.did';
 import { idlFactory as certifiedFactoryIdlFactory } from '$declarations/icp_swap_factory/icp_swap_factory.factory.certified.did';
 import { idlFactory as factoryIdlFactory } from '$declarations/icp_swap_factory/icp_swap_factory.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';

--- a/src/frontend/src/lib/canisters/icp-swap.errors.ts
+++ b/src/frontend/src/lib/canisters/icp-swap.errors.ts
@@ -1,4 +1,4 @@
-import type { Error as FactoryError } from '$declarations/icp_swap_factory/icp_swap_factory.did';
+import type { Error as FactoryError } from '$declarations/icp_swap_factory/declarations/icp_swap_factory.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
 export const mapIcpSwapFactoryError = (err: FactoryError): CanisterInternalError => {

--- a/src/frontend/src/tests/lib/canisters/icp-swap-factory.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/icp-swap-factory.spec.ts
@@ -3,7 +3,7 @@ import type {
 	PoolData,
 	Result_8,
 	_SERVICE as SwapFactoryService
-} from '$declarations/icp_swap_factory/icp_swap_factory.did';
+} from '$declarations/icp_swap_factory/declarations/icp_swap_factory.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { ICPSwapFactoryCanister } from '$lib/canisters/icp-swap-factory.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/9521, we are going to introduce the use of library [`@icp-sdk/bindgen`](https://js.icp.build/bindgen/latest/) that helps us creating the bindings, substituting effectively `dfx generate`.

However, since the new library saves the generated files in a sub-directory /declarations, we need to adapt our code. And the change is quite through a lot of files.

To easy this transition, in this PR we just change the imports that refers to `icp_swap_factory` bindings to the new path.
