### PR TITLE
feat(frontend): add GldtStakeDissolveEvents section

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStake.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStake.svelte
@@ -3,6 +3,7 @@
 	import { afterNavigate, goto } from '$app/navigation';
 	import { EARNING_ENABLED } from '$env/earning';
 	import GldtInfoBox from '$icp/components/stake/gldt/GldtInfoBox.svelte';
+	import GldtStakeDissolveEvents from '$icp/components/stake/gldt/GldtStakeDissolveEvents.svelte';
 	import GldtStakeEarnCard from '$icp/components/stake/gldt/GldtStakeEarnCard.svelte';
 	import GldtStakePositionCard from '$icp/components/stake/gldt/GldtStakePositionCard.svelte';
 	import GldtStakeRewards from '$icp/components/stake/gldt/GldtStakeRewards.svelte';
@@ -59,6 +60,7 @@
 		{/snippet}
 	</StakeProviderContainer>
 
+	<GldtStakeDissolveEvents {gldtToken} />
 	<GldtStakeRewards />
 	<GldtInfoBox />
 </div>

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvents.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvents.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import GldtStakeDissolveEvent from '$icp/components/stake/gldt/GldtStakeDissolveEvent.svelte';
+	import { withdrawGldtStakingDissolvedTokens } from '$icp/services/gldt-stake.services';
+	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
+	import type { IcToken } from '$icp/types/ic-token';
+	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import {
+		TRACK_COUNT_WITHDRAW_ERROR,
+		TRACK_COUNT_WITHDRAW_SUCCESS
+	} from '$lib/constants/analytics.constants';
+	import { STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON } from '$lib/constants/test-ids.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
+
+	interface Props {
+		gldtToken?: IcToken;
+	}
+
+	let { gldtToken }: Props = $props();
+
+	const { store: gldtStakeStore } = getContext<GldtStakeContext>(GLDT_STAKE_CONTEXT_KEY);
+
+	let sortedEvents = $derived(
+		($gldtStakeStore?.position?.dissolve_events ?? []).sort((a, b) =>
+			Number(a.dissolved_date - b.dissolved_date)
+		)
+	);
+
+	let withdrawButtonEnabled = $derived(
+		($gldtStakeStore?.position?.dissolve_events ?? []).some(({ completed }) => completed)
+	);
+
+	let loading = $state(false);
+
+	const onWithdraw = async () => {
+		if (isNullish($authIdentity)) {
+			return;
+		}
+
+		try {
+			loading = true;
+
+			const withdrawCompleted = () => {
+				trackEvent({
+					name: TRACK_COUNT_WITHDRAW_SUCCESS,
+					metadata: {
+						token: 'GLDT'
+					}
+				});
+			};
+
+			const result = await withdrawGldtStakingDissolvedTokens({
+				identity: $authIdentity,
+				withdrawCompleted
+			});
+
+			gldtStakeStore.setPosition(result);
+
+			toastsShow({
+				text: $i18n.stake.text.withdraw_successful,
+				level: 'success',
+				duration: 2000
+			});
+		} catch (err: unknown) {
+			trackEvent({
+				name: TRACK_COUNT_WITHDRAW_ERROR,
+				metadata: {
+					token: 'GLDT'
+				}
+			});
+
+			toastsError({
+				msg: { text: $i18n.stake.error.unexpected_error_on_withdraw },
+				err
+			});
+		}
+
+		loading = false;
+	};
+</script>
+
+{#if nonNullish(gldtToken) && sortedEvents.length > 0}
+	<StakeContentSection>
+		{#snippet title()}
+			<h4>{$i18n.stake.text.unlock_requests}</h4>
+		{/snippet}
+
+		{#snippet action()}
+			<Button
+				colorStyle="success"
+				disabled={!withdrawButtonEnabled}
+				{loading}
+				onclick={onWithdraw}
+				paddingSmall
+				testId={STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON}
+			>
+				{$i18n.stake.text.withdraw}
+			</Button>
+		{/snippet}
+
+		{#snippet content()}
+			<div class="mt-4">
+				{#each sortedEvents as event, index (index)}
+					<GldtStakeDissolveEvent {event} {gldtToken} />
+				{/each}
+			</div>
+		{/snippet}
+	</StakeContentSection>
+{/if}

--- a/src/frontend/src/lib/constants/analytics.constants.ts
+++ b/src/frontend/src/lib/constants/analytics.constants.ts
@@ -191,3 +191,5 @@ export const TRACK_COUNT_UNSTAKE_SUCCESS = 'unstake_success';
 export const TRACK_COUNT_UNSTAKE_ERROR = 'unstake_error';
 export const TRACK_COUNT_CLAIM_STAKING_REWARD_SUCCESS = 'claim_staking_reward_success';
 export const TRACK_COUNT_CLAIM_STAKING_REWARD_ERROR = 'claim_staking_reward_error';
+export const TRACK_COUNT_WITHDRAW_SUCCESS = 'dissolved_tokens_withdraw_success';
+export const TRACK_COUNT_WITHDRAW_ERROR = 'dissolved_tokens_withdraw_error';

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -313,6 +313,7 @@ export const STAKE_REVIEW_FORM_BUTTON = 'stake-review-form-button';
 export const STAKE_FORM_REVIEW_BUTTON = 'stake-form-next-button';
 export const STAKE_PROVIDER_LOGO = 'stake-provider-logo';
 export const STAKE_PROVIDER_EXTERNAL_URL = 'stake-provider-external-url';
+export const STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON = 'stake-dissolve-events-withdraw-button';
 
 // PWA
 export const PWA_INFO_BANNER_TEST_ID = 'pwa-info-banner';

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvents.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvents.spec.ts
@@ -1,0 +1,80 @@
+import type {
+	DissolveStakeEvent,
+	StakePositionResponse
+} from '$declarations/gldt_stake/gldt_stake.did';
+import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import GldtStakeDissolveEvents from '$icp/components/stake/gldt/GldtStakeDissolveEvents.svelte';
+import {
+	GLDT_STAKE_CONTEXT_KEY,
+	initGldtStakeStore,
+	type GldtStakeContext
+} from '$icp/stores/gldt-stake.store';
+import type { IcToken } from '$icp/types/ic-token';
+import { STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON } from '$lib/constants/test-ids.constants';
+import type { TokenId } from '$lib/types/token';
+import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
+import en from '$tests/mocks/i18n.mock';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
+import { nonNullish } from '@dfinity/utils';
+import { render } from '@testing-library/svelte';
+
+describe('GldtStakeDissolveEvents', () => {
+	const gldtToken = {
+		...mockIcrcCustomToken,
+		id: Symbol('GLDT') as TokenId,
+		standard: 'icrc',
+		ledgerCanisterId: GLDT_LEDGER_CANISTER_ID,
+		symbol: 'GLDT'
+	} as IcToken;
+
+	const getEvents = (events: DissolveStakeEvent[]): StakePositionResponse => ({
+		...stakePositionMockResponse,
+		dissolve_events: events
+	});
+
+	const mockContext = (position: StakePositionResponse | undefined) => {
+		const store = initGldtStakeStore();
+
+		nonNullish(position) && store.setPosition(position);
+
+		return new Map<symbol, GldtStakeContext>([[GLDT_STAKE_CONTEXT_KEY, { store }]]);
+	};
+
+	it('does not display the section if events are not available', () => {
+		const { getByText } = render(GldtStakeDissolveEvents, {
+			props: { gldtToken },
+			context: mockContext(getEvents([]))
+		});
+
+		expect(() => getByText(en.stake.text.unlock_requests)).toThrow();
+	});
+
+	it('does display the section if events are available', () => {
+		const { getByText } = render(GldtStakeDissolveEvents, {
+			props: { gldtToken },
+			context: mockContext(getEvents(stakePositionMockResponse.dissolve_events))
+		});
+
+		expect(getByText(en.stake.text.unlock_requests)).toBeInTheDocument();
+	});
+
+	it('should keep the withdraw button enabled if events are withdrawable', () => {
+		const { getByTestId } = render(GldtStakeDissolveEvents, {
+			props: { gldtToken },
+			context: mockContext(getEvents(stakePositionMockResponse.dissolve_events))
+		});
+
+		expect(getByTestId(STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON)).not.toHaveAttribute('disabled');
+	});
+
+	it('should keep the withdraw button disabled if events are not withdrawable', () => {
+		const { getByTestId } = render(GldtStakeDissolveEvents, {
+			props: { gldtToken },
+			context: mockContext(
+				getEvents([{ ...stakePositionMockResponse.dissolve_events[0], completed: false }])
+			)
+		});
+
+		expect(getByTestId(STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON)).toHaveAttribute('disabled');
+	});
+});


### PR DESCRIPTION
# Motivation

We can now add the dissolve events section to the GLDT stake page.

<img width="643" height="1083" alt="Screenshot 2025-11-27 at 11 44 15" src="https://github.com/user-attachments/assets/408ff6e7-9fe7-4532-88a5-cb19df7741a3" />
