### PR TITLE
feat(frontend): display gldt_stake canister error messages

### DIFF
--- a/src/frontend/src/icp/canisters/gldt_stake.errors.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.errors.ts
@@ -3,27 +3,35 @@ import { CanisterInternalError } from '$lib/canisters/errors';
 
 export const mapGldtStakeCanisterError = (err: ManageStakePositionError): CanisterInternalError => {
 	if ('StartDissolvingError' in err) {
-		return new CanisterInternalError('Failed to start dissolving');
+		return new CanisterInternalError(
+			Object.values(err.StartDissolvingError)[0] ?? 'Failed to start dissolving'
+		);
 	}
 
 	if ('AddStakeError' in err) {
-		return new CanisterInternalError('Failed to add stake');
+		return new CanisterInternalError(Object.values(err.AddStakeError)[0] ?? 'Failed to add stake');
 	}
 
 	if ('DissolveInstantlyError' in err) {
-		return new CanisterInternalError('Failed to dissolve instantly');
+		return new CanisterInternalError(
+			Object.values(err.DissolveInstantlyError)[0] ?? 'Failed to dissolve instantly'
+		);
 	}
 
 	if ('WithdrawError' in err) {
-		return new CanisterInternalError('Failed to withdraw');
+		return new CanisterInternalError(Object.values(err.WithdrawError)[0] ?? 'Failed to withdraw');
 	}
 
 	if ('ClaimRewardError' in err) {
-		return new CanisterInternalError('Failed to claim reward');
+		return new CanisterInternalError(
+			Object.values(err.ClaimRewardError[0])[0] ?? 'Failed to claim reward'
+		);
 	}
 
 	if ('GeneralError' in err) {
-		return new CanisterInternalError('General gldt_stake error');
+		return new CanisterInternalError(
+			Object.values(err.GeneralError)[0] ?? 'General gldt_stake error'
+		);
 	}
 
 	return new CanisterInternalError('Unknown GldtStakeCanisterError');

--- a/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
@@ -122,8 +122,9 @@ describe('gldt_stake.canister', () => {
 		});
 
 		it('should throw an error if manage_stake_position returns an AddStakeError error', async () => {
+			const canisterErrorMessage = 'error';
 			service.manage_stake_position.mockResolvedValue({
-				Err: { AddStakeError: { TransferError: 'error' } }
+				Err: { AddStakeError: { TransferError: canisterErrorMessage } }
 			});
 
 			const { manageStakePosition } = await createGldtStakeCanister({
@@ -132,7 +133,7 @@ describe('gldt_stake.canister', () => {
 
 			const res = manageStakePosition(params);
 
-			await expect(res).rejects.toThrow(new CanisterInternalError('Failed to add stake'));
+			await expect(res).rejects.toThrow(new CanisterInternalError(canisterErrorMessage));
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The gldt_stake canister returns meaningful messages when staking/unstaking action fails on their end. Therefore, it makes sense to display them instead of default strings if we can parse the values.
