### PR TITLE
feat(frontend): implement GldtUnstakeDissolveTypeSelector component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtUnstakeDissolveTypeSelector.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtUnstakeDissolveTypeSelector.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import GldtUnstakeDelayedDissolveTerms from '$icp/components/stake/gldt/GldtUnstakeDelayedDissolveTerms.svelte';
+	import GldtUnstakeDissolveValue from '$icp/components/stake/gldt/GldtUnstakeDissolveValue.svelte';
+	import GldtUnstakeImmediateDissolveTerms from '$icp/components/stake/gldt/GldtUnstakeImmediateDissolveTerms.svelte';
+	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
+	import type { IcToken } from '$icp/types/ic-token';
+	import Hr from '$lib/components/ui/Hr.svelte';
+	import RadioBox from '$lib/components/ui/RadioBox.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { OptionAmount } from '$lib/types/send';
+	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
+
+	interface Props {
+		dissolveInstantly: boolean;
+		amountToReceive?: number;
+		amount: OptionAmount;
+	}
+
+	let { dissolveInstantly = $bindable(), amountToReceive = $bindable(), amount }: Props = $props();
+
+	const { store: gldtStakeStore } = getContext<GldtStakeContext>(GLDT_STAKE_CONTEXT_KEY);
+
+	const { sendToken, sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let tokenFee = $derived(
+		formatTokenBigintToNumber({
+			value: ($sendToken as IcToken).fee,
+			displayDecimals: $sendTokenDecimals,
+			unitName: $sendTokenDecimals
+		})
+	);
+
+	let instantDissolveFee = $derived(
+		formatTokenBigintToNumber({
+			value: $gldtStakeStore?.position?.instant_dissolve_fee ?? ZERO,
+			displayDecimals: $sendTokenDecimals,
+			unitName: $sendTokenDecimals
+		})
+	);
+
+	let delayedDissolveAmount = $derived(
+		nonNullish(amount) ? Math.max(Number(amount) - tokenFee, 0) : 0
+	);
+
+	let immediateDissolveAmount = $derived(
+		nonNullish(amount) ? Math.max(Number(amount) - instantDissolveFee - tokenFee, 0) : 0
+	);
+
+	$effect(() => {
+		amountToReceive = dissolveInstantly ? immediateDissolveAmount : delayedDissolveAmount;
+	});
+</script>
+
+<div class="w-full">
+	<RadioBox
+		checked={!dissolveInstantly}
+		onChange={() => (dissolveInstantly = false)}
+		styleClass="mb-4"
+	>
+		{#snippet label()}
+			<GldtUnstakeDissolveValue
+				amount={delayedDissolveAmount}
+				isTitle
+				label={$i18n.stake.text.delayed_dissolve}
+			/>
+		{/snippet}
+
+		{#snippet description()}
+			<GldtUnstakeDissolveValue amount={tokenFee} label={$i18n.stake.text.included_token_fee} />
+
+			<Hr spacing="md" />
+
+			<GldtUnstakeDelayedDissolveTerms />
+		{/snippet}
+	</RadioBox>
+
+	<RadioBox checked={dissolveInstantly} onChange={() => (dissolveInstantly = true)}>
+		{#snippet label()}
+			<GldtUnstakeDissolveValue
+				amount={immediateDissolveAmount}
+				isTitle
+				label={$i18n.stake.text.immediate_dissolve}
+			/>
+		{/snippet}
+
+		{#snippet description()}
+			<GldtUnstakeDissolveValue
+				amount={instantDissolveFee}
+				label={$i18n.stake.text.included_dissolve_fee}
+			/>
+
+			<GldtUnstakeDissolveValue
+				amount={tokenFee}
+				label={$i18n.stake.text.included_token_fee}
+				styleClass="mt-2"
+			/>
+
+			<Hr spacing="md" />
+
+			<GldtUnstakeImmediateDissolveTerms />
+		{/snippet}
+	</RadioBox>
+</div>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "You stake",
 			"delayed_dissolve": "Receive with a delay",
 			"immediate_dissolve": "Receive immediately",
+			"included_token_fee": "Included network fee",
+			"included_dissolve_fee": "Included unlock fee",
 			"delayed_dissolve_terms": "When unlocking $token from staking, the tokens are locked for $delay days without receiving further rewards, before they can be withdrawn.",
 			"delayed_dissolve_info": "When you start unlocking your $token stake, you will no longer receive new rewards.",
 			"immediate_dissolve_terms": "You will receive your $token immediately but are charged a fee on the $token tokens you are unlocking."

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1755,6 +1755,8 @@
 			"stake_review_subtitle": "",
 			"delayed_dissolve": "",
 			"immediate_dissolve": "",
+			"included_token_fee": "",
+			"included_dissolve_fee": "",
 			"delayed_dissolve_terms": "",
 			"delayed_dissolve_info": "",
 			"immediate_dissolve_terms": ""

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1411,6 +1411,8 @@ interface I18nStake {
 		stake_review_subtitle: string;
 		delayed_dissolve: string;
 		immediate_dissolve: string;
+		included_token_fee: string;
+		included_dissolve_fee: string;
 		delayed_dissolve_terms: string;
 		delayed_dissolve_info: string;
 		immediate_dissolve_terms: string;

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeDissolveTypeSelector.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeDissolveTypeSelector.spec.ts
@@ -1,0 +1,35 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import GldtUnstakeDissolveTypeSelector from '$icp/components/stake/gldt/GldtUnstakeDissolveTypeSelector.svelte';
+import {
+	GLDT_STAKE_CONTEXT_KEY,
+	initGldtStakeStore,
+	type GldtStakeContext
+} from '$icp/stores/gldt-stake.store';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('GldtUnstakeDissolveTypeSelector', () => {
+	const mockContext = () =>
+		new Map<symbol, SendContext | GldtStakeContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_CONTEXT_KEY, { store: initGldtStakeStore() }]
+		]);
+
+	it('should switch between selected radio buttons correctly', async () => {
+		const { getAllByRole } = render(GldtUnstakeDissolveTypeSelector, {
+			props: { dissolveInstantly: true, amount: 1 },
+			context: mockContext()
+		});
+
+		const delayedDissolveCheckbox = getAllByRole('radio')[0] as HTMLInputElement;
+		const dissolveInstantlyCheckbox = getAllByRole('radio')[1] as HTMLInputElement;
+
+		expect(dissolveInstantlyCheckbox.checked).toBeTruthy();
+		expect(delayedDissolveCheckbox.checked).toBeFalsy();
+
+		await fireEvent.click(delayedDissolveCheckbox);
+
+		expect(dissolveInstantlyCheckbox.checked).toBeFalsy();
+		expect(delayedDissolveCheckbox.checked).toBeTruthy();
+	});
+});


### PR DESCRIPTION
# Motivation

We can now add a component for selecting a dissolve type - immediate or delayed.

<img width="561" height="412" alt="Screenshot 2025-10-30 at 16 56 58" src="https://github.com/user-attachments/assets/c570c304-f139-4877-b82a-d20b37dcbac5" />
