### PR TITLE
feat(frontend): Remove `eager` loading from `Img` component

### DIFF
--- a/src/frontend/src/lib/components/ui/Img.svelte
+++ b/src/frontend/src/lib/components/ui/Img.svelte
@@ -3,7 +3,6 @@
 		src: string;
 		alt?: string;
 		role?: string;
-		loading?: 'eager' | 'lazy';
 		width?: string;
 		height?: string;
 		rounded?: boolean;
@@ -19,7 +18,6 @@
 		src,
 		alt = '',
 		role = 'presentation',
-		loading = 'lazy',
 		width,
 		height,
 		rounded = false,
@@ -41,7 +39,7 @@
 	data-tid={testId}
 	decoding="async"
 	{height}
-	{loading}
+	loading="lazy"
 	onerror={onError}
 	onload={onLoad}
 	{role}


### PR DESCRIPTION
# Motivation

As a generic policy, we should always load the images as `lazy`. So we can remove the prop `loading` from `Img` component.
