### PR TITLE
chore(frontend): Make index of `TransactionsDateGroup` more deterministic

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
@@ -25,7 +25,7 @@
 			>
 		</StickyHeader>
 
-		{#each transactions as transactionUi, index (`${transactionUi.transaction.id}-${index}`)}
+		{#each transactions as transactionUi (`${transactionUi.transaction.id}-${transactionUi.token.id.description}`)}
 			{@const { component, token, transaction } = transactionUi}
 
 			<div in:slide={SLIDE_DURATION}>


### PR DESCRIPTION
# Motivation

In component `TransactionsDateGroup`, it is preferable not to have a variable index as part of the key of a list.
