### PR TITLE
style(frontend): Fix overflow x landing page

### DIFF
--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -65,7 +65,7 @@
 {:else}
 	<div class:h-dvh={$authNotSignedIn}>
 		<div
-			class="relative flex flex-col pb-5 md:pb-0"
+			class="relative flex flex-col overflow-x-hidden pb-5 md:pb-0"
 			class:h-full={$authSignedIn}
 			class:min-h-[100dvh]={$authNotSignedIn}
 		>


### PR DESCRIPTION
# Motivation

Currently we can scroll sideways on the landing page as the image overflows to the right of the screen on mobile.

# Changes

Prevent overflow-x in the layout. This will also affect the logged in application, but sideways scrolling the main layout shouldnt be allowed there either.

# Tests

Before:
<img width="402" height="683" alt="image" src="https://github.com/user-attachments/assets/b0bbcf38-009d-4477-89da-45180fbe4da3" />
<img width="402" height="683" alt="image" src="https://github.com/user-attachments/assets/b05c9f12-ea25-4b35-b7e7-7ac9fb7259d4" />


After:
<img width="402" height="683" alt="image" src="https://github.com/user-attachments/assets/d75fe48a-f4ca-4a45-b2f3-44afa3825dfc" />

