### PR TITLE
refactor(frontend): Extract send step for filtering network config

### DIFF
--- a/src/frontend/src/lib/config/send.config.ts
+++ b/src/frontend/src/lib/config/send.config.ts
@@ -6,6 +6,15 @@ interface SendWizardStepsParams extends WizardStepsParams {
 	converting?: boolean;
 }
 
+const sendWizardStepsFilterNetworks = ({
+	i18n
+}: SendWizardStepsParams): WizardSteps<WizardStepsSend> => [
+	{
+		name: WizardStepsSend.FILTER_NETWORKS,
+		title: i18n.send.text.select_network_filter
+	}
+];
+
 export const sendWizardSteps = ({
 	i18n,
 	converting
@@ -43,10 +52,7 @@ export const allSendWizardSteps = (params: SendWizardStepsParams): WizardSteps<W
 		name: WizardStepsSend.TOKENS_LIST,
 		title: params.i18n.send.text.select_token
 	},
-	{
-		name: WizardStepsSend.FILTER_NETWORKS,
-		title: params.i18n.send.text.select_network_filter
-	},
+	...sendWizardStepsFilterNetworks(params),
 	...sendWizardStepsWithQrCodeScan(params)
 ];
 
@@ -74,9 +80,6 @@ export const allSendNftsWizardSteps = (
 		name: WizardStepsSend.NFTS_LIST,
 		title: params.i18n.send.text.select_nft
 	},
-	{
-		name: WizardStepsSend.FILTER_NETWORKS,
-		title: params.i18n.send.text.select_network_filter
-	},
+	...sendWizardStepsFilterNetworks(params),
 	...sendNftsWizardSteps(params)
 ];


### PR DESCRIPTION
# Motivation

To reduce code repetition, we extract the send steps config of Filtering networks.