### PR TITLE
feat(frontend): new date formatting util

### DIFF
--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -189,6 +189,31 @@ export const formatSecondsToNormalizedDate = ({
 	});
 };
 
+/** Formats a timestamp to a day difference.
+ *
+ * It uses the current date to compare the date with.
+ *
+ * @param {Object} params - The option object.
+ * @param {number} params.timestamp - The timestamp to format.
+ * @param {number} params.language - Current language.
+ */
+export const formatTimestampToDaysDifference = ({
+	timestamp,
+	language
+}: {
+	timestamp: number;
+	language?: Languages;
+}): string => {
+	const date = new Date(timestamp);
+	const today = new Date();
+
+	const dateUTC = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+	const todayUTC = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+	const daysDifference = Math.ceil((dateUTC - todayUTC) / MILLISECONDS_IN_DAY);
+
+	return getRelativeTimeFormatter(language).format(daysDifference, 'day');
+};
+
 export const formatCurrency = ({
 	value,
 	currency,

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -8,6 +8,7 @@ import {
 	formatSecondsToDate,
 	formatSecondsToNormalizedDate,
 	formatStakeApyNumber,
+	formatTimestampToDaysDifference,
 	formatToShortDateString,
 	formatToken,
 	formatTokenBigintToNumber
@@ -449,6 +450,40 @@ describe('format.utils', () => {
 
 				expect(result).toMatch('December 25, 2022');
 			});
+		});
+	});
+
+	describe('formatTimestampToDaysDifference', () => {
+		const currentDate = new Date();
+
+		it('should return "today" for the current date', () => {
+			const currentDateTimestamp = currentDate.getTime();
+
+			expect(formatTimestampToDaysDifference({ timestamp: currentDateTimestamp })).toBe('today');
+		});
+
+		it('should return "yesterday" for the previous date', () => {
+			const yesterday = new Date(currentDate);
+			yesterday.setDate(currentDate.getDate() - 1);
+			const yesterdayTimestamp = yesterday.getTime();
+
+			expect(formatTimestampToDaysDifference({ timestamp: yesterdayTimestamp })).toBe('yesterday');
+		});
+
+		it('should return 7 days for the future date', () => {
+			const yesterday = new Date(currentDate);
+			yesterday.setDate(currentDate.getDate() + 7);
+			const yesterdayTimestamp = yesterday.getTime();
+
+			expect(formatTimestampToDaysDifference({ timestamp: yesterdayTimestamp })).toBe('in 7 days');
+		});
+
+		it('should return "tomorrow" for the next date', () => {
+			const yesterday = new Date(currentDate);
+			yesterday.setDate(currentDate.getDate() + 1);
+			const yesterdayTimestamp = yesterday.getTime();
+
+			expect(formatTimestampToDaysDifference({ timestamp: yesterdayTimestamp })).toBe('tomorrow');
 		});
 	});
 


### PR DESCRIPTION
# Motivation

For the "unlocked requests" section, we need to implement a new util that is going to format provided timestamps into how many days left until that date.

<img width="606" height="263" alt="Screenshot 2025-11-27 at 09 37 03" src="https://github.com/user-attachments/assets/79194755-4146-4c4f-b5e5-d9ad730d9cd3" />
