### PR TITLE
feat(frontend): remove nullishSignOut from GldtStakeWizard

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeWizard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeWizard.svelte
@@ -18,7 +18,6 @@
 	import { ProgressStepsStake } from '$lib/enums/progress-steps';
 	import { WizardStepsStake } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
-	import { nullishSignOut } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import { toastsError } from '$lib/stores/toasts.store';
@@ -53,7 +52,6 @@
 
 	const stake = async () => {
 		if (isNullish($authIdentity)) {
-			await nullishSignOut();
 			return;
 		}
 


### PR DESCRIPTION
# Motivation

As we recently agreed, we don't need to use `nullishSignOut` inside the wizards. Therefore, removing it from `GldtStakeWizard`.
