### PR TITLE
feat(dependabot): Increase the triage period of new versions to one month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,14 +13,14 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      default-days: 30
 
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      default-days: 30
     allow:
       - dependency-type: all
     ignore:


### PR DESCRIPTION
# Motivation

Typically, we are in no rush to bump packages automatically. If we really need it, we can do it manually always.

So, to have a safer triage for newest versions, we extend the default period to 30 days. 