### PR TITLE
feat(frontend): errors in gldt_stake manage_stake_position method

### DIFF
--- a/src/frontend/src/icp/canisters/gldt_stake.canister.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.canister.ts
@@ -1,10 +1,11 @@
 import type {
 	_SERVICE as GldtStakeService,
 	ManageStakePositionArgs,
-	Result_3 as ManageStakePositionResult
+	StakePositionResponse
 } from '$declarations/gldt_stake/declarations/gldt_stake.did';
 import { idlFactory as idlCertifiedFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.certified.did';
 import { idlFactory as idlFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.did';
+import { mapGldtStakeCanisterError } from '$icp/canisters/gldt_stake.errors';
 import { getAgent } from '$lib/actors/agents.ic';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { Canister, createServices } from '@dfinity/utils';
@@ -34,9 +35,17 @@ export class GldtStakeCanister extends Canister<GldtStakeService> {
 		return get_apy_overall(null);
 	};
 
-	manageStakePosition = (params: ManageStakePositionArgs): Promise<ManageStakePositionResult> => {
+	manageStakePosition = async (
+		params: ManageStakePositionArgs
+	): Promise<StakePositionResponse | undefined> => {
 		const { manage_stake_position } = this.caller({ certified: true });
 
-		return manage_stake_position(params);
+		const response = await manage_stake_position(params);
+
+		if ('Ok' in response) {
+			return response.Ok;
+		}
+
+		throw mapGldtStakeCanisterError(response.Err);
 	};
 }

--- a/src/frontend/src/icp/canisters/gldt_stake.errors.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.errors.ts
@@ -1,0 +1,30 @@
+import type { ManageStakePositionError } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import { CanisterInternalError } from '$lib/canisters/errors';
+
+export const mapGldtStakeCanisterError = (err: ManageStakePositionError): CanisterInternalError => {
+	if ('StartDissolvingError' in err) {
+		return new CanisterInternalError('Failed to start dissolving');
+	}
+
+	if ('AddStakeError' in err) {
+		return new CanisterInternalError('Failed to add stake');
+	}
+
+	if ('DissolveInstantlyError' in err) {
+		return new CanisterInternalError('Failed to dissolve instantly');
+	}
+
+	if ('WithdrawError' in err) {
+		return new CanisterInternalError('Failed to withdraw');
+	}
+
+	if ('ClaimRewardError' in err) {
+		return new CanisterInternalError('Failed to claim reward');
+	}
+
+	if ('GeneralError' in err) {
+		return new CanisterInternalError('General gldt_stake error');
+	}
+
+	return new CanisterInternalError('Unknown GldtStakeCanisterError');
+};

--- a/src/frontend/src/tests/mocks/gldt_stake.mock.ts
+++ b/src/frontend/src/tests/mocks/gldt_stake.mock.ts
@@ -1,27 +1,26 @@
-import type { Duration, Result_3 } from '$declarations/gldt_stake/gldt_stake.did';
+import type { StakePositionResponse } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { Duration } from '$declarations/gldt_stake/gldt_stake.did';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 
 export const stakePositionMockResponse = {
-	Ok: {
-		staked: 10000n,
-		dissolve_delay: {
-			secs: 100n,
-			nanos: 1000
-		} as Duration,
-		claimable_rewards: toNullable([{ ICP: null }, 100n]),
-		created_at: 10000n,
-		age_bonus_multiplier: 10,
-		owned_by: mockPrincipal,
-		dissolve_events: [
-			{
-				dissolved_date: 1000n,
-				completed: true,
-				amount: 1000n,
-				percentage: 1000
-			}
-		],
-		weighted_stake: 1000n,
-		instant_dissolve_fee: 1000n
-	}
-} as Result_3;
+	staked: 10000n,
+	dissolve_delay: {
+		secs: 100n,
+		nanos: 1000
+	} as Duration,
+	claimable_rewards: toNullable([{ ICP: null }, 100n]),
+	created_at: 10000n,
+	age_bonus_multiplier: 10,
+	owned_by: mockPrincipal,
+	dissolve_events: [
+		{
+			dissolved_date: 1000n,
+			completed: true,
+			amount: 1000n,
+			percentage: 1000
+		}
+	],
+	weighted_stake: 1000n,
+	instant_dissolve_fee: 1000n
+} as StakePositionResponse;


### PR DESCRIPTION
# Motivation

We can now extend `manage_stake_position` with error cases.
