### PR TITLE
chore(frontend): Correctly rename the import of the app constant module

### DIFF
--- a/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
+++ b/src/frontend/src/tests/eth/components/loaders/LoaderMultipleEthTransactions.spec.ts
@@ -14,7 +14,7 @@ import { erc721CustomTokensStore } from '$eth/stores/erc721-custom-tokens.store'
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { getIdbEthTransactions } from '$lib/api/idb-transactions.api';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { syncTransactionsFromCache } from '$lib/services/listener.services';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { createMockErc1155CustomTokens } from '$tests/mocks/erc1155-tokens.mock';
@@ -121,7 +121,7 @@ describe('LoaderMultipleEthTransactions', () => {
 		setupTestnetsStore('enabled');
 		setupUserNetworksStore('allEnabled');
 
-		vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => false);
+		vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => false);
 
 		erc20UserTokensStore.resetAll();
 		erc20UserTokensStore.setAll(mockErc20CertifiedUserTokens);

--- a/src/frontend/src/tests/eth/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/tokens.derived.spec.ts
@@ -1,7 +1,7 @@
 import * as ethEnv from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { get } from 'svelte/store';
@@ -16,7 +16,7 @@ describe('tokens.derived', () => {
 
 			vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => true);
 
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => false);
 		});
 
 		it('should return only ETH by default', () => {

--- a/src/frontend/src/tests/icp/api/gldt_stake.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/gldt_stake.api.spec.ts
@@ -1,6 +1,6 @@
 import { getApyOverall, manageStakePosition } from '$icp/api/gldt_stake.api';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
 import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
@@ -14,7 +14,7 @@ describe('gldt_stake.api', () => {
 		// eslint-disable-next-line require-await
 		vi.spyOn(GldtStakeCanister, 'create').mockImplementation(async () => gldtStakeCanisterMock);
 
-		vi.spyOn(appContants, 'GLDT_STAKE_CANISTER_ID', 'get').mockImplementation(
+		vi.spyOn(appConstants, 'GLDT_STAKE_CANISTER_ID', 'get').mockImplementation(
 			() => mockLedgerCanisterId
 		);
 	});

--- a/src/frontend/src/tests/lib/api/llm.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/llm.api.spec.ts
@@ -1,7 +1,7 @@
 import type { chat_request_v1, chat_response_v1 } from '$declarations/llm/declarations/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import { LlmCanister } from '$lib/canisters/llm.canister';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -26,7 +26,7 @@ describe('llm.api', () => {
 			// eslint-disable-next-line require-await
 			vi.spyOn(LlmCanister, 'create').mockImplementation(async () => llmCanisterMock);
 
-			vi.spyOn(appContants, 'LLM_CANISTER_ID', 'get').mockImplementation(
+			vi.spyOn(appConstants, 'LLM_CANISTER_ID', 'get').mockImplementation(
 				() => mockLedgerCanisterId
 			);
 		});

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '$btc/services/btc-address.services';
 import { loadEthAddress } from '$eth/services/eth-address.services';
 import Loader from '$lib/components/loaders/Loader.svelte';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { LOADER_MODAL } from '$lib/constants/test-ids.constants';
 import { initLoader } from '$lib/services/loader.services';
 import {
@@ -161,7 +161,7 @@ describe('Loader', () => {
 			setupTestnetsStore('enabled');
 			setupUserNetworksStore('allEnabled');
 
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 			render(Loader, { children: mockSnippet });
 
@@ -185,7 +185,7 @@ describe('Loader', () => {
 
 			setupTestnetsStore('enabled');
 
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => false);
 
 			ethAddressStore.reset();
 
@@ -344,7 +344,7 @@ describe('Loader', () => {
 			});
 
 			it('should call local addresses loaders when in local env', async () => {
-				vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
+				vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 				render(Loader, { children: mockSnippet });
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderTokens.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderTokens.spec.ts
@@ -7,7 +7,7 @@ import { loadErc20Tokens } from '$eth/services/erc20.services';
 import { loadErc721Tokens } from '$eth/services/erc721.services';
 import { loadIcrcTokens } from '$icp/services/icrc.services';
 import LoaderTokens from '$lib/components/loaders/LoaderTokens.svelte';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import {
 	ethAddressStore,
 	solAddressDevnetStore,
@@ -350,7 +350,7 @@ describe('LoaderTokens', () => {
 
 			setupTestnetsStore('enabled');
 
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 			userProfileStore.set({
 				certified: false,

--- a/src/frontend/src/tests/lib/derived/all-tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/all-tokens.derived.spec.ts
@@ -33,7 +33,7 @@ import type { Erc721TokenToggleable } from '$eth/types/erc721-token-toggleable';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import {
 	allCrossChainSwapTokens,
 	allDisabledKongSwapCompatibleIcrcTokens,
@@ -101,7 +101,7 @@ describe('all-tokens.derived', () => {
 
 		vi.spyOn(btcEnv, 'BTC_MAINNET_ENABLED', 'get').mockImplementation(() => true);
 		vi.spyOn(ethEnv, 'ETH_MAINNET_ENABLED', 'get').mockImplementation(() => true);
-		vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => false);
+		vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => false);
 
 		// Mock the store subscriptions with empty arrays by default
 		vi.spyOn(erc20Tokens, 'subscribe').mockImplementation((fn) => {
@@ -264,7 +264,7 @@ describe('all-tokens.derived', () => {
 			setupTestnetsStore('enabled');
 			setupUserNetworksStore('allEnabled');
 
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 			const tokens = get(allTokens);
 			const tokenSymbols = tokens.map((token) => token.id.description);

--- a/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -38,7 +38,7 @@ import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { IcToken } from '$icp/types/ic-token';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { enabledUniqueTokensSymbols, fungibleTokens, tokens } from '$lib/derived/tokens.derived';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
@@ -121,7 +121,7 @@ describe('tokens.derived', () => {
 		setupTestnetsStore('reset');
 		setupUserNetworksStore('allEnabled');
 
-		vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => false);
+		vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => false);
 	});
 
 	describe('tokens', () => {
@@ -209,7 +209,7 @@ describe('tokens.derived', () => {
 
 		it('should return local tokens too when testnets are enabled and env is LOCAL', () => {
 			setupTestnetsStore('enabled');
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementation(() => true);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementation(() => true);
 
 			expect(get(tokens)).toEqual([
 				ICP_TOKEN,

--- a/src/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -1,4 +1,4 @@
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { getOptionalDerivationOrigin } from '$lib/utils/auth.utils';
 
 describe('auth utils', () => {
@@ -19,10 +19,10 @@ describe('auth utils', () => {
 			beforeEach(() => {
 				vi.resetModules();
 				vi.resetAllMocks();
-				vi.spyOn(appContants, 'AUTH_ALTERNATIVE_ORIGINS', 'get').mockReturnValue(
+				vi.spyOn(appConstants, 'AUTH_ALTERNATIVE_ORIGINS', 'get').mockReturnValue(
 					alternativeOrigins.join(',')
 				);
-				vi.spyOn(appContants, 'AUTH_DERIVATION_ORIGIN', 'get').mockReturnValue(derivationOrigin);
+				vi.spyOn(appConstants, 'AUTH_DERIVATION_ORIGIN', 'get').mockReturnValue(derivationOrigin);
 			});
 
 			afterEach(() => {
@@ -50,8 +50,8 @@ describe('auth utils', () => {
 			beforeEach(() => {
 				vi.resetModules();
 				vi.resetAllMocks();
-				vi.spyOn(appContants, 'AUTH_ALTERNATIVE_ORIGINS', 'get').mockReturnValue('');
-				vi.spyOn(appContants, 'AUTH_DERIVATION_ORIGIN', 'get').mockReturnValue(derivationOrigin);
+				vi.spyOn(appConstants, 'AUTH_ALTERNATIVE_ORIGINS', 'get').mockReturnValue('');
+				vi.spyOn(appConstants, 'AUTH_DERIVATION_ORIGIN', 'get').mockReturnValue(derivationOrigin);
 			});
 
 			afterEach(() => {

--- a/src/frontend/src/tests/lib/utils/env.networks.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/env.networks.utils.spec.ts
@@ -3,7 +3,7 @@ import {
 	SOLANA_LOCAL_NETWORK,
 	SOLANA_MAINNET_NETWORK
 } from '$env/networks/networks.sol.env';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import type { Network } from '$lib/types/network';
 import { defineSupportedNetworks } from '$lib/utils/env.networks.utils';
 
@@ -21,7 +21,7 @@ describe('env.networks.utils', () => {
 		};
 
 		beforeEach(() => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValue(false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValue(false);
 		});
 
 		const mockParams = { ...mockBaseParams, $testnetsEnabled: true };
@@ -44,7 +44,7 @@ describe('env.networks.utils', () => {
 
 		describe('when local networks are enabled', () => {
 			beforeEach(() => {
-				vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(true);
+				vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValueOnce(true);
 			});
 
 			it('should return all networks', () => {

--- a/src/frontend/src/tests/lib/utils/env.tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/env.tokens.utils.spec.ts
@@ -1,5 +1,5 @@
 import { SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import type { Token } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 
@@ -17,7 +17,7 @@ describe('env.tokens.utils', () => {
 		};
 
 		beforeEach(() => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValue(false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValue(false);
 		});
 
 		const mockParams = { ...mockBaseParams, $testnetsEnabled: true };
@@ -38,7 +38,7 @@ describe('env.tokens.utils', () => {
 
 		describe('when local networks are enabled', () => {
 			beforeEach(() => {
-				vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(true);
+				vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValueOnce(true);
 			});
 
 			it('should return all tokens', () => {

--- a/src/frontend/src/tests/lib/utils/networks.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/networks.utils.spec.ts
@@ -21,7 +21,7 @@ import {
 	SOLANA_MAINNET_NETWORK
 } from '$env/networks/networks.sol.env';
 import type { EthereumNetwork } from '$eth/types/network';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import type { Network } from '$lib/types/network';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { defineEnabledNetworks, getContractExplorerUrl } from '$lib/utils/networks.utils';
@@ -64,7 +64,7 @@ describe('networks.utils', () => {
 		};
 
 		beforeEach(() => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValue(false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValue(false);
 		});
 
 		describe('when testnets are disabled', () => {
@@ -96,7 +96,7 @@ describe('networks.utils', () => {
 			});
 
 			it('should ignore the local networks when they are enabled', () => {
-				vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(false);
+				vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValueOnce(false);
 
 				expect(defineEnabledNetworks(mockParams)).toEqual(mainnetNetworks);
 			});
@@ -145,7 +145,7 @@ describe('networks.utils', () => {
 
 			describe('when local networks are enabled', () => {
 				beforeEach(() => {
-					vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(true);
+					vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValueOnce(true);
 				});
 
 				it('should return all networks', () => {

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -13,7 +13,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { saveErc20CustomTokens, saveErc20UserTokens } from '$eth/services/manage-tokens.services';
 import { saveIcrcCustomTokens } from '$icp/services/manage-tokens.services';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -544,7 +544,7 @@ describe('tokens.utils', () => {
 		};
 
 		beforeEach(() => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValue(false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValue(false);
 		});
 
 		describe('when testnets are disabled', () => {
@@ -576,7 +576,7 @@ describe('tokens.utils', () => {
 			});
 
 			it('should ignore the local tokens when they are enabled', () => {
-				vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(false);
+				vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValueOnce(false);
 
 				expect(defineEnabledTokens(mockParams)).toEqual(mainnetTokens);
 			});
@@ -623,7 +623,7 @@ describe('tokens.utils', () => {
 
 			describe('when local networks are enabled', () => {
 				beforeEach(() => {
-					vi.spyOn(appContants, 'LOCAL', 'get').mockReturnValueOnce(true);
+					vi.spyOn(appConstants, 'LOCAL', 'get').mockReturnValueOnce(true);
 				});
 
 				it('should return all tokens', () => {

--- a/src/frontend/src/tests/sol/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/sol/derived/tokens.derived.spec.ts
@@ -1,5 +1,5 @@
 import { SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
-import * as appContants from '$lib/constants/app.constants';
+import * as appConstants from '$lib/constants/app.constants';
 import { enabledSolanaTokens } from '$sol/derived/tokens.derived';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
@@ -21,13 +21,13 @@ describe('tokens.derived', () => {
 		});
 
 		it('should return testnet tokens when they are enabled', () => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementationOnce(() => false);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementationOnce(() => false);
 
 			expect(get(enabledSolanaTokens)).toEqual([SOLANA_TOKEN, SOLANA_DEVNET_TOKEN]);
 		});
 
 		it('should return localnet token when in local env', () => {
-			vi.spyOn(appContants, 'LOCAL', 'get').mockImplementationOnce(() => true);
+			vi.spyOn(appConstants, 'LOCAL', 'get').mockImplementationOnce(() => true);
 
 			expect(get(enabledSolanaTokens)).toEqual([
 				SOLANA_TOKEN,


### PR DESCRIPTION
# Motivation

Correcting a typo: `appContants` --> `appConstants`
