### PR TITLE
feat(frontend): Accept GIFs as image for NFT media

### DIFF
--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -320,7 +320,7 @@ export const getMediaStatus = async (mediaUrl?: string): Promise<NftMediaStatusE
 			return NftMediaStatusEnum.OK;
 		}
 
-		if (!type.startsWith('image/')) {
+		if (!type.startsWith('image/') && !type.startsWith('.gif')) {
 			return NftMediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE;
 		}
 

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -811,6 +811,23 @@ describe('nfts.utils', () => {
 			expect(result).toBe(NftMediaStatusEnum.OK);
 		});
 
+		it('returns OK for valid gif under the size limit', async () => {
+			global.fetch = vi.fn().mockResolvedValueOnce({
+				headers: {
+					get: (h: string) =>
+						h === 'Content-Type'
+							? '.gif;charset=utf-8'
+							: h === 'Content-Length'
+								? (NFT_MAX_FILESIZE_LIMIT - 100).toString()
+								: null
+				}
+			});
+
+			const result = await getMediaStatus('https://example.com/image.gif');
+
+			expect(result).toBe(NftMediaStatusEnum.OK);
+		});
+
 		it('returns INVALID_DATA for invalid URL', async () => {
 			const result = await getMediaStatus('not-a-url');
 


### PR DESCRIPTION
# Motivation

We allow GIFs when checking the media status of an NFT.