### PR TITLE
feat(frontend): make StakeReview component more general

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeReview.svelte
@@ -4,6 +4,7 @@
 	import GldtStakeFees from '$icp/components/stake/gldt/GldtStakeFees.svelte';
 	import GldtStakeProvider from '$icp/components/stake/gldt/GldtStakeProvider.svelte';
 	import { isInvalidDestinationIc } from '$icp/utils/ic-send.utils';
+	import SendReviewDestination from '$lib/components/send/SendReviewDestination.svelte';
 	import StakeReview from '$lib/components/stake/StakeReview.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -18,22 +19,28 @@
 		onStake: () => void;
 	}
 
-	let { destination = '', amount, onBack, onStake }: Props = $props();
+	let { destination: address = '', amount, onBack, onStake }: Props = $props();
 
 	const { sendTokenStandard } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	// Should never happen given that the same checks are performed on previous wizard step
 	let invalid = $derived(
 		isInvalidDestinationIc({
-			destination,
+			destination: address,
 			tokenStandard: $sendTokenStandard
 		}) || invalidAmount(amount)
 	);
 </script>
 
-<StakeReview {amount} {destination} disabled={invalid} {onBack} {onStake}>
+<StakeReview {amount} disabled={invalid} {onBack} onConfirm={onStake}>
 	{#snippet subtitle()}
 		{$i18n.stake.text.stake_review_subtitle}
+	{/snippet}
+
+	{#snippet destination()}
+		<div class="mb-4">
+			<SendReviewDestination destination={address} />
+		</div>
 	{/snippet}
 
 	{#snippet provider()}

--- a/src/frontend/src/icp/components/stake/gldt/GldtUnstakeReview.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtUnstakeReview.svelte
@@ -46,7 +46,7 @@
 	);
 </script>
 
-<StakeReview {amount} disabled={invalid} {onBack} onStake={onUnstake}>
+<StakeReview {amount} disabled={invalid} {onBack} onConfirm={onUnstake}>
 	{#snippet subtitle()}
 		{$i18n.stake.text.unstake_review_subtitle}
 	{/snippet}

--- a/src/frontend/src/lib/components/stake/StakeReview.svelte
+++ b/src/frontend/src/lib/components/stake/StakeReview.svelte
@@ -1,28 +1,28 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
-	import SendReviewDestination from '$lib/components/send/SendReviewDestination.svelte';
 	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
-	import type { Address } from '$lib/types/address';
 	import type { OptionAmount } from '$lib/types/send';
 
 	interface Props {
 		amount?: OptionAmount;
-		destination?: Address;
+		destination?: Snippet;
 		disabled?: boolean;
 		network?: Snippet;
 		fee?: Snippet;
 		provider?: Snippet;
 		subtitle?: Snippet;
-		onBack: () => void;
-		onStake: () => void;
+		onBack?: () => void;
+		onClose?: () => void;
+		onConfirm: () => void;
 	}
 
 	let {
@@ -34,7 +34,8 @@
 		provider,
 		subtitle,
 		onBack,
-		onStake
+		onClose,
+		onConfirm
 	}: Props = $props();
 
 	const { sendToken, sendTokenExchangeRate } = getContext<SendContext>(SEND_CONTEXT_KEY);
@@ -48,11 +49,7 @@
 		token={$sendToken}
 	/>
 
-	{#if nonNullish(destination)}
-		<div class="mb-4">
-			<SendReviewDestination {destination} />
-		</div>
-	{/if}
+	{@render destination?.()}
 
 	{@render network?.()}
 
@@ -62,8 +59,13 @@
 
 	{#snippet toolbar()}
 		<ButtonGroup testId="toolbar">
-			<ButtonBack onclick={onBack} />
-			<Button {disabled} onclick={onStake} testId={STAKE_REVIEW_FORM_BUTTON}>
+			{#if nonNullish(onBack)}
+				<ButtonBack onclick={onBack} />
+			{:else if nonNullish(onClose)}
+				<ButtonCancel onclick={onClose} />
+			{/if}
+
+			<Button {disabled} onclick={onConfirm} testId={STAKE_REVIEW_FORM_BUTTON}>
 				{$i18n.send.text.send}
 			</Button>
 		</ButtonGroup>

--- a/src/frontend/src/tests/lib/components/stake/StakeReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeReview.spec.ts
@@ -2,7 +2,6 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import StakeReview from '$lib/components/stake/StakeReview.svelte';
 import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
-import { mockPrincipalText } from '$tests/mocks/identity.mock';
 import { render } from '@testing-library/svelte';
 
 describe('StakeReview', () => {
@@ -11,9 +10,8 @@ describe('StakeReview', () => {
 
 	const props = {
 		amount: 0.01,
-		destination: mockPrincipalText,
 		disabled: false,
-		onStake: () => {},
+		onConfirm: () => {},
 		onBack: () => {}
 	};
 


### PR DESCRIPTION
# Motivation

We need to make the `StakeReview` component more general so it can be easily reused by stake/unstake/claim rewards flows.
