### PR TITLE
refactor(frontend): Migrate IC fee context components to Svelte 5

### DIFF
--- a/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
+++ b/src/frontend/src/icp/components/fee/EthereumFeeContext.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { getContext, onDestroy } from 'svelte';
+	import { getContext, onDestroy, type Snippet, untrack } from 'svelte';
 	import { tokenAsIcToken, tokenWithFallbackAsIcToken } from '$icp/derived/ic-token.derived';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import { loadEip1559TransactionPrice } from '$icp/services/cketh.services';
@@ -9,7 +9,6 @@
 		ETHEREUM_FEE_CONTEXT_KEY,
 		type EthereumFeeContext
 	} from '$icp/stores/ethereum-fee.store';
-	import type { IcToken } from '$icp/types/ic-token';
 	import { isTokenCkEthLedger } from '$icp/utils/ic-send.utils';
 	import { isTokenIcrcTestnet } from '$icp/utils/icrc-ledger.utils';
 	import {
@@ -21,13 +20,20 @@
 	import { token } from '$lib/stores/token.store';
 	import type { NetworkId } from '$lib/types/network';
 
-	export let networkId: NetworkId | undefined = undefined;
+	interface Props {
+		networkId?: NetworkId;
+		children: Snippet;
+	}
 
-	let ckEthConvert = false;
-	$: ckEthConvert = isConvertCkEthToEth({ token: $tokenWithFallbackAsIcToken, networkId });
+	let { networkId, children }: Props = $props();
 
-	let ckErc20Convert = false;
-	$: ckErc20Convert = isConvertCkErc20ToErc20({ token: $tokenWithFallbackAsIcToken, networkId });
+	let ckEthConvert = $derived(
+		isConvertCkEthToEth({ token: $tokenWithFallbackAsIcToken, networkId })
+	);
+
+	let ckErc20Convert = $derived(
+		isConvertCkErc20ToErc20({ token: $tokenWithFallbackAsIcToken, networkId })
+	);
 
 	// This is the amount of ckETH to be burned to cover for the fees of the transaction eth_sendRawTransaction(destination_eth_address, amount) described in the withdrawal scheme.
 	// It will be requested to be approved using the transaction icrc2_approve(minter, tx_fee) described in the first step of the withdrawal scheme.
@@ -36,35 +42,42 @@
 	// NOTE: the endpoint gives a timestamp of the last update too, that could come in handy.
 	// For ckETH, see https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/cketh.adoc#cost-of-a-withdrawal
 	// For ckERC20, see https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/ckerc20.adoc#withdrawal-ckerc20-to-erc20
-	let maxTransactionFeeCkEth: bigint | undefined = undefined;
-	$: maxTransactionFeeCkEth = nonNullish($tokenId)
-		? $eip1559TransactionPriceStore?.[$tokenId]?.data.max_transaction_fee
-		: undefined;
+	let maxTransactionFeeCkEth = $derived(
+		nonNullish($tokenId)
+			? $eip1559TransactionPriceStore?.[$tokenId]?.data.max_transaction_fee
+			: undefined
+	);
 
-	let tokenCkEth: IcToken | undefined;
-	$: tokenCkEth = $icrcTokens
-		.filter(isTokenCkEthLedger)
-		.find(
-			(tokenCkEth) => isTokenIcrcTestnet(tokenCkEth ?? {}) === isTokenIcrcTestnet($token ?? {})
-		);
+	let tokenCkEth = $derived(
+		$icrcTokens
+			.filter(isTokenCkEthLedger)
+			.find(
+				(tokenCkEth) => isTokenIcrcTestnet(tokenCkEth ?? {}) === isTokenIcrcTestnet($token ?? {})
+			)
+	);
 
 	// For ckERC20, include the ckETH ledger fee for the transaction icrc2_approve(minter, tx_fee) to the ckETH ledger, described in the first step of the withdrawal scheme.
 	// For ckETH, such fee is already shown in the ckETH ledger fee section, so no need to include it here.
 	// See https://github.com/dfinity/ic/blob/master/rs/ethereum/cketh/docs/ckerc20.adoc#withdrawal-ckerc20-to-erc20
-	let maxTransactionFeePlusLedgerApproveCkEth: bigint | undefined = undefined;
-	$: maxTransactionFeePlusLedgerApproveCkEth = nonNullish(maxTransactionFeeCkEth)
-		? maxTransactionFeeCkEth + (tokenCkEth?.fee ?? ZERO)
-		: undefined;
+	let maxTransactionFeePlusLedgerApproveCkEth = $derived(
+		nonNullish(maxTransactionFeeCkEth)
+			? maxTransactionFeeCkEth + (tokenCkEth?.fee ?? ZERO)
+			: undefined
+	);
 
-	let maxTransactionFee: bigint | undefined = undefined;
-	$: maxTransactionFee = ckEthConvert
-		? maxTransactionFeeCkEth
-		: ckErc20Convert
-			? maxTransactionFeePlusLedgerApproveCkEth
-			: undefined;
+	let maxTransactionFee = $derived(
+		ckEthConvert
+			? maxTransactionFeeCkEth
+			: ckErc20Convert
+				? maxTransactionFeePlusLedgerApproveCkEth
+				: undefined
+	);
 
 	const { store } = getContext<EthereumFeeContext>(ETHEREUM_FEE_CONTEXT_KEY);
-	$: store.setFee({ maxTransactionFee });
+
+	$effect(() => {
+		store.setFee({ maxTransactionFee });
+	});
 
 	const updateContext = () => {
 		if (ckEthConvert || ckErc20Convert) {
@@ -75,7 +88,11 @@
 		store.setFee(null);
 	};
 
-	$: (maxTransactionFee, updateContext());
+	$effect(() => {
+		[maxTransactionFee];
+
+		untrack(() => updateContext());
+	});
 
 	const loadFee = async () => {
 		clearTimer();
@@ -97,7 +114,11 @@
 		timer = setInterval(load, 30000);
 	};
 
-	$: (networkId, (async () => await loadFee())());
+	$effect(() => {
+		[networkId];
+
+		untrack(() => loadFee());
+	});
 
 	let timer: NodeJS.Timeout | undefined;
 
@@ -106,4 +127,4 @@
 	onDestroy(clearTimer);
 </script>
 
-<slot />
+{@render children()}


### PR DESCRIPTION
# Motivation

Migrating `BitcoinFeeContext` and `EthereumFeeContext` to Svelte 5.
