### PR TITLE
feat(did): Temporarily undo the removal of subfolder `declarations` (missed commit)

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -93,7 +93,7 @@ generate_declarations() {
     # icp-bindgen generates the files in a `declarations` subfolder
     # using a different suffix for JavaScript as the one we used to use.
     # That's why we have to post-process the results.
-    # TODO: re-remove the generated folder once we adapt all imports to the new "old" location.
+    # TODO: change back `cp` to `mv` once we adapt all imports to the new "old" location.
     cp "${generatedTsfile}" "${didfolder}"
     cp "${generatedJsfile}" "${didfolder}"
     # TODO: re-remove the generated folder once we adapt all imports to the new "old" location.


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/10417, I forgot to change the `mv` (move) to `cp` (copy) for the newly generated files.
