### PR TITLE
fix(frontend): Enable frontend derivation for all envs except LOCAL

### DIFF
--- a/src/frontend/src/env/address.env.ts
+++ b/src/frontend/src/env/address.env.ts
@@ -1,4 +1,4 @@
 import { LOCAL } from '$lib/constants/app.constants';
 
 // TODO: to be removed when the feature is fully implemented for local environment too
-export const FRONTEND_DERIVATION_ENABLED = LOCAL;
+export const FRONTEND_DERIVATION_ENABLED = !LOCAL;


### PR DESCRIPTION
# Motivation

I introduced a bug 🤦‍♂️...

We want the frontend derivation for all envs **except LOCAL** (and not the opposite).
