### PR TITLE
feat(frontend): reset all vars on GetTokenModal "close" event

### DIFF
--- a/src/frontend/src/lib/components/get-token/GetTokenModal.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
 	import BuyModalContent from '$lib/components/buy/BuyModalContent.svelte';
 	import GetTokenWizardStep from '$lib/components/get-token/GetTokenWizardStep.svelte';
 	import ReceiveAddressQrCode from '$lib/components/receive/ReceiveAddressQrCode.svelte';
@@ -11,6 +12,19 @@
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsGetToken } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		MODAL_NETWORKS_LIST_CONTEXT_KEY,
+		type ModalNetworksListContext
+	} from '$lib/stores/modal-networks-list.store';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
+	import {
+		SWAP_AMOUNTS_CONTEXT_KEY,
+		type SwapAmountsContext
+	} from '$lib/stores/swap-amounts.store';
+	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { Address } from '$lib/types/address';
 	import type { WizardStepsGetTokenType } from '$lib/types/get-token';
 	import type { OptionAmount } from '$lib/types/send';
@@ -28,6 +42,18 @@
 	}
 
 	let { token, currentApy, receiveAddress }: Props = $props();
+
+	const { reset: resetSwapStore } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
+
+	const { resetFilters: resetTokensListFilters } = getContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY
+	);
+
+	const { resetAllowedNetworkIds } = getContext<ModalNetworksListContext>(
+		MODAL_NETWORKS_LIST_CONTEXT_KEY
+	);
+
+	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
 
 	let steps = $derived(
 		getTokenWizardSteps({ i18n: $i18n, tokenSymbol: getTokenDisplaySymbol(token) })
@@ -60,8 +86,17 @@
 		}
 
 		selectTokenType = undefined;
+		swapAmount = undefined;
+		receiveAmount = undefined;
+		slippageValue = SWAP_DEFAULT_SLIPPAGE_VALUE;
 		swapProgressStep = ProgressStepsSwap.INITIALIZATION;
 		showSelectProviderModal = false;
+		allNetworksEnabled = true;
+
+		resetSwapStore();
+		resetTokensListFilters();
+		resetAllowedNetworkIds();
+		swapAmountsStore.reset();
 	};
 
 	const close = () =>

--- a/src/frontend/src/tests/lib/components/get-token/GetTokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/get-token/GetTokenModal.spec.ts
@@ -5,19 +5,75 @@ import {
 	GET_TOKEN_MODAL_OPEN_SWAP_BUTTON,
 	SWAP_SWITCH_TOKENS_BUTTON
 } from '$lib/constants/test-ids.constants';
+import {
+	MODAL_NETWORKS_LIST_CONTEXT_KEY,
+	initModalNetworksListContext
+} from '$lib/stores/modal-networks-list.store';
+import {
+	MODAL_TOKENS_LIST_CONTEXT_KEY,
+	initModalTokensListContext
+} from '$lib/stores/modal-tokens-list.store';
+import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
+import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockKongBackendTokens } from '$tests/mocks/kong_backend.mock';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
 
 describe('GetTokenModal', () => {
+	const mockContext = new Map();
+
+	const mockSwapContext = () => {
+		const mockToken = { ...mockValidIcToken, enabled: true };
+
+		const originalContext = initSwapContext({
+			sourceToken: mockToken,
+			destinationToken: mockToken
+		});
+
+		const mockSwapContext = {
+			...originalContext,
+			sourceTokenExchangeRate: readable(10),
+			destinationTokenExchangeRate: readable(2)
+		};
+
+		mockContext.set(SWAP_CONTEXT_KEY, mockSwapContext);
+	};
+
+	const setupSwapAmountsStore = () => {
+		const swapAmountsStore = initSwapAmountsStore();
+		mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: swapAmountsStore });
+		return swapAmountsStore;
+	};
+
+	const setupModalTokensListContext = () => {
+		mockContext.set(MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] }));
+	};
+
+	const setupModalNetworksListContext = () => {
+		mockContext.set(
+			MODAL_NETWORKS_LIST_CONTEXT_KEY,
+			initModalNetworksListContext({ networks: [] })
+		);
+	};
+
+	beforeEach(() => {
+		mockSwapContext();
+		setupSwapAmountsStore();
+		setupModalTokensListContext();
+		setupModalNetworksListContext();
+	});
+
 	const renderGetTokenModal = () =>
 		render(GetTokenModal, {
 			props: {
 				token: ICP_TOKEN,
 				currentApy: 10
-			}
+			},
+			context: mockContext
 		});
 
 	it('should display GET_TOKEN step', () => {


### PR DESCRIPTION
# Motivation

We can now reset all vars when user closes the get token modal.
