### PR TITLE
feat(dependabot): Group for solana kit dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,8 @@ updates:
     groups:
       solana-kit:
         patterns:
-          - "@solana-program/compute-budget"
-          - "@solana-program/system"
-          - "@solana-program/token"
-          - "@solana-program/token-2022"
-          - "@solana/kit"
+          - '@solana-program/compute-budget'
+          - '@solana-program/system'
+          - '@solana-program/token'
+          - '@solana-program/token-2022'
+          - '@solana/kit'


### PR DESCRIPTION
# Motivation

Inspired from https://github.com/dfinity/papi/pull/122, we are going to group the Solana dependencies in dependabot, since they require to be bumped together most of the time.
