### PR TITLE
refactor(frontend): re-use EarningYearlyAmount component

### DIFF
--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
@@ -9,6 +9,7 @@
 	import type { IcToken } from '$icp/types/ic-token';
 	import { setCustomToken } from '$icp-eth/services/custom-token.services';
 	import { isGLDTToken } from '$icp-eth/utils/token.utils';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import GetTokenModal from '$lib/components/get-token/GetTokenModal.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import StakeModal from '$lib/components/stake/StakeModal.svelte';
@@ -85,23 +86,12 @@
 	{#snippet content()}
 		<div class="text-sm">{$i18n.stake.text.earning_potential}</div>
 
-		<div
-			class="my-1 text-lg font-bold whitespace-nowrap sm:text-xl"
-			class:text-brand-primary-alt={$enabledMainnetFungibleTokensUsdBalance > 0}
-			class:text-tertiary={$enabledMainnetFungibleTokensUsdBalance === 0}
-		>
-			{`${$enabledMainnetFungibleTokensUsdBalance > 0 && currentApy > 0 ? '+ ' : ''}`}{replacePlaceholders(
-				$i18n.stake.text.active_earning_per_year,
-				{
-					$amount: `${formatCurrency({
-						value: ($enabledMainnetFungibleTokensUsdBalance * currentApy) / 100,
-						currency: $currentCurrency,
-						exchangeRate: $currencyExchangeStore,
-						language: $currentLanguage
-					})}`
-				}
-			)}
-		</div>
+		<EarningYearlyAmount
+			showAsNeutral
+			showPlusSign={$enabledMainnetFungibleTokensUsdBalance > 0 && currentApy > 0}
+			styleClass="my-1 text-lg font-bold sm:text-xl"
+			value={($enabledMainnetFungibleTokensUsdBalance * currentApy) / 100}
+		/>
 
 		{#if $icrcCustomTokensNotInitialized || nonNullish(gldtToken)}
 			<div class="flex items-center justify-center gap-2 text-sm sm:text-base">

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakePositionCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakePositionCard.svelte
@@ -5,6 +5,7 @@
 	import { icrcCustomTokensInitialized } from '$icp/derived/icrc.derived';
 	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
 	import type { IcToken } from '$icp/types/ic-token';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import UnstakeModal from '$lib/components/stake/UnstakeModal.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -19,7 +20,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { formatCurrency, formatToken } from '$lib/utils/format.utils';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { calculateTokenUsdAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
@@ -53,20 +53,11 @@
 	{#snippet content()}
 		<div class="text-sm">{$i18n.stake.text.active_earning}</div>
 
-		<div
-			class="my-1 text-lg font-bold sm:text-xl"
-			class:text-success-primary={stakedAmountUsd > 0}
-			class:text-tertiary={stakedAmountUsd === 0}
-		>
-			{replacePlaceholders($i18n.stake.text.active_earning_per_year, {
-				$amount: `${formatCurrency({
-					value: (stakedAmountUsd * currentApy) / 100,
-					currency: $currentCurrency,
-					exchangeRate: $currencyExchangeStore,
-					language: $currentLanguage
-				})}`
-			})}
-		</div>
+		<EarningYearlyAmount
+			showAsSuccess
+			styleClass="my-1 text-lg font-bold sm:text-xl"
+			value={(stakedAmountUsd * currentApy) / 100}
+		/>
 
 		<div class="flex items-center justify-center gap-2 text-sm sm:text-base">
 			{#if stakedAmountUsd > 0}

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -43,6 +43,7 @@
 					<span class="font-bold">
 						{#if cardField === EarningCardFields.EARNING_POTENTIAL}
 							<EarningYearlyAmount
+								showAsError
 								showPlusSign
 								value={nonNullish(cardFields[cardField])
 									? Number(cardFields[cardField])
@@ -54,7 +55,7 @@
 							</EarningYearlyAmount>
 						{:else if cardField === EarningCardFields.CURRENT_EARNING}
 							<EarningYearlyAmount
-								formatPositiveAmount
+								showAsSuccess
 								value={nonNullish(cardFields[cardField]) &&
 								nonNullish(cardFields[EarningCardFields.APY])
 									? (Number(cardFields[cardField]) * Number(cardFields[EarningCardFields.APY])) /

--- a/src/frontend/src/lib/components/earning/EarningPositionCard.svelte
+++ b/src/frontend/src/lib/components/earning/EarningPositionCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
-	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { allEarningPositionsUsd, allEarningYearlyAmountUsd } from '$lib/derived/earning.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
@@ -15,11 +14,7 @@
 		<div class="text-sm font-bold">{$i18n.stake.text.active_earning}</div>
 
 		<div class="my-1 text-lg font-bold sm:text-xl">
-			<EarningYearlyAmount formatPositiveAmount value={$allEarningYearlyAmountUsd}>
-				{#snippet fallback()}
-					<SkeletonText />
-				{/snippet}
-			</EarningYearlyAmount>
+			<EarningYearlyAmount showAsSuccess value={$allEarningYearlyAmountUsd} />
 		</div>
 
 		<div class="text-sm sm:text-base">

--- a/src/frontend/src/lib/components/earning/EarningPotentialCard.svelte
+++ b/src/frontend/src/lib/components/earning/EarningPotentialCard.svelte
@@ -3,7 +3,6 @@
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import IconHelp from '$lib/components/icons/lucide/IconHelp.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
-	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { highestEarningPotentialUsd } from '$lib/derived/earning.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
@@ -33,13 +32,10 @@
 
 		<div class="my-1 text-lg font-bold sm:text-xl">
 			<EarningYearlyAmount
+				showAsError
 				showPlusSign={$highestEarningPotentialUsd > 0}
 				value={$highestEarningPotentialUsd}
-			>
-				{#snippet fallback()}
-					<SkeletonText />
-				{/snippet}
-			</EarningYearlyAmount>
+			/>
 		</div>
 
 		<div class="text-sm sm:text-base">

--- a/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
+++ b/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
@@ -11,14 +12,25 @@
 
 	interface Props {
 		value?: number;
+		styleClass?: string;
 		showPlusSign?: boolean;
-		formatPositiveAmount?: boolean;
+		showAsNeutral?: boolean;
+		showAsError?: boolean;
+		showAsSuccess?: boolean;
 		fallback?: Snippet;
 	}
 
-	const { value, showPlusSign = false, formatPositiveAmount = false, fallback }: Props = $props();
+	const {
+		value,
+		showPlusSign = false,
+		styleClass,
+		showAsNeutral = false,
+		showAsSuccess = false,
+		showAsError = false,
+		fallback
+	}: Props = $props();
 
-	const formattedCurrency = $derived(
+	let formattedCurrency = $derived(
 		nonNullish(value)
 			? formatCurrency({
 					value,
@@ -29,25 +41,30 @@
 			: undefined
 	);
 
-	const yearlyAmount = $derived(
+	let yearlyAmount = $derived(
 		nonNullish(formattedCurrency)
 			? replacePlaceholders($i18n.stake.text.active_earning_per_year, {
 					$amount: `${formattedCurrency}`
 				})
 			: undefined
 	);
+
+	let positiveAmount = $derived(nonNullish(value) && value > 0);
 </script>
 
 {#if nonNullish(yearlyAmount)}
 	<span
-		class="whitespace-nowrap"
-		class:text-error-primary={!formatPositiveAmount}
-		class:text-success-primary={formatPositiveAmount && nonNullish(value) && value > 0}
-		class:text-tertiary={value === 0}
+		class={`whitespace-nowrap ${styleClass ?? ''}`}
+		class:text-brand-primary-alt={positiveAmount && showAsNeutral}
+		class:text-error-primary={positiveAmount && showAsError}
+		class:text-success-primary={positiveAmount && showAsSuccess}
+		class:text-tertiary={!positiveAmount}
 		in:fade
 	>
 		{`${showPlusSign ? '+ ' : ''}${yearlyAmount}`}
 	</span>
 {:else if nonNullish(fallback)}
 	{@render fallback()}
+{:else}
+	<SkeletonText />
 {/if}

--- a/src/frontend/src/lib/components/get-token/GetTokenCardContent.svelte
+++ b/src/frontend/src/lib/components/get-token/GetTokenCardContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import { GET_TOKEN_MODAL_POTENTIAL_USD_BALANCE } from '$lib/constants/test-ids.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
@@ -9,7 +10,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { formatCurrency } from '$lib/utils/format.utils';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
@@ -72,21 +72,10 @@
 		{$i18n.stake.text.earning_potential}:
 	</div>
 
-	<div
-		class="text-lg font-bold whitespace-nowrap sm:text-xl"
-		class:text-brand-primary-alt={positivePotentialTokenBalance}
-		class:text-disabled={!positivePotentialTokenBalance}
-	>
-		{`${positivePotentialTokenBalance && currentApy > 0 ? '+ ' : ''}`}{replacePlaceholders(
-			$i18n.stake.text.active_earning_per_year,
-			{
-				$amount: `${formatCurrency({
-					value: (potentialTokensUsdBalance * currentApy) / 100,
-					currency: $currentCurrency,
-					exchangeRate: $currencyExchangeStore,
-					language: $currentLanguage
-				})}`
-			}
-		)}
-	</div>
+	<EarningYearlyAmount
+		showAsNeutral
+		showPlusSign={positivePotentialTokenBalance && currentApy > 0}
+		styleClass="text-lg font-bold sm:text-xl"
+		value={(potentialTokensUsdBalance * currentApy) / 100}
+	/>
 </div>

--- a/src/frontend/src/tests/lib/components/earning/EarningYearlyAmount.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningYearlyAmount.spec.ts
@@ -56,24 +56,32 @@ describe('EarningYearlyAmount', () => {
 		expect(screen.getByText(getFormattedText('+ $10.00'))).toBeInTheDocument();
 	});
 
-	it('applies text-success-primary class for positive amount when formatPositiveAmount is true', () => {
-		const { container } = render(EarningYearlyAmount, { value: 5, formatPositiveAmount: true });
+	it('applies text-success-primary class for positive amount when showAsSuccess is true', () => {
+		const { container } = render(EarningYearlyAmount, { value: 5, showAsSuccess: true });
 
 		const span = container.querySelector('span');
 
 		expect(span).toHaveClass('text-success-primary');
 	});
 
-	it('applies text-error-primary when formatPositiveAmount is false', () => {
-		const { container } = render(EarningYearlyAmount, { value: 5, formatPositiveAmount: false });
+	it('applies text-error-primary when showAsError is true', () => {
+		const { container } = render(EarningYearlyAmount, { value: 5, showAsError: true });
 
 		const span = container.querySelector('span');
 
 		expect(span).toHaveClass('text-error-primary');
 	});
 
-	it('applies text-tertiary when formatPositiveAmount is true but amount is 0', () => {
-		const { container } = render(EarningYearlyAmount, { value: 0, formatPositiveAmount: true });
+	it('applies text-brand-primary-alt when showAsNeutral is true', () => {
+		const { container } = render(EarningYearlyAmount, { value: 5, showAsNeutral: true });
+
+		const span = container.querySelector('span');
+
+		expect(span).toHaveClass('text-brand-primary-alt');
+	});
+
+	it('applies text-tertiary when amount is 0', () => {
+		const { container } = render(EarningYearlyAmount, { value: 0 });
 
 		const span = container.querySelector('span');
 


### PR DESCRIPTION
# Motivation

We need to re-use the "yearly amount" component where possible. To do that, the component must support different styling (error, success, neutral).
