### PR TITLE
feat(frontend): Use token address as identifier for ERC721 services

### DIFF
--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -152,7 +152,7 @@ const loadCustomTokensWithMetadata = async (
 
 				return {
 					...{
-						id: parseCustomTokenId({ identifier: symbol, chainId: network.chainId }),
+						id: parseCustomTokenId({ identifier: tokenAddress, chainId: network.chainId }),
 						name: tokenAddress,
 						address: tokenAddress,
 						network,


### PR DESCRIPTION
# Motivation

For consistency, for ERC721 services, we use the token address as identifier (same as ERC1155 and ERC20).
