### PR TITLE
refactor(frontend): Extract NFT service to save custom tokens

### DIFF
--- a/src/frontend/src/lib/services/nft.services.ts
+++ b/src/frontend/src/lib/services/nft.services.ts
@@ -9,6 +9,7 @@ import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import type { ProgressStepsSend } from '$lib/enums/progress-steps';
 import { nftStore } from '$lib/stores/nft.store';
 import type { Address } from '$lib/types/address';
+import type { CustomToken } from '$lib/types/custom-token';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Nft, NftId, NonFungibleToken } from '$lib/types/nft';
 import { isNetworkIdEthereum, isNetworkIdEvm } from '$lib/utils/network.utils';
@@ -47,7 +48,7 @@ export const saveNftCustomToken = async ({
 	$ethAddress
 }: {
 	identity: OptionIdentity;
-	token: NonFungibleToken;
+	token: CustomToken<NonFungibleToken>;
 	$ethAddress: OptionEthAddress;
 }) => {
 	if (isNullish(identity)) {

--- a/src/frontend/src/tests/lib/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/nft.services.spec.ts
@@ -135,7 +135,7 @@ describe('nft.services', () => {
 
 		const mockParams = {
 			identity: mockIdentity,
-			token: mockValidErc721Token,
+			token: { ...mockValidErc721Token, enabled: true },
 			$ethAddress: mockEthAddress
 		};
 
@@ -164,21 +164,27 @@ describe('nft.services', () => {
 		it('should save an ERC721 custom token', async () => {
 			await saveNftCustomToken({
 				...mockParams,
-				token: mockValidErc721Token
+				token: { ...mockValidErc721Token, enabled: true }
 			});
 
-			expect(erc721Spy).toHaveBeenCalledExactlyOnceWith();
+			expect(erc721Spy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokens: [{ ...mockValidErc721Token, enabled: true }]
+			});
 			expect(erc1155Spy).not.toHaveBeenCalled();
 		});
 
 		it('should save an ERC1155 custom token', async () => {
 			await saveNftCustomToken({
 				...mockParams,
-				token: mockValidErc1155Token
+				token: { ...mockValidErc1155Token, enabled: true }
 			});
 
 			expect(erc721Spy).not.toHaveBeenCalled();
-			expect(erc1155Spy).toHaveBeenCalledExactlyOnceWith();
+			expect(erc1155Spy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokens: [{ ...mockValidErc1155Token, enabled: true }]
+			});
 		});
 
 		it.todo('should load NFT');


### PR DESCRIPTION
# Motivation

It is useful to have a separate service to save NFT custom tokens, since we want to expand it with other standards. 
