### PR TITLE
refactor(frontend): Split load methods in `LoaderCollections`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -142,8 +142,8 @@
 		}
 	};
 
-	const onLoad = async () => {
-		if (!NFTS_ENABLED || isNullish($authIdentity)) {
+	const loadErcTokens = async () => {
+		if (isNullish($authIdentity)) {
 			return;
 		}
 
@@ -164,6 +164,14 @@
 				identity: $authIdentity
 			});
 		}
+	};
+
+	const onLoad = async () => {
+		if (!NFTS_ENABLED) {
+			return;
+		}
+
+		await Promise.all([loadErcTokens()]);
 	};
 </script>
 


### PR DESCRIPTION
# Motivation

We are going to re-use the `LoaderCollections` component to load IC collections too. So, we need to re-organize the methods that are called by the `onLoad` function, in order to add more.
