### PR TITLE
feat(frontend): implement gldt_stake APY store

### DIFF
--- a/src/frontend/src/icp/stores/gldt-stake-apy.store.ts
+++ b/src/frontend/src/icp/stores/gldt-stake-apy.store.ts
@@ -1,0 +1,31 @@
+import type { Option } from '$lib/types/utils';
+import { writable, type Readable } from 'svelte/store';
+
+export type GldtStakeApyStoreData = Option<{
+	apy?: number;
+}>;
+
+export interface GldtStakeApyStore extends Readable<GldtStakeApyStoreData> {
+	setApy: (value: number) => void;
+	reset: () => void;
+}
+
+export const initGldtStakeApyStore = (): GldtStakeApyStore => {
+	const { subscribe, set } = writable<GldtStakeApyStoreData>(undefined);
+
+	return {
+		subscribe,
+
+		reset: () => set(undefined),
+
+		setApy: (value: number) => {
+			set({ apy: value });
+		}
+	};
+};
+
+export interface GldtStakeApyContext {
+	store: GldtStakeApyStore;
+}
+
+export const GLDT_STAKE_APY_CONTEXT_KEY = Symbol('gldt-stake-apy');

--- a/src/frontend/src/tests/icp/stores/gldt-stake-apy.store.spec.ts
+++ b/src/frontend/src/tests/icp/stores/gldt-stake-apy.store.spec.ts
@@ -1,0 +1,33 @@
+import { initGldtStakeApyStore } from '$icp/stores/gldt-stake-apy.store';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
+import { get } from 'svelte/store';
+
+describe('gldt-stake-apy.store', () => {
+	const apyValue = 10;
+
+	beforeEach(() => {
+		mockPage.reset();
+	});
+
+	it('should ensure derived stores update at most once when the store changes', async () => {
+		await testDerivedUpdates(() => initGldtStakeApyStore().setApy(apyValue));
+	});
+
+	it('should have all expected values', () => {
+		const store = initGldtStakeApyStore();
+
+		store.setApy(apyValue);
+
+		expect(get(store)).toStrictEqual({ apy: apyValue });
+	});
+
+	it('should reset the value', () => {
+		const store = initGldtStakeApyStore();
+
+		store.setApy(apyValue);
+		store.reset();
+
+		expect(get(store)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
# Motivation

We are going to fetch gldt-stake APY value and save the value in the store.
