### PR TITLE
style(frontend): Refactor carousel slide styles to flex

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -59,8 +59,8 @@
 	};
 </script>
 
-<div class="flex h-full w-full items-center justify-between gap-2">
-	<div class="mr-2 flex">
+<div class="flex h-full w-full items-center justify-between">
+	<div class="mr-4 flex">
 		<Img
 			alt={replacePlaceholders($i18n.dapps.alt.logo, {
 				$dAppName: resolveText({ i18n: $i18n, path: dAppName })


### PR DESCRIPTION
# Motivation

We need to adjust the layout slightly. As a result of that the carousel close button will be positioned wrongly.

# Changes

Convert the carousel slide CSS to use a flex layout to make it more robust.

# Tests

Visually it looks exactly the same.

Before (staging):
<img width="383" height="162" alt="image" src="https://github.com/user-attachments/assets/e6778217-f6fc-4080-ac69-6b3720da2b45" />

<img width="597" height="145" alt="image" src="https://github.com/user-attachments/assets/21ddf6c4-e735-4504-8ead-d34458216870" />


After:
<img width="356" height="162" alt="image" src="https://github.com/user-attachments/assets/a636a364-7d21-448f-8cf3-c958bc1c3d00" />

<img width="630" height="162" alt="image" src="https://github.com/user-attachments/assets/e070c6f0-8e40-4a6c-b09a-64a4906f76bf" />

