### PR TITLE
chore(frontend): Correct text of test for XTC ledger

### DIFF
--- a/src/frontend/src/tests/icp/api/xtc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/xtc-ledger.api.spec.ts
@@ -33,7 +33,7 @@ describe('xtc-ledger.api', () => {
 			ledgerCanisterMock.transfer.mockResolvedValue(transactionId);
 		});
 
-		it('successfully calls balance endpoint', async () => {
+		it('successfully calls transfer endpoint', async () => {
 			const result = await transfer(params);
 
 			expect(result).toEqual(transactionId);


### PR DESCRIPTION
# Motivation

While creating tests for EXT v2 tokens, I noticed a small error for the description in one test of XTC ledger. 
