### PR TITLE
feat(frontend): add manageStakePosition to gldt_stake api

### DIFF
--- a/src/frontend/src/icp/api/gldt_stake.api.ts
+++ b/src/frontend/src/icp/api/gldt_stake.api.ts
@@ -1,3 +1,7 @@
+import type {
+	ManageStakePositionArgs,
+	StakePositionResponse
+} from '$declarations/gldt_stake/declarations/gldt_stake.did';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
 import { GLDT_STAKE_CANISTER_ID } from '$lib/constants/app.constants';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';
@@ -10,6 +14,17 @@ export const getApyOverall = async ({ identity }: CanisterApiFunctionParams): Pr
 	const { getApyOverall } = await gldtStakeCanister({ identity });
 
 	return getApyOverall();
+};
+
+export const manageStakePosition = async ({
+	positionParams,
+	identity
+}: CanisterApiFunctionParams<{ positionParams: ManageStakePositionArgs }>): Promise<
+	StakePositionResponse | undefined
+> => {
+	const { manageStakePosition } = await gldtStakeCanister({ identity });
+
+	return manageStakePosition(positionParams);
 };
 
 const gldtStakeCanister = async ({

--- a/src/frontend/src/tests/icp/api/gldt_stake.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/gldt_stake.api.spec.ts
@@ -1,24 +1,26 @@
-import { getApyOverall } from '$icp/api/gldt_stake.api';
+import { getApyOverall, manageStakePosition } from '$icp/api/gldt_stake.api';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
 import * as appContants from '$lib/constants/app.constants';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
 import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mock } from 'vitest-mock-extended';
 
 describe('gldt_stake.api', () => {
+	const gldtStakeCanisterMock = mock<GldtStakeCanister>();
+
+	beforeEach(() => {
+		// eslint-disable-next-line require-await
+		vi.spyOn(GldtStakeCanister, 'create').mockImplementation(async () => gldtStakeCanisterMock);
+
+		vi.spyOn(appContants, 'GLDT_STAKE_CANISTER_ID', 'get').mockImplementation(
+			() => mockLedgerCanisterId
+		);
+	});
+
 	describe('getApyOverall', () => {
-		const gldtStakeCanisterMock = mock<GldtStakeCanister>();
 		const response = 10;
-
-		beforeEach(() => {
-			// eslint-disable-next-line require-await
-			vi.spyOn(GldtStakeCanister, 'create').mockImplementation(async () => gldtStakeCanisterMock);
-
-			vi.spyOn(appContants, 'GLDT_STAKE_CANISTER_ID', 'get').mockImplementation(
-				() => mockLedgerCanisterId
-			);
-		});
 
 		it('correctly calls the gldt_stake canister getApyOverall method', async () => {
 			mockAuthStore();
@@ -34,6 +36,30 @@ describe('gldt_stake.api', () => {
 
 		it('throws an error if the gldt_stake canister getApyOverall method called without identity', async () => {
 			const res = getApyOverall({
+				identity: null
+			});
+
+			await expect(res).rejects.toThrow();
+		});
+	});
+
+	describe('manageStakePosition', () => {
+		it('correctly calls the gldt_stake canister manageStakePosition method', async () => {
+			mockAuthStore();
+			gldtStakeCanisterMock.manageStakePosition.mockResolvedValue(stakePositionMockResponse);
+
+			const result = await manageStakePosition({
+				positionParams: { AddStake: { amount: 1n } },
+				identity: mockIdentity
+			});
+
+			expect(gldtStakeCanisterMock.manageStakePosition).toHaveBeenCalledOnce();
+			expect(result).toBe(stakePositionMockResponse);
+		});
+
+		it('throws an error if the gldt_stake canister manageStakePosition method called without identity', async () => {
+			const res = manageStakePosition({
+				positionParams: { AddStake: { amount: 1n } },
 				identity: null
 			});
 


### PR DESCRIPTION
# Motivation

We can now add `manageStakePosition` to the gldt_stake API methods.
