### PR TITLE
refactor(frontend): Finish migrating component `Assets` to Svelte 5

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { NFTS_ENABLED } from '$env/nft.env';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
 	import Nft from '$lib/components/nfts/Nft.svelte';
@@ -64,12 +64,12 @@
 											{
 												label: $i18n.tokens.text.title,
 												id: TokenTypes.TOKENS,
-												path: `${AppPath.Tokens}${$page.url.search}`
+												path: `${AppPath.Tokens}${page.url.search}`
 											},
 											{
 												label: $i18n.nfts.text.title,
 												id: TokenTypes.NFTS,
-												path: `${AppPath.Nfts}${$page.url.search}`
+												path: `${AppPath.Nfts}${page.url.search}`
 											}
 										]}
 										trackEventName={PLAUSIBLE_EVENTS.VIEW_OPEN}


### PR DESCRIPTION
# Motivation

Finishing migrating component `Assets` to Svelte 5: we need to use page from `$app/state`.
