### PR TITLE
feat(frontend): update GldtStakePositionCard component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakePositionCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakePositionCard.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import UnstakeModal from '$lib/components/stake/UnstakeModal.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonWithModal from '$lib/components/ui/ButtonWithModal.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
@@ -15,9 +17,9 @@
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { formatCurrency } from '$lib/utils/format.utils';
+	import { formatCurrency, formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { calculateTokenUsdAmount } from '$lib/utils/token.utils';
+	import { calculateTokenUsdAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
 		gldtToken?: IcToken;
@@ -27,10 +29,16 @@
 
 	const { store: gldtStakeStore } = getContext<GldtStakeContext>(GLDT_STAKE_CONTEXT_KEY);
 
+	let gldtTokenSymbol = $derived(nonNullish(gldtToken) ? getTokenDisplaySymbol(gldtToken) : 'GLDT');
+
+	let stakedAmount = $derived(
+		nonNullish(gldtToken) ? ($gldtStakeStore?.position?.staked ?? ZERO) : ZERO
+	);
+
 	let stakedAmountUsd = $derived(
 		nonNullish(gldtToken)
 			? (calculateTokenUsdAmount({
-					amount: $gldtStakeStore?.position?.staked ?? ZERO,
+					amount: stakedAmount,
 					token: gldtToken,
 					$exchanges
 				}) ?? 0)
@@ -44,7 +52,11 @@
 	{#snippet content()}
 		<div class="text-sm">{$i18n.stake.text.active_earning}</div>
 
-		<div class="my-1 text-lg font-bold" class:text-success-primary={stakedAmountUsd > 0}>
+		<div
+			class="my-1 text-lg font-bold sm:text-xl"
+			class:text-success-primary={stakedAmountUsd > 0}
+			class:text-tertiary={stakedAmountUsd === 0}
+		>
 			{replacePlaceholders($i18n.stake.text.active_earning_per_year, {
 				$amount: `${formatCurrency({
 					value: (stakedAmountUsd * currentApy) / 100,
@@ -55,29 +67,47 @@
 			})}
 		</div>
 
-		<div class="text-sm font-bold">
-			{formatCurrency({
-				value: stakedAmountUsd,
-				currency: $currentCurrency,
-				exchangeRate: $currencyExchangeStore,
-				language: $currentLanguage
-			})}
+		<div class="flex justify-center gap-2 text-sm sm:text-base">
+			{#if stakedAmountUsd > 0}
+				<span class="font-bold">
+					{formatCurrency({
+						value: stakedAmountUsd,
+						currency: $currentCurrency,
+						exchangeRate: $currencyExchangeStore,
+						language: $currentLanguage
+					})}
+				</span>
+			{/if}
+
+			{#if nonNullish(gldtToken)}
+				<span class="text-tertiary" in:fade>
+					{formatToken({
+						value: stakedAmount,
+						unitName: gldtToken.decimals
+					})}
+					{gldtTokenSymbol}
+				</span>
+			{:else}
+				<div class="w-16">
+					<SkeletonText />
+				</div>
+			{/if}
 		</div>
 	{/snippet}
 
 	{#snippet buttons()}
-		{#if nonNullish(gldtToken)}
-			<ButtonWithModal isOpen={$modalGldtUnstake} onOpen={modalStore.openGldtUnstake}>
-				{#snippet button(onclick)}
-					<Button disabled={stakedAmountUsd === 0} fullWidth {onclick}>
-						{$i18n.stake.text.unstake}
-					</Button>
-				{/snippet}
+		<ButtonWithModal isOpen={$modalGldtUnstake} onOpen={modalStore.openGldtUnstake}>
+			{#snippet button(onclick)}
+				<Button disabled={stakedAmountUsd === 0 || isNullish(gldtToken)} fullWidth {onclick}>
+					{$i18n.stake.text.unstake}
+				</Button>
+			{/snippet}
 
-				{#snippet modal()}
+			{#snippet modal()}
+				{#if nonNullish(gldtToken)}
 					<UnstakeModal token={gldtToken} totalStaked={$gldtStakeStore?.position?.staked} />
-				{/snippet}
-			</ButtonWithModal>
-		{/if}
+				{/if}
+			{/snippet}
+		</ButtonWithModal>
 	{/snippet}
 </StakeContentCard>


### PR DESCRIPTION
# Motivation

In this PR, we introduce an "empty" state to the GldtStakePositionCard component, as well as update the state in which user has some GLDT staked.

<img width="288" height="244" alt="Screenshot 2025-11-11 at 09 58 12" src="https://github.com/user-attachments/assets/f990c343-f847-433b-9431-e300e0b1e955" />

<img width="279" height="237" alt="Screenshot 2025-11-11 at 09 58 37" src="https://github.com/user-attachments/assets/5f662203-6209-41bb-ae7c-36e14d6df206" />
