### PR TITLE
feat(frontend): Expand service `saveCustomTokens` for all variants

### DIFF
--- a/src/frontend/src/lib/services/save-custom-tokens.services.ts
+++ b/src/frontend/src/lib/services/save-custom-tokens.services.ts
@@ -1,3 +1,6 @@
+import { erc1155CustomTokensStore } from '$eth/stores/erc1155-custom-tokens.store';
+import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
+import { erc721CustomTokensStore } from '$eth/stores/erc721-custom-tokens.store';
 import { loadCustomTokens } from '$icp/services/icrc.services';
 import { extCustomTokensStore } from '$icp/stores/ext-custom-tokens.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
@@ -5,9 +8,59 @@ import { setManyCustomTokens } from '$lib/api/backend.api';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import type { SaveTokensParams } from '$lib/services/manage-tokens.services';
 import { i18n } from '$lib/stores/i18n.store';
-import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
+import type {
+	ErcSaveCustomToken,
+	SaveCustomTokenWithKey,
+	TokenVariant
+} from '$lib/types/custom-token';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
+import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
+import { assertNever } from '@dfinity/utils';
 import { get } from 'svelte/store';
+
+const parseErcIdentifier = (
+	token: TokenVariant<'Erc20' | 'Erc721' | 'Erc1155', ErcSaveCustomToken>
+) => `${token.address}#${token.chainId}`;
+
+const hideTokenByKey = (token: SaveCustomTokenWithKey) => {
+	if (token.networkKey === 'Icrc') {
+		icrcCustomTokensStore.reset(token.ledgerCanisterId);
+
+		return;
+	}
+
+	if (token.networkKey === 'ExtV2') {
+		extCustomTokensStore.resetByIdentifier(token.canisterId);
+
+		return;
+	}
+
+	if (token.networkKey === 'Erc20') {
+		erc20CustomTokensStore.resetByIdentifier(parseErcIdentifier(token));
+
+		return;
+	}
+
+	if (token.networkKey === 'Erc721') {
+		erc721CustomTokensStore.resetByIdentifier(parseErcIdentifier(token));
+
+		return;
+	}
+
+	if (token.networkKey === 'Erc1155') {
+		erc1155CustomTokensStore.resetByIdentifier(parseErcIdentifier(token));
+
+		return;
+	}
+
+	if (token.networkKey === 'SplMainnet' || token.networkKey === 'SplDevnet') {
+		splCustomTokensStore.resetByIdentifier(token.address);
+
+		return;
+	}
+
+	assertNever(token.networkKey, `Unexpected networkKey: ${token.networkKey}`);
+};
 
 export const saveCustomTokens = async ({
 	progress,
@@ -26,13 +79,7 @@ export const saveCustomTokens = async ({
 
 	// Hide tokens that have been disabled
 	const disabledTokens = tokens.filter(({ enabled }) => !enabled);
-	disabledTokens.forEach((token) =>
-		token.networkKey === 'Icrc'
-			? icrcCustomTokensStore.reset(token.ledgerCanisterId)
-			: token.networkKey === 'ExtV2'
-				? extCustomTokensStore.resetByIdentifier(token.canisterId)
-				: null
-	);
+	disabledTokens.forEach(hideTokenByKey);
 
 	// Reload all custom tokens for simplicity reason.
 	await loadCustomTokens({ identity });

--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -14,7 +14,7 @@ type CustomTokenNetworkKeys = BackendToken extends infer T
 		: never
 	: never;
 
-type TokenVariant<K extends CustomTokenNetworkKeys, T> = T & { networkKey: K };
+export type TokenVariant<K extends CustomTokenNetworkKeys, T> = T & { networkKey: K };
 
 export type IcrcSaveCustomToken = Pick<IcToken, 'ledgerCanisterId' | 'indexCanisterId'>;
 
@@ -26,7 +26,7 @@ export type ErcSaveCustomToken = Pick<Erc20Token, 'address'> &
 export type SplSaveCustomToken = Pick<SplToken, 'address' | 'decimals' | 'symbol'>;
 
 export type SaveCustomToken = UserTokenState &
-	(IcrcSaveCustomToken | ErcSaveCustomToken | SplSaveCustomToken);
+	(IcrcSaveCustomToken | ExtSaveCustomToken | ErcSaveCustomToken | SplSaveCustomToken);
 
 export type SaveCustomTokenWithKey = UserTokenState &
 	(

--- a/src/frontend/src/tests/lib/services/save-custom-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/save-custom-tokens.services.spec.ts
@@ -1,0 +1,164 @@
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
+import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
+import { erc1155CustomTokensStore } from '$eth/stores/erc1155-custom-tokens.store';
+import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
+import { erc721CustomTokensStore } from '$eth/stores/erc721-custom-tokens.store';
+import { loadCustomTokens } from '$icp/services/icrc.services';
+import { extCustomTokensStore } from '$icp/stores/ext-custom-tokens.store';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import { setManyCustomTokens } from '$lib/api/backend.api';
+import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
+import type { SaveTokensParams } from '$lib/services/manage-tokens.services';
+import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
+import type {
+	ErcSaveCustomToken,
+	ExtSaveCustomToken,
+	IcrcSaveCustomToken,
+	SaveCustomTokenWithKey,
+	SplSaveCustomToken
+} from '$lib/types/custom-token';
+import type { NonEmptyArray } from '$lib/types/utils';
+import { toCustomToken } from '$lib/utils/custom-token.utils';
+import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
+import { mockEthAddress, mockEthAddress2, mockEthAddress3 } from '$tests/mocks/eth.mock';
+import { mockExtV2TokenCanisterId } from '$tests/mocks/ext-v2-token.mock';
+import en from '$tests/mocks/i18n.mock';
+import { mockIndexCanisterId, mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockSplAddress } from '$tests/mocks/sol.mock';
+
+vi.mock('$lib/api/backend.api', () => ({
+	setManyCustomTokens: vi.fn()
+}));
+
+vi.mock('$icp/services/icrc.services', () => ({
+	loadCustomTokens: vi.fn()
+}));
+
+describe('save-custom-tokens.services', () => {
+	describe('saveCustomTokens', () => {
+		const mockIcrcToken: IcrcSaveCustomToken = {
+			ledgerCanisterId: mockLedgerCanisterId,
+			indexCanisterId: mockIndexCanisterId
+		};
+		const mockExtToken: ExtSaveCustomToken = {
+			canisterId: mockExtV2TokenCanisterId
+		};
+		const mockErc20Token: ErcSaveCustomToken = {
+			address: mockEthAddress,
+			chainId: ETHEREUM_NETWORK.chainId
+		};
+		const mockErc721Token: ErcSaveCustomToken = {
+			address: mockEthAddress2,
+			chainId: BASE_NETWORK.chainId
+		};
+		const mockErc1155Token: ErcSaveCustomToken = {
+			address: mockEthAddress3,
+			chainId: SEPOLIA_NETWORK.chainId
+		};
+		const mockSplToken: SplSaveCustomToken = {
+			address: mockSplAddress,
+			decimals: 8,
+			symbol: 'TEST'
+		};
+		const mockTokens: SaveCustomTokenWithKey[] = [
+			{ ...mockIcrcToken, networkKey: 'Icrc', enabled: true },
+			{ ...mockExtToken, networkKey: 'ExtV2', enabled: true },
+			{ ...mockErc20Token, networkKey: 'Erc20', enabled: true },
+			{ ...mockErc721Token, networkKey: 'Erc721', enabled: true },
+			{ ...mockErc1155Token, networkKey: 'Erc1155', enabled: true },
+			{ ...mockSplToken, networkKey: 'SplMainnet', enabled: true }
+		];
+
+		const mockProgress = vi.fn();
+
+		const mockParams: SaveTokensParams<SaveCustomTokenWithKey> = {
+			progress: mockProgress,
+			identity: mockIdentity,
+			tokens: mockTokens as NonEmptyArray<SaveCustomTokenWithKey>
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(icrcCustomTokensStore, 'reset');
+			vi.spyOn(extCustomTokensStore, 'resetByIdentifier');
+			vi.spyOn(erc20CustomTokensStore, 'resetByIdentifier');
+			vi.spyOn(erc721CustomTokensStore, 'resetByIdentifier');
+			vi.spyOn(erc1155CustomTokensStore, 'resetByIdentifier');
+			vi.spyOn(splCustomTokensStore, 'resetByIdentifier');
+		});
+
+		it('should call the endpoint to set many custom tokens', async () => {
+			await saveCustomTokens(mockParams);
+
+			const expectedTokens = mockTokens.map(toCustomToken);
+
+			expect(setManyCustomTokens).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokens: expectedTokens,
+				nullishIdentityErrorMessage: en.auth.error.no_internet_identity
+			});
+		});
+
+		it('should set the progress callback', async () => {
+			await saveCustomTokens(mockParams);
+
+			expect(mockProgress).toHaveBeenCalledTimes(2);
+			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsAddToken.SAVE);
+			expect(mockProgress).toHaveBeenNthCalledWith(2, ProgressStepsAddToken.UPDATE_UI);
+		});
+
+		it('should hide the disabled tokens', async () => {
+			const tokens = mockTokens.map((token) => ({
+				...token,
+				enabled: false
+			})) as NonEmptyArray<SaveCustomTokenWithKey>;
+
+			await saveCustomTokens({ ...mockParams, tokens });
+
+			expect(icrcCustomTokensStore.reset).toHaveBeenCalledExactlyOnceWith(mockLedgerCanisterId);
+			expect(extCustomTokensStore.resetByIdentifier).toHaveBeenCalledExactlyOnceWith(
+				mockExtV2TokenCanisterId
+			);
+			expect(erc20CustomTokensStore.resetByIdentifier).toHaveBeenCalledExactlyOnceWith(
+				`${mockEthAddress}#${ETHEREUM_NETWORK.chainId}`
+			);
+			expect(erc721CustomTokensStore.resetByIdentifier).toHaveBeenCalledExactlyOnceWith(
+				`${mockEthAddress2}#${BASE_NETWORK.chainId}`
+			);
+			expect(erc1155CustomTokensStore.resetByIdentifier).toHaveBeenCalledExactlyOnceWith(
+				`${mockEthAddress3}#${SEPOLIA_NETWORK.chainId}`
+			);
+			expect(splCustomTokensStore.resetByIdentifier).toHaveBeenCalledExactlyOnceWith(
+				mockSplAddress
+			);
+		});
+
+		it('should reload custom tokens at the end', async () => {
+			await saveCustomTokens(mockParams);
+
+			expect(loadCustomTokens).toHaveBeenCalledExactlyOnceWith({ identity: mockIdentity });
+		});
+
+		it('should fail if the setManyCustomTokens fails', async () => {
+			const mockError = new Error('Mocked error when setting tokens');
+
+			vi.mocked(setManyCustomTokens).mockRejectedValueOnce(mockError);
+
+			await expect(saveCustomTokens(mockParams)).rejects.toThrow(mockError);
+
+			expect(mockProgress).toHaveBeenCalledExactlyOnceWith(ProgressStepsAddToken.SAVE);
+
+			expect(loadCustomTokens).not.toHaveBeenCalled();
+		});
+
+		it('should fail if the loadCustomTokens fails', async () => {
+			const mockError = new Error('Mocked error when loading tokens');
+
+			vi.mocked(loadCustomTokens).mockRejectedValueOnce(mockError);
+
+			await expect(saveCustomTokens(mockParams)).rejects.toThrow(mockError);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We want to have a single generic service for saving custom tokens, so we expand the existing `saveCustomTokens` with all variants of standard.
