### PR TITLE
chore(frontend): Missing mocks resets in tests

### DIFF
--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeContext.spec.ts
@@ -40,6 +40,8 @@ describe('UtxosFeeContext', () => {
 	};
 
 	beforeEach(() => {
+		vi.clearAllMocks();
+
 		mockPage.reset();
 		store = initUtxosFeeStore();
 		store.reset();

--- a/src/frontend/src/tests/icp/components/fee/IcTokenFeeContext.spec.ts
+++ b/src/frontend/src/tests/icp/components/fee/IcTokenFeeContext.spec.ts
@@ -27,6 +27,8 @@ describe('IcTokenFeeContext', () => {
 	};
 
 	beforeEach(() => {
+		vi.clearAllMocks();
+
 		icTokenFeeStore.reset();
 	});
 

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeContext.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeContext.spec.ts
@@ -31,6 +31,8 @@ describe('GldtStakeContext', () => {
 	};
 
 	beforeEach(() => {
+		vi.clearAllMocks();
+
 		icTokenFeeStore.reset();
 	});
 

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -476,6 +476,10 @@ describe('reward.services', () => {
 			sprinkles: []
 		} as unknown as UserData;
 
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
 		vi.spyOn(rewardApi, 'getUserInfo')
 			.mockResolvedValueOnce({
 				...baseMockUserData,


### PR DESCRIPTION
# Motivation

Some tests are missing the mock clearing, just for completeness.
