### PR TITLE
fix(frontend): Resolve Plausible imports and related tests

### DIFF
--- a/src/frontend/src/lib/services/analytics-wrapper.ts
+++ b/src/frontend/src/lib/services/analytics-wrapper.ts
@@ -1,3 +1,1 @@
-const PLAUSIBLE_PACKAGE_NAME = '@plausible-analytics/tracker' as const;
-
-export const loadPlausibleTracker = async () => await import(PLAUSIBLE_PACKAGE_NAME);
+export const loadPlausibleTracker = async () => await import('@plausible-analytics/tracker');

--- a/src/frontend/src/tests/mocks/plausible-tracker.mock.ts
+++ b/src/frontend/src/tests/mocks/plausible-tracker.mock.ts
@@ -1,0 +1,15 @@
+export interface PlausibleTracker {
+	init: (options?: Record<string, unknown>) => void;
+	track: (eventName: string, options?: Record<string, unknown>) => void;
+}
+
+const tracker: PlausibleTracker = {
+	init: () => {
+		// no-op in tests
+	},
+	track: () => {
+		// no-op in tests
+	}
+};
+
+export default tracker;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,10 @@ export default defineConfig(
 				{
 					find: '$declarations',
 					replacement: resolve(__dirname, 'src/declarations')
+				},
+				{
+					find: '@plausible-analytics/tracker',
+					replacement: resolve(__dirname, 'src/frontend/src/tests/mocks/plausible-tracker.mock')
 				}
 			]
 		},


### PR DESCRIPTION
# Motivation

When I bumped `vitest to v4`, I changed the dynamic import or package `@plausible-analytics/tracker` to use a constant, since it was raising issues with the tests:

> Error: Failed to resolve entry for package "@plausible-analytics/tracker". The package may have incorrect main/module/exports specified in its package.json.
>   Plugin: vite:import-analysis
>   File: /Users/antonio.ventilii/projects/oisy-wallet/src/frontend/src/lib/services/analytics-wrapper.ts:1:61
>   1  |  export const loadPlausibleTracker = async () => await import("@plausible-analytics/tracker");
>      |                                                               ^                                                                                                                                                                                                                                                            
> 

However, Plausible detected that we had an incorrect usage of the package at this point and the events are not being registered anymore.

To fix it, we revert the dynamic import and, to fix the tests, we mock the plausible imports.

# Changes

- Revert the dynamic import of Plausible tracker to use a string directly.
- Create mock class for the tracker.
- Resolve the mock tracker as alias in vitest.

# Tests

Current tests should work.
