### PR TITLE
feat(frontend): Reduce debouncing in `LoaderNfts`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -26,7 +26,7 @@
 		await Promise.allSettled(promises);
 	};
 
-	const debounceLoad = debounce(onLoad, 1000);
+	const debounceLoad = debounce(onLoad);
 
 	$effect(() => {
 		[$enabledNonFungibleTokens, NFTS_ENABLED, $ethAddress];


### PR DESCRIPTION
# Motivation

No need for a grand debounce interval for component `LoaderNfts`, we can reduce it to the default.
