### PR TITLE
feat(frontend): Component to review EXT token when custom-adding

### DIFF
--- a/src/frontend/src/icp-eth/types/add-token.ts
+++ b/src/frontend/src/icp-eth/types/add-token.ts
@@ -10,8 +10,14 @@ interface IcAddTokenData {
 	indexCanisterId: string | undefined;
 }
 
+interface ExtAddTokenData {
+	extCanisterId: string;
+}
+
 interface SplAddTokenData {
 	splTokenAddress: SolAddress;
 }
 
-export type AddTokenData = OneOf<[EthAddTokenData, IcAddTokenData, SplAddTokenData]>;
+export type AddTokenData = OneOf<
+	[EthAddTokenData, IcAddTokenData, ExtAddTokenData, SplAddTokenData]
+>;

--- a/src/frontend/src/icp/components/tokens/IcAddExtTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddExtTokenReview.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import { blur, fade } from 'svelte/transition';
+	import { extTokens } from '$icp/derived/ext.derived';
+	import {
+		loadAndAssertAddCustomToken,
+		type ValidateTokenData
+	} from '$icp/services/ext-add-custom-tokens.service';
+	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
+	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import Card from '$lib/components/ui/Card.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import SkeletonCardWithoutAmount from '$lib/components/ui/SkeletonCardWithoutAmount.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		extCanisterId?: string;
+		metadata?: ValidateTokenData;
+		onBack: () => void;
+		onSave: () => void;
+	}
+
+	let { extCanisterId, metadata = $bindable(), onBack, onSave }: Props = $props();
+
+	let invalid = $derived(isNullish(metadata));
+
+	const back = () => onBack();
+
+	onMount(() => {
+		const { result, data } = loadAndAssertAddCustomToken({
+			canisterId: extCanisterId,
+			identity: $authIdentity,
+			extTokens: $extTokens
+		});
+
+		if (result === 'error' || isNullish(data)) {
+			back();
+			return;
+		}
+
+		metadata = data;
+	});
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-4 rounded-lg bg-brand-subtle-20 p-4">
+		{#if isNullish(metadata)}
+			<SkeletonCardWithoutAmount>{$i18n.tokens.import.text.verifying}</SkeletonCardWithoutAmount>
+		{:else}
+			<div in:blur>
+				<Card noMargin>
+					{metadata.token.name}
+
+					{#snippet icon()}
+						{#if nonNullish(metadata)}
+							<Logo
+								alt={replacePlaceholders($i18n.core.alt.logo, { $name: metadata.token.name })}
+								color="white"
+								size="lg"
+								src={metadata.token.icon}
+							/>
+						{/if}
+					{/snippet}
+
+					{#snippet description()}
+						{#if nonNullish(metadata)}
+							<span class="break-all">
+								{metadata.token.symbol}
+							</span>
+						{/if}
+					{/snippet}
+				</Card>
+			</div>
+		{/if}
+	</div>
+
+	{#if nonNullish(metadata)}
+		{@const { network: safeNetwork, canisterId: safeCanisterId } = metadata.token}
+		<div in:fade>
+			<Value element="div" ref="network">
+				{#snippet label()}
+					{$i18n.tokens.manage.text.network}
+				{/snippet}
+				{#snippet content()}
+					<NetworkWithLogo network={safeNetwork} />
+				{/snippet}
+			</Value>
+
+			<Value element="div" ref="canisterId">
+				{#snippet label()}{$i18n.tokens.import.text.canister_id}{/snippet}
+				{#snippet content()}
+					{safeCanisterId}
+				{/snippet}
+			</Value>
+
+			<AddTokenWarning />
+		</div>
+	{/if}
+
+	{#snippet toolbar()}
+		<div in:fade>
+			{#if nonNullish(metadata)}
+				<ButtonGroup>
+					<ButtonBack onclick={back} />
+					<Button disabled={invalid} onclick={onSave}>
+						{$i18n.tokens.import.text.add_the_token}
+					</Button>
+				</ButtonGroup>
+			{/if}
+		</div>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -18,8 +18,10 @@
 	import type { Erc721Metadata } from '$eth/types/erc721';
 	import type { SaveErc721CustomToken } from '$eth/types/erc721-custom-token';
 	import type { EthereumNetwork } from '$eth/types/network';
+	import IcAddExtTokenReview from '$icp/components/tokens/IcAddExtTokenReview.svelte';
 	import IcAddIcrcTokenReview from '$icp/components/tokens/IcAddIcrcTokenReview.svelte';
-	import type { ValidateTokenData } from '$icp/services/ic-add-custom-tokens.service';
+	import type { ValidateTokenData as ValidateExtTokenData } from '$icp/services/ext-add-custom-tokens.service';
+	import type { ValidateTokenData as ValidateIcrcTokenData } from '$icp/services/ic-add-custom-tokens.service';
 	import { saveIcrcCustomTokens } from '$icp/services/manage-tokens.services';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import { TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.constants';
@@ -53,9 +55,19 @@
 		onSuccess: () => void;
 		onError: () => void;
 		onBack: () => void;
+		isNftsPage?: boolean;
 	}
 
-	let { network, tokenData, progress, modalNext, onSuccess, onError, onBack }: Props = $props();
+	let {
+		network,
+		tokenData,
+		progress,
+		modalNext,
+		onSuccess,
+		onError,
+		onBack,
+		isNftsPage = false
+	}: Props = $props();
 
 	const addIcrcToken = async () => {
 		if (isNullish(ledgerCanisterId)) {
@@ -233,24 +245,31 @@
 			identity: $authIdentity
 		});
 
-	let icrcMetadata: ValidateTokenData | undefined = $state();
+	let icrcMetadata: ValidateIcrcTokenData | undefined = $state();
+
+	let extMetadata: ValidateExtTokenData | undefined = $state();
 
 	let ethMetadata: Erc20Metadata | Erc721Metadata | undefined = $state();
 
 	let splMetadata: TokenMetadata | undefined = $state();
 
-	let { ledgerCanisterId, indexCanisterId, ethContractAddress, splTokenAddress } =
+	let { ledgerCanisterId, indexCanisterId, extCanisterId, ethContractAddress, splTokenAddress } =
 		$derived(tokenData);
 </script>
 
 {#if isNetworkIdICP(network?.id)}
-	<IcAddIcrcTokenReview
-		{indexCanisterId}
-		{ledgerCanisterId}
-		{onBack}
-		onSave={addIcrcToken}
-		bind:metadata={icrcMetadata}
-	/>
+	{#if isNftsPage}
+		<!-- TODO: add logic to add an EXT token -->
+		<IcAddExtTokenReview {extCanisterId} {onBack} onSave={() => {}} bind:metadata={extMetadata} />
+	{:else}
+		<IcAddIcrcTokenReview
+			{indexCanisterId}
+			{ledgerCanisterId}
+			{onBack}
+			onSave={addIcrcToken}
+			bind:metadata={icrcMetadata}
+		/>
+	{/if}
 {:else if nonNullish(network) && (isNetworkIdEthereum(network?.id) || isNetworkIdEvm(network?.id))}
 	<EthAddTokenReview
 		contractAddress={ethContractAddress}

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -92,6 +92,7 @@
 	{#key currentStep?.name}
 		{#if currentStep?.name === WizardStepsManageTokens.REVIEW}
 			<AddTokenReviewByNetwork
+				{isNftsPage}
 				modalNext={() => modal?.set(3)}
 				{network}
 				onBack={modal.back}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1118,6 +1118,7 @@
 				"review": "مراجعة",
 				"saving": "جاري الحفظ...",
 				"updating": "جاري تحديث قائمة التوكنات",
+				"canister_id": "",
 				"ledger_canister_id": "معرف حاوية السجل",
 				"index_canister_id": "معرف حاوية الفهرس",
 				"minter_canister_id": "معرف حاوية المينتر",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1118,6 +1118,7 @@
 				"review": "Zkontrolovat",
 				"saving": "Ukládání...",
 				"updating": "Aktualizace seznamu tokenů",
+				"canister_id": "",
 				"ledger_canister_id": "ID kanystru účetní knihy",
 				"index_canister_id": "ID kanystru indexu",
 				"minter_canister_id": "ID kanystru minteru",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1118,6 +1118,7 @@
 				"review": "Überprüfen",
 				"saving": "Speichere...",
 				"updating": "Aktualisiere Token-Liste",
+				"canister_id": "",
 				"ledger_canister_id": "Ledger-Canister-ID",
 				"index_canister_id": "Index-Canister-ID",
 				"minter_canister_id": "Minter-Canister-ID",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1118,6 +1118,7 @@
 				"review": "Review",
 				"saving": "Saving...",
 				"updating": "Updating token list",
+				"canister_id": "Canister ID",
 				"ledger_canister_id": "Ledger Canister ID",
 				"index_canister_id": "Index Canister ID",
 				"minter_canister_id": "Minter Canister ID",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1118,6 +1118,7 @@
 				"review": "Revisar",
 				"saving": "Guardando...",
 				"updating": "Actualizando lista de tokens",
+				"canister_id": "",
 				"ledger_canister_id": "ID del Canister de Ledger",
 				"index_canister_id": "ID del Canister de Índice",
 				"minter_canister_id": "ID del Canister de Minter",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1118,6 +1118,7 @@
 				"review": "Aperçu",
 				"saving": "Enregistrement...",
 				"updating": "Mise à jour de la liste des tokens",
+				"canister_id": "",
 				"ledger_canister_id": "ID du canister du registre",
 				"index_canister_id": "ID du canister d'index",
 				"minter_canister_id": "ID du canister minter",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1118,6 +1118,7 @@
 				"review": "समीक्षा",
 				"saving": "सहेज रहा है...",
 				"updating": "टोकन सूची अपडेट कर रहा है",
+				"canister_id": "",
 				"ledger_canister_id": "लेज़र कैनिस्टर आईडी",
 				"index_canister_id": "इंडेक्स कैनिस्टर आईडी",
 				"minter_canister_id": "मिन्टर कैनिस्टर आईडी",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1118,6 +1118,7 @@
 				"review": "Rivedi",
 				"saving": "Salvataggio...",
 				"updating": "Aggiornamento lista token",
+				"canister_id": "",
 				"ledger_canister_id": "ID Canister Ledger",
 				"index_canister_id": "ID Canister Index",
 				"minter_canister_id": "ID Canister Minter",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1118,6 +1118,7 @@
 				"review": "確認",
 				"saving": "保存中...",
 				"updating": "トークンリストを更新中",
+				"canister_id": "",
 				"ledger_canister_id": "台帳キャニスターID",
 				"index_canister_id": "インデックスキャニスターID",
 				"minter_canister_id": "ミントキャニスターID",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1118,6 +1118,7 @@
 				"review": "Przegląd",
 				"saving": "Zapisywanie...",
 				"updating": "Aktualizacja listy tokenów",
+				"canister_id": "",
 				"ledger_canister_id": "Identyfikator kanistra rejestru",
 				"index_canister_id": "Identyfikator kanistra indeksu",
 				"minter_canister_id": "Identyfikator kanistra mintera",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1118,6 +1118,7 @@
 				"review": "Rever",
 				"saving": "Salvando...",
 				"updating": "Atualizando lista de tokens",
+				"canister_id": "",
 				"ledger_canister_id": "ID do Canister Ledger",
 				"index_canister_id": "ID do Canister Index",
 				"minter_canister_id": "ID do Canister Minter",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1118,6 +1118,7 @@
 				"review": "Проверить",
 				"saving": "Сохранение...",
 				"updating": "Обновление списка токенов",
+				"canister_id": "",
 				"ledger_canister_id": "ID контейнера реестра",
 				"index_canister_id": "ID контейнера индекса",
 				"minter_canister_id": "ID контейнера минтера",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1118,6 +1118,7 @@
 				"review": "Xem lại",
 				"saving": "Đang lưu...",
 				"updating": "Đang cập nhật danh sách token",
+				"canister_id": "",
 				"ledger_canister_id": "ID Canister ledger",
 				"index_canister_id": "ID Canister index",
 				"minter_canister_id": "ID Canister minter",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1118,6 +1118,7 @@
 				"review": "审查",
 				"saving": "正在保存...",
 				"updating": "正在更新代币列表",
+				"canister_id": "",
 				"ledger_canister_id": "账本 Canister ID",
 				"index_canister_id": "索引 Canister ID",
 				"minter_canister_id": "铸币 Canister ID",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -897,6 +897,7 @@ interface I18nTokens {
 			review: string;
 			saving: string;
 			updating: string;
+			canister_id: string;
 			ledger_canister_id: string;
 			index_canister_id: string;
 			minter_canister_id: string;


### PR DESCRIPTION
# Motivation

We want to add custom tokens for EXT standard too.

Copying directly from `IcAddIcrcTokenReview`, we create the parallel component for the EXT tokens: `IcAddExtTokenReview`.

# Changes

- Extend the list of add-token data with EXT tokens: the only thing required is the canister ID.
- Copy `IcAddIcrcTokenReview` in `IcAddExtTokenReview` and remove the logic for the Index Canister, and the metadata: for now we don't really have metadata for EXT tokens.
- Adapt `AddTokenReviewByNetwork` using the same logic of the NFT page.

# Tests

Current tests should work.