### PR TITLE
fix(frontend): Temporary disable EXT collections loading

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -58,6 +58,7 @@
 		}
 	};
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- we will re-enable in the next release
 	const loadExtTokens = async ({ identity, customTokens }: LoadTokensParams) => {
 		const extEnabledCustomToken = customTokens.reduce<CanisterIdText[]>(
 			(acc, { token, enabled }) =>
@@ -123,7 +124,7 @@
 			customTokens
 		};
 
-		await Promise.all([loadErcTokens(params), loadExtTokens(params)]);
+		await Promise.all([loadErcTokens(params)]);
 	};
 </script>
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderCollections.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderCollections.spec.ts
@@ -104,7 +104,7 @@ describe('LoaderCollections', () => {
 		});
 	});
 
-	it('should add new EXT collections', async () => {
+	it.skip('should add new EXT collections', async () => {
 		extGetTokensByOwnerSpy.mockResolvedValueOnce([1, 2, 3]);
 
 		render(LoaderCollections);
@@ -149,7 +149,7 @@ describe('LoaderCollections', () => {
 		});
 	});
 
-	it('should not add EXT collections if there are no new collections', async () => {
+	it.skip('should not add EXT collections if there are no new collections', async () => {
 		extGetTokensByOwnerSpy.mockResolvedValueOnce([]);
 
 		render(LoaderCollections);
@@ -218,7 +218,7 @@ describe('LoaderCollections', () => {
 		});
 	});
 
-	it('should not add existing EXT collections', async () => {
+	it.skip('should not add existing EXT collections', async () => {
 		const existingExtCustomToken: CustomToken = {
 			token: {
 				ExtV2: {
@@ -251,7 +251,7 @@ describe('LoaderCollections', () => {
 		});
 	});
 
-	it('should handle EXT error gracefully', async () => {
+	it.skip('should handle EXT error gracefully', async () => {
 		const mockError = new Error('EXT error');
 		extGetTokensByOwnerSpy.mockRejectedValueOnce(mockError);
 


### PR DESCRIPTION
# Motivation

The EXT collections loading is slowing down the app a lot (good catch @DenysKarmazynDFINITY !!!).

So, while we investigate, we remove it from the current release.
