### PR TITLE
refactor(frontend): Specific type for Stake Providers configs

### DIFF
--- a/src/frontend/src/lib/config/stake.config.ts
+++ b/src/frontend/src/lib/config/stake.config.ts
@@ -3,7 +3,7 @@ import {
 	WizardStepsStake,
 	WizardStepsUnstake
 } from '$lib/enums/wizard-steps';
-import { StakeProvider } from '$lib/types/stake';
+import { StakeProvider, type StakeProviderConfig } from '$lib/types/stake';
 import type { WizardStepsParams } from '$lib/types/steps';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import type { WizardSteps } from '@dfinity/gix-components';
@@ -65,15 +65,7 @@ export const claimStakingRewardWizardSteps = ({
 	}
 ];
 
-export const stakeProvidersConfig: Record<
-	StakeProvider,
-	{
-		name: string;
-		logo: string;
-		url: string;
-		pageDescriptionKey: string;
-	}
-> = {
+export const stakeProvidersConfig: Record<StakeProvider, StakeProviderConfig> = {
 	[StakeProvider.GLDT]: {
 		name: 'Gold DAO',
 		logo: '/images/dapps/gold-dao-logo.svg',

--- a/src/frontend/src/lib/types/stake.ts
+++ b/src/frontend/src/lib/types/stake.ts
@@ -9,3 +9,10 @@ export interface ClaimStakingRewardParams {
 	token: Token;
 	rewardAmount: Amount;
 }
+
+export interface StakeProviderConfig {
+	name: string;
+	logo: string;
+	url: string;
+	pageDescriptionKey: string;
+}


### PR DESCRIPTION
# Motivation

It will be useful to have a type for all the stake providers configurations: we are going to re-use it to define the earnings providers.
