### PR TITLE
refactor(frontend): Simplify `LoaderTokens` children

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { Identity } from '@dfinity/agent';
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import type { Snippet } from 'svelte';
 	import { get } from 'svelte/store';
 	import type { CustomToken } from '$declarations/backend/declarations/backend.did';
 	import { NFTS_ENABLED } from '$env/nft.env';
@@ -22,12 +21,6 @@
 	import type { OwnedContract } from '$lib/types/nft';
 	import type { NonEmptyArray } from '$lib/types/utils';
 	import { areAddressesEqual } from '$lib/utils/address.utils';
-
-	interface Props {
-		children?: Snippet;
-	}
-
-	let { children }: Props = $props();
 
 	const handleErc721 = async ({
 		contracts,
@@ -184,6 +177,4 @@
 	};
 </script>
 
-<IntervalLoader interval={NFT_TIMER_INTERVAL_MILLIS} {onLoad}>
-	{@render children?.()}
-</IntervalLoader>
+<IntervalLoader interval={NFT_TIMER_INTERVAL_MILLIS} {onLoad} />

--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { debounce, isNullish } from '@dfinity/utils';
-	import { type Snippet, untrack } from 'svelte';
+	import { untrack } from 'svelte';
 	import { NFTS_ENABLED } from '$env/nft.env';
 	import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
 	import { ethAddress } from '$lib/derived/address.derived';
@@ -10,12 +10,6 @@
 	import type { Nft, NftId, NonFungibleToken } from '$lib/types/nft';
 	import { getTokensByNetwork } from '$lib/utils/nft.utils';
 	import { findNftsByToken, findRemovedNfts, getUpdatedNfts } from '$lib/utils/nfts.utils';
-
-	interface Props {
-		children?: Snippet;
-	}
-
-	let { children }: Props = $props();
 
 	const handleRemovedNfts = ({
 		token,
@@ -79,5 +73,3 @@
 		untrack(() => debounceLoad());
 	});
 </script>
-
-{@render children?.()}

--- a/src/frontend/src/lib/components/loaders/LoaderTokens.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderTokens.svelte
@@ -88,8 +88,8 @@
 	});
 </script>
 
-<LoaderCollections>
-	<LoaderNfts>
-		{@render children()}
-	</LoaderNfts>
-</LoaderCollections>
+{@render children()}
+
+<LoaderCollections />
+
+<LoaderNfts />


### PR DESCRIPTION
# Motivation

Component `LoaderTokens` has two children: `LoaderCollections` and `LoaderNfts`. They are nested children, but none of them has conditional rendering.

So, we can extract them as separate components, to simplify the code.
