### PR TITLE
chore(frontend): Remove unused tailwind class in main layout

### DIFF
--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -77,7 +77,7 @@
 						<NavigationMenu>
 							{#if tokensRoute || nftsRoute}
 								<Responsive up="xl">
-									<div class="hidden xl:block" transition:fade>
+									<div transition:fade>
 										<DappsCarousel />
 									</div>
 								</Responsive>


### PR DESCRIPTION
# Motivation

It is not necessary to specify `hidden xl:block` for the `DappsCarousel` in the main layout: it is anyway a child of component `<Responsive up="xl">`