### PR TITLE
refactor(frontend): Migrate token skeletons to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenBalanceSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenBalanceSkeleton.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import type { CardData } from '$lib/types/token-card';
 
-	export let data: CardData;
+	interface Props {
+		data: CardData;
+		children: Snippet;
+	}
+
+	let { data, children }: Props = $props();
 </script>
 
 {#if data.balance === undefined}
 	<span class="mt-1 block w-full max-w-[50px]"><SkeletonText /></span>
 {:else}
-	<slot />
+	{@render children()}
 {/if}

--- a/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { exchangeNotInitialized } from '$lib/derived/exchange.derived';
 	import type { CardData } from '$lib/types/token-card';
 
-	export let data: CardData;
+	interface Props {
+		data: CardData;
+		children: Snippet;
+	}
+
+	let { data, children }: Props = $props();
 </script>
 
 {#if data.balance === undefined || $exchangeNotInitialized}
 	<span class="mt-1 block w-full max-w-[50px]"><SkeletonText /></span>
 {:else}
-	<slot />
+	{@render children()}
 {/if}


### PR DESCRIPTION
# Motivation

Migrating components `TokenBalanceSkeleton` and `TokenExchangeValueSkeleton` to Svelte 5.
