### PR TITLE
style(frontend): Auto-hide content in transactions list

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
@@ -43,10 +43,9 @@
 	</div>
 {/if}
 
-
 <style lang="scss">
-  .content-auto {
-    content-visibility: auto;
-    contain-intrinsic-size: 0 150px;
-  }
+	.content-auto {
+		content-visibility: auto;
+		contain-intrinsic-size: 0 150px;
+	}
 </style>


### PR DESCRIPTION
# Motivation

For long lists, we can enable the auto-visibility of contents that will avoid rendering the list elements that are out of sight.
