### PR TITLE
refactor(frontend): Nft metadata move network on top

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftMetadataList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftMetadataList.svelte
@@ -29,6 +29,16 @@
 
 <List condensed itemStyleClass="flex-col sm:flex-row" styleClass="text-sm text-primary">
 	<ListItem>
+		<span class="text-tertiary">{$i18n.networks.network}</span>
+		{#if nonNullish(collection?.network)}
+			<NetworkWithLogo network={collection.network} />
+		{:else}
+			<span class="min-w-12">
+				<SkeletonText />
+			</span>
+		{/if}
+	</ListItem>
+	<ListItem>
 		<span class="text-tertiary">{$i18n.nfts.text.collection_name}</span>
 		{#if nonNullish(collection?.name)}
 			<span class="flex items-center">
@@ -73,16 +83,6 @@
 		<span class="text-tertiary">{$i18n.nfts.text.display_preference}</span>
 		{#if nonNullish(collection)}
 			<NftImageConsentPreference {collection} />
-		{:else}
-			<span class="min-w-12">
-				<SkeletonText />
-			</span>
-		{/if}
-	</ListItem>
-	<ListItem>
-		<span class="text-tertiary">{$i18n.networks.network}</span>
-		{#if nonNullish(collection?.network)}
-			<NetworkWithLogo network={collection.network} />
 		{:else}
 			<span class="min-w-12">
 				<SkeletonText />


### PR DESCRIPTION
# Motivation

We refactor the Nft metadata list because we want to add and adjust some fields.

# Changes

Moved network row to the top

# Tests

<img width="603" height="546" alt="image" src="https://github.com/user-attachments/assets/718b1660-0111-4bb2-940d-dd7f4e955f2f" />

