### PR TITLE
feat(frontend): Disable testnets in Manage Tokens modal

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
+++ b/src/frontend/src/lib/components/networks/NetworkSwitcherList.svelte
@@ -17,6 +17,7 @@
 		labelsSize?: LabelSize;
 		supportedNetworks?: NetworkType[];
 		allNetworksEnabled?: boolean;
+		showTestnets?: boolean;
 		onSelected?: (networkId: OptionNetworkId) => void;
 	}
 
@@ -25,6 +26,7 @@
 		labelsSize = 'md',
 		supportedNetworks,
 		allNetworksEnabled = true,
+		showTestnets = true,
 		onSelected
 	}: Props = $props();
 
@@ -55,7 +57,7 @@
 	{/each}
 </ul>
 
-{#if $testnetsEnabled && $networksTestnets.length && isNullish(supportedNetworks)}
+{#if showTestnets && $testnetsEnabled && $networksTestnets.length && isNullish(supportedNetworks)}
 	<span class="mt-6 mb-3 flex px-3 font-bold" transition:slide={SLIDE_EASING}
 		>{$i18n.networks.test_networks}</span
 	>

--- a/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
@@ -40,6 +40,7 @@
 		labelsSize="lg"
 		onSelected={onNetworkSelect}
 		selectedNetworkId={$filterNetwork?.id}
+		showTestnets={false}
 		supportedNetworks={filteredNetworks}
 	/>
 


### PR DESCRIPTION
# Motivation

When we select a network from the main tokens list (All Networks), it does not make sense to allow the user to select the testnets too.

### Before

<img width="1279" height="1437" alt="Screenshot 2025-11-03 at 11 42 18" src="https://github.com/user-attachments/assets/16b1cc34-bb8f-4a55-a06e-2057058dae10" />

### After

<img width="1281" height="1438" alt="Screenshot 2025-11-03 at 11 40 18" src="https://github.com/user-attachments/assets/9c9d3359-b7f9-4e51-985e-bdafe10de220" />

