### PR TITLE
feat(frontend): implement GldtStakeDissolveEvent component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvent.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvent.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import type { DissolveStakeEvent } from '$declarations/gldt_stake/gldt_stake.did';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
+	import Tag from '$lib/components/ui/Tag.svelte';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Token } from '$lib/types/token';
+	import {
+		formatCurrency,
+		formatSecondsToDate,
+		formatTimestampToDaysDifference,
+		formatToken
+	} from '$lib/utils/format.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { calculateTokenUsdAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	interface Props {
+		gldtToken: Token;
+		event: DissolveStakeEvent;
+	}
+
+	let { gldtToken, event }: Props = $props();
+
+	let dissolvedDateTimestamp = $derived(Number(event.dissolved_date));
+
+	let formattedAmount = $derived(
+		formatToken({
+			value: event.amount,
+			unitName: gldtToken.decimals
+		})
+	);
+</script>
+
+<div
+	class="mb-3 flex w-full items-center justify-between border-b border-tertiary pb-3 last:mb-0 last:border-b-0"
+>
+	<div class="flex items-center sm:w-1/3">
+		<div class="mr-2 sm:mr-4">
+			<Responsive up="md">
+				<TokenLogo badge={{ type: 'network' }} color="white" data={gldtToken} />
+			</Responsive>
+			<Responsive down="sm">
+				<TokenLogo badge={{ type: 'network' }} color="white" data={gldtToken} logoSize="xs" />
+			</Responsive>
+		</div>
+
+		<div class="flex flex-col text-sm">
+			<span class="font-bold">{getTokenDisplaySymbol(gldtToken)}</span>
+
+			<span class="text-tertiary">
+				{gldtToken.name}
+			</span>
+		</div>
+	</div>
+
+	<div class="flex flex-col items-center sm:w-1/3">
+		{#if event.completed}
+			<Tag variant="success">{$i18n.stake.text.unlocked}</Tag>
+		{:else}
+			<Tag variant="warning">
+				{replacePlaceholders($i18n.stake.text.unlocking_in, {
+					$time: formatTimestampToDaysDifference({
+						timestamp: dissolvedDateTimestamp,
+						language: $currentLanguage
+					})
+				})}
+			</Tag>
+		{/if}
+		<span class="mt-0.5 text-sm text-tertiary">
+			{formatSecondsToDate({
+				seconds: dissolvedDateTimestamp / 1000,
+				language: $currentLanguage,
+				formatOptions: {
+					year: undefined
+				}
+			})}
+		</span>
+	</div>
+
+	<div class="flex flex-col text-right sm:w-1/3">
+		<span class="text-sm font-bold sm:text-lg">{formattedAmount}</span>
+		<span class="text-sm text-tertiary">
+			{formatCurrency({
+				value:
+					calculateTokenUsdAmount({
+						amount: event.amount,
+						token: gldtToken,
+						$exchanges
+					}) ?? 0,
+				currency: $currentCurrency,
+				exchangeRate: $currencyExchangeStore,
+				language: $currentLanguage
+			})}
+		</span>
+	</div>
+</div>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "You will receive your $token immediately but are charged a fee on the $token tokens you are unlocking.",
 			"amount_to_receive": "Amount to receive",
 			"unclaimed_rewards": "Unclaimed rewards",
+			"unlock_requests": "Unlock requests",
+			"unlocking_in": "Unlocking $time",
+			"unlocked": "Unlocked",
+			"withdraw": "Withdraw",
+			"withdraw_successful": "Tokens have been successfully withdrawn.",
 			"claim_reward": "Claim reward",
 			"claim_rewards": "Claim rewards",
 			"claim_now": "Claim now",
 			"claiming": "Claiming...",
 			"get_tokens_with_amount": "Get up to $amount $token_symbol",
 			"get_tokens": "Get more $token_symbol"
+		},
+		"error": {
+			"unexpected_error_on_withdraw": "Something went wrong while withdrawing tokens."
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1837,12 +1837,20 @@
 			"immediate_dissolve_terms": "",
 			"amount_to_receive": "",
 			"unclaimed_rewards": "",
+			"unlock_requests": "",
+			"unlocking_in": "",
+			"unlocked": "",
+			"withdraw": "",
+			"withdraw_successful": "",
 			"claim_reward": "",
 			"claim_rewards": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",
 			"get_tokens": ""
+		},
+		"error": {
+			"unexpected_error_on_withdraw": ""
 		},
 		"terms": {
 			"gldt": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1463,6 +1463,11 @@ interface I18nStake {
 		immediate_dissolve_terms: string;
 		amount_to_receive: string;
 		unclaimed_rewards: string;
+		unlock_requests: string;
+		unlocking_in: string;
+		unlocked: string;
+		withdraw: string;
+		withdraw_successful: string;
 		claim_reward: string;
 		claim_rewards: string;
 		claim_now: string;
@@ -1470,6 +1475,7 @@ interface I18nStake {
 		get_tokens_with_amount: string;
 		get_tokens: string;
 	};
+	error: { unexpected_error_on_withdraw: string };
 	terms: {
 		gldt: {
 			item1_title: string;

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvent.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvent.spec.ts
@@ -1,0 +1,50 @@
+import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import GldtStakeDissolveEvent from '$icp/components/stake/gldt/GldtStakeDissolveEvent.svelte';
+import type { IcToken } from '$icp/types/ic-token';
+import type { TokenId } from '$lib/types/token';
+import { formatTimestampToDaysDifference } from '$lib/utils/format.utils';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
+import en from '$tests/mocks/i18n.mock';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
+import { render } from '@testing-library/svelte';
+
+describe('GldtStakeDissolveEvent', () => {
+	const gldtToken = {
+		...mockIcrcCustomToken,
+		id: Symbol('GLDT') as TokenId,
+		standard: 'icrc',
+		ledgerCanisterId: GLDT_LEDGER_CANISTER_ID,
+		symbol: 'GLDT'
+	} as IcToken;
+
+	it('should display correct tag if event is unlocked', () => {
+		const { getByText } = render(GldtStakeDissolveEvent, {
+			props: { gldtToken, event: stakePositionMockResponse.dissolve_events[0] }
+		});
+
+		expect(getByText(en.stake.text.unlocked)).toBeInTheDocument();
+	});
+
+	it('should display correct tag if event is not unlocked', () => {
+		const { getByText } = render(GldtStakeDissolveEvent, {
+			props: {
+				gldtToken,
+				event: {
+					...stakePositionMockResponse.dissolve_events[0],
+					completed: false
+				}
+			}
+		});
+
+		expect(
+			getByText(
+				replacePlaceholders(en.stake.text.unlocking_in, {
+					$time: formatTimestampToDaysDifference({
+						timestamp: Number(stakePositionMockResponse.dissolve_events[0].dissolved_date)
+					})
+				})
+			)
+		).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/mocks/gldt_stake.mock.ts
+++ b/src/frontend/src/tests/mocks/gldt_stake.mock.ts
@@ -18,10 +18,10 @@ export const stakePositionMockResponse = {
 	owned_by: mockPrincipal,
 	dissolve_events: [
 		{
-			dissolved_date: 1000n,
+			dissolved_date: 1764237501193n,
 			completed: true,
 			amount: 1000n,
-			percentage: 1000
+			percentage: 1
 		}
 	],
 	weighted_stake: 1000n,


### PR DESCRIPTION
# Motivation

We need to add a component for displaying GDLT stake unlock requests.

Mobile:
<img width="430" height="238" alt="Screenshot 2025-11-27 at 10 54 46" src="https://github.com/user-attachments/assets/fd929775-91d1-4eaf-8497-ccc0434ab624" />

Desktop:
<img width="606" height="263" alt="Screenshot 2025-11-27 at 09 37 03" src="https://github.com/user-attachments/assets/bcd402ec-113a-4f06-99c9-99255f87202f" />
