### PR TITLE
feat(frontend): Extend `postMessage` schema with reference

### DIFF
--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -232,11 +232,19 @@ export const PostMessageDataResponsePowProtectorNextAllowanceSchema =
 		nextAllowanceMs: z.custom<bigint>().optional()
 	});
 
+const PostMessageCommonSchema = z.object({
+	ref: z.string().optional()
+});
+
 export const inferPostMessageSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
 	z.union([
 		z.object({
+			...PostMessageCommonSchema.shape,
 			msg: z.union([PostMessageRequestSchema, PostMessageResponseSchema]),
 			data: z.strictObject(dataSchema).shape.optional()
 		}),
-		PostMessageDataErrorSchema
+		z.object({
+			...PostMessageCommonSchema.shape,
+			...PostMessageDataErrorSchema.shape
+		})
 	]);

--- a/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
@@ -771,6 +771,7 @@ describe('post-message.schema', () => {
 		const [validRequestMsg] = PostMessageRequestSchema.options;
 		const [validResponseMsg] = PostMessageResponseSchema.options;
 		const validData = { additionalInfo: 'sample info' };
+		const validRef = 'unique-ref-123';
 
 		it('should validate with a valid request msg and data matching dataSchema', () => {
 			const validPayload = {
@@ -817,6 +818,16 @@ describe('post-message.schema', () => {
 			const validPayload = {
 				msg: validResponseMsg,
 				data: validData
+			};
+
+			expect(SchemaWithCustomData.parse(validPayload)).toEqual(validPayload);
+		});
+
+		it('should validate with a valid ref', () => {
+			const validPayload = {
+				msg: validRequestMsg,
+				data: validData,
+				ref: validRef
 			};
 
 			expect(SchemaWithCustomData.parse(validPayload)).toEqual(validPayload);


### PR DESCRIPTION
# Motivation

It is useful to have a reference for each message of the post message, as way of identifying the "destination" of the message. It will be particularly useful if we are going to use a singleton worker.