### PR TITLE
build(frontend): remove gldt_stake local deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,7 +26,6 @@ dfx deploy cycles_ledger
 dfx deploy cycles_depositor
 dfx deploy rewards
 dfx deploy llm
-dfx deploy gldt_stake
 
 dfx deploy sol_rpc
 


### PR DESCRIPTION
# Motivation

There is a problem with the gldt_stake local deployment. For now, we will remove it from `deploy.sh` as it's not really useful locally.
