### PR TITLE
feat(frontend): Allow AppWorker to be a singleton

### DIFF
--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -5,7 +5,7 @@ import {
 } from '$btc/services/btc-listener.services';
 import type { BtcPostMessageDataResponseWallet } from '$btc/types/btc-post-message';
 import { STAGING } from '$lib/constants/app.constants';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -25,7 +25,7 @@ import { get } from 'svelte/store';
 
 export class BtcWalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		tokenId: TokenId,
 		private readonly data: PostMessageDataRequestBtc,
 		hideToast: boolean

--- a/src/frontend/src/icp/services/worker.btc-statuses.services.ts
+++ b/src/frontend/src/icp/services/worker.btc-statuses.services.ts
@@ -1,6 +1,6 @@
 import { onLoadBtcStatusesError, syncBtcStatuses } from '$icp/services/ckbtc-listener.services';
 import type { IcCkWorkerParams } from '$icp/types/ck-listener';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type {
 	PostMessage,
 	PostMessageDataRequestIcCk,
@@ -12,7 +12,7 @@ import type { TokenId } from '$lib/types/token';
 
 export class BtcStatusesWorker extends AppWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		tokenId: TokenId,
 		private readonly minterCanisterId: IcCkWorkerParams['minterCanisterId']
 	) {

--- a/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
+++ b/src/frontend/src/icp/services/worker.ck-minter-info.services.ts
@@ -11,7 +11,7 @@ import {
 import type { SyncCkMinterInfoError, SyncCkMinterInfoSuccess } from '$icp/types/ck';
 import type { IcCkWorker, IcCkWorkerInitResult, IcCkWorkerParams } from '$icp/types/ck-listener';
 import type { IcCkMetadata } from '$icp/types/ic-token';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type {
 	PostMessage,
 	PostMessageDataRequestIcCk,
@@ -49,7 +49,7 @@ export const initCkETHMinterInfoWorker: IcCkWorker = (params): Promise<IcCkWorke
 
 export class CkMinterInfoWorker extends AppWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		private readonly tokenId: TokenId,
 		private readonly minterCanisterId: IcCkWorkerParams['minterCanisterId'],
 		private readonly postMessageKey: CkMinterInfoWorkerCallbacks['postMessageKey'],

--- a/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
+++ b/src/frontend/src/icp/services/worker.ckbtc-update-balance.services.ts
@@ -5,7 +5,7 @@ import {
 } from '$icp/services/ckbtc-listener.services';
 import { btcAddressStore } from '$icp/stores/btc.store';
 import type { IcCkWorkerParams } from '$icp/types/ck-listener';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type {
 	PostMessage,
 	PostMessageDataRequestIcCkBTCUpdateBalance,
@@ -20,7 +20,7 @@ import { get } from 'svelte/store';
 
 export class CkBTCUpdateBalanceWorker extends AppWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		private readonly tokenId: TokenId,
 		private readonly minterCanisterId: IcCkWorkerParams['minterCanisterId'],
 		private readonly twinToken: IcCkWorkerParams['twinToken']

--- a/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
@@ -4,7 +4,7 @@ import {
 	onTransactionsCleanUp
 } from '$icp/services/ic-transactions.services';
 import type { IcToken } from '$icp/types/ic-token';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type { WalletWorker } from '$lib/types/listener';
 import type {
 	PostMessage,
@@ -17,7 +17,7 @@ import type { TokenId } from '$lib/types/token';
 
 export class Dip20WalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		tokenId: TokenId,
 		private readonly canisterId: IcToken['ledgerCanisterId']
 	) {

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -4,7 +4,7 @@ import {
 	onTransactionsCleanUp
 } from '$icp/services/ic-transactions.services';
 import type { IcToken } from '$icp/types/ic-token';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type { WalletWorker } from '$lib/types/listener';
 import type {
 	PostMessage,
@@ -17,7 +17,7 @@ import type { TokenId } from '$lib/types/token';
 
 export class IcpWalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		tokenId: TokenId,
 		private readonly indexCanisterId: IcToken['indexCanisterId']
 	) {

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -4,7 +4,7 @@ import {
 	onTransactionsCleanUp
 } from '$icp/services/ic-transactions.services';
 import type { IcToken } from '$icp/types/ic-token';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type { WalletWorker } from '$lib/types/listener';
 import type {
 	PostMessage,
@@ -18,7 +18,7 @@ import { nonNullish } from '@dfinity/utils';
 
 export class IcrcWalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		tokenId: TokenId,
 		private readonly ledgerCanisterId: IcToken['ledgerCanisterId'],
 		private readonly indexCanisterId: IcToken['indexCanisterId'],

--- a/src/frontend/src/icp/services/worker.pow-protection.services.ts
+++ b/src/frontend/src/icp/services/worker.pow-protection.services.ts
@@ -2,7 +2,7 @@ import {
 	syncPowNextAllowance,
 	syncPowProgress
 } from '$icp/services/pow-protector-listener.services';
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import type {
 	PostMessage,
 	PostMessageDataRequest,
@@ -13,7 +13,7 @@ import type {
 
 // TODO: add tests for POW worker/scheduler
 export class PowProtectorWorker extends AppWorker {
-	private constructor(worker: Worker) {
+	private constructor(worker: WorkerData) {
 		super(worker);
 
 		this.setOnMessage(

--- a/src/frontend/src/lib/services/_worker.services.ts
+++ b/src/frontend/src/lib/services/_worker.services.ts
@@ -4,12 +4,22 @@ import type {
 	PostMessageDataRequest,
 	PostMessageDataResponseLoose
 } from '$lib/types/post-message';
+import { isNullish } from '@dfinity/utils';
+
+export interface WorkerData {
+	worker: Worker;
+	isSingleton: boolean;
+}
 
 export abstract class AppWorker {
 	readonly #worker: Worker;
 	readonly #queue: WorkerQueue;
 
-	protected constructor(worker: Worker) {
+	private static _singletonWorker?: Worker;
+
+	protected constructor(workerData: WorkerData) {
+		const { worker } = workerData;
+
 		this.#worker = worker;
 		this.#queue = new WorkerQueue(worker);
 	}
@@ -19,8 +29,20 @@ export abstract class AppWorker {
 		return new Workers.default();
 	}
 
-	static async getInstance(): Promise<Worker> {
-		return await this.newInstance();
+	protected static async getInstanceAsSingleton(): Promise<Worker> {
+		if (isNullish(this._singletonWorker)) {
+			this._singletonWorker = await this.newInstance();
+		}
+
+		return this._singletonWorker;
+	}
+
+	static async getInstance(
+		{ asSingleton = false }: { asSingleton?: boolean } = { asSingleton: false }
+	): Promise<WorkerData> {
+		const worker = asSingleton ? await this.getInstanceAsSingleton() : await this.newInstance();
+
+		return { worker, isSingleton: asSingleton };
 	}
 
 	protected setOnMessage = <T extends PostMessageDataRequest | PostMessageDataResponseLoose>(

--- a/src/frontend/src/lib/services/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/worker.auth.services.ts
@@ -1,11 +1,11 @@
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import { idleSignOut } from '$lib/services/auth.services';
 import { authRemainingTimeStore, type AuthStoreData } from '$lib/stores/auth.store';
 import type { PostMessage, PostMessageDataResponseAuth } from '$lib/types/post-message';
 import { isNullish } from '@dfinity/utils';
 
 export class AuthWorker extends AppWorker {
-	private constructor(worker: Worker) {
+	private constructor(worker: WorkerData) {
 		super(worker);
 
 		this.setOnMessage(

--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -1,4 +1,4 @@
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import { syncExchange } from '$lib/services/exchange.services';
 import { toastsError } from '$lib/stores/toasts.store';
 import type {
@@ -12,7 +12,7 @@ import { isNullish } from '@dfinity/utils';
 let errorMessages: { msg: string; timestamp: number }[] = [];
 
 export class ExchangeWorker extends AppWorker {
-	private constructor(worker: Worker) {
+	private constructor(worker: WorkerData) {
 		super(worker);
 
 		this.setOnMessage(

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -1,4 +1,4 @@
-import { AppWorker } from '$lib/services/_worker.services';
+import { AppWorker, type WorkerData } from '$lib/services/_worker.services';
 import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
@@ -21,7 +21,7 @@ import { get } from 'svelte/store';
 
 export class SolWalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
-		worker: Worker,
+		worker: WorkerData,
 		tokenId: TokenId,
 		private readonly data: PostMessageDataRequestSol
 	) {


### PR DESCRIPTION
# Motivation

Some of the workers are using too much memory in some devices (for example iOS). So, we will give the possibility to work them as singleton: one worker to receive all the incoming messages. 