### PR TITLE
feat(frontend): Use `AppWorker` class for Solana Wallet worker

### DIFF
--- a/src/frontend/src/sol/components/core/SolLoaderWallets.svelte
+++ b/src/frontend/src/sol/components/core/SolLoaderWallets.svelte
@@ -14,7 +14,7 @@
 		isNetworkIdSOLMainnet
 	} from '$lib/utils/network.utils';
 	import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
-	import { initSolWalletWorker as initWalletWorker } from '$sol/services/worker.sol-wallet.services';
+	import { SolWalletWorker } from '$sol/services/worker.sol-wallet.services';
 
 	interface Props {
 		children: Snippet;
@@ -32,6 +32,6 @@
 	);
 </script>
 
-<WalletWorkers {initWalletWorker} tokens={walletWorkerTokens}>
+<WalletWorkers initWalletWorker={SolWalletWorker.init} tokens={walletWorkerTokens}>
 	{@render children()}
 </WalletWorkers>

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -1,3 +1,4 @@
+import { AppWorker } from '$lib/services/_worker.services';
 import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
@@ -5,7 +6,7 @@ import {
 } from '$lib/stores/address.store';
 import type { WalletWorker } from '$lib/types/listener';
 import type { PostMessage, PostMessageDataRequestSol } from '$lib/types/post-message';
-import type { Token } from '$lib/types/token';
+import type { Token, TokenId } from '$lib/types/token';
 import { isNetworkIdSOLDevnet, isNetworkIdSOLLocal } from '$lib/utils/network.utils';
 import {
 	syncWallet,
@@ -18,100 +19,100 @@ import { isTokenSpl } from '$sol/utils/spl.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export const initSolWalletWorker = async ({ token }: { token: Token }): Promise<WalletWorker> => {
-	const {
-		id: tokenId,
-		network: { id: networkId }
-	} = token;
+export class SolWalletWorker extends AppWorker implements WalletWorker {
+	private constructor(
+		worker: Worker,
+		tokenId: TokenId,
+		private readonly data: PostMessageDataRequestSol
+	) {
+		super(worker);
 
-	const WalletWorker = await import('$lib/workers/workers?worker');
-	let worker: Worker | null = new WalletWorker.default();
+		worker.onmessage = ({
+			data: dataMsg
+		}: MessageEvent<PostMessage<SolPostMessageDataResponseWallet>>) => {
+			const { msg, data } = dataMsg;
 
-	const isDevnetNetwork = isNetworkIdSOLDevnet(networkId);
-	const isLocalNetwork = isNetworkIdSOLLocal(networkId);
+			switch (msg) {
+				case 'syncSolWallet':
+					syncWallet({
+						tokenId,
+						data: data as SolPostMessageDataResponseWallet
+					});
+					return;
 
-	await syncWalletFromCache({ tokenId, networkId });
+				case 'syncSolWalletError':
+					syncWalletError({
+						tokenId,
+						error: data.error,
+						hideToast: true
+					});
+					return;
+			}
+		};
+	}
 
-	worker.onmessage = ({
-		data: dataMsg
-	}: MessageEvent<PostMessage<SolPostMessageDataResponseWallet>>) => {
-		const { msg, data } = dataMsg;
+	static async init({ token }: { token: Token }): Promise<SolWalletWorker> {
+		const {
+			id: tokenId,
+			network: { id: networkId }
+		} = token;
 
-		switch (msg) {
-			case 'syncSolWallet':
-				syncWallet({
-					tokenId,
-					data: data as SolPostMessageDataResponseWallet
-				});
-				return;
+		await syncWalletFromCache({ tokenId, networkId });
 
-			case 'syncSolWalletError':
-				syncWalletError({
-					tokenId,
-					error: data.error,
-					hideToast: true
-				});
-				return;
-		}
-	};
+		const isDevnetNetwork = isNetworkIdSOLDevnet(networkId);
+		const isLocalNetwork = isNetworkIdSOLLocal(networkId);
 
-	// TODO: stop/start the worker on address change (same as for worker.btc-wallet.services.ts)
-	const address = get(
-		isDevnetNetwork
-			? solAddressDevnetStore
-			: isLocalNetwork
-				? solAddressLocalnetStore
-				: solAddressMainnetStore
-	);
-	assertNonNullish(address, 'No Solana address provided to start Solana wallet worker.');
+		// TODO: stop/start the worker on address change (same as for worker.btc-wallet.services.ts)
+		const address = get(
+			isDevnetNetwork
+				? solAddressDevnetStore
+				: isLocalNetwork
+					? solAddressLocalnetStore
+					: solAddressMainnetStore
+		);
+		assertNonNullish(address, 'No Solana address provided to start Solana wallet worker.');
 
-	const network = mapNetworkIdToNetwork(token.network.id);
-	assertNonNullish(network, 'No Solana network provided to start Solana wallet worker.');
+		const network = mapNetworkIdToNetwork(token.network.id);
+		assertNonNullish(network, 'No Solana network provided to start Solana wallet worker.');
 
-	// If the token is an SPL token, we need to pass the token address and the owner address to the worker.
-	// Otherwise, we pass undefined, which will be considered as the native SOLANA token.
-	const { address: tokenAddress, owner: tokenOwnerAddress } = isTokenSpl(token)
-		? token
-		: { address: undefined, owner: undefined };
+		// If the token is an SPL token, we need to pass the token address and the owner address to the worker.
+		// Otherwise, we pass undefined, which will be considered as the native SOLANA token.
+		const { address: tokenAddress, owner: tokenOwnerAddress } = isTokenSpl(token)
+			? token
+			: { address: undefined, owner: undefined };
 
-	const data: PostMessageDataRequestSol = {
-		address,
-		solanaNetwork: network,
-		tokenAddress,
-		tokenOwnerAddress
-	};
+		const data: PostMessageDataRequestSol = {
+			address,
+			solanaNetwork: network,
+			tokenAddress,
+			tokenOwnerAddress
+		};
 
-	const stop = () => {
-		worker?.postMessage({
+		const worker = await AppWorker.getInstance();
+		return new SolWalletWorker(worker, tokenId, data);
+	}
+
+	protected override stopTimer = () => {
+		this.postMessage({
 			msg: 'stopSolWalletTimer'
 		});
 	};
 
-	let isDestroying = false;
-
-	return {
-		start: () => {
-			worker?.postMessage({
-				msg: 'startSolWalletTimer',
-				data
-			} as PostMessage<PostMessageDataRequestSol>);
-		},
-		stop,
-		trigger: () => {
-			worker?.postMessage({
-				msg: 'triggerSolWalletTimer',
-				data
-			} as PostMessage<PostMessageDataRequestSol>);
-		},
-		destroy: () => {
-			if (isDestroying) {
-				return;
-			}
-			isDestroying = true;
-			stop();
-			worker?.terminate();
-			worker = null;
-			isDestroying = false;
-		}
+	start = () => {
+		this.postMessage({
+			msg: 'startSolWalletTimer',
+			data: this.data
+		} as PostMessage<PostMessageDataRequestSol>);
 	};
-};
+
+	stop = () => {
+		this.stopTimer();
+	};
+
+	trigger = () => {
+		this.postMessage({
+			msg: 'triggerSolWalletTimer',
+			data: this.data
+		} as PostMessage<PostMessageDataRequestSol>);
+	};
+}

--- a/src/frontend/src/tests/sol/components/core/SolLoaderWallets.spec.ts
+++ b/src/frontend/src/tests/sol/components/core/SolLoaderWallets.spec.ts
@@ -7,16 +7,12 @@ import {
 } from '$lib/stores/address.store';
 import SolLoaderWallets from '$sol/components/core/SolLoaderWallets.svelte';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
-import { initSolWalletWorker } from '$sol/services/worker.sol-wallet.services';
+import { SolWalletWorker } from '$sol/services/worker.sol-wallet.services';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
-
-vi.mock('$sol/services/worker.sol-wallet.services', () => ({
-	initSolWalletWorker: vi.fn()
-}));
 
 describe('SolLoaderWallets', () => {
 	beforeEach(() => {
@@ -31,6 +27,8 @@ describe('SolLoaderWallets', () => {
 		setupUserNetworksStore('allEnabled');
 
 		vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => false);
+
+		vi.spyOn(SolWalletWorker, 'init');
 	});
 
 	it('should not initialize wallet workers when no addresses are available', () => {
@@ -38,7 +36,7 @@ describe('SolLoaderWallets', () => {
 
 		// With testnets enabled, we expect mainnet + devnet tokens
 		expect(get(enabledSolanaTokens)).toHaveLength(2);
-		expect(initSolWalletWorker).not.toHaveBeenCalled();
+		expect(SolWalletWorker.init).not.toHaveBeenCalled();
 	});
 
 	it('should initialize wallet workers only for networks with available addresses', () => {
@@ -64,7 +62,7 @@ describe('SolLoaderWallets', () => {
 
 		const { rerender } = render(SolLoaderWallets, { children: mockSnippet });
 
-		expect(initSolWalletWorker).not.toHaveBeenCalled();
+		expect(SolWalletWorker.init).not.toHaveBeenCalled();
 
 		solAddressDevnetStore.set({ data: devnetAddress, certified: true });
 		await rerender({});


### PR DESCRIPTION
# Motivation

After PR https://github.com/dfinity/oisy-wallet/pull/9589, we can use the abstract class `AppWorker` for all the workers.

In this PR we adapt the Solana Wallet worker.