### PR TITLE
feat(frontend): implement gldt_stake getConfig API method

### DIFF
--- a/src/frontend/src/icp/api/gldt_stake.api.ts
+++ b/src/frontend/src/icp/api/gldt_stake.api.ts
@@ -2,6 +2,7 @@ import type {
 	Args_2,
 	DailyAnalytics,
 	ManageStakePositionArgs,
+	Response,
 	StakePositionResponse
 } from '$declarations/gldt_stake/gldt_stake.did';
 import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
@@ -16,6 +17,12 @@ export const getApyOverall = async ({ identity }: CanisterApiFunctionParams): Pr
 	const { getApyOverall } = await gldtStakeCanister({ identity });
 
 	return getApyOverall();
+};
+
+export const getConfig = async ({ identity }: CanisterApiFunctionParams): Promise<Response> => {
+	const { getConfig } = await gldtStakeCanister({ identity });
+
+	return getConfig();
 };
 
 export const getDailyAnalytics = async ({

--- a/src/frontend/src/tests/icp/api/gldt_stake.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/gldt_stake.api.spec.ts
@@ -1,5 +1,6 @@
 import {
 	getApyOverall,
+	getConfig,
 	getDailyAnalytics,
 	getPosition,
 	manageStakePosition
@@ -8,6 +9,7 @@ import { GldtStakeCanister } from '$icp/canisters/gldt_stake.canister';
 import * as appConstants from '$lib/constants/app.constants';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import {
+	configMockResponse,
 	dailyAnalyticsMockResponse,
 	stakePositionMockResponse
 } from '$tests/mocks/gldt_stake.mock';
@@ -112,6 +114,28 @@ describe('gldt_stake.api', () => {
 
 		it('throws an error if the gldt_stake canister getPosition method called without identity', async () => {
 			const res = getPosition({
+				identity: null
+			});
+
+			await expect(res).rejects.toThrow();
+		});
+	});
+
+	describe('getConfig', () => {
+		it('correctly calls the gldt_stake canister getConfig method', async () => {
+			mockAuthStore();
+			gldtStakeCanisterMock.getConfig.mockResolvedValue(configMockResponse);
+
+			const result = await getConfig({
+				identity: mockIdentity
+			});
+
+			expect(gldtStakeCanisterMock.getConfig).toHaveBeenCalledOnce();
+			expect(result).toBe(configMockResponse);
+		});
+
+		it('throws an error if the gldt_stake canister getConfig method called without identity', async () => {
+			const res = getConfig({
 				identity: null
 			});
 


### PR DESCRIPTION
# Motivation

We need to implement the gldt_stake `getConfig` API method.
