### PR TITLE
style(frontend): center the secondary auth button on the sign page

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -55,6 +55,7 @@
 
 	{#if isPrimaryIdentityVersion2}
 		<ButtonAuthenticateWithIndentityNumber
+			{fullWidth}
 			onclick={() => onAuthenticate(InternetIdentityDomain.VERSION_1_0)}
 		/>
 	{/if}

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithIndentityNumber.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithIndentityNumber.svelte
@@ -6,13 +6,15 @@
 
 	interface Props {
 		onclick: () => void;
+		fullWidth?: boolean;
 	}
 
-	let { onclick }: Props = $props();
+	let { onclick, fullWidth }: Props = $props();
 </script>
 
 <div
-	class="mt-2 flex w-full items-center justify-center gap-2 text-sm font-bold text-brand-primary sm:w-80"
+	class="mt-2 flex w-full items-center justify-center gap-2 text-sm font-bold text-brand-primary"
+	class:sm:w-80={!fullWidth}
 >
 	<ExternalLink
 		ariaLabel={$i18n.auth.text.sign_in_with_identity_number}


### PR DESCRIPTION
# Motivation

The secondary auth button was not correctly centered on the sign page.

<img width="622" height="586" alt="Screenshot 2025-12-12 at 14 47 26" src="https://github.com/user-attachments/assets/c8336e95-7b18-40b9-bb7e-cc7c19705c00" />
