### PR TITLE
feat(frontend): Fetch EXT NFT collections in `LoaderCollections`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -77,7 +77,8 @@
 				const tokens = await getTokensByOwner({
 					identity,
 					owner: identity.getPrincipal(),
-					canisterId
+					canisterId,
+					certified: false
 				});
 
 				return tokens.length > 0 ? [canisterId] : [];

--- a/src/frontend/src/tests/lib/components/loaders/LoaderCollections.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderCollections.spec.ts
@@ -116,7 +116,8 @@ describe('LoaderCollections', () => {
 				expect(extGetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
 					identity: mockIdentity,
 					owner: mockPrincipal,
-					canisterId
+					canisterId,
+					certified: false
 				});
 			});
 
@@ -160,7 +161,8 @@ describe('LoaderCollections', () => {
 				expect(extGetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
 					identity: mockIdentity,
 					owner: mockPrincipal,
-					canisterId
+					canisterId,
+					certified: false
 				});
 			});
 
@@ -240,7 +242,8 @@ describe('LoaderCollections', () => {
 				expect(extGetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
 					identity: mockIdentity,
 					owner: mockPrincipal,
-					canisterId
+					canisterId,
+					certified: false
 				});
 			});
 
@@ -261,7 +264,8 @@ describe('LoaderCollections', () => {
 				expect(extGetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
 					identity: mockIdentity,
 					owner: mockPrincipal,
-					canisterId
+					canisterId,
+					certified: false
 				});
 			});
 


### PR DESCRIPTION
# Motivation

We want to load actively the EXT collections that the user owns NFTs in. The flow is similar to ERC collections.

However, for now, we have no other way of knowing what EXT tokens/collections the user has NFT with.

So, we loop through a curated list, and we use the method `getTokensByOwner` to check if the user has any NFTs from that collection.
