### PR TITLE
feat(frontend): prefer set instead of update in auth.store

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -42,7 +42,7 @@ export interface AuthStore extends Readable<AuthStoreData> {
 }
 
 const initAuthStore = (): AuthStore => {
-	const { subscribe, set, update } = writable<AuthStoreData>({
+	const { subscribe, set } = writable<AuthStoreData>({
 		identity: undefined
 	});
 
@@ -148,10 +148,7 @@ const initAuthStore = (): AuthStore => {
 					onSuccess: async () => {
 						await overwriteStoredIdentityKey();
 
-						update((state: AuthStoreData) => ({
-							...state,
-							identity: authClient?.getIdentity()
-						}));
+						set({ identity: authClient?.getIdentity() });
 
 						try {
 							// If the user has more than one tab open in the same browser,
@@ -184,10 +181,7 @@ const initAuthStore = (): AuthStore => {
 			// This fixes a "sign in -> sign-out -> sign in again" flow without reloading the window.
 			authClient = null;
 
-			update((state: AuthStoreData) => ({
-				...state,
-				identity: null
-			}));
+			set({ identity: null });
 		},
 
 		/**


### PR DESCRIPTION
# Motivation

While relatively unlikely, using `update` to assing the identity to the `auth.store` could potentially introduce some sort of additional data. Using `set` is safer as only the field defined will actually be applied to the state - i.e. it replaces the state.

# Changes

- Use `set()` instead of `update()` in `auth.store`