### PR TITLE
refactor(frontend): Shorten loop in service `loadNfts`

### DIFF
--- a/src/frontend/src/lib/services/nft.services.ts
+++ b/src/frontend/src/lib/services/nft.services.ts
@@ -33,12 +33,13 @@ export const loadNfts = async ({
 	const tokensByNetwork = getTokensByNetwork(tokens);
 
 	const promises = Array.from(tokensByNetwork).map(async ([networkId, tokens]) => {
-		const tokensToLoad = force
-			? tokens
-			: tokens.filter((token) => {
-					const nftsByToken = findNftsByToken({ nfts: loadedNfts, token });
-					return nftsByToken.length === 0;
-				});
+		const tokensToLoad =
+			force || loadedNfts.length === 0
+				? tokens
+				: tokens.filter((token) => {
+						const nftsByToken = findNftsByToken({ nfts: loadedNfts, token });
+						return nftsByToken.length === 0;
+					});
 
 		if (tokensToLoad.length > 0) {
 			const nfts: Nft[] = await loadNftsByNetwork({


### PR DESCRIPTION
# Motivation

We can shorten the loop in `loadNfts` since we don't need to filter if the `loadedNfts` are empty.
