### PR TITLE
feat(frontend): add gldt_stake manage_stake_position method

### DIFF
--- a/src/frontend/src/icp/canisters/gldt_stake.canister.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.canister.ts
@@ -1,4 +1,8 @@
-import type { _SERVICE as GldtStakeService } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type {
+	_SERVICE as GldtStakeService,
+	ManageStakePositionArgs,
+	Result_3 as ManageStakePositionResult
+} from '$declarations/gldt_stake/declarations/gldt_stake.did';
 import { idlFactory as idlCertifiedFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.certified.did';
 import { idlFactory as idlFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
@@ -28,5 +32,11 @@ export class GldtStakeCanister extends Canister<GldtStakeService> {
 		const { get_apy_overall } = this.caller({ certified: true });
 
 		return get_apy_overall(null);
+	};
+
+	manageStakePosition = (params: ManageStakePositionArgs): Promise<ManageStakePositionResult> => {
+		const { manage_stake_position } = this.caller({ certified: true });
+
+		return manage_stake_position(params);
 	};
 }

--- a/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
@@ -1,6 +1,7 @@
 import type { _SERVICE as GldtStakeService } from '$declarations/gldt_stake/declarations/gldt_stake.did';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import type { ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
@@ -49,6 +50,36 @@ describe('gldt_stake.canister', () => {
 			});
 
 			const res = getApyOverall();
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
+
+	describe('manageStakePosition', () => {
+		const params = { AddStake: { amount: 1n } };
+
+		it('manages stake position successfully', async () => {
+			service.manage_stake_position.mockResolvedValue(stakePositionMockResponse);
+
+			const { manageStakePosition } = await createGldtStakeCanister({ serviceOverride: service });
+
+			const result = await manageStakePosition(params);
+
+			expect(result).toEqual(stakePositionMockResponse);
+			expect(service.manage_stake_position).toHaveBeenCalledWith(params);
+		});
+
+		it('throws an error if manage_stake_position method fails', async () => {
+			service.manage_stake_position.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { manageStakePosition } = await createGldtStakeCanister({
+				serviceOverride: service
+			});
+
+			const res = manageStakePosition(params);
 
 			await expect(res).rejects.toThrow(mockResponseError);
 		});

--- a/src/frontend/src/tests/mocks/gldt_stake.mock.ts
+++ b/src/frontend/src/tests/mocks/gldt_stake.mock.ts
@@ -1,0 +1,27 @@
+import type { Duration, Result_3 } from '$declarations/gldt_stake/gldt_stake.did';
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+import { toNullable } from '@dfinity/utils';
+
+export const stakePositionMockResponse = {
+	Ok: {
+		staked: 10000n,
+		dissolve_delay: {
+			secs: 100n,
+			nanos: 1000
+		} as Duration,
+		claimable_rewards: toNullable([{ ICP: null }, 100n]),
+		created_at: 10000n,
+		age_bonus_multiplier: 10,
+		owned_by: mockPrincipal,
+		dissolve_events: [
+			{
+				dissolved_date: 1000n,
+				completed: true,
+				amount: 1000n,
+				percentage: 1000
+			}
+		],
+		weighted_stake: 1000n,
+		instant_dissolve_fee: 1000n
+	}
+} as Result_3;


### PR DESCRIPTION
# Motivation

We need to add `manage_stake_position` as a gldt_stake canister method. It will be used to initiate the staking process.
