### PR TITLE
feat(frontend): Remove unused QR actions in `ReceiveAddressQrCodeContent`

### DIFF
--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
@@ -25,10 +25,6 @@
 		addressToken={ETHEREUM_TOKEN}
 		copyAriaLabel={$i18n.receive.ethereum.text.ethereum_address_copied}
 		network={ETHEREUM_NETWORK}
-		qrCodeAction={{
-			enabled: true,
-			ariaLabel: $i18n.receive.ethereum.text.display_ethereum_address_qr
-		}}
 		testId={HOW_TO_CONVERT_ETHEREUM_QR_CODE}
 		on:icBack
 	/>

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -112,7 +112,6 @@
 					addressToken={ICP_TOKEN}
 					copyAriaLabel={$i18n.receive.icp.text.internet_computer_principal_copied}
 					network={ICP_NETWORK}
-					qrCodeAction={{ enabled: false }}
 					on:icBack={modal?.back}
 				/>
 			{:else if currentStep?.name === WizardStepsReceive.RECEIVE || currentStep?.name === WizardStepsConvert.CONVERT || currentStep?.name === WizardStepsConvert.REVIEW || currentStep?.name === WizardStepsConvert.CONVERTING || currentStep?.name === WizardStepsConvert.DESTINATION || currentStep?.name === WizardStepsSend.QR_CODE_SCAN}

--- a/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
@@ -78,7 +78,6 @@
 			{addressToken}
 			copyAriaLabel={copyAriaLabel ?? $i18n.wallet.text.wallet_address_copied}
 			network={addressToken.network}
-			qrCodeAction={{ enabled: false }}
 			on:icBack={displayAddresses}
 		/>
 	{:else}

--- a/src/frontend/src/lib/components/receive/ReceiveAddressQrCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQrCode.svelte
@@ -6,7 +6,6 @@
 	import { RECEIVE_TOKENS_MODAL_QR_CODE_OUTPUT } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
-	import type { ReceiveQRCodeAction } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
 
 	export let address: undefined | string;
@@ -14,7 +13,6 @@
 	export let addressToken: Token | undefined;
 
 	export let network: Network;
-	export let qrCodeAction: ReceiveQRCodeAction;
 	export let copyAriaLabel: string;
 	export let testId: string | undefined = undefined;
 
@@ -28,7 +26,6 @@
 		{addressToken}
 		{copyAriaLabel}
 		{network}
-		{qrCodeAction}
 		testId={RECEIVE_TOKENS_MODAL_QR_CODE_OUTPUT}
 		on:click
 	/>

--- a/src/frontend/src/lib/components/receive/ReceiveAddressQrCodeContent.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQrCodeContent.svelte
@@ -4,7 +4,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Address, OptionAddress } from '$lib/types/address';
 	import type { Network } from '$lib/types/network';
-	import type { ReceiveQRCodeAction } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
 
 	export let address: OptionAddress<Address>;
@@ -15,7 +14,6 @@
 	export let copyButtonTestId: string | undefined = undefined;
 
 	export let network: Network;
-	export let qrCodeAction: ReceiveQRCodeAction;
 	export let copyAriaLabel: string;
 
 	// TODO: replace properties (address, labels etc.) with a mandatory property of type ReceiveQrCode
@@ -29,7 +27,7 @@
 	{copyButtonTestId}
 	labelRef="address"
 	{network}
-	{qrCodeAction}
+	qrCodeAction={{ enabled: false }}
 	{testId}
 >
 	{#snippet title()}

--- a/src/frontend/src/lib/components/receive/ReceiveModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveModal.svelte
@@ -38,7 +38,6 @@
 			{copyAriaLabel}
 			copyButtonTestId={RECEIVE_TOKENS_MODAL_COPY_ADDRESS_BUTTON}
 			{network}
-			qrCodeAction={{ enabled: false }}
 		/>
 
 		{@render content?.()}


### PR DESCRIPTION
# Motivation

The component `ReceiveAddressQrCodeContent` was being used only with no QR actions. There is only one instance in which the property was passed as true, but no action was being passed for the action, leading to a dead button.

