### PR TITLE
fix(frontend): Provide SPL tokens 2022 with metadata on loading

### DIFF
--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -140,10 +140,14 @@ const loadCustomTokensWithMetadata = async (
 
 			const metadata = await getSplMetadata({ address, network: solNetwork });
 
-			return [
-				...(await acc),
-				{ ...token, owner, ...rest, ...(nonNullish(metadata) ? hardenMetadata(metadata) : {}) }
-			];
+			const newToken: SplCustomToken = {
+				...token,
+				owner,
+				...rest,
+				...(nonNullish(metadata) ? hardenMetadata(metadata) : {})
+			};
+
+			return [...(await acc), newToken];
 		}, Promise.resolve([]));
 
 		return [...existingTokens, ...customTokens];


### PR DESCRIPTION
# Motivation

After PR https://github.com/dfinity/oisy-wallet/pull/10319, we are automatically getting the metadata from the token info too. So we don't really need to check if the fetched metadata are nullish, we can directly return the results.
