### PR TITLE
refactor(frontend): Earn nav text

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -68,7 +68,7 @@
 			"dapp_explorer": "Explore",
 			"activity": "Activity",
 			"airdrops": "Rewards",
-			"earning": "Earn & Rewards",
+			"earning": "Earn",
 			"source_code_on_github": "Source code on GitHub",
 			"view_on_explorer": "View on explorer",
 			"source_code": "Source code",


### PR DESCRIPTION
# Motivation

We want to shorten the navigation item label for the earn page, especially so it looks better on the mobile navigation.

# Changes

Changed to only say Earn.

# Tests
<img width="364" height="304" alt="image" src="https://github.com/user-attachments/assets/7c9d07c8-8272-44fe-9102-007d02954811" />

<img width="419" height="304" alt="image" src="https://github.com/user-attachments/assets/8aa65deb-d0ec-4873-8c68-440b20f62327" />
