### PR TITLE
feat(frontend): update Earning opportunity card

### DIFF
--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -31,7 +31,7 @@
 	{#snippet description()}
 		<p>{resolveText({ i18n: $i18n, path: cardData.description })}</p>
 
-		<List condensed itemStyleClass="flex-col md:flex-row gap-2 whitespace-nowrap text-xs">
+		<List condensed itemStyleClass="gap-2 text-xs">
 			{#each cardData.fields as cardField, i (`${cardField}-${i}`)}
 				<ListItem>
 					<span class="text-tertiary"
@@ -55,7 +55,6 @@
 						{:else if cardField === EarningCardFields.CURRENT_EARNING}
 							<EarningYearlyAmount
 								formatPositiveAmount
-								showPlusSign
 								value={nonNullish(cardFields[cardField]) &&
 								nonNullish(cardFields[EarningCardFields.APY])
 									? (Number(cardFields[cardField]) * Number(cardFields[EarningCardFields.APY])) /

--- a/src/frontend/src/lib/components/earning/EarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/EarningOpportunityCard.svelte
@@ -15,7 +15,7 @@
 	const { titles, logo, badge, description, button }: Props = $props();
 </script>
 
-<div class="flex flex-col rounded-lg border-1 border-disabled bg-disabled p-4">
+<div class="flex flex-col rounded-lg border-1 border-disabled bg-disabled px-3 py-4">
 	<div class="mb-3 flex flex-1 flex-col gap-3 text-sm">
 		<span class="flex items-start">
 			<span class="flex flex-1">{@render logo()}</span>

--- a/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
+++ b/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
@@ -40,7 +40,7 @@
 
 {#if nonNullish(yearlyAmount)}
 	<span
-		class:text-brand-primary={!formatPositiveAmount}
+		class:text-error-primary={!formatPositiveAmount}
 		class:text-success-primary={formatPositiveAmount && nonNullish(value) && value > 0}
 		class:text-tertiary={value === 0}
 		in:fade

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1801,7 +1801,7 @@
 			"apy": "APY",
 			"currentStaked": "Staked",
 			"currentEarning": "Actively earning",
-			"earningPotential": "Max. earning potential",
+			"earningPotential": "Missing earning potential",
 			"terms": "Terms"
 		},
 		"terms": {

--- a/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
@@ -73,7 +73,7 @@ describe('DefaultEarningOpportunityCard', () => {
 			cardFields: mockCardFields
 		});
 
-		expect(screen.getByText('+$2.5/year')).toBeInTheDocument();
+		expect(screen.getByText('$2.5/year')).toBeInTheDocument();
 		expect(screen.getByText('+$200/year')).toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/lib/components/earning/EarningYearlyAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningYearlyAmount.spec.ts
@@ -64,12 +64,12 @@ describe('EarningYearlyAmount', () => {
 		expect(span).toHaveClass('text-success-primary');
 	});
 
-	it('applies text-brand-primary when formatPositiveAmount is false', () => {
+	it('applies text-error-primary when formatPositiveAmount is false', () => {
 		const { container } = render(EarningYearlyAmount, { value: 5, formatPositiveAmount: false });
 
 		const span = container.querySelector('span');
 
-		expect(span).toHaveClass('text-brand-primary');
+		expect(span).toHaveClass('text-error-primary');
 	});
 
 	it('applies text-tertiary when formatPositiveAmount is true but amount is 0', () => {


### PR DESCRIPTION
# Motivation

We need to update some texts and styling of the Earning opportunity card.

<img width="278" height="475" alt="Screenshot 2025-12-04 at 09 51 18" src="https://github.com/user-attachments/assets/ca5a91ca-37f5-4d99-8478-47cedd3e0c0c" />
