### PR TITLE
feat(frontend): new title and description in EarningOpportunityCard

### DIFF
--- a/src/frontend/src/env/earning-cards.json
+++ b/src/frontend/src/env/earning-cards.json
@@ -1,7 +1,7 @@
 [
 	{
 		"id": "sprinkles_s1e5",
-		"title": "earning.cards.sprinkles.title",
+		"titles": ["earning.cards.sprinkles.title"],
 		"description": "earning.cards.sprinkles.description",
 		"logo": "/images/rewards/oisy-reward-logo.svg",
 		"fields": [],
@@ -9,7 +9,7 @@
 	},
 	{
 		"id": "gldt-staking",
-		"title": "earning.cards.gldt.title",
+		"titles": ["earning.cards.gldt.title1", "earning.cards.gldt.title2"],
 		"description": "earning.cards.gldt.description",
 		"logo": "/images/dapps/gold-dao-logo.svg",
 		"fields": ["apy", "currentStaked", "currentEarning", "earningPotential", "terms"],

--- a/src/frontend/src/env/schema/env-earning-cards.schema.ts
+++ b/src/frontend/src/env/schema/env-earning-cards.schema.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 
 export const EarningCardsSchema = z.object({
 	id: z.string(),
-	title: z.string(),
+	titles: z.array(z.string()),
 	description: z.string(),
 	logo: z.string(),
 	fields: z.array(z.enum(EarningCardFields)),

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -20,16 +20,13 @@
 	const formattedApy = $derived(cardFields.apy ? `${cardFields.apy}%` : '-');
 </script>
 
-<EarningOpportunityCard>
+<EarningOpportunityCard titles={cardData.titles}>
 	{#snippet logo()}
 		<Logo size="lg" src={cardData.logo} />
 	{/snippet}
 	{#snippet badge()}
 		{$i18n.stake.text.current_apy_label}
 		<span class="ml-1 font-bold text-success-primary">{formattedApy}</span>
-	{/snippet}
-	{#snippet title()}
-		{resolveText({ i18n: $i18n, path: cardData.title })}
 	{/snippet}
 	{#snippet description()}
 		<p>{resolveText({ i18n: $i18n, path: cardData.description })}</p>

--- a/src/frontend/src/lib/components/earning/EarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/EarningOpportunityCard.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { resolveText } from '$lib/utils/i18n.utils';
 
 	interface Props {
+		titles: string[];
 		logo: Snippet;
 		badge: Snippet;
-		title: Snippet;
 		description: Snippet;
 		button: Snippet;
 	}
 
-	const { logo, badge, title, description, button }: Props = $props();
+	const { titles, logo, badge, description, button }: Props = $props();
 </script>
 
 <div class="flex flex-col rounded-lg border-1 border-disabled bg-disabled p-4">
@@ -22,7 +25,20 @@
 			>
 		</span>
 
-		<h3>{@render title()}</h3>
+		<h3>
+			{#each titles as titlePath, i (`${titlePath}-${i}`)}
+				{#if i > 0}
+					<Responsive up="md">
+						<br />
+					</Responsive>
+					<Responsive down="sm">
+						<span> - </span>
+					</Responsive>
+				{/if}
+
+				<span>{resolveText({ i18n: $i18n, path: titlePath })}</span>
+			{/each}
+		</h3>
 
 		<span>{@render description()}</span>
 	</div>

--- a/src/frontend/src/lib/components/earning/RewardsEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/RewardsEarningOpportunityCard.svelte
@@ -40,7 +40,7 @@
 </script>
 
 {#if nonNullish(cardData)}
-	<EarningOpportunityCard>
+	<EarningOpportunityCard titles={cardData.titles}>
 		{#snippet logo()}
 			<Logo size="lg" src={cardData.logo} />
 		{/snippet}
@@ -48,9 +48,6 @@
 			<span class="mr-2"><IconCalendarDays size="14" /></span>
 			{$i18n.rewards.text.active_date}
 			{`${formatToShortDateString({ date: currentReward.endDate, i18n: $i18n })} ${currentReward.endDate.getDate()}`}
-		{/snippet}
-		{#snippet title()}
-			{resolveText({ i18n: $i18n, path: cardData.title })}
 		{/snippet}
 		{#snippet description()}
 			<p>{resolveText({ i18n: $i18n, path: cardData.description })}</p>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1786,8 +1786,9 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "GLDT Staking",
-				"description": "Stake GLDT tokens to earn rewards backed by physical gold",
+				"title1": "Gold DAO",
+				"title2": "Earn with Gold",
+				"description": "Stake GLDT to earn daily rewards in governance tokens, unlocking passive income from gold holdings.",
 				"action": "Stake GLDT"
 			},
 			"sprinkles": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1786,7 +1786,8 @@
 		},
 		"cards": {
 			"gldt": {
-				"title": "",
+				"title1": "",
+				"title2": "",
 				"description": "",
 				"action": ""
 			},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1420,7 +1420,7 @@ interface I18nEarning {
 		go_to_earn: string;
 	};
 	cards: {
-		gldt: { title: string; description: string; action: string };
+		gldt: { title1: string; title2: string; description: string; action: string };
 		sprinkles: { title: string; description: string; action: string };
 	};
 	card_fields: {

--- a/src/frontend/src/tests/lib/components/earning/AllEarningOpportunityCardList.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/AllEarningOpportunityCardList.spec.ts
@@ -72,7 +72,7 @@ describe('AllEarningOpportunityCardList', () => {
 		vi.spyOn(earningCardsEnv, 'earningCards', 'get').mockReturnValue([
 			{
 				id: mockRewardCampaigns[mockRewardCampaigns.length - 1].id,
-				title: 'mock.rewards.title',
+				titles: ['mock.rewards.title'],
 				description: 'mock.rewards.description',
 				logo: '/images/rewards/oisy-reward-logo.svg',
 				fields: [],
@@ -80,7 +80,7 @@ describe('AllEarningOpportunityCardList', () => {
 			},
 			{
 				id: 'gldt-staking',
-				title: 'mock.gldt.title',
+				titles: ['mock.gldt.title'],
 				description: 'mock.gldt.description',
 				logo: '/mock/logo.svg',
 				fields: [

--- a/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
@@ -13,7 +13,7 @@ describe('DefaultEarningOpportunityCard', () => {
 
 	const mockCardData = {
 		id: 'gldt-staking',
-		title: 'mock.card.title',
+		titles: ['mock.card.title'],
 		description: 'mock.card.description',
 		logo: '/mock/logo.svg',
 		fields: [

--- a/src/frontend/src/tests/lib/components/earning/Earning.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/Earning.spec.ts
@@ -57,7 +57,7 @@ describe('EarningOpportunitiesPage', () => {
 		vi.spyOn(earningCardsEnv, 'earningCards', 'get').mockReturnValue([
 			{
 				id: mockRewardCampaigns[mockRewardCampaigns.length - 1].id,
-				title: 'mock.rewards.title',
+				titles: ['mock.rewards.title'],
 				description: 'mock.rewards.description',
 				logo: '/img/logo1.svg',
 				fields: [],
@@ -65,7 +65,7 @@ describe('EarningOpportunitiesPage', () => {
 			},
 			{
 				id: 'gldt-staking',
-				title: 'mock.gldt.title',
+				titles: ['mock.gldt.title'],
 				description: 'mock.gldt.description',
 				logo: '/mock/logo.svg',
 				fields: [EarningCardFields.APY, EarningCardFields.CURRENT_STAKED],

--- a/src/frontend/src/tests/lib/components/earning/EarningOpportunityCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningOpportunityCard.spec.ts
@@ -7,19 +7,20 @@ describe('EarningOpportunityCard', () => {
 	const props = {
 		logo: createMockSnippet('logo'),
 		badge: createMockSnippet('badge'),
-		title: createMockSnippet('title'),
+		titles: ['title1', 'title2'],
 		description: createMockSnippet('description'),
 		button: createMockSnippet('button')
 	};
 
 	it('renders all snippet sections (logo, badge, title, description, button)', () => {
-		render(EarningOpportunityCard, props);
+		const { getByTestId, getByText } = render(EarningOpportunityCard, props);
 
-		expect(screen.getByTestId('logo')).toBeInTheDocument();
-		expect(screen.getByTestId('badge')).toBeInTheDocument();
-		expect(screen.getByTestId('title')).toBeInTheDocument();
-		expect(screen.getByTestId('description')).toBeInTheDocument();
-		expect(screen.getByTestId('button')).toBeInTheDocument();
+		expect(getByTestId('logo')).toBeInTheDocument();
+		expect(getByTestId('badge')).toBeInTheDocument();
+		expect(getByText('title1')).toBeInTheDocument();
+		expect(getByText('title2')).toBeInTheDocument();
+		expect(getByTestId('description')).toBeInTheDocument();
+		expect(getByTestId('button')).toBeInTheDocument();
 	});
 
 	it('applies the expected container classes', () => {

--- a/src/frontend/src/tests/lib/components/earning/RewardsEarningOpportunityCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/RewardsEarningOpportunityCard.spec.ts
@@ -52,7 +52,7 @@ describe('RewardsEarningOpportunityCard', () => {
 		vi.spyOn(earningCardsEnv, 'earningCards', 'get').mockReturnValue([
 			{
 				id: currentReward.id,
-				title: 'mock.rewards.title',
+				titles: ['mock.rewards.title'],
 				description: 'mock.rewards.description',
 				logo: '/images/rewards/oisy-reward-logo.svg',
 				fields: [],
@@ -134,7 +134,7 @@ describe('RewardsEarningOpportunityCard', () => {
 		const earningCards = [
 			{
 				id: 'abc',
-				title: 'x',
+				titles: ['x'],
 				description: 'y',
 				logo: 'z',
 				actionText: 'a',
@@ -178,7 +178,7 @@ describe('RewardsEarningOpportunityCard', () => {
 		vi.spyOn(earningCardsEnv, 'earningCards', 'get').mockReturnValue([
 			{
 				id: 'xyz',
-				title: 'mock.title',
+				titles: ['mock.title'],
 				description: 'mock.desc',
 				logo: 'mock.svg',
 				fields: [],
@@ -235,7 +235,7 @@ describe('RewardsEarningOpportunityCard', () => {
 		vi.spyOn(earningCardsEnv, 'earningCards', 'get').mockReturnValue([
 			{
 				id: 'abc',
-				title: 'mock.title',
+				titles: ['mock.title'],
 				description: 'mock.desc',
 				logo: 'x',
 				fields: [],


### PR DESCRIPTION
# Motivation

We need to update title and description in `EarningOpportunityCard`: just a translation update for `description` and additional logic for `title` (on mobile, we show a hyphen, on a desktop - `br`).

Desktop:
<img width="283" height="478" alt="Screenshot 2025-12-03 at 16 08 57" src="https://github.com/user-attachments/assets/ff3dcf24-abbe-4ab9-898f-c8454758f1a4" />

Mobile:
<img width="336" height="586" alt="Screenshot 2025-12-03 at 16 09 06" src="https://github.com/user-attachments/assets/822dd207-4ece-4f66-8040-e6b522e3d9b4" />
