### PR TITLE
feat(frontend): Derived stores for EXT default tokens

### DIFF
--- a/src/frontend/src/icp/derived/ext.derived.ts
+++ b/src/frontend/src/icp/derived/ext.derived.ts
@@ -1,21 +1,59 @@
 import { extCustomTokensStore } from '$icp/stores/ext-custom-tokens.store';
+import { extDefaultTokensStore } from '$icp/stores/ext-default-tokens.store';
 import type { ExtCustomToken } from '$icp/types/ext-custom-token';
+import type { ExtToken } from '$icp/types/ext-token';
+import type { CanisterIdText } from '$lib/types/canister';
+import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
 import { derived, type Readable } from 'svelte/store';
 
+const extDefaultTokens: Readable<ExtToken[]> = derived(
+	[extDefaultTokensStore],
+	([$extTokensStore]) => $extTokensStore ?? []
+);
+
+const extDefaultTokensCanisterIds: Readable<CanisterIdText[]> = derived(
+	[extDefaultTokens],
+	([$extDefaultTokens]) => $extDefaultTokens.map(({ canisterId }) => canisterId)
+);
+
 /**
- * The list of EXT custom tokens the user has added, enabled or disabled.
+ * The list of EXT custom tokens the user has added, enabled, or disabled.
  */
 export const extCustomTokens: Readable<ExtCustomToken[]> = derived(
 	[extCustomTokensStore],
 	([$extCustomTokensStore]) => $extCustomTokensStore?.map(({ data: token }) => token) ?? []
 );
 
+const extDefaultTokensToggleable: Readable<ExtCustomToken[]> = derived(
+	[extDefaultTokens, extCustomTokens],
+	([$extDefaultTokens, $extCustomTokens]) =>
+		$extDefaultTokens.map(({ canisterId, ...rest }) => {
+			const customToken = $extCustomTokens.find(
+				({ canisterId: canisterIdCustomToken }) => canisterIdCustomToken === canisterId
+			);
+
+			return mapDefaultTokenToToggleable<ExtToken>({
+				defaultToken: { canisterId, ...rest },
+				customToken
+			});
+		})
+);
+
+const extCustomTokensToggleable: Readable<ExtCustomToken[]> = derived(
+	[extCustomTokens, extDefaultTokensCanisterIds],
+	([$extCustomTokens, $extDefaultTokensCanisterIds]) =>
+		$extCustomTokens.filter(({ canisterId }) => !$extDefaultTokensCanisterIds.includes(canisterId))
+);
+
 /**
  * The list of all EXT tokens.
  */
 export const extTokens: Readable<ExtCustomToken[]> = derived(
-	[extCustomTokens],
-	([$extCustomTokens]) => [...$extCustomTokens]
+	[extDefaultTokensToggleable, extCustomTokensToggleable],
+	([$extDefaultTokensToggleable, $extCustomTokensToggleable]) => [
+		...$extDefaultTokensToggleable,
+		...$extCustomTokensToggleable
+	]
 );
 
 /**

--- a/src/frontend/src/icp/stores/ext-default-tokens.store.ts
+++ b/src/frontend/src/icp/stores/ext-default-tokens.store.ts
@@ -1,0 +1,4 @@
+import type { ExtToken } from '$icp/types/ext-token';
+import { initDefaultTokensStore } from '$lib/stores/default-tokens.store';
+
+export const extDefaultTokensStore = initDefaultTokensStore<ExtToken>();

--- a/src/frontend/src/tests/icp/derived/ext.derived.spec.ts
+++ b/src/frontend/src/tests/icp/derived/ext.derived.spec.ts
@@ -1,5 +1,6 @@
 import { enabledExtTokens, extCustomTokens } from '$icp/derived/ext.derived';
 import { extCustomTokensStore } from '$icp/stores/ext-custom-tokens.store';
+import { extDefaultTokensStore } from '$icp/stores/ext-default-tokens.store';
 import type { ExtCustomToken } from '$icp/types/ext-custom-token';
 import { mockValidExtV2Token, mockValidExtV2Token2 } from '$tests/mocks/ext-tokens.mock';
 import { get } from 'svelte/store';
@@ -40,7 +41,10 @@ describe('ext.derived', () => {
 		beforeEach(() => {
 			vi.resetAllMocks();
 
+			extDefaultTokensStore.reset();
 			extCustomTokensStore.resetAll();
+
+			extDefaultTokensStore.set([mockExtCustomToken1]);
 
 			extCustomTokensStore.setAll([
 				{ data: mockExtCustomToken1, certified: false },


### PR DESCRIPTION
# Motivation

Since we have a default store for EXT tokens, we can create accordingly the derived stores (same as the other standards).
