### PR TITLE
refactor(frontend): Remove fallback for network ID description

### DIFF
--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -42,7 +42,7 @@ export const loadTokenAddress = async <T extends Address>({
 		toastsError({
 			msg: {
 				text: replacePlaceholders(get(i18n).init.error.loading_address, {
-					$symbol: networkId.description ?? ''
+					$symbol: `${networkId.description}`
 				})
 			},
 			err

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -67,7 +67,7 @@ export const parseToAiAssistantTokens = (tokens: Token[]): AiAssistantToken[] =>
 				name,
 				symbol,
 				standard,
-				networkId: networkId.description ?? ''
+				networkId: `${networkId.description}`
 			}
 		];
 	}, []);

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -74,7 +74,7 @@ const tokenUrl = ({
 	)}${nonNullish(networkId.description) ? `&${networkParam(networkId)}` : ''}`;
 
 export const networkParam = (networkId: NetworkId | undefined): string =>
-	isNullish(networkId) ? '' : `${NETWORK_PARAM}=${networkId.description ?? ''}`;
+	isNullish(networkId) ? '' : `${NETWORK_PARAM}=${networkId.description}`;
 
 export const networkUrl = ({
 	path,

--- a/src/frontend/src/sol/utils/safe-network.utils.ts
+++ b/src/frontend/src/sol/utils/safe-network.utils.ts
@@ -15,7 +15,7 @@ export const safeMapNetworkIdToNetwork = (networkId: NetworkId): SolanaNetworkTy
 
 	throw new NullishError(
 		replacePlaceholders(get(i18n).init.error.no_solana_network, {
-			$network: networkId.description ?? ''
+			$network: `${networkId.description}`
 		})
 	);
 };

--- a/src/frontend/src/tests/lib/services/address.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/address.services.spec.ts
@@ -88,7 +88,7 @@ describe('address.services', () => {
 			expect(spyToastsError).toHaveBeenCalledWith({
 				msg: {
 					text: replacePlaceholders(en.init.error.loading_address, {
-						$symbol: mockNetworkId.description ?? ''
+						$symbol: `${mockNetworkId.description}`
 					})
 				},
 				err: expect.any(Error)


### PR DESCRIPTION
# Motivation

For coverage purposes, we remove the condition to fallback on Network ID description.
