### PR TITLE
fix(frontend): Add `#key` to all `#if` statements to avoid DOM rendering race condition

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertTokenWizard.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertTokenWizard.svelte
@@ -154,29 +154,31 @@
 </script>
 
 <UtxosFeeContext amount={sendAmount} {amountError} {networkId} source={sourceAddress}>
-	{#if currentStep?.name === WizardStepsConvert.CONVERT}
-		<BtcConvertForm
-			{onNext}
-			source={sourceAddress}
-			bind:sendAmount
-			bind:receiveAmount
-			bind:amountError
-		>
-			{#snippet cancel()}
-				{#if formCancelAction === 'back'}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsConvert.CONVERT}
+			<BtcConvertForm
+				{onNext}
+				source={sourceAddress}
+				bind:sendAmount
+				bind:receiveAmount
+				bind:amountError
+			>
+				{#snippet cancel()}
+					{#if formCancelAction === 'back'}
+						<ButtonBack onclick={back} />
+					{:else}
+						<ButtonCancel onclick={close} />
+					{/if}
+				{/snippet}
+			</BtcConvertForm>
+		{:else if currentStep?.name === WizardStepsConvert.REVIEW}
+			<BtcConvertReview onConvert={convert} {receiveAmount} {sendAmount}>
+				{#snippet cancel()}
 					<ButtonBack onclick={back} />
-				{:else}
-					<ButtonCancel onclick={close} />
-				{/if}
-			{/snippet}
-		</BtcConvertForm>
-	{:else if currentStep?.name === WizardStepsConvert.REVIEW}
-		<BtcConvertReview onConvert={convert} {receiveAmount} {sendAmount}>
-			{#snippet cancel()}
-				<ButtonBack onclick={back} />
-			{/snippet}
-		</BtcConvertReview>
-	{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
-		<BtcConvertProgress {convertProgressStep} />
-	{/if}
+				{/snippet}
+			</BtcConvertReview>
+		{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
+			<BtcConvertProgress {convertProgressStep} />
+		{/if}
+	{/key}
 </UtxosFeeContext>

--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -204,22 +204,24 @@
 	};
 </script>
 
-{#if currentStep?.name === WizardStepsSend.REVIEW}
-	<BtcSendReview
-		{amount}
-		{destination}
-		{onBack}
-		onSend={send}
-		{selectedContact}
-		{source}
-		bind:utxosFee
-	/>
-{:else if currentStep?.name === WizardStepsSend.SENDING}
-	<BtcSendProgress {sendProgressStep} />
-{:else if currentStep?.name === WizardStepsSend.SEND}
-	<BtcSendForm {onBack} {onNext} {onTokensList} {selectedContact} bind:destination bind:amount>
-		{#snippet cancel()}
-			<ButtonBack onclick={back} />
-		{/snippet}
-	</BtcSendForm>
-{/if}
+{#key currentStep?.name}
+	{#if currentStep?.name === WizardStepsSend.REVIEW}
+		<BtcSendReview
+			{amount}
+			{destination}
+			{onBack}
+			onSend={send}
+			{selectedContact}
+			{source}
+			bind:utxosFee
+		/>
+	{:else if currentStep?.name === WizardStepsSend.SENDING}
+		<BtcSendProgress {sendProgressStep} />
+	{:else if currentStep?.name === WizardStepsSend.SEND}
+		<BtcSendForm {onBack} {onNext} {onTokensList} {selectedContact} bind:destination bind:amount>
+			{#snippet cancel()}
+				<ButtonBack onclick={back} />
+			{/snippet}
+		</BtcSendForm>
+	{/if}
+{/key}

--- a/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertTokenWizard.svelte
@@ -188,30 +188,32 @@
 	{sourceNetwork}
 	targetNetwork={ICP_NETWORK}
 >
-	{#if currentStep?.name === WizardStepsConvert.CONVERT}
-		<EthConvertForm {destination} {onNext} bind:sendAmount bind:receiveAmount>
-			{#snippet cancel()}
-				{#if formCancelAction === 'back'}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsConvert.CONVERT}
+			<EthConvertForm {destination} {onNext} bind:sendAmount bind:receiveAmount>
+				{#snippet cancel()}
+					{#if formCancelAction === 'back'}
+						<ButtonBack onclick={back} />
+					{:else}
+						<ButtonCancel onclick={close} />
+					{/if}
+				{/snippet}
+			</EthConvertForm>
+		{:else if currentStep?.name === WizardStepsConvert.REVIEW}
+			<EthConvertReview onConvert={convert} {receiveAmount} {sendAmount}>
+				{#snippet cancel()}
 					<ButtonBack onclick={back} />
-				{:else}
-					<ButtonCancel onclick={close} />
-				{/if}
-			{/snippet}
-		</EthConvertForm>
-	{:else if currentStep?.name === WizardStepsConvert.REVIEW}
-		<EthConvertReview onConvert={convert} {receiveAmount} {sendAmount}>
-			{#snippet cancel()}
-				<ButtonBack onclick={back} />
-			{/snippet}
-		</EthConvertReview>
-	{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
-		<EthConvertProgress
-			{convertProgressStep}
-			{destination}
-			nativeEthereumToken={$nativeEthereumTokenWithFallback}
-			sourceTokenId={$sourceToken.id}
-		/>
-	{:else}
-		{@render children?.()}
-	{/if}
+				{/snippet}
+			</EthConvertReview>
+		{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
+			<EthConvertProgress
+				{convertProgressStep}
+				{destination}
+				nativeEthereumToken={$nativeEthereumTokenWithFallback}
+				sourceTokenId={$sourceToken.id}
+			/>
+		{:else}
+			{@render children?.()}
+		{/if}
+	{/key}
 </EthFeeContext>

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -341,33 +341,35 @@
 	sendTokenId={$sendTokenId}
 	{sourceNetwork}
 >
-	{#if currentStep?.name === WizardStepsSend.REVIEW}
-		<EthSendReview
-			{amount}
-			{destination}
-			{nft}
-			{onBack}
-			onSend={nonNullish(nft) ? nftSend : send}
-			{selectedContact}
-		/>
-	{:else if currentStep?.name === WizardStepsSend.SENDING}
-		<InProgressWizard
-			progressStep={sendProgressStep}
-			steps={sendSteps({ i18n: $i18n, sendWithApproval })}
-		/>
-	{:else if currentStep?.name === WizardStepsSend.SEND}
-		<EthSendForm
-			{nativeEthereumToken}
-			{onBack}
-			{onNext}
-			{onTokensList}
-			{selectedContact}
-			bind:destination
-			bind:amount
-		>
-			{#snippet cancel()}
-				<ButtonBack onclick={back} />
-			{/snippet}
-		</EthSendForm>
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSend.REVIEW}
+			<EthSendReview
+				{amount}
+				{destination}
+				{nft}
+				{onBack}
+				onSend={nonNullish(nft) ? nftSend : send}
+				{selectedContact}
+			/>
+		{:else if currentStep?.name === WizardStepsSend.SENDING}
+			<InProgressWizard
+				progressStep={sendProgressStep}
+				steps={sendSteps({ i18n: $i18n, sendWithApproval })}
+			/>
+		{:else if currentStep?.name === WizardStepsSend.SEND}
+			<EthSendForm
+				{nativeEthereumToken}
+				{onBack}
+				{onNext}
+				{onTokensList}
+				{selectedContact}
+				bind:destination
+				bind:amount
+			>
+				{#snippet cancel()}
+					<ButtonBack onclick={back} />
+				{/snippet}
+			</EthSendForm>
+		{/if}
+	{/key}
 </EthFeeContext>

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -265,38 +265,40 @@
 		sendTokenId={$sourceToken.id}
 		sourceNetwork={$sourceToken.network as EthereumNetwork}
 	>
-		{#if currentStep?.name === WizardStepsSwap.SWAP}
-			<SwapEthForm
-				{isApproveNeeded}
-				{isSwapAmountsLoading}
-				{nativeEthereumToken}
-				{onClose}
-				{onNext}
-				{onShowTokensList}
-				bind:swapAmount
-				bind:receiveAmount
-				bind:slippageValue
-			/>
-		{:else if currentStep?.name === WizardStepsSwap.REVIEW}
-			<SwapReview
-				isSwapAmountsLoading={isSwapAmountsLoading &&
-					receiveAmount !== $swapAmountsStore?.selectedProvider?.receiveAmount}
-				{onBack}
-				onSwap={swap}
-				{receiveAmount}
-				{slippageValue}
-				{swapAmount}
-			>
-				{#snippet swapFees()}
-					<EthFeeDisplay>
-						{#snippet label()}
-							<Html text={$i18n.fee.text.total_fee} />
-						{/snippet}
-					</EthFeeDisplay>
-				{/snippet}
-			</SwapReview>
-		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
-			<SwapProgress sendWithApproval={true} {swapProgressStep} />
-		{/if}
+		{#key currentStep?.name}
+			{#if currentStep?.name === WizardStepsSwap.SWAP}
+				<SwapEthForm
+					{isApproveNeeded}
+					{isSwapAmountsLoading}
+					{nativeEthereumToken}
+					{onClose}
+					{onNext}
+					{onShowTokensList}
+					bind:swapAmount
+					bind:receiveAmount
+					bind:slippageValue
+				/>
+			{:else if currentStep?.name === WizardStepsSwap.REVIEW}
+				<SwapReview
+					isSwapAmountsLoading={isSwapAmountsLoading &&
+						receiveAmount !== $swapAmountsStore?.selectedProvider?.receiveAmount}
+					{onBack}
+					onSwap={swap}
+					{receiveAmount}
+					{slippageValue}
+					{swapAmount}
+				>
+					{#snippet swapFees()}
+						<EthFeeDisplay>
+							{#snippet label()}
+								<Html text={$i18n.fee.text.total_fee} />
+							{/snippet}
+						</EthFeeDisplay>
+					{/snippet}
+				</SwapReview>
+			{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
+				<SwapProgress sendWithApproval={true} {swapProgressStep} />
+			{/if}
+		{/key}
 	</EthFeeContext>
 {/if}

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendTokenModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendTokenModal.svelte
@@ -190,24 +190,26 @@
 		{sourceNetwork}
 	>
 		<CkEthLoader nativeTokenId={$sendTokenId}>
-			{#if currentStep?.name === WizardStepsSend.SENDING}
-				<SendProgress
-					progressStep={sendProgressStep}
-					steps={walletConnectSendSteps({ i18n: $i18n, sendWithApproval })}
-				/>
-			{:else if currentStep?.name === WizardStepsSend.REVIEW}
-				<EthWalletConnectSendReview
-					{amount}
-					{application}
-					{data}
-					{destination}
-					{erc20Approve}
-					onApprove={send}
-					onReject={reject}
-					{sourceNetwork}
-					{targetNetwork}
-				/>
-			{/if}
+			{#key currentStep?.name}
+				{#if currentStep?.name === WizardStepsSend.SENDING}
+					<SendProgress
+						progressStep={sendProgressStep}
+						steps={walletConnectSendSteps({ i18n: $i18n, sendWithApproval })}
+					/>
+				{:else if currentStep?.name === WizardStepsSend.REVIEW}
+					<EthWalletConnectSendReview
+						{amount}
+						{application}
+						{data}
+						{destination}
+						{erc20Approve}
+						onApprove={send}
+						onReject={reject}
+						{sourceNetwork}
+						{targetNetwork}
+					/>
+				{/if}
+			{/key}
 		</CkEthLoader>
 	</EthFeeContext>
 </WizardModal>

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
@@ -85,9 +85,11 @@
 		>
 	{/snippet}
 
-	{#if currentStep?.name === WizardStepsSign.SIGNING}
-		<InProgressWizard progressStep={signProgressStep} steps={walletConnectSignSteps($i18n)} />
-	{:else if currentStep?.name === WizardStepsSign.REVIEW}
-		<WalletConnectSignReview onApprove={approve} onReject={reject} {request} />
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSign.SIGNING}
+			<InProgressWizard progressStep={signProgressStep} steps={walletConnectSignSteps($i18n)} />
+		{:else if currentStep?.name === WizardStepsSign.REVIEW}
+			<WalletConnectSignReview onApprove={approve} onReject={reject} {request} />
+		{/if}
+	{/key}
 </WizardModal>

--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
@@ -17,15 +17,17 @@
 	let { currentStep, formCancelAction = 'close' }: Props = $props();
 </script>
 
-{#if currentStep?.name === WizardStepsHowToConvert.INFO}
-	<HowToConvertEthereumInfo {formCancelAction} on:icQRCode on:icConvert on:icBack />
-{:else if currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE}
-	<ReceiveAddressQrCode
-		address={$ethAddress ?? ''}
-		addressToken={ETHEREUM_TOKEN}
-		copyAriaLabel={$i18n.receive.ethereum.text.ethereum_address_copied}
-		network={ETHEREUM_NETWORK}
-		testId={HOW_TO_CONVERT_ETHEREUM_QR_CODE}
-		on:icBack
-	/>
-{/if}
+{#key currentStep?.name}
+	{#if currentStep?.name === WizardStepsHowToConvert.INFO}
+		<HowToConvertEthereumInfo {formCancelAction} on:icQRCode on:icConvert on:icBack />
+	{:else if currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE}
+		<ReceiveAddressQrCode
+			address={$ethAddress ?? ''}
+			addressToken={ETHEREUM_TOKEN}
+			copyAriaLabel={$i18n.receive.ethereum.text.ethereum_address_copied}
+			network={ETHEREUM_NETWORK}
+			testId={HOW_TO_CONVERT_ETHEREUM_QR_CODE}
+			on:icBack
+		/>
+	{/if}
+{/key}

--- a/src/frontend/src/icp/components/convert/IcConvertTokenWizard.svelte
+++ b/src/frontend/src/icp/components/convert/IcConvertTokenWizard.svelte
@@ -202,55 +202,57 @@
 
 <EthereumFeeContext {networkId}>
 	<BitcoinFeeContext amount={sendAmount} {networkId} token={$sourceToken}>
-		{#if currentStep?.name === WizardStepsConvert.CONVERT}
-			<IcConvertForm
-				destination={isDestinationCustom ? customDestination : defaultDestination}
-				{isDestinationCustom}
-				{onDestination}
-				{onNext}
-				bind:sendAmount
-				bind:receiveAmount
-			>
-				{#snippet cancel()}
-					{#if formCancelAction === 'back'}
+		{#key currentStep?.name}
+			{#if currentStep?.name === WizardStepsConvert.CONVERT}
+				<IcConvertForm
+					destination={isDestinationCustom ? customDestination : defaultDestination}
+					{isDestinationCustom}
+					{onDestination}
+					{onNext}
+					bind:sendAmount
+					bind:receiveAmount
+				>
+					{#snippet cancel()}
+						{#if formCancelAction === 'back'}
+							<ButtonBack onclick={back} />
+						{:else}
+							<ButtonCancel onclick={close} />
+						{/if}
+					{/snippet}
+				</IcConvertForm>
+			{:else if currentStep?.name === WizardStepsConvert.REVIEW}
+				<IcConvertReview
+					destination={isDestinationCustom ? customDestination : defaultDestination}
+					{isDestinationCustom}
+					onConvert={convert}
+					{receiveAmount}
+					{sendAmount}
+				>
+					{#snippet cancel()}
 						<ButtonBack onclick={back} />
-					{:else}
-						<ButtonCancel onclick={close} />
-					{/if}
-				{/snippet}
-			</IcConvertForm>
-		{:else if currentStep?.name === WizardStepsConvert.REVIEW}
-			<IcConvertReview
-				destination={isDestinationCustom ? customDestination : defaultDestination}
-				{isDestinationCustom}
-				onConvert={convert}
-				{receiveAmount}
-				{sendAmount}
-			>
-				{#snippet cancel()}
-					<ButtonBack onclick={back} />
-				{/snippet}
-			</IcConvertReview>
-		{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
-			<IcConvertProgress {convertProgressStep} />
-		{:else if currentStep?.name === WizardStepsConvert.DESTINATION}
-			<DestinationWizardStep
-				{networkId}
-				{onDestinationBack}
-				{onQRCodeScan}
-				tokenStandard={$destinationToken.standard}
-				bind:customDestination
-			>
-				{#snippet title()}{$i18n.convert.text.send_to}{/snippet}
-			</DestinationWizardStep>
-		{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-			<SendQrCodeScan
-				expectedToken={$destinationToken}
-				onDecodeQrCode={decodeQrCode}
-				{onQRCodeBack}
-				bind:destination={customDestination}
-				bind:amount={sendAmount}
-			/>
-		{/if}
+					{/snippet}
+				</IcConvertReview>
+			{:else if currentStep?.name === WizardStepsConvert.CONVERTING}
+				<IcConvertProgress {convertProgressStep} />
+			{:else if currentStep?.name === WizardStepsConvert.DESTINATION}
+				<DestinationWizardStep
+					{networkId}
+					{onDestinationBack}
+					{onQRCodeScan}
+					tokenStandard={$destinationToken.standard}
+					bind:customDestination
+				>
+					{#snippet title()}{$i18n.convert.text.send_to}{/snippet}
+				</DestinationWizardStep>
+			{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
+				<SendQrCodeScan
+					expectedToken={$destinationToken}
+					onDecodeQrCode={decodeQrCode}
+					{onQRCodeBack}
+					bind:destination={customDestination}
+					bind:amount={sendAmount}
+				/>
+			{/if}
+		{/key}
 	</BitcoinFeeContext>
 </EthereumFeeContext>

--- a/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveCkEthereumModal.svelte
@@ -93,33 +93,35 @@
 			bind:receiveAmount
 			bind:convertProgressStep
 		>
-			{#if currentStep?.name === WizardStepsHowToConvert.INFO || currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE}
-				<HowToConvertEthereumWizardSteps
-					{currentStep}
-					formCancelAction="back"
-					on:icBack={() =>
-						goToStep(
-							currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE
-								? WizardStepsHowToConvert.INFO
-								: WizardStepsReceive.RECEIVE
-						)}
-					on:icQRCode={() => goToStep(WizardStepsHowToConvert.ETH_QR_CODE)}
-					on:icConvert={() => goToStep(WizardStepsConvert.CONVERT)}
-				/>
-			{:else if currentStep?.name === WizardStepsReceive.QR_CODE}
-				<ReceiveAddressQrCode
-					address={$icrcAccountIdentifierText ?? ''}
-					addressToken={ICP_TOKEN}
-					copyAriaLabel={$i18n.receive.icp.text.internet_computer_principal_copied}
-					network={ICP_NETWORK}
-					on:icBack={modal?.back}
-				/>
-			{:else if currentStep?.name === WizardStepsReceive.RECEIVE || currentStep?.name === WizardStepsConvert.CONVERT || currentStep?.name === WizardStepsConvert.REVIEW || currentStep?.name === WizardStepsConvert.CONVERTING || currentStep?.name === WizardStepsConvert.DESTINATION || currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-				<IcReceiveInfoCkEthereum
-					on:icQRCode={() => goToStep(WizardStepsReceive.QR_CODE)}
-					on:icHowToConvert={() => goToStep(WizardStepsHowToConvert.INFO)}
-				/>
-			{/if}
+			{#key currentStep?.name}
+				{#if currentStep?.name === WizardStepsHowToConvert.INFO || currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE}
+					<HowToConvertEthereumWizardSteps
+						{currentStep}
+						formCancelAction="back"
+						on:icBack={() =>
+							goToStep(
+								currentStep?.name === WizardStepsHowToConvert.ETH_QR_CODE
+									? WizardStepsHowToConvert.INFO
+									: WizardStepsReceive.RECEIVE
+							)}
+						on:icQRCode={() => goToStep(WizardStepsHowToConvert.ETH_QR_CODE)}
+						on:icConvert={() => goToStep(WizardStepsConvert.CONVERT)}
+					/>
+				{:else if currentStep?.name === WizardStepsReceive.QR_CODE}
+					<ReceiveAddressQrCode
+						address={$icrcAccountIdentifierText ?? ''}
+						addressToken={ICP_TOKEN}
+						copyAriaLabel={$i18n.receive.icp.text.internet_computer_principal_copied}
+						network={ICP_NETWORK}
+						on:icBack={modal?.back}
+					/>
+				{:else if currentStep?.name === WizardStepsReceive.RECEIVE || currentStep?.name === WizardStepsConvert.CONVERT || currentStep?.name === WizardStepsConvert.REVIEW || currentStep?.name === WizardStepsConvert.CONVERTING || currentStep?.name === WizardStepsConvert.DESTINATION || currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
+					<IcReceiveInfoCkEthereum
+						on:icQRCode={() => goToStep(WizardStepsReceive.QR_CODE)}
+						on:icHowToConvert={() => goToStep(WizardStepsHowToConvert.INFO)}
+					/>
+				{/if}
+			{/key}
 		</EthConvertTokenWizard>
 	</WizardModal>
 </ConvertContexts>

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -140,14 +140,16 @@
 	const close = () => onClose();
 </script>
 
-{#if currentStep?.name === WizardStepsSend.REVIEW}
-	<IcSendReview {amount} {destination} {onBack} onSend={send} {selectedContact} />
-{:else if currentStep?.name === WizardStepsSend.SENDING}
-	<IcSendProgress {sendProgressStep} />
-{:else if currentStep?.name === WizardStepsSend.SEND}
-	<IcSendForm {onBack} {onNext} {onTokensList} {selectedContact} bind:destination bind:amount>
-		{#snippet cancel()}
-			<ButtonBack onclick={back} />
-		{/snippet}
-	</IcSendForm>
-{/if}
+{#key currentStep?.name}
+	{#if currentStep?.name === WizardStepsSend.REVIEW}
+		<IcSendReview {amount} {destination} {onBack} onSend={send} {selectedContact} />
+	{:else if currentStep?.name === WizardStepsSend.SENDING}
+		<IcSendProgress {sendProgressStep} />
+	{:else if currentStep?.name === WizardStepsSend.SEND}
+		<IcSendForm {onBack} {onNext} {onTokensList} {selectedContact} bind:destination bind:amount>
+			{#snippet cancel()}
+				<ButtonBack onclick={back} />
+			{/snippet}
+		</IcSendForm>
+	{/if}
+{/key}

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeWizard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeWizard.svelte
@@ -63,10 +63,12 @@
 	};
 </script>
 
-{#if currentStep?.name === WizardStepsStake.STAKE}
-	<GldtStakeForm {onClose} {onNext} bind:amount />
-{:else if currentStep?.name === WizardStepsStake.REVIEW}
-	<GldtStakeReview {amount} {onBack} onStake={stake} />
-{:else if currentStep?.name === WizardStepsStake.STAKING}
-	<StakeProgress {stakeProgressStep} />
-{/if}
+{#key currentStep?.name}
+	{#if currentStep?.name === WizardStepsStake.STAKE}
+		<GldtStakeForm {onClose} {onNext} bind:amount />
+	{:else if currentStep?.name === WizardStepsStake.REVIEW}
+		<GldtStakeReview {amount} {onBack} onStake={stake} />
+	{:else if currentStep?.name === WizardStepsStake.STAKING}
+		<StakeProgress {stakeProgressStep} />
+	{/if}
+{/key}

--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -240,29 +240,32 @@
 </script>
 
 <IcTokenFeeContext token={$sourceToken as IcToken}>
-	{#if currentStep?.name === WizardStepsSwap.SWAP}
-		<SwapIcpForm
-			{isSwapAmountsLoading}
-			{onClose}
-			{onNext}
-			{onShowTokensList}
-			{sourceTokenFee}
-			on:icShowProviderList
-			bind:swapAmount
-			bind:receiveAmount
-			bind:slippageValue
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.REVIEW}
-		<SwapReview {onBack} onSwap={swap} {receiveAmount} {slippageValue} {swapAmount}>
-			{#snippet swapFees()}
-				<SwapFees />
-			{/snippet}
-		</SwapReview>
-	{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
-		<SwapProgress
-			{swapProgressStep}
-			swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ICP_SWAP}
-			bind:failedSteps={swapFailedProgressSteps}
-		/>
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSwap.SWAP}
+			<SwapIcpForm
+				{isSwapAmountsLoading}
+				{onClose}
+				{onNext}
+				{onShowTokensList}
+				{sourceTokenFee}
+				on:icShowProviderList
+				bind:swapAmount
+				bind:receiveAmount
+				bind:slippageValue
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.REVIEW}
+			<SwapReview {onBack} onSwap={swap} {receiveAmount} {slippageValue} {swapAmount}>
+				{#snippet swapFees()}
+					<SwapFees />
+				{/snippet}
+			</SwapReview>
+		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
+			<SwapProgress
+				{swapProgressStep}
+				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
+					SwapProvider.ICP_SWAP}
+				bind:failedSteps={swapFailedProgressSteps}
+			/>
+		{/if}
+	{/key}
 </IcTokenFeeContext>

--- a/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
+++ b/src/frontend/src/lib/components/address-book/AddressBookModal.svelte
@@ -305,234 +305,238 @@
 		{/if}
 	{/snippet}
 
-	{#if currentStepName === AddressBookSteps.ADDRESS_BOOK}
-		<AddressBookStep
-			{contacts}
-			onAddContact={() => {
-				currentContactId = undefined;
-				currentAddressIndex = undefined;
-				previousStepName = AddressBookSteps.ADDRESS_BOOK;
-				gotoStep(AddressBookSteps.EDIT_CONTACT_NAME);
-			}}
-			onShowAddress={({ contact, addressIndex }) => {
-				currentContact = contact;
-				currentAddressIndex = addressIndex;
-				previousStepName = AddressBookSteps.ADDRESS_BOOK;
-				gotoStep(AddressBookSteps.SHOW_ADDRESS);
-			}}
-			onShowContact={(contact) => {
-				currentContactId = contact.id;
-				gotoStep(AddressBookSteps.SHOW_CONTACT);
-			}}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.SHOW_CONTACT && nonNullish(currentContact)}
-		<ShowContactStep
-			contact={currentContact}
-			onAddAddress={() => {
-				currentAddressIndex = undefined;
-				gotoStep(AddressBookSteps.EDIT_ADDRESS);
-			}}
-			onClose={() => {
-				navigateToEntrypointOrCallback(() => gotoStep(AddressBookSteps.ADDRESS_BOOK));
-			}}
-			onEdit={(contact) => {
-				currentContactId = contact.id;
-				gotoStep(AddressBookSteps.EDIT_CONTACT);
-			}}
-			onShowAddress={(addressIndex) => {
-				currentAddressIndex = addressIndex;
-				previousStepName = AddressBookSteps.SHOW_CONTACT;
-				gotoStep(AddressBookSteps.SHOW_ADDRESS);
-			}}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT && nonNullish(currentContact)}
-		<!-- TODO find a better way to render EditContactStep with different onDeleteAddress functions -->
-		<Responsive down="sm">
-			<EditContactStep
+	{#key currentStepName}
+		{#if currentStepName === AddressBookSteps.ADDRESS_BOOK}
+			<AddressBookStep
+				{contacts}
+				onAddContact={() => {
+					currentContactId = undefined;
+					currentAddressIndex = undefined;
+					previousStepName = AddressBookSteps.ADDRESS_BOOK;
+					gotoStep(AddressBookSteps.EDIT_CONTACT_NAME);
+				}}
+				onShowAddress={({ contact, addressIndex }) => {
+					currentContact = contact;
+					currentAddressIndex = addressIndex;
+					previousStepName = AddressBookSteps.ADDRESS_BOOK;
+					gotoStep(AddressBookSteps.SHOW_ADDRESS);
+				}}
+				onShowContact={(contact) => {
+					currentContactId = contact.id;
+					gotoStep(AddressBookSteps.SHOW_CONTACT);
+				}}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.SHOW_CONTACT && nonNullish(currentContact)}
+			<ShowContactStep
 				contact={currentContact}
 				onAddAddress={() => {
 					currentAddressIndex = undefined;
+					gotoStep(AddressBookSteps.EDIT_ADDRESS);
+				}}
+				onClose={() => {
+					navigateToEntrypointOrCallback(() => gotoStep(AddressBookSteps.ADDRESS_BOOK));
+				}}
+				onEdit={(contact) => {
+					currentContactId = contact.id;
+					gotoStep(AddressBookSteps.EDIT_CONTACT);
+				}}
+				onShowAddress={(addressIndex) => {
+					currentAddressIndex = addressIndex;
 					previousStepName = AddressBookSteps.SHOW_CONTACT;
-					gotoStep(AddressBookSteps.EDIT_ADDRESS);
-				}}
-				onAvatarEdit={handleAddAvatar}
-				onClose={() => gotoStep(AddressBookSteps.SHOW_CONTACT)}
-				onDeleteAddress={(index) => {
-					currentAddressIndex = index;
-				}}
-				onDeleteContact={() => {
-					isDeletingContact = true;
-				}}
-				onEdit={(contact) => {
-					currentContact = contact;
-					gotoStep(AddressBookSteps.EDIT_CONTACT_NAME);
-				}}
-				onEditAddress={(index) => {
-					currentAddressIndex = index;
-					gotoStep(AddressBookSteps.EDIT_ADDRESS);
+					gotoStep(AddressBookSteps.SHOW_ADDRESS);
 				}}
 			/>
-		</Responsive>
-		<Responsive up="md">
-			<EditContactStep
+		{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT && nonNullish(currentContact)}
+			<!-- TODO find a better way to render EditContactStep with different onDeleteAddress functions -->
+			<Responsive down="sm">
+				<EditContactStep
+					contact={currentContact}
+					onAddAddress={() => {
+						currentAddressIndex = undefined;
+						previousStepName = AddressBookSteps.SHOW_CONTACT;
+						gotoStep(AddressBookSteps.EDIT_ADDRESS);
+					}}
+					onAvatarEdit={handleAddAvatar}
+					onClose={() => gotoStep(AddressBookSteps.SHOW_CONTACT)}
+					onDeleteAddress={(index) => {
+						currentAddressIndex = index;
+					}}
+					onDeleteContact={() => {
+						isDeletingContact = true;
+					}}
+					onEdit={(contact) => {
+						currentContact = contact;
+						gotoStep(AddressBookSteps.EDIT_CONTACT_NAME);
+					}}
+					onEditAddress={(index) => {
+						currentAddressIndex = index;
+						gotoStep(AddressBookSteps.EDIT_ADDRESS);
+					}}
+				/>
+			</Responsive>
+			<Responsive up="md">
+				<EditContactStep
+					contact={currentContact}
+					onAddAddress={() => {
+						currentAddressIndex = undefined;
+						gotoStep(AddressBookSteps.EDIT_ADDRESS);
+					}}
+					onAvatarEdit={handleAddAvatar}
+					onClose={() => gotoStep(AddressBookSteps.SHOW_CONTACT)}
+					onDeleteAddress={confirmDeleteAddress}
+					onDeleteContact={confirmDeleteContact}
+					onEdit={(contact) => {
+						currentContact = contact;
+						gotoStep(AddressBookSteps.EDIT_CONTACT_NAME);
+					}}
+					onEditAddress={(index) => {
+						currentAddressIndex = index;
+						gotoStep(AddressBookSteps.EDIT_ADDRESS);
+					}}
+				/>
+			</Responsive>
+		{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT_NAME}
+			<EditContactNameStep
+				bind:this={editContactNameStep}
 				contact={currentContact}
-				onAddAddress={() => {
-					currentAddressIndex = undefined;
-					gotoStep(AddressBookSteps.EDIT_ADDRESS);
-				}}
-				onAvatarEdit={handleAddAvatar}
-				onClose={() => gotoStep(AddressBookSteps.SHOW_CONTACT)}
-				onDeleteAddress={confirmDeleteAddress}
-				onDeleteContact={confirmDeleteContact}
-				onEdit={(contact) => {
-					currentContact = contact;
-					gotoStep(AddressBookSteps.EDIT_CONTACT_NAME);
-				}}
-				onEditAddress={(index) => {
-					currentAddressIndex = index;
-					gotoStep(AddressBookSteps.EDIT_ADDRESS);
-				}}
-			/>
-		</Responsive>
-	{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT_NAME}
-		<EditContactNameStep
-			bind:this={editContactNameStep}
-			contact={currentContact}
-			disabled={loading}
-			isNewContact={isNullish(currentContact)}
-			onAddContact={async (contact: Pick<ContactUi, 'name'>) => {
-				const createdContact = await callCreateContact({ name: contact.name });
-				if (modalData?.entrypoint) {
-					currentAddressIndex = undefined;
-					currentContact = createdContact;
-					gotoStep(AddressBookSteps.EDIT_ADDRESS);
-					previousStepName = AddressBookSteps.SAVE_ADDRESS;
-				} else {
-					if (nonNullish(createdContact)) {
-						currentContactId = createdContact.id;
-						gotoStep(AddressBookSteps.SHOW_CONTACT);
+				disabled={loading}
+				isNewContact={isNullish(currentContact)}
+				onAddContact={async (contact: Pick<ContactUi, 'name'>) => {
+					const createdContact = await callCreateContact({ name: contact.name });
+					if (modalData?.entrypoint) {
+						currentAddressIndex = undefined;
+						currentContact = createdContact;
+						gotoStep(AddressBookSteps.EDIT_ADDRESS);
+						previousStepName = AddressBookSteps.SAVE_ADDRESS;
 					} else {
-						gotoStep(AddressBookSteps.ADDRESS_BOOK);
+						if (nonNullish(createdContact)) {
+							currentContactId = createdContact.id;
+							gotoStep(AddressBookSteps.SHOW_CONTACT);
+						} else {
+							gotoStep(AddressBookSteps.ADDRESS_BOOK);
+						}
 					}
-				}
-			}}
-			onClose={() => {
-				navigateToEntrypointOrCallback(handleClose);
-			}}
-			onSaveContact={async (contact: ContactUi) => {
-				await callUpdateContact({ contact });
-				gotoStep(AddressBookSteps.EDIT_CONTACT);
-			}}
-			bind:title={editContactNameTitle}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.EDIT_ADDRESS && nonNullish(currentContact)}
-		<EditAddressStep
-			address={nonNullish(currentAddressIndex)
-				? currentContact?.addresses[currentAddressIndex]
-				: nonNullish(qrCodeAddress)
-					? { address: qrCodeAddress }
-					: undefined}
-			contact={currentContact}
-			disabled={loading}
-			isNewAddress={isNullish(currentAddressIndex)}
-			onAddAddress={handleAddAddress}
-			onClose={() => {
-				currentAddressIndex = undefined;
-				handleClose();
-			}}
-			onQRCodeScan={() =>
-				nonNullish(modal) &&
-				goToWizardStep({ modal, steps, stepName: AddressBookSteps.QR_CODE_SCAN })}
-			onSaveAddress={handleSaveAddress}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.DELETE_ADDRESS && nonNullish(currentContact) && nonNullish(currentAddressIndex)}
-		<DeleteAddressConfirmContent
-			address={currentContact.addresses[currentAddressIndex]}
-			contact={currentContact}
-			disabled={loading}
-			onCancel={() => {
-				currentAddressIndex = undefined;
-				gotoStep(AddressBookSteps.EDIT_CONTACT);
-			}}
-			onDelete={() => nonNullish(currentAddressIndex) && handleDeleteAddress(currentAddressIndex)}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.SHOW_ADDRESS}
-		{#if nonNullish(currentAddressIndex) && nonNullish(currentContact?.addresses?.[currentAddressIndex])}
-			<AddressBookInfoPage
-				address={currentContact.addresses[currentAddressIndex]}
+				}}
+				onClose={() => {
+					navigateToEntrypointOrCallback(handleClose);
+				}}
+				onSaveContact={async (contact: ContactUi) => {
+					await callUpdateContact({ contact });
+					gotoStep(AddressBookSteps.EDIT_CONTACT);
+				}}
+				bind:title={editContactNameTitle}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.EDIT_ADDRESS && nonNullish(currentContact)}
+			<EditAddressStep
+				address={nonNullish(currentAddressIndex)
+					? currentContact?.addresses[currentAddressIndex]
+					: nonNullish(qrCodeAddress)
+						? { address: qrCodeAddress }
+						: undefined}
+				contact={currentContact}
+				disabled={loading}
+				isNewAddress={isNullish(currentAddressIndex)}
+				onAddAddress={handleAddAddress}
 				onClose={() => {
 					currentAddressIndex = undefined;
 					handleClose();
 				}}
+				onQRCodeScan={() =>
+					nonNullish(modal) &&
+					goToWizardStep({ modal, steps, stepName: AddressBookSteps.QR_CODE_SCAN })}
+				onSaveAddress={handleSaveAddress}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.DELETE_ADDRESS && nonNullish(currentContact) && nonNullish(currentAddressIndex)}
+			<DeleteAddressConfirmContent
+				address={currentContact.addresses[currentAddressIndex]}
+				contact={currentContact}
+				disabled={loading}
+				onCancel={() => {
+					currentAddressIndex = undefined;
+					gotoStep(AddressBookSteps.EDIT_CONTACT);
+				}}
+				onDelete={() => nonNullish(currentAddressIndex) && handleDeleteAddress(currentAddressIndex)}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.SHOW_ADDRESS}
+			{#if nonNullish(currentAddressIndex) && nonNullish(currentContact?.addresses?.[currentAddressIndex])}
+				<AddressBookInfoPage
+					address={currentContact.addresses[currentAddressIndex]}
+					onClose={() => {
+						currentAddressIndex = undefined;
+						handleClose();
+					}}
+				/>
+			{/if}
+		{:else if currentStep?.name === AddressBookSteps.DELETE_CONTACT && nonNullish(currentContact)}
+			<DeleteContactConfirmContent
+				contact={currentContact}
+				disabled={loading}
+				onCancel={() => {
+					gotoStep(AddressBookSteps.EDIT_CONTACT);
+				}}
+				onDelete={handleDeleteContact}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.SAVE_ADDRESS}
+			<SaveAddressStep
+				onClose={close}
+				onCreateContact={() => {
+					currentContact = undefined;
+					gotoStep(AddressBookSteps.CREATE_CONTACT);
+				}}
+				onSelectContact={(contact: ContactUi) => {
+					currentContact = contact;
+					currentAddressIndex = undefined;
+					gotoStep(AddressBookSteps.EDIT_ADDRESS);
+				}}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.CREATE_CONTACT}
+			<CreateContactStep
+				disabled={loading}
+				onBack={() => gotoStep(AddressBookSteps.SAVE_ADDRESS)}
+				onSave={async (contact: ContactUi) => {
+					loading = true;
+					currentContact = contact;
+					currentAddressIndex = undefined;
+					const createdContact = await callCreateContact({ name: contact.name });
+					await callUpdateContact({ contact: { ...createdContact, ...contact } });
+					close();
+				}}
+			/>
+		{:else if currentStep?.name === AddressBookSteps.QR_CODE_SCAN}
+			<AddressBookQrCodeStep
+				onCancel={() =>
+					nonNullish(modal) &&
+					goToWizardStep({ modal, steps, stepName: AddressBookSteps.EDIT_ADDRESS })}
+				onScan={({ code }) => {
+					qrCodeAddress = code;
+				}}
 			/>
 		{/if}
-	{:else if currentStep?.name === AddressBookSteps.DELETE_CONTACT && nonNullish(currentContact)}
-		<DeleteContactConfirmContent
+	{/key}
+</WizardModal>
+
+{#key currentStep?.name}
+	{#if currentStep?.name === AddressBookSteps.EDIT_CONTACT && nonNullish(currentContact) && nonNullish(currentAddressIndex)}
+		<DeleteAddressConfirmBottomSheet
+			address={currentContact.addresses[currentAddressIndex]}
+			contact={currentContact}
+			disabled={loading}
+			onCancel={() => (currentAddressIndex = undefined)}
+			onDelete={() => nonNullish(currentAddressIndex) && handleDeleteAddress(currentAddressIndex)}
+		/>
+	{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT && nonNullish(currentContact) && isDeletingContact}
+		<DeleteContactConfirmBottomSheet
 			contact={currentContact}
 			disabled={loading}
 			onCancel={() => {
-				gotoStep(AddressBookSteps.EDIT_CONTACT);
+				isDeletingContact = false;
 			}}
-			onDelete={handleDeleteContact}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.SAVE_ADDRESS}
-		<SaveAddressStep
-			onClose={close}
-			onCreateContact={() => {
-				currentContact = undefined;
-				gotoStep(AddressBookSteps.CREATE_CONTACT);
-			}}
-			onSelectContact={(contact: ContactUi) => {
-				currentContact = contact;
-				currentAddressIndex = undefined;
-				gotoStep(AddressBookSteps.EDIT_ADDRESS);
-			}}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.CREATE_CONTACT}
-		<CreateContactStep
-			disabled={loading}
-			onBack={() => gotoStep(AddressBookSteps.SAVE_ADDRESS)}
-			onSave={async (contact: ContactUi) => {
-				loading = true;
-				currentContact = contact;
-				currentAddressIndex = undefined;
-				const createdContact = await callCreateContact({ name: contact.name });
-				await callUpdateContact({ contact: { ...createdContact, ...contact } });
-				close();
-			}}
-		/>
-	{:else if currentStep?.name === AddressBookSteps.QR_CODE_SCAN}
-		<AddressBookQrCodeStep
-			onCancel={() =>
-				nonNullish(modal) &&
-				goToWizardStep({ modal, steps, stepName: AddressBookSteps.EDIT_ADDRESS })}
-			onScan={({ code }) => {
-				qrCodeAddress = code;
+			onDelete={() => {
+				isDeletingContact = false;
+				if (nonNullish(currentContact)) {
+					handleDeleteContact(currentContact.id);
+				}
 			}}
 		/>
 	{/if}
-</WizardModal>
-
-{#if currentStep?.name === AddressBookSteps.EDIT_CONTACT && nonNullish(currentContact) && nonNullish(currentAddressIndex)}
-	<DeleteAddressConfirmBottomSheet
-		address={currentContact.addresses[currentAddressIndex]}
-		contact={currentContact}
-		disabled={loading}
-		onCancel={() => (currentAddressIndex = undefined)}
-		onDelete={() => nonNullish(currentAddressIndex) && handleDeleteAddress(currentAddressIndex)}
-	/>
-{:else if currentStep?.name === AddressBookSteps.EDIT_CONTACT && nonNullish(currentContact) && isDeletingContact}
-	<DeleteContactConfirmBottomSheet
-		contact={currentContact}
-		disabled={loading}
-		onCancel={() => {
-			isDeletingContact = false;
-		}}
-		onDelete={() => {
-			isDeletingContact = false;
-			if (nonNullish(currentContact)) {
-				handleDeleteContact(currentContact.id);
-			}
-		}}
-	/>
-{/if}
+{/key}

--- a/src/frontend/src/lib/components/auth/AuthHelpModal.svelte
+++ b/src/frontend/src/lib/components/auth/AuthHelpModal.svelte
@@ -55,11 +55,13 @@
 		<span class="text-xl">{titleString}</span>
 	{/snippet}
 
-	{#if currentStep?.name === WizardStepsAuthHelp.OVERVIEW}
-		<AuthHelpForm {onLostIdentity} {onOther} />
-	{:else if currentStep?.name === WizardStepsAuthHelp.HELP_IDENTITY}
-		<AuthHelpIdentityForm hideBack={usesIdentityHelp} {onBack} onDone={close} />
-	{:else if currentStep?.name === WizardStepsAuthHelp.HELP_OTHER}
-		<AuthHelpOtherForm {onBack} onDone={close} />
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsAuthHelp.OVERVIEW}
+			<AuthHelpForm {onLostIdentity} {onOther} />
+		{:else if currentStep?.name === WizardStepsAuthHelp.HELP_IDENTITY}
+			<AuthHelpIdentityForm hideBack={usesIdentityHelp} {onBack} onDone={close} />
+		{:else if currentStep?.name === WizardStepsAuthHelp.HELP_OTHER}
+			<AuthHelpOtherForm {onBack} onDone={close} />
+		{/if}
+	{/key}
 </WizardModal>

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -315,47 +315,49 @@
 >
 	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-	{#if currentStep?.name === WizardStepsManageTokens.REVIEW}
-		{#if isNetworkIdICP(network?.id)}
-			<IcAddTokenReview
-				{indexCanisterId}
-				{ledgerCanisterId}
-				onBack={modal.back}
-				onSave={addIcrcToken}
-				bind:metadata={icrcMetadata}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsManageTokens.REVIEW}
+			{#if isNetworkIdICP(network?.id)}
+				<IcAddTokenReview
+					{indexCanisterId}
+					{ledgerCanisterId}
+					onBack={modal.back}
+					onSave={addIcrcToken}
+					bind:metadata={icrcMetadata}
+				/>
+			{:else if nonNullish(network) && (isNetworkIdEthereum(network?.id) || isNetworkIdEvm(network?.id))}
+				<EthAddTokenReview
+					contractAddress={ethContractAddress}
+					{network}
+					onBack={modal.back}
+					onSave={saveEthToken}
+					bind:metadata={ethMetadata}
+				/>
+			{:else if nonNullish(network) && isNetworkIdSolana(network?.id)}
+				<SolAddTokenReview
+					{network}
+					onBack={modal.back}
+					onSave={saveSplToken}
+					tokenAddress={splTokenAddress}
+					bind:metadata={splMetadata}
+				/>
+			{/if}
+		{:else if currentStep?.name === WizardStepsManageTokens.SAVING}
+			<InProgressWizard
+				progressStep={saveProgressStep}
+				steps={addTokenSteps($i18n)}
+				warningType="manage"
 			/>
-		{:else if nonNullish(network) && (isNetworkIdEthereum(network?.id) || isNetworkIdEvm(network?.id))}
-			<EthAddTokenReview
-				contractAddress={ethContractAddress}
-				{network}
-				onBack={modal.back}
-				onSave={saveEthToken}
-				bind:metadata={ethMetadata}
-			/>
-		{:else if nonNullish(network) && isNetworkIdSolana(network?.id)}
-			<SolAddTokenReview
-				{network}
-				onBack={modal.back}
-				onSave={saveSplToken}
-				tokenAddress={splTokenAddress}
-				bind:metadata={splMetadata}
+		{:else if currentStep?.name === WizardStepsManageTokens.IMPORT}
+			<AddTokenByNetwork onBack={modal.back} onNext={modal.next} bind:network bind:tokenData />
+		{:else if currentStep?.name === WizardStepsManageTokens.MANAGE}
+			<ManageTokens
+				{infoElement}
+				{initialSearch}
+				{isNftsPage}
+				onAddToken={modal.next}
+				onSave={saveTokens}
 			/>
 		{/if}
-	{:else if currentStep?.name === WizardStepsManageTokens.SAVING}
-		<InProgressWizard
-			progressStep={saveProgressStep}
-			steps={addTokenSteps($i18n)}
-			warningType="manage"
-		/>
-	{:else if currentStep?.name === WizardStepsManageTokens.IMPORT}
-		<AddTokenByNetwork onBack={modal.back} onNext={modal.next} bind:network bind:tokenData />
-	{:else if currentStep?.name === WizardStepsManageTokens.MANAGE}
-		<ManageTokens
-			{infoElement}
-			{initialSearch}
-			{isNftsPage}
-			onAddToken={modal.next}
-			onSave={saveTokens}
-		/>
-	{/if}
+	{/key}
 </WizardModal>

--- a/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressModal.svelte
@@ -71,16 +71,18 @@
 		{/if}
 	{/snippet}
 
-	{#if currentStep?.name === steps[1].name && nonNullish(addressToken)}
-		<ReceiveAddressQrCode
-			{address}
-			{addressLabel}
-			{addressToken}
-			copyAriaLabel={copyAriaLabel ?? $i18n.wallet.text.wallet_address_copied}
-			network={addressToken.network}
-			on:icBack={displayAddresses}
-		/>
-	{:else}
-		<svelte:component this={infoCmp} on:icQRCode={displayQRCode} />
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === steps[1].name && nonNullish(addressToken)}
+			<ReceiveAddressQrCode
+				{address}
+				{addressLabel}
+				{addressToken}
+				copyAriaLabel={copyAriaLabel ?? $i18n.wallet.text.wallet_address_copied}
+				network={addressToken.network}
+				on:icBack={displayAddresses}
+			/>
+		{:else}
+			<svelte:component this={infoCmp} on:icQRCode={displayQRCode} />
+		{/if}
+	{/key}
 </WizardModal>

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -213,53 +213,55 @@
 	>
 		{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-		{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
-			<SendTokensList
-				onSelectNetworkFilter={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
-				{onSendToken}
-			/>
-		{:else if currentStep?.name === WizardStepsSend.NFTS_LIST}
-			<SendNftsList
-				onSelect={selectNft}
-				onSelectNetwork={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
-			/>
-		{:else if currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
-			<ModalNetworksFilter onNetworkFilter={() => goToStep(WizardStepsSend.TOKENS_LIST)} />
-		{:else if currentStep?.name === WizardStepsSend.DESTINATION}
-			<SendDestinationWizardStep
-				formCancelAction={isTransactionsPage || (isNftsPage && nonNullish($pageNft))
-					? 'close'
-					: 'back'}
-				onBack={() => goToStep(WizardStepsSend.TOKENS_LIST)}
-				onClose={close}
-				onNext={modal.next}
-				onQRCodeScan={() => goToStep(WizardStepsSend.QR_CODE_SCAN)}
-				bind:destination
-				bind:activeSendDestinationTab
-				bind:selectedContact
-			/>
-		{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
-			<SendQrCodeScan
-				expectedToken={$token}
-				{onDecodeQrCode}
-				onQRCodeBack={() => goToStep(WizardStepsSend.DESTINATION)}
-				bind:destination
-				bind:amount
-			/>
-		{:else if currentStep?.name === WizardStepsSend.SEND || currentStep?.name === WizardStepsSend.REVIEW || currentStep?.name === WizardStepsSend.SENDING}
-			<SendWizard
-				{currentStep}
-				{destination}
-				nft={selectedNft}
-				onBack={modal.back}
-				onClose={close}
-				onNext={modal.next}
-				onSendBack={() => goToStep(WizardStepsSend.DESTINATION)}
-				onTokensList={() => goToStep(WizardStepsSend.TOKENS_LIST)}
-				{selectedContact}
-				bind:amount
-				bind:sendProgressStep
-			/>
-		{/if}
+		{#key currentStep?.name}
+			{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
+				<SendTokensList
+					onSelectNetworkFilter={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
+					{onSendToken}
+				/>
+			{:else if currentStep?.name === WizardStepsSend.NFTS_LIST}
+				<SendNftsList
+					onSelect={selectNft}
+					onSelectNetwork={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
+				/>
+			{:else if currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
+				<ModalNetworksFilter onNetworkFilter={() => goToStep(WizardStepsSend.TOKENS_LIST)} />
+			{:else if currentStep?.name === WizardStepsSend.DESTINATION}
+				<SendDestinationWizardStep
+					formCancelAction={isTransactionsPage || (isNftsPage && nonNullish($pageNft))
+						? 'close'
+						: 'back'}
+					onBack={() => goToStep(WizardStepsSend.TOKENS_LIST)}
+					onClose={close}
+					onNext={modal.next}
+					onQRCodeScan={() => goToStep(WizardStepsSend.QR_CODE_SCAN)}
+					bind:destination
+					bind:activeSendDestinationTab
+					bind:selectedContact
+				/>
+			{:else if currentStep?.name === WizardStepsSend.QR_CODE_SCAN}
+				<SendQrCodeScan
+					expectedToken={$token}
+					{onDecodeQrCode}
+					onQRCodeBack={() => goToStep(WizardStepsSend.DESTINATION)}
+					bind:destination
+					bind:amount
+				/>
+			{:else if currentStep?.name === WizardStepsSend.SEND || currentStep?.name === WizardStepsSend.REVIEW || currentStep?.name === WizardStepsSend.SENDING}
+				<SendWizard
+					{currentStep}
+					{destination}
+					nft={selectedNft}
+					onBack={modal.back}
+					onClose={close}
+					onNext={modal.next}
+					onSendBack={() => goToStep(WizardStepsSend.DESTINATION)}
+					onTokensList={() => goToStep(WizardStepsSend.TOKENS_LIST)}
+					{selectedContact}
+					bind:amount
+					bind:sendProgressStep
+				/>
+			{/if}
+		{/key}
 	</WizardModal>
 </SendTokenContext>

--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -214,36 +214,38 @@
 >
 	{#snippet title()}{titleString}{/snippet}
 
-	{#if currentStep?.name === WizardStepsSwap.TOKENS_LIST}
-		<SwapTokensList
-			onCloseTokensList={closeTokenList}
-			onSelectNetworkFilter={() => goToStep(WizardStepsSwap.FILTER_NETWORKS)}
-			onSelectToken={selectToken}
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.FILTER_NETWORKS}
-		<ModalNetworksFilter
-			{allNetworksEnabled}
-			filteredNetworks={$filteredNetworks}
-			onNetworkFilter={() => goToStep(WizardStepsSwap.TOKENS_LIST)}
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.SELECT_PROVIDER}
-		<SwapProviderListModal
-			on:icSelectProvider={selectProvider}
-			on:icCloseProviderList={() => goToStep(WizardStepsSwap.SWAP)}
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.SWAP || currentStep?.name === WizardStepsSwap.REVIEW || currentStep?.name === WizardStepsSwap.SWAPPING}
-		<SwapTokenWizard
-			{currentStep}
-			onBack={modal.back}
-			onClose={close}
-			onNext={modal.next}
-			onShowTokensList={showTokensList}
-			bind:swapAmount
-			bind:receiveAmount
-			bind:slippageValue
-			bind:swapProgressStep
-			bind:swapFailedProgressSteps
-			on:icShowProviderList={() => goToStep(WizardStepsSwap.SELECT_PROVIDER)}
-		/>
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSwap.TOKENS_LIST}
+			<SwapTokensList
+				onCloseTokensList={closeTokenList}
+				onSelectNetworkFilter={() => goToStep(WizardStepsSwap.FILTER_NETWORKS)}
+				onSelectToken={selectToken}
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.FILTER_NETWORKS}
+			<ModalNetworksFilter
+				{allNetworksEnabled}
+				filteredNetworks={$filteredNetworks}
+				onNetworkFilter={() => goToStep(WizardStepsSwap.TOKENS_LIST)}
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.SELECT_PROVIDER}
+			<SwapProviderListModal
+				on:icSelectProvider={selectProvider}
+				on:icCloseProviderList={() => goToStep(WizardStepsSwap.SWAP)}
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.SWAP || currentStep?.name === WizardStepsSwap.REVIEW || currentStep?.name === WizardStepsSwap.SWAPPING}
+			<SwapTokenWizard
+				{currentStep}
+				onBack={modal.back}
+				onClose={close}
+				onNext={modal.next}
+				onShowTokensList={showTokensList}
+				bind:swapAmount
+				bind:receiveAmount
+				bind:slippageValue
+				bind:swapProgressStep
+				bind:swapFailedProgressSteps
+				on:icShowProviderList={() => goToStep(WizardStepsSwap.SELECT_PROVIDER)}
+			/>
+		{/if}
+	{/key}
 </WizardModal>

--- a/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenModal.svelte
@@ -134,13 +134,15 @@
 >
 	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-	{#if currentStep?.name === WizardStepsHideToken.HIDING}
-		<InProgressWizard
-			progressStep={hideProgressStep}
-			steps={HIDE_TOKEN_STEPS}
-			warningType="manage"
-		/>
-	{:else if currentStep?.name === WizardStepsHideToken.HIDE}
-		<HideTokenReview onCancel={close} onHide={hide} />
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsHideToken.HIDING}
+			<InProgressWizard
+				progressStep={hideProgressStep}
+				steps={HIDE_TOKEN_STEPS}
+				warningType="manage"
+			/>
+		{:else if currentStep?.name === WizardStepsHideToken.HIDE}
+			<HideTokenReview onCancel={close} onHide={hide} />
+		{/if}
+	{/key}
 </WizardModal>

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -324,67 +324,69 @@
 >
 	{#snippet title()}{currentStep?.title}{/snippet}
 
-	{#if currentStepName === TokenModalSteps.CONTENT}
-		<Responsive up="md">
-			<TokenModalContent
+	{#key currentStepName}
+		{#if currentStepName === TokenModalSteps.CONTENT}
+			<Responsive up="md">
+				<TokenModalContent
+					{token}
+					{...isDeletable && { onDeleteClick: () => gotoStep(TokenModalSteps.DELETE_CONFIRMATION) }}
+					{...isEditable && {
+						onEditClick: () => gotoStep(TokenModalSteps.EDIT)
+					}}
+				>
+					{@render children?.()}
+				</TokenModalContent>
+			</Responsive>
+			<Responsive down="sm">
+				<TokenModalContent
+					{token}
+					{...isDeletable && { onDeleteClick: () => (showBottomSheetDeleteConfirmation = true) }}
+					{...isEditable && {
+						onEditClick: () => gotoStep(TokenModalSteps.EDIT)
+					}}
+				>
+					{@render children?.()}
+				</TokenModalContent>
+			</Responsive>
+		{:else if currentStepName === TokenModalSteps.DELETE_CONFIRMATION}
+			<TokenModalDeleteConfirmation
+				{loading}
+				onCancel={() => gotoStep(TokenModalSteps.CONTENT)}
+				onConfirm={() => onTokenDelete(token)}
 				{token}
-				{...isDeletable && { onDeleteClick: () => gotoStep(TokenModalSteps.DELETE_CONFIRMATION) }}
-				{...isEditable && {
-					onEditClick: () => gotoStep(TokenModalSteps.EDIT)
-				}}
-			>
-				{@render children?.()}
-			</TokenModalContent>
-		</Responsive>
-		<Responsive down="sm">
-			<TokenModalContent
-				{token}
-				{...isDeletable && { onDeleteClick: () => (showBottomSheetDeleteConfirmation = true) }}
-				{...isEditable && {
-					onEditClick: () => gotoStep(TokenModalSteps.EDIT)
-				}}
-			>
-				{@render children?.()}
-			</TokenModalContent>
-		</Responsive>
-	{:else if currentStepName === TokenModalSteps.DELETE_CONFIRMATION}
-		<TokenModalDeleteConfirmation
-			{loading}
-			onCancel={() => gotoStep(TokenModalSteps.CONTENT)}
-			onConfirm={() => onTokenDelete(token)}
-			{token}
-		/>
-	{:else if currentStepName === TokenModalSteps.EDIT && nonNullish(token) && isTokenIcrc(token)}
-		<ContentWithToolbar>
-			<AddTokenByNetworkDropdown
-				availableNetworks={[token.network]}
-				disabled
-				networkName={token.network.name}
 			/>
+		{:else if currentStepName === TokenModalSteps.EDIT && nonNullish(token) && isTokenIcrc(token)}
+			<ContentWithToolbar>
+				<AddTokenByNetworkDropdown
+					availableNetworks={[token.network]}
+					disabled
+					networkName={token.network.name}
+				/>
 
-			<IcAddTokenForm
-				editMode
-				ledgerCanisterId={token.ledgerCanisterId}
-				bind:indexCanisterId={icrcTokenIndexCanisterId}
-			/>
+				<IcAddTokenForm
+					editMode
+					ledgerCanisterId={token.ledgerCanisterId}
+					bind:indexCanisterId={icrcTokenIndexCanisterId}
+				/>
 
-			{#snippet toolbar()}
-				<ButtonGroup>
-					<ButtonBack onclick={() => gotoStep(TokenModalSteps.CONTENT)} />
+				{#snippet toolbar()}
+					<ButtonGroup>
+						<ButtonBack onclick={() => gotoStep(TokenModalSteps.CONTENT)} />
 
-					<Button
-						disabled={icrcTokenIndexCanisterId === (token.indexCanisterId ?? '')}
-						onclick={() => onTokenEdit(token)}
-						testId={TOKEN_MODAL_SAVE_BUTTON}
-					>
-						{$i18n.core.text.save}
-					</Button>
-				</ButtonGroup>
-			{/snippet}
-		</ContentWithToolbar>
-	{:else if currentStepName === TokenModalSteps.EDIT_PROGRESS}
-		<InProgressWizard progressStep={saveProgressStep} steps={addTokenSteps($i18n)} />
-	{/if}
+						<Button
+							disabled={icrcTokenIndexCanisterId === (token.indexCanisterId ?? '')}
+							onclick={() => onTokenEdit(token)}
+							testId={TOKEN_MODAL_SAVE_BUTTON}
+						>
+							{$i18n.core.text.save}
+						</Button>
+					</ButtonGroup>
+				{/snippet}
+			</ContentWithToolbar>
+		{:else if currentStepName === TokenModalSteps.EDIT_PROGRESS}
+			<InProgressWizard progressStep={saveProgressStep} steps={addTokenSteps($i18n)} />
+		{/if}
+	{/key}
 </WizardModal>
 
 {#if currentStepName === TokenModalSteps.CONTENT && showBottomSheetDeleteConfirmation}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -482,10 +482,12 @@
 			</WalletConnectModalTitle>
 		{/snippet}
 
-		{#if currentStep?.name === WizardStepsWalletConnect.REVIEW}
-			<WalletConnectReview onApprove={approve} onCancel={reject} onReject={reject} {proposal} />
-		{:else if currentStep?.name === WizardStepsWalletConnect.CONNECT}
-			<WalletConnectForm onConnect={userConnect} />
-		{/if}
+		{#key currentStep?.name}
+			{#if currentStep?.name === WizardStepsWalletConnect.REVIEW}
+				<WalletConnectReview onApprove={approve} onCancel={reject} onReject={reject} {proposal} />
+			{:else if currentStep?.name === WizardStepsWalletConnect.CONNECT}
+				<WalletConnectForm onConnect={userConnect} />
+			{/if}
+		{/key}
 	</WizardModal>
 {/if}

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -229,15 +229,17 @@
 </script>
 
 <SolFeeContext {destination} observe={currentStep?.name !== WizardStepsSend.SENDING}>
-	{#if currentStep?.name === WizardStepsSend.REVIEW}
-		<SolSendReview {amount} {destination} {network} {onBack} onSend={send} {selectedContact} />
-	{:else if currentStep?.name === WizardStepsSend.SENDING}
-		<InProgressWizard progressStep={sendProgressStep} steps={sendSteps($i18n)} />
-	{:else if currentStep?.name === WizardStepsSend.SEND}
-		<SolSendForm {onBack} {onNext} {onTokensList} {selectedContact} bind:destination bind:amount>
-			{#snippet cancel()}
-				<ButtonBack onclick={back} />
-			{/snippet}
-		</SolSendForm>
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSend.REVIEW}
+			<SolSendReview {amount} {destination} {network} {onBack} onSend={send} {selectedContact} />
+		{:else if currentStep?.name === WizardStepsSend.SENDING}
+			<InProgressWizard progressStep={sendProgressStep} steps={sendSteps($i18n)} />
+		{:else if currentStep?.name === WizardStepsSend.SEND}
+			<SolSendForm {onBack} {onNext} {onTokensList} {selectedContact} bind:destination bind:amount>
+				{#snippet cancel()}
+					<ButtonBack onclick={back} />
+				{/snippet}
+			</SolSendForm>
+		{/if}
+	{/key}
 </SolFeeContext>

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -153,21 +153,23 @@
 		</WalletConnectModalTitle>
 	{/snippet}
 
-	{#if currentStep?.name === WizardStepsSign.SIGNING}
-		<InProgressWizard
-			progressStep={signProgressStep}
-			steps={walletConnectSignSteps({ i18n: $i18n, signWithSending })}
-		/>
-	{:else if currentStep?.name === WizardStepsSign.REVIEW}
-		<SolWalletConnectSignReview
-			{amount}
-			{application}
-			{data}
-			destination={destination ?? ''}
-			onApprove={sign}
-			onReject={reject}
-			source={address ?? ''}
-			{token}
-		/>
-	{/if}
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSign.SIGNING}
+			<InProgressWizard
+				progressStep={signProgressStep}
+				steps={walletConnectSignSteps({ i18n: $i18n, signWithSending })}
+			/>
+		{:else if currentStep?.name === WizardStepsSign.REVIEW}
+			<SolWalletConnectSignReview
+				{amount}
+				{application}
+				{data}
+				destination={destination ?? ''}
+				onApprove={sign}
+				onReject={reject}
+				source={address ?? ''}
+				{token}
+			/>
+		{/if}
+	{/key}
 </WizardModal>


### PR DESCRIPTION
# Motivation

Credits to @roman-nazaruk 

We encountered a strange situation where the components from two different branches of `#if` / `:else if` statement were rendered at the same time.

<img width="531" height="737" alt="image-20251010-082011" src="https://github.com/user-attachments/assets/2d04483f-dd92-4fa4-bd79-f53ff3b6c4d1" />


Svelte swaps `if/else if` branches using its normal diffing and transition logic, which can briefly put both branches in the DOM at the same time (especially if either branch has intros/outros or any pending microtasks):

- Svelte tries to be smart and reuse/update DOM between mutually exclusive blocks.

- When the condition flips, Svelte runs the outgoing block’s outro and the incoming block’s intro concurrently by default; during that period both components exist in the DOM, so you can see a flash of both.

With `#key`, Svelte destroys the old branch first, then creates the new one, so there is no momentary overlap.


### Additional comments

Another solution could be to `await tick()` when changing conditions, but it seems more of a workaround than a solution.
