### PR TITLE
feat(frontend): Do not stop loading ERC1155 custom tokens on single error

### DIFF
--- a/src/frontend/src/eth/services/erc1155.services.ts
+++ b/src/frontend/src/eth/services/erc1155.services.ts
@@ -166,9 +166,22 @@ const loadCustomTokensWithMetadata = async (
 			}
 		);
 
-	const customTokens = await Promise.all(customTokenPromises);
+	const customTokens = await Promise.allSettled(customTokenPromises);
 
-	return customTokens.filter(nonNullish);
+	return customTokens.reduce<Erc1155CustomToken[]>((acc, result) => {
+		if (result.status === 'fulfilled' && nonNullish(result.value)) {
+			acc.push(result.value);
+		}
+
+		if (result.status === 'rejected') {
+			toastsError({
+				msg: { text: get(i18n).init.error.erc1155_custom_tokens },
+				err: result.reason
+			});
+		}
+
+		return acc;
+	}, []);
 };
 
 const loadCustomTokenData = ({


### PR DESCRIPTION
# Motivation

It does not make sense that a single failure while loading ERC1155 custom tokens blocks all the others too. So, we accept all of them for now, and raise the toast error singularly.
