### PR TITLE
feat(frontend): Set awaiting time for batch ETH transactions loader

### DIFF
--- a/src/frontend/src/lib/services/batch.services.ts
+++ b/src/frontend/src/lib/services/batch.services.ts
@@ -11,7 +11,7 @@ export const batch = async function* <T>({
 		const batch = promises.slice(i, i + batchSize);
 		const results = await Promise.allSettled(batch.map((fn) => fn()));
 		yield results;
-		await randomWait({});
+		await randomWait({ max: 1000 });
 	}
 };
 


### PR DESCRIPTION
# Motivation

We load the transactions for ETH tokens in batches, since we are limited to a certain amount of calls per seconds. However, we can just wait 1 second to reset that count, while the function `randomWait` waits randomly between 1 and 2 seconds by default.