### PR TITLE
test(frontend): Coherent tests for component `Transaction`

### DIFF
--- a/src/frontend/src/tests/lib/components/transactions/Transaction.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/Transaction.spec.ts
@@ -22,7 +22,7 @@ describe('Transaction', () => {
 		contactsStore.reset();
 	});
 
-	it('should render `from` when we RECEIVE address', async () => {
+	it('should render `from` when we RECEIVE address', () => {
 		const fromAddress = '0xfeedface';
 
 		const { container, getByText } = render(Transaction, {
@@ -171,7 +171,7 @@ describe('Transaction', () => {
 		).toBeInTheDocument();
 	});
 
-	it('should render token logo in token icon mode for fungible tokens (amount visible)', async () => {
+	it('should render token logo in token icon mode for fungible tokens (amount visible)', () => {
 		const { getByText, getByAltText } = render(Transaction, {
 			type: 'receive',
 			status: 'confirmed',


### PR DESCRIPTION
# Motivation

We make the test for component `Transaction` a bit more coherent and scalable.
