### PR TITLE
style(frontend): default cursor if no onClick provided in LogoButton

### DIFF
--- a/src/frontend/src/lib/components/ui/LogoButton.svelte
+++ b/src/frontend/src/lib/components/ui/LogoButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { IconCheck } from '@dfinity/gix-components';
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import type { MouseEventHandler } from 'svelte/elements';
 	import { fade } from 'svelte/transition';
@@ -53,7 +53,12 @@
 	class:rounded-lg={rounded}
 	class:w-full={dividers || fullWidth}
 >
-	<button class="flex w-full border-0 px-2" data-tid={testId} onclick={onClick}>
+	<button
+		class="flex w-full border-0 px-2"
+		class:cursor-default={isNullish(onClick)}
+		data-tid={testId}
+		onclick={onClick}
+	>
 		<span
 			class="logo-button-wrapper flex w-full flex-row justify-between rounded-none border-t-0 border-r-0 border-l-0"
 			class:border-b={dividers}


### PR DESCRIPTION
# Motivation

When `LogoButton` is not clickable (no `onClick` provided), we don't want to show default `cursor-pointer`.
