### PR TITLE
feat(dependabot): Add a cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,22 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    cooldown:
+      - default-days: 7
 
   - package-ecosystem: cargo
     directory: '/'
     schedule:
       interval: weekly
+    cooldown:
+      - default-days: 7
 
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: weekly
+    cooldown:
+      - default-days: 7
     allow:
       - dependency-type: all
     ignore:


### PR DESCRIPTION
# Motivation

Theoretically, we are in no rush to bump a dependency as soon as it is out. So, just to give a period of triage, we add the [cooldown](https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) option to the dependabot configurations, setting it to one week.
