### PR TITLE
feat(frontend): remove @walletconnect/auth-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
 				"@solana-program/token-2022": "^0.6.0",
 				"@solana/kit": "^4.0.0",
 				"@velora-dex/sdk": "^9.0.0",
-				"@walletconnect/auth-client": "^2.1.2",
 				"alchemy-sdk": "^3.6.5",
 				"bitcoinjs-lib": "^6.1.7",
 				"browser-image-compression": "^2.0.2",
@@ -5172,54 +5171,6 @@
 				"base-x": "^3.0.2"
 			}
 		},
-		"node_modules/@stablelib/binary": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-			"integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@stablelib/int": "^1.0.1"
-			}
-		},
-		"node_modules/@stablelib/hash": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-			"integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
-			"license": "MIT"
-		},
-		"node_modules/@stablelib/int": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-			"integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
-			"license": "MIT"
-		},
-		"node_modules/@stablelib/random": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-			"integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
-			"license": "MIT",
-			"dependencies": {
-				"@stablelib/binary": "^1.0.1",
-				"@stablelib/wipe": "^1.0.1"
-			}
-		},
-		"node_modules/@stablelib/sha256": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
-			"integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@stablelib/binary": "^1.0.1",
-				"@stablelib/hash": "^1.0.1",
-				"@stablelib/wipe": "^1.0.1"
-			}
-		},
-		"node_modules/@stablelib/wipe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
-			"license": "MIT"
-		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -6455,30 +6406,6 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@walletconnect/auth-client": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@walletconnect/auth-client/-/auth-client-2.1.2.tgz",
-			"integrity": "sha512-ubJLn+vGb8sTdBFX6xAh4kjR5idrtS3RBngQWaJJJpEPBQmxMb8pM2q0FIRs8Is4K6jKy+uEhusMV+7ZBmTzjw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ethersproject/hash": "^5.7.0",
-				"@ethersproject/transactions": "^5.7.0",
-				"@stablelib/random": "^1.0.2",
-				"@stablelib/sha256": "^1.0.1",
-				"@walletconnect/core": "^2.10.1",
-				"@walletconnect/events": "^1.0.1",
-				"@walletconnect/heartbeat": "^1.2.1",
-				"@walletconnect/jsonrpc-utils": "^1.0.8",
-				"@walletconnect/logger": "^2.0.1",
-				"@walletconnect/time": "^1.0.2",
-				"@walletconnect/utils": "^2.10.1",
-				"events": "^3.3.0",
-				"isomorphic-unfetch": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@walletconnect/core": {
 			"version": "2.22.3",
 			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.22.3.tgz",
@@ -6736,16 +6663,6 @@
 				"@react-native-async-storage/async-storage": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@walletconnect/logger": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.3.tgz",
-			"integrity": "sha512-wRsD0eDQSajj8YMM/jpxoH1yeSLyS7FPkh0VKCQ1BWrERTy1Z7/DmOE8FYm/gmd7Cg6BNXVWiymhGq6wnmlq8w==",
-			"license": "MIT",
-			"dependencies": {
-				"@walletconnect/safe-json": "^1.0.2",
-				"pino": "7.11.0"
 			}
 		},
 		"node_modules/@walletconnect/relay-api": {
@@ -8485,18 +8402,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/duplexify": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-			"integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-			"license": "MIT",
-			"dependencies": {
-				"end-of-stream": "^1.4.1",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1",
-				"stream-shift": "^1.0.2"
-			}
-		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -8531,15 +8436,6 @@
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-			"license": "MIT",
-			"dependencies": {
-				"once": "^1.4.0"
-			}
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.3",
@@ -9661,15 +9557,6 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/fast-redact": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/fast-stable-stringify": {
 			"version": "1.0.0",
@@ -10869,16 +10756,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
-		"node_modules/isomorphic-unfetch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-			"integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
-			"license": "MIT",
-			"dependencies": {
-				"node-fetch": "^2.6.1",
-				"unfetch": "^4.2.0"
-			}
-		},
 		"node_modules/isomorphic-ws": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
@@ -11982,21 +11859,6 @@
 				"ufo": "^1.6.1"
 			}
 		},
-		"node_modules/on-exit-leak-free": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-			"integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
-			"license": "MIT"
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12227,44 +12089,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
-		},
-		"node_modules/pino": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-			"integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
-			"license": "MIT",
-			"dependencies": {
-				"atomic-sleep": "^1.0.0",
-				"fast-redact": "^3.0.0",
-				"on-exit-leak-free": "^0.2.0",
-				"pino-abstract-transport": "v0.5.0",
-				"pino-std-serializers": "^4.0.0",
-				"process-warning": "^1.0.0",
-				"quick-format-unescaped": "^4.0.3",
-				"real-require": "^0.1.0",
-				"safe-stable-stringify": "^2.1.0",
-				"sonic-boom": "^2.2.1",
-				"thread-stream": "^0.15.1"
-			},
-			"bin": {
-				"pino": "bin.js"
-			}
-		},
-		"node_modules/pino-abstract-transport": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-			"integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"duplexify": "^4.1.2",
-				"split2": "^4.0.0"
-			}
-		},
-		"node_modules/pino-std-serializers": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-			"integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
-			"license": "MIT"
 		},
 		"node_modules/playwright": {
 			"version": "1.56.1",
@@ -12647,12 +12471,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/process-warning": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-			"integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
-			"license": "MIT"
-		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -12732,20 +12550,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -12757,15 +12561,6 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/real-require": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
-			"integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/redent": {
@@ -13336,15 +13131,6 @@
 			"integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
 			"license": "MIT"
 		},
-		"node_modules/sonic-boom": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
-			"integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
-			"license": "MIT",
-			"dependencies": {
-				"atomic-sleep": "^1.0.0"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -13405,21 +13191,6 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"stream-chain": "^2.2.5"
-			}
-		},
-		"node_modules/stream-shift": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-			"integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-			"license": "MIT"
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -13883,15 +13654,6 @@
 			"resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
 			"integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
 		},
-		"node_modules/thread-stream": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-			"integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
-			"license": "MIT",
-			"dependencies": {
-				"real-require": "^0.1.0"
-			}
-		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -14323,12 +14085,6 @@
 			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"license": "MIT"
 		},
-		"node_modules/unfetch": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-			"integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-			"license": "MIT"
-		},
 		"node_modules/unstorage": {
 			"version": "1.17.2",
 			"resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.2.tgz",
@@ -14451,7 +14207,8 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
@@ -15110,12 +14867,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"license": "ISC"
 		},
 		"node_modules/ws": {
 			"version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
 		"@solana-program/token-2022": "^0.6.0",
 		"@solana/kit": "^4.0.0",
 		"@velora-dex/sdk": "^9.0.0",
-		"@walletconnect/auth-client": "^2.1.2",
 		"alchemy-sdk": "^3.6.5",
 		"bitcoinjs-lib": "^6.1.7",
 		"browser-image-compression": "^2.0.2",

--- a/src/frontend/src/lib/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/lib/constants/wallet-connect.constants.ts
@@ -1,8 +1,8 @@
 import { OISY_DESCRIPTION, OISY_ICON, OISY_NAME, OISY_URL } from '$lib/constants/oisy.constants';
-import type { AuthClientTypes } from '@walletconnect/auth-client';
+import type { WalletKitTypes } from '@reown/walletkit';
 import type { ErrorResponse } from '@walletconnect/jsonrpc-utils';
 
-export const WALLET_CONNECT_METADATA: AuthClientTypes.Metadata = {
+export const WALLET_CONNECT_METADATA: WalletKitTypes.Metadata = {
 	name: OISY_NAME,
 	description: OISY_DESCRIPTION,
 	url: OISY_URL,


### PR DESCRIPTION
# Motivation

Last version of `@walletconnect/auth-client` was released 2 years ago and does not seem to be an official bindings. 
Furthermore, we only use it for types that are actually provided in the official `@reown/walletkit` package.

# Notes

Follow-up of #5246

# Changes

- Remove dependency
- Use types from `@reown/walletkit`
