### PR TITLE
style(frontend): Adjust padding of `WarningBanner`

### DIFF
--- a/src/frontend/src/lib/components/ui/WarningBanner.svelte
+++ b/src/frontend/src/lib/components/ui/WarningBanner.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <div
-	class={`inline-flex w-full items-center justify-center gap-2 rounded-lg border border-warning-solid bg-warning-subtle-10 p-2 md:py-2 md:px-6 text-xs font-bold text-warning-primary sm:w-fit md:text-base ${styleClass ?? ''}`}
+	class={`inline-flex w-full items-center justify-center gap-2 rounded-lg border border-warning-solid bg-warning-subtle-10 p-2 text-xs font-bold text-warning-primary sm:w-fit md:px-6 md:py-2 md:text-base ${styleClass ?? ''}`}
 	data-tid={testId}
 >
 	<IconWarning inline></IconWarning>


### PR DESCRIPTION
# Motivation

For smaller screen, it would be ideal to have symmetric padding for the component `WarningBanner`.

### Before

<img width="602" height="602" alt="Screenshot 2025-10-22 at 14 49 10" src="https://github.com/user-attachments/assets/5ac464aa-7f7b-429a-b5ba-c3574cf5d6e8" />

### After

<img width="605" height="596" alt="Screenshot 2025-10-22 at 14 49 03" src="https://github.com/user-attachments/assets/736f4f75-1fe4-49b0-bbbe-294735bb0846" />

