### PR TITLE
fix(frontend): check if wc method is v4 to sign it in modal

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
@@ -4,6 +4,10 @@
 	import type { WalletKitTypes } from '@reown/walletkit';
 	import WalletConnectSignReview from '$eth/components/wallet-connect/WalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$eth/constants/steps.constants';
+	import {
+		SESSION_REQUEST_ETH_SIGN_LEGACY,
+		SESSION_REQUEST_ETH_SIGN_V4
+	} from '$eth/constants/wallet-connect.constants';
 	import { signMessage } from '$eth/services/wallet-connect.services';
 	import { getSignParamsMessageTypedDataV4 } from '$eth/utils/wallet-connect.utils';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
@@ -14,10 +18,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionWalletConnectListener } from '$lib/types/wallet-connect';
-	import {
-		SESSION_REQUEST_ETH_SIGN_LEGACY,
-		SESSION_REQUEST_ETH_SIGN_V4
-	} from '$eth/constants/wallet-connect.constants';
 
 	interface Props {
 		listener: OptionWalletConnectListener;


### PR DESCRIPTION
# Motivation

We encountered an issue while signing a message from magiceden via WC.

# Changes

Added a condition to check if the WC method is supported with getSignParamsMessageTypedDataV4 before parsing the request parameters.
 
 # Tests
 
<img width="909" height="967" alt="image" src="https://github.com/user-attachments/assets/6f963981-eb20-432d-af3f-f341edcaa290" />

