### PR TITLE
feat(frontend): update LockPage unlock function

### DIFF
--- a/src/frontend/src/lib/components/auth/LockPage.svelte
+++ b/src/frontend/src/lib/components/auth/LockPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { themeStore } from '@dfinity/gix-components';
+	import { PRIMARY_INTERNET_IDENTITY_VERSION } from '$env/auth.env';
 	import OisyWalletLogoLink from '$lib/components/core/OisyWalletLogoLink.svelte';
 	import IconKey from '$lib/components/icons/IconKey.svelte';
 	import IconLogout from '$lib/components/icons/IconLogout.svelte';
@@ -11,6 +12,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authLocked } from '$lib/stores/locked.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { InternetIdentityDomain } from '$lib/types/auth';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
 	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));
@@ -18,7 +20,11 @@
 	const imgStyleClass = 'h-full object-contain mx-auto object-top';
 
 	const handleUnlock = async () => {
-		const { success } = await signIn({});
+		const { success } = await signIn({
+			...(PRIMARY_INTERNET_IDENTITY_VERSION === '2.0' && {
+				domain: InternetIdentityDomain.VERSION_2_0
+			})
+		});
 
 		if (success === 'ok') {
 			authLocked.unlock({ source: 'login from lock page' });

--- a/src/frontend/src/tests/lib/components/auth/LockPage.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/LockPage.spec.ts
@@ -1,7 +1,9 @@
+import * as authEnv from '$env/auth.env';
 import LockPage from '$lib/components/auth/LockPage.svelte';
 import * as authServices from '$lib/services/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { authLocked } from '$lib/stores/locked.store';
+import { InternetIdentityDomain } from '$lib/types/auth';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
@@ -45,6 +47,21 @@ describe('LockPage', () => {
 		await fireEvent.click(unlockButton);
 
 		expect(signInMock).toHaveBeenCalledWith({});
+		expect(authLocked.unlock).toHaveBeenCalledWith({
+			source: 'login from lock page'
+		});
+	});
+
+	it('should call signIn with domain param if env var is set to 2.0', async () => {
+		vi.spyOn(authEnv, 'PRIMARY_INTERNET_IDENTITY_VERSION', 'get').mockImplementation(() => '2.0');
+		const signInMock = vi.spyOn(authServices, 'signIn').mockResolvedValue({ success: 'ok' });
+
+		const { getByText } = render(LockPage);
+		const unlockButton = getByText(get(i18n).lock.text.unlock);
+
+		await fireEvent.click(unlockButton);
+
+		expect(signInMock).toHaveBeenCalledWith({ domain: InternetIdentityDomain.VERSION_2_0 });
 		expect(authLocked.unlock).toHaveBeenCalledWith({
 			source: 'login from lock page'
 		});


### PR DESCRIPTION
# Motivation

We need to update the unlock functionality - it should now check the PRIMARY_INTERNET_IDENTITY_VERSION env var value to identify which domain to use. 
