### PR TITLE
feat(frontend): Allow to reset custom tokens via identifier

### DIFF
--- a/src/frontend/src/icp/services/ic-custom-tokens.services.ts
+++ b/src/frontend/src/icp/services/ic-custom-tokens.services.ts
@@ -1,4 +1,5 @@
 import { loadCustomTokens } from '$icp/services/icrc.services';
+import { extCustomTokensStore } from '$icp/stores/ext-custom-tokens.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { setManyCustomTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
@@ -26,7 +27,11 @@ export const saveCustomTokens = async ({
 	// Hide tokens that have been disabled
 	const disabledTokens = tokens.filter(({ enabled }) => !enabled);
 	disabledTokens.forEach((token) =>
-		token.networkKey === 'Icrc' ? icrcCustomTokensStore.reset(token.ledgerCanisterId) : null
+		token.networkKey === 'Icrc'
+			? icrcCustomTokensStore.reset(token.ledgerCanisterId)
+			: token.networkKey === 'ExtV2'
+				? extCustomTokensStore.resetByIdentifier(token.canisterId)
+				: null
 	);
 
 	// Reload all custom tokens for simplicity reason.

--- a/src/frontend/src/lib/stores/custom-tokens.store.ts
+++ b/src/frontend/src/lib/stores/custom-tokens.store.ts
@@ -1,12 +1,14 @@
-import type { Erc20ContractAddress } from '$eth/types/erc20';
+import type { Erc20Token } from '$eth/types/erc20';
 import { isTokenErc } from '$eth/utils/erc.utils';
 import type { ExtToken } from '$icp/types/ext-token';
+import type { IcToken } from '$icp/types/ic-token';
 import { isTokenExtV2 } from '$icp/utils/ext.utils';
+import { isTokenIc } from '$icp/utils/icrc.utils';
 import type { CustomToken } from '$lib/types/custom-token';
 import type { CertifiedData } from '$lib/types/store';
 import type { Token, TokenId } from '$lib/types/token';
 import type { Option } from '$lib/types/utils';
-import type { SplTokenAddress } from '$sol/types/spl';
+import type { SplToken } from '$sol/types/spl';
 import { isTokenSpl } from '$sol/utils/spl.utils';
 import { writable, type Readable } from 'svelte/store';
 
@@ -16,13 +18,14 @@ export interface CertifiedCustomTokensStore<T extends Token>
 	extends Readable<CertifiedCustomTokensData<T>> {
 	setAll: (tokens: CertifiedData<CustomToken<T>>[]) => void;
 	reset: (tokenId: TokenId) => void;
+	resetByIdentifier: (identifier: Identifier) => void;
 	resetAll: () => void;
 }
 
 type Identifier =
-	| TokenId
-	| Erc20ContractAddress['address']
-	| SplTokenAddress
+	| `${Erc20Token['address']}${'#'}${Erc20Token['network']['chainId']}`
+	| SplToken['address']
+	| IcToken['ledgerCanisterId']
 	| ExtToken['canisterId'];
 
 export const initCertifiedCustomTokensStore = <
@@ -30,14 +33,16 @@ export const initCertifiedCustomTokensStore = <
 >(): CertifiedCustomTokensStore<T> => {
 	const { subscribe, update, set } = writable<CertifiedCustomTokensData<T>>(undefined);
 
-	const getIdentifier = <T extends Token>(token: T): Identifier =>
+	const getIdentifier = <T extends Token>(token: T): Identifier | TokenId =>
 		isTokenSpl(token)
 			? token.address
 			: isTokenErc(token)
 				? `${token.address}#${token.network.chainId}`
 				: isTokenExtV2(token)
 					? token.canisterId
-					: token.id;
+					: isTokenIc(token)
+						? token.ledgerCanisterId
+						: token.id;
 
 	return {
 		setAll: (tokens: CertifiedData<CustomToken<T>>[]) =>
@@ -60,6 +65,10 @@ export const initCertifiedCustomTokensStore = <
 			]),
 		reset: (tokenId: TokenId) =>
 			update((state) => [...(state ?? []).filter(({ data: { id } }) => id !== tokenId)]),
+		resetByIdentifier: (identifier: Identifier) =>
+			update((state) => [
+				...(state ?? []).filter(({ data }) => getIdentifier(data) !== identifier)
+			]),
 		resetAll: () => set(null),
 		subscribe
 	};

--- a/src/frontend/src/tests/lib/stores/custom-tokens.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/custom-tokens.store.spec.ts
@@ -23,6 +23,8 @@ import {
 	mockValidErc721Token
 } from '$tests/mocks/erc721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
+import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { get } from 'svelte/store';
 
 describe('custom-token.store', () => {
@@ -277,6 +279,57 @@ describe('custom-token.store', () => {
 				});
 
 				expect(get(mockStore)).toEqual([]);
+			});
+		});
+
+		describe('resetByIdentifier', () => {
+			let mockTokens: CertifiedData<CustomToken<Token>>[];
+
+			beforeEach(() => {
+				const tokens = [
+					mockValidSplToken,
+					mockValidErc20Token,
+					mockValidIcrcToken,
+					mockValidExtV2Token,
+					ICP_TOKEN,
+					ETHEREUM_TOKEN,
+					SOLANA_TOKEN
+				];
+				mockTokens = tokens.map((token) => ({
+					data: { ...token, enabled },
+					certified
+				}));
+				mockStore.setAll(mockTokens);
+			});
+
+			it('should remove a token given its identifier', () => {
+				mockStore.resetByIdentifier(mockValidSplToken.address);
+
+				expect(get(mockStore)).toEqual(mockTokens.slice(1));
+
+				mockStore.resetByIdentifier(
+					`${mockValidErc20Token.address}#${mockValidErc20Token.network.chainId}`
+				);
+
+				expect(get(mockStore)).toEqual(mockTokens.slice(2));
+
+				mockStore.resetByIdentifier(mockValidIcrcToken.ledgerCanisterId);
+
+				expect(get(mockStore)).toEqual(mockTokens.slice(3));
+
+				mockStore.resetByIdentifier(mockValidExtV2Token.canisterId);
+
+				expect(get(mockStore)).toEqual(mockTokens.slice(4));
+
+				mockStore.resetByIdentifier(ICP_TOKEN.ledgerCanisterId);
+
+				expect(get(mockStore)).toEqual(mockTokens.slice(5));
+			});
+
+			it('should do nothing if the token does not exist', () => {
+				mockStore.resetByIdentifier('non-existing-token-identifier');
+
+				expect(get(mockStore)).toEqual(mockTokens);
 			});
 		});
 


### PR DESCRIPTION
# Motivation

We want to generalize how we reset the custom token store, to make it more scalable. So, we first need another method to reset the store when we still don't know the token ID (for example, when we are saving new custom tokens).

# Changes

- Add new method `resetByIdentifier` to custom token store: it use everything apart from token ID.
- Fix the correct types for `Identifier` of custom tokens.
- Apply the new method to service `saveCustomTokens`.

# Tests

Added tests.
