### PR TITLE
refactor(frontend): Migrate `SignerPermissions` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/signer/SignerOrigin.svelte
+++ b/src/frontend/src/lib/components/signer/SignerOrigin.svelte
@@ -29,7 +29,6 @@
 	};
 
 	// Null being used if mapping the origin does not work - i.e. invalid origin. Probably an edge case.
-
 	let host = $derived(mapHost(origin));
 </script>
 

--- a/src/frontend/src/lib/components/signer/SignerPermissions.svelte
+++ b/src/frontend/src/lib/components/signer/SignerPermissions.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
 	import { IconWallet } from '@dfinity/gix-components';
-	import {
-		ICRC25_PERMISSION_GRANTED,
-		ICRC27_ACCOUNTS,
-		type IcrcScope,
-		type IcrcScopedMethod,
-		type PermissionsConfirmation
-	} from '@dfinity/oisy-wallet-signer';
+	import { ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS } from '@dfinity/oisy-wallet-signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { type Component, getContext } from 'svelte';
+	import { getContext } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import IconAstronautHelmet from '$lib/components/icons/IconAstronautHelmet.svelte';
@@ -26,11 +20,9 @@
 		permissionsPrompt: { payload, reset: resetPrompt }
 	} = getContext<SignerContext>(SIGNER_CONTEXT_KEY);
 
-	let scopes: IcrcScope[];
-	$: scopes = $payload?.requestedScopes ?? [];
+	let scopes = $derived($payload?.requestedScopes ?? []);
 
-	let confirm: PermissionsConfirmation | undefined;
-	$: confirm = $payload?.confirm;
+	let confirm = $derived($payload?.confirm);
 
 	/**
 	 * During the initial UX review, it was decided that permissions should not be permanently denied when "Rejected," but instead should be ignored.
@@ -67,8 +59,7 @@
 
 	const onApprove = () => approvePermissions();
 
-	let listItems: Record<IcrcScopedMethod, { icon: Component; label: string }>;
-	$: listItems = {
+	let listItems = $derived({
 		icrc27_accounts: {
 			icon: IconWallet,
 			label: replaceOisyPlaceholders($i18n.signer.permissions.text.icrc27_accounts)
@@ -77,16 +68,15 @@
 			icon: IconShield,
 			label: $i18n.signer.permissions.text.icrc49_call_canister
 		}
-	};
+	});
 
-	let requestAccountsPermissions = false;
-	$: requestAccountsPermissions = nonNullish(
-		scopes.find(({ scope: { method } }) => method === ICRC27_ACCOUNTS)
+	let requestAccountsPermissions = $derived(
+		nonNullish(scopes.find(({ scope: { method } }) => method === ICRC27_ACCOUNTS))
 	);
 </script>
 
 {#if nonNullish($payload)}
-	<form method="POST" on:submit={onApprove} in:fade>
+	<form method="POST" onsubmit={onApprove} in:fade>
 		<h2 class="mb-4 text-center">{$i18n.signer.permissions.text.title}</h2>
 
 		<SignerOrigin payload={$payload} />
@@ -96,10 +86,10 @@
 
 			<ul class="mt-2.5 flex list-none flex-col gap-1">
 				{#each scopes as { scope: { method } } (method)}
-					{@const { icon, label } = listItems[method]}
+					{@const { icon: Icon, label } = listItems[method]}
 
 					<li class="flex items-center gap-2 pb-1.5 break-normal">
-						<svelte:component this={icon} size="24" />
+						<Icon size="24" />
 						{label}
 					</li>
 				{/each}


### PR DESCRIPTION
# Motivation

Migrating component `SignerPermissions` to Svelte 5.
