### PR TITLE
feat(frontend): extend GetTokenWizardStep with 2 buttons

### DIFF
--- a/src/frontend/src/lib/components/get-token/GetTokenWizardStep.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenWizardStep.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
+	import GetTokenActionItem from '$lib/components/get-token/GetTokenActionItem.svelte';
 	import GetTokenCardContent from '$lib/components/get-token/GetTokenCardContent.svelte';
+	import IconQr from '$lib/components/icons/IconQr.svelte';
+	import IconlyBuy from '$lib/components/icons/iconly/IconlyBuy.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import SwapLoader from '$lib/components/swap/SwapLoader.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -128,6 +131,62 @@
 				</ExternalLink>
 			{/snippet}
 		</StakeContentCard>
+	</div>
+
+	<div class="mt-6 mb-2 text-base font-bold sm:text-lg">
+		{replacePlaceholders($i18n.get_token.text.get_more_token, {
+			$token: tokenSymbol
+		})}
+	</div>
+
+	<div class="flex w-full flex-col gap-2">
+		<GetTokenActionItem>
+			{#snippet icon()}
+				<IconQr />
+			{/snippet}
+
+			{#snippet title()}
+				{replacePlaceholders($i18n.get_token.text.receive_token_title, {
+					$token: tokenSymbol
+				})}
+			{/snippet}
+
+			{#snippet description()}
+				{replacePlaceholders($i18n.get_token.text.receive_token_text, {
+					$token: tokenSymbol
+				})}
+			{/snippet}
+
+			{#snippet button()}
+				<Button onclick={() => onGoToStep(WizardStepsGetToken.RECEIVE)} paddingSmall>
+					{replacePlaceholders($i18n.get_token.text.receive_token, {
+						$token: tokenSymbol
+					})}
+				</Button>
+			{/snippet}
+		</GetTokenActionItem>
+
+		<GetTokenActionItem>
+			{#snippet icon()}
+				<IconlyBuy />
+			{/snippet}
+
+			{#snippet title()}
+				{$i18n.get_token.text.buy_assets_title}
+			{/snippet}
+
+			{#snippet description()}
+				{replacePlaceholders($i18n.get_token.text.buy_assets_text, {
+					$token: tokenSymbol
+				})}
+			{/snippet}
+
+			{#snippet button()}
+				<Button onclick={() => onGoToStep(WizardStepsGetToken.BUY_TOKEN)} paddingSmall>
+					{$i18n.get_token.text.buy_assets}
+				</Button>
+			{/snippet}
+		</GetTokenActionItem>
 	</div>
 
 	{#snippet toolbar()}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "Ready to swap",
 			"convert_assets": "Convert Assets",
 			"convertible_assets": "Convertible assets",
-			"how_to_convert": "How to convert"
+			"how_to_convert": "How to convert",
+			"get_more_token": "Get more $token",
+			"receive_token": "Receive $token",
+			"receive_token_title": "Receive $token directly",
+			"receive_token_text": "Receive $token directly to your account",
+			"buy_assets": "Buy assets",
+			"buy_assets_title": "Buy convertible assets",
+			"buy_assets_text": "Buy more assets and convert to $token"
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1844,7 +1844,14 @@
 			"ready_to_swap": "",
 			"convert_assets": "",
 			"convertible_assets": "",
-			"how_to_convert": ""
+			"how_to_convert": "",
+			"get_more_token": "",
+			"receive_token": "",
+			"receive_token_title": "",
+			"receive_token_text": "",
+			"buy_assets": "",
+			"buy_assets_title": "",
+			"buy_assets_text": ""
 		}
 	},
 	"temporal": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1472,6 +1472,13 @@ interface I18nGet_token {
 		convert_assets: string;
 		convertible_assets: string;
 		how_to_convert: string;
+		get_more_token: string;
+		receive_token: string;
+		receive_token_title: string;
+		receive_token_text: string;
+		buy_assets: string;
+		buy_assets_title: string;
+		buy_assets_text: string;
 	};
 }
 

--- a/src/frontend/src/tests/lib/components/get-token/GetTokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/get-token/GetTokenModal.spec.ts
@@ -21,14 +21,14 @@ describe('GetTokenModal', () => {
 		});
 
 	it('should display GET_TOKEN step', () => {
-		const { getByText } = renderGetTokenModal();
+		const { getAllByText } = renderGetTokenModal();
 
 		expect(
-			getByText(
+			getAllByText(
 				replacePlaceholders(en.stake.text.get_tokens, {
 					$token_symbol: ICP_TOKEN.symbol
 				})
-			)
+			)[0]
 		).toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/lib/components/get-token/GetTokenWizardStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/get-token/GetTokenWizardStep.spec.ts
@@ -43,34 +43,34 @@ describe('GetTokenWizardStep', () => {
 			readable(balance)
 		);
 
-		const { getByText } = render(GetTokenWizardStep, {
+		const { getAllByText } = render(GetTokenWizardStep, {
 			props,
 			context: mockContext()
 		});
 
 		expect(
-			getByText(
+			getAllByText(
 				replacePlaceholders(en.stake.text.get_tokens, {
 					$token_symbol: ETHEREUM_TOKEN.symbol
 				})
-			)
+			)[0]
 		).toBeInTheDocument();
 	});
 
 	it('renders correct title if balance is not available', () => {
 		exchangeStore.set([{ ethereum: { usd: exchangeRate } }]);
 
-		const { getByText } = render(GetTokenWizardStep, {
+		const { getAllByText } = render(GetTokenWizardStep, {
 			props,
 			context: mockContext()
 		});
 
 		expect(
-			getByText(
+			getAllByText(
 				replacePlaceholders(en.stake.text.get_tokens, {
 					$token_symbol: ETHEREUM_TOKEN.symbol
 				})
-			)
+			)[0]
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
# Motivation

We can now add 2 additional buttons to the GetToken modal.

<img width="590" height="779" alt="Screenshot 2025-11-25 at 11 40 39" src="https://github.com/user-attachments/assets/b64dff20-7c96-4d52-a9f0-5e874858a44e" />
