### PR TITLE
style(frontend): Increase screen size for simple OISY logo

### DIFF
--- a/src/frontend/src/lib/components/core/SeasonalOisyLogoLarge.svelte
+++ b/src/frontend/src/lib/components/core/SeasonalOisyLogoLarge.svelte
@@ -13,12 +13,12 @@
 
 <SeasonalGuard>
 	{#snippet halloween()}
-		<div class="invert-on-dark-theme logo-container hidden w-24 cursor-pointer xs:block">
+		<div class="invert-on-dark-theme logo-container hidden w-24 cursor-pointer 1.5xs:block">
 			<OisyLogoLargeHalloween description={ariaLabel} />
 		</div>
 	{/snippet}
 
-	<picture class="invert-on-dark-theme hidden w-24 xs:block" aria-label={ariaLabel}>
+	<picture class="invert-on-dark-theme hidden w-24 1.5xs:block" aria-label={ariaLabel}>
 		<source media="(max-width: 639px)" srcset={oisyLogoSmall} />
 		<Img alt={ariaLabel} src={oisyLogoLarge} />
 	</picture>

--- a/src/frontend/src/lib/styles/tailwind/theme-variables.ts
+++ b/src/frontend/src/lib/styles/tailwind/theme-variables.ts
@@ -3,6 +3,7 @@ export const themeVariables = {
 		// we need to use rem instead of px because the default tailwind values changed to rem,
 		// and mixing units breaks custom screen definitions
 		xs: '28rem', // 448px
+		'1.5xs': '32rem', // 512px
 		'1.5md': '56rem', // 896px
 		'1.5lg': '72rem', // 1152px
 		'1.5xl': '88rem', // 1408px


### PR DESCRIPTION
# Motivation

Our header has started to be a bit too busy, so we render the large OISY logo only after 512px (32rem).

### Before

<img width="464" height="399" alt="Screenshot 2025-12-04 at 15 10 02" src="https://github.com/user-attachments/assets/188fd150-af8c-4995-8b75-115dd756b04a" />

### After

<img width="465" height="398" alt="Screenshot 2025-12-04 at 15 09 51" src="https://github.com/user-attachments/assets/29db6f51-c9ac-4605-9a05-5ab87f6c3711" />

