### PR TITLE
chore(frontend): Remove unused `EarningCardFields` enum value

### DIFF
--- a/src/frontend/src/env/types/env.earning-cards.ts
+++ b/src/frontend/src/env/types/env.earning-cards.ts
@@ -6,7 +6,6 @@ export enum EarningCardFields {
 	CURRENT_STAKED = 'currentStaked',
 	CURRENT_EARNING = 'currentEarning',
 	EARNING_POTENTIAL = 'earningPotential',
-	CLAIMABLE_REWARDS = 'claimableRewards',
 	TERMS = 'terms'
 }
 


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/10547, I mistakenly included an additional enum value in `EarningCardFields`. It was a test for something else.
