### PR TITLE
chore(build): Run npm audit for `glob` vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9846,9 +9846,9 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {


### PR DESCRIPTION
# Motivation

There is a new high severity vulnerability for glob package:

`glob CLI: Command injection via -c/--cmd executes matches with shell:true`

Link [here](https://github.com/advisories/GHSA-5j98-mcp5-4vw2).

# Changes

- `npm audit fix`
