### PR TITLE
feat(did): Temporarily undo the removal of subfolder `declarations`

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -96,7 +96,7 @@ generate_declarations() {
     mv "${generatedTsfile}" "${didfolder}"
     mv "${generatedJsfile}" "${didfolder}"
     # TODO: re-remove the generated folder once we adapt all imports to the new "old" location.
-    # rm -r "${generatedFolder}"å
+    # rm -r "${generatedFolder}"
   else
     echo "DID file skipped: $didfile"
   fi


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is the first step.
