### PR TITLE
feat(frontend): round to 2 decimals the gldt_stake APY

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeApyContext.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeApyContext.svelte
@@ -23,7 +23,9 @@
 		}
 
 		try {
-			gldtStakeApyStore.setApy(await getApyOverall({ identity: $authIdentity }));
+			const apy = await getApyOverall({ identity: $authIdentity });
+
+			gldtStakeApyStore.setApy(Math.round(apy * 100) / 100);
 		} catch (_err: unknown) {
 			gldtStakeApyStore.reset();
 		}

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeApyContext.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeApyContext.spec.ts
@@ -14,7 +14,9 @@ import { render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('GldtStakeApyContext', () => {
-	const mockApy = 10;
+	const mockApy = 10.1232131232121;
+	const parsedMockApy = Math.round(mockApy * 100) / 100;
+
 	const mockContext = (store: GldtStakeApyStore) =>
 		new Map([[GLDT_STAKE_APY_CONTEXT_KEY, { store }]]);
 	const mockGetApyOverall = () =>
@@ -46,7 +48,7 @@ describe('GldtStakeApyContext', () => {
 			expect(getApyOverallSpy).toHaveBeenCalledExactlyOnceWith({
 				identity: mockIdentity
 			});
-			expect(setApySpy).toHaveBeenCalledExactlyOnceWith(mockApy);
+			expect(setApySpy).toHaveBeenCalledExactlyOnceWith(parsedMockApy);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The value that comes from the gldt_stake canister contains too many decimals, therefore we'd like to shorten it for the better UI experience.
