### PR TITLE
style(frontend): Show original ID for NFT in metadata list

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftMetadataList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftMetadataList.svelte
@@ -72,10 +72,7 @@
 				<span class="truncate">
 					{nft?.id}
 				</span>
-				<AddressActions
-					copyAddress={nft?.id}
-					copyAddressText={$i18n.nfts.text.id_copied ?? ''}
-				/>
+				<AddressActions copyAddress={nft?.id} copyAddressText={$i18n.nfts.text.id_copied ?? ''} />
 			</span>
 		</ListItem>
 	{/if}


### PR DESCRIPTION
# Motivation

Since it is related to metadata, we should show the original NFT ID and not the visual OISY ID.
