### PR TITLE
feat(frontend): Temporary banner for AWS outage

### DIFF
--- a/src/frontend/src/lib/components/core/Banner.svelte
+++ b/src/frontend/src/lib/components/core/Banner.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { Html, IconClose, IconWarning } from '@dfinity/gix-components';
+	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { BETA, STAGING } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { isPWAStandalone } from '$lib/utils/device.utils';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils.js';
-	import IconInfo from "$lib/components/icons/lucide/IconInfo.svelte";
 
 	let envBannerVisible = $state(true);
 
@@ -23,7 +23,7 @@
 	// No need to localise this string since we expect it to be fixed shortly.
 	const temporaryBannerString =
 		'Due to an ongoing AWS outage, some Ethereum RPC providers are temporarily unavailable. This may affect how your Ethereum and related tokens display in OISY.<br>' +
-		'OISY itself remains fully operational as it runs on a decentralized infrastructure (Internet Computer).'
+		'OISY itself remains fully operational as it runs on a decentralized infrastructure (Internet Computer).';
 </script>
 
 {#if STAGING && envBannerVisible}


### PR DESCRIPTION
# Motivation

There is an AWS outage that is reverberating in Infura too, cause OISY to be unable to load Ethereum/EVM tokes and balances.

From https://status.infura.io/:

<img width="1278" height="1438" alt="Screenshot 2025-10-20 at 13 01 16" src="https://github.com/user-attachments/assets/42d24379-d481-434b-acae-f1baabaf94a3" />

Temporarily, we release an hotfix with a banner that warns the users.

<img width="1279" height="1436" alt="Screenshot 2025-10-20 at 14 53 47" src="https://github.com/user-attachments/assets/011f8a23-269d-43ec-92c9-016c9c6a3695" />

