### PR TITLE
fix(frontend): Sticky headers

### DIFF
--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -16,7 +16,6 @@
 	import MobileNavigationMenu from '$lib/components/navigation/MobileNavigationMenu.svelte';
 	import NavigationMenu from '$lib/components/navigation/NavigationMenu.svelte';
 	import NavigationMenuMainItems from '$lib/components/navigation/NavigationMenuMainItems.svelte';
-	import NftPagesContext from '$lib/components/nfts/NftPagesContext.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import SplitPane from '$lib/components/ui/SplitPane.svelte';
 	import { aiAssistantConsoleOpen } from '$lib/derived/ai-assistant.derived';


### PR DESCRIPTION
# Motivation

The sticky headers got broken by #10049. Since we only use sticky headers in the signed in part of the app and the overflow happens on the landing page we can conditionally set the overflow-x-hidden.

# Changes

Adjusted class depending on signedIn state

# Tests


https://github.com/user-attachments/assets/0d5fbf2a-97bb-49fc-9cd5-302c99c3eb78


