### PR TITLE
style(frontend): whitespace-nowrap for yearly amount values

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
@@ -86,7 +86,7 @@
 		<div class="text-sm">{$i18n.stake.text.earning_potential}</div>
 
 		<div
-			class="my-1 text-lg font-bold sm:text-xl"
+			class="my-1 text-lg font-bold whitespace-nowrap sm:text-xl"
 			class:text-brand-primary-alt={$enabledMainnetFungibleTokensUsdBalance > 0}
 			class:text-tertiary={$enabledMainnetFungibleTokensUsdBalance === 0}
 		>

--- a/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
+++ b/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
@@ -40,6 +40,7 @@
 
 {#if nonNullish(yearlyAmount)}
 	<span
+		class="whitespace-nowrap"
 		class:text-error-primary={!formatPositiveAmount}
 		class:text-success-primary={formatPositiveAmount && nonNullish(value) && value > 0}
 		class:text-tertiary={value === 0}

--- a/src/frontend/src/lib/components/get-token/GetTokenCardContent.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenCardContent.svelte
@@ -73,7 +73,7 @@
 	</div>
 
 	<div
-		class="text-lg font-bold sm:text-xl"
+		class="text-lg font-bold whitespace-nowrap sm:text-xl"
 		class:text-brand-primary-alt={positivePotentialTokenBalance}
 		class:text-disabled={!positivePotentialTokenBalance}
 	>


### PR DESCRIPTION
# Motivation

We need to use `whitespace-nowrap` for yearly amount values since there is now a whitespace between + and the value.
