### PR TITLE
style(frontend): update StakeContentCard styling

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeContentCard.svelte
+++ b/src/frontend/src/lib/components/stake/StakeContentCard.svelte
@@ -4,19 +4,28 @@
 	interface Props {
 		content: Snippet;
 		buttons: Snippet;
+		primaryStyle?: boolean;
 	}
 
-	let { content, buttons }: Props = $props();
+	let { content, buttons, primaryStyle = false }: Props = $props();
 </script>
 
 <div
-	class="flex w-full flex-col items-center justify-between rounded-xl border border-solid border-disabled bg-secondary p-4 sm:w-1/2"
+	class="flex w-full flex-col items-center justify-between rounded-xl border-solid border-disabled p-4 sm:w-1/2"
+	class:bg-brand-subtle-10={primaryStyle}
+	class:bg-secondary={!primaryStyle}
+	class:border={!primaryStyle}
+	class:border-0={primaryStyle}
 >
-	<div class="mb-8 flex flex-col justify-center gap-2 text-center">
+	<div
+		class="mb-8 flex flex-col justify-center text-center"
+		class:gap-2={!primaryStyle}
+		class:gap-4={primaryStyle}
+	>
 		{@render content()}
 	</div>
 
-	<div class="w-full">
+	<div class="flex w-full flex-col gap-2">
 		{@render buttons()}
 	</div>
 </div>


### PR DESCRIPTION
# Motivation

We need to update the component the way that it can be used in different cases.

`primaryStyle = false`:
<img width="276" height="298" alt="Screenshot 2025-11-19 at 14 11 37" src="https://github.com/user-attachments/assets/9716e1bb-9675-4057-9a52-2bfe21dddc57" />

`primaryStyle = true`
<img width="276" height="297" alt="Screenshot 2025-11-19 at 14 11 33" src="https://github.com/user-attachments/assets/29263f94-faf0-4f8c-85ef-1fdac3c04b5e" />
