### PR TITLE
feat(frontend): Manage NFT button inside context menu

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftSettingsMenu.svelte
+++ b/src/frontend/src/lib/components/nfts/NftSettingsMenu.svelte
@@ -19,12 +19,12 @@
 	} from '$lib/enums/plausible';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import {
 		nftGroupByCollectionStore,
 		showHiddenStore,
 		showSpamStore
 	} from '$lib/stores/settings.store';
-	import {modalStore} from "$lib/stores/modal.store";
 
 	let visible = $state(false);
 


### PR DESCRIPTION
# Motivation

We want to show the Manage NFT button inside the main context menu too.

<img width="2560" height="1431" alt="Screenshot 2025-11-04 at 09 14 18" src="https://github.com/user-attachments/assets/ded3407b-bf50-463f-bb38-d3bf75d7c998" />
<img width="2558" height="1427" alt="Screenshot 2025-11-04 at 09 14 26" src="https://github.com/user-attachments/assets/86e20547-1af9-4704-bb96-44b5a0cd6d57" />

