### PR TITLE
feat(build): Remove formatting from bindings generate script

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -108,4 +108,3 @@ done
 node scripts/did.update.types.mjs
 # Clean up..
 node scripts/did.delete.types.mjs
-npm run format


### PR DESCRIPTION
# Motivation

Just to spare time and CI efforts, we can remove `npm run format` from `generate.sh` script. The other CIs will take care of running it anyway, and in general they will manage the cache for that script, centralizing the execution.
