### PR TITLE
refactor(frontend): Rename service for auto-loading ICRC tokens

### DIFF
--- a/src/frontend/src/icp-eth/components/convert/ConvertEth.svelte
+++ b/src/frontend/src/icp-eth/components/convert/ConvertEth.svelte
@@ -6,7 +6,7 @@
 	import { isNotSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import CkEthLoader from '$icp-eth/components/core/CkEthLoader.svelte';
-	import { autoLoadCustomToken } from '$icp-eth/services/custom-token.services';
+	import { autoLoadIcrcToken } from '$icp-eth/services/icrc-token.services';
 	import { autoLoadUserToken } from '$icp-eth/services/user-token.services';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { toCkEthHelperContractAddress } from '$icp-eth/utils/cketh.utils';
@@ -73,7 +73,7 @@
 			return;
 		}
 
-		const { result: resultCustomToken } = await autoLoadCustomToken({
+		const { result: resultCustomToken } = await autoLoadIcrcToken({
 			icrcCustomTokens: $icrcTokens,
 			sendToken: $tokenWithFallback,
 			identity: $authIdentity

--- a/src/frontend/src/icp-eth/services/icrc-token.services.ts
+++ b/src/frontend/src/icp-eth/services/icrc-token.services.ts
@@ -38,7 +38,7 @@ const findCustomToken = ({
  * @param {OptionIdentity} params.identity - The user's identity.
  * @returns {Promise<{ result: 'loaded' | 'skipped' | 'error' }>} The result of the operation.
  */
-export const autoLoadCustomToken = async ({
+export const autoLoadIcrcToken = async ({
 	icrcCustomTokens,
 	sendToken,
 	identity

--- a/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
+++ b/src/frontend/src/icp/components/stake/gldt/GldtStakeEarnCard.svelte
@@ -7,7 +7,7 @@
 	import { loadCustomTokens } from '$icp/services/icrc.services';
 	import { GLDT_STAKE_CONTEXT_KEY, type GldtStakeContext } from '$icp/stores/gldt-stake.store';
 	import type { IcToken } from '$icp/types/ic-token';
-	import { setCustomToken } from '$icp-eth/services/custom-token.services';
+	import { setCustomToken } from '$icp-eth/services/icrc-token.services';
 	import { isGLDTToken } from '$icp-eth/utils/token.utils';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import GetTokenModal from '$lib/components/get-token/GetTokenModal.svelte';

--- a/src/frontend/src/lib/components/vip/VipRewardStateModal.svelte
+++ b/src/frontend/src/lib/components/vip/VipRewardStateModal.svelte
@@ -3,7 +3,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { icrcTokens } from '$icp/derived/icrc.derived';
 	import { loadCustomTokens } from '$icp/services/icrc.services';
-	import { setCustomToken } from '$icp-eth/services/custom-token.services';
+	import { setCustomToken } from '$icp-eth/services/icrc-token.services';
 	import { isGLDTToken } from '$icp-eth/utils/token.utils';
 	import failedVipReward from '$lib/assets/failed-vip-reward.svg';
 	import successfulBinanceReward from '$lib/assets/successful-binance-reward.svg';

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -6,7 +6,7 @@ import type { EthAddress } from '$eth/types/address';
 import type { Erc20Token } from '$eth/types/erc20';
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
-import { setCustomToken as setCustomIcrcToken } from '$icp-eth/services/custom-token.services';
+import { setCustomToken as setCustomIcrcToken } from '$icp-eth/services/icrc-token.services';
 import { approve } from '$icp/api/icrc-ledger.api';
 import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
 import { hasSufficientIcrcAllowance, loadCustomTokens } from '$icp/services/icrc.services';

--- a/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
+++ b/src/frontend/src/tests/icp-eth/services/custom-token.services.spec.ts
@@ -1,5 +1,5 @@
 import { IC_CKBTC_INDEX_CANISTER_ID } from '$env/networks/networks.icrc.env';
-import { autoLoadCustomToken, setCustomToken } from '$icp-eth/services/custom-token.services';
+import { autoLoadIcrcToken, setCustomToken } from '$icp-eth/services/icrc-token.services';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { BackendCanister } from '$lib/canisters/backend.canister';
@@ -21,7 +21,7 @@ vi.mock('$app/environment', () => ({
 	browser: true
 }));
 
-describe('custom-token.services', () => {
+describe('icrc-token.services', () => {
 	const backendCanisterMock = mock<BackendCanister>();
 	const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
@@ -46,7 +46,7 @@ describe('custom-token.services', () => {
 		};
 
 		it('should return "skipped" when the token standard does not match', async () => {
-			const result = await autoLoadCustomToken({
+			const result = await autoLoadIcrcToken({
 				icrcCustomTokens: mockIcrcCustomTokens,
 				sendToken: mockValidToken,
 				identity: mockIdentity
@@ -77,7 +77,7 @@ describe('custom-token.services', () => {
 				const [first, ...rest] = customTokens;
 				const icrcCustomTokens = [{ ...first, indexCanisterId }, ...rest];
 
-				const { result } = await autoLoadCustomToken({
+				const { result } = await autoLoadIcrcToken({
 					icrcCustomTokens,
 					sendToken: mockSendToken,
 					identity: mockIdentity
@@ -159,7 +159,7 @@ describe('custom-token.services', () => {
 						['icrc1:fee', { Nat: mockValidSendToken.fee }]
 					]);
 
-					const { result } = await autoLoadCustomToken({
+					const { result } = await autoLoadIcrcToken({
 						icrcCustomTokens: mockIcrcCustomTokens,
 						sendToken: mockValidSendToken,
 						identity: mockIdentity
@@ -199,7 +199,7 @@ describe('custom-token.services', () => {
 
 				backendCanisterMock.listCustomTokens.mockResolvedValue([]);
 
-				const { result } = await autoLoadCustomToken({
+				const { result } = await autoLoadIcrcToken({
 					icrcCustomTokens: mockIcrcCustomTokens,
 					sendToken: mockValidSendToken,
 					identity: mockIdentity
@@ -219,7 +219,7 @@ describe('custom-token.services', () => {
 				const err = new Error('test');
 				backendCanisterMock.listCustomTokens.mockRejectedValue(err);
 
-				const { result } = await autoLoadCustomToken({
+				const { result } = await autoLoadIcrcToken({
 					icrcCustomTokens: mockIcrcCustomTokens,
 					sendToken: mockValidSendToken,
 					identity: mockIdentity
@@ -256,7 +256,7 @@ describe('custom-token.services', () => {
 					const err = new Error('test');
 					ledgerCanisterMock.metadata.mockRejectedValue(err);
 
-					const { result } = await autoLoadCustomToken({
+					const { result } = await autoLoadIcrcToken({
 						icrcCustomTokens: mockIcrcCustomTokens,
 						sendToken: mockValidSendToken,
 						identity: mockIdentity

--- a/src/frontend/src/tests/lib/components/vip/VipRewardStateModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/vip/VipRewardStateModal.spec.ts
@@ -1,5 +1,5 @@
 import { GLDT_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
-import { setCustomToken } from '$icp-eth/services/custom-token.services';
+import { setCustomToken } from '$icp-eth/services/icrc-token.services';
 import { loadCustomTokens } from '$icp/services/icrc.services';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';


### PR DESCRIPTION
# Motivation

It makes more sense to rename the service `autoLoadCustomToken` to `autoLoadIcrcToken` since it focuses on ICRC in the ck-universe.
