### PR TITLE
feat(frontend): Remove temporary banner for AWS outage

### DIFF
--- a/src/frontend/src/lib/components/core/Banner.svelte
+++ b/src/frontend/src/lib/components/core/Banner.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { Html, IconClose, IconWarning } from '@dfinity/gix-components';
-	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { BETA, STAGING } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -14,16 +13,6 @@
 	let pwaBannerVisible = $state(true);
 
 	const closePwaBanner = () => (pwaBannerVisible = false);
-
-	let awsTemporaryBannerVisible = $state(true);
-
-	const closeAwsTemporaryBanner = () => (awsTemporaryBannerVisible = false);
-
-	// We are using a temporary banner as a workaround for the AWS outage.
-	// No need to localise this string since we expect it to be fixed shortly.
-	const temporaryBannerString =
-		'Due to an ongoing AWS outage, some Ethereum RPC providers are temporarily unavailable. This may affect how your Ethereum and related tokens display in OISY.<br>' +
-		'OISY itself remains fully operational as it runs on a decentralized infrastructure (Internet Computer).';
 </script>
 
 {#if STAGING && envBannerVisible}
@@ -60,24 +49,6 @@
 				<IconClose />
 			</button>
 		</WarningBanner>
-	</div>
-{/if}
-
-<!-- TODO: remove this temporary WarningBanner again as soon as AWS fixes the issue -->
-{#if awsTemporaryBannerVisible}
-	<div
-		class="fixed left-[50%] top-6 z-10 flex min-w-80 -translate-x-[50%] justify-between gap-4 rounded-lg bg-primary"
-	>
-		<div
-			class="border-info-solid bg-info-subtle-10 text-info-primary inline-flex w-full items-center justify-center gap-2 rounded-lg border px-6 py-2 text-xs font-bold sm:w-fit md:text-base"
-		>
-			<IconInfo></IconInfo>
-
-			<span class="w-full px-2"><Html text={temporaryBannerString} /></span>
-			<button aria-label={$i18n.core.text.close} onclick={closeAwsTemporaryBanner}>
-				<IconClose />
-			</button>
-		</div>
 	</div>
 {/if}
 


### PR DESCRIPTION
# Motivation

The AWS outage was fixed, so we can remove the temporary warning banner.