### PR TITLE
feat(frontend): update StakeProvider design

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeForm.svelte
+++ b/src/frontend/src/lib/components/stake/StakeForm.svelte
@@ -94,9 +94,9 @@
 		<SendReviewDestination {destination} />
 	</div>
 
-	{@render provider?.()}
-
 	{@render fee?.()}
+
+	{@render provider?.()}
 
 	{#snippet toolbar()}
 		<ButtonGroup testId="toolbar">

--- a/src/frontend/src/lib/components/stake/StakeProvider.svelte
+++ b/src/frontend/src/lib/components/stake/StakeProvider.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
-	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { stakeProvidersConfig } from '$lib/config/stake.config';
 	import {
 		STAKE_PROVIDER_EXTERNAL_URL,
@@ -9,6 +8,7 @@
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { StakeProvider } from '$lib/types/stake';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
 		provider: StakeProvider;
@@ -17,27 +17,31 @@
 	let { provider }: Props = $props();
 </script>
 
-<ModalValue>
-	{#snippet label()}
-		{$i18n.stake.text.provider}
-	{/snippet}
-
-	{#snippet mainValue()}
-		<div class="flex items-center gap-1">
+<div class="my-4 rounded-lg border border-disabled bg-secondary px-2 py-3">
+	<div class="flex justify-between">
+		<div class="flex items-center gap-3">
 			<Logo
 				alt={stakeProvidersConfig[provider].name}
+				size="xs"
 				src={stakeProvidersConfig[provider].logo}
 				testId={STAKE_PROVIDER_LOGO}
 			/>
-
-			<span>{stakeProvidersConfig[provider].name}</span>
-
-			<ExternalLink
-				ariaLabel={stakeProvidersConfig[provider].name}
-				href={stakeProvidersConfig[provider].url}
-				iconSize="15"
-				testId={STAKE_PROVIDER_EXTERNAL_URL}
-			/>
+			<span class="font-bold">
+				{replacePlaceholders($i18n.stake.text.provider, {
+					$provider: stakeProvidersConfig[provider].name
+				})}
+			</span>
 		</div>
-	{/snippet}
-</ModalValue>
+
+		<ExternalLink
+			ariaLabel={stakeProvidersConfig[provider].name}
+			href={stakeProvidersConfig[provider].url}
+			iconAsLast
+			iconSize="15"
+			styleClass="text-sm"
+			testId={STAKE_PROVIDER_EXTERNAL_URL}
+		>
+			{$i18n.stake.text.visit_provider}
+		</ExternalLink>
+	</div>
+</div>

--- a/src/frontend/src/lib/components/stake/StakeReview.svelte
+++ b/src/frontend/src/lib/components/stake/StakeReview.svelte
@@ -50,9 +50,9 @@
 
 	{@render network?.()}
 
-	{@render provider?.()}
-
 	{@render fee?.()}
+
+	{@render provider?.()}
 
 	{#snippet toolbar()}
 		<ButtonGroup testId="toolbar">

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1714,7 +1714,8 @@
 			"review": "Review transaction",
 			"executing_transaction": "Executing transaction...",
 			"unsupported_token_staking": "Staking for the selected token is not supported.",
-			"provider": "Staking provider",
+			"provider": "Staking terms provided by $provider",
+			"visit_provider": "Visit website",
 			"current_apy": "Current APY",
 			"stake_review_subtitle": "You stake"
 		}

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1715,6 +1715,7 @@
 			"executing_transaction": "",
 			"unsupported_token_staking": "",
 			"provider": "",
+			"visit_provider": "",
 			"current_apy": "",
 			"stake_review_subtitle": ""
 		}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1392,6 +1392,7 @@ interface I18nStake {
 		executing_transaction: string;
 		unsupported_token_staking: string;
 		provider: string;
+		visit_provider: string;
 		current_apy: string;
 		stake_review_subtitle: string;
 	};

--- a/src/frontend/static/images/dapps/gold-dao-logo.svg
+++ b/src/frontend/static/images/dapps/gold-dao-logo.svg
@@ -1,17 +1,94 @@
-<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g clip-path="url(#clip0_18808_70578)">
-        <circle cx="11" cy="11" r="11" fill="url(#pattern0_18808_70578)"/>
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_19327_3887)">
+        <path d="M4.68616 4.70648C-1.56162 10.9429 -1.56162 21.0547 4.68749 27.2924C10.9366 33.5302 21.0666 33.5302 27.3144 27.2938C33.5622 21.0573 33.5622 10.9456 27.3131 4.70781C21.064 -1.52999 10.9339 -1.52999 4.68616 4.70648ZM25.799 25.781C20.3627 31.2074 11.5463 31.2074 6.10864 25.7797C0.671055 20.352 0.669725 11.5528 6.10732 6.12506C11.5449 0.697323 20.36 0.698654 25.7976 6.12639C31.2352 11.5541 31.2366 20.3533 25.799 25.781Z"
+              fill="url(#paint0_linear_19327_3887)"/>
+        <path d="M15.9994 2.03467C8.31058 2.03467 2.07739 8.25789 2.07739 15.9328C2.07739 23.6077 8.31058 29.831 15.9994 29.831C23.6883 29.831 29.9215 23.6077 29.9215 15.9328C29.9215 8.25789 23.6883 2.03467 15.9994 2.03467Z"
+              fill="white"/>
+        <path d="M9.42622 9.10784L15.4243 6.15667C15.8002 5.97239 16.2398 5.97504 16.613 6.16331L22.1024 8.94347C22.5673 9.17944 22.8595 9.65538 22.8595 10.1751V13.5174C22.8595 14.1087 22.5261 14.6496 21.9988 14.9174L16.5121 17.6936C16.1814 17.8607 15.7895 17.6207 15.7895 17.2508V16.2313C15.7895 16.0443 15.8958 15.872 16.0632 15.7871L20.482 13.5665C20.6494 13.483 20.7543 13.3119 20.7556 13.1249L20.7689 10.6683C20.7689 10.4787 20.664 10.3064 20.494 10.2215L16.2239 8.08969C16.0844 8.01942 15.9197 8.01942 15.7803 8.08969L9.86449 11.021C9.53383 11.1853 9.146 10.944 9.146 10.5768V9.5533C9.146 9.36371 9.25353 9.19135 9.42356 9.10784H9.42622Z"
+              fill="url(#paint1_linear_19327_3887)"/>
+        <path d="M15.7868 10.9135L9.75693 13.9323C9.38501 14.1192 9.1499 14.4984 9.1499 14.9147V22.1097C9.1499 22.5048 9.37177 22.8667 9.72373 23.0484L15.4362 25.9889C15.7948 26.1733 16.2199 26.1745 16.5785 25.9916L22.2432 23.116C22.623 22.9238 22.8621 22.5339 22.8621 22.1084V16.7973C22.8621 16.3054 22.3441 15.9846 21.9031 16.2034L16.2278 19.0166C15.9715 19.144 15.8095 19.4051 15.8095 19.6902V20.6023C15.8095 20.9497 16.1747 21.1751 16.4868 21.0199L20.1858 19.1731C20.4568 19.0379 20.7755 19.2341 20.7755 19.5364V21.3408C20.7755 21.5516 20.6573 21.7464 20.4687 21.8419L16.3447 23.9432C16.1336 24.0506 15.8825 24.052 15.6713 23.9432L11.6243 21.895C11.3892 21.7756 11.2405 21.5357 11.2405 21.2718V15.6638C11.2405 15.4808 11.3441 15.3124 11.5075 15.2303L15.9277 13.0016C16.0884 12.9207 16.188 12.7564 16.1867 12.5773L16.176 11.1469C16.1747 10.9493 15.9662 10.8233 15.7908 10.9108L15.7868 10.9135Z"
+              fill="url(#paint2_linear_19327_3887)"/>
     </g>
     <defs>
-        <pattern id="pattern0_18808_70578" patternContentUnits="objectBoundingBox" width="1" height="1">
-            <use xlink:href="#image0_18808_70578" transform="translate(0.217532 0.0909091) scale(0.0194805)"/>
-        </pattern>
-        <clipPath id="clip0_18808_70578">
-            <path d="M0 11C0 4.92487 4.92487 0 11 0C17.0751 0 22 4.92487 22 11C22 17.0751 17.0751 22 11 22C4.92487 22 0 17.0751 0 11Z"
+        <linearGradient id="paint0_linear_19327_3887" x1="4.6859" y1="27.2922" x2="27.2713" y2="4.66579"
+                        gradientUnits="userSpaceOnUse">
+            <stop stop-color="#5E4D15"/>
+            <stop offset="0.06" stop-color="#7C6517"/>
+            <stop offset="0.14" stop-color="#C09E44"/>
+            <stop offset="0.18" stop-color="#DBB556"/>
+            <stop offset="0.21" stop-color="#D1AB4F"/>
+            <stop offset="0.27" stop-color="#B6933E"/>
+            <stop offset="0.31" stop-color="#A07F31"/>
+            <stop offset="0.41" stop-color="#73571B"/>
+            <stop offset="0.46" stop-color="#5E4411"/>
+            <stop offset="0.49" stop-color="#6D5014"/>
+            <stop offset="0.55" stop-color="#96721E"/>
+            <stop offset="0.59" stop-color="#B38A26"/>
+            <stop offset="0.62" stop-color="#C09934"/>
+            <stop offset="0.65" stop-color="#C6A03B"/>
+            <stop offset="0.66" stop-color="#C9A542"/>
+            <stop offset="0.68" stop-color="#D3B655"/>
+            <stop offset="0.71" stop-color="#E4D075"/>
+            <stop offset="0.73" stop-color="#F8F19D"/>
+            <stop offset="0.78" stop-color="#F9F2A1"/>
+            <stop offset="0.82" stop-color="#E6D47F"/>
+            <stop offset="0.89" stop-color="#C7A449"/>
+            <stop offset="0.93" stop-color="#BC9234"/>
+        </linearGradient>
+        <linearGradient id="paint1_linear_19327_3887" x1="-1.33474" y1="29.0648" x2="30.3765" y2="-2.70399"
+                        gradientUnits="userSpaceOnUse">
+            <stop/>
+            <stop offset="0.06" stop-color="#232323"/>
+            <stop offset="0.1" stop-color="#4F4F4F"/>
+            <stop offset="0.16" stop-color="#939393"/>
+            <stop offset="0.19" stop-color="#AEAEAE"/>
+            <stop offset="0.24" stop-color="#A4A4A4"/>
+            <stop offset="0.34" stop-color="#898989"/>
+            <stop offset="0.35" stop-color="#878787"/>
+            <stop offset="0.36" stop-color="#7B7B7B"/>
+            <stop offset="0.42" stop-color="#454545"/>
+            <stop offset="0.44" stop-color="#303030"/>
+            <stop offset="0.46" stop-color="#3F3F3F"/>
+            <stop offset="0.49" stop-color="#686868"/>
+            <stop offset="0.53" stop-color="#B0B0B0"/>
+            <stop offset="0.65" stop-color="#AFAFAF"/>
+            <stop offset="0.67" stop-color="#B6B6B6"/>
+            <stop offset="0.7" stop-color="#C9C9C9"/>
+            <stop offset="0.74" stop-color="#E9E9E9"/>
+            <stop offset="0.75" stop-color="#EDEDED"/>
+            <stop offset="0.83" stop-color="#EEEEEE"/>
+            <stop offset="0.86" stop-color="#C9C9C9"/>
+            <stop offset="0.9" stop-color="#939393"/>
+            <stop offset="0.93" stop-color="#7E7E7E"/>
+        </linearGradient>
+        <linearGradient id="paint2_linear_19327_3887" x1="2.35892" y1="32.1379" x2="32.9459" y2="1.49541"
+                        gradientUnits="userSpaceOnUse">
+            <stop stop-color="#5E4D15"/>
+            <stop offset="0.06" stop-color="#7C6517"/>
+            <stop offset="0.19" stop-color="#C09E44"/>
+            <stop offset="0.26" stop-color="#DBB556"/>
+            <stop offset="0.28" stop-color="#D1AB4F"/>
+            <stop offset="0.32" stop-color="#B6933E"/>
+            <stop offset="0.34" stop-color="#A07F31"/>
+            <stop offset="0.42" stop-color="#73571B"/>
+            <stop offset="0.46" stop-color="#5E4411"/>
+            <stop offset="0.49" stop-color="#6D5014"/>
+            <stop offset="0.55" stop-color="#96721E"/>
+            <stop offset="0.59" stop-color="#B38A26"/>
+            <stop offset="0.62" stop-color="#C09934"/>
+            <stop offset="0.65" stop-color="#C6A03B"/>
+            <stop offset="0.66" stop-color="#C9A542"/>
+            <stop offset="0.68" stop-color="#D3B655"/>
+            <stop offset="0.71" stop-color="#E4D075"/>
+            <stop offset="0.73" stop-color="#F8F19D"/>
+            <stop offset="0.78" stop-color="#F9F2A1"/>
+            <stop offset="0.82" stop-color="#E6D47F"/>
+            <stop offset="0.89" stop-color="#C7A449"/>
+            <stop offset="0.93" stop-color="#BC9234"/>
+        </linearGradient>
+        <clipPath id="clip0_19327_3887">
+            <path d="M0 16C0 7.16344 7.16344 0 16 0C24.8366 0 32 7.16344 32 16C32 24.8366 24.8366 32 16 32C7.16344 32 0 24.8366 0 16Z"
                   fill="white"/>
         </clipPath>
-        <image id="image0_18808_70578" width="29" height="42" preserveAspectRatio="none"
-               xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB0AAAAqCAYAAABP7FAaAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAHaADAAQAAAABAAAAKgAAAADNenLHAAAHo0lEQVRYCZ1Xa2xVxRae2Wfvc04LhVR5aFUE4zsRH7kqMUYkGKxiHzzEF9iAguItJUhu7BNqXxeqopaXUhHrKyilQInEZzSCpCYmii+iP643RoVQrL2B9pyz98wev7V353TTnvaUO8l0nVmzZn3zrVmzZpezs2xtbW0lnPN/YdmF6NuVUuVz5849cTZu+EiN9+zZswK2peg5A9b0YrzVNM11eXl5JwfMpRymBSUwMCsFoxxIBskGyj7PvYZhbEZvTAc+JOi+ffuKAVAGh0lmQcCUFKAMhUI9AN4E5o25ubldqewGgba2tpZgwVMaLAgUYNgK/S6MqyGv0o71PIAZgHsgN0L3zEDwJGhdXV1xVlZW6ZgxYy5Apx1rX0kJgHfh5OnCwsIftRKJVQBdBcY3ah3JPmCSp0CiCf3ZGTNmdNMcLyoqmjVq1Kgdo0ePzhk7diyDZCSxgSDwG3BcX1BQ8BMtStVw9rNgQ2c/Q89rYAAy9FOWZRVPnz79dT5//vyvMzMzrwOwB0QsqRMo5CswbMjPz/9FO0on29vbpwkhyrCBfLLVwCThi0UikSvMnp6ezBSOmrHjusWLF/+aYm5YFTbYAYMChP1anGu9lHK2XoCNUPZfZ8ZiMSegfAFGjWjHtO7/lSgYR7D2nr179x6FzyvJDyJAoBmmbdtPYnw9+qvI3E6aHK41r5wy0Yiq0nCY/7Co9pdXhrOlOYD8AXElgJOm5uHDhz/EiPqwrWHxeeMjUas8xsRjljAyGGd7sCAtKELKAez5JmDXdZU5LBImyx+YMNG0QmVCsWWGdDOUdxi4aUoZ6dbSPACTdnSmAGVDgj5x9/jzQmG1Ju6o5ZZymbIA5EAy8uGic3/75HmYFmRKjJFcg0EX3jnufEvJKlvJ5ZagbCOP9Ie6D8ghucvepJl0jZgSQwIcxHRl/oSJvVJWSKGWOlJFg85sjxkBqphSfFvISqwvfelk2gxH5l6DRVcRILUk01X3XngOM9Qa6ciVFEGGUBIjR5D0G/YYV8rd7HBz/cadx9Jm+P79+y9D0tRg9f2aoZY40y4zMxpqdKR8hPefN47LBwPwaWyyybYTG17/5NSffXsYUgBsEu7iWgAu0UbB0AI4hvnDpmkZN2sQMvQDwf9CmjRFTPni1ve6/9IOhpLbt2+nul0FsMcJhJpmFpC/IokWLViwoMu0TCPsQ9GZeST3h4T9UOOBk6c8xTB/Vq9ePS47O7sMpfQJOIwGXycNDvkbXPx7zpw5W7QrM2Qis5h+xrBL5b7f2J4eEK/TKpTQehTyDO2MgAKv03ECwzPYpOe1BFMC1EmDisFDfoS1RQqJz5FxYLeBQkc92DA+DuB6vF6btL6lfMrUjEioEkeZlWWI+8HUDyuFmIMxilZfGuklg2V3d7dF7+6AdhxM15WUlLyo9U0rJl2N16xGumxe3JEsAs+nrdDdpmXhomsrMEaoz9x6cu6MH6K3t9e77NB2Amx9NBrdUlFRESOr2iU5V1ghXmNLdwEz4N2rZBw45J9bYAzQQDHkbnrMgwcPdk6bNm0p/Ft4/F9raWnxwFbdO/7ScIg/bTvugygiyEqKIvkjWhRJ0il8RYBpMKAjq6iMdXR0JF+YR2eNnWJFzLWOrYq4Bf8eEMkzarU/Rj1AIhFN/dZRJo+8LbsjexLq4hrJ+CMMzxBdAttbTl6oE1MX/AJ5oyQzI2FKHs8Sk1g+sjNly/MnVgopay2Uy2DJJE9+reaHQOEbDIuDjKn+I5HAlF4BzHrgCk9LmrYsLyfTMt1azkGNFqIlgRX7wDWMhk2tnZ+T/qn7JkwF49uSjH2m/VnkoQUPmFalaOdkmREb3zvkyAshFmLZATBfu+P9/30VXIKb4jCnb2dk7xrKDIf7QcnYHQHTqBNzXCvi++ZsF/K/tvm9k98FwfRvB9fFP1v/jBWT3IyGLUpkr5FEbdDb6tMOFtW7Ok9XFk1eEpLOFxt2H/95sEW/Bm8zTqAf2MUZgimVQSpn2lAk/zfRmlSyruW/O1Lpg7qHZ2adK6Q7lbJXfwgofHIYkbDpoLNoxGQkEe4Vbc/d0rz72VsuDjo4299L7sx+XHHzO3wAjie2Eh1FgwkHsfx+d+HL0lXL4gkHSsHiCeHJhA0p5DYRY7ULq7/8baSgxfPOX+gKt8Fx5EUSRZey2gzhIqKjNDJUwLu84/y+bU4zHuBHCSjYbQJG+iFTt7gx0VBUf+T3ocDLFk4ulFKsRzgvFwCC9ABl3z3uA37HONG1SOcQ+2Ff/qUiwdfFbWfeQMaOkN5msPvNQiTqH2s4mvwoq//n5TOVEGDm3iRQlWDjASaBKaTSbcP+q976pMv7FzMJqhkc2Zl3Q1zIGgDPDrImYM0cv7fhq/EY5K1wPpNC6IHAhqQeQ7ZjXLW1/cS32j/JQaB6suPt3Fsd230+Hhf/IOa0AZ8x7jo5BiMAezofyB8jD0h/QNpO5bqdf3yt/QXlkKDa6NBrufnxhF0H0Gs0U9oEnbUYwAzgH6EqlVe+/J8zqpL2pWVaUG348dbbH0pItyaREJf4jIUHSuBIlk/Ry0s2HKX/TdO2EYNqTweapi9NOE41wpgD9ocSUlYtrf7mMz0/Evk3UAQn6UXSwvQAAAAASUVORK5CYII="/>
     </defs>
 </svg>


### PR DESCRIPTION
# Motivation

The first step of implement the final design of Stake form is to update how the provider info looks like. The component will be extended with further data in the follow-up PRs.

Before:
<img width="595" height="598" alt="Screenshot 2025-10-17 at 10 15 41" src="https://github.com/user-attachments/assets/bd3701c8-7747-4309-bd48-24c5553ef916" />


After:
<img width="598" height="651" alt="Screenshot 2025-10-17 at 10 14 57" src="https://github.com/user-attachments/assets/52d8f97d-c052-4cd0-a481-4f8d1d05f526" />
