### PR TITLE
refactor(frontend): Use common service `saveCustomTokensWithKey`

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -5,29 +5,21 @@
 	import EthAddTokenReview from '$eth/components/tokens/EthAddTokenReview.svelte';
 	import { isInterfaceErc1155 } from '$eth/services/erc1155.services';
 	import { isInterfaceErc721 } from '$eth/services/erc721.services';
-	import {
-		saveErc1155CustomTokens,
-		saveErc20UserTokens,
-		saveErc721CustomTokens
-	} from '$eth/services/manage-tokens.services';
-	import { saveErc20CustomTokens } from '$eth/services/manage-tokens.services.js';
-	import type { SaveErc1155CustomToken } from '$eth/types/erc1155-custom-token';
+	import { saveErc20UserTokens } from '$eth/services/manage-tokens.services';
 	import type { Erc20Metadata } from '$eth/types/erc20';
-	import type { SaveErc20CustomToken } from '$eth/types/erc20-custom-token.js';
 	import type { SaveUserToken } from '$eth/types/erc20-user-token';
 	import type { Erc721Metadata } from '$eth/types/erc721';
-	import type { SaveErc721CustomToken } from '$eth/types/erc721-custom-token';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import IcAddExtTokenReview from '$icp/components/tokens/IcAddExtTokenReview.svelte';
 	import IcAddIcrcTokenReview from '$icp/components/tokens/IcAddIcrcTokenReview.svelte';
 	import type { ValidateTokenData as ValidateExtTokenData } from '$icp/services/ext-add-custom-tokens.service';
 	import type { ValidateTokenData as ValidateIcrcTokenData } from '$icp/services/ic-add-custom-tokens.service';
-	import { saveIcrcCustomTokens } from '$icp/services/manage-tokens.services';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import { TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import type { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import { saveCustomTokensWithKey } from '$lib/services/manage-tokens.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
@@ -38,12 +30,10 @@
 		isNetworkIdEthereum,
 		isNetworkIdEvm,
 		isNetworkIdICP,
-		isNetworkIdSolana
+		isNetworkIdSolana,
+		isNetworkIdSOLDevnet
 	} from '$lib/utils/network.utils';
 	import SolAddTokenReview from '$sol/components/tokens/SolAddTokenReview.svelte';
-	import { saveSplCustomTokens } from '$sol/services/manage-tokens.services';
-	import type { SolanaNetwork } from '$sol/types/network';
-	import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 
 	interface Props {
 		network?: Network;
@@ -77,9 +67,8 @@
 			return;
 		}
 
-		await saveIc([
+		await saveTokens([
 			{
-				...icrcMetadata,
 				enabled: true,
 				networkKey: 'Icrc',
 				ledgerCanisterId,
@@ -96,9 +85,8 @@
 			return;
 		}
 
-		await saveIc([
+		await saveTokens([
 			{
-				...extMetadata,
 				enabled: true,
 				networkKey: 'ExtV2',
 				canisterId: extCanisterId
@@ -126,8 +114,7 @@
 
 		const newToken = {
 			address: ethContractAddress,
-			...ethMetadata,
-			network: network as EthereumNetwork,
+			chainId: (network as EthereumNetwork).chainId,
 			enabled: true
 		};
 
@@ -138,7 +125,7 @@
 			});
 
 			if (isErc721) {
-				await saveErc721([newToken]);
+				await saveTokens([{ ...newToken, networkKey: 'Erc721' }]);
 
 				return;
 			}
@@ -149,16 +136,18 @@
 			});
 
 			if (isErc1155) {
-				await saveErc1155([newToken]);
+				await saveTokens([{ ...newToken, networkKey: 'Erc1155' }]);
 
 				return;
 			}
 		}
 
 		if (ethMetadata.decimals > 0) {
-			await saveErc20Deprecated([newToken]);
+			await saveErc20Deprecated([
+				{ ...ethMetadata, ...newToken, network: network as EthereumNetwork }
+			]);
 
-			await saveErc20([newToken]);
+			await saveTokens([{ ...newToken, networkKey: 'Erc20' }]);
 
 			return;
 		}
@@ -167,7 +156,7 @@
 			name: TRACK_UNRECOGNISED_ERC_INTERFACE,
 			metadata: {
 				address: newToken.address,
-				network: `${newToken.network.id.description}`
+				network: `${network.id.description}`
 			}
 		});
 
@@ -192,18 +181,21 @@
 			return;
 		}
 
-		saveSpl([
+		// This does not happen at this point, but it is useful type-wise
+		assertNonNullish(network);
+
+		saveTokens([
 			{
 				address: splTokenAddress,
 				...splMetadata,
-				network: network as SolanaNetwork,
-				enabled: true
+				enabled: true,
+				networkKey: isNetworkIdSOLDevnet(network.id) ? 'SplDevnet' : 'SplMainnet'
 			}
 		]);
 	};
 
-	const saveIc = (tokens: SaveCustomTokenWithKey[]): Promise<void> =>
-		saveIcrcCustomTokens({
+	const saveTokens = (tokens: SaveCustomTokenWithKey[]): Promise<void> =>
+		saveCustomTokensWithKey({
 			tokens,
 			progress,
 			modalNext,
@@ -215,46 +207,6 @@
 	// TODO: UserToken is deprecated - remove this when the migration to CustomToken is complete
 	const saveErc20Deprecated = (tokens: SaveUserToken[]): Promise<void> =>
 		saveErc20UserTokens({
-			tokens,
-			progress,
-			modalNext,
-			onSuccess,
-			onError,
-			identity: $authIdentity
-		});
-
-	const saveErc20 = (tokens: SaveErc20CustomToken[]): Promise<void> =>
-		saveErc20CustomTokens({
-			tokens,
-			progress,
-			modalNext,
-			onSuccess,
-			onError,
-			identity: $authIdentity
-		});
-
-	const saveErc721 = (tokens: SaveErc721CustomToken[]): Promise<void> =>
-		saveErc721CustomTokens({
-			tokens,
-			progress,
-			modalNext,
-			onSuccess,
-			onError,
-			identity: $authIdentity
-		});
-
-	const saveErc1155 = (tokens: SaveErc1155CustomToken[]): Promise<void> =>
-		saveErc1155CustomTokens({
-			tokens,
-			progress,
-			modalNext,
-			onSuccess,
-			onError,
-			identity: $authIdentity
-		});
-
-	const saveSpl = (tokens: SaveSplCustomToken[]): Promise<void> =>
-		saveSplCustomTokens({
 			tokens,
 			progress,
 			modalNext,

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -9,6 +9,7 @@ import {
 } from '$lib/constants/analytics.constants';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
+import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
@@ -121,4 +122,17 @@ export const saveTokens = async <
 			metadata: mapIcErrorMetadata(err)
 		});
 	}
+};
+
+export const saveCustomTokensWithKey = async ({
+	tokens,
+	...rest
+}: {
+	tokens: SaveCustomTokenWithKey[];
+} & ManageTokensSaveParams) => {
+	await saveTokens({
+		...rest,
+		tokens,
+		save: saveCustomTokens
+	});
 };


### PR DESCRIPTION
# Motivation

Service `saveCustomTokensWithKey` can be used for all standard instead of custom services for each one.