### PR TITLE
feat(frontend): Always enable new collections

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -51,6 +51,7 @@
 					}) && tokenChainId === network.chainId
 				);
 			});
+
 			if (nonNullish(existingToken)) {
 				return acc;
 			}
@@ -58,7 +59,7 @@
 			const newToken: SaveErc721CustomToken = {
 				address: contract.address,
 				network,
-				enabled: !contract.isSpam
+				enabled: true
 			};
 
 			return [...acc, newToken];
@@ -101,6 +102,7 @@
 					}) && tokenChainId === network.chainId
 				);
 			});
+
 			if (nonNullish(existingToken)) {
 				return acc;
 			}
@@ -108,7 +110,7 @@
 			const newToken: SaveErc1155CustomToken = {
 				address: contract.address,
 				network,
-				enabled: !contract.isSpam
+				enabled: true
 			};
 
 			return [...acc, newToken];


### PR DESCRIPTION
# Motivation

Until now we were enabling automatically new collections ONLY when Alchemy does not define them as Spam. However, we checked and it does not seem we can really really on this information (some collections are wrongly defined as spams).

So, for now we enable them all if they are new.
