### PR TITLE
feat(frontend): minimal GLDT unstake fraction

### DIFF
--- a/src/frontend/src/icp/services/gldt-stake.services.ts
+++ b/src/frontend/src/icp/services/gldt-stake.services.ts
@@ -78,7 +78,7 @@ export const unstakeGldt = async ({
 	progress?.(ProgressStepsUnstake.UNSTAKE);
 
 	// TODO: replace "fraction" with "amount" when the gldt_stake canister allows that
-	const fraction = Math.round(Number((amount * 100n) / totalStakedAmount));
+	const fraction = Math.max(Math.round(Number((amount * 100n) / totalStakedAmount)), 1);
 	const response = await manageStakePosition({
 		identity,
 		positionParams: dissolveInstantly


### PR DESCRIPTION
# Motivation

We need to fix the case where user inputs a very low amount of GLDT to unstake which results in fraction being 0 and hence gldt-stake canister error. This approach is needed only until Gold DAO team provides us with the endpoint that accepts amount to unstake as a number and not as a percentage.
