### PR TITLE
refactor(frontend): Rename component that shows fullscreen media

### DIFF
--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -60,7 +60,7 @@
 	{:else if $modalNftImageConsent && nonNullish($modalNftImageConsentData)}
 		<NftImageConsentModal collection={$modalNftImageConsentData} />
 	{:else if $modalNftFullscreenDisplayOpen && nonNullish($modalNftFullscreenDisplayData?.imageUrl)}
-		<FullscreenMediaModal imageSrc={$modalNftFullscreenDisplayData.imageUrl} />
+		<FullscreenMediaModal mediaSrc={$modalNftFullscreenDisplayData.imageUrl} />
 	{:else if $modalReceive && $modalReceiveId === getSymbol('menu-addresses')}
 		<ReceiveAddressModal infoCmp={ReceiveAddresses} />
 	{/if}

--- a/src/frontend/src/lib/components/ui/FullscreenMediaModal.svelte
+++ b/src/frontend/src/lib/components/ui/FullscreenMediaModal.svelte
@@ -13,17 +13,17 @@
 	import type { Option } from '$lib/types/utils';
 
 	interface Props {
-		imageSrc: string;
+		mediaSrc: string;
 	}
 
-	let { imageSrc }: Props = $props();
+	let { mediaSrc }: Props = $props();
 
 	// Value `null` means that the media type is not supported, or it is not possible to fetch the type.
 	// Value `undefined` means that we have not yet fetched the media type.
 	let mediaType = $state<Option<MediaType>>();
 
 	const updateMediaType = async () => {
-		const { type } = await extractMediaTypeAndSize(imageSrc);
+		const { type } = await extractMediaTypeAndSize(mediaSrc);
 
 		mediaType = type;
 	};
@@ -33,7 +33,7 @@
 	});
 
 	$effect(() => {
-		[imageSrc];
+		[mediaSrc];
 
 		untrack(() => updateMediaType());
 	});
@@ -45,10 +45,10 @@
 	</div>
 	<div class="pointer-events-none absolute inset-0 z-9 grid place-items-center">
 		{#if mediaType === MediaType.Img}
-			<Img src={imageSrc} styleClass="rounded-lg w-auto h-auto block max-h-[90dvh] max-w-[90dvw]" />
+			<Img src={mediaSrc} styleClass="rounded-lg w-auto h-auto block max-h-[90dvh] max-w-[90dvw]" />
 		{:else if mediaType === MediaType.Video}
 			<Video
-				src={imageSrc}
+				src={mediaSrc}
 				styleClass="rounded-lg w-auto h-auto block max-h-[90dvh] max-w-[90dvw]"
 			/>
 		{:else if mediaType === null}

--- a/src/frontend/src/tests/lib/components/ui/FullscreenMediaModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/FullscreenMediaModal.spec.ts
@@ -23,7 +23,7 @@ describe('FullscreenMediaModal', () => {
 
 		const { container } = render(FullscreenMediaModal, {
 			props: {
-				imageSrc: 'https://www.example.com/test-image.png'
+				mediaSrc: 'https://www.example.com/test-image.png'
 			}
 		});
 
@@ -41,7 +41,7 @@ describe('FullscreenMediaModal', () => {
 
 		const { container } = render(FullscreenMediaModal, {
 			props: {
-				imageSrc: 'https://www.example.com/test-video.mp4'
+				mediaSrc: 'https://www.example.com/test-video.mp4'
 			}
 		});
 
@@ -56,7 +56,7 @@ describe('FullscreenMediaModal', () => {
 	it('shows the close icon in the top-right corner', () => {
 		const { container } = render(FullscreenMediaModal, {
 			props: {
-				imageSrc: 'https://www.example.com/test-image.png'
+				mediaSrc: 'https://www.example.com/test-image.png'
 			}
 		});
 
@@ -68,7 +68,7 @@ describe('FullscreenMediaModal', () => {
 	it('calls modalStore.close when backdrop is clicked', async () => {
 		const { getByTestId } = render(FullscreenMediaModal, {
 			props: {
-				imageSrc: 'https://www.example.com/test-image.png'
+				mediaSrc: 'https://www.example.com/test-image.png'
 			}
 		});
 
@@ -81,7 +81,7 @@ describe('FullscreenMediaModal', () => {
 	it('applies max size constraints to the fullscreen-modal container', async () => {
 		render(FullscreenMediaModal, {
 			props: {
-				imageSrc: 'https://www.example.com/test-image.png'
+				mediaSrc: 'https://www.example.com/test-image.png'
 			}
 		});
 


### PR DESCRIPTION
# Motivation

Since now it could show even video and not only image, component `FullscreenImgModal` should be renamed as `FullscreenMediaModal`.
