### PR TITLE
feat(frontend): Do not show WalletConnect toast message on login

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -456,7 +456,7 @@
 	};
 </script>
 
-<svelte:window onoisyDisconnectWalletConnect={disconnect} />
+<svelte:window onoisyDisconnectWalletConnect={disconnectListener} />
 
 {#if nonNullish(listener)}
 	<WalletConnectButton onclick={disconnect}>


### PR DESCRIPTION
# Motivation

When we disconnect WalletConnect through event, we don't really need to show the toast message: any emitter will not care about feedback.
