### PR TITLE
style(frontend): Black spinner

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -178,7 +178,7 @@
 <svelte:window onstorage={syncAuthStore} />
 
 {#await init()}
-	<div in:fade class="text-brand-primary">
+	<div class="text-brand-primary" in:fade>
 		<Spinner />
 	</div>
 {:then _}


### PR DESCRIPTION
# Motivation

For a brief moment, the app.html spinner disappears and the Gix component spinner appears. Since the spinner from gix is currently unstyled, it appears black which looks off.

# Changes

Pass correct color to the spinner for a seamless transition

# Tests

Before:
<img width="309" height="344" alt="image" src="https://github.com/user-attachments/assets/b0ba282c-8030-4f8d-bab0-2b1cffc94979" />


No more flashing black spinner:

https://github.com/user-attachments/assets/6df5e917-3f34-4ccb-bfda-2ad81c508476

