### PR TITLE
refactor(frontend): Use more tailwind classes in `Banner` component

### DIFF
--- a/src/frontend/src/lib/components/core/Banner.svelte
+++ b/src/frontend/src/lib/components/core/Banner.svelte
@@ -10,7 +10,9 @@
 </script>
 
 {#if STAGING && envBannerVisible}
-	<div class="test-banner flex justify-between gap-4">
+	<div
+		class="test-banner fixed top-0 left-1/2 flex max-w-screen-md -translate-x-1/2 justify-between gap-4 border-4 border-solid border-black bg-error-primary"
+	>
 		<span class="flex items-center justify-center gap-4">
 			<IconWarning size="48px" />
 			<h3 class="clamp-4">{$i18n.core.info.test_banner}</h3>
@@ -32,24 +34,14 @@
 
 <style lang="scss">
 	div.test-banner {
-		position: fixed;
-		top: 0;
-		left: 50%;
-		transform: translate(-50%, 0);
-
 		z-index: calc(var(--overlay-z-index) + 10);
-
-		background: var(--color-background-error-primary);
 
 		padding: var(--padding-2x) var(--padding-3x);
 		margin: var(--padding-3x) 0;
 
 		border-radius: var(--border-radius);
 
-		border: 4px solid black;
-
 		width: calc(100% - var(--padding-4x));
-		max-width: 768px;
 
 		box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.1215686275);
 	}


### PR DESCRIPTION
# Motivation

In an effort to use more and more tailwind classes, we move some CSS styles to Tailwind in component `Banner`.

No changes:

### Before

<img width="1507" height="800" alt="Screenshot 2025-10-29 at 21 31 48" src="https://github.com/user-attachments/assets/cb241a4d-c251-408b-a147-31fe7f8ba812" />


### After

<img width="1507" height="795" alt="Screenshot 2025-10-29 at 21 31 42" src="https://github.com/user-attachments/assets/0b735679-15d2-4379-a23f-1add1157ce5d" />

