### PR TITLE
feat(frontend): Update NFTs in store when already existing

### DIFF
--- a/src/frontend/src/lib/stores/nft.store.ts
+++ b/src/frontend/src/lib/stores/nft.store.ts
@@ -23,21 +23,21 @@ const initNftStore = (): NftStore => {
 					return nfts;
 				}
 
-				const newNfts = nfts.filter(
-					(newNft) =>
-						!currentNfts.some(
-							(existingNft) =>
-								existingNft.id === newNft.id &&
+				const oldNfts = currentNfts.filter(
+					(oldNft) =>
+						!nfts.some(
+							(newNft) =>
+								newNft.id === oldNft.id &&
 								areAddressesEqual({
-									address1: existingNft.collection.address,
-									address2: newNft.collection.address,
-									networkId: existingNft.collection.network.id
+									address1: newNft.collection.address,
+									address2: oldNft.collection.address,
+									networkId: newNft.collection.network.id
 								}) &&
-								existingNft.collection.network.id === newNft.collection.network.id
+								newNft.collection.network.id === oldNft.collection.network.id
 						)
 				);
 
-				return [...currentNfts, ...newNfts];
+				return [...oldNfts, ...nfts];
 			});
 		},
 		removeSelectedNfts: (nfts: Nft[]) => {

--- a/src/frontend/src/tests/lib/stores/nft.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/nft.store.spec.ts
@@ -37,6 +37,18 @@ describe('nftStore', () => {
 			expect(get(nftStore)).toEqual([mockValidErc721Nft]);
 		});
 
+		it('should update already existing NFTs to store', () => {
+			const duplicateNft = { ...mockValidErc721Nft, imageUrl: 'newUrl' };
+
+			nftStore.addAll([mockValidErc721Nft]);
+
+			expect(get(nftStore)).toEqual([mockValidErc721Nft]);
+
+			nftStore.addAll([duplicateNft]);
+
+			expect(get(nftStore)).toEqual([duplicateNft]);
+		});
+
 		it('should add NFT with same token id but different collection address', () => {
 			const similarNft: Nft = {
 				...mockValidErc721Nft,
@@ -48,7 +60,7 @@ describe('nftStore', () => {
 			expect(get(nftStore)).toEqual([mockValidErc721Nft, similarNft]);
 		});
 
-		it('should not add NFT with address written in different case', () => {
+		it('should add NFT with address written in different case', () => {
 			nftStore.addAll([mockValidErc721Nft]);
 
 			const similarNft: Nft = {
@@ -61,7 +73,7 @@ describe('nftStore', () => {
 
 			nftStore.addAll([similarNft]);
 
-			expect(get(nftStore)).toEqual([mockValidErc721Nft]);
+			expect(get(nftStore)).toEqual([similarNft]);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The logic of `addAll` method of `nftStore` should be updated: currently it was not updating NFTs that already exists. However, it is always better to expect that adding new NFTs would overwrite the ones that already are there.
