### PR TITLE
feat(frontend): adjust gldt-stake stake service

### DIFF
--- a/src/frontend/src/icp/services/gldt-stake.services.ts
+++ b/src/frontend/src/icp/services/gldt-stake.services.ts
@@ -39,7 +39,7 @@ export const stakeGldt = async ({
 
 	const response = await manageStakePosition({
 		identity,
-		positionParams: { AddStake: { amount } }
+		positionParams: { AddStake: { amount: amount + gldtToken.fee } }
 	});
 
 	stakeCompleted();

--- a/src/frontend/src/tests/icp/services/gldt-stake.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/gldt-stake.services.spec.ts
@@ -56,7 +56,7 @@ describe('gldt-stake.services', () => {
 			expect(mockProgress).toHaveBeenNthCalledWith(2, ProgressStepsStake.STAKE);
 			expect(gldtStakeApi.manageStakePosition).toHaveBeenCalledExactlyOnceWith({
 				identity: mockIdentity,
-				positionParams: { AddStake: { amount: mockAmount } }
+				positionParams: { AddStake: { amount: mockAmount + gldtToken.fee } }
 			});
 			expect(response).toBe(stakePositionMockResponse);
 			expect(mockProgress).toHaveBeenNthCalledWith(3, ProgressStepsStake.UPDATE_UI);


### PR DESCRIPTION
# Motivation

When sending amount to the gldt_stake canister, we need to provide the GLDT token fee on top of the user input.
