### PR TITLE
feat(frontend): No error if missing symbol in ERC721

### DIFF
--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -143,20 +143,13 @@ const loadCustomTokensWithMetadata = async (
 					return;
 				}
 
-				const { symbol } = metadata;
-
-				assertNonNullish(
-					symbol,
-					`Inconsistency in token data: no symbol found for token ${tokenAddress}`
-				);
-
 				return {
 					...{
 						id: parseCustomTokenId({ identifier: tokenAddress, chainId: network.chainId }),
 						name: tokenAddress,
 						address: tokenAddress,
 						network,
-						symbol,
+						symbol: metadata.symbol ?? '', // The symbol is used with the amount, no issue with having it empty for NFTs
 						decimals: 0, // Erc721 contracts don't have decimals, but to avoid unexpected behavior, we set it to 0
 						standard: 'erc721' as const,
 						category: 'custom' as const,


### PR DESCRIPTION
# Motivation

Similar to ERC1155 tokens, we don't really care about missing symbols for ERC721 NFTs: it is not really used if not associated to the amount.
