### PR TITLE
chore(frontend): Contain painting of general background

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -228,6 +228,9 @@
 			}
 
 			#app-background-container {
+				contain: paint;
+				pointer-events: none;
+
 				position: fixed;
 				top: 0;
 				left: 50%;
@@ -243,6 +246,9 @@
 			}
 
 			#app-background {
+				contain: paint;
+				pointer-events: none;
+
 				width: 100%;
 				min-width: 1728px;
 			}


### PR DESCRIPTION
# Motivation

To avoid triggering repainting for the main background, we contain its own painting. Ideally this will improve the GPU usage of OISY.

The compositor can now:
- Clip repaints: only repaint inside this container’s box, not the whole screen.
- Keep its own GPU texture cached, reused frame-to-frame without re-rasterizing the SVG.
- Avoid merging it into other paint layers, reducing blending passes.

That means far less memory churn and fewer GPU uploads.