### PR TITLE
refactor(frontend): Switch interval to timeout in `UserSnapshotWorker`

### DIFF
--- a/src/frontend/src/lib/components/rewards/UserSnapshotWorker.svelte
+++ b/src/frontend/src/lib/components/rewards/UserSnapshotWorker.svelte
@@ -70,7 +70,7 @@
 
 		await sync();
 
-		scheduleNext()
+		scheduleNext();
 	};
 
 	const stopTimer = () => {


### PR DESCRIPTION
# Motivation

Using `setTimeout` (recursive) is generally safer than `setInterval` when the callback is asynchronous, because it waits for the previous run to finish before scheduling the next one. It guarantees serial execution and avoids race conditions.

### With `setInterval`

- The timer ticks at fixed intervals no matter how long the callback takes.
- If the callback takes longer than `interval`, the next call starts before the previous one finishes → overlapping executions (race conditions, unexpected states, or API overload).

### With recursive `setTimeout`

- Each cycle is scheduled after the previous `await` completes.
- The delay is still roughly the same, but ensures no overlap and makes execution timing predictable.

In this PR we migrate the component `UserSnapshotWorker`.
