### PR TITLE
feat(frontend): update GLDT stake button

### DIFF
--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "$provider Staking",
 			"gldt_stake_page_description": "Stake GLDT tokens to earn rewards backed by physical gold",
 			"stake": "Stake $token_symbol",
+			"stake_amount": "Stake $amount $token_symbol",
+			"not_enough_to_stake": "No $token_symbol to stake",
 			"unstake": "Unstake",
 			"unstaking": "Unstaking...",
 			"unstake_token": "Unstake $token_symbol",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "Стейкинг",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1732,6 +1732,8 @@
 			"stake_page_title": "",
 			"gldt_stake_page_description": "",
 			"stake": "",
+			"stake_amount": "",
+			"not_enough_to_stake": "",
 			"unstake": "",
 			"unstaking": "",
 			"unstake_token": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1387,6 +1387,8 @@ interface I18nStake {
 		stake_page_title: string;
 		gldt_stake_page_description: string;
 		stake: string;
+		stake_amount: string;
+		not_enough_to_stake: string;
 		unstake: string;
 		unstaking: string;
 		unstake_token: string;

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeEarnCard.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeEarnCard.spec.ts
@@ -6,6 +6,8 @@ import {
 	type GldtStakeContext
 } from '$icp/stores/gldt-stake.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcToken } from '$icp/types/ic-token';
+import { balancesStore } from '$lib/stores/balances.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
@@ -14,6 +16,12 @@ import { render } from '@testing-library/svelte';
 describe('GldtStakeEarnCard', () => {
 	const mockContext = () =>
 		new Map<symbol, GldtStakeContext>([[GLDT_STAKE_CONTEXT_KEY, { store: initGldtStakeStore() }]]);
+	const gldtToken = {
+		...mockIcrcCustomToken,
+		standard: 'icrc',
+		ledgerCanisterId: GLDT_LEDGER_CANISTER_ID,
+		symbol: 'GLDT'
+	} as IcToken;
 
 	beforeEach(() => {
 		icrcCustomTokensStore.resetAll();
@@ -37,21 +45,36 @@ describe('GldtStakeEarnCard', () => {
 		);
 	});
 
-	it('should display correct values if GLDT token is available', () => {
+	it('should display "no GLDT to stake" if GLDT token is available but no balance', () => {
 		const { container } = render(GldtStakeEarnCard, {
 			props: {
-				gldtToken: {
-					...mockIcrcCustomToken,
-					standard: 'icrc',
-					ledgerCanisterId: GLDT_LEDGER_CANISTER_ID,
-					symbol: 'GLDT'
-				}
+				gldtToken
 			},
 			context: mockContext()
 		});
 
 		expect(container).toHaveTextContent(
-			replacePlaceholders(en.stake.text.stake, { $token_symbol: 'GLDT' })
+			replacePlaceholders(en.stake.text.not_enough_to_stake, { $token_symbol: gldtToken.symbol })
+		);
+	});
+
+	it('should display "stake GLDT" if GLDT token is available but no balance', () => {
+		balancesStore.set({
+			id: gldtToken.id,
+			data: { data: 10000000n, certified: true }
+		});
+		const { container } = render(GldtStakeEarnCard, {
+			props: {
+				gldtToken
+			},
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(
+			replacePlaceholders(en.stake.text.stake_amount, {
+				$token_symbol: gldtToken.symbol,
+				$amount: '0.1'
+			})
 		);
 	});
 });


### PR DESCRIPTION
# Motivation

We need to make the GLDT stake button more dynamic - we will have a separate state for "no gldt available" and for "stake N GLDT" cases.

<img width="277" height="236" alt="Screenshot 2025-11-14 at 11 22 44" src="https://github.com/user-attachments/assets/58176365-6ad9-4671-b188-a0208b2b875d" />

<img width="285" height="238" alt="Screenshot 2025-11-14 at 11 09 51" src="https://github.com/user-attachments/assets/4541eecc-0ec2-4da4-a1c3-3f62a47dcb95" />
