### PR TITLE
feat(frontend): split BuyModal component

### DIFF
--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
 	import { isOnRamperDev } from '$env/rest/onramper.env';
-	import OnramperWidget from '$lib/components/onramper/OnramperWidget.svelte';
+	import BuyModalContent from '$lib/components/buy/BuyModalContent.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 </script>
@@ -11,15 +11,5 @@
 		{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}
 	{/snippet}
 
-	<div class="stretch flex overflow-hidden">
-		<div class="w-full overflow-auto">
-			<OnramperWidget />
-		</div>
-	</div>
+	<BuyModalContent />
 </Modal>
-
-<style lang="scss">
-	.stretch {
-		--stretch-padding-bottom: var(--padding-3x);
-	}
-</style>

--- a/src/frontend/src/lib/components/buy/BuyModalContent.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModalContent.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import OnramperWidget from '$lib/components/onramper/OnramperWidget.svelte';
+</script>
+
+<div class="stretch flex overflow-hidden">
+	<div class="w-full overflow-auto">
+		<OnramperWidget />
+	</div>
+</div>
+
+<style lang="scss">
+	.stretch {
+		--stretch-padding-bottom: var(--padding-3x);
+	}
+</style>

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -10,6 +10,7 @@
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 	import { icpAccountIdentifierText } from '$icp/derived/ic.derived';
+	import { BUY_MODAL_ONRAMPER_IFRAME } from '$lib/constants/test-ids.constants';
 	import { btcAddressMainnet, ethAddress, solAddressMainnet } from '$lib/derived/address.derived';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { networkBitcoin, networkEthereum, networkSolana } from '$lib/derived/network.derived';
@@ -116,6 +117,7 @@
 
 <iframe
 	allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
+	data-tid={BUY_MODAL_ONRAMPER_IFRAME}
 	height="680px"
 	onload={changeThemeOnIframeLoad}
 	sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -324,3 +324,6 @@ export const OPEN_CRYPTO_PAY_ENTER_MANUALLY_BUTTON = 'open-crypto-pay-enter-manu
 // Get Token Modal
 export const GET_TOKEN_MODAL_POTENTIAL_USD_BALANCE = 'get-token-modal-potential-usd-balance';
 export const GET_TOKEN_MODAL_OPEN_SWAP_BUTTON = 'get-token-modal-open-swap-button';
+
+// BUY MODAL
+export const BUY_MODAL_ONRAMPER_IFRAME = 'buy-modal-onramper-iframe';

--- a/src/frontend/src/tests/lib/components/buy/BuyModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyModal.spec.ts
@@ -1,0 +1,19 @@
+import * as onRamperEnv from '$env/rest/onramper.env';
+import BuyModal from '$lib/components/buy/BuyModal.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('BuyModal', () => {
+	it('renders correct title if isOnRamperDev is true', () => {
+		const { getByText } = render(BuyModal);
+
+		expect(getByText(en.buy.text.buy_dev)).toBeInTheDocument();
+	});
+
+	it('renders correct title if isOnRamperDev is false', () => {
+		vi.spyOn(onRamperEnv, 'isOnRamperDev', 'get').mockImplementation(() => false);
+		const { getByText } = render(BuyModal);
+
+		expect(getByText(en.buy.text.buy)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
@@ -1,0 +1,11 @@
+import BuyModalContent from '$lib/components/buy/BuyModalContent.svelte';
+import { BUY_MODAL_ONRAMPER_IFRAME } from '$lib/constants/test-ids.constants';
+import { render } from '@testing-library/svelte';
+
+describe('BuyModalContent', () => {
+	it('renders correct title if isOnRamperDev is true', () => {
+		const { getByTestId } = render(BuyModalContent);
+
+		expect(getByTestId(BUY_MODAL_ONRAMPER_IFRAME)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

To re-use BuyModal content in the Stake flow, we need to split it. Also, adding missing tests.