### PR TITLE
fix(frontend): Missing reactivity in `SettingsModalEnabledNetworks`

### DIFF
--- a/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsModalEnabledNetworks.svelte
@@ -34,7 +34,7 @@
 	import { emit } from '$lib/utils/events.utils';
 	import { isNetworkIdICP } from '$lib/utils/network.utils.js';
 
-	let enabledNetworks =$state( { ...$userNetworks });
+	let enabledNetworks = $state({ ...$userNetworks });
 	const enabledNetworksInitial = { ...$userNetworks };
 
 	let enabledTestnet = $state($testnetsEnabled);


### PR DESCRIPTION
# Motivation

When I migrated `SettingsModalEnabledNetworks` to Svelte 5, I forgot to make the list of modified network as a `$state` for reactivity.
