### PR TITLE
fix(frontend): Show `IcReceiveIcp` in NFT page too

### DIFF
--- a/src/frontend/src/icp/components/receive/IcReceiveIcp.svelte
+++ b/src/frontend/src/icp/components/receive/IcReceiveIcp.svelte
@@ -11,7 +11,7 @@
 	import ReceiveButtonWithModal from '$lib/components/receive/ReceiveButtonWithModal.svelte';
 	import { modalIcpReceive } from '$lib/derived/modal.derived';
 	import { modalStore } from '$lib/stores/modal.store';
-	import {isRouteNfts, isRouteTokens} from '$lib/utils/nav.utils';
+	import { isRouteNfts, isRouteTokens } from '$lib/utils/nav.utils';
 
 	const { tokenStandard, open, close } = getContext<ReceiveTokenContext>(RECEIVE_TOKEN_CONTEXT_KEY);
 


### PR DESCRIPTION
# Motivation

We are missing an additional page for showing the `IcReceive` modal.
