### PR TITLE
feat(frontend): Increase the NFT media file limit to 10MB

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -215,5 +215,5 @@ export const CONTACT_MAX_NAME_LENGTH = 100;
 // Network bonus multiplier
 export const NETWORK_BONUS_MULTIPLIER_DEFAULT = 1;
 
-// NFT max filesize limit (5MB)
-export const NFT_MAX_FILESIZE_LIMIT = 1024 * 1024 * 5;
+// NFT max filesize limit (10MB)
+export const NFT_MAX_FILESIZE_LIMIT = 1024 * 1024 * 10;

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -958,7 +958,7 @@ describe('nfts.utils', () => {
 			expect(result).toBe(NftMediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE);
 		});
 
-		it('returns FILESIZE_LIMIT_EXCEEDED when file size > 5MB', async () => {
+		it('returns FILESIZE_LIMIT_EXCEEDED when file size exceeds the limit', async () => {
 			global.fetch = vi.fn().mockResolvedValueOnce({
 				headers: {
 					get: (h: string) =>


### PR DESCRIPTION
# Motivation

Some NFT images are slightly above 5MB, so we increase the limit to 10MB.
