### PR TITLE
feat(frontend): Remove custom name from EXT NFT

### DIFF
--- a/src/frontend/src/icp/utils/ext.utils.ts
+++ b/src/frontend/src/icp/utils/ext.utils.ts
@@ -17,14 +17,6 @@ export const isTokenExtV2CustomToken = (token: Token): token is ExtCustomToken =
 // The minting number (that wallets, frontends, etc. usually show) is 1-based indexed, it's simply (TokenIndex + 1).
 export const parseExtTokenIndex = (index: TokenIndex): TokenIndex => index + 1;
 
-export const parseExtTokenName = ({
-	index,
-	token
-}: {
-	index: TokenIndex;
-	token: ExtToken;
-}): string => `${token.name} #${parseExtTokenIndex(index)}`;
-
 /**
  * Converts a token index to a token identifier.
  *

--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -1,6 +1,6 @@
 import type { TokenIndex } from '$declarations/ext_v2_token/ext_v2_token.did';
 import type { ExtToken } from '$icp/types/ext-token';
-import { extIndexToIdentifier, parseExtTokenIndex, parseExtTokenName } from '$icp/utils/ext.utils';
+import { extIndexToIdentifier, parseExtTokenIndex } from '$icp/utils/ext.utils';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
@@ -33,7 +33,6 @@ export const mapExtNft = async ({
 	return {
 		id: parseNftId(identifier),
 		oisyId: parseNftId(parseExtTokenIndex(index).toString()),
-		name: parseExtTokenName({ index, token }),
 		imageUrl,
 		thumbnailUrl,
 		mediaStatus,

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -33,7 +33,6 @@ describe('nft.utils', () => {
 			expect(result).toStrictEqual({
 				id: result.id,
 				oisyId: (mockIndex + 1).toString(),
-				name: `${mockValidExtV2Token.name} #${mockIndex + 1}`,
 				imageUrl: `https://${mockValidExtV2Token.canisterId}.raw.icp0.io/?tokenid=${mockIdentifier}`,
 				thumbnailUrl: `https://${mockValidExtV2Token.canisterId}.raw.icp0.io/?tokenid=${mockIdentifier}&type=thumbnail`,
 				mediaStatus: {


### PR DESCRIPTION
# Motivation

There is no need to invent/adapt the NFT name for EXT standard. The correct rendering of the display name should be handled at consumer-time.
