### PR TITLE
style(frontend): Expand text in `SkeletonCardWithoutAmount`

### DIFF
--- a/src/frontend/src/lib/components/ui/SkeletonCardWithoutAmount.svelte
+++ b/src/frontend/src/lib/components/ui/SkeletonCardWithoutAmount.svelte
@@ -13,9 +13,7 @@
 </script>
 
 <Card noMargin>
-	<span
-		class={`inline-block max-w-full ${isNullish(children) ? 'w-[120px] sm:w-[200px]' : ''}`}
-	>
+	<span class={`inline-block max-w-full ${isNullish(children) ? 'w-[120px] sm:w-[200px]' : ''}`}>
 		{#if nonNullish(children)}
 			{@render children()}
 		{:else}


### PR DESCRIPTION
# Motivation

If there are children in component `SkeletonCardWithoutAmount` we should not have a fixed width. It is necessary only for the `SkeletonText` component width.

Thanks to @peterpeterparker for the heads-up

### Before

<img width="591" height="300" alt="Screenshot 2025-10-23 at 14 44 17" src="https://github.com/user-attachments/assets/7ddddb03-439c-4054-bd27-bc231e4cc0de" />

### After

<img width="616" height="308" alt="Screenshot 2025-10-23 at 14 44 07" src="https://github.com/user-attachments/assets/945e2dcb-c3e6-4257-8ff3-c677d693b0d5" />

