### PR TITLE
refactor(frontend): More explicit constructor on worker mocks

### DIFF
--- a/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
@@ -29,13 +29,19 @@ vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
 
 let workerInstance: Worker;
 
-vi.mock('$lib/workers/workers?worker', () => ({
-	default: vi.fn().mockImplementation(() => {
-		// @ts-expect-error testing this on purpose with a mock class
-		workerInstance = new Worker();
-		return workerInstance;
-	})
-}));
+vi.mock('$lib/workers/workers?worker', () => {
+	class MockWorkers {
+		constructor() {
+			// @ts-expect-error testing this on purpose with a mock class
+			workerInstance = new Worker();
+			return workerInstance;
+		}
+	}
+
+	return {
+		default: MockWorkers
+	};
+});
 
 const mockId = 'abcdefgh';
 

--- a/src/frontend/src/tests/icp/services/worker.pow-protector.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.pow-protector.services.spec.ts
@@ -27,13 +27,19 @@ vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
 
 let workerInstance: Worker;
 
-vi.mock('$lib/workers/workers?worker', () => ({
-	default: vi.fn().mockImplementation(() => {
-		// @ts-expect-error testing this on purpose with a mock class
-		workerInstance = new Worker();
-		return workerInstance;
-	})
-}));
+vi.mock('$lib/workers/workers?worker', () => {
+	class MockWorkers {
+		constructor() {
+			// @ts-expect-error testing this on purpose with a mock class
+			workerInstance = new Worker();
+			return workerInstance;
+		}
+	}
+
+	return {
+		default: MockWorkers
+	};
+});
 
 const mockId = 'abcdefgh';
 

--- a/src/frontend/src/tests/lib/services/worker.auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/worker.auth.services.spec.ts
@@ -22,13 +22,19 @@ vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
 
 let workerInstance: Worker;
 
-vi.mock('$lib/workers/workers?worker', () => ({
-	default: vi.fn().mockImplementation(() => {
-		// @ts-expect-error testing this on purpose with a mock class
-		workerInstance = new Worker();
-		return workerInstance;
-	})
-}));
+vi.mock('$lib/workers/workers?worker', () => {
+	class MockWorkers {
+		constructor() {
+			// @ts-expect-error testing this on purpose with a mock class
+			workerInstance = new Worker();
+			return workerInstance;
+		}
+	}
+
+	return {
+		default: MockWorkers
+	};
+});
 
 const mockId = 'abcdefgh';
 

--- a/src/frontend/src/tests/lib/services/worker.exchange.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/worker.exchange.service.spec.ts
@@ -31,13 +31,19 @@ vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
 
 let workerInstance: Worker;
 
-vi.mock('$lib/workers/workers?worker', () => ({
-	default: vi.fn().mockImplementation(() => {
-		// @ts-expect-error testing this on purpose with a mock class
-		workerInstance = new Worker();
-		return workerInstance;
-	})
-}));
+vi.mock('$lib/workers/workers?worker', () => {
+	class MockWorkers {
+		constructor() {
+			// @ts-expect-error testing this on purpose with a mock class
+			workerInstance = new Worker();
+			return workerInstance;
+		}
+	}
+
+	return {
+		default: MockWorkers
+	};
+});
 
 const mockId = 'abcdefgh';
 

--- a/src/frontend/src/tests/lib/services/worker.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/worker.services.spec.ts
@@ -11,13 +11,19 @@ class MockWorker {
 
 let workerInstance: Worker;
 
-vi.mock('$lib/workers/workers?worker', () => ({
-	default: vi.fn().mockImplementation(() => {
-		// @ts-expect-error testing this on purpose with a mock class
-		workerInstance = new Worker();
-		return workerInstance;
-	})
-}));
+vi.mock('$lib/workers/workers?worker', () => {
+	class MockWorkers {
+		constructor() {
+			// @ts-expect-error testing this on purpose with a mock class
+			workerInstance = new Worker();
+			return workerInstance;
+		}
+	}
+
+	return {
+		default: MockWorkers
+	};
+});
 
 describe('_worker.services', () => {
 	describe('AppWorker', () => {


### PR DESCRIPTION
# Motivation

We want to make our mocking of the `worker` instance more solid with a constructor.
