### PR TITLE
feat(frontend): pass "text" snippet in the address modal

### DIFF
--- a/src/frontend/src/lib/components/receive/ReceiveAddressQrCode.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQrCode.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import ReceiveAddressQrCodeContent from '$lib/components/receive/ReceiveAddressQrCodeContent.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
@@ -15,9 +16,10 @@
 		copyAriaLabel: string;
 		testId?: string;
 		onBack: () => void;
+		text?: Snippet;
 	}
 
-	let { address, addressLabel, addressToken, network, copyAriaLabel, testId, onBack }: Props =
+	let { address, addressLabel, addressToken, network, copyAriaLabel, testId, onBack, text }: Props =
 		$props();
 </script>
 
@@ -29,6 +31,7 @@
 		{copyAriaLabel}
 		{network}
 		testId={RECEIVE_TOKENS_MODAL_QR_CODE_OUTPUT}
+		{text}
 	/>
 
 	{#snippet toolbar()}

--- a/src/frontend/src/lib/components/receive/ReceiveAddressQrCodeContent.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveAddressQrCodeContent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import ReceiveAddress from '$lib/components/receive/ReceiveAddress.svelte';
 	import ReceiveQrCode from '$lib/components/receive/ReceiveQrCode.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -14,6 +15,7 @@
 		copyButtonTestId?: string;
 		network: Network;
 		copyAriaLabel: string;
+		text?: Snippet;
 	}
 
 	let {
@@ -23,7 +25,8 @@
 		testId,
 		copyButtonTestId,
 		network,
-		copyAriaLabel
+		copyAriaLabel,
+		text
 	}: Props = $props();
 
 	// TODO: replace properties (address, labels etc.) with a mandatory property of type ReceiveQrCode
@@ -39,6 +42,7 @@
 	{network}
 	qrCodeAction={{ enabled: false }}
 	{testId}
+	{text}
 >
 	{#snippet title()}
 		{addressLabel ?? $i18n.wallet.text.address}


### PR DESCRIPTION
# Motivation

`ReceiveAddress` can accept an additional prop `text`, we need to pass it down from the parent.
