### PR TITLE
refactor(frontend): Switch interval to timeout in Exchange worker

### DIFF
--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -58,7 +58,17 @@ const startExchangeTimer = async (data: PostMessageDataRequestExchangeTimer | un
 	// We sync now but also schedule the update afterward
 	await sync();
 
-	timer = setInterval(sync, SYNC_EXCHANGE_TIMER_INTERVAL);
+	const scheduleNext = (): void => {
+		timer = setTimeout(async () => {
+			await sync();
+
+			if (nonNullish(timer)) {
+				scheduleNext();
+			}
+		}, SYNC_EXCHANGE_TIMER_INTERVAL);
+	};
+
+	scheduleNext();
 };
 
 const stopTimer = () => {
@@ -66,7 +76,7 @@ const stopTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
 


### PR DESCRIPTION
# Motivation

Using `setTimeout` (recursive) is generally safer than `setInterval` when the callback is asynchronous, because it waits for the previous run to finish before scheduling the next one. It guarantees serial execution and avoids race conditions.

### With `setInterval`

- The timer ticks at fixed intervals no matter how long the callback takes.
- If the callback takes longer than `interval`, the next call starts before the previous one finishes → overlapping executions (race conditions, unexpected states, or API overload).

### With recursive `setTimeout`

- Each cycle is scheduled after the previous `await` completes.
- The delay is still roughly the same, but ensures no overlap and makes execution timing predictable.

In this PR we migrate the worker for Exchange rates.
