### PR TITLE
chore(frontend): Make `AuthWorker` constructor private

### DIFF
--- a/src/frontend/src/lib/services/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/worker.auth.services.ts
@@ -5,7 +5,7 @@ import type { PostMessage, PostMessageDataResponseAuth } from '$lib/types/post-m
 import { isNullish } from '@dfinity/utils';
 
 export class AuthWorker extends AppWorker {
-	constructor(worker: Worker) {
+	private constructor(worker: Worker) {
 		super(worker);
 
 		worker.onmessage = async ({


### PR DESCRIPTION
# Motivation

We don't want to initialize `AuthWorker` in a different way than using `AuthWorker.init()`