### PR TITLE
feat(frontend): expose gldt_stake get_daily_analytics

### DIFF
--- a/src/frontend/src/icp/canisters/gldt_stake.canister.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.canister.ts
@@ -1,4 +1,6 @@
 import type {
+	Args_2,
+	DailyAnalytics,
 	_SERVICE as GldtStakeService,
 	ManageStakePositionArgs,
 	StakePositionResponse
@@ -7,9 +9,10 @@ import { idlFactory as idlCertifiedFactoryGldtStake } from '$declarations/gldt_s
 import { idlFactory as idlFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.did';
 import { mapGldtStakeCanisterError } from '$icp/canisters/gldt_stake.errors';
 import { getAgent } from '$lib/actors/agents.ic';
+import { ZERO } from '$lib/constants/app.constants';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import type { Principal } from '@dfinity/principal';
-import { Canister, createServices, fromNullable } from '@dfinity/utils';
+import { Canister, createServices, fromNullable, toNullable } from '@dfinity/utils';
 
 export class GldtStakeCanister extends Canister<GldtStakeService> {
 	static async create({
@@ -34,6 +37,17 @@ export class GldtStakeCanister extends Canister<GldtStakeService> {
 		const { get_apy_overall } = this.caller({ certified: true });
 
 		return get_apy_overall(null);
+	};
+
+	getDailyAnalytics = async (params?: Args_2): Promise<DailyAnalytics> => {
+		const defaultParams = { starting_day: ZERO, limit: toNullable(1n) };
+
+		const { get_daily_analytics } = this.caller({ certified: true });
+
+		const [data] = await get_daily_analytics({ ...defaultParams, ...(params ?? {}) });
+		const [_, dailyAnalytics] = data;
+
+		return dailyAnalytics;
 	};
 
 	manageStakePosition = async (

--- a/src/frontend/src/tests/mocks/gldt_stake.mock.ts
+++ b/src/frontend/src/tests/mocks/gldt_stake.mock.ts
@@ -1,4 +1,7 @@
-import type { StakePositionResponse } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type {
+	DailyAnalytics,
+	StakePositionResponse
+} from '$declarations/gldt_stake/declarations/gldt_stake.did';
 import type { Duration } from '$declarations/gldt_stake/gldt_stake.did';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
@@ -24,3 +27,10 @@ export const stakePositionMockResponse = {
 	weighted_stake: 1000n,
 	instant_dissolve_fee: 1000n
 } as StakePositionResponse;
+
+export const dailyAnalyticsMockResponse = {
+	apy: 5,
+	staked_gldt: 1000000n,
+	rewards: toNullable([{ ICP: null }, 100n]),
+	weighted_stake: 1000n
+} as DailyAnalytics;


### PR DESCRIPTION
# Motivation

The gldt_stake "current APY" value needs to be taken from `get_daily_analytics` response. Therefore, we need to expose this method. 
