### PR TITLE
fix(frontend): Dont show nfts in token search

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -69,7 +69,12 @@
 		enableMoreTokensList = getFilteredTokenList({
 			filter,
 			list: sortTokenOrGroupUi(
-				getDisabledOrModifiedTokens({ $allTokens, modifiedTokens, selectedNetwork })
+				getDisabledOrModifiedTokens({
+					$allTokens,
+					modifiedTokens,
+					selectedNetwork,
+					includeNonFungibleTokens: false
+				})
 			)
 		});
 

--- a/src/frontend/src/lib/utils/token-list.utils.ts
+++ b/src/frontend/src/lib/utils/token-list.utils.ts
@@ -4,6 +4,7 @@ import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { TokenUi } from '$lib/types/token-ui';
 import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { showTokenFilteredBySelectedNetwork } from '$lib/utils/network.utils';
+import { isTokenNonFungible } from '$lib/utils/nft.utils';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { SvelteMap } from 'svelte/reactivity';
@@ -41,11 +42,13 @@ export const getFilteredTokenGroup = ({
 export const getDisabledOrModifiedTokens = ({
 	$allTokens,
 	modifiedTokens,
-	selectedNetwork
+	selectedNetwork,
+	includeNonFungibleTokens = true
 }: {
 	$allTokens: TokenToggleable<Token>[];
 	modifiedTokens: SvelteMap<TokenId, Token>;
 	selectedNetwork?: Network;
+	includeNonFungibleTokens?: boolean;
 }): TokenUiOrGroupUi[] =>
 	($allTokens ?? []).reduce<TokenUiOrGroupUi[]>((acc, token) => {
 		const isModified = nonNullish(modifiedTokens.get(token.id));
@@ -55,7 +58,9 @@ export const getDisabledOrModifiedTokens = ({
 				token,
 				$selectedNetwork: selectedNetwork,
 				$pseudoNetworkChainFusion: isNullish(selectedNetwork)
-			})
+			}) &&
+			includeNonFungibleTokens &&
+			!isTokenNonFungible(token)
 		) {
 			acc.push({
 				token: token as TokenUi

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -259,5 +259,45 @@ describe('token-list.utils', () => {
 
 			expect(result).toEqual([]);
 		});
+
+		it('excludes non-fungible tokens when includeNonFungibleTokens is false', () => {
+			const nftToken = {
+				...ICP_TOKEN,
+				id: parseTokenId('nft1'),
+				standard: 'ERC721', // or however your isTokenNonFungible() detects NFTs
+				enabled: false
+			} as unknown as TokenToggleable<Token>;
+
+			vi.mocked(showTokenFilteredBySelectedNetwork).mockReturnValue(true);
+
+			const result = getDisabledOrModifiedTokens({
+				$allTokens: [nftToken],
+				modifiedTokens: emptyTokensMap,
+				selectedNetwork: ICP_NETWORK,
+				includeNonFungibleTokens: false
+			});
+
+			expect(result).toEqual([]); // NFT excluded
+		});
+
+		it('includes non-fungible tokens when includeNonFungibleTokens is true', () => {
+			const nftToken = {
+				...ICP_TOKEN,
+				id: parseTokenId('nft2'),
+				standard: 'ERC721',
+				enabled: false
+			} as unknown as TokenToggleable<Token>;
+
+			vi.mocked(showTokenFilteredBySelectedNetwork).mockReturnValue(true);
+
+			const result = getDisabledOrModifiedTokens({
+				$allTokens: [nftToken],
+				modifiedTokens: emptyTokensMap,
+				selectedNetwork: ICP_NETWORK,
+				includeNonFungibleTokens: true
+			});
+
+			expect(result).toEqual([{ token: nftToken }]); // NFT included
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

In the `enable more tokens` section when filtering/searchin tokens in the token view, we dont want to show NonFungibleTokens.

# Changes

- Extended condition in the filter utils
- Pass new param from tokenlist

# Tests

Extended tests
