### PR TITLE
feat(frontend): hide help button in RewardsEarning card

### DIFF
--- a/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsRequirements.svelte
@@ -56,9 +56,11 @@
 					size={type === 'earnings-card' ? 210 : undefined}
 				/>
 
-				<button class="p-0.5 text-tertiary" onclick={() => (infoExpanded = !infoExpanded)}>
-					<IconHelp size="18" />
-				</button>
+				{#if type !== 'earnings-card'}
+					<button class="p-0.5 text-tertiary" onclick={() => (infoExpanded = !infoExpanded)}>
+						<IconHelp size="18" />
+					</button>
+				{/if}
 			{/if}
 		</div>
 


### PR DESCRIPTION
# Motivation

We need to hide the help button in the RewardsEarningOpportunityCard component. It still should be shown when user opens the rewards modal.
