### PR TITLE
style(frontend): Auto-hide content in tokens list

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -197,5 +197,6 @@
 <style lang="scss">
 	.content-auto {
 		content-visibility: auto;
+		contain-intrinsic-size: 0 150px;
 	}
 </style>


### PR DESCRIPTION
# Motivation

For long lists, we can enable the auto-visibility of contents that will avoid rendering the list elements that are out of sight.
