### PR TITLE
feat(devops): Increase margin in vitest coverage threshold

### DIFF
--- a/scripts/build.vitest.thresholds.ts
+++ b/scripts/build.vitest.thresholds.ts
@@ -74,7 +74,7 @@ const main = () => {
 	const original = readFileSync(ORIGINAL_FILE, 'utf8');
 
 	// The coverage calculation is a bit flaky, so to avoid being stuck, we reduce it to have an acceptable margin
-	const withMargin = applyMargin({ text: current, margin: 0.2 });
+	const withMargin = applyMargin({ text: current, margin: 0.3 });
 
 	// Ensure thresholds never decrease
 	const finalText = enforceNonDecreasingThresholds({


### PR DESCRIPTION
# Motivation

The vitest coverage is a bit flaky: with increasing number of tests and lines, it rounds numbers for coverage, increasing the propagated error. This leads to small differences in saved thresholds VS real thresholds (really between 8 and 5 bps). To avoid it, we increase the margin when saving them.