### PR TITLE
refactor(frontend): Use `MockInstance` in contact test module

### DIFF
--- a/src/frontend/src/tests/lib/services/manage-contacts.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-contacts.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
+import type { MockInstance } from 'vitest';
 
 const mockContactImage: ContactImage | null = {
 	data: new Uint8Array([1, 2, 3]),
@@ -132,7 +133,7 @@ describe('manage-contacts.service', () => {
 
 	describe('updateContact', () => {
 		const mockUpdateContact = vi.spyOn(backendApi, 'updateContact');
-		let updateContactSpy: ReturnType<typeof vi.spyOn>;
+		let updateContactSpy: MockInstance;
 
 		beforeEach(() => {
 			vi.resetAllMocks();


### PR DESCRIPTION
# Motivation

It is more correct to use `MockInstance` when mocking a function.
