### PR TITLE
refactor(frontend): Reuse internal service in `SendModal` component

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -184,19 +184,15 @@
 
 	const selectNft = (nft: Nft) => {
 		selectedNft = nft;
+
 		const token = findNonFungibleToken({
 			tokens: $nonFungibleTokens,
 			networkId: nft.collection.network.id,
 			address: nft.collection.address
 		});
+
 		if (nonNullish(token)) {
-			loadTokenAndRun({
-				token,
-				// eslint-disable-next-line require-await
-				callback: async () => {
-					goToStep(WizardStepsSend.DESTINATION);
-				}
-			});
+			onSendToken(token);
 		}
 	};
 </script>


### PR DESCRIPTION
# Motivation

There is an existing method `onSendToken` in `SendModal` component that can be reused by the NFT flow.
