### PR TITLE
feat(frontend): Fall back to EXT legacy tokens method

### DIFF
--- a/src/frontend/src/icp/api/ext-v2-token.api.ts
+++ b/src/frontend/src/icp/api/ext-v2-token.api.ts
@@ -126,7 +126,10 @@ export const getTokensByOwner = async ({
 		try {
 			return await getTokensByOwnerLegacy({ certified, ...getIcrcAccount(owner) });
 		} catch (legacyErr: unknown) {
-			if (legacyErr instanceof CanisterInternalError) {
+			if (
+				legacyErr instanceof CanisterInternalError &&
+				!(primaryErr instanceof CanisterInternalError)
+			) {
 				throw legacyErr;
 			}
 

--- a/src/frontend/src/tests/icp/api/ext-v2-token.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/ext-v2-token.api.spec.ts
@@ -149,6 +149,23 @@ describe('ext-v2-token.api', () => {
 			);
 		});
 
+		it('should raise the error of the first method if both errors are handled', async () => {
+			const mockError1 = new CanisterInternalError('First error');
+			const mockError2 = new CanisterInternalError('Legacy error');
+
+			tokenCanisterMock.getTokensByOwner.mockRejectedValueOnce(mockError1);
+
+			tokenCanisterMock.getTokensByOwnerLegacy.mockRejectedValueOnce(mockError2);
+
+			await expect(getTokensByOwner(params)).rejects.toThrowError(mockError1);
+
+			expect(tokenCanisterMock.getTokensByOwner).toHaveBeenCalledExactlyOnceWith(expectedParams);
+
+			expect(tokenCanisterMock.getTokensByOwnerLegacy).toHaveBeenCalledExactlyOnceWith(
+				expectedParams
+			);
+		});
+
 		it('should raise the error of the first method if fallback fails', async () => {
 			const mockError = new Error('First error');
 


### PR DESCRIPTION
# Motivation

Some EXT token canisters do not support the newest method for transfer `tokens_ext`, so, we need to fallback on the legacy one if needed. In this PR, we try the legacy method in service `getTokensByOwner `, if the first one fails.