### PR TITLE
build(frontend): bump verifiable-credentials lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@dfinity/ledger-icrc": "^5.0.0",
 				"@dfinity/oisy-wallet-signer": "^2.0.0",
 				"@dfinity/utils": "^4.0.0",
-				"@dfinity/verifiable-credentials": "^1.1.0",
+				"@dfinity/verifiable-credentials": "^1.2.0",
 				"@dfinity/zod-schemas": "^3.0.0",
 				"@icp-sdk/auth": "^4.2.0",
 				"@icp-sdk/core": "^4.2.1",
@@ -622,9 +622,9 @@
 			}
 		},
 		"node_modules/@dfinity/verifiable-credentials": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/verifiable-credentials/-/verifiable-credentials-1.1.0.tgz",
-			"integrity": "sha512-PpjM+h16za1npCa21RcIY7PW3v4e3aGk/yyzz9yJSTapcv4dtsVTuzG0v6ckXfOGnjB+Modc/mldohYo7bu2mA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/verifiable-credentials/-/verifiable-credentials-1.2.0.tgz",
+			"integrity": "sha512-ktqRYc3d/ZKvrf1QwxznxSsFYQ4rcbPBhDm9SPwjZm1X1k+1TB/PVTUz5ZMfL8JaaJyJAoAoaGt9OC9wcDU8xQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"nanoid": "^5.0.7"
@@ -633,13 +633,13 @@
 				"node": ">=v22"
 			},
 			"peerDependencies": {
-				"@dfinity/principal": "*"
+				"@icp-sdk/core": "^*"
 			}
 		},
 		"node_modules/@dfinity/verifiable-credentials/node_modules/nanoid": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+			"integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"@dfinity/ledger-icrc": "^5.0.0",
 		"@dfinity/oisy-wallet-signer": "^2.0.0",
 		"@dfinity/utils": "^4.0.0",
-		"@dfinity/verifiable-credentials": "^1.1.0",
+		"@dfinity/verifiable-credentials": "^1.2.0",
 		"@dfinity/zod-schemas": "^3.0.0",
 		"@icp-sdk/auth": "^4.2.0",
 		"@icp-sdk/core": "^4.2.1",


### PR DESCRIPTION
# Motivation

The `@dfinity/verifiable-credentials` has been upgraded to also points directly to `@icp-sdk/core`.

# Changes

- Bump lib as released in https://github.com/dfinity/verifiable-credentials-sdk/releases/tag/release-2025-11-05
