### PR TITLE
chore(frontend): Correct type definition for util `isTokenNonFungible`

### DIFF
--- a/src/frontend/src/lib/utils/nft.utils.ts
+++ b/src/frontend/src/lib/utils/nft.utils.ts
@@ -1,5 +1,3 @@
-import type { Erc1155Token } from '$eth/types/erc1155';
-import type { Erc721Token } from '$eth/types/erc721';
 import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
 import { isTokenErc721 } from '$eth/utils/erc721.utils';
 import { isTokenExtV2 } from '$icp/utils/ext.utils';
@@ -10,7 +8,7 @@ import type {
 } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
 
-export const isTokenNonFungible = (token: Token): token is Erc721Token | Erc1155Token =>
+export const isTokenNonFungible = (token: Token): token is NonFungibleToken =>
 	isTokenErc721(token) || isTokenErc1155(token);
 
 export const isTokenFungible = (token: Token): boolean => !isTokenNonFungible(token);


### PR DESCRIPTION
# Motivation

Just to be more correct, we specify the output type of util `isTokenNonFungible`.