### PR TITLE
chore(frontend): Add comment on util `mapAssociatedTokenAccountInstrucion`

### DIFF
--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -263,7 +263,7 @@ const mapToken2022ParsedInstruction = async ({
 };
 
 // This is just a placeholder to "treat" ATA instructions in SOL.
-// For now, we don't map any of them because we don't need it.
+// For now, we don't map any of them because we don't need to.
 // It is just for completeness in util `mapSolParsedInstruction` to be aware of this kind of instruction.
 const mapAssociatedTokenAccountInstruction = ({
 	type


### PR DESCRIPTION
# Motivation

As suggested by @peterpeterparker , we should have a comment for util `mapAssociatedTokenAccountInstrucion` since it is basically doing nothing.

The function is just a placeholder for completeness of `mapSolParsedInstruction`: we show that we are aware of ATA instructions, but currently we don't need them.
