### PR TITLE
fix(dependabot): Add dependabot group for vitest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,4 +39,5 @@ updates:
       vitest-group:
         patterns:
           - 'vitest'
+          - 'vitest-mock-extended'
           - '@vitest/coverage-v8'


### PR DESCRIPTION
# Motivation

The `vitest` dependencies should be updated together since they can have the same dependencies.
