### PR TITLE
refactor(frontend): Remove code duplication in ETH NFT send services

### DIFF
--- a/src/frontend/src/eth/types/nft-send.ts
+++ b/src/frontend/src/eth/types/nft-send.ts
@@ -3,7 +3,7 @@ import type { EthereumNetwork } from '$eth/types/network';
 import type { ProgressStepsSend } from '$lib/enums/progress-steps';
 import type { Identity } from '@icp-sdk/core/agent';
 
-interface CommonNftTransferParams {
+export interface CommonNftTransferParams {
 	sourceNetwork: EthereumNetwork;
 	identity: Identity;
 	from: EthAddress;


### PR DESCRIPTION
# Motivation

To simplify the code we extract a sub-service for the ERC721 and ERC1155 transfers.
