### PR TITLE
chore(frontend): legacy import leftover in config

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -5,7 +5,7 @@ import {
 	disableConsoleLog,
 	failTestsThatLogToConsole
 } from '$tests/utils/console.test-utils';
-import type { HttpAgent } from '@dfinity/agent';
+import type { HttpAgent } from '@icp-sdk/core/agent';
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/svelte';
 import 'fake-indexeddb/auto';


### PR DESCRIPTION
# Motivation

Found a legacy import leftover in the configuration while testing in #10548.

# Changes

- `@dfinity` -> `@icp-sdk`
