### PR TITLE
feat(frontend): add limits for AI tool executions

### DIFF
--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -1,4 +1,5 @@
 import type { tool } from '$declarations/llm/llm.did';
+import { ToolResultType } from '$lib/types/ai-assistant';
 import { toNullable } from '@dfinity/utils';
 
 export const AI_ASSISTANT_LLM_MODEL = 'qwen3:32b';
@@ -232,3 +233,10 @@ export const getAiAssistantToolsDescription = ({
 	] as tool[];
 
 export const MAX_SUPPORTED_AI_ASSISTANT_CHAT_LENGTH = 100;
+
+export const TOOL_CALLS_LIMITS: Record<ToolResultType, number> = {
+	[ToolResultType.REVIEW_SEND_TOKENS]: 1,
+	[ToolResultType.SHOW_BALANCE]: 10,
+	[ToolResultType.SHOW_ALL_CONTACTS]: 1,
+	[ToolResultType.SHOW_FILTERED_CONTACTS]: 10
+};

--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -2,7 +2,8 @@ import type { chat_message_v1 } from '$declarations/llm/llm.did';
 import { llmChat } from '$lib/api/llm.api';
 import {
 	AI_ASSISTANT_LLM_MODEL,
-	getAiAssistantToolsDescription
+	getAiAssistantToolsDescription,
+	TOOL_CALLS_LIMITS
 } from '$lib/constants/ai-assistant.constants';
 import {
 	AI_ASSISTANT_TEXTUAL_RESPONSE_RECEIVED,
@@ -63,12 +64,22 @@ export const askLlm = async ({
 		identity
 	});
 	const toolResults: ToolResult[] = [];
+	const toolCallsCounters: Record<ToolResultType, number> = {
+		[ToolResultType.REVIEW_SEND_TOKENS]: 0,
+		[ToolResultType.SHOW_BALANCE]: 0,
+		[ToolResultType.SHOW_ALL_CONTACTS]: 0,
+		[ToolResultType.SHOW_FILTERED_CONTACTS]: 0
+	};
 
 	if (nonNullish(tool_calls) && tool_calls.length > 0) {
 		for (const toolCall of tool_calls) {
-			const result = executeTool({ toolCall, requestStartTimestamp });
+			const toolType = toolCall.function.name as ToolResultType;
 
-			nonNullish(result) && toolResults.push(result);
+			if (toolCallsCounters[toolType] < TOOL_CALLS_LIMITS[toolType]) {
+				const result = executeTool({ toolCall, requestStartTimestamp });
+				nonNullish(result) && toolResults.push(result);
+				toolCallsCounters[toolType] += 1;
+			}
 		}
 	} else {
 		trackEvent({

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -2,7 +2,7 @@ import type { chat_response_v1 } from '$declarations/llm/llm.did';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { llmChat } from '$lib/api/llm.api';
 import { extendedAddressContacts } from '$lib/derived/contacts.derived';
-import { askLlm, executeTool } from '$lib/services/ai-assistant.services';
+import * as aiAssistantServices from '$lib/services/ai-assistant.services';
 import { contactsStore } from '$lib/stores/contacts.store';
 import type { ContactUi } from '$lib/types/contact';
 import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
@@ -52,7 +52,7 @@ describe('ai-assistant.services', () => {
 
 			vi.mocked(llmChat).mockResolvedValue(response);
 
-			const result = await askLlm({
+			const result = await aiAssistantServices.askLlm({
 				identity: mockIdentity,
 				messages: [{ user: { content: 'test' } }]
 			});
@@ -77,7 +77,7 @@ describe('ai-assistant.services', () => {
 
 			vi.mocked(llmChat).mockResolvedValue(response);
 
-			const result = await askLlm({
+			const result = await aiAssistantServices.askLlm({
 				identity: mockIdentity,
 				messages: [{ user: { content: 'test' } }]
 			});
@@ -87,6 +87,35 @@ describe('ai-assistant.services', () => {
 				text: fromNullable(response.message.content),
 				tool: {
 					calls: [showAllContactsToolCall],
+					results: [
+						{
+							result: { contacts: [] },
+							type: 'show_all_contacts'
+						}
+					]
+				}
+			});
+		});
+
+		it('parses only one tool call if the limit for a tool has been reached', async () => {
+			const response = {
+				message: {
+					content: toNullable(),
+					tool_calls: [showAllContactsToolCall, showAllContactsToolCall, showAllContactsToolCall]
+				}
+			} as chat_response_v1;
+
+			vi.mocked(llmChat).mockResolvedValue(response);
+
+			const result = await aiAssistantServices.askLlm({
+				identity: mockIdentity,
+				messages: [{ user: { content: 'test' } }]
+			});
+
+			expect(result).toStrictEqual({
+				text: fromNullable(response.message.content),
+				tool: {
+					calls: [showAllContactsToolCall, showAllContactsToolCall, showAllContactsToolCall],
 					results: [
 						{
 							result: { contacts: [] },
@@ -114,7 +143,7 @@ describe('ai-assistant.services', () => {
 		});
 
 		it('parses show_all_contacts tool and returns all contacts', () => {
-			const result = executeTool({
+			const result = aiAssistantServices.executeTool({
 				toolCall: showAllContactsToolCall,
 				requestStartTimestamp: 1000
 			});
@@ -128,7 +157,7 @@ describe('ai-assistant.services', () => {
 		});
 
 		it('parses show_filtered_contacts tool and returns contacts', () => {
-			const result = executeTool({
+			const result = aiAssistantServices.executeTool({
 				toolCall: showFilteredContactsToolCall,
 				requestStartTimestamp: 1000
 			});
@@ -142,7 +171,7 @@ describe('ai-assistant.services', () => {
 		});
 
 		it('parses show_balance tool and returns the expected data', () => {
-			const result = executeTool({
+			const result = aiAssistantServices.executeTool({
 				toolCall: showBalanceToolCall,
 				requestStartTimestamp: 1000
 			});


### PR DESCRIPTION
# Motivation

One of the security review points was to introduce upper limits for tool calls executions. In this PR, we implement the suggested approach.
