### PR TITLE
chore(ci): ignore icp-sdk in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
       - dependency-type: all
     ignore:
       - dependency-name: '@dfinity/*'
+      - dependency-name: '@icp-sdk/*'
       - dependency-name: '@types/*'
       - dependency-name: 'typescript'
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Motivation

As suggested by @AntonioVentilii in review https://github.com/dfinity/oisy-wallet/pull/9192#discussion_r2495142721 we want to ignore anything `@icp-sdk/*` in the dependabot

# Changes

- Add exclusion to yml file
