### PR TITLE
style(frontend): Hide NFT media review button for small screens

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftDisplayGuard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftDisplayGuard.svelte
@@ -51,6 +51,8 @@
 	};
 
 	const isLoading = $derived(isNullish(nft));
+
+	let hoveredReviewButton = $derived(type === 'card' && nonNullish(hasConsent));
 </script>
 
 {#if nonNullish(hasConsent) && hasConsent}
@@ -82,9 +84,16 @@
 			{/if}
 			{#if type !== 'card-selectable' && type !== 'nft-logo'}
 				<span
-					class="max-h-full overflow-hidden opacity-100 transition-all duration-300 ease-in-out group-hover:max-h-full group-hover:opacity-100"
-					class:lg:max-h-0={type === 'card' && nonNullish(hasConsent)}
-					class:lg:opacity-0={type === 'card' && nonNullish(hasConsent)}
+					class="overflow-hidden"
+					class:duration-300={hoveredReviewButton}
+					class:ease-in-out={hoveredReviewButton}
+					class:lg:group-hover:max-h-full={hoveredReviewButton}
+					class:lg:group-hover:opacity-100={hoveredReviewButton}
+					class:max-h-0={hoveredReviewButton}
+					class:max-h-full={!hoveredReviewButton}
+					class:opacity-0={hoveredReviewButton}
+					class:opacity-100={!hoveredReviewButton}
+					class:transition-all={hoveredReviewButton}
 				>
 					<Button
 						colorStyle="secondary-light"


### PR DESCRIPTION
# Motivation

For small screens, initially, we thought of showing the media review button for all NFTs even when the user already gave/rejected the consent.

However, if the user already made a decision, maybe it is better to avoid showing it entirely.

### Before

<img width="612" height="1437" alt="Screenshot 2025-10-31 at 08 48 55" src="https://github.com/user-attachments/assets/9cd242ac-6ae0-4fbc-8155-2626826b921e" />

### After


https://github.com/user-attachments/assets/02b1150d-6206-4583-b0e0-46fa0924e772

