### PR TITLE
chore(frontend): Add type `TransactionWithinSizeLimit` to Solana transactions

### DIFF
--- a/src/frontend/src/sol/services/sol-sign.services.ts
+++ b/src/frontend/src/sol/services/sol-sign.services.ts
@@ -1,6 +1,7 @@
 import type { SolTransactionMessage } from '$sol/types/sol-send';
 import type { SolSignedTransaction } from '$sol/types/sol-transaction';
 import {
+	assertIsTransactionWithBlockhashLifetime,
 	getSignatureFromTransaction,
 	signTransactionMessageWithSigners,
 	type Signature
@@ -10,6 +11,9 @@ export const signTransaction = async (
 	transactionMessage: SolTransactionMessage
 ): Promise<{ signedTransaction: SolSignedTransaction; signature: Signature }> => {
 	const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+
+	// This is purely for type-safe reasons: the `transactionMessage` input is already passed with a blockhash lifetime
+	assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 	const signature = getSignatureFromTransaction(signedTransaction);
 

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -11,7 +11,8 @@ import {
 	type GetSignaturesForAddressApi,
 	type Signature,
 	type Transaction,
-	type TransactionWithBlockhashLifetime
+	type TransactionWithBlockhashLifetime,
+	type TransactionWithinSizeLimit
 } from '@solana/kit';
 
 export type SolTransactionType = Extract<
@@ -63,6 +64,7 @@ export type SolSignature = ReturnType<
 
 export type SolSignedTransaction = Transaction &
 	FullySignedTransaction &
+	TransactionWithinSizeLimit &
 	TransactionWithBlockhashLifetime;
 
 export interface MappedSolTransaction {

--- a/src/frontend/src/sol/utils/sol-sign.utils.ts
+++ b/src/frontend/src/sol/utils/sol-sign.utils.ts
@@ -11,7 +11,8 @@ import {
 	type SignatureDictionary,
 	type Transaction,
 	type TransactionPartialSigner,
-	type TransactionWithLifetime
+	type TransactionWithLifetime,
+	type TransactionWithinSizeLimit
 } from '@solana/kit';
 
 export interface CreateSignerParams {
@@ -60,7 +61,7 @@ export const createSigner = ({
 	const signer: TransactionPartialSigner = {
 		address: solAddress(address),
 		signTransactions: async (
-			transactions: (Transaction & TransactionWithLifetime)[]
+			transactions: (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[]
 		): Promise<SignatureDictionary[]> =>
 			await signTransactions({ identity, transactions, address, network })
 	};

--- a/src/frontend/src/tests/sol/utils/sol-sign.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-sign.utils.spec.ts
@@ -5,7 +5,7 @@ import type { SolanaNetworkType } from '$sol/types/network';
 import { createSigner } from '$sol/utils/sol-sign.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
-import type { Transaction, TransactionWithLifetime } from '@solana/kit';
+import type { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
 describe('sol-sign.utils', () => {
@@ -14,9 +14,9 @@ describe('sol-sign.utils', () => {
 
 		const mockSignedBytes = [4, 5, 6];
 		const mockNetwork: SolanaNetworkType = 'mainnet';
-		const mockTransaction: Transaction & TransactionWithLifetime = {
+		const mockTransaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime = {
 			messageBytes: new Uint8Array([1, 2, 3])
-		} as unknown as Transaction & TransactionWithLifetime;
+		} as unknown as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
 
 		beforeEach(() => {
 			vi.clearAllMocks();


### PR DESCRIPTION
# Motivation

The [new version v4 of Solana Kit](https://github.com/anza-xyz/kit/releases/tag/v4.0.0) splits the `Transaction` type returned between `Transaction` and `TransactionWithinSizeLimit`.

So, we need to adapt the code consequentially.
