### PR TITLE
chore(frontend): Remove unused toast error in Exchange worker

### DIFF
--- a/src/frontend/src/lib/services/worker.exchange.services.ts
+++ b/src/frontend/src/lib/services/worker.exchange.services.ts
@@ -46,10 +46,6 @@ export class ExchangeWorker extends AppWorker {
 		});
 	};
 
-	protected override destroyCallback = () => {
-		errorMessages = [];
-	};
-
 	startExchangeTimer = (data: PostMessageDataRequestExchangeTimer) => {
 		this.postMessage({
 			msg: 'startExchangeTimer',


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/631, the error toast of the exchange was hidden because it was causing too many issues. Ultimately we decided that in any case we will not the toast error for exchange error, just a console log, to avoid polluting the user interface.

We already have skeletons and visual feedbacks for errors while fetching exchange rate.
