### PR TITLE
fix(frontend): Bad z-index in `StickyHeader`

### DIFF
--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -28,7 +28,7 @@
 <svelte:window onscroll={handleScroll} />
 
 <div bind:this={rootElement}>
-	<div class="sticky top-0 z-10 whitespace-nowrap px-1 pt-6" class:bg-page={scrolledSoon}>
+	<div class="z-3 sticky top-0 whitespace-nowrap px-1 pt-6" class:bg-page={scrolledSoon}>
 		{@render header()}
 	</div>
 


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/9765 I forgot to push the commit that fixes the z-index of `StickyHeader`.

NOTE: `z-3` does not exists among the Tailwind classes, but that was the value that was assigned before the refactoring, so I would prefer to keep it as it was. We can revisit in another PR.
