### PR TITLE
feat(frontend): New Token standard EXT V2

### DIFF
--- a/src/frontend/src/lib/schema/token.schema.ts
+++ b/src/frontend/src/lib/schema/token.schema.ts
@@ -13,6 +13,7 @@ export const TokenStandardSchema = z.enum([
 	'icp',
 	'icrc',
 	'dip20',
+	'extV2',
 	'bitcoin',
 	'solana',
 	'spl'

--- a/src/frontend/src/tests/lib/schema/token.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/token.schema.spec.ts
@@ -50,6 +50,18 @@ describe('token.schema', () => {
 			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
 		});
 
+		it('should validate "dip20" as a supported token standard', () => {
+			const validStandard = 'dip20';
+
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
+		it('should validate "extV2" as a supported token standard', () => {
+			const validStandard = 'extV2';
+
+			expect(TokenStandardSchema.parse(validStandard)).toEqual(validStandard);
+		});
+
 		it('should validate "bitcoin" as a supported token standard', () => {
 			const validStandard = 'bitcoin';
 


### PR DESCRIPTION
# Motivation

We are going to onboard the EXT v2 Token on OISY, mostly used for NFTs: documentation [here](https://github.com/Toniq-Labs/ext-v2-token/tree/main).