### PR TITLE
feat(frontend): Do not stop loading ERC721 custom tokens on single error

### DIFF
--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -172,9 +172,22 @@ const loadCustomTokensWithMetadata = async (
 			}
 		);
 
-	const customTokens = await Promise.all(customTokenPromises);
+	const customTokens = await Promise.allSettled(customTokenPromises);
 
-	return customTokens.filter(nonNullish);
+	return customTokens.reduce<Erc721CustomToken[]>((acc, result) => {
+		if (result.status === 'fulfilled' && nonNullish(result.value)) {
+			acc.push(result.value);
+		}
+
+		if (result.status === 'rejected' && params.certified) {
+			toastsError({
+				msg: { text: get(i18n).init.error.erc721_custom_tokens },
+				err: result.reason
+			});
+		}
+
+		return acc;
+	}, []);
 };
 
 const loadCustomTokenData = ({


### PR DESCRIPTION
# Motivation

It does not make sense that a single failure while loading ERC721 custom tokens blocks all the others too. So, we accept all of them for now, and raise the toast error singularly.
