### PR TITLE
feat(frontend): adjust StakeReview component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
@@ -5,6 +5,7 @@
 	import GldtStakeProvider from '$icp/components/stake/gldt/GldtStakeProvider.svelte';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
 	import StakeReview from '$lib/components/stake/StakeReview.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { Address } from '$lib/types/address';
 	import type { OptionAmount } from '$lib/types/send';
@@ -31,6 +32,10 @@
 </script>
 
 <StakeReview {amount} {destination} disabled={invalid} {onBack} {onStake}>
+	{#snippet subtitle()}
+		{$i18n.stake.text.stake_review_subtitle}
+	{/snippet}
+
 	{#snippet provider()}
 		<GldtStakeProvider />
 	{/snippet}

--- a/src/frontend/src/lib/components/stake/StakeReview.svelte
+++ b/src/frontend/src/lib/components/stake/StakeReview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
 	import SendReviewDestination from '$lib/components/send/SendReviewDestination.svelte';
 	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
@@ -14,11 +15,12 @@
 
 	interface Props {
 		amount?: OptionAmount;
-		destination: Address;
+		destination?: Address;
 		disabled?: boolean;
 		network?: Snippet;
 		fee?: Snippet;
 		provider?: Snippet;
+		subtitle?: Snippet;
 		onBack: () => void;
 		onStake: () => void;
 	}
@@ -30,6 +32,7 @@
 		network,
 		fee,
 		provider,
+		subtitle,
 		onBack,
 		onStake
 	}: Props = $props();
@@ -38,15 +41,18 @@
 </script>
 
 <ContentWithToolbar>
-	<SendTokenReview exchangeRate={$sendTokenExchangeRate} sendAmount={amount} token={$sendToken}>
-		{#snippet subtitle()}
-			{$i18n.stake.text.stake_review_subtitle}
-		{/snippet}
-	</SendTokenReview>
+	<SendTokenReview
+		exchangeRate={$sendTokenExchangeRate}
+		sendAmount={amount}
+		{subtitle}
+		token={$sendToken}
+	/>
 
-	<div class="mb-4">
-		<SendReviewDestination {destination} />
-	</div>
+	{#if nonNullish(destination)}
+		<div class="mb-4">
+			<SendReviewDestination {destination} />
+		</div>
+	{/if}
 
 	{@render network?.()}
 


### PR DESCRIPTION
# Motivation

To re-use StakeReview in the unstaking flow, we need to make it's subtitle settable by parent, as well as to make `destination` optional.
