### PR TITLE
feat(frontend): Redundant NFTs loading in `LoaderTokens`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderTokens.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderTokens.svelte
@@ -1,16 +1,10 @@
 <script lang="ts">
-	import { debounce, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { NFTS_ENABLED } from '$env/nft.env';
-	import {
-		erc1155CustomTokensInitialized,
-		erc1155CustomTokensNotInitialized
-	} from '$eth/derived/erc1155.derived';
+	import { erc1155CustomTokensNotInitialized } from '$eth/derived/erc1155.derived';
 	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
-	import {
-		erc721CustomTokensInitialized,
-		erc721CustomTokensNotInitialized
-	} from '$eth/derived/erc721.derived';
+	import { erc721CustomTokensNotInitialized } from '$eth/derived/erc721.derived';
 	import { loadErc1155Tokens } from '$eth/services/erc1155.services';
 	import { loadErc20Tokens } from '$eth/services/erc20.services';
 	import { loadErc721Tokens } from '$eth/services/erc721.services';
@@ -25,7 +19,6 @@
 		solAddressMainnet
 	} from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { enabledNonFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import {
 		networkEthereumEnabled,
 		networkEvmMainnetEnabled,
@@ -36,8 +29,6 @@
 		networkSolanaMainnetEnabled
 	} from '$lib/derived/networks.derived';
 	import { testnetsEnabled } from '$lib/derived/testnets.derived';
-	import { loadNfts } from '$lib/services/nft.services';
-	import { nftStore } from '$lib/stores/nft.store';
 	import { splCustomTokensNotInitialized } from '$sol/derived/spl.derived';
 	import { loadSplTokens } from '$sol/services/spl.services';
 
@@ -93,25 +84,6 @@
 	$effect(() => {
 		if (loadSpl) {
 			loadSplTokens({ identity: $authIdentity });
-		}
-	});
-
-	const debounceLoadNfts = debounce(async () => {
-		await loadNfts({
-			tokens: $enabledNonFungibleNetworkTokens ?? [],
-			loadedNfts: $nftStore ?? [],
-			walletAddress: $ethAddress
-		});
-	}, 1000);
-
-	$effect(() => {
-		if (
-			NFTS_ENABLED &&
-			($erc721CustomTokensInitialized || $erc1155CustomTokensInitialized) &&
-			nonNullish($ethAddress) &&
-			$enabledNonFungibleNetworkTokens.length > 0
-		) {
-			debounceLoadNfts();
 		}
 	});
 </script>

--- a/src/frontend/src/tests/lib/components/loaders/LoaderTokens.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderTokens.spec.ts
@@ -61,10 +61,6 @@ vi.mock('$sol/services/spl.services', () => ({
 	loadSplTokens: vi.fn()
 }));
 
-vi.mock('$lib/services/nft.services', () => ({
-	loadNfts: vi.fn()
-}));
-
 vi.mock('$lib/api/backend.api', () => ({
 	listCustomTokens: vi.fn().mockResolvedValue([])
 }));


### PR DESCRIPTION
# Motivation

In component `LoaderTokens` we are setting the NFT store with the service `loadNfts`. However, the same is happening in component `LoaderNfts`, and at intervals. So, we can remove it from here.
