### PR TITLE
refactor(frontend): Avoid referring to subfolder for `gldt_stake` bindings

### DIFF
--- a/src/frontend/src/icp/api/gldt_stake.api.ts
+++ b/src/frontend/src/icp/api/gldt_stake.api.ts
@@ -3,7 +3,7 @@ import type {
 	DailyAnalytics,
 	ManageStakePositionArgs,
 	StakePositionResponse
-} from '$declarations/gldt_stake/declarations/gldt_stake.did';
+} from '$declarations/gldt_stake/gldt_stake.did';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
 import { GLDT_STAKE_CANISTER_ID } from '$lib/constants/app.constants';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';

--- a/src/frontend/src/icp/canisters/gldt_stake.canister.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.canister.ts
@@ -4,7 +4,7 @@ import type {
 	_SERVICE as GldtStakeService,
 	ManageStakePositionArgs,
 	StakePositionResponse
-} from '$declarations/gldt_stake/declarations/gldt_stake.did';
+} from '$declarations/gldt_stake/gldt_stake.did';
 import { idlFactory as idlCertifiedFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.certified.did';
 import { idlFactory as idlFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.did';
 import { mapGldtStakeCanisterError } from '$icp/canisters/gldt_stake.errors';

--- a/src/frontend/src/icp/canisters/gldt_stake.errors.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.errors.ts
@@ -1,4 +1,4 @@
-import type { ManageStakePositionError } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { ManageStakePositionError } from '$declarations/gldt_stake/gldt_stake.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 
 export const mapGldtStakeCanisterError = (err: ManageStakePositionError): CanisterInternalError => {

--- a/src/frontend/src/icp/services/gldt-stake.services.ts
+++ b/src/frontend/src/icp/services/gldt-stake.services.ts
@@ -1,7 +1,4 @@
-import type {
-	StakePositionResponse,
-	TokenSymbol
-} from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { StakePositionResponse, TokenSymbol } from '$declarations/gldt_stake/gldt_stake.did';
 import { manageStakePosition } from '$icp/api/gldt_stake.api';
 import { approve } from '$icp/api/icrc-ledger.api';
 import { loadCustomTokens } from '$icp/services/icrc.services';

--- a/src/frontend/src/icp/stores/gldt-stake.store.ts
+++ b/src/frontend/src/icp/stores/gldt-stake.store.ts
@@ -1,4 +1,4 @@
-import type { StakePositionResponse } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { StakePositionResponse } from '$declarations/gldt_stake/gldt_stake.did';
 import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 

--- a/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
@@ -1,4 +1,4 @@
-import type { _SERVICE as GldtStakeService } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { _SERVICE as GldtStakeService } from '$declarations/gldt_stake/gldt_stake.did';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { ZERO } from '$lib/constants/app.constants';

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeRewards.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeRewards.spec.ts
@@ -1,7 +1,4 @@
-import type {
-	StakePositionResponse,
-	TokenSymbol
-} from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { StakePositionResponse, TokenSymbol } from '$declarations/gldt_stake/gldt_stake.did';
 import GldtStakeRewards from '$icp/components/stake/gldt/GldtStakeRewards.svelte';
 import * as icrcServices from '$icp/services/icrc.services';
 import {

--- a/src/frontend/src/tests/icp/services/gldt-stake.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/gldt-stake.services.spec.ts
@@ -1,4 +1,4 @@
-import type { TokenSymbol } from '$declarations/gldt_stake/declarations/gldt_stake.did';
+import type { TokenSymbol } from '$declarations/gldt_stake/gldt_stake.did';
 import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as gldtStakeApi from '$icp/api/gldt_stake.api';

--- a/src/frontend/src/tests/mocks/gldt_stake.mock.ts
+++ b/src/frontend/src/tests/mocks/gldt_stake.mock.ts
@@ -1,8 +1,8 @@
 import type {
 	DailyAnalytics,
+	Duration,
 	StakePositionResponse
-} from '$declarations/gldt_stake/declarations/gldt_stake.did';
-import type { Duration } from '$declarations/gldt_stake/gldt_stake.did';
+} from '$declarations/gldt_stake/gldt_stake.did';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `gldt_stake` bindings.
