### PR TITLE
fix(frontend): Type-safe values when switching languages

### DIFF
--- a/src/frontend/src/lib/components/core/LanguageDropdown.svelte
+++ b/src/frontend/src/lib/components/core/LanguageDropdown.svelte
@@ -7,15 +7,15 @@
 	import Dropdown from '$lib/components/ui/Dropdown.svelte';
 	import { LANGUAGE_DROPDOWN } from '$lib/constants/test-ids.constants';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { Languages } from '$lib/enums/languages';
+	import type { Languages } from '$lib/enums/languages';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	let dropdown = $state<Dropdown>();
 
 	const currentLang: string = $derived(LANGUAGES[$currentLanguage]);
 
-	const handleLangChange = async (lang: string) => {
-		await i18n.switchLang(Languages[lang as keyof typeof Languages]);
+	const handleLangChange = async (lang: Languages) => {
+		await i18n.switchLang(lang);
 		dropdown?.close();
 	};
 </script>
@@ -42,7 +42,7 @@
 							alignLeft
 							colorStyle="tertiary-alt"
 							fullWidth
-							onclick={() => handleLangChange(langKey)}
+							onclick={() => handleLangChange(langVal)}
 							paddingSmall
 							styleClass="py-1 rounded-md font-normal text-primary underline-none pl-0.5 min-w-28"
 							transparent


### PR DESCRIPTION
# Motivation

As per suggestion https://github.com/dfinity/oisy-wallet/pull/9840/#discussion_r2450478419, we should avoid casting when switching languages and use directly the type `Languages` that collects all available values.