### PR TITLE
feat(frontend): add GLDT stake carousel slide

### DIFF
--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { dAppDescriptions } from '$env/dapp-descriptions.env';
+	import { EARNING_ENABLED } from '$env/earning';
 	import { rewardCampaigns, FEATURED_REWARD_CAROUSEL_SLIDE_ID } from '$env/reward-campaigns.env';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import { addUserHiddenDappId } from '$lib/api/backend.api';
 	import Carousel from '$lib/components/carousel/Carousel.svelte';
 	import DappsCarouselSlide from '$lib/components/dapps/DappsCarouselSlide.svelte';
+	import { stakeProvidersConfig } from '$lib/config/stake.config';
+	import { AppPath } from '$lib/constants/routes.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		userProfileLoaded,
@@ -18,6 +21,7 @@
 		CarouselSlideOisyDappDescription,
 		OisyDappDescription
 	} from '$lib/types/dapp-description';
+	import { StakeProvider } from '$lib/types/stake';
 	import { filterCarouselDapps } from '$lib/utils/dapps.utils';
 	import { emit } from '$lib/utils/events.utils';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -57,6 +61,20 @@
 			: undefined
 	);
 
+	let gldtStakePageSlide = $derived(
+		EARNING_ENABLED
+			? ({
+					id: stakeProvidersConfig[StakeProvider.GLDT].name,
+					carousel: {
+						text: $i18n.stake.text.gldt_stake_carousel_slide_title,
+						callToAction: $i18n.stake.text.gldt_stake_carousel_slide_cta
+					},
+					logo: stakeProvidersConfig[StakeProvider.GLDT].logo,
+					name: stakeProvidersConfig[StakeProvider.GLDT].name
+				} as CarouselSlideOisyDappDescription)
+			: undefined
+	);
+
 	/*
 	 TODO: rename and adjust DappsCarousel for different data sources (not only dApps descriptions).
 	 1. The component now displays data from difference sources - featured airdrop and dApps
@@ -68,6 +86,7 @@
 		filterCarouselDapps({
 			dAppDescriptions: [
 				...(nonNullish(featureAirdropSlide) ? [featureAirdropSlide] : []),
+				...(nonNullish(gldtStakePageSlide) ? [gldtStakePageSlide] : []),
 				...dAppDescriptions
 			],
 			hiddenDappsIds
@@ -125,6 +144,10 @@
 						: undefined}
 					{dappsCarouselSlide}
 					onCloseCarouselSlide={closeSlide}
+					pagePath={nonNullish(gldtStakePageSlide) &&
+					gldtStakePageSlide.id === dappsCarouselSlide.id
+						? AppPath.EarnGold
+						: undefined}
 				/>
 			{/each}
 		</Carousel>

--- a/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarouselSlide.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate, goto } from '$app/navigation';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
@@ -7,20 +9,30 @@
 		TRACK_COUNT_CAROUSEL_CLOSE,
 		TRACK_COUNT_CAROUSEL_OPEN
 	} from '$lib/constants/analytics.constants';
+	import type { AppPath } from '$lib/constants/routes.constants';
+	import { networkId } from '$lib/derived/network.derived';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { CarouselSlideOisyDappDescription } from '$lib/types/dapp-description';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { resolveText } from '$lib/utils/i18n.utils.js';
+	import { networkUrl } from '$lib/utils/nav.utils';
 
 	interface Props {
 		dappsCarouselSlide: CarouselSlideOisyDappDescription;
 		airdrop?: RewardCampaignDescription;
+		pagePath?: AppPath;
 		onCloseCarouselSlide: (dappId: CarouselSlideOisyDappDescription['id']) => void;
 	}
 
-	let { dappsCarouselSlide, airdrop, onCloseCarouselSlide }: Props = $props();
+	let { dappsCarouselSlide, airdrop, pagePath, onCloseCarouselSlide }: Props = $props();
+
+	let fromRoute = $state<NavigationTarget | null>(null);
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
 
 	let {
 		id: dappId,
@@ -42,6 +54,15 @@
 
 		if (nonNullish(airdrop)) {
 			modalStore.openRewardDetails({ id: rewardModalId, data: airdrop });
+		} else if (nonNullish(pagePath)) {
+			goto(
+				networkUrl({
+					path: pagePath,
+					networkId: $networkId,
+					usePreviousRoute: true,
+					fromRoute
+				})
+			);
 		} else {
 			modalStore.openDappDetails({ id: dappModalId, data: dappsCarouselSlide });
 		}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "Your staking positions will appear here",
 			"description_empty": "It looks like you haven't staked any tokens yet",
 			"full_history": "Show full history",
-			"recent_history": "Close full history"
+			"recent_history": "Close full history",
+			"gldt_stake_carousel_slide_title": "Earn APY with Gold DAO Staking",
+			"gldt_stake_carousel_slide_cta": "Learn more"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Something went wrong while withdrawing tokens."

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1858,7 +1858,9 @@
 			"title_empty": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": ""
+			"recent_history": "",
+			"gldt_stake_carousel_slide_title": "",
+			"gldt_stake_carousel_slide_cta": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": ""

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1485,6 +1485,8 @@ interface I18nStake {
 		description_empty: string;
 		full_history: string;
 		recent_history: string;
+		gldt_stake_carousel_slide_title: string;
+		gldt_stake_carousel_slide_cta: string;
 	};
 	error: { unexpected_error_on_withdraw: string };
 	terms: {

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -3,8 +3,10 @@ import * as dapps from '$env/dapp-descriptions.env';
 import * as rewards from '$env/reward-campaigns.env';
 import { FEATURED_REWARD_CAROUSEL_SLIDE_ID } from '$env/reward-campaigns.env';
 import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
+import { stakeProvidersConfig } from '$lib/config/stake.config';
 import { CAROUSEL_CONTAINER } from '$lib/constants/test-ids.constants';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import { StakeProvider } from '$lib/types/stake';
 import { mockDappsDescriptions } from '$tests/mocks/dapps.mock';
 import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
 import { toNullable } from '@dfinity/utils';
@@ -18,7 +20,7 @@ describe('DappsCarousel', () => {
 		userProfileStore.set({ profile: mockUserProfile, certified: false });
 	});
 
-	it('should render nothing if there is no dApps and rewards', () => {
+	it('should render nothing if there is no dApps, no rewards and earning is not enabled', () => {
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue([]);
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 
@@ -27,7 +29,7 @@ describe('DappsCarousel', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('should render nothing if no dApps has the carousel prop and no rewards', () => {
+	it('should render nothing if no dApps has the carousel prop, no rewards and earning is not enabled', () => {
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue(
 			mockDappsDescriptions.map((dapp) => ({ ...dapp, carousel: undefined }))
@@ -38,7 +40,7 @@ describe('DappsCarousel', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('should render nothing if no dApps and featured reward is unknown', () => {
+	it('should render nothing if no dApps, featured reward is unknown and earning is not enabled', () => {
 		vi.spyOn(rewards, 'FEATURED_REWARD_CAROUSEL_SLIDE_ID', 'get').mockReturnValue(
 			'test' as typeof FEATURED_REWARD_CAROUSEL_SLIDE_ID
 		);
@@ -58,6 +60,7 @@ describe('DappsCarousel', () => {
 					...mockUserSettings.dapp.dapp_carousel,
 					hidden_dapp_ids: [
 						FEATURED_REWARD_CAROUSEL_SLIDE_ID,
+						stakeProvidersConfig[StakeProvider.GLDT].name,
 						...mockDappsDescriptions.map(({ id }) => id)
 					]
 				}


### PR DESCRIPTION
# Motivation

We need to add a carousel slide for the GLDT stake page.

<img width="365" height="201" alt="Screenshot 2025-12-02 at 10 35 58" src="https://github.com/user-attachments/assets/385f1dd2-8a3d-4a71-8120-299a96d862c0" />
