### PR TITLE
feat(frontend): More precise checks for `isVCHFToken` and `isVEURToken`

### DIFF
--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -437,6 +437,12 @@ const ADDITIONAL_ICRC_PRODUCTION_DATA = mapIcrcData(additionalIcrcTokens);
 export const GLDT_LEDGER_CANISTER_ID: LedgerCanisterIdText =
 	ADDITIONAL_ICRC_PRODUCTION_DATA.GLDT?.ledgerCanisterId ?? '6c7su-kiaaa-aaaar-qaira-cai';
 
+export const VCHF_LEDGER_CANISTER_ID: LedgerCanisterIdText =
+	ADDITIONAL_ICRC_PRODUCTION_DATA.VCHF?.ledgerCanisterId ?? 'ly36x-wiaaa-aaaai-aqj7q-cai';
+
+export const VEUR_LEDGER_CANISTER_ID: LedgerCanisterIdText =
+	ADDITIONAL_ICRC_PRODUCTION_DATA.VEUR?.ledgerCanisterId ?? 'wu6g4-6qaaa-aaaan-qmrza-cai';
+
 export const GHOSTNODE_LEDGER_CANISTER_ID: LedgerCanisterIdText =
 	ADDITIONAL_ICRC_PRODUCTION_DATA.GHOSTNODE?.ledgerCanisterId ?? 'sx3gz-hqaaa-aaaar-qaoca-cai';
 

--- a/src/frontend/src/icp-eth/utils/token.utils.ts
+++ b/src/frontend/src/icp-eth/utils/token.utils.ts
@@ -1,4 +1,8 @@
-import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import {
+	GLDT_LEDGER_CANISTER_ID,
+	VCHF_LEDGER_CANISTER_ID,
+	VEUR_LEDGER_CANISTER_ID
+} from '$env/networks/networks.icrc.env';
 import { isTokenIcrc } from '$icp/utils/icrc.utils';
 import type { Token } from '$lib/types/token';
 
@@ -7,6 +11,12 @@ export const isGLDTToken = (token: Token): boolean =>
 	token.symbol === 'GLDT' &&
 	token.ledgerCanisterId === GLDT_LEDGER_CANISTER_ID;
 
-export const isVCHFToken = (token: Token): boolean => isTokenIcrc(token) && token.symbol === 'VCHF';
+export const isVCHFToken = (token: Token): boolean =>
+	isTokenIcrc(token) &&
+	token.symbol === 'VCHF' &&
+	token.ledgerCanisterId === VCHF_LEDGER_CANISTER_ID;
 
-export const isVEURToken = (token: Token): boolean => isTokenIcrc(token) && token.symbol === 'VEUR';
+export const isVEURToken = (token: Token): boolean =>
+	isTokenIcrc(token) &&
+	token.symbol === 'VEUR' &&
+	token.ledgerCanisterId === VEUR_LEDGER_CANISTER_ID;

--- a/src/frontend/src/tests/icp-eth/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/icp-eth/utils/token.utils.spec.ts
@@ -1,4 +1,8 @@
-import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
+import {
+	GLDT_LEDGER_CANISTER_ID,
+	VCHF_LEDGER_CANISTER_ID,
+	VEUR_LEDGER_CANISTER_ID
+} from '$env/networks/networks.icrc.env';
 import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
 import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
 import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
@@ -52,7 +56,14 @@ describe('token.utils', () => {
 
 	describe('isVCHFToken', () => {
 		it('should return true for token VCHF', () => {
-			expect(isVCHFToken({ ...mockValidIcToken, standard: 'icrc', symbol: 'VCHF' })).toBeTruthy();
+			expect(
+				isVCHFToken({
+					...mockValidIcToken,
+					standard: 'icrc',
+					symbol: 'VCHF',
+					ledgerCanisterId: VCHF_LEDGER_CANISTER_ID
+				} as Token)
+			).toBeTruthy();
 		});
 
 		it('should return false for token VCHF that is not ICRC token', () => {
@@ -83,7 +94,14 @@ describe('token.utils', () => {
 
 	describe('isVEURToken', () => {
 		it('should return true for token VEUR', () => {
-			expect(isVEURToken({ ...mockValidIcToken, standard: 'icrc', symbol: 'VEUR' })).toBeTruthy();
+			expect(
+				isVEURToken({
+					...mockValidIcToken,
+					standard: 'icrc',
+					symbol: 'VEUR',
+					ledgerCanisterId: VEUR_LEDGER_CANISTER_ID
+				} as Token)
+			).toBeTruthy();
 		});
 
 		it('should return false for token VEUR that is not ICRC token', () => {


### PR DESCRIPTION
# Motivation

When trying to compare an ICRC token, it is safer to always compare the Ledger canister ID too.
