### PR TITLE
feat(frontend): use analytics endpoint to fetch gldt_stake APY

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeContext.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
-	import { getApyOverall } from '$icp/api/gldt_stake.api';
+	import { getDailyAnalytics } from '$icp/api/gldt_stake.api';
 	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
 	import { authIdentity } from '$lib/derived/auth.derived';
 
@@ -20,7 +20,7 @@
 		}
 
 		try {
-			const apy = await getApyOverall({ identity: $authIdentity });
+			const { apy } = await getDailyAnalytics({ identity: $authIdentity });
 
 			gldtStakeStore.setApy(Math.round(apy * 100) / 100);
 		} catch (_err: unknown) {

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeContext.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeContext.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '$icp/stores/gldt-stake.store';
 import { icTokenFeeStore } from '$icp/stores/ic-token-fee.store';
 import * as authStore from '$lib/derived/auth.derived';
+import { dailyAnalyticsMockResponse } from '$tests/mocks/gldt_stake.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import type { Identity } from '@dfinity/agent';
@@ -14,12 +15,11 @@ import { render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('GldtStakeContext', () => {
-	const mockApy = 10.1232131232121;
-	const parsedMockApy = Math.round(mockApy * 100) / 100;
+	const parsedMockApy = Math.round(dailyAnalyticsMockResponse.apy * 100) / 100;
 
 	const mockContext = (store: GldtStakeStore) => new Map([[GLDT_STAKE_CONTEXT_KEY, { store }]]);
 	const mockGetApyOverall = () =>
-		vi.spyOn(gldtStakeApi, 'getApyOverall').mockResolvedValue(mockApy);
+		vi.spyOn(gldtStakeApi, 'getDailyAnalytics').mockResolvedValue(dailyAnalyticsMockResponse);
 	const mockAuthStore = (value: Identity | null = mockIdentity) =>
 		vi.spyOn(authStore, 'authIdentity', 'get').mockImplementation(() => readable(value));
 


### PR DESCRIPTION
# Motivation

We can now update the gldt stake context to use analytics endpoint for retrieving current gldt_stake APY.
