### PR TITLE
feat(frontend): reset all vars on SwapModal "close" event

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapModal.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { getContext } from 'svelte';
 	import SwapModalWizardSteps from '$lib/components/swap/SwapModalWizardSteps.svelte';
 	import { swapWizardSteps } from '$lib/config/swap.config';
 	import { SWAP_DEFAULT_SLIPPAGE_VALUE } from '$lib/constants/swap.constants';
@@ -7,9 +8,34 @@
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		MODAL_NETWORKS_LIST_CONTEXT_KEY,
+		type ModalNetworksListContext
+	} from '$lib/stores/modal-networks-list.store';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
+	import {
+		SWAP_AMOUNTS_CONTEXT_KEY,
+		type SwapAmountsContext
+	} from '$lib/stores/swap-amounts.store';
+	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapSelectTokenType } from '$lib/types/swap';
 	import { closeModal } from '$lib/utils/modal.utils';
+
+	const { reset: resetSwapStore } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
+
+	const { resetFilters: resetTokensListFilters } = getContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY
+	);
+
+	const { resetAllowedNetworkIds } = getContext<ModalNetworksListContext>(
+		MODAL_NETWORKS_LIST_CONTEXT_KEY
+	);
+
+	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
 	let modal = $state<WizardModal<WizardStepsSwap>>();
 
@@ -37,7 +63,17 @@
 
 	const close = () =>
 		closeModal(() => {
+			resetSwapStore();
+			resetTokensListFilters();
+			resetAllowedNetworkIds();
+			swapAmountsStore.reset();
+
+			swapAmount = undefined;
+			receiveAmount = undefined;
 			currentStep = undefined;
+			slippageValue = SWAP_DEFAULT_SLIPPAGE_VALUE;
+			swapProgressStep = ProgressStepsSwap.INITIALIZATION;
+			allNetworksEnabled = true;
 			selectTokenType = undefined;
 			showSelectProviderModal = false;
 		});


### PR DESCRIPTION
# Motivation

We can now reset all vars when user closes the swap modal.
