### PR TITLE
refactor(frontend): Migrate `ExchangeTokenValue` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeTokenValue.svelte
@@ -2,14 +2,14 @@
 	import TokenExchangeBalance from '$lib/components/tokens/TokenExchangeBalance.svelte';
 	import TokenExchangeValueSkeleton from '$lib/components/tokens/TokenExchangeValueSkeleton.svelte';
 	import type { CardData } from '$lib/types/token-card';
-	import type { TokenUi } from '$lib/types/token-ui';
 
-	export let data: CardData;
+	interface Props {
+		data: CardData;
+	}
 
-	let balance: TokenUi['balance'];
-	let usdBalance: TokenUi['usdBalance'];
+	let { data }: Props = $props();
 
-	$: ({ balance, usdBalance } = data);
+	let { balance, usdBalance } = $derived(data);
 </script>
 
 <TokenExchangeValueSkeleton {data}>

--- a/src/frontend/src/lib/components/tokens/TokenExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeBalance.svelte
@@ -7,19 +7,24 @@
 	import type { TokenFinancialData } from '$lib/types/token';
 	import { formatCurrency } from '$lib/utils/format.utils';
 
-	export let balance: TokenFinancialData['balance'];
-	export let usdBalance: TokenFinancialData['usdBalance'];
-	export let nullishBalanceMessage: string | undefined = undefined;
+	interface Props {
+		balance: TokenFinancialData['balance'];
+		usdBalance: TokenFinancialData['usdBalance'];
+		nullishBalanceMessage?: string;
+	}
 
-	let exchangeBalance: string | undefined;
-	$: exchangeBalance = nonNullish(usdBalance)
-		? formatCurrency({
-				value: usdBalance,
-				currency: $currentCurrency,
-				exchangeRate: $currencyExchangeStore,
-				language: $currentLanguage
-			})
-		: undefined;
+	let { balance, usdBalance, nullishBalanceMessage }: Props = $props();
+
+	let exchangeBalance = $derived(
+		nonNullish(usdBalance)
+			? formatCurrency({
+					value: usdBalance,
+					currency: $currentCurrency,
+					exchangeRate: $currencyExchangeStore,
+					language: $currentLanguage
+				})
+			: undefined
+	);
 </script>
 
 <output class="break-all">


### PR DESCRIPTION
# Motivation

Migrating `ExchangeTokenValue` (and its direct children) to Svelte 5.
