### PR TITLE
feat(frontend): implement GetTokenActionItem

### DIFF
--- a/src/frontend/src/lib/components/get-token/GetTokenActionItem.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenActionItem.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		icon: Snippet;
+		title: Snippet;
+		description: Snippet;
+		button: Snippet;
+	}
+
+	let { icon, title, description, button }: Props = $props();
+</script>
+
+<div class="flex items-start justify-between rounded-xl border-1 border-solid border-disabled p-3">
+	<div class="text-brand-primary">
+		{@render icon()}
+	</div>
+
+	<div class="mx-2 flex w-full flex-col gap-0.5 sm:mx-4">
+		<span class="text-sm font-bold sm:text-base">{@render title()}</span>
+		<span class="text-xs text-tertiary sm:text-sm">{@render description()}</span>
+	</div>
+
+	<div class="flex xs:shrink-0">
+		{@render button()}
+	</div>
+</div>

--- a/src/frontend/src/tests/lib/components/get-token/GetTokenActionItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/get-token/GetTokenActionItem.spec.ts
@@ -1,0 +1,19 @@
+import GetTokenActionItem from '$lib/components/get-token/GetTokenActionItem.svelte';
+import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import { render } from '@testing-library/svelte';
+
+describe('GetTokenActionItem', () => {
+	it('renders snippets correctly', () => {
+		const { getByTestId } = render(GetTokenActionItem, {
+			icon: createMockSnippet('icon'),
+			title: createMockSnippet('title'),
+			description: createMockSnippet('description'),
+			button: createMockSnippet('button')
+		});
+
+		expect(getByTestId('icon')).toBeInTheDocument();
+		expect(getByTestId('title')).toBeInTheDocument();
+		expect(getByTestId('description')).toBeInTheDocument();
+		expect(getByTestId('button')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to create a new UI component for the GetToken modal.

<img width="528" height="172" alt="Screenshot 2025-11-25 at 11 07 38" src="https://github.com/user-attachments/assets/2bd6876d-1b07-4be6-88ba-bacf885f7d41" />
