### PR TITLE
fix(frontend): LLM canister initialisation

### DIFF
--- a/src/frontend/src/lib/canisters/llm.canister.ts
+++ b/src/frontend/src/lib/canisters/llm.canister.ts
@@ -4,6 +4,7 @@ import type {
 	chat_response_v1
 } from '$declarations/llm/declarations/llm.did';
 import { idlFactory as idlCertifiedFactoryLlm } from '$declarations/llm/llm.factory.certified.did';
+import { idlFactory as idlFactoryLlm } from '$declarations/llm/llm.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices } from '@dfinity/utils';
@@ -20,7 +21,7 @@ export class LlmCanister extends Canister<LlmService> {
 				...options,
 				agent
 			},
-			idlFactory: idlCertifiedFactoryLlm,
+			idlFactory: idlFactoryLlm,
 			certifiedIdlFactory: idlCertifiedFactoryLlm
 		});
 


### PR DESCRIPTION
# Motivation

Just noticed that the LLM canister had a small issue with the initialization class. The issue did not have any effect as we always call `chat` with `certified: true`, but still worth fixing. 
