### PR TITLE
feat(frontend): extend gldt-stake store

### DIFF
--- a/src/frontend/src/icp/stores/gldt-stake.store.ts
+++ b/src/frontend/src/icp/stores/gldt-stake.store.ts
@@ -1,17 +1,20 @@
+import type { StakePositionResponse } from '$declarations/gldt_stake/declarations/gldt_stake.did';
 import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
 export type GldtStakeStoreData = Option<{
 	apy?: number;
+	position?: StakePositionResponse;
 }>;
 
 export interface GldtStakeStore extends Readable<GldtStakeStoreData> {
 	setApy: (value: number) => void;
+	setPosition: (value?: StakePositionResponse) => void;
 	reset: () => void;
 }
 
 export const initGldtStakeStore = (): GldtStakeStore => {
-	const { subscribe, set } = writable<GldtStakeStoreData>(undefined);
+	const { subscribe, set, update } = writable<GldtStakeStoreData>(undefined);
 
 	return {
 		subscribe,
@@ -19,7 +22,11 @@ export const initGldtStakeStore = (): GldtStakeStore => {
 		reset: () => set(undefined),
 
 		setApy: (value: number) => {
-			set({ apy: value });
+			update((state) => ({ ...state, apy: value }));
+		},
+
+		setPosition: (value?: StakePositionResponse) => {
+			update((state) => ({ ...state, position: value }));
 		}
 	};
 };

--- a/src/frontend/src/tests/icp/stores/gldt-stake.store.spec.ts
+++ b/src/frontend/src/tests/icp/stores/gldt-stake.store.spec.ts
@@ -1,4 +1,5 @@
 import { initGldtStakeStore } from '$icp/stores/gldt-stake.store';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
 import { get } from 'svelte/store';
@@ -18,14 +19,16 @@ describe('gldt-stake.store', () => {
 		const store = initGldtStakeStore();
 
 		store.setApy(apyValue);
+		store.setPosition(stakePositionMockResponse);
 
-		expect(get(store)).toStrictEqual({ apy: apyValue });
+		expect(get(store)).toStrictEqual({ apy: apyValue, position: stakePositionMockResponse });
 	});
 
 	it('should reset the value', () => {
 		const store = initGldtStakeStore();
 
 		store.setApy(apyValue);
+		store.setPosition(stakePositionMockResponse);
 		store.reset();
 
 		expect(get(store)).toBeUndefined();


### PR DESCRIPTION
# Motivation

We need to extend the gldt-stake store with the user's staking position.
