### PR TITLE
feat(frontend): Remove one loop from ERC721 loader service

### DIFF
--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -110,8 +110,7 @@ const loadCustomTokensWithMetadata = async (
 				`Inconsistency in token data: no symbol found for token ${tokenAddress}`
 			);
 
-			return {
-				...(await acc),
+			const newToken = {
 				...{
 					id: parseCustomTokenId({ identifier: symbol, chainId: network.chainId }),
 					name: tokenAddress,
@@ -130,6 +129,8 @@ const loadCustomTokensWithMetadata = async (
 				},
 				...metadata
 			};
+
+			return [...(await acc), newToken];
 		},
 		Promise.resolve([])
 	);


### PR DESCRIPTION
# Motivation

To try and improve performance, we remove one loop from the ERC721 custom tokens loader.
