### PR TITLE
chore(frontend): Remove unused events from `SwapTokenWizard`

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapTokenWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokenWizard.svelte
@@ -77,10 +77,7 @@
 			bind:receiveAmount
 			bind:slippageValue
 			bind:swapProgressStep
-			on:icClose
-			on:icShowTokensList
 			on:icShowProviderList
-			on:icNext
 		/>
 	{:else}
 		<SwapEthWizard


### PR DESCRIPTION
# Motivation

There were some left-over unused events in component `SwapTokenWizard`.
