### PR TITLE
fix(frontend): Stay on nfts page via nav item assets

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -42,6 +42,7 @@
 		nonNullish(testIdPrefix) ? `${testIdPrefix}-${testId}` : testId;
 
 	const isTransactionsRoute = $derived(isRouteTransactions(page));
+	const isNftsRoute = $derived(isRouteNfts(page));
 
 	let fromRoute = $state<NavigationTarget | null>(null);
 
@@ -53,7 +54,7 @@
 <NavigationItem
 	ariaLabel={$i18n.navigation.alt.tokens}
 	href={networkUrl({
-		path: AppPath.Tokens,
+		path: isNftsRoute ? AppPath.Nfts : AppPath.Tokens,
 		networkId: $networkId,
 		usePreviousRoute: isTransactionsRoute,
 		fromRoute


### PR DESCRIPTION
# Motivation

If youre on an Nfts page, clicking the Assets main nav menu item should bring you to Nfts root, not the tokens page.

# Changes

Added condition and adjusted path for Assets main nav menu item.
