### PR TITLE
fix(frontend): Hide network switcher on Nft pages

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { page } from '$app/state';
 	import AboutWhyOisy from '$lib/components/about/AboutWhyOisy.svelte';
 	import AboutWhyOisyModal from '$lib/components/about/AboutWhyOisyModal.svelte';
@@ -14,7 +15,6 @@
 	import { modalAboutWhyOisy, modalWalletConnect } from '$lib/derived/modal.derived';
 	import { routeCollection } from '$lib/derived/nav.derived';
 	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
-	import { nonNullish } from '@dfinity/utils';
 
 	// Used to set z-index dynamically (https://github.com/dfinity/oisy-wallet/pull/8340)
 	let networkSwitcherOpen = $state(false);


### PR DESCRIPTION
# Motivation

We should not display the network switcher on Nft collection or detail pages where the network is bound to the collection or Nft.

# Changes

Added condition to not render the dropdown if on collection/nft routes
