### PR TITLE
refactor(frontend): Avoid referring to subfolder for `signer` bindings

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -5,7 +5,7 @@ import type { BtcAddress } from '$btc/types/address';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { estimateTransactionSize, extractUtxoTxIds } from '$btc/utils/btc-utxos.utils';
-import type { SendBtcResponse } from '$declarations/signer/declarations/signer.did';
+import type { SendBtcResponse } from '$declarations/signer/signer.did';
 import { getPendingTransactionUtxoTxIds, txidStringToUint8Array } from '$icp/utils/btc.utils';
 import { addPendingBtcTransaction } from '$lib/api/backend.api';
 import { sendBtc as sendBtcApi } from '$lib/api/signer.api';

--- a/src/frontend/src/env/networks/networks.sol.env.ts
+++ b/src/frontend/src/env/networks/networks.sol.env.ts
@@ -1,4 +1,4 @@
-import type { SchnorrKeyId } from '$declarations/signer/declarations/signer.did';
+import type { SchnorrKeyId } from '$declarations/signer/signer.did';
 import { SOL_DEVNET_EXPLORER_URL, SOL_MAINNET_EXPLORER_URL } from '$env/explorers.env';
 import { ALCHEMY_API_KEY } from '$env/rest/alchemy.env';
 import { QUICKNODE_API_KEY } from '$env/rest/quicknode.env';

--- a/src/frontend/src/eth/services/approve.services.ts
+++ b/src/frontend/src/eth/services/approve.services.ts
@@ -1,4 +1,4 @@
-import type { EthSignTransactionRequest } from '$declarations/signer/declarations/signer.did';
+import type { EthSignTransactionRequest } from '$declarations/signer/signer.did';
 import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import { getNonce } from '$eth/services/nonce.services';

--- a/src/frontend/src/eth/services/nft-send.services.ts
+++ b/src/frontend/src/eth/services/nft-send.services.ts
@@ -1,4 +1,4 @@
-import type { EthSignTransactionRequest } from '$declarations/signer/declarations/signer.did';
+import type { EthSignTransactionRequest } from '$declarations/signer/signer.did';
 import { ERC1155_ABI } from '$eth/constants/erc1155.constants';
 import { ERC721_ABI } from '$eth/constants/erc721.constants';
 import { infuraProviders } from '$eth/providers/infura.providers';

--- a/src/frontend/src/eth/services/prepare.services.ts
+++ b/src/frontend/src/eth/services/prepare.services.ts
@@ -1,4 +1,4 @@
-import type { EthSignTransactionRequest } from '$declarations/signer/declarations/signer.did';
+import type { EthSignTransactionRequest } from '$declarations/signer/signer.did';
 import type { NetworkChainId } from '$eth/types/network';
 import { i18n } from '$lib/stores/i18n.store';
 import type { TransferParams } from '$lib/types/send';

--- a/src/frontend/src/eth/services/send.services.ts
+++ b/src/frontend/src/eth/services/send.services.ts
@@ -1,4 +1,4 @@
-import type { EthSignTransactionRequest } from '$declarations/signer/declarations/signer.did';
+import type { EthSignTransactionRequest } from '$declarations/signer/signer.did';
 import { ETH_BASE_FEE } from '$eth/constants/eth.constants';
 import { infuraCkErc20Providers } from '$eth/providers/infura-ckerc20.providers';
 import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';

--- a/src/frontend/src/eth/services/swap.services.ts
+++ b/src/frontend/src/eth/services/swap.services.ts
@@ -1,4 +1,4 @@
-import type { EthSignTransactionRequest } from '$declarations/signer/declarations/signer.did';
+import type { EthSignTransactionRequest } from '$declarations/signer/signer.did';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import { processTransactionSent } from '$eth/services/eth-transaction.services';
 import { getNonce } from '$eth/services/nonce.services';

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -3,7 +3,7 @@ import type {
 	BitcoinNetwork,
 	EthSignTransactionRequest,
 	SendBtcResponse
-} from '$declarations/signer/declarations/signer.did';
+} from '$declarations/signer/signer.did';
 import type { EthAddress } from '$eth/types/address';
 import { SignerCanister } from '$lib/canisters/signer.canister';
 import { SIGNER_CANISTER_ID } from '$lib/constants/app.constants';

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -8,7 +8,7 @@ import type {
 	GetBalanceRequest,
 	SendBtcResponse,
 	_SERVICE as SignerService
-} from '$declarations/signer/declarations/signer.did';
+} from '$declarations/signer/signer.did';
 import { idlFactory as idlCertifiedFactorySigner } from '$declarations/signer/signer.factory.certified.did';
 import { idlFactory as idlFactorySigner } from '$declarations/signer/signer.factory.did';
 import type { EthAddress } from '$eth/types/address';

--- a/src/frontend/src/lib/canisters/signer.constants.ts
+++ b/src/frontend/src/lib/canisters/signer.constants.ts
@@ -1,4 +1,4 @@
-import type { BitcoinAddressType, PaymentType } from '$declarations/signer/declarations/signer.did';
+import type { BitcoinAddressType, PaymentType } from '$declarations/signer/signer.did';
 import { BACKEND_CANISTER_PRINCIPAL } from '$lib/constants/app.constants';
 
 export const P2WPKH: BitcoinAddressType = { P2WPKH: null };

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -3,7 +3,7 @@ import type {
 	PaymentError,
 	GetAddressError as SignerCanisterBtcError,
 	SendBtcError as SignerCanisterSendBtcError
-} from '$declarations/signer/declarations/signer.did';
+} from '$declarations/signer/signer.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { jsonReplacer } from '@dfinity/utils';
 

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -14,7 +14,7 @@ import type {
 	SchnorrKeyId,
 	BitcoinNetwork as SignerBitcoinNetwork,
 	Utxo as SignerUtxo
-} from '$declarations/signer/declarations/signer.did';
+} from '$declarations/signer/signer.did';
 import type { IcToken } from '$icp/types/ic-token';
 import type { Address } from '$lib/types/address';
 import type { Token } from '$lib/types/token';

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,5 +1,5 @@
 import type { BitcoinNetwork as BackendBitcoinNetwork } from '$declarations/backend/declarations/backend.did';
-import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/declarations/signer.did';
+import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import { SUPPORTED_ARBITRUM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { SUPPORTED_BASE_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.bsc.env';

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -3,7 +3,7 @@ import type {
 	EthSignTransactionRequest,
 	RejectionCode_1,
 	_SERVICE as SignerService
-} from '$declarations/signer/declarations/signer.did';
+} from '$declarations/signer/signer.did';
 import { SOLANA_KEY_ID } from '$env/networks/networks.sol.env';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { SignerCanister } from '$lib/canisters/signer.canister';

--- a/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
@@ -1,5 +1,5 @@
 import type { BtcAddress } from '$btc/types/address';
-import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/declarations/signer.did';
+import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import {
 	IC_CKBTC_INDEX_CANISTER_ID,
 	IC_CKBTC_LEDGER_CANISTER_ID,


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `signer` bindings that was done in PR https://github.com/dfinity/oisy-wallet/pull/9561
