### PR TITLE
feat(frontend): implement StakeRewardToken component

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeRewardToken.svelte
+++ b/src/frontend/src/lib/components/stake/StakeRewardToken.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import { stopPropagation } from '@dfinity/gix-components';
+	import Divider from '$lib/components/common/Divider.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { Token } from '$lib/types/token';
+	import { formatCurrency, formatToken } from '$lib/utils/format.utils';
+	import { calculateTokenUsdAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	interface Props {
+		token: Token;
+		amount: bigint;
+	}
+
+	let { token, amount }: Props = $props();
+
+	let disabled = $derived(amount === ZERO);
+
+	let formattedAmount = $derived(
+		formatToken({
+			value: amount,
+			unitName: token.decimals
+		})
+	);
+
+	const onClick = () => {
+		modalStore.openGldtClaimStakingReward({
+			id: Symbol(),
+			data: {
+				token,
+				rewardAmount: formattedAmount
+			}
+		});
+	};
+</script>
+
+<LogoButton hover={false}>
+	{#snippet logo()}
+		<span class="mr-2 flex">
+			<TokenLogo badge={{ type: 'network' }} color="white" data={token} />
+		</span>
+	{/snippet}
+
+	{#snippet title()}
+		<span class="text-sm">
+			{getTokenDisplaySymbol(token)}
+
+			<span class="font-normal text-tertiary">
+				<Divider />{token.name}
+			</span>
+		</span>
+	{/snippet}
+
+	{#snippet titleEnd()}
+		{formattedAmount}
+	{/snippet}
+
+	{#snippet description()}
+		{token.network.name}
+	{/snippet}
+
+	{#snippet descriptionEnd()}
+		{formatCurrency({
+			value:
+				calculateTokenUsdAmount({
+					amount,
+					token,
+					$exchanges
+				}) ?? 0,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage,
+			notBelowThreshold: !disabled
+		})}
+	{/snippet}
+
+	{#snippet action()}
+		<Button
+			colorStyle="success"
+			{disabled}
+			onclick={stopPropagation(onClick)}
+			paddingSmall
+			styleClass="ml-8"
+		>
+			{$i18n.stake.text.claim_reward}
+		</Button>
+	{/snippet}
+</LogoButton>

--- a/src/frontend/src/tests/lib/components/stake/StakeRewardToken.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeRewardToken.spec.ts
@@ -1,0 +1,50 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import StakeRewardToken from '$lib/components/stake/StakeRewardToken.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { formatToken } from '$lib/utils/format.utils';
+import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+import { render } from '@testing-library/svelte';
+
+describe('StakeRewardToken', () => {
+	const props = {
+		token: ICP_TOKEN,
+		amount: 1000n
+	};
+
+	it('renders data correctly if amount is correct', () => {
+		const { container } = render(StakeRewardToken, {
+			props
+		});
+
+		expect(container).toHaveTextContent(getTokenDisplaySymbol(ICP_TOKEN));
+		expect(container).toHaveTextContent(ICP_TOKEN.name);
+		expect(container).toHaveTextContent(ICP_TOKEN.network.name);
+		expect(container).toHaveTextContent(
+			formatToken({
+				value: props.amount,
+				unitName: ICP_TOKEN.decimals
+			})
+		);
+		expect(container).toHaveTextContent('< $0.01');
+	});
+
+	it('renders data correctly if amount is zero', () => {
+		const { container } = render(StakeRewardToken, {
+			props: {
+				...props,
+				amount: ZERO
+			}
+		});
+
+		expect(container).toHaveTextContent(getTokenDisplaySymbol(ICP_TOKEN));
+		expect(container).toHaveTextContent(ICP_TOKEN.name);
+		expect(container).toHaveTextContent(ICP_TOKEN.network.name);
+		expect(container).toHaveTextContent(
+			formatToken({
+				value: ZERO,
+				unitName: ICP_TOKEN.decimals
+			})
+		);
+		expect(container).toHaveTextContent('$0.00');
+	});
+});


### PR DESCRIPTION
# Motivation

We need to create a component for displaying a reward token and amount that can be claimed via the modal.

<img width="602" height="172" alt="Screenshot 2025-11-07 at 10 07 40" src="https://github.com/user-attachments/assets/3b44ad4c-3529-4f06-baf5-3a163435f07f" />
