### PR TITLE
feat(frontend): Use Info banner instead of Warning for PWA Message

### DIFF
--- a/src/frontend/src/lib/components/core/PwaBanner.svelte
+++ b/src/frontend/src/lib/components/core/PwaBanner.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Html, IconClose } from '@dfinity/gix-components';
-	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
+	import InfoBanner from '$lib/components/ui/InfoBanner.svelte';
 	import {
-		PWA_WARNING_BANNER_CLOSE_BUTTON_TEST_ID,
-		PWA_WARNING_BANNER_TEST_ID
+		PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID,
+		PWA_INFO_BANNER_TEST_ID
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { isPWAStandalone } from '$lib/utils/device.utils';
@@ -19,17 +19,17 @@
 	<div
 		class="fixed left-[50%] top-6 z-10 flex min-w-80 -translate-x-[50%] justify-between gap-4 rounded-lg bg-primary"
 	>
-		<WarningBanner testId={PWA_WARNING_BANNER_TEST_ID}>
+		<InfoBanner testId={PWA_INFO_BANNER_TEST_ID}>
 			<span class="w-full px-2">
 				<Html text={replaceOisyPlaceholders($i18n.core.warning.standalone_mode)} />
 			</span>
 			<button
 				aria-label={$i18n.core.text.close}
-				data-tid={PWA_WARNING_BANNER_CLOSE_BUTTON_TEST_ID}
+				data-tid={PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID}
 				onclick={closePwaBanner}
 			>
 				<IconClose />
 			</button>
-		</WarningBanner>
+		</InfoBanner>
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/ui/InfoBanner.svelte
+++ b/src/frontend/src/lib/components/ui/InfoBanner.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
+
+	interface Props {
+		children: Snippet;
+		testId?: string;
+	}
+
+	let { children, testId }: Props = $props();
+</script>
+
+<div
+	class="border-info-solid bg-info-subtle-10 text-info-primary inline-flex w-full items-center justify-center gap-2 rounded-lg border p-2 text-xs sm:w-fit md:px-6 md:py-2 md:text-base"
+	data-tid={testId}
+>
+	<IconInfo />
+
+	{@render children()}
+</div>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -315,5 +315,5 @@ export const STAKE_PROVIDER_LOGO = 'stake-provider-logo';
 export const STAKE_PROVIDER_EXTERNAL_URL = 'stake-provider-external-url';
 
 // PWA
-export const PWA_WARNING_BANNER_TEST_ID = 'pwa-warning-banner';
-export const PWA_WARNING_BANNER_CLOSE_BUTTON_TEST_ID = 'pwa-warning-banner-close-button';
+export const PWA_INFO_BANNER_TEST_ID = 'pwa-info-banner';
+export const PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID = 'pwa-info-banner-close-button';

--- a/src/frontend/src/tests/lib/components/core/PwaBanner.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/PwaBanner.spec.ts
@@ -1,7 +1,7 @@
 import PwaBanner from '$lib/components/core/PwaBanner.svelte';
 import {
-	PWA_WARNING_BANNER_CLOSE_BUTTON_TEST_ID,
-	PWA_WARNING_BANNER_TEST_ID
+	PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID,
+	PWA_INFO_BANNER_TEST_ID
 } from '$lib/constants/test-ids.constants';
 import * as deviceUtils from '$lib/utils/device.utils';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -18,28 +18,28 @@ describe('PwaBanner', () => {
 
 		const { queryByTestId } = render(PwaBanner);
 
-		expect(queryByTestId(PWA_WARNING_BANNER_TEST_ID)).toBeNull();
-		expect(queryByTestId(PWA_WARNING_BANNER_TEST_ID)).not.toBeInTheDocument();
+		expect(queryByTestId(PWA_INFO_BANNER_TEST_ID)).toBeNull();
+		expect(queryByTestId(PWA_INFO_BANNER_TEST_ID)).not.toBeInTheDocument();
 	});
 
 	it('should show the banner for PWA environment', () => {
 		const { getByTestId } = render(PwaBanner);
 
-		expect(getByTestId(PWA_WARNING_BANNER_TEST_ID)).toBeDefined();
-		expect(getByTestId(PWA_WARNING_BANNER_TEST_ID)).toBeInTheDocument();
+		expect(getByTestId(PWA_INFO_BANNER_TEST_ID)).toBeDefined();
+		expect(getByTestId(PWA_INFO_BANNER_TEST_ID)).toBeInTheDocument();
 	});
 
 	it('should hide the banner after clicking the close button', async () => {
 		const { getByTestId, queryByTestId } = render(PwaBanner);
 
-		expect(getByTestId(PWA_WARNING_BANNER_TEST_ID)).toBeDefined();
-		expect(getByTestId(PWA_WARNING_BANNER_TEST_ID)).toBeInTheDocument();
+		expect(getByTestId(PWA_INFO_BANNER_TEST_ID)).toBeDefined();
+		expect(getByTestId(PWA_INFO_BANNER_TEST_ID)).toBeInTheDocument();
 
-		expect(getByTestId(PWA_WARNING_BANNER_CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
+		expect(getByTestId(PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID)).toBeInTheDocument();
 
-		await fireEvent.click(getByTestId(PWA_WARNING_BANNER_CLOSE_BUTTON_TEST_ID));
+		await fireEvent.click(getByTestId(PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID));
 
-		expect(queryByTestId(PWA_WARNING_BANNER_TEST_ID)).toBeNull();
-		expect(queryByTestId(PWA_WARNING_BANNER_TEST_ID)).not.toBeInTheDocument();
+		expect(queryByTestId(PWA_INFO_BANNER_TEST_ID)).toBeNull();
+		expect(queryByTestId(PWA_INFO_BANNER_TEST_ID)).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

We prefer to show the PWA message as info instead of a warning, to be less impactful.

# Changes

- Create new component `InfoBanner`, similar to `WarningBanner`.
- Replace the banner component in `PwaBanner`.

# Tests

### Before

<img width="605" height="596" alt="Screenshot 2025-10-22 at 14 49 03" src="https://github.com/user-attachments/assets/0d9f780d-c675-4402-a2df-f625de70701d" />

### After

<img width="659" height="649" alt="Screenshot 2025-10-23 at 09 30 37" src="https://github.com/user-attachments/assets/4a92ca99-b8c9-45e5-903d-981f76fd9fcc" />

