### PR TITLE
feat(frontend): Add section to collection

### DIFF
--- a/src/frontend/src/lib/schema/nft.schema.ts
+++ b/src/frontend/src/lib/schema/nft.schema.ts
@@ -1,3 +1,4 @@
+import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { NetworkAppMetadataSchema, NetworkSchema } from '$lib/schema/network.schema';
 import { TokenSchema } from '$lib/schema/token.schema';
 import * as z from 'zod';
@@ -39,7 +40,8 @@ export const NftCollectionSchema = z.object({
 	description: z.string().optional(),
 	network: NftNetworkSchema,
 	newestAcquiredAt: z.date().optional(),
-	allowExternalContentSource: z.boolean().optional()
+	allowExternalContentSource: z.boolean().optional(),
+	section: z.enum(CustomTokenSection).optional()
 });
 
 export const NftSchema = z.object({

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -139,6 +139,7 @@ export const mapTokenToCollection = (token: NonFungibleToken): NftCollection =>
 		id: token.id,
 		network: token.network,
 		standard: token.standard,
+		section: token.section,
 		...(notEmptyString(token.symbol) && { symbol: token.symbol }),
 		...(notEmptyString(token.name) && { name: token.name }),
 		...(notEmptyString(token.description) && { description: token.description }),

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -5,6 +5,7 @@ import {
 import { ETHEREUM_NETWORK, ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { NFT_MAX_FILESIZE_LIMIT } from '$lib/constants/app.constants';
+import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { NftMediaStatusEnum, NftNetworkSchema } from '$lib/schema/nft.schema';
 import { NftError } from '$lib/types/errors';
 import type { Nft, NftId } from '$lib/types/nft';
@@ -483,6 +484,41 @@ describe('nfts.utils', () => {
 				id: AZUKI_ELEMENTAL_BEANS_TOKEN.id,
 				network: NftNetworkSchema.parse(AZUKI_ELEMENTAL_BEANS_TOKEN.network),
 				standard: AZUKI_ELEMENTAL_BEANS_TOKEN.standard
+			});
+		});
+
+		it('should map token section correctly', () => {
+			const result = mapTokenToCollection({
+				...AZUKI_ELEMENTAL_BEANS_TOKEN,
+				section: CustomTokenSection.HIDDEN
+			});
+
+			expect(result).toEqual({
+				address: AZUKI_ELEMENTAL_BEANS_TOKEN.address,
+				description: AZUKI_ELEMENTAL_BEANS_TOKEN.description,
+				id: AZUKI_ELEMENTAL_BEANS_TOKEN.id,
+				name: AZUKI_ELEMENTAL_BEANS_TOKEN.name,
+				network: NftNetworkSchema.parse(AZUKI_ELEMENTAL_BEANS_TOKEN.network),
+				standard: AZUKI_ELEMENTAL_BEANS_TOKEN.standard,
+				section: CustomTokenSection.HIDDEN,
+				symbol: AZUKI_ELEMENTAL_BEANS_TOKEN.symbol
+			});
+		});
+
+		it('should have undefined section if not set', () => {
+			const result = mapTokenToCollection({
+				...AZUKI_ELEMENTAL_BEANS_TOKEN
+			});
+
+			expect(result).toEqual({
+				address: AZUKI_ELEMENTAL_BEANS_TOKEN.address,
+				description: AZUKI_ELEMENTAL_BEANS_TOKEN.description,
+				id: AZUKI_ELEMENTAL_BEANS_TOKEN.id,
+				name: AZUKI_ELEMENTAL_BEANS_TOKEN.name,
+				network: NftNetworkSchema.parse(AZUKI_ELEMENTAL_BEANS_TOKEN.network),
+				standard: AZUKI_ELEMENTAL_BEANS_TOKEN.standard,
+				section: undefined,
+				symbol: AZUKI_ELEMENTAL_BEANS_TOKEN.symbol
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

To easier filter out hidden and spam Nft collections we add it to the collection object.

Since we refresh the data after changing the section (#9734) this mapping is called after any change to the section. This means we are safe to read from the collection as it should always reflect the newest state.

# Changes

- Added section to collection schema
- Added section to collection mapping

# Tests

Added tests