### PR TITLE
refactor(frontend): Rename property to show token in group

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.eurc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.eurc.env.ts
@@ -24,7 +24,7 @@ export const EURC_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckEURC',
 	groupData: EURC_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true
+	neverCollapseInTokenGroup: true
 };
 
 export const SEPOLIA_EURC_SYMBOL = 'SepoliaEURC';

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.link.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.link.env.ts
@@ -24,7 +24,7 @@ export const LINK_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckLINK',
 	groupData: LINK_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'link_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.oct.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.oct.env.ts
@@ -24,7 +24,7 @@ export const OCT_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckOCT',
 	groupData: OCT_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'oct_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.pepe.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.pepe.env.ts
@@ -24,7 +24,7 @@ export const PEPE_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckPEPE',
 	groupData: PEPE_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'pepe_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.shib.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.shib.env.ts
@@ -24,7 +24,7 @@ export const SHIB_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckSHIB',
 	groupData: SHIB_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'shib_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.uni.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.uni.env.ts
@@ -24,5 +24,5 @@ export const UNI_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckUNI',
 	groupData: UNI_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true
+	neverCollapseInTokenGroup: true
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.usdc.env.ts
@@ -24,7 +24,7 @@ export const USDC_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckUSDC',
 	groupData: USDC_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'usdc_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.usdt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.usdt.env.ts
@@ -24,7 +24,7 @@ export const USDT_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckUSDT',
 	groupData: USDT_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'usdt_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.wbtc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.wbtc.env.ts
@@ -24,7 +24,7 @@ export const WBTC_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckWBTC',
 	groupData: WBTC_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'wbtc_ethereum'
 	}

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.wsteth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.wsteth.env.ts
@@ -24,5 +24,5 @@ export const WSTETH_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckWSTETH',
 	groupData: WSTETH_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true
+	neverCollapseInTokenGroup: true
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.xaut.env.ts
@@ -24,5 +24,5 @@ export const XAUT_TOKEN: RequiredErc20Token = {
 	exchange: 'erc20',
 	twinTokenSymbol: 'ckXAUT',
 	groupData: XAUT_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true
+	neverCollapseInTokenGroup: true
 };

--- a/src/frontend/src/env/tokens/tokens.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens.btc.env.ts
@@ -28,7 +28,7 @@ export const BTC_MAINNET_TOKEN: RequiredTokenWithLinkedData = {
 	icon: bitcoin,
 	twinTokenSymbol: 'ckBTC',
 	groupData: BTC_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: { onramperId: 'btc' }
 };
 

--- a/src/frontend/src/env/tokens/tokens.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens.eth.env.ts
@@ -26,7 +26,7 @@ export const ETHEREUM_TOKEN: RequiredTokenWithLinkedData = {
 	icon: eth,
 	twinTokenSymbol: 'ckETH',
 	groupData: ETH_TOKEN_GROUP,
-	alwaysShowInTokenGroup: true,
+	neverCollapseInTokenGroup: true,
 	buy: {
 		onramperId: 'eth'
 	}

--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -38,7 +38,7 @@
 
 	const headerData: CardData = $derived(mapHeaderData(tokenGroup));
 
-	const showTokenInGroup = (token: TokenUi) => token.alwaysShowInTokenGroup;
+	const showTokenInGroup = (token: TokenUi) => token.neverCollapseInTokenGroup;
 	const isCkToken = (token: TokenUi) => nonNullish(token.oisyName?.prefix); // logic taken from old ck badge
 
 	// list of filtered tokens, filtered by string input

--- a/src/frontend/src/lib/schema/token.schema.ts
+++ b/src/frontend/src/lib/schema/token.schema.ts
@@ -41,7 +41,7 @@ const TokenOisyNameSchema = z.object({
 export const TokenAppearanceSchema = z.object({
 	oisySymbol: TokenOisySymbolSchema.optional(),
 	oisyName: TokenOisyNameSchema.optional(),
-	alwaysShowInTokenGroup: z.boolean().optional()
+	neverCollapseInTokenGroup: z.boolean().optional()
 });
 
 const TokenBuySchema = z.object({


### PR DESCRIPTION
# Motivation

The property `alwaysShowInTokenGroup` should represent the idea that a token should never be hidden in a `TokenGroup` that has a lot of items, since we show only a few of them in the dropdown, and we collapse the rest.

So, we rename it to `neverCollapseInTokenGroup` to be more explicit.