### PR TITLE
refactor(frontend): Page collections Nfts derived

### DIFF
--- a/src/frontend/src/lib/derived/page-nft.derived.ts
+++ b/src/frontend/src/lib/derived/page-nft.derived.ts
@@ -21,7 +21,7 @@ export const pageCollectionNfts: Readable<Nft[]> = derived(
 						id: { description: networkId }
 					}
 				}
-				// TODO: Confirm that `$routeNftNetwork` is the network name (not the ID) when comparing to `networkName` here.
+				// TODO: Remove check by network name once routing refactoring has been completed
 			}) =>
 				address === $routeCollection &&
 				(nonNullish($routeNftNetwork)


### PR DESCRIPTION
# Motivation

For the upcoming routing changes, we temporarily adjust the pageCollectionNfts derived store to work with both routes and query params.

# Changes

Added fallback for when routeNftNetwork will be removed
