### PR TITLE
fix(frontend): Disable body scroll if modals open

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -166,7 +166,7 @@
 
 	$effect(() => {
 		if (isIos()) {
-			if ($modalStore?.type) {
+			if (nonNullish($modalStore?.type)) {
 				lockBodyScroll();
 			} else {
 				unlockBodyScroll();


### PR DESCRIPTION
# Motivation

We change the fix for an issue on iOS browsers regarding scroll bleed in modals. The scrolls lead to scrolling the main page instead of the modal on iOS browsers.

# Changes

- Removed fix by limiting touch events
- Added new fix that is fixing the main page (position: fixed) and after that restoring the scroll. This is the recommended and safe (and much more reliable) way of how to solve the scroll bleed in modals.

# Tests


https://github.com/user-attachments/assets/46b8ccca-b1cf-413e-a91b-afcab88a82ad


