### PR TITLE
style(frontend): No need to display the NFT name if it is nullish

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import {isNullish, nonNullish} from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { goto } from '$app/navigation';
 	import { isCollectionErc1155 } from '$eth/utils/erc1155.utils';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
@@ -134,7 +134,7 @@
 
 	<span class="flex w-full flex-col gap-1 px-2 pb-2" class:text-disabled={disabled}>
 		<span class="truncate text-sm font-bold" class:text-primary={!disabled}>
-			{withCollectionLabel || isNullish(nft.name) ? nft.collection.name : (nft.name)}
+			{withCollectionLabel || isNullish(nft.name) ? nft.collection.name : nft.name}
 		</span>
 		<span class="truncate text-xs" class:text-tertiary={!disabled}>
 			#{getNftDisplayId(nft)}


### PR DESCRIPTION
# Motivation

In case of nullish NFT name, we should fallback to the collection name. At the same ti9me, if it is nullish, it does not make sense to append it in the label.
