### PR TITLE
feat(frontend): added new isAllowanceSufficient for icrc2 tokens

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -350,6 +350,10 @@ export const loadDisabledIcrcTokensExchanges = async ({
 /**
  * Checks if the owner has sufficient allowance for the spender to execute a transaction.
  *
+ * The allowanceBuffer ensures the allowance won't expire while the transaction is being processed.
+ * For example, if the allowance expires in 10 seconds but the swap takes 20 seconds to complete,
+ * we should request a new approval instead of starting a transaction that will fail.
+ *
  * @returns `true` if allowance is sufficient and won't expire within the buffer period, `false` otherwise
  *
  */


### PR DESCRIPTION
# Motivation

We need to check for existing allowance in the swap flow to avoid unnecessary double approvals when slippage is exceeded or when a transaction fails.

# Changes

- Added new method hasSufficientIcrcAllowance that checks if the user has sufficient ICRC-2 allowance before initiating an approve transaction

# Tests

Covered new method with the tests