### PR TITLE
feat(frontend): Render the nested NFT URLs with `object`

### DIFF
--- a/src/frontend/src/lib/components/ui/Img.svelte
+++ b/src/frontend/src/lib/components/ui/Img.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
+
 	interface Props {
 		src: string;
 		alt?: string;
@@ -28,21 +30,91 @@
 		onLoad,
 		onError
 	}: Props = $props();
+
+	const onErrorHandler = (e: unknown) => {
+		onError?.();
+
+		console.log('Image failed to load:', src, e);
+	};
+
+	let style = $derived(fitHeight ? `max-width: inherit; height: ${height};` : undefined);
+
+	let asDocument = $state(false);
+
+	let svgMarkup = $state<string | undefined>();
+
+	const checkIfDocument = async () => {
+		try {
+			const res = await fetch(src);
+
+			const type = res.headers.get('Content-Type') ?? '';
+
+			console.log('Checking if image is a document:', type);
+
+			// only inspect if it's actually an SVG
+			if (!type.includes('image/svg+xml')) {
+				return;
+			}
+
+			const text = await res.text();
+
+			svgMarkup = text;
+
+			const hasNested = /<image[^>]+href=/i.test(text);
+
+			console.log('Image is a document:', hasNested, text);
+
+			if (hasNested) {
+				asDocument = true;
+			}
+		} catch (err: unknown) {
+			console.log('Failed to check if image is a document:', err, src);
+			// do nothing
+		}
+	};
+
+	$effect(() => {
+		[src];
+
+		untrack(() => checkIfDocument());
+	});
 </script>
 
-<img
-	style={fitHeight ? `max-width: inherit; height: ${height};` : undefined}
-	class={styleClass}
-	class:grayscale
-	class:rounded-full={rounded}
-	{alt}
-	data-tid={testId}
-	decoding="async"
-	{height}
-	loading="lazy"
-	onerror={onError}
-	onload={onLoad}
-	{role}
-	{src}
-	{width}
-/>
+{#if asDocument}
+	<div
+		{style}
+		class={styleClass}
+		aria-label={alt}
+		data-tid={testId}
+		{role}
+	>
+		{@html svgMarkup}
+	</div>
+	<iframe
+		{style}
+		class={styleClass}
+		data-tid={testId}
+		{height}
+		{role}
+		{src}
+		title={alt}
+		{width}
+	></iframe>
+{:else}
+	<img
+		{style}
+		class={styleClass}
+		class:grayscale
+		class:rounded-full={rounded}
+		{alt}
+		data-tid={testId}
+		decoding="async"
+		{height}
+		loading="lazy"
+		onerror={onErrorHandler}
+		onload={onLoad}
+		{role}
+		{src}
+		{width}
+	/>
+{/if}


### PR DESCRIPTION
# DO NOT MERGE

This PR is just a showcase for now.

We have the issue that some NFT URLs have nested URLs in themselves (for example https://rhg63-2aaaa-aaaag-qcwhq-cai.raw.icp0.io/?index=15757).

The asset URL returns an SVG that contains a nested <image> element, and modern browsers block external-resource loading when an SVG is displayed through <img>, which is why it renders as a placeholder.

The safest fallback, embedding the URL inside an <iframe>, is not possible because the remote server sends headers that prevent the content from being framed, so the browser blocks it entirely.
<object> fails for the same framing restriction.

The only remaining way to display the asset exactly as served is to fetch the SVG markup and inject it directly into the DOM. However, inlining remote SVG is unsafe unless fully trusted, because SVG can contain scripts and event handlers that execute in our origin. Therefore, this method would require sanitising the SVG or changes on the provider’s side to allow safe embedding.

# Motivation

<!-- Describe the motivation that lead to the PR -->

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
