### PR TITLE
refactor(frontend): Make the derived test utils more modular

### DIFF
--- a/src/frontend/src/tests/utils/derived.test-utils.ts
+++ b/src/frontend/src/tests/utils/derived.test-utils.ts
@@ -24,10 +24,12 @@ const isReadable = (value: unknown): value is Readable<unknown> =>
 
 const derivedList: Record<string, Readable<unknown>> = {};
 
-for (const [modulePath, module] of moduleGroups) {
-	for (const [name, exported] of Object.entries(module)) {
-		if (isReadable(exported)) {
-			derivedList[`${modulePath}:${name}`] = exported;
+for (const [modulePath, modules] of moduleGroups) {
+	for (const module of Object.values(modules)) {
+		for (const [name, exported] of Object.entries(module)) {
+			if (isReadable(exported)) {
+				derivedList[`${modulePath}:${name}`] = exported;
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Motivation

To improve manageability, we make the list of derived stores in the derived test utils more modular.
