### PR TITLE
fix(frontend): Disable hero swap button if on Nft page

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapButton.svelte
+++ b/src/frontend/src/lib/components/swap/SwapButton.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { getContext } from 'svelte';
 	import ButtonHero from '$lib/components/hero/ButtonHero.svelte';
 	import IconCkConvert from '$lib/components/icons/IconCkConvert.svelte';
 	import { SWAP_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
-	import { i18n } from '$lib/stores/i18n.store';
-	import { getContext } from 'svelte';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';
+	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
 		onclick: () => void;


### PR DESCRIPTION
# Motivation

Showing the swap buttons in the hero doesnt make sense if the user is on the Nft page, so we disable them.

# Changes

Added inflow and outflow conditions from hero context to the SwapButton

# Tests

Any other page:
<img width="621" height="367" alt="image" src="https://github.com/user-attachments/assets/3a1aca62-88c0-467a-8ace-117177b15b66" />

Nfts page:
<img width="621" height="367" alt="image" src="https://github.com/user-attachments/assets/aeb7fab0-c9d5-45f9-8796-9e5918ca7e26" />

