### PR TITLE
style(frontend): No need for pulsating for nullish Token exchange balance

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeBalance.svelte
@@ -31,7 +31,9 @@
 	{#if nonNullish(balance) && nonNullish(exchangeBalance)}
 		{exchangeBalance}
 	{:else if isNullish(balance) || isNullish(exchangeBalance)}
-		<span class:animate-pulse={nonNullish(nullishBalanceMessage)}>{nullishBalanceMessage ?? '-'}</span>
+		<span class:animate-pulse={nonNullish(nullishBalanceMessage)}
+			>{nullishBalanceMessage ?? '-'}</span
+		>
 	{:else}
 		<span class:animate-pulse={isNullish(balance)}>{$i18n.tokens.balance.error.not_applicable}</span
 		>


### PR DESCRIPTION
# Motivation

The majority of cases is when the exchange balance is nullish because there is no price. In those cases it does not really make sense to have it pulsating, since there is nothing working behind to be awaited.
