### PR TITLE
refactor(frontend): Display the Dapp Carousel always in the Assets route

### DIFF
--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -43,11 +43,11 @@
 
 	let earningRoute = $derived(isRouteEarning(page));
 
+	let assetsRoute = $derived(tokensRoute || nftsRoute || earningRoute);
+
 	let transactionsRoute = $derived(isRouteTransactions(page));
 
-	let showHero = $derived(
-		(tokensRoute || nftsRoute || earningRoute || transactionsRoute) && !nftsCollectionRoute
-	);
+	let showHero = $derived((assetsRoute || transactionsRoute) && !nftsCollectionRoute);
 
 	$effect(() => {
 		token.set(nftsCollectionRoute ? ($pageNonFungibleToken ?? $pageToken) : $pageToken); // we could be on the nfts page without a pageNonFungibleToken set
@@ -84,7 +84,7 @@
 				<SplitPane>
 					{#snippet menu()}
 						<NavigationMenu>
-							{#if tokensRoute || nftsRoute || earningRoute}
+							{#if assetsRoute}
 								<Responsive up="1.5xl">
 									<DappsCarousel />
 								</Responsive>
@@ -97,6 +97,12 @@
 					{/if}
 
 					<Loaders>
+						{#if assetsRoute}
+							<Responsive down="xl">
+								<DappsCarousel wrapperStyleClass="mb-6 flex justify-center xl:hidden" />
+							</Responsive>
+						{/if}
+
 						{@render children()}
 					</Loaders>
 				</SplitPane>

--- a/src/frontend/src/routes/(app)/+page.svelte
+++ b/src/frontend/src/routes/(app)/+page.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
-	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Assets from '$lib/components/tokens/Assets.svelte';
-	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { TokenTypes } from '$lib/enums/token-types';
 </script>
-
-<Responsive down="xl">
-	<DappsCarousel wrapperStyleClass="mb-6 flex justify-center xl:hidden" />
-</Responsive>
 
 <Assets tab={TokenTypes.TOKENS} />

--- a/src/frontend/src/routes/(app)/nfts/+page.svelte
+++ b/src/frontend/src/routes/(app)/nfts/+page.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
-	import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
 	import Assets from '$lib/components/tokens/Assets.svelte';
-	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { TokenTypes } from '$lib/enums/token-types';
 </script>
-
-<Responsive down="xl">
-	<DappsCarousel wrapperStyleClass="mb-6 flex justify-center xl:hidden" />
-</Responsive>
 
 <Assets tab={TokenTypes.NFTS} />


### PR DESCRIPTION
# Motivation

In the asset route there should always be the Dapp Carousel, so we refactor to have it directly in the Layout.
