### PR TITLE
feat(frontend): Delete testnet addresses IDB cache on logout

### DIFF
--- a/src/frontend/src/lib/api/idb-addresses.api.ts
+++ b/src/frontend/src/lib/api/idb-addresses.api.ts
@@ -111,14 +111,29 @@ export const getIdbSolAddressMainnet = (principal: Principal): Promise<IdbSolAdd
 export const deleteIdbBtcAddressMainnet = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbBtcAddressesStoreMainnet);
 
+export const deleteIdbBtcAddressTestnet = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbBtcAddressesStoreTestnet);
+
 export const deleteIdbEthAddress = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbEthAddressesStore);
 
 export const deleteIdbSolAddressMainnet = (principal: Principal): Promise<void> =>
 	del(principal.toText(), idbSolAddressesStoreMainnet);
 
+export const deleteIdbSolAddressDevnet = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbSolAddressesStoreDevnet);
+
+export const deleteIdbSolAddressLocal = (principal: Principal): Promise<void> =>
+	del(principal.toText(), idbSolAddressesStoreLocal);
+
 export const clearIdbBtcAddressMainnet = (): Promise<void> => clear(idbBtcAddressesStoreMainnet);
+
+export const clearIdbBtcAddressTestnet = (): Promise<void> => clear(idbBtcAddressesStoreTestnet);
 
 export const clearIdbEthAddress = (): Promise<void> => clear(idbEthAddressesStore);
 
 export const clearIdbSolAddressMainnet = (): Promise<void> => clear(idbSolAddressesStoreMainnet);
+
+export const clearIdbSolAddressDevnet = (): Promise<void> => clear(idbSolAddressesStoreDevnet);
+
+export const clearIdbSolAddressLocal = (): Promise<void> => clear(idbSolAddressesStoreLocal);

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -1,10 +1,16 @@
 import { walletConnectPaired } from '$eth/stores/wallet-connect.store';
 import {
 	clearIdbBtcAddressMainnet,
+	clearIdbBtcAddressTestnet,
 	clearIdbEthAddress,
+	clearIdbSolAddressDevnet,
+	clearIdbSolAddressLocal,
 	clearIdbSolAddressMainnet,
 	deleteIdbBtcAddressMainnet,
+	deleteIdbBtcAddressTestnet,
 	deleteIdbEthAddress,
+	deleteIdbSolAddressDevnet,
+	deleteIdbSolAddressLocal,
 	deleteIdbSolAddressMainnet
 } from '$lib/api/idb-addresses.api';
 import { clearIdbBalances, deleteIdbBalances } from '$lib/api/idb-balances.api';
@@ -221,8 +227,11 @@ const clearIdbStore = async (clearIdbStore: () => Promise<void>) => {
 const deleteIdbStoreList = [
 	// Addresses
 	deleteIdbBtcAddressMainnet,
+	deleteIdbBtcAddressTestnet,
 	deleteIdbEthAddress,
 	deleteIdbSolAddressMainnet,
+	deleteIdbSolAddressDevnet,
+	deleteIdbSolAddressLocal,
 	// Tokens
 	deleteIdbAllCustomTokens,
 	// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
@@ -239,8 +248,11 @@ const deleteIdbStoreList = [
 const clearIdbStoreList = [
 	// Addresses
 	clearIdbBtcAddressMainnet,
+	clearIdbBtcAddressTestnet,
 	clearIdbEthAddress,
 	clearIdbSolAddressMainnet,
+	clearIdbSolAddressDevnet,
+	clearIdbSolAddressLocal,
 	// Tokens
 	clearIdbAllCustomTokens,
 	// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete

--- a/src/frontend/src/tests/lib/api/idb-addresses.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/idb-addresses.api.spec.ts
@@ -1,9 +1,15 @@
 import {
 	clearIdbBtcAddressMainnet,
+	clearIdbBtcAddressTestnet,
 	clearIdbEthAddress,
+	clearIdbSolAddressDevnet,
+	clearIdbSolAddressLocal,
 	clearIdbSolAddressMainnet,
 	deleteIdbBtcAddressMainnet,
+	deleteIdbBtcAddressTestnet,
 	deleteIdbEthAddress,
+	deleteIdbSolAddressDevnet,
+	deleteIdbSolAddressLocal,
 	deleteIdbSolAddressMainnet,
 	getIdbBtcAddressMainnet,
 	getIdbEthAddress,
@@ -56,8 +62,14 @@ describe('idb-addresses.api', () => {
 			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
 		});
 
-		it('should delete BTC address', async () => {
+		it('should delete BTC mainnet address', async () => {
 			await deleteIdbBtcAddressMainnet(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+
+		it('should delete BTC Testnet address', async () => {
+			await deleteIdbBtcAddressTestnet(mockPrincipal);
 
 			expect(idbKeyval.del).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
 		});
@@ -146,8 +158,20 @@ describe('idb-addresses.api', () => {
 			expect(idbKeyval.get).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
 		});
 
-		it('should delete SOL address', async () => {
+		it('should delete SOL mainnet address', async () => {
 			await deleteIdbSolAddressMainnet(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+
+		it('should delete SOL devnet address', async () => {
+			await deleteIdbSolAddressDevnet(mockPrincipal);
+
+			expect(idbKeyval.del).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
+		});
+
+		it('should delete SOL local address', async () => {
+			await deleteIdbSolAddressLocal(mockPrincipal);
 
 			expect(idbKeyval.del).toHaveBeenCalledWith(mockPrincipal.toText(), expect.any(Object));
 		});
@@ -176,6 +200,14 @@ describe('idb-addresses.api', () => {
 		});
 	});
 
+	describe('clearIdbBtcAddressTestnet', () => {
+		it('should clear BTC addresses', async () => {
+			await clearIdbBtcAddressTestnet();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
 	describe('clearIdbEthAddress', () => {
 		it('should clear ETH addresses', async () => {
 			await clearIdbEthAddress();
@@ -187,6 +219,22 @@ describe('idb-addresses.api', () => {
 	describe('clearIdbSolAddressMainnet', () => {
 		it('should clear SOL addresses', async () => {
 			await clearIdbSolAddressMainnet();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbSolAddressDevnet', () => {
+		it('should clear SOL addresses', async () => {
+			await clearIdbSolAddressDevnet();
+
+			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
+		});
+	});
+
+	describe('clearIdbSolAddressLocal', () => {
+		it('should clear SOL addresses', async () => {
+			await clearIdbSolAddressLocal();
 
 			expect(idbKeyval.clear).toHaveBeenCalledExactlyOnceWith(expect.any(Object));
 		});

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -119,8 +119,8 @@ describe('auth.services', () => {
 
 			await signOut({});
 
-			// 3 addresses + 1(+1) tokens
-			expect(idbKeyval.del).toHaveBeenCalledTimes(5);
+			// 6 addresses (mainnet and testnet) + 1(+1) tokens
+			expect(idbKeyval.del).toHaveBeenCalledTimes(8);
 
 			// 4 transactions + 1 balances
 			expect(delMultiKeysByPrincipal).toHaveBeenCalledTimes(5);
@@ -129,8 +129,8 @@ describe('auth.services', () => {
 		it('should clean the IDB storage for all principals', async () => {
 			await signOut({ clearAllPrincipalsStorages: true });
 
-			// 3 addresses + 1(+1) tokens + 4 txs + 1 balance
-			expect(idbKeyval.clear).toHaveBeenCalledTimes(10);
+			// 6 addresses (mainnet and testnet) + 1(+1) tokens + 4 txs + 1 balance
+			expect(idbKeyval.clear).toHaveBeenCalledTimes(13);
 		});
 
 		it("should disconnect WalletConnect's session", async () => {
@@ -242,8 +242,8 @@ describe('auth.services', () => {
 
 			await errorSignOut(mockText);
 
-			// 3 addresses + 1(+1) tokens
-			expect(idbKeyval.del).toHaveBeenCalledTimes(5);
+			// 6 addresses (mainnet and testnet) + 1(+1) tokens
+			expect(idbKeyval.del).toHaveBeenCalledTimes(8);
 
 			// 4 transactions + 1 balances
 			expect(delMultiKeysByPrincipal).toHaveBeenCalledTimes(5);
@@ -368,8 +368,8 @@ describe('auth.services', () => {
 
 			await warnSignOut(mockText);
 
-			// 3 addresses + 1(+1) tokens
-			expect(idbKeyval.del).toHaveBeenCalledTimes(5);
+			// 6 addresses (mainnet and testnet) + 1(+1) tokens
+			expect(idbKeyval.del).toHaveBeenCalledTimes(8);
 
 			// 4 transactions + 1 balances
 			expect(delMultiKeysByPrincipal).toHaveBeenCalledTimes(5);
@@ -494,8 +494,8 @@ describe('auth.services', () => {
 
 			await nullishSignOut();
 
-			// 3 addresses + 1(+1) tokens
-			expect(idbKeyval.del).toHaveBeenCalledTimes(5);
+			// 6 addresses (mainnet and testnet) + 1(+1) tokens
+			expect(idbKeyval.del).toHaveBeenCalledTimes(8);
 
 			// 4 transactions + 1 balances
 			expect(delMultiKeysByPrincipal).toHaveBeenCalledTimes(5);


### PR DESCRIPTION
# Motivation

For security reasons, we prefer to delete the testnet addresses from IDB cache on logout: they are indexed with the principal.
