### PR TITLE
style(frontend): adjust StakeContentCard component

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeContentCard.svelte
+++ b/src/frontend/src/lib/components/stake/StakeContentCard.svelte
@@ -9,8 +9,9 @@
 	let { content, buttons }: Props = $props();
 </script>
 
-<!-- TODO: add styling according to the designs -->
-<div class="flex w-1/2 flex-col items-center justify-between rounded-xl bg-secondary p-4">
+<div
+	class="flex w-full flex-col items-center justify-between rounded-xl border border-solid border-disabled bg-secondary p-4 sm:w-1/2"
+>
 	<div class="mb-8 flex flex-col justify-center gap-2 text-center">
 		{@render content()}
 	</div>


### PR DESCRIPTION
# Motivation

We need to adjust the styling of the StakeContentSection component.

Updated design:
<img width="619" height="638" alt="Screenshot 2025-11-10 at 12 51 10" src="https://github.com/user-attachments/assets/ee53653c-d798-4088-8fa8-3ff91fa44a66" />
