### PR TITLE
chore(frontend): Remove ETH address check from `LoaderNfts`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderNfts.svelte
@@ -30,7 +30,7 @@
 	const debounceLoad = debounce(onLoad);
 
 	$effect(() => {
-		[$enabledNonFungibleTokens, $authIdentity,$ethAddress];
+		[$enabledNonFungibleTokens, $authIdentity, $ethAddress];
 
 		untrack(() => debounceLoad());
 	});


### PR DESCRIPTION
# Motivation

In component `LoaderNfts` there is no need to check for defined ETH address, since it is handled directly inside the service, and since we have other networks for NFTs.

So, for example, if all networks are disabled except ICP, we still want to load the NFTs