### PR TITLE
feat(frontend): REVERT: add interval in `LoaderNfts`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -3,6 +3,8 @@
 	import { untrack } from 'svelte';
 	import { NFTS_ENABLED } from '$env/nft.env';
 	import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
+	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
+	import { NFT_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { enabledNonFungibleTokens } from '$lib/derived/tokens.derived';
 	import { loadNftsByNetwork } from '$lib/services/nft.services';
@@ -73,3 +75,5 @@
 		untrack(() => debounceLoad());
 	});
 </script>
+
+<IntervalLoader interval={NFT_TIMER_INTERVAL_MILLIS} {onLoad} skipInitialLoad={true} />


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/9827, I made the `LoaderNfts` more reactive. And I removed the interval, expecting all cases to be covered by the reactivity.

However, if a collection is already enabled and we receive a new NFT for such collection, the list is not updated. So, to avoid this issue, we create an interval service to fetch them every time.
