### PR TITLE
feat(frontend): Adds fromRoute to Nft components

### DIFF
--- a/src/frontend/src/lib/components/nfts/Nft.svelte
+++ b/src/frontend/src/lib/components/nfts/Nft.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onMount } from 'svelte';
 	import { afterNavigate, goto } from '$app/navigation';
 	import { page } from '$app/state';
@@ -12,7 +13,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { NonFungibleToken } from '$lib/types/nft';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	const nft = $derived($pageNft);
 

--- a/src/frontend/src/lib/components/nfts/Nft.svelte
+++ b/src/frontend/src/lib/components/nfts/Nft.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import NftCollectionCard from '$lib/components/nfts/NftCollectionDescription.svelte';
 	import NftHero from '$lib/components/nfts/NftHero.svelte';
@@ -12,6 +12,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { NonFungibleToken } from '$lib/types/nft';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	const nft = $derived($pageNft);
 
@@ -34,8 +35,14 @@
 			}
 		};
 	});
+
+	let fromRoute = $state<NavigationTarget | null>(null);
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
 </script>
 
-<NftHero {nft} {token} />
+<NftHero {fromRoute} {nft} {token} />
 
-<NftCollectionCard collection={nft?.collection} />
+<NftCollectionCard collection={nft?.collection} {fromRoute} />

--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { goto } from '$app/navigation';
 	import { isCollectionErc1155 } from '$eth/utils/erc1155.utils';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
@@ -19,7 +20,6 @@
 	} from '$lib/enums/plausible';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import type { Nft } from '$lib/types/nft';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		nft: Nft;

--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -19,6 +19,7 @@
 	} from '$lib/enums/plausible';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import type { Nft } from '$lib/types/nft';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		nft: Nft;
@@ -29,6 +30,7 @@
 		type?: 'default' | 'card-selectable' | 'card-link';
 		onSelect?: (nft: Nft) => void;
 		source?: 'default' | typeof NFT_LIST_ROUTE | typeof NFT_COLLECTION_ROUTE;
+		fromRoute?: NavigationTarget | null;
 	}
 
 	let {
@@ -39,7 +41,8 @@
 		isSpam,
 		type = 'default',
 		onSelect,
-		source = 'default'
+		source = 'default',
+		fromRoute
 	}: Props = $props();
 
 	const onClick = () => {

--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -41,8 +41,7 @@
 		isSpam,
 		type = 'default',
 		onSelect,
-		source = 'default',
-		fromRoute
+		source = 'default'
 	}: Props = $props();
 
 	const onClick = () => {

--- a/src/frontend/src/lib/components/nfts/NftCollection.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import NftCard from '$lib/components/nfts/NftCard.svelte';
 	import NftCardSkeleton from '$lib/components/nfts/NftCardSkeleton.svelte';
@@ -16,6 +16,7 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { Nft, NftCollection, NonFungibleToken } from '$lib/types/nft';
 	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	const collectionNfts: Nft[] = $derived($pageCollectionNfts);
 
@@ -46,6 +47,12 @@
 			}
 		};
 	});
+
+	let fromRoute = $state<NavigationTarget | null>(null);
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
 </script>
 
 <NftCollectionHero nfts={collectionNfts} {token} />
@@ -54,6 +61,7 @@
 	{#if collectionNfts.length > 0}
 		{#each collectionNfts as nft, index (`${nft.id}-${index}`)}
 			<NftCard
+				{fromRoute}
 				isHidden={nonNullish(token) && token.section === CustomTokenSection.HIDDEN}
 				isSpam={nonNullish(token) && token.section === CustomTokenSection.SPAM}
 				{nft}

--- a/src/frontend/src/lib/components/nfts/NftCollection.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onMount } from 'svelte';
 	import { afterNavigate, goto } from '$app/navigation';
 	import { page } from '$app/state';
@@ -16,7 +17,6 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { Nft, NftCollection, NonFungibleToken } from '$lib/types/nft';
 	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	const collectionNfts: Nft[] = $derived($pageCollectionNfts);
 

--- a/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import NftDisplayGuard from '$lib/components/nfts/NftDisplayGuard.svelte';
 	import BgImg from '$lib/components/ui/BgImg.svelte';
@@ -18,7 +19,6 @@
 	import type { NftCollectionUi } from '$lib/types/nft';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { filterSortByCollection } from '$lib/utils/nfts.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		collection: NftCollectionUi;

--- a/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
@@ -18,14 +18,16 @@
 	import type { NftCollectionUi } from '$lib/types/nft';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { filterSortByCollection } from '$lib/utils/nfts.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		collection: NftCollectionUi;
 		disabled?: boolean;
 		testId?: string;
+		fromRoute: NavigationTarget | null;
 	}
 
-	const { collection, disabled, testId }: Props = $props();
+	const { collection, disabled, testId, fromRoute }: Props = $props();
 
 	const collectionNfts = $derived(
 		filterSortByCollection({

--- a/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionCard.svelte
@@ -27,7 +27,7 @@
 		fromRoute: NavigationTarget | null;
 	}
 
-	const { collection, disabled, testId, fromRoute }: Props = $props();
+	const { collection, disabled, testId }: Props = $props();
 
 	const collectionNfts = $derived(
 		filterSortByCollection({

--- a/src/frontend/src/lib/components/nfts/NftCollectionDescription.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionDescription.svelte
@@ -22,7 +22,7 @@
 		fromRoute: NavigationTarget | null;
 	}
 
-	const { collection, fromRoute }: Props = $props();
+	const { collection }: Props = $props();
 
 	const token = $derived(
 		nonNullish(collection)

--- a/src/frontend/src/lib/components/nfts/NftCollectionDescription.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionDescription.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { fade } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import IconExpand from '$lib/components/icons/IconExpand.svelte';
@@ -15,7 +16,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NftCollection } from '$lib/types/nft';
 	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		collection?: NftCollection;

--- a/src/frontend/src/lib/components/nfts/NftCollectionDescription.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionDescription.svelte
@@ -15,12 +15,14 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NftCollection } from '$lib/types/nft';
 	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		collection?: NftCollection;
+		fromRoute: NavigationTarget | null;
 	}
 
-	const { collection }: Props = $props();
+	const { collection, fromRoute }: Props = $props();
 
 	const token = $derived(
 		nonNullish(collection)

--- a/src/frontend/src/lib/components/nfts/NftCollectionList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionList.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 	import EmptyNftsList from '$lib/components/nfts/EmptyNftsList.svelte';
 	import NftCollectionCard from '$lib/components/nfts/NftCollectionCard.svelte';
 	import type { NftCollectionUi } from '$lib/types/nft';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		title: string;

--- a/src/frontend/src/lib/components/nfts/NftCollectionList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionList.svelte
@@ -3,6 +3,7 @@
 	import EmptyNftsList from '$lib/components/nfts/EmptyNftsList.svelte';
 	import NftCollectionCard from '$lib/components/nfts/NftCollectionCard.svelte';
 	import type { NftCollectionUi } from '$lib/types/nft';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		title: string;
@@ -10,9 +11,10 @@
 		icon?: Snippet;
 		nftCollections: NftCollectionUi[];
 		testId?: string;
+		fromRoute: NavigationTarget | null;
 	}
 
-	let { title, asMainSection = false, icon, nftCollections, testId }: Props = $props();
+	let { title, asMainSection = false, icon, nftCollections, testId, fromRoute }: Props = $props();
 
 	const notEmptyCollections = $derived(nftCollections.filter((c) => c.nfts.length > 0));
 </script>
@@ -27,7 +29,7 @@
 		{#if notEmptyCollections.length > 0}
 			<div class="grid grid-cols-2 gap-3 gap-y-4 py-4 md:grid-cols-3">
 				{#each notEmptyCollections as collection, index (`${String(collection.collection.id)}-${index}`)}
-					<NftCollectionCard {collection} />
+					<NftCollectionCard {collection} {fromRoute} />
 				{/each}
 			</div>
 		{:else}

--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -16,13 +16,15 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store.js';
 	import type { Nft, NonFungibleToken } from '$lib/types/nft';
+	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		token?: NonFungibleToken;
 		nft?: Nft;
+		fromRoute: NavigationTarget | null;
 	}
 
-	const { token, nft }: Props = $props();
+	const { token, nft, fromRoute }: Props = $props();
 
 	const breadcrumbItems = $derived.by(() => {
 		let breadcrumbs = [{ label: $i18n.navigation.text.tokens, url: AppPath.Nfts as string }];

--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -24,7 +24,7 @@
 		fromRoute: NavigationTarget | null;
 	}
 
-	const { token, nft, fromRoute }: Props = $props();
+	const { token, nft }: Props = $props();
 
 	const breadcrumbItems = $derived.by(() => {
 		let breadcrumbs = [{ label: $i18n.navigation.text.tokens, url: AppPath.Nfts as string }];

--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
 	import { fade } from 'svelte/transition';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import NftActionButtons from '$lib/components/nfts/NftActionButtons.svelte';
@@ -16,7 +17,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store.js';
 	import type { Nft, NonFungibleToken } from '$lib/types/nft';
-	import type { NavigationTarget } from '@sveltejs/kit';
 
 	interface Props {
 		token?: NonFungibleToken;

--- a/src/frontend/src/lib/components/nfts/NftsList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftsList.svelte
@@ -22,6 +22,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Nft, NftCollectionUi } from '$lib/types/nft';
 	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate } from '$app/navigation';
 
 	interface CollectionBuckets {
 		common: NftCollectionUi[];
@@ -107,6 +109,12 @@
 			!(hasCommonCollections || hasVisibleSpamCollections || hasVisibleHiddenCollections)
 		);
 	});
+
+	let fromRoute = $state<NavigationTarget | null>(null);
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
 </script>
 
 <NftsDisplayHandler bind:nfts bind:nftCollections>
@@ -116,6 +124,7 @@
 		{:else}
 			<NftCollectionList
 				asMainSection
+				{fromRoute}
 				nftCollections={commonCollections}
 				testId={NFT_COLLECTION_LIST_COMMON}
 				title={$i18n.nfts.text.collections}
@@ -123,6 +132,7 @@
 
 			{#if $showHidden}
 				<NftCollectionList
+					{fromRoute}
 					nftCollections={hiddenCollections}
 					testId={NFT_COLLECTION_LIST_HIDDEN}
 					title={$i18n.nfts.text.hidden}
@@ -135,6 +145,7 @@
 
 			{#if $showSpam}
 				<NftCollectionList
+					{fromRoute}
 					nftCollections={spamCollections}
 					testId={NFT_COLLECTION_LIST_SPAM}
 					title={$i18n.nfts.text.spam}
@@ -155,7 +166,7 @@
 			title={$i18n.nfts.text.all_assets}
 		>
 			{#snippet nftListItem({ nft })}
-				<NftCard {nft} source={NFT_LIST_ROUTE} type="card-link" />
+				<NftCard {fromRoute} {nft} source={NFT_LIST_ROUTE} type="card-link" />
 			{/snippet}
 		</NftList>
 
@@ -165,7 +176,7 @@
 					<IconEyeOff size="24" />
 				{/snippet}
 				{#snippet nftListItem({ nft })}
-					<NftCard isHidden {nft} source={NFT_LIST_ROUTE} type="card-link" />
+					<NftCard {fromRoute} isHidden {nft} source={NFT_LIST_ROUTE} type="card-link" />
 				{/snippet}
 			</NftList>
 		{/if}
@@ -176,7 +187,7 @@
 					<IconAlertOctagon size="24" />
 				{/snippet}
 				{#snippet nftListItem({ nft })}
-					<NftCard isSpam {nft} source={NFT_LIST_ROUTE} type="card-link" />
+					<NftCard {fromRoute} isSpam {nft} source={NFT_LIST_ROUTE} type="card-link" />
 				{/snippet}
 			</NftList>
 		{/if}

--- a/src/frontend/src/lib/components/nfts/NftsList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftsList.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate } from '$app/navigation';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import EmptyNftsList from '$lib/components/nfts/EmptyNftsList.svelte';
@@ -22,8 +24,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Nft, NftCollectionUi } from '$lib/types/nft';
 	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
-	import { afterNavigate } from '$app/navigation';
 
 	interface CollectionBuckets {
 		common: NftCollectionUi[];


### PR DESCRIPTION
# Motivation

In preparation for a future refactoring of the Nft routing, we add fromRoute props to Nft components that need it for building URLs to other Nft pages.

# Changes

Adds new props to several Nft components
