### PR TITLE
feat(frontend): implement ClaimStakingRewardWizard component

### DIFF
--- a/src/frontend/src/lib/components/stake/ClaimStakingRewardWizard.svelte
+++ b/src/frontend/src/lib/components/stake/ClaimStakingRewardWizard.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import type { WizardStep } from '@dfinity/gix-components';
+	import GldtClaimStakingRewardWizard from '$icp/components/stake/gldt/GldtClaimStakingRewardWizard.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Amount } from '$lib/types/send';
+	import { StakeProvider } from '$lib/types/stake';
+
+	interface Props {
+		rewardAmount: Amount;
+		provider: StakeProvider;
+		claimStakingRewardProgressStep: string;
+		currentStep?: WizardStep;
+		onClose: () => void;
+		onNext: () => void;
+		onBack: () => void;
+	}
+
+	let {
+		rewardAmount,
+		claimStakingRewardProgressStep = $bindable(),
+		currentStep,
+		provider,
+		onClose,
+		onNext,
+		onBack
+	}: Props = $props();
+</script>
+
+{#if provider === StakeProvider.GLDT}
+	<GldtClaimStakingRewardWizard
+		{currentStep}
+		{onBack}
+		{onClose}
+		{onNext}
+		{rewardAmount}
+		bind:claimStakingRewardProgressStep
+	/>
+{:else}
+	<MessageBox styleClass="mt-6">{$i18n.stake.text.unsupported_token_staking}</MessageBox>
+{/if}

--- a/src/frontend/src/tests/lib/components/stake/ClaimStakingRewardWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/ClaimStakingRewardWizard.spec.ts
@@ -1,0 +1,56 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import {
+	GLDT_STAKE_CONTEXT_KEY,
+	initGldtStakeStore,
+	type GldtStakeContext
+} from '$icp/stores/gldt-stake.store';
+import ClaimStakingRewardWizard from '$lib/components/stake/ClaimStakingRewardWizard.svelte';
+import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
+import { WizardStepsClaimStakingReward } from '$lib/enums/wizard-steps';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import { StakeProvider } from '$lib/types/stake';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('ClaimStakingRewardWizard', () => {
+	const mockContext = () =>
+		new Map<symbol, SendContext | GldtStakeContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })],
+			[GLDT_STAKE_CONTEXT_KEY, { store: initGldtStakeStore() }]
+		]);
+
+	const props = {
+		rewardAmount: 0.001,
+		provider: StakeProvider.GLDT,
+		claimStakingRewardProgressStep: 'test',
+		currentStep: {
+			name: WizardStepsClaimStakingReward.REVIEW,
+			title: 'test'
+		},
+		onClose: () => {},
+		onBack: () => {},
+		onNext: () => {}
+	};
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it('renders GLDT token wizard', () => {
+		const { getByTestId } = render(ClaimStakingRewardWizard, {
+			props,
+			context: mockContext()
+		});
+
+		expect(getByTestId(STAKE_REVIEW_FORM_BUTTON)).toBeInTheDocument();
+	});
+
+	it('renders unsupported staking message', () => {
+		const { container } = render(ClaimStakingRewardWizard, {
+			props: { ...props, provider: 'random' as StakeProvider },
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.stake.text.unsupported_token_staking);
+	});
+});


### PR DESCRIPTION
# Motivation

We can now implement `ClaimStakingRewardWizard`.
