### PR TITLE
feat(frontend): Send gas information for tracking BTC send transactions

### DIFF
--- a/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendTokenWizard.svelte
@@ -133,6 +133,12 @@
 
 		onNext();
 
+		const sendTrackingEventMetadata = {
+			token: $sendToken.symbol,
+			network: `${networkId.description}`,
+			feeSatoshis: utxosFee.feeSatoshis.toString()
+		};
+
 		if (BTC_EXTENSION_FEATURE_FLAG_ENABLED) {
 			// Validate UTXOs before proceeding
 			try {
@@ -151,10 +157,7 @@
 
 				trackEvent({
 					name: TRACK_COUNT_BTC_VALIDATION_ERROR,
-					metadata: {
-						token: $sendToken.symbol,
-						network: `${networkId?.description ?? 'unknown'}`
-					}
+					metadata: sendTrackingEventMetadata
 				});
 
 				// go back to the previous step so the user can correct/ try again
@@ -163,6 +166,7 @@
 				return;
 			}
 		}
+
 		try {
 			progress(ProgressStepsSendBtc.SEND);
 			await sendBtc({
@@ -176,10 +180,7 @@
 
 			trackEvent({
 				name: TRACK_COUNT_BTC_SEND_SUCCESS,
-				metadata: {
-					token: $sendToken.symbol,
-					network: `${networkId.description}`
-				}
+				metadata: sendTrackingEventMetadata
 			});
 
 			progress(ProgressStepsSendBtc.DONE);
@@ -188,10 +189,7 @@
 		} catch (err: unknown) {
 			trackEvent({
 				name: TRACK_COUNT_BTC_SEND_ERROR,
-				metadata: {
-					token: $sendToken.symbol,
-					network: `${networkId.description}`
-				}
+				metadata: sendTrackingEventMetadata
 			});
 
 			toastsError({

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendBtcToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendBtcToken.svelte
@@ -115,11 +115,6 @@
 			metadata: sharedTrackingEventMetadata
 		});
 
-		const sendTrackingEventMetadata = {
-			...sharedTrackingEventMetadata,
-			source: AI_ASSISTANT_SEND_TOKEN_SOURCE
-		};
-
 		if (isNullish($authIdentity)) {
 			return;
 		}
@@ -161,6 +156,12 @@
 
 		loading = true;
 
+		const sendTrackingEventMetadata = {
+			...sharedTrackingEventMetadata,
+			source: AI_ASSISTANT_SEND_TOKEN_SOURCE,
+			feeSatoshis: utxosFee.feeSatoshis.toString()
+		};
+
 		// Validate UTXOs before proceeding
 		try {
 			await validateBtcSend({
@@ -191,6 +192,7 @@
 
 			return;
 		}
+
 		try {
 			await sendBtc({
 				destination,


### PR DESCRIPTION
# Motivation

We want to have information on gas and fees too when we send an BTC transaction, to better analyze issues.