### PR TITLE
fix(frontend): reset utxos when user amount changes

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -77,6 +77,13 @@
 				: $btcAddressMainnet) ?? ''
 	);
 
+	$effect(() => {
+		[amount];
+
+		// if amount changes, we want to re-fetch the utxos
+		utxosFee = undefined;
+	});
+
 	const close = () => onClose();
 	const back = () => onSendBack();
 


### PR DESCRIPTION
# Motivation

We want to reset the utxos when user amount changes. The solution is temporarily, since we are going to update the send flow for BTC (move the fee calculation from the review screen to the send form).
