### PR TITLE
refactor(frontend): Refer to new path for `icp_swap_pool` bindings

### DIFF
--- a/src/frontend/src/lib/api/icp-swap-pool.api.ts
+++ b/src/frontend/src/lib/api/icp-swap-pool.api.ts
@@ -1,4 +1,4 @@
-import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did';
+import type { PoolMetadata } from '$declarations/icp_swap_pool/declarations/icp_swap_pool.did';
 import { ICPSwapPoolCanister } from '$lib/canisters/icp-swap-pool.canister';
 import type {
 	ICPSwapDepositWithdrawParams,

--- a/src/frontend/src/lib/canisters/icp-swap-pool.canister.ts
+++ b/src/frontend/src/lib/canisters/icp-swap-pool.canister.ts
@@ -5,7 +5,7 @@ import type {
 	SwapArgs,
 	_SERVICE as SwapPoolService,
 	WithdrawArgs
-} from '$declarations/icp_swap_pool/icp_swap_pool.did';
+} from '$declarations/icp_swap_pool/declarations/icp_swap_pool.did';
 import { idlFactory as certifiedPoolIdlFactory } from '$declarations/icp_swap_pool/icp_swap_pool.factory.certified.did';
 import { idlFactory as poolIdlFactory } from '$declarations/icp_swap_pool/icp_swap_pool.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';

--- a/src/frontend/src/tests/lib/canisters/icp-swap-pool.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/icp-swap-pool.spec.ts
@@ -4,7 +4,7 @@ import type {
 	SwapArgs,
 	_SERVICE as SwapPoolService,
 	WithdrawArgs
-} from '$declarations/icp_swap_pool/icp_swap_pool.did';
+} from '$declarations/icp_swap_pool/declarations/icp_swap_pool.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { ICPSwapPoolCanister } from '$lib/canisters/icp-swap-pool.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';

--- a/src/frontend/src/tests/lib/services/icp-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/icp-swap.services.spec.ts
@@ -1,4 +1,4 @@
-import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did';
+import type { PoolMetadata } from '$declarations/icp_swap_pool/declarations/icp_swap_pool.did';
 import { approve } from '$icp/api/icrc-ledger.api';
 import { sendIcrc } from '$icp/services/ic-send.services';
 import { loadCustomTokens } from '$icp/services/icrc.services';

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1,4 +1,4 @@
-import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did';
+import type { PoolMetadata } from '$declarations/icp_swap_pool/declarations/icp_swap_pool.did';
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/9521, we are going to introduce the use of library [`@icp-sdk/bindgen`](https://js.icp.build/bindgen/latest/) that helps us creating the bindings, substituting effectively `dfx generate`.

However, since the new library saves the generated files in a sub-directory /declarations, we need to adapt our code. And the change is quite through a lot of files.

To easy this transition, in this PR we just change the imports that refers to `icp_swap_pool` bindings to the new path.
