### PR TITLE
feat(frontend): Make all IC wallet worker singletons in iOS

### DIFF
--- a/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
@@ -75,14 +75,6 @@ export class Dip20WalletWorker extends AppWorker implements WalletWorker {
 	}: IcToken): Promise<Dip20WalletWorker> {
 		await syncWalletFromCache({ tokenId, networkId });
 
-		console.log(
-			isIOS(),
-			'Initializing Dip20WalletWorker for token:',
-			tokenId,
-			'canister:',
-			canisterId
-		);
-
 		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
 		return new Dip20WalletWorker(worker, tokenId, canisterId);
 	}

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -80,14 +80,6 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 
 		await syncWalletFromCache({ tokenId, networkId });
 
-		console.log(
-			isIOS(),
-			'Initializing IcpWalletWorker for token:',
-			tokenId,
-			'canister:',
-			indexCanisterId
-		);
-
 		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
 		return new IcpWalletWorker(worker, tokenId, indexCanisterId);
 	}

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -85,14 +85,6 @@ export class IcrcWalletWorker extends AppWorker implements WalletWorker {
 	}: IcToken): Promise<IcrcWalletWorker> {
 		await syncWalletFromCache({ tokenId, networkId });
 
-		console.log(
-			isIOS(),
-			'Initializing IcrcWalletWorker for token:',
-			tokenId,
-			'canister:',
-			ledgerCanisterId
-		);
-
 		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
 		return new IcrcWalletWorker(worker, tokenId, ledgerCanisterId, indexCanisterId, env);
 	}


### PR DESCRIPTION
# Motivation

We are facing serious _jetsam_ problems with iOS (mostly iPhones). Basically, the memory pressure is such that, on some wallets, the OISY page auto-refreshes or crashes at first touches, making it almost impossible to use it.

We are trying to make it "lighter". One way to do it is to make the IC wallet workers as singletons for iOS.