### PR TITLE
feat(frontend): adjust send context

### DIFF
--- a/src/frontend/src/lib/components/send/SendTokenContext.svelte
+++ b/src/frontend/src/lib/components/send/SendTokenContext.svelte
@@ -2,14 +2,16 @@
 	import { setContext, type Snippet } from 'svelte';
 	import { DEFAULT_ETHEREUM_TOKEN } from '$lib/constants/tokens.constants';
 	import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { OptionBalance } from '$lib/types/balance';
 	import type { OptionToken } from '$lib/types/token';
 
 	interface Props {
 		token: OptionToken;
 		children: Snippet;
+		customSendBalance?: OptionBalance;
 	}
 
-	let { token, children }: Props = $props();
+	let { token, children, customSendBalance }: Props = $props();
 
 	let selectedToken = $derived(token ?? DEFAULT_ETHEREUM_TOKEN);
 
@@ -17,7 +19,8 @@
 	 * Send modal context store
 	 */
 	const { sendToken, ...rest } = initSendContext({
-		token: token ?? DEFAULT_ETHEREUM_TOKEN
+		token: token ?? DEFAULT_ETHEREUM_TOKEN,
+		customSendBalance
 	});
 
 	setContext<SendContext>(SEND_CONTEXT_KEY, {

--- a/src/frontend/src/lib/stores/send.store.ts
+++ b/src/frontend/src/lib/stores/send.store.ts
@@ -25,7 +25,13 @@ const initSendStore = (token: Token): SendStore => {
 	};
 };
 
-export const initSendContext = ({ token }: { token: Token }): SendContext => {
+export const initSendContext = ({
+	token,
+	customSendBalance
+}: {
+	token: Token;
+	customSendBalance?: OptionBalance;
+}): SendContext => {
 	const sendToken = initSendStore(token);
 
 	const sendTokenDecimals = derived(sendToken, ({ decimals }) => decimals);
@@ -36,7 +42,7 @@ export const initSendContext = ({ token }: { token: Token }): SendContext => {
 
 	const sendBalance = derived(
 		[balancesStore, sendTokenId],
-		([$balanceStore, $sendTokenId]) => $balanceStore?.[$sendTokenId]?.data
+		([$balanceStore, $sendTokenId]) => customSendBalance ?? $balanceStore?.[$sendTokenId]?.data
 	);
 
 	const sendTokenExchangeRate = derived([exchanges, sendToken], ([$exchanges, $sendToken]) =>


### PR DESCRIPTION
# Motivation

In the unstaking flow, instead of user's GLDT token balance, we need to use the total staked amount. In order to keep using the Send context, we need to create a possibility to set a custom `sendBalance` when initialising the stores. 
