### PR TITLE
feat(frontend): add destination to StakeReview

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
@@ -6,12 +6,13 @@
 	import StakeProvider from '$lib/components/stake/StakeProvider.svelte';
 	import StakeReview from '$lib/components/stake/StakeReview.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { Address } from '$lib/types/address';
 	import type { OptionAmount } from '$lib/types/send';
 	import { StakeProvider as StakeProviderType } from '$lib/types/stake';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
 	interface Props {
-		destination?: string;
+		destination: Address;
 		amount?: OptionAmount;
 		onBack: () => void;
 		onStake: () => void;
@@ -30,7 +31,7 @@
 	);
 </script>
 
-<StakeReview {amount} disabled={invalid} {onBack} {onStake}>
+<StakeReview {amount} {destination} disabled={invalid} {onBack} {onStake}>
 	{#snippet provider()}
 		<StakeProvider provider={StakeProviderType.GLDT} />
 	{/snippet}

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeWizard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeWizard.svelte
@@ -71,7 +71,7 @@
 	{#if currentStep?.name === WizardStepsStake.STAKE}
 		<GldtStakeForm {destination} {onClose} {onNext} bind:amount />
 	{:else if currentStep?.name === WizardStepsStake.REVIEW}
-		<GldtStakeReview {amount} {onBack} onStake={stake} />
+		<GldtStakeReview {amount} {destination} {onBack} onStake={stake} />
 	{:else if currentStep?.name === WizardStepsStake.STAKING}
 		<StakeProgress {stakeProgressStep} />
 	{/if}

--- a/src/frontend/src/lib/components/stake/StakeReview.svelte
+++ b/src/frontend/src/lib/components/stake/StakeReview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getContext, type Snippet } from 'svelte';
+	import SendReviewDestination from '$lib/components/send/SendReviewDestination.svelte';
 	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
@@ -8,10 +9,12 @@
 	import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { Address } from '$lib/types/address';
 	import type { OptionAmount } from '$lib/types/send';
 
 	interface Props {
 		amount?: OptionAmount;
+		destination: Address;
 		disabled?: boolean;
 		network?: Snippet;
 		fee?: Snippet;
@@ -20,7 +23,16 @@
 		onStake: () => void;
 	}
 
-	let { amount, disabled = false, network, fee, provider, onBack, onStake }: Props = $props();
+	let {
+		amount,
+		destination,
+		disabled = false,
+		network,
+		fee,
+		provider,
+		onBack,
+		onStake
+	}: Props = $props();
 
 	const { sendToken, sendTokenExchangeRate } = getContext<SendContext>(SEND_CONTEXT_KEY);
 </script>
@@ -31,6 +43,10 @@
 			{$i18n.stake.text.stake_review_subtitle}
 		{/snippet}
 	</SendTokenReview>
+
+	<div class="mb-4">
+		<SendReviewDestination {destination} />
+	</div>
 
 	{@render network?.()}
 

--- a/src/frontend/src/tests/lib/components/stake/StakeReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeReview.spec.ts
@@ -2,6 +2,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import StakeReview from '$lib/components/stake/StakeReview.svelte';
 import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { mockPrincipalText } from '$tests/mocks/identity.mock';
 import { render } from '@testing-library/svelte';
 
 describe('StakeReview', () => {
@@ -10,9 +11,10 @@ describe('StakeReview', () => {
 
 	const props = {
 		amount: 0.01,
+		destination: mockPrincipalText,
 		disabled: false,
-		onClose: () => {},
-		onNext: () => {}
+		onStake: () => {},
+		onBack: () => {}
 	};
 
 	it('should keep the next button clickable if all requirements are met', () => {


### PR DESCRIPTION
# Motivation

We need to display the destination also on the stake review step.

<img width="591" height="617" alt="Screenshot 2025-10-16 at 09 23 46" src="https://github.com/user-attachments/assets/2db3d075-732d-488f-9feb-e1feed01bb81" />
