### PR TITLE
fix(frontend): issue with Swap contexts in GetTokenModal

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
@@ -12,6 +12,7 @@
 	import GetTokenModal from '$lib/components/get-token/GetTokenModal.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import StakeModal from '$lib/components/stake/StakeModal.svelte';
+	import SwapContexts from '$lib/components/swap/SwapContexts.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonWithModal from '$lib/components/ui/ButtonWithModal.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
@@ -155,11 +156,13 @@
 				{/snippet}
 
 				{#snippet modal()}
-					<GetTokenModal
-						{currentApy}
-						receiveAddress={$icrcAccountIdentifierText}
-						token={gldtToken}
-					/>
+					<SwapContexts>
+						<GetTokenModal
+							{currentApy}
+							receiveAddress={$icrcAccountIdentifierText}
+							token={gldtToken}
+						/>
+					</SwapContexts>
 				{/snippet}
 			</ButtonWithModal>
 

--- a/src/frontend/src/lib/components/get-token/GetTokenModal.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenModal.svelte
@@ -5,7 +5,6 @@
 	import BuyModalContent from '$lib/components/buy/BuyModalContent.svelte';
 	import GetTokenWizardStep from '$lib/components/get-token/GetTokenWizardStep.svelte';
 	import ReceiveAddressQrCode from '$lib/components/receive/ReceiveAddressQrCode.svelte';
-	import SwapContexts from '$lib/components/swap/SwapContexts.svelte';
 	import SwapModalWizardSteps from '$lib/components/swap/SwapModalWizardSteps.svelte';
 	import { getTokenWizardSteps } from '$lib/config/get-token.config';
 	import { SWAP_DEFAULT_SLIPPAGE_VALUE } from '$lib/constants/swap.constants';
@@ -124,53 +123,51 @@
 	};
 </script>
 
-<SwapContexts>
-	<WizardModal
-		bind:this={modal}
-		disablePointerEvents={currentStep?.name === WizardStepsGetToken.SWAPPING ||
-			currentStep?.name === WizardStepsGetToken.FILTER_NETWORKS}
-		onClose={close}
-		{steps}
-		bind:currentStep
-	>
-		{#snippet title()}{currentStep?.title ?? ''}{/snippet}
+<WizardModal
+	bind:this={modal}
+	disablePointerEvents={currentStep?.name === WizardStepsGetToken.SWAPPING ||
+		currentStep?.name === WizardStepsGetToken.FILTER_NETWORKS}
+	onClose={close}
+	{steps}
+	bind:currentStep
+>
+	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-		{#key currentStep?.name}
-			{#if currentStep?.name === WizardStepsGetToken.GET_TOKEN}
-				<GetTokenWizardStep {currentApy} onClose={close} onGoToStep={goToStep} {token} />
-			{:else if currentStep?.name === WizardStepsGetToken.RECEIVE}
-				<ReceiveAddressQrCode
-					address={receiveAddress}
-					addressLabel={$i18n.wallet.text.wallet_address}
-					addressToken={token}
-					copyAriaLabel={$i18n.wallet.text.wallet_address_copied}
-					network={token.network}
-					onBack={() => goToStep(WizardStepsGetToken.GET_TOKEN)}
-				>
-					{#snippet text()}
-						{replacePlaceholders($i18n.wallet.text.use_address_from_to, {
-							$token: getTokenDisplaySymbol(token)
-						})}
-					{/snippet}
-				</ReceiveAddressQrCode>
-			{:else if currentStep?.name === WizardStepsGetToken.BUY_TOKEN}
-				<BuyModalContent />
-			{:else if showSwapWizard}
-				<SwapModalWizardSteps
-					{currentStep}
-					{modal}
-					onClose={closeSwapWizard}
-					{steps}
-					bind:swapAmount
-					bind:receiveAmount
-					bind:slippageValue
-					bind:swapProgressStep
-					bind:swapFailedProgressSteps
-					bind:allNetworksEnabled
-					bind:showSelectProviderModal
-					bind:selectTokenType
-				/>
-			{/if}
-		{/key}
-	</WizardModal>
-</SwapContexts>
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsGetToken.GET_TOKEN}
+			<GetTokenWizardStep {currentApy} onClose={close} onGoToStep={goToStep} {token} />
+		{:else if currentStep?.name === WizardStepsGetToken.RECEIVE}
+			<ReceiveAddressQrCode
+				address={receiveAddress}
+				addressLabel={$i18n.wallet.text.wallet_address}
+				addressToken={token}
+				copyAriaLabel={$i18n.wallet.text.wallet_address_copied}
+				network={token.network}
+				onBack={() => goToStep(WizardStepsGetToken.GET_TOKEN)}
+			>
+				{#snippet text()}
+					{replacePlaceholders($i18n.wallet.text.use_address_from_to, {
+						$token: getTokenDisplaySymbol(token)
+					})}
+				{/snippet}
+			</ReceiveAddressQrCode>
+		{:else if currentStep?.name === WizardStepsGetToken.BUY_TOKEN}
+			<BuyModalContent />
+		{:else if showSwapWizard}
+			<SwapModalWizardSteps
+				{currentStep}
+				{modal}
+				onClose={closeSwapWizard}
+				{steps}
+				bind:swapAmount
+				bind:receiveAmount
+				bind:slippageValue
+				bind:swapProgressStep
+				bind:swapFailedProgressSteps
+				bind:allNetworksEnabled
+				bind:showSelectProviderModal
+				bind:selectTokenType
+			/>
+		{/if}
+	{/key}
+</WizardModal>

--- a/src/frontend/src/tests/lib/components/get-token/GetTokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/get-token/GetTokenModal.spec.ts
@@ -1,4 +1,5 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { IC_TOKEN_FEE_CONTEXT_KEY, icTokenFeeStore } from '$icp/stores/ic-token-fee.store';
 import * as kongBackendApi from '$lib/api/kong_backend.api';
 import GetTokenModal from '$lib/components/get-token/GetTokenModal.svelte';
 import {
@@ -22,6 +23,10 @@ import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockKongBackendTokens } from '$tests/mocks/kong_backend.mock';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
+
+vi.mock('$icp/api/icrc-ledger.api', () => ({
+	icrc1SupportedStandards: () => Promise.resolve([])
+}));
 
 describe('GetTokenModal', () => {
 	const mockContext = new Map();
@@ -53,6 +58,14 @@ describe('GetTokenModal', () => {
 		mockContext.set(MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] }));
 	};
 
+	const setupIcTokenFeeStore = () => {
+		icTokenFeeStore.setIcTokenFee({
+			tokenSymbol: mockValidIcToken.symbol,
+			fee: 1000n
+		});
+		mockContext.set(IC_TOKEN_FEE_CONTEXT_KEY, { store: icTokenFeeStore });
+	};
+
 	const setupModalNetworksListContext = () => {
 		mockContext.set(
 			MODAL_NETWORKS_LIST_CONTEXT_KEY,
@@ -63,6 +76,7 @@ describe('GetTokenModal', () => {
 	beforeEach(() => {
 		mockSwapContext();
 		setupSwapAmountsStore();
+		setupIcTokenFeeStore();
 		setupModalTokensListContext();
 		setupModalNetworksListContext();
 	});


### PR DESCRIPTION
# Motivation

After the recent changes related to the Swap data resetting, we need to move `SwapContexts` from `GetTokenModal` to its parent (same as it's done for the Swap modal).
