### PR TITLE
feat(frontend): display APY value in StakeForm and StakeReview

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeForm.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeForm.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import GldtStakeFees from '$icp/components/stake/gldt/GldtStakeFees.svelte';
+	import {
+		GLDT_STAKE_APY_CONTEXT_KEY,
+		type GldtStakeApyContext
+	} from '$icp/stores/gldt-stake-apy.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import StakeForm from '$lib/components/stake/StakeForm.svelte';
 	import StakeProvider from '$lib/components/stake/StakeProvider.svelte';
@@ -23,6 +27,8 @@
 
 	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
+	const { store: gldtStakeApyStore } = getContext<GldtStakeApyContext>(GLDT_STAKE_APY_CONTEXT_KEY);
+
 	let totalFee = $derived(($sendToken as IcToken).fee * 2n);
 
 	const onCustomValidate = (userAmount: bigint): TokenActionErrorType =>
@@ -36,7 +42,7 @@
 
 <StakeForm {destination} {onClose} {onCustomValidate} {onNext} {totalFee} bind:amount>
 	{#snippet provider()}
-		<StakeProvider provider={StakeProviderType.GLDT} />
+		<StakeProvider currentApy={$gldtStakeApyStore?.apy} provider={StakeProviderType.GLDT} />
 	{/snippet}
 
 	{#snippet fee()}

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
@@ -2,6 +2,10 @@
 	import { getContext } from 'svelte';
 	import IcReviewNetwork from '$icp/components/send/IcReviewNetwork.svelte';
 	import GldtStakeFees from '$icp/components/stake/gldt/GldtStakeFees.svelte';
+	import {
+		GLDT_STAKE_APY_CONTEXT_KEY,
+		type GldtStakeApyContext
+	} from '$icp/stores/gldt-stake-apy.store';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import StakeProvider from '$lib/components/stake/StakeProvider.svelte';
 	import StakeReview from '$lib/components/stake/StakeReview.svelte';
@@ -22,6 +26,8 @@
 
 	const { sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
+	const { store: gldtStakeApyStore } = getContext<GldtStakeApyContext>(GLDT_STAKE_APY_CONTEXT_KEY);
+
 	// Should never happen given that the same checks are performed on previous wizard step
 	let invalid = $derived(
 		isInvalidDestinationIc({
@@ -33,7 +39,7 @@
 
 <StakeReview {amount} {destination} disabled={invalid} {onBack} {onStake}>
 	{#snippet provider()}
-		<StakeProvider provider={StakeProviderType.GLDT} />
+		<StakeProvider currentApy={$gldtStakeApyStore?.apy} provider={StakeProviderType.GLDT} />
 	{/snippet}
 
 	{#snippet network()}

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeForm.spec.ts
@@ -1,5 +1,10 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import GldtStakeForm from '$icp/components/stake/gldt/GldtStakeForm.svelte';
+import {
+	GLDT_STAKE_APY_CONTEXT_KEY,
+	initGldtStakeApyStore,
+	type GldtStakeApyContext
+} from '$icp/stores/gldt-stake-apy.store';
 import * as appConstants from '$lib/constants/app.constants';
 import {
 	STAKE_FORM_REVIEW_BUTTON,
@@ -12,7 +17,10 @@ import { fireEvent, render, waitFor } from '@testing-library/svelte';
 
 describe('GldtStakeForm', () => {
 	const mockContext = () =>
-		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+		new Map<symbol, SendContext | GldtStakeApyContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_APY_CONTEXT_KEY, { store: initGldtStakeApyStore() }]
+		]);
 
 	const props = {
 		amount: 0.01,

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeReview.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeReview.spec.ts
@@ -1,5 +1,10 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import GldtStakeReview from '$icp/components/stake/gldt/GldtStakeReview.svelte';
+import {
+	GLDT_STAKE_APY_CONTEXT_KEY,
+	initGldtStakeApyStore,
+	type GldtStakeApyContext
+} from '$icp/stores/gldt-stake-apy.store';
 import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import { mockPrincipalText } from '$tests/mocks/identity.mock';
@@ -8,7 +13,10 @@ import { render } from '@testing-library/svelte';
 
 describe('GldtStakeReview', () => {
 	const mockContext = () =>
-		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+		new Map<symbol, SendContext | GldtStakeApyContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_APY_CONTEXT_KEY, { store: initGldtStakeApyStore() }]
+		]);
 
 	const props = {
 		amount: 0.01,

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeWizard.spec.ts
@@ -1,6 +1,11 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import GldtStakeWizard from '$icp/components/stake/gldt/GldtStakeWizard.svelte';
 import * as gldtStakeService from '$icp/services/gldt-stake.services';
+import {
+	GLDT_STAKE_APY_CONTEXT_KEY,
+	initGldtStakeApyStore,
+	type GldtStakeApyContext
+} from '$icp/stores/gldt-stake-apy.store';
 import * as appConstants from '$lib/constants/app.constants';
 import {
 	STAKE_FORM_REVIEW_BUTTON,
@@ -16,7 +21,10 @@ import { fireEvent, render } from '@testing-library/svelte';
 
 describe('GldtStakeWizard', () => {
 	const mockContext = () =>
-		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+		new Map<symbol, SendContext | GldtStakeApyContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_APY_CONTEXT_KEY, { store: initGldtStakeApyStore() }]
+		]);
 
 	const props = {
 		amount: 0.001,

--- a/src/frontend/src/tests/lib/components/stake/StakeModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeModal.spec.ts
@@ -1,4 +1,9 @@
 import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import {
+	GLDT_STAKE_APY_CONTEXT_KEY,
+	initGldtStakeApyStore,
+	type GldtStakeApyContext
+} from '$icp/stores/gldt-stake-apy.store';
 import StakeModal from '$lib/components/stake/StakeModal.svelte';
 import * as appConstants from '$lib/constants/app.constants';
 import { STAKE_FORM_REVIEW_BUTTON } from '$lib/constants/test-ids.constants';
@@ -24,7 +29,10 @@ describe('StakeModal', () => {
 					symbol: 'GLDT',
 					ledgerCanisterId: GLDT_LEDGER_CANISTER_ID
 				} as Token
-			}
+			},
+			context: new Map<symbol, GldtStakeApyContext>([
+				[GLDT_STAKE_APY_CONTEXT_KEY, { store: initGldtStakeApyStore() }]
+			])
 		});
 
 		const firstStepTitle = 'Stake GLDT';

--- a/src/frontend/src/tests/lib/components/stake/StakeWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeWizard.spec.ts
@@ -1,17 +1,25 @@
 import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import {
+	GLDT_STAKE_APY_CONTEXT_KEY,
+	initGldtStakeApyStore,
+	type GldtStakeApyContext
+} from '$icp/stores/gldt-stake-apy.store';
 import type { IcToken } from '$icp/types/ic-token';
 import StakeWizard from '$lib/components/stake/StakeWizard.svelte';
 import * as appConstants from '$lib/constants/app.constants';
 import { STAKE_FORM_REVIEW_BUTTON } from '$lib/constants/test-ids.constants';
 import { WizardStepsStake } from '$lib/enums/wizard-steps';
-import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import en from '$tests/mocks/i18n.mock';
 import { mockLedgerCanisterId, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('StakeWizard', () => {
 	const mockContext = (token: IcToken) =>
-		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token })]]);
+		new Map<symbol, SendContext | GldtStakeApyContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token })],
+			[GLDT_STAKE_APY_CONTEXT_KEY, { store: initGldtStakeApyStore() }]
+		]);
 
 	const props = {
 		amount: 0.001,


### PR DESCRIPTION
# Motivation

We can now use the APY value stored in the context, and pass it down to `StakeProvider`.
