### PR TITLE
fix(frontend): Expand NFT images for SVG without size

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -110,7 +110,7 @@
 									data: nft
 								})}
 						>
-							<Img src={nft.imageUrl} styleClass="max-h-full max-w-full" />
+							<Img src={nft.imageUrl} styleClass="max-h-full max-w-full w-full" />
 						</button>
 					</NftDisplayGuard>
 					<span class="absolute right-0 bottom-0 m-2.5">


### PR DESCRIPTION
# Motivation

Some NFTs are loaded from SVG websites but without given size, so they shrink and do not appear.

### Before

<img width="1284" height="1027" alt="Screenshot 2025-12-03 at 17 47 14" src="https://github.com/user-attachments/assets/84678561-0982-426f-a5ef-80b539be77bd" />

### After

<img width="1281" height="1020" alt="Screenshot 2025-12-03 at 17 47 50" src="https://github.com/user-attachments/assets/7f789705-cf4c-4d23-a391-66b3459015ff" />

### No change in the rest

<img width="1277" height="1121" alt="Screenshot 2025-12-03 at 17 48 02" src="https://github.com/user-attachments/assets/593e08cd-4aea-4633-9d5a-fab4ecd88102" />
<img width="1282" height="1225" alt="Screenshot 2025-12-03 at 17 48 12" src="https://github.com/user-attachments/assets/657ebe62-951f-47fb-8233-9ed6e66eaec6" />

