### PR TITLE
chore(frontend): Remove unnecessary `undefined` from `$state` rune

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionsHeader.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionsHeader.svelte
@@ -4,7 +4,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 
-	let cmp = $state<Collapsible | undefined>(undefined);
+	let cmp = $state<Collapsible | undefined>();
 
 	const onInfoButtonClick = () => {
 		cmp?.toggleContent();

--- a/src/frontend/src/eth/components/swap/SwapEthForm.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthForm.svelte
@@ -49,7 +49,7 @@
 	const { sourceToken, destinationToken, sourceTokenBalance } =
 		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	let errorType: TokenActionErrorType = $state<TokenActionErrorType | undefined>(undefined);
+	let errorType = $state<TokenActionErrorType | undefined>();
 
 	const {
 		feeStore: storeFeeData,

--- a/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
@@ -20,7 +20,7 @@
 
 	let listener = $state<WebSocketListener | undefined>();
 
-	let currentBlockNumber = $state<number | undefined>(undefined);
+	let currentBlockNumber = $state<number | undefined>();
 
 	const loadCurrentBlockNumber = async () => {
 		try {

--- a/src/frontend/src/lib/components/swap/SwapSlippage.svelte
+++ b/src/frontend/src/lib/components/swap/SwapSlippage.svelte
@@ -34,7 +34,7 @@
 
 	let slippageValueError = $derived(parsedValue >= maxSlippageInvalidValue || parsedValue <= 0);
 
-	let cmp = $state<Collapsible | undefined>(undefined);
+	let cmp = $state<Collapsible | undefined>();
 	let expanded = $state(false);
 
 	const extendedToggleContent = () => {

--- a/src/frontend/src/tests/lib/components/ui/ResponsivePopoverTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/ResponsivePopoverTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ResponsivePopover from '$lib/components/ui/ResponsivePopover.svelte';
 
-	let button: HTMLButtonElement | undefined = $state(undefined);
+	let button = $state<HTMLButtonElement | undefined>();
 </script>
 
 <button bind:this={button}>Test</button>


### PR DESCRIPTION
# Motivation

The rune `$state` does not need to be initialized explicitly with `undefined`.
