### PR TITLE
feat(frontend): implement GldtUnstakeForm component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtUnstakeForm.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtUnstakeForm.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import GldtUnstakeDissolveTypeSelector from '$icp/components/stake/gldt/GldtUnstakeDissolveTypeSelector.svelte';
+	import StakeForm from '$lib/components/stake/StakeForm.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
+	import { validateUserAmount } from '$lib/utils/user-amount.utils';
+
+	interface Props {
+		amount: OptionAmount;
+		amountToReceive?: number;
+		dissolveInstantly: boolean;
+		onClose: () => void;
+		onNext: () => void;
+	}
+
+	let {
+		amount = $bindable(),
+		onNext,
+		onClose,
+		dissolveInstantly = $bindable(),
+		amountToReceive = $bindable()
+	}: Props = $props();
+
+	const { sendToken, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	const onCustomValidate = (userAmount: bigint): TokenActionErrorType =>
+		validateUserAmount({
+			userAmount,
+			token: $sendToken,
+			balance: $sendBalance ?? ZERO
+		});
+</script>
+
+<StakeForm {onClose} {onCustomValidate} {onNext} totalFee={ZERO} bind:amount>
+	{#snippet fee()}
+		<GldtUnstakeDissolveTypeSelector {amount} bind:dissolveInstantly bind:amountToReceive />
+	{/snippet}
+</StakeForm>

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtUnstakeForm.spec.ts
@@ -1,0 +1,73 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import GldtUnstakeForm from '$icp/components/stake/gldt/GldtUnstakeForm.svelte';
+import {
+	GLDT_STAKE_CONTEXT_KEY,
+	initGldtStakeStore,
+	type GldtStakeContext
+} from '$icp/stores/gldt-stake.store';
+import {
+	STAKE_FORM_REVIEW_BUTTON,
+	TOKEN_INPUT_CURRENCY_TOKEN
+} from '$lib/constants/test-ids.constants';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+describe('GldtUnstakeForm', () => {
+	const mockContext = () => {
+		const store = initGldtStakeStore();
+		store.setPosition(stakePositionMockResponse);
+
+		return new Map<symbol, SendContext | GldtStakeContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_CONTEXT_KEY, { store }]
+		]);
+	};
+
+	const props = {
+		amount: 1,
+		dissolveInstantly: true,
+		onClose: () => {},
+		onNext: () => {}
+	};
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it('should keep the next button clickable if all requirements are met', () => {
+		const { getByTestId } = render(GldtUnstakeForm, {
+			props,
+			context: mockContext()
+		});
+
+		expect(getByTestId(STAKE_FORM_REVIEW_BUTTON)).not.toHaveAttribute('disabled');
+	});
+
+	it('should disable the next button clickable if amount is incorrect', () => {
+		const { getByTestId } = render(GldtUnstakeForm, {
+			props: {
+				...props,
+				amount: undefined
+			},
+			context: mockContext()
+		});
+
+		expect(getByTestId(STAKE_FORM_REVIEW_BUTTON)).toHaveAttribute('disabled');
+	});
+
+	it('should disable the next button clickable if balance is lower than provided amount', async () => {
+		const { getByTestId } = render(GldtUnstakeForm, {
+			props,
+			context: mockContext()
+		});
+
+		const input = getByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
+
+		await fireEvent.input(input, { target: { value: '9999999' } });
+
+		await waitFor(() => {
+			expect(getByTestId(STAKE_FORM_REVIEW_BUTTON)).toHaveAttribute('disabled');
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We can now build a GldtUnstake form component. Under the hood it re-uses "StakeForm" component.

<img width="605" height="827" alt="Screenshot 2025-10-31 at 10 45 56" src="https://github.com/user-attachments/assets/f4d09a9c-586a-42cc-8dd9-31fea22621a9" />
