### PR TITLE
style(frontend): Make top padding of `StickyHeader` only when it is sticky

### DIFF
--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -28,7 +28,11 @@
 <svelte:window onscroll={handleScroll} />
 
 <div bind:this={rootElement}>
-	<div class="z-3 sticky top-0 whitespace-nowrap px-1" class:bg-page={scrolledSoon} class:pt-6={scrolledSoon}>
+	<div
+		class="z-3 sticky top-0 whitespace-nowrap px-1"
+		class:bg-page={scrolledSoon}
+		class:pt-6={scrolledSoon}
+	>
 		{@render header()}
 	</div>
 


### PR DESCRIPTION
# Motivation

To have a better UI, we revert to having the top padding of the `StickyHeader` component only when it is sticky.


### Before

<img width="838" height="1388" alt="Screenshot 2025-10-23 at 14 50 52" src="https://github.com/user-attachments/assets/6c468de4-a679-47ec-91ab-fdd83ef7b6ea" />

### After

<img width="840" height="1389" alt="Screenshot 2025-10-23 at 14 50 34" src="https://github.com/user-attachments/assets/a18a0b02-9a5e-4417-9b0a-9b70679f814f" />

### Video


https://github.com/user-attachments/assets/761e1b21-8637-4e37-9df6-f01a545c29c5



