### PR TITLE
feat(frontend): implement GldtUnstakeImmediateDissolveTerms component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtUnstakeImmediateDissolveTerms.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtUnstakeImmediateDissolveTerms.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import IconClock from '$lib/components/icons/lucide/IconClock.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		isReview?: boolean;
+	}
+
+	let { isReview = false }: Props = $props();
+
+	const { sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
+</script>
+
+<span class="flex w-full text-xs">
+	<IconClock />
+
+	<span class="ml-2 flex w-full flex-col" class:text-xs={!isReview}>
+		{#if isReview}
+			<span class="mb-1 font-bold">
+				{$i18n.stake.text.immediate_dissolve}
+			</span>
+		{/if}
+
+		<span class="text-tertiary">
+			{replacePlaceholders($i18n.stake.text.immediate_dissolve_terms, {
+				$token: $sendTokenSymbol
+			})}
+		</span>
+	</span>
+</span>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "Based on the latest rewards. The effective APY depends on the amount of $token staked in total each day.",
 			"stake_review_subtitle": "You stake",
 			"delayed_dissolve": "Receive with a delay",
+			"immediate_dissolve": "Receive immediately",
 			"delayed_dissolve_terms": "When unlocking $token from staking, the tokens are locked for $delay days without receiving further rewards, before they can be withdrawn.",
-			"delayed_dissolve_info": "When you start unlocking your $token stake, you will no longer receive new rewards."
+			"delayed_dissolve_info": "When you start unlocking your $token stake, you will no longer receive new rewards.",
+			"immediate_dissolve_terms": "You will receive your $token immediately but are charged a fee on the $token tokens you are unlocking."
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "Информация о текущем APY",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1754,8 +1754,10 @@
 			"current_apy_info": "",
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
+			"immediate_dissolve": "",
 			"delayed_dissolve_terms": "",
-			"delayed_dissolve_info": ""
+			"delayed_dissolve_info": "",
+			"immediate_dissolve_terms": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1410,8 +1410,10 @@ interface I18nStake {
 		current_apy_info: string;
 		stake_review_subtitle: string;
 		delayed_dissolve: string;
+		immediate_dissolve: string;
 		delayed_dissolve_terms: string;
 		delayed_dissolve_info: string;
+		immediate_dissolve_terms: string;
 	};
 }
 

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeImmediateDissolveTerms.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeImmediateDissolveTerms.spec.ts
@@ -1,0 +1,37 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import GldtUnstakeImmediateDissolveTerms from '$icp/components/stake/gldt/GldtUnstakeImmediateDissolveTerms.svelte';
+import {
+	GLDT_STAKE_CONTEXT_KEY,
+	initGldtStakeStore,
+	type GldtStakeContext
+} from '$icp/stores/gldt-stake.store';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('GldtUnstakeImmediateDissolveTerms', () => {
+	const mockContext = () => {
+		const store = initGldtStakeStore();
+		store.setPosition(stakePositionMockResponse);
+
+		return new Map<symbol, SendContext | GldtStakeContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_CONTEXT_KEY, { store }]
+		]);
+	};
+
+	it('should display correct values', () => {
+		const { container } = render(GldtUnstakeImmediateDissolveTerms, {
+			props: { isReview: true },
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.stake.text.immediate_dissolve);
+
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.immediate_dissolve_terms, { $token: ICP_TOKEN.symbol })
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

Same as with the "delayed" dissolve, we need a re-usable component for the "immediate" action.