### PR TITLE
feat(did): Reinstate the removal of subfolder `declarations`

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -95,7 +95,7 @@ generate_declarations() {
     # That's why we have to post-process the results.
     mv "${generatedTsfile}" "${didfolder}"
     mv "${generatedJsfile}" "${didfolder}"
-     rm -r "${generatedFolder}"
+    rm -r "${generatedFolder}"
   else
     echo "DID file skipped: $didfile"
   fi


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is the last step: we reinstate the removal of the subfolder `declarations`.
