### PR TITLE
chore(frontend): Use correct type in `loadAndAssertAddCustomToken`

### DIFF
--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -26,10 +26,7 @@ export const loadAndAssertAddCustomToken = async ({
 	icrcTokens: IcToken[];
 }): Promise<{
 	result: 'success' | 'error';
-	data?: {
-		token: IcTokenWithoutId;
-		balance: bigint;
-	};
+	data?: ValidateTokenData;
 }> => {
 	assertNonNullish(identity);
 


### PR DESCRIPTION
# Motivation

Use the correct output type in service `loadAndAssertAddCustomToken`.
