### PR TITLE
refactor(frontend): Make SNS tokens list static

### DIFF
--- a/src/frontend/src/env/tokens/tokens.ic.env.ts
+++ b/src/frontend/src/env/tokens/tokens.ic.env.ts
@@ -1,10 +1,10 @@
+import { SNS_BUILTIN_TOKENS } from '$env/tokens/tokens.sns.env';
 import { buildDip20Tokens } from '$icp/services/dip20-tokens.services';
-import { buildIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 import type { IcTokenExtended } from '$icp/types/icrc-custom-token';
 import { parseTokenId } from '$lib/validation/token.validation';
 
 export const IC_BUILTIN_TOKENS: IcTokenExtended[] = [
-	...buildIcrcCustomTokens(),
+	...SNS_BUILTIN_TOKENS,
 	...buildDip20Tokens()
 ].map((token) => ({
 	...token,

--- a/src/frontend/src/env/tokens/tokens.sns.env.ts
+++ b/src/frontend/src/env/tokens/tokens.sns.env.ts
@@ -1,0 +1,11 @@
+import {
+	buildIcrcCustomTokens,
+	buildIndexedIcrcCustomTokens
+} from '$icp/services/icrc-custom-tokens.services';
+import type { LedgerCanisterIdText } from '$icp/types/canister';
+import type { IcTokenWithoutIdExtended } from '$icp/types/icrc-custom-token';
+
+export const SNS_BUILTIN_TOKENS: IcTokenWithoutIdExtended[] = buildIcrcCustomTokens();
+
+export const SNS_BUILTIN_TOKENS_INDEXED: Record<LedgerCanisterIdText, IcTokenWithoutIdExtended> =
+	buildIndexedIcrcCustomTokens(SNS_BUILTIN_TOKENS);

--- a/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/icrc-custom-tokens.services.ts
@@ -9,11 +9,10 @@ import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import { get } from 'svelte/store';
 
-export const buildIndexedIcrcCustomTokens = (): Record<
-	LedgerCanisterIdText,
-	IcTokenWithoutIdExtended
-> =>
-	buildIcrcCustomTokens().reduce(
+export const buildIndexedIcrcCustomTokens = (
+	tokens: IcTokenWithoutIdExtended[]
+): Record<LedgerCanisterIdText, IcTokenWithoutIdExtended> =>
+	tokens.reduce(
 		(acc, { ledgerCanisterId, ...rest }) => ({
 			...acc,
 			[`${ledgerCanisterId}`]: {

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -1,10 +1,10 @@
 import type { CustomToken, IcrcToken } from '$declarations/backend/backend.did';
 import { ICRC_CK_TOKENS_LEDGER_CANISTER_IDS, ICRC_TOKENS } from '$env/networks/networks.icrc.env';
+import { SNS_BUILTIN_TOKENS_INDEXED } from '$env/tokens/tokens.sns.env';
 import type { Erc20ContractAddress, Erc20Token } from '$eth/types/erc20';
 import { balance, allowance as icrcAllowance, metadata } from '$icp/api/icrc-ledger.api';
 import { buildIndexedDip20Tokens } from '$icp/services/dip20-tokens.services';
 import { buildIndexedIcpTokens } from '$icp/services/icp-tokens.services';
-import { buildIndexedIcrcCustomTokens } from '$icp/services/icrc-custom-tokens.services';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
@@ -164,7 +164,7 @@ const loadCustomIcrcTokensData = async ({
 }): Promise<IcrcCustomToken[]> => {
 	const indexedIcrcCustomTokens = {
 		...buildIndexedIcpTokens(),
-		...buildIndexedIcrcCustomTokens(),
+		...SNS_BUILTIN_TOKENS_INDEXED,
 		...buildIndexedDip20Tokens()
 	};
 


### PR DESCRIPTION
# Motivation

We don't really need to call the services for the ICRC custom tokens on the static list for SNS tokens. We can ultimately just have a static list and re-use that, since the JSON file will not change on runtime.
