### PR TITLE
feat(frontend): update StakeContentSection component

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeContentSection.svelte
+++ b/src/frontend/src/lib/components/stake/StakeContentSection.svelte
@@ -5,14 +5,19 @@
 	interface Props {
 		title: Snippet;
 		content: Snippet;
+		action?: Snippet;
 	}
 
-	let { content, title }: Props = $props();
+	let { content, title, action }: Props = $props();
 </script>
 
 <div class="flex flex-col rounded-xl bg-surface p-4" in:fade>
-	<div class="relative flex w-full items-start justify-between">
+	<div class="relative flex w-full items-center justify-between">
 		{@render title()}
+
+		<div>
+			{@render action?.()}
+		</div>
 	</div>
 
 	<div class="mt-2 flex w-full flex-col">

--- a/src/frontend/src/tests/lib/components/stake/StakeContentSection.spec.ts
+++ b/src/frontend/src/tests/lib/components/stake/StakeContentSection.spec.ts
@@ -5,7 +5,8 @@ import { render } from '@testing-library/svelte';
 describe('StakeContentSection', () => {
 	const props = {
 		content: createMockSnippet('content'),
-		title: createMockSnippet('title')
+		title: createMockSnippet('title'),
+		action: createMockSnippet('action')
 	};
 
 	it('renders provided snippets correctly', () => {
@@ -15,5 +16,6 @@ describe('StakeContentSection', () => {
 
 		expect(getByTestId('content')).toBeInTheDocument();
 		expect(getByTestId('title')).toBeInTheDocument();
+		expect(getByTestId('action')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

`StakeContentSection` needs to accept an additional snippet `action` so we can display "Withdraw" button next to header.

<img width="606" height="263" alt="Screenshot 2025-11-27 at 09 37 03" src="https://github.com/user-attachments/assets/fa68951b-50af-430e-9d9d-7290b94fccb9" />
