### PR TITLE
feat(frontend): Fallback to show always NFT name

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -54,16 +54,22 @@
 			return;
 		}
 
-		if (nonNullish(nft.name)) {
+		const {
+			id,
+			name,
+			collection: { name: collectionName }
+		} = nft;
+
+		if (nonNullish(name)) {
 			// sometimes NFT names include the number itself, in that case we do not display the number
-			return nft.name.includes(`#${nft.id}`) ? nft.name : `${nft.name} #${nft.id}`;
+			return name.includes(`#${id}`) ? name : `${name} #${id}`;
 		}
 
-		if (nonNullish(nft.collection.name)) {
-			return `${nft.collection.name} #${nft.id}`
+		if (nonNullish(collectionName)) {
+			return `${collectionName} #${id}`;
 		}
 
-		return `#${nft.id}`
+		return `#${id}`;
 	});
 </script>
 


### PR DESCRIPTION
# Motivation

We decided to fallback to the token ID only for the name of the NFT.
