### PR TITLE
fix(devops): Correct order in CI for Frontend Test Coverage Thresholds

### DIFF
--- a/.github/workflows/frontend-update-coverage-thresholds.yml
+++ b/.github/workflows/frontend-update-coverage-thresholds.yml
@@ -78,7 +78,6 @@ jobs:
         run: rm vitest.config.before.ts
 
       - name: Format
-        if: steps.check_changes.outputs.changes_detected == 'true'
         run: npm run format:file --file=vitest.config.ts
 
       - name: Check for Coverage Thresholds Changes


### PR DESCRIPTION
# Motivation

The formatting of the vitest file should happen BEFORE we check for changes, since the format could be the only thing that changes.
