### PR TITLE
feat(frontend): update GldtStake component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStake.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStake.svelte
@@ -15,11 +15,11 @@
 	} from '$icp/stores/gldt-stake.store';
 	import { isGLDTToken } from '$icp-eth/utils/token.utils';
 	import IconBackArrow from '$lib/components/icons/lucide/IconBackArrow.svelte';
+	import StakeProviderContainer from '$lib/components/stake/StakeProviderContainer.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
-	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { networkId } from '$lib/derived/network.derived';
-	import { i18n } from '$lib/stores/i18n.store';
+	import { StakeProvider } from '$lib/types/stake';
 	import { networkUrl } from '$lib/utils/nav.utils';
 
 	let fromRoute = $state<NavigationTarget | null>(null);
@@ -28,44 +28,45 @@
 		fromRoute = from;
 	});
 
-	setContext<GldtStakeContextType>(GLDT_STAKE_CONTEXT_KEY, {
+	const { store: gldtStakeStore } = setContext<GldtStakeContextType>(GLDT_STAKE_CONTEXT_KEY, {
 		store: initGldtStakeStore()
 	});
 
 	let gldtToken = $derived($enabledIcrcTokens.find(isGLDTToken));
 </script>
 
-<div class="flex flex-row items-center">
-	{#if EARNING_ENABLED}
-		<ButtonIcon
-			ariaLabel="icon"
-			colorStyle="secondary-light"
-			link={false}
-			onclick={() =>
-				goto(
-					networkUrl({
-						path: AppPath.Earning,
-						networkId: $networkId,
-						usePreviousRoute: true,
-						fromRoute
-					})
-				)}
-			styleClass="mr-3"
-		>
-			{#snippet icon()}
-				<IconBackArrow />
-			{/snippet}
-		</ButtonIcon>
-	{/if}
-
-	<PageTitle>{$i18n.earning.cards.gold_description}</PageTitle>
-</div>
-
 <GldtStakeContext>
-	<div class="flex justify-between gap-4">
-		<GldtStakeEarnCard {gldtToken} />
-		<GldtStakePositionCard {gldtToken} />
-	</div>
+	<StakeProviderContainer currentApy={$gldtStakeStore?.apy} provider={StakeProvider.GLDT}>
+		{#snippet backButton()}
+			{#if EARNING_ENABLED}
+				<ButtonIcon
+					ariaLabel="icon"
+					colorStyle="tertiary"
+					link={false}
+					onclick={() =>
+						goto(
+							networkUrl({
+								path: AppPath.Earning,
+								networkId: $networkId,
+								usePreviousRoute: true,
+								fromRoute
+							})
+						)}
+				>
+					{#snippet icon()}
+						<IconBackArrow />
+					{/snippet}
+				</ButtonIcon>
+			{/if}
+		{/snippet}
+
+		{#snippet content()}
+			<div class="mt-6 flex flex-col justify-between gap-4 sm:flex-row">
+				<GldtStakeEarnCard {gldtToken} />
+				<GldtStakePositionCard {gldtToken} />
+			</div>
+		{/snippet}
+	</StakeProviderContainer>
 
 	<div class="my-8">
 		<GldtStakeRewards />

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStake.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStake.spec.ts
@@ -1,11 +1,12 @@
 import GldtStake from '$icp/components/stake/gldt/GldtStake.svelte';
-import en from '$tests/mocks/i18n.mock';
+import { stakeProvidersConfig } from '$lib/config/stake.config';
+import { StakeProvider } from '$lib/types/stake';
 import { render } from '@testing-library/svelte';
 
 describe('GldtStake', () => {
 	it('renders page title correctly', () => {
 		const { container } = render(GldtStake);
 
-		expect(container).toHaveTextContent(en.earning.cards.gold_description);
+		expect(container).toHaveTextContent(stakeProvidersConfig[StakeProvider.GLDT].name);
 	});
 });


### PR DESCRIPTION
# Motivation

We can now update the GldtStake component according to the design specs.

<img width="619" height="638" alt="Screenshot 2025-11-10 at 12 51 10" src="https://github.com/user-attachments/assets/5fa0b4b7-0ddb-4629-9565-0d505627faa5" />
