### PR TITLE
feat(frontend): add space after + in all earn-related components

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
@@ -90,7 +90,7 @@
 			class:text-brand-primary-alt={$enabledMainnetFungibleTokensUsdBalance > 0}
 			class:text-tertiary={$enabledMainnetFungibleTokensUsdBalance === 0}
 		>
-			{`${$enabledMainnetFungibleTokensUsdBalance > 0 && currentApy > 0 ? '+' : ''}`}{replacePlaceholders(
+			{`${$enabledMainnetFungibleTokensUsdBalance > 0 && currentApy > 0 ? '+ ' : ''}`}{replacePlaceholders(
 				$i18n.stake.text.active_earning_per_year,
 				{
 					$amount: `${formatCurrency({

--- a/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
+++ b/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
@@ -45,7 +45,7 @@
 		class:text-tertiary={value === 0}
 		in:fade
 	>
-		{`${showPlusSign ? '+' : ''}${yearlyAmount}`}
+		{`${showPlusSign ? '+ ' : ''}${yearlyAmount}`}
 	</span>
 {:else if nonNullish(fallback)}
 	{@render fallback()}

--- a/src/frontend/src/lib/components/get-token/GetTokenCardContent.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenCardContent.svelte
@@ -77,7 +77,7 @@
 		class:text-brand-primary-alt={positivePotentialTokenBalance}
 		class:text-disabled={!positivePotentialTokenBalance}
 	>
-		{`${positivePotentialTokenBalance && currentApy > 0 ? '+' : ''}`}{replacePlaceholders(
+		{`${positivePotentialTokenBalance && currentApy > 0 ? '+ ' : ''}`}{replacePlaceholders(
 			$i18n.stake.text.active_earning_per_year,
 			{
 				$amount: `${formatCurrency({

--- a/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
@@ -74,7 +74,7 @@ describe('DefaultEarningOpportunityCard', () => {
 		});
 
 		expect(screen.getByText('$2.5/year')).toBeInTheDocument();
-		expect(screen.getByText('+$200/year')).toBeInTheDocument();
+		expect(screen.getByText('+ $200/year')).toBeInTheDocument();
 	});
 
 	it('renders dash when a field is missing', () => {

--- a/src/frontend/src/tests/lib/components/earning/EarningPotentialCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningPotentialCard.spec.ts
@@ -69,8 +69,8 @@ describe('EarningPotentialCard', () => {
 
 		render(EarningPotentialCard);
 
-		// 200 * 15% = 30 -> "+$30.00"
-		expect(screen.getByText(/\+\$30\.00/)).toBeInTheDocument();
+		// 200 * 15% = 30 -> "+ $30.00"
+		expect(screen.getByText('+ $30.00/year')).toBeInTheDocument();
 	});
 
 	it('handles null earning potential gracefully', () => {

--- a/src/frontend/src/tests/lib/components/earning/EarningYearlyAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningYearlyAmount.spec.ts
@@ -53,7 +53,7 @@ describe('EarningYearlyAmount', () => {
 	it('renders with plus sign when showPlusSign is true', () => {
 		render(EarningYearlyAmount, { value: 10, showPlusSign: true });
 
-		expect(screen.getByText(getFormattedText('+$10.00'))).toBeInTheDocument();
+		expect(screen.getByText(getFormattedText('+ $10.00'))).toBeInTheDocument();
 	});
 
 	it('applies text-success-primary class for positive amount when formatPositiveAmount is true', () => {


### PR DESCRIPTION
# Motivation

We should always have a space after the + sign in all earn-related components.
