### PR TITLE
refactor(frontend): Migrate `SignerConsentMessage` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/signer/SignerConsentMessageWarning.svelte
+++ b/src/frontend/src/lib/components/signer/SignerConsentMessageWarning.svelte
@@ -5,12 +5,15 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
-	export let consentInfo: ResultConsentInfo | undefined;
+	interface Props {
+		consentInfo?: ResultConsentInfo;
+	}
+
+	let { consentInfo }: Props = $props();
 
 	// The ICRC-49 standard specifies that a user should be warned when a consent message is interpreted on the frontend side instead of being retrieved through a canister.
 	// See https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md#message-processing
-	let displayWarning: boolean | undefined;
-	$: displayWarning = nonNullish(consentInfo) && 'Warn' in consentInfo;
+	let displayWarning = $derived(nonNullish(consentInfo) && 'Warn' in consentInfo);
 </script>
 
 {#if displayWarning}


### PR DESCRIPTION
# Motivation

Migrating component `SignerConsentMessage` (and its direct children). to Svelte 5.
