### PR TITLE
refactor(frontend): Migrate `MobileNavigationMenu` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/navigation/MobileNavigationMenu.svelte
+++ b/src/frontend/src/lib/components/navigation/MobileNavigationMenu.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { MOBILE_NAVIGATION_MENU } from '$lib/constants/test-ids.constants';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
 </script>
 
 <Responsive down="md">
@@ -8,6 +15,6 @@
 		class="mobile-nav z-3 border-t-1 visible fixed bottom-0 left-0 right-0 flex flex-row border-tertiary bg-primary-inverted-alt md:hidden"
 		data-tid={MOBILE_NAVIGATION_MENU}
 	>
-		<slot />
+		{@render children()}
 	</div>
 </Responsive>


### PR DESCRIPTION
# Motivation

Migrating component `MobileNavigationMenu` to Svelte 5.
