### PR TITLE
fix(frontend): Nft pages context/store

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftPagesContext.svelte
+++ b/src/frontend/src/lib/components/nfts/NftPagesContext.svelte
@@ -15,9 +15,7 @@
 
 	const { children }: Props = $props();
 
-	const { store } = setContext<NftPagesContext>(NFT_PAGES_CONTEXT_KEY, {
-		store: initNftPagesStore()
-	});
+	const store = setContext<NftPagesContext>(NFT_PAGES_CONTEXT_KEY, initNftPagesStore());
 
 	$effect(() => {
 		// Add conditions to exclude certain pages from updating the origin network

--- a/src/frontend/src/lib/stores/nft-pages.store.ts
+++ b/src/frontend/src/lib/stores/nft-pages.store.ts
@@ -40,8 +40,6 @@ export const initNftPagesStore = (): NftPagesStore => {
 	};
 };
 
-export interface NftPagesContext {
-	store: NftPagesStore;
-}
+export interface NftPagesContext extends NftPagesStore {}
 
 export const NFT_PAGES_CONTEXT_KEY = Symbol('nft-pages');


### PR DESCRIPTION
# Motivation

Destructuring the context value can lead to issues in tests when no context is set. For this we move the store inside the context to the root level of the context.

Since the store itself allows for multple values, this does not affect scalability in the future.

# Changes

Dont use subprop for store inside context
