### PR TITLE
refactor(frontend): Avoid referring to subfolder for `xtc_ledger` bindings

### DIFF
--- a/src/frontend/src/icp/canisters/xtc-ledger.canister.ts
+++ b/src/frontend/src/icp/canisters/xtc-ledger.canister.ts
@@ -1,4 +1,4 @@
-import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/xtc_ledger.did';
 import { idlFactory as idlCertifiedFactoryXtcLedger } from '$declarations/xtc_ledger/xtc_ledger.factory.certified.did';
 import { idlFactory as idlFactoryXtcLedger } from '$declarations/xtc_ledger/xtc_ledger.factory.did';
 import { mapXtcLedgerCanisterError } from '$icp/canisters/xtc-ledger.errors';

--- a/src/frontend/src/icp/canisters/xtc-ledger.errors.ts
+++ b/src/frontend/src/icp/canisters/xtc-ledger.errors.ts
@@ -1,4 +1,4 @@
-import type { TxError } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { TxError } from '$declarations/xtc_ledger/xtc_ledger.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
 export const mapXtcLedgerCanisterError = (err: TxError): CanisterInternalError => {

--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
 import { IcWalletScheduler, type IcWalletMsg } from '$icp/schedulers/ic-wallet.scheduler';
 import type { Dip20TransactionWithId } from '$icp/types/api';
 import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic-transaction';

--- a/src/frontend/src/icp/types/api.ts
+++ b/src/frontend/src/icp/types/api.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
 
 export interface Dip20TransactionWithId {
 	id: bigint;

--- a/src/frontend/src/icp/types/ic-transaction.ts
+++ b/src/frontend/src/icp/types/ic-transaction.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
 import type { Dip20TransactionWithId } from '$icp/types/api';
 import type { icpTransactionTypes } from '$lib/schema/transaction.schema';
 import type { TransactionId, TransactionType } from '$lib/types/transaction';

--- a/src/frontend/src/icp/utils/dip20-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/dip20-transactions.utils.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
 import type { Dip20TransactionWithId } from '$icp/types/api';
 import type {
 	Dip20Transaction,

--- a/src/frontend/src/icp/workers/dip20-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/dip20-wallet.worker.ts
@@ -1,4 +1,4 @@
-import type { Event } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { Event } from '$declarations/xtc_ledger/xtc_ledger.did';
 import { balance, transactions } from '$icp/api/xtc-ledger.api';
 import { IcWalletBalanceAndTransactionsScheduler } from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';

--- a/src/frontend/src/tests/icp/canisters/xtc-ledger.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/xtc-ledger.canister.spec.ts
@@ -1,4 +1,4 @@
-import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/declarations/xtc_ledger.did';
+import type { _SERVICE as XtcLedgerService } from '$declarations/xtc_ledger/xtc_ledger.did';
 import { XtcLedgerCanister } from '$icp/canisters/xtc-ledger.canister';
 import type { XtcLedgerTransferParams } from '$icp/types/xtc-ledger';
 import { CanisterInternalError } from '$lib/canisters/errors';


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `xtc_ledger` bindings that was done in PR https://github.com/dfinity/oisy-wallet/pull/9559
