### PR TITLE
feat(build): Unbundle i18n JSON files when chunking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ const config: UserConfig = {
 				manualChunks: (id) => {
 					const folder = dirname(id);
 
-					if (id.includes(resolve('./src/frontend/src/lib/i18n/')) && id.endsWith('.json')) {
+					if (folder.includes('src/frontend/src/lib/i18n') && id.endsWith('.json')) {
 						return `i18n-${basename(id, '.json')}`;
 					}
 


### PR DESCRIPTION
# Motivation

As per @peterpeterparker's suggestion, we are going to lazy-load the i18n JSON files, instead of letting the user load them all at once. Before that we need to guarantee that such files are at least not bundled together in the same chunks.

### Before --> 2 chunks (biggest 5.4 MB)


<img width="968" height="842" alt="Screenshot 2025-10-22 at 10 39 36" src="https://github.com/user-attachments/assets/ccee1fdd-8c1f-40ec-a36a-e7a7172c3820" />



### After --> 16 chunks (biggest 4 MB)

<img width="1061" height="693" alt="Screenshot 2025-10-22 at 10 57 34" src="https://github.com/user-attachments/assets/dd0a0bfa-e57e-41d6-b155-e9e901d9d831" />



