### PR TITLE
chore(frontend): Remove redundant NFT loading in Consent Modal

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftImageConsentModal.svelte
+++ b/src/frontend/src/lib/components/nfts/NftImageConsentModal.svelte
@@ -22,7 +22,7 @@
 		PLAUSIBLE_EVENTS
 	} from '$lib/enums/plausible';
 	import { trackEvent } from '$lib/services/analytics.services';
-	import {  updateNftMediaConsent } from '$lib/services/nft.services';
+	import { updateNftMediaConsent } from '$lib/services/nft.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { nftStore } from '$lib/stores/nft.store';


### PR DESCRIPTION
# Motivation

Service `updateNftMediaConsent` already re-load all NFTs, so there is no need to do it again.
