### PR TITLE
feat(frontend): update GLDT staking cards

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
@@ -8,6 +8,7 @@
 	import type { IcToken } from '$icp/types/ic-token';
 	import { setCustomToken } from '$icp-eth/services/custom-token.services';
 	import { isGLDTToken } from '$icp-eth/utils/token.utils';
+	import GetTokenModal from '$lib/components/get-token/GetTokenModal.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import StakeModal from '$lib/components/stake/StakeModal.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -18,7 +19,7 @@
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { modalGldtStake } from '$lib/derived/modal.derived';
+	import { modalGetToken, modalGldtStake } from '$lib/derived/modal.derived';
 	import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens.derived';
 	import { nullishSignOut } from '$lib/services/auth.services';
 	import { autoLoadSingleToken } from '$lib/services/token.services';
@@ -59,6 +60,8 @@
 			? Math.round($enabledMainnetFungibleTokensUsdBalance / gldtTokenExchangeRate)
 			: 0
 	);
+
+	let getMoreTokensButtonDisabled = $derived(potentialGldtTokenBalance <= 0);
 
 	const enableStakingToken = async () => {
 		if (isNullish($authIdentity)) {
@@ -101,7 +104,7 @@
 		</div>
 
 		{#if $icrcCustomTokensNotInitialized || nonNullish(gldtToken)}
-			<div class="flex justify-center gap-2 text-sm sm:text-base">
+			<div class="flex items-center justify-center gap-2 text-sm sm:text-base">
 				{#if $enabledMainnetFungibleTokensUsdBalance > 0}
 					<span class="font-bold">
 						{formatCurrency({
@@ -135,9 +138,29 @@
 
 	{#snippet buttons()}
 		{#if nonNullish(gldtToken)}
-			<ButtonWithModal isOpen={$modalGldtStake} onOpen={modalStore.openGldtStake}>
+			<ButtonWithModal isOpen={$modalGetToken} onOpen={modalStore.openGetToken}>
 				{#snippet button(onclick)}
 					<Button disabled={gldtStakeButtonDisabled} fullWidth {onclick}>
+						{replacePlaceholders(
+							getMoreTokensButtonDisabled
+								? $i18n.stake.text.get_tokens
+								: $i18n.stake.text.get_tokens_with_amount,
+							{
+								$token_symbol: gldtTokenSymbol,
+								$amount: `${potentialGldtTokenBalance}`
+							}
+						)}
+					</Button>
+				{/snippet}
+
+				{#snippet modal()}
+					<GetTokenModal {currentApy} token={gldtToken} />
+				{/snippet}
+			</ButtonWithModal>
+
+			<ButtonWithModal isOpen={$modalGldtStake} onOpen={modalStore.openGldtStake}>
+				{#snippet button(onclick)}
+					<Button colorStyle="success" disabled={gldtStakeButtonDisabled} fullWidth {onclick}>
 						{replacePlaceholders(
 							gldtStakeButtonDisabled
 								? $i18n.stake.text.not_enough_to_stake

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakePositionCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakePositionCard.svelte
@@ -68,7 +68,7 @@
 			})}
 		</div>
 
-		<div class="flex justify-center gap-2 text-sm sm:text-base">
+		<div class="flex items-center justify-center gap-2 text-sm sm:text-base">
 			{#if stakedAmountUsd > 0}
 				<span class="font-bold">
 					{formatCurrency({


### PR DESCRIPTION
# Motivation

We can now update the GLDT staking cards with the Get Token modal and related buttons.

<img width="561" height="294" alt="Screenshot 2025-11-21 at 13 08 41" src="https://github.com/user-attachments/assets/fe105f13-da3e-449f-bda1-35030d201ce9" />
