### PR TITLE
feat(frontend): Hide addresses that do not support NFTs

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddresses.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { page } from '$app/state';
 	import type { OptionBtcAddress } from '$btc/types/address';
 	import {
 		BTC_MAINNET_NETWORK,
@@ -72,7 +73,6 @@
 	import type { ReceiveQRCode } from '$lib/types/receive';
 	import type { Token } from '$lib/types/token';
 	import { isRouteNfts } from '$lib/utils/nav.utils';
-	import { page } from '$app/state';
 
 	interface Props {
 		onQRCode: (details: ReceiveQRCode) => void;
@@ -264,7 +264,8 @@
 <ContentWithToolbar>
 	<div class="flex flex-col gap-2">
 		{#each receiveAddressList as { title: _title, text: _text, condition, labelRef, address, network, testId, copyAriaLabel, qrCodeAction } (labelRef)}
-			{@const showAddress = condition !== false && (!isNftsPage || (isNftsPage && network.supportsNft))}
+			{@const showAddress =
+				condition !== false && (!isNftsPage || (isNftsPage && network.supportsNft))}
 
 			{#if showAddress}
 				{#if nonNullish(_text)}


### PR DESCRIPTION
# Motivation

For the NFT page, it does not make sense to show the addresses in the `Receive` modal of the networks that do not support NFTs

<img width="1509" height="798" alt="Screenshot 2025-10-29 at 13 38 40" src="https://github.com/user-attachments/assets/ccef7635-92c7-4fab-a214-f43c76e1c23f" />


https://github.com/user-attachments/assets/f17d4c77-cd19-4338-b40c-c5f584e42ec6


