### PR TITLE
fix(frontend): Adjust filter when selecting disabled tokens in `Assets`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -72,8 +72,7 @@
 				getDisabledOrModifiedTokens({
 					$allTokens,
 					modifiedTokens,
-					selectedNetwork,
-					includeNonFungibleTokens: false
+					selectedNetwork
 				})
 			)
 		});

--- a/src/frontend/src/lib/utils/token-list.utils.ts
+++ b/src/frontend/src/lib/utils/token-list.utils.ts
@@ -42,13 +42,11 @@ export const getFilteredTokenGroup = ({
 export const getDisabledOrModifiedTokens = ({
 	$allTokens,
 	modifiedTokens,
-	selectedNetwork,
-	includeNonFungibleTokens = true
+	selectedNetwork
 }: {
 	$allTokens: TokenToggleable<Token>[];
 	modifiedTokens: SvelteMap<TokenId, Token>;
 	selectedNetwork?: Network;
-	includeNonFungibleTokens?: boolean;
 }): TokenUiOrGroupUi[] =>
 	($allTokens ?? []).reduce<TokenUiOrGroupUi[]>((acc, token) => {
 		const isModified = nonNullish(modifiedTokens.get(token.id));
@@ -59,7 +57,6 @@ export const getDisabledOrModifiedTokens = ({
 				$selectedNetwork: selectedNetwork,
 				$pseudoNetworkChainFusion: isNullish(selectedNetwork)
 			}) &&
-			includeNonFungibleTokens &&
 			!isTokenNonFungible(token)
 		) {
 			acc.push({

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -264,40 +264,19 @@ describe('token-list.utils', () => {
 			const nftToken = {
 				...ICP_TOKEN,
 				id: parseTokenId('nft1'),
-				standard: 'ERC721', // or however your isTokenNonFungible() detects NFTs
+				standard: 'erc721',
 				enabled: false
-			} as unknown as TokenToggleable<Token>;
+			} as TokenToggleable<Token>;
 
 			vi.mocked(showTokenFilteredBySelectedNetwork).mockReturnValue(true);
 
 			const result = getDisabledOrModifiedTokens({
 				$allTokens: [nftToken],
 				modifiedTokens: emptyTokensMap,
-				selectedNetwork: ICP_NETWORK,
-				includeNonFungibleTokens: false
+				selectedNetwork: ICP_NETWORK
 			});
 
 			expect(result).toEqual([]); // NFT excluded
-		});
-
-		it('includes non-fungible tokens when includeNonFungibleTokens is true', () => {
-			const nftToken = {
-				...ICP_TOKEN,
-				id: parseTokenId('nft2'),
-				standard: 'ERC721',
-				enabled: false
-			} as unknown as TokenToggleable<Token>;
-
-			vi.mocked(showTokenFilteredBySelectedNetwork).mockReturnValue(true);
-
-			const result = getDisabledOrModifiedTokens({
-				$allTokens: [nftToken],
-				modifiedTokens: emptyTokensMap,
-				selectedNetwork: ICP_NETWORK,
-				includeNonFungibleTokens: true
-			});
-
-			expect(result).toEqual([{ token: nftToken }]); // NFT included
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We want to show the tokens in filtering in `Assets` page. However, we want to hide the NFTs.


<img width="760" height="1549" alt="Screenshot 2025-10-30 at 12 49 51" src="https://github.com/user-attachments/assets/cd83ab01-13c5-44d6-85c3-c3219199c094" />

