### PR TITLE
fix(frontend): Make coverage threshold consistent

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 


### PR DESCRIPTION
# Motivation

There is an inconsistency in the merging of the sharded run reports, between the complete run and the sharded ones.

It causes an issue when comparing the saved thresholds (complete run) with the coverage run in each PR (sharded run).

So, for now, we run the sharded tests to save the new thresholds.

The [issue was tracked in the vitest repo](https://github.com/vitest-dev/vitest/issues/8616), but note that it could be either our code or directly vitest.
