### PR TITLE
fix(frontend): build gldt_stake script

### DIFF
--- a/scripts/build.gldt_stake.sh
+++ b/scripts/build.gldt_stake.sh
@@ -19,7 +19,7 @@ EOF
 DFX_NETWORK="${DFX_NETWORK:-local}"
 export GLDT_STAKE_BUILDENV="$DFX_NETWORK"
 
-GLDT_STAKE_REPO_DOWNLOADS_URL="https://github.com/GoldDAO/gold-dao/releases/latest/download"
+GLDT_STAKE_REPO_DOWNLOADS_URL="https://github.com/GoldDAO/gold-dao/releases/tag/gldt_stake-v1.0.15/download"
 # shellcheck disable=SC2034 # This variable is used - see ${!asset_url} below.
 CANDID_URL="${GLDT_STAKE_REPO_DOWNLOADS_URL}/can.did"
 # shellcheck disable=SC2034 # This variable is used - see ${!asset_url} below.


### PR DESCRIPTION
# Motivation

Unfortunately, the way the GoldDAO repo is structure does not allow us to use "/latest" release approach. Instead, we will have to use a specific tag to retrieve the assets.
