### PR TITLE
feat(frontend): use unfiltered by network tokens in the balance tool

### DIFF
--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -10,8 +10,8 @@ import {
 	AI_ASSISTANT_TOOL_EXECUTION_TRIGGERED
 } from '$lib/constants/analytics.constants';
 import { extendedAddressContacts as extendedAddressContactsStore } from '$lib/derived/contacts.derived';
-import { combinedDerivedSortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
 import { networks } from '$lib/derived/networks.derived';
+import { enabledFungibleTokensUi } from '$lib/derived/tokens-ui.derived';
 import { enabledTokens, enabledUniqueTokensSymbols } from '$lib/derived/tokens.derived';
 import { trackEvent } from '$lib/services/analytics.services';
 import {
@@ -129,7 +129,7 @@ export const executeTool = ({
 	} else if (name === ToolResultType.SHOW_BALANCE) {
 		result = parseShowBalanceToolArguments({
 			filterParams,
-			tokensUi: get(combinedDerivedSortedFungibleNetworkTokensUi),
+			tokensUi: get(enabledFungibleTokensUi),
 			networks: get(networks)
 		});
 


### PR DESCRIPTION
# Motivation

We need to use unfiltered by network tokens when calculating results in the AI balance tool requests.