### PR TITLE
feat(frontend): Adds reward requirements type for earning cards

### DIFF
--- a/src/frontend/src/lib/components/rewards/EligibilityBadge.svelte
+++ b/src/frontend/src/lib/components/rewards/EligibilityBadge.svelte
@@ -19,7 +19,7 @@
 		testId={nonNullish(testId) ? `${testId}-badge` : undefined}
 		variant={isEligible ? 'eligible' : 'not-eligible'}
 	>
-		<div class="flex items-center gap-1.5 text-sm">
+		<div class="flex items-center gap-1.5">
 			{#if isEligible}
 				<IconCircleCheck size="14" />
 				{$i18n.rewards.text.youre_eligible}

--- a/src/frontend/src/lib/components/rewards/NetworkBonusImage.svelte
+++ b/src/frontend/src/lib/components/rewards/NetworkBonusImage.svelte
@@ -4,13 +4,14 @@
 	interface Props {
 		multiplier: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 		disabled?: boolean;
+		size?: number;
 	}
 
-	let { multiplier, disabled = false }: Props = $props();
+	let { multiplier, disabled = false, size = 245 }: Props = $props();
 </script>
 
 <div data-tid={REWARDS_NETWORK_MULTIPLIER_IMAGE}>
-	<svg fill="none" height="28" viewBox="0 0 245 28" width="245" xmlns="http://www.w3.org/2000/svg">
+	<svg fill="none" height="28" viewBox="0 0 245 28" width={size} xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M0 14C0 6.26801 6.26801 0 14 0H230.937C238.669 0 244.937 6.26801 244.937 14C244.937 21.732 238.669 28 230.937 28H14C6.26802 28 0 21.732 0 14Z"
 			fill={disabled ? 'black' : 'url(#paint0_linear_17618_27124)'}

--- a/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
@@ -15,9 +15,10 @@
 	interface Props {
 		criterion: CampaignCriterion;
 		testId?: string;
+		truncate?: boolean;
 	}
 
-	let { criterion, testId }: Props = $props();
+	let { criterion, testId, truncate = false }: Props = $props();
 
 	const getCriterionText = (criterion: CampaignCriterion): string | undefined => {
 		if (RewardCriterionType.MIN_LOGINS === criterion.type) {
@@ -70,7 +71,7 @@
 		>
 			<IconCheckCircleFill size={24} />
 		</span>
-		<span>
+		<span class:truncate>
 			{criterionText}
 		</span>
 	</span>

--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -17,9 +17,17 @@
 		networkBonusMultiplier: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 		criteria: CampaignCriterion[];
 		reward: RewardCampaignDescription;
+		type?: 'default' | 'earnings-card';
 	}
 
-	let { isEligible, hasNetworkBonus, networkBonusMultiplier, criteria, reward }: Props = $props();
+	let {
+		isEligible,
+		hasNetworkBonus,
+		networkBonusMultiplier,
+		criteria,
+		reward,
+		type = 'default'
+	}: Props = $props();
 
 	let infoExpanded = $state(false);
 </script>
@@ -30,15 +38,23 @@
 		class:flex-row={!hasNetworkBonus}
 		class:items-center={!hasNetworkBonus}
 	>
-		<span class="text-base font-semibold">
-			{$i18n.rewards.requirements.requirements_title}
-		</span>
+		{#if type !== 'earnings-card'}
+			<span class="text-base font-semibold">
+				{$i18n.rewards.requirements.requirements_title}
+			</span>
+		{/if}
 
 		<div class="flex flex-wrap gap-2.5" class:pl-3={!hasNetworkBonus}>
-			<EligibilityBadge {isEligible} />
+			<span class:text-sm={type === 'default'} class:text-xs={type === 'earnings-card'}>
+				<EligibilityBadge {isEligible} />
+			</span>
 
 			{#if hasNetworkBonus && nonNullish(networkBonusMultiplier)}
-				<NetworkBonusImage disabled={!isEligible} multiplier={networkBonusMultiplier} />
+				<NetworkBonusImage
+					disabled={!isEligible}
+					multiplier={networkBonusMultiplier}
+					size={type === 'earnings-card' ? 210 : undefined}
+				/>
 
 				<button class="p-0.5 text-tertiary" onclick={() => (infoExpanded = !infoExpanded)}>
 					<IconHelp size="18" />


### PR DESCRIPTION
# Motivation

We add a type prop to the rewards requirements because we need a slightly adjusted version for the earning cards.

# Changes

Adjusted network multiplier to make it fit better on the earning cards
Adjusted text size for eligibility badge to make it same size as the multiplier
Truncate the requirement criteria texts
Dont show title on earning card

# Tests

Variant default (as it was):
<img width="538" height="227" alt="image" src="https://github.com/user-attachments/assets/d2aac69d-42b5-47b2-9875-548acc70a994" />


Variant earning-card:
<img width="263" height="242" alt="image" src="https://github.com/user-attachments/assets/081c22bd-eeaa-47eb-92c3-899c11714908" />

