### PR TITLE
feat(frontend): implement gldt_stake API methods

### DIFF
--- a/src/frontend/src/lib/api/gldt_stake.api.ts
+++ b/src/frontend/src/lib/api/gldt_stake.api.ts
@@ -1,0 +1,30 @@
+import { GldtStakeCanister } from '$lib/canisters/gldt_stake.canister';
+import { GLDT_STAKE_CANISTER_ID } from '$lib/constants/app.constants';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
+import { Principal } from '@dfinity/principal';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
+
+let canister: GldtStakeCanister | undefined = undefined;
+
+export const getApyOverall = async ({ identity }: CanisterApiFunctionParams): Promise<number> => {
+	const { getApyOverall } = await gldtStakeCanister({ identity });
+
+	return getApyOverall();
+};
+
+const gldtStakeCanister = async ({
+	identity,
+	nullishIdentityErrorMessage,
+	canisterId = GLDT_STAKE_CANISTER_ID
+}: CanisterApiFunctionParams): Promise<GldtStakeCanister> => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	if (isNullish(canister)) {
+		canister = await GldtStakeCanister.create({
+			identity,
+			canisterId: Principal.fromText(canisterId)
+		});
+	}
+
+	return canister;
+};

--- a/src/frontend/src/tests/lib/api/gldt_stake.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/gldt_stake.api.spec.ts
@@ -1,0 +1,43 @@
+import { getApyOverall } from '$lib/api/gldt_stake.api';
+import { GldtStakeCanister } from '$lib/canisters/gldt_stake.canister';
+import * as appContants from '$lib/constants/app.constants';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mock } from 'vitest-mock-extended';
+
+describe('gldt_stake.api', () => {
+	describe('getApyOverall', () => {
+		const gldtStakeCanisterMock = mock<GldtStakeCanister>();
+		const response = 10;
+
+		beforeEach(() => {
+			// eslint-disable-next-line require-await
+			vi.spyOn(GldtStakeCanister, 'create').mockImplementation(async () => gldtStakeCanisterMock);
+
+			vi.spyOn(appContants, 'GLDT_STAKE_CANISTER_ID', 'get').mockImplementation(
+				() => mockLedgerCanisterId
+			);
+		});
+
+		it('correctly calls the gldt_stake canister getApyOverall method', async () => {
+			mockAuthStore();
+			gldtStakeCanisterMock.getApyOverall.mockResolvedValue(response);
+
+			const result = await getApyOverall({
+				identity: mockIdentity
+			});
+
+			expect(gldtStakeCanisterMock.getApyOverall).toHaveBeenCalledOnce();
+			expect(result).toBe(response);
+		});
+
+		it('throws an error if the gldt_stake canister getApyOverall method called without identity', async () => {
+			const res = getApyOverall({
+				identity: null
+			});
+
+			await expect(res).rejects.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We can now implement gldt_stake API methods.
