### PR TITLE
chore(frontend): Make service `initPlausibleAnalytics` fake-async for state of the art

### DIFF
--- a/src/frontend/src/lib/services/analytics.services.ts
+++ b/src/frontend/src/lib/services/analytics.services.ts
@@ -5,7 +5,8 @@ import Plausible from 'plausible-tracker';
 
 let plausibleTracker: ReturnType<typeof Plausible> | null = null;
 
-export const initPlausibleAnalytics = () => {
+// eslint-disable-next-line require-await -- We use this service during initialisation among other async functions, so for consistency we force the asynchronicity here.
+export const initPlausibleAnalytics = async () => {
 	if (!PLAUSIBLE_ENABLED || isNullish(PLAUSIBLE_DOMAIN)) {
 		return;
 	}


### PR DESCRIPTION
# Motivation

Service `initPlausibleAnalytics` is used during initialization together with other async functions:

```ts
await Promise.allSettled([syncAuthStore(), initPlausibleAnalytics(), i18n.init()]);
```

However, it is not an asynchronous function, so the statement is a bit incongruous. To have a state-of-the-art code we forcefully make it `async`.

# Note on Lint

I prefer to make an exception to the lint rule `require-await` instead of returning a `Promise.resolve`: if and when `initPlausibleAnalytics` will become really `async`, the linter will warn us of an unused exception. It seems cleaner.