### PR TITLE
feat(frontend): create gldt_stake canister class

### DIFF
--- a/src/frontend/src/lib/canisters/gldt_stake.canister.ts
+++ b/src/frontend/src/lib/canisters/gldt_stake.canister.ts
@@ -1,0 +1,32 @@
+import type { _SERVICE as GldtStakeService } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import { idlFactory as idlCertifiedFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.certified.did';
+import { idlFactory as idlFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.did';
+import { getAgent } from '$lib/actors/agents.ic';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { Canister, createServices } from '@dfinity/utils';
+
+export class GldtStakeCanister extends Canister<GldtStakeService> {
+	static async create({
+		identity,
+		...options
+	}: CreateCanisterOptions<GldtStakeService>): Promise<GldtStakeCanister> {
+		const agent = await getAgent({ identity });
+
+		const { service, certifiedService, canisterId } = createServices<GldtStakeService>({
+			options: {
+				...options,
+				agent
+			},
+			idlFactory: idlFactoryGldtStake,
+			certifiedIdlFactory: idlCertifiedFactoryGldtStake
+		});
+
+		return new GldtStakeCanister(canisterId, service, certifiedService);
+	}
+
+	getApyOverall = (): Promise<number> => {
+		const { get_apy_overall } = this.caller({ certified: true });
+
+		return get_apy_overall(null);
+	};
+}

--- a/src/frontend/src/tests/lib/canisters/gldt_stake.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/gldt_stake.canister.spec.ts
@@ -1,0 +1,56 @@
+import type { _SERVICE as GldtStakeService } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import { GldtStakeCanister } from '$lib/canisters/gldt_stake.canister';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import type { ActorSubclass } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+import { mock } from 'vitest-mock-extended';
+
+describe('gldt_stake.canister', () => {
+	const createGldtStakeCanister = ({
+		serviceOverride
+	}: Pick<CreateCanisterOptions<GldtStakeService>, 'serviceOverride'>) =>
+		GldtStakeCanister.create({
+			canisterId: Principal.fromText('sqpxs-piaaa-aaaaj-qneva-cai'),
+			identity: mockIdentity,
+			serviceOverride,
+			certifiedServiceOverride: serviceOverride
+		});
+
+	const service = mock<ActorSubclass<GldtStakeService>>();
+	const mockResponseError = new Error('gldt_stake error');
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('getApyOverall', () => {
+		it('returns APY number successfully', async () => {
+			const response = 10;
+
+			service.get_apy_overall.mockResolvedValue(response);
+
+			const { getApyOverall } = await createGldtStakeCanister({ serviceOverride: service });
+
+			const result = await getApyOverall();
+
+			expect(result).toEqual(response);
+			expect(service.get_apy_overall).toHaveBeenCalledOnce();
+		});
+
+		it('throws an error if get_apy_overall method fails', async () => {
+			service.get_apy_overall.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { getApyOverall } = await createGldtStakeCanister({
+				serviceOverride: service
+			});
+
+			const res = getApyOverall();
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We can now create gldt_stake canister class. The first method we add is `get_apy_overall` - the number we're going to display in different places across the GLDT staking flow.
