### PR TITLE
fix(frontend): Avoid token contract as symbol for NFTs

### DIFF
--- a/src/frontend/src/eth/services/erc1155.services.ts
+++ b/src/frontend/src/eth/services/erc1155.services.ts
@@ -150,7 +150,7 @@ const loadCustomTokensWithMetadata = async (
 						name: tokenAddress,
 						address: tokenAddress,
 						network,
-						symbol: tokenAddress,
+						symbol: metadata.symbol ?? '', // The symbol is used with the amount, no issue with having it empty for NFTs
 						decimals: 0, // Erc1155 contracts don't have decimals, but to avoid unexpected behavior, we set it to 0
 						standard: 'erc1155' as const,
 						category: 'custom' as const,


### PR DESCRIPTION
# Motivation

It does not really make sense to fallback to token contracts for each NFT contract. We can have an empty symbol for now since it is very rare and since it is only associated with the amount.
