### PR TITLE
chore(frontend): update GLDT stake provider config URL

### DIFF
--- a/src/frontend/src/lib/config/stake.config.ts
+++ b/src/frontend/src/lib/config/stake.config.ts
@@ -39,6 +39,6 @@ export const stakeProvidersConfig: Record<
 	[StakeProvider.GLDT]: {
 		name: 'Gold DAO',
 		logo: '/images/dapps/gold-dao-logo.svg',
-		url: 'https://www.gold-dao.org/'
+		url: 'https://app.gldt.org/earn/'
 	}
 };


### PR DESCRIPTION
# Motivation

We need to point users to the GLDT "earn" page instead of the gold-dao landing.
