### PR TITLE
refactor(frontend): Add assertion to never when parsing cached custom tokens

### DIFF
--- a/src/frontend/src/icp/utils/ext.utils.ts
+++ b/src/frontend/src/icp/utils/ext.utils.ts
@@ -17,6 +17,14 @@ export const isTokenExtV2CustomToken = (token: Token): token is ExtCustomToken =
 // The minting number (that wallets, frontends, etc. usually show) is 1-based indexed, it's simply (TokenIndex + 1).
 export const parseExtTokenIndex = (index: TokenIndex): TokenIndex => index + 1;
 
+export const parseExtTokenName = ({
+	index,
+	token
+}: {
+	index: TokenIndex;
+	token: ExtToken;
+}): string => `${token.name} #${parseExtTokenIndex(index)}`;
+
 /**
  * Converts a token index to a token identifier.
  *

--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -1,6 +1,6 @@
 import type { TokenIndex } from '$declarations/ext_v2_token/ext_v2_token.did';
 import type { ExtToken } from '$icp/types/ext-token';
-import { extIndexToIdentifier, parseExtTokenIndex } from '$icp/utils/ext.utils';
+import { extIndexToIdentifier, parseExtTokenIndex, parseExtTokenName } from '$icp/utils/ext.utils';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
@@ -33,6 +33,7 @@ export const mapExtNft = async ({
 	return {
 		id: parseNftId(identifier),
 		oisyId: parseNftId(parseExtTokenIndex(index).toString()),
+		name: parseExtTokenName({ index, token }),
 		imageUrl,
 		thumbnailUrl,
 		mediaStatus,


### PR DESCRIPTION
# Motivation

To avoid future surprises when we are going to add a new variant, we exhaust all possibilities in the parser of cached tokens. It will be useful to analyze each new variant.
