### PR TITLE
feat(frontend): implement "reset" method in swap.store

### DIFF
--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -24,7 +24,7 @@ type IsTokensIcrc2Map = Record<string, boolean>;
 
 export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 	const data = writable<SwapData>(swapData);
-	const { update } = data;
+	const { update, set } = data;
 	const isTokensIcrc2 = writable<IsTokensIcrc2Map | undefined>();
 	const isErc20PermitSupported = writable<IsTokensIcrc2Map | undefined>();
 
@@ -121,7 +121,14 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 			isErc20PermitSupported.update((state) => ({
 				...state,
 				[address]: isPermitSupported
-			}))
+			})),
+
+		reset: () => {
+			set({
+				sourceToken: undefined,
+				destinationToken: undefined
+			});
+		}
 	};
 };
 
@@ -146,6 +153,7 @@ export interface SwapContext {
 	setSourceToken: (token: Token) => void;
 	setDestinationToken: (token: Token | undefined) => void;
 	switchTokens: () => void;
+	reset: () => void;
 }
 
 export const SWAP_CONTEXT_KEY = Symbol('swap');

--- a/src/frontend/src/tests/lib/stores/swap.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap.store.spec.ts
@@ -77,6 +77,43 @@ describe('swapStore', () => {
 		expect(get(destinationTokenExchangeRate)).toStrictEqual(ckBtcExchangeValue);
 	});
 
+	it('should reset all values', () => {
+		const {
+			sourceToken,
+			sourceTokenBalance,
+			sourceTokenExchangeRate,
+			destinationTokenExchangeRate,
+			destinationTokenBalance,
+			destinationToken,
+			reset
+		} = initSwapContext({
+			destinationToken: mockToken1,
+			sourceToken: mockToken2
+		});
+		const ckBtcBalance = bn1Bi;
+		const icpBalance = bn2Bi;
+
+		balancesStore.set({
+			id: mockToken1.id,
+			data: { data: ckBtcBalance, certified: true }
+		});
+		balancesStore.set({
+			id: mockToken2.id,
+			data: { data: icpBalance, certified: true }
+		});
+
+		reset();
+
+		expect(get(sourceToken)).toBe(undefined);
+		expect(get(destinationToken)).toBe(undefined);
+
+		expect(get(sourceTokenBalance)).toBe(undefined);
+		expect(get(destinationTokenBalance)).toBe(undefined);
+
+		expect(get(sourceTokenExchangeRate)).toBe(undefined);
+		expect(get(destinationTokenExchangeRate)).toBe(undefined);
+	});
+
 	it('should set tokens correctly', () => {
 		const { sourceToken, destinationToken, setSourceToken, setDestinationToken } = initSwapContext({
 			destinationToken: mockToken1,


### PR DESCRIPTION
# Motivation

We need to implement "reset" method in swap.store.