### PR TITLE
feat(frontend): Load ETH transactions from cache reactively

### DIFF
--- a/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
+++ b/src/frontend/src/eth/components/loaders/LoaderMultipleEthTransactions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
-	import { onMount, type Snippet, untrack } from 'svelte';
+	import { type Snippet, untrack } from 'svelte';
 	import { NFTS_ENABLED } from '$env/nft.env';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 	import { batchLoadTransactions } from '$eth/services/eth-transactions-batch.services';
@@ -55,7 +55,7 @@
 		untrack(() => debounceLoad());
 	});
 
-	onMount(async () => {
+	const loadFromCache = async () => {
 		const principal = $authIdentity?.getPrincipal();
 
 		if (isNullish(principal)) {
@@ -77,6 +77,14 @@
 				});
 			})
 		);
+	};
+
+	const debounceLoadFromCache = debounce(loadFromCache);
+
+	$effect(() => {
+		[tokens, $authIdentity];
+
+		untrack(() => debounceLoadFromCache());
 	});
 </script>
 


### PR DESCRIPTION
# Motivation

We are loading the ETH transactions from the cache only on mounting of components, so we could risk that the list of tokens is not really set.

Since we want more reactivity, we would like to trigger the cache loading everytime the list is updated.

NOTE: In any case, nothing will be saved from cache if the transaction store already has entries for that specific tokens.

# Changes

- Trigger the ETH transaction loader when the enable tokens list changes.

# Tests

Current tests should work as expected.
