### PR TITLE
fix(frontend): Pass down NFT in IC send flow

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -217,6 +217,7 @@
 		<IcSendReview
 			{amount}
 			{destination}
+			{nft}
 			{onBack}
 			onSend={nonNullish(nft) ? nftSend : send}
 			{selectedContact}

--- a/src/frontend/src/lib/components/send/SendWizard.svelte
+++ b/src/frontend/src/lib/components/send/SendWizard.svelte
@@ -99,6 +99,7 @@
 		<IcSendTokenWizard
 			{currentStep}
 			{destination}
+			{nft}
 			{onBack}
 			{onClose}
 			{onNext}


### PR DESCRIPTION
# Motivation

I forgot to pass down the NFT when we are in the IC send flow.
