### PR TITLE
fix(frontend): Use correct length of modified tokens in TokensList

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -98,9 +98,10 @@
 	};
 
 	let modifiedTokens: Record<TokenId, Token> = $state({});
-	let modifiedTokensLen = $derived(Object.keys(modifiedTokens).length);
 
-	let saveDisabled = $derived(Object.keys(modifiedTokens).length === 0);
+	let modifiedTokensLen = $derived(Object.getOwnPropertySymbols(modifiedTokens).length);
+
+	let saveDisabled = $derived(modifiedTokensLen === 0);
 
 	const onToggle = ({ id, ...rest }: Token) => {
 		const { [id]: current, ...tokens } = modifiedTokens;


### PR DESCRIPTION
# Motivation

The correct way to calculate the length of a record indexed by Symbols is using `Object.getOwnPropertySymbols`