### PR TITLE
fix(frontend): fixed opencryptoPay network name

### DIFF
--- a/src/frontend/src/lib/services/open-crypto-pay.services.ts
+++ b/src/frontend/src/lib/services/open-crypto-pay.services.ts
@@ -230,7 +230,7 @@ export const pay = async ({
 	const apiUrl = getPaymentUri({
 		callback,
 		quoteId,
-		network: token.network.name,
+		network: token.network.pay?.openCryptoPay ?? token.network.name,
 		rawTransaction
 	});
 


### PR DESCRIPTION
# Motivation

Fix for openCryptoPay network name for fetching url(BNB network)
