### PR TITLE
build(frontend): remove broken manual chunks configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { basename, dirname, resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { defineConfig, loadEnv, type UserConfig } from 'vite';
 import { defineViteReplacements, readCanisterIds } from './vite.utils';
 


### PR DESCRIPTION
# Motivation

**UPDATE**: Actually it still works out, it's just the generated chunks we are manually defining does not inherit the name we gave them but some random hash file name. e.g. `vendor` becomes `B7UP1QGh.js`. Therefore I close this.

~~The `rollup.output.manualChunks` is broken or at least as no effect anymore. From having a look at production and building locally, `npm run build` seems to emit chunks no matter what.~~

~~Not sure exactly when it got broken but, find similar issue on SvelteKit - https://github.com/sveltejs/kit/issues/13496 - which share a similar solution - kind of, emitting solely one chunk, we emitted three - which makes me think that anyway, this option is not supported anymore.~~

~~Moreover, OISY is probably shipped in production since a certain of time with chunks. ~~

~~That's why I propose to "just" remove the ignore configuration.~~

# Changes

- Remove `rollup.output.manualChunks` in `vite.config`

# Screenshots

<img width="1533" height="1034" alt="Capture d’écran 2025-10-16 à 18 54 34" src="https://github.com/user-attachments/assets/44cce818-7869-4bcd-9841-6c72065ecb04" />
<img width="1533" height="1034" alt="Capture d’écran 2025-10-16 à 18 53 48" src="https://github.com/user-attachments/assets/3bb12d94-a48c-4777-8286-b3a9984850a8" />

