### PR TITLE
feat(frontend): Disable Receive button for NFTs when not supported

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -33,13 +33,14 @@
 		networkICP,
 		networkSolana,
 		pseudoNetworkChainFusion,
-		networkArbitrum
+		networkArbitrum,
+		selectedNetworkNftUnsupported
 	} from '$lib/derived/network.derived';
 	import { pageToken } from '$lib/derived/page-token.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { type HeroContext, initHeroContext, HERO_CONTEXT_KEY } from '$lib/stores/hero.store';
-	import { isRouteTransactions } from '$lib/utils/nav.utils';
+	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
 	import { mapTokenUi } from '$lib/utils/token.utils';
 	import { isTrumpToken as isTrumpTokenUtil } from '$sol/utils/token.utils';
 
@@ -53,10 +54,11 @@
 			: undefined
 	);
 
-	const { loading, outflowActionsDisabled, ...rest } = initHeroContext();
+	const { loading, outflowActionsDisabled, inflowActionsDisabled, ...rest } = initHeroContext();
 	setContext<HeroContext>(HERO_CONTEXT_KEY, {
 		loading,
 		outflowActionsDisabled,
+		inflowActionsDisabled,
 		...rest
 	});
 
@@ -70,8 +72,14 @@
 
 	let isTransactionsPage = $derived(isRouteTransactions(page));
 
+	let isNftsPage = $derived(isRouteNfts(page));
+
 	$effect(() => {
 		outflowActionsDisabled.set(isTransactionsPage && ($balanceZero || isNullish($balance)));
+	});
+
+	$effect(() => {
+		inflowActionsDisabled.set(isNftsPage && $selectedNetworkNftUnsupported);
 	});
 
 	let isTrumpToken = $derived(nonNullish($pageToken) ? isTrumpTokenUtil($pageToken) : false);

--- a/src/frontend/src/lib/components/receive/ReceiveButton.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveButton.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import { getContext } from 'svelte';
 	import ButtonHero from '$lib/components/hero/ButtonHero.svelte';
 	import IconQr from '$lib/components/icons/IconQr.svelte';
 	import { RECEIVE_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
+	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
@@ -10,11 +12,13 @@
 	}
 
 	let { onClick }: Props = $props();
+
+	const { inflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
 <ButtonHero
 	ariaLabel={$i18n.receive.text.receive}
-	disabled={$isBusy}
+	disabled={$isBusy || $inflowActionsDisabled}
 	onclick={onClick}
 	testId={RECEIVE_TOKENS_MODAL_OPEN_BUTTON}
 >

--- a/src/frontend/src/lib/stores/hero.store.ts
+++ b/src/frontend/src/lib/stores/hero.store.ts
@@ -4,6 +4,7 @@ export interface HeroContext {
 	loading: Writable<boolean>;
 	loaded: Readable<boolean>;
 	outflowActionsDisabled: Writable<boolean>;
+	inflowActionsDisabled: Writable<boolean>;
 }
 
 export const initHeroContext = (): HeroContext => {
@@ -11,11 +12,13 @@ export const initHeroContext = (): HeroContext => {
 	const loaded = derived(loading, ($loading) => !$loading);
 
 	const outflowActionsDisabled = writable<boolean>(true);
+	const inflowActionsDisabled = writable<boolean>(true);
 
 	return {
 		loading,
 		loaded,
-		outflowActionsDisabled
+		outflowActionsDisabled,
+		inflowActionsDisabled
 	};
 };
 

--- a/src/frontend/src/tests/lib/stores/hero.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/hero.store.spec.ts
@@ -69,5 +69,19 @@ describe('hero.store', () => {
 				expect(get(outflowActionsDisabled)).toBeTruthy();
 			});
 		});
+
+		describe('inflowActionsDisabled', () => {
+			const { inflowActionsDisabled } = initHeroContext();
+
+			it('should be a writable store', () => {
+				expect(inflowActionsDisabled).toHaveProperty('set');
+				expect(inflowActionsDisabled).toHaveProperty('update');
+				expect(inflowActionsDisabled).toHaveProperty('subscribe');
+			});
+
+			it('should be initialized to true', () => {
+				expect(get(inflowActionsDisabled)).toBeTruthy();
+			});
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

If a network does not support NFTs, we should not allow the user to open the Receive modal, to avoid confusions.

# Changes

- Add a new store `inflowActionsDisabled` to the Hero Context.
- Set the store depending on NFT page and NFT support by network.
- Call the store in the Receive button.

# Test

### Before

<img width="1512" height="794" alt="Screenshot 2025-10-29 at 15 34 02" src="https://github.com/user-attachments/assets/8dff03a3-496f-41ea-90aa-ec90d60c5a7b" />


### After

<img width="1511" height="795" alt="Screenshot 2025-10-29 at 15 34 40" src="https://github.com/user-attachments/assets/088b0ff7-7605-468c-8ad5-0af5c0623094" />

