### PR TITLE
chore(frontend): added bech32 npm package for decoding LUD-01

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"@solana/kit": "^5.0.0",
 				"@velora-dex/sdk": "^9.0.0",
 				"alchemy-sdk": "^3.6.5",
+				"bech32": "^2.0.0",
 				"bitcoinjs-lib": "^6.1.7",
 				"browser-image-compression": "^2.0.2",
 				"buffer": "^6.0.3",
@@ -453,12 +454,6 @@
 				"@dfinity/utils": "^4",
 				"@icp-sdk/core": "^4"
 			}
-		},
-		"node_modules/@dfinity/ckbtc/node_modules/bech32": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-			"license": "MIT"
 		},
 		"node_modules/@dfinity/cketh": {
 			"version": "5.0.0",
@@ -1808,6 +1803,12 @@
 				"bech32": "1.1.4",
 				"ws": "8.18.0"
 			}
+		},
+		"node_modules/@ethersproject/providers/node_modules/bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+			"license": "MIT"
 		},
 		"node_modules/@ethersproject/providers/node_modules/ws": {
 			"version": "7.5.10",
@@ -7625,9 +7626,9 @@
 			]
 		},
 		"node_modules/bech32": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
 			"license": "MIT"
 		},
 		"node_modules/bidi-js": {
@@ -7665,12 +7666,6 @@
 			"engines": {
 				"node": ">=8.0.0"
 			}
-		},
-		"node_modules/bitcoinjs-lib/node_modules/bech32": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-			"integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-			"license": "MIT"
 		},
 		"node_modules/blakejs": {
 			"version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"@solana/kit": "^5.0.0",
 		"@velora-dex/sdk": "^9.0.0",
 		"alchemy-sdk": "^3.6.5",
+		"bech32": "^2.0.0",
 		"bitcoinjs-lib": "^6.1.7",
 		"browser-image-compression": "^2.0.2",
 		"buffer": "^6.0.3",


### PR DESCRIPTION
# Motivation

We aim to integrate with OpenCryptoPay from dfx.swiss. According to their documentation, we need to decode the API URL using the standard LNURL-01 standard. To implement this, we use the `bech32` npm package for proper LNURL decoding.

NPM Package: https://www.npmjs.com/package/bech32