### PR TITLE
feat(frontend): Set language at HTML properties when switching

### DIFF
--- a/src/frontend/src/lib/stores/i18n.store.ts
+++ b/src/frontend/src/lib/stores/i18n.store.ts
@@ -26,9 +26,9 @@ const loadLang = async (lang: Languages): Promise<I18n> => {
 	}
 };
 
-const saveLang = (lang: Languages) => set({ key: 'lang', value: lang });
-
 const updateHtmlLang = (lang: Languages) => document.documentElement.setAttribute('lang', lang);
+
+const saveLang = (lang: Languages) => set({ key: 'lang', value: lang });
 
 export interface I18nStore extends Readable<I18n> {
 	init: () => Promise<void>;


### PR DESCRIPTION
# Motivation

As suggested in https://github.com/dfinity/oisy-wallet/pull/9840#discussion_r2450495660 , we should set the language as property of the HTML document too, when switching.

<img width="1272" height="505" alt="Screenshot 2025-10-22 at 12 00 25" src="https://github.com/user-attachments/assets/23091d39-6b85-4775-82fd-cfc7b369c894" />

