### PR TITLE
refactor(frontend): Move type `CoingeckoErc20PriceParams` to exchange module

### DIFF
--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -8,7 +8,7 @@ import type {
 	CoingeckoSimplePriceResponse,
 	CoingeckoSimpleTokenPriceResponse
 } from '$lib/types/coingecko';
-import type { CoingeckoErc20PriceParams } from '$lib/types/exchange';
+import type { CoingeckoErc20PriceParams } from '$lib/types/coingecko-erc20';
 import type { PostMessageDataResponseExchange } from '$lib/types/post-message';
 import {
 	findMissingLedgerCanisterIds,

--- a/src/frontend/src/lib/types/coingecko-erc20.ts
+++ b/src/frontend/src/lib/types/coingecko-erc20.ts
@@ -1,0 +1,7 @@
+import type { Erc20ContractAddress } from '$eth/types/erc20';
+import type { CoingeckoPlatformId } from '$lib/types/coingecko';
+
+export interface CoingeckoErc20PriceParams {
+	coingeckoPlatformId: CoingeckoPlatformId;
+	contractAddresses: Erc20ContractAddress[];
+}

--- a/src/frontend/src/lib/types/exchange.ts
+++ b/src/frontend/src/lib/types/exchange.ts
@@ -1,9 +1,4 @@
-import type { Erc20ContractAddress } from '$eth/types/erc20';
-import type {
-	CoingeckoPlatformId,
-	CoingeckoSimplePrice,
-	CoingeckoSimpleTokenPrice
-} from '$lib/types/coingecko';
+import type { CoingeckoSimplePrice, CoingeckoSimpleTokenPrice } from '$lib/types/coingecko';
 import type { TokenId } from '$lib/types/token';
 
 export type Exchange = 'ethereum' | 'erc20' | 'icp';
@@ -12,8 +7,3 @@ export type ExchangesData = Record<
 	TokenId,
 	(CoingeckoSimplePrice | CoingeckoSimpleTokenPrice) | undefined
 >;
-
-export interface CoingeckoErc20PriceParams {
-	coingeckoPlatformId: CoingeckoPlatformId;
-	contractAddresses: Erc20ContractAddress[];
-}

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -15,7 +15,7 @@ import {
 	exchangeRateUsdToCurrency
 } from '$lib/services/exchange.services';
 import type { CoingeckoPlatformId } from '$lib/types/coingecko';
-import type { CoingeckoErc20PriceParams } from '$lib/types/exchange';
+import type { CoingeckoErc20PriceParams } from '$lib/types/coingecko-erc20';
 import type {
 	PostMessage,
 	PostMessageDataRequestExchangeTimer,


### PR DESCRIPTION
# Motivation

To avoid circular reference, we move `CoingeckoErc20PriceParams` to the `exchange` type module.
