### PR TITLE
refactor(frontend): Split `$effect` in `NftsDisplayHandler`

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftsDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/nfts/NftsDisplayHandler.svelte
@@ -25,6 +25,9 @@
 			filter: $tokenListStore.filter,
 			sort: $nftSortStore
 		});
+	});
+
+	$effect(() => {
 		nftCollections = filterSortByCollection({
 			items: getNftCollectionUi({
 				$nftStore,


### PR DESCRIPTION
# Motivation

To keep reactiveness independent, we can split the `$effect` in `NftsDisplayHandler` for NFTs and NFT collections.