### PR TITLE
fix(dependabot): Typo in `cooldown` specifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,14 +13,14 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      - default-days: 7
+      default-days: 7
 
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: weekly
     cooldown:
-      - default-days: 7
+      default-days: 7
     allow:
       - dependency-type: all
     ignore:


### PR DESCRIPTION
# Motivation

In the `cooldown` configurations there is no need for a list.
