### PR TITLE
refactor(frontend): Avoid casting in util `getDefaultLang`

### DIFF
--- a/src/frontend/src/lib/utils/i18n.utils.ts
+++ b/src/frontend/src/lib/utils/i18n.utils.ts
@@ -1,3 +1,4 @@
+import { SUPPORTED_LANGUAGES } from '$env/i18n';
 import {
 	OISY_DESCRIPTION,
 	OISY_NAME,
@@ -82,11 +83,10 @@ export const mergeWithFallback = ({
 
 export const getDefaultLang = (): Languages => {
 	const browserLocale = new Intl.Locale(navigator.language);
-	const browserLanguage = Object.keys(Languages).find(
-		(l) => Languages[l as keyof typeof Languages] === browserLocale.language
-	);
+	const browserLanguage = SUPPORTED_LANGUAGES.find(([_, l]) => l === browserLocale.language);
 	if (nonNullish(browserLanguage)) {
-		return Languages[browserLanguage as keyof typeof Languages];
+		const [_, lang] = browserLanguage;
+		return lang;
 	}
 	return Languages.ENGLISH;
 };

--- a/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
@@ -219,7 +219,7 @@ describe('i18n-utils', () => {
 		});
 
 		it('returns FRENCH when browser language is fr-CH', () => {
-			mockNavigatorLanguage('fr-FRCH');
+			mockNavigatorLanguage('fr-CH');
 
 			expect(getDefaultLang()).toBe(Languages.FRENCH);
 		});


### PR DESCRIPTION
# Motivation

In util `getDefaultLang`, we can remove the forced casting to `Languages` if we use directly the values of constant `SUPPORTED_LANGUAGES`.
