### PR TITLE
feat(frontend): adjust GldtStakeProvider component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeForm.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeForm.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import GldtStakeFees from '$icp/components/stake/gldt/GldtStakeFees.svelte';
-	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
+	import GldtStakeProvider from '$icp/components/stake/gldt/GldtStakeProvider.svelte';
 	import type { IcToken } from '$icp/types/ic-token';
 	import StakeForm from '$lib/components/stake/StakeForm.svelte';
-	import StakeProvider from '$lib/components/stake/StakeProvider.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Address } from '$lib/types/address';
 	import type { OptionAmount } from '$lib/types/send';
-	import { StakeProvider as StakeProviderType } from '$lib/types/stake';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
 
@@ -24,8 +22,6 @@
 
 	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const { store: gldtStakeApyStore } = getContext<GldtStakeContext>(GLDT_STAKE_CONTEXT_KEY);
-
 	let totalFee = $derived(($sendToken as IcToken).fee * 2n);
 
 	const onCustomValidate = (userAmount: bigint): TokenActionErrorType =>
@@ -39,7 +35,7 @@
 
 <StakeForm {destination} {onClose} {onCustomValidate} {onNext} {totalFee} bind:amount>
 	{#snippet provider()}
-		<StakeProvider currentApy={$gldtStakeApyStore?.apy} provider={StakeProviderType.GLDT} />
+		<GldtStakeProvider />
 	{/snippet}
 
 	{#snippet fee()}

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeProvider.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeProvider.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
+	import IconLineChart from '$lib/components/icons/lucide/IconLineChart.svelte';
+	import StakeProvider from '$lib/components/stake/StakeProvider.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { StakeProvider as StakeProviderType } from '$lib/types/stake';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	const { sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const { store: gldtStakeApyStore } = getContext<GldtStakeContext>(GLDT_STAKE_CONTEXT_KEY);
+</script>
+
+<StakeProvider provider={StakeProviderType.GLDT}>
+	{#snippet content()}
+		<div class="flex">
+			<IconLineChart />
+
+			<div class="ml-3 w-full text-sm">
+				<div class="mb-1 font-bold">
+					{replacePlaceholders($i18n.stake.text.current_apy, {
+						$apy: `${$gldtStakeApyStore?.apy}`
+					})}
+				</div>
+
+				<div class="text-tertiary">
+					{replacePlaceholders($i18n.stake.text.current_apy_info, { $token: $sendTokenSymbol })}
+				</div>
+			</div>
+		</div>
+	{/snippet}
+</StakeProvider>

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
@@ -2,14 +2,12 @@
 	import { getContext } from 'svelte';
 	import IcReviewNetwork from '$icp/components/send/IcReviewNetwork.svelte';
 	import GldtStakeFees from '$icp/components/stake/gldt/GldtStakeFees.svelte';
-	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
+	import GldtStakeProvider from '$icp/components/stake/gldt/GldtStakeProvider.svelte';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
-	import StakeProvider from '$lib/components/stake/StakeProvider.svelte';
 	import StakeReview from '$lib/components/stake/StakeReview.svelte';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Address } from '$lib/types/address';
 	import type { OptionAmount } from '$lib/types/send';
-	import { StakeProvider as StakeProviderType } from '$lib/types/stake';
 	import { invalidAmount } from '$lib/utils/input.utils';
 
 	interface Props {
@@ -23,8 +21,6 @@
 
 	const { sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const { store: gldtStakeApyStore } = getContext<GldtStakeContext>(GLDT_STAKE_CONTEXT_KEY);
-
 	// Should never happen given that the same checks are performed on previous wizard step
 	let invalid = $derived(
 		isInvalidDestinationIc({
@@ -36,7 +32,7 @@
 
 <StakeReview {amount} {destination} disabled={invalid} {onBack} {onStake}>
 	{#snippet provider()}
-		<StakeProvider currentApy={$gldtStakeApyStore?.apy} provider={StakeProviderType.GLDT} />
+		<GldtStakeProvider />
 	{/snippet}
 
 	{#snippet network()}

--- a/src/frontend/src/lib/components/stake/StakeProvider.svelte
+++ b/src/frontend/src/lib/components/stake/StakeProvider.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
-	import IconLineChart from '$lib/components/icons/lucide/IconLineChart.svelte';
+	import type { Snippet } from 'svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { stakeProvidersConfig } from '$lib/config/stake.config';
@@ -9,18 +8,15 @@
 		STAKE_PROVIDER_LOGO
 	} from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { StakeProvider } from '$lib/types/stake';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
 		provider: StakeProvider;
-		currentApy?: number;
+		content: Snippet;
 	}
 
-	let { provider, currentApy = 0 }: Props = $props();
-
-	const { sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	let { provider, content }: Props = $props();
 </script>
 
 <div class="my-4 rounded-lg border border-disabled bg-secondary px-2 py-3">
@@ -51,17 +47,7 @@
 		</ExternalLink>
 	</div>
 
-	<div class="mt-3 flex px-4">
-		<div class="mt-0.5"><IconLineChart /></div>
-
-		<div class="ml-3 w-full text-sm">
-			<div class="mb-1 font-bold">
-				{replacePlaceholders($i18n.stake.text.current_apy, { $apy: `${currentApy}` })}
-			</div>
-
-			<div class="text-tertiary">
-				{replacePlaceholders($i18n.stake.text.current_apy_info, { $token: $sendTokenSymbol })}
-			</div>
-		</div>
+	<div class="mt-4 flex flex-col px-4">
+		{@render content()}
 	</div>
 </div>

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeProvider.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeProvider.spec.ts
@@ -1,0 +1,50 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import GldtStakeProvider from '$icp/components/stake/gldt/GldtStakeProvider.svelte';
+import {
+	GLDT_STAKE_CONTEXT_KEY,
+	initGldtStakeStore,
+	type GldtStakeContext
+} from '$icp/stores/gldt-stake.store';
+import { stakeProvidersConfig } from '$lib/config/stake.config';
+import {
+	STAKE_PROVIDER_EXTERNAL_URL,
+	STAKE_PROVIDER_LOGO
+} from '$lib/constants/test-ids.constants';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { StakeProvider as StakeProviderType } from '$lib/types/stake';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('GldtStakeProvider', () => {
+	const apy = 10;
+	const mockContext = () => {
+		const store = initGldtStakeStore();
+		store.setApy(apy);
+
+		return new Map<symbol, SendContext | GldtStakeContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_CONTEXT_KEY, { store }]
+		]);
+	};
+
+	it('renders provided provider data correctly', () => {
+		const { container, getByTestId } = render(GldtStakeProvider, {
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(stakeProvidersConfig[StakeProviderType.GLDT].name);
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.current_apy, {
+				$apy: `${apy}`
+			})
+		);
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.current_apy_info, {
+				$token: `${ICP_TOKEN.symbol}`
+			})
+		);
+		expect(getByTestId(STAKE_PROVIDER_LOGO)).toBeInTheDocument();
+		expect(getByTestId(STAKE_PROVIDER_EXTERNAL_URL)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/stake/StakeProvider.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeProvider.spec.ts
@@ -7,13 +7,15 @@ import {
 } from '$lib/constants/test-ids.constants';
 import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import { StakeProvider as StakeProviderType } from '$lib/types/stake';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render } from '@testing-library/svelte';
 
 describe('StakeProvider', () => {
 	const mockContext = () =>
 		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
 	const props = {
-		provider: StakeProviderType.GLDT
+		provider: StakeProviderType.GLDT,
+		content: mockSnippet
 	};
 
 	it('renders provided provider data correctly', () => {


### PR DESCRIPTION
# Motivation

To re-use the StakeProvider component in the unstaking flow, we need to extract some data into a separate component.
