### PR TITLE
feat(frontend): Hide Swap and Buy buttons in Hero for NFTs

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -47,7 +47,8 @@
 	let isNftsPage = $derived(isRouteNfts(page));
 
 	let swapAction = $derived(
-	(	!isTransactionsPage || (isTransactionsPage && !$networkSolana && !$networkBitcoin)) && !isNftsPage
+		(!isTransactionsPage || (isTransactionsPage && !$networkSolana && !$networkBitcoin)) &&
+			!isNftsPage
 	);
 
 	let sendAction = $derived(!$allBalancesZero || isTransactionsPage);


### PR DESCRIPTION
# Motivation

For the NFTs page, it does not make sense to show the Swap and Buy buttons for now.

<img width="1278" height="1440" alt="Screenshot 2025-11-03 at 16 26 41" src="https://github.com/user-attachments/assets/1089843d-22d9-44fb-ae76-326ae4ce4c2d" />

