### PR TITLE
fix(frontend): Correct progress steps when sending IC NFTs

### DIFF
--- a/src/frontend/src/eth/services/nft-send.services.ts
+++ b/src/frontend/src/eth/services/nft-send.services.ts
@@ -1,6 +1,7 @@
 import { transferErc1155, transferErc721 } from '$eth/services/nft-transfer.services';
 import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
 import { isTokenErc721 } from '$eth/utils/erc721.utils';
+import type { ProgressStepsSend } from '$lib/enums/progress-steps';
 import type { SendNftCommonParams, TransferParams } from '$lib/types/send';
 import { isNetworkIdEthereum, isNetworkIdEvm } from '$lib/utils/network.utils';
 import { isNullish } from '@dfinity/utils';
@@ -15,7 +16,7 @@ export const sendNft = async ({
 	maxFeePerGas,
 	maxPriorityFeePerGas,
 	progress
-}: SendNftCommonParams &
+}: SendNftCommonParams<ProgressStepsSend> &
 	Pick<TransferParams, 'from' | 'to' | 'maxFeePerGas' | 'maxPriorityFeePerGas'> & {
 		gas: bigint;
 	}) => {

--- a/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
+++ b/src/frontend/src/icp/components/send/IcSendTokenWizard.svelte
@@ -2,7 +2,6 @@
 	import type { WizardStep } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import type { ProgressStep } from '$eth/types/send';
 	import IcSendForm from '$icp/components/send/IcSendForm.svelte';
 	import IcSendProgress from '$icp/components/send/IcSendProgress.svelte';
 	import IcSendReview from '$icp/components/send/IcSendReview.svelte';
@@ -99,7 +98,7 @@
 				tokenId: nft.id,
 				to: destination,
 				identity: $authIdentity,
-				progress: (step: ProgressStep) => (sendProgressStep = step)
+				progress: (step: ProgressStepsSendIc) => (sendProgressStep = step)
 			});
 
 			trackEvent({
@@ -113,6 +112,8 @@
 					network: $sendToken.network.name
 				}
 			});
+
+			sendProgressStep = ProgressStepsSendIc.DONE;
 
 			setTimeout(() => close(), 750);
 		} catch (err: unknown) {

--- a/src/frontend/src/icp/services/nft-send.services.ts
+++ b/src/frontend/src/icp/services/nft-send.services.ts
@@ -1,5 +1,6 @@
 import { transferExtV2 } from '$icp/services/nft-transfer.services';
 import { isTokenExtV2 } from '$icp/utils/ext.utils';
+import type { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { SendNftCommonParams, TransferParams } from '$lib/types/send';
 import { isNetworkIdICP } from '$lib/utils/network.utils';
 import { isNullish } from '@dfinity/utils';
@@ -11,7 +12,7 @@ export const sendNft = async ({
 	identity,
 	progress,
 	to
-}: SendNftCommonParams & Pick<TransferParams, 'to'>) => {
+}: SendNftCommonParams<ProgressStepsSendIc> & Pick<TransferParams, 'to'>) => {
 	if (isNullish(identity)) {
 		return;
 	}

--- a/src/frontend/src/icp/services/nft-transfer.services.ts
+++ b/src/frontend/src/icp/services/nft-transfer.services.ts
@@ -1,8 +1,5 @@
 import { transfer } from '$icp/api/ext-v2-token.api';
-import {
-	ProgressStepsSend as ProgressStepsSendEnum,
-	type ProgressStepsSend
-} from '$lib/enums/progress-steps';
+import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
@@ -17,11 +14,11 @@ export const transferExtV2 = async ({
 	to: Principal;
 	tokenIdentifier: string;
 	amount: bigint;
-	progress?: (step: ProgressStepsSend) => void;
+	progress?: (step: ProgressStepsSendIc) => void;
 }) => {
-	progress?.(ProgressStepsSendEnum.SIGN_TRANSFER);
+	progress?.(ProgressStepsSendIc.SEND);
 
 	await transfer(rest);
 
-	progress?.(ProgressStepsSendEnum.TRANSFER);
+	progress?.(ProgressStepsSendIc.RELOAD);
 };

--- a/src/frontend/src/lib/types/send.ts
+++ b/src/frontend/src/lib/types/send.ts
@@ -1,4 +1,4 @@
-import type { ProgressStepsSend } from '$lib/enums/progress-steps';
+import type { ProgressStepsSend, ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { NftId, NonFungibleToken } from '$lib/types/nft';
 
@@ -11,11 +11,11 @@ export interface TransferParams {
 	data?: string;
 }
 
-export interface SendNftCommonParams {
+export interface SendNftCommonParams<Steps extends ProgressStepsSend | ProgressStepsSendIc> {
 	token: NonFungibleToken;
 	tokenId: NftId;
 	identity: OptionIdentity;
-	progress?: (step: ProgressStepsSend) => void;
+	progress?: (step: Steps) => void;
 }
 
 export class InsufficientFundsError extends Error {}

--- a/src/frontend/src/tests/icp/services/nft-transfer.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft-transfer.service.spec.ts
@@ -1,6 +1,6 @@
 import { transfer } from '$icp/api/ext-v2-token.api';
 import { transferExtV2 } from '$icp/services/nft-transfer.services';
-import { ProgressStepsSend as ProgressStepsSendEnum } from '$lib/enums/progress-steps';
+import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { bn3Bi } from '$tests/mocks/balances.mock';
 import { mockExtV2TokenCanisterId, mockExtV2TokenIdentifier } from '$tests/mocks/ext-v2-token.mock';
 import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
@@ -39,8 +39,8 @@ describe('nft-transfer.services', () => {
 			await transferExtV2(mockParams);
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
-			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsSendEnum.SIGN_TRANSFER);
-			expect(mockProgress).toHaveBeenNthCalledWith(2, ProgressStepsSendEnum.TRANSFER);
+			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsSendIc.SEND);
+			expect(mockProgress).toHaveBeenNthCalledWith(2, ProgressStepsSendIc.RELOAD);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

I mistakenly put the wrong progress steps in the flow for sending IC NFTs.

# Changes

- Adapt interface `SendNftCommonParams` to have generic steps (we adapt both for ETH and IC networks).
- Make component `IcSendTokenWizard` use `ProgressStepsSendIc`.
- Correct steps in service `sendNft` for ICP network.

# Tests

Adapted tests and a practical one:

<img width="656" height="462" alt="Screenshot 2025-12-09 at 10 10 06" src="https://github.com/user-attachments/assets/4b14e5c5-f1c2-4e50-9024-d55609b97f42" />

