### PR TITLE
feat(build): Set storage language when loading HTML document

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -22,6 +22,20 @@
 			}
 		</script>
 
+		<!-- Init language as fast as possible -->
+		<script language-loader>
+			try {
+				const currentLanguage =
+					localStorage.lang === null || localStorage.lang === undefined || localStorage.lang === ''
+						? undefined
+						: JSON.parse(localStorage.lang);
+
+				document.documentElement.setAttribute('lang', currentLanguage ?? 'en');
+			} catch (error) {
+				console.error('Error initializing language', error);
+			}
+		</script>
+
 		<style>
 			:root {
 				&,


### PR DESCRIPTION
# Motivation

It is useful to load the language at document level if it is already cached in the storage.
