### PR TITLE
refactor(frontend): Avoid referring to subfolder for `sol_rpc` bindings

### DIFF
--- a/src/frontend/src/sol/canisters/sol-rpc.canister.ts
+++ b/src/frontend/src/sol/canisters/sol-rpc.canister.ts
@@ -7,7 +7,7 @@ import type {
 	Slot,
 	_SERVICE as SolRpcService,
 	SolanaCluster
-} from '$declarations/sol_rpc/declarations/sol_rpc.did';
+} from '$declarations/sol_rpc/sol_rpc.did';
 import { idlFactory as idlCertifiedFactorySolRpc } from '$declarations/sol_rpc/sol_rpc.factory.certified.did';
 import { idlFactory as idlFactorySolRpc } from '$declarations/sol_rpc/sol_rpc.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';

--- a/src/frontend/src/sol/canisters/sol-rpc.constants.ts
+++ b/src/frontend/src/sol/canisters/sol-rpc.constants.ts
@@ -2,7 +2,7 @@ import type {
 	ConsensusStrategy,
 	GetAccountInfoEncoding,
 	RpcConfig
-} from '$declarations/sol_rpc/declarations/sol_rpc.did';
+} from '$declarations/sol_rpc/sol_rpc.did';
 import { toNullable } from '@dfinity/utils';
 
 const SOL_RPC_CONSENSUS_STRATEGY: ConsensusStrategy = {

--- a/src/frontend/src/sol/canisters/sol-rpc.errors.ts
+++ b/src/frontend/src/sol/canisters/sol-rpc.errors.ts
@@ -1,4 +1,4 @@
-import type { RpcError, RpcSource } from '$declarations/sol_rpc/declarations/sol_rpc.did';
+import type { RpcError, RpcSource } from '$declarations/sol_rpc/sol_rpc.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { assertNever, fromNullable, jsonReplacer } from '@dfinity/utils';
 

--- a/src/frontend/src/sol/types/sol-rpc.ts
+++ b/src/frontend/src/sol/types/sol-rpc.ts
@@ -1,4 +1,4 @@
-import type { AccountInfo, ParsedAccount } from '$declarations/sol_rpc/declarations/sol_rpc.did';
+import type { AccountInfo, ParsedAccount } from '$declarations/sol_rpc/sol_rpc.did';
 import type { Address, GetAccountInfoApi } from '@solana/kit';
 
 export type ParsedAccountInfo = Omit<AccountInfo, 'data'> & {

--- a/src/frontend/src/tests/mocks/sol-rpc.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-rpc.mock.ts
@@ -1,4 +1,4 @@
-import type { AccountInfo } from '$declarations/sol_rpc/declarations/sol_rpc.did';
+import type { AccountInfo } from '$declarations/sol_rpc/sol_rpc.did';
 import { SYSTEM_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 

--- a/src/frontend/src/tests/sol/canisters/sol-rpc.canister.spec.ts
+++ b/src/frontend/src/tests/sol/canisters/sol-rpc.canister.spec.ts
@@ -4,7 +4,7 @@ import type {
 	RpcError,
 	RpcSource,
 	_SERVICE as SolRpcService
-} from '$declarations/sol_rpc/declarations/sol_rpc.did';
+} from '$declarations/sol_rpc/sol_rpc.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { SolRpcCanister, networkToCluster } from '$sol/canisters/sol-rpc.canister';


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `sol_rpc` bindings that was done in PR https://github.com/dfinity/oisy-wallet/pull/9560
