### PR TITLE
refactor(frontend): Avoid referring to subfolder for `llm` bindings

### DIFF
--- a/src/frontend/src/lib/api/llm.api.ts
+++ b/src/frontend/src/lib/api/llm.api.ts
@@ -1,4 +1,4 @@
-import type { chat_request_v1, chat_response_v1 } from '$declarations/llm/declarations/llm.did';
+import type { chat_request_v1, chat_response_v1 } from '$declarations/llm/llm.did';
 import { LlmCanister } from '$lib/canisters/llm.canister';
 import { LLM_CANISTER_ID } from '$lib/constants/app.constants';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';

--- a/src/frontend/src/lib/canisters/llm.canister.ts
+++ b/src/frontend/src/lib/canisters/llm.canister.ts
@@ -2,7 +2,7 @@ import type {
 	_SERVICE as LlmService,
 	chat_request_v1,
 	chat_response_v1
-} from '$declarations/llm/declarations/llm.did';
+} from '$declarations/llm/llm.did';
 import { idlFactory as idlCertifiedFactoryLlm } from '$declarations/llm/llm.factory.certified.did';
 import { idlFactory as idlFactoryLlm } from '$declarations/llm/llm.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';

--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -1,4 +1,4 @@
-import type { tool } from '$declarations/llm/declarations/llm.did';
+import type { tool } from '$declarations/llm/llm.did';
 import { toNullable } from '@dfinity/utils';
 
 export const AI_ASSISTANT_LLM_MODEL = 'qwen3:32b';

--- a/src/frontend/src/lib/derived/ai-assistant.derived.ts
+++ b/src/frontend/src/lib/derived/ai-assistant.derived.ts
@@ -1,4 +1,4 @@
-import type { chat_message_v1 } from '$declarations/llm/declarations/llm.did';
+import type { chat_message_v1 } from '$declarations/llm/llm.did';
 import {
 	getAiAssistantSystemPrompt,
 	MAX_SUPPORTED_AI_ASSISTANT_CHAT_LENGTH

--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -1,4 +1,4 @@
-import type { chat_message_v1 } from '$declarations/llm/declarations/llm.did';
+import type { chat_message_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import {
 	AI_ASSISTANT_LLM_MODEL,

--- a/src/frontend/src/tests/lib/api/llm.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/llm.api.spec.ts
@@ -1,4 +1,4 @@
-import type { chat_request_v1, chat_response_v1 } from '$declarations/llm/declarations/llm.did';
+import type { chat_request_v1, chat_response_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import { LlmCanister } from '$lib/canisters/llm.canister';
 import * as appConstants from '$lib/constants/app.constants';

--- a/src/frontend/src/tests/lib/canisters/llm.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/llm.canister.spec.ts
@@ -2,7 +2,7 @@ import type {
 	_SERVICE as LlmService,
 	chat_request_v1,
 	chat_response_v1
-} from '$declarations/llm/declarations/llm.did';
+} from '$declarations/llm/llm.did';
 import { LlmCanister } from '$lib/canisters/llm.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockIdentity } from '$tests/mocks/identity.mock';

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantConsole.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantConsole.spec.ts
@@ -1,4 +1,4 @@
-import type { chat_response_v1 } from '$declarations/llm/declarations/llm.did';
+import type { chat_response_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import AiAssistantConsole from '$lib/components/ai-assistant/AiAssistantConsole.svelte';
 import { AI_ASSISTANT_SEND_MESSAGE_BUTTON } from '$lib/constants/test-ids.constants';

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -1,4 +1,4 @@
-import type { chat_response_v1 } from '$declarations/llm/declarations/llm.did';
+import type { chat_response_v1 } from '$declarations/llm/llm.did';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { llmChat } from '$lib/api/llm.api';
 import { extendedAddressContacts } from '$lib/derived/contacts.derived';


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `llm` bindings that was done in PR https://github.com/dfinity/oisy-wallet/pull/9563
