### PR TITLE
feat(frontend): Extend debouncing of IDB transaction setter

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsIdbSetter.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsIdbSetter.svelte
@@ -10,10 +10,10 @@
 		setIdbIcTransactions,
 		setIdbSolTransactions
 	} from '$lib/api/idb-transactions.api';
+	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledTokens } from '$lib/derived/tokens.derived';
 	import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
-    import {WALLET_TIMER_INTERVAL_MILLIS} from "$lib/constants/app.constants";
 
 	interface Props {
 		children?: Snippet;


### PR DESCRIPTION
# Motivation

We don't really need to save the transactions in IDB that frequently: we can use the same frequency of the wallet updater in debouncing, to avoid slow flows.
