### PR TITLE
fix(frontend): Switch to default language if not set

### DIFF
--- a/src/frontend/src/lib/stores/i18n.store.ts
+++ b/src/frontend/src/lib/stores/i18n.store.ts
@@ -54,6 +54,14 @@ const initI18n = (): I18nStore => {
 		init: async () => {
 			const lang = get<Languages>({ key: 'lang' }) ?? getDefaultLang();
 
+			// English is the default one in case no language is set.
+			// Or either way is what most users would have as default in their machines.
+			if (lang === Languages.ENGLISH) {
+				saveLang(lang);
+				// No need to reload the store, store is already initialised with the default
+				return;
+			}
+
 			await switchLang(lang);
 		},
 


### PR DESCRIPTION
# Motivation

There is an issue when the user has the storage language set the same as the machine default language: the i18n store does not initialize with the correct language:

<img width="3066" height="2068" alt="Capture d’écran 2025-10-22 à 17 31 52" src="https://github.com/user-attachments/assets/01486d23-b440-4e50-80ef-28f60cc6c9a0" />


To fix it we remove the condition that was impending the correct switch.

NOTE: `switchLang` already use `saveLang` internally.


Thanks to @peterpeterparker for the heads-up!
