### PR TITLE
fix(frontend): Do not reschedule the timer in `TokensDisplayHandler`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { onDestroy, type Snippet } from 'svelte';
+	import { onDestroy, type Snippet, untrack } from 'svelte';
 	import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 	import { showZeroBalances } from '$lib/derived/settings.derived';
 	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
@@ -43,6 +43,8 @@
 		if (!animating) {
 			apply();
 
+			clearTimer();
+
 			return;
 		}
 
@@ -50,15 +52,17 @@
 	};
 
 	const scheduleRetry = () => {
+		if (nonNullish(timer)) {
+			return;
+		}
+
 		timer = setTimeout(updateTokensToDisplay, 500);
 	};
 
 	$effect(() => {
-		[sortedTokensOrGroups];
+		[sortedTokensOrGroups, animating];
 
-		updateTokensToDisplay();
-
-		return clearTimer;
+		untrack(() => updateTokensToDisplay());
 	});
 
 	onDestroy(clearTimer);


### PR DESCRIPTION
# Motivation

It is more correct to not re-create a timer when already exists in `TokensDisplayHandler`. 
