### PR TITLE
feat(frontend): Expose method `getMintingAccount` for ICRC ledger API

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -6,6 +6,7 @@ import type { OptionIdentity } from '$lib/types/identity';
 import type { Identity } from '@dfinity/agent';
 import {
 	IcrcLedgerCanister,
+	fromCandidAccount,
 	toCandidAccount,
 	type GetBlocksParams,
 	type IcrcAccount,
@@ -17,7 +18,7 @@ import {
 	type IcrcTokens
 } from '@dfinity/ledger-icrc';
 import { Principal } from '@dfinity/principal';
-import { assertNonNullish, type QueryParams } from '@dfinity/utils';
+import { assertNonNullish, fromDefinedNullable, type QueryParams } from '@dfinity/utils';
 
 /**
  * Retrieves metadata for the ICRC token.
@@ -243,6 +244,23 @@ export const icrc1SupportedStandards = async ({
 	const { icrc1SupportedStandards } = await ledgerCanister({ identity, ledgerCanisterId });
 
 	return icrc1SupportedStandards({ certified });
+};
+
+export const getMintingAccount = async ({
+	certified = true,
+	identity,
+	ledgerCanisterId
+}: {
+	identity: OptionIdentity;
+	ledgerCanisterId: CanisterIdText;
+} & QueryParams): Promise<IcrcAccount | undefined> => {
+	assertNonNullish(identity);
+
+	const { getMintingAccount } = await ledgerCanister({ identity, ledgerCanisterId });
+
+	const account = await getMintingAccount({ certified });
+
+	return fromCandidAccount(fromDefinedNullable(account));
 };
 
 const ledgerCanister = async ({

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -4,6 +4,7 @@ import {
 	approve,
 	balance,
 	getBlocks,
+	getMintingAccount,
 	icrc1SupportedStandards,
 	metadata,
 	transactionFee,
@@ -559,6 +560,45 @@ describe('icrc-ledger.api', () => {
 
 		it('throws an error if identity is undefined', async () => {
 			await expect(icrc1SupportedStandards({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('getMintingAccount', () => {
+		const params = {
+			certified: true,
+			ledgerCanisterId: IC_CKBTC_LEDGER_CANISTER_ID,
+			identity: mockIdentity
+		};
+
+		const candidAccount = { owner: mockPrincipal, subaccount: toNullable([1, 2, 3]) };
+		const expectedAccount = { owner: mockPrincipal, subaccount: [1, 2, 3] };
+
+		beforeEach(() => {
+			ledgerCanisterMock.getMintingAccount.mockResolvedValue(toNullable(candidAccount));
+		});
+
+		it('successfully calls getMintingAccount endpoint', async () => {
+			const result = await getMintingAccount(params);
+
+			expect(result).toEqual(expectedAccount);
+
+			expect(ledgerCanisterMock.getMintingAccount).toHaveBeenCalledExactlyOnceWith({
+				certified: true
+			});
+		});
+
+		it('successfully calls getMintingAccount endpoint as query', async () => {
+			const result = await getMintingAccount({ ...params, certified: false });
+
+			expect(result).toEqual(expectedAccount);
+
+			expect(ledgerCanisterMock.getMintingAccount).toHaveBeenCalledExactlyOnceWith({
+				certified: false
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(getMintingAccount({ ...params, identity: undefined })).rejects.toThrow();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We are going to allow users that are minting account to send tokens even with zero balance (`Mint` transaction). In order to do that, we need to expose the method `getMintingAccount` of the ICRC ledger canister.
