### PR TITLE
feat(lint): Temporary disable Svelte rule `no-navigation-without-resolve`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,13 @@ export default [
 		}
 	},
 
+	// TODO: re-enable this rule when we fix all the warnings that it causes.
+	{
+		rules: {
+			'svelte/no-navigation-without-resolve': 'off'
+		}
+	},
+
 	{
 		ignores: [
 			'**/.DS_Store',


### PR DESCRIPTION
# Motivation

There is a new rule in the `recommended` suite of Svelte Lint plugin: [no-navigation-without-resolve](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-navigation-without-resolve/).

The rule enforces resolving the internal URLs. However, in our code it raises quite a lot of warnings (see CI https://github.com/dfinity/oisy-wallet/actions/runs/18709289138/job/53353612091?pr=9761).

We have an higher priority to bump the OISY signer, so for now we simply disable the rule, and work on the fixes step-by-step.