### PR TITLE
refactor(frontend): Migrate receive modal children components to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveCopy.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveCopy.svelte
@@ -3,9 +3,13 @@
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard.utils';
 
-	export let address: string;
-	export let copyAriaLabel: string;
-	export let testId: string | undefined = undefined;
+	interface Props {
+		address: string;
+		copyAriaLabel: string;
+		testId?: string;
+	}
+
+	let { address, copyAriaLabel, testId }: Props = $props();
 </script>
 
 <ButtonIcon

--- a/src/frontend/src/lib/components/receive/ReceiveQrCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveQrCode.svelte
@@ -7,13 +7,16 @@
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let address: string;
-	export let addressToken: Token | undefined = undefined;
+	interface Props {
+		address: string;
+		addressToken?: Token;
+	}
 
-	let symbol: string | undefined;
-	$: symbol = addressToken?.symbol;
+	let { address, addressToken }: Props = $props();
 
-	let render = true;
+	let symbol = $derived(addressToken?.symbol);
+
+	let render = $state(true);
 
 	const rerender = debounce(() => {
 		render = false;
@@ -21,7 +24,7 @@
 	});
 </script>
 
-<svelte:window on:resize={rerender} />
+<svelte:window onresize={rerender} />
 
 <div
 	class="mx-auto mb-8 aspect-square h-80 max-h-[44vh] max-w-[100%] rounded-xl bg-white p-4"

--- a/src/frontend/src/lib/components/receive/ReceiveTitle.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveTitle.svelte
@@ -3,7 +3,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	export let title: string | undefined;
+	interface Props {
+		title?: string;
+	}
+
+	let { title }: Props = $props();
 </script>
 
 {isNullish(title)


### PR DESCRIPTION
# Motivation

Migrating to Svelte 5 all children components of the Receive modal
