### PR TITLE
style(frontend): Move Earn menu item one position above

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -116,25 +116,6 @@
 	{/snippet}
 </NavigationItem>
 
-<NavigationItem
-	ariaLabel={$i18n.navigation.alt.dapp_explorer}
-	href={networkUrl({
-		path: AppPath.Explore,
-		networkId,
-		usePreviousRoute: isTransactionsRoute,
-		fromRoute
-	})}
-	selected={isRouteDappExplorer(page)}
-	testId={addTestIdPrefix(NAVIGATION_ITEM_EXPLORER)}
->
-	{#snippet icon()}
-		<AnimatedIconUfo />
-	{/snippet}
-	{#snippet label()}
-		{$i18n.navigation.text.dapp_explorer}
-	{/snippet}
-</NavigationItem>
-
 <!-- Todo: remove condition once the feature is completed -->
 {#if EARNING_ENABLED}
 	<NavigationItem
@@ -157,7 +138,29 @@
 			{$i18n.navigation.text.earning}
 		{/snippet}
 	</NavigationItem>
-{:else}
+{/if}
+
+<NavigationItem
+	ariaLabel={$i18n.navigation.alt.dapp_explorer}
+	href={networkUrl({
+		path: AppPath.Explore,
+		networkId,
+		usePreviousRoute: isTransactionsRoute,
+		fromRoute
+	})}
+	selected={isRouteDappExplorer(page)}
+	testId={addTestIdPrefix(NAVIGATION_ITEM_EXPLORER)}
+>
+	{#snippet icon()}
+		<AnimatedIconUfo />
+	{/snippet}
+	{#snippet label()}
+		{$i18n.navigation.text.dapp_explorer}
+	{/snippet}
+</NavigationItem>
+
+<!-- Todo: remove condition once the feature is completed -->
+{#if !EARNING_ENABLED}
 	<NavigationItem
 		ariaLabel={$i18n.navigation.alt.airdrops}
 		href={networkUrl({


### PR DESCRIPTION
# Motivation

When earning is enabled, we want the `Earn` navigation item right after `Activity`.

<img width="639" height="478" alt="Screenshot 2025-12-03 at 14 41 54" src="https://github.com/user-attachments/assets/aa93c737-e748-4422-b07a-246c4a7ca286" />
<img width="421" height="145" alt="Screenshot 2025-12-03 at 14 44 56" src="https://github.com/user-attachments/assets/13a832ab-5616-4c53-9382-d25cea8a21b9" />

