### PR TITLE
feat(frontend): Filter NFT by identifiers too

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -38,6 +38,7 @@ import type { UserNetworks } from '$lib/types/user-networks';
 import { areAddressesPartiallyEqual } from '$lib/utils/address.utils';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
 import { isNetworkIdSOLDevnet } from '$lib/utils/network.utils';
+import { isTokenNonFungible } from '$lib/utils/nft.utils';
 import { filterEnabledToken, mapTokenUi } from '$lib/utils/token.utils';
 import { isUserNetworkEnabled } from '$lib/utils/user-networks.utils';
 import type { SplCustomToken } from '$sol/types/spl-custom-token';
@@ -273,7 +274,7 @@ export const filterTokens = <T extends Token>({
 			return true;
 		}
 
-		if (isTokenErc20(token) || isTokenSpl(token)) {
+		if (isTokenErc20(token) || isTokenErc721(token) || isTokenErc1155(token) || isTokenSpl(token)) {
 			return areAddressesPartiallyEqual({
 				address1: token.address,
 				address2: filter,
@@ -289,6 +290,12 @@ export const filterTokens = <T extends Token>({
 				(nonNullish(indexCanisterId) &&
 					indexCanisterId.toLowerCase().includes(filter.toLowerCase()))
 			);
+		}
+
+		if (isTokenExtV2(token)) {
+			const { canisterId } = token;
+
+			return canisterId.toLowerCase().includes(filter.toLowerCase());
 		}
 
 		return false;
@@ -521,6 +528,6 @@ export const filterTokensByNft = ({
 	isNullish(filterNfts)
 		? tokens
 		: tokens.filter((t) => {
-				const isNft = isTokenErc1155(t) || isTokenErc721(t) || isTokenExtV2(t);
+				const isNft = isTokenNonFungible(t);
 				return filterNfts ? isNft : !isNft;
 			});

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -577,7 +577,10 @@ describe('tokens.utils', () => {
 			...mockTokens,
 			mockValidIcrcToken,
 			mockValidIcCkToken,
+			mockValidExtV2Token,
 			mockValidErc20Token,
+			mockValidErc721Token,
+			mockValidErc1155Token,
 			mockValidSplToken
 		];
 
@@ -602,23 +605,22 @@ describe('tokens.utils', () => {
 			expect(filterTokens({ tokens, filter: '' })).toStrictEqual(tokens);
 		});
 
-		it('should filter by address for ERC tokens', () => {
-			expect(filterTokens({ tokens, filter: mockValidErc20Token.address })).toStrictEqual([
-				mockValidErc20Token
-			]);
+		it.each([mockValidErc20Token, mockValidErc721Token, mockValidErc1155Token])(
+			'should filter by address for ERC tokens with standard $standard',
+			(token) => {
+				expect(filterTokens({ tokens, filter: token.address })).toStrictEqual([token]);
 
-			expect(
-				filterTokens({ tokens, filter: mockValidErc20Token.address.toLowerCase() })
-			).toStrictEqual([mockValidErc20Token]);
+				expect(filterTokens({ tokens, filter: token.address.toLowerCase() })).toStrictEqual([
+					token
+				]);
 
-			expect(
-				filterTokens({ tokens, filter: mockValidErc20Token.address.toUpperCase() })
-			).toStrictEqual([mockValidErc20Token]);
+				expect(filterTokens({ tokens, filter: token.address.toUpperCase() })).toStrictEqual([
+					token
+				]);
 
-			expect(
-				filterTokens({ tokens, filter: mockValidErc20Token.address.slice(0, 5) })
-			).toStrictEqual([mockValidErc20Token]);
-		});
+				expect(filterTokens({ tokens, filter: token.address.slice(0, 5) })).toStrictEqual([token]);
+			}
+		);
 
 		it('should filter by address for SPL tokens', () => {
 			expect(filterTokens({ tokens, filter: mockValidSplToken.address })).toStrictEqual([
@@ -682,6 +684,24 @@ describe('tokens.utils', () => {
 					filter: mockToken.indexCanisterId.slice(0, 5)
 				})
 			).toStrictEqual([mockToken]);
+		});
+
+		it('should filter by canister IDs for EXT tokens', () => {
+			expect(filterTokens({ tokens, filter: mockValidExtV2Token.canisterId })).toStrictEqual([
+				mockValidExtV2Token
+			]);
+
+			expect(
+				filterTokens({ tokens, filter: mockValidExtV2Token.canisterId.toLowerCase() })
+			).toStrictEqual([mockValidExtV2Token]);
+
+			expect(
+				filterTokens({ tokens, filter: mockValidExtV2Token.canisterId.toUpperCase() })
+			).toStrictEqual([mockValidExtV2Token]);
+
+			expect(
+				filterTokens({ tokens, filter: mockValidExtV2Token.canisterId.slice(0, 5) })
+			).toStrictEqual([mockValidExtV2Token]);
 		});
 
 		it('should not filter by network', () => {


### PR DESCRIPTION
# Motivation

Including all NFTs standard in the util that filters the tokens too.
