### PR TITLE
test(frontend): Correct component in `NftCollectionHero` tests

### DIFF
--- a/src/frontend/src/tests/lib/components/nfts/NftCollectionHero.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCollectionHero.spec.ts
@@ -1,7 +1,6 @@
 import { POLYGON_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import NftCollectionHero from '$lib/components/nfts/NftCollectionHero.svelte';
-import NftHero from '$lib/components/nfts/NftHero.svelte';
 import {
 	NFT_COLLECTION_ACTION_HIDE,
 	NFT_COLLECTION_ACTION_SPAM,
@@ -124,10 +123,10 @@ describe('NftCollectionHero', () => {
 			value: ETHEREUM_NETWORK_ID.description
 		});
 
-		const { container } = render(NftHero, {
+		const { container } = render(NftCollectionHero, {
 			props: {
 				token: { ...AZUKI_ELEMENTAL_BEANS_TOKEN },
-				nft: mockValidErc1155Nft
+				nfts: mockNftCollectionUi.nfts
 			}
 		});
 
@@ -148,10 +147,10 @@ describe('NftCollectionHero', () => {
 			collectionId: `${mockValidErc1155Nft.collection.network.name}-${mockValidErc1155Nft.collection.address}`
 		});
 
-		const { container } = render(NftHero, {
+		const { container } = render(NftCollectionHero, {
 			props: {
 				token: { ...AZUKI_ELEMENTAL_BEANS_TOKEN },
-				nft: mockValidErc1155Nft
+				nfts: mockNftCollectionUi.nfts
 			}
 		});
 


### PR DESCRIPTION
# Motivation

Typo in the tests for `NftCollectionHero`: we were using the `NftHero`.
