### PR TITLE
feat(frontend): Change spelling of Open CryptoPay

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1054,13 +1054,13 @@
 		"text": {
 			"pay": "Pay",
 			"dialog_title": "Pay with $oisy_name",
-			"dialog_description": "$oisy_name lets you pay instantly with crypto across supported chains. At any shop that uses <span class=\"font-bold\">Open CryptoPay</span>, simply scan their payment QR code. Choose the token you want to pay with and confirm the transaction on-chain.",
+			"dialog_description": "$oisy_name lets you pay instantly with crypto across supported chains. At any shop that uses <span class=\"font-bold\">Open&nbsp;CryptoPay</span>, simply scan their payment QR code. Choose the token you want to pay with and confirm the transaction on-chain.",
 			"dialog_button": "Pay with $oisy_short",
 			"where_you_can_pay": "See where you can pay with $oisy_name"
 		},
 		"alt": {
 			"pay": "Dialog with information on how to pay",
-			"where_you_can_pay": "Open the Open CryptoPay website to check where you can pay"
+			"where_you_can_pay": "Open the Open&nbsp;CryptoPay website to check where you can pay"
 		}
 	},
 	"tokens": {


### PR DESCRIPTION
# Motivation

We spell it **`OpenCryptoPay`**.
They spell it almost always as **`Open CryptoPay`** on their website.
(see https://opencryptopay.io/)

<img width="460" height="254" alt="image" src="https://github.com/user-attachments/assets/2ee3dac7-0d1e-457d-801f-b804cd541238" />


# Changes

- change it from **`OpenCryptoPay`** to **`Open CryptoPay`**
- use non breaking spaces

# Tests
<img width="285" height="320" alt="image" src="https://github.com/user-attachments/assets/d3f0f283-55a3-4fb9-8a79-f92ae81dacb3" />

