### PR TITLE
fix(frontend): Add EXT tokens to `loadNetworkCustomTokens` service

### DIFF
--- a/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
@@ -2,6 +2,7 @@ import { listCustomTokens } from '$lib/api/backend.api';
 import * as idbTokensApi from '$lib/api/idb-tokens.api';
 import { loadNetworkCustomTokens } from '$lib/services/custom-tokens.services';
 import { mockCustomTokens } from '$tests/mocks/custom-tokens.mock';
+import { mockExtV2TokenCanisterId } from '$tests/mocks/ext-v2-token.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockIndexCanisterId, mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -156,7 +157,7 @@ describe('custom-tokens.services', () => {
 			});
 		});
 
-		it('should parse correctly the cached ledger and index canister IDs from the custom tokens', async () => {
+		it('should parse correctly the cached ledger and index canister IDs from the ICRC custom tokens', async () => {
 			mockGetIdbTokens.mockResolvedValue([
 				{
 					token: {
@@ -179,6 +180,34 @@ describe('custom-tokens.services', () => {
 			});
 
 			expect(result).toStrictEqual(mockCustomTokens.slice(0, 1));
+
+			expect(mockGetIdbTokens).toHaveBeenCalledExactlyOnceWith(mockIdentity.getPrincipal());
+
+			expect(listCustomTokens).not.toHaveBeenCalled();
+		});
+
+		it('should parse correctly the cached canister ID from the EXT custom tokens', async () => {
+			mockGetIdbTokens.mockResolvedValue([
+				{
+					token: {
+						ExtV2: {
+							canister_id: Principal.fromText(mockExtV2TokenCanisterId).toUint8Array()
+						}
+					},
+					version: toNullable(10n),
+					enabled: false,
+					section: toNullable(),
+					allow_external_content_source: toNullable()
+				}
+			]);
+
+			const result = await loadNetworkCustomTokens({
+				...mockParams,
+				certified: false,
+				useCache: true
+			});
+
+			expect(result).toStrictEqual(mockCustomTokens.slice(2, 3));
 
 			expect(mockGetIdbTokens).toHaveBeenCalledExactlyOnceWith(mockIdentity.getPrincipal());
 

--- a/src/frontend/src/tests/mocks/custom-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/custom-tokens.mock.ts
@@ -6,6 +6,7 @@ import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import { EXT_BUILTIN_TOKENS } from '$env/tokens/tokens-ext/tokens.ext.env';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { mockEthAddress, mockEthAddress2, mockEthAddress3 } from '$tests/mocks/eth.mock';
+import { mockExtV2TokenCanisterId } from '$tests/mocks/ext-v2-token.mock';
 import { mockIndexCanisterId, mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { toNullable } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
@@ -31,6 +32,17 @@ export const mockCustomTokens: CustomToken[] = [
 			}
 		},
 		version: toNullable(1n),
+		enabled: false,
+		section: toNullable(),
+		allow_external_content_source: toNullable()
+	},
+	{
+		token: {
+			ExtV2: {
+				canister_id: Principal.fromText(mockExtV2TokenCanisterId)
+			}
+		},
+		version: toNullable(10n),
 		enabled: false,
 		section: toNullable(),
 		allow_external_content_source: toNullable()


### PR DESCRIPTION
# Motivation

Missing EXT standard in service `loadNetworkCustomTokens` when parsing principals.