### PR TITLE
style(frontend): adjust StakeContentSection component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeRewards.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeRewards.svelte
@@ -56,7 +56,7 @@
 {#if nonNullish($gldtStakeStore?.position)}
 	<StakeContentSection>
 		{#snippet title()}
-			{$i18n.stake.text.unclaimed_rewards}
+			<h4>{$i18n.stake.text.unclaimed_rewards}</h4>
 		{/snippet}
 
 		{#snippet content()}

--- a/src/frontend/src/lib/components/stake/StakeContentSection.svelte
+++ b/src/frontend/src/lib/components/stake/StakeContentSection.svelte
@@ -5,18 +5,14 @@
 	interface Props {
 		title: Snippet;
 		content: Snippet;
-		action?: Snippet;
 	}
 
-	let { content, action, title }: Props = $props();
+	let { content, title }: Props = $props();
 </script>
 
-<!-- TODO: add styling according to the designs -->
-<div class="rounded-xl bg-secondary p-4" in:fade>
-	<div class="flex w-full justify-between">
-		<h4>{@render title()}</h4>
-
-		{@render action?.()}
+<div class="rounded-xl bg-surface p-4" in:fade>
+	<div class="relative flex w-full items-start justify-between">
+		{@render title()}
 	</div>
 
 	<div class="mt-2">


### PR DESCRIPTION
# Motivation

We need to adjust the styling of the StakeContentSection component.

Updated design:

<img width="619" height="638" alt="Screenshot 2025-11-10 at 12 51 10" src="https://github.com/user-attachments/assets/a57dec91-c4a8-42f1-af26-05e020b29685" />
