### PR TITLE
refactor(frontend): Avoid referring to subfolder for `ext_v2_token` bindings

### DIFF
--- a/src/frontend/src/icp/canisters/ext-v2-token.canister.ts
+++ b/src/frontend/src/icp/canisters/ext-v2-token.canister.ts
@@ -1,7 +1,7 @@
 import type {
 	_SERVICE as ExtV2TokenService,
 	Transaction
-} from '$declarations/ext_v2_token/declarations/ext_v2_token.did';
+} from '$declarations/ext_v2_token/ext_v2_token.did';
 import { idlFactory as idlCertifiedFactoryExtV2Token } from '$declarations/ext_v2_token/ext_v2_token.factory.certified.did';
 import { idlFactory as idlFactoryExtV2Token } from '$declarations/ext_v2_token/ext_v2_token.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';

--- a/src/frontend/src/tests/icp/canisters/ext-v2-token.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/ext-v2-token.canister.spec.ts
@@ -1,7 +1,7 @@
 import type {
 	_SERVICE as ExtV2TokenService,
 	Transaction
-} from '$declarations/ext_v2_token/declarations/ext_v2_token.did';
+} from '$declarations/ext_v2_token/ext_v2_token.did';
 import { ExtV2TokenCanister } from '$icp/canisters/ext-v2-token.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockExtV2TokenCanisterId, mockExtV2Transactions } from '$tests/mocks/ext-v2-token.mock';

--- a/src/frontend/src/tests/mocks/ext-v2-token.mock.ts
+++ b/src/frontend/src/tests/mocks/ext-v2-token.mock.ts
@@ -1,4 +1,4 @@
-import type { Transaction } from '$declarations/ext_v2_token/declarations/ext_v2_token.did';
+import type { Transaction } from '$declarations/ext_v2_token/ext_v2_token.did';
 import type { CanisterIdText } from '$lib/types/canister';
 import { bn1Bi, bn2Bi } from '$tests/mocks/balances.mock';
 import { mockAccountIdentifierText, mockAccountIdentifierText2 } from '$tests/mocks/identity.mock';


### PR DESCRIPTION
# Motivation

With the new bindings generation script (PR https://github.com/dfinity/oisy-wallet/pull/10409), we prefer to not have the subfolder `declarations` that bindgen creates, but to consolidate the bindings in the same folder.

However, our current imports are using such subfolder.

The plan is:

- Undo the removal of the subfolder (temporarily).
- Adapt all the imports to use the "old" main folder for declarations (split in a few PRs, since it is quite a lot of changes).
- Re-remove the subfolder.


This PR is part of the second step: we undo the reference to subfolder for the `ext_v2_token` bindings.