### PR TITLE
feat(frontend): implement "resetFilters" method in modal-tokens-list.store

### DIFF
--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -128,7 +128,18 @@ export const initModalTokensListContext = (
 			update((state) => ({
 				...state,
 				filterNetworksIds: networksIds
-			}))
+			})),
+		resetFilters: () => {
+			update((state) => ({
+				...state,
+				filterQuery: undefined,
+				filterNetwork: undefined,
+				filterZeroBalance: undefined,
+				sortByBalance: undefined,
+				filterNetworksIds: undefined,
+				filterNfts: undefined
+			}));
+		}
 	};
 };
 
@@ -140,6 +151,7 @@ export interface ModalTokensListContext {
 	setFilterQuery: (query: string) => void;
 	setFilterNetwork: (network: Network | undefined) => void;
 	setFilterNetworksIds: (networksIds: NetworkId[] | undefined) => void;
+	resetFilters: () => void;
 }
 
 export const MODAL_TOKENS_LIST_CONTEXT_KEY = Symbol('modal-tokens-list');

--- a/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
@@ -91,6 +91,22 @@ describe('modalTokensListStore', () => {
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi2, mockTokenUi1]);
 	});
 
+	it('should reset all filters', () => {
+		const { filterNetwork, filteredTokens, filterQuery, resetFilters } = initModalTokensListContext(
+			{
+				filterNetwork: ICP_NETWORK,
+				filterQuery: 'test',
+				tokens: [mockToken1, mockToken2]
+			}
+		);
+
+		resetFilters();
+
+		expect(get(filterNetwork)).toBe(undefined);
+		expect(get(filterQuery)).toBe(undefined);
+		expect(get(filteredTokens)).toStrictEqual([mockTokenUi2, mockTokenUi1]);
+	});
+
 	it('should filter tokens by network', () => {
 		const { filterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
 			filterNetwork: ETHEREUM_NETWORK,


### PR DESCRIPTION
# Motivation

We need to implement "resetFilters" method in modal-tokens-list.store. `tokens` property should stay unaffected.
