### PR TITLE
refactor(frontend): Deconstruct `LoaderNfts` to accept more standard

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -43,10 +43,6 @@
 		const promises = Array.from(tokensByNetwork).map(async ([networkId, tokens]) => {
 			const nfts = await loadNfts({ networkId, tokens });
 
-			if (nfts.length === 0) {
-				return;
-			}
-
 			nftStore.setAllByNetwork({ networkId, nfts });
 		});
 


### PR DESCRIPTION
# Motivation

We want to add more services in `LoaderNfts` (like loading EXT NFTs). So, we refactor it to be easier to expand.
