### PR TITLE
refactor(frontend): Avoid referring to subfolder for `rewards` bindings

### DIFF
--- a/src/frontend/src/lib/api/reward.api.ts
+++ b/src/frontend/src/lib/api/reward.api.ts
@@ -7,7 +7,7 @@ import type {
 	UserData,
 	UserSnapshot,
 	VipReward
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import { RewardCanister } from '$lib/canisters/reward.canister';
 import { REWARDS_CANISTER_ID } from '$lib/constants/app.constants';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';

--- a/src/frontend/src/lib/canisters/reward.canister.ts
+++ b/src/frontend/src/lib/canisters/reward.canister.ts
@@ -8,7 +8,7 @@ import type {
 	UserData,
 	UserSnapshot,
 	VipReward
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import { idlFactory as idlCertifiedFactoryReward } from '$declarations/rewards/rewards.factory.certified.did';
 import { idlFactory as idlFactoryReward } from '$declarations/rewards/rewards.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';

--- a/src/frontend/src/lib/services/reward.services.ts
+++ b/src/frontend/src/lib/services/reward.services.ts
@@ -5,7 +5,7 @@ import type {
 	RewardInfo,
 	SetReferrerResponse,
 	VipReward
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import type { IcToken } from '$icp/types/ic-token';
 import {
 	claimVipReward as claimVipRewardApi,

--- a/src/frontend/src/lib/services/user-snapshot.services.ts
+++ b/src/frontend/src/lib/services/user-snapshot.services.ts
@@ -7,7 +7,7 @@ import type {
 	AccountSnapshotFor as RcAccountSnapshotFor,
 	TransactionType as RcTransactionType,
 	Transaction_Any
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { isTokenErc1155 } from '$eth/utils/erc1155.utils';

--- a/src/frontend/src/lib/types/reward.ts
+++ b/src/frontend/src/lib/types/reward.ts
@@ -1,7 +1,4 @@
-import type {
-	ClaimedVipReward,
-	ClaimVipRewardResponse
-} from '$declarations/rewards/declarations/rewards.did';
+import type { ClaimedVipReward, ClaimVipRewardResponse } from '$declarations/rewards/rewards.did';
 import type { RewardCampaignDescription } from '$env/types/env-reward';
 import type { QrCodeType } from '$lib/enums/qr-code-types';
 import type { RewardCriterionType } from '$lib/enums/reward-criterion-type';

--- a/src/frontend/src/lib/utils/rewards.utils.ts
+++ b/src/frontend/src/lib/utils/rewards.utils.ts
@@ -1,7 +1,4 @@
-import type {
-	CriterionEligibility,
-	EligibilityReport
-} from '$declarations/rewards/declarations/rewards.did';
+import type { CriterionEligibility, EligibilityReport } from '$declarations/rewards/rewards.did';
 import type { RewardCampaignDescription } from '$env/types/env-reward';
 import { RewardCriterionType } from '$lib/enums/reward-criterion-type';
 import type {

--- a/src/frontend/src/tests/lib/canisters/reward.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/reward.canister.spec.ts
@@ -7,7 +7,7 @@ import type {
 	_SERVICE as RewardService,
 	UserData,
 	UserSnapshot
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import { RewardCanister } from '$lib/canisters/reward.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockIdentity } from '$tests/mocks/identity.mock';

--- a/src/frontend/src/tests/lib/components/core/Menu.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Menu.spec.ts
@@ -1,4 +1,4 @@
-import type { UserData } from '$declarations/rewards/declarations/rewards.did';
+import type { UserData } from '$declarations/rewards/rewards.did';
 import * as rewardApi from '$lib/api/reward.api';
 import Menu from '$lib/components/core/Menu.svelte';
 import {

--- a/src/frontend/src/tests/lib/components/guard/RewardGuard.spec.ts
+++ b/src/frontend/src/tests/lib/components/guard/RewardGuard.spec.ts
@@ -1,4 +1,4 @@
-import type { RewardInfo, UserData } from '$declarations/rewards/declarations/rewards.did';
+import type { RewardInfo, UserData } from '$declarations/rewards/rewards.did';
 import * as rewardCampaignsEnv from '$env/reward-campaigns.env';
 import {
 	SPRINKLES_SEASON_1_EPISODE_3_ID,

--- a/src/frontend/src/tests/lib/components/referral/ReferralCodeModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/referral/ReferralCodeModal.spec.ts
@@ -1,4 +1,4 @@
-import type { ReferrerInfo } from '$declarations/rewards/declarations/rewards.did';
+import type { ReferrerInfo } from '$declarations/rewards/rewards.did';
 import * as rewardApi from '$lib/api/reward.api';
 import ReferralCodeModal from '$lib/components/referral/ReferralCodeModal.svelte';
 import { OISY_REFERRAL_URL } from '$lib/constants/oisy.constants';

--- a/src/frontend/src/tests/lib/components/vip/VipQrCodeModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/vip/VipQrCodeModal.spec.ts
@@ -1,4 +1,4 @@
-import type { NewVipRewardResponse } from '$declarations/rewards/declarations/rewards.did';
+import type { NewVipRewardResponse } from '$declarations/rewards/rewards.did';
 import * as rewardApi from '$lib/api/reward.api';
 import VipQrCodeModal from '$lib/components/vip/VipQrCodeModal.svelte';
 import {

--- a/src/frontend/src/tests/lib/services/reward.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/reward.services.spec.ts
@@ -5,7 +5,7 @@ import type {
 	ReferrerInfo,
 	RewardInfo,
 	UserData
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as rewardApi from '$lib/api/reward.api';
 import { ZERO } from '$lib/constants/app.constants';

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -2,7 +2,7 @@ import type {
 	AccountSnapshot_Any,
 	Transaction_Any,
 	UserSnapshot
-} from '$declarations/rewards/declarations/rewards.did';
+} from '$declarations/rewards/rewards.did';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';

--- a/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/rewards.utils.spec.ts
@@ -1,4 +1,4 @@
-import type { EligibilityReport } from '$declarations/rewards/declarations/rewards.did';
+import type { EligibilityReport } from '$declarations/rewards/rewards.did';
 import {
 	SPRINKLES_SEASON_1_EPISODE_3_ID,
 	SPRINKLES_SEASON_1_EPISODE_4_ID,


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `rewards` bindings that was done in PR https://github.com/dfinity/oisy-wallet/pull/9562
