### PR TITLE
refactor(frontend): Migrate IC transactions status components to Svelte 5

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcNoIndexPlaceholder.svelte
+++ b/src/frontend/src/icp/components/transactions/IcNoIndexPlaceholder.svelte
@@ -5,7 +5,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-
 	interface Props {
 		placeholderType?: 'missing' | 'not-working';
 	}

--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -15,7 +15,7 @@
 	import { token } from '$lib/stores/token.store';
 	import type { SyncState } from '$lib/types/sync';
 
-	let receiveProgressStep=$state< string | undefined >();
+	let receiveProgressStep = $state<string | undefined>();
 
 	const modalId = Symbol();
 
@@ -73,7 +73,7 @@
 		}
 	};
 
-	let ckBtcUpdateBalanceSyncState=$state<  SyncState | undefined >();
+	let ckBtcUpdateBalanceSyncState = $state<SyncState | undefined>();
 	const debounceUpdateSyncState = debounce(
 		(state: SyncState) => (ckBtcUpdateBalanceSyncState = state)
 	);

--- a/src/frontend/src/icp/components/transactions/IcTransactionsEthereumStatus.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsEthereumStatus.svelte
@@ -5,11 +5,11 @@
 	import type { SyncState } from '$lib/types/sync';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	let ckEthPendingTransactionsSyncState=$state< SyncState | undefined>();
+	let ckEthPendingTransactionsSyncState = $state<SyncState | undefined>();
 	const onSyncPendingState = ({ detail: state }: CustomEvent<SyncState>) =>
 		(ckEthPendingTransactionsSyncState = state);
 
-	let ckEthMinterInfoSyncState=$state< SyncState | undefined >();
+	let ckEthMinterInfoSyncState = $state<SyncState | undefined>();
 	const onSyncMinterInfoState = ({ detail: state }: CustomEvent<SyncState>) =>
 		(ckEthMinterInfoSyncState = state);
 </script>


### PR DESCRIPTION
# Motivation

Migrate components for IC transactions status to Svelte 5.
