### PR TITLE
refactor(frontend): Assets tab prop

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -25,10 +25,10 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
-		tab?: TokenTypes;
+		tab: TokenTypes;
 	}
 
-	let { tab = TokenTypes.TOKENS }: Props = $props();
+	let { tab }: Props = $props();
 
 	let activeTab = $state(tab);
 

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -2,10 +2,11 @@
 	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Assets from '$lib/components/tokens/Assets.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
+	import { TokenTypes } from '$lib/enums/token-types';
 </script>
 
 <Responsive down="xl">
 	<DappsCarousel wrapperStyleClass="mb-6 flex justify-center xl:hidden" />
 </Responsive>
 
-<Assets />
+<Assets tab={TokenTypes.TOKENS} />

--- a/src/frontend/src/routes/(app)/wc/+page.svelte
+++ b/src/frontend/src/routes/(app)/wc/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Assets from '$lib/components/tokens/Assets.svelte';
+	import { TokenTypes } from '$lib/enums/token-types';
 </script>
 
-<Assets />
+<Assets tab={TokenTypes.TOKENS} />


### PR DESCRIPTION
# Motivation

For a future PR about route refactoring, we need to explicitely pass the tab prop for the Assets component.

# Changes

Make prop non optional and pass it always
