### PR TITLE
refactor(frontend): Add NFTs to store right after loading

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -58,6 +58,8 @@
 		const promises = Array.from(tokensByNetwork).map(async ([networkId, tokens]) => {
 			const nfts = await loadNftsByNetwork({ networkId, tokens, walletAddress: $ethAddress });
 
+			nftStore.addAll(nfts);
+
 			tokens.forEach((token) => {
 				const nftsByToken = findNftsByToken({ nfts, token });
 
@@ -66,8 +68,6 @@
 				if (isTokenErc1155(token)) {
 					handleUpdatedNfts({ token, inventory: nfts });
 				}
-
-				nftStore.addAll(nftsByToken);
 			});
 		});
 


### PR DESCRIPTION
# Motivation

When we fetch the NFTs they are already filtered for the tokens we require. So, we don't need to re-filter them and add them in bulk by single token. We can add them all on the spot.
