### PR TITLE
feat(frontend): expose gldt_stake get_config method

### DIFF
--- a/src/frontend/src/icp/canisters/gldt_stake.canister.ts
+++ b/src/frontend/src/icp/canisters/gldt_stake.canister.ts
@@ -3,6 +3,7 @@ import type {
 	DailyAnalytics,
 	_SERVICE as GldtStakeService,
 	ManageStakePositionArgs,
+	Response,
 	StakePositionResponse
 } from '$declarations/gldt_stake/gldt_stake.did';
 import { idlFactory as idlCertifiedFactoryGldtStake } from '$declarations/gldt_stake/gldt_stake.factory.certified.did';
@@ -37,6 +38,12 @@ export class GldtStakeCanister extends Canister<GldtStakeService> {
 		const { get_apy_overall } = this.caller({ certified: true });
 
 		return get_apy_overall(null);
+	};
+
+	getConfig = (): Promise<Response> => {
+		const { get_config } = this.caller({ certified: true });
+
+		return get_config(null);
 	};
 
 	getDailyAnalytics = async (params?: Args_2): Promise<DailyAnalytics> => {

--- a/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/gldt_stake.canister.spec.ts
@@ -4,6 +4,7 @@ import { CanisterInternalError } from '$lib/canisters/errors';
 import { ZERO } from '$lib/constants/app.constants';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import {
+	configMockResponse,
 	dailyAnalyticsMockResponse,
 	stakePositionMockResponse
 } from '$tests/mocks/gldt_stake.mock';
@@ -164,6 +165,34 @@ describe('gldt_stake.canister', () => {
 			});
 
 			const res = getPosition(params);
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
+
+	describe('getConfig', () => {
+		it('returns config successfully', async () => {
+			service.get_config.mockResolvedValue(configMockResponse);
+
+			const { getConfig } = await createGldtStakeCanister({ serviceOverride: service });
+
+			const result = await getConfig();
+
+			expect(result).toEqual(configMockResponse);
+			expect(service.get_config).toHaveBeenCalledOnce();
+		});
+
+		it('throws an error if get_config method fails', async () => {
+			service.get_config.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { getConfig } = await createGldtStakeCanister({
+				serviceOverride: service
+			});
+
+			const res = getConfig();
 
 			await expect(res).rejects.toThrow(mockResponseError);
 		});

--- a/src/frontend/src/tests/mocks/gldt_stake.mock.ts
+++ b/src/frontend/src/tests/mocks/gldt_stake.mock.ts
@@ -1,6 +1,7 @@
 import type {
 	DailyAnalytics,
 	Duration,
+	Response,
 	StakePositionResponse
 } from '$declarations/gldt_stake/gldt_stake.did';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
@@ -34,3 +35,12 @@ export const dailyAnalyticsMockResponse = {
 	rewards: toNullable([{ ICP: null }, 100n]),
 	weighted_stake: 1000n
 } as DailyAnalytics;
+
+export const configMockResponse = {
+	reward_tokens: ['ICP'],
+	max_dissolve_events: 5n,
+	early_unlock_fee: 0.05,
+	unlock_delay: 50000n,
+	stake_limit_max: 100000000n,
+	stake_limit_min: 10000n
+} as Response;


### PR DESCRIPTION
# Motivation

We need to expose `get_config` method of `gldt_stake` canister.
