### PR TITLE
feat(frontend): implement GldtUnstakeDissolveValue component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtUnstakeDissolveValue.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtUnstakeDissolveValue.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { formatCurrency } from '$lib/utils/format.utils';
+
+	interface Props {
+		amount: number;
+		label: string;
+		isTitle?: boolean;
+		styleClass?: string;
+	}
+
+	let { amount, label, isTitle = false, styleClass }: Props = $props();
+
+	const { sendTokenExchangeRate, sendTokenSymbol } = getContext<SendContext>(SEND_CONTEXT_KEY);
+</script>
+
+<span class={`flex w-full items-center justify-between ${styleClass ?? ''}`}>
+	<span
+		class:font-bold={isTitle}
+		class:text-sm={isTitle}
+		class:text-tertiary={!isTitle}
+		class:text-xs={!isTitle}
+	>
+		{label}
+	</span>
+
+	<span class="flex items-center gap-2">
+		<span
+			class="text-sm"
+			class:font-bold={isTitle}
+			class:text-sm={isTitle}
+			class:text-xs={!isTitle}
+		>
+			{amount}
+			{$sendTokenSymbol}
+		</span>
+
+		<span class="text-xs text-tertiary">
+			{formatCurrency({
+				value: amount * ($sendTokenExchangeRate ?? 0),
+				currency: $currentCurrency,
+				exchangeRate: $currencyExchangeStore,
+				language: $currentLanguage
+			})}
+		</span>
+	</span>
+</span>

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeDissolveValue.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeDissolveValue.spec.ts
@@ -1,0 +1,20 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import GldtUnstakeDissolveValue from '$icp/components/stake/gldt/GldtUnstakeDissolveValue.svelte';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { render } from '@testing-library/svelte';
+
+describe('GldtUnstakeDissolveValue', () => {
+	const mockContext = () =>
+		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+
+	it('should switch between selected radio buttons correctly', () => {
+		const amount = 1;
+
+		const { getByText } = render(GldtUnstakeDissolveValue, {
+			props: { label: 'label', amount },
+			context: mockContext()
+		});
+
+		expect(getByText(`${amount} ${ICP_TOKEN.symbol}`)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to create a small UI component for displaying all values related to the GLDT unstake dissolve action.

<img width="459" height="63" alt="Screenshot 2025-10-30 at 14 44 11" src="https://github.com/user-attachments/assets/540ab6cc-9f33-4af1-9b65-3d81b90697da" />
