### PR TITLE
chore(frontend): Remove unnecessary `undefined` type for optional Props

### DIFF
--- a/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
+++ b/src/frontend/src/icp/components/convert/HowToConvertEthereumWizardSteps.svelte
@@ -11,7 +11,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
-		currentStep: WizardStep | undefined;
+		currentStep?: WizardStep;
 		formCancelAction?: 'back' | 'close';
 	}
 

--- a/src/frontend/src/icp/components/tokens/IcTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcTokenModal.svelte
@@ -13,7 +13,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
-		fromRoute: NavigationTarget | undefined;
+		fromRoute?: NavigationTarget;
 	}
 	let { fromRoute }: Props = $props();
 

--- a/src/frontend/src/icp/components/transactions/IcTransactionLabel.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionLabel.svelte
@@ -10,8 +10,8 @@
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
-		label: string | undefined;
-		type: IcTransactionType | undefined;
+		label?: string;
+		type?: IcTransactionType;
 		token: OptionToken;
 		amount?: bigint;
 	}

--- a/src/frontend/src/lib/components/receive/ReceiveModal.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveModal.svelte
@@ -16,7 +16,7 @@
 	interface Props {
 		content?: Snippet;
 		address?: OptionAddress<Address>;
-		addressToken?: Token | undefined;
+		addressToken?: Token;
 		network: Network;
 		copyAriaLabel: string;
 	}

--- a/src/frontend/src/lib/components/rewards/RewardEarningsCard.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardEarningsCard.svelte
@@ -13,7 +13,7 @@
 	interface Props {
 		amount: bigint;
 		usdAmount: number;
-		token: IcToken | undefined;
+		token?: IcToken;
 		loading?: boolean;
 		testId?: string;
 	}

--- a/src/frontend/src/lib/components/send/SendQrCodeScan.svelte
+++ b/src/frontend/src/lib/components/send/SendQrCodeScan.svelte
@@ -12,7 +12,7 @@
 
 	interface Props {
 		expectedToken: OptionToken;
-		destination: string | undefined;
+		destination?: string;
 		amount: OptionAmount;
 		onDecodeQrCode: ({
 			status,

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -7,7 +7,7 @@
 	import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';
 
 	interface Props {
-		tokens: TokenUiOrGroupUi[] | undefined;
+		tokens?: TokenUiOrGroupUi[];
 		animating: boolean;
 		children: Snippet;
 	}

--- a/src/frontend/src/lib/components/ui/Badge.svelte
+++ b/src/frontend/src/lib/components/ui/Badge.svelte
@@ -4,8 +4,8 @@
 
 	interface Props {
 		children?: Snippet;
-		styleClass?: string | undefined;
-		testId?: string | undefined;
+		styleClass?: string;
+		testId?: string;
 		variant?: BadgeVariant;
 		width?: 'w-full' | 'w-fit';
 	}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectData.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectData.svelte
@@ -6,7 +6,7 @@
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 
 	interface Props {
-		data: string | undefined;
+		data?: string;
 		label: string;
 	}
 

--- a/src/frontend/src/sol/components/tokens/SolTokenModal.svelte
+++ b/src/frontend/src/sol/components/tokens/SolTokenModal.svelte
@@ -14,7 +14,7 @@
 	import { isTokenSpl } from '$sol/utils/spl.utils';
 
 	interface Props {
-		fromRoute: NavigationTarget | undefined;
+		fromRoute?: NavigationTarget;
 	}
 	let { fromRoute }: Props = $props();
 


### PR DESCRIPTION
# Motivation

It is not necessary to define the type of a Prop as `undefined` if it can be optional.
