### PR TITLE
build(frontend): bundle single js and css

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -42,6 +42,10 @@ const config = {
 
 		version: {
 			name: version
+		},
+
+		output: {
+			bundleStrategy: 'single'
 		}
 	}
 };


### PR DESCRIPTION
# Motivation

Our strategy to serve the bundles in three chunks is broken as we discovered in #9718. While searching for the similar issue, one linked to a new option (documented [here](https://svelte.dev/docs/kit/configuration#output)) which allows for bundling a single JS and CSS files.

While it generates a really huge file - 1.7 Mb Gzipped 😰 - maybe it would be still interesting to have a look to see if it improves performance?

# Changes

- Use output option `single`
