### PR TITLE
refactor(frontend): Switch interval to timeout in Auth worker

### DIFF
--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -27,7 +27,7 @@ const scheduleNext = (): void => {
 	timer = setTimeout(async () => {
 		await onIdleSignOut();
 
-		if (timer !== undefined) {
+		if (nonNullish(timer)) {
 			scheduleNext();
 		}
 	}, AUTH_TIMER_INTERVAL);


### PR DESCRIPTION
# Motivation

Using `setTimeout` (recursive) is generally safer than `setInterval` when the callback is asynchronous, because it waits for the previous run to finish before scheduling the next one. It guarantees serial execution and avoids race conditions.

### With `setInterval`

- The timer ticks at fixed intervals no matter how long the callback takes.
- If the callback takes longer than `interval`, the next call starts before the previous one finishes → overlapping executions (race conditions, unexpected states, or API overload).

### With recursive `setTimeout`

- Each cycle is scheduled after the previous `await` completes.
- The delay is still roughly the same, but ensures no overlap and makes execution timing predictable.

In this PR we migrate the worker for Auth rates.
