### PR TITLE
feat(frontend): update gldt-stake.store

### DIFF
--- a/src/frontend/src/icp/stores/gldt-stake.store.ts
+++ b/src/frontend/src/icp/stores/gldt-stake.store.ts
@@ -1,15 +1,18 @@
-import type { StakePositionResponse } from '$declarations/gldt_stake/gldt_stake.did';
+import type { Response, StakePositionResponse } from '$declarations/gldt_stake/gldt_stake.did';
 import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
 export type GldtStakeStoreData = Option<{
 	apy?: number;
 	position?: StakePositionResponse;
+	config?: Response;
 }>;
 
 export interface GldtStakeStore extends Readable<GldtStakeStoreData> {
 	setApy: (value?: number) => void;
 	resetApy: () => void;
+	setConfig: (value?: Response) => void;
+	resetConfig: () => void;
 	setPosition: (value?: StakePositionResponse) => void;
 	resetPosition: () => void;
 	reset: () => void;
@@ -20,6 +23,9 @@ export const initGldtStakeStore = (): GldtStakeStore => {
 
 	const setApy = (value?: number) => {
 		update((state) => ({ ...state, apy: value }));
+	};
+	const setConfig = (value?: Response) => {
+		update((state) => ({ ...state, config: value }));
 	};
 	const setPosition = (value?: StakePositionResponse) => {
 		update((state) => ({ ...state, position: value }));
@@ -33,6 +39,10 @@ export const initGldtStakeStore = (): GldtStakeStore => {
 		setApy,
 
 		resetApy: () => setApy(undefined),
+
+		setConfig,
+
+		resetConfig: () => setApy(undefined),
 
 		setPosition,
 

--- a/src/frontend/src/tests/icp/stores/gldt-stake.store.spec.ts
+++ b/src/frontend/src/tests/icp/stores/gldt-stake.store.spec.ts
@@ -1,5 +1,5 @@
 import { initGldtStakeStore } from '$icp/stores/gldt-stake.store';
-import { stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
+import { configMockResponse, stakePositionMockResponse } from '$tests/mocks/gldt_stake.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
 import { get } from 'svelte/store';
@@ -19,9 +19,14 @@ describe('gldt-stake.store', () => {
 		const store = initGldtStakeStore();
 
 		store.setApy(apyValue);
+		store.setConfig(configMockResponse);
 		store.setPosition(stakePositionMockResponse);
 
-		expect(get(store)).toStrictEqual({ apy: apyValue, position: stakePositionMockResponse });
+		expect(get(store)).toStrictEqual({
+			apy: apyValue,
+			position: stakePositionMockResponse,
+			config: configMockResponse
+		});
 	});
 
 	it('should reset the value', () => {
@@ -29,6 +34,7 @@ describe('gldt-stake.store', () => {
 
 		store.setApy(apyValue);
 		store.setPosition(stakePositionMockResponse);
+		store.setConfig(configMockResponse);
 		store.reset();
 
 		expect(get(store)).toBeUndefined();


### PR DESCRIPTION
# Motivation

We can now update gldt-stake.store with the config value.
