### PR TITLE
feat(frontend): Extract util to check if a token is enabled

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -231,3 +231,10 @@ export const getTokenDisplaySymbol = (token: Token | CardData): string =>
 
 export const isTokenToggleable = <T extends Token>(token: T): token is TokenToggleable<T> =>
 	'enabled' in token;
+
+/**
+ * Checks if a token is specifically defined as enabled/disabled, otherwise it defaults to true.
+ * This is useful for native tokens that will never have the `enabled` prop.
+ */
+export const filterEnabledToken = <T extends Token>(token: T): boolean =>
+	isTokenToggleable(token) ? token.enabled : true;

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -33,7 +33,7 @@ import type { TokenUi } from '$lib/types/token-ui';
 import type { UserNetworks } from '$lib/types/user-networks';
 import { areAddressesPartiallyEqual } from '$lib/utils/address.utils';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
-import { calculateTokenUsdBalance, isTokenToggleable, mapTokenUi } from '$lib/utils/token.utils';
+import { calculateTokenUsdBalance, filterEnabledToken, mapTokenUi } from '$lib/utils/token.utils';
 import { isUserNetworkEnabled } from '$lib/utils/user-networks.utils';
 import { saveSplCustomTokens } from '$sol/services/manage-tokens.services';
 import type { SplTokenToggleable } from '$sol/types/spl-token-toggleable';
@@ -199,7 +199,7 @@ export const sumMainnetTokensUsdBalancesPerNetwork = ({
  * @returns The list of "enabled" tokens.
  */
 export const filterEnabledTokens = <T extends Token>([$tokens]: [$tokens: T[]]): T[] =>
-	$tokens.filter((token) => (isTokenToggleable(token) ? token.enabled : true));
+	$tokens.filter(filterEnabledToken);
 
 /** Pins enabled tokens at the top of the list, preserving the order of the parts.
  *

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -16,6 +16,7 @@ import { usdValue } from '$lib/utils/exchange.utils';
 import {
 	calculateTokenUsdAmount,
 	calculateTokenUsdBalance,
+	filterEnabledToken,
 	findTwinToken,
 	getMaxTransactionAmount,
 	getTokenDisplaySymbol,
@@ -541,6 +542,34 @@ describe('token.utils', () => {
 			expect(isTokenToggleable({ ...ICP_TOKEN, enabled: 'random-string' })).toBeTruthy();
 
 			expect(isTokenToggleable({ ...ICP_TOKEN, enabled: {} })).toBeTruthy();
+		});
+	});
+
+	describe('filterEnabledToken', () => {
+		it('should return true if token has property `enabled` as true', () => {
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: true })).toBeTruthy();
+		});
+
+		it('should return false if token has property `enabled` as false', () => {
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: false })).toBeFalsy();
+		});
+
+		it('should return true if token has no property `enabled`', () => {
+			expect(filterEnabledToken(ICP_TOKEN)).toBeTruthy();
+		});
+
+		it('should return false if token has nullish `enabled`', () => {
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: undefined })).toBeFalsy();
+
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: null })).toBeFalsy();
+		});
+
+		it('should return true if token has property `enabled` but not boolean', () => {
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: 123 })).toBeTruthy();
+
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: 'random-string' })).toBeTruthy();
+
+			expect(filterEnabledToken({ ...ICP_TOKEN, enabled: {} })).toBeTruthy();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

It is useful to have a specific util to check if a token is enabled or not.

# Note

This util reuses the existing logic: if a token has not specified the `enabled` property, it will defaults to `true`. This is useful for native tokens.
