### PR TITLE
chore(frontend): Remove redundant util `transactionMessageHasBlockhashLifetime`

### DIFF
--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -35,14 +35,14 @@ import { createSigner, signTransaction, type CreateSignerParams } from '$sol/uti
 import {
 	decodeTransactionMessage,
 	mapSolTransactionMessage,
-	parseSolBase64TransactionMessage,
-	transactionMessageHasBlockhashLifetime
+	parseSolBase64TransactionMessage
 } from '$sol/utils/sol-transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import {
 	getBase58Decoder,
 	getBase64Decoder,
 	getTransactionEncoder,
+	isTransactionMessageWithBlockhashLifetime,
 	address as solAddress,
 	type Base64EncodedWireTransaction
 } from '@solana/kit';
@@ -134,7 +134,7 @@ const getSignatureWithSending = async ({
 
 	// It should not happen, since we receive transaction with blockhash lifetime,
 	// but just to guarantee the correct type casting
-	if (!transactionMessageHasBlockhashLifetime(transactionMessageRaw)) {
+	if (!isTransactionMessageWithBlockhashLifetime(transactionMessageRaw)) {
 		console.warn(
 			'WalletConnect Solana transaction does not have blockhash lifetime, cannot be sent'
 		);

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -1,5 +1,4 @@
 import { ZERO } from '$lib/constants/app.constants';
-import type { SolTransactionMessage } from '$sol/types/sol-send';
 import type { MappedSolTransaction } from '$sol/types/sol-transaction';
 import type { CompilableTransactionMessage } from '$sol/types/sol-transaction-message';
 import { mapSolInstruction } from '$sol/utils/sol-instructions.utils';
@@ -52,8 +51,3 @@ export const mapSolTransactionMessage = ({
 		},
 		{ amount: undefined }
 	);
-
-export const transactionMessageHasBlockhashLifetime = (
-	message: CompilableTransactionMessage
-): message is SolTransactionMessage =>
-	'blockhash' in message.lifetimeConstraint && 'lastValidBlockHeight' in message.lifetimeConstraint;

--- a/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/wallet-connect.services.spec.ts
@@ -39,8 +39,21 @@ import { mockSolSignedTransaction } from '$tests/mocks/sol-transactions.mock';
 import { mockAtaAddress, mockSolAddress } from '$tests/mocks/sol.mock';
 import type { WalletKitTypes } from '@reown/walletkit';
 import type { SignatureBytes } from '@solana/keys';
-import { getBase58Encoder, type Rpc, type SolanaRpcApi } from '@solana/kit';
+import {
+	getBase58Encoder,
+	isTransactionMessageWithBlockhashLifetime,
+	type Rpc,
+	type SolanaRpcApi
+} from '@solana/kit';
 import type { MockInstance } from 'vitest';
+
+vi.mock(import('@solana/kit'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		isTransactionMessageWithBlockhashLifetime: vi.fn()
+	};
+});
 
 vi.mock(import('$sol/utils/sol-transactions.utils'), async (importOriginal) => {
 	const actual = await importOriginal();
@@ -98,7 +111,7 @@ describe('wallet-connect.services', () => {
 		vi.spyOn(solTransactionsUtils, 'decodeTransactionMessage').mockImplementation(
 			() => mockSolSignedTransaction
 		);
-		vi.spyOn(solTransactionsUtils, 'transactionMessageHasBlockhashLifetime').mockReturnValue(true);
+		vi.mocked(isTransactionMessageWithBlockhashLifetime).mockReturnValue(true);
 
 		vi.spyOn(solSendServices, 'setLifetimeAndFeePayerToTransaction').mockResolvedValue(
 			mockTransactionMessage as unknown as SolTransactionMessage


### PR DESCRIPTION
# Motivation

Instead of using the util `transactionMessageHasBlockhashLifetime`, we can rely on `isTransactionMessageWithBlockhashLifetime` form `@solana/kit`