### PR TITLE
feat(frontend): update staking reward components

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeRewards.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeRewards.svelte
@@ -53,7 +53,7 @@
 	});
 </script>
 
-{#if nonNullish($gldtStakeStore?.position)}
+{#if nonNullish($gldtStakeStore?.position) && rewardTokens.length > 0}
 	<StakeContentSection>
 		{#snippet title()}
 			<h4>{$i18n.stake.text.unclaimed_rewards}</h4>

--- a/src/frontend/src/lib/components/stake/StakeRewardToken.svelte
+++ b/src/frontend/src/lib/components/stake/StakeRewardToken.svelte
@@ -4,6 +4,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
@@ -44,8 +45,13 @@
 
 <LogoButton hover={false}>
 	{#snippet logo()}
-		<span class="mr-2 flex">
-			<TokenLogo badge={{ type: 'network' }} color="white" data={token} />
+		<span class="flex sm:mr-2">
+			<Responsive up="md">
+				<TokenLogo badge={{ type: 'network' }} color="white" data={token} />
+			</Responsive>
+			<Responsive down="sm">
+				<TokenLogo badge={{ type: 'network' }} color="white" data={token} logoSize="xs" />
+			</Responsive>
 		</span>
 	{/snippet}
 
@@ -53,7 +59,7 @@
 		<span class="text-sm">
 			{getTokenDisplaySymbol(token)}
 
-			<span class="font-normal text-tertiary">
+			<span class="hidden font-normal text-tertiary sm:block">
 				<Divider />{token.name}
 			</span>
 		</span>
@@ -88,9 +94,14 @@
 			{disabled}
 			onclick={stopPropagation(onClick)}
 			paddingSmall
-			styleClass="ml-8"
+			styleClass="sm:ml-8 ml-2 sm:text-base text-sm"
 		>
-			{$i18n.stake.text.claim_reward}
+			<Responsive up="md">
+				{$i18n.stake.text.claim_reward}
+			</Responsive>
+			<Responsive down="sm">
+				{$i18n.stake.text.claim_reward_short}
+			</Responsive>
 		</Button>
 	{/snippet}
 </LogoButton>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "Unclaimed rewards",
 			"claim_reward": "Claim reward",
 			"claim_rewards": "Claim rewards",
+			"claim_reward_short": "Claim",
 			"claim_now": "Claim now",
 			"claiming": "Claiming...",
 			"get_tokens_with_amount": "Get up to $amount $token_symbol",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1839,6 +1839,7 @@
 			"unclaimed_rewards": "",
 			"claim_reward": "",
 			"claim_rewards": "",
+			"claim_reward_short": "",
 			"claim_now": "",
 			"claiming": "",
 			"get_tokens_with_amount": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1465,6 +1465,7 @@ interface I18nStake {
 		unclaimed_rewards: string;
 		claim_reward: string;
 		claim_rewards: string;
+		claim_reward_short: string;
 		claim_now: string;
 		claiming: string;
 		get_tokens_with_amount: string;


### PR DESCRIPTION
# Motivation

We need to polish the staking reward components, mostly to look them better on mobile screens.

<img width="443" height="161" alt="Screenshot 2025-11-27 at 11 15 14" src="https://github.com/user-attachments/assets/5b718806-f6a6-46d0-b224-f00e8233f6e6" />
