### PR TITLE
fix(frontend): Show Buy button in all supported networks

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -59,8 +59,8 @@
 	let tooManyButtons = $derived(
 		sendAction &&
 			swapAction &&
-			(convertErc20 || convertEth || convertCkBtc || convertBtc) &&
-			buyAction
+			isTransactionsPage &&
+			(convertErc20 || convertEth || convertCkBtc || convertBtc)
 	);
 </script>
 


### PR DESCRIPTION
# Motivation

To reduce the amount of buttons in the Hero, we avoid showing more than 4 buttons, sacrificing the `Buy` button in case.

However, the logic to define "too-many-buttons" is not considering that the conversion buttons appear only in the transaction page, causing some network to hide the Buy button, while it should be shown.

And it should not count the Buy button, since it is the "sacrificed" one.

### Before

<img width="1510" height="797" alt="Screenshot 2025-10-29 at 13 50 13" src="https://github.com/user-attachments/assets/f0fc4742-c56a-4174-ba29-a1f640490e31" />
<img width="1509" height="805" alt="Screenshot 2025-10-29 at 13 50 21" src="https://github.com/user-attachments/assets/5cbd6911-7683-4dae-a4fa-041752c22317" />

### After

<img width="1508" height="795" alt="Screenshot 2025-10-29 at 13 52 30" src="https://github.com/user-attachments/assets/819e6054-6eea-4203-bbee-14bb30b9a5b1" />
<img width="1511" height="802" alt="Screenshot 2025-10-29 at 13 52 38" src="https://github.com/user-attachments/assets/b53b5dab-5d71-4db7-8e7b-2b828131f501" />

