### PR TITLE
fix(frontend): No upperbound block number when fetching ETH transactions

### DIFF
--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -21,7 +21,7 @@ import type { NftId } from '$lib/types/nft';
 import type { Transaction } from '$lib/types/transaction';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
-import { assertNonNullish } from '@dfinity/utils';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import {
 	EtherscanProvider as EtherscanProviderLib,
 	Network,
@@ -58,7 +58,7 @@ export class EtherscanProvider {
 			action: 'txlist',
 			address,
 			startblock: startBlock ?? 0,
-			endblock: endBlock ?? 99999999,
+			...(nonNullish(endBlock) ? { endblock: endBlock } : {}),
 			sort: 'asc'
 		};
 
@@ -100,7 +100,7 @@ export class EtherscanProvider {
 			action: 'txlistinternal',
 			address,
 			startblock: startBlock ?? 0,
-			endblock: endBlock ?? 99999999,
+			...(nonNullish(endBlock) ? { endblock: endBlock } : {}),
 			sort: 'asc'
 		};
 
@@ -151,7 +151,6 @@ export class EtherscanProvider {
 			contractAddress,
 			address,
 			startblock: 0,
-			endblock: 99999999,
 			sort: 'desc'
 		};
 
@@ -203,7 +202,6 @@ export class EtherscanProvider {
 			contractAddress,
 			address,
 			startblock: 0,
-			endblock: 99999999,
 			sort: 'desc'
 		};
 
@@ -254,7 +252,6 @@ export class EtherscanProvider {
 			contractAddress,
 			address,
 			startblock: 0,
-			endblock: 99999999,
 			sort: 'desc'
 		};
 
@@ -306,7 +303,6 @@ export class EtherscanProvider {
 			address,
 			contractaddress: contractAddress,
 			startblock: 0,
-			endblock: 99999999,
 			sort: 'desc'
 		};
 

--- a/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/etherscan.providers.spec.ts
@@ -157,7 +157,6 @@ describe('etherscan.providers', () => {
 					action: 'txlist',
 					address,
 					startblock: 0,
-					endblock: 99999999,
 					sort: 'asc'
 				});
 			});
@@ -174,7 +173,6 @@ describe('etherscan.providers', () => {
 					action: 'txlistinternal',
 					address,
 					startblock: 0,
-					endblock: 99999999,
 					sort: 'asc'
 				});
 			});


### PR DESCRIPTION
# Motivation

When we request the transaction history to Etherscan we define the parameter endblock as a big number to have theoretically no upper-bound for the request. However, we managed to touch the limit of some networks: for example Arbitrum was not providing some ERC1155 transactions.

I tested it and we can omit the upper-bound to consider it unbounded and receive all transactions.

### Before

<img width="698" height="1550" alt="Screenshot 2025-11-05 at 09 49 29" src="https://github.com/user-attachments/assets/3e104f7f-62b9-4a91-ad36-6397d4fb3258" />

### After
 
<img width="702" height="1550" alt="Screenshot 2025-11-05 at 09 49 34" src="https://github.com/user-attachments/assets/835cd796-bce2-499c-a929-e28e94f4b959" />
