### PR TITLE
fix(build): Install minimal profile for rust

### DIFF
--- a/scripts/setup-rust
+++ b/scripts/setup-rust
@@ -22,7 +22,7 @@ echo "Using rust version '$RUST_VERSION' and nightly '$NIGHTLY_VERSION'"
 RUSTUP_VERSION="$(jq -re .rustup.version dev-tools.json)"
 
 # here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
-run curl --fail "https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/${RUSTUP_VERSION}/rustup-init.sh" -sSf | run sh -s -- -y --no-modify-path --profile minimal
+run curl --fail "https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/${RUSTUP_VERSION}/rustup-init.sh" -sSf | run sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
 rustup toolchain install --profile minimal            # Version from rust-toolchain.toml
 rustup toolchain install "$version" --profile minimal # Version from dev-tools.json
 rustup component add clippy


### PR DESCRIPTION
# Motivation

In the CIs we are encountering an issue with memory:

> error: failed to extract package: No space left on device (os error 28)

for example [here](https://github.com/dfinity/oisy-wallet/actions/runs/19824533412/job/56794488584?pr=10484).

So, as first attempt, we install rust in the scripts with a minimal profile (not default).

