### PR TITLE
feat(frontend): use dissolved_date to check if events are unlocked

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvent.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvent.svelte
@@ -58,7 +58,7 @@
 	</div>
 
 	<div class="flex flex-col items-center sm:w-1/3">
-		{#if event.completed}
+		{#if dissolvedDateTimestamp <= Date.now()}
 			<Tag variant="success">{$i18n.stake.text.unlocked}</Tag>
 		{:else}
 			<Tag variant="warning">

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvents.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeDissolveEvents.svelte
@@ -32,7 +32,9 @@
 	);
 
 	let withdrawButtonEnabled = $derived(
-		($gldtStakeStore?.position?.dissolve_events ?? []).some(({ completed }) => completed)
+		($gldtStakeStore?.position?.dissolve_events ?? []).some(
+			({ dissolved_date }) => Number(dissolved_date) <= Date.now()
+		)
 	);
 
 	let loading = $state(false);

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvent.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvent.spec.ts
@@ -27,12 +27,14 @@ describe('GldtStakeDissolveEvent', () => {
 	});
 
 	it('should display correct tag if event is not unlocked', () => {
+		const timestamp = BigInt(Date.now() + 100000000);
+
 		const { getByText } = render(GldtStakeDissolveEvent, {
 			props: {
 				gldtToken,
 				event: {
 					...stakePositionMockResponse.dissolve_events[0],
-					completed: false
+					dissolved_date: timestamp
 				}
 			}
 		});
@@ -41,7 +43,7 @@ describe('GldtStakeDissolveEvent', () => {
 			getByText(
 				replacePlaceholders(en.stake.text.unlocking_in, {
 					$time: formatTimestampToDaysDifference({
-						timestamp: Number(stakePositionMockResponse.dissolve_events[0].dissolved_date)
+						timestamp: Number(timestamp)
 					})
 				})
 			)

--- a/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvents.spec.ts
+++ b/src/frontend/src/tests/icp/components/stake/gldt/GldtStakeDissolveEvents.spec.ts
@@ -71,7 +71,12 @@ describe('GldtStakeDissolveEvents', () => {
 		const { getByTestId } = render(GldtStakeDissolveEvents, {
 			props: { gldtToken },
 			context: mockContext(
-				getEvents([{ ...stakePositionMockResponse.dissolve_events[0], completed: false }])
+				getEvents([
+					{
+						...stakePositionMockResponse.dissolve_events[0],
+						dissolved_date: BigInt(Date.now() + 100000000)
+					}
+				])
 			)
 		});
 


### PR DESCRIPTION
# Motivation

Instead of relying on the `completed` flag returned by GLDT stake canister, we need to check if the date already in the past manually.
