### PR TITLE
refactor(frontend): Make `postMessage` protected in abstract class `AppWorker`

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
@@ -78,6 +78,7 @@
 			{addressToken}
 			copyAriaLabel={copyAriaLabel ?? $i18n.wallet.text.wallet_address_copied}
 			network={addressToken.network}
+			qrCodeAction={{ enabled: false }}
 			on:icBack={displayAddresses}
 		/>
 	{:else}


### PR DESCRIPTION
# Motivation

We don't really want that instances of the `AppWorker` (or its implementations) to call the `postMessage` in the consumer. It should be called only through public methods.