### PR TITLE
fix(frontend): Persist query params on assets tabs

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { page } from '$app/stores';
 	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
+	import { page } from '$app/stores';
 	import { NFTS_ENABLED } from '$env/nft.env';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
 	import Nft from '$lib/components/nfts/Nft.svelte';


### PR DESCRIPTION
# Motivation

Currently, on the assets page when we switch between tokens and Nfts, the network query param is lost.

# Changes

Add the url.search to the tabs paths.
